### PR TITLE
fix(core): remove custom options in comments upsell request

### DIFF
--- a/packages/sanity/src/structure/comments/src/context/upsell/CommentsUpsellProvider.tsx
+++ b/packages/sanity/src/structure/comments/src/context/upsell/CommentsUpsellProvider.tsx
@@ -1,4 +1,3 @@
-import {type ClientConfig} from '@sanity/client'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {template} from 'lodash'
 import {useCallback, useEffect, useMemo, useState} from 'react'
@@ -17,13 +16,6 @@ import {CommentsUpsellDialog} from '../../components'
 import {type CommentsUpsellData} from '../../types'
 import {CommentsUpsellContext} from './CommentsUpsellContext'
 import {type CommentsUpsellContextValue} from './types'
-
-const UPSELL_CLIENT_OPTIONS: Partial<ClientConfig> = {
-  apiVersion: '2023-12-11',
-  useProjectHostname: false,
-  withCredentials: false,
-  useCdn: true,
-}
 
 const FEATURE = 'comments'
 const TEMPLATE_OPTIONS = {interpolate: /{{([\s\S]+?)}}/g}
@@ -94,11 +86,9 @@ export function CommentsUpsellProvider(props: {children: React.ReactNode}) {
   }, [telemetry])
 
   useEffect(() => {
-    const data$ = client
-      .withConfig(UPSELL_CLIENT_OPTIONS)
-      .observable.request<CommentsUpsellData | null>({
-        uri: '/journey/comments',
-      })
+    const data$ = client.observable.request<CommentsUpsellData | null>({
+      uri: '/journey/comments',
+    })
 
     const sub = data$.subscribe({
       next: (data) => {


### PR DESCRIPTION
fixes: SGH-6 
fixes: https://github.com/sanity-io/visual-editing/issues/1079

### Description

Some users continue reporting CORS issues with the request done to `'/journey/comments` this removes the custom options given they are not needed and where added for the initial iteration in which we requested the data directly from one of our studios. 

This change, aligns this request to the one in [free trial provider](https://github.com/sanity-io/sanity/blob/edx-1082/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx#L68).  

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes CORS issue report accessing to `/journey/comments` 
<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
