### PR TITLE
fix(codegen): include babel.config.json in the published package

### DIFF
--- a/packages/@sanity/codegen/package.json
+++ b/packages/@sanity/codegen/package.json
@@ -45,7 +45,8 @@
   "files": [
     "lib",
     "src",
-    "!**/__tests__/**"
+    "!**/__tests__/**",
+    "babel.config.json"
   ],
   "scripts": {
     "prebuild": "run-s clean",


### PR DESCRIPTION
### Description

When generating types we depend on babel.config.json being bundled with the package.

```
» ls /Users/sgulseth/workspace/src/github.com/sanity-io/turtle-blue/node_modules/.pnpm/@sanity+codegen@3.35.0/node_modules/@sanity/codegen/
LICENSE  README.md  lib/  node_modules/  package.json  src/
```

Confirmed that the file gets added when running `npm pack .` in this branch.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->


### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
n/a

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
n/a - no notes needed
