### PR TITLE
fix(pte): fix an issue where when PTE throws exception after resize

### DIFF
--- a/packages/sanity/src/structure/comments/plugin/input/helpers.ts
+++ b/packages/sanity/src/structure/comments/plugin/input/helpers.ts
@@ -110,7 +110,7 @@ export function getSelectionBoundingRect(): DOMRect | null {
   try {
     range = selection?.getRangeAt(0)
   } catch (error) {
-    console.error('Error getting range from portable text', error)
+    console.error('Unable to get selection rect for portable text comment input', error)
   }
   const rect = range?.getBoundingClientRect()
 

--- a/packages/sanity/src/structure/comments/plugin/input/helpers.ts
+++ b/packages/sanity/src/structure/comments/plugin/input/helpers.ts
@@ -106,7 +106,12 @@ export function useAuthoringReferenceElement(
 
 export function getSelectionBoundingRect(): DOMRect | null {
   const selection = window.getSelection()
-  const range = selection?.getRangeAt(0)
+  let range = null
+  try {
+    range = selection?.getRangeAt(0)
+  } catch (error) {
+    console.error('Error getting range from portable text', error)
+  }
   const rect = range?.getBoundingClientRect()
 
   return rect || null


### PR DESCRIPTION
### Description

While investigating EDX-906, I noticed an uncaught exception thrown if a PTE input was expanded and then the validation panel was shown or hidden. This error seems to benign and should not be surfaced.

Before:

https://github.com/sanity-io/sanity/assets/6889008/d99fde5f-e4a7-48f0-a430-cf40e2616af6


After:


https://github.com/sanity-io/sanity/assets/6889008/fa600c22-6c45-4ed0-8108-21edb716deca



### What to review

I am not 100% this is the right fix. It definitely makes the problem not visible but I wonder if something is not being cleaned up properly when the validation panel is shown or hidden.

### Testing

Manual UI testing

