### PR TITLE
chore(deps): update dependency @sanity/eslint-config-i18n to ^1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@optimize-lodash/rollup-plugin": "^4.0.4",
     "@playwright/test": "^1.41.2",
     "@sanity/client": "^6.15.6",
-    "@sanity/eslint-config-i18n": "^1.0.0",
+    "@sanity/eslint-config-i18n": "^1.1.0",
     "@sanity/eslint-config-studio": "^3.0.1",
     "@sanity/pkg-utils": "^4.4.3",
     "@sanity/test": "0.0.1-alpha.1",

--- a/packages/sanity/src/core/components/StatusButton.tsx
+++ b/packages/sanity/src/core/components/StatusButton.tsx
@@ -1,9 +1,9 @@
 import {useTheme} from '@sanity/ui'
 import {type ForwardedRef, forwardRef, type HTMLProps, type ReactNode, useMemo} from 'react'
-import {useTranslation} from 'react-i18next'
 import styled from 'styled-components'
 
 import {Button, type ButtonProps} from '../../ui-components'
+import {useTranslation} from '../i18n'
 
 /** @hidden @beta */
 export type StatusButtonProps = ButtonProps & {

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -2,6 +2,7 @@ import {fromUrl} from '@sanity/bifur-client'
 import {createClient, type SanityClient} from '@sanity/client'
 import {type CurrentUser, type Schema, type SchemaValidationProblem} from '@sanity/types'
 import {studioTheme} from '@sanity/ui'
+//eslint-disable-next-line @sanity/i18n/no-i18next-import
 import {type i18n} from 'i18next'
 import {startCase} from 'lodash'
 import {type ComponentType, createElement, type ElementType, isValidElement} from 'react'

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -9,6 +9,7 @@ import {
   type SchemaType,
   type SchemaTypeDefinition,
 } from '@sanity/types'
+//eslint-disable-next-line @sanity/i18n/no-i18next-import
 import {type i18n} from 'i18next'
 import {type ComponentType, type ReactNode} from 'react'
 import {type Observable} from 'rxjs'

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
@@ -5,11 +5,11 @@ import {
 } from '@sanity/portable-text-editor'
 import {isKeySegment} from '@sanity/types'
 import {memo, useCallback, useMemo} from 'react'
-import {useTranslation} from 'react-i18next'
 
 import {type PopoverProps} from '../../../../../ui-components'
 import {CollapseMenu, CollapseMenuButton} from '../../../../components/collapseMenu'
 import {ContextMenuButton} from '../../../../components/contextMenuButton'
+import {useTranslation} from '../../../../i18n'
 import {getActionIcon} from './helpers'
 import {useActiveActionKeys, useFocusBlock} from './hooks'
 import {type PTEToolbarAction, type PTEToolbarActionGroup} from './types'

--- a/packages/sanity/src/core/i18n/.eslintrc
+++ b/packages/sanity/src/core/i18n/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@sanity/i18n/no-i18next-import": 0
+  }
+}

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialButton.tsx
@@ -2,10 +2,10 @@ import {purple, yellow} from '@sanity/color'
 import {BoltIcon} from '@sanity/icons'
 import {Card, Text} from '@sanity/ui'
 import {forwardRef, type Ref} from 'react'
-import {useTranslation} from 'react-i18next'
 import styled from 'styled-components'
 
 import {Button} from '../../../../../ui-components'
