### PR TITLE
fix(tasks): update how addonDatasetProvider ready state is set

### DIFF
--- a/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
+++ b/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
@@ -111,12 +111,15 @@ export function AddonDatasetProvider(props: AddonDatasetSetupProviderProps) {
     // a client for it and set it in the context value so that the consumers can use
     // it to execute comment operations and set up the real time listener for the addon
     // dataset.
-    getAddonDatasetName().then((addonDatasetName) => {
-      if (!addonDatasetName) return
-      const client = handleCreateClient(addonDatasetName)
-      setAddonDatasetClient(client)
-      setReady(true)
-    })
+    getAddonDatasetName()
+      .then((addonDatasetName) => {
+        if (!addonDatasetName) return
+        const client = handleCreateClient(addonDatasetName)
+        setAddonDatasetClient(client)
+      })
+      .finally(() => {
+        setReady(true)
+      })
   }, [getAddonDatasetName, handleCreateClient])
 
   const ctxValue = useMemo(


### PR DESCRIPTION
### Description

Fixes an issue in which when trying to create the addon dataset through the tasks plugin, this was not being created.
This is caused because the `ready: true` value was only set if the dataset name exists.

By updating this, the addon provider will return `ready:true` after fetching the dataset, either it exists or not. 
This flag is used by [`<TasksAddonWorkspaceProvider />`](https://github.com/sanity-io/sanity/blob/fix-task-addon-creation/packages/sanity/src/tasks/src/tasks/components/form/addonWorkspace/TasksAddOnWorkspaceProvider.tsx#L68) to decide if it should or not create the addon dataset. 


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
