### PR TITLE
fix(core): change scrollIntoView block to be nearest

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -44,7 +44,7 @@ export function useTrackFocusPath(props: Props): void {
         scrollIntoView(openItem.elementRef.current, {
           scrollMode: 'if-needed',
           boundary: boundaryElement,
-          block: 'start',
+          block: 'nearest',
           inline: 'start',
         })
       }


### PR DESCRIPTION
### Description
Kind of the same as this [pr](https://github.com/sanity-io/sanity/pull/6310) - when adding a link to the bottom of the PTE, it would scroll to the top and it wasn't possible to scroll down to the open popover. 

This PR sets the `block` to scroll to `nearest` instead of `start` to have the least amount of scroll movement. 

Fixes issues [5909](https://github.com/sanity-io/sanity/issues/5909) and [5586](https://github.com/sanity-io/sanity/issues/5586). 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Opening a link in a PTE where the paragraph is longer than the PTE block itself. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes issue where creating a link at the bottom of a PTE would scroll to the top. 
<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
