### PR TITLE
chore: reduce test flakiness by increasing timeout to 60s

### DIFF
--- a/packages/@sanity/cli/test/telemetry.test.ts
+++ b/packages/@sanity/cli/test/telemetry.test.ts
@@ -3,24 +3,28 @@ import {expect, test} from '@jest/globals'
 import {describeCliTest} from './shared/describe'
 import {runSanityCmdCommand} from './shared/environment'
 
+const testTimeout = 60000 // 60 seconds
+
 describeCliTest('CLI: `sanity telemetry status`', () => {
-  test('sanity telemetry status: granted', async () => {
-    await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
-      env: {
-        DEBUG: 'sanity:*',
-        CI: 'false',
-      },
-    })
+  test(
+    'sanity telemetry status: granted',
+    async () => {
+      await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
+        env: {
+          DEBUG: 'sanity:*',
+          CI: 'false',
+        },
+      })
 
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
-      env: {
-        CI: 'false',
-        // Disables color for snapshot report
-        FORCE_COLOR: '0',
-      },
-    })
+      const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
+        env: {
+          CI: 'false',
+          // Disables color for snapshot report
+          FORCE_COLOR: '0',
+        },
+      })
 
-    expect(result.stdout).toMatchInlineSnapshot(`
+      expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Enabled
 
 Telemetry data on general usage and errors is collected to help us improve Sanity.
@@ -29,24 +33,28 @@ Learn more about the data being collected here:
 https://www.sanity.io/telemetry
 "
 `)
-  })
+    },
+    testTimeout,
+  )
 
-  test('sanity telemetry status: denied', async () => {
-    await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
-      env: {
-        CI: 'false',
-      },
-    })
+  test(
+    'sanity telemetry status: denied',
+    async () => {
+      await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
+        env: {
+          CI: 'false',
+        },
+      })
 
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
-      env: {
-        CI: 'false',
-        // Disables color for snapshot report
-        FORCE_COLOR: '0',
-      },
-    })
+      const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
+        env: {
+          CI: 'false',
+          // Disables color for snapshot report
+          FORCE_COLOR: '0',
+        },
+      })
 
-    expect(result.stdout).toMatchInlineSnapshot(`
+      expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Disabled
 
 You've opted out of telemetry data collection.
@@ -56,19 +64,23 @@ Learn more here:
 https://www.sanity.io/telemetry
 "
 `)
-  })
+    },
+    testTimeout,
+  )
 
-  test('sanity telemetry status: denied using DO_NOT_TRACK', async () => {
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
-      env: {
-        CI: 'false',
-        DO_NOT_TRACK: '1',
-        // Disables color for snapshot report
-        FORCE_COLOR: '0',
-      },
-    })
+  test(
+    'sanity telemetry status: denied using DO_NOT_TRACK',
+    async () => {
+      const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
+        env: {
+          CI: 'false',
+          DO_NOT_TRACK: '1',
+          // Disables color for snapshot report
+          FORCE_COLOR: '0',
+        },
+      })
 
-    expect(result.stdout).toMatchInlineSnapshot(`
+      expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Disabled
 
 You've opted out of telemetry data collection.
@@ -80,26 +92,30 @@ Learn more here:
 https://www.sanity.io/telemetry
 "
 `)
-  })
+    },
+    testTimeout,
+  )
 })
 
 describeCliTest('CLI: `sanity telemetry enable`', () => {
-  test('sanity telemetry enable: success', async () => {
-    await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
-      env: {
-        CI: 'false',
-      },
-    })
+  test(
+    'sanity telemetry enable: success',
+    async () => {
+      await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
+        env: {
+          CI: 'false',
+        },
+      })
 
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
-      env: {
-        CI: 'false',
-        // Disables color for snapshot report
-        FORCE_COLOR: '0',
-      },
-    })
+      const result = await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
+        env: {
+          CI: 'false',
+          // Disables color for snapshot report
+          FORCE_COLOR: '0',
+        },
+      })
 
