### PR TITLE
chore(import): disable `import/extensions` rule for middleware import

### DIFF
--- a/packages/@sanity/cli/src/actions/init-plugin/bootstrapFromTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-plugin/bootstrapFromTemplate.ts
@@ -2,6 +2,7 @@ import {absolutify, pathIsEmpty} from '@sanity/util/fs'
 import decompress from 'decompress'
 import fs from 'fs/promises'
 import {getIt} from 'get-it'
+// eslint-disable-next-line import/extensions
 import {promise} from 'get-it/middleware'
 import path from 'path'
 import resolveFrom from 'resolve-from'

--- a/packages/@sanity/cli/test/shared/request.ts
+++ b/packages/@sanity/cli/test/shared/request.ts
@@ -1,4 +1,5 @@
 import {getIt} from 'get-it'
+// eslint-disable-next-line import/extensions
 import {promise} from 'get-it/middleware'
 
 const requester = getIt([promise()])

--- a/packages/@sanity/export/src/requestStream.js
+++ b/packages/@sanity/export/src/requestStream.js
@@ -1,4 +1,5 @@
 const {getIt} = require('get-it')
+// eslint-disable-next-line import/extensions
 const {keepAlive, promise} = require('get-it/middleware')
 const debug = require('./debug')
 

--- a/packages/@sanity/import-cli/src/sanity-import.js
+++ b/packages/@sanity/import-cli/src/sanity-import.js
@@ -6,6 +6,7 @@ const path = require('path')
 const {createClient} = require('@sanity/client')
 const sanityImport = require('@sanity/import')
 const {getIt} = require('get-it')
+// eslint-disable-next-line import/extensions
 const {promise} = require('get-it/middleware')
 const meow = require('meow')
 const ora = require('ora')

--- a/packages/@sanity/import/src/util/getHashedBufferForUri.js
+++ b/packages/@sanity/import/src/util/getHashedBufferForUri.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto')
 const {URL} = require('url')
 const {getIt} = require('get-it')
+// eslint-disable-next-line import/extensions
 const {promise} = require('get-it/middleware')
 const getUri = require('get-uri')
 const miss = require('mississippi')

--- a/packages/@sanity/import/test/helpers/helpers.js
+++ b/packages/@sanity/import/test/helpers/helpers.js
@@ -1,4 +1,5 @@
 const {createClient, requester: defaultRequester} = require('@sanity/client')
+// eslint-disable-next-line import/extensions
 const {injectResponse} = require('get-it/middleware')
 const noop = require('lodash/noop')
 

--- a/packages/sanity/src/_internal/cli/actions/backup/downloadAsset.ts
+++ b/packages/sanity/src/_internal/cli/actions/backup/downloadAsset.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import {pipeline} from 'node:stream/promises'
 
 import {getIt} from 'get-it'
+// eslint-disable-next-line import/extensions
 import {keepAlive, promise} from 'get-it/middleware'
 
 import debug from './debug'

--- a/packages/sanity/src/_internal/cli/actions/backup/downloadDocument.ts
+++ b/packages/sanity/src/_internal/cli/actions/backup/downloadDocument.ts
@@ -1,4 +1,5 @@
 import {getIt, type MiddlewareResponse} from 'get-it'
+// eslint-disable-next-line import/extensions
 import {keepAlive, promise} from 'get-it/middleware'
 
 import debug from './debug'

--- a/packages/sanity/src/_internal/cli/commands/dataset/importDatasetCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/importDatasetCommand.ts
@@ -3,6 +3,7 @@ import sanityImport from '@sanity/import'
 import {createReadStream} from 'fs'
 import fs from 'fs/promises'
 import {getIt} from 'get-it'
+// eslint-disable-next-line import/extensions
 import {promise} from 'get-it/middleware'
 import padStart from 'lodash/padStart'
 import path from 'path'

--- a/packages/sanity/src/_internal/cli/util/getUrlHeaders.ts
+++ b/packages/sanity/src/_internal/cli/util/getUrlHeaders.ts
@@ -1,4 +1,5 @@
 import {getIt} from 'get-it'
+// eslint-disable-next-line import/extensions
 import {promise} from 'get-it/middleware'
 
 const request = getIt([promise()])


### PR DESCRIPTION
### Description

This is done to unblock us - more investigation needed into whether the rule is wrong or the module is wrong, but seems to work fine so lets make our builds work for now.

### Notes for release

None.