### PR TITLE
fix(structure): push taskCreateAction to the end of the actions array

### DIFF
--- a/packages/sanity/src/structure/structureTool.ts
+++ b/packages/sanity/src/structure/structureTool.ts
@@ -88,7 +88,15 @@ export const structureTool = definePlugin<StructureToolOptions | void>((options)
       actions: (prevActions) => {
         // NOTE: since it's possible to have several structure tools in one Studio,
         // we need to check whether the document actions already exist in the Studio config
-        return Array.from(new Set([...prevActions, ...documentActions]))
+        const actions = Array.from(new Set([...prevActions, ...documentActions]))
+
+        // Find `TaskCreateAction` and push it to the end of the actions list, users are inserting into the actions array at specific positions.
+        const taskCreateAction = actions.find((action) => action.name === 'TaskCreateAction')
+        if (taskCreateAction) {
+          actions.splice(actions.indexOf(taskCreateAction), 1)
+          actions.push(taskCreateAction)
+        }
+        return actions
       },
       badges: (prevBadges) => {
         // NOTE: since it's possible to have several structure tools in one Studio,


### PR DESCRIPTION
### Description

With the addition of tasks plugin we introduced a new action. `TasksCreateAction` 
This action, because of the way we resolve the plugins structure, is added at the start of the actions list.

Some users are inserting actions into an specific position of the actions array, assuming the first action is the `PublishAction`

Actions array before:
```
  [TasksCreateAction, Publish, Unpublish, ...]
```

Actions array after:
```
  [Publish, Unpublish, ..., TasksCreateAction]
```

This will not break the implementation of users who are doing changes like this:

```
export const resolveDocumentActions: DocumentActionsResolver = (prev) => {
  prev.splice(1, 0, CustomAction)
  prev.splice(2, 0, DividerAction)
  return prev
}

```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
