### PR TITLE
feat: add cmd to generate a JSON representation of schema

### DIFF
--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -77,7 +77,7 @@
     "@sanity/generate-help-url": "^3.0.0",
     "@sanity/types": "3.32.0",
     "arrify": "^1.0.1",
-    "groq-js": "1.5.0-canary.1",
+    "groq-js": "^1.5.0-canary.1",
     "humanize-list": "^1.0.1",
     "leven": "^3.1.0",
     "lodash": "^4.17.21",

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -77,6 +77,7 @@
     "@sanity/generate-help-url": "^3.0.0",
     "@sanity/types": "3.32.0",
     "arrify": "^1.0.1",
+    "groq-js": "1.5.0-canary.1",
     "humanize-list": "^1.0.1",
     "leven": "^3.1.0",
     "lodash": "^4.17.21",
@@ -84,6 +85,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
+    "@sanity/icons": "^2.8.0",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/@sanity/schema/src/_exports/_internal.ts
+++ b/packages/@sanity/schema/src/_exports/_internal.ts
@@ -4,6 +4,7 @@ export {
   resolveSearchConfig,
   resolveSearchConfigForBaseFieldPaths,
 } from '../legacy/searchConfig/resolve'
+export {extractSchema} from '../sanity/extractSchema'
 export {groupProblems} from '../sanity/groupProblems'
 export {
   type _FIXME_ as FIXME,

--- a/packages/@sanity/schema/src/sanity/extractSchema.ts
+++ b/packages/@sanity/schema/src/sanity/extractSchema.ts
@@ -214,8 +214,19 @@ export function extractSchema(
       }
     }
 
