### PR TITLE
refactor(codegen): move Result appending into type generation

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -74,19 +74,6 @@ describe('findQueries', () => {
     expect(queries.length).toBe(0)
   })
 
-  test("should name queries with 'Result' at the end", () => {
-    const source = `
-      import { groq } from "groq";
-      const postQuery = groq\`*[_type == "author"]\`
-      const res = sanity.fetch(postQueryResult);
-    `
-
-    const queries = findQueriesInSource(source, 'test.ts')
-    const queryResult = queries[0]
-
-    expect(queryResult?.name.substr(-6)).toBe('Result')
-  })
-
   test('should import', () => {
     const source = `
       import { groq } from "groq";
@@ -106,8 +93,7 @@ describe('findQueries', () => {
     }
 
     const queries = findQueriesInSource(source, 'test.ts', undefined, resolver)
-    const queryResult = queries[0]
-
-    expect(queryResult?.name.substr(-6)).toBe('Result')
+    expect(queries.length).toBe(1)
+    expect(queries[0].result).toBe('*[_type == "foo"]')
   })
 })

--- a/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
+++ b/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
@@ -46,7 +46,7 @@ export function findQueriesInSource(
         babelTypes.isIdentifier(node.id) &&
         init.tag.name === groqTagName
       ) {
-        const queryName = `${node.id.name}Result`
+        const queryName = `${node.id.name}`
         const queryResult = resolveExpression({
           node: init,
           file,

--- a/packages/sanity/src/_internal/cli/threads/typegenGenerate.ts
+++ b/packages/sanity/src/_internal/cli/threads/typegenGenerate.ts
@@ -95,10 +95,10 @@ async function main() {
         const ast = parse(query)
         const queryTypes = typeEvaluate(ast, schema)
 
-        const type = typeGenerator.generateTypeNodeTypes(queryName, queryTypes)
+        const type = typeGenerator.generateTypeNodeTypes(`${queryName}Result`, queryTypes)
 
         fileQueryTypes.push({
-          queryName: queryName,
+          queryName,
           query,
           type,
           unknownTypes: countUnknownTypes(queryTypes),


### PR DESCRIPTION
### Description

Moves `Result` appending to the type identifier into the type generation. This way we can keep the actual query name across usages.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
👍 
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
N/A - no notes needed