### PR TITLE
feat(core): redirect to previous path after login

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/types.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/types.ts
@@ -78,7 +78,16 @@ export interface AuthState {
  * @beta
  * @hidden
  */
-export interface LoginComponentProps {
-  projectId: string
-  basePath: string
-}
+export type LoginComponentProps =
+  | {
+      projectId: string
+      /** @deprecated use redirectPath instead */
+      basePath: string
+      redirectPath?: string
+    }
+  | {
+      projectId: string
+      redirectPath: string
+      /** @deprecated use redirectPath instead */
+      basePath?: string
+    }

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
@@ -1,6 +1,5 @@
 import {AddIcon, ArrowLeftIcon, ChevronRightIcon} from '@sanity/icons'
 import {Box, Card, Flex, Stack} from '@sanity/ui'
-import {omit} from 'lodash'
 import {useCallback, useState} from 'react'
 
 import {Button} from '../../../../../../ui-components'
@@ -58,7 +57,14 @@ export function WorkspaceAuth() {
         >
           <Stack padding={2} paddingBottom={3} paddingTop={4}>
             <LoginComponent
-              {...omit(selectedWorkspace, ['type', '__internal'])}
+              projectId={selectedWorkspace.projectId}
+              redirectPath={
+                window.location.pathname.startsWith(selectedWorkspace.basePath)
+                  ? // NOTE: the fragment cannot be preserved because it's used
+                    // to transfer an sid to a token
+                    `${window.location.pathname}${window.location.search}`
+                  : selectedWorkspace.basePath
+              }
               key={selectedWorkspaceName}
             />
           </Stack>


### PR DESCRIPTION
### Description

The following PR updates the `origin` parameter of our login to include the current path so that after the user logs in, they should be redirected to the path they were trying to get to instead of having to click the link again.

https://github.com/sanity-io/sanity/assets/10551026/8605fcb6-9767-44b0-802f-0a1340178822

### What to review

Ensure that the code works and does what is expected. Ensure there are no breaking changes to the API as well (I deprecated a key).

### Testing

See the video.

### Notes for release

- Resolves an issue where users were not redirected to their original destination after re-authenticating, ensuring seamless access to linked content within the Studio.