+    // Ignore empty objects
     if (Object.keys(attributes).length === 0) {
       return {type: 'unknown'} satisfies UnknownTypeNode
+    }
+
+    if (schemaType.type?.name !== 'document') {
+      attributes._type = {
+        type: 'objectAttribute',
+        value: {
+          type: 'string',
+          value: schemaType.name,
+        },
+      }
     }
 
     return {

--- a/packages/@sanity/schema/src/sanity/extractSchema.ts
+++ b/packages/@sanity/schema/src/sanity/extractSchema.ts
@@ -497,25 +497,29 @@ function sortByDependencies(compiledSchema: SchemaDef): string[] {
 
   // Sorts the types by their dependencies
   const typeNames: string[] = []
-  const tempMark = new Set<SanitySchemaType>()
-  const permMark = new Set<SanitySchemaType>()
+  // holds a temporary mark for types that are currently being visited, to detect cyclic dependencies
+  const currentlyVisiting = new Set<SanitySchemaType>()
+
+  // holds a permanent mark for types that have been already visited
+  const visited = new Set<SanitySchemaType>()
+
   // visit implements a depth-first search
   function visit(type: SanitySchemaType) {
-    if (permMark.has(type)) {
+    if (visited.has(type)) {
       return
     }
     // If we find a type that is already in the temporary mark, we have a cyclic dependency.
-    if (tempMark.has(type)) {
+    if (currentlyVisiting.has(type)) {
       return
     }
     // mark this as a temporary mark, meaning it's being visited
-    tempMark.add(type)
+    currentlyVisiting.add(type)
     const deps = dependencyMap.get(type)
     if (deps !== undefined) {
       deps.forEach((dep) => visit(dep))
     }
-    tempMark.delete(type)
-    permMark.add(type)
+    currentlyVisiting.delete(type)
+    visited.add(type)
 
     if (!typeNames.includes(type.name)) {
       typeNames.unshift(type.name)

--- a/packages/@sanity/schema/src/sanity/extractSchema.ts
+++ b/packages/@sanity/schema/src/sanity/extractSchema.ts
@@ -1,0 +1,712 @@
+import {
+  type ArrayDefinition,
+  type ArrayOfType,
+  type BlockDefinition,
+  type CrossDatasetReferenceDefinition,
+  type DocumentDefinition,
+  type FieldDefinition,
+  type FileDefinition,
+  type ImageDefinition,
+  type NumberDefinition,
+  type ObjectDefinition,
+  type ReferenceDefinition,
+  type Rule,
+  type SchemaTypeDefinition,
+  type StringDefinition,
+} from '@sanity/types'
+import {
+  type ArrayTypeNode,
+  createReferenceTypeNode,
+  type InlineTypeNode,
+  type NumberTypeNode,
+  type ObjectAttribute,
+  type ObjectTypeNode,
+  type PrimitiveTypeNode,
+  type SchemaType,
+  type StringTypeNode,
+  type TypeNode,
+  type UnionTypeNode,
+  type UnknownTypeNode,
+} from 'groq-js'
+
+const documentDefaultFields = (typeName: string): Record<string, ObjectAttribute> => ({
+  _id: {
+    type: 'objectAttribute',
+    value: {type: 'string'},
+  },
+  _type: {
+    type: 'objectAttribute',
+    value: {type: 'string', value: typeName},
+  },
+  _createdAt: {
+    type: 'objectAttribute',
+    value: {type: 'string'},
+  },
+  _updatedAt: {
+    type: 'objectAttribute',
+    value: {type: 'string'},
+  },
+  _rev: {
+    type: 'objectAttribute',
+    value: {type: 'string'},
+  },
+})
+const typesMap = new Map<string, TypeNode>([
+  ['text', {type: 'string'}],
+  ['url', {type: 'string'}],
+  ['datetime', {type: 'string'}],
+  ['date', {type: 'string'}],
+  ['boolean', {type: 'boolean'}],
+  ['email', {type: 'string'}],
+])
+
+export interface ExtractSchemaOptions {
+  enforceRequiredFields?: boolean
+}
+
+export function extractSchema(
+  schemaTypeDefinitions: SchemaTypeDefinition[],
+  extractOptions: ExtractSchemaOptions = {},
+): SchemaType {
+  const schema: SchemaType = []
+  schemaTypeDefinitions.forEach((type) => {
+    if (isDocumentType(type)) {
+      const attributes = documentDefaultFields(type.name) satisfies Record<string, ObjectAttribute>
+
+      for (const field of type.fields || []) {
+        const fieldIsRequired = isFieldRequired(field)
+        attributes[field.name] = {
+          type: 'objectAttribute',
+          optional: extractOptions.enforceRequiredFields ? fieldIsRequired : true,
+          value: parseField(field, extractOptions),
+        } satisfies ObjectAttribute
+      }
+
+      schema.push({
+        name: type.name,
+        type: 'document',
+        attributes,
+      })
+      return
+    }
+
+    if (isObjectType(type)) {
+      const attributes = type.fields.reduce<Record<string, ObjectAttribute>>((acc, field) => {
+        const fieldIsRequired = isFieldRequired(field)
+        acc[field.name] = {
+          type: 'objectAttribute',
+          optional: extractOptions.enforceRequiredFields ? !fieldIsRequired : true,
+          value: parseField(field, extractOptions),
+        } satisfies ObjectAttribute
+
+        return acc
+      }, {}) satisfies Record<string, ObjectAttribute>
+
+      attributes._type = {
+        type: 'objectAttribute',
+        value: {
+          type: 'string',
+          value: type.name,
+        },
+      } satisfies ObjectAttribute<StringTypeNode>
+
+      schema.push({
+        name: type.name,
+        type: 'type',
+        value: {
+          type: 'object',
+          attributes,
+        },
+      })
+      return
+    }
+    if (isArrayType(type)) {
+      schema.push({
+        type: 'type',
+        name: type.name,
+        value: createArray(type, extractOptions),
+      })
+      return
+    }
+
+    if (isBlockType(type)) {
+      schema.push({
+        type: 'type',
+        name: type.name,
+        value: createBlock(type, extractOptions),
+      })
+      return
+    }
+    if (isImageType(type)) {
+      schema.push({
+        type: 'type',
+        name: type.name,
+        value: createImage(type, extractOptions),
+      })
+      return
+    }
+    if (isFileType(type)) {
+      schema.push({
+        type: 'type',
+        name: type.name,
+        value: createFile(type, extractOptions),
+      })
+      return
+    }
+
+    if (isReferenceType(type)) {
+      schema.push({
+        type: 'type',
+        name: type.name,
+        value: createReferenceTypeNodeDefintion(type),
+      })
+      return
+    }
+
+    if (isCrossDatasetReferenceType(type)) {
+      schema.push({
+        type: 'type',
+        name: type.name,
+        value: createCrossDatasetReferenceTypeNodeDefintion(type),
+      })
+      return
+    }
+
+    if (isStringType(type)) {
+      schema.push({
+        type: 'type',
+        name: type.name,
+        value: createStringTypeNodeDefintion(type),
+      })
+    }
+
+    if (isNumberType(type)) {
+      schema.push({
+        type: 'type',
+        name: type.name,
+        value: createNumberTypeNodeDefintion(type),
+      })
+    }
+
+    if (typesMap.has(type.type)) {
+      schema.push({
+        type: 'type',
+        name: type.name,
+        value: typesMap.get(type.type),
+      })
+      return
+    }
+
+    schema.push({
+      type: 'type',
+      name: type.name,
+      value: {
+        type: 'inline',
+        name: type.type,
+      } satisfies InlineTypeNode,
+    })
+  })
+
+  return schema
+}
+
+function createKeyField(): ObjectAttribute<StringTypeNode> {
+  return {
+    type: 'objectAttribute',
+    value: {
+      type: 'string',
+    },
+  }
+}
+
+function isFieldRequired(field: FieldDefinition): boolean {
+  if (!field.validation) {
+    return false
+  }
+  const rules = Array.isArray(field.validation) ? field.validation : [field.validation]
+  for (const rule of rules) {
+    let required = false
+    const proxy = new Proxy(
+      {},
+      {
+        get: (target, methodName) => () => {
+          if (methodName === 'required') {
+            required = true
+          }
+          return proxy
+        },
+      },
+    ) as Rule
+    if (typeof rule === 'function') {
+      rule(proxy)
+      if (required) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+function parseField(field: FieldDefinition, extractOptions: ExtractSchemaOptions): TypeNode {
+  if (isObjectType(field)) {
+    const attributes: Record<string, ObjectAttribute> = {}
+    field.fields.forEach((f) => {
+      const fieldIsRequired = isFieldRequired(f)
+      attributes[f.name] = {
+        type: 'objectAttribute',
+        value: parseField(f, extractOptions),
+        optional: extractOptions.enforceRequiredFields ? fieldIsRequired : true,
+      }
+    })
+    attributes._type = {
+      type: 'objectAttribute',
+      value: {
+        type: 'string',
+        value: field.name,
+      },
+    } satisfies ObjectAttribute<StringTypeNode>
+
+    return {
+      type: field.type,
+      attributes,
+    }
+  }
+
+  if (isArrayType(field)) {
+    return createArray(field, extractOptions)
+  }
+
+  if (isBlockType(field)) {
+    return createBlock(field, extractOptions)
+  }
+  if (isImageType(field)) {
+    return createImage(field, extractOptions)
+  }
+  if (isFileType(field)) {
+    return createFile(field, extractOptions)
+  }
+
+  if (isReferenceType(field)) {
+    return createReferenceTypeNodeDefintion(field)
+  }
+
+  if (isCrossDatasetReferenceType(field)) {
+    return createCrossDatasetReferenceTypeNodeDefintion(field)
+  }
+
+  if (isStringType(field)) {
+    return createStringTypeNodeDefintion(field)
+  }
+
+  if (isNumberType(field)) {
+    return createNumberTypeNodeDefintion(field)
+  }
+
+  if (typesMap.has(field.type)) {
+    return typesMap.get(field.type)
+  }
+
+  return {
+    type: 'inline',
+    name: field.type,
+  }
+}
+
+function isDocumentType(n: SchemaTypeDefinition): n is DocumentDefinition {
+  return n.type === 'document'
+}
+function isFieldDefinition(n: unknown): n is FieldDefinition {
+  return (
+    n !== null &&
+    typeof n === 'object' &&
+    'type' in n &&
+    (('fieldset' in n && typeof n.fieldset === 'string') ||
+      !('fieldset' in n) ||
+      typeof n.fieldset === 'undefined') &&
+    (('group' in n && (typeof n.group === 'string' || Array.isArray(n.group))) ||
+      !('group' in n) ||
+      typeof n.group === 'undefined')
+  )
+}
+
+function isObjectType(n: {type: string}): n is ObjectDefinition {
+  return n.type === 'object'
+}
+function isArrayType(n: {type: string}): n is ArrayDefinition {
+  return n.type === 'array'
+}
+function isBlockType(n: {type: string}): n is BlockDefinition {
+  return n.type === 'block'
+}
+function isReferenceType(n: {type: string}): n is ReferenceDefinition {
+  return n.type === 'reference'
+}
+function isCrossDatasetReferenceType(n: {type: string}): n is CrossDatasetReferenceDefinition {
+  return n.type === 'crossDatasetReference'
+}
+function isImageType(n: {type: string}): n is ImageDefinition {
+  return n.type === 'image'
+}
+function isFileType(n: {type: string}): n is FileDefinition {
+  return n.type === 'file'
+}
+function isStringType(n: {type: string}): n is StringDefinition {
+  return n.type === 'string'
+}
+function isNumberType(n: {type: string}): n is NumberDefinition {
+  return n.type === 'number'
+}
+
+function createPrimitiveAttribute(
+  key: string,
+  type: PrimitiveTypeNode['type'],
+  optional = false,
+): Record<string, ObjectAttribute<PrimitiveTypeNode>> {
+  return {
+    [key]: {
+      type: 'objectAttribute',
+      value: {type},
+      optional,
+    },
+  }
+}
+
+function createStringTypeNodeDefintion(
+  stringDefinition: StringDefinition,
+): StringTypeNode | UnionTypeNode<StringTypeNode> {
+  if (stringDefinition.options?.list) {
+    return {
+      type: 'union',
+      of: stringDefinition.options.list.map((v) => ({
+        type: 'string',
+        value: typeof v === 'string' ? v : v.value,
+      })),
+    }
+  }
+  return {
+    type: 'string',
+  }
+}
+
+function createNumberTypeNodeDefintion(
+  numberDefinition: NumberDefinition,
+): NumberTypeNode | UnionTypeNode<NumberTypeNode> {
+  if (numberDefinition.options?.list) {
+    return {
+      type: 'union',
+      of: numberDefinition.options.list.map((v) => ({
+        type: 'number',
+        value: typeof v === 'number' ? v : v.value,
+      })),
+    }
+  }
+  return {
+    type: 'number',
+  }
+}
+
+function createImage(
+  imageDefinition: ImageDefinition,
+  extractOptions: ExtractSchemaOptions,
+): ObjectTypeNode {
+  const attributes: Record<string, ObjectAttribute> = {}
+  for (const field of imageDefinition.fields || []) {
+    const fieldIsRequired = isFieldRequired(field)
+    attributes[field.name] = {
+      type: 'objectAttribute',
+      value: parseField(field, extractOptions),
+      optional: extractOptions.enforceRequiredFields ? fieldIsRequired : true,
+    }
+  }
+
+  if (imageDefinition.options?.hotspot) {
+    attributes.hotspot = {
+      type: 'objectAttribute',
+      value: {
+        type: 'object',
+        attributes: {
+          _type: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+              value: 'sanity.imageHotspot',
+            },
+          },
+          ...createPrimitiveAttribute('x', 'number'),
+          ...createPrimitiveAttribute('y', 'number'),
+          ...createPrimitiveAttribute('height', 'number'),
+          ...createPrimitiveAttribute('width', 'number'),
+        },
+      },
+      optional: true,
+    }
+    attributes.crop = {
+      type: 'objectAttribute',
+      value: {
+        type: 'object',
+        attributes: {
+          _type: {
+            type: 'objectAttribute',
+            value: {
+              type: 'string',
+              value: 'sanity.imageCrop',
+            },
+          },
+          ...createPrimitiveAttribute('top', 'number'),
+          ...createPrimitiveAttribute('bottom', 'number'),
+          ...createPrimitiveAttribute('left', 'number'),
+          ...createPrimitiveAttribute('right', 'number'),
+        },
+      },
+      optional: true,
+    }
+  }
+  return {
+    type: 'object',
+    attributes: {
+      _type: {
+        type: 'objectAttribute',
+        value: {
+          type: 'string',
+          value: 'image',
+        },
+      },
+      asset: {
+        type: 'objectAttribute',
+        value: createReferenceTypeNode('sanity.imageAsset'),
+      },
+      ...attributes,
+    },
+  }
+}
+function createFile(
+  fileDefinition: FileDefinition,
+  extractOptions: ExtractSchemaOptions,
+): ObjectTypeNode {
+  const attributes: Record<string, ObjectAttribute> = {}
+  for (const field of fileDefinition.fields || []) {
+    const fieldIsRequired = isFieldRequired(field)
+    attributes[field.name] = {
+      type: 'objectAttribute',
+      value: parseField(field, extractOptions),
+      optional: extractOptions.enforceRequiredFields ? fieldIsRequired : true,
+    }
+  }
+
+  return {
+    type: 'object',
+    attributes: {
+      _type: {
+        type: 'objectAttribute',
+        value: {
+          type: 'string',
+          value: 'file',
+        },
+      },
+      ...attributes,
+    },
+  }
+}
+
+function createArray(
+  arrayDefinition: ArrayDefinition,
+  extractOptions: ExtractSchemaOptions,
+): ArrayTypeNode {
+  const of = [
+    ...arrayDefinition.of.map((f) => {
+      if (isFieldDefinition(f)) {
+        const field = parseField(f, extractOptions)
+        if (field.type === 'inline') {
+          return {
+            type: 'object',
+            attributes: {
+              _key: createKeyField(),
+            },
+            rest: field,
+          } satisfies ObjectTypeNode
+        }
+
+        if (field.type === 'object') {
+          field.rest = {
+            type: 'object',
+            attributes: {
+              _key: createKeyField(),
+            },
+          }
+          return field
+        }
+
+        return field
+      }
+
+      if (typesMap.has(f.type)) {
+        return typesMap.get(f.type)
+      }
+
+      return createReferenceTypeNode(f.type, true)
+    }),
+  ] satisfies TypeNode[]
+
+  return {
+    type: 'array',
+    of:
+      of.length > 1
+        ? {
+            type: 'union',
+            of,
+          }
+        : of[0],
+  }
+}
+
+function createBlock(
+  blockDefinition: BlockDefinition,
+  extractOptions: ExtractSchemaOptions,
+): ObjectTypeNode {
+  const styleField = {
+    type: 'objectAttribute',
+    optional: true,
+    value: {
+      type: 'union',
+      of:
+        blockDefinition.styles?.map((style) => ({
+          type: 'string',
+          value: style.value,
+        })) || [],
+    },
+  } satisfies ObjectAttribute<UnionTypeNode<StringTypeNode>>
+  const listItemField = {
+    type: 'objectAttribute',
+    optional: true,
+    value: {
+      type: 'union',
+      of:
+        blockDefinition.lists?.map((list) => ({
+          type: 'string',
+          value: list.value,
+        })) || [],
+    },
+  } satisfies ObjectAttribute<UnionTypeNode<StringTypeNode>>
+  const levelField = {
+    type: 'objectAttribute',
+    optional: true,
+    value: {
+      type: 'number',
+    },
+  } satisfies ObjectAttribute<NumberTypeNode>
+  const marks: TypeNode[] = [
+    {type: 'string'},
+    ...(blockDefinition.marks?.decorators?.map(
+      (mark): TypeNode => ({
+        type: 'string',
+        value: mark.value,
+      }),
+    ) || []),
+  ]
+  const childrenField = {
+    type: 'objectAttribute',
+    value: {
+      type: 'array',
+      of: {
+        type: 'union',
+        of: [
+          {
+            type: 'object',
+            attributes: {
+              _key: createKeyField(),
+              text: {
+                type: 'objectAttribute',
+                value: {
+                  type: 'string',
+                },
+              } satisfies ObjectAttribute<StringTypeNode>,
+              marks: {
+                type: 'objectAttribute',
+                value: {
+                  type: 'array',
+                  of: {
+                    type: 'union',
+                    of: marks,
+                  },
+                },
+              } satisfies ObjectAttribute<ArrayTypeNode<UnionTypeNode>>,
+            },
+          } satisfies ObjectTypeNode,
+        ],
+      } satisfies UnionTypeNode<ObjectTypeNode>,
+    },
+  } satisfies ObjectAttribute<ArrayTypeNode<UnionTypeNode<ObjectTypeNode>>>
+
+  const markDefsField: ObjectAttribute<ArrayTypeNode> = {
+    type: 'objectAttribute',
+    value: {
+      type: 'array',
+      of: {
+        type: 'union',
+        of:
+          blockDefinition.marks?.annotations?.map((annotation) =>
+            createMarkDefField(annotation, extractOptions),
+          ) || [],
+      },
+    },
+  }
+  return {
+    type: 'object',
+    attributes: {
+      _key: createKeyField(),
+      level: levelField,
+      style: styleField,
+      listItem: listItemField,
+      children: childrenField,
+      markDefs: markDefsField,
+    },
+  }
+}
+
+function createMarkDefField(
+  annotation: ArrayOfType<'object' | 'reference'>,
+  extractOptions: ExtractSchemaOptions,
+): TypeNode {
+  if (annotation.type === 'object' && 'fields' in annotation) {
+    const attributes: Record<string, ObjectAttribute> = {}
+    for (const field of annotation.fields) {
+      attributes[field.name] = {
+        type: 'objectAttribute',
+        value: parseField(field, extractOptions),
+        optional: true,
+      } satisfies ObjectAttribute
+    }
+
+    return {
+      type: 'object',
+      attributes,
+    }
+  }
+
+  if (annotation.type === 'reference' && 'to' in annotation) {
+    return createReferenceTypeNodeDefintion(annotation)
+  }
+
+  return {
+    type: 'object',
+    attributes: {},
+  }
+}
+
+function createReferenceTypeNodeDefintion(
+  reference: Pick<ReferenceDefinition, 'to'>,
+): ObjectTypeNode | UnionTypeNode<ObjectTypeNode> {
+  if (Array.isArray(reference.to)) {
+    return {
+      type: 'union',
+      of: reference.to.map((t) => createReferenceTypeNode(t.type)),
+    }
+  }
+  return createReferenceTypeNode(reference.to.type)
+}
+function createCrossDatasetReferenceTypeNodeDefintion(
+  _: CrossDatasetReferenceDefinition,
+): TypeNode {
+  return {type: 'unknown'} satisfies UnknownTypeNode
+}

--- a/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
+++ b/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
@@ -1,0 +1,2767 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Extract schema test Extracts  schema general 1`] = `
+Array [
+  Object {
+    "attributes": Object {
+      "_createdAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_id": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_rev": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_type": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+          "value": "validDocument",
+        },
+      },
+      "_updatedAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "blocks": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "of": Object {
+            "attributes": Object {
+              "_key": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                },
+              },
+              "children": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "of": Object {
+                    "of": Array [
+                      Object {
+                        "attributes": Object {
+                          "_key": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                          "marks": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "of": Object {
+                                "of": Array [
+                                  Object {
+                                    "type": "string",
+                                  },
+                                ],
+                                "type": "union",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "text": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                        },
+                        "type": "object",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "type": "array",
+                },
+              },
+              "level": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "number",
+                },
+              },
+              "listItem": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "of": Array [],
+                  "type": "union",
+                },
+              },
+              "markDefs": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "of": Object {
+                    "of": Array [],
+                    "type": "union",
+                  },
+                  "type": "array",
+                },
+              },
+              "style": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "of": Array [],
+                  "type": "union",
+                },
+              },
+            },
+            "rest": Object {
+              "attributes": Object {
+                "_key": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                  },
+                },
+              },
+              "type": "object",
+            },
+            "type": "object",
+          },
+          "type": "array",
+        },
+      },
+      "list": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "of": Array [
+            Object {
+              "type": "string",
+              "value": "a",
+            },
+            Object {
+              "type": "string",
+              "value": "b",
+            },
+            Object {
+              "type": "string",
+              "value": "c",
+            },
+          ],
+          "type": "union",
+        },
+      },
+      "number": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "number",
+        },
+      },
+      "other": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "attributes": Object {
+            "_ref": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+              },
+            },
+            "_type": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+                "value": "reference",
+              },
+            },
+            "_weak": Object {
+              "optional": true,
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "boolean",
+              },
+            },
+          },
+          "dereferencesTo": "otherValidDocument",
+          "type": "object",
+        },
+      },
+      "others": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "of": Array [
+            Object {
+              "attributes": Object {
+                "_ref": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                  },
+                },
+                "_type": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                    "value": "reference",
+                  },
+                },
+                "_weak": Object {
+                  "optional": true,
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "boolean",
+                  },
+                },
+              },
+              "dereferencesTo": "otherValidDocument",
+              "type": "object",
+            },
+          ],
+          "type": "union",
+        },
+      },
+      "someInlinedObject": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "name": "obj",
+          "type": "inline",
+        },
+      },
+      "title": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+    },
+    "name": "validDocument",
+    "type": "document",
+  },
+  Object {
+    "name": "blocks",
+    "type": "type",
+    "value": Object {
+      "attributes": Object {
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "blocks",
+          },
+        },
+        "arrayOfArticles": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "of": Object {
+              "attributes": Object {
+                "_key": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                  },
+                },
+              },
+              "rest": Object {
+                "name": "blocksTest",
+                "type": "inline",
+              },
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "blockInBlock": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "of": Object {
+              "attributes": Object {
+                "_key": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                  },
+                },
+                "children": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "of": Object {
+                      "of": Array [
+                        Object {
+                          "attributes": Object {
+                            "_key": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                            "marks": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Object {
+                                  "of": Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                  ],
+                                  "type": "union",
+                                },
+                                "type": "array",
+                              },
+                            },
+                            "text": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "type": "object",
+                        },
+                      ],
+                      "type": "union",
+                    },
+                    "type": "array",
+                  },
+                },
+                "level": Object {
+                  "optional": true,
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "number",
+                  },
+                },
+                "listItem": Object {
+                  "optional": true,
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "of": Array [],
+                    "type": "union",
+                  },
+                },
+                "markDefs": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "of": Object {
+                      "of": Array [],
+                      "type": "union",
+                    },
+                    "type": "array",
+                  },
+                },
+                "style": Object {
+                  "optional": true,
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "of": Array [],
+                    "type": "union",
+                  },
+                },
+              },
+              "rest": Object {
+                "attributes": Object {
+                  "_key": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                },
+                "type": "object",
+              },
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "blockList": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "of": Object {
+              "attributes": Object {
+                "_type": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                    "value": "blockListEntry",
+                  },
+                },
+                "blocks": Object {
+                  "optional": true,
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "of": Object {
+                      "attributes": Object {
+                        "_key": Object {
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "type": "string",
+                          },
+                        },
+                        "children": Object {
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "of": Object {
+                              "of": Array [
+                                Object {
+                                  "attributes": Object {
+                                    "_key": Object {
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "marks": Object {
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "of": Object {
+                                          "of": Array [
+                                            Object {
+                                              "type": "string",
+                                            },
+                                          ],
+                                          "type": "union",
+                                        },
+                                        "type": "array",
+                                      },
+                                    },
+                                    "text": Object {
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "type": "string",
+                                      },
+                                    },
+                                  },
+                                  "type": "object",
+                                },
+                              ],
+                              "type": "union",
+                            },
+                            "type": "array",
+                          },
+                        },
+                        "level": Object {
+                          "optional": true,
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "type": "number",
+                          },
+                        },
+                        "listItem": Object {
+                          "optional": true,
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "of": Array [],
+                            "type": "union",
+                          },
+                        },
+                        "markDefs": Object {
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "of": Object {
+                              "of": Array [],
+                              "type": "union",
+                            },
+                            "type": "array",
+                          },
+                        },
+                        "style": Object {
+                          "optional": true,
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "of": Array [],
+                            "type": "union",
+                          },
+                        },
+                      },
+                      "rest": Object {
+                        "attributes": Object {
+                          "_key": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                        },
+                        "type": "object",
+                      },
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                },
+                "title": Object {
+                  "optional": true,
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                  },
+                },
+              },
+              "rest": Object {
+                "attributes": Object {
+                  "_key": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                },
+                "type": "object",
+              },
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "customized": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "of": Object {
+              "of": Array [
+                Object {
+                  "attributes": Object {
+                    "_key": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "name": "author",
+                    "type": "inline",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_key": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                    "children": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Object {
+                          "of": Array [
+                            Object {
+                              "attributes": Object {
+                                "_key": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "marks": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "of": Object {
+                                      "of": Array [
+                                        Object {
+                                          "type": "string",
+                                        },
+                                        Object {
+                                          "type": "string",
+                                          "value": "strong",
+                                        },
+                                        Object {
+                                          "type": "string",
+                                          "value": "em",
+                                        },
+                                        Object {
+                                          "type": "string",
+                                          "value": "color",
+                                        },
+                                      ],
+                                      "type": "union",
+                                    },
+                                    "type": "array",
+                                  },
+                                },
+                                "text": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                              },
+                              "type": "object",
+                            },
+                          ],
+                          "type": "union",
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "level": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "number",
+                      },
+                    },
+                    "listItem": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Array [
+                          Object {
+                            "type": "string",
+                            "value": "bullet",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "number",
+                          },
+                        ],
+                        "type": "union",
+                      },
+                    },
+                    "markDefs": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Object {
+                          "of": Array [
+                            Object {
+                              "attributes": Object {
+                                "_ref": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "_type": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                    "value": "reference",
+                                  },
+                                },
+                                "_weak": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "boolean",
+                                  },
+                                },
+                              },
+                              "dereferencesTo": "author",
+                              "type": "object",
+                            },
+                            Object {
+                              "attributes": Object {
+                                "testString": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                              },
+                              "type": "object",
+                            },
+                          ],
+                          "type": "union",
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "style": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Array [
+                          Object {
+                            "type": "string",
+                            "value": "normal",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "h1",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "h2",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "blockquote",
+                          },
+                        ],
+                        "type": "union",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+              ],
+              "type": "union",
+            },
+            "type": "array",
+          },
+        },
+        "deep": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "attributes": Object {
+              "_type": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                  "value": "deep",
+                },
+              },
+              "blocks": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "of": Object {
+                    "of": Array [
+                      Object {
+                        "attributes": Object {
+                          "_type": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                              "value": "image",
+                            },
+                          },
+                          "asset": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "attributes": Object {
+                                "_ref": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "_type": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                    "value": "reference",
+                                  },
+                                },
+                                "_weak": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "boolean",
+                                  },
+                                },
+                              },
+                              "dereferencesTo": "sanity.imageAsset",
+                              "type": "object",
+                            },
+                          },
+                        },
+                        "rest": Object {
+                          "attributes": Object {
+                            "_key": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "type": "object",
+                        },
+                        "type": "object",
+                      },
+                      Object {
+                        "attributes": Object {
+                          "_key": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                        },
+                        "rest": Object {
+                          "name": "author",
+                          "type": "inline",
+                        },
+                        "type": "object",
+                      },
+                      Object {
+                        "attributes": Object {
+                          "_key": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                          "children": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "of": Object {
+                                "of": Array [
+                                  Object {
+                                    "attributes": Object {
+                                      "_key": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
+                                        },
+                                      },
+                                      "marks": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "of": Object {
+                                            "of": Array [
+                                              Object {
+                                                "type": "string",
+                                              },
+                                              Object {
+                                                "type": "string",
+                                                "value": "strong",
+                                              },
+                                              Object {
+                                                "type": "string",
+                                                "value": "em",
+                                              },
+                                            ],
+                                            "type": "union",
+                                          },
+                                          "type": "array",
+                                        },
+                                      },
+                                      "text": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
+                                        },
+                                      },
+                                    },
+                                    "type": "object",
+                                  },
+                                ],
+                                "type": "union",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "level": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "number",
+                            },
+                          },
+                          "listItem": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "of": Array [
+                                Object {
+                                  "type": "string",
+                                  "value": "bullet",
+                                },
+                                Object {
+                                  "type": "string",
+                                  "value": "number",
+                                },
+                              ],
+                              "type": "union",
+                            },
+                          },
+                          "markDefs": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "of": Object {
+                                "of": Array [
+                                  Object {
+                                    "attributes": Object {
+                                      "_ref": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
+                                        },
+                                      },
+                                      "_type": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
+                                          "value": "reference",
+                                        },
+                                      },
+                                      "_weak": Object {
+                                        "optional": true,
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "boolean",
+                                        },
+                                      },
+                                    },
+                                    "dereferencesTo": "author",
+                                    "type": "object",
+                                  },
+                                ],
+                                "type": "union",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "style": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "of": Array [
+                                Object {
+                                  "type": "string",
+                                  "value": "normal",
+                                },
+                                Object {
+                                  "type": "string",
+                                  "value": "h1",
+                                },
+                                Object {
+                                  "type": "string",
+                                  "value": "h2",
+                                },
+                                Object {
+                                  "type": "string",
+                                  "value": "blockquote",
+                                },
+                              ],
+                              "type": "union",
+                            },
+                          },
+                        },
+                        "rest": Object {
+                          "attributes": Object {
+                            "_key": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "type": "object",
+                        },
+                        "type": "object",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "type": "array",
+                },
+              },
+              "something": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "type": "object",
+          },
+        },
+        "defaults": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "of": Object {
+              "of": Array [
+                Object {
+                  "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "image",
+                      },
+                    },
+                    "asset": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "attributes": Object {
+                          "_ref": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                          "_type": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                              "value": "reference",
+                            },
+                          },
+                          "_weak": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "boolean",
+                            },
+                          },
+                        },
+                        "dereferencesTo": "sanity.imageAsset",
+                        "type": "object",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_ref": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "reference",
+                      },
+                    },
+                    "_weak": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "boolean",
+                      },
+                    },
+                  },
+                  "dereferencesTo": "author",
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_ref": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "reference",
+                      },
+                    },
+                    "_weak": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "boolean",
+                      },
+                    },
+                  },
+                  "dereferencesTo": "book",
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "objectWithNestedArray",
+                      },
+                    },
+                    "array": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Object {
+                          "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": undefined,
+                              },
+                            },
+                            "author": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Array [
+                                  Object {
+                                    "attributes": Object {
+                                      "_ref": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
+                                        },
+                                      },
+                                      "_type": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
+                                          "value": "reference",
+                                        },
+                                      },
+                                      "_weak": Object {
+                                        "optional": true,
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "boolean",
+                                        },
+                                      },
+                                    },
+                                    "dereferencesTo": "author",
+                                    "type": "object",
+                                  },
+                                ],
+                                "type": "union",
+                              },
+                            },
+                            "title": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "rest": Object {
+                            "attributes": Object {
+                              "_key": Object {
+                                "type": "objectAttribute",
+                                "value": Object {
+                                  "type": "string",
+                                },
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "title": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_key": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "name": "author",
+                    "type": "inline",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_key": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "name": "code",
+                    "type": "inline",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "testObject",
+                      },
+                    },
+                    "field1": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "otherTestObject",
+                      },
+                    },
+                    "field1": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                    "field3": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Object {
+                          "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": undefined,
+                              },
+                            },
+                            "aNumber": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "number",
+                              },
+                            },
+                            "aString": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "rest": Object {
+                            "attributes": Object {
+                              "_key": Object {
+                                "type": "objectAttribute",
+                                "value": Object {
+                                  "type": "string",
+                                },
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_key": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "name": "spotifyEmbed",
+                    "type": "inline",
+                  },
+                  "type": "object",
+                },
+              ],
+              "type": "union",
+            },
+            "type": "array",
+          },
+        },
+        "first": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "of": Object {
+              "attributes": Object {
+                "_key": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                  },
+                },
+                "children": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "of": Object {
+                      "of": Array [
+                        Object {
+                          "attributes": Object {
+                            "_key": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                            "marks": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Object {
+                                  "of": Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                  ],
+                                  "type": "union",
+                                },
+                                "type": "array",
+                              },
+                            },
+                            "text": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "type": "object",
+                        },
+                      ],
+                      "type": "union",
+                    },
+                    "type": "array",
+                  },
+                },
+                "level": Object {
+                  "optional": true,
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "number",
+                  },
+                },
+                "listItem": Object {
+                  "optional": true,
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "of": Array [],
+                    "type": "union",
+                  },
+                },
+                "markDefs": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "of": Object {
+                      "of": Array [
+                        Object {
+                          "attributes": Object {
+                            "href": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "type": "object",
+                        },
+                      ],
+                      "type": "union",
+                    },
+                    "type": "array",
+                  },
+                },
+                "style": Object {
+                  "optional": true,
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "of": Array [],
+                    "type": "union",
+                  },
+                },
+              },
+              "rest": Object {
+                "attributes": Object {
+                  "_key": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                },
+                "type": "object",
+              },
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "minimal": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "of": Object {
+              "attributes": Object {
+                "_key": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                  },
+                },
+                "children": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "of": Object {
+                      "of": Array [
+                        Object {
+                          "attributes": Object {
+                            "_key": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                            "marks": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Object {
+                                  "of": Array [
+                                    Object {
+                                      "type": "string",
+                                    },
+                                  ],
+                                  "type": "union",
+                                },
+                                "type": "array",
+                              },
+                            },
+                            "text": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "type": "object",
+                        },
+                      ],
+                      "type": "union",
+                    },
+                    "type": "array",
+                  },
+                },
+                "level": Object {
+                  "optional": true,
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "number",
+                  },
+                },
+                "listItem": Object {
+                  "optional": true,
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "of": Array [],
+                    "type": "union",
+                  },
+                },
+                "markDefs": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "of": Object {
+                      "of": Array [],
+                      "type": "union",
+                    },
+                    "type": "array",
+                  },
+                },
+                "style": Object {
+                  "optional": true,
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "of": Array [],
+                    "type": "union",
+                  },
+                },
+              },
+              "rest": Object {
+                "attributes": Object {
+                  "_key": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                },
+                "type": "object",
+              },
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "nestedWithDualColumnCTA": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "of": Object {
+              "attributes": Object {
+                "_type": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                    "value": "localeRichtext",
+                  },
+                },
+                "en": Object {
+                  "optional": true,
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "of": Object {
+                      "of": Array [
+                        Object {
+                          "attributes": Object {
+                            "_key": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                            "children": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Object {
+                                  "of": Array [
+                                    Object {
+                                      "attributes": Object {
+                                        "_key": Object {
+                                          "type": "objectAttribute",
+                                          "value": Object {
+                                            "type": "string",
+                                          },
+                                        },
+                                        "marks": Object {
+                                          "type": "objectAttribute",
+                                          "value": Object {
+                                            "of": Object {
+                                              "of": Array [
+                                                Object {
+                                                  "type": "string",
+                                                },
+                                              ],
+                                              "type": "union",
+                                            },
+                                            "type": "array",
+                                          },
+                                        },
+                                        "text": Object {
+                                          "type": "objectAttribute",
+                                          "value": Object {
+                                            "type": "string",
+                                          },
+                                        },
+                                      },
+                                      "type": "object",
+                                    },
+                                  ],
+                                  "type": "union",
+                                },
+                                "type": "array",
+                              },
+                            },
+                            "level": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "number",
+                              },
+                            },
+                            "listItem": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Array [],
+                                "type": "union",
+                              },
+                            },
+                            "markDefs": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Object {
+                                  "of": Array [],
+                                  "type": "union",
+                                },
+                                "type": "array",
+                              },
+                            },
+                            "style": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Array [],
+                                "type": "union",
+                              },
+                            },
+                          },
+                          "rest": Object {
+                            "attributes": Object {
+                              "_key": Object {
+                                "type": "objectAttribute",
+                                "value": Object {
+                                  "type": "string",
+                                },
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "type": "object",
+                        },
+                        Object {
+                          "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": "image",
+                              },
+                            },
+                            "asset": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "attributes": Object {
+                                  "_ref": Object {
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
+                                    },
+                                  },
+                                  "_type": Object {
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
+                                      "value": "reference",
+                                    },
+                                  },
+                                  "_weak": Object {
+                                    "optional": true,
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "boolean",
+                                    },
+                                  },
+                                },
+                                "dereferencesTo": "sanity.imageAsset",
+                                "type": "object",
+                              },
+                            },
+                          },
+                          "rest": Object {
+                            "attributes": Object {
+                              "_key": Object {
+                                "type": "objectAttribute",
+                                "value": Object {
+                                  "type": "string",
+                                },
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "type": "object",
+                        },
+                        Object {
+                          "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": "twoColCTA",
+                              },
+                            },
+                            "columnone": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Object {
+                                  "attributes": Object {
+                                    "_key": Object {
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "type": "string",
+                                      },
+                                    },
+                                  },
+                                  "rest": Object {
+                                    "name": "richTextObject",
+                                    "type": "inline",
+                                  },
+                                  "type": "object",
+                                },
+                                "type": "array",
+                              },
+                            },
+                            "columntwo": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Object {
+                                  "attributes": Object {
+                                    "_key": Object {
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "type": "string",
+                                      },
+                                    },
+                                  },
+                                  "rest": Object {
+                                    "name": "richTextObject",
+                                    "type": "inline",
+                                  },
+                                  "type": "object",
+                                },
+                                "type": "array",
+                              },
+                            },
+                          },
+                          "rest": Object {
+                            "attributes": Object {
+                              "_key": Object {
+                                "type": "objectAttribute",
+                                "value": Object {
+                                  "type": "string",
+                                },
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "type": "object",
+                        },
+                      ],
+                      "type": "union",
+                    },
+                    "type": "array",
+                  },
+                },
+              },
+              "rest": Object {
+                "attributes": Object {
+                  "_key": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                },
+                "type": "object",
+              },
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "readOnlyWithDefaults": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "of": Object {
+              "of": Array [
+                Object {
+                  "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "image",
+                      },
+                    },
+                    "asset": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "attributes": Object {
+                          "_ref": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                          "_type": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                              "value": "reference",
+                            },
+                          },
+                          "_weak": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "boolean",
+                            },
+                          },
+                        },
+                        "dereferencesTo": "sanity.imageAsset",
+                        "type": "object",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_ref": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "reference",
+                      },
+                    },
+                    "_weak": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "boolean",
+                      },
+                    },
+                  },
+                  "dereferencesTo": "author",
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_ref": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "reference",
+                      },
+                    },
+                    "_weak": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "boolean",
+                      },
+                    },
+                  },
+                  "dereferencesTo": "book",
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_key": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "name": "author",
+                    "type": "inline",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_key": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "name": "code",
+                    "type": "inline",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "testObject",
+                      },
+                    },
+                    "field1": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "otherTestObject",
+                      },
+                    },
+                    "field1": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                    "field3": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Object {
+                          "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": undefined,
+                              },
+                            },
+                            "aNumber": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "number",
+                              },
+                            },
+                            "aString": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "rest": Object {
+                            "attributes": Object {
+                              "_key": Object {
+                                "type": "objectAttribute",
+                                "value": Object {
+                                  "type": "string",
+                                },
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+              ],
+              "type": "union",
+            },
+            "type": "array",
+          },
+        },
+        "recursive": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "attributes": Object {
+              "_type": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                  "value": "recursive",
+                },
+              },
+              "blocks": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "of": Object {
+                    "of": Array [
+                      Object {
+                        "attributes": Object {
+                          "_key": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                          "children": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "of": Object {
+                                "of": Array [
+                                  Object {
+                                    "attributes": Object {
+                                      "_key": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
+                                        },
+                                      },
+                                      "marks": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "of": Object {
+                                            "of": Array [
+                                              Object {
+                                                "type": "string",
+                                              },
+                                            ],
+                                            "type": "union",
+                                          },
+                                          "type": "array",
+                                        },
+                                      },
+                                      "text": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
+                                        },
+                                      },
+                                    },
+                                    "type": "object",
+                                  },
+                                ],
+                                "type": "union",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "level": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "number",
+                            },
+                          },
+                          "listItem": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "of": Array [],
+                              "type": "union",
+                            },
+                          },
+                          "markDefs": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "of": Object {
+                                "of": Array [],
+                                "type": "union",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "style": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "of": Array [],
+                              "type": "union",
+                            },
+                          },
+                        },
+                        "rest": Object {
+                          "attributes": Object {
+                            "_key": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "type": "object",
+                        },
+                        "type": "object",
+                      },
+                      Object {
+                        "attributes": Object {
+                          "_key": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                        },
+                        "rest": Object {
+                          "name": "blocksTest",
+                          "type": "inline",
+                        },
+                        "type": "object",
+                      },
+                    ],
+                    "type": "union",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "type": "object",
+          },
+        },
+        "reproCH9436": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "of": Object {
+              "of": Array [
+                Object {
+                  "attributes": Object {
+                    "_key": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                    "children": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Object {
+                          "of": Array [
+                            Object {
+                              "attributes": Object {
+                                "_key": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "marks": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "of": Object {
+                                      "of": Array [
+                                        Object {
+                                          "type": "string",
+                                        },
+                                      ],
+                                      "type": "union",
+                                    },
+                                    "type": "array",
+                                  },
+                                },
+                                "text": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                              },
+                              "type": "object",
+                            },
+                          ],
+                          "type": "union",
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "level": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "number",
+                      },
+                    },
+                    "listItem": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Array [],
+                        "type": "union",
+                      },
+                    },
+                    "markDefs": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Object {
+                          "of": Array [],
+                          "type": "union",
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "style": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Array [],
+                        "type": "union",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "image",
+                      },
+                    },
+                    "asset": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "attributes": Object {
+                          "_ref": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                          "_type": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                              "value": "reference",
+                            },
+                          },
+                          "_weak": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "boolean",
+                            },
+                          },
+                        },
+                        "dereferencesTo": "sanity.imageAsset",
+                        "type": "object",
+                      },
+                    },
+                    "caption": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Object {
+                          "attributes": Object {
+                            "_key": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                            "children": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Object {
+                                  "of": Array [
+                                    Object {
+                                      "attributes": Object {
+                                        "_key": Object {
+                                          "type": "objectAttribute",
+                                          "value": Object {
+                                            "type": "string",
+                                          },
+                                        },
+                                        "marks": Object {
+                                          "type": "objectAttribute",
+                                          "value": Object {
+                                            "of": Object {
+                                              "of": Array [
+                                                Object {
+                                                  "type": "string",
+                                                },
+                                                Object {
+                                                  "type": "string",
+                                                  "value": "strong",
+                                                },
+                                                Object {
+                                                  "type": "string",
+                                                  "value": "em",
+                                                },
+                                                Object {
+                                                  "type": "string",
+                                                  "value": "underline",
+                                                },
+                                                Object {
+                                                  "type": "string",
+                                                  "value": "strikethrough",
+                                                },
+                                                Object {
+                                                  "type": "string",
+                                                  "value": "superscript",
+                                                },
+                                                Object {
+                                                  "type": "string",
+                                                  "value": "subscript",
+                                                },
+                                                Object {
+                                                  "type": "string",
+                                                  "value": "alignleft",
+                                                },
+                                                Object {
+                                                  "type": "string",
+                                                  "value": "aligncenter",
+                                                },
+                                                Object {
+                                                  "type": "string",
+                                                  "value": "alignright",
+                                                },
+                                                Object {
+                                                  "type": "string",
+                                                  "value": "alignjustify",
+                                                },
+                                              ],
+                                              "type": "union",
+                                            },
+                                            "type": "array",
+                                          },
+                                        },
+                                        "text": Object {
+                                          "type": "objectAttribute",
+                                          "value": Object {
+                                            "type": "string",
+                                          },
+                                        },
+                                      },
+                                      "type": "object",
+                                    },
+                                  ],
+                                  "type": "union",
+                                },
+                                "type": "array",
+                              },
+                            },
+                            "level": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "number",
+                              },
+                            },
+                            "listItem": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Array [],
+                                "type": "union",
+                              },
+                            },
+                            "markDefs": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Object {
+                                  "of": Array [],
+                                  "type": "union",
+                                },
+                                "type": "array",
+                              },
+                            },
+                            "style": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Array [],
+                                "type": "union",
+                              },
+                            },
+                          },
+                          "rest": Object {
+                            "attributes": Object {
+                              "_key": Object {
+                                "type": "objectAttribute",
+                                "value": Object {
+                                  "type": "string",
+                                },
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+              ],
+              "type": "union",
+            },
+            "type": "array",
+          },
+        },
+        "title": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+        "withGeopoint": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "of": Object {
+              "of": Array [
+                Object {
+                  "attributes": Object {
+                    "_key": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                    "children": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Object {
+                          "of": Array [
+                            Object {
+                              "attributes": Object {
+                                "_key": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "marks": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "of": Object {
+                                      "of": Array [
+                                        Object {
+                                          "type": "string",
+                                        },
+                                      ],
+                                      "type": "union",
+                                    },
+                                    "type": "array",
+                                  },
+                                },
+                                "text": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                              },
+                              "type": "object",
+                            },
+                          ],
+                          "type": "union",
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "level": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "number",
+                      },
+                    },
+                    "listItem": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Array [],
+                        "type": "union",
+                      },
+                    },
+                    "markDefs": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Object {
+                          "of": Array [],
+                          "type": "union",
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "style": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "of": Array [],
+                        "type": "union",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+                Object {
+                  "attributes": Object {
+                    "_key": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                      },
+                    },
+                  },
+                  "rest": Object {
+                    "name": "geopoint",
+                    "type": "inline",
+                  },
+                  "type": "object",
+                },
+              ],
+              "type": "union",
+            },
+            "type": "array",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  Object {
+    "attributes": Object {
+      "_createdAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_id": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_rev": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_type": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+          "value": "otherValidDocument",
+        },
+      },
+      "_updatedAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "title": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+    },
+    "name": "otherValidDocument",
+    "type": "document",
+  },
+  Object {
+    "name": "object",
+    "type": "type",
+    "value": Object {
+      "name": "obj",
+      "type": "inline",
+    },
+  },
+]
+`;

--- a/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
+++ b/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
@@ -3,6 +3,226 @@
 exports[`Extract schema test Extracts  schema general 1`] = `
 Array [
   Object {
+    "name": "sanity.imagePaletteSwatch",
+    "type": "type",
+    "value": Object {
+      "attributes": Object {
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "sanity.imagePaletteSwatch",
+          },
+        },
+        "background": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+        "foreground": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+        "population": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+        "title": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  Object {
+    "name": "sanity.imagePalette",
+    "type": "type",
+    "value": Object {
+      "attributes": Object {
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "sanity.imagePalette",
+          },
+        },
+        "darkMuted": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "name": "sanity.imagePaletteSwatch",
+            "type": "inline",
+          },
+        },
+        "darkVibrant": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "name": "sanity.imagePaletteSwatch",
+            "type": "inline",
+          },
+        },
+        "dominant": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "name": "sanity.imagePaletteSwatch",
+            "type": "inline",
+          },
+        },
+        "lightMuted": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "name": "sanity.imagePaletteSwatch",
+            "type": "inline",
+          },
+        },
+        "lightVibrant": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "name": "sanity.imagePaletteSwatch",
+            "type": "inline",
+          },
+        },
+        "muted": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "name": "sanity.imagePaletteSwatch",
+            "type": "inline",
+          },
+        },
+        "vibrant": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "name": "sanity.imagePaletteSwatch",
+            "type": "inline",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  Object {
+    "name": "sanity.imageDimensions",
+    "type": "type",
+    "value": Object {
+      "attributes": Object {
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "sanity.imageDimensions",
+          },
+        },
+        "aspectRatio": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+        "height": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+        "width": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  Object {
+    "name": "geopoint",
+    "type": "type",
+    "value": Object {
+      "attributes": Object {
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "geopoint",
+          },
+        },
+        "alt": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+        "lat": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+        "lng": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  Object {
+    "name": "slug",
+    "type": "type",
+    "value": Object {
+      "attributes": Object {
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "slug",
+          },
+        },
+        "current": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+        "source": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  Object {
     "attributes": Object {
       "_createdAt": Object {
         "type": "objectAttribute",
@@ -26,7 +246,7 @@ Array [
         "type": "objectAttribute",
         "value": Object {
           "type": "string",
-          "value": "validDocument",
+          "value": "sanity.fileAsset",
         },
       },
       "_updatedAt": Object {
@@ -35,208 +255,81 @@ Array [
           "type": "string",
         },
       },
-      "blocks": Object {
+      "altText": Object {
         "optional": true,
         "type": "objectAttribute",
         "value": Object {
-          "of": Object {
-            "attributes": Object {
-              "_key": Object {
-                "type": "objectAttribute",
-                "value": Object {
-                  "type": "string",
-                },
-              },
-              "children": Object {
-                "type": "objectAttribute",
-                "value": Object {
-                  "of": Object {
-                    "of": Array [
-                      Object {
-                        "attributes": Object {
-                          "_key": Object {
-                            "type": "objectAttribute",
-                            "value": Object {
-                              "type": "string",
-                            },
-                          },
-                          "marks": Object {
-                            "type": "objectAttribute",
-                            "value": Object {
-                              "of": Object {
-                                "of": Array [
-                                  Object {
-                                    "type": "string",
-                                  },
-                                ],
-                                "type": "union",
-                              },
-                              "type": "array",
-                            },
-                          },
-                          "text": Object {
-                            "type": "objectAttribute",
-                            "value": Object {
-                              "type": "string",
-                            },
-                          },
-                        },
-                        "type": "object",
-                      },
-                    ],
-                    "type": "union",
-                  },
-                  "type": "array",
-                },
-              },
-              "level": Object {
-                "optional": true,
-                "type": "objectAttribute",
-                "value": Object {
-                  "type": "number",
-                },
-              },
-              "listItem": Object {
-                "optional": true,
-                "type": "objectAttribute",
-                "value": Object {
-                  "of": Array [],
-                  "type": "union",
-                },
-              },
-              "markDefs": Object {
-                "type": "objectAttribute",
-                "value": Object {
-                  "of": Object {
-                    "of": Array [],
-                    "type": "union",
-                  },
-                  "type": "array",
-                },
-              },
-              "style": Object {
-                "optional": true,
-                "type": "objectAttribute",
-                "value": Object {
-                  "of": Array [],
-                  "type": "union",
-                },
-              },
-            },
-            "rest": Object {
-              "attributes": Object {
-                "_key": Object {
-                  "type": "objectAttribute",
-                  "value": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "type": "object",
-            },
-            "type": "object",
-          },
-          "type": "array",
+          "type": "string",
         },
       },
-      "list": Object {
+      "assetId": Object {
         "optional": true,
         "type": "objectAttribute",
         "value": Object {
-          "of": Array [
-            Object {
-              "type": "string",
-              "value": "a",
-            },
-            Object {
-              "type": "string",
-              "value": "b",
-            },
-            Object {
-              "type": "string",
-              "value": "c",
-            },
-          ],
-          "type": "union",
+          "type": "string",
         },
       },
-      "number": Object {
+      "description": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "extension": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "label": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "mimeType": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "originalFilename": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "path": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "sha1hash": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "size": Object {
         "optional": true,
         "type": "objectAttribute",
         "value": Object {
           "type": "number",
         },
       },
-      "other": Object {
+      "source": Object {
         "optional": true,
         "type": "objectAttribute",
         "value": Object {
-          "attributes": Object {
-            "_ref": Object {
-              "type": "objectAttribute",
-              "value": Object {
-                "type": "string",
-              },
-            },
-            "_type": Object {
-              "type": "objectAttribute",
-              "value": Object {
-                "type": "string",
-                "value": "reference",
-              },
-            },
-            "_weak": Object {
-              "optional": true,
-              "type": "objectAttribute",
-              "value": Object {
-                "type": "boolean",
-              },
-            },
-          },
-          "dereferencesTo": "otherValidDocument",
-          "type": "object",
-        },
-      },
-      "others": Object {
-        "optional": true,
-        "type": "objectAttribute",
-        "value": Object {
-          "of": Array [
-            Object {
-              "attributes": Object {
-                "_ref": Object {
-                  "type": "objectAttribute",
-                  "value": Object {
-                    "type": "string",
-                  },
-                },
-                "_type": Object {
-                  "type": "objectAttribute",
-                  "value": Object {
-                    "type": "string",
-                    "value": "reference",
-                  },
-                },
-                "_weak": Object {
-                  "optional": true,
-                  "type": "objectAttribute",
-                  "value": Object {
-                    "type": "boolean",
-                  },
-                },
-              },
-              "dereferencesTo": "otherValidDocument",
-              "type": "object",
-            },
-          ],
-          "type": "union",
-        },
-      },
-      "someInlinedObject": Object {
-        "optional": true,
-        "type": "objectAttribute",
-        "value": Object {
-          "name": "obj",
+          "name": "sanity.assetSourceData",
           "type": "inline",
         },
       },
@@ -247,12 +340,26 @@ Array [
           "type": "string",
         },
       },
+      "uploadId": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "url": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
     },
-    "name": "validDocument",
+    "name": "sanity.fileAsset",
     "type": "document",
   },
   Object {
-    "name": "blocks",
+    "name": "code",
     "type": "type",
     "value": Object {
       "attributes": Object {
@@ -260,7 +367,37 @@ Array [
           "type": "objectAttribute",
           "value": Object {
             "type": "string",
-            "value": "blocks",
+            "value": "code",
+          },
+        },
+        "thecode": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  Object {
+    "name": "customStringType",
+    "type": "type",
+    "value": Object {
+      "type": "string",
+    },
+  },
+  Object {
+    "name": "blocksTest",
+    "type": "type",
+    "value": Object {
+      "attributes": Object {
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "blocksTest",
           },
         },
         "arrayOfArticles": Object {
@@ -291,45 +428,156 @@ Array [
           "value": Object {
             "of": Object {
               "attributes": Object {
-                "_key": Object {
-                  "type": "objectAttribute",
-                  "value": Object {
-                    "type": "string",
-                  },
-                },
                 "children": Object {
+                  "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
                     "of": Object {
                       "of": Array [
                         Object {
                           "attributes": Object {
-                            "_key": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                              },
-                            },
                             "marks": Object {
+                              "optional": true,
                               "type": "objectAttribute",
                               "value": Object {
                                 "of": Object {
-                                  "of": Array [
-                                    Object {
-                                      "type": "string",
-                                    },
-                                  ],
-                                  "type": "union",
+                                  "type": "string",
                                 },
                                 "type": "array",
                               },
                             },
                             "text": Object {
+                              "optional": true,
                               "type": "objectAttribute",
                               "value": Object {
                                 "type": "string",
                               },
                             },
+                          },
+                          "rest": Object {
+                            "attributes": Object {
+                              "_key": Object {
+                                "type": "objectAttribute",
+                                "value": Object {
+                                  "type": "string",
+                                },
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "type": "object",
+                        },
+                        Object {
+                          "attributes": Object {
+                            "footnote": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Object {
+                                  "attributes": Object {
+                                    "children": Object {
+                                      "optional": true,
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "of": Object {
+                                          "attributes": Object {
+                                            "marks": Object {
+                                              "optional": true,
+                                              "type": "objectAttribute",
+                                              "value": Object {
+                                                "of": Object {
+                                                  "type": "string",
+                                                },
+                                                "type": "array",
+                                              },
+                                            },
+                                            "text": Object {
+                                              "optional": true,
+                                              "type": "objectAttribute",
+                                              "value": Object {
+                                                "type": "string",
+                                              },
+                                            },
+                                          },
+                                          "rest": Object {
+                                            "attributes": Object {
+                                              "_key": Object {
+                                                "type": "objectAttribute",
+                                                "value": Object {
+                                                  "type": "string",
+                                                },
+                                              },
+                                            },
+                                            "type": "object",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "type": "array",
+                                      },
+                                    },
+                                    "level": Object {
+                                      "optional": true,
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "type": "number",
+                                      },
+                                    },
+                                    "listItem": Object {
+                                      "optional": true,
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "of": Array [],
+                                        "type": "union",
+                                      },
+                                    },
+                                    "markDefs": Object {
+                                      "optional": true,
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "type": "null",
+                                      },
+                                    },
+                                    "style": Object {
+                                      "optional": true,
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "of": Array [
+                                          Object {
+                                            "type": "string",
+                                            "value": "normal",
+                                          },
+                                        ],
+                                        "type": "union",
+                                      },
+                                    },
+                                  },
+                                  "rest": Object {
+                                    "attributes": Object {
+                                      "_key": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
+                                        },
+                                      },
+                                    },
+                                    "type": "object",
+                                  },
+                                  "type": "object",
+                                },
+                                "type": "array",
+                              },
+                            },
+                          },
+                          "rest": Object {
+                            "attributes": Object {
+                              "_key": Object {
+                                "type": "objectAttribute",
+                                "value": Object {
+                                  "type": "string",
+                                },
+                              },
+                            },
+                            "type": "object",
                           },
                           "type": "object",
                         },
@@ -350,16 +598,45 @@ Array [
                   "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
-                    "of": Array [],
+                    "of": Array [
+                      Object {
+                        "type": "string",
+                        "value": "bullet",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "number",
+                      },
+                    ],
                     "type": "union",
                   },
                 },
                 "markDefs": Object {
+                  "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
                     "of": Object {
-                      "of": Array [],
-                      "type": "union",
+                      "attributes": Object {
+                        "href": Object {
+                          "optional": true,
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "type": "string",
+                          },
+                        },
+                      },
+                      "rest": Object {
+                        "attributes": Object {
+                          "_key": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                        },
+                        "type": "object",
+                      },
+                      "type": "object",
                     },
                     "type": "array",
                   },
@@ -368,7 +645,40 @@ Array [
                   "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
-                    "of": Array [],
+                    "of": Array [
+                      Object {
+                        "type": "string",
+                        "value": "normal",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "h1",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "h2",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "h3",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "h4",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "h5",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "h6",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "blockquote",
+                      },
+                    ],
                     "type": "union",
                   },
                 },
@@ -395,63 +705,48 @@ Array [
           "value": Object {
             "of": Object {
               "attributes": Object {
-                "_type": Object {
-                  "type": "objectAttribute",
-                  "value": Object {
-                    "type": "string",
-                    "value": "blockListEntry",
-                  },
-                },
                 "blocks": Object {
                   "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
                     "of": Object {
                       "attributes": Object {
-                        "_key": Object {
-                          "type": "objectAttribute",
-                          "value": Object {
-                            "type": "string",
-                          },
-                        },
                         "children": Object {
+                          "optional": true,
                           "type": "objectAttribute",
                           "value": Object {
                             "of": Object {
-                              "of": Array [
-                                Object {
-                                  "attributes": Object {
-                                    "_key": Object {
-                                      "type": "objectAttribute",
-                                      "value": Object {
-                                        "type": "string",
-                                      },
+                              "attributes": Object {
+                                "marks": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "of": Object {
+                                      "type": "string",
                                     },
-                                    "marks": Object {
-                                      "type": "objectAttribute",
-                                      "value": Object {
-                                        "of": Object {
-                                          "of": Array [
-                                            Object {
-                                              "type": "string",
-                                            },
-                                          ],
-                                          "type": "union",
-                                        },
-                                        "type": "array",
-                                      },
-                                    },
-                                    "text": Object {
-                                      "type": "objectAttribute",
-                                      "value": Object {
-                                        "type": "string",
-                                      },
+                                    "type": "array",
+                                  },
+                                },
+                                "text": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                              },
+                              "rest": Object {
+                                "attributes": Object {
+                                  "_key": Object {
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
                                     },
                                   },
-                                  "type": "object",
                                 },
-                              ],
-                              "type": "union",
+                                "type": "object",
+                              },
+                              "type": "object",
                             },
                             "type": "array",
                           },
@@ -467,16 +762,45 @@ Array [
                           "optional": true,
                           "type": "objectAttribute",
                           "value": Object {
-                            "of": Array [],
+                            "of": Array [
+                              Object {
+                                "type": "string",
+                                "value": "bullet",
+                              },
+                              Object {
+                                "type": "string",
+                                "value": "number",
+                              },
+                            ],
                             "type": "union",
                           },
                         },
                         "markDefs": Object {
+                          "optional": true,
                           "type": "objectAttribute",
                           "value": Object {
                             "of": Object {
-                              "of": Array [],
-                              "type": "union",
+                              "attributes": Object {
+                                "href": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                              },
+                              "rest": Object {
+                                "attributes": Object {
+                                  "_key": Object {
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
+                                    },
+                                  },
+                                },
+                                "type": "object",
+                              },
+                              "type": "object",
                             },
                             "type": "array",
                           },
@@ -485,7 +809,40 @@ Array [
                           "optional": true,
                           "type": "objectAttribute",
                           "value": Object {
-                            "of": Array [],
+                            "of": Array [
+                              Object {
+                                "type": "string",
+                                "value": "normal",
+                              },
+                              Object {
+                                "type": "string",
+                                "value": "h1",
+                              },
+                              Object {
+                                "type": "string",
+                                "value": "h2",
+                              },
+                              Object {
+                                "type": "string",
+                                "value": "h3",
+                              },
+                              Object {
+                                "type": "string",
+                                "value": "h4",
+                              },
+                              Object {
+                                "type": "string",
+                                "value": "h5",
+                              },
+                              Object {
+                                "type": "string",
+                                "value": "h6",
+                              },
+                              Object {
+                                "type": "string",
+                                "value": "blockquote",
+                              },
+                            ],
                             "type": "union",
                           },
                         },
@@ -538,72 +895,192 @@ Array [
               "of": Array [
                 Object {
                   "attributes": Object {
-                    "_key": Object {
+                    "_ref": Object {
                       "type": "objectAttribute",
                       "value": Object {
                         "type": "string",
                       },
                     },
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "reference",
+                      },
+                    },
+                    "_weak": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "boolean",
+                      },
+                    },
                   },
+                  "dereferencesTo": "author",
                   "rest": Object {
-                    "name": "author",
-                    "type": "inline",
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
                   },
                   "type": "object",
                 },
                 Object {
                   "attributes": Object {
-                    "_key": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                      },
-                    },
                     "children": Object {
+                      "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
                         "of": Object {
                           "of": Array [
                             Object {
                               "attributes": Object {
-                                "_key": Object {
-                                  "type": "objectAttribute",
-                                  "value": Object {
-                                    "type": "string",
-                                  },
-                                },
                                 "marks": Object {
+                                  "optional": true,
                                   "type": "objectAttribute",
                                   "value": Object {
                                     "of": Object {
-                                      "of": Array [
-                                        Object {
-                                          "type": "string",
-                                        },
-                                        Object {
-                                          "type": "string",
-                                          "value": "strong",
-                                        },
-                                        Object {
-                                          "type": "string",
-                                          "value": "em",
-                                        },
-                                        Object {
-                                          "type": "string",
-                                          "value": "color",
-                                        },
-                                      ],
-                                      "type": "union",
+                                      "type": "string",
                                     },
                                     "type": "array",
                                   },
                                 },
                                 "text": Object {
+                                  "optional": true,
                                   "type": "objectAttribute",
                                   "value": Object {
                                     "type": "string",
                                   },
                                 },
+                              },
+                              "rest": Object {
+                                "attributes": Object {
+                                  "_key": Object {
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
+                                    },
+                                  },
+                                },
+                                "type": "object",
+                              },
+                              "type": "object",
+                            },
+                            Object {
+                              "attributes": Object {
+                                "asset": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "attributes": Object {
+                                      "_ref": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
+                                        },
+                                      },
+                                      "_type": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
+                                          "value": "reference",
+                                        },
+                                      },
+                                      "_weak": Object {
+                                        "optional": true,
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "boolean",
+                                        },
+                                      },
+                                    },
+                                    "dereferencesTo": "sanity.imageAsset",
+                                    "type": "object",
+                                  },
+                                },
+                                "authors": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "of": Object {
+                                      "attributes": Object {
+                                        "_ref": Object {
+                                          "type": "objectAttribute",
+                                          "value": Object {
+                                            "type": "string",
+                                          },
+                                        },
+                                        "_type": Object {
+                                          "type": "objectAttribute",
+                                          "value": Object {
+                                            "type": "string",
+                                            "value": "reference",
+                                          },
+                                        },
+                                        "_weak": Object {
+                                          "optional": true,
+                                          "type": "objectAttribute",
+                                          "value": Object {
+                                            "type": "boolean",
+                                          },
+                                        },
+                                      },
+                                      "dereferencesTo": "author",
+                                      "rest": Object {
+                                        "attributes": Object {
+                                          "_key": Object {
+                                            "type": "objectAttribute",
+                                            "value": Object {
+                                              "type": "string",
+                                            },
+                                          },
+                                        },
+                                        "type": "object",
+                                      },
+                                      "type": "object",
+                                    },
+                                    "type": "array",
+                                  },
+                                },
+                                "caption": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "crop": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "name": "sanity.imageCrop",
+                                    "type": "inline",
+                                  },
+                                },
+                                "hotspot": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "name": "sanity.imageHotspot",
+                                    "type": "inline",
+                                  },
+                                },
+                              },
+                              "rest": Object {
+                                "attributes": Object {
+                                  "_key": Object {
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
+                                    },
+                                  },
+                                },
+                                "type": "object",
                               },
                               "type": "object",
                             },
@@ -638,6 +1115,7 @@ Array [
                       },
                     },
                     "markDefs": Object {
+                      "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
                         "of": Object {
@@ -666,6 +1144,17 @@ Array [
                                 },
                               },
                               "dereferencesTo": "author",
+                              "rest": Object {
+                                "attributes": Object {
+                                  "_key": Object {
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
+                                    },
+                                  },
+                                },
+                                "type": "object",
+                              },
                               "type": "object",
                             },
                             Object {
@@ -677,6 +1166,17 @@ Array [
                                     "type": "string",
                                   },
                                 },
+                              },
+                              "rest": Object {
+                                "attributes": Object {
+                                  "_key": Object {
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
+                                    },
+                                  },
+                                },
+                                "type": "object",
                               },
                               "type": "object",
                             },
@@ -736,13 +1236,6 @@ Array [
           "type": "objectAttribute",
           "value": Object {
             "attributes": Object {
-              "_type": Object {
-                "type": "objectAttribute",
-                "value": Object {
-                  "type": "string",
-                  "value": "deep",
-                },
-              },
               "blocks": Object {
                 "optional": true,
                 "type": "objectAttribute",
@@ -751,14 +1244,8 @@ Array [
                     "of": Array [
                       Object {
                         "attributes": Object {
-                          "_type": Object {
-                            "type": "objectAttribute",
-                            "value": Object {
-                              "type": "string",
-                              "value": "image",
-                            },
-                          },
                           "asset": Object {
+                            "optional": true,
                             "type": "objectAttribute",
                             "value": Object {
                               "attributes": Object {
@@ -787,6 +1274,22 @@ Array [
                               "type": "object",
                             },
                           },
+                          "crop": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "name": "sanity.imageCrop",
+                              "type": "inline",
+                            },
+                          },
+                          "hotspot": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "name": "sanity.imageHotspot",
+                              "type": "inline",
+                            },
+                          },
                         },
                         "rest": Object {
                           "attributes": Object {
@@ -803,73 +1306,79 @@ Array [
                       },
                       Object {
                         "attributes": Object {
-                          "_key": Object {
+                          "_ref": Object {
                             "type": "objectAttribute",
                             "value": Object {
                               "type": "string",
                             },
                           },
+                          "_type": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                              "value": "reference",
+                            },
+                          },
+                          "_weak": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "boolean",
+                            },
+                          },
                         },
+                        "dereferencesTo": "author",
                         "rest": Object {
-                          "name": "author",
-                          "type": "inline",
+                          "attributes": Object {
+                            "_key": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "type": "object",
                         },
                         "type": "object",
                       },
                       Object {
                         "attributes": Object {
-                          "_key": Object {
-                            "type": "objectAttribute",
-                            "value": Object {
-                              "type": "string",
-                            },
-                          },
                           "children": Object {
+                            "optional": true,
                             "type": "objectAttribute",
                             "value": Object {
                               "of": Object {
-                                "of": Array [
-                                  Object {
-                                    "attributes": Object {
-                                      "_key": Object {
-                                        "type": "objectAttribute",
-                                        "value": Object {
-                                          "type": "string",
-                                        },
+                                "attributes": Object {
+                                  "marks": Object {
+                                    "optional": true,
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "of": Object {
+                                        "type": "string",
                                       },
-                                      "marks": Object {
-                                        "type": "objectAttribute",
-                                        "value": Object {
-                                          "of": Object {
-                                            "of": Array [
-                                              Object {
-                                                "type": "string",
-                                              },
-                                              Object {
-                                                "type": "string",
-                                                "value": "strong",
-                                              },
-                                              Object {
-                                                "type": "string",
-                                                "value": "em",
-                                              },
-                                            ],
-                                            "type": "union",
-                                          },
-                                          "type": "array",
-                                        },
-                                      },
-                                      "text": Object {
-                                        "type": "objectAttribute",
-                                        "value": Object {
-                                          "type": "string",
-                                        },
+                                      "type": "array",
+                                    },
+                                  },
+                                  "text": Object {
+                                    "optional": true,
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
+                                    },
+                                  },
+                                },
+                                "rest": Object {
+                                  "attributes": Object {
+                                    "_key": Object {
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "type": "string",
                                       },
                                     },
-                                    "type": "object",
                                   },
-                                ],
-                                "type": "union",
+                                  "type": "object",
+                                },
+                                "type": "object",
                               },
                               "type": "array",
                             },
@@ -899,38 +1408,45 @@ Array [
                             },
                           },
                           "markDefs": Object {
+                            "optional": true,
                             "type": "objectAttribute",
                             "value": Object {
                               "of": Object {
-                                "of": Array [
-                                  Object {
-                                    "attributes": Object {
-                                      "_ref": Object {
-                                        "type": "objectAttribute",
-                                        "value": Object {
-                                          "type": "string",
-                                        },
-                                      },
-                                      "_type": Object {
-                                        "type": "objectAttribute",
-                                        "value": Object {
-                                          "type": "string",
-                                          "value": "reference",
-                                        },
-                                      },
-                                      "_weak": Object {
-                                        "optional": true,
-                                        "type": "objectAttribute",
-                                        "value": Object {
-                                          "type": "boolean",
-                                        },
+                                "attributes": Object {
+                                  "_ref": Object {
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
+                                    },
+                                  },
+                                  "_type": Object {
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
+                                      "value": "reference",
+                                    },
+                                  },
+                                  "_weak": Object {
+                                    "optional": true,
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "boolean",
+                                    },
+                                  },
+                                },
+                                "dereferencesTo": "author",
+                                "rest": Object {
+                                  "attributes": Object {
+                                    "_key": Object {
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "type": "string",
                                       },
                                     },
-                                    "dereferencesTo": "author",
-                                    "type": "object",
                                   },
-                                ],
-                                "type": "union",
+                                  "type": "object",
+                                },
+                                "type": "object",
                               },
                               "type": "array",
                             },
@@ -999,14 +1515,8 @@ Array [
               "of": Array [
                 Object {
                   "attributes": Object {
-                    "_type": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                        "value": "image",
-                      },
-                    },
                     "asset": Object {
+                      "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
                         "attributes": Object {
@@ -1033,6 +1543,22 @@ Array [
                         },
                         "dereferencesTo": "sanity.imageAsset",
                         "type": "object",
+                      },
+                    },
+                    "crop": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "name": "sanity.imageCrop",
+                        "type": "inline",
+                      },
+                    },
+                    "hotspot": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "name": "sanity.imageHotspot",
+                        "type": "inline",
                       },
                     },
                   },
@@ -1125,59 +1651,40 @@ Array [
                 },
                 Object {
                   "attributes": Object {
-                    "_type": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                        "value": "objectWithNestedArray",
-                      },
-                    },
                     "array": Object {
                       "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
-                            "_type": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                                "value": undefined,
-                              },
-                            },
                             "author": Object {
                               "optional": true,
                               "type": "objectAttribute",
                               "value": Object {
-                                "of": Array [
-                                  Object {
-                                    "attributes": Object {
-                                      "_ref": Object {
-                                        "type": "objectAttribute",
-                                        "value": Object {
-                                          "type": "string",
-                                        },
-                                      },
-                                      "_type": Object {
-                                        "type": "objectAttribute",
-                                        "value": Object {
-                                          "type": "string",
-                                          "value": "reference",
-                                        },
-                                      },
-                                      "_weak": Object {
-                                        "optional": true,
-                                        "type": "objectAttribute",
-                                        "value": Object {
-                                          "type": "boolean",
-                                        },
-                                      },
+                                "attributes": Object {
+                                  "_ref": Object {
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
                                     },
-                                    "dereferencesTo": "author",
-                                    "type": "object",
                                   },
-                                ],
-                                "type": "union",
+                                  "_type": Object {
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
+                                      "value": "reference",
+                                    },
+                                  },
+                                  "_weak": Object {
+                                    "optional": true,
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "boolean",
+                                    },
+                                  },
+                                },
+                                "dereferencesTo": "author",
+                                "type": "object",
                               },
                             },
                             "title": Object {
@@ -1227,16 +1734,38 @@ Array [
                 },
                 Object {
                   "attributes": Object {
-                    "_key": Object {
+                    "_ref": Object {
                       "type": "objectAttribute",
                       "value": Object {
                         "type": "string",
                       },
                     },
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "reference",
+                      },
+                    },
+                    "_weak": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "boolean",
+                      },
+                    },
                   },
+                  "dereferencesTo": "author",
                   "rest": Object {
-                    "name": "author",
-                    "type": "inline",
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
                   },
                   "type": "object",
                 },
@@ -1257,43 +1786,6 @@ Array [
                 },
                 Object {
                   "attributes": Object {
-                    "_type": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                        "value": "testObject",
-                      },
-                    },
-                    "field1": Object {
-                      "optional": true,
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                      },
-                    },
-                  },
-                  "rest": Object {
-                    "attributes": Object {
-                      "_key": Object {
-                        "type": "objectAttribute",
-                        "value": Object {
-                          "type": "string",
-                        },
-                      },
-                    },
-                    "type": "object",
-                  },
-                  "type": "object",
-                },
-                Object {
-                  "attributes": Object {
-                    "_type": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                        "value": "otherTestObject",
-                      },
-                    },
                     "field1": Object {
                       "optional": true,
                       "type": "objectAttribute",
@@ -1307,13 +1799,6 @@ Array [
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
-                            "_type": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                                "value": undefined,
-                              },
-                            },
                             "aNumber": Object {
                               "optional": true,
                               "type": "objectAttribute",
@@ -1359,21 +1844,6 @@ Array [
                   },
                   "type": "object",
                 },
-                Object {
-                  "attributes": Object {
-                    "_key": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                      },
-                    },
-                  },
-                  "rest": Object {
-                    "name": "spotifyEmbed",
-                    "type": "inline",
-                  },
-                  "type": "object",
-                },
               ],
               "type": "union",
             },
