### PR TITLE
fix(typegen): fixes a case where we track ratio as NaN

### DIFF
--- a/packages/@sanity/cli/src/actions/typegen/generateAction.ts
+++ b/packages/@sanity/cli/src/actions/typegen/generateAction.ts
@@ -152,7 +152,8 @@ export default async function typegenGenerateAction(
     filesWithErrors: stats.errors,
     typeNodesGenerated: stats.typeNodesGenerated,
     unknownTypeNodesGenerated: stats.unknownTypeNodesGenerated,
-    unknownTypeNodesRatio: stats.unknownTypeNodesGenerated / stats.typeNodesGenerated,
+    unknownTypeNodesRatio:
+      stats.typeNodesGenerated > 0 ? stats.unknownTypeNodesGenerated / stats.typeNodesGenerated : 0,
   })
 
   trace.complete()


### PR DESCRIPTION
### Description

If `typeNodesGenerated` is `0` the ratio is `NaN`, it then gets serialized to null - which is not what we want

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Would be nice to have some proper testing for telemetry labels and variants; but think that's out of scope for this issue  

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
No notes needed 
