### PR TITLE
chore: improve test output of `test:exports`

### DIFF
--- a/packages/@repo/test-exports/test/exports.test.cjs
+++ b/packages/@repo/test-exports/test/exports.test.cjs
@@ -11,7 +11,7 @@ for (const [workspace, paths] of Object.entries(workspaces)) {
       return
     }
     for (const path of paths) {
-      await t.test(path, () => {
+      await t.test(`require('${path}')`, () => {
         // eslint-disable-next-line import/no-dynamic-require
         require(path)
       })

--- a/packages/@repo/test-exports/test/exports.test.mjs
+++ b/packages/@repo/test-exports/test/exports.test.mjs
@@ -12,7 +12,7 @@ for (const [workspace, paths] of Object.entries(workspaces)) {
     }
     for (const path of paths) {
       // eslint-disable-next-line @typescript-eslint/no-shadow, @typescript-eslint/no-unused-vars
-      await t.test(path, async (t) => {
+      await t.test(`await import('${path}')`, async (t) => {
         try {
           await import(path)
         } catch (error) {


### PR DESCRIPTION
Improves the test output of `pnpm test:exports` from:
```bash
@repo/test-exports:test: ▶ @sanity/schema
@repo/test-exports:test:   ✔ @sanity/schema (0.244875ms)
@repo/test-exports:test:   ✔ @sanity/schema/_internal (4.150458ms)
@repo/test-exports:test: ▶ @sanity/schema (4.640667ms)
@repo/test-exports:test: ▶ @sanity/types
@repo/test-exports:test:   ✔ @sanity/types (0.327041ms)
@repo/test-exports:test: ▶ @sanity/types (0.418833ms)
```

To easier distinguish the CJS tests from the ESM ones:
```bash
@repo/test-exports:test: ▶ @sanity/schema
@repo/test-exports:test:   ✔ require('@sanity/schema') (0.244875ms)
@repo/test-exports:test:   ✔ require('@sanity/schema/_internal') (4.150458ms)
@repo/test-exports:test: ▶ @sanity/schema (4.640667ms)
@repo/test-exports:test: ▶ @sanity/types
@repo/test-exports:test:   ✔ await import('@sanity/types') (0.327041ms)
@repo/test-exports:test: ▶ @sanity/types (0.418833ms)
```