### PR TITLE
chore: add `@repo/test-exports` suite

### DIFF
--- a/.github/workflows/testExports.yml
+++ b/.github/workflows/testExports.yml
@@ -1,0 +1,48 @@
+name: Test exports works in native node ESM and CJS
+on:
+  push:
+jobs:
+  typeCheck:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 8
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
+            v1-${{ runner.os }}-pnpm-store-
+            v1-${{ runner.os }}-
+
+      - name: Install project dependencies
+        run: pnpm install
+
+      - name: Check export conditions in native node ESM and CJS
+        # Adds the github reporter on the CI to highlight in diffs failling tests
+        run: pnpm test:exports -- --test-reporter node-test-github-reporter

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "start": "run-s dev",
     "test": "jest --forceExit",
     "test:e2e": "playwright test",
+    "test:exports": "turbo run test --filter=@repo/test-exports",
     "tsdoc:dev": "sanity-tsdoc dev",
     "updated": "lerna updated",
     "watch": "lerna run --parallel --stream --scope '{@sanity/*,sanity}' watch"

--- a/packages/@repo/test-exports/.depcheckrc.json
+++ b/packages/@repo/test-exports/.depcheckrc.json
@@ -1,0 +1,22 @@
+{
+  "ignores": [
+    "@repo/test-exports",
+    "@sanity/block-tools",
+    "@sanity/cli",
+    "@sanity/codegen",
+    "@sanity/diff",
+    "@sanity/export",
+    "@sanity/import",
+    "@sanity/import-cli",
+    "@sanity/migrate",
+    "@sanity/mutator",
+    "@sanity/portable-text-editor",
+    "@sanity/schema",
+    "@sanity/types",
+    "@sanity/util",
+    "@sanity/vision",
+    "groq",
+    "sanity",
+    "node-test-github-reporter"
+  ]
+}

--- a/packages/@repo/test-exports/package.json
+++ b/packages/@repo/test-exports/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@repo/test-exports",
+  "version": "3.37.0",
+  "private": true,
+  "description": "Ensures that all the monorepo packages that are published works in native node ESM and CJS runtimes",
+  "exports": {
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "test": "node --test"
+  },
+  "dependencies": {
+    "@sanity/block-tools": "workspace:*",
+    "@sanity/cli": "workspace:*",
+    "@sanity/codegen": "workspace:*",
+    "@sanity/diff": "workspace:*",
+    "@sanity/export": "workspace:*",
+    "@sanity/import": "workspace:*",
+    "@sanity/import-cli": "workspace:*",
+    "@sanity/migrate": "workspace:*",
+    "@sanity/mutator": "workspace:*",
+    "@sanity/portable-text-editor": "workspace:*",
+    "@sanity/schema": "workspace:*",
+    "@sanity/types": "workspace:*",
+    "@sanity/util": "workspace:*",
+    "@sanity/vision": "workspace:*",
+    "groq": "workspace:*",
+    "sanity": "workspace:*"
+  },
+  "devDependencies": {
+    "@repo/tsconfig": "workspace:*",
+    "node-test-github-reporter": "^1.2.0"
+  }
+}

--- a/packages/@repo/test-exports/test/exports.cjs
+++ b/packages/@repo/test-exports/test/exports.cjs
@@ -1,0 +1,28 @@
+const path = require('node:path')
+const _pkg = require('@repo/test-exports/package.json')
+
+const {dependencies} = _pkg
+
+module.exports = (condition) => {
+  if (!condition) {
+    throw new TypeError('condition is required')
+  }
+  const workspaces = {}
+  for (const workspace of Object.keys(dependencies)) {
+    // eslint-disable-next-line import/no-dynamic-require
+    const pkg = require(`${workspace}/package.json`)
+    if (pkg.exports) {
+      workspaces[workspace] = []
+      for (const [key, value] of Object.entries(pkg.exports)) {
+        if (typeof value === 'object' && condition in value) {
+          workspaces[workspace].push(path.join(workspace, key))
+        }
+      }
+    } else {
+      // @TODO all packages should declare `exports`
+      console.warn('No exports found in:', workspace)
+    }
+  }
+
+  return workspaces
+}

--- a/packages/@repo/test-exports/test/exports.test.cjs
+++ b/packages/@repo/test-exports/test/exports.test.cjs
@@ -1,0 +1,16 @@
+const {test} = require('node:test')
+
+const getExports = require('./exports.cjs')
+
+const workspaces = getExports('require')
+
+for (const [workspace, paths] of Object.entries(workspaces)) {
+  test(workspace, async (t) => {
+    for (const path of paths) {
+      await t.test(path, () => {
+        // eslint-disable-next-line import/no-dynamic-require
+        require(path)
+      })
+    }
+  })
+}

--- a/packages/@repo/test-exports/test/exports.test.mjs
+++ b/packages/@repo/test-exports/test/exports.test.mjs
@@ -1,0 +1,16 @@
+import {test} from 'node:test'
+
+import getExports from './exports.cjs'
+
+const workspaces = getExports('import')
+
+for (const [workspace, paths] of Object.entries(workspaces)) {
+  test(workspace, async (t) => {
+    for (const path of paths) {
+      // eslint-disable-next-line @typescript-eslint/no-shadow, @typescript-eslint/no-unused-vars
+      await t.test(path, async (t) => {
+        await import(path)
+      })
+    }
+  })
+}

--- a/packages/@repo/test-exports/tsconfig.json
+++ b/packages/@repo/test-exports/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "@repo/tsconfig/build.json",
+  "include": ["./test"],
+  "exclude": [
+    "./src/**/__fixtures__",
+    "./src/**/__mocks__",
+    "./src/**/__workshop__",
+    "./src/**/*.test.ts",
+    "./src/**/*.test.tsx"
+  ],
+  "compilerOptions": {
+    "rootDir": ".",
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "module": "Preserve",
+    "allowJs": true,
+    "checkJs": true,
+    "noImplicitAny": false
+  }
+}

