### PR TITLE
fix(comments): permission check

### DIFF
--- a/packages/sanity/src/structure/comments/plugin/field/CommentsField.tsx
+++ b/packages/sanity/src/structure/comments/plugin/field/CommentsField.tsx
@@ -92,6 +92,7 @@ function CommentFieldInner(
 
   const {
     comments,
+    hasPermission,
     isCommentsOpen,
     isCreatingDataset,
     mentionOptions,
@@ -315,6 +316,11 @@ function CommentFieldInner(
       hasComments,
     ],
   )
+
+  // Render the default field component if the user doesn't have permission
+  if (!hasPermission) {
+    return props.renderDefault(props)
+  }
 
   return (
     <FieldStack {...applyCommentsFieldAttr(PathUtils.toString(props.path))} ref={rootRef}>

--- a/packages/sanity/src/structure/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/structure/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -63,8 +63,16 @@ export const CommentsPortableTextInputInner = React.memo(function CommentsPortab
   const currentUser = useCurrentUser()
   const portal = usePortal()
 
-  const {mentionOptions, comments, operation, onCommentsOpen, getComment, setStatus, status} =
-    useComments()
+  const {
+    comments,
+    getComment,
+    hasPermission,
+    mentionOptions,
+    onCommentsOpen,
+    operation,
+    setStatus,
+    status,
+  } = useComments()
   const {setSelectedPath, selectedPath} = useCommentsSelectedPath()
   const {scrollToComment, scrollToGroup} = useCommentsScroll()
   const {handleOpenDialog} = useCommentsUpsell()
@@ -501,6 +509,11 @@ export const CommentsPortableTextInputInner = React.memo(function CommentsPortab
     currentSelection && canSubmit && selectionReferenceElement && !mouseDownRef.current,
   )
   const showFloatingInput = Boolean(nextCommentSelection && popoverAuthoringReferenceElement)
+
+  // Render the default input if the user doesn't have permission
+  if (!hasPermission) {
+    return props.renderDefault(props)
+  }
 
   return (
     <>

--- a/packages/sanity/src/structure/comments/src/context/comments/types.ts
+++ b/packages/sanity/src/structure/comments/src/context/comments/types.ts
@@ -19,6 +19,8 @@ export interface CommentsContextValue {
   isCommentsOpen?: boolean
   onCommentsOpen?: () => void
 
+  hasPermission: boolean
+
   comments: {
     data: {
       open: CommentThreadItem[]


### PR DESCRIPTION
### Description

This pull request ensures that the user has `read` permissions on the current document to determine whether the comments UI should be displayed in fields. The add-on dataset permission allows users with `read` access to both read and write comments, making it the only necessary permission to check.

### What to Review

- Ensure the permission check functions correctly by testing with various roles.

### Notes for Release

N/A
