### PR TITLE
fix(comments): drop permission check

### DIFF
--- a/packages/sanity/src/structure/comments/plugin/field/CommentsField.tsx
+++ b/packages/sanity/src/structure/comments/plugin/field/CommentsField.tsx
@@ -92,7 +92,6 @@ function CommentFieldInner(
 
   const {
     comments,
-    hasPermission,
     isCommentsOpen,
     isCreatingDataset,
     mentionOptions,
@@ -316,11 +315,6 @@ function CommentFieldInner(
       hasComments,
     ],
   )
-
-  // Render the default field component if the user doesn't have permission
-  if (!hasPermission) {
-    return props.renderDefault(props)
-  }
 
   return (
     <FieldStack {...applyCommentsFieldAttr(PathUtils.toString(props.path))} ref={rootRef}>

--- a/packages/sanity/src/structure/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/structure/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -63,16 +63,8 @@ export const CommentsPortableTextInputInner = React.memo(function CommentsPortab
   const currentUser = useCurrentUser()
   const portal = usePortal()
 
-  const {
-    comments,
-    getComment,
-    hasPermission,
-    mentionOptions,
-    onCommentsOpen,
-    operation,
-    setStatus,
-    status,
-  } = useComments()
+  const {comments, getComment, mentionOptions, onCommentsOpen, operation, setStatus, status} =
+    useComments()
   const {setSelectedPath, selectedPath} = useCommentsSelectedPath()
   const {scrollToComment, scrollToGroup} = useCommentsScroll()
   const {handleOpenDialog} = useCommentsUpsell()
@@ -509,11 +501,6 @@ export const CommentsPortableTextInputInner = React.memo(function CommentsPortab
     currentSelection && canSubmit && selectionReferenceElement && !mouseDownRef.current,
   )
   const showFloatingInput = Boolean(nextCommentSelection && popoverAuthoringReferenceElement)
-
-  // Render the default input if the user doesn't have permission
-  if (!hasPermission) {
-    return props.renderDefault(props)
-  }
 
   return (
     <>

--- a/packages/sanity/src/structure/comments/src/context/comments/CommentsProvider.tsx
+++ b/packages/sanity/src/structure/comments/src/context/comments/CommentsProvider.tsx
@@ -4,7 +4,6 @@ import {
   getPublishedId,
   useAddonDataset,
   useCurrentUser,
-  useDocumentValuePermissions,
   useEditState,
   useSchema,
   useUserListWithPermissions,
@@ -82,14 +81,6 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
 
   // A map to keep track of the latest transaction ID for each comment document.
   const transactionsIdMap = useMemo(() => new Map<DocumentId, TransactionId>(), [])
-
-  // We only need to check for read permission on the document since users with
-  // read permission on the document can both read and write comments.
-  // This is how permission work for the comments add-on dataset.
-  const [readPermission] = useDocumentValuePermissions({
-    document: documentValue || {_type: documentType, _id: publishedId},
-    permission: 'read',
-  })
 
   // When the latest transaction ID is received, we remove the transaction id from the map.
   const handleOnLatestTransactionIdReceived = useCallback(
@@ -276,8 +267,6 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
       isCommentsOpen,
       onCommentsOpen,
 
-      hasPermission: Boolean(readPermission?.granted),
-
       comments: {
         data: threadItemsByStatus,
         error,
@@ -299,7 +288,6 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
       getComment,
       isCommentsOpen,
       onCommentsOpen,
-      readPermission?.granted,
       threadItemsByStatus,
       error,
       loading,

--- a/packages/sanity/src/structure/comments/src/context/comments/types.ts
+++ b/packages/sanity/src/structure/comments/src/context/comments/types.ts
@@ -19,8 +19,6 @@ export interface CommentsContextValue {
   isCommentsOpen?: boolean
   onCommentsOpen?: () => void
 
-  hasPermission: boolean
-
   comments: {
     data: {
       open: CommentThreadItem[]


### PR DESCRIPTION
### Description

This pull request addresses an issue where the PTE changes from fullscreen to collapsed when content is changed in the editor. This problem was caused by the permission check logic for comments introduced in #6057.

The issue can be resolved by storing the permission result in a `useRef` instead of returning the value directly from `useDocumentValuePermissions` in the `CommentsProvider`. However, since users can both **create** and **read** comments if they only have **read** permissions, this permission check is not entirely necessary. This is because if a user does not have **read** permissions, they would not be able to see the document and, therefore, could not create a comment.

With this consideration, this pull request reverts the permission check logic introduced in #6057, thereby fixing the fullscreen issue in PTE and removing any unnecessary logic in the `CommentsProvider`.

### What to review

- Make sure that the PTE do not collapse when content is edited


### Notes for release

N/A
