### PR TITLE
fix(core): set scroll boundary to nearest

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useScrollSelectionIntoView.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useScrollSelectionIntoView.tsx
@@ -16,7 +16,7 @@ export function useScrollSelectionIntoView(scrollElement: HTMLElement | null) {
           scrollIntoView(leafEl, {
             scrollMode: 'if-needed',
             boundary: scrollElement,
-            block: 'start',
+            block: 'nearest',
             inline: 'nearest',
           })
         }

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useScrollSelectionIntoView.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useScrollSelectionIntoView.tsx
@@ -14,7 +14,6 @@ export function useScrollSelectionIntoView(scrollElement: HTMLElement | null) {
             return
           }
           scrollIntoView(leafEl, {
-            behavior: 'smooth',
             scrollMode: 'if-needed',
             boundary: scrollElement,
             block: 'nearest',

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useScrollSelectionIntoView.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useScrollSelectionIntoView.tsx
@@ -14,6 +14,7 @@ export function useScrollSelectionIntoView(scrollElement: HTMLElement | null) {
             return
           }
           scrollIntoView(leafEl, {
+            behavior: 'smooth',
             scrollMode: 'if-needed',
             boundary: scrollElement,
             block: 'nearest',


### PR DESCRIPTION
### Description
There was an issue with deleting characters in a pte where the length of the paragraph exceeded the size of the box - it would jump to the top of the pte. 

By setting the `block` in the `scrollIntoView()` to `nearest` instead of `start`, which means the browser will align `leafEl` with the least amount of vertical movement. 


https://github.com/sanity-io/sanity/assets/44635000/f2d786d1-9d31-4d9a-bafa-404e83706161

Fixes [5648](https://github.com/sanity-io/sanity/issues/5648)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Deleting characters will not cause the view to jump to the top. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes issue where the cursor would move out of viewpoint when deleting a character in PTE. 
Does changing this have any other implications in the studio?
<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
