### PR TITLE
fix(cli): add note about webhooks in migration run command

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -181,11 +181,13 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
 
     output.print(
       `\n${chalk.yellow(
-        chalk.bold(
-          'Note: If configued, migrations will trigger webhooks. You can disable webhooks on https://manage.sanity.io',
-        ),
-      )}\n`,
+        chalk.bold('Note: If your dataset has active webhooks, migrations will trigger them.'),
+      )}`,
     )
+    output.print(
+      `Run ${chalk.cyan('sanity manage')} to open the management interface in your web browser, then go to the API section to turn off webhooks.`,
+    )
+    output.print(`You can safely turn them back on after completing the migration.\n`)
 
     const response =
       flags.confirm &&

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -180,14 +180,11 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
     }
 
     output.print(
-      `\n${chalk.yellow(
-        chalk.bold('Note: If your dataset has active webhooks, migrations will trigger them.'),
-      )}`,
+      `\n${chalk.yellow(chalk.bold('Note: During migrations, your webhooks stay active.'))}`,
     )
     output.print(
-      `Run ${chalk.cyan('sanity manage')} to open the management interface in your web browser, then go to the API section to turn off webhooks.`,
+      `To adjust them, launch the management interface with ${chalk.cyan('sanity manage')}, navigate to the API settings, and toggle the webhooks before and after the migration as needed.\n`,
     )
-    output.print(`You can safely turn them back on after completing the migration.\n`)
 
     const response =
       flags.confirm &&

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -179,6 +179,14 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
       return
     }
 
+    output.print(
+      `\n${chalk.yellow(
+        chalk.bold(
+          'Note: If configued, migrations will trigger webhooks. You can disable webhooks on https://manage.sanity.io',
+        ),
+      )}\n`,
+    )
+
     const response =
       flags.confirm &&
       (await prompt.single<boolean>({


### PR DESCRIPTION
Fixes SDX-1156

### Description

Adds a message to warn users that migrations will trigger web hooks.

<img width="1178" alt="image" src="https://github.com/sanity-io/sanity/assets/6889008/b08d2c89-bc4b-4793-aff3-f270591b09ee">

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->
Is this the right message?

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

No behavioral change

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
