### PR TITLE
fix(portable-text-editor): fix and test issue with merge block operation

### DIFF
--- a/packages/@sanity/portable-text-editor/e2e-tests/__tests__/writingTogether.collaborative.test.ts
+++ b/packages/@sanity/portable-text-editor/e2e-tests/__tests__/writingTogether.collaborative.test.ts
@@ -65,6 +65,67 @@ describe('collaborate editing', () => {
     })
   })
 
+  it('should not remove content for both users if one user backspaces into a block that starts with a mark.', async () => {
+    const exampleValue = [
+      {
+        _key: 'randomKey0',
+        _type: 'block',
+        children: [
+          {
+            _key: 'randomKey1',
+            _type: 'span',
+            marks: ['strong'],
+            text: 'Example Text: ',
+          },
+          {
+            _type: 'span',
+            marks: [],
+            text: "This is a very long example text that will completely disappear later on. It's kind of a bad magic trick, really. Just writing more text so the disappearance becomes more apparent. This is a very long example text that will completely disappear later on. It's kind of a bad magic trick, really. Just writing more text so the disappearance becomes more apparent. This is a very long example text that will completely disappear later on. It's kind of a bad magic trick, really. Just writing more text so the disappearance becomes more apparent.",
+            _key: 'randomKey2',
+          },
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+    await setDocumentValue(exampleValue)
+    const [editorA, editorB] = await getEditors()
+    await editorA.setSelection({
+      anchor: {path: [{_key: 'randomKey0'}, 'children', {_key: 'randomKey2'}], offset: 542},
+      focus: {path: [{_key: 'randomKey0'}, 'children', {_key: 'randomKey2'}], offset: 542},
+    })
+    await editorA.pressKey('Enter')
+    await editorA.pressKey('Backspace')
+
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    const valA = await editorA.getValue()
+    const valB = await editorB.getValue()
+    expect(valA).toEqual(valB)
+    expect(valB).toEqual([
+      {
+        _key: 'randomKey0',
+        _type: 'block',
+        children: [
+          {
+            _key: 'randomKey1',
+            _type: 'span',
+            marks: ['strong'],
+            text: 'Example Text: ',
+          },
+          {
+            _type: 'span',
+            marks: [],
+            text: "This is a very long example text that will completely disappear later on. It's kind of a bad magic trick, really. Just writing more text so the disappearance becomes more apparent. This is a very long example text that will completely disappear later on. It's kind of a bad magic trick, really. Just writing more text so the disappearance becomes more apparent. This is a very long example text that will completely disappear later on. It's kind of a bad magic trick, really. Just writing more text so the disappearance becomes more apparent.",
+            _key: 'randomKey2',
+          },
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+  })
+
   it('will reset the value when someone deletes everything, and when they start to type again, they will produce their own respective blocks.', async () => {
     await setDocumentValue(initialValue)
     const [editorA, editorB] = await getEditors()

--- a/packages/@sanity/portable-text-editor/package.json
+++ b/packages/@sanity/portable-text-editor/package.json
@@ -57,7 +57,7 @@
     "clean": "rimraf lib",
     "lint": "eslint .",
     "prettier": "prettier --write './**/*.{ts,tsx,js,css,html}'",
-    "dev": "cd ./test/ && ts-node serve",
+    "dev": "cd ./e2e-tests/ && ts-node serve",
     "test": "jest",
     "test:e2e": "jest --config=e2e-tests/e2e.config.cjs",
     "test:watch": "jest --watch",


### PR DESCRIPTION
### Description

There is an issue where a certain merge block operation goes rogue when there are multiple editors in a document.

I have pinned this issue down to invalid paths being used when trying to remove the children of a block as part of the transformation happening on the receiving client when a whole block is set through a set patch.

After fixing this, the added test passes (it failed without this fix).


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That the changes are ok.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Should be covered by automatic tests now, but see #EDX-946 for more details on how to manually reproduce it.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
* Fixed a bug with the Portable Text Editor where merging two text blocks could result in data loss in the topmost block when several editors were inside the document.

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
