### PR TITLE
fix(core): remove duplicateds tasks plugins

### DIFF
--- a/packages/sanity/src/core/config/flattenConfig.ts
+++ b/packages/sanity/src/core/config/flattenConfig.ts
@@ -17,7 +17,16 @@ export const flattenConfig = (
     flattenConfig(plugin, [...path, currentConfig.name]),
   )
 
-  const resolved = [...allPlugins, rootConfig]
+  // We need to check if the task plugin was added, it could be inserted more than once, in that case we only want to add it once.
+  const tasksPlugin = allPlugins.find((plugin) => plugin.config.name === 'sanity/tasks')
 
+  const resolved = [
+    ...allPlugins.filter((plugin) => plugin.config.name !== 'sanity/tasks'),
+    rootConfig,
+  ]
+
+  if (tasksPlugin) {
+    resolved.push(tasksPlugin)
+  }
   return resolved
 }


### PR DESCRIPTION
### Description
🟡 Suggestions will be highly appreciated  🟡 

#### Context
- `Tasks` plugin is inserted into the studios through the `structure` plugin [here](https://github.com/sanity-io/sanity/blob/remove-duplicated-plugin/packages/sanity/src/structure/structureTool.ts#L105).
- Users could be importing more than once the `structure` plugin in their studios, this produces an unwanted result in which `tasks` plugin is inserted as many times as the structure plugin.   <img width="400" alt="Screenshot 2024-03-26 at 19 58 18" src="https://github.com/sanity-io/sanity/assets/46196328/fdf499dc-d68a-4afb-883c-a156011b0f11">


#### What this fix is doing.
It checks in the flattenConfig function for the tasks plugin, and removes it from the `allPlugins` list, and adds it back only once.

#### Best case scenario.

Eventually, we will need to have a way to add `default plugins` into the studio, in this default plugin we will insert `tasks` and `comments` plugin, instead of doing it through structure. To solve this, [we tried doing this changes](https://github.com/sanity-io/sanity/pull/5935/files#diff-22e2a98e220de1e91be9b2accdb53c098b538ce42579c31580b51473e584bb71), which resulted in a build error 
```
TypeError: (0 , import_sanity.defineLocaleResourceBundle) is not a function
    at Object.<anonymous> (~/code/sanity/packages/sanity/src/tasks/i18n/index.ts:15:43)

```
so we discarded that path. 

- How could we add this default plugin not through `structure` but through any of the functions that are preparing the environment?



### What to review

- Is there any other way to do this? How? 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
