### PR TITLE
chore(renovate): pin framer-motion to known stable

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>sanity-io/renovate-config", ":dependencyDashboardApproval"],
+  "extends": ["github>sanity-io/renovate-config", "github>sanity-io/renovate-config:studio-v3", ":dependencyDashboardApproval"],
   "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
   "packageRules": [
     {


### PR DESCRIPTION
Updates renovatebot to use the preset that specifies the latest stable `framer-motion` that we've thoroughly tested in `@sanity/presentation` and `@sanity/ui`: https://github.com/sanity-io/renovate-config/commit/23fe9b1ec84932ef8487f91908b2c452c2c4c8e9