### PR TITLE
feat(core): display custom styles in PTE style selector

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/BlockStyleSelect.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/BlockStyleSelect.tsx
@@ -58,8 +58,6 @@ const TEXT_STYLE_OPTIONS: Record<string, (title: ReactNode) => ReactNode> = {
   blockquote: (title) => <BlockQuote data-option="blockquote">{title}</BlockQuote>,
 }
 
-const TEXT_STYLE_KEYS = Object.keys(TEXT_STYLE_OPTIONS)
-
 const preventDefault = (event: MouseEvent<HTMLButtonElement>) => event.preventDefault()
 
 const emptyStyle: BlockStyleItem = {
@@ -118,16 +116,29 @@ export const BlockStyleSelect = memo(function BlockStyleSelect(
     [editor, focusBlock],
   )
 
-  const renderOption = useCallback((style: string, title: string) => {
-    const hasTextStyle = TEXT_STYLE_KEYS.includes(style)
-    const renderStyle = TEXT_STYLE_OPTIONS[style]
+  const renderOption = useCallback(
+    (item: BlockStyleItem) => {
+      const {style, styleComponent} = item
+      const renderStyle = TEXT_STYLE_OPTIONS[style]
+      const title = item.i18nTitleKey ? t(item.i18nTitleKey) : item?.title || item.style
 
-    if (hasTextStyle) {
-      return renderStyle(title)
-    }
+      const CustomComponent = typeof styleComponent === 'function' ? styleComponent : undefined
 
-    return <Text>{title}</Text>
-  }, [])
+      // If we have default support for the style and there is no custom component
+      // defined, we render the default style.
+      if (renderStyle && !CustomComponent) {
+        return renderStyle(title)
+      }
+
+      // If we have a custom component, we render that
+      if (CustomComponent) {
+        return <CustomComponent>{title}</CustomComponent>
+      }
+
+      return <Text>{title}</Text>
+    },
+    [t],
+  )
 
   const button = useMemo(
     () => (
@@ -155,16 +166,13 @@ export const BlockStyleSelect = memo(function BlockStyleSelect(
               // eslint-disable-next-line react/jsx-no-bind
               onClick={_disabled ? undefined : () => handleChange(item)}
             >
-              {renderOption(
-                item.style,
-                item.i18nTitleKey ? t(item.i18nTitleKey) : item?.title || item.style,
-              )}
+              {renderOption(item)}
             </StyledMenuItem>
           )
         })}
       </Menu>
     ),
-    [_disabled, activeItems, handleChange, items, renderOption, t],
+    [_disabled, activeItems, handleChange, items, renderOption],
   )
 
   return (


### PR DESCRIPTION
### Description

This pull request ensures that the component defined for custom PTE styles is displayed in the style selector.

```tsx
import {type BlockStyleProps, defineField} from 'sanity'

function MyStyleComponent(props: BlockStyleProps) {
  const {children} = props
  
  return <div style={{color: 'magenta'}}>{children}</div>
}

const body = defineField({
  type: 'array',
  name: 'body',
  of: [
    {
      type: 'block',
      styles: [{title: 'My style', value: 'my-style', component: MyStyleComponent}],
    },
  ],
})
```
<img width="614" alt="Screenshot 2024-04-09 at 16 05 38" src="https://github.com/sanity-io/sanity/assets/15094168/1481eb57-5017-4146-a1b7-4f84e8dc911f">



### What to review

Ensure that the component for the custom style is rendered correctly.

### Notes for release

Fixes an issue where the component for custom PTE styles was not being rendered in the style selector.
