### PR TITLE
fix: ensure that useStructureToolSetting updates only when necessary

### DIFF
--- a/packages/sanity/src/structure/useStructureToolSetting.ts
+++ b/packages/sanity/src/structure/useStructureToolSetting.ts
@@ -38,10 +38,12 @@ export function useStructureToolSetting<ValueType>(
 
   const set = useCallback(
     (newValue: ValueType) => {
-      setValue(newValue)
-      keyValueStore.setKey(keyValueStoreKey, newValue as string)
+      if (newValue !== value) {
+        setValue(newValue)
+        keyValueStore.setKey(keyValueStoreKey, newValue as string)
+      }
     },
-    [keyValueStore, keyValueStoreKey],
+    [keyValueStore, keyValueStoreKey, value],
   )
 
   return useMemo(() => [value, set], [set, value])


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
We should ensure we're avoiding unnecessary calls to the backend whenever possible, as well as any unnecessary re-renders. This PR adds a check to ensure actions only happen in the case of new state.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->
The check and any gotchas for loops or side effects.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
This util is tested in an E2E test that is currently being refactored.