### PR TITLE
fix: regression hiding tool buttons when embedded on Next.js

### DIFF
--- a/packages/sanity/src/core/components/collapseMenu/ObserveElement.tsx
+++ b/packages/sanity/src/core/components/collapseMenu/ObserveElement.tsx
@@ -9,7 +9,7 @@ interface ObserveElementProps {
 
 export function ObserveElement(props: ObserveElementProps) {
   const {onIntersectionChange, children, options, ...rest} = props
-  const [el, setEl] = useState<HTMLDivElement | null>(null)
+  const [el, setEl] = useState<HTMLSpanElement | null>(null)
 
   useEffect(() => {
     const target = el?.closest('[data-ui="Flex"]')
@@ -27,7 +27,7 @@ export function ObserveElement(props: ObserveElementProps) {
   return (
     <Flex {...rest}>
       {children}
-      <div hidden ref={setEl} />
+      <span hidden ref={setEl} />
     </Flex>
   )
 }

--- a/packages/sanity/src/core/components/collapseMenu/ObserveElement.tsx
+++ b/packages/sanity/src/core/components/collapseMenu/ObserveElement.tsx
@@ -12,20 +12,22 @@ export function ObserveElement(props: ObserveElementProps) {
   const [el, setEl] = useState<HTMLDivElement | null>(null)
 
   useEffect(() => {
-    if (!el) return undefined
+    const target = el?.closest('[data-ui="Flex"]')
+    if (!target) return undefined
 
     const io = new IntersectionObserver(onIntersectionChange, options)
-    io.observe(el)
+    io.observe(target)
 
     return () => {
-      io.unobserve(el)
+      io.unobserve(target)
       io.disconnect()
     }
   }, [el, onIntersectionChange, options])
 
   return (
-    <Flex ref={setEl} {...rest}>
+    <Flex {...rest}>
       {children}
+      <div hidden ref={setEl} />
     </Flex>
   )
 }


### PR DESCRIPTION
### Description

After [updating](https://github.com/sanity-io/template-nextjs-personal-website/commit/bcc3a2c656a6d05e6a1ba526eb5635ad77d3c754) to the just-released Next.js 14.2 I noticed the tools in the navbar were gone:

<img width="1212" alt="image" src="https://github.com/sanity-io/sanity/assets/81981/438d3e1e-8931-454a-a353-3181a7e117e2">

[It appears to be related to the underlying pre-release of React v18.3.](https://github.com/radix-ui/primitives/issues/2769), which Next [is using](https://github.com/vercel/next.js/blob/6d96c3f468801fc2d8f648ccf468d689f930ce06/package.json#L201).

After working around it the menu appears again:

<img width="1212" alt="image" src="https://github.com/sanity-io/sanity/assets/81981/54cfa88b-72e7-48a8-835a-d07293c7629f">


The fix is verified here: 
- [live deploy](https://template-nextjs-personal-website-git-test-canary-fix.sanity.build/studio/presentation/home/home)
- [git branch](https://github.com/sanity-io/template-nextjs-personal-website/tree/test-canary-fix)

### What to review

The menu should work just as before, since the Flex element is still selected, but now by calling `.closest` on the `<span />` node, which is unaffected by how `@sanity/ui` and `styled-components` are dealing with forwarded refs.


### Notes for release

Fixed a regression impacting embedded Studios on Next v14.2 where the tools navbar menu were missing
