### PR TITLE
fix: use pane key in list settings that do not have a type available

### DIFF
--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -110,7 +110,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   const showIcons = displayOptions?.showIcons !== false
   const [layout, setLayout] = useStructureToolSetting<GeneralPreviewLayoutKey>(
     'layout',
-    typeName,
+    typeName ?? pane.id, //pane.id for anything that is not documentTypeList
     defaultLayout,
   )
 
@@ -133,7 +133,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
 
   const [sortOrderRaw, setSortOrder] = useStructureToolSetting<SortOrder>(
     'sort-order',
-    typeName,
+    typeName ?? pane.id, //pane.id for anything that is not documentTypeList
     defaultSortOrder,
   )
 


### PR DESCRIPTION
### Description
Setting a custom sort order function on a `documentList` will send over an incomplete key to /users/me/keyvalue, which will return a 400 error, because it is sending keys like `studio.structure-tool.sort-order`, which is not a valid format.

This PR uses the paneKey (which has its own regex restrictions) if a type is not available.

### What to review
Are there any edge cases here that might be an issue?

### Testing
e2e tests do exist for this functionality, but are currently a bit flaky and thus not available.

### Notes for release
Resolves an issue where custom sort orders, or sort orders in lists that are not `documentTypeList`s, would send invalid requests to the persistent user settings backend.