### PR TITLE
feat(tasks): add feedback link to tasks

### DIFF
--- a/packages/sanity/src/tasks/i18n/resources.ts
+++ b/packages/sanity/src/tasks/i18n/resources.ts
@@ -125,10 +125,8 @@ const tasksLocaleStrings = defineLocalesResources('tasks', {
   'form.status.success': 'Task created',
   /** The text displayed when no tasks are found */
   'list.empty.text': 'No tasks',
-  /** The text for the link displayed at the bottom of the tasks list inviting users provide feedback */
-  'list.feedback.link': 'share feedback on Tasks',
   /** The text displayed at the bottom of the tasks list inviting users provide feedback */
-  'list.feedback.text': 'Help us improve, ',
+  'list.feedback.text': 'Help us improve, <Link>share feedback on Tasks</Link> ',
   /** The label for the copy link menu item */
   'menuitem.copylink.text': 'Copy link to task',
   /** The label for the delete task menu item */

--- a/packages/sanity/src/tasks/i18n/resources.ts
+++ b/packages/sanity/src/tasks/i18n/resources.ts
@@ -125,6 +125,10 @@ const tasksLocaleStrings = defineLocalesResources('tasks', {
   'form.status.success': 'Task created',
   /** The text displayed when no tasks are found */
   'list.empty.text': 'No tasks',
+  /** The text for the link displayed at the bottom of the tasks list inviting users provide feedback */
+  'list.feedback.link': 'share feedback on Tasks',
+  /** The text displayed at the bottom of the tasks list inviting users provide feedback */
+  'list.feedback.text': 'Help us improve, ',
   /** The label for the copy link menu item */
   'menuitem.copylink.text': 'Copy link to task',
   /** The label for the delete task menu item */

--- a/packages/sanity/src/tasks/src/tasks/components/sidebar/TaskListFeedbackFooter.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/sidebar/TaskListFeedbackFooter.tsx
@@ -1,6 +1,6 @@
 import {LaunchIcon} from '@sanity/icons'
 import {Box, Text} from '@sanity/ui'
-import {useTranslation} from 'sanity'
+import {Translate, useTranslation} from 'sanity'
 import {styled} from 'styled-components'
 
 import {tasksLocaleNamespace} from '../../../../i18n'
@@ -18,15 +18,20 @@ const Link = styled.a`
   }
 `
 
+function LinkComponent(props: {children?: React.ReactNode}) {
+  return (
+    <Link href={FEEDBACK_FORM_LINK} target="_blank" rel="noreferrer">
+      <Span>{props.children}</Span> <LaunchIcon />
+    </Link>
+  )
+}
+
 export function TasksListFeedbackFooter() {
   const {t} = useTranslation(tasksLocaleNamespace)
   return (
     <Box padding={4}>
       <Text muted size={1}>
-        {t('list.feedback.text')}{' '}
-        <Link href={FEEDBACK_FORM_LINK} target="_blank" rel="noreferrer">
-          <Span>{t('list.feedback.link')} </Span> <LaunchIcon />
-        </Link>
+        <Translate i18nKey="list.feedback.text" t={t} components={{Link: LinkComponent}} />
       </Text>
     </Box>
   )

--- a/packages/sanity/src/tasks/src/tasks/components/sidebar/TaskListFeedbackFooter.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/sidebar/TaskListFeedbackFooter.tsx
@@ -1,0 +1,33 @@
+import {LaunchIcon} from '@sanity/icons'
+import {Box, Text} from '@sanity/ui'
+import {useTranslation} from 'sanity'
+import {styled} from 'styled-components'
+
+import {tasksLocaleNamespace} from '../../../../i18n'
+
+const FEEDBACK_FORM_LINK = 'https://snty.link/tasks-feedback'
+
+const Span = styled.span`
+  margin-right: 0.2em;
+`
+
+const Link = styled.a`
+  white-space: nowrap;
+  > [data-sanity-icon] {
+    --card-icon-color: var(--card-link-color);
+  }
+`
+
+export function TasksListFeedbackFooter() {
+  const {t} = useTranslation(tasksLocaleNamespace)
+  return (
+    <Box padding={4}>
+      <Text muted size={1}>
+        {t('list.feedback.text')}{' '}
+        <Link href={FEEDBACK_FORM_LINK} target="_blank" rel="noreferrer">
+          <Span>{t('list.feedback.link')} </Span> <LaunchIcon />
+        </Link>
+      </Text>
+    </Box>
+  )
+}

--- a/packages/sanity/src/tasks/src/tasks/components/sidebar/TasksSidebar.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/sidebar/TasksSidebar.tsx
@@ -7,6 +7,7 @@ import {useTasks, useTasksEnabled, useTasksNavigation} from '../../context'
 import {TasksFormBuilder} from '../form'
 import {TasksList} from '../list/TasksList'
 import {TasksUpsellPanel} from '../upsell/TasksUpsellPanel'
+import {TasksListFeedbackFooter} from './TaskListFeedbackFooter'
 import {TasksListTabs} from './TasksListTabs'
 import {TasksSidebarHeader} from './TasksSidebarHeader'
 
@@ -96,6 +97,7 @@ export function TasksStudioSidebarInner() {
       >
         {content}
       </ContentFlex>
+      {viewMode === 'list' && <TasksListFeedbackFooter />}
     </RootCard>
   )
 }


### PR DESCRIPTION
### Description

Adds feedback link to tasks. Inviting users to add feedback on how we can improve.

![tasks feedback footer](https://github.com/sanity-io/sanity/assets/46196328/c678da62-f494-4d8c-a18a-47dafe0bf434)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
