### PR TITLE
feat(core): adopt Actions API

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -34,6 +34,7 @@ import {restore} from './operations/restore'
 import {unpublish} from './operations/unpublish'
 import {patch as serverPatch} from './serverOperations/patch'
 import {publish as serverPublish} from './serverOperations/publish'
+import {unpublish as serverUnpublish} from './serverOperations/unpublish'
 
 interface ExecuteArgs {
   operationName: keyof OperationsAPI
@@ -63,6 +64,7 @@ const serverOperationImpls = {
   ...operationImpls,
   patch: serverPatch,
   publish: serverPublish,
+  unpublish: serverUnpublish,
 }
 
 const execute = (

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -32,6 +32,7 @@ import {patch} from './operations/patch'
 import {publish} from './operations/publish'
 import {restore} from './operations/restore'
 import {unpublish} from './operations/unpublish'
+import {del as serverDel} from './serverOperations/delete'
 import {patch as serverPatch} from './serverOperations/patch'
 import {publish as serverPublish} from './serverOperations/publish'
 import {unpublish as serverUnpublish} from './serverOperations/unpublish'
@@ -62,6 +63,8 @@ const operationImpls = {
 //as we add server operations one by one, we can add them here
 const serverOperationImpls = {
   ...operationImpls,
+  del: serverDel,
+  delete: serverDel,
   patch: serverPatch,
   publish: serverPublish,
   unpublish: serverUnpublish,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -33,6 +33,7 @@ import {publish} from './operations/publish'
 import {restore} from './operations/restore'
 import {unpublish} from './operations/unpublish'
 import {patch as serverPatch} from './serverOperations/patch'
+import {publish as serverPublish} from './serverOperations/publish'
 
 interface ExecuteArgs {
   operationName: keyof OperationsAPI
@@ -61,6 +62,7 @@ const operationImpls = {
 const serverOperationImpls = {
   ...operationImpls,
   patch: serverPatch,
+  publish: serverPublish,
 }
 
 const execute = (

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
@@ -3,6 +3,7 @@ import {emitOperation} from '../operationEvents'
 import {publish} from '../operations/publish'
 import {patch as serverPatch} from '../serverOperations/patch'
 import {publish as serverPublish} from '../serverOperations/publish'
+import {unpublish as serverUnpublish} from '../serverOperations/unpublish'
 import {commit} from './commit'
 import {del} from './delete'
 import {discardChanges} from './discardChanges'
@@ -71,6 +72,7 @@ export function createOperationsAPI(args: OperationArgs): OperationsAPI {
       ...operationsAPI,
       patch: wrap('patch', serverPatch, args),
       publish: wrap('publish', serverPublish, args),
+      unpublish: wrap('unpublish', serverUnpublish, args),
     }
   }
   return operationsAPI

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
@@ -2,6 +2,7 @@ import {type IdPair} from '../../types'
 import {emitOperation} from '../operationEvents'
 import {publish} from '../operations/publish'
 import {patch as serverPatch} from '../serverOperations/patch'
+import {publish as serverPublish} from '../serverOperations/publish'
 import {commit} from './commit'
 import {del} from './delete'
 import {discardChanges} from './discardChanges'
@@ -69,6 +70,7 @@ export function createOperationsAPI(args: OperationArgs): OperationsAPI {
     return {
       ...operationsAPI,
       patch: wrap('patch', serverPatch, args),
+      publish: wrap('publish', serverPublish, args),
     }
   }
   return operationsAPI

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
@@ -1,6 +1,7 @@
 import {type IdPair} from '../../types'
 import {emitOperation} from '../operationEvents'
 import {publish} from '../operations/publish'
+import {del as serverDel} from '../serverOperations/delete'
 import {patch as serverPatch} from '../serverOperations/patch'
 import {publish as serverPublish} from '../serverOperations/publish'
 import {unpublish as serverUnpublish} from '../serverOperations/unpublish'
@@ -70,6 +71,8 @@ export function createOperationsAPI(args: OperationArgs): OperationsAPI {
   if (args.serverActionsEnabled) {
     return {
       ...operationsAPI,
+      delete: wrap('delete', serverDel, args),
+      del: wrap('delete', serverDel, args),
       patch: wrap('patch', serverPatch, args),
       publish: wrap('publish', serverPublish, args),
       unpublish: wrap('unpublish', serverUnpublish, args),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/delete.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/delete.ts
@@ -1,0 +1,29 @@
+import {type OperationImpl} from '../operations/types'
+
+export const del: OperationImpl<[], 'NOTHING_TO_DELETE'> = {
+  disabled: ({snapshots}) => (snapshots.draft || snapshots.published ? false : 'NOTHING_TO_DELETE'),
+  execute: ({client: globalClient, schema, idPair, typeName}) => {
+    const vXClient = globalClient.withConfig({apiVersion: 'X'})
+
+    const {dataset} = globalClient.config()
+
+    return vXClient.observable.request({
+      url: `/data/actions/${dataset}`,
+      method: 'post',
+      tag: 'document.delete',
+      // this disables referential integrity for cross-dataset references. we
+      // have this set because we warn against deletes in the `ConfirmDeleteDialog`
+      // UI. This operation is run when "delete anyway" is clicked
+      query: {skipCrossDatasetReferenceValidation: 'true'},
+      body: {
+        actions: [
+          {
+            actionType: 'sanity.action.document.delete',
+            draftId: idPair.draftId,
+            publishedId: idPair.publishedId,
+          },
+        ],
+      },
+    })
+  },
+}

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.ts
@@ -1,0 +1,35 @@
+import {type OperationImpl} from '../operations/index'
+import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
+
+type DisabledReason = 'LIVE_EDIT_ENABLED' | 'ALREADY_PUBLISHED' | 'NO_CHANGES'
+
+export const publish: OperationImpl<[], DisabledReason> = {
+  disabled: ({schema, typeName, snapshots}) => {
+    if (isLiveEditEnabled(schema, typeName)) {
+      return 'LIVE_EDIT_ENABLED'
+    }
+    if (!snapshots.draft) {
+      return snapshots.published ? 'ALREADY_PUBLISHED' : 'NO_CHANGES'
+    }
+    return false
+  },
+  execute: ({client: globalClient, idPair}) => {
+    const vXClient = globalClient.withConfig({apiVersion: 'X'})
+    const {dataset} = globalClient.config()
+
+    return vXClient.observable.request({
+      url: `/data/actions/${dataset}`,
+      method: 'post',
+      tag: 'document.publish',
+      body: {
+        actions: [
+          {
+            actionType: 'sanity.action.document.publish',
+            draftId: idPair.draftId,
+            publishedId: idPair.publishedId,
+          },
+        ],
+      },
+    })
+  },
+}

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/unpublish.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/unpublish.ts
@@ -1,0 +1,36 @@
+import {type OperationImpl} from '../operations/types'
+import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
+
+type DisabledReason = 'LIVE_EDIT_ENABLED' | 'NOT_PUBLISHED'
+
+export const unpublish: OperationImpl<[], DisabledReason> = {
+  disabled: ({schema, snapshots, typeName}) => {
+    if (isLiveEditEnabled(schema, typeName)) {
+      return 'LIVE_EDIT_ENABLED'
+    }
+    return snapshots.published ? false : 'NOT_PUBLISHED'
+  },
+  execute: ({client: globalClient, idPair}) => {
+    const vXClient = globalClient.withConfig({apiVersion: 'X'})
+    const {dataset} = globalClient.config()
+
+    return vXClient.observable.request({
+      url: `/data/actions/${dataset}`,
+      method: 'post',
+      // this disables referential integrity for cross-dataset references. we
+      // have this set because we warn against unpublishes in the `ConfirmDeleteDialog`
+      // UI. This operation is run when "unpublish anyway" is clicked
+      query: {skipCrossDatasetReferenceValidation: 'true'},
+      tag: 'document.unpublish',
+      body: {
+        actions: [
+          {
+            actionType: 'sanity.action.document.unpublish',
+            draftId: idPair.draftId,
+            publishedId: idPair.publishedId,
+          },
+        ],
+      },
+    })
+  },
+}

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
@@ -75,7 +75,7 @@ export const FormHeader = ({documentId, schemaType, title}: DocumentHeaderProps)
         </Text>
       )}
 
-      <Heading as="h2" data-heading muted={!title}>
+      <Heading as="h2" data-heading muted={!title} data-testid="document-panel-document-title">
         {title ?? t('document-view.form-view.form-title-fallback')}
       </Heading>
     </TitleContainer>

--- a/test/e2e/tests/document-actions/publish.spec.ts
+++ b/test/e2e/tests/document-actions/publish.spec.ts
@@ -1,0 +1,22 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+test(`document panel displays correct title for published document`, async ({
+  page,
+  createDraftDocument,
+}) => {
+  const title = 'Test Title'
+
+  await createDraftDocument('/test/content/book')
+  await page.getByTestId('field-title').getByTestId('string-input').fill(title)
+
+  // Ensure the correct title is displayed before publishing.
+  await expect(page.getByTestId('document-panel-document-title')).toHaveText(title)
+
+  // Wait for the document to be published.
+  page.getByTestId('action-Publish').click()
+  await expect(page.getByText('Published just now')).toBeVisible()
+
+  // Ensure the correct title is displayed after publishing.
+  expect(page.getByTestId('document-panel-document-title')).toHaveText(title)
+})


### PR DESCRIPTION
### Description

This branch adds Actions API integrations for the following document operations:

- Publish
- Unpublish
- Delete

They can be enabled using the `unstable_serverActions.enabled` configuration option.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
