### PR TITLE
fix(structure): remove 'ago' suffix when published time was yesterday

### DIFF
--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -41,6 +41,9 @@ function getDisabledReason(
 function AlreadyPublished({publishedAt}: {publishedAt: string}) {
   const {t} = useTranslation(structureLocaleNamespace)
   const timeSincePublished = useRelativeTime(publishedAt)
+  if (timeSincePublished === 'yesterday') {
+    return <span>{t('action.publish.already-published-yesterday.tooltip')}</span>
+  }
   return <span>{t('action.publish.already-published.tooltip', {timeSincePublished})}</span>
 }
 

--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -40,10 +40,7 @@ function getDisabledReason(
 
 function AlreadyPublished({publishedAt}: {publishedAt: string}) {
   const {t} = useTranslation(structureLocaleNamespace)
-  const timeSincePublished = useRelativeTime(publishedAt)
-  if (timeSincePublished === 'yesterday') {
-    return <span>{t('action.publish.already-published-yesterday.tooltip')}</span>
-  }
+  const timeSincePublished = useRelativeTime(publishedAt, {useTemporalPhrase: true})
   return <span>{t('action.publish.already-published.tooltip', {timeSincePublished})}</span>
 }
 

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -38,6 +38,8 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'action.duplicate.label': 'Duplicate',
   /** Label for the "Duplicate" document action while the document is being duplicated */
   'action.duplicate.running.label': 'Duplicating…',
+  /** Tooltip text when publish button is disabled because the document is already published and published time was 'yesterday'.*/
+  'action.publish.already-published-yesterday.tooltip': 'Published yesterday',
   /** Tooltip when publish button is disabled because the document is already published, and published time is unavailable.*/
   'action.publish.already-published.no-time-ago.tooltip': 'Already published',
   /** Tooltip when publish button is disabled because the document is already published.*/

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -38,12 +38,10 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'action.duplicate.label': 'Duplicate',
   /** Label for the "Duplicate" document action while the document is being duplicated */
   'action.duplicate.running.label': 'Duplicating…',
-  /** Tooltip text when publish button is disabled because the document is already published and published time was 'yesterday'.*/
-  'action.publish.already-published-yesterday.tooltip': 'Published yesterday',
   /** Tooltip when publish button is disabled because the document is already published, and published time is unavailable.*/
   'action.publish.already-published.no-time-ago.tooltip': 'Already published',
   /** Tooltip when publish button is disabled because the document is already published.*/
-  'action.publish.already-published.tooltip': 'Published {{timeSincePublished}} ago',
+  'action.publish.already-published.tooltip': 'Published {{timeSincePublished}}',
 
   /** Tooltip when action is disabled because the studio is not ready.*/
   'action.publish.disabled.not-ready': 'Operation not ready',


### PR DESCRIPTION
### Description
Adds a new translation string for when the published time was "yesterday" to avoid "ago" suffix
<img width="250" alt="Screenshot 2024-03-27 at 12 59 51" src="https://github.com/sanity-io/sanity/assets/44635000/2b9a3e75-a114-4d37-b91d-e52a31c5cf01">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The tooltip text for the publish button when the document is already published
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->


### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes tooltip text for publish button when document is already published
<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
