### PR TITLE
chore(comments): add support for comments layout avatar config

### DIFF
--- a/packages/sanity/src/structure/comments/src/components/avatars/SpacerAvatar.tsx
+++ b/packages/sanity/src/structure/comments/src/components/avatars/SpacerAvatar.tsx
@@ -3,8 +3,6 @@ import {type AvatarSize} from '@sanity/ui'
 import {getTheme_v2} from '@sanity/ui/theme'
 import styled, {css} from 'styled-components'
 
-export const AVATAR_HEIGHT = 25
-
 /**
  * This component is used to as a spacer in situations where we want to align
  * components without avatars with components that have avatars.

--- a/packages/sanity/src/structure/comments/src/components/avatars/SpacerAvatar.tsx
+++ b/packages/sanity/src/structure/comments/src/components/avatars/SpacerAvatar.tsx
@@ -5,21 +5,14 @@ import styled, {css} from 'styled-components'
 
 export const AVATAR_HEIGHT = 25
 
-const Spacer = styled.div<{$size: number}>((props) => {
-  const theme = getTheme_v2(props.theme)
-
-  return css`
-    min-width: ${theme.avatar.sizes[props.$size]?.size}px;
-  `
-})
-
 /**
  * This component is used to as a spacer in situations where we want to align
  * components without avatars with components that have avatars.
  */
-export function SpacerAvatar({show = true, size = 1}: {show?: boolean; size?: AvatarSize}) {
-  if (!show) {
-    return null
-  }
-  return <Spacer $size={size} />
-}
+export const SpacerAvatar = styled.div<{$size?: AvatarSize}>((props) => {
+  const theme = getTheme_v2(props.theme)
+  const {$size = 1} = props
+  return css`
+    min-width: ${theme.avatar.sizes[$size]?.size}px;
+  `
+})

--- a/packages/sanity/src/structure/comments/src/components/avatars/SpacerAvatar.tsx
+++ b/packages/sanity/src/structure/comments/src/components/avatars/SpacerAvatar.tsx
@@ -1,15 +1,25 @@
-import type * as React from 'react'
+import {type AvatarSize} from '@sanity/ui'
+// eslint-disable-next-line camelcase
+import {getTheme_v2} from '@sanity/ui/theme'
+import styled, {css} from 'styled-components'
 
 export const AVATAR_HEIGHT = 25
 
-const INLINE_STYLE: React.CSSProperties = {
-  minWidth: AVATAR_HEIGHT,
-}
+const Spacer = styled.div<{$size: number}>((props) => {
+  const theme = getTheme_v2(props.theme)
+
+  return css`
+    min-width: ${theme.avatar.sizes[props.$size]?.size}px;
+  `
+})
 
 /**
  * This component is used to as a spacer in situations where we want to align
  * components without avatars with components that have avatars.
  */
