### PR TITLE
feat(core): make PTE resizable

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
@@ -7,8 +7,17 @@ import {css, styled} from 'styled-components'
 import {ScrollContainer} from '../../../components/scroll'
 import {createListName, TEXT_LEVELS} from './text'
 
-export const Root = styled(Card)<{$fullscreen: boolean}>`
-  height: ${({$fullscreen}) => ($fullscreen ? '100%' : '19em')};
+export const Root = styled(Card)`
+  &[data-fullscreen='true'] {
+    height: 100%;
+  }
+
+  &[data-fullscreen='false'] {
+    min-height: 5em;
+    resize: vertical;
+    overflow: auto;
+    height: 19em;
+  }
 
   &:not([hidden]) {
     display: flex;

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -189,7 +189,7 @@ export function Editor(props: EditorProps) {
   const collapsibleToolbar = id === FORM_BUILDER_DEFAULT_ID
 
   return (
-    <Root $fullscreen={isFullscreen} data-testid="pt-editor">
+    <Root data-fullscreen={isFullscreen} data-testid="pt-editor">
       {isActive && (
         <TooltipDelayGroupProvider>
           <ToolbarCard data-testid="pt-editor__toolbar-card" shadow={1}>


### PR DESCRIPTION
### Description

This pull request makes the PTE resizable in non-fullscreen mode.

<img width="605" alt="Screenshot 2024-04-08 at 15 33 45" src="https://github.com/sanity-io/sanity/assets/15094168/65ac9e89-67ce-4a6c-827b-d78bc52c9d81">

### What to review

- Make sure resizing the editor works

### Notes for release

Make the Portable Text Editor resizable
