### PR TITLE
fix(i18n): allow list formatter without arguments in `Translate` component

### DIFF
--- a/packages/sanity/src/core/i18n/Translate.tsx
+++ b/packages/sanity/src/core/i18n/Translate.tsx
@@ -1,6 +1,7 @@
 import {type TFunction} from 'i18next'
 import {type ComponentType, createElement, type ReactNode, useMemo} from 'react'
 
+import {useListFormat} from '../hooks/useListFormat'
 import {type CloseTagToken, simpleParser, type TextToken, type Token} from './simpleParser'
 
 const COMPONENT_NAME_RE = /^[A-Z]/
@@ -19,6 +20,8 @@ const RECOGNIZED_HTML_TAGS = [
   'sub',
   'sup',
 ]
+
+type FormatterFns = {list: (value: Iterable<string>) => string}
 
 /**
  * A map of component names to React components. The component names are the names used within the
@@ -106,25 +109,35 @@ export function Translate(props: TranslationProps) {
   })
 
   const tokens = useMemo(() => simpleParser(translated), [translated])
-  return <>{render(tokens, props.values, props.components || {})}</>
+  const listFormat = useListFormat()
+  const formatters: FormatterFns = {
+    list: (listValues: Iterable<string>) => listFormat.format(listValues),
+  }
+  return <>{render(tokens, props.values, props.components || {}, formatters)}</>
 }
 
 function render(
   tokens: Token[],
   values: TranslationProps['values'],
   componentMap: TranslateComponentMap,
+  formatters: FormatterFns,
 ): ReactNode {
   const [head, ...tail] = tokens
   if (!head) {
     return null
   }
   if (head.type === 'interpolation') {
+    const value = values ? values[head.variable] : undefined
+    if (typeof value === 'undefined') {
+      return `{{${head.variable}}}`
+    }
+
+    const formattedValue = applyFormatters(value, head.formatters || [], formatters)
+
     return (
       <>
-        {!values || typeof values[head.variable] === 'undefined'
-          ? `{{${head.variable}}}`
-          : values[head.variable]}
-        {render(tail, values, componentMap)}
+        {formattedValue}
+        {render(tail, values, componentMap, formatters)}
       </>
     )
   }
@@ -132,7 +145,7 @@ function render(
     return (
       <>
         {head.text}
-        {render(tail, values, componentMap)}
+        {render(tail, values, componentMap, formatters)}
       </>
     )
   }
@@ -145,7 +158,7 @@ function render(
     return (
       <>
         <Component />
-        {render(tail, values, componentMap)}
+        {render(tail, values, componentMap, formatters)}
       </>
     )
   }
@@ -171,15 +184,33 @@ function render(
 
     return Component ? (
       <>
-        <Component>{render(children, values, componentMap)}</Component>
-        {render(remaining, values, componentMap)}
+        <Component>{render(children, values, componentMap, formatters)}</Component>
+        {render(remaining, values, componentMap, formatters)}
       </>
     ) : (
       <>
-        {createElement(head.name, {}, render(children, values, componentMap))}
-        {render(remaining, values, componentMap)}
+        {createElement(head.name, {}, render(children, values, componentMap, formatters))}
+        {render(remaining, values, componentMap, formatters)}
       </>
     )
   }
   return null
+}
+
+function applyFormatters(
+  value: Required<TranslationProps>['values'][string],
+  formatters: string[],
+  formatterFns: FormatterFns,
+): string {
+  let formattedValue = value
+  for (const formatter of formatters) {
+    if (formatter === 'list') {
+      if (Array.isArray(value)) {
+        formattedValue = formatterFns.list(value)
+      } else {
+        throw new Error('List formatter used on non-array value')
+      }
+    }
+  }
+  return `${formattedValue}`
 }

--- a/packages/sanity/src/core/i18n/Translate.tsx
+++ b/packages/sanity/src/core/i18n/Translate.tsx
@@ -111,7 +111,7 @@ export function Translate(props: TranslationProps) {
   const tokens = useMemo(() => simpleParser(translated), [translated])
   const listFormat = useListFormat()
   const formatters: FormatterFns = {
-    list: (listValues: Iterable<string>) => listFormat.format(listValues),
+    list: (listValues) => listFormat.format(listValues),
   }
   return <>{render(tokens, props.values, props.components || {}, formatters)}</>
 }

--- a/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
+++ b/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
@@ -137,4 +137,18 @@ describe('Translate component', () => {
       'An escaped, <strong>interpolated</strong> thing',
     )
   })
+
+  it('it allows using list formatter for interpolated values', async () => {
+    const wrapper = await getWrapper([
+      createBundle({peopleSignedUp: '{{count}} people signed up: {{people, list}}'}),
+    ])
+    const people = ['Bjørge', 'Rita', 'Espen']
+    const {findByTestId} = render(
+      <TestComponent i18nKey="peopleSignedUp" values={{count: people.length, people}} />,
+      {wrapper},
+    )
+    expect(await findByTestId('output')).toHaveTextContent(
+      '3 people signed up: Bjørge, Rita, and Espen',
+    )
+  })
 })

--- a/packages/sanity/src/core/i18n/__tests__/simpleParser.test.ts
+++ b/packages/sanity/src/core/i18n/__tests__/simpleParser.test.ts
@@ -107,11 +107,18 @@ describe('simpleParser', () => {
       {type: 'tagClose', name: 'Bold'},
     ])
   })
+  test('interpolations with allowed formatters', () => {
+    expect(simpleParser('{{count}} people signed up: {{people, list}}')).toMatchObject([
+      {type: 'interpolation', variable: 'count'},
+      {type: 'text', text: ' people signed up: '},
+      {type: 'interpolation', variable: 'people', formatters: ['list']},
+    ])
+  })
 })
 describe('simpleParser - errors', () => {
-  test('formatters in interpolations', () => {
-    expect(() => simpleParser('This is not allowed: {{countries, list}}')).toThrow(
-      `Interpolations with formatters are not supported when using <Translate>. Found "countries, list". Utilize "useTranslation" instead, or format the values passed to <Translate> ahead of time.`,
+  test('other formatters in interpolations', () => {
+    expect(() => simpleParser('This is not allowed: {{count, number}}')).toThrow(
+      `Interpolations with formatters are not supported when using <Translate>. Found "{{count, number}}". Utilize "useTranslation" instead, or format the values passed to <Translate> ahead of time.`,
     )
   })
   test('unpaired tags', () => {

--- a/packages/sanity/src/core/i18n/simpleParser.ts
+++ b/packages/sanity/src/core/i18n/simpleParser.ts
@@ -33,6 +33,7 @@ export type TextToken = {
 export type InterpolationToken = {
   type: 'interpolation'
   variable: string
+  formatters?: string[]
 }
 
 /**
@@ -154,14 +155,21 @@ function textTokenWithInterpolation(text: string): Token[] {
 }
 
 function parseInterpolation(interpolation: string): InterpolationToken {
-  const variable = interpolation.replace(/^\{\{|\}\}$/g, '').trim()
-  // Disallow formatters for interpolations when using the `Translate` function:
-  // Since we do not have a _key_ to format (only a substring), we do not want i18next to look up
-  // a matching string value for the "stub" value. We could potentially change this in the future,
-  // if we feel it is a useful feature.
-  if (variable.includes(',')) {
+  const [variable, ...formatters] = interpolation
+    .replace(/^\{\{|\}\}$/g, '')
+    .trim()
+    .split(/\s*,\s*/)
+
+  // To save us from reimplementing all of i18next's formatter logic, we only curently support the
+  // `list` formatter, and only without any arguments. This may change in the future, but deeming
+  // this good enough for now.
+  if (formatters.length === 1 && formatters[0] === 'list') {
+    return {type: 'interpolation', variable, formatters}
+  }
+
+  if (formatters.length > 0) {
     throw new Error(
-      `Interpolations with formatters are not supported when using <Translate>. Found "${variable}". Utilize "useTranslation" instead, or format the values passed to <Translate> ahead of time.`,
+      `Interpolations with formatters are not supported when using <Translate>. Found "${interpolation}". Utilize "useTranslation" instead, or format the values passed to <Translate> ahead of time.`,
     )
   }
 


### PR DESCRIPTION
### Description

It seems we [used a formatter](https://github.com/sanity-io/sanity/issues/6003) in a resource passed to `<Translate>`, which won't work as the "simple parser" does not reimplement all the logic from i18next. I initially did an approach where I changed the key to not use a formatter, but it quickly got a bit messy to think about whether the key should be a _new_ key, and how to reason about old versions of it.

Instead, I chose to implement _partial_ support for formatters inside of the `Translate` component - currently only for the `list` formatter, and only without arguments. In time we can see if we can expand on this, but this fixes #6003 and moves us a bit forward at least.

### What to review

- Code makes sense
- There aren't any regressions in how this works

### Testing

- Added tests for both parser and for the Translate function

### Notes for release

- Fixed an issue where the studio might crash on "orphaned marks" in the Portable Text Editor
