### PR TITLE
feat(core): store recent search history in backend

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/datastores/useStoredSearch.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/datastores/useStoredSearch.ts
@@ -2,11 +2,11 @@ import {useCallback, useEffect, useMemo, useState} from 'react'
 import {map, startWith} from 'rxjs/operators'
 
 import {useClient} from '../../../../../hooks'
-import {useCurrentUser, useKeyValueStore} from '../../../../../store'
+import {useKeyValueStore} from '../../../../../store'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../../../studioClient'
 
 export const RECENT_SEARCH_VERSION = 2
-const STORED_SEARCHES_NAMESPACE = 'search::recent'
+const STORED_SEARCHES_NAMESPACE = 'studio.search.recent'
 
 interface StoredSearch {
   version: number
@@ -21,13 +21,9 @@ const defaultValue: StoredSearch = {
 export function useStoredSearch(): [StoredSearch, (_value: StoredSearch) => void] {
   const keyValueStore = useKeyValueStore()
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
-  const currentUser = useCurrentUser()
-  const {dataset, projectId} = client.config()
+  const {dataset} = client.config()
 
-  const keyValueStoreKey = useMemo(
-    () => `${STORED_SEARCHES_NAMESPACE}__${projectId}:${dataset}:${currentUser?.id}`,
-    [currentUser, dataset, projectId],
-  )
+  const keyValueStoreKey = useMemo(() => `${STORED_SEARCHES_NAMESPACE}.${dataset}`, [dataset])
 
   const [value, setValue] = useState<StoredSearch>(defaultValue)
 

--- a/test/e2e/tests/navbar/search.spec.ts
+++ b/test/e2e/tests/navbar/search.spec.ts
@@ -1,7 +1,14 @@
 import {expect} from '@playwright/test'
 import {test} from '@sanity/test'
 
-test('searching creates saved searches', async ({page, createDraftDocument, baseURL}) => {
+const SEARCH_KEY = 'studio.search.recent'
+test('searching creates saved searches', async ({
+  page,
+  createDraftDocument,
+  baseURL,
+  sanityClient,
+}) => {
+  const {dataset} = sanityClient.config()
   await createDraftDocument('/test/content/book')
 
   await page.getByTestId('field-title').getByTestId('string-input').fill('A searchable title')
@@ -12,17 +19,13 @@ test('searching creates saved searches', async ({page, createDraftDocument, base
   await page.getByTestId('search-results').click()
 
   //search query should be saved
-  const localStorage = await page.evaluate(() => window.localStorage)
-  const keyMatch = Object.keys(localStorage).find((key) => key.startsWith('search::recent'))
-  const savedSearches = JSON.parse(localStorage[keyMatch!]).recentSearches
+  const savedSearches = await sanityClient
+    .request({
+      uri: `/users/me/keyvalue/${SEARCH_KEY}.${dataset}`,
+      withCredentials: true,
+    })
+    .then((res) => res.recentSearches)
   expect(savedSearches[0].terms.query).toBe('A se')
-
-  //search query should be saved after browsing
-  await page.goto('https://example.com')
-  await page.goto(baseURL ?? '/test/content')
-  const postNavigationLocalStorage = await page.evaluate(() => window.localStorage)
-  const postNavigationSearches = JSON.parse(postNavigationLocalStorage[keyMatch!]).recentSearches
-  expect(postNavigationSearches[0].terms.query).toBe('A se')
 
   //search should save multiple queries
   await page.getByTestId('studio-search').click()
@@ -36,8 +39,12 @@ test('searching creates saved searches', async ({page, createDraftDocument, base
   await page.getByTestId('search-results').isVisible()
   await page.getByTestId('search-results').click()
 
-  const secondSearchStorage = await page.evaluate(() => window.localStorage)
-  const secondSearches = JSON.parse(secondSearchStorage[keyMatch!]).recentSearches
+  const secondSearches = await sanityClient
+    .request({
+      uri: `/users/me/keyvalue/${SEARCH_KEY}.${dataset}`,
+      withCredentials: true,
+    })
+    .then((res) => res.recentSearches)
   expect(secondSearches[0].terms.query).toBe('A searchable')
   expect(secondSearches[1].terms.query).toBe('A search')
   expect(secondSearches[2].terms.query).toBe('A se')


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
Changes the key of recent searches to fetch from the backend store.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->
Please feel free to review if the files changed here make sense. Testing suites (like recentSearches.test.tsx) pass -- they are now noisier because of some state updates, but other tests in our suit also unfortunately suffer from the same issue.


### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
Two existing test files are in play here -- recentSearches.test.tsx and navbar.spec.ts. The e2e test won't pass until the backend is up and running in production.