### PR TITLE
fix(cli): improve error handling on missing extracted schema

### DIFF
--- a/packages/@sanity/cli/src/actions/typegen/generateAction.ts
+++ b/packages/@sanity/cli/src/actions/typegen/generateAction.ts
@@ -14,6 +14,7 @@ import {TypesGeneratedTrace} from './generate.telemetry'
 
 export interface TypegenGenerateTypesCommandFlags {
   configPath?: string
+  'config-path'?: string
 }
 
 const generatedFileWarning = `/**
@@ -40,7 +41,9 @@ export default async function typegenGenerateAction(
   const trace = telemetry.trace(TypesGeneratedTrace)
   trace.start()
 
-  const codegenConfig = await readConfig(flags.configPath || 'sanity-typegen.json')
+  const codegenConfig = await readConfig(
+    flags.configPath || flags['config-path'] || 'sanity-typegen.json',
+  )
 
   const workerPath = await getCliWorkerPath('typegenGenerate')
 

--- a/packages/@sanity/cli/src/actions/typegen/generateAction.ts
+++ b/packages/@sanity/cli/src/actions/typegen/generateAction.ts
@@ -13,7 +13,6 @@ import {
 import {TypesGeneratedTrace} from './generate.telemetry'
 
 export interface TypegenGenerateTypesCommandFlags {
-  configPath?: string
   'config-path'?: string
 }
 
@@ -41,9 +40,7 @@ export default async function typegenGenerateAction(
   const trace = telemetry.trace(TypesGeneratedTrace)
   trace.start()
 
-  const codegenConfig = await readConfig(
-    flags.configPath || flags['config-path'] || 'sanity-typegen.json',
-  )
+  const codegenConfig = await readConfig(flags['config-path'] || 'sanity-typegen.json')
 
   try {
     const {isFile} = await stat(codegenConfig.schema)

--- a/packages/@sanity/cli/src/actions/typegen/generateAction.ts
+++ b/packages/@sanity/cli/src/actions/typegen/generateAction.ts
@@ -57,6 +57,7 @@ export default async function typegenGenerateAction(
         codegenConfig.schema === './schema.json' ? ` - did you run "sanity schema extract"?` : ''
       throw new Error(`Schema file not found: ${codegenConfig.schema}${hint}`)
     }
+    throw err
   }
   const workerPath = await getCliWorkerPath('typegenGenerate')
 

--- a/packages/@sanity/cli/src/actions/typegen/generateAction.ts
+++ b/packages/@sanity/cli/src/actions/typegen/generateAction.ts
@@ -43,8 +43,8 @@ export default async function typegenGenerateAction(
   const codegenConfig = await readConfig(flags['config-path'] || 'sanity-typegen.json')
 
   try {
-    const {isFile} = await stat(codegenConfig.schema)
-    if (!isFile) {
+    const schemaStats = await stat(codegenConfig.schema)
+    if (!schemaStats.isFile()) {
       throw new Error(`Schema path is not a file: ${codegenConfig.schema}`)
     }
   } catch (err) {

--- a/packages/@sanity/cli/src/commands/typegen/generateTypesCommand.ts
+++ b/packages/@sanity/cli/src/commands/typegen/generateTypesCommand.ts
@@ -10,6 +10,10 @@ Usage
   sanity typegen generate [options]
 
 Options:
+  --config-path <path>
+    Specifies the path to the typegen configuration file. This file should be a JSON file that contains settings for the type generation process.
+    Default: "sanity-typegen.json"
+
   --help, -h
     Displays this help message, providing information on command usage and options.
 

--- a/packages/@sanity/cli/test/__fixtures__/v3/folder-typegen.json
+++ b/packages/@sanity/cli/test/__fixtures__/v3/folder-typegen.json
@@ -1,0 +1,3 @@
+{
+  "schema": "./components"
+}

--- a/packages/@sanity/cli/test/__fixtures__/v3/missing-typegen.json
+++ b/packages/@sanity/cli/test/__fixtures__/v3/missing-typegen.json
@@ -1,0 +1,3 @@
+{
+  "schema": "./custom-schema.json"
+}

--- a/packages/@sanity/cli/test/__fixtures__/v3/working-schema.json
+++ b/packages/@sanity/cli/test/__fixtures__/v3/working-schema.json
@@ -1,0 +1,84 @@
+[
+  {
+    "name": "person",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "person"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "name": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "slug",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "slug"
+          }
+        },
+        "current": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "source": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  }
+]

--- a/packages/@sanity/cli/test/__fixtures__/v3/working-typegen.json
+++ b/packages/@sanity/cli/test/__fixtures__/v3/working-typegen.json
@@ -1,0 +1,3 @@
+{
+  "schema": "./working-schema.json"
+}

--- a/packages/@sanity/cli/test/typegen.test.ts
+++ b/packages/@sanity/cli/test/typegen.test.ts
@@ -1,0 +1,37 @@
+import {expect, test} from '@jest/globals'
+
+import {describeCliTest} from './shared/describe'
+import {runSanityCmdCommand} from './shared/environment'
+
+describeCliTest('CLI: `sanity typegen`', () => {
+  test('sanity typegen generate: missing schema, default path', async () => {
+    const err = await runSanityCmdCommand('v3', ['typegen', 'generate']).catch((error) => error)
+    expect(err.code).toBe(1)
+    expect(err.stderr).toContain('did you run "sanity schema extract"')
+    expect(err.stderr).toContain('Schema file not found')
+  })
+
+  test('sanity typegen generate: missing schema, custom path', async () => {
+    const err = await runSanityCmdCommand('v3', [
+      'typegen',
+      'generate',
+      '--config-path',
+      'missing-typegen.json',
+    ]).catch((error) => error)
+    expect(err.code).toBe(1)
+    expect(err.stderr).not.toContain('did you run "sanity schema extract"')
+    expect(err.stderr).toContain('custom-schema.json')
+  })
+
+  test('sanity typegen generate: working schema', async () => {
+    const result = await runSanityCmdCommand('v3', [
+      'typegen',
+      'generate',
+      '--config-path',
+      'working-typegen.json',
+    ])
+
+    expect(result.code).toBe(0)
+    expect(result.stderr).toContain('Generated TypeScript types for 2 schema types')
+  })
+})

--- a/packages/@sanity/cli/test/typegen.test.ts
+++ b/packages/@sanity/cli/test/typegen.test.ts
@@ -23,6 +23,17 @@ describeCliTest('CLI: `sanity typegen`', () => {
     expect(err.stderr).toContain('custom-schema.json')
   })
 
+  test('sanity typegen generate: typegen config is not a file', async () => {
+    const err = await runSanityCmdCommand('v3', [
+      'typegen',
+      'generate',
+      '--config-path',
+      'folder-typegen.json',
+    ]).catch((error) => error)
+    expect(err.code).toBe(1)
+    expect(err.stderr).toContain('Schema path is not a file')
+  })
+
   test('sanity typegen generate: working schema', async () => {
     const result = await runSanityCmdCommand('v3', [
       'typegen',


### PR DESCRIPTION
### Description

When you run `sanity typegen generate`, a fairly common case is that one may have forgotten to run `sanity schema extract` first. This currently gives a rather unhelpful error (if you're unfamiliar with the setup):
```
Error: ENOENT: no such file or directory, open './schema.json'
```

With this PR, I propose that we give a more helpful error if you have not provided even a custom path for the schema:
```
Error: Schema file not found: ./schema.json - did you run "sanity schema extract"?
```

I also noticed that using a `--config-path` flag did not work, only `--configPath`. To be consistent with other CLI commands, I changed this to allow both forms.

### Testing

Added some basic tests to ensure that the different forms work and gives the expected output.

### Notes for release

- Improved error message when extracted schema (from `sanity schema extract`) could not be found when running `sanity typegen generate`