### PR TITLE
fix(pte): PTE inline block object modal closing on validation state changes

### DIFF
--- a/dev/test-studio/schema/standard/portableText/allTheBellsAndWhistles.ts
+++ b/dev/test-studio/schema/standard/portableText/allTheBellsAndWhistles.ts
@@ -88,11 +88,36 @@ export const ptAllTheBellsAndWhistlesType = defineType({
                     type: 'string',
                     name: 'color',
                     title: 'Color',
+                    validation: (rule: Rule) => rule.required(),
                   },
                 ],
               },
             ],
           },
+          of: [
+            defineField({
+              type: 'object',
+              name: 'inlineImage',
+              preview: {
+                select: {
+                  media: 'asset',
+                },
+              },
+              fields: [
+                defineField({
+                  name: 'inlineImage',
+                  type: 'image',
+                  title: 'Inline image',
+                }),
+                defineField({
+                  name: 'caption',
+                  type: 'string',
+                  title: 'Caption',
+                  validation: (rule) => rule.required(),
+                }),
+              ],
+            }),
+          ],
         }),
 
         defineField({
@@ -106,7 +131,6 @@ export const ptAllTheBellsAndWhistlesType = defineType({
           preview: {
             select: {
               media: 'asset',
-              title: 'caption',
             },
           },
           fields: [
@@ -114,6 +138,7 @@ export const ptAllTheBellsAndWhistlesType = defineType({
               title: 'Caption',
               name: 'caption',
               type: 'string',
+              validation: (rule) => rule.required(),
             }),
             {
               name: 'alt',

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -211,7 +211,8 @@ export const InlineObject = (props: InlineObjectProps) => {
         <Tooltip
           placement="bottom"
           portal="editor"
-          disabled={!tooltipEnabled}
+          // If the object modal is open, disable the tooltip to avoid it rerendering the inner items when the validation changes.
+          disabled={isOpen ? true : !tooltipEnabled}
           content={toolTipContent}
         >
           {/* This relative span must be here for the ToolTip to properly show */}
@@ -221,7 +222,14 @@ export const InlineObject = (props: InlineObjectProps) => {
         </Tooltip>
       </span>
     ),
-    [componentProps, memberItem?.elementRef, renderInlineBlock, toolTipContent, tooltipEnabled],
+    [
+      componentProps,
+      memberItem?.elementRef,
+      renderInlineBlock,
+      toolTipContent,
+      tooltipEnabled,
+      isOpen,
+    ],
   )
 }
 


### PR DESCRIPTION
Same issue as in https://github.com/sanity-io/sanity/pull/5766 but in this case affecting inline objects.

When we have validation errors the tooltip is enabled, when validation errors disappear the tooltip is disabled.
Making that update when the modal is open it will trigger a "unmount" and "re-mount" of the InlineObject causing the  modal to unmount and remount, triggering the animation again and losing the input focus.

By checking if the modal is open to **enable / disable** the tooltip, we can be sure that this component won't unmount and mount causing  issues. 

https://github.com/sanity-io/sanity/assets/46196328/f2ca9093-7d42-4059-b09f-cec3bc221fd7


### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
