### PR TITLE
fix(tasks): change tasks button in nav to be toggle

### DIFF
--- a/packages/sanity/src/tasks/plugin/TasksStudioNavbar.tsx
+++ b/packages/sanity/src/tasks/plugin/TasksStudioNavbar.tsx
@@ -1,5 +1,5 @@
 import {PanelRightIcon, TaskIcon} from '@sanity/icons'
-import {useMemo} from 'react'
+import {useCallback, useMemo} from 'react'
 import {type NavbarProps, useTranslation} from 'sanity'
 
 import {tasksLocaleNamespace} from '../i18n'
@@ -10,10 +10,19 @@ const EMPTY_ARRAY: [] = []
 function TasksStudioNavbarInner(props: NavbarProps) {
   const {
     handleOpenTasks,
+    handleCloseTasks,
     state: {isOpen},
   } = useTasksNavigation()
 
   const {t} = useTranslation(tasksLocaleNamespace)
+
+  const handleClick = useCallback(() => {
+    if (isOpen) {
+      handleCloseTasks()
+    } else {
+      handleOpenTasks()
+    }
+  }, [isOpen, handleOpenTasks, handleCloseTasks])
 
   const actions = useMemo((): NavbarProps['__internal_actions'] => {
     return [
@@ -22,7 +31,7 @@ function TasksStudioNavbarInner(props: NavbarProps) {
         icon: PanelRightIcon,
         location: 'topbar',
         name: 'tasks-topbar',
-        onAction: handleOpenTasks,
+        onAction: handleClick,
         selected: isOpen,
         title: t('actions.open.text'),
       },
@@ -30,12 +39,12 @@ function TasksStudioNavbarInner(props: NavbarProps) {
         icon: TaskIcon,
         location: 'sidebar',
         name: 'tasks-sidebar',
-        onAction: handleOpenTasks,
+        onAction: handleClick,
         selected: isOpen,
         title: t('actions.open.text'),
       },
     ]
-  }, [handleOpenTasks, isOpen, props?.__internal_actions, t])
+  }, [handleClick, isOpen, props?.__internal_actions, t])
 
   return props.renderDefault({
     ...props,


### PR DESCRIPTION
### Description

Change tasks button in nav to be toggle.
Clicking the task button should open the tasks sidebar if it's closed and should close it if it's open.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
