### PR TITLE
Revert "chore(deps): update dependency use-hot-module-reload to v2"

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -296,7 +296,7 @@
     "tar-fs": "^2.1.1",
     "tar-stream": "^3.1.7",
     "use-device-pixel-ratio": "^1.1.0",
-    "use-hot-module-reload": "^2.0.0",
+    "use-hot-module-reload": "^1.0.1",
     "use-sync-external-store": "^1.2.0",
     "vite": "^4.5.1",
     "yargs": "^17.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1744,8 +1744,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.2(react@18.2.0)
       use-hot-module-reload:
-        specifier: ^2.0.0
-        version: 2.0.0(react@18.2.0)
+        specifier: ^1.0.1
+        version: 1.0.3(react@18.2.0)
       use-sync-external-store:
         specifier: ^1.2.0
         version: 1.2.0(react@18.2.0)
@@ -18723,8 +18723,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /use-hot-module-reload@2.0.0(react@18.2.0):
-    resolution: {integrity: sha512-RbL/OY1HjHNf5BYSFV3yDtQhIGKjCx9ntEjnUBYsOGc9fTo94nyFTcjtD42/twJkPgMljWpszUIpTGD3LuwHSg==}
+  /use-hot-module-reload@1.0.3(react@18.2.0):
+    resolution: {integrity: sha512-Wk/sjFhOF+a6PkovJvDAT3c8yE1DluZsSB3L+gTS8pM4ht2yg/LqBj4YLwnYJSdPnFqGWvu93CMdso8bcKw36A==}
     peerDependencies:
       react: '>=17.0.0'
     dependencies:


### PR DESCRIPTION
Reverts sanity-io/sanity#6180 as it was accidentally merged, it shouldn’t be updated until after #5983 lands