### PR TITLE
fix(vision): fixes bug where codemirror would insert a new line on cmd-return

### DIFF
--- a/packages/@sanity/vision/src/codemirror/extensions.ts
+++ b/packages/@sanity/vision/src/codemirror/extensions.ts
@@ -8,7 +8,7 @@ import {
   syntaxHighlighting,
 } from '@codemirror/language'
 import {highlightSelectionMatches} from '@codemirror/search'
-import {Extension} from '@codemirror/state'
+import {type Extension} from '@codemirror/state'
 import {
   drawSelection,
   highlightActiveLine,
@@ -31,5 +31,16 @@ export const codemirrorExtensions: Extension[] = [
   history(),
   drawSelection(),
   syntaxHighlighting(defaultHighlightStyle, {fallback: true}),
-  keymap.of([defaultKeymap, historyKeymap].flat().filter(Boolean)),
+  keymap.of(
+    [
+      // Override the default keymap for Mod-Enter to not insert a new line, we have a custom event handler for executing queries
+      {key: 'Mod-Enter', run: () => true},
+
+      // Add the default keymap and history keymap
+      defaultKeymap,
+      historyKeymap,
+    ]
+      .flat()
+      .filter(Boolean),
+  ),
 ]


### PR DESCRIPTION
### Description
Fixes an annoying bug where code mirror would insert another new line on cmd-return, which also executes the query

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Should be safe, tested fine on mac

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

n/a

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

Fix  bug where Vision would insert another new line on cmd-return.

