### PR TITLE
fix(codegen): use relative path when globbing for files

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInPath.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInPath.test.ts
@@ -6,9 +6,30 @@ import {describe, expect, test} from '@jest/globals'
 import {findQueriesInPath} from '../findQueriesInPath'
 
 describe('findQueriesInPath', () => {
+  test('Can find queries in path', async () => {
+    const stream = findQueriesInPath({
+      path: path.join('**', 'typescript', '__tests__', 'fixtures', 'source1.ts'),
+    })
+    const res = []
+    for await (const result of stream) {
+      res.push(result)
+    }
+    expect(res.length).toBe(1)
+    expect(res[0].type).toBe('queries')
+    assert(res[0].type === 'queries') // workaround for TS
+    expect(res[0].queries.length).toBe(1)
+    // filename can be either of these two
+    // depending on whether the test is run from the monorepo root or from the package root
+    expect(
+      res[0].filename === 'src/typescript/__tests__/fixtures/source1.ts' ||
+        res[0].filename === 'packages/@sanity/codegen/src/typescript/__tests__/fixtures/source1.ts',
+    ).toBe(true)
+    expect(res[0].queries[0].name).toBe('postQuery')
+    expect(res[0].queries[0].result).toBe('*[_type == "author"]')
+  })
   test('should throw an error if the query name already exists', async () => {
     const stream = findQueriesInPath({
-      path: path.join(__dirname, 'fixtures', '{source1,source2}.ts'),
+      path: path.join('**', 'fixtures', '{source1,source2}.ts'),
     })
     await stream.next()
     const result = await stream.next()

--- a/packages/@sanity/codegen/src/typescript/findQueriesInPath.ts
+++ b/packages/@sanity/codegen/src/typescript/findQueriesInPath.ts
@@ -15,8 +15,6 @@ const defaultBabelOptions = {
   extends: join(__dirname, '..', '..', 'babel.config.json'),
 }
 
-const queryNames = new Set()
-
 type ResultQueries = {
   type: 'queries'
   filename: string
@@ -46,11 +44,12 @@ export async function* findQueriesInPath({
   babelOptions?: TransformOptions
   resolver?: NodeJS.RequireResolve
 }): AsyncGenerator<ResultQueries | ResultError> {
+  const queryNames = new Set()
   // Holds all query names found in the source files
   debug(`Globing ${path}`)
 
   const stream = glob.stream(path, {
-    absolute: true,
+    absolute: false,
     ignore: ['**/node_modules/**'], // we never want to look in node_modules
     onlyFiles: true,
   })


### PR DESCRIPTION
### Description

We were using absolute paths, so we ended up printing user information in the type comments.

Now we generate:
```
// Source: src/pages/resources/[slug]/index.tsx
// Variable: categoryQuery
// Query: ...
```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
👍 

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

n/a - no notes needed