### PR TITLE
chore(typegen): show schema extraction and typegen in help texts

### DIFF
--- a/packages/@sanity/cli/src/commands/typegen/generateTypesCommand.ts
+++ b/packages/@sanity/cli/src/commands/typegen/generateTypesCommand.ts
@@ -42,7 +42,6 @@ const generateTypegenCommand: CliCommandDefinition = {
   signature: '',
   description,
   helpText,
-  hideFromHelp: true,
   action: async (args, context) => {
     const mod = await import('../../actions/typegen/generateAction')
 

--- a/packages/sanity/src/_internal/cli/commands/schema/extractSchemaCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/schema/extractSchemaCommand.ts
@@ -22,7 +22,6 @@ const extractSchemaCommand: CliCommandDefinition = {
   signature: '',
   description,
   helpText,
-  hideFromHelp: true,
   action: async (args, context) => {
     const mod = await import('../../actions/schema/extractAction')
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

We now want to display both schema extract and typegen in `--help`

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

n/a

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
n/a - no notes needed
