### PR TITLE
refactor: support `strict: true` in `@sanity/schema` codebase

### DIFF
--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -81,11 +81,13 @@
     "humanize-list": "^1.0.1",
     "leven": "^3.1.0",
     "lodash": "^4.17.21",
-    "object-inspect": "^1.6.0"
+    "object-inspect": "^1.13.1"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@sanity/icons": "^2.11.6",
+    "@types/arrify": "^1.0.1",
+    "@types/object-inspect": "^1.13.0",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/@sanity/schema/src/core/traverseSchema.ts
+++ b/packages/@sanity/schema/src/core/traverseSchema.ts
@@ -54,7 +54,7 @@ export function traverseSchema(
     registry[(type && type.name) || `__unnamed_${i}`] = {}
   })
 
-  function getType(typeName) {
+  function getType(typeName: any) {
     return typeName === 'type'
       ? TYPE_TYPE
       : coreTypesRegistry[typeName] || registry[typeName] || null
@@ -62,17 +62,17 @@ export function traverseSchema(
 
   const duplicateNames = uniq(flatten(getDupes(typeNames)))
 
-  function isDuplicate(typeName) {
+  function isDuplicate(typeName: any) {
     return duplicateNames.includes(typeName)
   }
   function getTypeNames() {
     return typeNames.concat(coreTypeNames)
   }
-  function isReserved(typeName) {
+  function isReserved(typeName: any) {
     return typeName === 'type' || reservedTypeNames.includes(typeName)
   }
 
-  const visitType = (isRoot) => (typeDef, index) => {
+  const visitType = (isRoot: any) => (typeDef: any, index: any) => {
     return visitor(typeDef, {
       visit: visitType(false),
       isRoot,

--- a/packages/@sanity/schema/src/legacy/Schema.ts
+++ b/packages/@sanity/schema/src/legacy/Schema.ts
@@ -1,9 +1,9 @@
 import * as types from './types'
 
-function compileRegistry(schemaDef) {
+function compileRegistry(schemaDef: any) {
   const registry = Object.assign(Object.create(null), types)
 
-  const defsByName = schemaDef.types.reduce((acc, def) => {
+  const defsByName = schemaDef.types.reduce((acc: any, def: any) => {
     if (acc[def.name]) {
       throw new Error(`Duplicate type name added to schema: ${def.name}`)
     }
@@ -15,7 +15,7 @@ function compileRegistry(schemaDef) {
 
   return registry
 
-  function ensure(typeName) {
+  function ensure(typeName: any) {
     if (!registry[typeName]) {
       if (!defsByName[typeName]) {
         throw new Error(`Unknown type: ${typeName}`)
@@ -24,12 +24,12 @@ function compileRegistry(schemaDef) {
     }
   }
 
-  function extendMember(memberDef) {
+  function extendMember(memberDef: any) {
     ensure(memberDef.type)
     return registry[memberDef.type].extend(memberDef, extendMember).get()
   }
 
-  function add(typeDef) {
+  function add(typeDef: any) {
     ensure(typeDef.type)
     if (registry[typeDef.name]) {
       return
@@ -84,7 +84,7 @@ export class DeprecatedDefaultSchema extends Schema {
 
     const stack = new Error(
       'The default export of `@sanity/schema` is deprecated. Use `import {Schema} from "@sanity/schema"` instead.',
-    ).stack.replace(/^Error/, 'Warning')
+    ).stack!.replace(/^Error/, 'Warning')
 
     // eslint-disable-next-line no-console
     console.warn(stack)

--- a/packages/@sanity/schema/src/legacy/actionUtils.ts
+++ b/packages/@sanity/schema/src/legacy/actionUtils.ts
@@ -17,7 +17,7 @@ const readActions = (schemaType: SchemaType): string[] => {
       'experimental-actions-replaced-by-document-actions',
     )}".
 `)
-    hasWarned[schemaType.name] = true
+    ;(hasWarned as any)[schemaType.name] = true
   }
 
   return ACTIONS_FLAG in schemaType ? (schemaType[ACTIONS_FLAG] as string[]) : DEFAULT_ACTIONS

--- a/packages/@sanity/schema/src/legacy/ordering/guessOrderingConfig.ts
+++ b/packages/@sanity/schema/src/legacy/ordering/guessOrderingConfig.ts
@@ -5,16 +5,16 @@ const CANDIDATES = ['title', 'name', 'label', 'heading', 'header', 'caption', 'd
 
 const PRIMITIVES = ['string', 'boolean', 'number']
 
-const isPrimitive = (field) => PRIMITIVES.includes(field.type)
+const isPrimitive = (field: any) => PRIMITIVES.includes(field.type)
 
-export default function guessOrderingConfig(objectTypeDef): SortOrdering[] {
+export default function guessOrderingConfig(objectTypeDef: any): SortOrdering[] {
   let candidates = CANDIDATES.filter((candidate) =>
-    objectTypeDef.fields.some((field) => isPrimitive(field) && field.name === candidate),
+    objectTypeDef.fields.some((field: any) => isPrimitive(field) && field.name === candidate),
   )
 
   // None of the candidates were found, fallback to all fields
   if (candidates.length === 0) {
-    candidates = objectTypeDef.fields.filter(isPrimitive).map((field) => field.name)
+    candidates = objectTypeDef.fields.filter(isPrimitive).map((field: any) => field.name)
   }
 
   return candidates.map(

--- a/packages/@sanity/schema/src/legacy/preview/JSONStringifyHuman.ts
+++ b/packages/@sanity/schema/src/legacy/preview/JSONStringifyHuman.ts
@@ -1,6 +1,6 @@
 import {pick} from 'lodash'
 
-function isEmpty(object) {
+function isEmpty(object: any) {
   for (const key in object) {
     if (object.hasOwnProperty(key)) {
       return false
@@ -9,7 +9,7 @@ function isEmpty(object) {
   return true
 }
 
-function _stringify(value, options, depth) {
+function _stringify(value: any, options: any, depth: any): any {
   if (depth > options.maxDepth) {
     return '...'
   }
@@ -18,7 +18,7 @@ function _stringify(value, options, depth) {
       return '[empty]'
     }
     const capLength = Math.max(value.length - options.maxBreadth)
-    const asString = value
+    const asString: any = value
       .slice(0, options.maxBreadth)
       .map((item, index) => _stringify(item, options, depth + 1))
       .concat(capLength > 0 ? `…+${capLength}` : [])
@@ -47,7 +47,7 @@ function _stringify(value, options, depth) {
 }
 
 export default function stringify(
-  value,
+  value: any,
   options: {maxDepth?: number; maxBreadth?: number; ignoreKeys?: string[]} = {},
 ) {
   const opts = {

--- a/packages/@sanity/schema/src/legacy/preview/createPreviewGetter.ts
+++ b/packages/@sanity/schema/src/legacy/preview/createPreviewGetter.ts
@@ -3,14 +3,14 @@ import {pick} from 'lodash'
 import {warnIfPreviewHasFields, warnIfPreviewOnOptions} from './deprecationUtils'
 import guessPreviewConfig from './guessPreviewConfig'
 
-function parseSelection(selection) {
-  return selection.reduce((acc, field) => {
+function parseSelection(selection: any) {
+  return selection.reduce((acc: any, field: any) => {
     acc[field] = field
     return acc
   }, {})
 }
 
-function parsePreview(preview) {
+function parsePreview(preview: any) {
   if (!preview) {
     return preview
   }
@@ -27,7 +27,7 @@ function parsePreview(preview) {
   }
 }
 
-export default function createPreviewGetter(objectTypeDef) {
+export default function createPreviewGetter(objectTypeDef: any) {
   return function previewGetter() {
     warnIfPreviewOnOptions(objectTypeDef)
     warnIfPreviewHasFields(objectTypeDef)

--- a/packages/@sanity/schema/src/legacy/preview/deprecationUtils.ts
+++ b/packages/@sanity/schema/src/legacy/preview/deprecationUtils.ts
@@ -1,4 +1,4 @@
-export function warnIfPreviewOnOptions(type) {
+export function warnIfPreviewOnOptions(type: any) {
   if (type.options && type.options.preview) {
     // eslint-disable-next-line no-console
     console.warn(`Heads up! The preview config is no longer defined on "options", but instead on the type/field itself.
@@ -7,7 +7,7 @@ Please move {options: {preview: ...}} to {..., preview: ...} on the type/field d
   }
 }
 
-export function warnIfPreviewHasFields(type) {
+export function warnIfPreviewHasFields(type: any) {
   const preview = type.preview || (type.options || {}).preview
   if (preview && 'fields' in preview) {
     // eslint-disable-next-line no-console

--- a/packages/@sanity/schema/src/legacy/preview/fallbackPrepare.ts
+++ b/packages/@sanity/schema/src/legacy/preview/fallbackPrepare.ts
@@ -9,8 +9,8 @@ const OPTIONS = {
   ignoreKeys: ['_id', '_type', '_key', '_ref'],
 }
 
-export function createFallbackPrepare(fieldNames) {
-  return (value) => ({
+export function createFallbackPrepare(fieldNames: any) {
+  return (value: any) => ({
     title: stringify(pick(value, fieldNames), OPTIONS),
   })
 }

--- a/packages/@sanity/schema/src/legacy/preview/guessPreviewConfig.ts
+++ b/packages/@sanity/schema/src/legacy/preview/guessPreviewConfig.ts
@@ -7,51 +7,51 @@ import {isBlockField} from './portableText'
 const TITLE_CANDIDATES = ['title', 'name', 'label', 'heading', 'header', 'caption']
 const DESCRIPTION_CANDIDATES = ['description', ...TITLE_CANDIDATES]
 
-function fieldHasReferenceTo(fieldDef, refType) {
-  return arrify(fieldDef.to || []).some((memberTypeDef) => memberTypeDef.type === refType)
+function fieldHasReferenceTo(fieldDef: any, refType: any) {
+  return arrify(fieldDef.to || []).some((memberTypeDef: any) => memberTypeDef.type === refType)
 }
 
-function isImageAssetField(fieldDef) {
+function isImageAssetField(fieldDef: any) {
   return fieldHasReferenceTo(fieldDef, 'sanity.imageAsset')
 }
 
-function resolveImageAssetPath(typeDef) {
+function resolveImageAssetPath(typeDef: any) {
   const fields = typeDef.fields || []
   const imageAssetField = fields.find(isImageAssetField)
   if (imageAssetField) {
     return imageAssetField.name
   }
-  const fieldWithImageAsset = fields.find((fieldDef) =>
+  const fieldWithImageAsset = fields.find((fieldDef: any) =>
     (fieldDef.fields || []).some(isImageAssetField),
   )
 
   return fieldWithImageAsset ? `${fieldWithImageAsset.name}.asset` : undefined
 }
 
-function isFileAssetField(fieldDef) {
+function isFileAssetField(fieldDef: any) {
   return fieldHasReferenceTo(fieldDef, 'sanity.fileAsset')
 }
 
-function resolveFileAssetPath(typeDef) {
+function resolveFileAssetPath(typeDef: any) {
   const fields = typeDef.fields || []
   const assetField = fields.find(isFileAssetField)
   if (assetField) {
     return assetField.name
   }
-  const fieldWithFileAsset = fields.find((fieldDef) =>
+  const fieldWithFileAsset = fields.find((fieldDef: any) =>
     (fieldDef.fields || []).some(isFileAssetField),
   )
   return fieldWithFileAsset ? `${fieldWithFileAsset.name}.asset` : undefined
 }
 
-export default function guessPreviewFields(rawObjectTypeDef) {
+export default function guessPreviewFields(rawObjectTypeDef: any) {
   const objectTypeDef = {fields: [], ...rawObjectTypeDef}
 
   const stringFieldNames = objectTypeDef.fields
-    .filter((field) => field.type === 'string')
-    .map((field) => field.name)
+    .filter((field: any) => field.type === 'string')
+    .map((field: any) => field.name)
 
-  const blockFieldNames = objectTypeDef.fields.filter(isBlockField).map((field) => field.name)
+  const blockFieldNames = objectTypeDef.fields.filter(isBlockField).map((field: any) => field.name)
 
   // Check if we have fields with names that is listed in candidate fields
   let titleField = TITLE_CANDIDATES.find(
@@ -71,7 +71,7 @@ export default function guessPreviewFields(rawObjectTypeDef) {
     descField = stringFieldNames[1] || blockFieldNames[1]
   }
 
-  const mediaField = objectTypeDef.fields.find((field) => field.type === 'image')
+  const mediaField = objectTypeDef.fields.find((field: any) => field.type === 'image')
 
   const imageAssetPath = resolveImageAssetPath(objectTypeDef)
 
@@ -87,8 +87,8 @@ export default function guessPreviewFields(rawObjectTypeDef) {
 
   if (!titleField && !imageAssetPath) {
     // last resort, pick all fields and concat them
-    const fieldNames = objectTypeDef.fields.map((field) => field.name)
-    const fieldMapping = fieldNames.reduce((acc, fieldName) => {
+    const fieldNames = objectTypeDef.fields.map((field: any) => field.name)
+    const fieldMapping = fieldNames.reduce((acc: any, fieldName: any) => {
       acc[fieldName] = fieldName
       return acc
     }, {})

--- a/packages/@sanity/schema/src/legacy/preview/portableText.ts
+++ b/packages/@sanity/schema/src/legacy/preview/portableText.ts
@@ -5,5 +5,8 @@ type FieldDef = {
 }
 
 export function isBlockField(field: FieldDef): boolean {
-  return field.type === 'array' && field.of && field.of.some((member) => member.type === 'block')
+  return (
+    (field.type === 'array' && field.of && field.of.some((member) => member.type === 'block')) ||
+    false
+  )
 }

--- a/packages/@sanity/schema/src/legacy/preview/primitivePreview.ts
+++ b/packages/@sanity/schema/src/legacy/preview/primitivePreview.ts
@@ -1,3 +1,3 @@
 export default {
-  prepare: (val) => ({title: String(val)}),
+  prepare: (val: any) => ({title: String(val)}),
 }

--- a/packages/@sanity/schema/src/legacy/searchConfig/normalize.ts
+++ b/packages/@sanity/schema/src/legacy/searchConfig/normalize.ts
@@ -1,6 +1,6 @@
 import {isPlainObject, toPath} from 'lodash'
 
-export function normalizeSearchConfigs(configs) {
+export function normalizeSearchConfigs(configs: any) {
   if (!Array.isArray(configs)) {
     throw new Error(
       'The search config of a document type must be an array of search config objects',

--- a/packages/@sanity/schema/src/legacy/searchConfig/resolve.ts
+++ b/packages/@sanity/schema/src/legacy/searchConfig/resolve.ts
@@ -2,7 +2,7 @@ import {isFinite, uniqBy} from 'lodash'
 
 export const DEFAULT_MAX_FIELD_DEPTH = 5
 
-const stringFieldsSymbols = {}
+const stringFieldsSymbols = {} as Record<number, symbol>
 
 const getStringFieldSymbol = (maxDepth: number) => {
   if (!stringFieldsSymbols[maxDepth]) {
@@ -12,15 +12,15 @@ const getStringFieldSymbol = (maxDepth: number) => {
   return stringFieldsSymbols[maxDepth]
 }
 
-const isReference = (type) => type.type && type.type.name === 'reference'
+const isReference = (type: any) => type.type && type.type.name === 'reference'
 
 const portableTextFields = ['style', 'list']
-const isPortableTextBlock = (type) =>
+const isPortableTextBlock: any = (type: any) =>
   type.name === 'block' || (type.type && isPortableTextBlock(type.type))
-const isPortableTextArray = (type) =>
+const isPortableTextArray = (type: any) =>
   type.jsonType === 'array' && Array.isArray(type.of) && type.of.some(isPortableTextBlock)
 
-function reduceType(type, reducer, acc, path = [], maxDepth) {
+function reduceType(type: any, reducer: any, acc: any, path = [], maxDepth: any) {
   if (maxDepth < 0) {
     return acc
   }
@@ -37,16 +37,16 @@ function reduceType(type, reducer, acc, path = [], maxDepth) {
   return accumulator
 }
 
-function reduceArray(arrayType, reducer, accumulator, path, maxDepth) {
+function reduceArray(arrayType: any, reducer: any, accumulator: any, path: any, maxDepth: any) {
   return arrayType.of.reduce(
-    (acc, ofType) => reduceType(ofType, reducer, acc, path, maxDepth - 1),
+    (acc: any, ofType: any) => reduceType(ofType, reducer, acc, path, maxDepth - 1),
     accumulator,
   )
 }
 
-function reduceObject(objectType, reducer, accumulator, path, maxDepth) {
+function reduceObject(objectType: any, reducer: any, accumulator: any, path: any, maxDepth: any) {
   const isPtBlock = isPortableTextBlock(objectType)
-  return objectType.fields.reduce((acc, field) => {
+  return objectType.fields.reduce((acc: any, field: any) => {
     // Don't include styles and list types as searchable paths for portable text blocks
     if (isPtBlock && portableTextFields.includes(field.name)) {
       return acc
@@ -97,7 +97,7 @@ export function deriveFromPreview(
     }
 
     fields.push({
-      weight: PREVIEW_FIELD_WEIGHT_MAP[fieldName],
+      weight: (PREVIEW_FIELD_WEIGHT_MAP as any)[fieldName],
       path,
     })
   }
@@ -105,15 +105,15 @@ export function deriveFromPreview(
   return fields
 }
 
-function getCachedStringFieldPaths(type, maxDepth: number) {
+function getCachedStringFieldPaths(type: any, maxDepth: number) {
   const symbol = getStringFieldSymbol(maxDepth)
   if (!type[symbol]) {
     type[symbol] = uniqBy(
       [
         ...BASE_WEIGHTS,
         ...deriveFromPreview(type, maxDepth),
-        ...getStringFieldPaths(type, maxDepth).map((path) => ({weight: 1, path})),
-        ...getPortableTextFieldPaths(type, maxDepth).map((path) => ({
+        ...getStringFieldPaths(type, maxDepth).map((path: any) => ({weight: 1, path})),
+        ...getPortableTextFieldPaths(type, maxDepth).map((path: any) => ({
           weight: 1,
           path,
           mapWith: 'pt::text',
@@ -125,7 +125,7 @@ function getCachedStringFieldPaths(type, maxDepth: number) {
   return type[symbol]
 }
 
-function getCachedBaseFieldPaths(type, maxDepth: number) {
+function getCachedBaseFieldPaths(type: any, maxDepth: number) {
   const symbol = getStringFieldSymbol(maxDepth)
   if (!type[symbol]) {
     type[symbol] = uniqBy([...BASE_WEIGHTS, ...deriveFromPreview(type, maxDepth)], (spec) =>
@@ -135,28 +135,28 @@ function getCachedBaseFieldPaths(type, maxDepth: number) {
   return type[symbol]
 }
 
-function getStringFieldPaths(type, maxDepth: number) {
-  const reducer = (accumulator, childType, path) =>
+function getStringFieldPaths(type: any, maxDepth: number) {
+  const reducer = (accumulator: any, childType: any, path: any) =>
     childType.jsonType === 'string' ? [...accumulator, path] : accumulator
 
   return reduceType(type, reducer, [], [], maxDepth)
 }
 
-function getPortableTextFieldPaths(type, maxDepth) {
-  const reducer = (accumulator, childType, path) =>
+function getPortableTextFieldPaths(type: any, maxDepth: any) {
+  const reducer = (accumulator: any, childType: any, path: any) =>
     isPortableTextArray(childType) ? [...accumulator, path] : accumulator
 
   return reduceType(type, reducer, [], [], maxDepth)
 }
 
-export function resolveSearchConfigForBaseFieldPaths(type, maxDepth?: number) {
+export function resolveSearchConfigForBaseFieldPaths(type: any, maxDepth?: number) {
   return getCachedBaseFieldPaths(type, normalizeMaxDepth(maxDepth))
 }
 
 /**
  * @internal
  */
-export function resolveSearchConfig(type, maxDepth?: number) {
+export function resolveSearchConfig(type: any, maxDepth?: number) {
   return getCachedStringFieldPaths(type, normalizeMaxDepth(maxDepth))
 }
 
@@ -167,9 +167,9 @@ export function resolveSearchConfig(type, maxDepth?: number) {
  * @internal
  */
 function normalizeMaxDepth(maxDepth?: number) {
-  if (!isFinite(maxDepth) || maxDepth < 1 || maxDepth > DEFAULT_MAX_FIELD_DEPTH) {
+  if (!isFinite(maxDepth) || maxDepth! < 1 || maxDepth! > DEFAULT_MAX_FIELD_DEPTH) {
     return DEFAULT_MAX_FIELD_DEPTH - 1
   }
 
-  return maxDepth - 1
+  return maxDepth! - 1
 }

--- a/packages/@sanity/schema/src/legacy/types/any.ts
+++ b/packages/@sanity/schema/src/legacy/types/any.ts
@@ -14,10 +14,10 @@ export const AnyType = {
   get() {
     return ANY_CORE
   },
-  extend(subTypeDef, extendMember) {
+  extend(subTypeDef: any, extendMember: any) {
     const parsed = Object.assign(pick(ANY_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: ANY_CORE,
-      of: subTypeDef.of.map((fieldDef) => {
+      of: subTypeDef.of.map((fieldDef: any) => {
         return {
           name: fieldDef.name,
           type: extendMember(omit(fieldDef, 'name')),
@@ -27,12 +27,12 @@ export const AnyType = {
 
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           if (extensionDef.of) {
             throw new Error('Cannot override `of` property of subtypes of "array"')
           }

--- a/packages/@sanity/schema/src/legacy/types/array.ts
+++ b/packages/@sanity/schema/src/legacy/types/array.ts
@@ -16,24 +16,24 @@ export const ArrayType = {
   get() {
     return ARRAY_CORE
   },
-  extend(subTypeDef, createMemberType) {
+  extend(subTypeDef: any, createMemberType: any) {
     const parsed = Object.assign(pick(ARRAY_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: ARRAY_CORE,
     })
     lazyGetter(parsed, 'of', () => {
-      return subTypeDef.of.map((ofTypeDef) => {
+      return subTypeDef.of.map((ofTypeDef: any) => {
         return createMemberType(ofTypeDef)
       })
     })
 
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           if (extensionDef.of) {
             throw new Error('Cannot override `of` property of subtypes of "array"')
           }

--- a/packages/@sanity/schema/src/legacy/types/blocks/block.ts
+++ b/packages/@sanity/schema/src/legacy/types/blocks/block.ts
@@ -36,7 +36,7 @@ export const BlockType = {
   get() {
     return BLOCK_CORE
   },
-  extend(subTypeDef, extendMember) {
+  extend(subTypeDef: any, extendMember: any) {
     const options = {...(subTypeDef.options || DEFAULT_OPTIONS)}
 
     const {marks, styles, lists, of, ...rest} = subTypeDef
@@ -83,12 +83,12 @@ export const BlockType = {
 
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           if (extensionDef.fields) {
             throw new Error('Cannot override `fields` of subtypes of "block"')
           }
@@ -102,13 +102,13 @@ export const BlockType = {
   },
 }
 
-function ensureNormalStyle(styles) {
-  return styles.some((style) => style.value === 'normal')
+function ensureNormalStyle(styles: any) {
+  return styles.some((style: any) => style.value === 'normal')
     ? styles
     : [BLOCK_STYLES.normal, ...styles]
 }
 
-function createStyleField(styles) {
+function createStyleField(styles: any) {
   return {
     name: 'style',
     title: 'Style',
@@ -119,7 +119,7 @@ function createStyleField(styles) {
   }
 }
 
-function createListItemField(lists) {
+function createListItemField(lists: any) {
   return {
     name: 'listItem',
     title: 'List type',
@@ -132,7 +132,7 @@ function createListItemField(lists) {
 
 const DEFAULT_ANNOTATIONS = [DEFAULT_LINK_ANNOTATION]
 
-function createChildrenField(marks, of = []) {
+function createChildrenField(marks: any, of = []) {
   return {
     name: 'children',
     title: 'Content',
@@ -144,7 +144,7 @@ function createChildrenField(marks, of = []) {
         annotations: marks && marks.annotations ? marks.annotations : DEFAULT_ANNOTATIONS,
         decorators: marks && marks.decorators ? marks.decorators : DEFAULT_DECORATORS,
       },
-      ...of.filter((memberType) => memberType.type !== 'span'),
+      ...of.filter((memberType: any) => memberType.type !== 'span'),
     ],
   }
 }

--- a/packages/@sanity/schema/src/legacy/types/blocks/defaults.ts
+++ b/packages/@sanity/schema/src/legacy/types/blocks/defaults.ts
@@ -12,7 +12,7 @@ export const DEFAULT_LINK_ANNOTATION = {
       type: 'url',
       title: 'Link',
       description: 'A valid web, email, phone, or relative link.',
-      validation: (Rule) =>
+      validation: (Rule: any) =>
         Rule.uri({
           scheme: ['http', 'https', 'tel', 'mailto'],
           allowRelative: true,

--- a/packages/@sanity/schema/src/legacy/types/blocks/span.ts
+++ b/packages/@sanity/schema/src/legacy/types/blocks/span.ts
@@ -40,7 +40,7 @@ export const SpanType = {
   get() {
     return SPAN_CORE
   },
-  extend(subTypeDef, extendMember) {
+  extend(subTypeDef: any, extendMember: any) {
     const options = {...(subTypeDef.options || DEFAULT_OPTIONS)}
 
     const {annotations = [], marks = []} = subTypeDef
@@ -70,12 +70,12 @@ export const SpanType = {
 
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           if (extensionDef.fields) {
             throw new Error('Cannot override `fields` of subtypes of "span"')
           }

--- a/packages/@sanity/schema/src/legacy/types/boolean.ts
+++ b/packages/@sanity/schema/src/legacy/types/boolean.ts
@@ -16,7 +16,7 @@ export const BooleanType = {
   get() {
     return BOOLEAN_CORE
   },
-  extend(subTypeDef) {
+  extend(subTypeDef: any) {
     const parsed = Object.assign(pick(BOOLEAN_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: BOOLEAN_CORE,
       preview: primitivePreview,
@@ -24,12 +24,12 @@ export const BooleanType = {
 
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
             type: parent,
           })

--- a/packages/@sanity/schema/src/legacy/types/crossDatasetReference.ts
+++ b/packages/@sanity/schema/src/legacy/types/crossDatasetReference.ts
@@ -40,7 +40,7 @@ const CROSS_DATASET_REFERENCE_CORE = {
   jsonType: 'object',
 }
 
-function humanize(arr, conjunction) {
+function humanize(arr: any, conjunction: any) {
   const len = arr.length
   if (len === 1) {
     return arr[0]
@@ -50,12 +50,12 @@ function humanize(arr, conjunction) {
   return `${first.join(', ')} ${conjunction} ${last}`
 }
 
-function buildTitle(type) {
+function buildTitle(type: any) {
   if (!type.to || type.to.length === 0) {
     return 'Cross dataset Reference'
   }
   return `Cross dataset reference to ${humanize(
-    arrify(type.to).map((toType) => toType.title || capitalize(toType.type)),
+    arrify(type.to).map((toType: any) => toType.title || capitalize(toType.type)),
     'or',
   ).toLowerCase()}`
 }
@@ -64,7 +64,7 @@ export const CrossDatasetReferenceType = {
   get() {
     return CROSS_DATASET_REFERENCE_CORE
   },
-  extend(subTypeDef, createMemberType) {
+  extend(subTypeDef: any, createMemberType: any) {
     if (!subTypeDef.to) {
       throw new Error(
         `Missing "to" field in cross dataset reference definition. Check the type ${subTypeDef.name}`,
@@ -89,7 +89,7 @@ export const CrossDatasetReferenceType = {
     })
 
     lazyGetter(parsed, 'to', () => {
-      return arrify(subTypeDef.to).map((toType) => {
+      return arrify(subTypeDef.to).map((toType: any) => {
         return {
           ...toType,
           // eslint-disable-next-line camelcase
@@ -102,12 +102,12 @@ export const CrossDatasetReferenceType = {
 
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           if (extensionDef.of) {
             throw new Error('Cannot override `of` of subtypes of "reference"')
           }

--- a/packages/@sanity/schema/src/legacy/types/date.ts
+++ b/packages/@sanity/schema/src/legacy/types/date.ts
@@ -16,19 +16,19 @@ export const DateType = {
   get() {
     return DATE_CORE
   },
-  extend(subTypeDef) {
+  extend(subTypeDef: any) {
     const parsed = Object.assign(pick(DATE_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: DATE_CORE,
       preview: primitivePreview,
     })
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
             type: parent,
           })

--- a/packages/@sanity/schema/src/legacy/types/datetime.ts
+++ b/packages/@sanity/schema/src/legacy/types/datetime.ts
@@ -16,19 +16,19 @@ export const DateTimeType = {
   get() {
     return DATETIME_CORE
   },
-  extend(subTypeDef) {
+  extend(subTypeDef: any) {
     const parsed = Object.assign(pick(DATETIME_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: DATETIME_CORE,
       preview: primitivePreview,
     })
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
             type: parent,
           })

--- a/packages/@sanity/schema/src/legacy/types/email.ts
+++ b/packages/@sanity/schema/src/legacy/types/email.ts
@@ -16,19 +16,19 @@ export const EmailType = {
   get() {
     return EMAIL_CORE
   },
-  extend(subTypeDef) {
+  extend(subTypeDef: any) {
     const parsed = Object.assign(pick(EMAIL_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: EMAIL_CORE,
       preview: primitivePreview,
     })
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
             type: parent,
           })

--- a/packages/@sanity/schema/src/legacy/types/file.ts
+++ b/packages/@sanity/schema/src/legacy/types/file.ts
@@ -28,7 +28,7 @@ export const FileType = {
   get() {
     return FILE_CORE
   },
-  extend(rawSubTypeDef, createMemberType) {
+  extend(rawSubTypeDef: any, createMemberType: any) {
     const options = {...(rawSubTypeDef.options || DEFAULT_OPTIONS)}
 
     const fields = [ASSET_FIELD, ...(rawSubTypeDef.fields || [])]
@@ -39,7 +39,7 @@ export const FileType = {
       type: FILE_CORE,
       title: subTypeDef.title || (subTypeDef.name ? startCase(subTypeDef.name) : ''),
       options: options,
-      fields: subTypeDef.fields.map((fieldDef) => {
+      fields: subTypeDef.fields.map((fieldDef: any) => {
         const {name, fieldset, ...rest} = fieldDef
 
         const compiledField = {
@@ -65,12 +65,12 @@ export const FileType = {
 
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           if (extensionDef.fields) {
             throw new Error('Cannot override `fields` of subtypes of "file"')
           }

--- a/packages/@sanity/schema/src/legacy/types/image.ts
+++ b/packages/@sanity/schema/src/legacy/types/image.ts
@@ -21,7 +21,7 @@ export const ImageType = {
   get() {
     return IMAGE_CORE
   },
-  extend(rawSubTypeDef, createMemberType) {
+  extend(rawSubTypeDef: any, createMemberType: any) {
     const options = {...(rawSubTypeDef.options || DEFAULT_OPTIONS)}
 
     let hotspotFields = [HOTSPOT_FIELD, CROP_FIELD]
@@ -36,7 +36,7 @@ export const ImageType = {
       type: IMAGE_CORE,
       title: subTypeDef.title || (subTypeDef.name ? startCase(subTypeDef.name) : ''),
       options: options,
-      fields: subTypeDef.fields.map((fieldDef) => {
+      fields: subTypeDef.fields.map((fieldDef: any) => {
         const {name, fieldset, ...rest} = fieldDef
 
         const compiledField = {
@@ -62,12 +62,12 @@ export const ImageType = {
 
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           if (extensionDef.fields) {
             throw new Error('Cannot override `fields` of subtypes of "image"')
           }

--- a/packages/@sanity/schema/src/legacy/types/number.ts
+++ b/packages/@sanity/schema/src/legacy/types/number.ts
@@ -16,7 +16,7 @@ export const NumberType = {
   get() {
     return NUMBER_CORE
   },
-  extend(subTypeDef) {
+  extend(subTypeDef: any) {
     const parsed = Object.assign(pick(NUMBER_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: NUMBER_CORE,
       preview: primitivePreview,
@@ -24,12 +24,12 @@ export const NumberType = {
 
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
             type: parent,
           })

--- a/packages/@sanity/schema/src/legacy/types/object.ts
+++ b/packages/@sanity/schema/src/legacy/types/object.ts
@@ -32,7 +32,7 @@ export const ObjectType = {
       jsonType: 'object',
     }
   },
-  extend(rawSubTypeDef, createMemberType) {
+  extend(rawSubTypeDef: any, createMemberType: any) {
     const subTypeDef = {fields: [], ...rawSubTypeDef}
 
     const options = {...(subTypeDef.options || {})}
@@ -41,7 +41,7 @@ export const ObjectType = {
       title: subTypeDef.title || (subTypeDef.name ? startCase(subTypeDef.name) : ''),
       options: options,
       orderings: subTypeDef.orderings || guessOrderingConfig(subTypeDef),
-      fields: subTypeDef.fields.map((fieldDef) => {
+      fields: subTypeDef.fields.map((fieldDef: any) => {
         const {name, fieldset, group, ...rest} = fieldDef
 
         const compiledField = {
@@ -91,12 +91,12 @@ export const ObjectType = {
 
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           if (extensionDef.fields) {
             throw new Error('Cannot override `fields` of subtypes of "object"')
           }

--- a/packages/@sanity/schema/src/legacy/types/reference.ts
+++ b/packages/@sanity/schema/src/legacy/types/reference.ts
@@ -28,7 +28,7 @@ const REFERENCE_CORE = {
   jsonType: 'object',
 }
 
-function humanize(arr, conjunction) {
+function humanize(arr: any, conjunction: any) {
   const len = arr.length
   if (len === 1) {
     return arr[0]
@@ -38,12 +38,12 @@ function humanize(arr, conjunction) {
   return `${first.join(', ')} ${conjunction} ${last}`
 }
 
-function buildTitle(type) {
+function buildTitle(type: any) {
   if (!type.to || type.to.length === 0) {
     return 'Reference'
   }
   return `Reference to ${humanize(
-    arrify(type.to).map((toType) => toType.title),
+    arrify(type.to).map((toType: any) => toType.title),
     'or',
   ).toLowerCase()}`
 }
@@ -52,7 +52,7 @@ export const ReferenceType = {
   get() {
     return REFERENCE_CORE
   },
-  extend(subTypeDef, createMemberType) {
+  extend(subTypeDef: any, createMemberType: any) {
     if (!subTypeDef.to) {
       throw new Error(
         `Missing "to" field in reference definition. Check the type ${subTypeDef.name}`,
@@ -77,19 +77,19 @@ export const ReferenceType = {
     })
 
     lazyGetter(parsed, 'to', () => {
-      return arrify(subTypeDef.to).map((toType) => createMemberType(toType))
+      return arrify(subTypeDef.to).map((toType: any) => createMemberType(toType))
     })
 
     lazyGetter(parsed, 'title', () => subTypeDef.title || buildTitle(parsed))
 
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           if (extensionDef.of) {
             throw new Error('Cannot override `of` of subtypes of "reference"')
           }

--- a/packages/@sanity/schema/src/legacy/types/string.ts
+++ b/packages/@sanity/schema/src/legacy/types/string.ts
@@ -16,7 +16,7 @@ export const StringType = {
   get() {
     return STRING_CORE
   },
-  extend(subTypeDef) {
+  extend(subTypeDef: any) {
     const parsed = Object.assign(pick(STRING_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: STRING_CORE,
       preview: primitivePreview,
@@ -24,12 +24,12 @@ export const StringType = {
 
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
             type: parent,
           })

--- a/packages/@sanity/schema/src/legacy/types/text.ts
+++ b/packages/@sanity/schema/src/legacy/types/text.ts
@@ -16,7 +16,7 @@ export const TextType = {
   get() {
     return TEXT_CORE
   },
-  extend(subTypeDef) {
+  extend(subTypeDef: any) {
     const parsed = Object.assign(pick(TEXT_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: TEXT_CORE,
       preview: primitivePreview,
@@ -24,12 +24,12 @@ export const TextType = {
 
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
             type: parent,
           })

--- a/packages/@sanity/schema/src/legacy/types/url.ts
+++ b/packages/@sanity/schema/src/legacy/types/url.ts
@@ -16,19 +16,19 @@ export const UrlType = {
   get() {
     return URL_CORE
   },
-  extend(subTypeDef) {
+  extend(subTypeDef: any) {
     const parsed = Object.assign(pick(URL_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: URL_CORE,
       preview: primitivePreview,
     })
     return subtype(parsed)
 
-    function subtype(parent) {
+    function subtype(parent: any) {
       return {
         get() {
           return parent
         },
-        extend: (extensionDef) => {
+        extend: (extensionDef: any) => {
           const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
             type: parent,
           })

--- a/packages/@sanity/schema/src/legacy/types/utils.ts
+++ b/packages/@sanity/schema/src/legacy/types/utils.ts
@@ -2,7 +2,7 @@ interface Config {
   enumerable?: boolean
   writable?: boolean
 }
-export function lazyGetter(target, key, getter, config: Config = {}) {
+export function lazyGetter(target: any, key: any, getter: any, config: Config = {}) {
   Object.defineProperty(target, key, {
     configurable: true,
     enumerable: config.enumerable !== false,

--- a/packages/@sanity/schema/src/sanity/extractSchema.ts
+++ b/packages/@sanity/schema/src/sanity/extractSchema.ts
@@ -152,8 +152,8 @@ export function extractSchema(
     }
 
     // if we have already seen the base type, we can just reference it
-    if (inlineFields.has(schemaType.type)) {
-      return {type: 'inline', name: schemaType.type.name} satisfies InlineTypeNode
+    if (inlineFields.has(schemaType.type!)) {
+      return {type: 'inline', name: schemaType.type!.name} satisfies InlineTypeNode
     }
 
     // If we have a type that is point to a type, that is pointing to a type, we assume this is a circular reference
@@ -172,7 +172,7 @@ export function extractSchema(
 
     // map some known types
     if (schemaType.type && typesMap.has(schemaType.type.name)) {
-      return typesMap.get(schemaType.type.name)
+      return typesMap.get(schemaType.type.name)!
     }
 
     // Cross dataset references are not supported
@@ -461,7 +461,7 @@ function gatherReferenceNames(type: ReferenceSchemaType): string[] {
 
 function gatherReferenceTypes(type: ReferenceSchemaType): ObjectSchemaType[] {
   const refTo = 'to' in type ? type.to : []
-  if ('type' in type && isReferenceType(type.type)) {
+  if ('type' in type && isReferenceType(type.type!)) {
     return [...gatherReferenceTypes(type.type), ...refTo]
   }
 
@@ -523,21 +523,21 @@ function sortByDependencies(compiledSchema: SchemaDef): string[] {
     if ('fields' in schemaType) {
       for (const field of gatherFields(schemaType)) {
         const last = lastType(field.type)
-        if (last.name === 'document') {
-          dependencies.add(last)
+        if (last!.name === 'document') {
+          dependencies.add(last!)
           continue
         }
 
         let schemaTypeName: string | undefined
-        if (schemaType.type.type) {
-          schemaTypeName = field.type.type.name
-        } else if ('jsonType' in schemaType.type) {
+        if (schemaType.type!.type) {
+          schemaTypeName = field.type.type!.name
+        } else if ('jsonType' in schemaType.type!) {
           schemaTypeName = field.type.jsonType
         }
 
         if (schemaTypeName === 'object' || schemaTypeName === 'block') {
           if (isReferenceType(field.type)) {
-            field.type.to.forEach((ref) => dependencies.add(ref.type))
+            field.type.to.forEach((ref) => dependencies.add(ref.type!))
           } else {
             dependencies.add(field.type)
           }

--- a/packages/@sanity/schema/src/sanity/groupProblems.ts
+++ b/packages/@sanity/schema/src/sanity/groupProblems.ts
@@ -21,7 +21,7 @@ function createTypeWithMembersProblemsAccessor(
   memberPropertyName: string,
   getMembers = (type: SchemaType) => get(type, memberPropertyName),
 ) {
-  return function getProblems(type, parentPath: ProblemPath): TypeWithProblems[] {
+  return function getProblems(type: any, parentPath: ProblemPath): TypeWithProblems[] {
     const currentPath: ProblemPath = [
       ...parentPath,
       {kind: 'type', type: type.type, name: type.name},
@@ -36,7 +36,7 @@ function createTypeWithMembersProblemsAccessor(
             name: memberPropertyName,
           }
           const memberPath: ProblemPath = [...currentPath, propertySegment]
-          return getTypeProblems(memberType, memberPath)
+          return getTypeProblems(memberType, memberPath as any)
         })
       : [
           [
@@ -57,7 +57,8 @@ function createTypeWithMembersProblemsAccessor(
   }
 }
 
-const arrify = (val) => (Array.isArray(val) ? val : (typeof val === 'undefined' && []) || [val])
+const arrify = (val: any) =>
+  Array.isArray(val) ? val : (typeof val === 'undefined' && []) || [val]
 
 const getObjectProblems = createTypeWithMembersProblemsAccessor('fields')
 const getImageProblems = createTypeWithMembersProblemsAccessor('fields')
@@ -68,12 +69,12 @@ const getReferenceProblems = createTypeWithMembersProblemsAccessor('to', (type) 
 )
 const getBlockAnnotationProblems = createTypeWithMembersProblemsAccessor('marks.annotations')
 const getBlockMemberProblems = createTypeWithMembersProblemsAccessor('of')
-const getBlockProblems = (type, problems) => [
+const getBlockProblems = (type: any, problems: any) => [
   ...getBlockAnnotationProblems(type, problems),
   ...getBlockMemberProblems(type, problems),
 ]
 
-function getDefaultProblems(type, path = []): TypeWithProblems[] {
+function getDefaultProblems(type: any, path = []): TypeWithProblems[] {
   return [
     {
       path: [...path, {kind: 'type', type: type.type, name: type.name}],

--- a/packages/@sanity/schema/src/sanity/validateSchema.ts
+++ b/packages/@sanity/schema/src/sanity/validateSchema.ts
@@ -24,16 +24,16 @@ const typeVisitors = {
   crossDatasetReference: crossDatasetReference,
 }
 
-const getNoopVisitor = (visitorContext) => (schemaDef) => ({
+const getNoopVisitor = (visitorContext: any) => (schemaDef: any) => ({
   name: `<unnamed_type_@_index_${visitorContext.index}>`,
   ...schemaDef,
   _problems: [],
 })
 
-function combine(...visitors) {
-  return (schemaType, visitorContext) => {
+function combine(...visitors: any) {
+  return (schemaType: any, visitorContext: any) => {
     return visitors.reduce(
-      (result, visitor) => {
+      (result: any, visitor: any) => {
         const res = visitor(result, visitorContext)
         return {
           ...res,
@@ -51,7 +51,7 @@ function combine(...visitors) {
 export function validateSchema(schemaTypes: _FIXME_) {
   return traverseSanitySchema(schemaTypes, (schemaDef, visitorContext) => {
     const typeVisitor =
-      (schemaDef && schemaDef.type && typeVisitors[schemaDef.type]) ||
+      (schemaDef && schemaDef.type && (typeVisitors as any)[schemaDef.type]) ||
       getNoopVisitor(visitorContext)
 
     if (visitorContext.isRoot) {

--- a/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
+++ b/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
@@ -36,7 +36,7 @@ function createValidationResult(
   message: string,
   helpId: string | null,
 ): SchemaValidationResult {
-  if (helpId && !Object.keys(HELP_IDS).some((id) => HELP_IDS[id] === helpId)) {
+  if (helpId && !Object.keys(HELP_IDS).some((id) => (HELP_IDS as any)[id] === helpId)) {
     throw new Error(
       `Used the unknown helpId "${helpId}", please add it to the array in createValidationResult.js`,
     )
@@ -44,12 +44,12 @@ function createValidationResult(
   return {
     severity,
     message,
-    helpId,
+    helpId: helpId!,
   }
 }
 
 export const error = (message: string, helpId?: string | null): SchemaValidationResult =>
-  createValidationResult('error', message, helpId)
+  createValidationResult('error', message, helpId!)
 
 export const warning = (message: string, helpId?: string | null): SchemaValidationResult =>
-  createValidationResult('warning', message, helpId)
+  createValidationResult('warning', message, helpId!)

--- a/packages/@sanity/schema/src/sanity/validation/types/array.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/array.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error - add typings for humanize-list
 import humanizeList from 'humanize-list'
 import {flatten, partition} from 'lodash'
 
@@ -5,15 +6,15 @@ import {coreTypeNames} from '../../coreTypes'
 import {error, HELP_IDS, warning} from '../createValidationResult'
 import {getDupes} from '../utils/getDupes'
 
-function isPrimitiveTypeName(typeName) {
+function isPrimitiveTypeName(typeName: any) {
   return typeName === 'string' || typeName === 'number' || typeName === 'boolean'
 }
 
-function isAssignable(typeName, type) {
+function isAssignable(typeName: any, type: any) {
   return (typeof type.name === 'string' ? type.name : type.type) === typeName
 }
 
-function quote(n) {
+function quote(n: any) {
   return `"${n}"`
 }
 
@@ -31,12 +32,12 @@ function format(value: unknown) {
   return quote(value)
 }
 
-export default (typeDef, visitorContext) => {
+export default (typeDef: any, visitorContext: any) => {
   // name should already have been marked
   const ofIsArray = Array.isArray(typeDef.of)
 
   if (ofIsArray) {
-    const invalid = typeDef.of.reduce((errs, def, idx) => {
+    const invalid = typeDef.of.reduce((errs: any, def: any, idx: any) => {
       if (typeof def.name === 'string') {
         // If an array member has been given a "local" type name, we want to trigger an error if the given member type name
         // is one of the builtin types
@@ -122,9 +123,9 @@ export default (typeDef, visitorContext) => {
 
   // Don't allow object types without a name in block arrays
   const hasObjectTypesWithoutName = of.some(
-    (type) => type.type === 'object' && typeof type.name === 'undefined',
+    (type: any) => type.type === 'object' && typeof type.name === 'undefined',
   )
-  const hasBlockType = of.some((ofType) => ofType.type === 'block')
+  const hasBlockType = of.some((ofType: any) => ofType.type === 'block')
   if (hasBlockType && hasObjectTypesWithoutName) {
     problems.push(
       error(

--- a/packages/@sanity/schema/src/sanity/validation/types/block.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/block.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error - add typings for humanize-list
 import humanizeList from 'humanize-list'
 import {isPlainObject, omit} from 'lodash'
 
@@ -5,8 +6,8 @@ import {coreTypeNames} from '../../coreTypes'
 import {error, HELP_IDS, warning} from '../createValidationResult'
 import {isJSONTypeOf} from '../utils/isJSONTypeOf'
 
-const getTypeOf = (thing) => (Array.isArray(thing) ? 'array' : typeof thing)
-const quote = (str) => `"${str}"`
+const getTypeOf = (thing: any) => (Array.isArray(thing) ? 'array' : typeof thing)
+const quote = (str: any) => `"${str}"`
 const allowedKeys = [
   'components',
   'lists',
@@ -25,7 +26,7 @@ const allowedDecoratorKeys = ['blockEditor', 'title', 'value', 'icon', 'componen
 const allowedListKeys = ['title', 'value', 'icon', 'component']
 const supportedBuiltInObjectTypes = ['file', 'image', 'object', 'reference']
 
-export default function validateBlockType(typeDef, visitorContext) {
+export default function validateBlockType(typeDef: any, visitorContext: any) {
   const problems = []
   let styles = typeDef.styles
   let lists = typeDef.lists
@@ -71,7 +72,7 @@ export default function validateBlockType(typeDef, visitorContext) {
   }
 }
 
-function validateMarks(marks, visitorContext, problems) {
+function validateMarks(marks: any, visitorContext: any, problems: any) {
   let decorators = marks.decorators
   let annotations = marks.annotations
 
@@ -100,8 +101,8 @@ function validateMarks(marks, visitorContext, problems) {
     )
   } else if (decorators) {
     decorators
-      .filter((dec) => !!dec.blockEditor)
-      .forEach((dec) => {
+      .filter((dec: any) => !!dec.blockEditor)
+      .forEach((dec: any) => {
         dec.icon = dec.blockEditor.icon
         dec.component = dec.blockEditor.render
       })
@@ -119,7 +120,7 @@ function validateMarks(marks, visitorContext, problems) {
   return {...marks, decorators, annotations}
 }
 
-function validateLists(lists, visitorContext, problems) {
+function validateLists(lists: any, visitorContext: any, problems: any) {
   if (!Array.isArray(lists)) {
     problems.push(error(`"lists" declaration should be an array, got ${getTypeOf(lists)}`))
     return problems
@@ -161,7 +162,7 @@ function validateLists(lists, visitorContext, problems) {
   return lists
 }
 
-function validateStyles(styles, visitorContext, problems) {
+function validateStyles(styles: any, visitorContext: any, problems: any) {
   if (!Array.isArray(styles)) {
     problems.push(error(`"styles" declaration should be an array, got ${getTypeOf(styles)}`))
     return problems
@@ -213,8 +214,8 @@ function validateStyles(styles, visitorContext, problems) {
   return styles
 }
 
-function validateDecorators(decorators, visitorContext, problems) {
-  decorators.forEach((decorator, index) => {
+function validateDecorators(decorators: any, visitorContext: any, problems: any) {
+  decorators.forEach((decorator: any, index: any) => {
     if (!isPlainObject(decorator)) {
       problems.push(error(`Annotation must be an object, got ${getTypeOf(decorator)}`))
       return
@@ -263,8 +264,8 @@ function validateDecorators(decorators, visitorContext, problems) {
   return decorators
 }
 
-function validateAnnotations(annotations, visitorContext, problems) {
-  return annotations.map((annotation) => {
+function validateAnnotations(annotations: any, visitorContext: any, problems: any) {
+  return annotations.map((annotation: any) => {
     if (!isPlainObject(annotation)) {
       return {
         ...annotation,
@@ -302,7 +303,7 @@ function validateAnnotations(annotations, visitorContext, problems) {
   })
 }
 
-function validateMembers(members, visitorContext, problems) {
+function validateMembers(members: any, visitorContext: any, problems: any) {
   if (!Array.isArray(members)) {
     problems.push(error(`"of" declaration should be an array, got ${getTypeOf(members)}`))
     return undefined

--- a/packages/@sanity/schema/src/sanity/validation/types/common.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/common.ts
@@ -2,7 +2,7 @@ import {validateNonObjectFieldsProp} from '../utils/validateNonObjectFieldsProp'
 import {validateTypeName} from '../utils/validateTypeName'
 import {validateDeprecatedProperties} from './deprecated'
 
-export default (typeDef, visitorContext) => {
+export default (typeDef: any, visitorContext: any) => {
   return {
     ...typeDef,
     _problems: [

--- a/packages/@sanity/schema/src/sanity/validation/types/crossDatasetReference.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/crossDatasetReference.ts
@@ -4,7 +4,7 @@ import {type SchemaValidationResult} from '../../typedefs'
 import {error, HELP_IDS} from '../createValidationResult'
 import {getDupes} from '../utils/getDupes'
 
-function normalizeToProp(typeDef) {
+function normalizeToProp(typeDef: any) {
   if (Array.isArray(typeDef.to)) {
     return typeDef.to
   }
@@ -20,7 +20,7 @@ export function isValidDatasetName(name: string): string | true {
   )
 }
 
-export default (typeDef, visitorContext) => {
+export default (typeDef: any, visitorContext: any) => {
   const isValidTo = Array.isArray(typeDef.to) || isPlainObject(typeDef.to)
   const normalizedTo = normalizeToProp(typeDef)
 
@@ -47,7 +47,7 @@ export default (typeDef, visitorContext) => {
     )
   }
 
-  normalizedTo.forEach((crossDatasetTypeDef, index) => {
+  normalizedTo.forEach((crossDatasetTypeDef: any, index: any) => {
     if (!crossDatasetTypeDef.type) {
       problems.push(
         error(

--- a/packages/@sanity/schema/src/sanity/validation/types/deprecated.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/deprecated.ts
@@ -1,7 +1,7 @@
 import {type SchemaValidationResult} from '../../typedefs'
 import {warning} from '../createValidationResult'
 
-export function validateDeprecatedProperties(type): SchemaValidationResult[] {
+export function validateDeprecatedProperties(type: any): SchemaValidationResult[] {
   const warnings = []
 
   if (type?.inputComponent) {

--- a/packages/@sanity/schema/src/sanity/validation/types/document.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/document.ts
@@ -3,7 +3,7 @@ import {isPlainObject} from 'lodash'
 import {error} from '../createValidationResult'
 import object from './object'
 
-export default (typeDefinition, visitorContext) => {
+export default (typeDefinition: any, visitorContext: any) => {
   const typeDef = object(typeDefinition, visitorContext)
   const {initialValue, initialValues} = typeDef
 

--- a/packages/@sanity/schema/src/sanity/validation/types/file.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/file.ts
@@ -1,7 +1,7 @@
 import {error, HELP_IDS} from '../createValidationResult'
 import {validateField, validateFields} from './object'
 
-export default (typeDef, visitorContext) => {
+export default (typeDef: any, visitorContext: any) => {
   const problems = []
   const fields = typeDef.fields
 

--- a/packages/@sanity/schema/src/sanity/validation/types/image.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/image.ts
@@ -3,7 +3,7 @@ import {validateField, validateFields} from './object'
 
 const autoMeta = ['dimensions', 'hasAlpha', 'isOpaque']
 
-export default (typeDef, visitorContext) => {
+export default (typeDef: any, visitorContext: any) => {
   const problems = []
   const fields = typeDef.fields
 
@@ -38,7 +38,7 @@ export default (typeDef, visitorContext) => {
         )}`,
       ),
     )
-    options = {...options, metadata: metadata.filter((meta) => !autoMeta.includes(meta))}
+    options = {...options, metadata: metadata!.filter((meta) => !autoMeta.includes(meta))}
   } else if (fieldsWithInvalidName.length > 0) {
     problems.push(
       error(

--- a/packages/@sanity/schema/src/sanity/validation/types/object.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/object.ts
@@ -18,7 +18,7 @@ interface PreviewConfig {
   prepare?: Function
 }
 
-function validateFieldName(name): Array<any> {
+function validateFieldName(name: any): Array<any> {
   if (typeof name !== 'string') {
     return [
       error(
@@ -58,7 +58,7 @@ function validateFieldName(name): Array<any> {
   return []
 }
 
-export function validateField(field, _visitorContext) {
+export function validateField(field: any, _visitorContext: any) {
   if (!isPlainObject(field)) {
     return [
       error(
@@ -78,7 +78,7 @@ export function validateField(field, _visitorContext) {
   return problems
 }
 
-function getDuplicateFields(array: Array<Field>): Array<Array<Field>> {
+function getDuplicateFields(array: Array<Field>): Array<Array<Field> | null> {
   const dupes: {[name: string]: Array<Field>} = {}
   array.forEach((field) => {
     if (!dupes[field.name]) {
@@ -108,7 +108,7 @@ export function validateFields(fields: any, options = {allowEmpty: false}) {
   getDuplicateFields(fieldsWithNames).forEach((dupes) => {
     problems.push(
       error(
-        `Found ${dupes.length} fields with name "${dupes[0].name}" in object`,
+        `Found ${dupes!.length} fields with name "${dupes![0].name}" in object`,
         HELP_IDS.OBJECT_FIELD_NOT_UNIQUE,
       ),
     )
@@ -160,26 +160,26 @@ export function validatePreview(preview: PreviewConfig) {
     ]
   }
 
-  return Object.keys(preview.select).reduce((errs, key) => {
-    return typeof preview.select[key] === 'string'
+  return Object.keys(preview.select).reduce((errs: any, key) => {
+    return typeof preview.select![key] === 'string'
       ? errs
       : errs.concat(
           error(
             `The key "${key}" of "preview.select" must be a string, instead saw "${typeof preview
-              .select[key]}"`,
+              .select![key]}"`,
           ),
         )
   }, [])
 }
 
-export default (typeDef, visitorContext) => {
+export default (typeDef: any, visitorContext: any) => {
   let problems = validateFields(typeDef.fields)
 
   let preview = typeDef.preview
   if (preview) {
     const previewErrors = validatePreview(typeDef.preview)
     problems = problems.concat(previewErrors)
-    preview = previewErrors.some((err) => err.severity === 'error') ? {} : preview
+    preview = previewErrors.some((err: any) => err.severity === 'error') ? {} : preview
   }
 
   if (
@@ -195,7 +195,7 @@ export default (typeDef, visitorContext) => {
   return {
     ...typeDef,
     preview,
-    fields: (Array.isArray(typeDef.fields) ? typeDef.fields : []).map((field, index) => {
+    fields: (Array.isArray(typeDef.fields) ? typeDef.fields : []).map((field: any, index: any) => {
       const {name, ...fieldTypeDef} = field
       const {_problems, ...fieldType} = visitorContext.visit(fieldTypeDef, index)
       return {

--- a/packages/@sanity/schema/src/sanity/validation/types/reference.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/reference.ts
@@ -4,14 +4,14 @@ import {type SchemaValidationResult} from '../../typedefs'
 import {error, HELP_IDS} from '../createValidationResult'
 import {getDupes} from '../utils/getDupes'
 
-function normalizeToProp(typeDef) {
+function normalizeToProp(typeDef: any) {
   if (Array.isArray(typeDef.to)) {
     return typeDef.to
   }
   return typeDef.to ? [typeDef.to] : typeDef.to
 }
 
-export default (typeDef, visitorContext) => {
+export default (typeDef: any, visitorContext: any) => {
   const isValidTo = Array.isArray(typeDef.to) || isPlainObject(typeDef.to)
   const normalizedTo = normalizeToProp(typeDef)
 

--- a/packages/@sanity/schema/src/sanity/validation/types/rootType.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/rootType.ts
@@ -1,7 +1,7 @@
 import {error, HELP_IDS, warning} from '../createValidationResult'
 import {validateComponent} from '../utils/validateComponent'
 
-export default (typeDef, visitorContext) => {
+export default (typeDef: any, visitorContext: any) => {
   const hasName = Boolean(typeDef.name)
   if (!hasName && Object.keys(typeDef).length === 1) {
     // Short-circuit on obviously invalid types (only key is _problems)
@@ -54,6 +54,6 @@ export default (typeDef, visitorContext) => {
   }
 }
 
-function looksLikeEsmModule(typeDef) {
+function looksLikeEsmModule(typeDef: any) {
   return !typeDef.name && typeDef.default && (typeDef.default.name || typeDef.default.title)
 }

--- a/packages/@sanity/schema/src/sanity/validation/types/slug.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/slug.ts
@@ -1,6 +1,6 @@
 import {HELP_IDS, warning} from '../createValidationResult'
 
-export default (typeDef, visitorContext) => {
+export default (typeDef: any, visitorContext: any) => {
   const problems = []
 
   if (typeDef.options && typeDef.options.slugifyFn) {

--- a/packages/@sanity/schema/src/sanity/validation/utils/getDupes.ts
+++ b/packages/@sanity/schema/src/sanity/validation/utils/getDupes.ts
@@ -1,5 +1,5 @@
-export function getDupes(array, selector = (v) => v) {
-  const dupes = array.reduce((acc, item) => {
+export function getDupes(array: any, selector = (v: any) => v) {
+  const dupes = array.reduce((acc: any, item: any) => {
     const key = selector(item)
     if (!acc[key]) {
       acc[key] = []

--- a/packages/@sanity/schema/src/sanity/validation/utils/isJSONTypeOf.ts
+++ b/packages/@sanity/schema/src/sanity/validation/utils/isJSONTypeOf.ts
@@ -1,4 +1,4 @@
-export function isJSONTypeOf(type, jsonType, visitorContext) {
+export function isJSONTypeOf(type: any, jsonType: any, visitorContext: any) {
   if ('jsonType' in type) {
     return type.jsonType === jsonType
   }

--- a/packages/@sanity/schema/src/sanity/validation/utils/validateNonObjectFieldsProp.ts
+++ b/packages/@sanity/schema/src/sanity/validation/utils/validateNonObjectFieldsProp.ts
@@ -5,7 +5,7 @@ import {error} from '../createValidationResult'
 
 export function validateNonObjectFieldsProp(
   typeDef: SchemaType,
-  visitorContext,
+  visitorContext: any,
 ): SchemaValidationResult[] {
   if (!('fields' in typeDef)) {
     return []

--- a/packages/@sanity/schema/src/sanity/validation/utils/validateTypeName.ts
+++ b/packages/@sanity/schema/src/sanity/validation/utils/validateTypeName.ts
@@ -1,11 +1,12 @@
+// @ts-expect-error - add typings for humanize-list
 import humanize from 'humanize-list'
 import leven from 'leven'
 
 import {error, HELP_IDS} from '../createValidationResult'
 
-const quote = (str) => `"${str}"`
+const quote = (str: any) => `"${str}"`
 
-export function validateTypeName(typeName: string, visitorContext) {
+export function validateTypeName(typeName: string, visitorContext: any) {
   const possibleTypeNames = visitorContext.getTypeNames()
 
   if (!typeName) {
@@ -25,11 +26,11 @@ export function validateTypeName(typeName: string, visitorContext) {
 
   if (!isValid) {
     const suggestions = possibleTypeNames
-      .map((possibleTypeName) => {
+      .map((possibleTypeName: any) => {
         return [leven(typeName, possibleTypeName), possibleTypeName]
       })
-      .filter(([distance]) => distance < 3)
-      .map(([_, name]) => name)
+      .filter(([distance]: any) => distance < 3)
+      .map(([_, name]: any) => name)
 
     const suggestion =
       suggestions.length > 0

--- a/packages/@sanity/schema/tsconfig.json
+++ b/packages/@sanity/schema/tsconfig.json
@@ -4,10 +4,7 @@
   "compilerOptions": {
     "composite": true,
     "rootDir": ".",
-    "outDir": "./lib/dts",
-
-    "noUnusedLocals": false,
-    "strict": false
+    "outDir": "./lib/dts"
   },
   "references": [{"path": "../types/tsconfig.lib.json"}]
 }

--- a/packages/@sanity/schema/tsconfig.lib.json
+++ b/packages/@sanity/schema/tsconfig.lib.json
@@ -4,10 +4,7 @@
   "compilerOptions": {
     "composite": true,
     "rootDir": ".",
-    "outDir": "./lib/dts",
-
-    "noUnusedLocals": false,
-    "strict": false
+    "outDir": "./lib/dts"
   },
   "references": [{"path": "../types/tsconfig.lib.json"}]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1267,7 +1267,7 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       object-inspect:
-        specifier: ^1.6.0
+        specifier: ^1.13.1
         version: 1.13.1
     devDependencies:
       '@jest/globals':
@@ -1276,6 +1276,12 @@ importers:
       '@sanity/icons':
         specifier: ^2.11.6
         version: 2.11.6(react@18.2.0)
+      '@types/arrify':
+        specifier: ^1.0.1
+        version: 1.0.4
+      '@types/object-inspect':
+        specifier: ^1.13.0
+        version: 1.13.0
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -7256,6 +7262,10 @@ packages:
 
   /@types/normalize-package-data@2.4.4:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  /@types/object-inspect@1.13.0:
+    resolution: {integrity: sha512-lwGTVESDDV+XsQ1pH4UifpJ1f7OtXzQ6QBOX2Afq2bM/T3oOt8hF6exJMjjIjtEWeAN2YAo25J7HxWh97CCz9w==}
+    dev: true
 
   /@types/offscreencanvas@2019.7.3:
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}


### PR DESCRIPTION
### Description

This change was done in #5983 and is required for #5983 to land. But as that PR is already quite large it's split up into its own PR to reduce the cognitive load for reviewers.
The objective is first and foremost to remove the requirement for these in the tsconfig for `@sanity/schema`:
```json
{
  "noUnusedLocals": false,
  "strict": false
}
```
so that all our packages use the same compiler settings and can be used with `compilerOptions.paths` for IDE and language service features that can typecheck code between packages without first needing to save the file, or build the package.
Note that this `compilerOptions.paths` setup is implemented in #5983, this PR lays the groundwork for it.

### What to review

Everything should continue to build, this is a TS concern and generated JS should be identical.

### Testing

If the CI pass we're good, no manual testing needed.

### Notes for release

N/A
