### PR TITLE
fix(cli): formalize requirement of styled-components@6 and @sanity/ui@2

### DIFF
--- a/packages/@sanity/cli/src/studioDependencies.ts
+++ b/packages/@sanity/cli/src/studioDependencies.ts
@@ -10,7 +10,6 @@ export const studioDependencies = {
     // Non-Sanity dependencies
     react: '^18.2.0',
     'react-dom': '^18.2.0',
-    'react-is': '^18.2.0', // Peer dependency of styled-components
     'styled-components': '^6.0.7',
   },
 

--- a/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
+++ b/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
@@ -20,6 +20,8 @@ interface PackageInfo {
 const PACKAGES = [
   {name: 'react', supported: ['^18'], deprecatedBelow: null},
   {name: 'react-dom', supported: ['^18'], deprecatedBelow: null},
+  {name: 'styled-components', supported: ['^6'], deprecatedBelow: null},
+  {name: '@sanity/ui', supported: ['^2'], deprecatedBelow: null},
 ]
 
 export function checkStudioDependencyVersions(workDir: string): void {


### PR DESCRIPTION
### Description

This formalizes the requirement of using `styled-components@6.x` and `@sanity/ui@2.x` by showing an error on sanity start if the studio project depends on incompatible versions of these. The error will include a link to a help article explaining more in-depth details about how to upgrade.

### What to review
Any downside to making this move? We have been "soft requiring" these versions for a while, and you could make the argument that we should have added these sooner :)

### Testing
n/a

### Notes for release

- Formalize requirement of styled-components@6 and @sanity/ui@2.