@@ -1386,50 +1856,42 @@ Array [
           "value": Object {
             "of": Object {
               "attributes": Object {
-                "_key": Object {
-                  "type": "objectAttribute",
-                  "value": Object {
-                    "type": "string",
-                  },
-                },
                 "children": Object {
+                  "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
                     "of": Object {
-                      "of": Array [
-                        Object {
-                          "attributes": Object {
-                            "_key": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                              },
+                      "attributes": Object {
+                        "marks": Object {
+                          "optional": true,
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "of": Object {
+                              "type": "string",
                             },
-                            "marks": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "of": Object {
-                                  "of": Array [
-                                    Object {
-                                      "type": "string",
-                                    },
-                                  ],
-                                  "type": "union",
-                                },
-                                "type": "array",
-                              },
-                            },
-                            "text": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                              },
+                            "type": "array",
+                          },
+                        },
+                        "text": Object {
+                          "optional": true,
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "type": "string",
+                          },
+                        },
+                      },
+                      "rest": Object {
+                        "attributes": Object {
+                          "_key": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
                             },
                           },
-                          "type": "object",
                         },
-                      ],
-                      "type": "union",
+                        "type": "object",
+                      },
+                      "type": "object",
                     },
                     "type": "array",
                   },
@@ -1445,29 +1907,45 @@ Array [
                   "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
-                    "of": Array [],
+                    "of": Array [
+                      Object {
+                        "type": "string",
+                        "value": "bullet",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "number",
+                      },
+                    ],
                     "type": "union",
                   },
                 },
                 "markDefs": Object {
+                  "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
                     "of": Object {
-                      "of": Array [
-                        Object {
-                          "attributes": Object {
-                            "href": Object {
-                              "optional": true,
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                              },
+                      "attributes": Object {
+                        "href": Object {
+                          "optional": true,
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "type": "string",
+                          },
+                        },
+                      },
+                      "rest": Object {
+                        "attributes": Object {
+                          "_key": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
                             },
                           },
-                          "type": "object",
                         },
-                      ],
-                      "type": "union",
+                        "type": "object",
+                      },
+                      "type": "object",
                     },
                     "type": "array",
                   },
