### PR TITLE
fix: resolve PTE inconsistency by passing serverActionsEnabled to documentEvents

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -151,9 +151,9 @@ export default defineConfig([
     plugins: [sharedSettings()],
     basePath: '/test',
     icon: SanityMonogram,
-    // unstable_serverActions: {
-    //   enabled: true,
-    // },
+    unstable_serverActions: {
+      enabled: true,
+    },
   },
   {
     name: 'partialIndexing',

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -151,9 +151,9 @@ export default defineConfig([
     plugins: [sharedSettings()],
     basePath: '/test',
     icon: SanityMonogram,
-    unstable_serverActions: {
-      enabled: true,
-    },
+    // unstable_serverActions: {
+    //   enabled: true,
+    // },
   },
   {
     name: 'partialIndexing',

--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -144,7 +144,7 @@ export function useDocumentStore(): DocumentStore {
         initialValueTemplates: templates,
         schema,
         i18n,
-        serverActionsEnabled: workspace.serverActions?.enabled,
+        serverActionsEnabled: !!workspace.serverActions?.enabled,
       })
 
     resourceCache.set({

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -148,7 +148,7 @@ function submitCommitRequest(
   return from(
     serverActionsEnabled
       ? serverCommitMutations(client, idPair, request.mutation.params)
-      : serverCommitMutations(client, idPair, request.mutation.params),
+      : commitMutations(client, request.mutation.params),
   ).pipe(
     tap({
       error: (error) => {

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -143,7 +143,7 @@ function submitCommitRequest(
   client: SanityClient,
   idPair: IdPair,
   request: CommitRequest,
-  serverActionsEnabled?: boolean,
+  serverActionsEnabled: boolean,
 ) {
   return from(
     serverActionsEnabled
@@ -172,7 +172,7 @@ function submitCommitRequest(
 export function checkoutPair(
   client: SanityClient,
   idPair: IdPair,
-  serverActionsEnabled?: boolean,
+  serverActionsEnabled: boolean,
 ): Pair {
   const {publishedId, draftId} = idPair
 

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -148,7 +148,7 @@ function submitCommitRequest(
   return from(
     serverActionsEnabled
       ? serverCommitMutations(client, idPair, request.mutation.params)
-      : commitMutations(client, request.mutation.params),
+      : serverCommitMutations(client, idPair, request.mutation.params),
   ).pipe(
     tap({
       error: (error) => {

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/consistencyStatus.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/consistencyStatus.ts
@@ -5,6 +5,7 @@ import {distinctUntilChanged, map, publishReplay, refCount, switchMap} from 'rxj
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {memoizedPair} from './memoizedPair'
+import {memoizeKeyGen} from './memoizeKeyGen'
 
 // A stream of all events related to either published or draft, each event comes with a 'target'
 // that specifies which version (draft|published) the event is about
@@ -12,9 +13,9 @@ export const consistencyStatus: (
   client: SanityClient,
   idPair: IdPair,
   typeName: string,
-  serverActionsEnabled?: boolean,
+  serverActionsEnabled: boolean,
 ) => Observable<boolean> = memoize(
-  (client: SanityClient, idPair: IdPair, typeName: string, serverActionsEnabled?: boolean) => {
+  (client: SanityClient, idPair: IdPair, typeName: string, serverActionsEnabled: boolean) => {
     return memoizedPair(client, idPair, typeName, serverActionsEnabled).pipe(
       switchMap(({draft, published}) =>
         combineLatest([draft.consistency$, published.consistency$]),
@@ -27,9 +28,5 @@ export const consistencyStatus: (
       refCount(),
     )
   },
-  (client, idPair, typeName) => {
-    const config = client.config()
-
-    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}`
-  },
+  memoizeKeyGen,
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/documentEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/documentEvents.ts
@@ -15,7 +15,7 @@ export const documentEvents = memoize(
     client: SanityClient,
     idPair: IdPair,
     typeName: string,
-    serverActionsEnabled?: boolean,
+    serverActionsEnabled: boolean,
   ): Observable<DocumentVersionEvent> => {
     return memoizedPair(client, idPair, typeName, serverActionsEnabled).pipe(
       switchMap(({draft, published}) => merge(draft.events, published.events)),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editOperations.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editOperations.ts
@@ -34,5 +34,5 @@ export const editOperations = memoize(
       merge(operationEvents$.pipe(mergeMap(() => EMPTY)), operations$),
     ).pipe(shareReplay({refCount: true, bufferSize: 1}))
   },
-  (ctx, idPair, typeName) => memoizeKeyGen(ctx.client, idPair, typeName),
+  (ctx, idPair, typeName) => memoizeKeyGen(ctx.client, idPair, typeName, ctx.serverActionsEnabled),
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editOperations.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editOperations.ts
@@ -18,7 +18,7 @@ export const editOperations = memoize(
       client: SanityClient
       historyStore: HistoryStore
       schema: Schema
-      serverActionsEnabled?: boolean
+      serverActionsEnabled: boolean
     },
     idPair: IdPair,
     typeName: string,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
@@ -34,14 +34,13 @@ export const editState = memoize(
     ctx: {
       client: SanityClient
       schema: Schema
-      serverActionsEnabled?: boolean
+      serverActionsEnabled: boolean
     },
     idPair: IdPair,
     typeName: string,
-    serverActionsEnabled?: boolean,
   ): Observable<EditStateFor> => {
     const liveEdit = isLiveEditEnabled(ctx.schema, typeName)
-    return snapshotPair(ctx.client, idPair, typeName, true).pipe(
+    return snapshotPair(ctx.client, idPair, typeName, ctx.serverActionsEnabled).pipe(
       switchMap((versions) =>
         combineLatest([
           versions.draft.snapshots$,
@@ -74,5 +73,5 @@ export const editState = memoize(
       refCount(),
     )
   },
-  (ctx, idPair, typeName) => memoizeKeyGen(ctx.client, idPair, typeName),
+  (ctx, idPair, typeName) => memoizeKeyGen(ctx.client, idPair, typeName, ctx.serverActionsEnabled),
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
@@ -41,7 +41,7 @@ export const editState = memoize(
     serverActionsEnabled?: boolean,
   ): Observable<EditStateFor> => {
     const liveEdit = isLiveEditEnabled(ctx.schema, typeName)
-    return snapshotPair(ctx.client, idPair, typeName, !!ctx.serverActionsEnabled).pipe(
+    return snapshotPair(ctx.client, idPair, typeName, true).pipe(
       switchMap((versions) =>
         combineLatest([
           versions.draft.snapshots$,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizeKeyGen.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizeKeyGen.ts
@@ -6,7 +6,7 @@ export function memoizeKeyGen(
   client: SanityClient,
   idPair: IdPair,
   typeName: string,
-  serverActionsEnabled?: boolean,
+  serverActionsEnabled: boolean,
 ) {
   const config = client.config()
   return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}${serverActionsEnabled ? '-serverActionsEnabled' : ''}`

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
@@ -11,13 +11,13 @@ export const memoizedPair: (
   client: SanityClient,
   idPair: IdPair,
   typeName: string,
-  serverActionsEnabled?: boolean,
+  serverActionsEnabled: boolean,
 ) => Observable<Pair> = memoize(
   (
     client: SanityClient,
     idPair: IdPair,
     _typeName: string,
-    serverActionsEnabled?: boolean,
+    serverActionsEnabled: boolean,
   ): Observable<Pair> => {
     return new Observable<Pair>((subscriber) => {
       const pair = checkoutPair(client, idPair, serverActionsEnabled)

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
@@ -8,6 +8,7 @@ import {map, publishReplay, refCount, switchMap} from 'rxjs/operators'
 import {type HistoryStore} from '../../history'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
+import {memoizeKeyGen} from './memoizeKeyGen'
 import {type OperationArgs} from './operations'
 import {snapshotPair} from './snapshotPair'
 
@@ -42,8 +43,6 @@ export const operationArgs = memoize(
     )
   },
   (ctx, idPair, typeName) => {
-    const config = ctx.client.config()
-
-    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}`
+    return memoizeKeyGen(ctx.client, idPair, typeName, ctx.serverActionsEnabled)
   },
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
@@ -18,12 +18,12 @@ export const operationArgs = memoize(
       client: SanityClient
       historyStore: HistoryStore
       schema: Schema
-      serverActionsEnabled?: boolean
+      serverActionsEnabled: boolean
     },
     idPair: IdPair,
     typeName: string,
   ): Observable<OperationArgs> => {
-    return snapshotPair(ctx.client, idPair, typeName, !!ctx.serverActionsEnabled).pipe(
+    return snapshotPair(ctx.client, idPair, typeName, ctx.serverActionsEnabled).pipe(
       switchMap((versions) =>
         combineLatest([versions.draft.snapshots$, versions.published.snapshots$]).pipe(
           map(

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -147,7 +147,7 @@ export const operationEvents = memoize(
           // E.g. if the user types `publish` which is async and then starts patching (sync) then the publish
           // should be cancelled
           switchMap((args) =>
-            operationArgs(ctx, args.idPair, args.typeName).pipe(
+            operationArgs({...ctx, serverActionsEnabled: false}, args.idPair, args.typeName).pipe(
               take(1),
               switchMap((operationArguments) => {
                 const requiresConsistency = REQUIRES_CONSISTENCY.includes(args.operationName)
@@ -159,6 +159,7 @@ export const operationEvents = memoize(
                   ctx.client,
                   args.idPair,
                   args.typeName,
+                  ctx.serverActionsEnabled,
                 ).pipe(filter(Boolean))
                 const ready$ = requiresConsistency ? isConsistent$.pipe(take(1)) : of(true)
                 return ready$.pipe(
@@ -201,6 +202,6 @@ export const operationEvents = memoize(
   (ctx) => {
     const config = ctx.client.config()
     // we only want one of these per dataset+projectid
-    return `${config.dataset ?? ''}-${config.projectId ?? ''}`
+    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${ctx.serverActionsEnabled}`
   },
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -74,7 +74,7 @@ const execute = (
   operationName: keyof typeof operationImpls,
   operationArguments: OperationArgs,
   extraArgs: any[],
-  serverActionsEnabled?: boolean,
+  serverActionsEnabled: boolean,
 ): Observable<any> => {
   const operation = serverActionsEnabled
     ? serverOperationImpls[operationName]
@@ -137,7 +137,7 @@ export const operationEvents = memoize(
     client: SanityClient
     historyStore: HistoryStore
     schema: Schema
-    serverActionsEnabled?: boolean
+    serverActionsEnabled: boolean
   }) => {
     const result$: Observable<IntermediarySuccess | IntermediaryError> = operationCalls$.pipe(
       groupBy((op) => op.idPair.publishedId),
@@ -147,7 +147,7 @@ export const operationEvents = memoize(
           // E.g. if the user types `publish` which is async and then starts patching (sync) then the publish
           // should be cancelled
           switchMap((args) =>
-            operationArgs({...ctx, serverActionsEnabled: false}, args.idPair, args.typeName).pipe(
+            operationArgs(ctx, args.idPair, args.typeName).pipe(
               take(1),
               switchMap((operationArguments) => {
                 const requiresConsistency = REQUIRES_CONSISTENCY.includes(args.operationName)
@@ -202,6 +202,6 @@ export const operationEvents = memoize(
   (ctx) => {
     const config = ctx.client.config()
     // we only want one of these per dataset+projectid
-    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${ctx.serverActionsEnabled}`
+    return `${config.dataset ?? ''}-${config.projectId ?? ''}${ctx.serverActionsEnabled ? '-serverActionsEnabled' : ''}`
   },
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/types.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/types.ts
@@ -49,5 +49,5 @@ export interface OperationArgs {
   snapshots: {draft: null | SanityDocument; published: null | SanityDocument}
   draft: DocumentVersionSnapshots
   published: DocumentVersionSnapshots
-  serverActionsEnabled?: boolean
+  serverActionsEnabled: boolean
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/snapshotPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/snapshotPair.ts
@@ -8,6 +8,7 @@ import {type IdPair, type PendingMutationsEvent, type ReconnectEvent} from '../t
 import {memoize} from '../utils/createMemoizer'
 import {type DocumentVersion} from './checkoutPair'
 import {memoizedPair} from './memoizedPair'
+import {memoizeKeyGen} from './memoizeKeyGen'
 
 // return true if the event comes with a document snapshot
 function isSnapshotEvent(event: BufferedDocumentEvent | ReconnectEvent): event is SnapshotEvent & {
@@ -78,14 +79,5 @@ export const snapshotPair = memoize(
       refCount(),
     )
   },
-  (
-    client: SanityClient,
-    idPair: IdPair,
-    typeName: string,
-    serverActionsEnabled: boolean,
-  ): string => {
-    const config = client.config()
-
-    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}-${serverActionsEnabled}`
-  },
+  memoizeKeyGen,
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/validation.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/validation.test.ts
@@ -52,7 +52,14 @@ function createSubscription(
   const getClient = () => client
 
   const stream = validation(
-    {client, getClient, schema, observeDocumentPairAvailability, i18n: getFallbackLocaleSource()},
+    {
+      client,
+      getClient,
+      schema,
+      observeDocumentPairAvailability,
+      i18n: getFallbackLocaleSource(),
+      serverActionsEnabled: false,
+    },
     {publishedId: 'example-id', draftId: 'drafts.example-id'},
     'movie',
   ).pipe(publish())
@@ -292,6 +299,7 @@ describe('validation', () => {
           getClient: () => client,
           observeDocumentPairAvailability: jest.fn(() => EMPTY),
           i18n: getFallbackLocaleSource(),
+          serverActionsEnabled: false,
         },
         {publishedId: 'example-id', draftId: 'drafts.example-id'},
         'movie',

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
@@ -35,6 +35,7 @@ import {validateDocumentObservable, type ValidationContext} from '../../../../va
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {editState} from './editState'
+import {memoizeKeyGen} from './memoizeKeyGen'
 
 /**
  * @hidden
@@ -94,6 +95,7 @@ export const validation = memoize(
       observeDocumentPairAvailability: ObserveDocumentPairAvailability
       schema: Schema
       i18n: LocaleSource
+      serverActionsEnabled: boolean
     },
     {draftId, publishedId}: IdPair,
     typeName: string,
@@ -189,8 +191,6 @@ export const validation = memoize(
     )
   },
   (ctx, idPair, typeName) => {
-    const config = ctx.client.config()
-
-    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}`
+    return memoizeKeyGen(ctx.client, idPair, typeName, ctx.serverActionsEnabled)
   },
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-store.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-store.ts
@@ -80,7 +80,7 @@ export interface DocumentStoreOptions {
   schema: Schema
   initialValueTemplates: Template[]
   i18n: LocaleSource
-  serverActionsEnabled?: boolean
+  serverActionsEnabled: boolean
 }
 
 /** @internal */
@@ -140,7 +140,12 @@ export function createDocumentStore({
         )
       },
       documentEvents(publishedId, type) {
-        return documentEvents(ctx.client, getIdPairFromPublished(publishedId), type)
+        return documentEvents(
+          ctx.client,
+          getIdPairFromPublished(publishedId),
+          type,
+          serverActionsEnabled,
+        )
       },
       editOperations(publishedId, type) {
         return editOperations(ctx, getIdPairFromPublished(publishedId), type)


### PR DESCRIPTION
### Description
When the `serverActions` config flag was set, we noticed inconsistent behavior coming from the Portable Text Editor: strings were being duplicated, new lines were being inserted, and patches generally seemed to be repeated or inconsistent.

This behavior can be tracked down to `document-store` -- `documentEvents` were not being initialized with the `serverActionsEnabled` parameter. 

Interestingly, before this was tracked down, forcing both `serverActions: enabled` and `serverActions: disabled` to use the Actions API still resulted in this inconsistent behavior, and I suspect that the `patchChannel` used in FormView (and published to by `documentEvents`) was in some way misaligned about remote and local patches (possibly because of inconsistent memoization) so there are some fixes to ensure that memoization functions are more aligned and that serverActions parameters are always required.

(A nice side effect is that the `serverActions` logic throughout the document store should become easier to remove in the future).

### What to review
You should be able to pull down this branch and type in a Portable Text Editor with server actions enabled and see consistent behavior.

### Testing
I'm a bit unclear on how to test this one. It was more of a configuration oversight.