### PR TITLE
feat(vision): link to edit documents

### DIFF
--- a/packages/@sanity/vision/src/components/ResultView.tsx
+++ b/packages/@sanity/vision/src/components/ResultView.tsx
@@ -2,7 +2,7 @@ import JSONInspector from '@rexxars/react-json-inspector'
 import {LinkIcon} from '@sanity/icons'
 import {Code} from '@sanity/ui'
 import LRU from 'quick-lru'
-import {useWorkspace} from 'sanity'
+import {useDataset} from 'sanity'
 import {IntentLink} from 'sanity/router'
 
 import {ResultViewWrapper} from './ResultView.styled'
@@ -11,7 +11,7 @@ const lru = new LRU({maxSize: 50000})
 
 export function ResultView(props: {data: unknown; datasetName: string}): JSX.Element {
   const {data, datasetName} = props
-  const workspace = useWorkspace()
+  const workspaceDataset = useDataset()
 
   if (isRecord(data) || Array.isArray(data)) {
     return (
@@ -21,7 +21,7 @@ export function ResultView(props: {data: unknown; datasetName: string}): JSX.Ele
           search={false}
           isExpanded={isExpanded}
           onClick={toggleExpanded}
-          interactiveLabel={workspace.dataset === datasetName ? DocumentEditLabel : undefined}
+          interactiveLabel={workspaceDataset === datasetName ? DocumentEditLabel : undefined}
         />
       </ResultViewWrapper>
     )

--- a/packages/@sanity/vision/src/components/ResultView.tsx
+++ b/packages/@sanity/vision/src/components/ResultView.tsx
@@ -1,13 +1,17 @@
 import JSONInspector from '@rexxars/react-json-inspector'
+import {LinkIcon} from '@sanity/icons'
 import {Code} from '@sanity/ui'
 import LRU from 'quick-lru'
+import {useWorkspace} from 'sanity'
+import {IntentLink} from 'sanity/router'
 
 import {ResultViewWrapper} from './ResultView.styled'
 
 const lru = new LRU({maxSize: 50000})
 
-export function ResultView(props: {data: unknown}) {
-  const {data} = props
+export function ResultView(props: {data: unknown; datasetName: string}): JSX.Element {
+  const {data, datasetName} = props
+  const workspace = useWorkspace()
 
   if (isRecord(data) || Array.isArray(data)) {
     return (
@@ -17,12 +21,25 @@ export function ResultView(props: {data: unknown}) {
           search={false}
           isExpanded={isExpanded}
           onClick={toggleExpanded}
+          interactiveLabel={workspace.dataset === datasetName ? DocumentEditLabel : undefined}
         />
       </ResultViewWrapper>
     )
   }
 
   return <Code language="json">{JSON.stringify(data)}</Code>
+}
+
+function DocumentEditLabel(props: {value: string; isKey: boolean; keypath: string}) {
+  if (props.isKey || (!props.keypath.endsWith('_id') && !props.keypath.endsWith('_ref'))) {
+    return null
+  }
+
+  return (
+    <IntentLink intent="edit" params={{id: props.value}}>
+      <LinkIcon />
+    </IntentLink>
+  )
 }
 
 function isExpanded(keyPath: string, value: unknown): boolean {

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -954,9 +954,9 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
                         </Box>
                       )}
                       {error && <QueryErrorDialog error={error} />}
-                      {hasResult && <ResultView data={queryResult} />}
+                      {hasResult && <ResultView data={queryResult} datasetName={dataset} />}
                       {listenInProgress && listenMutations.length > 0 && (
-                        <ResultView data={listenMutations} />
+                        <ResultView data={listenMutations} datasetName={dataset} />
                       )}
                     </Box>
                   </Result>


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Suggestion: Add a link icon next to each _id and _ref attributes

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Pq5PDa6N07kCDwnO5Zhh/e5af16e0-bb13-476c-aaed-4b90b184e861.png)


### What to review

Is this "safe"? Ref #6074 the user might be querying another dataset 🤔  Though it provides an easy way to inspect a document.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

N/A

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

n/a - no notes needed
