### PR TITLE
chore(codegen): track ratio between unknown nodes and all type nodes

### DIFF
--- a/packages/@sanity/cli/src/actions/typegen/generate.telemetry.ts
+++ b/packages/@sanity/cli/src/actions/typegen/generate.telemetry.ts
@@ -8,6 +8,7 @@ interface TypesGeneratedTraceAttrubutes {
   filesWithErrors: number
   typeNodesGenerated: number
   unknownTypeNodesGenerated: number
+  unknownTypeNodesRatio: number
 }
 
 export const TypesGeneratedTrace = defineTrace<TypesGeneratedTraceAttrubutes>({

--- a/packages/@sanity/cli/src/actions/typegen/generateAction.ts
+++ b/packages/@sanity/cli/src/actions/typegen/generateAction.ts
@@ -134,6 +134,7 @@ export default async function typegenGenerateAction(
     filesWithErrors: stats.errors,
     typeNodesGenerated: stats.typeNodesGenerated,
     unknownTypeNodesGenerated: stats.unknownTypeNodesGenerated,
+    unknownTypeNodesRatio: stats.unknownTypeNodesGenerated / stats.typeNodesGenerated,
   })
 
   trace.complete()


### PR DESCRIPTION
### Description

we want to track the ratio between unknown type nodes and all type nodes. This help us track how well built out feature wise we are

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

n/a

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

n/a - no notes needed
