### PR TITLE
fix: add missing project reference

### DIFF
--- a/packages/@sanity/codegen/tsconfig.json
+++ b/packages/@sanity/codegen/tsconfig.json
@@ -8,5 +8,8 @@
     "outDir": "./lib/dts",
     "declarationDir": "./lib/dts",
   },
-  "references": [{"path": "../../@sanity/types/tsconfig.lib.json"}],
+  "references": [
+    {"path": "../../@sanity/types/tsconfig.lib.json"},
+    {"path": "../../groq/tsconfig.lib.json"},
+  ],
 }

--- a/packages/@sanity/codegen/tsconfig.lib.json
+++ b/packages/@sanity/codegen/tsconfig.lib.json
@@ -7,5 +7,9 @@
     "rootDir": ".",
     "outDir": "./lib/dts",
     "declarationDir": "./lib/dts"
-  }
+  },
+  "references": [
+    {"path": "../../@sanity/types/tsconfig.lib.json"},
+    {"path": "../../groq/tsconfig.lib.json"}
+  ]
 }

--- a/packages/sanity/tsconfig.json
+++ b/packages/sanity/tsconfig.json
@@ -42,6 +42,7 @@
     {"path": "../@sanity/types/tsconfig.lib.json"},
     {"path": "../@sanity/cli/tsconfig.lib.json"},
     {"path": "../@sanity/util/tsconfig.lib.json"},
-    {"path": "../@sanity/migrate/tsconfig.lib.json"}
-  ]
+    {"path": "../@sanity/migrate/tsconfig.lib.json"},
+    {"path": "../groq/tsconfig.lib.json"}
+  ],
 }

--- a/packages/sanity/tsconfig.lib.json
+++ b/packages/sanity/tsconfig.lib.json
@@ -41,6 +41,7 @@
     {"path": "../@sanity/types/tsconfig.lib.json"},
     {"path": "../@sanity/cli/tsconfig.lib.json"},
     {"path": "../@sanity/util/tsconfig.lib.json"},
-    {"path": "../@sanity/migrate/tsconfig.lib.json"}
+    {"path": "../@sanity/migrate/tsconfig.lib.json"},
+    {"path": "../groq/tsconfig.lib.json"}
   ]
 }


### PR DESCRIPTION
### Description

This repo is using [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) which lets us to run `tsc --build` from source files, and have TypeScript build the packages in topological order (e.g. start by building the packages that's depended on by other packages). Unfortunately TS isn't workspace aware, so the workspace dependencies needs to be explicitly declared as references in `tsconfig.json`. This PR adds them where they are needed.

### Testing
The type check should now pass on CI.

### Notes for release
n/a