### PR TITLE
fix: prevent key value store from firing setKey for each open subscri…

### DIFF
--- a/packages/sanity/src/core/store/key-value/KeyValueStore.ts
+++ b/packages/sanity/src/core/store/key-value/KeyValueStore.ts
@@ -1,6 +1,6 @@
 import {type SanityClient} from '@sanity/client'
-import {merge, Observable, Subject} from 'rxjs'
-import {filter, map, switchMap} from 'rxjs/operators'
+import {merge, type Observable, Subject} from 'rxjs'
+import {filter, map, shareReplay, switchMap, take} from 'rxjs/operators'
 
 import {serverBackend} from './backends/server'
 import {type KeyValueStore, type KeyValueStoreValue} from './types'
@@ -12,14 +12,15 @@ export function createKeyValueStore({client}: {client: SanityClient}): KeyValueS
   const setKey$ = new Subject<{key: string; value: KeyValueStoreValue}>()
 
   const updates$ = setKey$.pipe(
-    switchMap((event) =>
-      storageBackend.setKey(event.key, event.value).pipe(
+    switchMap((event) => {
+      return storageBackend.setKey(event.key, event.value).pipe(
         map((nextValue) => ({
           key: event.key,
           value: nextValue,
         })),
-      ),
-    ),
+      )
+    }),
+    shareReplay(1),
   )
 
   const getKey = (key: string): Observable<KeyValueStoreValue> => {
@@ -33,27 +34,18 @@ export function createKeyValueStore({client}: {client: SanityClient}): KeyValueS
   }
 
   const setKey = (key: string, value: KeyValueStoreValue): Observable<KeyValueStoreValue> => {
+    setKey$.next({key, value})
+
     /*
      * The backend returns the result of the set operation, so we can just pass that along.
      * Most utils do not use it (they will take advantage of local state first) but it reflects the
      * backend function and could be useful for debugging.
      */
-    const response = new Observable<KeyValueStoreValue>((subscriber) => {
-      const subscription = storageBackend.setKey(key, value).subscribe({
-        next: (nextValue) => {
-          subscriber.next(nextValue as KeyValueStoreValue)
-          subscriber.complete()
-        },
-        //storageBackend should handle its own errors, we're just passing along the result.
-        error: (err) => {
-          subscriber.error(err)
-        },
-      })
-      return () => subscription.unsubscribe()
-    })
-
-    setKey$.next({key, value})
-    return response
+    return updates$.pipe(
+      filter((update) => update.key === key),
+      map((update) => update.value as KeyValueStoreValue),
+      take(1),
+    )
   }
 
   return {getKey, setKey}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
The KeyValueStore used to emit a setKey event (setting off a PUT call to the backend) for every open subscription. This means we could fire off 3-4 PUT calls for the same key in quick succession. To keep state tidy and make this scalable, I've added a shareReplay function here, which we use in other parts of the studio (especially stores in the resource cache). I've seen no ill effects or stale data, so I think it's a decent solution.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->
Any gotchas with this approach, or any other negative side effects I may be missing. 

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
There are e2e tests for this branch, but no tests specifically for this case. I can add additional tests in the refactor PR for e2e tests.