### PR TITLE
fix(schema): make `current` field for slugs required

### DIFF
--- a/packages/sanity/src/core/schema/types/slug.ts
+++ b/packages/sanity/src/core/schema/types/slug.ts
@@ -1,3 +1,5 @@
+import {type Rule} from '@sanity/types'
+
 export default {
   title: 'Slug',
   name: 'slug',
@@ -7,6 +9,7 @@ export default {
       name: 'current',
       title: 'Current slug',
       type: 'string',
+      validation: (Rule: Rule): Rule => Rule.required(),
     },
     {
       // The source field is deprecated/unused, but leaving it included and hidden


### PR DESCRIPTION
### Description

With the new schema extraction and typegen functionality, we're seeing a lot of signal around required fields in types. Slug fields can be set as `Rule.required()`, but the resulting type will have a `current` property that is _not_ required. This may require some explanation:

Our studio schema validation currently works on a "parent is present" basis. Consider the following schema stub:
```ts
[
  {
    name: 'business',
    type: 'document',
    fields: [
      {
        name: 'address',
        type: 'address',
      },
    ],
  },
  {
    name: 'address',
    type: 'object',
    fields: [
      {
        name: 'street',
        type: 'string',
        validation: Rule => Rule.required(),
      },
      {
        name: 'zip',
        type: 'number',
      }
    ],
  },
]
```

A `business` document without an address is considered valid, since the `address` _field_  is not marked as required. A document with an address field that only has a `zip` value is _not_ considered valid, since the field now _has_ a value, but does _not_ have a `street`, which _is_ marked as required. In other words:
```ts
{_id: 'a', _type: 'business'} // valid
{_id: 'b', _type: 'business', address: {}} // invalid, does not have `street`
{_id: 'c', _type: 'business', address: {street: 'California St'}} // valid
{_id: 'c', _type: 'business', address: {zip: 94708}} // invalid, does not have `street`
```

This PR sets the `current` field on the `slug` type to always be required. The rationale for this is that the studio will automatically remove any "empty" object stub and string value (`{_type: 'slug', current: ''}` gets removed), and there are no other fields on the slug type to actually set. This leads me to believe that setting this field to required will make no difference to any studio users, since a non-required slug field will still not be required, and any required slug field will still... be required. However, the value add here is that in _type generation_ context, the `current` field will now correctly be set as non-optional (if used with the enforce required fields flag).

### What to review

- Is my rationale/reasoning correct?
- Will this have side effects I have not accounted for?

### Testing

I've manually tested the change, but since there is no difference in the studio experience, it is hard to add any additional tests for this.

### Notes for release

- Made the `current` field on slugs required when used in type generation contexts with the enforce required fields flag.
