### PR TITLE
fix(cli): do not suggest v2 cli commands on "no such command" error

### DIFF
--- a/packages/@sanity/cli/src/util/noSuchCommandText.ts
+++ b/packages/@sanity/cli/src/util/noSuchCommandText.ts
@@ -26,6 +26,10 @@ const coreCommands = [
   'users',
 ]
 
+// These are disabled in v3, but still present because of v2.
+// We don't want to suggest them anymore, though.
+const discouragedCommands = ['upgrade', 'check', 'configcheck', 'uninstall']
+
 const helpText = `
 Run the command again within a Sanity project directory, where "sanity"
 is installed as a dependency.`
@@ -54,6 +58,7 @@ function suggestCommand(
 ) {
   // Try to find something similar
   const closest = group
+    .filter((command) => !discouragedCommands.includes(command.name))
     .map((command) => leven(command.name, cmdName))
     .reduce(
       (current: {index: number; distance: number}, distance: number, index: number) =>


### PR DESCRIPTION
### Description

If you use a command that does not exist, such as `sanity update`, but there is a similarly named command (`sanity upgrade`), we suggest it. However, this currently includes commands that were part of Sanity v2 and that we no longer support. This PR prevents the CLI from suggesting these.

### What to review

`sanity update` does not suggest `sanity upgrade`.

### Testing

Did not add tests for this since it is not the most critical functionality to maintain, and we'll be phasing out support for v2 commands in the next major.

### Notes for release

- Fixes an issue where the CLI might suggest commands that only work on Sanity v2 if you mistype a command name
