### PR TITLE
fix(tasks): update info passed to the tasks comments notification context

### DIFF
--- a/packages/sanity/src/tasks/src/tasks/components/form/tasksFormBuilder/FormEdit.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/form/tasksFormBuilder/FormEdit.tsx
@@ -21,9 +21,11 @@ import {CommentsProvider} from '../../../../../../structure/comments'
 import {MenuButton, MenuItem} from '../../../../../../ui-components'
 import {tasksLocaleNamespace} from '../../../../../i18n'
 import {useTasksNavigation} from '../../../context'
+import {useActivityLog} from '../../../hooks/useActivityLog'
 import {useRemoveTask} from '../../../hooks/useRemoveTask'
 import {type TaskDocument} from '../../../types'
 import {TasksActivityLog} from '../../activity'
+import {CurrentWorkspaceProvider} from '../CurrentWorkspaceProvider'
 import {AssigneeEditFormField} from '../fields/assignee'
 import {DateEditFormField} from '../fields/DateEditFormField'
 import {StatusSelector} from '../fields/StatusSelector'
@@ -95,6 +97,7 @@ function FormEditInner(props: ObjectInputProps) {
   const value = props.value as TaskDocument
   const currentUser = useCurrentUser()
   const {t} = useTranslation(tasksLocaleNamespace)
+  const activityData = useActivityLog(value).changes
   const handleChangeAndSubscribe = useCallback(
     (patch: FormPatch | PatchEvent | FormPatch[]) => {
       const subscribers = value.subscribers || []
@@ -155,16 +158,22 @@ function FormEditInner(props: ObjectInputProps) {
       </Card>
 
       {props.renderDefault(props)}
-
       <CommentsProvider
         documentId={value._id}
         documentType="tasks.task"
         sortOrder="asc"
         type="task"
       >
-        <Card borderTop paddingTop={4} marginTop={4} paddingBottom={6}>
-          <TasksActivityLog value={value} onChange={props.onChange} path={['subscribers']} />
-        </Card>
+        <CurrentWorkspaceProvider>
+          <Card borderTop paddingTop={4} marginTop={4} paddingBottom={6}>
+            <TasksActivityLog
+              value={value}
+              onChange={props.onChange}
+              path={['subscribers']}
+              activityData={activityData}
+            />
+          </Card>
+        </CurrentWorkspaceProvider>
       </CommentsProvider>
     </>
   )

--- a/packages/sanity/src/tasks/src/tasks/hooks/useActivityLog.ts
+++ b/packages/sanity/src/tasks/src/tasks/hooks/useActivityLog.ts
@@ -1,0 +1,70 @@
+import {useCallback, useEffect, useState} from 'react'
+import {getPublishedId, type TransactionLogEventWithEffects, useClient} from 'sanity'
+
+import {getJsonStream} from '../../../../core/store/_legacy/history/history/getJsonStream'
+import {type FieldChange, trackFieldChanges} from '../components/activity/helpers/parseTransactions'
+import {API_VERSION} from '../constants/API_VERSION'
+import {type TaskDocument} from '../types'
+
+export function useActivityLog(task: TaskDocument): {
+  changes: FieldChange[]
+} {
+  const [changes, setChanges] = useState<FieldChange[]>([])
+  const client = useClient({apiVersion: API_VERSION})
+  const {dataset, token} = client.config()
+
+  const queryParams = `tag=sanity.studio.tasks.history&effectFormat=mendoza&excludeContent=true&includeIdentifiedDocumentsOnly=true&reverse=true`
+  const transactionsUrl = client.getUrl(
+    `/data/history/${dataset}/transactions/${getPublishedId(task._id)}?${queryParams}`,
+  )
+
+  const fetchAndParse = useCallback(
+    async (newestTaskDocument: TaskDocument) => {
+      try {
+        const transactions: TransactionLogEventWithEffects[] = []
+
+        const stream = await getJsonStream(transactionsUrl, token)
+        const reader = stream.getReader()
+        let result
+        for (;;) {
+          result = await reader.read()
+          if (result.done) {
+            break
+          }
+          if ('error' in result.value) {
+            throw new Error(result.value.error.description || result.value.error.type)
+          }
+          transactions.push(result.value)
+        }
+
+        const fieldsToTrack: (keyof Omit<TaskDocument, '_rev'>)[] = [
+          'createdByUser',
+          'title',
+          'description',
+          'dueBy',
+          'assignedTo',
+          'status',
+          'target',
+        ]
+
+        const parsedChanges = await trackFieldChanges(
+          newestTaskDocument,
+          [...transactions],
+          fieldsToTrack,
+        )
+
+        setChanges(parsedChanges)
+      } catch (error) {
+        console.error('Failed to fetch and parse activity log', error)
+      }
+    },
+    [transactionsUrl, token],
+  )
+
+  useEffect(() => {
+    fetchAndParse(task)
+    // Task is updated on every change, wait until the revision changes to update the activity log.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchAndParse, task._rev])
+  return {changes}
+}


### PR DESCRIPTION
When creating a comment inside a task we need to pass a notification context for it.
The data obtained for the context was incorrect because it was pulling from the addon workspace instead the users current workspace. 
This Pr updates this to pull the data from the correct workspace.

It also moves `useActivityLog` to the hooks folder, and uses it from the FormEdit, given that hook needs to have access to the addon workspace.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