@@ -1476,7 +1954,40 @@ Array [
                   "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
-                    "of": Array [],
+                    "of": Array [
+                      Object {
+                        "type": "string",
+                        "value": "normal",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "h1",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "h2",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "h3",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "h4",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "h5",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "h6",
+                      },
+                      Object {
+                        "type": "string",
+                        "value": "blockquote",
+                      },
+                    ],
                     "type": "union",
                   },
                 },
@@ -1503,50 +2014,42 @@ Array [
           "value": Object {
             "of": Object {
               "attributes": Object {
-                "_key": Object {
-                  "type": "objectAttribute",
-                  "value": Object {
-                    "type": "string",
-                  },
-                },
                 "children": Object {
+                  "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
                     "of": Object {
-                      "of": Array [
-                        Object {
-                          "attributes": Object {
-                            "_key": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                              },
+                      "attributes": Object {
+                        "marks": Object {
+                          "optional": true,
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "of": Object {
+                              "type": "string",
                             },
-                            "marks": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "of": Object {
-                                  "of": Array [
-                                    Object {
-                                      "type": "string",
-                                    },
-                                  ],
-                                  "type": "union",
-                                },
-                                "type": "array",
-                              },
-                            },
-                            "text": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                              },
+                            "type": "array",
+                          },
+                        },
+                        "text": Object {
+                          "optional": true,
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "type": "string",
+                          },
+                        },
+                      },
+                      "rest": Object {
+                        "attributes": Object {
+                          "_key": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
                             },
                           },
-                          "type": "object",
                         },
-                      ],
-                      "type": "union",
+                        "type": "object",
+                      },
+                      "type": "object",
                     },
                     "type": "array",
                   },
@@ -1567,279 +2070,23 @@ Array [
                   },
                 },
                 "markDefs": Object {
+                  "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
-                    "of": Object {
-                      "of": Array [],
-                      "type": "union",
-                    },
-                    "type": "array",
+                    "type": "null",
                   },
                 },
                 "style": Object {
                   "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
-                    "of": Array [],
+                    "of": Array [
+                      Object {
+                        "type": "string",
+                        "value": "normal",
+                      },
+                    ],
                     "type": "union",
-                  },
-                },
-              },
-              "rest": Object {
-                "attributes": Object {
-                  "_key": Object {
-                    "type": "objectAttribute",
-                    "value": Object {
-                      "type": "string",
-                    },
-                  },
-                },
-                "type": "object",
-              },
-              "type": "object",
-            },
-            "type": "array",
-          },
-        },
-        "nestedWithDualColumnCTA": Object {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": Object {
-            "of": Object {
-              "attributes": Object {
-                "_type": Object {
-                  "type": "objectAttribute",
-                  "value": Object {
-                    "type": "string",
-                    "value": "localeRichtext",
-                  },
-                },
-                "en": Object {
-                  "optional": true,
-                  "type": "objectAttribute",
-                  "value": Object {
-                    "of": Object {
-                      "of": Array [
-                        Object {
-                          "attributes": Object {
-                            "_key": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                              },
-                            },
-                            "children": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "of": Object {
-                                  "of": Array [
-                                    Object {
-                                      "attributes": Object {
-                                        "_key": Object {
-                                          "type": "objectAttribute",
-                                          "value": Object {
-                                            "type": "string",
-                                          },
-                                        },
-                                        "marks": Object {
-                                          "type": "objectAttribute",
-                                          "value": Object {
-                                            "of": Object {
-                                              "of": Array [
-                                                Object {
-                                                  "type": "string",
-                                                },
-                                              ],
-                                              "type": "union",
-                                            },
-                                            "type": "array",
-                                          },
-                                        },
-                                        "text": Object {
-                                          "type": "objectAttribute",
-                                          "value": Object {
-                                            "type": "string",
-                                          },
-                                        },
-                                      },
-                                      "type": "object",
-                                    },
-                                  ],
-                                  "type": "union",
-                                },
-                                "type": "array",
-                              },
-                            },
-                            "level": Object {
-                              "optional": true,
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "number",
-                              },
-                            },
-                            "listItem": Object {
-                              "optional": true,
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "of": Array [],
-                                "type": "union",
-                              },
-                            },
-                            "markDefs": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "of": Object {
-                                  "of": Array [],
-                                  "type": "union",
-                                },
-                                "type": "array",
-                              },
-                            },
-                            "style": Object {
-                              "optional": true,
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "of": Array [],
-                                "type": "union",
-                              },
-                            },
-                          },
-                          "rest": Object {
-                            "attributes": Object {
-                              "_key": Object {
-                                "type": "objectAttribute",
-                                "value": Object {
-                                  "type": "string",
-                                },
-                              },
-                            },
-                            "type": "object",
-                          },
-                          "type": "object",
-                        },
-                        Object {
-                          "attributes": Object {
-                            "_type": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                                "value": "image",
-                              },
-                            },
-                            "asset": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "attributes": Object {
-                                  "_ref": Object {
-                                    "type": "objectAttribute",
-                                    "value": Object {
-                                      "type": "string",
-                                    },
-                                  },
-                                  "_type": Object {
-                                    "type": "objectAttribute",
-                                    "value": Object {
-                                      "type": "string",
-                                      "value": "reference",
-                                    },
-                                  },
-                                  "_weak": Object {
-                                    "optional": true,
-                                    "type": "objectAttribute",
-                                    "value": Object {
-                                      "type": "boolean",
-                                    },
-                                  },
-                                },
-                                "dereferencesTo": "sanity.imageAsset",
-                                "type": "object",
-                              },
-                            },
-                          },
-                          "rest": Object {
-                            "attributes": Object {
-                              "_key": Object {
-                                "type": "objectAttribute",
-                                "value": Object {
-                                  "type": "string",
-                                },
-                              },
-                            },
-                            "type": "object",
-                          },
-                          "type": "object",
-                        },
-                        Object {
-                          "attributes": Object {
-                            "_type": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                                "value": "twoColCTA",
-                              },
-                            },
-                            "columnone": Object {
-                              "optional": true,
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "of": Object {
-                                  "attributes": Object {
-                                    "_key": Object {
-                                      "type": "objectAttribute",
-                                      "value": Object {
-                                        "type": "string",
-                                      },
-                                    },
-                                  },
-                                  "rest": Object {
-                                    "name": "richTextObject",
-                                    "type": "inline",
-                                  },
-                                  "type": "object",
-                                },
-                                "type": "array",
-                              },
-                            },
-                            "columntwo": Object {
-                              "optional": true,
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "of": Object {
-                                  "attributes": Object {
-                                    "_key": Object {
-                                      "type": "objectAttribute",
-                                      "value": Object {
-                                        "type": "string",
-                                      },
-                                    },
-                                  },
-                                  "rest": Object {
-                                    "name": "richTextObject",
-                                    "type": "inline",
-                                  },
-                                  "type": "object",
-                                },
-                                "type": "array",
-                              },
-                            },
-                          },
-                          "rest": Object {
-                            "attributes": Object {
-                              "_key": Object {
-                                "type": "objectAttribute",
-                                "value": Object {
-                                  "type": "string",
-                                },
-                              },
-                            },
-                            "type": "object",
-                          },
-                          "type": "object",
-                        },
-                      ],
-                      "type": "union",
-                    },
-                    "type": "array",
                   },
                 },
               },
@@ -1867,14 +2114,8 @@ Array [
               "of": Array [
                 Object {
                   "attributes": Object {
-                    "_type": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                        "value": "image",
-                      },
-                    },
                     "asset": Object {
+                      "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
                         "attributes": Object {
@@ -1901,6 +2142,22 @@ Array [
                         },
                         "dereferencesTo": "sanity.imageAsset",
                         "type": "object",
+                      },
+                    },
+                    "crop": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "name": "sanity.imageCrop",
+                        "type": "inline",
+                      },
+                    },
+                    "hotspot": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "name": "sanity.imageHotspot",
+                        "type": "inline",
                       },
                     },
                   },
@@ -1993,16 +2250,38 @@ Array [
                 },
                 Object {
                   "attributes": Object {
-                    "_key": Object {
+                    "_ref": Object {
                       "type": "objectAttribute",
                       "value": Object {
                         "type": "string",
                       },
                     },
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "reference",
+                      },
+                    },
+                    "_weak": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "boolean",
+                      },
+                    },
                   },
+                  "dereferencesTo": "author",
                   "rest": Object {
-                    "name": "author",
-                    "type": "inline",
+                    "attributes": Object {
+                      "_key": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "type": "object",
                   },
                   "type": "object",
                 },
