### PR TITLE
fix(codegen): prevent crash due to incorrect babel config path

### DIFF
--- a/packages/@sanity/cli/test/__fixtures__/v3/package.json
+++ b/packages/@sanity/cli/test/__fixtures__/v3/package.json
@@ -13,6 +13,7 @@
     "start": "sanity dev"
   },
   "dependencies": {
+    "groq": "^3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sanity": "^3.0.0",

--- a/packages/@sanity/cli/test/__fixtures__/v3/src/queries.ts
+++ b/packages/@sanity/cli/test/__fixtures__/v3/src/queries.ts
@@ -1,0 +1,3 @@
+import groq from 'groq'
+
+export const PAGE_QUERY = groq`*[_type == "page" && slug.current == $slug][0]`

--- a/packages/@sanity/cli/test/typegen.test.ts
+++ b/packages/@sanity/cli/test/typegen.test.ts
@@ -43,6 +43,8 @@ describeCliTest('CLI: `sanity typegen`', () => {
     ])
 
     expect(result.code).toBe(0)
-    expect(result.stderr).toContain('Generated TypeScript types for 2 schema types')
+    expect(result.stderr).toContain(
+      'Generated TypeScript types for 2 schema types and 1 GROQ queries in 1 file',
+    )
   })
 })

--- a/packages/@sanity/codegen/src/getBabelConfig.ts
+++ b/packages/@sanity/codegen/src/getBabelConfig.ts
@@ -1,0 +1,39 @@
+import {existsSync} from 'node:fs'
+import {join, resolve} from 'node:path'
+
+import {type TransformOptions} from '@babel/core'
+
+/**
+ * Because of bundlers and compilers, knowing the exact path the babel configuration will be
+ * located at post - build is not always trivial. We traverse from the current directory upwards
+ * until we find the first `babel.config.json` and use that path.
+ *
+ * @param path - The path to start looking for the babel configuration
+ * @returns The path to the `babel.config.json` file
+ * @internal
+ */
+export function findBabelConfig(path: string): string {
+  const configPath = join(path, 'babel.config.json')
+  if (existsSync(configPath)) {
+    return configPath
+  }
+
+  const parent = resolve(join(path, '..'))
+  if (parent && parent !== path) {
+    return findBabelConfig(parent)
+  }
+
+  throw new Error('Could not find `babel.config.json` in @sanity/codegen')
+}
+
+/**
+ * Get the default babel configuration for `@sanity/codegen`
+ *
+ * @param path - The path to start looking for the babel configuration. Defaults to `__dirname`
+ * @returns A babel configuration object
+ * @internal
+ */
+export function getBabelConfig(path?: string): TransformOptions {
+  const configPath = findBabelConfig(path || __dirname)
+  return {extends: configPath}
+}

--- a/packages/@sanity/codegen/src/readConfig.ts
+++ b/packages/@sanity/codegen/src/readConfig.ts
@@ -3,7 +3,7 @@ import * as json5 from 'json5'
 import * as z from 'zod'
 
 export const configDefintion = z.object({
-  path: z.string().or(z.array(z.string())).default('./src/**/*.{ts,tsx,js,jsx}'),
+  path: z.string().or(z.array(z.string())).default('./src/**/*.{ts,tsx,js,jsx,mjs,cjs}'),
   schema: z.string().default('./schema.json'),
   generates: z.string().default('./sanity.types.ts'),
 })

--- a/packages/@sanity/codegen/src/typescript/findQueriesInPath.ts
+++ b/packages/@sanity/codegen/src/typescript/findQueriesInPath.ts
@@ -1,19 +1,15 @@
 import fs from 'node:fs/promises'
-import {join} from 'node:path'
 
 import {type TransformOptions} from '@babel/core'
 import createDebug from 'debug'
 import glob from 'globby'
 
+import {getBabelConfig} from '../getBabelConfig'
 import {type NamedQueryResult} from './expressionResolvers'
 import {findQueriesInSource} from './findQueriesInSource'
 import {getResolver} from './moduleResolver'
 
 const debug = createDebug('sanity:codegen:findQueries:debug')
