### PR TITLE
fix(schema): correctly assert optional fields with enforce required fields

### DIFF
--- a/packages/@sanity/schema/src/sanity/extractSchema.ts
+++ b/packages/@sanity/schema/src/sanity/extractSchema.ts
@@ -207,10 +207,15 @@ export function extractSchema(
       if (value === null) {
         continue
       }
+
+      // if we extract with enforceRequiredFields, we will mark the field as optional only if it is not a required field,
+      // else we will always mark it as optional
+      const optional = extractOptions.enforceRequiredFields ? fieldIsRequired === false : true
+
       attributes[field.name] = {
         type: 'objectAttribute',
         value,
-        optional: extractOptions.enforceRequiredFields ? fieldIsRequired : true,
+        optional,
       }
     }
 

--- a/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
+++ b/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
 
 import {describe, expect, test} from '@jest/globals'
-import {defineType} from '@sanity/types'
+import {defineField, defineType} from '@sanity/types'
 
 import {Schema} from '../../src/legacy/Schema'
 import {extractSchema} from '../../src/sanity/extractSchema'
@@ -365,6 +365,76 @@ describe('Extract schema test', () => {
       'book',
       'author',
     ])
+  })
+
+  test('all fields are marked as optional without "enforceRequiredFields"', () => {
+    const schema1 = createSchema({
+      name: 'test',
+      types: [
+        {
+          title: 'Book',
+          name: 'book',
+          type: 'document',
+          fields: [
+            {
+              title: 'Title',
+              name: 'title',
+              type: 'string',
+            },
+            defineField({
+              title: 'Subtitle',
+              name: 'subtitle',
+              type: 'string',
+              validation: (Rule) => Rule.required(),
+            }),
+          ],
+        },
+      ],
+    })
+
+    const extracted = extractSchema(schema1, {enforceRequiredFields: false})
+
+    const book = extracted.find((type) => type.name === 'book')
+    expect(book).toBeDefined()
+    assert(book !== undefined) // this is a workaround for TS, but leave the expect above for clarity in case of failure
+    assert(book.type === 'document') // this is a workaround for TS, but leave the expect above for clarity in case of failure
+    expect(book.attributes.title.optional).toBe(true)
+    expect(book.attributes.subtitle.optional).toBe(true)
+  })
+
+  test('can extract with enforceRequiredFields', () => {
+    const schema1 = createSchema({
+      name: 'test',
+      types: [
+        {
+          title: 'Book',
+          name: 'book',
+          type: 'document',
+          fields: [
+            {
+              title: 'Title',
+              name: 'title',
+              type: 'string',
+            },
+            defineField({
+              title: 'Subtitle',
+              name: 'subtitle',
+              type: 'string',
+              validation: (Rule) => Rule.required(),
+            }),
+          ],
+        },
+      ],
+    })
+
+    const extracted = extractSchema(schema1, {enforceRequiredFields: true})
+
+    const book = extracted.find((type) => type.name === 'book')
+    expect(book).toBeDefined()
+    assert(book !== undefined) // this is a workaround for TS, but leave the expect above for clarity in case of failure
+    assert(book.type === 'document') // this is a workaround for TS, but leave the expect above for clarity in case of failure
+    expect(book.attributes.title.optional).toBe(true)
+    expect(book.attributes.subtitle.optional).toBe(false)
   })
 
   describe('Can extract sample fixtures', () => {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

We were asserting the optional value wrong for required fields 🤦

### What to review

Agree that it's correct now?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

✅  

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

fixes a bug, where all fields got marked as non-optional, when extracting schema with `--enforce-required-fields`