+import {useTranslation} from '../../../../i18n'
 
 const CenteredStroke = styled.div`
   position: absolute;

--- a/packages/sanity/src/core/studio/components/navbar/search/SearchButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/SearchButton.tsx
@@ -1,8 +1,8 @@
 import {SearchIcon} from '@sanity/icons'
 import {type ForwardedRef, forwardRef} from 'react'
-import {useTranslation} from 'react-i18next'
 
 import {Button} from '../../../../../ui-components'
+import {useTranslation} from '../../../../i18n'
 import {GLOBAL_SEARCH_KEY, GLOBAL_SEARCH_KEY_MODIFIER} from './constants'
 
 interface SearchButtonProps {

--- a/packages/sanity/src/structure/comments/plugin/input/components/FloatingButtonPopover.tsx
+++ b/packages/sanity/src/structure/comments/plugin/input/components/FloatingButtonPopover.tsx
@@ -2,7 +2,7 @@ import {AddCommentIcon} from '@sanity/icons'
 import {useClickOutside} from '@sanity/ui'
 import {motion, type Variants} from 'framer-motion'
 import {useState} from 'react'
-import {useTranslation} from 'react-i18next'
+import {useTranslation} from 'sanity'
 import styled from 'styled-components'
 
 import {Button, Popover, type PopoverProps} from '../../../../../ui-components'

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemReferencedValue.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemReferencedValue.tsx
@@ -4,7 +4,7 @@ import {LinkRemovedIcon} from '@sanity/icons'
 import {isPortableTextTextBlock} from '@sanity/types'
 import {Box, Flex, Stack, Text, type Theme} from '@sanity/ui'
 import {useMemo} from 'react'
-import {useTranslation} from 'react-i18next'
+import {useTranslation} from 'sanity'
 import styled, {css} from 'styled-components'
 
 import {Tooltip} from '../../../../../ui-components'

--- a/packages/sanity/src/structure/panes/document/document-layout/DocumentLayout.tsx
+++ b/packages/sanity/src/structure/panes/document/document-layout/DocumentLayout.tsx
@@ -7,13 +7,13 @@ import {
 } from '@sanity/ui'
 import isHotkey from 'is-hotkey'
 import {useCallback, useMemo, useState} from 'react'
-import {useTranslation} from 'react-i18next'
 import {
   ChangeConnectorRoot,
   type DocumentFieldActionNode,
   type DocumentInspectorMenuItem,
   FieldActionsProvider,
   FieldActionsResolver,
+  useTranslation,
   useZIndex,
 } from 'sanity'
 import {type Path} from 'sanity-diff-patch'

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
@@ -1,6 +1,6 @@
 import {type ObjectSchemaType} from '@sanity/types'
 import {Heading, Stack, Text} from '@sanity/ui'
-import {useTranslation} from 'react-i18next'
+import {useTranslation} from 'sanity'
 import styled, {css} from 'styled-components'
 
 import {structureLocaleNamespace} from '../../../../i18n'

--- a/packages/sanity/src/ui-components/dialog/Dialog.tsx
+++ b/packages/sanity/src/ui-components/dialog/Dialog.tsx
@@ -9,7 +9,8 @@ import {
 } from '@sanity/ui'
 import type * as React from 'react'
 import {type ComponentProps, forwardRef} from 'react'
-import {useTranslation} from 'react-i18next'
+
+import {useTranslation} from '../../core/i18n'
 
 /** @internal */
 export type DialogProps = Pick<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^6.15.6
         version: 6.15.6
       '@sanity/eslint-config-i18n':
-        specifier: ^1.0.0
-        version: 1.0.0(eslint@8.57.0)(typescript@5.3.3)
+        specifier: ^1.1.0
+        version: 1.1.0(eslint@8.57.0)(typescript@5.3.3)
       '@sanity/eslint-config-studio':
         specifier: ^3.0.1
         version: 3.0.1(eslint@8.57.0)(typescript@5.3.3)
@@ -5984,11 +5984,11 @@ packages:
     resolution: {integrity: sha512-dSZqGeYjHKGIkqAzGqLcG92LZyJGX+nYbs/FWawhBbTBDWi21kvQ0hsL3DJThuFVWtZMWTQijN3z6Cnd44Pf2g==}
     engines: {node: '>=14.18'}
 
-  /@sanity/eslint-config-i18n@1.0.0(eslint@8.57.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-BIeD9IVT7O5I6vDyDaICoidN02qeImdXDRAW062iHY9gV4JrGScWBFio2HQLso7C+Z6SrQB8jOft6SzeYqDhdQ==}
+  /@sanity/eslint-config-i18n@1.1.0(eslint@8.57.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-mMD0CB1R3n9vN+wWpmjIge1EW2yVYlNIO/N4LJd1kNZUs5FhyT4ZeFoJT79wj3lmr9K+yoHjqjTQ5HuZkRCSXw==}
     dependencies:
       '@rushstack/eslint-patch': 1.7.0
-      '@sanity/eslint-plugin-i18n': 1.0.0
+      '@sanity/eslint-plugin-i18n': 1.1.0
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       eslint-plugin-i18next: 6.0.3
     transitivePeerDependencies:
@@ -6037,8 +6037,8 @@ packages:
       - typescript
     dev: true
 
-  /@sanity/eslint-plugin-i18n@1.0.0:
-    resolution: {integrity: sha512-ibPaZttafAWLRz2SXAk8LOBr+nykU4BoMUYjdQVIx/N3D2deZdJp0s1c0lmljkrE2B3LmB0B7oTzF9CUrw3Kyg==}
+  /@sanity/eslint-plugin-i18n@1.1.0:
+    resolution: {integrity: sha512-EpoqPVqaP2NSmG8vGa4zsD6BuyBTVHwmD3VigOya7roHB8GZXuJjDg6+SXzhb+cTVuZtWaAjt8NMYVYx4uWCIQ==}
     dev: true
 
   /@sanity/eventsource@5.0.1:


### PR DESCRIPTION
### Description

I received a request to review #6039, which instantly failed linting. In order to maintain some clarity and conversation, I've updated that package manually and put in the fixes to make the linter pass myself.

### What to review
There's a broader .eslintrc in the i18n directory, since it likely makes sense to import from that package there. Type imports got an `eslint-disable-next-line` comments. Everywhere else, utils are being imported from either Sanity or local directories, as needed.

### Testing
N/A