### PR TITLE
feat(core): add groups to document actions, introduce paneActions group

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -73,7 +73,17 @@ const config = {
       {
         ignores: {
           componentPatterns: ['motion$'],
-          attributes: ['animate', 'closed', 'exit', 'fill', 'full', 'initial', 'size', 'sortOrder'],
+          attributes: [
+            'animate',
+            'closed',
+            'exit',
+            'fill',
+            'full',
+            'initial',
+            'size',
+            'sortOrder',
+            'group',
+          ],
         },
       },
     ],

--- a/packages/sanity/src/core/components/hookCollection/GetHookCollectionState.tsx
+++ b/packages/sanity/src/core/components/hookCollection/GetHookCollectionState.tsx
@@ -9,10 +9,16 @@ import {type ActionHook} from './types'
 
 /** @internal */
 export interface GetHookCollectionStateProps<T, K> {
+  /**
+   * Arguments that will be received by the action hooks, `onComplete` will be added by the HookStateContainer component.
+   */
   args: T
   children: (props: {states: K[]}) => ReactNode
-  hooks: ActionHook<T, K>[]
+  hooks: ActionHook<T & {onComplete: () => void}, K>[]
   onReset?: () => void
+  /**
+   * Name for the hook group. If provided, only hooks with the same group name will be included in the collection.
+   */
   group?: string
 }
 

--- a/packages/sanity/src/core/config/document/actions.ts
+++ b/packages/sanity/src/core/config/document/actions.ts
@@ -118,6 +118,11 @@ export type DocumentActionDialogProps =
 /**
  * @hidden
  * @beta */
