### PR TITLE
fix: update TelemetryUserProperties to use key machinePlatform instead of platform

### DIFF
--- a/packages/@sanity/cli/src/cli.ts
+++ b/packages/@sanity/cli/src/cli.ts
@@ -88,7 +88,7 @@ export async function runCli(cliRoot: string, {cliVersion}: {cliVersion: string}
     runtimeVersion: process.version,
     runtime: detectRuntime(),
     cliVersion: pkg.version,
-    platform: process.platform,
+    machinePlatform: process.platform,
     cpuArchitecture: process.arch,
     projectId: cliConfig?.config?.api?.projectId,
     dataset: cliConfig?.config?.api?.dataset,

--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -98,7 +98,7 @@ export interface TelemetryUserProperties {
   runtime: string
   runtimeVersion: string
   cliVersion: string
-  platform: string
+  machinePlatform: string
   cpuArchitecture: string
   projectId?: string
   dataset?: string


### PR DESCRIPTION
Merely renaming userProperty key from `platform` to `machine_platform` to be more descriptive