### PR TITLE
feat(schema): handle assetRequired when extracting schema with enforceRequiredFields

### DIFF
--- a/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
+++ b/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
@@ -458,6 +458,66 @@ describe('Extract schema test', () => {
     expect(book.attributes.optionalTitle.optional).toBe(true)
   })
 
+  test('enforceRequiredFields handles `assetRequired`', () => {
+    const schema1 = createSchema({
+      name: 'test',
+      types: [
+        {
+          title: 'Book',
+          name: 'book',
+          type: 'document',
+          fields: [
+            {
+              title: 'Title',
+              name: 'title',
+              type: 'string',
+            },
+            defineField({
+              title: 'Required Image',
+              name: 'requiredImage',
+              type: 'image',
+              validation: (Rule) => Rule.required(),
+            }),
+            defineField({
+              title: 'Asset Required Image',
+              name: 'assetRequiredImage',
+              type: 'image',
+              validation: (Rule) => Rule.required().assetRequired(),
+            }),
+            {
+              title: 'Asset Required File Rule Spec',
+              name: 'assetRequiredFileRuleSpec',
+              type: 'file',
+              validation: {
+                _required: 'required',
+                _rules: [{flag: 'assetRequired', constraint: {assetType: 'file'}}],
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    const extracted = extractSchema(schema1, {enforceRequiredFields: true})
+    const book = extracted.find((type) => type.name === 'book')
+    expect(book).toBeDefined()
+    assert(book !== undefined) // this is a workaround for TS, but leave the expect above for clarity in case of failure
+    assert(book.type === 'document') // this is a workaround for TS, but leave the expect above for clarity in case of failure
+    expect(book.attributes.title.optional).toBe(true)
+
+    expect(book.attributes.requiredImage.optional).toBe(false)
+    assert(book.attributes.requiredImage.value.type === 'object') // this is a workaround for TS, but leave the expect above for clarity in case of failure
+    expect(book.attributes.requiredImage.value.attributes.asset.optional).toBe(true) // we dont set assetRequired(), so it should be optional
+
+    expect(book.attributes.assetRequiredImage.optional).toBe(false)
+    assert(book.attributes.assetRequiredImage.value.type === 'object') // this is a workaround for TS, but leave the expect above for clarity in case of failure
+    expect(book.attributes.assetRequiredImage.value.attributes.asset.optional).toBe(false) // with assetRequired(), it should be required
+
+    expect(book.attributes.assetRequiredFileRuleSpec.optional).toBe(false)
+    assert(book.attributes.assetRequiredFileRuleSpec.value.type === 'object') // this is a workaround for TS, but leave the expect above for clarity in case of failure
+    expect(book.attributes.assetRequiredFileRuleSpec.value.attributes.asset.optional).toBe(false) // with assetRequired defined in _rules, it should be required
+  })
+
   describe('can handle `list` option that is not an array', () => {
     const schema = createSchema(schemaFixtures.listObjectOption)
     const extracted = extractSchema(schema)


### PR DESCRIPTION
### Description

Follow up from #6151 

If the schema is setting `assetRequired()` on an asset-field, we mark the underlying asset attribute as non-optional

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Correct implementation? Tested it with a compiled schema as well, and works as expected.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing


<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

n/a - no notes needed
