### PR TITLE
fix(core): hidden caret on code formatted text

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx
@@ -1,17 +1,22 @@
 import {type BlockDecoratorRenderProps} from '@sanity/portable-text-editor'
+import {type Theme} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
-import {styled} from 'styled-components'
+import {css, styled} from 'styled-components'
 
 import {type BlockDecoratorProps} from '../../../types'
 import {TEXT_DECORATOR_TAGS} from './constants'
 
-const Root = styled.span`
-  /* Make sure the annotation styling is visible */
-  &[data-mark='code'] {
-    mix-blend-mode: multiply;
-    color: inherit;
-  }
-`
+const Root = styled.span(({theme}: {theme: Theme}) => {
+  const isDark = theme.sanity.color.dark
+
+  return css`
+    /* Make sure the annotation styling is visible */
+    &[data-mark='code'] {
+      color: inherit;
+      mix-blend-mode: ${isDark ? 'screen' : 'multiply'};
+    }
+  `
+})
 
 export function Decorator(props: BlockDecoratorRenderProps) {
   const {value, focused, selected, children, schemaType} = props


### PR DESCRIPTION
### Description

This pull request addresses an issue where the caret was not visible on code-formatted text within the PTE when using the dark scheme.

### What to Review

- Verify that the caret is now visible on code-formatted text when using the dark scheme.

### Notes for Release

N/A
