### PR TITLE
fix(tasks): enable check for document action and badge

### DIFF
--- a/packages/sanity/src/tasks/plugin/TaskCreateAction.tsx
+++ b/packages/sanity/src/tasks/plugin/TaskCreateAction.tsx
@@ -1,16 +1,19 @@
 import {useCallback} from 'react'
 import {type DocumentActionDescription} from 'sanity'
 
-import {useTasksNavigation} from '../src'
+import {useTasksEnabled, useTasksNavigation} from '../src'
 import {TaskIcon} from '../src/tasks/components/TaskIcon'
 
-export function TaskCreateAction(): DocumentActionDescription {
+export function TaskCreateAction(): DocumentActionDescription | null {
   const {handleOpenTasks, setViewMode} = useTasksNavigation()
+  const {enabled} = useTasksEnabled()
 
   const handleCreateTaskFromDocument = useCallback(() => {
     handleOpenTasks()
     setViewMode({type: 'create'})
   }, [handleOpenTasks, setViewMode])
+
+  if (!enabled) return null
 
   return {
     icon: TaskIcon,

--- a/packages/sanity/src/tasks/plugin/TasksBadge.tsx
+++ b/packages/sanity/src/tasks/plugin/TasksBadge.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react'
+import {type DocumentBadgeDescription} from 'sanity'
 
-import {useTasks} from '../src'
+import {useTasks, useTasksEnabled} from '../src'
 
 /**
  * Badge that shows how many pending tasks are assigned to the current document.
@@ -8,8 +9,10 @@ import {useTasks} from '../src'
  * discovery of the pending tasks.
  * @internal
  */
-export function DocumentBadge() {
+export function TasksBadge(): DocumentBadgeDescription | null {
   const {data, activeDocument} = useTasks()
+  const {enabled} = useTasksEnabled()
+
   const pendingTasks = useMemo(
     () =>
       data.filter((item) => {
@@ -18,7 +21,9 @@ export function DocumentBadge() {
     [activeDocument, data],
   )
 
+  if (!enabled) return null
   if (pendingTasks.length === 0) return null
+
   return {
     label: ` ${pendingTasks.length} open tasks`,
     color: 'primary' as const,

--- a/packages/sanity/src/tasks/plugin/index.tsx
+++ b/packages/sanity/src/tasks/plugin/index.tsx
@@ -1,7 +1,7 @@
 import {definePlugin, type ObjectInputProps} from 'sanity'
 
 import {TaskCreateAction} from './TaskCreateAction'
-import {DocumentBadge} from './TasksBadge'
+import {TasksBadge} from './TasksBadge'
 import {TasksDocumentInputLayout} from './TasksDocumentInputLayout'
 import {TasksStudioActiveToolLayout} from './TasksStudioActiveToolLayout'
 import {TasksStudioLayout} from './TasksStudioLayout'
@@ -15,10 +15,10 @@ export const tasks = definePlugin({
   name: 'sanity/tasks',
   document: {
     badges: (prev) => {
-      return (prev || []).concat(DocumentBadge)
+      return [...prev, TasksBadge].filter(Boolean)
     },
-    actions: (prev = []) => {
-      return [TaskCreateAction, ...prev]
+    actions: (prev) => {
+      return [...prev, TaskCreateAction].filter(Boolean)
     },
   },
   studio: {


### PR DESCRIPTION
### Description

This pull request makes sure that the document action and badge related to Tasks is only included if the feature is enabled.

### What to review

- Make sure that the document action and badge is only included when the feature is enabled

### Notes for release

N/A
