### PR TITLE
fix(core): remount drag and drop list when readOnly changes

### DIFF
--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
@@ -90,6 +90,7 @@ export function GridArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
                 items={memberKeys}
                 onItemMove={onItemMove}
                 sortable={sortable}
+                readOnly={readOnly}
               >
                 {members.map((member) => (
                   <Item key={member.key} sortable={sortable} id={member.key} flex={1}>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
@@ -228,6 +228,7 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
                 onItemMoveStart={handleItemMoveStart}
                 onItemMoveEnd={handleItemMoveEnd}
                 sortable={sortable}
+                readOnly={readOnly}
                 style={{
                   // This is not memoized since it changes on scroll so it will change anyways making memo useless
                   position: 'absolute',

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
@@ -188,6 +188,7 @@ export class ArrayOfPrimitivesInput extends PureComponent<ArrayOfPrimitivesInput
                   items={membersWithSortIds.map((m) => m.id)}
                   sortable={isSortable}
                   gap={1}
+                  readOnly={readOnly}
                 >
                   {membersWithSortIds.map(({member, id}, index) => {
                     return (

--- a/packages/sanity/src/core/form/inputs/arrays/common/list.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/common/list.tsx
@@ -166,10 +166,11 @@ interface ListProps extends ComponentProps<typeof Grid> {
   onItemMoveStart?: (event: DragStartEvent) => void
   onItemMoveEnd?: () => void
   children?: ReactNode
+  readOnly?: boolean
 }
 
 export function List(props: ListProps) {
-  const {onItemMove, onItemMoveEnd, onItemMoveStart, sortable, ...rest} = props
+  const {onItemMove, onItemMoveEnd, onItemMoveStart, sortable, readOnly, ...rest} = props
 
   // Note: this is here to make SortableList API compatible with onItemMove
   const handleSortEnd = useCallback(
@@ -181,6 +182,8 @@ export function List(props: ListProps) {
 
   return sortable ? (
     <SortableList
+      // Change the key to force a remount of the dnd context.
+      key={readOnly ? 'readonly' : 'sortable'}
       onItemMove={handleSortEnd}
       onItemMoveStart={onItemMoveStart}
       onItemMoveEnd={onItemMoveEnd}


### PR DESCRIPTION
### Description

There is an issue in the list component, when the form status changes from `readOnly = true` to `readOnly = false`  the dnd context gets into a broken state and users can't drag elements inside the list.
This can be reproduced some times when publishing the document, but not always. The easiest way to reproduce it is to switch to a previous version of the document and then to the current version.


https://github.com/sanity-io/sanity/assets/46196328/41981fa8-f074-4fd6-a72b-d7f2b135acfa



I think this is caused because we are un-mounting the [`DragHandle` ](https://github.com/sanity-io/sanity/blob/c246c298a25c89f1378abd33fb9ef8aa36f3d05b/packages/sanity/src/core/form/inputs/arrays/common/DragHandle.tsx#L22-L23)  when changing to `readOnly`, then when remounting it it doesn't work as expected.

By forcing a different element key depending if it's  readOnly or not the issue is fixed, because all the inner elements are remounted.
Other solution will be not to unmount the DragHandle and pass the readOnly prop to it, and disable it in readOnly [see commit here](https://github.com/sanity-io/sanity/commit/2fc24d531aa01074bca4f64c10bdc992308bd5c6)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

What is preferable? Force a new key or add the readOnly prop

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
