### PR TITLE
fix(core): ignore locally applied createIfNotExists mutations when using server actions

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -84,6 +84,8 @@ function toActions(idPair: IdPair, mutationParams: Mutation['params']) {
         draftId: idPair.draftId,
       }
     }
+    // This action is not always interoperable with the equivalent mutation. It will fail if the
+    // published version of the document already exists.
     if (mutations.createIfNotExists) {
       return {
         actionType: 'sanity.action.document.create',

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -71,6 +71,14 @@ function setVersion<T>(version: 'draft' | 'published') {
   return (ev: T): T & {version: 'draft' | 'published'} => ({...ev, version})
 }
 
+function requireId<T extends {_id?: string; _type: string}>(
+  value: T,
+): asserts value is T & {_id: string} {
+  if (!value._id) {
+    throw new Error('Expected document to have an _id')
+  }
+}
+
 function toActions(idPair: IdPair, mutationParams: Mutation['params']) {
   return mutationParams.mutations.flatMap<HttpAction>((mutations) => {
     if (Object.keys(mutations).length > 1) {
@@ -91,6 +99,8 @@ function toActions(idPair: IdPair, mutationParams: Mutation['params']) {
       return []
     }
     if (mutations.create) {
+      // the actions API requires attributes._id to be set, while it's optional in the mutation API
+      requireId(mutations.create)
       return {
         actionType: 'sanity.action.document.create',
         publishedId: idPair.publishedId,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
@@ -27,24 +27,31 @@ export const patch: OperationImpl<[patches: any[], initialDocument?: Record<stri
       return
     }
 
-    // If there's no published or draft document, create one.
-    if (!snapshots.published && !snapshots.draft) {
-      draft.patch([
+    const patchMutation = draft.patch(patches)
+
+    if (snapshots.published) {
+      draft.mutate([
+        // If there's no draft, the user's edits will be based on the published document in the form in front of them
+        // so before patching it we need to make sure it's created based on the current published version first.
         draft.createIfNotExists({
           ...initialDocument,
+          ...snapshots.published,
           _id: idPair.draftId,
           _type: typeName,
         }),
-        draft.patch(patches),
+        ...patchMutation,
       ])
-
       return
     }
-
-    // If there's no draft, the user's edits will be based on the published document in the form
-    // in front of them. This is handled in Content Lake by the `sanity.action.document.edit`
-    // action.
-    const document = snapshots.draft ? draft : published
-    document.mutate(document.patch(patches))
+    const ensureDraft = snapshots.draft
+      ? []
+      : [
+          draft.create({
+            ...initialDocument,
+            _id: idPair.draftId,
+            _type: typeName,
+          }),
+        ]
+    draft.mutate([...ensureDraft, ...patchMutation])
   },
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
@@ -23,22 +23,28 @@ export const patch: OperationImpl<[patches: any[], initialDocument?: Record<stri
           ]
       // No drafting, so patch and commit the published document
       published.mutate(mutations)
-    } else {
-      const patchMutation = draft.patch(patches)
-      const mutations = snapshots.draft
-        ? patchMutation
-        : [
-            // If there's no draft, the user's edits will be based on the published document in the form in front of them
-            // so before patching it we need to make sure it's created based on the current published version first.
-            draft.createIfNotExists({
-              ...initialDocument,
-              ...snapshots.published,
-              _id: idPair.draftId,
-              _type: typeName,
-            }),
-            ...patchMutation,
-          ]
-      draft.mutate(mutations)
+
+      return
     }
+
+    // If there's no published or draft document, create one.
+    if (!snapshots.published && !snapshots.draft) {
+      draft.patch([
+        draft.createIfNotExists({
+          ...initialDocument,
+          _id: idPair.draftId,
+          _type: typeName,
+        }),
+        draft.patch(patches),
+      ])
+
+      return
+    }
+
+    // If there's no draft, the user's edits will be based on the published document in the form
+    // in front of them. This is handled in Content Lake by the `sanity.action.document.edit`
+    // action.
+    const document = snapshots.draft ? draft : published
+    document.mutate(document.patch(patches))
   },
 }

--- a/test/e2e/tests/inputs/reference.spec.ts
+++ b/test/e2e/tests/inputs/reference.spec.ts
@@ -1,0 +1,65 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+import {withDefaultClient} from '../../helpers'
+
+withDefaultClient((context) => {
+  test(`value can be changed after the document has been published`, async ({
+    page,
+    createDraftDocument,
+  }) => {
+    test.slow()
+
+    // Create test documents to use as reference targets.
+    await Promise.all(
+      [
+        {
+          _type: 'author',
+          _id: 'authorA',
+          name: 'Author A',
+        },
+        {
+          _type: 'author',
+          _id: 'authorB',
+          name: 'Author B',
+        },
+      ].map((document) => context.client.createIfNotExists(document)),
+    )
+
+    await createDraftDocument('/test/content/book')
+
+    // Reference fields don't seem to be given a test id, so this selection can't be more specific
+    // at the moment e.g. `page.getByTestId('field-author')`.
+    const referenceInput = page.getByTestId('reference-input')
+    const paneFooter = page.getByTestId('pane-footer')
+    const publishButton = page.getByTestId('action-Publish')
+    const authorListbox = page.locator('#author-listbox')
+
+    // Open the Author reference input.
+    await referenceInput.getByLabel('Open').click()
+    await expect(authorListbox).toBeVisible()
+
+    // Select the first document in the list.
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('Enter')
+
+    // Wait for the document to be published.
+    publishButton.click()
+    await expect(paneFooter).toContainText('Published just now')
+
+    // Open the Author reference input.
+    await page.locator('#author-menuButton').click()
+    await page.getByRole('menuitem').getByText('Replace').click()
+    await referenceInput.getByLabel('Open').click()
+    await expect(authorListbox).toBeVisible()
+
+    // Select the next document in the list.
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('Enter')
+    await expect(paneFooter).toContainText('Saved')
+
+    // Wait for the document to be published.
+    publishButton.click()
+    await expect(paneFooter).toContainText('Published just now')
+  })
+})

--- a/test/e2e/tests/inputs/text.spec.ts
+++ b/test/e2e/tests/inputs/text.spec.ts
@@ -70,4 +70,28 @@ test.describe('inputs: text', () => {
     expect(await field.inputValue()).toBe(currentExpectedValue)
     expect(await getRemoteValue()).toBe(currentExpectedValue)
   })
+
+  test(`value can be changed after the document has been published`, async ({
+    page,
+    createDraftDocument,
+  }) => {
+    await createDraftDocument('/test/content/book')
+
+    const titleInput = page.getByTestId('field-title').getByTestId('string-input')
+    const paneFooter = page.getByTestId('pane-footer')
+    const publishButton = page.getByTestId('action-Publish')
+
+    await titleInput.fill('Title A')
+
+    // Wait for the document to be published.
+    publishButton.click()
+    await expect(paneFooter).toContainText('Published just now')
+
+    // Change the title.
+    await titleInput.fill('Title B')
+
+    // Wait for the document to be published.
+    publishButton.click()
+    await expect(paneFooter).toContainText('Published just now')
+  })
 })


### PR DESCRIPTION

### Description
When using server actions, `createIfNotExists` should never be submitted to the actions API, as these are applied server side as part of the edit action (we still want them to be applied optimistically though).

When patching locally, and we don’t have either a published or a draft we need to submit a create mutation in order to ensure that the draft exist. This will fail if someone concurrently creates it, but that’s ok, and what we want.

### What to review
- Does the logic make sense?

### Testing


### Notes for release
n/a - internal for now