### PR TITLE
fix(typegen): add placeholder group to allow typegen to show in help

### DIFF
--- a/packages/@sanity/cli/src/commands/index.ts
+++ b/packages/@sanity/cli/src/commands/index.ts
@@ -15,6 +15,7 @@ import enableTelemetryCommand from './telemetry/enableTelemetryCommand'
 import telemetryGroup from './telemetry/telemetryGroup'
 import telemetryStatusCommand from './telemetry/telemetryStatusCommand'
 import generateTypegenCommand from './typegen/generateTypesCommand'
+import typegenGroup from './typegen/typegenGroup'
 import upgradeCommand from './upgrade/upgradeCommand'
 import versionsCommand from './versions/versionsCommand'
 
@@ -37,4 +38,5 @@ export const baseCommands: (CliCommandDefinition | CliCommandGroupDefinition)[] 
   enableTelemetryCommand,
   telemetryStatusCommand,
   generateTypegenCommand,
+  typegenGroup,
 ]

--- a/packages/@sanity/cli/src/commands/typegen/typegenGroup.ts
+++ b/packages/@sanity/cli/src/commands/typegen/typegenGroup.ts
@@ -1,0 +1,10 @@
+import {type CliCommandGroupDefinition} from '../../types'
+
+const typegenGroup: CliCommandGroupDefinition = {
+  name: 'typegen',
+  signature: '[COMMAND]',
+  isGroupRoot: true,
+  description: 'Beta: Generate TypeScript types for schema and GROQ',
+}
+
+export default typegenGroup


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds missing typegen group cmd

```
» pnpm sanity help
usage: sanity [--default] [-v|--version] [-d|--debug] [-h|--help] <command> [<args>]

Commands:
   backup     Manage backups.
   build      Builds the Sanity Studio configuration into a static bundle
   codemod    Updates Sanity Studio codebase with a code modification script
   cors       Configures CORS settings for Sanity projects
   dataset    Manages datasets, like create or delete, within projects
   debug      Provides diagnostic info for Sanity Studio troubleshooting
   deploy     Builds and deploys Sanity Studio to Sanity hosting
   dev        Starts a local dev server for Sanity Studio with live reloading
   docs       Opens Sanity Studio documentation in your web browser
   documents  Manages documents in your Sanity Content Lake datasets
   exec       Executes a script within the Sanity Studio context
   graphql    Deploys changes to your project's GraphQL API(s)
   help       Displays help information about Sanity CLI commands
   hook       Sets up and manages webhooks within your Sanity project
   init       Initializes a new Sanity Studio and/or project
   install    Installs dependencies for Sanity Studio project
   login      Authenticates the CLI for access to Sanity projects
   logout     Logs out the CLI from the current user session
   manage     Opens project management interface in your web browser
   migration  Manages content migrations for Content Lake datasets
   preview    Starts a server to preview a production build of Sanity Studio
   projects   Lists all projects associated with your logged-in account
   schema     Interacts with Sanity Studio schema configurations
   start      Alias for `sanity preview`
   telemetry  Manages telemetry settings, opting in or out of data collection
   typegen    Sanity TypeGen (Beta)
   undeploy   Removes the deployed Sanity Studio from Sanity hosting
   users      Manages users of your Sanity project
   versions   Shows installed versions of Sanity Studio and components

See 'sanity help <command>' for specific information on a subcommand.
github.com/sanity-io/sanity ‹fix/typegen-cmd-group› » pnpm sanity help typegen
usage: sanity typegen [--default] [-v|--version] [-d|--debug] [-h|--help] <command> [<args>]

Commands:
   generate  Generates TypeScript types from schema types and GROQ queries

See 'sanity help typegen <command>' for specific information on a subcommand.
```

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

are we missing anything else?

### Testing

can we test this? 

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

n/a - no notes needed