### PR TITLE
feat(codegen): add typegen methods to codegen package

### DIFF
--- a/packages/@sanity/codegen/package.json
+++ b/packages/@sanity/codegen/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.23.9",
+    "@babel/generator": "^7.23.6",
     "@babel/preset-env": "^7.23.8",
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
@@ -66,11 +67,14 @@
     "@babel/traverse": "^7.23.5",
     "@babel/types": "^7.23.9",
     "debug": "^4.3.4",
+    "globby": "^10.0.0",
+    "groq-js": "1.5.0-canary.1",
     "tsconfig-paths": "^4.2.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@types/babel__core": "^7.20.5",
+    "@types/babel__generator": "^7.6.8",
     "@types/babel__register": "^7.17.3",
     "@types/babel__traverse": "^7.18.1",
     "@types/debug": "^4.1.12",

--- a/packages/@sanity/codegen/src/_exports/index.ts
+++ b/packages/@sanity/codegen/src/_exports/index.ts
@@ -1,3 +1,6 @@
+export {readSchema} from '../readSchema'
+export {findQueriesInPath} from '../typescript/findQueriesInPath'
 export {findQueriesInSource} from '../typescript/findQueriesInSource'
 export {getResolver} from '../typescript/moduleResolver'
 export {registerBabel} from '../typescript/registerBabel'
+export {TypeGenerator} from '../typescript/typeGenerator'

--- a/packages/@sanity/codegen/src/readSchema.ts
+++ b/packages/@sanity/codegen/src/readSchema.ts
@@ -1,0 +1,14 @@
+import {readFile} from 'fs/promises'
+import {type SchemaType} from 'groq-js'
+
+/**
+ * Read a schema from a given path
+ * @param path - The path to the schema
+ * @returns The schema
+ * @internal
+ * @beta
+ **/
+export async function readSchema(path: string): Promise<SchemaType> {
+  const content = await readFile(path, 'utf-8')
+  return JSON.parse(content) // todo: ZOD validation?
+}