+export type DocumentActionGroup = 'default' | 'paneActions'
+
+/**
+ * @hidden
+ * @beta */
 export interface DocumentActionDescription {
   tone?: ButtonTone
   dialog?: DocumentActionDialogProps | false | null
@@ -127,4 +132,8 @@ export interface DocumentActionDescription {
   onHandle?: () => void
   shortcut?: string | null
   title?: ReactNode
+  /**
+   * @beta
+   */
+  group?: DocumentActionGroup[]
 }

--- a/packages/sanity/src/structure/components/RenderActionCollectionState.tsx
+++ b/packages/sanity/src/structure/components/RenderActionCollectionState.tsx
@@ -1,6 +1,7 @@
 import type * as React from 'react'
 import {
   type DocumentActionDescription,
+  type DocumentActionGroup,
   type DocumentActionProps,
   GetHookCollectionState,
 } from 'sanity'
@@ -16,14 +17,20 @@ export interface RenderActionCollectionProps {
   actionProps: DocumentActionProps
   children: (props: {states: DocumentActionDescription[]}) => React.ReactNode
   onActionComplete?: () => void
+  group?: DocumentActionGroup
 }
 
 /** @internal */
 export const RenderActionCollectionState = (props: RenderActionCollectionProps) => {
-  const {actions, children, actionProps, onActionComplete} = props
+  const {actions, children, actionProps, onActionComplete, group} = props
 
   return (
-    <GetHookCollectionState onReset={onActionComplete} hooks={actions} args={actionProps}>
+    <GetHookCollectionState
+      onReset={onActionComplete}
+      hooks={actions}
+      args={actionProps}
+      group={group}
+    >
       {children}
     </GetHookCollectionState>
   )

--- a/packages/sanity/src/structure/components/RenderActionCollectionState.tsx
+++ b/packages/sanity/src/structure/components/RenderActionCollectionState.tsx
@@ -14,7 +14,7 @@ export interface Action<Args, Description> {
 /** @internal */
 export interface RenderActionCollectionProps {
   actions: Action<DocumentActionProps, DocumentActionDescription>[]
-  actionProps: DocumentActionProps
+  actionProps: Omit<DocumentActionProps, 'onComplete'>
   children: (props: {states: DocumentActionDescription[]}) => React.ReactNode
   onActionComplete?: () => void
   group?: DocumentActionGroup

--- a/packages/sanity/src/structure/components/pane/PaneContextMenuButton.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneContextMenuButton.tsx
@@ -1,5 +1,5 @@
-import {Menu} from '@sanity/ui'
-import {useId} from 'react'
+import {Menu, MenuDivider} from '@sanity/ui'
+import {type ReactNode, useId} from 'react'
 import {ContextMenuButton} from 'sanity'
 
 import {MenuButton, type PopoverProps} from '../../../ui-components'
@@ -8,6 +8,7 @@ import {type _PaneMenuItem, type _PaneMenuNode} from './types'
 
 interface PaneContextMenuButtonProps {
   nodes: _PaneMenuNode[]
+  actionsNodes?: ReactNode
 }
 
 const CONTEXT_MENU_POPOVER_PROPS: PopoverProps = {
@@ -31,7 +32,7 @@ function nodesHasTone(nodes: _PaneMenuNode[], tone: NonNullable<_PaneMenuItem['t
  * @beta This API will change. DO NOT USE IN PRODUCTION.
  */
 export function PaneContextMenuButton(props: PaneContextMenuButtonProps) {
-  const {nodes} = props
+  const {nodes, actionsNodes} = props
   const id = useId()
 
   const hasCritical = nodesHasTone(nodes, 'critical')
@@ -49,9 +50,14 @@ export function PaneContextMenuButton(props: PaneContextMenuButtonProps) {
       id={id}
       menu={
         <Menu>
+          {actionsNodes && (
+            <>
+              {actionsNodes}
+              <MenuDivider />
+            </>
+          )}
           {nodes.map((node, nodeIndex) => {
             const isAfterGroup = nodes[nodeIndex - 1]?.type === 'group'
-
             return <PaneMenuButtonItem isAfterGroup={isAfterGroup} key={node.key} node={node} />
           })}
         </Menu>

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -1,7 +1,7 @@
 import {ArrowLeftIcon, CloseIcon, SplitVerticalIcon} from '@sanity/icons'
 import {Flex} from '@sanity/ui'
 import type * as React from 'react'
-import {createElement, forwardRef, memo, useMemo} from 'react'
+import {createElement, forwardRef, memo, useMemo, useState} from 'react'
 import {useFieldActions, useTimelineSelector, useTranslation} from 'sanity'
 
 import {Button, TooltipDelayGroupProvider} from '../../../../../ui-components'
@@ -9,6 +9,7 @@ import {
   PaneContextMenuButton,
   PaneHeader,
   PaneHeaderActionButton,
+  RenderActionCollectionState,
   usePane,
   usePaneRouter,
 } from '../../../../components'
@@ -16,6 +17,7 @@ import {structureLocaleNamespace} from '../../../../i18n'
 import {isMenuNodeButton, isNotMenuNodeButton, resolveMenuNodes} from '../../../../menuNodes'
 import {type PaneMenuItem} from '../../../../types'
 import {useStructureTool} from '../../../../useStructureTool'
+import {ActionDialogWrapper, ActionMenuListItem} from '../../statusBar/ActionMenuButton'
 import {TimelineMenu} from '../../timeline'
 import {useDocumentPane} from '../../useDocumentPane'
 import {DocumentHeaderTabs} from './DocumentHeaderTabs'
@@ -33,6 +35,8 @@ export const DocumentPanelHeader = memo(
   ) {
     const {menuItems} = _props
     const {
+      actions,
+      editState,
       onMenuAction,
       onPaneClose,
       onPaneSplit,
@@ -46,6 +50,7 @@ export const DocumentPanelHeader = memo(
     const {features} = useStructureTool()
     const {index, BackLink, hasGroupSiblings} = usePaneRouter()
     const {actions: fieldActions} = useFieldActions()
+    const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null)
 
     const menuNodes = useMemo(
       () =>
@@ -130,8 +135,34 @@ export const DocumentPanelHeader = memo(
                 <PaneHeaderActionButton key={item.key} node={item} />
               ))}
 
-              <PaneContextMenuButton nodes={contextMenuNodes} key="context-menu" />
-
+              <RenderActionCollectionState
+                actions={actions || []}
+                // @ts-expect-error TODO: fix the document actions
+                actionProps={editState}
+                group="paneActions"
+              >
+                {({states}) => (
+                  <ActionDialogWrapper actionStates={states} referenceElement={referenceElement}>
+                    {({handleAction}) => (
+                      <div ref={setReferenceElement}>
+                        <PaneContextMenuButton
+                          nodes={contextMenuNodes}
+                          key="context-menu"
+                          actionsNodes={states?.map((actionState, actionIndex) => (
+                            <ActionMenuListItem
+                              key={actionState.label}
+                              actionState={actionState}
+                              disabled={Boolean(actionState.disabled)}
+                              index={actionIndex}
+                              onAction={handleAction}
+                            />
+                          ))}
+                        />
+                      </div>
+                    )}
+                  </ActionDialogWrapper>
+                )}
+              </RenderActionCollectionState>
               {showSplitPaneButton && (
                 <Button
                   aria-label={t('buttons.split-pane-button.aria-label')}

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -134,35 +134,36 @@ export const DocumentPanelHeader = memo(
               {menuButtonNodes.map((item) => (
                 <PaneHeaderActionButton key={item.key} node={item} />
               ))}
+              {editState && (
+                <RenderActionCollectionState
+                  actions={actions || []}
+                  actionProps={editState}
+                  group="paneActions"
+                >
+                  {({states}) => (
+                    <ActionDialogWrapper actionStates={states} referenceElement={referenceElement}>
+                      {({handleAction}) => (
+                        <div ref={setReferenceElement}>
+                          <PaneContextMenuButton
+                            nodes={contextMenuNodes}
+                            key="context-menu"
+                            actionsNodes={states?.map((actionState, actionIndex) => (
+                              <ActionMenuListItem
+                                key={actionState.label}
+                                actionState={actionState}
+                                disabled={Boolean(actionState.disabled)}
+                                index={actionIndex}
+                                onAction={handleAction}
+                              />
+                            ))}
+                          />
+                        </div>
+                      )}
+                    </ActionDialogWrapper>
+                  )}
+                </RenderActionCollectionState>
+              )}
 
-              <RenderActionCollectionState
-                actions={actions || []}
-                // @ts-expect-error TODO: fix the document actions
-                actionProps={editState}
-                group="paneActions"
-              >
-                {({states}) => (
-                  <ActionDialogWrapper actionStates={states} referenceElement={referenceElement}>
-                    {({handleAction}) => (
-                      <div ref={setReferenceElement}>
-                        <PaneContextMenuButton
-                          nodes={contextMenuNodes}
-                          key="context-menu"
-                          actionsNodes={states?.map((actionState, actionIndex) => (
-                            <ActionMenuListItem
-                              key={actionState.label}
-                              actionState={actionState}
-                              disabled={Boolean(actionState.disabled)}
-                              index={actionIndex}
-                              onAction={handleAction}
-                            />
-                          ))}
-                        />
-                      </div>
-                    )}
-                  </ActionDialogWrapper>
-                )}
-              </RenderActionCollectionState>
               {showSplitPaneButton && (
                 <Button
                   aria-label={t('buttons.split-pane-button.aria-label')}

--- a/packages/sanity/src/structure/panes/document/statusBar/ActionMenuButton.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/ActionMenuButton.tsx
@@ -1,5 +1,5 @@
 import {Menu} from '@sanity/ui'
-import {useCallback, useId, useMemo, useState} from 'react'
+import {type ReactNode, useCallback, useId, useMemo, useState} from 'react'
 import {
   ContextMenuButton,
   type DocumentActionDescription,
@@ -25,7 +25,7 @@ export function ActionDialogWrapper({
   referenceElement,
 }: {
   actionStates: DocumentActionDescription[]
-  children: ({handleAction}: {handleAction: (idx: number) => void}) => React.ReactNode
+  children: ({handleAction}: {handleAction: (idx: number) => void}) => ReactNode
   referenceElement?: HTMLElement | null
 }) {
   const [actionIndex, setActionIndex] = useState(-1)

--- a/packages/sanity/src/structure/panes/document/statusBar/ActionMenuButton.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/ActionMenuButton.tsx
@@ -16,15 +16,45 @@ export interface ActionMenuButtonProps {
   disabled: boolean
 }
 
-export function ActionMenuButton(props: ActionMenuButtonProps) {
-  const {actionStates, disabled} = props
-  const idPrefix = useId()
+/**
+ * @internal
+ */
+export function ActionDialogWrapper({
+  actionStates,
+  children,
+  referenceElement,
+}: {
+  actionStates: DocumentActionDescription[]
+  children: ({handleAction}: {handleAction: (idx: number) => void}) => React.ReactNode
+  referenceElement?: HTMLElement | null
+}) {
   const [actionIndex, setActionIndex] = useState(-1)
-  const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null)
+  const currentAction = actionStates[actionIndex]
 
   const handleAction = useCallback((idx: number) => {
     setActionIndex(idx)
   }, [])
+
+  return (
+    <>
+      {currentAction && currentAction.dialog && (
+        <LegacyLayerProvider zOffset="paneFooter">
+          <ActionStateDialog dialog={currentAction.dialog} referenceElement={referenceElement} />
+        </LegacyLayerProvider>
+      )}
+      {children({handleAction})}
+    </>
+  )
+}
+
+/**
+ * @internal
+ */
+export function ActionMenuButton(props: ActionMenuButtonProps) {
+  const {actionStates, disabled} = props
+  const idPrefix = useId()
+
+  const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null)
 
   const popoverProps: PopoverProps = useMemo(
     () => ({
@@ -35,46 +65,41 @@ export function ActionMenuButton(props: ActionMenuButtonProps) {
     [],
   )
 
-  const currentAction = actionStates[actionIndex]
   const {t} = useTranslation(structureLocaleNamespace)
 
   return (
-    <>
-      <MenuButton
-        id={`${idPrefix}-action-menu`}
-        button={
-          <ContextMenuButton
-            aria-label={t('buttons.action-menu-button.aria-label')}
-            disabled={disabled}
-            data-testid="action-menu-button"
-            size="large"
-            tooltipProps={{content: t('buttons.action-menu-button.tooltip')}}
-          />
-        }
-        menu={
-          <Menu padding={1}>
-            {actionStates.map((actionState, idx) => (
-              <ActionMenuListItem
-                actionState={actionState}
-                disabled={disabled}
-                index={idx}
-                // eslint-disable-next-line react/no-array-index-key
-                key={idx}
-                onAction={handleAction}
-              />
-            ))}
-          </Menu>
-        }
-        popover={popoverProps}
-        ref={setReferenceElement}
-      />
-
-      {currentAction && currentAction.dialog && (
-        <LegacyLayerProvider zOffset="paneFooter">
-          <ActionStateDialog dialog={currentAction.dialog} referenceElement={referenceElement} />
-        </LegacyLayerProvider>
+    <ActionDialogWrapper actionStates={actionStates} referenceElement={referenceElement}>
+      {({handleAction}) => (
+        <MenuButton
+          id={`${idPrefix}-action-menu`}
+          button={
+            <ContextMenuButton
+              aria-label={t('buttons.action-menu-button.aria-label')}
+              disabled={disabled}
+              data-testid="action-menu-button"
+              size="large"
+              tooltipProps={{content: t('buttons.action-menu-button.tooltip')}}
+            />
+          }
+          menu={
+            <Menu padding={1}>
+              {actionStates.map((actionState, idx) => (
+                <ActionMenuListItem
+                  actionState={actionState}
+                  disabled={disabled}
+                  index={idx}
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={idx}
+                  onAction={handleAction}
+                />
+              ))}
+            </Menu>
+          }
+          popover={popoverProps}
+          ref={setReferenceElement}
+        />
       )}
-    </>
+    </ActionDialogWrapper>
   )
 }
 
@@ -85,7 +110,7 @@ interface ActionMenuListItemProps {
   onAction: (idx: number) => void
 }
 
-function ActionMenuListItem(props: ActionMenuListItemProps) {
+export function ActionMenuListItem(props: ActionMenuListItemProps) {
   const {actionState, disabled, index, onAction} = props
   const {onHandle} = actionState
 

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -87,7 +87,6 @@ export const DocumentStatusBarActions = memo(function DocumentStatusBarActions()
       // component={}
       // onActionComplete={handleActionComplete}
       actions={actions}
-      // @ts-expect-error TODO: fix the document actions
       actionProps={editState}
       group="default"
     >

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -89,6 +89,7 @@ export const DocumentStatusBarActions = memo(function DocumentStatusBarActions()
       actions={actions}
       // @ts-expect-error TODO: fix the document actions
       actionProps={editState}
+      group="default"
     >
       {({states}) => (
         <DocumentStatusBarActionsInner
@@ -118,7 +119,11 @@ export const HistoryStatusBarActions = memo(function HistoryStatusBarActions() {
   const historyActions = useMemo(() => [HistoryRestoreAction], [])
 
   return (
-    <RenderActionCollectionState actions={historyActions} actionProps={actionProps as any}>
+    <RenderActionCollectionState
+      actions={historyActions}
+      actionProps={actionProps as any}
+      group="default"
+    >
       {({states}) => (
         <DocumentStatusBarActionsInner
           disabled={connectionState !== 'connected' || Boolean(disabled)}


### PR DESCRIPTION
### Description

Introduces `groups` into [DocumentActions](https://www.sanity.io/docs/document-actions-api) allowing plugin developers to add actions and decide where they want this actions to show:
- `default` will add the actions to the same position as before, in the footer right next to the publish button.
- `paneActions` will add the action in the context menu right next to the inspectors and other pane actions.

This is initially intended to support creating `tasks` from within a document. 

#### Example of usage

```
export function ConfirmDialogAction({onComplete}): DocumentActionDescription {
  const [dialogOpen, setDialogOpen] = useState(false)

  return {
    label: 'Show confirm',
    onHandle: () => {
      setDialogOpen(true)
    },
    group: ['paneActions'],
    dialog: dialogOpen && {
      type: 'confirm',
      onCancel: onComplete,
      onConfirm: () => {
        alert('You confirmed!')
        onComplete()
      },
      message: 'Please confirm!',
    },
  }
}

const plugin = definePlugin({
  ...,
  document: {
    actions: (prev) => [...prev, ConfirmDialogAction],
  }
})
```

<img width="800" alt="Screenshot 2024-03-08 at 10 30 23" src="https://github.com/sanity-io/sanity/assets/46196328/21043e74-3478-4df9-8a8a-1c1b4677d81a">


https://github.com/sanity-io/sanity/assets/46196328/3b508edd-9175-4108-b748-cbfd223cfed3


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is there other way to simplify this?
Are the changes in `GetHookCollectionState` correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Create an action from within a plugin, the action should render in the selected group.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Add support for groups in document actions.

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
