### PR TITLE
fix(comments): update close icon to be consistent

### DIFF
--- a/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspectorHeader.tsx
+++ b/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspectorHeader.tsx
@@ -1,4 +1,4 @@
-import {CheckmarkIcon, ChevronDownIcon, DoubleChevronRightIcon} from '@sanity/icons'
+import {CheckmarkIcon, ChevronDownIcon, CloseIcon} from '@sanity/icons'
 import {Card, Flex, Menu, Text} from '@sanity/ui'
 import {forwardRef, useCallback} from 'react'
 import {BetaBadge, useTranslation} from 'sanity'
@@ -81,7 +81,7 @@ export const CommentsInspectorHeader = forwardRef(function CommentsInspectorHead
 
           <Button
             aria-label={t('close-pane-button-text-aria-label')}
-            icon={DoubleChevronRightIcon}
+            icon={CloseIcon}
             mode="bleed"
             onClick={onClose}
             tooltipProps={{content: t('close-pane-button-text')}}


### PR DESCRIPTION
### Description

Fixes EDX-728

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Before:

<img width="523" alt="image" src="https://github.com/sanity-io/sanity/assets/6889008/c58d837c-0c41-4154-877d-e5100d7b5567">


After:

<img width="534" alt="image" src="https://github.com/sanity-io/sanity/assets/6889008/dec76f66-4af1-4e29-ab23-238044b18be0">


### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Is this icon correct?

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Simple icon change

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
