### PR TITLE
fix: schema extraction object type name

### DIFF
--- a/packages/@sanity/schema/src/sanity/extractSchema.ts
+++ b/packages/@sanity/schema/src/sanity/extractSchema.ts
@@ -219,7 +219,7 @@ export function extractSchema(
       return {type: 'unknown'} satisfies UnknownTypeNode
     }
 
-    if (schemaType.type?.name !== 'document') {
+    if (schemaType.type?.name !== 'document' && schemaType.name !== 'object') {
       attributes._type = {
         type: 'objectAttribute',
         value: {

--- a/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
+++ b/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
@@ -1334,13 +1334,6 @@ Array [
           "type": "objectAttribute",
           "value": Object {
             "attributes": Object {
-              "_type": Object {
-                "type": "objectAttribute",
-                "value": Object {
-                  "type": "string",
-                  "value": "object",
-                },
-              },
               "blocks": Object {
                 "optional": true,
                 "type": "objectAttribute",
@@ -1797,13 +1790,6 @@ Array [
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
-                            "_type": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                                "value": "object",
-                              },
-                            },
                             "author": Object {
                               "optional": true,
                               "type": "objectAttribute",
@@ -1953,13 +1939,6 @@ Array [
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
-                            "_type": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                                "value": "object",
-                              },
-                            },
                             "aNumber": Object {
                               "optional": true,
                               "type": "objectAttribute",
@@ -2555,13 +2534,6 @@ Array [
                       "value": Object {
                         "of": Object {
                           "attributes": Object {
-                            "_type": Object {
-                              "type": "objectAttribute",
-                              "value": Object {
-                                "type": "string",
-                                "value": "object",
-                              },
-                            },
                             "aNumber": Object {
                               "optional": true,
                               "type": "objectAttribute",
@@ -2618,13 +2590,6 @@ Array [
           "type": "objectAttribute",
           "value": Object {
             "attributes": Object {
-              "_type": Object {
-                "type": "objectAttribute",
-                "value": Object {
-                  "type": "string",
-                  "value": "object",
-                },
-              },
               "blocks": Object {
                 "optional": true,
                 "type": "objectAttribute",


### PR DESCRIPTION
### Description

For some objects(I belive it's nested objects, but yet to verify) we sometimes generate object schema types with name set to `object`. This PR removes the _type if it's object, as it's better to miss data than to be wrong.

One example from the tests are `Homestead`, the compiled schema type look like:
```ts
{
  jsonType: 'object',
  type: { name: 'object', title: 'Object', type: null, jsonType: 'object' },
  name: 'object',
  title: 'Homestead',
  fields: [
    {
      name: 'lat',
      group: undefined,
      fieldset: undefined,
      type: [Object]
    },
    {
      name: 'lon',
      group: undefined,
      fieldset: undefined,
      type: [Object]
    }
  ],
  options: {},
  orderings: [
    { name: 'lat', i18n: [Object], title: 'Lat', by: [Array] },
    { name: 'lon', i18n: [Object], title: 'Lon', by: [Array] }
  ],
  fieldsets: [Getter],
  groups: [Getter],
  preview: [Getter]
}
```

However the field definition is:
```ts
{
  name: 'homestead',
  title: 'Homestead',
  type: 'object',
  fields: [
    {
      name: 'lat',
      title: 'Latitude',
      type: 'number',
      required: true,
    },
    {
      name: 'lon',
      title: 'Longitude',
      type: 'number',
      required: true,
    },
  ],
},
```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
N/A - no notes needed