### PR TITLE
fix(tasks): don't lowercase users when searching in the assignee menu

### DIFF
--- a/packages/sanity/src/tasks/src/tasks/components/form/fields/assignee/AssigneeSelectionMenu.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/form/fields/assignee/AssigneeSelectionMenu.tsx
@@ -10,7 +10,6 @@ import {
   Text,
   TextInput,
 } from '@sanity/ui'
-import {motion} from 'framer-motion'
 import {deburr} from 'lodash'
 import {type ChangeEvent, type KeyboardEvent, useCallback, useMemo, useRef, useState} from 'react'
 import {LoadingBlock, type UserWithPermission, useTranslation} from 'sanity'
@@ -93,17 +92,17 @@ function MentionsMenu({onSelect, value = ''}: {onSelect: SelectItemHandler; valu
 
     const deburredOptions = options?.map((option) => ({
       ...option,
-      displayName: deburr(option.displayName || '').toLocaleLowerCase(),
+      searchName: deburr(option.displayName || '').toLocaleLowerCase(),
     }))
 
     const filtered = deburredOptions
       ?.filter((option) => {
-        return option?.displayName?.includes(deburredSearchTerm)
+        return option?.searchName.includes(deburredSearchTerm)
       })
       // Sort by whether the displayName starts with the search term to get more relevant results first
       ?.sort((a, b) => {
-        const matchA = a.displayName?.startsWith(deburredSearchTerm)
-        const matchB = b.displayName?.startsWith(deburredSearchTerm)
+        const matchA = a.searchName.startsWith(deburredSearchTerm)
+        const matchB = b.searchName.startsWith(deburredSearchTerm)
 
         if (matchA && !matchB) return -1
         if (!matchA && matchB) return 1
@@ -183,23 +182,19 @@ export function AssigneeSelectionMenu(props: {
 }) {
   const {onSelect, menuButton, value} = props
 
-  const ref = useRef<HTMLDivElement | null>(null)
-
   return (
-    <motion.div initial={{opacity: 0}} animate={{opacity: 1}} ref={ref}>
-      <MenuButton
-        button={menuButton}
-        id="assign-user-menu"
-        menu={
-          <StyledMenu>
-            <MentionsMenu onSelect={onSelect} value={value} />
-          </StyledMenu>
-        }
-        popover={{
-          placement: 'bottom',
-          portal: true,
-        }}
-      />
-    </motion.div>
+    <MenuButton
+      button={menuButton}
+      id="assign-user-menu"
+      menu={
+        <StyledMenu>
+          <MentionsMenu onSelect={onSelect} value={value} />
+        </StyledMenu>
+      }
+      popover={{
+        placement: 'bottom',
+        portal: true,
+      }}
+    />
   )
 }


### PR DESCRIPTION
### Description

When searching for users in the tasks plugin, we are using lodash deburr to convert all the letters to latin letters. Also, we lowercase the display name. 
This, was going all the way to the UI, which should not happen.
This PR addresses that, by introducing a new property `searchName` when searching for users to avoid modifying the names that will be displayed in the UI.

<img width="582" alt="Screenshot 2024-03-27 at 15 31 39" src="https://github.com/sanity-io/sanity/assets/46196328/fb9146bd-bc06-4b4f-9eb5-82b903567d2c">


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

Fixes an issue in which user names displayed in the user selection dropdown inside tasks were changing when filtering
