### PR TITLE
feat(core): add prefix search support

### DIFF
--- a/packages/sanity/src/core/search/common/types.ts
+++ b/packages/sanity/src/core/search/common/types.ts
@@ -107,6 +107,7 @@ export type SearchOptions = {
   cursor?: string
   limit?: number
   isCrossDataset?: boolean
+  queryType?: 'prefixLast' | 'prefixNone'
 }
 
 /**

--- a/packages/sanity/src/core/search/text-search/createTextSearch.test.ts
+++ b/packages/sanity/src/core/search/text-search/createTextSearch.test.ts
@@ -2,7 +2,7 @@ import {describe, expect, it} from '@jest/globals'
 import {Schema} from '@sanity/schema'
 import {defineField, defineType} from '@sanity/types'
 
-import {getDocumentTypeConfiguration, getOrder} from './createTextSearch'
+import {getDocumentTypeConfiguration, getOrder, getQueryString} from './createTextSearch'
 
 const testType = Schema.compile({
   types: [
@@ -221,5 +221,19 @@ describe('getSort', () => {
         direction: 'asc',
       },
     ])
+  })
+})
+
+describe('getQueryString', () => {
+  it('appends a wildcard to search query when `queryType` is `prefixLast`', () => {
+    expect(getQueryString('test', {queryType: 'prefixLast'})).toEqual('test*')
+  })
+
+  it('appends no wildcard to empty search query when `queryType` is `prefixLast`', () => {
+    expect(getQueryString('', {queryType: 'prefixLast'})).toEqual('')
+  })
+
+  it('appends no wildcard to search query when `queryType` is `prefixNone`', () => {
+    expect(getQueryString('test', {queryType: 'prefixNone'})).toEqual('test')
   })
 })

--- a/packages/sanity/src/core/search/text-search/createTextSearch.test.ts
+++ b/packages/sanity/src/core/search/text-search/createTextSearch.test.ts
@@ -227,13 +227,11 @@ describe('getSort', () => {
 describe('getQueryString', () => {
   it('appends a wildcard to search query when `queryType` is `prefixLast`', () => {
     expect(getQueryString('test', {queryType: 'prefixLast'})).toEqual('test*')
-  })
-
-  it('appends no wildcard to empty search query when `queryType` is `prefixLast`', () => {
-    expect(getQueryString('', {queryType: 'prefixLast'})).toEqual('')
+    expect(getQueryString('', {queryType: 'prefixLast'})).toEqual('*')
   })
 
   it('appends no wildcard to search query when `queryType` is `prefixNone`', () => {
     expect(getQueryString('test', {queryType: 'prefixNone'})).toEqual('test')
+    expect(getQueryString('', {queryType: 'prefixNone'})).toEqual('')
   })
 })

--- a/packages/sanity/src/core/search/text-search/createTextSearch.ts
+++ b/packages/sanity/src/core/search/text-search/createTextSearch.ts
@@ -87,12 +87,7 @@ export function getQueryString(
   query: string,
   {queryType = 'prefixLast'}: Pick<SearchOptions, 'queryType'>,
 ): string {
-  // Empty wildcard search queries ("*") yield no results. However, Studio uses empty search
-  // queries to list documents (e.g. for document lists). Therefore, do not append a wildcard to
-  // any empty search string.
-  const shouldPrefixLast = queryType === 'prefixLast' && query.length !== 0
-
-  if (shouldPrefixLast) {
+  if (queryType === 'prefixLast') {
     return `${query}*`
   }
 


### PR DESCRIPTION
### Description

This branch enables Text Search API prefix searching for all Studio search surfaces. This is achieved by appending a wildcard token (`*`) to all search queries.

### What to review

Search and document lists (which are powered by search) work correctly when Text Search API is enabled.

### Testing

Added tests to `packages/sanity/src/core/search/text-search/createTextSearch.test.ts`.

### Notes for release

Added prefix search behaviour to the new search implementation. This allows partial matches to be surfaced when a search occurs before the user finished entering their query.
