### PR TITLE
refactor(renovate): ignore `slate` and `slate-react` as they're bumped manually

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,11 @@
   ],
   "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
   "packageRules": [
+     {
+      "description": "Slate upgrades are handled manually as they require extensive manual testing to verify it's safe to upgrade",
+      "matchPackageNames": ["slate", "slate-react"],
+      "enabled": false
+    },
     {
       "description": "Dependency updates to examples and the root should always use the chore scope as they aren't published to npm",
       "matchFileNames": ["package.json", "dev/**/package.json", "examples/**/package.json"],


### PR DESCRIPTION
Closes #6223