### PR TITLE
feat(core): add serverActions flag to config

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -11,7 +11,7 @@ import {presentationTool as pinnedPresentationTool} from '@sanity/presentation'
 import {debugSecrets} from '@sanity/preview-url-secret/sanity-plugin-debug-secrets'
 import {tsdoc} from '@sanity/tsdoc/studio'
 import {visionTool} from '@sanity/vision'
-import {defineConfig, definePlugin} from 'sanity'
+import {defineConfig, definePlugin, type WorkspaceOptions} from 'sanity'
 import {presentationTool} from 'sanity/presentation'
 import {structureTool} from 'sanity/structure'
 import {muxInput} from 'sanity-plugin-mux-input'
@@ -96,6 +96,7 @@ const sharedSettings = definePlugin({
     unstable_comments: {
       enabled: true,
     },
+
     badges: (prev, context) => (context.schemaType === 'author' ? [CustomBadge, ...prev] : prev),
   },
   plugins: [
@@ -151,6 +152,9 @@ export default defineConfig([
     plugins: [sharedSettings()],
     basePath: '/test',
     icon: SanityMonogram,
+    // unstable_serverActions: {
+    //   enabled: true,
+    // },
   },
   {
     name: 'partialIndexing',
@@ -308,4 +312,4 @@ export default defineConfig([
     ],
     basePath: '/presentation',
   },
-])
+]) as WorkspaceOptions[]

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -151,9 +151,9 @@ export default defineConfig([
     plugins: [sharedSettings()],
     basePath: '/test',
     icon: SanityMonogram,
-    // unstable_serverActions: {
-    //   enabled: true,
-    // },
+    unstable_serverActions: {
+      enabled: true,
+    },
   },
   {
     name: 'partialIndexing',

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -96,7 +96,6 @@ const sharedSettings = definePlugin({
     unstable_comments: {
       enabled: true,
     },
-
     badges: (prev, context) => (context.schemaType === 'author' ? [CustomBadge, ...prev] : prev),
   },
   plugins: [
@@ -152,9 +151,9 @@ export default defineConfig([
     plugins: [sharedSettings()],
     basePath: '/test',
     icon: SanityMonogram,
-    unstable_serverActions: {
-      enabled: true,
-    },
+    // unstable_serverActions: {
+    //   enabled: true,
+    // },
   },
   {
     name: 'partialIndexing',

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -152,9 +152,9 @@ export default defineConfig([
     plugins: [sharedSettings()],
     basePath: '/test',
     icon: SanityMonogram,
-    // unstable_serverActions: {
-    //   enabled: true,
-    // },
+    unstable_serverActions: {
+      enabled: true,
+    },
   },
   {
     name: 'partialIndexing',

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -197,6 +197,7 @@ export function prepareConfig(
         sources: resolvedSources,
       },
       tasks: rawWorkspace.unstable_tasks ?? {enabled: true},
+      serverActions: rawWorkspace.unstable_serverActions ?? {enabled: false},
     }
     preparedWorkspaces.set(rawWorkspace, workspaceSummary)
     return workspaceSummary

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -444,6 +444,14 @@ export interface WorkspaceOptions extends SourceOptions {
   unstable_tasks?: {
     enabled: boolean
   }
+
+  /**
+   * @hidden
+   * @beta
+   */
+  unstable_serverActions?: {
+    enabled: boolean
+  }
 }
 
 /**
@@ -754,6 +762,8 @@ export interface Source {
   }
   /** @beta */
   tasks?: WorkspaceOptions['unstable_tasks']
+  /** @beta */
+  serverActions?: WorkspaceOptions['unstable_serverActions']
 }
 
 /** @internal */
@@ -793,6 +803,7 @@ export interface WorkspaceSummary {
     }>
   }
   tasks: WorkspaceOptions['unstable_tasks']
+  serverActions: WorkspaceOptions['unstable_serverActions']
 }
 
 /**

--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -129,12 +129,13 @@ export function useDocumentStore(): DocumentStore {
   const resourceCache = useResourceCache()
   const historyStore = useHistoryStore()
   const documentPreviewStore = useDocumentPreviewStore()
+  const workspace = useWorkspace()
 
   return useMemo(() => {
     const documentStore =
       resourceCache.get<DocumentStore>({
         namespace: 'documentStore',
-        dependencies: [getClient, documentPreviewStore, historyStore, schema, i18n],
+        dependencies: [getClient, documentPreviewStore, historyStore, schema, i18n, workspace],
       }) ||
       createDocumentStore({
         getClient,
@@ -143,6 +144,7 @@ export function useDocumentStore(): DocumentStore {
         initialValueTemplates: templates,
         schema,
         i18n,
+        serverActionsEnabled: workspace.serverActions?.enabled,
       })
 
     resourceCache.set({
@@ -152,7 +154,16 @@ export function useDocumentStore(): DocumentStore {
     })
 
     return documentStore
-  }, [getClient, documentPreviewStore, historyStore, resourceCache, schema, templates, i18n])
+  }, [
+    getClient,
+    documentPreviewStore,
+    historyStore,
+    resourceCache,
+    schema,
+    templates,
+    i18n,
+    workspace,
+  ])
 }
 
 /** @internal */

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/actionTypes.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/actionTypes.ts
@@ -1,0 +1,26 @@
+import {type PatchMutation} from '@sanity/types'
+
+export interface HttpCreateAction {
+  actionType: 'sanity.action.document.create'
+  publishedId: string
+  attributes: {
+    _id: string
+    _type: string
+  }
+  ifExists: 'ignore' | 'fail'
+}
+
+export interface HttpDeleteAction {
+  actionType: 'sanity.action.document.delete'
+  draftId: string
+  publishedId: string
+}
+
+export interface HttpEditAction {
+  actionType: 'sanity.action.document.edit'
+  draftId: string
+  publishedId: string
+  patch: PatchMutation['patch']
+}
+
+export type HttpAction = HttpCreateAction | HttpDeleteAction | HttpEditAction

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -2,7 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {type Mutation} from '@sanity/mutator'
 import {type SanityDocument} from '@sanity/types'
 import {EMPTY, from, merge, type Observable, Subject} from 'rxjs'
-import {filter, map, mergeMap, mergeMapTo, share, tap} from 'rxjs/operators'
+import {filter, map, mergeMap, share, tap} from 'rxjs/operators'
 
 import {
   type BufferedDocumentEvent,
@@ -13,6 +13,7 @@ import {
 } from '../buffered-doc'
 import {getPairListener, type ListenerEvent} from '../getPairListener'
 import {type IdPair, type PendingMutationsEvent, type ReconnectEvent} from '../types'
+import {type HttpAction} from './actionTypes'
 
 const isMutationEventForDocId =
   (id: string) =>
@@ -70,6 +71,62 @@ function setVersion<T>(version: 'draft' | 'published') {
   return (ev: T): T & {version: 'draft' | 'published'} => ({...ev, version})
 }
 
+function toActions(idPair: IdPair, mutationParams: Mutation['params']) {
+  return mutationParams.mutations.map((mutations): HttpAction => {
+    if (Object.keys(mutations).length > 1) {
+      // todo: this might be a bit too strict, but I'm (lazily) trying to check if we ever get more than one mutation in a payload
+      throw new Error('Did not expect multiple mutations in the same payload')
+    }
+    if (mutations.delete) {
+      return {
+        actionType: 'sanity.action.document.delete',
+        publishedId: idPair.publishedId,
+        draftId: idPair.draftId,
+      }
+    }
+    if (mutations.createIfNotExists) {
+      return {
+        actionType: 'sanity.action.document.create',
+        publishedId: idPair.publishedId,
+        attributes: {
+          ...mutations.createIfNotExists,
+          _id: idPair.draftId,
+        },
+        ifExists: 'ignore',
+      }
+    }
+    if (mutations.patch) {
+      return {
+        actionType: 'sanity.action.document.edit',
+        draftId: idPair.draftId,
+        publishedId: idPair.publishedId,
+        patch: mutations.patch,
+      }
+    }
+    throw new Error('Todo: implement')
+  })
+}
+
+function serverCommitMutations(
+  defaultClient: SanityClient,
+  idPair: IdPair,
+  mutationParams: Mutation['params'],
+) {
+  const vXClient = defaultClient.withConfig({apiVersion: 'X'})
+
+  const {dataset} = defaultClient.config()
+
+  return vXClient.observable.request({
+    url: `/data/actions/${dataset}`,
+    method: 'post',
+    tag: 'document.commit',
+    body: {
+      transactionId: mutationParams.transactionId,
+      actions: toActions(idPair, mutationParams),
+    },
+  })
+}
+
 function commitMutations(client: SanityClient, mutationParams: Mutation['params']) {
   const {resultRev, ...mutation} = mutationParams
   return client.dataRequest('mutate', mutation, {
@@ -82,8 +139,18 @@ function commitMutations(client: SanityClient, mutationParams: Mutation['params'
   })
 }
 
-function submitCommitRequest(client: SanityClient, request: CommitRequest) {
-  return from(commitMutations(client, request.mutation.params)).pipe(
+function submitCommitRequest(
+  client: SanityClient,
+  idPair: IdPair,
+  request: CommitRequest,
+  serverActionsEnabled?: boolean,
+) {
+  // console.log('submitCommitRequest', serverActionsEnabled)
+  return from(
+    serverActionsEnabled
+      ? serverCommitMutations(client, idPair, request.mutation.params)
+      : commitMutations(client, request.mutation.params),
+  ).pipe(
     tap({
       error: (error) => {
         const isBadRequest =
@@ -103,8 +170,13 @@ function submitCommitRequest(client: SanityClient, request: CommitRequest) {
 }
 
 /** @internal */
-export function checkoutPair(client: SanityClient, idPair: IdPair): Pair {
+export function checkoutPair(
+  client: SanityClient,
+  idPair: IdPair,
+  serverActionsEnabled?: boolean,
+): Pair {
   const {publishedId, draftId} = idPair
+  // console.log('checkoutPair', serverActionsEnabled)
 
   const listenerEventsConnector = new Subject<ListenerEvent>()
   const listenerEvents$ = getPairListener(client, idPair).pipe(
@@ -131,8 +203,10 @@ export function checkoutPair(client: SanityClient, idPair: IdPair): Pair {
   )
 
   const commits$ = merge(draft.commitRequest$, published.commitRequest$).pipe(
-    mergeMap((commitRequest) => submitCommitRequest(client, commitRequest)),
-    mergeMapTo(EMPTY),
+    mergeMap((commitRequest) =>
+      submitCommitRequest(client, idPair, commitRequest, serverActionsEnabled),
+    ),
+    mergeMap(() => EMPTY),
     share(),
   )
 

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -176,7 +176,6 @@ export function checkoutPair(
   serverActionsEnabled?: boolean,
 ): Pair {
   const {publishedId, draftId} = idPair
-  // console.log('checkoutPair', serverActionsEnabled)
 
   const listenerEventsConnector = new Subject<ListenerEvent>()
   const listenerEvents$ = getPairListener(client, idPair).pipe(

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -145,7 +145,6 @@ function submitCommitRequest(
   request: CommitRequest,
   serverActionsEnabled?: boolean,
 ) {
-  // console.log('submitCommitRequest', serverActionsEnabled)
   return from(
     serverActionsEnabled
       ? serverCommitMutations(client, idPair, request.mutation.params)

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/consistencyStatus.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/consistencyStatus.ts
@@ -12,9 +12,10 @@ export const consistencyStatus: (
   client: SanityClient,
   idPair: IdPair,
   typeName: string,
+  serverActionsEnabled?: boolean,
 ) => Observable<boolean> = memoize(
-  (client: SanityClient, idPair: IdPair, typeName: string) => {
-    return memoizedPair(client, idPair, typeName).pipe(
+  (client: SanityClient, idPair: IdPair, typeName: string, serverActionsEnabled?: boolean) => {
+    return memoizedPair(client, idPair, typeName, serverActionsEnabled).pipe(
       switchMap(({draft, published}) =>
         combineLatest([draft.consistency$, published.consistency$]),
       ),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/documentEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/documentEvents.ts
@@ -11,8 +11,13 @@ import {memoizeKeyGen} from './memoizeKeyGen'
 // A stream of all events related to either published or draft, each event comes with a 'target'
 // that specifies which version (draft|published) the event is about
 export const documentEvents = memoize(
-  (client: SanityClient, idPair: IdPair, typeName: string): Observable<DocumentVersionEvent> => {
-    return memoizedPair(client, idPair, typeName).pipe(
+  (
+    client: SanityClient,
+    idPair: IdPair,
+    typeName: string,
+    serverActionsEnabled?: boolean,
+  ): Observable<DocumentVersionEvent> => {
+    return memoizedPair(client, idPair, typeName, serverActionsEnabled).pipe(
       switchMap(({draft, published}) => merge(draft.events, published.events)),
     )
   },

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editOperations.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editOperations.ts
@@ -18,6 +18,7 @@ export const editOperations = memoize(
       client: SanityClient
       historyStore: HistoryStore
       schema: Schema
+      serverActionsEnabled?: boolean
     },
     idPair: IdPair,
     typeName: string,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
@@ -34,12 +34,14 @@ export const editState = memoize(
     ctx: {
       client: SanityClient
       schema: Schema
+      serverActionsEnabled?: boolean
     },
     idPair: IdPair,
     typeName: string,
+    serverActionsEnabled?: boolean,
   ): Observable<EditStateFor> => {
     const liveEdit = isLiveEditEnabled(ctx.schema, typeName)
-    return snapshotPair(ctx.client, idPair, typeName).pipe(
+    return snapshotPair(ctx.client, idPair, typeName, !!ctx.serverActionsEnabled).pipe(
       switchMap((versions) =>
         combineLatest([
           versions.draft.snapshots$,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizeKeyGen.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizeKeyGen.ts
@@ -2,7 +2,12 @@ import {type SanityClient} from '@sanity/client'
 
 import {type IdPair} from '../types'
 
-export function memoizeKeyGen(client: SanityClient, idPair: IdPair, typeName: string) {
+export function memoizeKeyGen(
+  client: SanityClient,
+  idPair: IdPair,
+  typeName: string,
+  serverActionsEnabled?: boolean,
+) {
   const config = client.config()
-  return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}`
+  return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}${serverActionsEnabled ? '-serverActionsEnabled' : ''}`
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
@@ -11,10 +11,16 @@ export const memoizedPair: (
   client: SanityClient,
   idPair: IdPair,
   typeName: string,
+  serverActionsEnabled?: boolean,
 ) => Observable<Pair> = memoize(
-  (client: SanityClient, idPair: IdPair, _typeName: string): Observable<Pair> => {
+  (
+    client: SanityClient,
+    idPair: IdPair,
+    _typeName: string,
+    serverActionsEnabled?: boolean,
+  ): Observable<Pair> => {
     return new Observable<Pair>((subscriber) => {
-      const pair = checkoutPair(client, idPair)
+      const pair = checkoutPair(client, idPair, serverActionsEnabled)
       subscriber.next(pair)
 
       return pair.complete

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
@@ -17,11 +17,12 @@ export const operationArgs = memoize(
       client: SanityClient
       historyStore: HistoryStore
       schema: Schema
+      serverActionsEnabled?: boolean
     },
     idPair: IdPair,
     typeName: string,
   ): Observable<OperationArgs> => {
-    return snapshotPair(ctx.client, idPair, typeName).pipe(
+    return snapshotPair(ctx.client, idPair, typeName, !!ctx.serverActionsEnabled).pipe(
       switchMap((versions) =>
         combineLatest([versions.draft.snapshots$, versions.published.snapshots$]).pipe(
           map(

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -1,9 +1,10 @@
 /* eslint-disable max-nested-callbacks */
 import {type SanityClient} from '@sanity/client'
 import {type Schema} from '@sanity/types'
-import {asyncScheduler, defer, EMPTY, merge, type Observable, of, Subject} from 'rxjs'
+import {asyncScheduler, defer, EMPTY, merge, type Observable, of, Subject, timer} from 'rxjs'
 import {
   catchError,
+  concatMap,
   filter,
   groupBy,
   last,
@@ -55,12 +56,20 @@ const operationImpls = {
   restore,
 } as const
 
+//as we add server operations one by one, we can add them here
+const serverOperationImpls = {
+  ...operationImpls,
+}
+
 const execute = (
   operationName: keyof typeof operationImpls,
   operationArguments: OperationArgs,
   extraArgs: any[],
+  serverActionsEnabled?: boolean,
 ): Observable<any> => {
-  const operation = operationImpls[operationName]
+  const operation = serverActionsEnabled
+    ? serverOperationImpls[operationName]
+    : operationImpls[operationName]
   return defer(() =>
     merge(of(null), maybeObservable(operation.execute(operationArguments, ...extraArgs))),
   ).pipe(last())
@@ -115,7 +124,12 @@ interface IntermediaryError {
 
 /** @internal */
 export const operationEvents = memoize(
-  (ctx: {client: SanityClient; historyStore: HistoryStore; schema: Schema}) => {
+  (ctx: {
+    client: SanityClient
+    historyStore: HistoryStore
+    schema: Schema
+    serverActionsEnabled?: boolean
+  }) => {
     const result$: Observable<IntermediarySuccess | IntermediaryError> = operationCalls$.pipe(
       groupBy((op) => op.idPair.publishedId),
       mergeMap((groups$) =>
@@ -139,7 +153,14 @@ export const operationEvents = memoize(
                 ).pipe(filter(Boolean))
                 const ready$ = requiresConsistency ? isConsistent$.pipe(take(1)) : of(true)
                 return ready$.pipe(
-                  switchMap(() => execute(args.operationName, operationArguments, args.extraArgs)),
+                  switchMap(() =>
+                    execute(
+                      args.operationName,
+                      operationArguments,
+                      args.extraArgs,
+                      ctx.serverActionsEnabled,
+                    ),
+                  ),
                 )
               }),
               map((): IntermediarySuccess => ({type: 'success', args})),
@@ -158,6 +179,9 @@ export const operationEvents = memoize(
     const autoCommit$ = result$.pipe(
       filter((result) => result.type === 'success' && result.args.operationName === 'patch'),
       throttleTime(AUTOCOMMIT_INTERVAL, asyncScheduler, {leading: true, trailing: true}),
+      concatMap((result) =>
+        (window as any).SLOW ? timer(10000).pipe(map(() => result)) : of(result),
+      ),
       tap((result) => {
         emitOperation('commit', result.args.idPair, result.args.typeName, [])
       }),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -32,6 +32,7 @@ import {patch} from './operations/patch'
 import {publish} from './operations/publish'
 import {restore} from './operations/restore'
 import {unpublish} from './operations/unpublish'
+import {patch as serverPatch} from './serverOperations/patch'
 
 interface ExecuteArgs {
   operationName: keyof OperationsAPI
@@ -59,6 +60,7 @@ const operationImpls = {
 //as we add server operations one by one, we can add them here
 const serverOperationImpls = {
   ...operationImpls,
+  patch: serverPatch,
 }
 
 const execute = (

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
@@ -1,11 +1,11 @@
 import {type IdPair} from '../../types'
 import {emitOperation} from '../operationEvents'
+import {publish} from '../operations/publish'
 import {commit} from './commit'
 import {del} from './delete'
 import {discardChanges} from './discardChanges'
 import {duplicate} from './duplicate'
 import {patch} from './patch'
-import {publish} from './publish'
 import {restore} from './restore'
 import {type Operation, type OperationArgs, type OperationImpl, type OperationsAPI} from './types'
 import {unpublish} from './unpublish'
@@ -51,7 +51,7 @@ function wrap<ExtraArgs extends any[], DisabledReason extends string>(
 }
 
 export function createOperationsAPI(args: OperationArgs): OperationsAPI {
-  return {
+  const operationsAPI = {
     commit: wrap('commit', commit, args),
     delete: wrap('delete', del, args),
     del: wrap('delete', del, args),
@@ -62,4 +62,12 @@ export function createOperationsAPI(args: OperationArgs): OperationsAPI {
     duplicate: wrap('duplicate', duplicate, args),
     restore: wrap('restore', restore, args),
   }
+
+  //as we add server operations one by one, we can add them here
+  if (args.serverActionsEnabled) {
+    return {
+      ...operationsAPI,
+    }
+  }
+  return operationsAPI
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
@@ -1,6 +1,7 @@
 import {type IdPair} from '../../types'
 import {emitOperation} from '../operationEvents'
 import {publish} from '../operations/publish'
+import {patch as serverPatch} from '../serverOperations/patch'
 import {commit} from './commit'
 import {del} from './delete'
 import {discardChanges} from './discardChanges'
@@ -67,6 +68,7 @@ export function createOperationsAPI(args: OperationArgs): OperationsAPI {
   if (args.serverActionsEnabled) {
     return {
       ...operationsAPI,
+      patch: wrap('patch', serverPatch, args),
     }
   }
   return operationsAPI

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/types.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/types.ts
@@ -49,4 +49,5 @@ export interface OperationArgs {
   snapshots: {draft: null | SanityDocument; published: null | SanityDocument}
   draft: DocumentVersionSnapshots
   published: DocumentVersionSnapshots
+  serverActionsEnabled?: boolean
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/remoteSnapshots.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/remoteSnapshots.ts
@@ -14,8 +14,9 @@ export const remoteSnapshots = memoize(
     client: SanityClient,
     idPair: IdPair,
     typeName: string,
+    serverActionsEnabled: boolean,
   ): Observable<RemoteSnapshotVersionEvent> => {
-    return memoizedPair(client, idPair, typeName).pipe(
+    return memoizedPair(client, idPair, typeName, serverActionsEnabled).pipe(
       switchMap(({published, draft}) => merge(published.remoteSnapshot$, draft.remoteSnapshot$)),
     )
   },

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
@@ -1,0 +1,44 @@
+import {type OperationImpl} from '../operations/types'
+import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
+
+export const patch: OperationImpl<[patches: any[], initialDocument?: Record<string, any>]> = {
+  disabled: (): false => false,
+  execute: (
+    {schema, snapshots, idPair, draft, published, typeName},
+    patches = [],
+    initialDocument,
+  ): void => {
+    if (isLiveEditEnabled(schema, typeName)) {
+      // No drafting, so patch and commit the published document
+      const patchMutation = published.patch(patches)
+      // Note: if the document doesn't exist on the server yet, we need to create it first. We only want to do this if we can't see it locally
+      // if it's been deleted on the server we want that to become a mutation error when submitting.
+      const mutations = snapshots.published
+        ? patchMutation
+        : [
+            published.createIfNotExists({
+              _type: typeName,
+              ...initialDocument,
+            }),
+          ]
+      // No drafting, so patch and commit the published document
+      published.mutate(mutations)
+    } else {
+      const patchMutation = draft.patch(patches)
+      const mutations = snapshots.draft
+        ? patchMutation
+        : [
+            // If there's no draft, the user's edits will be based on the published document in the form in front of them
+            // so before patching it we need to make sure it's created based on the current published version first.
+            draft.createIfNotExists({
+              ...initialDocument,
+              ...snapshots.published,
+              _id: idPair.draftId,
+              _type: typeName,
+            }),
+            ...patchMutation,
+          ]
+      draft.mutate(mutations)
+    }
+  },
+}

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/snapshotPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/snapshotPair.ts
@@ -58,6 +58,7 @@ interface SnapshotPair {
   published: DocumentVersionSnapshots
 }
 
+/** @internal */
 export const snapshotPair = memoize(
   (
     client: SanityClient,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/snapshotPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/snapshotPair.ts
@@ -58,10 +58,14 @@ interface SnapshotPair {
   published: DocumentVersionSnapshots
 }
 
-/** @internal */
 export const snapshotPair = memoize(
-  (client: SanityClient, idPair: IdPair, typeName: string) => {
-    return memoizedPair(client, idPair, typeName).pipe(
+  (
+    client: SanityClient,
+    idPair: IdPair,
+    typeName: string,
+    serverActionsEnabled: boolean,
+  ): Observable<SnapshotPair> => {
+    return memoizedPair(client, idPair, typeName, serverActionsEnabled).pipe(
       map(({published, draft, transactionsPendingEvents$}): SnapshotPair => {
         return {
           transactionsPendingEvents$,
@@ -73,9 +77,14 @@ export const snapshotPair = memoize(
       refCount(),
     )
   },
-  (client, idPair, typeName) => {
+  (
+    client: SanityClient,
+    idPair: IdPair,
+    typeName: string,
+    serverActionsEnabled: boolean,
+  ): string => {
     const config = client.config()
 
-    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}`
+    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}-${serverActionsEnabled}`
   },
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-store.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-store.ts
@@ -113,8 +113,7 @@ export function createDocumentStore({
   return {
     // Public API
     checkoutPair(idPair) {
-      // console.log('checkoutPair', serverActionsEnabled)
-      return checkoutPair(client, idPair)
+      return checkoutPair(client, idPair, serverActionsEnabled)
     },
     initialValue(opts, context) {
       return getInitialValueStream(
@@ -133,7 +132,12 @@ export function createDocumentStore({
     },
     pair: {
       consistencyStatus(publishedId, type) {
-        return consistencyStatus(ctx.client, getIdPairFromPublished(publishedId), type)
+        return consistencyStatus(
+          ctx.client,
+          getIdPairFromPublished(publishedId),
+          type,
+          serverActionsEnabled,
+        )
       },
       documentEvents(publishedId, type) {
         return documentEvents(ctx.client, getIdPairFromPublished(publishedId), type)

--- a/packages/sanity/src/core/store/_legacy/document/document-store.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-store.ts
@@ -80,6 +80,7 @@ export interface DocumentStoreOptions {
   schema: Schema
   initialValueTemplates: Template[]
   i18n: LocaleSource
+  serverActionsEnabled?: boolean
 }
 
 /** @internal */
@@ -90,6 +91,7 @@ export function createDocumentStore({
   initialValueTemplates,
   schema,
   i18n,
+  serverActionsEnabled = false,
 }: DocumentStoreOptions): DocumentStore {
   const observeDocumentPairAvailability =
     documentPreviewStore.unstable_observeDocumentPairAvailability
@@ -98,11 +100,20 @@ export function createDocumentStore({
   // internal operations, and a `getClient` method that we expose to user-land
   // for things like validations
   const client = getClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
-  const ctx = {client, getClient, observeDocumentPairAvailability, historyStore, schema, i18n}
+  const ctx = {
+    client,
+    getClient,
+    observeDocumentPairAvailability,
+    historyStore,
+    schema,
+    i18n,
+    serverActionsEnabled,
+  }
 
   return {
     // Public API
     checkoutPair(idPair) {
+      // console.log('checkoutPair', serverActionsEnabled)
       return checkoutPair(client, idPair)
     },
     initialValue(opts, context) {
@@ -134,7 +145,7 @@ export function createDocumentStore({
         return editState(ctx, getIdPairFromPublished(publishedId), type)
       },
       operationEvents(publishedId, type) {
-        return operationEvents({client, historyStore, schema}).pipe(
+        return operationEvents({client, historyStore, schema, serverActionsEnabled}).pipe(
           filter(
             (result) =>
               result.args.idPair.publishedId === publishedId && result.args.typeName === type,

--- a/packages/sanity/src/core/store/_legacy/document/getPairListener.ts
+++ b/packages/sanity/src/core/store/_legacy/document/getPairListener.ts
@@ -2,7 +2,7 @@
 import {type SanityClient} from '@sanity/client'
 import {type SanityDocument} from '@sanity/types'
 import {groupBy} from 'lodash'
-import {defer, type Observable, of as observableOf} from 'rxjs'
+import {defer, type Observable, of as observableOf, of, timer} from 'rxjs'
 import {concatMap, map, mergeMap, scan} from 'rxjs/operators'
 
 import {
@@ -124,6 +124,9 @@ export function getPairListener(
     ),
     // note: this flattens the array, and in the case of an empty array, no event will be pushed downstream
     mergeMap((v) => v.next),
+    concatMap((result) =>
+      (window as any).SLOW ? timer(10000).pipe(map(() => result)) : of(result),
+    ),
   )
 
   function fetchInitialDocumentSnapshots(): Observable<Snapshots> {

--- a/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
+++ b/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
@@ -17,6 +17,7 @@ import {
   type SelectionState,
   type TimelineController,
   useHistoryStore,
+  useWorkspace,
 } from '../../..'
 import {useClient} from '../../../hooks'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
@@ -100,6 +101,9 @@ export function useTimelineStore({
   const snapshotsSubscriptionRef = useRef<Subscription | null>(null)
   const timelineStateRef = useRef<TimelineState>(INITIAL_TIMELINE_STATE)
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  const workspace = useWorkspace()
+
+  const serverActionsEnabled = useMemo(() => !!workspace.serverActions?.enabled, [workspace])
 
   /**
    * The mutable TimelineController, used internally
@@ -166,6 +170,7 @@ export function useTimelineStore({
         client,
         {draftId: `drafts.${documentId}`, publishedId: documentId},
         documentType,
+        serverActionsEnabled,
       ).subscribe((ev: RemoteSnapshotVersionEvent) => {
         controller.handleRemoteMutation(ev)
       })
@@ -176,7 +181,7 @@ export function useTimelineStore({
         snapshotsSubscriptionRef.current = null
       }
     }
-  }, [client, controller, documentId, documentType])
+  }, [client, controller, documentId, documentType, serverActionsEnabled])
 
   const timelineStore = useMemo(() => {
     return {


### PR DESCRIPTION
### Description
After some discussion, we decided that it would be beneficial to be able to internally use document actions in the studio sooner rather than later, to be able to dogfood and detect errors.

This PR adds a parameter to studio config to enable server actions.
It changes the datastores invocation of documentStore to read from the workspace, and pass that parameter down.
Within the document store, it will pass that parameter to various functions that change behavior.

The most dramatic changes were needed in checkoutPair, which is used in many places, and is sometimes memoized or consumed as `snapshotPair`.

All of these changes are temporary and should be removed once these APIs become permanent.

It also includes @bjoerge 's changes from #6116, since that refactored checkoutPair and necessitated the bulk of these changes. Including it also allows for easy testing. If we'd like the PR to be "clean" and only enable the flag and different code paths, please let me know and I can remove it.

### What to review
The various changed files. To test locally, pull down the branch and uncomment the `unstable_serverActions` line in the sanity.config.ts in the test studio. Open your network calls and go to a new or old document and start making edits. You should see changes going to the /actions endpoint.

### Testing
Unit tests are being set in a separate PR, and should test which endpoint/payload is being used.