-    expect(result.stdout).toMatchInlineSnapshot(`
+      expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Enabled
 
 You've now enabled telemetry data collection to help us improve Sanity.
@@ -108,18 +124,22 @@ Learn more about the data being collected here:
 https://www.sanity.io/telemetry
 "
 `)
-  })
+    },
+    testTimeout,
+  )
 
-  test('sanity telemetry enable: success (already enabled)', async () => {
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
-      env: {
-        CI: 'false',
-        // Disables color for snapshot report
-        FORCE_COLOR: '0',
-      },
-    })
+  test(
+    'sanity telemetry enable: success (already enabled)',
+    async () => {
+      const result = await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
+        env: {
+          CI: 'false',
+          // Disables color for snapshot report
+          FORCE_COLOR: '0',
+        },
+      })
 
-    expect(result.stdout).toMatchInlineSnapshot(`
+      expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Enabled
 
 You've already enabled telemetry data collection to help us improve Sanity.
@@ -128,26 +148,30 @@ Learn more about the data being collected here:
 https://www.sanity.io/telemetry
 "
 `)
-  })
+    },
+    testTimeout,
+  )
 })
 
 describeCliTest('CLI: `sanity telemetry disable`', () => {
-  test('sanity telemetry disable: success', async () => {
-    await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
-      env: {
-        CI: 'false',
-      },
-    })
+  test(
+    'sanity telemetry disable: success',
+    async () => {
+      await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
+        env: {
+          CI: 'false',
+        },
+      })
 
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
-      env: {
-        CI: 'false',
-        // Disables color for snapshot report
-        FORCE_COLOR: '0',
-      },
-    })
+      const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
+        env: {
+          CI: 'false',
+          // Disables color for snapshot report
+          FORCE_COLOR: '0',
+        },
+      })
 
-    expect(result.stdout).toMatchInlineSnapshot(`
+      expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Disabled
 
 You've opted out of telemetry data collection.
@@ -157,18 +181,22 @@ Learn more here:
 https://www.sanity.io/telemetry
 "
 `)
-  })
+    },
+    testTimeout,
+  )
 
-  test('sanity telemetry disable: success (already denied)', async () => {
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
-      env: {
-        CI: 'false',
-        // Disables color for snapshot report
-        FORCE_COLOR: '0',
-      },
-    })
+  test(
+    'sanity telemetry disable: success (already denied)',
+    async () => {
+      const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
+        env: {
+          CI: 'false',
+          // Disables color for snapshot report
+          FORCE_COLOR: '0',
+        },
+      })
 
-    expect(result.stdout).toMatchInlineSnapshot(`
+      expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Disabled
 
 You've already opted out of telemetry data collection.
@@ -178,19 +206,23 @@ Learn more here:
 https://www.sanity.io/telemetry
 "
 `)
-  })
+    },
+    testTimeout,
+  )
 
-  test('sanity telemetry disable: success (already denied using DO_NOT_TRACK)', async () => {
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
-      env: {
-        CI: 'false',
-        DO_NOT_TRACK: '1',
-        // Disables color for snapshot report
-        FORCE_COLOR: '0',
-      },
-    })
+  test(
+    'sanity telemetry disable: success (already denied using DO_NOT_TRACK)',
+    async () => {
+      const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
+        env: {
+          CI: 'false',
+          DO_NOT_TRACK: '1',
+          // Disables color for snapshot report
+          FORCE_COLOR: '0',
+        },
+      })
 
-    expect(result.stdout).toMatchInlineSnapshot(`
+      expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Disabled
 
 You've already opted out of telemetry data collection.
@@ -202,5 +234,7 @@ Learn more here:
 https://www.sanity.io/telemetry
 "
 `)
-  })
+    },
+    testTimeout,
+  )
 })


### PR DESCRIPTION
Tired of re-running failed jobs due to one of these timing out