### PR TITLE
fix(schemaExtract): guard for list options not being an array

### DIFF
--- a/packages/@sanity/schema/src/sanity/extractSchema.ts
+++ b/packages/@sanity/schema/src/sanity/extractSchema.ts
@@ -347,10 +347,11 @@ function isNumberType(typeDef: SanitySchemaType): typeDef is NumberSchemaType {
 function createStringTypeNodeDefintion(
   stringSchemaType: StringSchemaType,
 ): StringTypeNode | UnionTypeNode<StringTypeNode> {
-  if (stringSchemaType.options?.list) {
+  const listOptions = stringSchemaType.options?.list
+  if (listOptions && Array.isArray(listOptions)) {
     return {
       type: 'union',
-      of: stringSchemaType.options.list.map((v) => ({
+      of: listOptions.map((v) => ({
         type: 'string',
         value: typeof v === 'string' ? v : v.value,
       })),
@@ -364,10 +365,11 @@ function createStringTypeNodeDefintion(
 function createNumberTypeNodeDefintion(
   numberSchemaType: NumberSchemaType,
 ): NumberTypeNode | UnionTypeNode<NumberTypeNode> {
-  if (numberSchemaType.options?.list) {
+  const listOptions = numberSchemaType.options?.list
+  if (listOptions && Array.isArray(listOptions)) {
     return {
       type: 'union',
-      of: numberSchemaType.options.list.map((v) => ({
+      of: listOptions.map((v) => ({
         type: 'number',
         value: typeof v === 'number' ? v : v.value,
       })),

--- a/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
+++ b/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
@@ -437,6 +437,17 @@ describe('Extract schema test', () => {
     expect(book.attributes.subtitle.optional).toBe(false)
   })
 
+  describe('can handle `list` option that is not an array', () => {
+    const schema = createSchema(schemaFixtures.listObjectOption)
+    const extracted = extractSchema(schema)
+
+    const post = extracted.find((type) => type.name === 'post')
+    assert(post !== undefined) // this is a workaround for TS, but leave the expect above for clarity in case of failure
+    assert(post.type === 'document') // this is a workaround for TS, but leave the expect above for clarity in case of failure
+
+    expect(post.attributes.align.value.type).toBe('string')
+  })
+
   describe('Can extract sample fixtures', () => {
     const cases = Object.keys(schemaFixtures).map((schemaName) => {
       const schema = createSchema(schemaFixtures[schemaName])

--- a/packages/@sanity/schema/test/legacy/fixtures/schemas/index.ts
+++ b/packages/@sanity/schema/test/legacy/fixtures/schemas/index.ts
@@ -3,6 +3,7 @@ import assets from './assets'
 import blocks from './blocks'
 import exampleBlog from './example-blog'
 import fieldsets from './fieldsets'
+import listObjectOption from './listObjectOption'
 import messyDevSchema from './messy-dev'
 import oma from './oma'
 import reference from './reference'
@@ -12,12 +13,13 @@ import vega from './vega'
 export default {
   arrays,
   assets,
+  blocks,
   exampleBlog,
   fieldsets,
-  reference,
-  vega,
-  blocks,
-  oma,
-  selects,
+  listObjectOption,
   messyDevSchema,
+  oma,
+  reference,
+  selects,
+  vega,
 }

--- a/packages/@sanity/schema/test/legacy/fixtures/schemas/listObjectOption.ts
+++ b/packages/@sanity/schema/test/legacy/fixtures/schemas/listObjectOption.ts
@@ -1,0 +1,30 @@
+export default {
+  name: 'listObjectOption',
+  types: [
+    {
+      name: 'stringWithListOption',
+      type: 'string',
+    },
+    {
+      name: 'post',
+      type: 'document',
+      fields: [
+        {
+          name: 'title',
+          title: 'Title',
+          type: 'string',
+        },
+        {
+          name: 'align',
+          title: 'Alignment',
+          type: 'stringWithListOption',
+          options: {
+            list: {
+              options: ['left', 'right', 'center'],
+            },
+          },
+        },
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
### Description

We have gotten reports that `createStringTypeNodeDefintion` throws an error `stringSchemaType.options?.list.map is not a function` this indiciates that we, even though the types & docs says it will be an array, are not receiving an array.

I've noticed that in other parts of the code base we are guarding for `list` being an array https://github.com/sanity-io/sanity/blob/next/packages/%40sanity/block-tools/src/util/blockContentTypeFeatures.ts#L115

My suspicion is that we handle plugin types incorrectly, the report indicated usage of a [visual-options](https://github.com/fddigital-uk/sanity-plugin-visual-options/blob/trunk/src/index.js#L7-L14), which might indicate that we are parsing plugin types incorrectly.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

I think this work around should be fine for now? Will have a look at the root case separately

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

n/a

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

n/a - no notes needed