@@ -2023,13 +2302,6 @@ Array [
                 },
                 Object {
                   "attributes": Object {
-                    "_type": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                        "value": "testObject",
-                      },
-                    },
                     "field1": Object {
                       "optional": true,
                       "type": "objectAttribute",
@@ -2053,13 +2325,6 @@ Array [
                 },
                 Object {
                   "attributes": Object {
-                    "_type": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                        "value": "otherTestObject",
-                      },
-                    },
                     "field1": Object {
                       "optional": true,
                       "type": "objectAttribute",
@@ -2073,13 +2338,6 @@ Array [
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
-                            "_type": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                                "value": undefined,
-                              },
-                            },
                             "aNumber": Object {
                               "optional": true,
                               "type": "objectAttribute",
@@ -2136,13 +2394,6 @@ Array [
           "type": "objectAttribute",
           "value": Object {
             "attributes": Object {
-              "_type": Object {
-                "type": "objectAttribute",
-                "value": Object {
-                  "type": "string",
-                  "value": "recursive",
-                },
-              },
               "blocks": Object {
                 "optional": true,
                 "type": "objectAttribute",
@@ -2151,50 +2402,42 @@ Array [
                     "of": Array [
                       Object {
                         "attributes": Object {
-                          "_key": Object {
-                            "type": "objectAttribute",
-                            "value": Object {
-                              "type": "string",
-                            },
-                          },
                           "children": Object {
+                            "optional": true,
                             "type": "objectAttribute",
                             "value": Object {
                               "of": Object {
-                                "of": Array [
-                                  Object {
-                                    "attributes": Object {
-                                      "_key": Object {
-                                        "type": "objectAttribute",
-                                        "value": Object {
-                                          "type": "string",
-                                        },
+                                "attributes": Object {
+                                  "marks": Object {
+                                    "optional": true,
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "of": Object {
+                                        "type": "string",
                                       },
-                                      "marks": Object {
-                                        "type": "objectAttribute",
-                                        "value": Object {
-                                          "of": Object {
-                                            "of": Array [
-                                              Object {
-                                                "type": "string",
-                                              },
-                                            ],
-                                            "type": "union",
-                                          },
-                                          "type": "array",
-                                        },
-                                      },
-                                      "text": Object {
-                                        "type": "objectAttribute",
-                                        "value": Object {
-                                          "type": "string",
-                                        },
+                                      "type": "array",
+                                    },
+                                  },
+                                  "text": Object {
+                                    "optional": true,
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
+                                    },
+                                  },
+                                },
+                                "rest": Object {
+                                  "attributes": Object {
+                                    "_key": Object {
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "type": "string",
                                       },
                                     },
-                                    "type": "object",
                                   },
-                                ],
-                                "type": "union",
+                                  "type": "object",
+                                },
+                                "type": "object",
                               },
                               "type": "array",
                             },
@@ -2215,20 +2458,22 @@ Array [
                             },
                           },
                           "markDefs": Object {
+                            "optional": true,
                             "type": "objectAttribute",
                             "value": Object {
-                              "of": Object {
-                                "of": Array [],
-                                "type": "union",
-                              },
-                              "type": "array",
+                              "type": "null",
                             },
                           },
                           "style": Object {
                             "optional": true,
                             "type": "objectAttribute",
                             "value": Object {
-                              "of": Array [],
+                              "of": Array [
+                                Object {
+                                  "type": "string",
+                                  "value": "normal",
+                                },
+                              ],
                               "type": "union",
                             },
                           },
@@ -2279,50 +2524,42 @@ Array [
               "of": Array [
                 Object {
                   "attributes": Object {
-                    "_key": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                      },
-                    },
                     "children": Object {
+                      "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
                         "of": Object {
-                          "of": Array [
-                            Object {
-                              "attributes": Object {
-                                "_key": Object {
-                                  "type": "objectAttribute",
-                                  "value": Object {
-                                    "type": "string",
-                                  },
+                          "attributes": Object {
+                            "marks": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Object {
+                                  "type": "string",
                                 },
-                                "marks": Object {
-                                  "type": "objectAttribute",
-                                  "value": Object {
-                                    "of": Object {
-                                      "of": Array [
-                                        Object {
-                                          "type": "string",
-                                        },
-                                      ],
-                                      "type": "union",
-                                    },
-                                    "type": "array",
-                                  },
-                                },
-                                "text": Object {
-                                  "type": "objectAttribute",
-                                  "value": Object {
-                                    "type": "string",
-                                  },
+                                "type": "array",
+                              },
+                            },
+                            "text": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "rest": Object {
+                            "attributes": Object {
+                              "_key": Object {
+                                "type": "objectAttribute",
+                                "value": Object {
+                                  "type": "string",
                                 },
                               },
-                              "type": "object",
                             },
-                          ],
-                          "type": "union",
+                            "type": "object",
+                          },
+                          "type": "object",
                         },
                         "type": "array",
                       },
@@ -2338,16 +2575,45 @@ Array [
                       "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
-                        "of": Array [],
+                        "of": Array [
+                          Object {
+                            "type": "string",
+                            "value": "bullet",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "number",
+                          },
+                        ],
                         "type": "union",
                       },
                     },
                     "markDefs": Object {
+                      "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
                         "of": Object {
-                          "of": Array [],
-                          "type": "union",
+                          "attributes": Object {
+                            "href": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "rest": Object {
+                            "attributes": Object {
+                              "_key": Object {
+                                "type": "objectAttribute",
+                                "value": Object {
+                                  "type": "string",
+                                },
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "type": "object",
                         },
                         "type": "array",
                       },
@@ -2356,7 +2622,40 @@ Array [
                       "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
-                        "of": Array [],
+                        "of": Array [
+                          Object {
+                            "type": "string",
+                            "value": "normal",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "h1",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "h2",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "h3",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "h4",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "h5",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "h6",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "blockquote",
+                          },
+                        ],
                         "type": "union",
                       },
                     },
@@ -2376,14 +2675,8 @@ Array [
                 },
                 Object {
                   "attributes": Object {
-                    "_type": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                        "value": "image",
-                      },
-                    },
                     "asset": Object {
+                      "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
                         "attributes": Object {
@@ -2418,90 +2711,42 @@ Array [
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
-                            "_key": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                              },
-                            },
                             "children": Object {
+                              "optional": true,
                               "type": "objectAttribute",
                               "value": Object {
                                 "of": Object {
-                                  "of": Array [
-                                    Object {
-                                      "attributes": Object {
-                                        "_key": Object {
-                                          "type": "objectAttribute",
-                                          "value": Object {
-                                            "type": "string",
-                                          },
+                                  "attributes": Object {
+                                    "marks": Object {
+                                      "optional": true,
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "of": Object {
+                                          "type": "string",
                                         },
-                                        "marks": Object {
-                                          "type": "objectAttribute",
-                                          "value": Object {
-                                            "of": Object {
-                                              "of": Array [
-                                                Object {
-                                                  "type": "string",
-                                                },
-                                                Object {
-                                                  "type": "string",
-                                                  "value": "strong",
-                                                },
-                                                Object {
-                                                  "type": "string",
-                                                  "value": "em",
-                                                },
-                                                Object {
-                                                  "type": "string",
-                                                  "value": "underline",
-                                                },
-                                                Object {
-                                                  "type": "string",
-                                                  "value": "strikethrough",
-                                                },
-                                                Object {
-                                                  "type": "string",
-                                                  "value": "superscript",
-                                                },
-                                                Object {
-                                                  "type": "string",
-                                                  "value": "subscript",
-                                                },
-                                                Object {
-                                                  "type": "string",
-                                                  "value": "alignleft",
-                                                },
-                                                Object {
-                                                  "type": "string",
-                                                  "value": "aligncenter",
-                                                },
-                                                Object {
-                                                  "type": "string",
-                                                  "value": "alignright",
-                                                },
-                                                Object {
-                                                  "type": "string",
-                                                  "value": "alignjustify",
-                                                },
-                                              ],
-                                              "type": "union",
-                                            },
-                                            "type": "array",
-                                          },
-                                        },
-                                        "text": Object {
-                                          "type": "objectAttribute",
-                                          "value": Object {
-                                            "type": "string",
-                                          },
+                                        "type": "array",
+                                      },
+                                    },
+                                    "text": Object {
+                                      "optional": true,
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "type": "string",
+                                      },
+                                    },
+                                  },
+                                  "rest": Object {
+                                    "attributes": Object {
+                                      "_key": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
                                         },
                                       },
-                                      "type": "object",
                                     },
-                                  ],
-                                  "type": "union",
+                                    "type": "object",
+                                  },
+                                  "type": "object",
                                 },
                                 "type": "array",
                               },
@@ -2517,16 +2762,45 @@ Array [
                               "optional": true,
                               "type": "objectAttribute",
                               "value": Object {
-                                "of": Array [],
+                                "of": Array [
+                                  Object {
+                                    "type": "string",
+                                    "value": "bullet",
+                                  },
+                                  Object {
+                                    "type": "string",
+                                    "value": "number",
+                                  },
+                                ],
                                 "type": "union",
                               },
                             },
                             "markDefs": Object {
+                              "optional": true,
                               "type": "objectAttribute",
                               "value": Object {
                                 "of": Object {
-                                  "of": Array [],
-                                  "type": "union",
+                                  "attributes": Object {
+                                    "href": Object {
+                                      "optional": true,
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "type": "string",
+                                      },
+                                    },
+                                  },
+                                  "rest": Object {
+                                    "attributes": Object {
+                                      "_key": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
+                                        },
+                                      },
+                                    },
+                                    "type": "object",
+                                  },
+                                  "type": "object",
                                 },
                                 "type": "array",
                               },
@@ -2535,7 +2809,40 @@ Array [
                               "optional": true,
                               "type": "objectAttribute",
                               "value": Object {
-                                "of": Array [],
+                                "of": Array [
+                                  Object {
+                                    "type": "string",
+                                    "value": "normal",
+                                  },
+                                  Object {
+                                    "type": "string",
+                                    "value": "h1",
+                                  },
+                                  Object {
+                                    "type": "string",
+                                    "value": "h2",
+                                  },
+                                  Object {
+                                    "type": "string",
+                                    "value": "h3",
+                                  },
+                                  Object {
+                                    "type": "string",
+                                    "value": "h4",
+                                  },
+                                  Object {
+                                    "type": "string",
+                                    "value": "h5",
+                                  },
+                                  Object {
+                                    "type": "string",
+                                    "value": "h6",
+                                  },
+                                  Object {
+                                    "type": "string",
+                                    "value": "blockquote",
+                                  },
+                                ],
                                 "type": "union",
                               },
                             },
@@ -2554,6 +2861,22 @@ Array [
                           "type": "object",
                         },
                         "type": "array",
+                      },
+                    },
+                    "crop": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "name": "sanity.imageCrop",
+                        "type": "inline",
+                      },
+                    },
+                    "hotspot": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "name": "sanity.imageHotspot",
+                        "type": "inline",
                       },
                     },
                   },
@@ -2591,50 +2914,42 @@ Array [
               "of": Array [
                 Object {
                   "attributes": Object {
-                    "_key": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                      },
-                    },
                     "children": Object {
+                      "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
                         "of": Object {
-                          "of": Array [
-                            Object {
-                              "attributes": Object {
-                                "_key": Object {
-                                  "type": "objectAttribute",
-                                  "value": Object {
-                                    "type": "string",
-                                  },
+                          "attributes": Object {
+                            "marks": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "of": Object {
+                                  "type": "string",
                                 },
-                                "marks": Object {
-                                  "type": "objectAttribute",
-                                  "value": Object {
-                                    "of": Object {
-                                      "of": Array [
-                                        Object {
-                                          "type": "string",
-                                        },
-                                      ],
-                                      "type": "union",
-                                    },
-                                    "type": "array",
-                                  },
-                                },
-                                "text": Object {
-                                  "type": "objectAttribute",
-                                  "value": Object {
-                                    "type": "string",
-                                  },
+                                "type": "array",
+                              },
+                            },
+                            "text": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "rest": Object {
+                            "attributes": Object {
+                              "_key": Object {
+                                "type": "objectAttribute",
+                                "value": Object {
+                                  "type": "string",
                                 },
                               },
-                              "type": "object",
                             },
-                          ],
-                          "type": "union",
+                            "type": "object",
+                          },
+                          "type": "object",
                         },
                         "type": "array",
                       },
@@ -2650,16 +2965,45 @@ Array [
                       "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
-                        "of": Array [],
+                        "of": Array [
+                          Object {
+                            "type": "string",
+                            "value": "bullet",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "number",
+                          },
+                        ],
                         "type": "union",
                       },
                     },
                     "markDefs": Object {
+                      "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
                         "of": Object {
-                          "of": Array [],
-                          "type": "union",
+                          "attributes": Object {
+                            "href": Object {
+                              "optional": true,
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                          },
+                          "rest": Object {
+                            "attributes": Object {
+                              "_key": Object {
+                                "type": "objectAttribute",
+                                "value": Object {
+                                  "type": "string",
+                                },
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "type": "object",
                         },
                         "type": "array",
                       },
@@ -2668,7 +3012,40 @@ Array [
                       "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
-                        "of": Array [],
+                        "of": Array [
+                          Object {
+                            "type": "string",
+                            "value": "normal",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "h1",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "h2",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "h3",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "h4",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "h5",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "h6",
+                          },
+                          Object {
+                            "type": "string",
+                            "value": "blockquote",
+                          },
+                        ],
                         "type": "union",
                       },
                     },
@@ -2735,6 +3112,882 @@ Array [
         "type": "objectAttribute",
         "value": Object {
           "type": "string",
+          "value": "book",
+        },
+      },
+      "_updatedAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "name": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+    },
+    "name": "book",
+    "type": "document",
+  },
+  Object {
+    "attributes": Object {
+      "_createdAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_id": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_rev": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_type": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+          "value": "author",
+        },
+      },
+      "_updatedAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "name": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "profilePicture": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "attributes": Object {
+            "asset": Object {
+              "optional": true,
+              "type": "objectAttribute",
+              "value": Object {
+                "attributes": Object {
+                  "_ref": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                  "_type": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                      "value": "reference",
+                    },
+                  },
+                  "_weak": Object {
+                    "optional": true,
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "boolean",
+                    },
+                  },
+                },
+                "dereferencesTo": "sanity.imageAsset",
+                "type": "object",
+              },
+            },
+            "attribution": Object {
+              "optional": true,
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+              },
+            },
+            "caption": Object {
+              "optional": true,
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+              },
+            },
+            "crop": Object {
+              "optional": true,
+              "type": "objectAttribute",
+              "value": Object {
+                "name": "sanity.imageCrop",
+                "type": "inline",
+              },
+            },
+            "hotspot": Object {
+              "optional": true,
+              "type": "objectAttribute",
+              "value": Object {
+                "name": "sanity.imageHotspot",
+                "type": "inline",
+              },
+            },
+          },
+          "type": "object",
+        },
+      },
+    },
+    "name": "author",
+    "type": "document",
+  },
+  Object {
+    "name": "sanity.imageCrop",
+    "type": "type",
+    "value": Object {
+      "attributes": Object {
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "sanity.imageCrop",
+          },
+        },
+        "bottom": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+        "left": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+        "right": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+        "top": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  Object {
+    "name": "sanity.imageHotspot",
+    "type": "type",
+    "value": Object {
+      "attributes": Object {
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "sanity.imageHotspot",
+          },
+        },
+        "height": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+        "width": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+        "x": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+        "y": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  Object {
+    "attributes": Object {
+      "_createdAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_id": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_rev": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_type": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+          "value": "sanity.imageAsset",
+        },
+      },
+      "_updatedAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "altText": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "assetId": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "description": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "extension": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "label": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "metadata": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "name": "sanity.imageMetadata",
+          "type": "inline",
+        },
+      },
+      "mimeType": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "originalFilename": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "path": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "sha1hash": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "size": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "number",
+        },
+      },
+      "source": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "name": "sanity.assetSourceData",
+          "type": "inline",
+        },
+      },
+      "title": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "uploadId": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "url": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+    },
+    "name": "sanity.imageAsset",
+    "type": "document",
+  },
+  Object {
+    "name": "sanity.assetSourceData",
+    "type": "type",
+    "value": Object {
+      "attributes": Object {
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "sanity.assetSourceData",
+          },
+        },
+        "id": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+        "name": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+        "url": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  Object {
+    "name": "sanity.imageMetadata",
+    "type": "type",
+    "value": Object {
+      "attributes": Object {
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "sanity.imageMetadata",
+          },
+        },
+        "blurHash": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+        "dimensions": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "name": "sanity.imageDimensions",
+            "type": "inline",
+          },
+        },
+        "hasAlpha": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "boolean",
+          },
+        },
+        "isOpaque": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "boolean",
+          },
+        },
+        "location": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "name": "geopoint",
+            "type": "inline",
+          },
+        },
+        "lqip": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+        "palette": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "name": "sanity.imagePalette",
+            "type": "inline",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  Object {
+    "attributes": Object {
+      "_createdAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_id": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_rev": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_type": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+          "value": "validDocument",
+        },
+      },
+      "_updatedAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "blocks": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "of": Object {
+            "attributes": Object {
+              "children": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "of": Object {
+                    "attributes": Object {
+                      "marks": Object {
+                        "optional": true,
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "of": Object {
+                            "type": "string",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "text": Object {
+                        "optional": true,
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "rest": Object {
+                      "attributes": Object {
+                        "_key": Object {
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "type": "string",
+                          },
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+              "level": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "number",
+                },
+              },
+              "listItem": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "of": Array [
+                    Object {
+                      "type": "string",
+                      "value": "bullet",
+                    },
+                    Object {
+                      "type": "string",
+                      "value": "number",
+                    },
+                  ],
+                  "type": "union",
+                },
+              },
+              "markDefs": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "of": Object {
+                    "attributes": Object {
+                      "href": Object {
+                        "optional": true,
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                    },
+                    "rest": Object {
+                      "attributes": Object {
+                        "_key": Object {
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "type": "string",
+                          },
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+              "style": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "of": Array [
+                    Object {
+                      "type": "string",
+                      "value": "normal",
+                    },
+                    Object {
+                      "type": "string",
+                      "value": "h1",
+                    },
+                    Object {
+                      "type": "string",
+                      "value": "h2",
+                    },
+                    Object {
+                      "type": "string",
+                      "value": "h3",
+                    },
+                    Object {
+                      "type": "string",
+                      "value": "h4",
+                    },
+                    Object {
+                      "type": "string",
+                      "value": "h5",
+                    },
+                    Object {
+                      "type": "string",
+                      "value": "h6",
+                    },
+                    Object {
+                      "type": "string",
+                      "value": "blockquote",
+                    },
+                  ],
+                  "type": "union",
+                },
+              },
+            },
+            "rest": Object {
+              "attributes": Object {
+                "_key": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                  },
+                },
+              },
+              "type": "object",
+            },
+            "type": "object",
+          },
+          "type": "array",
+        },
+      },
+      "customStringType": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "name": "customStringType",
+          "type": "inline",
+        },
+      },
+      "list": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "of": Array [
+            Object {
+              "type": "string",
+              "value": "a",
+            },
+            Object {
+              "type": "string",
+              "value": "b",
+            },
+            Object {
+              "type": "string",
+              "value": "c",
+            },
+          ],
+          "type": "union",
+        },
+      },
+      "manuscript": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "attributes": Object {
+            "asset": Object {
+              "optional": true,
+              "type": "objectAttribute",
+              "value": Object {
+                "attributes": Object {
+                  "_ref": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                  "_type": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                      "value": "reference",
+                    },
+                  },
+                  "_weak": Object {
+                    "optional": true,
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "boolean",
+                    },
+                  },
+                },
+                "dereferencesTo": "sanity.fileAsset",
+                "type": "object",
+              },
+            },
+            "author": Object {
+              "optional": true,
+              "type": "objectAttribute",
+              "value": Object {
+                "attributes": Object {
+                  "_ref": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                    },
+                  },
+                  "_type": Object {
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "string",
+                      "value": "reference",
+                    },
+                  },
+                  "_weak": Object {
+                    "optional": true,
+                    "type": "objectAttribute",
+                    "value": Object {
+                      "type": "boolean",
+                    },
+                  },
+                },
+                "dereferencesTo": "author",
+                "type": "object",
+              },
+            },
+            "description": Object {
+              "optional": true,
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+              },
+            },
+          },
+          "type": "object",
+        },
+      },
+      "number": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "number",
+        },
+      },
+      "other": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "attributes": Object {
+            "_ref": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+              },
+            },
+            "_type": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+                "value": "reference",
+              },
+            },
+            "_weak": Object {
+              "optional": true,
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "boolean",
+              },
+            },
+          },
+          "dereferencesTo": "otherValidDocument",
+          "type": "object",
+        },
+      },
+      "others": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "attributes": Object {
+            "_ref": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+              },
+            },
+            "_type": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+                "value": "reference",
+              },
+            },
+            "_weak": Object {
+              "optional": true,
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "boolean",
+              },
+            },
+          },
+          "dereferencesTo": "otherValidDocument",
+          "type": "object",
+        },
+      },
+      "someInlinedObject": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "name": "obj",
+          "type": "inline",
+        },
+      },
+      "title": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+    },
+    "name": "validDocument",
+    "type": "document",
+  },
+  Object {
+    "attributes": Object {
+      "_createdAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_id": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_rev": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_type": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
           "value": "otherValidDocument",
         },
       },
@@ -2756,11 +4009,116 @@ Array [
     "type": "document",
   },
   Object {
-    "name": "object",
+    "name": "manuscript",
     "type": "type",
     "value": Object {
-      "name": "obj",
-      "type": "inline",
+      "attributes": Object {
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "manuscript",
+          },
+        },
+        "asset": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "attributes": Object {
+              "_ref": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                },
+              },
+              "_type": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                  "value": "reference",
+                },
+              },
+              "_weak": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "boolean",
+                },
+              },
+            },
+            "dereferencesTo": "sanity.fileAsset",
+            "type": "object",
+          },
+        },
+        "author": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "attributes": Object {
+              "_ref": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                },
+              },
+              "_type": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                  "value": "reference",
+                },
+              },
+              "_weak": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "boolean",
+                },
+              },
+            },
+            "dereferencesTo": "author",
+            "type": "object",
+          },
+        },
+        "description": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  Object {
+    "name": "obj",
+    "type": "type",
+    "value": Object {
+      "attributes": Object {
+        "_type": Object {
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+            "value": "obj",
+          },
+        },
+        "field1": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "string",
+          },
+        },
+        "field2": Object {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": Object {
+            "type": "number",
+          },
+        },
+      },
+      "type": "object",
     },
   },
 ]

