### PR TITLE
fix(comments): hide resolve action if no handler is provided

### DIFF
--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemContextMenu.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemContextMenu.tsx
@@ -98,7 +98,7 @@ export function CommentsListItemContextMenu(props: CommentsListItemContextMenuPr
             />
           )}
 
-          {isParent && (
+          {isParent && onStatusChange && (
             <Button
               aria-label={
                 status === 'open'
@@ -110,7 +110,6 @@ export function CommentsListItemContextMenu(props: CommentsListItemContextMenuPr
               icon={status === 'open' ? CheckmarkCircleIcon : UndoIcon}
               mode="bleed"
               onClick={onStatusChange}
-              hidden={!onStatusChange}
               tooltipProps={{
                 content:
                   status === 'open'


### PR DESCRIPTION
### Description

This pull request ensures that the resolve action is hidden from a comment item's context menu when no handler is provided.

### What to Review

- Verify that the resolve action is hidden when no handler is provided.

### Notes for Release

N/A
