### PR TITLE
fix(tasks): only display tasks with edits in the drafts menu

### DIFF
--- a/packages/sanity/src/tasks/src/tasks/components/sidebar/TasksHeaderDraftsMenu.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/sidebar/TasksHeaderDraftsMenu.tsx
@@ -16,11 +16,13 @@ export function DraftsMenu() {
 
   const draftTasks = useMemo(() => {
     if (!user?.id) return []
+
     return data.filter((task) => {
       const isAuthoredByUser = task.authorId === user.id
       const isDraft = !task.createdByUser
+      const hasEdits = task._updatedAt !== task._createdAt
       const isNotTheTaskBeingCreated = viewMode === 'create' ? task._id !== selectedTask : true
-      return isAuthoredByUser && isDraft && isNotTheTaskBeingCreated
+      return isAuthoredByUser && isDraft && isNotTheTaskBeingCreated && hasEdits
     })
   }, [data, selectedTask, user?.id, viewMode])
 


### PR DESCRIPTION
### Description

This pull request makes sure that we only display tasks with edits in the drafts menu. 

### What to review

- Make sure that only tasks with edits is displayed in the drafts menu

### Notes for release

N/A
