### PR TITLE
chore: fix start-studio build

### DIFF
--- a/dev/starter-studio/package.json
+++ b/dev/starter-studio/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "sanity": "workspace:*",
     "styled-components": "^6.1.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,6 +292,9 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
       sanity:
         specifier: workspace:*
         version: link:../../packages/sanity


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Starter studio was missing `react-dom` package as a dependency causing the build to fail

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Start studio build `cd dev/starter-studio && pnpm build`