### PR TITLE
feat(sanity): use actions API when discarding drafts

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -33,6 +33,7 @@ import {publish} from './operations/publish'
 import {restore} from './operations/restore'
 import {unpublish} from './operations/unpublish'
 import {del as serverDel} from './serverOperations/delete'
+import {discardChanges as serverDiscardChanges} from './serverOperations/discardChanges'
 import {patch as serverPatch} from './serverOperations/patch'
 import {publish as serverPublish} from './serverOperations/publish'
 import {unpublish as serverUnpublish} from './serverOperations/unpublish'
@@ -65,6 +66,7 @@ const serverOperationImpls = {
   ...operationImpls,
   del: serverDel,
   delete: serverDel,
+  discardChanges: serverDiscardChanges,
   patch: serverPatch,
   publish: serverPublish,
   unpublish: serverUnpublish,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
@@ -2,6 +2,7 @@ import {type IdPair} from '../../types'
 import {emitOperation} from '../operationEvents'
 import {publish} from '../operations/publish'
 import {del as serverDel} from '../serverOperations/delete'
+import {discardChanges as serverDiscardChanges} from '../serverOperations/discardChanges'
 import {patch as serverPatch} from '../serverOperations/patch'
 import {publish as serverPublish} from '../serverOperations/publish'
 import {unpublish as serverUnpublish} from '../serverOperations/unpublish'
@@ -73,6 +74,7 @@ export function createOperationsAPI(args: OperationArgs): OperationsAPI {
       ...operationsAPI,
       delete: wrap('delete', serverDel, args),
       del: wrap('delete', serverDel, args),
+      discardChanges: wrap('discardChanges', serverDiscardChanges, args),
       patch: wrap('patch', serverPatch, args),
       publish: wrap('publish', serverPublish, args),
       unpublish: wrap('unpublish', serverUnpublish, args),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/discardChanges.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/discardChanges.ts
@@ -1,0 +1,34 @@
+import {type OperationImpl} from '../operations/types'
+
+type DisabledReason = 'NO_CHANGES' | 'NOT_PUBLISHED'
+
+export const discardChanges: OperationImpl<[], DisabledReason> = {
+  disabled: ({snapshots}) => {
+    if (!snapshots.draft) {
+      return 'NO_CHANGES'
+    }
+    if (!snapshots.published) {
+      return 'NOT_PUBLISHED'
+    }
+    return false
+  },
+  execute: ({client: globalClient, idPair}) => {
+    const vXClient = globalClient.withConfig({apiVersion: 'X'})
+    const {dataset} = globalClient.config()
+
+    return vXClient.observable.request({
+      url: `/data/actions/${dataset}`,
+      method: 'post',
+      tag: 'document.discard-changes',
+      body: {
+        actions: [
+          {
+            actionType: 'sanity.action.document.discard',
+            draftId: idPair.draftId,
+            publishedId: idPair.publishedId,
+          },
+        ],
+      },
+    })
+  },
+}

--- a/packages/sanity/src/structure/panes/document/statusBar/dialogs/ConfirmDialog.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/dialogs/ConfirmDialog.tsx
@@ -77,12 +77,14 @@ function ConfirmDialogContent(props: {dialog: DocumentActionConfirmDialogProps})
       <Box paddingX={4} paddingY={3} style={{borderTop: '1px solid var(--card-border-color)'}}>
         <Grid columns={2} gap={2}>
           <Button
+            data-testid="confirm-dialog-cancel-button"
             icon={cancelButtonIcon}
             onClick={onCancel}
             mode="ghost"
             text={cancelButtonText || t('confirm-dialog.cancel-button.fallback-text')}
           />
           <Button
+            data-testid="confirm-dialog-confirm-button"
             icon={confirmButtonIcon}
             onClick={onConfirm}
             text={confirmButtonText || t('confirm-dialog.confirm-button.fallback-text')}

--- a/test/e2e/tests/document-actions/discardChanges.spec.ts
+++ b/test/e2e/tests/document-actions/discardChanges.spec.ts
@@ -1,0 +1,74 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+test(`isn't possible to discard changes if a changed document has no published version`, async ({
+  page,
+  createDraftDocument,
+}) => {
+  await createDraftDocument('/test/content/book')
+
+  const titleInput = page.getByTestId('field-title').getByTestId('string-input')
+  const actionMenuButton = page.getByTestId('action-menu-button')
+  const discardChangesButton = page.getByTestId('action-Discardchanges')
+  const deleteButton = page.getByTestId('action-Delete')
+
+  await titleInput.fill('This is a book')
+
+  await actionMenuButton.click()
+  await expect(deleteButton).toBeEnabled()
+  await expect(discardChangesButton).toBeHidden()
+})
+
+test(`is possible to discard changes if a changed document has a published version`, async ({
+  page,
+  createDraftDocument,
+}) => {
+  await createDraftDocument('/test/content/book')
+
+  const titleInput = page.getByTestId('field-title').getByTestId('string-input')
+  const paneFooter = page.getByTestId('pane-footer')
+  const publishButton = page.getByTestId('action-Publish')
+  const actionMenuButton = page.getByTestId('action-menu-button')
+  const discardChangesButton = page.getByTestId('action-Discardchanges')
+
+  await titleInput.fill('This is a book')
+
+  publishButton.click()
+  await expect(paneFooter).toContainText('Published just now')
+
+  await titleInput.fill('This is not a book')
+
+  await actionMenuButton.click()
+  await expect(discardChangesButton).toBeEnabled()
+})
+
+test(`displays the published document state after discarding changes`, async ({
+  page,
+  createDraftDocument,
+}) => {
+  await createDraftDocument('/test/content/book')
+
+  const titleInput = page.getByTestId('field-title').getByTestId('string-input')
+  const paneFooter = page.getByTestId('pane-footer')
+  const publishButton = page.getByTestId('action-Publish')
+  const actionMenuButton = page.getByTestId('action-menu-button')
+  const discardChangesButton = page.getByTestId('action-Discardchanges')
+  const confirmButton = page.getByTestId('confirm-dialog-confirm-button')
+
+  await titleInput.fill('This is a book')
+
+  publishButton.click()
+  await expect(paneFooter).toContainText('Published just now')
+
+  // Change the title.
+  await titleInput.fill('This is not a book')
+
+  // Discard the change.
+  await actionMenuButton.click()
+  await discardChangesButton.click()
+  await expect(confirmButton).toBeVisible()
+  await confirmButton.click()
+
+  // Ensure the initial title is displayed.
+  await expect(titleInput).toHaveValue('This is a book')
+})


### PR DESCRIPTION
### Description

This branch adopts the Actions API for discarding changes.

### What to review

Does everything work as expected when discarding changes?

### Testing

E2E tests for the discard changes document action added in `test/e2e/tests/document-actions/discardChanges.spec.ts`.