--- a/packages/@repo/test-exports/turbo.json
+++ b/packages/@repo/test-exports/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "pipeline": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,6 +606,64 @@ importers:
 
   packages/@repo/package.config: {}
 
+  packages/@repo/test-exports:
+    dependencies:
+      '@sanity/block-tools':
+        specifier: workspace:*
+        version: link:../../@sanity/block-tools
+      '@sanity/cli':
+        specifier: workspace:*
+        version: link:../../@sanity/cli
+      '@sanity/codegen':
+        specifier: workspace:*
+        version: link:../../@sanity/codegen
+      '@sanity/diff':
+        specifier: workspace:*
+        version: link:../../@sanity/diff
+      '@sanity/export':
+        specifier: workspace:*
+        version: link:../../@sanity/export
+      '@sanity/import':
+        specifier: workspace:*
+        version: link:../../@sanity/import
+      '@sanity/import-cli':
+        specifier: workspace:*
+        version: link:../../@sanity/import-cli
+      '@sanity/migrate':
+        specifier: workspace:*
+        version: link:../../@sanity/migrate
+      '@sanity/mutator':
+        specifier: workspace:*
+        version: link:../../@sanity/mutator
+      '@sanity/portable-text-editor':
+        specifier: workspace:*
+        version: link:../../@sanity/portable-text-editor
+      '@sanity/schema':
+        specifier: workspace:*
+        version: link:../../@sanity/schema
+      '@sanity/types':
+        specifier: workspace:*
+        version: link:../../@sanity/types
+      '@sanity/util':
+        specifier: workspace:*
+        version: link:../../@sanity/util
+      '@sanity/vision':
+        specifier: workspace:*
+        version: link:../../@sanity/vision
+      groq:
+        specifier: workspace:*
+        version: link:../../groq
+      sanity:
+        specifier: workspace:*
+        version: link:../../sanity
+    devDependencies:
+      '@repo/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      node-test-github-reporter:
+        specifier: ^1.2.0
+        version: 1.2.0
+
   packages/@repo/tsconfig: {}
 
   packages/@sanity/block-tools:
@@ -1947,6 +2005,20 @@ packages:
   /@aashutoshrathi/word-wrap@1.2.6:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /@actions/core@1.10.1:
+    resolution: {integrity: sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==}
+    dependencies:
+      '@actions/http-client': 2.2.1
+      uuid: 8.3.2
+    dev: true
+
+  /@actions/http-client@2.2.1:
+    resolution: {integrity: sha512-KhC/cZsq7f8I4LfZSJKgCvEwfkE8o1538VoBeoGzokVLLnbFDEAdFD3UhoMklxo2un9NJVBdANOresx7vTHlHw==}
+    dependencies:
+      tunnel: 0.0.6
+      undici: 5.28.4
     dev: true
 
   /@adobe/css-tools@4.3.3:
@@ -3953,6 +4025,11 @@ packages:
   /@eslint/js@8.57.0:
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@fastify/busboy@2.1.1:
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
     dev: true
 
   /@floating-ui/core@1.6.0:
@@ -9837,6 +9914,12 @@ packages:
     dependencies:
       is-arrayish: 0.2.1
 
+  /error-stack-parser@2.1.4:
+    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
+    dependencies:
+      stackframe: 1.3.4
+    dev: true
+
   /es-abstract@1.23.3:
     resolution: {integrity: sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==}
     engines: {node: '>= 0.4'}
@@ -14674,6 +14757,19 @@ packages:
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
 
+  /node-test-github-reporter@1.2.0:
+    resolution: {integrity: sha512-rnCQctMTPAqJrOhaHaj60IMS5qB5B2rusCGv7RIbY6FsTKjaRmS4OBKCVQb3kYdMNqj0Fw9btDOZkCi3OFHx/g==}
+    dependencies:
+      '@actions/core': 1.10.1
+      error-stack-parser: 2.1.4
+      node-test-parser: 2.2.2
+      stack-utils: 2.0.6
+    dev: true
+
+  /node-test-parser@2.2.2:
+    resolution: {integrity: sha512-Cbe0pabtJaZOrjvCguHe9kZLDrHZpRr+4+JO29hNf143qFUhGn6Xn5HxwQmh4vmyyLFlF2YmnJGIwfEX+aQ7mw==}
+    dev: true
+
   /nopt@7.2.0:
     resolution: {integrity: sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -17257,6 +17353,10 @@ packages:
       escape-string-regexp: 2.0.0
     dev: true
 
+  /stackframe@1.3.4:
+    resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
+    dev: true
+
   /static-extend@0.1.2:
     resolution: {integrity: sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==}
     engines: {node: '>=0.10.0'}
@@ -17994,6 +18094,11 @@ packages:
       - react
     dev: false
 
+  /tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+    dev: true
+
   /turbo-darwin-64@1.13.2:
     resolution: {integrity: sha512-CCSuD8CfmtncpohCuIgq7eAzUas0IwSbHfI8/Q3vKObTdXyN8vAo01gwqXjDGpzG9bTEVedD0GmLbD23dR0MLA==}
     cpu: [x64]
@@ -18194,6 +18299,13 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  /undici@5.28.4:
+    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
+    engines: {node: '>=14.0'}
+    dependencies:
+      '@fastify/busboy': 2.1.1
+    dev: true
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}


### PR DESCRIPTION
There are some issues in native ESM mode in Node when using `sanity` and other packages. 
In this PR I'm adding a testing suite that repros them, and guards against re-introducing them in the future once we've fixed the remaining issues.