### PR TITLE
fix(structure): use correct loading messages while resolving panes

### DIFF
--- a/packages/sanity/src/structure/__workshop__/LoadingPaneStory.tsx
+++ b/packages/sanity/src/structure/__workshop__/LoadingPaneStory.tsx
@@ -1,0 +1,19 @@
+import {Card, Stack, Text} from '@sanity/ui'
+
+import {PaneLayout} from '../components'
+import {LoadingPane} from '../panes'
+
+export default function LoadingPaneStory() {
+  return (
+    <Stack space={3}>
+      <Card padding={4} tone="positive">
+        <Text align="center">
+          Note: This is <em>intentionally</em> not resolving. We're testing the loading pane!
+        </Text>
+      </Card>
+      <PaneLayout height="fill">
+        <LoadingPane paneKey="loading" />
+      </PaneLayout>
+    </Stack>
+  )
+}

--- a/packages/sanity/src/structure/__workshop__/index.ts
+++ b/packages/sanity/src/structure/__workshop__/index.ts
@@ -15,5 +15,10 @@ export default defineScope({
       title: 'Document state',
       component: lazy(() => import('./DocumentStateStory')),
     },
+    {
+      name: 'loading-pane',
+      title: 'Loading pane',
+      component: lazy(() => import('./LoadingPaneStory')),
+    },
   ],
 })

--- a/packages/sanity/src/structure/panes/loading/LoadingPane.tsx
+++ b/packages/sanity/src/structure/panes/loading/LoadingPane.tsx
@@ -61,12 +61,12 @@ export const LoadingPane = memo((props: LoadingPaneProps) => {
 
   const [currentMessage, setCurrentMessage] = useState<string | null>(() => {
     if (typeof resolvedMessage === 'string') return resolvedMessage
-    return DEFAULT_MESSAGE_KEY
+    return t(DEFAULT_MESSAGE_KEY)
   })
 
   useEffect(() => {
     if (typeof resolvedMessage !== 'object') return undefined
-    if (typeof resolvedMessage.subscribe === 'function') return undefined
+    if (typeof resolvedMessage.subscribe !== 'function') return undefined
 
     const sub = resolvedMessage.subscribe((message) => {
       setCurrentMessage('messageKey' in message ? t(message.messageKey) : message.message)


### PR DESCRIPTION
### Description

While the structure panes are resolving (when using async resolvers), we show one or more loading messages. It starts with a "Loading..." message, shown after X ms. Later, after X seconds, it is supposed to show a "Still loading..." followed by a "Check if there's something wrong with your structure definition" kind of thing.

This code path has been broken for a while now, it seems:
1. The i18n changes had an error, so we're actually showing the resource key instead of the translated message for the first loading message
2. After v3, we checked for a subscribe method on what hopefully is an observable of loading messages, but we _returned_ if that was the case, when we actually wanted the opposite. If what was passed did _not_ have a subscribe method, we would actually have crashed here.

This PR fixes both of these cases.

### What to review

- Loading pane shows correct messages (use the workshop story to more easily see it, or create a `child` structure resolver that waits for 10+s before returning the child node

### Testing

I've added a workshop story for this. Ideally I'd also add automated tests, but seems like we're missing some established tests in the structure codebase that I can base them off of. 

### Notes for release

- Fixed incorrect loading message shown while a pane is resolving in the structure tool
