### PR TITLE
fix(core): allow `_projectId` and `_strengthOnPublish` in templates

### DIFF
--- a/dev/test-studio/schema/standard/crossDatasetReference.ts
+++ b/dev/test-studio/schema/standard/crossDatasetReference.ts
@@ -188,6 +188,42 @@ export default defineType({
       name: 'crossDatasetSubtype',
       type: 'crossDatasetSubtype',
     },
+    {
+      name: 'initialValueTest',
+      type: 'crossDatasetReference',
+      dataset: 'playground',
+      studioUrl: ({id, type}) => {
+        return type
+          ? `${document.location.protocol}//${document.location.host}/playground/content/${type};${id}`
+          : null
+      },
+      to: [
+        {
+          type: 'book',
+          icon: BookIcon,
+          preview: {
+            select: {
+              title: 'title',
+              subtitle: 'descriptionMd',
+              media: 'coverImage',
+            },
+            prepare(val) {
+              return {
+                title: val.title,
+                subtitle: val.subtitle,
+                media: val.coverImage,
+              }
+            },
+          },
+        },
+      ],
+      initialValue: () => ({
+        _type: 'crossDatasetReference',
+        _ref: '4203c6bd-98c2-418e-9558-3ed56ebaf1d8',
+        _dataset: 'playground',
+        _projectId: 'ppsg7ml5',
+      }),
+    },
   ],
   preview: {
     select: {

--- a/dev/test-studio/schema/standard/references.ts
+++ b/dev/test-studio/schema/standard/references.ts
@@ -235,6 +235,22 @@ export default defineType({
         },
       ],
     },
+    {
+      name: 'withInitialValue',
+      type: 'reference',
+      to: [{type: 'author'}],
+      initialValue: () => ({
+        _type: 'reference',
+        _ref: 'f9a5f215-da97-47fe-960f-3452c85ed205',
+        _weak: true,
+        _strengthenOnPublish: {
+          type: 'author',
+          template: {
+            id: 'author',
+          },
+        },
+      }),
+    },
   ],
   preview: {
     select: {

--- a/packages/sanity/src/core/templates/__tests__/resolve.test.ts
+++ b/packages/sanity/src/core/templates/__tests__/resolve.test.ts
@@ -90,12 +90,27 @@ describe('resolveInitialValue', () => {
     expect(
       resolveInitialValue(
         schema,
-        {...example, value: {bestFriend: {_ref: 'grrm', _type: 'reference', _weak: true}}},
+        {
+          ...example,
+          value: {
+            bestFriend: {
+              _ref: 'grrm',
+              _type: 'reference',
+              _weak: true,
+              _strengthenOnPublish: {type: 'author', template: {id: 'author'}},
+            },
+          },
+        },
         {},
         mockConfigContext,
       ),
     ).resolves.toMatchObject({
-      bestFriend: {_ref: 'grrm', _type: 'reference', _weak: true},
+      bestFriend: {
+        _ref: 'grrm',
+        _type: 'reference',
+        _weak: true,
+        _strengthenOnPublish: {type: 'author', template: {id: 'author'}},
+      },
     })
   })
 
@@ -105,13 +120,25 @@ describe('resolveInitialValue', () => {
         schema,
         {
           ...example,
-          value: {bestFriend: {_ref: 'grrm', _type: 'crossDatasetReference', _dataset: 'bffs'}},
+          value: {
+            bestFriend: {
+              _ref: 'grrm',
+              _type: 'crossDatasetReference',
+              _dataset: 'bffs',
+              _projectId: 'beep',
+            },
+          },
         },
         {},
         mockConfigContext,
       ),
     ).resolves.toMatchObject({
-      bestFriend: {_ref: 'grrm', _type: 'crossDatasetReference', _dataset: 'bffs'},
+      bestFriend: {
+        _ref: 'grrm',
+        _type: 'crossDatasetReference',
+        _dataset: 'bffs',
+        _projectId: 'beep',
+      },
     })
   })
 

--- a/packages/sanity/src/core/templates/validate.ts
+++ b/packages/sanity/src/core/templates/validate.ts
@@ -5,7 +5,15 @@ import {toString as pathToString} from '@sanity/util/paths'
 import {type Template, type TemplateParameter} from './types'
 import {isRecord} from './util/isRecord'
 
-const ALLOWED_REF_PROPS = ['_dataset', '_key', '_ref', '_type', '_weak']
+const ALLOWED_REF_PROPS = [
+  '_dataset',
+  '_projectId',
+  '_strengthenOnPublish',
+  '_key',
+  '_ref',
+  '_type',
+  '_weak',
+]
 const REQUIRED_TEMPLATE_PROPS: (keyof Template)[] = ['id', 'title', 'schemaType', 'value']
 
 function templateId(template: Template, i: number) {


### PR DESCRIPTION
### Description

A simple follow up to #5889 and adds `_projectId` and `_strengthOnPublish`.

This is the PR description from #5889:

> It is currently not possible to create a cross-dataset reference from an initial value template, as the template validation runs and disallows unknown properties on references, where `_dataset` was not an allowed prop.
> 
> Perhaps we should recurse down the type chain to look for a field that extends from `crossDatasetReference`, but this is beyond what we do for other types - eg we do not check for a `reference` type when encountering `_ref`. Leaving this for a future iteration to improve on if we feel it is worth it.

### What to review

- Can actually create a cross-dataset reference from an initial value template


### Testing

I actually tested this one manually and added fields for initial templates in our test studio.

### Notes for release

- Enhances support for reference types in initial value templates by allowing `_projectId` and `_strengthOnPublish` in templates, builds on #5889.
