### PR TITLE
fix(core): include request tag in Text Search API requests

### DIFF
--- a/packages/sanity/src/core/search/text-search/createTextSearch.ts
+++ b/packages/sanity/src/core/search/text-search/createTextSearch.ts
@@ -127,6 +127,7 @@ export const createTextSearch: SearchStrategyFactory<TextSearchResults> = (
         method: 'POST',
         json: true,
         body: textSearchParams,
+        tag: factoryOptions.tag,
       })
       .pipe(
         map((response) => {


### PR DESCRIPTION
### Description

The search request tag was not being included in Text Search API requests.

### What to review

The dedicated search tag is included when sending Text Search API requests.

### Testing

When a search request has a dedicated tag, it should be included in the Text Search API request.

| Surface | Tag |
| --- | --- |
| Global search | `sanity.studio.search.global` |
| Reference search | `sanity.studio.search.reference` |
| Cross Dataset Reference search | `sanity.studio.search.cross-dataset-reference` |

Note: Document list search doesn't use a dedicated tag at present.
