### PR TITLE
fix: use more reliable comparison in deduping search results

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/datastores/recentSearches.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/datastores/recentSearches.ts
@@ -1,5 +1,5 @@
 import {type ObjectSchemaType, type Schema} from '@sanity/types'
-import omit from 'lodash/omit'
+import {isEqual, omit} from 'lodash'
 import {useMemo} from 'react'
 
 import {useSchema} from '../../../../../hooks'
@@ -112,13 +112,12 @@ export function useRecentSearchesStore(): RecentSearchesStore {
       }
       // Add new search item, remove previous duplicates (if any) and truncate array.
       // When comparing search items, don't compare against the created date (which will always be different).
-      const comparator = JSON.stringify(omit(newSearchItem, 'created'))
       const newRecent: StoredSearch = {
         version: RECENT_SEARCH_VERSION,
         recentSearches: [
           newSearchItem,
           ...storedSearch.recentSearches.filter((r) => {
-            return JSON.stringify(omit(r, 'created')) !== comparator
+            return !isEqual(omit(r, 'created'), omit(newSearchItem, 'created'))
           }),
         ].slice(0, MAX_RECENT_SEARCHES),
       }


### PR DESCRIPTION
### Description

Since we moved the recent search results to a server-side service, we started seeing duplicate results in the global search results. The previous implementation, which stored search results in local storage, stringified recent searches before storing them and compared stringified new searches against them.

Since we switched to using a backend service, we could no longer rely on keys being in the same order. This PR uses the `isEqual` lodash method (used in many other places in the studio) to more reliably compare the values of the objects, rather than a string result.

### What to review
The changed file. Any performance or other repercussions from using this comparison.

### Testing
Tests already exist for this utility, but did not catch this because of mocking. A ticket has been created to better address this in the future. 

### Notes for release
Resolves an issue where the server-side storage of global recent searches was storing duplicate recent searches. Recent searches should now all be unique terms. 