### PR TITLE
chore: support IDE's using older TypeScript versions on the monorepo

### DIFF
--- a/packages/@repo/tsconfig/base.json
+++ b/packages/@repo/tsconfig/base.json
@@ -40,6 +40,11 @@
     // "noUnusedParameters": true,
     // "noImplicitReturns": true,
     // "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+
+    // These options are already set by "module": "Preserve" but if someone loads the monorepo in an older TS version you'll get confusing errors and so we set them here as a fallback
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
Unless your IDE, like VS Code, is set to use the monorepo version of TypeScript it might load the one it's bundled with. Which might not be 5.4 which is required to understand `module: "Preserve"`. This PR sets the other options `moduleResolution`, `esModuleInterop` and `resolveJsonModule` to what `module: "Preserve"` is using, to make sure everything still works