--- a/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
+++ b/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
@@ -428,6 +428,13 @@ Array [
           "value": Object {
             "of": Object {
               "attributes": Object {
+                "_type": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                    "value": "block",
+                  },
+                },
                 "children": Object {
                   "optional": true,
                   "type": "objectAttribute",
@@ -436,6 +443,13 @@ Array [
                       "of": Array [
                         Object {
                           "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": "span",
+                              },
+                            },
                             "marks": Object {
                               "optional": true,
                               "type": "objectAttribute",
@@ -469,18 +483,39 @@ Array [
                         },
                         Object {
                           "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": "footnote",
+                              },
+                            },
                             "footnote": Object {
                               "optional": true,
                               "type": "objectAttribute",
                               "value": Object {
                                 "of": Object {
                                   "attributes": Object {
+                                    "_type": Object {
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "type": "string",
+                                        "value": "block",
+                                      },
+                                    },
                                     "children": Object {
                                       "optional": true,
                                       "type": "objectAttribute",
                                       "value": Object {
                                         "of": Object {
                                           "attributes": Object {
+                                            "_type": Object {
+                                              "type": "objectAttribute",
+                                              "value": Object {
+                                                "type": "string",
+                                                "value": "span",
+                                              },
+                                            },
                                             "marks": Object {
                                               "optional": true,
                                               "type": "objectAttribute",
@@ -617,6 +652,13 @@ Array [
                   "value": Object {
                     "of": Object {
                       "attributes": Object {
+                        "_type": Object {
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "type": "string",
+                            "value": "link",
+                          },
+                        },
                         "href": Object {
                           "optional": true,
                           "type": "objectAttribute",
@@ -705,18 +747,39 @@ Array [
           "value": Object {
             "of": Object {
               "attributes": Object {
+                "_type": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                    "value": "blockListEntry",
+                  },
+                },
                 "blocks": Object {
                   "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
                     "of": Object {
                       "attributes": Object {
+                        "_type": Object {
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "type": "string",
+                            "value": "block",
+                          },
+                        },
                         "children": Object {
                           "optional": true,
                           "type": "objectAttribute",
                           "value": Object {
                             "of": Object {
                               "attributes": Object {
+                                "_type": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                    "value": "span",
+                                  },
+                                },
                                 "marks": Object {
                                   "optional": true,
                                   "type": "objectAttribute",
@@ -781,6 +844,13 @@ Array [
                           "value": Object {
                             "of": Object {
                               "attributes": Object {
+                                "_type": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                    "value": "link",
+                                  },
+                                },
                                 "href": Object {
                                   "optional": true,
                                   "type": "objectAttribute",
@@ -932,6 +1002,13 @@ Array [
                 },
                 Object {
                   "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "block",
+                      },
+                    },
                     "children": Object {
                       "optional": true,
                       "type": "objectAttribute",
@@ -940,6 +1017,13 @@ Array [
                           "of": Array [
                             Object {
                               "attributes": Object {
+                                "_type": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                    "value": "span",
+                                  },
+                                },
                                 "marks": Object {
                                   "optional": true,
                                   "type": "objectAttribute",
@@ -973,6 +1057,13 @@ Array [
                             },
                             Object {
                               "attributes": Object {
+                                "_type": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                    "value": "image",
+                                  },
+                                },
                                 "asset": Object {
                                   "optional": true,
                                   "type": "objectAttribute",
@@ -1159,6 +1250,13 @@ Array [
                             },
                             Object {
                               "attributes": Object {
+                                "_type": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                    "value": "test",
+                                  },
+                                },
                                 "testString": Object {
                                   "optional": true,
                                   "type": "objectAttribute",
@@ -1236,6 +1334,13 @@ Array [
           "type": "objectAttribute",
           "value": Object {
             "attributes": Object {
+              "_type": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                  "value": "object",
+                },
+              },
               "blocks": Object {
                 "optional": true,
                 "type": "objectAttribute",
@@ -1244,6 +1349,13 @@ Array [
                     "of": Array [
                       Object {
                         "attributes": Object {
+                          "_type": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                              "value": "image",
+                            },
+                          },
                           "asset": Object {
                             "optional": true,
                             "type": "objectAttribute",
@@ -1343,12 +1455,26 @@ Array [
                       },
                       Object {
                         "attributes": Object {
+                          "_type": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                              "value": "block",
+                            },
+                          },
                           "children": Object {
                             "optional": true,
                             "type": "objectAttribute",
                             "value": Object {
                               "of": Object {
                                 "attributes": Object {
+                                  "_type": Object {
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
+                                      "value": "span",
+                                    },
+                                  },
                                   "marks": Object {
                                     "optional": true,
                                     "type": "objectAttribute",
@@ -1515,6 +1641,13 @@ Array [
               "of": Array [
                 Object {
                   "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "image",
+                      },
+                    },
                     "asset": Object {
                       "optional": true,
                       "type": "objectAttribute",
@@ -1651,12 +1784,26 @@ Array [
                 },
                 Object {
                   "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "objectWithNestedArray",
+                      },
+                    },
                     "array": Object {
                       "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": "object",
+                              },
+                            },
                             "author": Object {
                               "optional": true,
                               "type": "objectAttribute",
@@ -1786,6 +1933,13 @@ Array [
                 },
                 Object {
                   "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "otherTestObject",
+                      },
+                    },
                     "field1": Object {
                       "optional": true,
                       "type": "objectAttribute",
@@ -1799,6 +1953,13 @@ Array [
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": "object",
+                              },
+                            },
                             "aNumber": Object {
                               "optional": true,
                               "type": "objectAttribute",
@@ -1856,12 +2017,26 @@ Array [
           "value": Object {
             "of": Object {
               "attributes": Object {
+                "_type": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                    "value": "block",
+                  },
+                },
                 "children": Object {
                   "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
                     "of": Object {
                       "attributes": Object {
+                        "_type": Object {
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "type": "string",
+                            "value": "span",
+                          },
+                        },
                         "marks": Object {
                           "optional": true,
                           "type": "objectAttribute",
@@ -1926,6 +2101,13 @@ Array [
                   "value": Object {
                     "of": Object {
                       "attributes": Object {
+                        "_type": Object {
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "type": "string",
+                            "value": "link",
+                          },
+                        },
                         "href": Object {
                           "optional": true,
                           "type": "objectAttribute",
@@ -2014,12 +2196,26 @@ Array [
           "value": Object {
             "of": Object {
               "attributes": Object {
+                "_type": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                    "value": "block",
+                  },
+                },
                 "children": Object {
                   "optional": true,
                   "type": "objectAttribute",
                   "value": Object {
                     "of": Object {
                       "attributes": Object {
+                        "_type": Object {
+                          "type": "objectAttribute",
+                          "value": Object {
+                            "type": "string",
+                            "value": "span",
+                          },
+                        },
                         "marks": Object {
                           "optional": true,
                           "type": "objectAttribute",
@@ -2114,6 +2310,13 @@ Array [
               "of": Array [
                 Object {
                   "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "image",
+                      },
+                    },
                     "asset": Object {
                       "optional": true,
                       "type": "objectAttribute",
@@ -2302,6 +2505,13 @@ Array [
                 },
                 Object {
                   "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "testObject",
+                      },
+                    },
                     "field1": Object {
                       "optional": true,
                       "type": "objectAttribute",
@@ -2325,6 +2535,13 @@ Array [
                 },
                 Object {
                   "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "otherTestObject",
+                      },
+                    },
                     "field1": Object {
                       "optional": true,
                       "type": "objectAttribute",
@@ -2338,6 +2555,13 @@ Array [
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": "object",
+                              },
+                            },
                             "aNumber": Object {
                               "optional": true,
                               "type": "objectAttribute",
@@ -2394,6 +2618,13 @@ Array [
           "type": "objectAttribute",
           "value": Object {
             "attributes": Object {
+              "_type": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                  "value": "object",
+                },
+              },
               "blocks": Object {
                 "optional": true,
                 "type": "objectAttribute",
@@ -2402,12 +2633,26 @@ Array [
                     "of": Array [
                       Object {
                         "attributes": Object {
+                          "_type": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                              "value": "block",
+                            },
+                          },
                           "children": Object {
                             "optional": true,
                             "type": "objectAttribute",
                             "value": Object {
                               "of": Object {
                                 "attributes": Object {
+                                  "_type": Object {
+                                    "type": "objectAttribute",
+                                    "value": Object {
+                                      "type": "string",
+                                      "value": "span",
+                                    },
+                                  },
                                   "marks": Object {
                                     "optional": true,
                                     "type": "objectAttribute",
@@ -2524,12 +2769,26 @@ Array [
               "of": Array [
                 Object {
                   "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "block",
+                      },
+                    },
                     "children": Object {
                       "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": "span",
+                              },
+                            },
                             "marks": Object {
                               "optional": true,
                               "type": "objectAttribute",
@@ -2594,6 +2853,13 @@ Array [
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": "link",
+                              },
+                            },
                             "href": Object {
                               "optional": true,
                               "type": "objectAttribute",
@@ -2675,6 +2941,13 @@ Array [
                 },
                 Object {
                   "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "imageWithPortableTextCaption",
+                      },
+                    },
                     "asset": Object {
                       "optional": true,
                       "type": "objectAttribute",
@@ -2711,12 +2984,26 @@ Array [
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": "block",
+                              },
+                            },
                             "children": Object {
                               "optional": true,
                               "type": "objectAttribute",
                               "value": Object {
                                 "of": Object {
                                   "attributes": Object {
+                                    "_type": Object {
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "type": "string",
+                                        "value": "span",
+                                      },
+                                    },
                                     "marks": Object {
                                       "optional": true,
                                       "type": "objectAttribute",
@@ -2781,6 +3068,13 @@ Array [
                               "value": Object {
                                 "of": Object {
                                   "attributes": Object {
+                                    "_type": Object {
+                                      "type": "objectAttribute",
+                                      "value": Object {
+                                        "type": "string",
+                                        "value": "link",
+                                      },
+                                    },
                                     "href": Object {
                                       "optional": true,
                                       "type": "objectAttribute",
@@ -2914,12 +3208,26 @@ Array [
               "of": Array [
                 Object {
                   "attributes": Object {
+                    "_type": Object {
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "type": "string",
+                        "value": "block",
+                      },
+                    },
                     "children": Object {
                       "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": "span",
+                              },
+                            },
                             "marks": Object {
                               "optional": true,
                               "type": "objectAttribute",
@@ -2984,6 +3292,13 @@ Array [
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
+                            "_type": Object {
+                              "type": "objectAttribute",
+                              "value": Object {
+                                "type": "string",
+                                "value": "link",
+                              },
+                            },
                             "href": Object {
                               "optional": true,
                               "type": "objectAttribute",
@@ -3177,6 +3492,13 @@ Array [
         "type": "objectAttribute",
         "value": Object {
           "attributes": Object {
+            "_type": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+                "value": "image",
+              },
+            },
             "asset": Object {
               "optional": true,
               "type": "objectAttribute",
@@ -3621,12 +3943,26 @@ Array [
         "value": Object {
           "of": Object {
             "attributes": Object {
+              "_type": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                  "value": "block",
+                },
+              },
               "children": Object {
                 "optional": true,
                 "type": "objectAttribute",
                 "value": Object {
                   "of": Object {
                     "attributes": Object {
+                      "_type": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                          "value": "span",
+                        },
+                      },
                       "marks": Object {
                         "optional": true,
                         "type": "objectAttribute",
@@ -3691,6 +4027,13 @@ Array [
                 "value": Object {
                   "of": Object {
                     "attributes": Object {
+                      "_type": Object {
+                        "type": "objectAttribute",
+                        "value": Object {
+                          "type": "string",
+                          "value": "link",
+                        },
+                      },
                       "href": Object {
                         "optional": true,
                         "type": "objectAttribute",
@@ -3807,6 +4150,13 @@ Array [
         "type": "objectAttribute",
         "value": Object {
           "attributes": Object {
+            "_type": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+                "value": "manuscript",
+              },
+            },
             "asset": Object {
               "optional": true,
               "type": "objectAttribute",

--- a/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
+++ b/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert'
+
+import {describe, expect, test} from '@jest/globals'
+
+import {extractSchema} from '../../src/sanity/extractSchema'
+import Block from './fixtures/block'
+
+describe('Extract schema test', () => {
+  test('Extracts  schema general', () => {
+    const schemaDef = [
+      {
+        title: 'Valid document',
+        name: 'validDocument',
+        type: 'document',
+        fields: [
+          {
+            title: 'Title',
+            name: 'title',
+            type: 'string',
+          },
+          {
+            title: 'List',
+            name: 'list',
+            type: 'string',
+            options: {
+              list: ['a', 'b', 'c'],
+            },
+          },
+          {
+            title: 'Number',
+            name: 'number',
+            type: 'number',
+          },
+          {
+            title: 'some other object',
+            name: 'someInlinedObject',
+            type: 'obj',
+          },
+          {
+            title: 'Blocks',
+            name: 'blocks',
+            type: 'array',
+            of: [{type: 'block'}],
+          },
+          {
+            type: 'reference',
+            name: 'other',
+            to: {
+              type: 'otherValidDocument',
+            },
+          },
+          {
+            type: 'reference',
+            name: 'others',
+            to: [
+              {
+                type: 'otherValidDocument',
+              },
+            ],
+          },
+        ],
+      },
+      Block,
+      {
+        title: 'Other valid document',
+        name: 'otherValidDocument',
+        type: 'document',
+        fields: [
+          {
+            title: 'Title',
+            name: 'title',
+            type: 'string',
+          },
+        ],
+      },
+      {
+        title: 'Obj',
+        type: 'obj',
+        name: 'object',
+        fields: [
+          {
+            title: 'Field #1',
+            name: 'field-1',
+            type: 'string',
+          },
+          {
+            title: 'Field #2',
+            name: 'field-2',
+            type: 'number',
+          },
+        ],
+      },
+    ]
+
+    const extracted = extractSchema(schemaDef)
+    expect(extracted).toHaveLength(4)
+    expect(extracted[0].name).toEqual('validDocument')
+    expect(extracted[0].type).toEqual('document')
+    assert(extracted[0].type === 'document') // this is a workaround for TS https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41179
+    expect(Object.keys(extracted[0].attributes)).toStrictEqual([
+      '_id',
+      '_type',
+      '_createdAt',
+      '_updatedAt',
+      '_rev',
+      'title',
+      'list',
+      'number',
+      'someInlinedObject',
+      'blocks',
+      'other',
+      'others',
+    ])
+
+    // Check that the block type is extracted correctly, as an array
+    expect(extracted[0].attributes.blocks.type).toEqual('objectAttribute')
+    expect(extracted[0].attributes.blocks.value.type).toEqual('array')
+    assert(extracted[0].attributes.blocks.value.type === 'array') // this is a workaround for TS
+    expect(extracted[0].attributes.blocks.value.of.type).toEqual('object')
+    assert(extracted[0].attributes.blocks.value.of.type === 'object') // this is a workaround for TS
+    expect(Object.keys(extracted[0].attributes.blocks.value.of.attributes)).toStrictEqual([
+      '_key',
+      'level',
+      'style',
+      'listItem',
+      'children',
+      'markDefs',
+    ])
+
+    expect(extracted).toMatchSnapshot()
+  })
+
+  test('Can extract example studio', async () => {
+    const schemaDef = await import('../../../schema/example/schema-def')
+    const extracted = extractSchema(schemaDef.default.types)
+    expect(extracted.length).toBeGreaterThan(0) // we don't really care about the exact number, just that it passes :+1:
+  })
+})

--- a/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
+++ b/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
@@ -287,7 +287,18 @@ describe('Extract schema test', () => {
       'listItem',
       'markDefs',
       'level',
+      '_type',
     ])
+
+    expect(validDocument.attributes.blocks.value.of.attributes.children.value.type).toEqual('array')
+    assert(validDocument.attributes.blocks.value.of.attributes.children.value.type === 'array') // this is a workaround for TS
+    expect(validDocument.attributes.blocks.value.of.attributes.children.value.of.type).toEqual(
+      'object',
+    )
+    assert(validDocument.attributes.blocks.value.of.attributes.children.value.of.type === 'object') // this is a workaround for TS
+    expect(
+      Object.keys(validDocument.attributes.blocks.value.of.attributes.children.value.of.attributes),
+    ).toStrictEqual(['marks', 'text', '_type'])
 
     expect(extracted).toMatchSnapshot()
   })

--- a/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
+++ b/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
@@ -371,9 +371,9 @@ describe('Extract schema test', () => {
       expect(extracted.length).toBeGreaterThan(0) // we don't really care about the exact number, just that it passes :+1:
     })
 
-    // const skips = cases.filter((v): v is {schemaName: string; schema: null} => v.schema === null)
-    // test.skip.each(skips)('extracts schema $schemaName', () => {
-    //   // Add a test for the skipped cases so we can track them in the test report
-    // })
+    const skips = cases.filter((v): v is {schemaName: string; schema: null} => v.schema === null)
+    test.skip.each(skips)('extracts schema $schemaName', () => {
+      // Add a test for the skipped cases so we can track them in the test report
+    })
   })
 })

--- a/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
+++ b/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
@@ -1,103 +1,264 @@
 import assert from 'node:assert'
 
 import {describe, expect, test} from '@jest/globals'
+import {defineType} from '@sanity/types'
 
+import {Schema} from '../../src/legacy/Schema'
 import {extractSchema} from '../../src/sanity/extractSchema'
+import {groupProblems} from '../../src/sanity/groupProblems'
+import {validateSchema} from '../../src/sanity/validateSchema'
+import schemaFixtures from '../legacy/fixtures/schemas'
+// built-in types
+import assetSourceData from './fixtures/assetSourceData'
 import Block from './fixtures/block'
+import fileAsset from './fixtures/fileAsset'
+import geopoint from './fixtures/geopoint'
+import imageAsset from './fixtures/imageAsset'
+import imageCrop from './fixtures/imageCrop'
+import imageDimensions from './fixtures/imageDimensions'
+import imageHotspot from './fixtures/imageHotspot'
+import imageMetadata from './fixtures/imageMetadata'
+import imagePalette from './fixtures/imagePalette'
+import imagePaletteSwatch from './fixtures/imagePaletteSwatch'
+import slug from './fixtures/slug'
+
+const builtinTypes = [
+  assetSourceData,
+  slug,
+  geopoint,
+  imageAsset,
+  fileAsset,
+  imageCrop,
+  imageHotspot,
+  imageMetadata,
+  imageDimensions,
+  imagePalette,
+  imagePaletteSwatch,
+]
+
+// taken from sanity/src/core/schema/createSchema.ts
+function createSchema(schemaDef: {name: string; types: any[]}) {
+  const validated = validateSchema(schemaDef.types).getTypes()
+  const validation = groupProblems(validated)
+  const hasErrors = validation.some((group) =>
+    group.problems.some((problem) => problem.severity === 'error'),
+  )
+
+  return Schema.compile({
+    name: 'test',
+    types: hasErrors ? [] : [...schemaDef.types, ...builtinTypes].filter(Boolean),
+  })
+}
 
 describe('Extract schema test', () => {
   test('Extracts  schema general', () => {
-    const schemaDef = [
-      {
-        title: 'Valid document',
-        name: 'validDocument',
-        type: 'document',
-        fields: [
-          {
-            title: 'Title',
-            name: 'title',
-            type: 'string',
-          },
-          {
-            title: 'List',
-            name: 'list',
-            type: 'string',
-            options: {
-              list: ['a', 'b', 'c'],
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          title: 'Valid document',
+          name: 'validDocument',
+          type: 'document',
+          fields: [
+            {
+              title: 'Title',
+              name: 'title',
+              type: 'string',
             },
-          },
-          {
-            title: 'Number',
-            name: 'number',
-            type: 'number',
-          },
-          {
-            title: 'some other object',
-            name: 'someInlinedObject',
-            type: 'obj',
-          },
-          {
-            title: 'Blocks',
-            name: 'blocks',
-            type: 'array',
-            of: [{type: 'block'}],
-          },
-          {
-            type: 'reference',
-            name: 'other',
-            to: {
-              type: 'otherValidDocument',
+            {
+              title: 'List',
+              name: 'list',
+              type: 'string',
+              options: {
+                list: ['a', 'b', 'c'],
+              },
+              validation: (Rule) => Rule.required(),
             },
-          },
-          {
-            type: 'reference',
-            name: 'others',
-            to: [
-              {
+            {
+              title: 'Number',
+              name: 'number',
+              type: 'number',
+            },
+            {
+              title: 'some other object',
+              name: 'someInlinedObject',
+              type: 'obj',
+            },
+            {
+              title: 'Manuscript',
+              name: 'manuscript',
+              type: 'manuscript',
+            },
+            {
+              title: 'customStringType',
+              name: 'customStringType',
+              type: 'customStringType',
+            },
+            {
+              title: 'Blocks',
+              name: 'blocks',
+              type: 'array',
+              of: [{type: 'block'}],
+            },
+            {
+              type: 'reference',
+              name: 'other',
+              to: {
                 type: 'otherValidDocument',
               },
-            ],
-          },
-        ],
-      },
-      Block,
-      {
-        title: 'Other valid document',
-        name: 'otherValidDocument',
-        type: 'document',
-        fields: [
-          {
-            title: 'Title',
-            name: 'title',
-            type: 'string',
-          },
-        ],
-      },
-      {
-        title: 'Obj',
-        type: 'obj',
-        name: 'object',
-        fields: [
-          {
-            title: 'Field #1',
-            name: 'field-1',
-            type: 'string',
-          },
-          {
-            title: 'Field #2',
-            name: 'field-2',
-            type: 'number',
-          },
-        ],
-      },
-    ]
+            },
+            {
+              type: 'reference',
+              name: 'others',
+              to: [
+                {
+                  type: 'otherValidDocument',
+                },
+              ],
+            },
+          ],
+        }),
+        {
+          title: 'Author',
+          name: 'author',
+          type: 'document',
+          fields: [
+            {
+              title: 'Name',
+              name: 'name',
+              type: 'string',
+            },
+            {
+              title: 'Profile picture',
+              name: 'profilePicture',
+              type: 'image',
+              options: {
+                hotspot: true,
+              },
+              fields: [
+                {
+                  name: 'caption',
+                  type: 'string',
+                  title: 'Caption',
+                },
+                {
+                  name: 'attribution',
+                  type: 'string',
+                  title: 'Attribution',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          title: 'Book',
+          name: 'book',
+          type: 'document',
+          fields: [
+            {
+              title: 'Name',
+              name: 'name',
+              type: 'string',
+            },
+          ],
+        },
+        Block,
+        {
+          title: 'Other valid document',
+          name: 'otherValidDocument',
+          type: 'document',
+          fields: [
+            {
+              title: 'Title',
+              name: 'title',
+              type: 'string',
+            },
+          ],
+        },
+        {
+          type: 'object',
+          name: 'obj',
+          fields: [
+            {
+              title: 'Field #1',
+              name: 'field1',
+              type: 'string',
+            },
+            {
+              title: 'Field #2',
+              name: 'field2',
+              type: 'number',
+            },
+          ],
+        },
+        defineType({
+          name: 'customStringType',
+          title: 'My custom string type',
+          type: 'string',
+        }),
+        {
+          type: 'object',
+          name: 'code',
+          fields: [
+            {
+              title: 'The Code!',
+              name: 'thecode',
+              type: 'string',
+            },
+          ],
+        },
+        {
+          title: 'Manuscript',
+          name: 'manuscript',
+          type: 'file',
+          fields: [
+            {
+              name: 'description',
+              type: 'string',
+              title: 'Description',
+            },
+            {
+              name: 'author',
+              type: 'reference',
+              title: 'Author',
+              to: {type: 'author'},
+            },
+          ],
+        },
+      ],
+    })
 
-    const extracted = extractSchema(schemaDef)
-    expect(extracted).toHaveLength(4)
-    expect(extracted[0].name).toEqual('validDocument')
-    expect(extracted[0].type).toEqual('document')
-    assert(extracted[0].type === 'document') // this is a workaround for TS https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41179
-    expect(Object.keys(extracted[0].attributes)).toStrictEqual([
+    const extracted = extractSchema(schema)
+    expect(extracted.map((v) => v.name)).toStrictEqual([
+      'sanity.imagePaletteSwatch',
+      'sanity.imagePalette',
+      'sanity.imageDimensions',
+      'geopoint',
+      'slug',
+      'sanity.fileAsset',
+      'code',
+      'customStringType',
+      'blocksTest',
+      'book',
+      'author',
+      'sanity.imageCrop',
+      'sanity.imageHotspot',
+      'sanity.imageAsset',
+      'sanity.assetSourceData',
+      'sanity.imageMetadata',
+      'validDocument',
+      'otherValidDocument',
+      'manuscript',
+      'obj',
+    ])
+    const validDocument = extracted.find((type) => type.name === 'validDocument')
+    expect(validDocument).toBeDefined()
+    assert(validDocument !== undefined) // this is a workaround for TS, but leave the expect above for clarity in case of failure
+
+    expect(validDocument.name).toEqual('validDocument')
+    expect(validDocument.type).toEqual('document')
+    assert(validDocument.type === 'document') // this is a workaround for TS https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41179
+    expect(Object.keys(validDocument.attributes)).toStrictEqual([
       '_id',
       '_type',
       '_createdAt',
@@ -107,32 +268,101 @@ describe('Extract schema test', () => {
       'list',
       'number',
       'someInlinedObject',
+      'manuscript',
+      'customStringType',
       'blocks',
       'other',
       'others',
     ])
 
     // Check that the block type is extracted correctly, as an array
-    expect(extracted[0].attributes.blocks.type).toEqual('objectAttribute')
-    expect(extracted[0].attributes.blocks.value.type).toEqual('array')
-    assert(extracted[0].attributes.blocks.value.type === 'array') // this is a workaround for TS
-    expect(extracted[0].attributes.blocks.value.of.type).toEqual('object')
-    assert(extracted[0].attributes.blocks.value.of.type === 'object') // this is a workaround for TS
-    expect(Object.keys(extracted[0].attributes.blocks.value.of.attributes)).toStrictEqual([
-      '_key',
-      'level',
+    expect(validDocument.attributes.blocks.type).toEqual('objectAttribute')
+    expect(validDocument.attributes.blocks.value.type).toEqual('array')
+    assert(validDocument.attributes.blocks.value.type === 'array') // this is a workaround for TS
+    expect(validDocument.attributes.blocks.value.of.type).toEqual('object')
+    assert(validDocument.attributes.blocks.value.of.type === 'object') // this is a workaround for TS
+    expect(Object.keys(validDocument.attributes.blocks.value.of.attributes)).toStrictEqual([
+      'children',
       'style',
       'listItem',
-      'children',
       'markDefs',
+      'level',
     ])
 
     expect(extracted).toMatchSnapshot()
   })
 
-  test('Can extract example studio', async () => {
-    const schemaDef = await import('../../../schema/example/schema-def')
-    const extracted = extractSchema(schemaDef.default.types)
-    expect(extracted.length).toBeGreaterThan(0) // we don't really care about the exact number, just that it passes :+1:
+  test('order of types does not matter', () => {
+    const schema1 = createSchema({
+      name: 'test',
+      types: [
+        {
+          title: 'Author',
+          name: 'author',
+          type: 'object',
+          fields: [
+            {
+              title: 'Name',
+              name: 'name',
+              type: 'string',
+            },
+          ],
+        },
+        {
+          title: 'Book',
+          name: 'book',
+          type: 'document',
+          fields: [
+            {
+              title: 'Name',
+              name: 'name',
+              type: 'string',
+            },
+            {
+              title: 'Author',
+              name: 'author',
+              type: 'author',
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(extractSchema(schema1).map((v) => v.name)).toStrictEqual([
+      'sanity.imagePaletteSwatch',
+      'sanity.imagePalette',
+      'sanity.imageDimensions',
+      'sanity.imageHotspot',
+      'sanity.imageCrop',
+      'sanity.fileAsset',
+      'sanity.imageAsset',
+      'sanity.imageMetadata',
+      'geopoint',
+      'slug',
+      'sanity.assetSourceData',
+      'book',
+      'author',
+    ])
+  })
+
+  describe('Can extract sample fixtures', () => {
+    const cases = Object.keys(schemaFixtures).map((schemaName) => {
+      const schema = createSchema(schemaFixtures[schemaName])
+      if (schema._original.types.length === 0) {
+        return {schemaName, schema: null}
+      }
+      return {schemaName, schema}
+    })
+    const passes = cases.filter((v): v is {schemaName: string; schema: Schema} => v.schema !== null)
+
+    test.each(passes)('extracts schema $schemaName', ({schema}) => {
+      const extracted = extractSchema(schema)
+      expect(extracted.length).toBeGreaterThan(0) // we don't really care about the exact number, just that it passes :+1:
+    })
+
+    // const skips = cases.filter((v): v is {schemaName: string; schema: null} => v.schema === null)
+    // test.skip.each(skips)('extracts schema $schemaName', () => {
+    //   // Add a test for the skipped cases so we can track them in the test report
+    // })
   })
 })

--- a/packages/@sanity/schema/test/extractSchema/fixtures/assetSourceData.ts
+++ b/packages/@sanity/schema/test/extractSchema/fixtures/assetSourceData.ts
@@ -1,0 +1,26 @@
+export default {
+  name: 'sanity.assetSourceData',
+  title: 'Asset Source Data',
+  type: 'object',
+  fields: [
+    {
+      name: 'name',
+      title: 'Source name',
+      description: 'A canonical name for the source this asset is originating from',
+      type: 'string',
+    },
+    {
+      name: 'id',
+      title: 'Asset Source ID',
+      description:
+        'The unique ID for the asset within the originating source so you can programatically find back to it',
+      type: 'string',
+    },
+    {
+      name: 'url',
+      title: 'Asset information URL',
+      description: 'A URL to find more information about this asset in the originating source',
+      type: 'string',
+    },
+  ],
+}

--- a/packages/@sanity/schema/test/extractSchema/fixtures/block.ts
+++ b/packages/@sanity/schema/test/extractSchema/fixtures/block.ts
@@ -1,0 +1,514 @@
+import {ComposeIcon, DropIcon, ImageIcon} from '@sanity/icons'
+
+const linkType = {
+  type: 'object',
+  name: 'link',
+  fields: [
+    {
+      type: 'string',
+      name: 'href',
+      validation: (Rule) => Rule.uri({scheme: ['http', 'https']}).required(),
+    },
+  ],
+  options: {
+    modal: {
+      type: 'popover',
+      width: 2,
+    },
+  },
+}
+
+export default {
+  name: 'blocks',
+  title: 'Blocks test',
+  type: 'object',
+  icon: ComposeIcon,
+  fields: [
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+    },
+    {
+      name: 'first',
+      title: 'Block array as first field',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          marks: {
+            annotations: [linkType],
+          },
+        },
+      ],
+    },
+    {
+      name: 'defaults',
+      title: 'Content',
+      description: 'Profound description of what belongs here',
+      type: 'array',
+      of: [
+        {type: 'image', title: 'Image', icon: ImageIcon},
+        {
+          type: 'reference',
+          name: 'authorReference',
+          to: {type: 'author'},
+          title: 'Reference to author',
+        },
+        {
+          type: 'reference',
+          name: 'bookReference',
+          to: {type: 'book'},
+          title: 'Reference to book',
+        },
+        {
+          type: 'object',
+          name: 'objectWithNestedArray',
+          title: 'An object with nested array',
+          fields: [
+            {
+              name: 'title',
+              type: 'string',
+            },
+            {
+              name: 'array',
+              type: 'array',
+              of: [
+                {
+                  type: 'object',
+                  fields: [
+                    {type: 'string', name: 'title'},
+                    {type: 'reference', name: 'author', to: [{type: 'author'}]},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {type: 'author', title: 'Embedded author'},
+        {type: 'code', title: 'Code'},
+        // {
+        //   type: 'color',
+        //   name: 'colorBlock',
+        //   title: 'Color (block)',
+        //   icon: DropIcon,
+        // },
+        {
+          type: 'object',
+          title: 'Test object',
+          name: 'testObject',
+          fields: [{name: 'field1', type: 'string'}],
+        },
+        {
+          type: 'object',
+          title: 'Other test object',
+          name: 'otherTestObject',
+          fields: [
+            {name: 'field1', type: 'string'},
+            {
+              name: 'field3',
+              type: 'array',
+              of: [
+                {
+                  type: 'object',
+                  fields: [
+                    {name: 'aString', type: 'string'},
+                    {name: 'aNumber', type: 'number'},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        // {
+        //   type: 'block',
+        //   of: [
+        //     {
+        //       type: 'color',
+        //       title: 'Color',
+        //     },
+        //   ],
+        // },
+        {
+          type: 'spotifyEmbed',
+          name: 'spotifyEmbed',
+          title: 'Spotify embed',
+        },
+      ],
+    },
+    {
+      name: 'nestedWithDualColumnCTA',
+      title: 'Nested, with dual column CTA',
+      type: 'array',
+      of: [
+        {
+          name: 'localeRichtext',
+          type: 'object',
+          fields: [
+            {
+              title: 'English',
+              name: 'en',
+              type: 'array',
+              of: [
+                {type: 'block'},
+                {type: 'image'},
+                {
+                  name: 'twoColCTA',
+                  type: 'object',
+                  title: 'Two Column CTA',
+                  description: 'Inserts two content blocks.',
+                  fields: [
+                    {
+                      name: 'columnone',
+                      title: 'Column One',
+                      type: 'array',
+                      of: [{type: 'richTextObject'}],
+                    },
+                    {
+                      name: 'columntwo',
+                      title: 'Column Two',
+                      type: 'array',
+                      of: [{type: 'richTextObject'}],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'readOnlyWithDefaults',
+      title: 'Read only with defaults',
+      description: 'This is read only',
+      type: 'array',
+      readOnly: true,
+      of: [
+        {type: 'image', title: 'Image'},
+        {
+          type: 'reference',
+          name: 'authorReference',
+          to: {type: 'author'},
+          title: 'Reference to author',
+        },
+        {
+          type: 'reference',
+          name: 'bookReference',
+          to: {type: 'book'},
+          title: 'Reference to book',
+        },
+        {type: 'author', title: 'Embedded author'},
+        {type: 'code', title: 'Code'},
+        // {
+        //   type: 'color',
+        //   name: 'colorBlock',
+        //   title: 'Color (block)',
+        // },
+        {
+          type: 'object',
+          title: 'Test object',
+          name: 'testObject',
+          fields: [{name: 'field1', type: 'string'}],
+        },
+        {
+          type: 'object',
+          title: 'Other test object',
+          name: 'otherTestObject',
+          fields: [
+            {name: 'field1', type: 'string'},
+            {
+              name: 'field3',
+              type: 'array',
+              of: [
+                {
+                  type: 'object',
+                  fields: [
+                    {name: 'aString', type: 'string'},
+                    {name: 'aNumber', type: 'number'},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        // {
+        //   type: 'block',
+        //   of: [
+        //     {
+        //       type: 'color',
+        //       title: 'Color',
+        //     },
+        //   ],
+        // },
+      ],
+    },
+    {
+      name: 'minimal',
+      title: 'Reset all options',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [],
+          lists: [],
+          marks: {
+            decorators: [],
+            annotations: [],
+          },
+        },
+      ],
+    },
+    {
+      name: 'reproCH9436',
+      title: 'Images',
+      type: 'array',
+      description: 'Repro case for https://app.clubhouse.io/sanity-io/story/9436/',
+      of: [
+        {type: 'block'},
+        {
+          name: 'imageWithPortableTextCaption',
+          type: 'image',
+          fields: [
+            {
+              name: 'caption',
+              title: 'Caption',
+              type: 'array',
+              description:
+                'The amount of toolbar buttons here should not affect the width of the PTE input or the width of the dialog which contains it',
+              options: {isHighlighted: true},
+              of: [
+                {
+                  title: 'Block',
+                  type: 'block',
+                  marks: {
+                    decorators: [
+                      // the number of decorators here will currently force the width of the PTE input
+                      // to be wider than the dialog, which again makes the dialog content overflow
+                      {title: 'Strong', value: 'strong'},
+                      {title: 'Emphasis', value: 'em'},
+                      {title: 'Underline', value: 'underline'},
+                      {title: 'Strikethrough', value: 'strikethrough'},
+                      {title: 'Superscript', value: 'superscript'},
+                      {title: 'Subscript', value: 'subscript'},
+                      {title: 'Left', value: 'alignleft'},
+                      {title: 'Center', value: 'aligncenter'},
+                      {title: 'Right', value: 'alignright'},
+                      {title: 'Justify', value: 'alignjustify'},
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'customized',
+      title: 'Customized with block types',
+      type: 'array',
+      of: [
+        {type: 'author', title: 'Author'},
+        {
+          type: 'block',
+          styles: [
+            {title: 'Normal', value: 'normal'},
+            {title: 'H1', value: 'h1'},
+            {title: 'H2', value: 'h2'},
+            {title: 'Quote', value: 'blockquote'},
+          ],
+          lists: [
+            {title: 'Bullet', value: 'bullet'},
+            {title: 'Numbered', value: 'number'},
+          ],
+          marks: {
+            decorators: [
+              {title: 'Strong', value: 'strong'},
+              {title: 'Emphasis', value: 'em'},
+              {title: 'Decorator with custom icon', value: 'color', icon: DropIcon},
+            ],
+            annotations: [
+              {
+                name: 'Author',
+                title: 'Author',
+                type: 'reference',
+                to: {type: 'author'},
+              },
+              {
+                title: 'Annotation with custom icon',
+                name: 'test',
+                type: 'object',
+                icon: DropIcon,
+                fields: [
+                  {
+                    name: 'testString',
+                    type: 'string',
+                  },
+                ],
+              },
+            ],
+          },
+          of: [
+            {
+              type: 'image',
+              title: 'Image',
+              fields: [
+                {title: 'Caption', name: 'caption', type: 'string', options: {isHighlighted: true}},
+                {
+                  title: 'Authors',
+                  name: 'authors',
+                  type: 'array',
+                  options: {isHighlighted: true},
+                  of: [{type: 'author', title: 'Author'}],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'withGeopoint',
+      title: 'With geopoints',
+      type: 'array',
+      of: [{type: 'block'}, {type: 'geopoint'}],
+    },
+    {
+      name: 'deep',
+      title: 'Blocks deep down',
+      type: 'object',
+      fields: [
+        {name: 'something', title: 'Something', type: 'string'},
+        {
+          name: 'blocks',
+          type: 'array',
+          title: 'Blocks',
+          of: [
+            {type: 'image', title: 'Image'},
+            {type: 'author', title: 'Author'},
+            {
+              type: 'block',
+              styles: [
+                {title: 'Normal', value: 'normal'},
+                {title: 'H1', value: 'h1'},
+                {title: 'H2', value: 'h2'},
+                {title: 'Quote', value: 'blockquote'},
+              ],
+              lists: [
+                {title: 'Bullet', value: 'bullet'},
+                {title: 'Numbered', value: 'number'},
+              ],
+              marks: {
+                decorators: [
+                  {title: 'Strong', value: 'strong'},
+                  {title: 'Emphasis', value: 'em'},
+                ],
+                annotations: [
+                  {name: 'Author', title: 'Author', type: 'reference', to: {type: 'author'}},
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Array of articles',
+      name: 'arrayOfArticles',
+      type: 'array',
+      of: [
+        {
+          type: 'blocksTest',
+        },
+      ],
+    },
+    {
+      title: 'Block in block',
+      name: 'blockInBlock',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          of: [
+            {
+              name: 'footnote',
+              title: 'Footnote',
+              type: 'object',
+              fields: [
+                {
+                  title: 'Footnote',
+                  name: 'footnote',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'block',
+                      lists: [],
+                      styles: [],
+                      marks: {
+                        decorators: [
+                          {title: 'Strong', value: 'strong'},
+                          {title: 'Emphasis', value: 'em'},
+                        ],
+                        annotations: [],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'recursive',
+      type: 'object',
+      fields: [
+        {
+          name: 'blocks',
+          type: 'array',
+          title: 'Blocks',
+          of: [
+            {
+              type: 'block',
+              styles: [],
+              lists: [],
+              marks: {
+                decorators: [],
+                annotations: [],
+              },
+            },
+            {
+              type: 'blocksTest',
+              title: 'Blocks test!',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'blockList',
+      title: 'Array of blocks',
+      type: 'array',
+      of: [
+        {
+          name: 'blockListEntry',
+          type: 'object',
+          fields: [
+            {
+              name: 'title',
+              title: 'Title',
+              type: 'string',
+            },
+            {
+              name: 'blocks',
+              type: 'array',
+              of: [{type: 'block'}],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/packages/@sanity/schema/test/extractSchema/fixtures/block.ts
+++ b/packages/@sanity/schema/test/extractSchema/fixtures/block.ts
@@ -132,11 +132,6 @@ export default {
         },
         {type: 'author', title: 'Embedded author'},
         {type: 'code', title: 'Code'},
-        // {
-        //   type: 'color',
-        //   name: 'colorBlock',
-        //   title: 'Color (block)',
-        // },
         {
           type: 'object',
           title: 'Test object',
@@ -164,15 +159,6 @@ export default {
             },
           ],
         },
-        // {
-        //   type: 'block',
-        //   of: [
-        //     {
-        //       type: 'color',
-        //       title: 'Color',
-        //     },
-        //   ],
-        // },
       ],
     },
     {

--- a/packages/@sanity/schema/test/extractSchema/fixtures/block.ts
+++ b/packages/@sanity/schema/test/extractSchema/fixtures/block.ts
@@ -19,7 +19,7 @@ const linkType = {
 }
 
 export default {
-  name: 'blocks',
+  name: 'blocksTest',
   title: 'Blocks test',
   type: 'object',
   icon: ComposeIcon,
@@ -87,18 +87,6 @@ export default {
         },
         {type: 'author', title: 'Embedded author'},
         {type: 'code', title: 'Code'},
-        // {
-        //   type: 'color',
-        //   name: 'colorBlock',
-        //   title: 'Color (block)',
-        //   icon: DropIcon,
-        // },
-        {
-          type: 'object',
-          title: 'Test object',
-          name: 'testObject',
-          fields: [{name: 'field1', type: 'string'}],
-        },
         {
           type: 'object',
           title: 'Other test object',
@@ -114,62 +102,6 @@ export default {
                   fields: [
                     {name: 'aString', type: 'string'},
                     {name: 'aNumber', type: 'number'},
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-        // {
-        //   type: 'block',
-        //   of: [
-        //     {
-        //       type: 'color',
-        //       title: 'Color',
-        //     },
-        //   ],
-        // },
-        {
-          type: 'spotifyEmbed',
-          name: 'spotifyEmbed',
-          title: 'Spotify embed',
-        },
-      ],
-    },
-    {
-      name: 'nestedWithDualColumnCTA',
-      title: 'Nested, with dual column CTA',
-      type: 'array',
-      of: [
-        {
-          name: 'localeRichtext',
-          type: 'object',
-          fields: [
-            {
-              title: 'English',
-              name: 'en',
-              type: 'array',
-              of: [
-                {type: 'block'},
-                {type: 'image'},
-                {
-                  name: 'twoColCTA',
-                  type: 'object',
-                  title: 'Two Column CTA',
-                  description: 'Inserts two content blocks.',
-                  fields: [
-                    {
-                      name: 'columnone',
-                      title: 'Column One',
-                      type: 'array',
-                      of: [{type: 'richTextObject'}],
-                    },
-                    {
-                      name: 'columntwo',
-                      title: 'Column Two',
-                      type: 'array',
-                      of: [{type: 'richTextObject'}],
-                    },
                   ],
                 },
               ],

--- a/packages/@sanity/schema/test/extractSchema/fixtures/fileAsset.ts
+++ b/packages/@sanity/schema/test/extractSchema/fixtures/fileAsset.ts
@@ -1,0 +1,103 @@
+export default {
+  name: 'sanity.fileAsset',
+  title: 'File',
+  type: 'document',
+  fieldsets: [
+    {
+      name: 'system',
+      title: 'System fields',
+      description: 'These fields are managed by the system and not editable',
+    },
+  ],
+  fields: [
+    {
+      name: 'originalFilename',
+      type: 'string',
+      title: 'Original file name',
+      readOnly: true,
+    },
+    {
+      name: 'label',
+      type: 'string',
+      title: 'Label',
+    },
+    {
+      name: 'title',
+      type: 'string',
+      title: 'Title',
+    },
+    {
+      name: 'description',
+      type: 'string',
+      title: 'Description',
+    },
+    {
+      name: 'altText',
+      type: 'string',
+      title: 'Alternative text',
+    },
+    {
+      name: 'sha1hash',
+      type: 'string',
+      title: 'SHA1 hash',
+      readOnly: true,
+      fieldset: 'system',
+    },
+    {
+      name: 'extension',
+      type: 'string',
+      title: 'File extension',
+      readOnly: true,
+      fieldset: 'system',
+    },
+    {
+      name: 'mimeType',
+      type: 'string',
+      title: 'Mime type',
+      readOnly: true,
+      fieldset: 'system',
+    },
+    {
+      name: 'size',
+      type: 'number',
+      title: 'File size in bytes',
+      readOnly: true,
+      fieldset: 'system',
+    },
+    {
+      name: 'assetId',
+      type: 'string',
+      title: 'Asset ID',
+      readOnly: true,
+      fieldset: 'system',
+    },
+    {
+      name: 'uploadId',
+      type: 'string',
+      readOnly: true,
+      hidden: true,
+      fieldset: 'system',
+    },
+    {
+      name: 'path',
+      type: 'string',
+      title: 'Path',
+      readOnly: true,
+      fieldset: 'system',
+    },
+    {
+      name: 'url',
+      type: 'string',
+      title: 'Url',
+      readOnly: true,
+      fieldset: 'system',
+    },
+    {
+      name: 'source',
+      type: 'sanity.assetSourceData',
+      title: 'Source',
+      readOnly: true,
+      fieldset: 'system',
+    },
+  ],
+}

--- a/packages/@sanity/schema/test/extractSchema/fixtures/geopoint.ts
+++ b/packages/@sanity/schema/test/extractSchema/fixtures/geopoint.ts
@@ -1,0 +1,22 @@
+export default {
+  title: 'Geographical Point',
+  name: 'geopoint',
+  type: 'object',
+  fields: [
+    {
+      name: 'lat',
+      type: 'number',
+      title: 'Latitude',
+    },
+    {
+      name: 'lng',
+      type: 'number',
+      title: 'Longitude',
+    },
+    {
+      name: 'alt',
+      type: 'number',
+      title: 'Altitude',
+    },
+  ],
+}

--- a/packages/@sanity/schema/test/extractSchema/fixtures/imageAsset.ts
+++ b/packages/@sanity/schema/test/extractSchema/fixtures/imageAsset.ts
@@ -1,0 +1,108 @@
+export default {
+  name: 'sanity.imageAsset',
+  title: 'Image',
+  type: 'document',
+  fieldsets: [
+    {
+      name: 'system',
+      title: 'System fields',
+      description: 'These fields are managed by the system and not editable',
+    },
+  ],
+  fields: [
+    {
+      name: 'originalFilename',
+      type: 'string',
+      title: 'Original file name',
+      readOnly: true,
+    },
+    {
+      name: 'label',
+      type: 'string',
+      title: 'Label',
+    },
+    {
+      name: 'title',
+      type: 'string',
+      title: 'Title',
+    },
+    {
+      name: 'description',
+      type: 'string',
+      title: 'Description',
+    },
+    {
+      name: 'altText',
+      type: 'string',
+      title: 'Alternative text',
+    },
+    {
+      name: 'sha1hash',
+      type: 'string',
+      title: 'SHA1 hash',
+      readOnly: true,
+      fieldset: 'system',
+    },
+    {
+      name: 'extension',
+      type: 'string',
+      readOnly: true,
+      title: 'File extension',
+      fieldset: 'system',
+    },
+    {
+      name: 'mimeType',
+      type: 'string',
+      readOnly: true,
+      title: 'Mime type',
+      fieldset: 'system',
+    },
+    {
+      name: 'size',
+      type: 'number',
+      title: 'File size in bytes',
+      readOnly: true,
+      fieldset: 'system',
+    },
+    {
+      name: 'assetId',
+      type: 'string',
+      title: 'Asset ID',
+      readOnly: true,
+      fieldset: 'system',
+    },
+    {
+      name: 'uploadId',
+      type: 'string',
+      readOnly: true,
+      hidden: true,
+      fieldset: 'system',
+    },
+    {
+      name: 'path',
+      type: 'string',
+      title: 'Path',
+      readOnly: true,
+      fieldset: 'system',
+    },
+    {
+      name: 'url',
+      type: 'string',
+      title: 'Url',
+      readOnly: true,
+      fieldset: 'system',
+    },
+    {
+      name: 'metadata',
+      type: 'sanity.imageMetadata',
+      title: 'Metadata',
+    },
+    {
+      name: 'source',
+      type: 'sanity.assetSourceData',
+      title: 'Source',
+      readOnly: true,
+      fieldset: 'system',
+    },
+  ],
+}

--- a/packages/@sanity/schema/test/extractSchema/fixtures/imageCrop.ts
+++ b/packages/@sanity/schema/test/extractSchema/fixtures/imageCrop.ts
@@ -1,0 +1,23 @@
+export default {
+  name: 'sanity.imageCrop',
+  title: 'Image crop',
+  type: 'object',
+  fields: [
+    {
+      name: 'top',
+      type: 'number',
+    },
+    {
+      name: 'bottom',
+      type: 'number',
+    },
+    {
+      name: 'left',
+      type: 'number',
+    },
+    {
+      name: 'right',
+      type: 'number',
+    },
+  ],
+}

--- a/packages/@sanity/schema/test/extractSchema/fixtures/imageDimensions.ts
+++ b/packages/@sanity/schema/test/extractSchema/fixtures/imageDimensions.ts
@@ -1,0 +1,10 @@
+export default {
+  name: 'sanity.imageDimensions',
+  type: 'object',
+  title: 'Image dimensions',
+  fields: [
+    {name: 'height', type: 'number', title: 'Height', readOnly: true},
+    {name: 'width', type: 'number', title: 'Width', readOnly: true},
+    {name: 'aspectRatio', type: 'number', title: 'Aspect ratio', readOnly: true},
+  ],
+}

--- a/packages/@sanity/schema/test/extractSchema/fixtures/imageHotspot.ts
+++ b/packages/@sanity/schema/test/extractSchema/fixtures/imageHotspot.ts
@@ -1,0 +1,23 @@
+export default {
+  name: 'sanity.imageHotspot',
+  title: 'Image hotspot',
+  type: 'object',
+  fields: [
+    {
+      name: 'x',
+      type: 'number',
+    },
+    {
+      name: 'y',
+      type: 'number',
+    },
+    {
+      name: 'height',
+      type: 'number',
+    },
+    {
+      name: 'width',
+      type: 'number',
+    },
+  ],
+}

--- a/packages/@sanity/schema/test/extractSchema/fixtures/imageMetadata.ts
+++ b/packages/@sanity/schema/test/extractSchema/fixtures/imageMetadata.ts
@@ -1,0 +1,56 @@
+export default {
+  name: 'sanity.imageMetadata',
+  title: 'Image metadata',
+  type: 'object',
+  fieldsets: [
+    {
+      name: 'extra',
+      title: 'Extra metadata…',
+      options: {
+        collapsable: true,
+      },
+    },
+  ],
+  fields: [
+    {
+      name: 'location',
+      type: 'geopoint',
+    },
+    {
+      name: 'dimensions',
+      title: 'Dimensions',
+      type: 'sanity.imageDimensions',
+      fieldset: 'extra',
+    },
+    {
+      name: 'palette',
+      type: 'sanity.imagePalette',
+      title: 'Palette',
+      fieldset: 'extra',
+    },
+    {
+      name: 'lqip',
+      title: 'LQIP (Low-Quality Image Placeholder)',
+      type: 'string',
+      readOnly: true,
+    },
+    {
+      name: 'blurHash',
+      title: 'BlurHash',
+      type: 'string',
+      readOnly: true,
+    },
+    {
+      name: 'hasAlpha',
+      title: 'Has alpha channel',
+      type: 'boolean',
+      readOnly: true,
+    },
+    {
+      name: 'isOpaque',
+      title: 'Is opaque',
+      type: 'boolean',
+      readOnly: true,
+    },
+  ],
+}

--- a/packages/@sanity/schema/test/extractSchema/fixtures/imagePalette.ts
+++ b/packages/@sanity/schema/test/extractSchema/fixtures/imagePalette.ts
@@ -1,0 +1,14 @@
+export default {
+  name: 'sanity.imagePalette',
+  title: 'Image palette',
+  type: 'object',
+  fields: [
+    {name: 'darkMuted', type: 'sanity.imagePaletteSwatch', title: 'Dark Muted'},
+    {name: 'lightVibrant', type: 'sanity.imagePaletteSwatch', title: 'Light Vibrant'},
+    {name: 'darkVibrant', type: 'sanity.imagePaletteSwatch', title: 'Dark Vibrant'},
+    {name: 'vibrant', type: 'sanity.imagePaletteSwatch', title: 'Vibrant'},
+    {name: 'dominant', type: 'sanity.imagePaletteSwatch', title: 'Dominant'},
+    {name: 'lightMuted', type: 'sanity.imagePaletteSwatch', title: 'Light Muted'},
+    {name: 'muted', type: 'sanity.imagePaletteSwatch', title: 'Muted'},
+  ],
+}

--- a/packages/@sanity/schema/test/extractSchema/fixtures/imagePaletteSwatch.ts
+++ b/packages/@sanity/schema/test/extractSchema/fixtures/imagePaletteSwatch.ts
@@ -1,0 +1,11 @@
+export default {
+  name: 'sanity.imagePaletteSwatch',
+  title: 'Image palette swatch',
+  type: 'object',
+  fields: [
+    {name: 'background', type: 'string', title: 'Background', readOnly: true},
+    {name: 'foreground', type: 'string', title: 'Foreground', readOnly: true},
+    {name: 'population', type: 'number', title: 'Population', readOnly: true},
+    {name: 'title', type: 'string', title: 'String', readOnly: true},
+  ],
+}

--- a/packages/@sanity/schema/test/extractSchema/fixtures/slug.ts
+++ b/packages/@sanity/schema/test/extractSchema/fixtures/slug.ts
@@ -1,0 +1,20 @@
+export default {
+  title: 'Slug',
+  name: 'slug',
+  type: 'object',
+  fields: [
+    {
+      name: 'current',
+      title: 'Current slug',
+      type: 'string',
+    },
+    {
+      // The source field is deprecated/unused, but leaving it included and hidden
+      // to prevent rendering "Unknown field" warnings on legacy data
+      name: 'source',
+      title: 'Source field',
+      type: 'string',
+      hidden: true,
+    },
+  ],
+}

--- a/packages/sanity/package.config.ts
+++ b/packages/sanity/package.config.ts
@@ -39,6 +39,11 @@ export default defineConfig({
       require: './lib/_internal/cli/threads/validateSchema.js',
       default: './lib/_internal/cli/threads/validateSchema.js',
     },
+    './_internal/cli/threads/extractSchema': {
+      source: './src/_internal/cli/threads/extractSchema.ts',
+      require: './lib/_internal/cli/threads/extractSchema.js',
+      default: './lib/_internal/cli/threads/extractSchema.js',
+    },
   }),
 
   extract: {

--- a/packages/sanity/src/_internal/cli/actions/schema/extractAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/schema/extractAction.ts
@@ -1,0 +1,71 @@
+import {writeFile} from 'node:fs/promises'
+import {dirname, join} from 'node:path'
+import {Worker} from 'node:worker_threads'
+
+import {type CliCommandArguments, type CliCommandContext} from '@sanity/cli'
+import readPkgUp from 'read-pkg-up'
+
+import {
+  type ExtractSchemaWorkerData,
+  type ExtractSchemaWorkerResult,
+} from '../../threads/extractSchema'
+
+interface ExtractFlags {
+  workspace?: string
+  path?: string
+  'enforce-required-fields'?: boolean
+}
+
+export type SchemaValidationFormatter = (result: ExtractSchemaWorkerResult) => string
+
+export default async function extractAction(
+  args: CliCommandArguments<ExtractFlags>,
+  {workDir, output}: CliCommandContext,
+): Promise<void> {
+  const flags = args.extOptions
+
+  const rootPkgPath = readPkgUp.sync({cwd: __dirname})?.path
+  if (!rootPkgPath) {
+    throw new Error('Could not find root directory for `sanity` package')
+  }
+
+  const workerPath = join(
+    dirname(rootPkgPath),
+    'lib',
+    '_internal',
+    'cli',
+    'threads',
+    'extractSchema.js',
+  )
+
+  const spinner = output
+    .spinner({})
+    .start(
+      flags['enforce-required-fields']
+        ? 'Extracting schema, with enforced required fields'
+        : 'Extracting schema',
+    )
+
+  const worker = new Worker(workerPath, {
+    workerData: {
+      workDir,
+      workspaceName: flags.workspace,
+      enforceRequiredFields: flags['enforce-required-fields'],
+    } satisfies ExtractSchemaWorkerData,
+    // eslint-disable-next-line no-process-env
+    env: process.env,
+  })
+
+  const {schema} = await new Promise<ExtractSchemaWorkerResult>((resolve, reject) => {
+    worker.addListener('message', resolve)
+    worker.addListener('error', reject)
+  })
+
+  const path = flags.path || join(process.cwd(), 'schema.json')
+
+  spinner.text = `Writing schema to ${path}`
+
+  await writeFile(path, JSON.stringify(schema, null, 2))
+
+  spinner.succeed('Extracted schema')
+}

--- a/packages/sanity/src/_internal/cli/actions/schema/extractAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/schema/extractAction.ts
@@ -14,6 +14,7 @@ interface ExtractFlags {
   workspace?: string
   path?: string
   'enforce-required-fields'?: boolean
+  format?: 'groq-type-nodes' | string
 }
 
 export type SchemaValidationFormatter = (result: ExtractSchemaWorkerResult) => string
@@ -23,6 +24,7 @@ export default async function extractAction(
   {workDir, output}: CliCommandContext,
 ): Promise<void> {
   const flags = args.extOptions
+  const formatFlat = flags.format || 'groq-type-nodes'
 
   const rootPkgPath = readPkgUp.sync({cwd: __dirname})?.path
   if (!rootPkgPath) {
@@ -51,6 +53,7 @@ export default async function extractAction(
       workDir,
       workspaceName: flags.workspace,
       enforceRequiredFields: flags['enforce-required-fields'],
+      format: formatFlat,
     } satisfies ExtractSchemaWorkerData,
     // eslint-disable-next-line no-process-env
     env: process.env,

--- a/packages/sanity/src/_internal/cli/commands/index.ts
+++ b/packages/sanity/src/_internal/cli/commands/index.ts
@@ -46,6 +46,7 @@ import listMigrationsCommand from './migration/listMigrationsCommand'
 import migrationGroup from './migration/migrationGroup'
 import runMigrationCommand from './migration/runMigrationCommand'
 import previewCommand from './preview/previewCommand'
+import extractSchemaCommand from './schema/extractSchemaCommand'
 import schemaGroup from './schema/schemaGroup'
 import validateSchemaCommand from './schema/validateSchemaCommand'
 import startCommand from './start/startCommand'
@@ -105,6 +106,7 @@ const commands: (CliCommandDefinition | CliCommandGroupDefinition)[] = [
   startCommand,
   schemaGroup,
   validateSchemaCommand,
+  extractSchemaCommand,
   previewCommand,
   uninstallCommand,
   execCommand,

--- a/packages/sanity/src/_internal/cli/commands/schema/extractSchemaCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/schema/extractSchemaCommand.ts
@@ -1,0 +1,32 @@
+import {type CliCommandDefinition} from '@sanity/cli'
+
+const description = 'Extracts a JSON representation of a Sanity schema within a Studio context.'
+
+const helpText = `
+**Note**: This command is experimental and subject to change.
+
+Options
+  --workspace <name> The name of the workspace to generate a schema for
+  --path Optional path to specify destination of the schema file
+  --enforce-required-fields Makes the schema generated treat fields marked as required as non-optional. Defaults to false.
+
+Examples
+  # Extracts schema types in a Sanity project with more than one workspace
+  sanity schema extract --workspace default
+`
+
+const extractSchemaCommand: CliCommandDefinition = {
+  name: 'extract',
+  group: 'schema',
+  signature: '',
+  description,
+  helpText,
+  hideFromHelp: true,
+  action: async (args, context) => {
+    const mod = await import('../../actions/schema/extractAction')
+
+    return mod.default(args, context)
+  },
+} satisfies CliCommandDefinition
+
+export default extractSchemaCommand

--- a/packages/sanity/src/_internal/cli/commands/schema/extractSchemaCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/schema/extractSchemaCommand.ts
@@ -9,6 +9,7 @@ Options
   --workspace <name> The name of the workspace to generate a schema for
   --path Optional path to specify destination of the schema file
   --enforce-required-fields Makes the schema generated treat fields marked as required as non-optional. Defaults to false.
+  --format=[groq-type-nodes] Format the schema as GROQ type nodes. Only available format at the moment.
 
 Examples
   # Extracts schema types in a Sanity project with more than one workspace

--- a/packages/sanity/src/_internal/cli/threads/extractSchema.ts
+++ b/packages/sanity/src/_internal/cli/threads/extractSchema.ts
@@ -10,6 +10,7 @@ export interface ExtractSchemaWorkerData {
   workDir: string
   workspaceName?: string
   enforceRequiredFields?: boolean
+  format: 'groq-type-nodes' | string
 }
 
 export interface ExtractSchemaWorkerResult {
@@ -25,13 +26,15 @@ const cleanup = mockBrowserEnvironment(opts.workDir)
 
 async function main() {
   try {
+    if (opts.format !== 'groq-type-nodes') {
+      throw new Error(`Unsupported format: "${opts.format}"`)
+    }
+
     const workspaces = await getStudioWorkspaces({basePath: opts.workDir})
 
     const workspace = getWorkspace({workspaces, workspaceName: opts.workspaceName})
 
-    const {types} = workspace.schema._original || {types: []}
-
-    const schema = extractSchema(types, {
+    const schema = extractSchema(workspace.schema, {
       enforceRequiredFields: opts.enforceRequiredFields,
     })
 

--- a/packages/sanity/src/_internal/cli/threads/extractSchema.ts
+++ b/packages/sanity/src/_internal/cli/threads/extractSchema.ts
@@ -1,0 +1,73 @@
+import {isMainThread, parentPort, workerData as _workerData} from 'node:worker_threads'
+
+import {extractSchema} from '@sanity/schema/_internal'
+import {type Workspace} from 'sanity'
+
+import {getStudioWorkspaces} from '../util/getStudioWorkspaces'
+import {mockBrowserEnvironment} from '../util/mockBrowserEnvironment'
+
+export interface ExtractSchemaWorkerData {
+  workDir: string
+  workspaceName?: string
+  enforceRequiredFields?: boolean
+}
+
+export interface ExtractSchemaWorkerResult {
+  schema: ReturnType<typeof extractSchema>
+}
+
+if (isMainThread || !parentPort) {
+  throw new Error('This module must be run as a worker thread')
+}
+
+const opts = _workerData as ExtractSchemaWorkerData
+const cleanup = mockBrowserEnvironment(opts.workDir)
+
+async function main() {
+  try {
+    const workspaces = await getStudioWorkspaces({basePath: opts.workDir})
+
+    const workspace = getWorkspace({workspaces, workspaceName: opts.workspaceName})
+
+    const {types} = workspace.schema._original || {types: []}
+
+    const schema = extractSchema(types, {
+      enforceRequiredFields: opts.enforceRequiredFields,
+    })
+
+    parentPort?.postMessage({
+      schema,
+    } satisfies ExtractSchemaWorkerResult)
+  } finally {
+    cleanup()
+  }
+}
+
+main()
+
+function getWorkspace({
+  workspaces,
+  workspaceName,
+}: {
+  workspaces: Workspace[]
+  workspaceName?: string
+}): Workspace {
+  if (workspaces.length === 0) {
+    throw new Error('No studio configuration found')
+  }
+
+  if (workspaces.length === 1) {
+    return workspaces[0]
+  }
+
+  if (workspaceName === undefined) {
+    throw new Error(
+      `Multiple workspaces found. Please specify which workspace to use with '--workspace'.`,
+    )
+  }
+  const workspace = workspaces.find((w) => w.name === workspaceName)
+  if (!workspace) {
+    throw new Error(`Could not find workspace "${workspaceName}"`)
+  }
+  return workspace
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1175,6 +1175,9 @@ importers:
       arrify:
         specifier: ^1.0.1
         version: 1.0.1
+      groq-js:
+        specifier: 1.5.0-canary.1
+        version: 1.5.0-canary.1
       humanize-list:
         specifier: ^1.0.1
         version: 1.0.1
@@ -1191,6 +1194,9 @@ importers:
       '@jest/globals':
         specifier: ^29.7.0
         version: 29.7.0
+      '@sanity/icons':
+        specifier: ^2.8.0
+        version: 2.11.2(react@18.2.0)
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -11492,6 +11498,15 @@ packages:
   /groq-js@1.4.3:
     resolution: {integrity: sha512-h2vFXJ/U5VX9bzlqqZLgx/XS0ibNJza4eMxUjZTqkpe3gKafFIJSkMP0RS/XEQR18gJMjXAJNziWdY7JYYfl7w==}
     engines: {node: '>= 14'}
+
+  /groq-js@1.5.0-canary.1:
+    resolution: {integrity: sha512-p3eqvL0mYS9bzCgpQT4IGs32MCDyyWOU7ilpr7UR4k7AedXYNtd/ha9UpszP6i2VrAXCfmJ63zvvTut6JCKgSQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      debug: 4.3.4(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /groq@3.32.0:
     resolution: {integrity: sha512-yK3XQapMcXFP4QyVAF/ceRAwfkKbJJFaDt1y4GBxhJ6tDp/9I8bPkDPv/h016CvegOsaUDy68VKGF/LpGX7b+g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1176,7 +1176,7 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       groq-js:
-        specifier: 1.5.0-canary.1
+        specifier: ^1.5.0-canary.1
         version: 1.5.0-canary.1
       humanize-list:
         specifier: ^1.0.1


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds a new command that can be executed within a sanity context to extract a JSON representation of the studios schema. This makes it easier for other tools(TM) to consume it without depending on browser environments etc. I tried to base most of the logic on `sanity schema validate` to keep consistency in the repo/package.


### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Correctness: Do we parse the schema correctly? 
Naming things: It's hard! Can we name the command line argument or flags differently?
Note that we consider this feature **beta**, anything more than in the help text it should be indicated?

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

```
$ pnpm build
$ sanity schema extract # somewhere there's a sanity.config.ts
```

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Beta: Extract sanity schema as JSON, to be consumed by other tools
