### PR TITLE
fix(core): reset global search results when `SEARCH_REQUEST_COMPLETE` occurs after any action causing search parameters to change

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.test.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.test.ts
@@ -5,7 +5,12 @@ import {useReducer} from 'react'
 
 import {type RecentSearch} from '../../datastores/recentSearches'
 import {type SearchOrdering} from '../../types'
-import {initialSearchState, searchReducer, type SearchReducerState} from './reducer'
+import {
+  initialSearchState,
+  type SearchAction,
+  searchReducer,
+  type SearchReducerState,
+} from './reducer'
 
 const mockUser: CurrentUser = {
   id: 'mock-user',
@@ -187,168 +192,109 @@ Array [
   })
 })
 
-it('should reset results after search term changes', () => {
-  const {result} = renderHook(() => useReducer(searchReducer, initialState))
-  const [, dispatch] = result.current
-
-  act(() =>
-    dispatch({
-      type: 'TERMS_QUERY_SET',
-      query: 'test query a',
-    }),
-  )
-
-  act(() =>
-    dispatch({
-      type: 'SEARCH_REQUEST_COMPLETE',
-      nextCursor: 'cursorA',
-      hits: [
-        {
-          hit: {
-            _type: 'person',
-            _id: 'personA',
-          },
-        },
-        {
-          hit: {
-            _type: 'person',
-            _id: 'personB',
-          },
-        },
-      ],
-    }),
-  )
-
-  const [stateA] = result.current
-
-  expect(stateA.result.hits).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "hit": Object {
-      "_id": "personA",
-      "_type": "person",
+it.each<SearchAction>([
+  {
+    type: 'SEARCH_CLEAR',
+  },
+  {
+    type: 'TERMS_QUERY_SET',
+    query: 'test query b',
+  },
+  {
+    type: 'TERMS_SET',
+    terms: {
+      query: 'test',
+      types: [],
     },
   },
-  Object {
-    "hit": Object {
-      "_id": "personB",
-      "_type": "person",
-    },
-  },
-]
-`)
-
-  act(() =>
-    dispatch({
-      type: 'TERMS_QUERY_SET',
-      query: 'test query b',
-    }),
-  )
-
-  act(() =>
-    dispatch({
-      type: 'SEARCH_REQUEST_COMPLETE',
-      nextCursor: undefined,
-      hits: [
-        {
-          hit: {
-            _type: 'person',
-            _id: 'personB',
-          },
-        },
-        {
-          hit: {
-            _type: 'person',
-            _id: 'personC',
-          },
-        },
-      ],
-    }),
-  )
-
-  const [stateB] = result.current
-
-  expect(stateB.result.hits).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "hit": Object {
-      "_id": "personB",
-      "_type": "person",
-    },
-  },
-  Object {
-    "hit": Object {
-      "_id": "personC",
-      "_type": "person",
-    },
-  },
-]
-`)
-})
-
-it('should reset results after ordering changes', () => {
-  const {result} = renderHook(() => useReducer(searchReducer, initialState))
-  const [, dispatch] = result.current
-
-  act(() =>
-    dispatch({
-      type: 'TERMS_QUERY_SET',
-      query: 'test query a',
-    }),
-  )
-
-  act(() =>
-    dispatch({
-      type: 'SEARCH_REQUEST_COMPLETE',
-      nextCursor: 'cursorA',
-      hits: [
-        {
-          hit: {
-            _type: 'person',
-            _id: 'personA',
-          },
-        },
-        {
-          hit: {
-            _type: 'person',
-            _id: 'personB',
-          },
-        },
-      ],
-    }),
-  )
-
-  const [stateA] = result.current
-
-  expect(stateA.result.hits).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "hit": Object {
-      "_id": "personA",
-      "_type": "person",
-    },
-  },
-  Object {
-    "hit": Object {
-      "_id": "personB",
-      "_type": "person",
-    },
-  },
-]
-`)
-
-  act(() =>
-    dispatch({
-      type: 'ORDERING_SET',
-      ordering: {
-        titleKey: 'search.ordering.test-label',
-        sort: {
-          field: '_createdAt',
-          direction: 'desc',
-        },
+  {
+    type: 'ORDERING_SET',
+    ordering: {
+      titleKey: 'search.ordering.test-label',
+      sort: {
+        field: '_createdAt',
+        direction: 'desc',
       },
+    },
+  },
+  {
+    type: 'ORDERING_RESET',
+  },
+  {
+    type: 'TERMS_FILTERS_ADD',
+    filter: {
+      filterName: 'test',
+      operatorType: 'test',
+    },
+  },
+  {
+    type: 'TERMS_FILTERS_REMOVE',
+    filterKey: 'test',
+  },
+  {
+    type: 'TERMS_FILTERS_SET_OPERATOR',
+    filterKey: 'test',
+    operatorType: 'test',
+  },
+  {
+    type: 'TERMS_FILTERS_SET_VALUE',
+    filterKey: 'test',
+  },
+  {
+    type: 'TERMS_FILTERS_CLEAR',
+  },
+])('should reset results when SEARCH_REQUEST_COMPLETE occurs after $type', async (action) => {
+  const {result} = renderHook(() => useReducer(searchReducer, initialState))
+  const [, dispatch] = result.current
+
+  act(() =>
+    dispatch({
+      type: 'TERMS_QUERY_SET',
+      query: 'test query a',
     }),
   )
+
+  act(() =>
+    dispatch({
+      type: 'SEARCH_REQUEST_COMPLETE',
+      nextCursor: 'cursorA',
+      hits: [
+        {
+          hit: {
+            _type: 'person',
+            _id: 'personA',
+          },
+        },
+        {
+          hit: {
+            _type: 'person',
+            _id: 'personB',
+          },
+        },
+      ],
+    }),
+  )
+
+  const [stateA] = result.current
+
+  expect(stateA.result.hits).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "hit": Object {
+      "_id": "personA",
+      "_type": "person",
+    },
+  },
+  Object {
+    "hit": Object {
+      "_id": "personB",
+      "_type": "person",
+    },
+  },
+]
+`)
+
+  act(() => dispatch(action))
 
   act(() =>
     dispatch({

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.ts
@@ -175,6 +175,10 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
         ...state,
         ordering: ORDERINGS.relevance,
         terms: stripRecent(state.terms),
+        result: {
+          ...state.result,
+          hasLocal: false,
+        },
       }
     case 'ORDERING_SET':
       return {
@@ -263,6 +267,10 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
             operatorDefinitions: state.definitions.operators,
           }),
         },
