### PR TITLE
test(sanity): use dev aliases in the validation test's worker threads

### DIFF
--- a/dev/aliases.cjs
+++ b/dev/aliases.cjs
@@ -18,6 +18,7 @@ const devAliases = {
   // because they will be escaped by the jest config
   '@sanity/block-tools': './packages/@sanity/block-tools/src',
   '@sanity/diff': './packages/@sanity/diff/src',
+  '@sanity/cli': './packages/@sanity/cli/src',
   '@sanity/mutator': './packages/@sanity/mutator/src',
   '@sanity/portable-text-editor': './packages/@sanity/portable-text-editor/src',
   '@sanity/schema': './packages/@sanity/schema/src/_exports',

--- a/packages/sanity/src/_internal/cli/threads/__tests__/validateDocuments.test.ts
+++ b/packages/sanity/src/_internal/cli/threads/__tests__/validateDocuments.test.ts
@@ -2,8 +2,10 @@ import {afterAll, beforeAll, describe, expect, it, jest} from '@jest/globals'
 import {type SanityDocument, type SanityProject} from '@sanity/client'
 import {evaluate, parse} from 'groq-js'
 import {createServer, type Server} from 'http'
+import path from 'path'
 import {Worker} from 'worker_threads'
 
+import {getAliases} from '../../server/aliases'
 import {createReceiver, type WorkerChannelReceiver} from '../../util/workerChannels'
 import {type ValidateDocumentsWorkerData, type ValidationWorkerChannel} from '../validateDocuments'
 
@@ -198,7 +200,10 @@ describe('validateDocuments', () => {
 
     const worker = new Worker(
       `
+        const moduleAlias = require('module-alias')
         const { register } = require('esbuild-register/dist/node')
+
+        moduleAlias.addAliases(${JSON.stringify(getAliases({monorepo: {path: path.resolve(__dirname, '../../../../../../..')}}))})
 
         const { unregister } = register({
           target: 'node18',


### PR DESCRIPTION
### Description

This registers dev resolve aliases in the validation worker thread when running the tests.

This allows us to run the test suite directly from source, without first having to build, which means we can skip the build step entirely before running unit tests on CI. See [this comment](https://github.com/sanity-io/sanity/pull/5920#discussion_r1515201182) for more context.


### What to review
Does it make sense?

### Testing
n/a

### Notes for release
n/a internal