### PR TITLE
refactor(tasks): include tasks plugin via config flag

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -15,7 +15,6 @@ import {presentationTool} from 'sanity/presentation'
 import {structureTool} from 'sanity/structure'
 import {muxInput} from 'sanity-plugin-mux-input'
 
-import {tasks} from '../../packages/sanity/src/tasks'
 import {imageAssetSource} from './assetSources'
 import {
   Annotation,
@@ -197,11 +196,14 @@ export default defineConfig([
     subtitle: 'Staging dataset',
     projectId: 'exx11uqh',
     dataset: 'playground',
-    plugins: [tasks(), sharedSettings()],
+    plugins: [sharedSettings()],
     basePath: '/staging',
     apiHost: 'https://api.sanity.work',
     auth: {
       loginMethod: 'token',
+    },
+    unstable_tasks: {
+      enabled: true,
     },
   },
   {

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -8,6 +8,7 @@ import {type ComponentType, createElement, type ElementType, isValidElement} fro
 import {isValidElementType} from 'react-is'
 import {map, shareReplay} from 'rxjs/operators'
 
+import {tasks} from '../../tasks'
 import {FileSource, ImageSource} from '../form/studio/assetSource'
 import {type LocaleSource} from '../i18n'
 import {prepareI18n} from '../i18n/i18nConfig'
@@ -151,8 +152,18 @@ export function prepareConfig(
       const i18n = prepareI18n(source)
       const source$ = auth.state.pipe(
         map(({client, authenticated, currentUser}) => {
+          const {plugins} = source
+          const nextPlugins = rawWorkspace.unstable_tasks
+            ? (plugins || []).concat(tasks())
+            : plugins || []
+
+          const nextSource = {
+            ...source,
+            plugins: nextPlugins,
+          }
+
           return resolveSource({
-            config: source,
+            config: nextSource,
             client,
             currentUser,
             schema,
@@ -195,6 +206,7 @@ export function prepareConfig(
       __internal: {
         sources: resolvedSources,
       },
+      tasks: rawWorkspace.unstable_tasks,
     }
     preparedWorkspaces.set(rawWorkspace, workspaceSummary)
     return workspaceSummary

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -433,6 +433,13 @@ export interface WorkspaceOptions extends SourceOptions {
    * @beta
    */
   unstable_sources?: SourceOptions[]
+  /**
+   * @hidden
+   * @beta
+   */
+  unstable_tasks?: {
+    enabled: boolean
+  }
 }
 
 /**
@@ -776,6 +783,7 @@ export interface WorkspaceSummary {
       source: Observable<Source>
     }>
   }
+  tasks: WorkspaceOptions['unstable_tasks']
 }
 
 /**


### PR DESCRIPTION
### Description

This aligns how to enable the tasks feature with how we enable other features, by adding back the `unstable_tasks` flag.

The challenge with the current method is that we have to include untranspiled config in the config by importing it from `packages/sanity/...`. There is no guarantee this will work, however.

### What to review

- That tasks still works in the staging workspace
