### PR TITLE
fix(structure): prevent duplication of search filters when `listenSearchQuery` is used (e.g. in document lists)

### DIFF
--- a/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
+++ b/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
@@ -117,7 +117,6 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Sanit
 
           const doFetch = () => {
             const searchTerms = {
-              filter,
               query: searchQuery || '',
               types,
             }


### PR DESCRIPTION
### Description

Both the `createSearch` factory and the returned `search` function accept a `filter` option. These filters are additive (joined together using the `&&` operator). We were accidentally providing the same filter to both functions, causing it to be needlessly duplicated in the produced search request.

### What to review

Document list filtering and search works the same way as before, but the produced search request no longer contains duplicated filters.

### Testing

We do not have tests for the `listenSearchQuery` function at the moment. Given this is a very limited change, I've not invested in adding a test suite at this point in time.