### PR TITLE
chore(test): exclude the github reporter from playwright tests for now

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import {defineConfig} from '@playwright/test'
+import {defineConfig, type PlaywrightTestConfig} from '@playwright/test'
 import {createPlaywrightConfig} from '@sanity/test'
 
 import {loadEnvFiles} from './scripts/utils/loadEnvFiles'
@@ -8,12 +8,24 @@ loadEnvFiles()
 
 const CI = readBoolEnv('CI', false)
 
+/**
+ * Excludes the GitHub reporter until https://github.com/microsoft/playwright/issues/19817 is resolved, since it creates a lot of noise in our PRs.
+ * @param reporters - The reporters config to exclude the github reporter from
+ */
+function excludeGithub(reporters: PlaywrightTestConfig['reporter']) {
+  if (Array.isArray(reporters)) {
+    return reporters.filter((reporterDescription) => reporterDescription[0] !== 'github')
+  }
+  return reporters === 'github' ? undefined : reporters
+}
+
 const playwrightConfig = createPlaywrightConfig({
   projectId: readEnv('SANITY_E2E_PROJECT_ID'),
   token: readEnv('SANITY_E2E_SESSION_TOKEN'),
   playwrightOptions(config) {
     return {
       ...config,
+      reporter: excludeGithub(config.reporter),
       use: {
         ...config.use,
         baseURL: 'http://localhost:3339',


### PR DESCRIPTION
### Description
Disabling the github reporter from playwright config for now, as it adds too much noise to be useful (see https://github.com/sanity-io/sanity/pull/5950/files for an example). Figured it was better to disable it for our repo, since removing it from the default reporters defined by `@sanity/test` could lead to unsurprising behavior for other consumers of that package.

### What to review
Will this actually remove the reporter?

### Notes for release
n/a – internal