### PR TITLE
feat(sanity): use actions API when publishing documents

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/publish.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/publish.test.ts
@@ -82,7 +82,7 @@ describe('publish', () => {
   })
 
   describe('execute', () => {
-    it('removes the `_updatedAt` field', () => {
+    it.skip('removes the `_updatedAt` field', () => {
       const client = createMockSanityClient()
 
       publish.execute({
@@ -106,7 +106,7 @@ describe('publish', () => {
       expect(client.$log).toMatchSnapshot()
     })
 
-    it('calls createOrReplace with _revision_lock_pseudo_field_ if there is an already published document', () => {
+    it.skip('calls createOrReplace with _revision_lock_pseudo_field_ if there is an already published document', () => {
       const client = createMockSanityClient()
 
       publish.execute({
@@ -137,7 +137,7 @@ describe('publish', () => {
       expect(client.$log).toMatchSnapshot()
     })
 
-    it('takes in any and strengthens references where _strengthenOnPublish is true', () => {
+    it.skip('takes in any and strengthens references where _strengthenOnPublish is true', () => {
       const client = createMockSanityClient()
 
       publish.execute({

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/publish.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/publish.ts
@@ -1,25 +1,5 @@
-import {isReference} from '@sanity/types'
-import {omit} from 'lodash'
-
 import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
 import {type OperationImpl} from './index'
-
-function strengthenOnPublish<T = any>(obj: T): T {
-  if (isReference(obj)) {
-    if (obj._strengthenOnPublish) {
-      return omit(
-        obj,
-        ['_strengthenOnPublish'].concat(obj._strengthenOnPublish.weak ? [] : ['_weak']),
-      ) as T
-    }
-    return obj
-  }
-  if (typeof obj !== 'object' || !obj) return obj
-  if (Array.isArray(obj)) return obj.map(strengthenOnPublish) as T
-  return Object.fromEntries(
-    Object.entries(obj).map(([key, value]) => [key, strengthenOnPublish(value)] as const),
-  ) as T
-}
 
 type DisabledReason = 'LIVE_EDIT_ENABLED' | 'ALREADY_PUBLISHED' | 'NO_CHANGES'
 
@@ -33,42 +13,23 @@ export const publish: OperationImpl<[], DisabledReason> = {
     }
     return false
   },
-  execute: ({client, idPair, snapshots}) => {
-    if (!snapshots.draft) {
-      throw new Error('cannot execute "publish" when draft is missing')
-    }
-    const value = strengthenOnPublish(omit(snapshots.draft, '_updatedAt'))
-    const tx = client.observable.transaction()
-    if (!snapshots.draft) {
-      throw new Error('cannot execute "publish" when draft is missing')
-    }
+  execute: ({client: globalClient, idPair}) => {
+    const vXClient = globalClient.withConfig({apiVersion: 'X'})
+    const {dataset} = globalClient.config()
 
-    if (snapshots.published) {
-      // If it exists already, we only want to update it if the revision on the remote server
-      // matches what our local state thinks it's at
-      tx.patch(idPair.publishedId, {
-        // Hack until other mutations support revision locking
-        unset: ['_revision_lock_pseudo_field_'],
-        ifRevisionID: snapshots.published._rev,
-      })
-
-      tx.createOrReplace({
-        ...value,
-        _id: idPair.publishedId,
-        _type: snapshots.draft._type,
-      })
-    } else {
-      // If the document has not been published, we want to create it - if it suddenly exists
-      // before being created, we don't want to overwrite if, instead we want to yield an error
-      tx.create({
-        ...value,
-        _id: idPair.publishedId,
-        _type: snapshots.draft._type,
-      })
-    }
-
-    tx.delete(idPair.draftId)
-
-    return tx.commit({tag: 'document.publish', visibility: 'async'})
+    return vXClient.observable.request({
+      url: `/data/actions/${dataset}`,
+      method: 'post',
+      tag: 'document.publish',
+      body: {
+        actions: [
+          {
+            actionType: 'sanity.action.document.publish',
+            draftId: idPair.draftId,
+            publishedId: idPair.publishedId,
+          },
+        ],
+      },
+    })
   },
 }

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
@@ -75,7 +75,7 @@ export const FormHeader = ({documentId, schemaType, title}: DocumentHeaderProps)
         </Text>
       )}
 
-      <Heading as="h2" data-heading muted={!title}>
+      <Heading as="h2" data-heading muted={!title} data-testid="document-panel-document-title">
         {title ?? t('document-view.form-view.form-title-fallback')}
       </Heading>
     </TitleContainer>

--- a/test/e2e/tests/document-actions/publish.spec.ts
+++ b/test/e2e/tests/document-actions/publish.spec.ts
@@ -1,0 +1,22 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+test(`document panel displays correct title for published document`, async ({
+  page,
+  createDraftDocument,
+}) => {
+  const title = 'Test Title'
+
+  await createDraftDocument('/test/content/book')
+  await page.getByTestId('field-title').getByTestId('string-input').fill(title)
+
+  // Ensure the correct title is displayed before publishing.
+  await expect(page.getByTestId('document-panel-document-title')).toHaveText(title)
+
+  // Wait for the document to be published.
+  page.getByTestId('action-Publish').click()
+  await expect(page.getByText('Published just now')).toBeVisible()
+
+  // Ensure the correct title is displayed after publishing.
+  expect(page.getByTestId('document-panel-document-title')).toHaveText(title)
+})


### PR DESCRIPTION
### Description

Note: I've skipped, rather than removed, the redundant unit tests for now. This is in case we keep the existing functionality behind a feature flag, and saves us regenerating test snapshots for now. I've made the implementation changes directly so it's easier to follow the changes (if we decided to feature flag this, we can easily grab the existing implementation from git).

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
