### PR TITLE
feat(codegen): expose referenced type as hidden symbol

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/__snapshots__/typeGenerator.test.ts.snap
+++ b/packages/@sanity/codegen/src/typescript/__tests__/__snapshots__/typeGenerator.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`generateSchemaTypes can generate well known types 1`] = `"export declare const internalGroqTypeReferenceTo: unique symbol;"`;
+
 exports[`generateSchemaTypes generateTypeNodeTypes should be able to generate types for type nodes: boolean 1`] = `"export type test_2 = boolean;"`;
 
 exports[`generateSchemaTypes generateTypeNodeTypes should be able to generate types for type nodes: null 1`] = `"export type test_5 = null;"`;
@@ -30,9 +32,11 @@ export type Post = {
   author?: {
     _ref: string;
     _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: \\"author\\";
   } | {
     _ref: string;
     _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: \\"ghost\\";
   };
   slug?: Slug;
   excerpt?: string;
@@ -41,6 +45,7 @@ export type Post = {
     asset: {
       _ref: string;
       _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: \\"sanity.imageAsset\\";
     };
     caption?: string;
     attribution?: string;

--- a/packages/@sanity/codegen/src/typescript/__tests__/typeGenerator.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/typeGenerator.test.ts
@@ -24,6 +24,12 @@ describe('generateSchemaTypes', () => {
     expect(typeDeclarations).toMatchSnapshot()
   })
 
+  test('can generate well known types', async () => {
+    const typeDeclarations = TypeGenerator.generateKnownTypes()
+
+    expect(typeDeclarations).toMatchSnapshot()
+  })
+
   test('should generate correct types for document schema with string fields', () => {
     const schema: SchemaType = [
       {
@@ -247,6 +253,7 @@ describe('generateSchemaTypes', () => {
     _ref: string;
     _type: \\"reference\\";
     _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: \\"author\\";
   };
 };
 

--- a/packages/sanity/src/_internal/cli/threads/codegenGenerateTypes.ts
+++ b/packages/sanity/src/_internal/cli/threads/codegenGenerateTypes.ts
@@ -58,7 +58,10 @@ async function main() {
   const schema = await readSchema(opts.schemaPath)
 
   const typeGenerator = new TypeGenerator(schema)
-  const schemaTypes = typeGenerator.generateSchemaTypes()
+  const schemaTypes = [
+    typeGenerator.generateSchemaTypes(),
+    TypeGenerator.generateKnownTypes(),
+  ].join('\n')
   const resolver = getResolver()
 
   parentPort?.postMessage({


### PR DESCRIPTION
### Description

Adds a symbol so that we can lookup which type a reference is referencing to.

Types generating ends up like:
```ts
{
      _ref: string;
      _type: "reference";
      _weak?: boolean;
      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
}

...

export declare const internalGroqTypeReferenceTo: unique symbol;
```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

No specific tests added for this as the feature is marked as "internal". We should build out general integration testing for codegen, but that can be done separately.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
N/A - no notes needed.
