### PR TITLE
fix(util): safely stringify path segments named as GROQ data types (e.g. `null`)

### DIFF
--- a/packages/@sanity/util/src/paths.ts
+++ b/packages/@sanity/util/src/paths.ts
@@ -15,6 +15,10 @@ const EMPTY_PATH: Path = []
 
 export const FOCUS_TERMINATOR = '$'
 
+// Fields named as GROQ data types cannot be accessed using dot notation. These fields must instead
+// be serialized using square bracket notation.
+const GROQ_DATA_TYPE_VALUES = ['true', 'false', 'null']
+
 export function get<R>(obj: unknown, path: Path | string): R | undefined
 export function get<R>(obj: unknown, path: Path | string, defaultValue: R): R
 export function get(obj: unknown, path: Path | string, defaultVal?: unknown): unknown {
@@ -164,14 +168,22 @@ export function toString(path: Path): string {
   }
 
   return path.reduce<string>((target, segment, i) => {
-    const segmentType = typeof segment
-    if (segmentType === 'number') {
+    const isHead = i === 0
+
+    if (typeof segment === 'number') {
       return `${target}[${segment}]`
     }
 
-    if (segmentType === 'string') {
-      const separator = i === 0 ? '' : '.'
-      return `${target}${separator}${segment}`
+    if (typeof segment === 'string') {
+      if (isHead) {
+        return segment
+      }
+
+      if (GROQ_DATA_TYPE_VALUES.includes(segment)) {
+        return `${target}["${segment}"]`
+      }
+
+      return `${target}.${segment}`
     }
 
     if (isKeySegment(segment) && segment._key) {

--- a/packages/@sanity/util/test/PathUtils.test.ts
+++ b/packages/@sanity/util/test/PathUtils.test.ts
@@ -1,4 +1,5 @@
 import {expect, test} from '@jest/globals'
+
 /* eslint-disable max-nested-callbacks, @typescript-eslint/ban-ts-comment */
 import {fromString, get, resolveKeyedPath, toString} from '../src/paths'
 
@@ -102,6 +103,14 @@ test('toString: handles deep prop segments', () => {
   expect(toString(['foo', 'bar'])).toEqual('foo.bar')
   expect(toString(['bar', 'foo'])).toEqual('bar.foo')
   expect(toString(['bar', 'foo', 'baz'])).toEqual('bar.foo.baz')
+})
+
+test('toString: handles deep prop segments named as GROQ data types', () => {
+  expect(toString(['foo', 'true'])).toEqual('foo["true"]')
+  expect(toString(['bar', 'false'])).toEqual('bar["false"]')
+  expect(toString(['bat', 'null'])).toEqual('bat["null"]')
+  expect(toString(['true', 'true'])).toEqual('true["true"]')
+  expect(toString(['true', 'false', 'null'])).toEqual('true["false"]["null"]')
 })
 
 test('toString: handles deep array index segments', () => {


### PR DESCRIPTION
### Description

Fields named as GROQ data types (`true`, `false`, and `null`) cannot be accessed using dot notation. These fields must instead be serialized using square bracket notation.

Segments names `true`, `false`, or `null` will now be serialized using square bracket notation. All other segments will continue to use dot notation.

#### Invalid

```groq
parent.true
```

#### Valid

```groq
parent["true"]
```

You can observe this by executing a GROQ query such as:

```groq
[{
  "true": "positive"
}, {
  "false": "negative"
}, {
  "null": "nothing"
}].null

// attribute expected
```

Versus:

```groq
[{
  "true": "positive"
}, {
  "false": "negative"
}, {
  "null": "nothing"
}]["null"]

// [
//   null,
//   null,
//   "nothing"
// ]
```

### What to review

The paths created by the `toString` function are correct.

### Testing

This branch adds tests to the `packages/@sanity/util/test/PathUtils.test.ts` test suite.