--- a/packages/@sanity/codegen/src/typescript/__tests__/__snapshots__/typeGenerator.test.ts.snap
+++ b/packages/@sanity/codegen/src/typescript/__tests__/__snapshots__/typeGenerator.test.ts.snap
@@ -1,0 +1,222 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateSchemaTypes generateTypeNodeTypes should be able to generate types for type nodes: boolean 1`] = `"export type test_2 = boolean;"`;
+
+exports[`generateSchemaTypes generateTypeNodeTypes should be able to generate types for type nodes: null 1`] = `"export type test_5 = null;"`;
+
+exports[`generateSchemaTypes generateTypeNodeTypes should be able to generate types for type nodes: number 1`] = `"export type test_3 = number;"`;
+
+exports[`generateSchemaTypes generateTypeNodeTypes should be able to generate types for type nodes: string 1`] = `"export type test = string;"`;
+
+exports[`generateSchemaTypes generateTypeNodeTypes should be able to generate types for type nodes: unknown 1`] = `"export type test_4 = unknown;"`;
+
+exports[`generateSchemaTypes should generate TypeScript type declarations for a schema 1`] = `
+"export type Author = {
+  _id: string;
+  _type: \\"author\\";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  name?: string;
+};
+
+export type Post = {
+  _id: string;
+  _type: \\"post\\";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  title?: string;
+  author?: {
+    _ref: string;
+    _weak?: boolean;
+  } | {
+    _ref: string;
+    _weak?: boolean;
+  };
+  slug?: Slug;
+  excerpt?: string;
+  mainImage?: {
+    _type: \\"image\\";
+    asset: {
+      _ref: string;
+      _weak?: boolean;
+    };
+    caption?: string;
+    attribution?: string;
+    hotspot?: {
+      _type: \\"sanity.imageHotspot\\";
+      x: number;
+      y: number;
+      height: number;
+      width: number;
+    };
+    crop?: {
+      _type: \\"sanity.imageCrop\\";
+      top: number;
+      bottom: number;
+      left: number;
+      right: number;
+    };
+  };
+  body?: BlockContent;
+};
+
+export type Ghost = {
+  _id: string;
+  _type: \\"ghost\\";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  name?: string;
+};
+
+export type BlockContent = Array<{
+  _key: string;
+  level?: number;
+  style?: \\"normal\\" | \\"h1\\" | \\"h2\\" | \\"h3\\" | \\"h4\\" | \\"blockquote\\";
+  listItem?: \\"bullet\\";
+  children: Array<{
+    _key: string;
+    text: string;
+    marks: Array<string | \\"strong\\" | \\"em\\">;
+  }>;
+  markDefs: Array<{
+    href?: string;
+  }>;
+  _key: string;
+}>;
+
+export type SanityAssetSourceData = {
+  name?: string;
+  id?: string;
+  url?: string;
+  _type: \\"sanity.assetSourceData\\";
+};
+
+export type Slug = {
+  current?: string;
+  source?: string;
+  _type: \\"slug\\";
+};
+
+export type Geopoint = {
+  lat?: number;
+  lng?: number;
+  alt?: number;
+  _type: \\"geopoint\\";
+};
+
+export type SanityImageAsset = {
+  _id: string;
+  _type: \\"sanity.imageAsset\\";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  originalFilename?: string;
+  label?: string;
+  title?: string;
+  description?: string;
+  altText?: string;
+  sha1hash?: string;
+  extension?: string;
+  mimeType?: string;
+  size?: number;
+  assetId?: string;
+  uploadId?: string;
+  path?: string;
+  url?: string;
+  metadata?: SanityImageMetadata;
+  source?: SanityAssetSourceData;
+};
+
+export type SanityFileAsset = {
+  _id: string;
+  _type: \\"sanity.fileAsset\\";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  originalFilename?: string;
+  label?: string;
+  title?: string;
+  description?: string;
+  altText?: string;
+  sha1hash?: string;
+  extension?: string;
+  mimeType?: string;
+  size?: number;
+  assetId?: string;
+  uploadId?: string;
+  path?: string;
+  url?: string;
+  source?: SanityAssetSourceData;
+};
+
+export type SanityImageCrop = {
+  top?: number;
+  bottom?: number;
+  left?: number;
+  right?: number;
+  _type: \\"sanity.imageCrop\\";
+};
+
+export type SanityImageHotspot = {
+  x?: number;
+  y?: number;
+  height?: number;
+  width?: number;
+  _type: \\"sanity.imageHotspot\\";
+};
+
+export type SanityImageMetadata = {
+  location?: Geopoint;
+  dimensions?: SanityImageDimensions;
+  palette?: SanityImagePalette;
+  lqip?: string;
+  blurHash?: string;
+  hasAlpha?: boolean;
+  isOpaque?: boolean;
+  _type: \\"sanity.imageMetadata\\";
+};
+
+export type SanityImageDimensions = {
+  height?: number;
+  width?: number;
+  aspectRatio?: number;
+  _type: \\"sanity.imageDimensions\\";
+};
+
+export type SanityImagePalette = {
+  darkMuted?: SanityImagePaletteSwatch;
+  lightVibrant?: SanityImagePaletteSwatch;
+  darkVibrant?: SanityImagePaletteSwatch;
+  vibrant?: SanityImagePaletteSwatch;
+  dominant?: SanityImagePaletteSwatch;
+  lightMuted?: SanityImagePaletteSwatch;
+  muted?: SanityImagePaletteSwatch;
+  _type: \\"sanity.imagePalette\\";
+};
+
+export type SanityImagePaletteSwatch = {
+  background?: string;
+  foreground?: string;
+  population?: number;
+  title?: string;
+  _type: \\"sanity.imagePaletteSwatch\\";
+};"
+`;
+
+exports[`generateSchemaTypes should generate correct types for document schema with inline fields 1`] = `
+"export type myObject = {
+  inlineField: {
+    test: string;
+  } & Test;
+  unknownObject: unknown;
+  arrayField: Array<string>;
+  unionField: {
+    test: string;
+  } | string | Test;
+};"
+`;
+
+exports[`generateSchemaTypes should generate correct types for document schema with inline fields 2`] = `"export type someOtherType = MyObject;"`;

--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInPath.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInPath.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert'
+import path from 'node:path'
+
+import {describe, expect, test} from '@jest/globals'
+
+import {findQueriesInPath} from '../findQueriesInPath'
+
+describe('findQueriesInPath', () => {
+  test('should throw an error if the query name already exists', async () => {
+    const stream = findQueriesInPath({
+      path: path.join(__dirname, 'fixtures', '{source1,source2}.ts'),
+    })
+    await stream.next()
+    const result = await stream.next()
+    if (!result.value) {
+      throw new Error('Expected to yield a result')
+    }
+    expect(result.value.type).toBe('error')
+    assert(result.value.type === 'error') // workaround for TS
+    expect(result.value.error.message).toMatch(/Duplicate query name found:/)
+  })
+})

--- a/packages/@sanity/codegen/src/typescript/__tests__/fixtures/schema.json
+++ b/packages/@sanity/codegen/src/typescript/__tests__/fixtures/schema.json
@@ -1,0 +1,1192 @@
+[
+  {
+    "name": "author",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "author"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "name": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  {
+    "name": "post",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "post"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "author": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "union",
+          "of": [
+            {
+              "type": "object",
+              "attributes": {
+                "_ref": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "_weak": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "boolean"
+                  },
+                  "optional": true
+                }
+              },
+              "dereferencesTo": "author"
+            },
+            {
+              "type": "object",
+              "attributes": {
+                "_ref": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "_weak": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "boolean"
+                  },
+                  "optional": true
+                }
+              },
+              "dereferencesTo": "ghost"
+            }
+          ]
+        }
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        }
+      },
+      "excerpt": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "mainImage": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "object",
+          "attributes": {
+            "_type": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string",
+                "value": "image"
+              }
+            },
+            "asset": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "object",
+                "attributes": {
+                  "_ref": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "_weak": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "boolean"
+                    },
+                    "optional": true
+                  }
+                },
+                "dereferencesTo": "sanity.imageAsset"
+              }
+            },
+            "caption": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "attribution": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "hotspot": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "object",
+                "attributes": {
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "sanity.imageHotspot"
+                    }
+                  },
+                  "x": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "number"
+                    },
+                    "optional": false
+                  },
+                  "y": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "number"
+                    },
+                    "optional": false
+                  },
+                  "height": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "number"
+                    },
+                    "optional": false
+                  },
+                  "width": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "number"
+                    },
+                    "optional": false
+                  }
+                }
+              },
+              "optional": true
+            },
+            "crop": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "object",
+                "attributes": {
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "sanity.imageCrop"
+                    }
+                  },
+                  "top": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "number"
+                    },
+                    "optional": false
+                  },
+                  "bottom": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "number"
+                    },
+                    "optional": false
+                  },
+                  "left": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "number"
+                    },
+                    "optional": false
+                  },
+                  "right": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "number"
+                    },
+                    "optional": false
+                  }
+                }
+              },
+              "optional": true
+            }
+          }
+        }
+      },
+      "body": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "inline",
+          "name": "blockContent"
+        }
+      }
+    }
+  },
+  {
+    "name": "ghost",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "ghost"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "name": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  {
+    "type": "type",
+    "name": "blockContent",
+    "value": {
+      "type": "array",
+      "of": {
+        "type": "object",
+        "attributes": {
+          "_key": {
+            "type": "objectAttribute",
+            "value": {
+              "type": "string"
+            }
+          },
+          "level": {
+            "type": "objectAttribute",
+            "optional": true,
+            "value": {
+              "type": "number"
+            }
+          },
+          "style": {
+            "type": "objectAttribute",
+            "optional": true,
+            "value": {
+              "type": "union",
+              "of": [
+                {
+                  "type": "string",
+                  "value": "normal"
+                },
+                {
+                  "type": "string",
+                  "value": "h1"
+                },
+                {
+                  "type": "string",
+                  "value": "h2"
+                },
+                {
+                  "type": "string",
+                  "value": "h3"
+                },
+                {
+                  "type": "string",
+                  "value": "h4"
+                },
+                {
+                  "type": "string",
+                  "value": "blockquote"
+                }
+              ]
+            }
+          },
+          "listItem": {
+            "type": "objectAttribute",
+            "optional": true,
+            "value": {
+              "type": "union",
+              "of": [
+                {
+                  "type": "string",
+                  "value": "bullet"
+                }
+              ]
+            }
+          },
+          "children": {
+            "type": "objectAttribute",
+            "value": {
+              "type": "array",
+              "of": {
+                "type": "union",
+                "of": [
+                  {
+                    "type": "object",
+                    "attributes": {
+                      "_key": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "text": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "marks": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "array",
+                          "of": {
+                            "type": "union",
+                            "of": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "string",
+                                "value": "strong"
+                              },
+                              {
+                                "type": "string",
+                                "value": "em"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "markDefs": {
+            "type": "objectAttribute",
+            "value": {
+              "type": "array",
+              "of": {
+                "type": "union",
+                "of": [
+                  {
+                    "type": "object",
+                    "attributes": {
+                      "href": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        },
+                        "optional": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "rest": {
+          "type": "object",
+          "attributes": {
+            "_key": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "sanity.assetSourceData",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "name": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "string"
+          }
+        },
+        "url": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "string"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.assetSourceData"
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "slug",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "current": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "string"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "slug"
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "geopoint",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "lat": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "lng": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "alt": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "geopoint"
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "sanity.imageAsset",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "sanity.imageAsset"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "originalFilename": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "label": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "description": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "altText": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "sha1hash": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "extension": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "mimeType": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "size": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "number"
+        }
+      },
+      "assetId": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "uploadId": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "path": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "url": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "metadata": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "inline",
+          "name": "sanity.imageMetadata"
+        }
+      },
+      "source": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "inline",
+          "name": "sanity.assetSourceData"
+        }
+      }
+    }
+  },
+  {
+    "name": "sanity.fileAsset",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "sanity.fileAsset"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "originalFilename": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "label": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "description": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "altText": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "sha1hash": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "extension": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "mimeType": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "size": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "number"
+        }
+      },
+      "assetId": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "uploadId": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "path": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "url": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "string"
+        }
+      },
+      "source": {
+        "type": "objectAttribute",
+        "optional": true,
+        "value": {
+          "type": "inline",
+          "name": "sanity.assetSourceData"
+        }
+      }
+    }
+  },
+  {
+    "name": "sanity.imageCrop",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "top": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "bottom": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "left": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "right": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imageCrop"
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "sanity.imageHotspot",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "x": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "y": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "height": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "width": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imageHotspot"
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "sanity.imageMetadata",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "location": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "inline",
+            "name": "geopoint"
+          }
+        },
+        "dimensions": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "inline",
+            "name": "sanity.imageDimensions"
+          }
+        },
+        "palette": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "inline",
+            "name": "sanity.imagePalette"
+          }
+        },
+        "lqip": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "string"
+          }
+        },
+        "blurHash": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "string"
+          }
+        },
+        "hasAlpha": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "boolean"
+          }
+        },
+        "isOpaque": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "boolean"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imageMetadata"
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "sanity.imageDimensions",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "height": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "width": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "aspectRatio": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imageDimensions"
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "sanity.imagePalette",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "darkMuted": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "inline",
+            "name": "sanity.imagePaletteSwatch"
+          }
+        },
+        "lightVibrant": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "inline",
+            "name": "sanity.imagePaletteSwatch"
+          }
+        },
+        "darkVibrant": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "inline",
+            "name": "sanity.imagePaletteSwatch"
+          }
+        },
+        "vibrant": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "inline",
+            "name": "sanity.imagePaletteSwatch"
+          }
+        },
+        "dominant": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "inline",
+            "name": "sanity.imagePaletteSwatch"
+          }
+        },
+        "lightMuted": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "inline",
+            "name": "sanity.imagePaletteSwatch"
+          }
+        },
+        "muted": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "inline",
+            "name": "sanity.imagePaletteSwatch"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imagePalette"
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "sanity.imagePaletteSwatch",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "background": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "string"
+          }
+        },
+        "foreground": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "string"
+          }
+        },
+        "population": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "number"
+          }
+        },
+        "title": {
+          "type": "objectAttribute",
+          "optional": true,
+          "value": {
+            "type": "string"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imagePaletteSwatch"
+          }
+        }
+      }
+    }
+  }
+]

--- a/packages/@sanity/codegen/src/typescript/__tests__/typeGenerator.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/typeGenerator.test.ts
@@ -1,0 +1,401 @@
+import path from 'node:path'
+
+import {describe, expect, test} from '@jest/globals'
+import {
+  createReferenceTypeNode,
+  type DocumentSchemaType,
+  type ObjectAttribute,
+  type ObjectTypeNode,
+  type SchemaType,
+  type StringTypeNode,
+  type TypeNode,
+} from 'groq-js'
+
+import {readSchema} from '../../readSchema'
+import {TypeGenerator} from '../typeGenerator'
+
+describe('generateSchemaTypes', () => {
+  test('should generate TypeScript type declarations for a schema', async () => {
+    const schema = await readSchema(path.join(__dirname, 'fixtures', 'schema.json'))
+
+    const typeGenerator = new TypeGenerator(schema)
+    const typeDeclarations = typeGenerator.generateSchemaTypes()
+
+    expect(typeDeclarations).toMatchSnapshot()
+  })
+
+  test('should generate correct types for document schema with string fields', () => {
+    const schema: SchemaType = [
+      {
+        type: 'document',
+        name: 'author',
+        attributes: {
+          _id: {
+            type: 'objectAttribute',
+            value: {type: 'string'},
+          },
+          name: {
+            type: 'objectAttribute',
+            value: {type: 'string'},
+            optional: true,
+          },
+        },
+      },
+    ]
+
+    const typeGenerator = new TypeGenerator(schema)
+    const actualOutput = typeGenerator.generateSchemaTypes()
+
+    expect(actualOutput).toMatchInlineSnapshot(`
+"export type Author = {
+  _id: string;
+  name?: string;
+};"
+`)
+  })
+
+  test('should generate correct types for document schema with number fields', () => {
+    const schema: SchemaType = [
+      {
+        type: 'document',
+        name: 'product',
+        attributes: {
+          price: {
+            type: 'objectAttribute',
+            value: {type: 'number'},
+          },
+        },
+      },
+    ]
+
+    const typeGenerator = new TypeGenerator(schema)
+    const actualOutput = typeGenerator.generateSchemaTypes()
+
+    expect(actualOutput).toMatchInlineSnapshot(`
+"export type Product = {
+  price: number;
+};"
+`)
+  })
+
+  test('should generate correct types for document schema with boolean fields', () => {
+    const schema: SchemaType = [
+      {
+        type: 'document',
+        name: 'task',
+        attributes: {
+          completed: {
+            type: 'objectAttribute',
+            value: {type: 'boolean'},
+          },
+        },
+      },
+    ]
+    const typeGenerator = new TypeGenerator(schema)
+    const actualOutput = typeGenerator.generateSchemaTypes()
+
+    expect(actualOutput).toMatchInlineSnapshot(`
+"export type Task = {
+  completed: boolean;
+};"
+`)
+  })
+
+  test('should generate correct types for document schema with object fields', () => {
+    const schema: SchemaType = [
+      {
+        type: 'document',
+        name: 'user',
+        attributes: {
+          address: {
+            type: 'objectAttribute',
+            value: {
+              type: 'object',
+              attributes: {
+                street: {
+                  type: 'objectAttribute',
+                  value: {type: 'string'},
+                },
+                city: {
+                  type: 'objectAttribute',
+                  value: {type: 'string'},
+                },
+              },
+            },
+          },
+        },
+      },
+    ]
+
+    const typeGenerator = new TypeGenerator(schema)
+    const actualOutput = typeGenerator.generateSchemaTypes()
+
+    expect(actualOutput).toMatchInlineSnapshot(`
+"export type User = {
+  address: {
+    street: string;
+    city: string;
+  };
+};"
+`)
+  })
+
+  test('should generate correct types for document schema with array fields', () => {
+    const schema: SchemaType = [
+      {
+        type: 'document',
+        name: 'blogPost',
+        attributes: {
+          tags: {
+            type: 'objectAttribute',
+            value: {
+              type: 'array',
+              of: {type: 'string'},
+            },
+          },
+        },
+      },
+    ]
+
+    const typeGenerator = new TypeGenerator(schema)
+    const actualOutput = typeGenerator.generateSchemaTypes()
+
+    expect(actualOutput).toMatchInlineSnapshot(`
+"export type BlogPost = {
+  tags: Array<string>;
+};"
+`)
+  })
+
+  test('should generate correct types for document schema with unknown fields', () => {
+    const schema: SchemaType = [
+      {
+        type: 'document',
+        name: 'dynamicData',
+        attributes: {
+          metadata: {
+            type: 'objectAttribute',
+            value: {type: 'unknown'},
+          },
+        },
+      },
+    ]
+
+    const typeGenerator = new TypeGenerator(schema)
+    const actualOutput = typeGenerator.generateSchemaTypes()
+
+    expect(actualOutput).toMatchInlineSnapshot(`
+"export type DynamicData = {
+  metadata: unknown;
+};"
+`)
+  })
+
+  test('should generate correct types for document schema with never fields', () => {
+    const schema: SchemaType = [
+      {
+        type: 'document',
+        name: 'impossible',
+        attributes: {
+          willNotHappen: {
+            type: 'objectAttribute',
+            value: {type: 'null'},
+          },
+        },
+      },
+    ]
+
+    const typeGenerator = new TypeGenerator(schema)
+    const actualOutput = typeGenerator.generateSchemaTypes()
+
+    expect(actualOutput).toMatchInlineSnapshot(`
+"export type Impossible = {
+  willNotHappen: null;
+};"
+`)
+  })
+
+  test('should generate correct types for document schema with custom type references', () => {
+    const blogPost = {
+      type: 'document',
+      name: 'blogPost',
+      attributes: {
+        author: {
+          type: 'objectAttribute',
+          value: createReferenceTypeNode('author'),
+        } satisfies ObjectAttribute<ObjectTypeNode>,
+      },
+    } satisfies DocumentSchemaType
+    const author = {
+      type: 'document',
+      name: 'author',
+      attributes: {
+        name: {
+          type: 'objectAttribute',
+          value: {type: 'string'},
+        } satisfies ObjectAttribute<StringTypeNode>,
+      },
+    } satisfies DocumentSchemaType
+    const schema = [blogPost, author] satisfies SchemaType
+
+    const typeGenerator = new TypeGenerator(schema)
+    const actualOutput = typeGenerator.generateSchemaTypes()
+
+    expect(actualOutput).toMatchInlineSnapshot(`
+"export type BlogPost = {
+  author: {
+    _ref: string;
+    _type: \\"reference\\";
+    _weak?: boolean;
+  };
+};
+
+export type Author = {
+  name: string;
+};"
+`)
+  })
+
+  test('should generate correct types for document schema with union fields', () => {
+    const schema: SchemaType = [
+      {
+        type: 'document',
+        name: 'mixedContent',
+        attributes: {
+          content: {
+            type: 'objectAttribute',
+            value: {
+              type: 'union',
+              of: [{type: 'string'}, {type: 'number'}],
+            },
+          },
+        },
+      },
+    ]
+
+    const typeGenerator = new TypeGenerator(schema)
+    const actualOutput = typeGenerator.generateSchemaTypes()
+
+    expect(actualOutput).toMatchInlineSnapshot(`
+"export type MixedContent = {
+  content: string | number;
+};"
+`)
+  })
+
+  test('should generate correct types for document schema with nullable attribute', () => {
+    const schema: SchemaType = [
+      {
+        type: 'document',
+        name: 'optionalData',
+        attributes: {
+          obsoleteField: {
+            type: 'objectAttribute',
+            value: {type: 'null'},
+          },
+        },
+      },
+    ]
+
+    const typeGenerator = new TypeGenerator(schema)
+    const actualOutput = typeGenerator.generateSchemaTypes()
+
+    expect(actualOutput).toMatchInlineSnapshot(`
+"export type OptionalData = {
+  obsoleteField: null;
+};"
+`)
+  })
+
+  describe('generateTypeNodeTypes', () => {
+    const typeGenerator = new TypeGenerator([])
+    test.each(['string', 'boolean', 'number', 'unknown', 'null'] as const)(
+      'should be able to generate types for type nodes: %s',
+      (typeName) => {
+        const out = typeGenerator.generateTypeNodeTypes('test', {
+          type: typeName,
+        } satisfies TypeNode)
+
+        expect(out).toMatchSnapshot()
+      },
+    )
+  })
+
+  test('should generate correct types for document schema with inline fields', () => {
+    const objectNode = {
+      type: 'object',
+      attributes: {
+        inlineField: {
+          type: 'objectAttribute',
+          value: {
+            type: 'object',
+            attributes: {
+              test: {
+                type: 'objectAttribute',
+                value: {type: 'string'},
+              },
+            },
+            rest: {
+              type: 'inline',
+              name: 'test',
+            },
+          },
+        },
+        unknownObject: {
+          type: 'objectAttribute',
+          value: {
+            type: 'object',
+            attributes: {
+              test: {
+                type: 'objectAttribute',
+                value: {type: 'string'},
+              },
+            },
+            rest: {
+              type: 'unknown',
+            },
+          },
+        },
+        arrayField: {
+          type: 'objectAttribute',
+          value: {
+            type: 'array',
+            of: {type: 'string'},
+          },
+        },
+        unionField: {
+          type: 'objectAttribute',
+          value: {
+            type: 'union',
+            of: [
+              {
+                type: 'object',
+                attributes: {
+                  test: {
+                    type: 'objectAttribute',
+                    value: {type: 'string'},
+                  },
+                },
+              },
+              {type: 'string'},
+              {
+                type: 'inline',
+                name: 'test',
+              },
+            ],
+          },
+        },
+      },
+    } satisfies TypeNode
+
+    const typeGenerator = new TypeGenerator([])
+    const objectNodeOut = typeGenerator.generateTypeNodeTypes('myObject', objectNode)
+    expect(objectNodeOut).toMatchSnapshot()
+
+    const someOtherTypeOut = typeGenerator.generateTypeNodeTypes('someOtherType', {
+      type: 'inline',
+      name: 'myObject',
+    })
+    expect(someOtherTypeOut).toMatchSnapshot()
+  })
+})

--- a/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
+++ b/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
@@ -12,13 +12,23 @@ const debug = createDebug('sanity:codegen:findQueries:debug')
 
 type resolveExpressionReturnType = string
 
+/**
+ * NamedQueryResult is a result of a named query
+ */
 export interface NamedQueryResult {
+  /** name is the name of the query */
   name: string
+  /** result is a groq query */
   result: resolveExpressionReturnType
 }
 
 const TAGGED_TEMPLATE_ALLOW_LIST = ['groq']
 
+/**
+ * resolveExpression takes a node and returns the resolved value of the expression.
+ * @beta
+ * @internal
+ */
 export function resolveExpression({
   node,
   file,

--- a/packages/@sanity/codegen/src/typescript/findQueriesInPath.ts
+++ b/packages/@sanity/codegen/src/typescript/findQueriesInPath.ts
@@ -1,0 +1,81 @@
+import fs from 'node:fs/promises'
+import {join} from 'node:path'
+
+import {type TransformOptions} from '@babel/core'
+import createDebug from 'debug'
+import glob from 'globby'
+
+import {type NamedQueryResult} from './expressionResolvers'
+import {findQueriesInSource} from './findQueriesInSource'
+import {getResolver} from './moduleResolver'
+
+const debug = createDebug('sanity:codegen:findQueries:debug')
+
+const defaultBabelOptions = {
+  extends: join(__dirname, '..', '..', 'babel.config.json'),
+}
+
+const queryNames = new Set()
+
+type ResultQueries = {
+  type: 'queries'
+  filename: string
+  queries: NamedQueryResult[]
+}
+type ResultError = {
+  type: 'error'
+  error: Error
+}
+
+/**
+ * findQueriesInPath takes a path or array of paths and returns all GROQ queries in the files.
+ * @param path - The path or array of paths to search for queries
+ * @param babelOptions - The babel configuration to use when parsing the source
+ * @param resolver - A resolver function to use when resolving module imports
+ * @returns An async generator that yields the results of the search
+ * @beta
+ * @internal
+ */
+export async function* findQueriesInPath({
+  path,
+  babelOptions = defaultBabelOptions,
+  resolver = getResolver(),
+}: {
+  path: string | string[]
+  babelOptions?: TransformOptions
+  resolver?: NodeJS.RequireResolve
+}): AsyncGenerator<ResultQueries | ResultError> {
+  // Holds all query names found in the source files
+  debug(`Globing ${path}`)
+
+  const stream = glob.stream(path, {
+    absolute: true,
+    ignore: ['**/node_modules/**'], // we never want to look in node_modules
+    onlyFiles: true,
+  })
+
+  for await (const filename of stream) {
+    if (typeof filename !== 'string') {
+      continue
+    }
+
+    debug(`Found file "${filename}"`)
+    try {
+      const source = await fs.readFile(filename, 'utf8')
+      const queries = findQueriesInSource(source, filename, babelOptions, resolver)
+      // Check and error on duplicate query names, because we can't generate types with the same name.
+      for (const query of queries) {
+        if (queryNames.has(query.name)) {
+          throw new Error(
+            `Duplicate query name found: "${query.name}". Query names must be unique across all files.`,
+          )
+        }
+        queryNames.add(query.name)
+      }
+      yield {type: 'queries', filename, queries}
+    } catch (error) {
+      debug(`Error in file "${filename}"`, error)
+      yield {type: 'error', error}
+    }
+  }
+}

--- a/packages/@sanity/codegen/src/typescript/typeGenerator.ts
+++ b/packages/@sanity/codegen/src/typescript/typeGenerator.ts
@@ -1,0 +1,239 @@
+import {CodeGenerator} from '@babel/generator'
+import * as t from '@babel/types'
+import {
+  type ArrayTypeNode,
+  type DocumentSchemaType,
+  type ObjectAttribute,
+  type ObjectTypeNode,
+  type SchemaType,
+  type TypeDeclarationSchemaType,
+  type TypeNode,
+  type UnionTypeNode,
+} from 'groq-js'
+
+/**
+ * A class used to generate TypeScript types from a given schema
+ * @internal
+ * @beta
+ */
+export class TypeGenerator {
+  private generatedTypeName: Set<string> = new Set()
+  private typeNameMap: Map<string, string> = new Map()
+
+  private readonly schema: SchemaType
+
+  constructor(schema: SchemaType) {
+    this.schema = schema
+  }
+
+  /**
+   * Generate TypeScript types for the given schema
+   * @returns string
+   * @internal
+   * @beta
+   */
+  generateSchemaTypes(): string {
+    const typeDeclarations: (t.TSTypeAliasDeclaration | t.ExportNamedDeclaration)[] = []
+
+    this.schema.forEach((schema) => {
+      const typeLiteral = this.getTypeNodeType(schema)
+
+      const typeAlias = t.tsTypeAliasDeclaration(
+        t.identifier(this.getTypeName(schema.name, true)),
+        null,
+        typeLiteral,
+      )
+
+      typeDeclarations.push(t.exportNamedDeclaration(typeAlias))
+    })
+
+    // Generate TypeScript code from the AST nodes
+    return typeDeclarations.map((decl) => new CodeGenerator(decl).generate().code).join('\n\n')
+  }
+
+  /**
+   * Takes a identifier and a type node and generates a type alias for the type node.
+   * @param identifierName - The name of the type to generated
+   * @param typeNode - The type node to generate the type for
+   * @returns
+   * @internal
+   * @beta
+   */
+  generateTypeNodeTypes(identifierName: string, typeNode: TypeNode): string {
+    const type = this.getTypeNodeType(typeNode)
+
+    const typeAlias = t.tsTypeAliasDeclaration(
+      t.identifier(this.getTypeName(identifierName, false)),
+      null,
+      type,
+    )
+
+    return new CodeGenerator(t.exportNamedDeclaration(typeAlias)).generate().code
+  }
+
+  /**
+   * Since we are sanitizing identifiers we migt end up with collisions. Ie there might be a type mux.video and muxVideo, both these
+   * types would be sanityized into MuxVideo. To avoid this we keep track of the generated type names and add a index to the name.
+   * When we reference a type we also keep track of the original name so we can reference the correct type later.
+   */
+  private getTypeName(name: string, shouldUppercaseFirstLetter: boolean): string {
+    const desiredName = shouldUppercaseFirstLetter
+      ? uppercaseFirstLetter(sanitizeIdentifier(name))
+      : sanitizeIdentifier(name)
+
+    let generatedName = desiredName
+    let i = 2
+    while (this.generatedTypeName.has(generatedName)) {
+      // add _ and a index and increment that index until we find a name that is not in the map
+      generatedName = `${desiredName}_${i++}`
+    }
+    this.generatedTypeName.add(generatedName)
+    this.typeNameMap.set(name, generatedName)
+    return generatedName
+  }
+
+  private getTypeNodeType(
+    typeNode: TypeNode | TypeDeclarationSchemaType | DocumentSchemaType,
+  ): t.TSType {
+    switch (typeNode.type) {
+      case 'string': {
+        if (typeNode.value !== undefined) {
+          return t.tsLiteralType(t.stringLiteral(typeNode.value))
+        }
+        return t.tsStringKeyword()
+      }
+      case 'number': {
+        if (typeNode.value !== undefined) {
+          return t.tsLiteralType(t.numericLiteral(typeNode.value))
+        }
+        return t.tsNumberKeyword()
+      }
+      case 'boolean': {
+        if (typeNode.value !== undefined) {
+          return t.tsLiteralType(t.booleanLiteral(typeNode.value))
+        }
+        return t.tsBooleanKeyword()
+      }
+      case 'unknown': {
+        return t.tsUnknownKeyword()
+      }
+      case 'document': {
+        return this.generateDocumentType(typeNode)
+      }
+      case 'type': {
+        return this.getTypeNodeType(typeNode.value)
+      }
+      case 'array': {
+        return this.generateArrayTsType(typeNode)
+      }
+      case 'object': {
+        return this.generateObjectTsType(typeNode)
+      }
+      case 'union': {
+        return this.generateUnionTsType(typeNode)
+      }
+      case 'inline': {
+        return t.tsTypeReference(
+          t.identifier(uppercaseFirstLetter(sanitizeIdentifier(typeNode.name))),
+        )
+      }
+      case 'null': {
+        return t.tsNullKeyword()
+      }
+
+      default:
+        // @ts-expect-error This should never happen
+        throw new Error(`Type "${typeNode.type}" not found in schema`)
+    }
+  }
+
+  // Helper function used to generate TS types for array type nodes.
+  private generateArrayTsType(typeNode: ArrayTypeNode): t.TSTypeReference {
+    const typeNodes = this.getTypeNodeType(typeNode.of)
+    const arrayType = t.tsTypeReference(
+      t.identifier('Array'),
+      t.tsTypeParameterInstantiation([typeNodes]),
+    )
+
+    return arrayType
+  }
+
+  // Helper function used to generate TS types for object properties.
+  private generateObjectProperty(key: string, attribute: ObjectAttribute): t.TSPropertySignature {
+    const type = this.getTypeNodeType(attribute.value)
+    const propertySignature = t.tsPropertySignature(
+      t.identifier(sanitizeIdentifier(key)),
+      t.tsTypeAnnotation(type),
+    )
+    propertySignature.optional = attribute.optional
+
+    return propertySignature
+  }
+
+  // Helper function used to generate TS types for object type nodes.
+  private generateObjectTsType(typeNode: ObjectTypeNode): t.TSType {
+    const props: t.TSPropertySignature[] = []
+    Object.entries(typeNode.attributes).forEach(([key, attribute]) => {
+      props.push(this.generateObjectProperty(key, attribute))
+    })
+    if (typeNode.rest !== undefined) {
+      switch (typeNode.rest.type) {
+        case 'unknown': {
+          return t.tsUnknownKeyword()
+        }
+        case 'object': {
+          Object.entries(typeNode.rest.attributes).forEach(([key, attribute]) => {
+            props.push(this.generateObjectProperty(key, attribute))
+          })
+          break
+        }
+        case 'inline': {
+          return t.tsIntersectionType([
+            t.tsTypeLiteral(props),
+            t.tsTypeReference(
+              t.identifier(
+                this.typeNameMap.get(typeNode.rest.name) ||
+                  uppercaseFirstLetter(sanitizeIdentifier(typeNode.rest.name)),
+              ),
+            ),
+          ])
+        }
+        default: {
+          // @ts-expect-error This should never happen
+          throw new Error(`Type "${typeNode.rest.type}" not found in schema`)
+        }
+      }
+    }
+    return t.tsTypeLiteral(props)
+  }
+
+  // Helper function used to generate TS types for union type nodes.
+  private generateUnionTsType(typeNode: UnionTypeNode): t.TSType {
+    if (typeNode.of.length === 0) {
+      return t.tsNeverKeyword()
+    }
+    if (typeNode.of.length === 1) {
+      return this.getTypeNodeType(typeNode.of[0])
+    }
+
+    const typeNodes = typeNode.of.map((node) => this.getTypeNodeType(node))
+
+    return t.tsUnionType(typeNodes)
+  }
+
+  // Helper function used to generate TS types for document type nodes.
+  private generateDocumentType(document: DocumentSchemaType): t.TSType {
+    const props = Object.entries(document.attributes).map(([key, node]) =>
+      this.generateObjectProperty(key, node),
+    )
+
+    return t.tsTypeLiteral(props)
+  }
+}
+function uppercaseFirstLetter(input: string): string {
+  return input.charAt(0).toUpperCase() + input.slice(1)
+}
+
+function sanitizeIdentifier(input: string): string {
+  return `${input.replace(/^\d/, '_').replace(/[^$\w]+(.)/g, (_, char) => char.toUpperCase())}`
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,6 +842,9 @@ importers:
       '@babel/core':
         specifier: ^7.23.9
         version: 7.24.0
+      '@babel/generator':
+        specifier: ^7.23.6
+        version: 7.23.6
       '@babel/preset-env':
         specifier: ^7.23.8
         version: 7.24.0(@babel/core@7.24.0)
@@ -863,6 +866,12 @@ importers:
       debug:
         specifier: ^4.3.4
         version: 4.3.4(supports-color@5.5.0)
+      globby:
+        specifier: ^10.0.0
+        version: 10.0.2
+      groq-js:
+        specifier: 1.5.0-canary.1
+        version: 1.5.0-canary.1
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -873,6 +882,9 @@ importers:
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
+      '@types/babel__generator':
+        specifier: ^7.6.8
+        version: 7.6.8
       '@types/babel__register':
         specifier: ^7.17.3
         version: 7.17.3


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR adds type generation method given a set of TypeNodes. It can generate type nodes from either a schema, or a TypeNode and return typescript types as a string.

* `readSchema.ts`: We don't provide any validation that the schema read is correct atm. That should be fine for now, as all schemas should be generated by the schema extract cmd.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->


### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

We should have good coverage on the type generation methods

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

N/A - No notes needed