### PR TITLE
fix(cli): ensure output path for types exist before writing

### DIFF
--- a/packages/@sanity/cli/src/actions/typegen/generateAction.ts
+++ b/packages/@sanity/cli/src/actions/typegen/generateAction.ts
@@ -1,5 +1,5 @@
-import {constants, open, stat} from 'node:fs/promises'
-import {join} from 'node:path'
+import {constants, mkdir, open, stat} from 'node:fs/promises'
+import {dirname, join} from 'node:path'
 
 import {readConfig} from '@sanity/codegen'
 import {Worker} from 'worker_threads'
@@ -70,8 +70,12 @@ export default async function typegenGenerateAction(
     env: process.env,
   })
 
+  const outputPath = join(process.cwd(), codegenConfig.generates)
+  const outputDir = dirname(outputPath)
+  await mkdir(outputDir, {recursive: true})
+
   const typeFile = await open(
-    join(process.cwd(), codegenConfig.generates),
+    outputPath,
     // eslint-disable-next-line no-bitwise
     constants.O_TRUNC | constants.O_CREAT | constants.O_WRONLY,
   )

--- a/packages/@sanity/cli/test/__fixtures__/v3/working-typegen.json
+++ b/packages/@sanity/cli/test/__fixtures__/v3/working-typegen.json
@@ -1,3 +1,4 @@
 {
-  "schema": "./working-schema.json"
+  "schema": "./working-schema.json",
+  "generates": "./out/types.ts"
 }


### PR DESCRIPTION
### Description

If the `generates` path in the typegen configuration points to a path that does not exist, it will crash with a `ENOENT: no such file or directory, open '<some-path>/<generates-path>'` error.

This PR fixes this by running a recursive directory creation process before writing the output file.

### What to review

- Changes makes sense, paths are correct

### Testing

Added a CLI test to reproduce - the `out` directory does not exist in the fixture, and thus should fail before this change and pass after this change.

### Notes for release

- Fixes an issue where `sanity typegen generate` would crash if the configured output path did not exist prior to running the command