### PR TITLE
fix(comments): lost comment message while document is reconnecting

### DIFF
--- a/packages/sanity/src/structure/comments/plugin/document-layout/CommentsDocumentLayout.tsx
+++ b/packages/sanity/src/structure/comments/plugin/document-layout/CommentsDocumentLayout.tsx
@@ -4,6 +4,7 @@ import {type DocumentLayoutProps} from 'sanity'
 import {useDocumentPane} from '../../..'
 import {COMMENTS_INSPECTOR_NAME} from '../../../panes/document/constants'
 import {
+  CommentsAuthoringPathProvider,
   CommentsEnabledProvider,
   CommentsProvider,
   CommentsSelectedPathProvider,
@@ -43,7 +44,9 @@ function CommentsDocumentLayoutInner(props: DocumentLayoutProps) {
       isCommentsOpen={inspector?.name === COMMENTS_INSPECTOR_NAME}
       onCommentsOpen={handleOpenCommentsInspector}
     >
-      <CommentsSelectedPathProvider>{props.renderDefault(props)}</CommentsSelectedPathProvider>
+      <CommentsSelectedPathProvider>
+        <CommentsAuthoringPathProvider>{props.renderDefault(props)}</CommentsAuthoringPathProvider>
+      </CommentsSelectedPathProvider>
     </CommentsProvider>
   )
 }

--- a/packages/sanity/src/structure/comments/plugin/field/CommentsFieldButton.tsx
+++ b/packages/sanity/src/structure/comments/plugin/field/CommentsFieldButton.tsx
@@ -39,11 +39,11 @@ interface CommentsFieldButtonProps {
   mentionOptions: UserListWithPermissionsHookValue
   onChange: (value: PortableTextBlock[]) => void
   onClick?: () => void
+  onClose: () => void
   onCommentAdd: () => void
   onDiscard: () => void
   onInputKeyDown?: (event: React.KeyboardEvent<Element>) => void
   open: boolean
-  setOpen: (open: boolean) => void
   value: CommentMessage
 }
 
@@ -56,11 +56,11 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
     mentionOptions,
     onChange,
     onClick,
+    onClose,
     onCommentAdd,
     onDiscard,
     onInputKeyDown,
     open,
-    setOpen,
     value,
   } = props
   const {t} = useTranslation(commentsLocaleNamespace)
