### PR TITLE
fix: improve document pane path handling

### DIFF
--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
@@ -102,7 +102,12 @@ export function ArrayOfObjectsField(props: {
       // blur, not when a child element receives blur, but React has decided
       // to let focus events bubble, so this workaround is needed
       // Background: https://github.com/facebook/react/issues/6410#issuecomment-671915381
-      if (event.currentTarget === event.target && event.currentTarget === focusRef.current) {
+      if (
+        event.currentTarget === event.target &&
+        (event.currentTarget === focusRef.current ||
+          // PortableTextInput forwarded ref is a custom handle, i.e. not an HTMLElement
+          !(focusRef.current instanceof HTMLElement))
+      ) {
         onPathBlur(member.field.path)
       }
     },

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -10,6 +10,7 @@ import {useToast} from '@sanity/ui'
 import {fromString as pathFromString, resolveKeyedPath} from '@sanity/util/paths'
 import {omit} from 'lodash'
 import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import deepEquals from 'react-fast-compare'
 import {
   type DocumentFieldAction,
   type DocumentInspector,
@@ -140,6 +141,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     params.path ? pathFromString(params.path) : EMPTY_ARRAY,
   )
   const focusPathRef = useRef(focusPath)
+  const openPathRef = useRef<Path>([])
   const activeViewId = params.view || (views[0] && views[0].id) || null
   const [timelineMode, setTimelineMode] = useState<'since' | 'rev' | 'closed'>('closed')
 
@@ -260,46 +262,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       })
     },
     [params, setPaneParams],
-  )
-
-  const handleFocus = useCallback(
-    (nextFocusPath: Path) => {
-      setFocusPath(nextFocusPath)
-
-      if (focusPathRef.current !== nextFocusPath) {
-        focusPathRef.current = nextFocusPath
-        onFocusPath?.(nextFocusPath)
-      }
-
-      presenceStore.setLocation([
-        {
-          type: 'document',
-          documentId,
-          path: nextFocusPath,
-          lastActiveAt: new Date().toISOString(),
-        },
-      ])
-    },
-    [documentId, onFocusPath, presenceStore, setFocusPath],
-  )
-
-  const handleBlur = useCallback(
-    (blurredPath: Path) => {
-      if (disableBlurRef.current) {
-        return
-      }
-
-      setFocusPath(EMPTY_ARRAY)
-
-      if (focusPathRef.current !== EMPTY_ARRAY) {
-        focusPathRef.current = EMPTY_ARRAY
-        onFocusPath?.(EMPTY_ARRAY)
-      }
-
-      // note: we're deliberately not syncing presence here since it would make the user avatar disappear when a
-      // user clicks outside a field without focusing another one
-    },
-    [onFocusPath, setFocusPath],
   )
 
   const patchRef = useRef<(event: PatchEvent) => void>(() => {
@@ -567,6 +529,47 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     [formStateRef],
   )
 
+  const handleFocus = useCallback(
+    (nextFocusPath: Path) => {
+      if (!deepEquals(focusPathRef.current, nextFocusPath)) {
+        setFocusPath(nextFocusPath)
+        focusPathRef.current = nextFocusPath
+        openPathRef.current = nextFocusPath
+        onFocusPath?.(nextFocusPath)
+      }
+
+      presenceStore.setLocation([
+        {
+          type: 'document',
+          documentId,
+          path: nextFocusPath,
+          lastActiveAt: new Date().toISOString(),
+        },
+      ])
+    },
+    [documentId, onFocusPath, presenceStore, setFocusPath],
+  )
+
+  const handleBlur = useCallback(
+    (blurredPath: Path) => {
+      if (disableBlurRef.current) {
+        return
+      }
+
+      setFocusPath(EMPTY_ARRAY)
+      setOpenPath(blurredPath)
+
+      if (focusPathRef.current !== EMPTY_ARRAY) {
+        focusPathRef.current = EMPTY_ARRAY
+        onFocusPath?.(EMPTY_ARRAY)
+      }
+
+      // note: we're deliberately not syncing presence here since it would make the user avatar disappear when a
+      // user clicks outside a field without focusing another one
+    },
+    [onFocusPath, setOpenPath, setFocusPath],
+  )
+
   const documentPane: DocumentPaneContextValue = useMemo(
     () => ({
       actions,
@@ -706,9 +709,13 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
       // Reset focus path when url params path changes
       setFocusPath(pathFromUrl)
-      setOpenPath(pathFromUrl)
 
-      if (focusPathRef.current !== pathFromUrl) {
+      if (!deepEquals(openPathRef.current, pathFromUrl)) {
+        openPathRef.current = pathFromUrl
+        setOpenPath(pathFromUrl)
+      }
+
+      if (!deepEquals(focusPathRef.current, pathFromUrl)) {
         focusPathRef.current = pathFromUrl
         onFocusPath?.(pathFromUrl)
       }


### PR DESCRIPTION
### Description

This PR makes some improvements to how the `DocumentPaneProvider` handles paths, specifically `openPath`. It also makes a small change so that missing PTE input blur events are now emitted.

There are a few UI issues that users are unlikely to encounter within the context of the Structure tool—but become much more prevalent within the context of Presentation—as they only occur when `openPath` state is set from a path provided via the URL:

- PTE cursor (sometimes) jumps to beginning of a block on focus.
- PTE scrolls to previously opened block on blur.
- PTE scrolls to block on click.

In addition:

- The PTE currently emits no handleable blur event (needed to fix these issues).
- Presentation's persistence of the path in the URL causes duplicate element focus.
- This duplication causes blocks that open modals to open on single click instead of double click.

### What to review

- That these changes don't have any obvious unintended side effects (the PTE is not so much my domain).
- That the updated `ArrayOfObjectsField`’s `handleBlur` logic is the best solution for detecting refs forwarded to the PTE input.
- That `deepEquals` is the right method for comparing path refs with new values. These replace strict equality checks that always evaluated to true as they were comparing arrays.

### Testing

The document pane and PTE should function exactly as before/expected, with the above issues resolved. CRX-630 contains a link to a video demonstrating some of the issues if any of the above is unclear.

### Notes for release