### PR TITLE
feat(cli): Set printWidth to 40 for Journey schema types

### DIFF
--- a/packages/@sanity/cli/src/util/journeyConfig.ts
+++ b/packages/@sanity/cli/src/util/journeyConfig.ts
@@ -184,7 +184,10 @@ async function fetchJourneySchema(schemaUrl: string): Promise<DocumentOrObject[]
 async function assembleJourneySchemaTypeFileContent(schemaType: DocumentOrObject): Promise<string> {
   const serialised = wrapSchemaTypeInHelpers(schemaType)
   const imports = getImports(serialised)
-  const prettifiedSchemaType = await format(serialised, {parser: 'typescript'})
+  const prettifiedSchemaType = await format(serialised, {
+    parser: 'typescript',
+    printWidth: 40,
+  })
   // Start file with import, then export the schema type as a named export
   return `${imports}\n\nexport const ${schemaType.name} = ${prettifiedSchemaType}\n`
 }


### PR DESCRIPTION
### Description

Settings a max print width when formatting schema types that are fetched from the Journey API.

### Before and after:
![image](https://github.com/sanity-io/sanity/assets/25268506/9138d473-c6bc-496b-a69d-ac529d84b274)

This makes it so each key is on its own line

### What to review

Is there a better way of doing this in with Prettier?

### Testing

No functionality change done, so everything should work as before

### Notes for release

None