@@ -73,9 +73,9 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
 
   const closePopover = useCallback(() => {
     if (!open) return
-    setOpen(false)
+    onClose()
     addCommentButtonElement?.focus()
-  }, [addCommentButtonElement, open, setOpen])
+  }, [addCommentButtonElement, open, onClose])
 
   const handleSubmit = useCallback(() => {
     onCommentAdd()

--- a/packages/sanity/src/structure/comments/src/context/authoring-path/CommentsAuthoringPathContext.ts
+++ b/packages/sanity/src/structure/comments/src/context/authoring-path/CommentsAuthoringPathContext.ts
@@ -1,0 +1,11 @@
+import {createContext} from 'react'
+
+import {type CommentsAuthoringPathContextValue} from './types'
+
+/**
+ * @beta
+ * @hidden
+ */
+export const CommentsAuthoringPathContext = createContext<CommentsAuthoringPathContextValue | null>(
+  null,
+)

--- a/packages/sanity/src/structure/comments/src/context/authoring-path/CommentsAuthoringPathProvider.tsx
+++ b/packages/sanity/src/structure/comments/src/context/authoring-path/CommentsAuthoringPathProvider.tsx
@@ -1,0 +1,41 @@
+import {type ReactNode, useCallback, useMemo, useState} from 'react'
+
+import {CommentsAuthoringPathContext} from './CommentsAuthoringPathContext'
+import {type CommentsAuthoringPathContextValue} from './types'
+
+interface CommentsAuthoringPathProviderProps {
+  children: ReactNode
+}
+
+/**
+ * @beta
+ * @hidden
+ * This provider keeps track of the path that the user is currently authoring a comment for.
+ * This is needed to make sure that we consistently keep the editor open when the user is
+ * authoring a comment. The state is kept in a context to make sure that it is preserved
+ * across re-renders. If this state was kept in a component, it would be reset every time
+ * the component re-renders, for example, when the form is temporarily set to `readOnly`
+ * while reconnecting.
+ */
+export function CommentsAuthoringPathProvider(props: CommentsAuthoringPathProviderProps) {
+  const {children} = props
+  const [authoringPath, setAuthoringPath] = useState<string | null>(null)
+
+  const handleSetAuthoringPath = useCallback((nextAuthoringPath: string | null) => {
+    setAuthoringPath(nextAuthoringPath)
+  }, [])
+
+  const value = useMemo(
+    (): CommentsAuthoringPathContextValue => ({
+      authoringPath,
+      setAuthoringPath: handleSetAuthoringPath,
+    }),
+    [authoringPath, handleSetAuthoringPath],
+  )
+
+  return (
+    <CommentsAuthoringPathContext.Provider value={value}>
+      {children}
+    </CommentsAuthoringPathContext.Provider>
+  )
+}

--- a/packages/sanity/src/structure/comments/src/context/authoring-path/index.ts
+++ b/packages/sanity/src/structure/comments/src/context/authoring-path/index.ts
@@ -1,0 +1,3 @@
+export * from './CommentsAuthoringPathContext'
+export * from './CommentsAuthoringPathProvider'
+export * from './types'

--- a/packages/sanity/src/structure/comments/src/context/authoring-path/types.ts
+++ b/packages/sanity/src/structure/comments/src/context/authoring-path/types.ts
@@ -1,0 +1,8 @@
+/**
+ * @beta
+ * @hidden
+ */
+export interface CommentsAuthoringPathContextValue {
+  setAuthoringPath: (nextAuthoringPath: string | null) => void
+  authoringPath: string | null
+}

--- a/packages/sanity/src/structure/comments/src/context/index.ts
+++ b/packages/sanity/src/structure/comments/src/context/index.ts
@@ -1,3 +1,4 @@
+export * from './authoring-path'
 export * from './comments'
 export * from './enabled'
 export * from './intent'

--- a/packages/sanity/src/structure/comments/src/hooks/index.ts
+++ b/packages/sanity/src/structure/comments/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './use-comment-operations'
 export * from './useComments'
+export * from './useCommentsAuthoringPath'
 export * from './useCommentsEnabled'
 export * from './useCommentsIntent'
 export * from './useCommentsOnboarding'

--- a/packages/sanity/src/structure/comments/src/hooks/useCommentsAuthoringPath.ts
+++ b/packages/sanity/src/structure/comments/src/hooks/useCommentsAuthoringPath.ts
@@ -1,0 +1,17 @@
+import {useContext} from 'react'
+
+import {CommentsAuthoringPathContext, type CommentsAuthoringPathContextValue} from '../context'
+
+/**
+ * @beta
+ * @hidden
+ */
+export function useCommentsAuthoringPath(): CommentsAuthoringPathContextValue {
+  const value = useContext(CommentsAuthoringPathContext)
+
+  if (!value) {
+    throw new Error('useCommentsAuthoringPath: missing context value')
+  }
+
+  return value
+}


### PR DESCRIPTION
### Description

This pull request addresses an issue where the comment input unmounts during document reconnection, leading to the loss of the comment being authored. To resolve this, the following solutions have been implemented:
- Introduction of a new `CommentsAuthoringPathContext`. This context is needed because if the "open state" of the comment input is managed locally within the component, the state resets when unmounting. By tracking the user's current authoring path in a context, it ensures the comment input remains open even when the component is re-rendered.
- Caching the message to make sure that it is not lost when re-rendering. Unlike the "authoring path", the comment message is not stored in a context to avoid potential performance degradation, as this would require all consumers to re-render whenever a comment is being authored.

### What to Review

Ensure that the comment input remains open during form reconnection and that the comment being authored is not lost. While working to debug this issue, I changed the `useConnectionState` hook to toggle between the "connected" and "reconnecting" states using a `setTimeout`, as shown below:

```ts
export function useConnectionState(publishedDocId: string, docTypeName: string): ConnectionState {
  const [state, setState] = useState<ConnectionState>(INITIAL)

  useEffect(() => {
    setTimeout(() => {
      setState('reconnecting')

      setTimeout(() => {
        setState('connected')
      }, 5000)
    }, 5000)
  }, [])

  return state
}

```

### Notes for release

N/A