### PR TITLE
fix(structure): remove padding prop in contextMenuButton

### DIFF
--- a/packages/sanity/src/core/components/contextMenuButton/ContextMenuButton.tsx
+++ b/packages/sanity/src/core/components/contextMenuButton/ContextMenuButton.tsx
@@ -4,10 +4,7 @@ import {type ForwardedRef, forwardRef, type HTMLProps} from 'react'
 import {Button, type ButtonProps} from '../../../ui-components'
 import {useTranslation} from '../..'
 
-type ContextMenuButtonProps = Pick<
-  ButtonProps,
-  'mode' | 'paddingY' | 'size' | 'tone' | 'tooltipProps'
->
+type ContextMenuButtonProps = Pick<ButtonProps, 'mode' | 'size' | 'tone' | 'tooltipProps'>
 
 /**
  * Simple context menu button (with horizontal ellipsis icon) with shared localization.

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
@@ -184,7 +184,7 @@ export function ReferenceField(props: ReferenceFieldProps) {
       readOnly ? null : (
         <Box flex="none">
           <MenuButton
-            button={<ContextMenuButton paddingY={3} />}
+            button={<ContextMenuButton />}
             id={`${inputId}-menuButton`}
             menu={
               <Menu>

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -190,7 +190,7 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
     () =>
       readOnly ? null : (
         <MenuButton
-          button={<ContextMenuButton paddingY={3} />}
+          button={<ContextMenuButton />}
           id={`${inputId}-menuButton`}
           menu={
             <Menu ref={menuRef}>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/ErrorItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/ErrorItem.tsx
@@ -30,7 +30,7 @@ export function ErrorItem(props: {member: ArrayItemError; sortable?: boolean}) {
       style={{height: '100%'}}
       menu={
         <MenuButton
-          button={<ContextMenuButton paddingY={3} />}
+          button={<ContextMenuButton />}
           id={`${id}-menuButton`}
           menu={
             <Menu>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
@@ -139,7 +139,7 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
     () =>
       readOnly ? null : (
         <MenuButton
-          button={<ContextMenuButton paddingY={3} />}
+          button={<ContextMenuButton />}
           id={`${props.inputId}-menuButton`}
           menu={
             <Menu>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -122,7 +122,7 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
     () =>
       readOnly ? null : (
         <MenuButton
-          button={<ContextMenuButton paddingY={3} />}
+          button={<ContextMenuButton />}
           id={`${props.inputId}-menuButton`}
           menu={
             <Menu>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
@@ -67,7 +67,7 @@ export const ItemRow = forwardRef(function ItemRow(
 
   const menu = (
     <MenuButton
-      button={<ContextMenuButton paddingY={3} />}
+      button={<ContextMenuButton />}
       id={`${inputId}-menuButton`}
       popover={MENU_BUTTON_POPOVER_PROPS}
       menu={


### PR DESCRIPTION
### Description
The `ContextMenuButton` should always be square. But it allowed the `paddingY` prop, which could be set and resulting in it not being square. 
This PR removes the `paddingY` prop from the `ContextMenuButton`. 
Before: 
<img width="103" alt="Screenshot 2024-03-21 at 11 07 22" src="https://github.com/sanity-io/sanity/assets/44635000/c750ef29-88c5-487f-85d6-79512a4590eb">

After: 
<img width="116" alt="Screenshot 2024-03-21 at 11 07 30" src="https://github.com/sanity-io/sanity/assets/44635000/3276e89c-42cf-49e0-ba20-3bcaf50124cb">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Removes unnecessary padding on various menu buttons
<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