-export function SpacerAvatar() {
-  return <div style={INLINE_STYLE} />
+export function SpacerAvatar({show = true, size = 1}: {show?: boolean; size?: AvatarSize}) {
+  if (!show) {
+    return null
+  }
+  return <Spacer $size={size} />
 }

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItem.tsx
@@ -28,6 +28,13 @@ const EMPTY_ARRAY: [] = []
 
 const MAX_COLLAPSED_REPLIES = 5
 
+const DEFAULT_AVATAR_CONFIG: CommentsListItemProps['avatarConfig'] = {
+  avatarSize: 1,
+  parentCommentAvatar: true,
+  replyAvatar: true,
+  threadCommentsAvatar: true,
+}
+
 // data-active = when the comment is selected
 // data-hovered = when the mouse is over the comment
 const StyledThreadCard = styled(ThreadCard)(() => {
@@ -75,6 +82,12 @@ const GhostButton = styled.button`
 `
 
 interface CommentsListItemProps {
+  avatarConfig?: {
+    avatarSize: AvatarSize
+    parentCommentAvatar: boolean
+    replyAvatar: boolean
+    threadCommentsAvatar: boolean
+  }
   canReply?: boolean
   currentUser: CurrentUser
   hasReferencedValue?: boolean
@@ -93,22 +106,11 @@ interface CommentsListItemProps {
   parentComment: CommentDocument
   readOnly?: boolean
   replies: CommentDocument[] | undefined
-  avatarConfig?: {
-    parentCommentAvatar: boolean
-    threadCommentsAvatar: boolean
-    replyAvatar: boolean
-    avatarSize: AvatarSize
-  }
 }
 
-const DEFAULT_AVATAR_CONFIG: CommentsListItemProps['avatarConfig'] = {
-  parentCommentAvatar: true,
-  threadCommentsAvatar: true,
-  replyAvatar: true,
-  avatarSize: 1,
-}
 export const CommentsListItem = React.memo(function CommentsListItem(props: CommentsListItemProps) {
   const {
+    avatarConfig = DEFAULT_AVATAR_CONFIG,
     canReply,
     currentUser,
     hasReferencedValue,
@@ -127,7 +129,6 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
     parentComment,
     readOnly,
     replies = EMPTY_ARRAY,
-    avatarConfig = DEFAULT_AVATAR_CONFIG,
   } = props
   const {t} = useTranslation(commentsLocaleNamespace)
   const [value, setValue] = useState<CommentMessage>(EMPTY_ARRAY)
@@ -255,7 +256,6 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
       splicedReplies.map((reply) => (
         <Stack as="li" key={reply._id} {...applyCommentIdAttr(reply._id)}>
           <CommentsListItemLayout
-            withAvatar={avatarConfig.threadCommentsAvatar}
             avatarSize={avatarConfig.avatarSize}
             canDelete={reply.authorId === currentUser.id}
             canEdit={reply.authorId === currentUser.id}
@@ -263,6 +263,7 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
             currentUser={currentUser}
             hasError={reply._state?.type === 'createError'}
             isRetrying={reply._state?.type === 'createRetrying'}
+            intent={commentIntentIfDiffers(parentComment, reply)}
             mentionOptions={mentionOptions}
             mode={mode}
             onCopyLink={onCopyLink}
@@ -272,12 +273,12 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
             onInputKeyDown={handleInputKeyDown}
             onReactionSelect={onReactionSelect}
             readOnly={readOnly}
-            intent={commentIntentIfDiffers(parentComment, reply)}
+            withAvatar={avatarConfig.threadCommentsAvatar}
           />
         </Stack>
       )),
     [
-      avatarConfig?.threadCommentsAvatar,
+      avatarConfig.threadCommentsAvatar,
       avatarConfig.avatarSize,
       currentUser,
       handleInputKeyDown,
@@ -317,7 +318,6 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
       >
         <Stack as="li" {...applyCommentIdAttr(parentComment._id)}>
           <CommentsListItemLayout
-            withAvatar={avatarConfig?.parentCommentAvatar}
             avatarSize={avatarConfig.avatarSize}
             canDelete={parentComment.authorId === currentUser.id}
             canEdit={parentComment.authorId === currentUser.id}
@@ -338,6 +338,7 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
             onReactionSelect={onReactionSelect}
             onStatusChange={onStatusChange}
             readOnly={readOnly}
+            withAvatar={avatarConfig.parentCommentAvatar}
           />
         </Stack>
 
@@ -358,7 +359,6 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
 
         {canReply && (
           <CommentInput
-            withAvatar={avatarConfig.replyAvatar}
             avatarSize={avatarConfig.avatarSize}
             currentUser={currentUser}
             expandOnFocus
@@ -376,6 +376,7 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
             readOnly={readOnly || mode === 'upsell'}
             ref={replyInputRef}
             value={value}
+            withAvatar={avatarConfig.replyAvatar}
           />
         )}
       </Stack>

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItem.tsx
@@ -1,6 +1,6 @@
 import {ChevronDownIcon} from '@sanity/icons'
 import {type CurrentUser} from '@sanity/types'
-import {Flex, Stack, useLayer} from '@sanity/ui'
+import {type AvatarSize, Flex, Stack, useLayer} from '@sanity/ui'
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {type UserListWithPermissionsHookValue, useTranslation} from 'sanity'
 import styled, {css} from 'styled-components'
@@ -93,8 +93,20 @@ interface CommentsListItemProps {
   parentComment: CommentDocument
   readOnly?: boolean
   replies: CommentDocument[] | undefined
+  avatarConfig?: {
+    parentCommentAvatar: boolean
+    threadCommentsAvatar: boolean
+    replyAvatar: boolean
+    avatarSize: AvatarSize
+  }
 }
 
+const DEFAULT_AVATAR_CONFIG: CommentsListItemProps['avatarConfig'] = {
+  parentCommentAvatar: true,
+  threadCommentsAvatar: true,
+  replyAvatar: true,
+  avatarSize: 1,
+}
 export const CommentsListItem = React.memo(function CommentsListItem(props: CommentsListItemProps) {
   const {
     canReply,
@@ -115,6 +127,7 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
     parentComment,
     readOnly,
     replies = EMPTY_ARRAY,
+    avatarConfig = DEFAULT_AVATAR_CONFIG,
   } = props
   const {t} = useTranslation(commentsLocaleNamespace)
   const [value, setValue] = useState<CommentMessage>(EMPTY_ARRAY)
@@ -242,6 +255,8 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
       splicedReplies.map((reply) => (
         <Stack as="li" key={reply._id} {...applyCommentIdAttr(reply._id)}>
           <CommentsListItemLayout
+            withAvatar={avatarConfig.threadCommentsAvatar}
+            avatarSize={avatarConfig.avatarSize}
             canDelete={reply.authorId === currentUser.id}
             canEdit={reply.authorId === currentUser.id}
             comment={reply}
@@ -262,6 +277,8 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
         </Stack>
       )),
     [
+      avatarConfig?.threadCommentsAvatar,
+      avatarConfig.avatarSize,
       currentUser,
       handleInputKeyDown,
       mentionOptions,
@@ -300,6 +317,8 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
       >
         <Stack as="li" {...applyCommentIdAttr(parentComment._id)}>
           <CommentsListItemLayout
+            withAvatar={avatarConfig?.parentCommentAvatar}
+            avatarSize={avatarConfig.avatarSize}
             canDelete={parentComment.authorId === currentUser.id}
             canEdit={parentComment.authorId === currentUser.id}
             comment={parentComment}
@@ -339,6 +358,8 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
 
         {canReply && (
           <CommentInput
+            withAvatar={avatarConfig.replyAvatar}
+            avatarSize={avatarConfig.avatarSize}
             currentUser={currentUser}
             expandOnFocus
             mentionOptions={mentionOptions}

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemContextMenu.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemContextMenu.tsx
@@ -81,6 +81,7 @@ export function CommentsListItemContextMenu(props: CommentsListItemContextMenuPr
 
   const {t} = useTranslation(commentsLocaleNamespace)
 
+  const hasContextMenuOptions = Boolean(canDelete || canEdit || onCopyLink)
   return (
     <TooltipDelayGroupProvider>
       <Flex>
@@ -117,51 +118,52 @@ export function CommentsListItemContextMenu(props: CommentsListItemContextMenuPr
               }}
             />
           )}
-
-          <MenuButton
-            id="comment-actions-menu"
-            button={
-              <ContextMenuButton
-                aria-label={t('list-item.open-menu-aria-label')}
-                disabled={readOnly}
-                hidden={!showMenuButton}
-              />
-            }
-            onOpen={onMenuOpen}
-            onClose={onMenuClose}
-            menu={
-              <Menu>
-                <MenuItem
-                  hidden={!canEdit}
-                  icon={EditIcon}
-                  onClick={onEditStart}
-                  text={t('list-item.edit-comment')}
-                  tooltipProps={
-                    mode === 'upsell' ? {content: t('list-item.edit-comment-upsell')} : undefined
-                  }
-                  disabled={mode === 'upsell'}
+          {hasContextMenuOptions && (
+            <MenuButton
+              id="comment-actions-menu"
+              button={
+                <ContextMenuButton
+                  aria-label={t('list-item.open-menu-aria-label')}
+                  disabled={readOnly}
+                  hidden={!showMenuButton}
                 />
+              }
+              onOpen={onMenuOpen}
+              onClose={onMenuClose}
+              menu={
+                <Menu>
+                  <MenuItem
+                    hidden={!canEdit}
+                    icon={EditIcon}
+                    onClick={onEditStart}
+                    text={t('list-item.edit-comment')}
+                    tooltipProps={
+                      mode === 'upsell' ? {content: t('list-item.edit-comment-upsell')} : undefined
+                    }
+                    disabled={mode === 'upsell'}
+                  />
 
-                <MenuItem
-                  hidden={!canDelete}
-                  icon={TrashIcon}
-                  onClick={onDeleteStart}
-                  text={t('list-item.delete-comment')}
-                  tone="critical"
-                />
+                  <MenuItem
+                    hidden={!canDelete}
+                    icon={TrashIcon}
+                    onClick={onDeleteStart}
+                    text={t('list-item.delete-comment')}
+                    tone="critical"
+                  />
 
-                <MenuDivider hidden={!canDelete && !canEdit} />
+                  <MenuDivider hidden={!canDelete && !canEdit} />
 
-                <MenuItem
-                  hidden={!onCopyLink}
-                  icon={LinkIcon}
-                  onClick={onCopyLink}
-                  text={t('list-item.copy-link')}
-                />
-              </Menu>
-            }
-            popover={POPOVER_PROPS}
-          />
+                  <MenuItem
+                    hidden={!onCopyLink}
+                    icon={LinkIcon}
+                    onClick={onCopyLink}
+                    text={t('list-item.copy-link')}
+                  />
+                </Menu>
+              }
+              popover={POPOVER_PROPS}
+            />
+          )}
         </FloatingCard>
       </Flex>
     </TooltipDelayGroupProvider>

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
@@ -137,6 +137,7 @@ const RootStack = styled(Stack)(({theme}) => {
 })
 
 interface CommentsListItemLayoutProps {
+  avatarSize?: AvatarSize
   canDelete?: boolean
   canEdit?: boolean
   comment: CommentDocument
@@ -157,13 +158,13 @@ interface CommentsListItemLayoutProps {
   onStatusChange?: (id: string, status: CommentStatus) => void
   readOnly?: boolean
   withAvatar?: boolean
-  avatarSize?: AvatarSize
 }
 
 const RELATIVE_TIME_OPTIONS: RelativeTimeOptions = {useTemporalPhrase: true}
 
 export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
   const {
+    avatarSize = 1,
     canDelete,
     canEdit,
     comment,
@@ -184,7 +185,6 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
     onStatusChange,
     readOnly,
     withAvatar = true,
-    avatarSize = 1,
   } = props
   const {_createdAt, authorId, message, _id, lastEditedAt} = comment
   const [user] = useUser(authorId)

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
@@ -1,6 +1,17 @@
 import {hues} from '@sanity/color'
 import {type CurrentUser} from '@sanity/types'
-import {Box, Card, Flex, Stack, Text, TextSkeleton, useClickOutside} from '@sanity/ui'
+import {
+  type AvatarSize,
+  Box,
+  Card,
+  Flex,
+  Stack,
+  Text,
+  TextSkeleton,
+  useClickOutside,
+} from '@sanity/ui'
+// eslint-disable-next-line camelcase
+import {getTheme_v2} from '@sanity/ui/theme'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {
   type RelativeTimeOptions,
@@ -26,7 +37,7 @@ import {
   type CommentsUIMode,
   type CommentUpdatePayload,
 } from '../../types'
-import {AVATAR_HEIGHT, CommentsAvatar, SpacerAvatar} from '../avatars'
+import {CommentsAvatar, SpacerAvatar} from '../avatars'
 import {FLEX_GAP} from '../constants'
 import {CommentMessageSerializer} from '../pte'
 import {CommentInput, type CommentInputHandle} from '../pte/comment-input'
@@ -72,9 +83,13 @@ const InnerStack = styled(Stack)`
   }
 `
 
-const ErrorFlex = styled(Flex)`
-  min-height: ${AVATAR_HEIGHT}px;
-`
+const ErrorFlex = styled(Flex)<{$size: AvatarSize}>((props) => {
+  const theme = getTheme_v2(props.theme)
+
+  return css`
+    min-height: ${theme.avatar.sizes[props.$size]?.size}px;
+  `
+})
 
 const RetryCardButton = styled(Card)`
   // Add not on hover
@@ -141,6 +156,8 @@ interface CommentsListItemLayoutProps {
   onReactionSelect?: (id: string, reaction: CommentReactionOption) => void
   onStatusChange?: (id: string, status: CommentStatus) => void
   readOnly?: boolean
+  withAvatar?: boolean
+  avatarSize?: AvatarSize
 }
 
 const RELATIVE_TIME_OPTIONS: RelativeTimeOptions = {useTemporalPhrase: true}
@@ -166,6 +183,8 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
     onReactionSelect,
     onStatusChange,
     readOnly,
+    withAvatar = true,
+    avatarSize = 1,
   } = props
   const {_createdAt, authorId, message, _id, lastEditedAt} = comment
   const [user] = useUser(authorId)
@@ -325,7 +344,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
     >
       <InnerStack space={1} data-muted={displayError}>
         <Flex align="center" gap={FLEX_GAP} flex={1}>
-          <CommentsAvatar user={user} />
+          {withAvatar && <CommentsAvatar user={user} size={avatarSize} />}
 
           <Flex direction="column" gap={2} paddingY={intent ? 2 : 0}>
             <Flex
@@ -401,7 +420,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
         {isTextSelectionComment(comment) && Boolean(comment?.contentSnapshot) && (
           <Flex gap={FLEX_GAP} marginBottom={3}>
-            <SpacerAvatar />
+            <SpacerAvatar size={avatarSize} show={withAvatar} />
 
             <CommentsListItemReferencedValue
               hasReferencedValue={hasReferencedValue}
@@ -412,7 +431,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
         {isEditing && (
           <Flex align="flex-start" gap={2}>
-            <SpacerAvatar />
+            <SpacerAvatar size={avatarSize} show={withAvatar} />
 
             <Stack flex={1}>
               <CommentInput
@@ -435,7 +454,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
         {!isEditing && (
           <Flex gap={FLEX_GAP}>
-            <SpacerAvatar />
+            <SpacerAvatar size={avatarSize} show={withAvatar} />
 
             <CommentMessageSerializer blocks={message} />
           </Flex>
@@ -443,7 +462,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
         {hasReactions && (
           <Flex gap={FLEX_GAP} marginTop={2}>
-            <SpacerAvatar />
+            <SpacerAvatar size={avatarSize} show={withAvatar} />
 
             <Box onClick={stopPropagation}>
               <CommentReactionsBar
@@ -459,8 +478,8 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
       </InnerStack>
 
       {displayError && (
-        <ErrorFlex gap={FLEX_GAP}>
-          <SpacerAvatar />
+        <ErrorFlex gap={FLEX_GAP} $size={avatarSize}>
+          <SpacerAvatar size={avatarSize} show={withAvatar} />
 
           <Flex align="center" gap={1} flex={1}>
             <Text muted size={1}>

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
@@ -64,6 +64,14 @@ const TimeText = styled(Text)(({theme}) => {
   `
 })
 
+const HeaderFlex = styled(Flex)<{$size: AvatarSize}>((props) => {
+  const theme = getTheme_v2(props.theme)
+
+  return css`
+    min-height: ${theme.avatar.sizes[props.$size]?.size}px;
+  `
+})
+
 const IntentText = styled(Text)(({theme}) => {
   const isDark = theme.sanity.color.dark
   const fg = hues.gray[isDark ? 200 : 800].hex
@@ -343,7 +351,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
       space={4}
     >
       <InnerStack space={1} data-muted={displayError}>
-        <Flex align="center" gap={FLEX_GAP} flex={1}>
+        <HeaderFlex align="center" gap={FLEX_GAP} flex={1} $size={avatarSize}>
           {withAvatar && <CommentsAvatar user={user} size={avatarSize} />}
 
           <Flex direction="column" gap={2} paddingY={intent ? 2 : 0}>
@@ -416,7 +424,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
               />
             </ContextMenuBox>
           )}
-        </Flex>
+        </HeaderFlex>
 
         {isTextSelectionComment(comment) && Boolean(comment?.contentSnapshot) && (
           <Flex gap={FLEX_GAP} marginBottom={3}>

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
@@ -420,7 +420,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
         {isTextSelectionComment(comment) && Boolean(comment?.contentSnapshot) && (
           <Flex gap={FLEX_GAP} marginBottom={3}>
-            <SpacerAvatar size={avatarSize} show={withAvatar} />
+            {withAvatar && <SpacerAvatar $size={avatarSize} />}
 
             <CommentsListItemReferencedValue
               hasReferencedValue={hasReferencedValue}
@@ -431,7 +431,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
         {isEditing && (
           <Flex align="flex-start" gap={2}>
-            <SpacerAvatar size={avatarSize} show={withAvatar} />
+            {withAvatar && <SpacerAvatar $size={avatarSize} />}
 
             <Stack flex={1}>
               <CommentInput
@@ -454,7 +454,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
         {!isEditing && (
           <Flex gap={FLEX_GAP}>
-            <SpacerAvatar size={avatarSize} show={withAvatar} />
+            {withAvatar && <SpacerAvatar $size={avatarSize} />}
 
             <CommentMessageSerializer blocks={message} />
           </Flex>
@@ -462,7 +462,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
         {hasReactions && (
           <Flex gap={FLEX_GAP} marginTop={2}>
-            <SpacerAvatar size={avatarSize} show={withAvatar} />
+            {withAvatar && <SpacerAvatar $size={avatarSize} />}
 
             <Box onClick={stopPropagation}>
               <CommentReactionsBar
@@ -479,7 +479,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
       {displayError && (
         <ErrorFlex gap={FLEX_GAP} $size={avatarSize}>
-          <SpacerAvatar size={avatarSize} show={withAvatar} />
+          {withAvatar && <SpacerAvatar $size={avatarSize} />}
 
           <Flex align="center" gap={1} flex={1}>
             <Text muted size={1}>

--- a/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInput.tsx
+++ b/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInput.tsx
@@ -1,6 +1,6 @@
 import {type EditorChange, keyGenerator, PortableTextEditor} from '@sanity/portable-text-editor'
 import {type CurrentUser, type PortableTextBlock} from '@sanity/types'
-import {focusFirstDescendant, focusLastDescendant, Stack} from '@sanity/ui'
+import {type AvatarSize, focusFirstDescendant, focusLastDescendant, Stack} from '@sanity/ui'
 import type * as React from 'react'
 import {forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState} from 'react'
 import {type UserListWithPermissionsHookValue} from 'sanity'
@@ -36,6 +36,7 @@ export interface CommentInputProps {
   readOnly?: boolean
   value: PortableTextBlock[] | null
   withAvatar?: boolean
+  avatarSize?: AvatarSize
 }
 
 interface CommentDiscardDialogController {
@@ -58,6 +59,7 @@ export interface CommentInputHandle {
 export const CommentInput = forwardRef<CommentInputHandle, CommentInputProps>(
   function CommentInput(props, ref) {
     const {
+      avatarSize,
       currentUser,
       expandOnFocus,
       focusLock = false,
@@ -221,6 +223,7 @@ export const CommentInput = forwardRef<CommentInputHandle, CommentInputProps>(
 
               <Stack ref={innerRef}>
                 <CommentInputInner
+                  avatarSize={avatarSize}
                   currentUser={currentUser}
                   focusLock={focusLock}
                   onBlur={onBlur}

--- a/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInputInner.tsx
+++ b/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInputInner.tsx
@@ -1,5 +1,5 @@
 import {type CurrentUser} from '@sanity/types'
-import {Box, Card, Flex, MenuDivider, Stack} from '@sanity/ui'
+import {type AvatarSize, Box, Card, Flex, MenuDivider, Stack} from '@sanity/ui'
 // eslint-disable-next-line camelcase
 import {getTheme_v2} from '@sanity/ui/theme'
 import {useCallback} from 'react'
@@ -81,7 +81,17 @@ const RootCard = styled(Card)(({theme}) => {
   `
 })
 
+const AvatarContainer = styled.div((props) => {
+  const theme = getTheme_v2(props.theme)
+  return `
+    min-height: ${theme.avatar.sizes[1]?.size}px;
+    display: flex;
+    align-items: center;
+  `
+})
+
 interface CommentInputInnerProps {
+  avatarSize?: AvatarSize
   currentUser: CurrentUser
   focusLock?: boolean
   onBlur?: (e: React.FormEvent<HTMLDivElement>) => void
@@ -93,15 +103,28 @@ interface CommentInputInnerProps {
 }
 
 export function CommentInputInner(props: CommentInputInnerProps) {
-  const {currentUser, focusLock, onBlur, onFocus, onKeyDown, onSubmit, placeholder, withAvatar} =
-    props
+  const {
+    avatarSize = 1,
+    currentUser,
+    focusLock,
+    onBlur,
+    onFocus,
+    onKeyDown,
+    onSubmit,
+    placeholder,
+    withAvatar,
+  } = props
 
   const [user] = useUser(currentUser.id)
   const {canSubmit, expandOnFocus, focused, hasChanges, insertAtChar, openMentions, readOnly} =
     useCommentInput()
 
   const {t} = useTranslation(commentsLocaleNamespace)
-  const avatar = withAvatar ? <CommentsAvatar user={user} /> : null
+  const avatar = withAvatar ? (
+    <AvatarContainer>
+      <CommentsAvatar user={user} size={avatarSize} />
+    </AvatarContainer>
+  ) : null
 
   const handleMentionButtonClicked = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
### Description

Adds support for avatar config in comments layout.
```
{
    parentCommentAvatar: boolean
    threadCommentsAvatar: boolean
    replyAvatar: boolean
    avatarSize: AvatarSize
  }

```
Supports building the UI needed for tasks. 
Notice how the avatar size is reduced and also removed from the parent comment. 

<img width="346" alt="Screenshot 2024-03-11 at 10 18 27" src="https://github.com/sanity-io/sanity/assets/46196328/fa52c73f-6346-475a-87bd-650c056a14bc">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
