### PR TITLE
fix(tasks): don't open tasks search on hotkey + enter

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/components/SearchPopover.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/SearchPopover.tsx
@@ -29,7 +29,10 @@ export interface SearchPopoverProps {
   disableIntentLink?: boolean
   onClose: () => void
   onItemSelect?: ItemSelectHandler
-  onOpen: () => void
+  /**
+   * If provided, will trigger to open the search popover when user types hotkey + k
+   */
+  onOpen?: () => void
   open: boolean
 }
 

--- a/packages/sanity/src/core/studio/components/navbar/search/components/common/SearchWrapper.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/common/SearchWrapper.tsx
@@ -7,7 +7,7 @@ interface SearchWrapperProps {
   children: ReactNode
   hasValidTerms: boolean
   onClose: () => void
-  onOpen: () => void
+  onOpen?: () => void
   open: boolean
 }
 

--- a/packages/sanity/src/tasks/src/tasks/components/form/fields/TargetField.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/form/fields/TargetField.tsx
@@ -236,7 +236,6 @@ export function TargetField(
               <SearchPopover
                 open={open}
                 onClose={handleCloseSearch}
-                onOpen={handleOpenSearch}
                 onItemSelect={handleItemSelect}
                 disableIntentLink
               />


### PR DESCRIPTION
### Description

Fixes an issue in which when tasks panel is open, cmd + K search changes target document rather than searches the studio.
This happens because the SearchPopover takes a `onOpen` prop which is triggered by the[ `useSearchHotkey` ](https://github.com/sanity-io/sanity/blob/edx-1223/packages/sanity/src/core/studio/components/navbar/search/hooks/useSearchHotkeys.ts#L38-L39) hook. Producing an undesired effect of opening by duplicated the search popover when tasks is open. Actually triggering the changes of the task form instead of the search change. 

Making this prop optional, and not passing it through from the `TargetField` fixes the issue.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
Fixes an issue in which when the tasks panel is open, cmd + K search changes target document rather than searches the studio.
