### PR TITLE
feat: indicate in metadata that the quickstart option was used in project creation

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -964,7 +964,6 @@ export default async function initSanity(
 
   function selectProjectTemplate() {
     // Make sure the --quickstart and --template are not used together
-    // Force template to clean if --quickstart is used
     if (flags.quickstart) {
       return 'quickstart'
     }

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -966,7 +966,7 @@ export default async function initSanity(
     // Make sure the --quickstart and --template are not used together
     // Force template to clean if --quickstart is used
     if (flags.quickstart) {
-      return 'clean'
+      return 'quickstart'
     }
 
     const defaultTemplate = unattended || flags.template ? flags.template || 'clean' : null

--- a/packages/@sanity/cli/src/actions/init-project/templates/index.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/index.ts
@@ -3,6 +3,7 @@ import blog from './blog'
 import clean from './clean'
 import getStartedTemplate from './getStarted'
 import moviedb from './moviedb'
+import quickstart from './quickstart'
 import shopify from './shopify'
 import shopifyOnline from './shopifyOnline'
 
@@ -13,7 +14,7 @@ const templates: Record<string, ProjectTemplate | undefined> = {
   moviedb,
   shopify,
   'shopify-online-storefront': shopifyOnline,
-  quickstart: clean, // empty project that dynamically imports its own schema
+  quickstart, // empty project that dynamically imports its own schema
 }
 
 export default templates

--- a/packages/@sanity/cli/src/actions/init-project/templates/index.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/index.ts
@@ -13,6 +13,7 @@ const templates: Record<string, ProjectTemplate | undefined> = {
   moviedb,
   shopify,
   'shopify-online-storefront': shopifyOnline,
+  quickstart: clean, // empty project that dynamically imports its own schema
 }
 
 export default templates

--- a/packages/@sanity/cli/src/actions/init-project/templates/quickstart.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/quickstart.ts
@@ -1,0 +1,5 @@
+import {type ProjectTemplate} from '../initProject'
+
+const quickStartTemplate: ProjectTemplate = {}
+
+export default quickStartTemplate

--- a/packages/@sanity/cli/templates/quickstart/README.md
+++ b/packages/@sanity/cli/templates/quickstart/README.md
@@ -1,0 +1,9 @@
+# Sanity Clean Content Studio
+
+Congratulations, you have now installed the Sanity Content Studio, an open source real-time content editing environment connected to the Sanity backend.
+
+Now you can do the following things:
+
+- [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
+- [Join the community Slack](https://slack.sanity.io/?utm_source=readme)
+- [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/quickstart/README.md
+++ b/packages/@sanity/cli/templates/quickstart/README.md
@@ -1,4 +1,4 @@
-# Sanity Clean Content Studio
+# Sanity Studio
 
 Congratulations, you have now installed the Sanity Content Studio, an open source real-time content editing environment connected to the Sanity backend.
 

--- a/packages/@sanity/cli/templates/quickstart/README.md
+++ b/packages/@sanity/cli/templates/quickstart/README.md
@@ -1,6 +1,6 @@
 # Sanity Studio
 
-Congratulations, you have now installed the Sanity Content Studio, an open source real-time content editing environment connected to the Sanity backend.
+Congratulations, you have now installed Sanity Studio, an open source real-time content editing environment connected to the Sanity Content Lake backend.
 
 Now you can do the following things:
 

--- a/packages/@sanity/cli/templates/quickstart/schemaTypes/index.js
+++ b/packages/@sanity/cli/templates/quickstart/schemaTypes/index.js
@@ -1,0 +1,1 @@
+export const schemaTypes = []

--- a/packages/@sanity/cli/templates/quickstart/static/.gitkeep
+++ b/packages/@sanity/cli/templates/quickstart/static/.gitkeep
@@ -1,0 +1,1 @@
+Files placed here will be served by the Sanity server under the `/static`-prefix


### PR DESCRIPTION
### Description

Project metadata.template should reflect if the --quickstart flag was used

### Testing

Project metadata should show `cli-quickstart` rather than `cli-clean` if the --quickstart flag was used for pulling down a project and its schema