-
-const defaultBabelOptions = {
-  extends: join(__dirname, '..', '..', 'babel.config.json'),
-}
 
 type ResultQueries = {
   type: 'queries'
@@ -37,7 +33,7 @@ type ResultError = {
  */
 export async function* findQueriesInPath({
   path,
-  babelOptions = defaultBabelOptions,
+  babelOptions = getBabelConfig(),
   resolver = getResolver(),
 }: {
   path: string | string[]

--- a/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
+++ b/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
@@ -1,19 +1,15 @@
 import {createRequire} from 'node:module'
-import {join} from 'node:path'
 
 import {type TransformOptions, traverse} from '@babel/core'
 import * as babelTypes from '@babel/types'
 
+import {getBabelConfig} from '../getBabelConfig'
 import {type NamedQueryResult, resolveExpression} from './expressionResolvers'
 import {parseSourceFile} from './parseSource'
 
 const require = createRequire(__filename)
 
 const groqTagName = 'groq'
-
-const defaultBabelOptions = {
-  extends: join(__dirname, '..', '..', 'babel.config.json'),
-}
 
 /**
  * findQueriesInSource takes a source string and returns all GROQ queries in it.
@@ -28,7 +24,7 @@ const defaultBabelOptions = {
 export function findQueriesInSource(
   source: string,
   filename: string,
-  babelConfig: TransformOptions = defaultBabelOptions,
+  babelConfig: TransformOptions = getBabelConfig(),
   resolver: NodeJS.RequireResolve = require.resolve,
 ): NamedQueryResult[] {
   const queries: NamedQueryResult[] = []

--- a/packages/@sanity/codegen/src/typescript/registerBabel.ts
+++ b/packages/@sanity/codegen/src/typescript/registerBabel.ts
@@ -1,17 +1,16 @@
-import {join} from 'node:path'
-
 import {type TransformOptions} from '@babel/core'
 import register from '@babel/register'
 
-const defaultBabelOptions = {
-  extends: join(__dirname, '..', '..', 'babel.config.json'),
-}
+import {getBabelConfig} from '../getBabelConfig'
 
 /**
  * Register Babel with the given options
+ *
  * @param babelOptions - The options to use when registering Babel
  * @beta
  */
-export function registerBabel(babelOptions: TransformOptions = defaultBabelOptions): void {
-  register({...babelOptions, extensions: ['.ts', '.tsx', '.js', '.jsx']})
+export function registerBabel(babelOptions?: TransformOptions): void {
+  const options = babelOptions || getBabelConfig()
+
+  register({...options, extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs']})
 }

--- a/packages/@sanity/codegen/src/typescript/registerBabel.ts
+++ b/packages/@sanity/codegen/src/typescript/registerBabel.ts
@@ -12,5 +12,5 @@ import {getBabelConfig} from '../getBabelConfig'
 export function registerBabel(babelOptions?: TransformOptions): void {
   const options = babelOptions || getBabelConfig()
 
-  register({...options, extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs']})
+  register({...options, extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']})
 }


### PR DESCRIPTION
### Description

In v3.37.0, the output directory structure of the `@sanity/codegen` module changed as a result of a `pkg-utils` upgrade:

- From: `lib/_exports/`
- To: `lib/`

This broke some assumptions inside of the module which defined a relative path from the source file to the location of the babel configuration, which resulted in errors such as `Error: Cannot find module '<dir>/node_modules/@sanity/babel.config.json'`  

This PR recursively looks for the configuration file from the directory of the output and upwards until it finds it, which should make regressions due to other bundling changes more resilient.

While researching this bug, I had queries inside of a `.mjs` file that was not being picked up, so I have also snuck in a change that finds queries in both `.mjs` and `.cjs` files as well.

### What to review

- `sanity schema extract && sanity typegen generate` in a project with queries works as expected

### Testing

Added a test to ensure that the CLI tool works when there are queries to be found. Added it from the CLI side as there is a remote possibility that the module could have been bundled, and we would still want it to work all the way through in this case.

### Notes for release

- Fixes an issue where `sanity typegen generate` would crash due to not finding a babel configuration file
