### PR TITLE
chore: update API version for production-ready cellar

### DIFF
--- a/packages/sanity/src/core/store/key-value/backends/server.ts
+++ b/packages/sanity/src/core/store/key-value/backends/server.ts
@@ -17,7 +17,7 @@ export interface ServerBackendOptions {
  * @internal
  */
 export function serverBackend({client: _client}: ServerBackendOptions): Backend {
-  const client = _client.withConfig({...DEFAULT_STUDIO_CLIENT_OPTIONS, apiVersion: 'vX'})
+  const client = _client.withConfig(DEFAULT_STUDIO_CLIENT_OPTIONS)
 
   const keyValueLoader = new DataLoader<string, KeyValueStoreValue | null>(async (keys) => {
     const value = await client

--- a/packages/sanity/src/core/studioClient.ts
+++ b/packages/sanity/src/core/studioClient.ts
@@ -10,5 +10,5 @@ import {type SourceClientOptions} from './config'
  * @internal
  */
 export const DEFAULT_STUDIO_CLIENT_OPTIONS: SourceClientOptions = {
-  apiVersion: '2023-11-13',
+  apiVersion: '2024-03-12',
 }


### PR DESCRIPTION
### Description

Updates the default studio client version to the key-value store's date of release. Since we haven't had a significant change in client behavior, and we generally ask that users use a current date for their own API versioning, this should be a non-breaking change, but is required to query our key-value store per internal guidelines.

### What to review

Is there anything that depended on the old client version? Any unexpected behaviors?

### Testing

All current tests should behave as normal.