### PR TITLE
fix(core): remove prev and next month buttons in calendar input

### DIFF
--- a/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/Calendar.tsx
@@ -203,10 +203,6 @@ export const Calendar = forwardRef(function Calendar(
           <Box flex={1}>
             <CalendarMonthSelect
               onChange={handleFocusedMonthChange}
-              labels={{
-                goToPreviousMonth: labels.goToPreviousMonth,
-                goToNextMonth: labels.goToNextMonth,
-              }}
               monthNames={labels.monthNames}
               value={focusedDate?.getMonth()}
             />
@@ -335,12 +331,8 @@ function CalendarMonthSelect(props: {
   onChange: (e: FormEvent<HTMLSelectElement>) => void
   value?: number
   monthNames: MonthNames
-  labels: {
-    goToPreviousMonth: string
-    goToNextMonth: string
-  }
 }) {
-  const {onChange, value, labels, monthNames} = props
+  const {onChange, value, monthNames} = props
 
   return (
     <Flex flex={1} gap={1}>

--- a/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/Calendar.tsx
@@ -202,7 +202,6 @@ export const Calendar = forwardRef(function Calendar(
         <Flex>
           <Box flex={1}>
             <CalendarMonthSelect
-              moveFocusedDate={moveFocusedDate}
               onChange={handleFocusedMonthChange}
               labels={{
                 goToPreviousMonth: labels.goToPreviousMonth,
@@ -333,7 +332,6 @@ function CalendarTimePresetButton(props: {
 }
 
 function CalendarMonthSelect(props: {
-  moveFocusedDate: (by: number) => void
   onChange: (e: FormEvent<HTMLSelectElement>) => void
   value?: number
   monthNames: MonthNames
@@ -342,25 +340,10 @@ function CalendarMonthSelect(props: {
     goToNextMonth: string
   }
 }) {
-  const {moveFocusedDate, onChange, value, labels, monthNames} = props
-
-  const handlePrevMonthClick = useCallback(() => moveFocusedDate(-1), [moveFocusedDate])
-
-  const handleNextMonthClick = useCallback(() => moveFocusedDate(1), [moveFocusedDate])
+  const {onChange, value, labels, monthNames} = props
 
   return (
     <Flex flex={1} gap={1}>
-      <Button
-        aria-label={labels.goToPreviousMonth}
-        onClick={handlePrevMonthClick}
-        mode="bleed"
-        icon={ChevronLeftIcon}
-        tooltipProps={{content: 'Previous month'}}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore - Button with specific styling requirements
-        {...CALENDAR_ICON_BUTTON_PROPS}
-      />
-
       <Box flex={1}>
         <Select fontSize={1} radius={2} value={value} onChange={onChange} padding={2}>
           {monthNames.map((monthName, i) => (
@@ -371,16 +354,6 @@ function CalendarMonthSelect(props: {
           ))}
         </Select>
       </Box>
-      <Button
-        aria-label={labels.goToNextMonth}
-        mode="bleed"
-        icon={ChevronRightIcon}
-        onClick={handleNextMonthClick}
-        tooltipProps={{content: 'Next month'}}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore - Button with specific styling requirements
-        {...CALENDAR_ICON_BUTTON_PROPS}
-      />
     </Flex>
   )
 }


### PR DESCRIPTION
### Description

Fixes EDX-1124
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Removes the previous and next buttons on the month for the calendar input

Before:
<img width="372" alt="image" src="https://github.com/sanity-io/sanity/assets/6889008/d248bf3c-9ea8-4ad0-ba81-b7bb9fd8449c">

After:

<img width="378" alt="image" src="https://github.com/sanity-io/sanity/assets/6889008/3f1185e8-9420-49f7-afea-03ab99fcbb0b">

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->
Anything I missed?

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
Code deletion, no test changes

