### PR TITLE
fix(cli): use stub file loader for scss, sass extensions

### DIFF
--- a/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
+++ b/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
@@ -120,17 +120,19 @@ function tryGetAceGlobal(basePath: string) {
 
 function getFileExtensions() {
   return [
+    '.css',
+    '.eot',
+    '.gif',
     '.jpeg',
     '.jpg',
+    '.otf',
     '.png',
-    '.gif',
+    '.sass',
+    '.scss',
     '.svg',
+    '.ttf',
     '.webp',
     '.woff',
     '.woff2',
-    '.ttf',
-    '.eot',
-    '.otf',
-    '.css',
   ]
 }


### PR DESCRIPTION
### Description

The mocked browser environment that we use for commands that need access to the schema did not have a stub loader for the SCSS and SASS file extensions. While not super common, if they are used in a dependency, they will currently crash.

This PR uses the stub loader for these file extensions, which just returns an empty object as the imported module. 

### Testing

There currently aren't any tests for the browser environment, and we're wanting to pursue something like [vite-node](https://www.npmjs.com/package/vite-node) to see if we can more closely resemble the environment that we have in the browser long term. In the meantime, I will not spend time adding tests for this since we already know this approach works for other extensions, such as `.css`.

### Notes for release

- Fixes an issue where importing `.scss` or `.sass` files from the studio configuration or a descendant of it would crash certain CLI commands
