### PR TITLE
fix(deps): narrow accepted peer dependency range of style-components

### DIFF
--- a/packages/@sanity/portable-text-editor/package.json
+++ b/packages/@sanity/portable-text-editor/package.json
@@ -104,7 +104,7 @@
   "peerDependencies": {
     "react": "^16.9 || ^17 || ^18",
     "rxjs": "^7",
-    "styled-components": "^5.2 || ^6"
+    "styled-components": "^6.1"
   },
   "engines": {
     "node": ">=18"

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -91,6 +91,6 @@
   },
   "peerDependencies": {
     "react": "^18",
-    "styled-components": "^5.2 || ^6"
+    "styled-components": "^6.1"
   }
 }

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -288,7 +288,7 @@
   "peerDependencies": {
     "react": "^18",
     "react-dom": "^18",
-    "styled-components": "^5.2 || ^6"
+    "styled-components": "^6.1"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
### Description

Initially wanted to leave a wide accepted peer range for styled-components to get a chance to ignore errors during npm install and rather surface a more meaningful error later on, but realizing that it's better to be correct (also tooling may depend on this). The runtime check will still provide a meaningful message if any peer dependency errors are bypassed by --legacy-peer-deps, --force etc.

### What to review
Is it sensible?

### Testing
n/a

### Notes for release

n/a as the move to styled-components@6 is covered pretty in-depth in the release notes already
