### PR TITLE
feat(core): fetch inspect mode settings from backend.

### DIFF
--- a/packages/sanity/src/structure/panes/document/inspectDialog/InspectDialog.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectDialog/InspectDialog.tsx
@@ -27,8 +27,8 @@ export function InspectDialog(props: InspectDialogProps) {
   where the inspect dialog lives.
   This also means that when a page is loaded, the state of the tabs remains and doesn't revert to the pane tab */
   const [viewModeId, onViewModeChange] = useStructureToolSetting(
-    'structure-tool',
-    `inspect-view-preferred-view-mode-${paneKey}`,
+    'inspect-view-mode',
+    null,
     'parsed',
   )
 

--- a/packages/sanity/src/structure/useStructureToolSetting.ts
+++ b/packages/sanity/src/structure/useStructureToolSetting.ts
@@ -8,14 +8,14 @@ const STRUCTURE_TOOL_NAMESPACE = 'studio.structure-tool'
  * @internal
  */
 export function useStructureToolSetting<ValueType>(
-  namespace: string | null,
+  namespace: string,
   key: string | null,
   defaultValue?: ValueType,
 ): [ValueType | undefined, (_value: ValueType) => void] {
   const keyValueStore = useKeyValueStore()
   const [value, setValue] = useState<ValueType | undefined>(defaultValue)
 
-  const keyValueStoreKey = `${STRUCTURE_TOOL_NAMESPACE}.${namespace}.${key}`
+  const keyValueStoreKey = [STRUCTURE_TOOL_NAMESPACE, namespace, key].filter(Boolean).join('.')
 
   const settings = useMemo(() => {
     return keyValueStore.getKey(keyValueStoreKey)

--- a/test/e2e/tests/desk/inspectDialog.spec.ts
+++ b/test/e2e/tests/desk/inspectDialog.spec.ts
@@ -1,0 +1,35 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+const INSPECT_KEY = 'studio.structure-tool.inspect-view-mode'
+
+test('clicking inspect mode sets value in storage', async ({
+  page,
+  sanityClient,
+  createDraftDocument,
+}) => {
+  await createDraftDocument('/test/content/book')
+  await page.getByTestId('document-pane').getByTestId('pane-context-menu-button').click()
+  await page.getByRole('menuitem', {name: 'Inspect Ctrl Alt I'}).click()
+
+  await page.getByRole('tab', {name: 'Raw JSON'}).click()
+  const rawResult = await sanityClient.request({
+    uri: `/users/me/keyvalue/${INSPECT_KEY}`,
+    withCredentials: true,
+  })
+  expect(rawResult[0]).toMatchObject({
+    key: INSPECT_KEY,
+    value: 'raw',
+  })
+
+  await page.getByRole('tab', {name: 'Parsed'}).click()
+  const parsedResult = await sanityClient.request({
+    uri: `/users/me/keyvalue/${INSPECT_KEY}`,
+    withCredentials: true,
+  })
+
+  expect(parsedResult[0]).toMatchObject({
+    key: INSPECT_KEY,
+    value: 'parsed',
+  })
+})


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
Changes the key of inspect mode to be a bit simpler and universal for all documents.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->
The new key for this setting, the default setting. The test is not confirmed -- please see the below note.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
E2E test staged, but can't properly check it until the backend service is out in production.