### PR TITLE
feat(core): integrate with Text Search API ordering

### DIFF
--- a/packages/sanity/src/core/search/common/types.ts
+++ b/packages/sanity/src/core/search/common/types.ts
@@ -133,7 +133,10 @@ export interface TextSearchDocumentTypeConfiguration {
 /**
  * @internal
  */
-export type TextSearchSort = Record<string, {order: SortDirection}>
+export interface TextSearchOrder {
+  attribute: string
+  direction: SortDirection
+}
 
 export type TextSearchParams = {
   query: {
@@ -181,9 +184,9 @@ export type TextSearchParams = {
    */
   types?: Record<string, TextSearchDocumentTypeConfiguration>
   /**
-   * Result sorting.
+   * Result ordering.
    */
-  sort?: TextSearchSort[]
+  order?: TextSearchOrder[]
 }
 
 export type TextSearchResponse<Attributes = Record<string, unknown>> = {

--- a/packages/sanity/src/core/search/text-search/createTextSearch.test.ts
+++ b/packages/sanity/src/core/search/text-search/createTextSearch.test.ts
@@ -2,7 +2,7 @@ import {describe, expect, it} from '@jest/globals'
 import {Schema} from '@sanity/schema'
 import {defineField, defineType} from '@sanity/types'
 
-import {getDocumentTypeConfiguration, getSort} from './createTextSearch'
+import {getDocumentTypeConfiguration, getOrder} from './createTextSearch'
 
 const testType = Schema.compile({
   types: [
@@ -201,7 +201,7 @@ describe('getDocumentTypeConfiguration', () => {
 describe('getSort', () => {
   it('transforms Studio sort options to valid Text Search sort options', () => {
     expect(
-      getSort([
+      getOrder([
         {
           field: 'title',
           direction: 'desc',
@@ -213,14 +213,12 @@ describe('getSort', () => {
       ]),
     ).toEqual([
       {
-        title: {
-          order: 'desc',
-        },
+        attribute: 'title',
+        direction: 'desc',
       },
       {
-        _createdAt: {
-          order: 'asc',
-        },
+        attribute: '_createdAt',
+        direction: 'asc',
       },
     ])
   })

--- a/packages/sanity/src/core/search/text-search/createTextSearch.ts
+++ b/packages/sanity/src/core/search/text-search/createTextSearch.ts
@@ -11,10 +11,10 @@ import {
   type SearchStrategyFactory,
   type SearchTerms,
   type TextSearchDocumentTypeConfiguration,
+  type TextSearchOrder,
   type TextSearchParams,
   type TextSearchResponse,
   type TextSearchResults,
-  type TextSearchSort,
 } from '../common'
 
 const DEFAULT_LIMIT = 1000
@@ -73,12 +73,11 @@ export function getDocumentTypeConfiguration(
   }, {})
 }
 
-export function getSort(sort: SearchSort[] = []): TextSearchSort[] {
-  return sort.map<TextSearchSort>(
+export function getOrder(sort: SearchSort[] = []): TextSearchOrder[] {
+  return sort.map<TextSearchOrder>(
     ({field, direction}) => ({
-      [field]: {
-        order: direction,
-      },
+      attribute: field,
+      direction,
     }),
     {},
   )
@@ -114,8 +113,7 @@ export const createTextSearch: SearchStrategyFactory<TextSearchResults> = (
         ...searchTerms.params,
       },
       types: getDocumentTypeConfiguration(searchOptions, searchTerms),
-      // TODO: `sort` is not supported by the Text Search API yet.
-      // sort: getSort(searchOptions.sort),
+      order: getOrder(searchOptions.sort),
       includeAttributes: ['_id', '_type'],
       fromCursor: searchOptions.cursor,
       limit: searchOptions.limit ?? DEFAULT_LIMIT,

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.ts
@@ -181,6 +181,10 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
         ...state,
         ordering: action.ordering,
         terms: stripRecent(state.terms),
+        result: {
+          ...state.result,
+          hasLocal: false,
+        },
       }
     case 'PAGE_INCREMENT':
       return {


### PR DESCRIPTION
### Description

This branch finalises the Text Search API ordering integration. Ordering is now formatted correctly and is included in Text Search API requests.

**Note: The Text Search API functionality to support this has not yet been deployed to production.**

It also includes a fix for global search results not resetting after ordering has changed. We didn't catch this before because ordering wasn't working at all.

### What to review

Does ordering results from global search and document lists work as expected?

### Testing

The `packages/sanity/src/core/search/text-search/createTextSearch.test.ts` test suite ensures ordering requests are formatted correctly.