### PR TITLE
feat(comments): support task comments

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -73,7 +73,7 @@ const config = {
       {
         ignores: {
           componentPatterns: ['motion$'],
-          attributes: ['animate', 'closed', 'exit', 'fill', 'full', 'initial', 'size'],
+          attributes: ['animate', 'closed', 'exit', 'fill', 'full', 'initial', 'size', 'sortOrder'],
         },
       },
     ],

--- a/packages/sanity/src/structure/comments/plugin/document-layout/CommentsDocumentLayout.tsx
+++ b/packages/sanity/src/structure/comments/plugin/document-layout/CommentsDocumentLayout.tsx
@@ -43,6 +43,9 @@ function CommentsDocumentLayoutInner(props: DocumentLayoutProps) {
       documentType={documentType}
       isCommentsOpen={inspector?.name === COMMENTS_INSPECTOR_NAME}
       onCommentsOpen={handleOpenCommentsInspector}
+      // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
+      sortOrder="desc"
+      type="field"
     >
       <CommentsSelectedPathProvider>
         <CommentsAuthoringPathProvider>{props.renderDefault(props)}</CommentsAuthoringPathProvider>

--- a/packages/sanity/src/structure/comments/plugin/document-layout/CommentsDocumentLayout.tsx
+++ b/packages/sanity/src/structure/comments/plugin/document-layout/CommentsDocumentLayout.tsx
@@ -43,7 +43,6 @@ function CommentsDocumentLayoutInner(props: DocumentLayoutProps) {
       documentType={documentType}
       isCommentsOpen={inspector?.name === COMMENTS_INSPECTOR_NAME}
       onCommentsOpen={handleOpenCommentsInspector}
-      // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
       sortOrder="desc"
       type="field"
     >

--- a/packages/sanity/src/structure/comments/plugin/field/CommentsField.tsx
+++ b/packages/sanity/src/structure/comments/plugin/field/CommentsField.tsx
@@ -222,6 +222,7 @@ function CommentFieldInner(
 
       // Construct the comment payload
       const nextComment: CommentCreatePayload = {
+        type: 'field',
         fieldPath: PathUtils.toString(props.path),
         message: value,
         parentCommentId: undefined,

--- a/packages/sanity/src/structure/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/structure/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -134,6 +134,7 @@ export const CommentsPortableTextInputInner = React.memo(function CommentsPortab
     const threadId = uuid()
 
     operation.create({
+      type: 'field',
       contentSnapshot: fragment,
       fieldPath: stringFieldPath,
       message: nextCommentValue,
@@ -173,7 +174,7 @@ export const CommentsPortableTextInputInner = React.memo(function CommentsPortab
       if (!comment) return
 
       setSelectedPath({
-        fieldPath: comment.target.path.field,
+        fieldPath: comment.target.path?.field || '',
         threadId: comment.threadId,
         origin: 'form',
       })
@@ -276,7 +277,7 @@ export const CommentsPortableTextInputInner = React.memo(function CommentsPortab
 
       const nextValue: CommentsTextSelectionItem[] = updatedDecoration
         ? [
-            ...(comment.target.path.selection?.value
+            ...(comment.target.path?.selection?.value
               .filter((r) => r._key !== nextRange[0]?._key)
               .concat(nextRange)
               .flat() || EMPTY_ARRAY),
@@ -287,7 +288,8 @@ export const CommentsPortableTextInputInner = React.memo(function CommentsPortab
         target: {
           ...comment.target,
           path: {
-            ...comment.target.path,
+            ...(comment.target?.path || {}),
+            field: comment.target.path?.field || '',
             selection: {
               type: 'text',
               value: nextValue,

--- a/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspector.tsx
@@ -9,7 +9,7 @@ import {EMPTY_PARAMS} from '../../../constants'
 import {useDocumentPane} from '../../../panes/document/useDocumentPane'
 import {commentsLocaleNamespace} from '../../i18n'
 import {
-  type CommentCreatePayload,
+  type CommentBaseCreatePayload,
   CommentDeleteDialog,
   type CommentReactionOption,
   CommentsList,
@@ -163,7 +163,8 @@ function CommentsInspectorInner(
       if (!comment) return
 
       operation.create({
-        fieldPath: comment.target.path.field,
+        type: 'field',
+        fieldPath: comment.target.path?.field || '',
         id: comment._id,
         message: comment.message,
         parentCommentId: comment.parentCommentId,
@@ -204,28 +205,38 @@ function CommentsInspectorInner(
   )
 
   const handleNewThreadCreate = useCallback(
-    (payload: CommentCreatePayload) => {
-      operation.create(payload)
+    (nextComment: CommentBaseCreatePayload) => {
+      const fieldPath = nextComment?.payload?.fieldPath || ''
+
+      operation.create({
+        type: 'field',
+        fieldPath,
+        ...nextComment,
+      })
 
       setSelectedPath({
-        fieldPath: payload.fieldPath,
+        fieldPath,
         origin: 'inspector',
-        threadId: payload.threadId,
+        threadId: nextComment.threadId,
       })
     },
     [operation, setSelectedPath],
   )
 
   const handleReply = useCallback(
-    (payload: CommentCreatePayload) => {
-      operation.create(payload)
+    (nextComment: CommentBaseCreatePayload) => {
+      operation.create({
+        ...nextComment,
+        type: 'field',
+        fieldPath: nextComment?.payload?.fieldPath || '',
+      })
     },
     [operation],
   )
 
   const handleEdit = useCallback(
-    (id: string, payload: CommentUpdatePayload) => {
-      operation.update(id, payload)
+    (id: string, nextComment: CommentUpdatePayload) => {
+      operation.update(id, nextComment)
     },
     [operation],
   )
@@ -276,7 +287,7 @@ function CommentsInspectorInner(
         if (!comment) return
 
         setSelectedPath({
-          fieldPath: comment.target.path.field || null,
+          fieldPath: comment.target.path?.field || null,
           origin: 'inspector',
           threadId: comment.threadId || null,
         })
@@ -331,7 +342,7 @@ function CommentsInspectorInner(
       setStatus(commentToScrollTo.status || 'open')
 
       setSelectedPath({
-        fieldPath: commentToScrollTo.target.path.field || null,
+        fieldPath: commentToScrollTo.target.path?.field || null,
         origin: 'url',
         threadId: commentToScrollTo.threadId || null,
       })

--- a/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspector.tsx
@@ -211,7 +211,11 @@ function CommentsInspectorInner(
       operation.create({
         type: 'field',
         fieldPath,
-        ...nextComment,
+        message: nextComment.message,
+        parentCommentId: nextComment.parentCommentId,
+        reactions: nextComment.reactions,
+        status: nextComment.status,
+        threadId: nextComment.threadId,
       })
 
       setSelectedPath({

--- a/packages/sanity/src/structure/comments/src/__workshop__/CommentInlineHighlightDebugStory.tsx
+++ b/packages/sanity/src/structure/comments/src/__workshop__/CommentInlineHighlightDebugStory.tsx
@@ -135,6 +135,7 @@ export default function CommentInlineHighlightDebugStory() {
     // Build comment thread items here so that we can test the validation of each comment
     // since that is done in the `buildCommentThreadItems` function.
     return buildCommentThreadItems({
+      type: 'field',
       comments: commentDocuments,
       currentUser,
       schemaType: schema.get('article'),
@@ -186,7 +187,7 @@ export default function CommentInlineHighlightDebugStory() {
                         selection: {
                           type: 'text',
                           value: [
-                            ...(comment.target.path.selection?.value
+                            ...(comment.target.path?.selection?.value
                               .filter((r) => r._key !== range._key)
                               .concat(currentBlockKey ? {...range, _key: currentBlockKey} : [])
                               .flat() || []),

--- a/packages/sanity/src/structure/comments/src/__workshop__/CommentsListStory.tsx
+++ b/packages/sanity/src/structure/comments/src/__workshop__/CommentsListStory.tsx
@@ -7,7 +7,7 @@ import {useCurrentUser, useUserListWithPermissions} from 'sanity'
 
 import {CommentsList} from '../components'
 import {
-  type CommentCreatePayload,
+  type CommentBaseCreatePayload,
   type CommentDocument,
   type CommentReactionOption,
   type CommentStatus,
@@ -196,7 +196,7 @@ export default function CommentsListStory() {
   const mentionOptions = useUserListWithPermissions(MENTION_HOOK_OPTIONS)
 
   const handleReplySubmit = useCallback(
-    (payload: CommentCreatePayload) => {
+    (payload: CommentBaseCreatePayload) => {
       const reply: CommentDocument = {
         ...BASE,
         ...payload,
@@ -235,7 +235,7 @@ export default function CommentsListStory() {
   )
 
   const handleNewThreadCreate = useCallback(
-    (payload: CommentCreatePayload) => {
+    (payload: CommentBaseCreatePayload) => {
       const comment: CommentDocument = {
         ...BASE,
         ...payload,
@@ -356,6 +356,7 @@ export default function CommentsListStory() {
       currentUser,
       documentValue: {},
       schemaType: schema.get('article'),
+      type: 'field',
     })
 
     return items

--- a/packages/sanity/src/structure/comments/src/__workshop__/CommentsProviderStory.tsx
+++ b/packages/sanity/src/structure/comments/src/__workshop__/CommentsProviderStory.tsx
@@ -25,7 +25,7 @@ export default function CommentsProviderStory() {
   return (
     <AddonDatasetProvider>
       <CommentsEnabledProvider documentType={_type} documentId={_id}>
-        <CommentsProvider documentType={_type} documentId={_id}>
+        <CommentsProvider documentType={_type} documentId={_id} type="field" sortOrder="desc">
           <ConditionalWrapper
             condition={_mode === 'upsell'}
             // eslint-disable-next-line react/jsx-no-bind
@@ -74,9 +74,15 @@ function Inner({mode}: {mode: CommentsUIMode}) {
       onCreateRetry={noop}
       onDelete={operation.remove}
       onEdit={operation.update}
-      onNewThreadCreate={operation.create}
+      // eslint-disable-next-line react/jsx-no-bind
+      onNewThreadCreate={(c) =>
+        operation.create({type: 'field', fieldPath: c.payload?.fieldPath || '', ...c})
+      }
       onReactionSelect={operation.react}
-      onReply={operation.create}
+      // eslint-disable-next-line react/jsx-no-bind
+      onReply={(c) =>
+        operation.create({type: 'field', fieldPath: c.payload?.fieldPath || '', ...c})
+      }
       selectedPath={null}
       status="open"
     />

--- a/packages/sanity/src/structure/comments/src/components/list/CommentThreadLayout.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentThreadLayout.tsx
@@ -14,7 +14,7 @@ import styled, {css} from 'styled-components'
 import {commentsLocaleNamespace} from '../../../i18n'
 import {type CommentsSelectedPath} from '../../context'
 import {
-  type CommentCreatePayload,
+  type CommentBaseCreatePayload,
   type CommentListBreadcrumbs,
   type CommentMessage,
   type CommentsUIMode,
@@ -47,7 +47,7 @@ interface CommentThreadLayoutProps {
   isSelected: boolean
   mentionOptions: UserListWithPermissionsHookValue
   mode: CommentsUIMode
-  onNewThreadCreate: (payload: CommentCreatePayload) => void
+  onNewThreadCreate: (payload: CommentBaseCreatePayload) => void
   onPathSelect?: (nextPath: CommentsSelectedPath) => void
   readOnly?: boolean
 }
@@ -71,8 +71,7 @@ export function CommentThreadLayout(props: CommentThreadLayoutProps) {
 
   const handleNewThreadCreate = useCallback(
     (payload: CommentMessage) => {
-      const nextComment: CommentCreatePayload = {
-        fieldPath,
+      const nextComment: CommentBaseCreatePayload = {
         message: payload,
         parentCommentId: undefined,
         status: 'open',
@@ -80,6 +79,10 @@ export function CommentThreadLayout(props: CommentThreadLayoutProps) {
         threadId: uuid(),
         // New comments have no reactions
         reactions: [],
+
+        payload: {
+          fieldPath,
+        },
       }
 
       onNewThreadCreate?.(nextComment)

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsList.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsList.tsx
@@ -6,7 +6,7 @@ import {type UserListWithPermissionsHookValue} from 'sanity'
 import {type CommentsSelectedPath} from '../../context'
 import {applyCommentsGroupAttr} from '../../hooks'
 import {
-  type CommentCreatePayload,
+  type CommentBaseCreatePayload,
   type CommentReactionOption,
   type CommentStatus,
   type CommentsUIMode,
@@ -51,10 +51,10 @@ export interface CommentsListProps {
   onCreateRetry: (id: string) => void
   onDelete: (id: string) => void
   onEdit: (id: string, payload: CommentUpdatePayload) => void
-  onNewThreadCreate: (payload: CommentCreatePayload) => void
+  onNewThreadCreate: (payload: CommentBaseCreatePayload) => void
   onPathSelect?: (nextPath: CommentsSelectedPath) => void
   onReactionSelect?: (id: string, reaction: CommentReactionOption) => void
-  onReply: (payload: CommentCreatePayload) => void
+  onReply: (payload: CommentBaseCreatePayload) => void
   onStatusChange?: (id: string, status: CommentStatus) => void
   readOnly?: boolean
   selectedPath: CommentsSelectedPath | null
@@ -185,7 +185,7 @@ const CommentsListInner = forwardRef(function CommentsListInner(
                       // selected path.
                       const threadIsSelected =
                         selectedPath?.threadId === item.parentComment.threadId &&
-                        selectedPath?.fieldPath === item.parentComment.target.path.field
+                        selectedPath?.fieldPath === item.parentComment.target.path?.field
 
                       return (
                         <CommentsListItem

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItem.tsx
@@ -11,7 +11,7 @@ import {type CommentsSelectedPath} from '../../context'
 import {commentIntentIfDiffers, hasCommentMessageValue} from '../../helpers'
 import {applyCommentIdAttr} from '../../hooks'
 import {
-  type CommentCreatePayload,
+  type CommentBaseCreatePayload,
   type CommentDocument,
   type CommentMessage,
   type CommentReactionOption,
@@ -88,7 +88,7 @@ interface CommentsListItemProps {
   onKeyDown?: (event: React.KeyboardEvent<Element>) => void
   onPathSelect?: (nextPath: CommentsSelectedPath) => void
   onReactionSelect?: (id: string, reaction: CommentReactionOption) => void
-  onReply: (payload: CommentCreatePayload) => void
+  onReply: (payload: CommentBaseCreatePayload) => void
   onStatusChange?: (id: string, status: CommentStatus) => void
   parentComment: CommentDocument
   readOnly?: boolean
@@ -132,8 +132,7 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
   const handleMouseLeave = useCallback(() => setMouseOver(false), [])
 
   const handleReplySubmit = useCallback(() => {
-    const nextComment: CommentCreatePayload = {
-      fieldPath: parentComment.target.path.field,
+    const nextComment: CommentBaseCreatePayload = {
       message: value,
       parentCommentId: parentComment._id,
       status: parentComment?.status || 'open',
@@ -141,6 +140,10 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
       threadId: parentComment.threadId,
       // A new comment will not have any reactions
       reactions: EMPTY_ARRAY,
+
+      payload: {
+        fieldPath: parentComment.target.path?.field || '',
+      },
     }
 
     onReply?.(nextComment)
@@ -149,7 +152,7 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
     onReply,
     parentComment._id,
     parentComment?.status,
-    parentComment.target.path.field,
+    parentComment.target.path?.field,
     parentComment.threadId,
     value,
   ])
@@ -198,12 +201,12 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
       if (!isTopLayer) return
 
       onPathSelect?.({
-        fieldPath: parentComment.target.path.field,
+        fieldPath: parentComment.target.path?.field || '',
         origin: 'inspector',
         threadId: parentComment.threadId,
       })
     },
-    [isTopLayer, onPathSelect, parentComment.target.path.field, parentComment.threadId],
+    [isTopLayer, onPathSelect, parentComment.target.path?.field, parentComment.threadId],
   )
 
   const handleExpand = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {

--- a/packages/sanity/src/structure/comments/src/store/useCommentsStore.ts
+++ b/packages/sanity/src/structure/comments/src/store/useCommentsStore.ts
@@ -33,11 +33,7 @@ const LISTEN_OPTIONS: ListenOptions = {
 export const SORT_FIELD = '_createdAt'
 export const SORT_ORDER = 'desc'
 
-const QUERY_FILTERS = [
-  `_type == "comment"`,
-  `target.document._ref == $documentId`,
-  `defined(target.path)`,
-]
+const QUERY_FILTERS = [`_type == "comment"`, `target.document._ref == $documentId`]
 
 const QUERY_PROJECTION = `{
   _createdAt,

--- a/packages/sanity/src/structure/comments/src/types.ts
+++ b/packages/sanity/src/structure/comments/src/types.ts
@@ -169,6 +169,12 @@ export interface CommentReactionItem {
 }
 
 /**
+ * @beta
+ * @hidden
+ */
+export type CommentsType = 'field' | 'task'
+
+/**
  * The state is used to track the state of the comment (e.g. if it failed to be created, etc.)
  * It is a local value and is not stored on the server.
  * When there's no state, the comment is considered to be in a "normal" state (e.g. created successfully).
@@ -204,17 +210,23 @@ export interface CommentDocument {
   contentSnapshot?: unknown
 
   target: {
-    path: CommentPath
+    path?: CommentPath
 
-    documentRevisionId: string
+    documentRevisionId?: string
     documentType: string
-    document: {
-      _dataset: string
-      _projectId: string
-      _ref: string
-      _type: 'crossDatasetReference'
-      _weak: boolean
-    }
+    document:
+      | {
+          _dataset: string
+          _projectId: string
+          _ref: string
+          _type: 'crossDatasetReference'
+          _weak: boolean
+        }
+      | {
+          _ref: string
+          _type: 'reference'
+          weak: boolean
+        }
   }
 }
 
@@ -228,20 +240,47 @@ export type CommentPostPayload = Omit<CommentDocument, '_rev' | '_updatedAt' | '
  * @beta
  * @hidden
  */
-export interface CommentCreatePayload {
+export interface CommentBaseCreatePayload {
+  id?: CommentDocument['_id']
+  message: CommentDocument['message']
+  parentCommentId: CommentDocument['parentCommentId']
+  reactions: CommentDocument['reactions']
+  status: CommentDocument['status']
+  threadId: CommentDocument['threadId']
+
+  payload?: {
+    fieldPath: string
+  }
+}
+
+/**
+ * @beta
+ * @hidden
+ */
+export interface CommentTaskCreatePayload extends CommentBaseCreatePayload {
+  // ...
+  type: 'task'
+}
+
+/**
+ * @beta
+ * @hidden
+ */
+export interface CommentFieldCreatePayload extends CommentBaseCreatePayload {
+  type: 'field'
   contentSnapshot?: CommentDocument['contentSnapshot']
   /**
    * The stringified path to the field where the comment was created.
    */
   fieldPath: string
-  id?: CommentDocument['_id']
-  message: CommentDocument['message']
-  parentCommentId: CommentDocument['parentCommentId']
-  reactions: CommentDocument['reactions']
   selection?: CommentPathSelection
-  status: CommentDocument['status']
-  threadId: CommentDocument['threadId']
 }
+
+/**
+ * @beta
+ * @hidden
+ */
+export type CommentCreatePayload = CommentTaskCreatePayload | CommentFieldCreatePayload
 
 /**
  * @beta

--- a/packages/sanity/src/structure/comments/src/utils/buildCommentThreadItems.ts
+++ b/packages/sanity/src/structure/comments/src/utils/buildCommentThreadItems.ts
@@ -2,7 +2,7 @@ import {type SanityDocument} from '@sanity/client'
 import {type CurrentUser, type SchemaType} from '@sanity/types'
 
 import {isTextSelectionComment} from '../helpers'
-import {type CommentDocument, type CommentThreadItem} from '../types'
+import {type CommentDocument, type CommentsType, type CommentThreadItem} from '../types'
 import {buildCommentBreadcrumbs} from './buildCommentBreadcrumbs'
 
 const EMPTY_ARRAY: [] = []
@@ -12,6 +12,7 @@ interface BuildCommentThreadItemsProps {
   currentUser: CurrentUser
   documentValue: Partial<SanityDocument> | null
   schemaType: SchemaType
+  type: CommentsType
 }
 
 /**
@@ -21,55 +22,85 @@ interface BuildCommentThreadItemsProps {
  * returned array.
  */
 export function buildCommentThreadItems(props: BuildCommentThreadItemsProps): CommentThreadItem[] {
-  const {comments, currentUser, documentValue, schemaType} = props
+  const {comments, currentUser, documentValue, schemaType, type} = props
   const parentComments = comments?.filter((c) => !c.parentCommentId)
 
-  const items = parentComments.map((parentComment) => {
-    const crumbs = buildCommentBreadcrumbs({
-      currentUser,
-      documentValue,
-      fieldPath: parentComment.target.path.field,
-      schemaType,
+  // If the comments are "task" comments, just group them together as thread items
+  // without any validation of the comments.
+  if (type === 'task') {
+    const taskCommentItems = parentComments.map((parentComment) => {
+      const replies = comments?.filter((r) => r.parentCommentId === parentComment._id)
+      const commentsCount = [parentComment, ...replies].length
+      const hasReferencedValue = false
+
+      const item: CommentThreadItem = {
+        commentsCount,
+        parentComment,
+        replies,
+        threadId: parentComment.threadId,
+        hasReferencedValue,
+        breadcrumbs: EMPTY_ARRAY,
+        fieldPath: '',
+      }
+
+      return item
     })
 
-    // NOTE: Keep this code commented out for now as we might want to use it later.
-    let hasTextSelection = false
+    return taskCommentItems
+  }
 
-    // If the comment is a text selection comment, we need to make sure that
-    // we can successfully build a range decoration selection from it.
-    if (isTextSelectionComment(parentComment)) {
-      hasTextSelection = Boolean(
-        parentComment.target.path.selection &&
-          parentComment.target.path.selection.value.some((v) => v.text),
-      )
-    }
+  // If the comments are "field" comments, we want to validate them against
+  // the document value and schema type.
+  if (type === 'field') {
+    const fieldCommentItems = parentComments.map((parentComment) => {
+      const crumbs = buildCommentBreadcrumbs({
+        currentUser,
+        documentValue,
+        fieldPath: parentComment.target.path?.field || '',
+        schemaType,
+      })
 
-    // Check if the comment has an invalid breadcrumb. The breadcrumbs can be invalid if:
-    // - The field is hidden by conditional fields
-    // - The field is not found in the schema type
-    // - The field is not found in the document value (array items only)
-    const hasInvalidBreadcrumb = crumbs.some((bc) => bc.invalid)
+      // NOTE: Keep this code commented out for now as we might want to use it later.
+      let hasTextSelection = false
 
-    // If the comment has an invalid breadcrumb or selection, we will omit it from the list.
-    if (hasInvalidBreadcrumb) return undefined
+      // If the comment is a text selection comment, we need to make sure that
+      // we can successfully build a range decoration selection from it.
+      if (isTextSelectionComment(parentComment)) {
+        hasTextSelection = Boolean(
+          parentComment.target.path?.selection &&
+            parentComment.target.path.selection.value.some((v) => v.text),
+        )
+      }
 
-    const replies = comments?.filter((r) => r.parentCommentId === parentComment._id)
-    const commentsCount = [parentComment, ...replies].length
-    const hasReferencedValue = hasTextSelection
+      // Check if the comment has an invalid breadcrumb. The breadcrumbs can be invalid if:
+      // - The field is hidden by conditional fields
+      // - The field is not found in the schema type
+      // - The field is not found in the document value (array items only)
+      const hasInvalidBreadcrumb = crumbs.some((bc) => bc.invalid)
 
-    const item: CommentThreadItem = {
-      breadcrumbs: crumbs,
-      commentsCount,
-      fieldPath: parentComment.target.path.field,
-      parentComment,
-      replies,
-      threadId: parentComment.threadId,
-      hasReferencedValue,
-    }
+      // If the comment has an invalid breadcrumb or selection, we will omit it from the list.
+      if (hasInvalidBreadcrumb) return undefined
 
-    return item
-  })
+      const replies = comments?.filter((r) => r.parentCommentId === parentComment._id)
+      const commentsCount = [parentComment, ...replies].length
+      const hasReferencedValue = hasTextSelection
 
-  // We use the `Boolean` function to filter out any `undefined` items from the array.
-  return items.filter(Boolean) as CommentThreadItem[]
+      const item: CommentThreadItem = {
+        breadcrumbs: crumbs,
+        commentsCount,
+        fieldPath: parentComment.target.path?.field || '',
+        parentComment,
+        replies,
+        threadId: parentComment.threadId,
+        hasReferencedValue,
+      }
+
+      return item
+    })
+
+    // We use the `Boolean` function to filter out any `undefined` items from the array.
+    return fieldCommentItems.filter(Boolean) as CommentThreadItem[]
+  }
+
+  return EMPTY_ARRAY
 }

--- a/packages/sanity/src/structure/comments/src/utils/inline-comments/buildRangeDecorationSelectionsFromComments.ts
+++ b/packages/sanity/src/structure/comments/src/utils/inline-comments/buildRangeDecorationSelectionsFromComments.ts
@@ -76,7 +76,7 @@ export function buildRangeDecorationSelectionsFromComments(
   const decorators: BuildCommentsRangeDecorationsResultItem[] = []
 
   textSelections.forEach((comment) => {
-    comment.target.path.selection?.value.forEach((selectionMember) => {
+    comment.target.path?.selection?.value.forEach((selectionMember) => {
       const matchedBlock = value.find((block) => block._key === selectionMember._key)
       if (!matchedBlock || !isPortableTextTextBlock(matchedBlock)) {
         return


### PR DESCRIPTION
### Description

This pull request introduces a `type` configuration to the comments feature (`"field" | "task"`) to enable the creation of comments in the upcoming Tasks feature. Additionally, the UI components have been made somewhat less tied to the field comments scenario by moving the previously required `fieldPath` value to an optional `payload` property. Although the UI components are still somewhat tied to the field comments scenario, this change is a step in the right direction towards making them more generic and adaptable to other contexts, such as when creating comments on tasks.

### What to review

- Make sure that field comments works as before

### Notes for release

N/A
