### PR TITLE
fix(core): handle no user id in `getUser`

### DIFF
--- a/packages/sanity/src/core/store/_legacy/user/userStore.ts
+++ b/packages/sanity/src/core/store/_legacy/user/userStore.ts
@@ -74,6 +74,8 @@ export function createUserStore({client: _client, currentUser}: UserStoreOptions
 
   return {
     getUser: async (userId) => {
+      if (!userId) return Promise.resolve(null)
+
       try {
         return await userLoader.load(userId)
       } catch (err) {


### PR DESCRIPTION
### Description

This pull request ensures that we do not proceed with fetching the user with `getUser` in `createUserStore` if there's no user id available. This is added because if there's no user id provided, we know that the fetch will fail. So, we can prevent the request from erroring by returning early instead.

### What to Review

- Make sure that `getUser` works as before.
- Does the change make sense?

### Notes for Release

N/A