+        result: {
+          ...state.result,
+          hasLocal: false,
+        },
       }
     }
     case 'TERMS_FILTERS_CLEAR': {
@@ -284,6 +292,10 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
             filters,
             operatorDefinitions: state.definitions.operators,
           }),
+        },
+        result: {
+          ...state.result,
+          hasLocal: false,
         },
       }
     }
@@ -311,6 +323,10 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
             filters,
             operatorDefinitions: state.definitions.operators,
           }),
+        },
+        result: {
+          ...state.result,
+          hasLocal: false,
         },
       }
     }
@@ -351,6 +367,10 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
             operatorDefinitions: state.definitions.operators,
           }),
         },
+        result: {
+          ...state.result,
+          hasLocal: false,
+        },
       }
     }
     case 'TERMS_FILTERS_SET_VALUE': {
@@ -375,6 +395,10 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
             filters,
             operatorDefinitions: state.definitions.operators,
           }),
+        },
+        result: {
+          ...state.result,
+          hasLocal: false,
         },
       }
     }


### PR DESCRIPTION
### Description

After a global search request completes, the reducer will either merge or replace the existing results held in state:

1. If the search parameters have changed (e.g. query, filter, or order), that means a different search has been performed. The results are replaced.
2. If the search parameters haven't changed, that means a subsequent page of results has been fetched for the current search parameters. The results are merged.

This is handled by setting `result.hasLocal` to `true` (if the results should be merged) or `false` (if the results should be replaced).

There are currently some instances of scenario 1 that we don't account for. This branch ensures `result.hasLocal` is set to `false` when any action is dispatched that changes the search parameters. Without this change, there are some actions (such as changing search filters) that will cause a new search API request to be executed, but will not have any effect on the results shown in the UI.

The only reason this isn't a widely reported problem at the moment is that it only impact the Text Search API search strategy (because it's the only search strategy that provides pagination), which hasn't rolled out yet.

**We should merge this prior to the Text Search API strategy rollout.**

### What to review

When _changing_ global search parameters (ordering or filtering), changes to the result set should always be reflected in the UI. First execute a search. After results appear, try reversing the ordering; the results shown in the UI should always change.

### Testing

Added tests to `packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.test.ts`.