### PR TITLE
chore(tasks): add e2e and integration tests

### DIFF
--- a/packages/sanity/src/tasks/i18n/resources.ts
+++ b/packages/sanity/src/tasks/i18n/resources.ts
@@ -120,6 +120,8 @@ const tasksLocaleStrings = defineLocalesResources('tasks', {
   /** The placeholder text for the title input */
   'form.input.title.placeholder': 'Task title',
   /** The status error message presented when the user does not supply a title */
+  'form.status.error.creation-failed': 'Task creation failed, please try again',
+  /** The status error message presented when the user does not supply a title */
   'form.status.error.title-required': 'Title is required',
   /** The status message upon successful creation of a task */
   'form.status.success': 'Task created',

--- a/packages/sanity/src/tasks/plugin/TasksFooterOpenTasks.tsx
+++ b/packages/sanity/src/tasks/plugin/TasksFooterOpenTasks.tsx
@@ -72,6 +72,7 @@ export function TasksFooterOpenTasks() {
   }
   return (
     <Button
+      data-testid="tasks-footer-open-tasks"
       mode="bleed"
       tooltipProps={{
         content: t('document.footer.open-tasks.placeholder', {

--- a/packages/sanity/src/tasks/src/tasks/components/TasksUserAvatar.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/TasksUserAvatar.tsx
@@ -48,7 +48,7 @@ export function TasksUserAvatar(props: {
 
   if (!user || !loadedUser) {
     return (
-      <AvatarRoot $size={size} $border={border}>
+      <AvatarRoot $size={size} $border={border} data-testid="no-user-avatar">
         <Text size={size}>
           <UserIcon />
         </Text>
@@ -64,7 +64,7 @@ export function TasksUserAvatar(props: {
       fallbackPlacements={['top', 'top-start']}
       placement="top-end"
     >
-      <AvatarRoot $size={size} $removeBg={!!loadedUser?.imageUrl}>
+      <AvatarRoot $size={size} $removeBg={!!loadedUser?.imageUrl} data-testid="user-avatar">
         <UserAvatar
           user={loadedUser}
           size={size}

--- a/packages/sanity/src/tasks/src/tasks/components/form/fields/TargetField.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/form/fields/TargetField.tsx
@@ -117,7 +117,7 @@ function Preview(props: {value: TaskTarget; handleRemove: () => void}) {
   }
 
   return (
-    <TargetRoot border radius={2}>
+    <TargetRoot border radius={2} data-testid="task-target-field">
       <Flex gap={1} align={'center'} justify={'space-between'}>
         <Card as={CardLink} radius={2} data-as="button">
           <SearchResultItemPreview

--- a/packages/sanity/src/tasks/src/tasks/components/form/fields/TitleField.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/form/fields/TitleField.tsx
@@ -81,6 +81,7 @@ export function Title(props: {
   return (
     <Root>
       <TitleInput
+        data-testid="title-input"
         ref={ref}
         autoFocus={!value}
         value={value}

--- a/packages/sanity/src/tasks/src/tasks/components/form/fields/assignee/AssigneeCreateFormField.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/form/fields/assignee/AssigneeCreateFormField.tsx
@@ -51,7 +51,12 @@ export function AssigneeCreateFormField(props: StringInputProps) {
           <Flex align="center" gap={3}>
             <Flex align="center" gap={1} flex={1}>
               <TasksUserAvatar user={mentionedUser} size={1} border={false} />
-              <Text size={1} textOverflow="ellipsis" muted={!mentionedUser}>
+              <Text
+                size={1}
+                textOverflow="ellipsis"
+                muted={!mentionedUser}
+                data-testid="assigned-user"
+              >
                 {displayText}
               </Text>
             </Flex>

--- a/packages/sanity/src/tasks/src/tasks/components/form/tasksFormBuilder/FormCreate.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/form/tasksFormBuilder/FormCreate.tsx
@@ -1,13 +1,12 @@
 import {TrashIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Box, Flex, Switch, Text, useToast} from '@sanity/ui'
-import {useCallback, useState} from 'react'
+import {useCallback, useEffect, useState} from 'react'
 import {type ObjectInputProps, set, useTranslation} from 'sanity'
 
 import {Button} from '../../../../../../ui-components'
-import {TaskCreated} from '../../../../../__telemetry__/tasks.telemetry'
 import {tasksLocaleNamespace} from '../../../../../i18n'
-import {useTasksNavigation} from '../../../context'
+import {useTasks, useTasksNavigation} from '../../../context'
 import {useRemoveTask} from '../../../hooks/useRemoveTask'
 import {type TaskDocument} from '../../../types'
 import {getMentionedUsers} from '../utils'
@@ -28,12 +27,9 @@ const getTaskSubscribers = (task: TaskDocument): string[] => {
   return subscribers
 }
 export function FormCreate(props: ObjectInputProps) {
+  const [creating, setCreating] = useState(false)
   const {onChange} = props
-  const {
-    setViewMode,
-    setActiveTab,
-    state: {viewMode},
-  } = useTasksNavigation()
+  const {setViewMode, setActiveTab} = useTasksNavigation()
   const toast = useToast()
   const telemetry = useTelemetry()
 
@@ -46,7 +42,51 @@ export function FormCreate(props: ObjectInputProps) {
   }, [setViewMode])
   const {handleRemove, removeStatus} = useRemoveTask({id: value._id, onRemoved: onRemove})
   const {t} = useTranslation(tasksLocaleNamespace)
-  const handleCreate = useCallback(() => {
+  const {data} = useTasks()
+  const savedTask = data.find((task) => task._id === value._id)
+
+  useEffect(() => {
+    // This useEffect takes care of closing the form when a task entered the "creation" state.
+    // That action is async and we don't have access to the promise, once the value is updated in the form we will close the form.
+    if (creating && savedTask?.createdByUser) {
+      toast.push({
+        closable: true,
+        status: 'success',
+        title: t('form.status.success'),
+      })
+
+      setCreating(false)
+      if (createMore) {
+        setViewMode({type: 'create'})
+      } else {
+        setActiveTab('subscribed')
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [creating, savedTask?.createdByUser])
+
+  useEffect(() => {
+    // If after 5 seconds the task is still in the "creating" state, we will show a toast to the user.
+    let timeoutId: NodeJS.Timeout | null = null
+    if (creating) {
+      timeoutId = setTimeout(() => {
+        setCreating(false)
+        toast.push({
+          closable: true,
+          status: 'error',
+          title: t('form.status.error.creation-failed'),
+        })
+      }, 5000)
+    }
+    // Cleanup function to clear the timeout
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [creating])
+
+  const handleCreate = useCallback(async () => {
+    setCreating(true)
     if (!value?.title) {
       toast.push({
         closable: true,
@@ -59,21 +99,7 @@ export function FormCreate(props: ObjectInputProps) {
       set(getTaskSubscribers(value), ['subscribers']),
       set(new Date().toISOString(), ['createdByUser']),
     ])
-
-    if (createMore) {
-      setViewMode({type: 'create'})
-    } else {
-      setActiveTab('subscribed')
-    }
-
-    telemetry.log(TaskCreated)
-
-    toast.push({
-      closable: true,
-      status: 'success',
-      title: t('form.status.success'),
-    })
-  }, [value, onChange, createMore, telemetry, toast, t, setViewMode, setActiveTab])
+  }, [value, onChange, t, toast])
 
   return (
     <>
@@ -101,7 +127,12 @@ export function FormCreate(props: ObjectInputProps) {
             </Text>
           </Flex>
 
-          <Button text={t('buttons.create.text')} onClick={handleCreate} />
+          <Button
+            text={t('buttons.create.text')}
+            onClick={handleCreate}
+            disabled={creating}
+            loading={creating}
+          />
         </Flex>
       </Box>
     </>

--- a/packages/sanity/src/tasks/src/tasks/components/list/TaskListItem.test.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/list/TaskListItem.test.tsx
@@ -1,0 +1,44 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {act, render} from '@testing-library/react'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {TasksListItem} from './TasksListItem'
+
+const mockedEditFn = jest.fn()
+jest.mock('../../hooks/useTaskOperations', () => ({
+  useTaskOperations: jest.fn(() => ({
+    edit: mockedEditFn,
+  })),
+}))
+
+describe('Tests TaskListItem', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks()
+  })
+  it('should change the status of the task when clicking the checkbox', async () => {
+    const wrapper = await createTestProvider()
+    const onSelect = jest.fn()
+    const taskListItemProps = {
+      documentId: '91ea0763-2620-4746-b2a2-5294dcacf29e',
+      title: 'Test task 29',
+      status: 'open' as const,
+    }
+    const component = render(<TasksListItem {...taskListItemProps} onSelect={onSelect} />, {
+      wrapper,
+    })
+    const checkbox = component.getByRole('checkbox')
+    await act(async () => {
+      checkbox.click()
+    })
+    expect(mockedEditFn).toHaveBeenCalledWith(taskListItemProps.documentId, {status: 'closed'})
+
+    component.rerender(
+      <TasksListItem {...taskListItemProps} status={'closed'} onSelect={onSelect} />,
+    )
+    const checkboxClosed = component.getByRole('checkbox')
+    await act(async () => {
+      checkboxClosed.click()
+    })
+    expect(mockedEditFn).toHaveBeenCalledWith(taskListItemProps.documentId, {status: 'open'})
+  })
+})

--- a/packages/sanity/src/tasks/src/tasks/components/list/TasksList.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/list/TasksList.tsx
@@ -54,7 +54,7 @@ function TaskList(props: TaskListProps) {
         </Flex>
       </SummaryBox>
 
-      <Stack space={4} marginTop={4} paddingBottom={5}>
+      <Stack space={4} marginTop={4} paddingBottom={5} data-testid={`${status}-tasks-list`}>
         {tasks?.length > 0 ? (
           tasks.map((task, index) => {
             const showDivider = index < tasks.length - 1

--- a/packages/sanity/src/tasks/src/tasks/components/list/TasksStatus.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/list/TasksStatus.tsx
@@ -12,15 +12,12 @@ export function TasksStatus(props: TasksStatusProps) {
   const operations = useTaskOperations()
   const {documentId, status} = props
 
-  const [checkboxValue, setCheckboxValue] = useState(status === 'closed')
   const [isLoading, setIsLoading] = useState(false)
 
   const handleCheckboxChange = useCallback(
     async (event: React.ChangeEvent<HTMLInputElement>) => {
       const isChecked = event.target.checked
-      setCheckboxValue(isChecked)
       setIsLoading(true)
-
       try {
         if (isChecked) {
           await operations.edit(documentId, {status: 'closed'})
@@ -43,7 +40,11 @@ export function TasksStatus(props: TasksStatusProps) {
           <Spinner style={{marginLeft: '3.5px', marginRight: '3.5px', marginTop: '3.5px'}} />
         </div>
       ) : (
-        <Checkbox onChange={handleCheckboxChange} checked={checkboxValue} disabled={isLoading} />
+        <Checkbox
+          onChange={handleCheckboxChange}
+          checked={status === 'closed'}
+          disabled={isLoading}
+        />
       )}
     </Flex>
   )

--- a/packages/sanity/src/tasks/src/tasks/components/sidebar/TasksSidebarHeader.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/sidebar/TasksSidebarHeader.tsx
@@ -41,7 +41,7 @@ export function TasksSidebarHeader(props: TasksSidebarHeaderProps) {
   const {t} = useTranslation(tasksLocaleNamespace)
 
   return (
-    <Flex justify="space-between" align="center" gap={1}>
+    <Flex justify="space-between" align="center" gap={1} data-testid="tasks-sidebar-header">
       <Flex align="center" flex={1}>
         {viewMode === 'list' ? (
           <Box padding={2}>
@@ -72,6 +72,7 @@ export function TasksSidebarHeader(props: TasksSidebarHeaderProps) {
         {viewMode === 'list' && (
           <Button
             icon={AddIcon}
+            data-testid="create-task-button"
             onClick={handleTaskCreate}
             mode="bleed"
             text={t('buttons.new.text')}

--- a/packages/sanity/src/tasks/src/tasks/context/navigation/TasksNavigationProvider.test.tsx
+++ b/packages/sanity/src/tasks/src/tasks/context/navigation/TasksNavigationProvider.test.tsx
@@ -1,0 +1,198 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {act, renderHook, waitFor} from '@testing-library/react'
+
+import {TaskLinkCopied, TaskLinkOpened} from '../../../../__telemetry__/tasks.telemetry'
+import {type TaskDocument} from '../../types'
+import {TasksNavigationProvider} from './TasksNavigationProvider'
+import {useTasksNavigation} from './useTasksNavigation'
+
+const mockToastPush = jest.fn()
+jest.mock('@sanity/ui', () => {
+  return {
+    useToast: jest.fn(() => ({push: mockToastPush})),
+  }
+})
+
+jest.mock('sanity/router', () => ({
+  useRouter: jest.fn(() => {
+    return {
+      state: {
+        _searchParams: [],
+      },
+    }
+  }),
+}))
+
+const mockTelemetryLog = jest.fn()
+jest.mock('@sanity/telemetry/react', () => {
+  return {
+    useTelemetry: jest.fn(() => ({
+      log: mockTelemetryLog,
+    })),
+  }
+})
+
+const mockWriteText = jest.fn(() => Promise.resolve())
+Object.defineProperty(navigator, 'clipboard', {
+  value: {writeText: mockWriteText},
+})
+
+Object.defineProperty(window, 'location', {
+  value: new URL('http://localhost:3333/'),
+})
+
+describe('useTasksNavigation', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should open the tasks view', () => {
+    const {result} = renderHook(() => useTasksNavigation(), {
+      wrapper: TasksNavigationProvider,
+    })
+
+    act(() => {
+      result.current.handleOpenTasks()
+    })
+
+    expect(result.current.state.isOpen).toBe(true)
+  })
+
+  it('should allow to switch between tabs', () => {
+    const {result} = renderHook(() => useTasksNavigation(), {
+      wrapper: TasksNavigationProvider,
+    })
+
+    act(() => {
+      result.current.handleOpenTasks()
+    })
+    expect(result.current.state.isOpen).toBe(true)
+    expect(result.current.state.activeTabId).toBe('assigned')
+
+    act(() => {
+      result.current.setActiveTab('subscribed')
+    })
+    expect(result.current.state.activeTabId).toBe('subscribed')
+
+    act(() => {
+      result.current.setActiveTab('document')
+    })
+    expect(result.current.state.activeTabId).toBe('document')
+  })
+  it('should reset the state when closing the view', () => {
+    const {result} = renderHook(() => useTasksNavigation(), {
+      wrapper: TasksNavigationProvider,
+    })
+
+    act(() => {
+      result.current.handleOpenTasks()
+      result.current.setActiveTab('subscribed')
+    })
+
+    expect(result.current.state.isOpen).toBe(true)
+    expect(result.current.state.activeTabId).toBe('subscribed')
+
+    act(() => {
+      result.current.handleCloseTasks()
+    })
+
+    expect(result.current.state.isOpen).toBe(false)
+    expect(result.current.state.activeTabId).toBe('assigned')
+  })
+  it('should support changing the view mode and resetting the states', () => {
+    const {result} = renderHook(() => useTasksNavigation(), {
+      wrapper: TasksNavigationProvider,
+    })
+
+    act(() => {
+      result.current.handleOpenTasks()
+      result.current.setViewMode({type: 'create'})
+    })
+    expect(result.current.state.isOpen).toBe(true)
+    expect(result.current.state.viewMode).toBe('create')
+
+    act(() => {
+      result.current.setViewMode({type: 'edit', id: '123'})
+    })
+    expect(result.current.state.viewMode).toBe('edit')
+    expect(result.current.state.selectedTask).toBe('123')
+
+    act(() => {
+      result.current.setViewMode({
+        type: 'duplicate',
+        duplicateTaskValues: {title: 'foo'} as unknown as TaskDocument,
+      })
+    })
+    expect(result.current.state.viewMode).toBe('duplicate')
+    expect(result.current.state.duplicateTaskValues).toEqual({title: 'foo'})
+    act(() => {
+      result.current.setViewMode({type: 'list'})
+    })
+    expect(result.current.state.viewMode).toBe('list')
+    expect(result.current.state.duplicateTaskValues).toEqual(null)
+
+    act(() => {
+      result.current.setViewMode({
+        type: 'draft',
+        id: 'draft-document',
+      })
+    })
+    expect(result.current.state.viewMode).toBe('draft')
+    expect(result.current.state.selectedTask).toBe('draft-document')
+    act(() => {
+      result.current.setViewMode({type: 'list'})
+    })
+    expect(result.current.state.viewMode).toBe('list')
+    expect(result.current.state.duplicateTaskValues).toEqual(null)
+    expect(result.current.state.selectedTask).toBe(null)
+  })
+
+  it('should support copying tasks links', () => {
+    const {result} = renderHook(() => useTasksNavigation(), {
+      wrapper: TasksNavigationProvider,
+    })
+
+    act(() => {
+      result.current.handleOpenTasks()
+      result.current.setViewMode({type: 'edit', id: '123'})
+    })
+    expect(result.current.state.selectedTask).toBe('123')
+    act(() => {
+      result.current.handleCopyLinkToTask()
+    })
+    waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith(
+        'http://localhost:3333/?sidebar=tasks&viewMode=edit&selectedTask=123',
+      )
+      expect(mockToastPush).toHaveBeenCalledWith({
+        closable: true,
+        status: 'info',
+        title: 'Copied link to clipboard',
+      })
+      expect(mockTelemetryLog).toHaveBeenCalledWith(TaskLinkCopied)
+    })
+  })
+
+  it('should redirect to the task if it is in the router', () => {
+    require('sanity/router').useRouter.mockReturnValueOnce({
+      state: {
+        _searchParams: [
+          ['sidebar', 'tasks'],
+          ['viewMode', 'edit'],
+          ['selectedTask', '2187ff8d-5adc-49a1-9ae6-148651d1b048'],
+        ],
+      },
+    })
+
+    const {result} = renderHook(() => useTasksNavigation(), {
+      wrapper: TasksNavigationProvider,
+    })
+
+    waitFor(() => {
+      expect(result.current.state.viewMode).toBe('edit')
+      expect(result.current.state.isOpen).toBe(true)
+      expect(result.current.state.selectedTask).toBe('2187ff8d-5adc-49a1-9ae6-148651d1b048')
+    })
+    expect(mockTelemetryLog).toHaveBeenCalledWith(TaskLinkOpened)
+  })
+})

--- a/packages/sanity/src/tasks/src/tasks/context/navigation/TasksNavigationProvider.tsx
+++ b/packages/sanity/src/tasks/src/tasks/context/navigation/TasksNavigationProvider.tsx
@@ -33,6 +33,7 @@ function reducer(state: State, action: Action): State {
     case 'CREATE_TASK':
       return {
         ...state,
+        duplicateTaskValues: null,
         viewMode: 'create',
         selectedTask: uuid(),
       }
@@ -40,12 +41,14 @@ function reducer(state: State, action: Action): State {
       return {
         ...state,
         viewMode: 'edit',
+        duplicateTaskValues: null,
         selectedTask: action.payload.id,
       }
     case 'EDIT_DRAFT':
       return {
         ...state,
         viewMode: 'draft',
+        duplicateTaskValues: null,
         selectedTask: action.payload.id,
       }
     case 'DUPLICATE_TASK':
@@ -59,11 +62,15 @@ function reducer(state: State, action: Action): State {
       return {
         ...state,
         viewMode: 'list',
+        selectedTask: null,
+        duplicateTaskValues: null,
         activeTabId: action.payload,
       }
     case 'NAVIGATE_TO_LIST':
       return {
         ...state,
+        duplicateTaskValues: null,
+        selectedTask: null,
         viewMode: 'list',
       }
     default:
@@ -115,6 +122,10 @@ export const TasksNavigationProvider = ({children}: {children: ReactNode}) => {
   }, [])
 
   const handleCopyLinkToTask = useCallback(() => {
+    if (!state.selectedTask) {
+      console.error('No task selected')
+      return
+    }
     const url = new URL(window.location.href)
     url.searchParams.set('sidebar', 'tasks')
     url.searchParams.set('viewMode', state.viewMode)
@@ -142,6 +153,7 @@ export const TasksNavigationProvider = ({children}: {children: ReactNode}) => {
 
   // This is casted to a string to make it stable across renders so it doesn't trigger multiple times the effect.
   const searchParamsAsString = new URLSearchParams(router.state._searchParams).toString()
+
   useEffect(() => {
     // listen to the URL to open the tasks view if the sidebar is set to task.
     if (searchParamsAsString) {
@@ -159,7 +171,8 @@ export const TasksNavigationProvider = ({children}: {children: ReactNode}) => {
         telemetry.log(TaskLinkOpened)
       }
     }
-  }, [searchParamsAsString, telemetry])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParamsAsString])
 
   return (
     <TasksNavigationContext.Provider

--- a/packages/sanity/src/tasks/src/tasks/hooks/useTaskOperations.test.ts
+++ b/packages/sanity/src/tasks/src/tasks/hooks/useTaskOperations.test.ts
@@ -1,0 +1,96 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {act, renderHook} from '@testing-library/react'
+import {type SanityClient} from 'sanity'
+
+import {useTaskOperations} from './useTaskOperations'
+
+const mockCreateAction = jest.fn()
+const mockCommit = jest.fn()
+const mockSet = jest.fn(() => ({commit: mockCommit}))
+const mockPatchAction = jest.fn(() => ({set: mockSet}))
+const mockDeleteAction = jest.fn()
+
+jest.mock('sanity', () => ({
+  useAddonDataset: jest.fn(() => {
+    return {
+      client: {
+        create: mockCreateAction,
+        patch: mockPatchAction,
+        delete: mockDeleteAction,
+      },
+      createAddonDataset: jest.fn(),
+    }
+  }),
+  useCurrentUser: jest.fn(() => ({
+    id: 'user123',
+  })),
+}))
+
+describe('tests useTaskOperations', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("creates the addonDataset if it doesn't exist", async () => {
+    const mockedCreateAddonDataset = jest.fn(async () => {
+      return {
+        create: mockCreateAction,
+        patch: mockPatchAction,
+        delete: mockDeleteAction,
+      } as unknown as SanityClient
+    })
+    require('sanity').useAddonDataset.mockReturnValueOnce({
+      client: null,
+      isCreatingDataset: false,
+      ready: false,
+      createAddonDataset: mockedCreateAddonDataset,
+    })
+
+    const {result} = renderHook(() => useTaskOperations())
+    await act(async () => {
+      await result.current.create({title: 'Test Task', description: [], status: 'open'})
+    })
+    expect(mockedCreateAddonDataset).toHaveBeenCalled()
+    expect(mockCreateAction).toHaveBeenCalledWith({
+      title: 'Test Task',
+      authorId: 'user123',
+      description: [],
+      status: 'open',
+      _type: 'tasks.task',
+    })
+  })
+
+  it('creates a task', async () => {
+    const {result} = renderHook(() => useTaskOperations())
+
+    result.current.create({title: 'Test Task', description: [], status: 'open'})
+
+    expect(mockCreateAction).toHaveBeenCalledWith({
+      title: 'Test Task',
+      authorId: 'user123',
+      description: [],
+      status: 'open',
+      _type: 'tasks.task',
+    })
+  })
+
+  it('edits a task', async () => {
+    const {result} = renderHook(() => useTaskOperations())
+
+    await act(async () => {
+      await result.current.edit('task123', {status: 'closed'})
+    })
+    expect(mockPatchAction).toHaveBeenCalledWith('task123')
+    expect(mockSet).toHaveBeenCalledWith({status: 'closed'})
+    expect(mockCommit).toHaveBeenCalled()
+  })
+
+  it('deletes a task', async () => {
+    const {result} = renderHook(() => useTaskOperations())
+
+    await act(async () => {
+      await result.current.remove('task123')
+    })
+    expect(mockDeleteAction).toHaveBeenCalledWith('task123')
+  })
+})

--- a/test/e2e/tests/tasks/navigation.spec.ts
+++ b/test/e2e/tests/tasks/navigation.spec.ts
@@ -1,0 +1,38 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+test('clicking on the footer tasks button shows document tasks', async ({page, baseURL}) => {
+  const documentId = '5103da86-77f1-47c0-869d-713e92f2657e'
+  const documentType = 'book'
+  await page.goto(`${baseURL}/test/intent/edit/id=${documentId};type=${documentType}/`)
+  await page.waitForTimeout(2000)
+  await page.getByTestId('tasks-footer-open-tasks').click()
+  // Should navigate back to the list view at subscribed tab
+  await page.waitForSelector('[id="document-tab"][data-selected]')
+  // The task should be visible in the list
+  await expect(page.getByRole('button', {name: 'Test task - do not remove'})).toBeVisible()
+})
+
+test('navbar navigation button should work as a toggle', async ({page, baseURL}) => {
+  await page.goto(baseURL ?? '/')
+  await page.waitForTimeout(2000)
+  const tasksNavbarButton = await page.getByRole('button', {name: 'Tasks'})
+  await tasksNavbarButton.click()
+  await expect(page.getByTestId('tasks-sidebar-header')).toBeVisible()
+  await tasksNavbarButton.click()
+  await expect(page.getByTestId('tasks-sidebar-header')).not.toBeVisible()
+})
+
+test('visiting the studio with a task link should redirect to the task', async ({
+  page,
+  baseURL,
+}) => {
+  await page.goto(
+    `${
+      baseURL ?? '/'
+    }/test/content/?sidebar=tasks&viewMode=edit&selectedTask=8409b5ad-5204-4cdb-9965-cb49beddf615`,
+  )
+  await page.waitForTimeout(2000)
+
+  await expect(page.getByText('Test task - do not remove')).toBeVisible()
+})

--- a/test/e2e/tests/tasks/task.spec.ts
+++ b/test/e2e/tests/tasks/task.spec.ts
@@ -1,0 +1,127 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+test('it is possible to create a new task from the tasks sidebar, edit and remove it.', async ({
+  page,
+  baseURL,
+}) => {
+  const taskName = `Test task ${Math.floor(Math.random() * 10000)}`
+  await page.goto(baseURL ?? '/')
+  await page.waitForTimeout(2000)
+  const tasksNavbarButton = await page.getByRole('button', {name: 'Tasks'})
+  await tasksNavbarButton.click()
+  const newTaskButton = await page.getByTestId('create-task-button')
+  await newTaskButton.click()
+
+  // Completes the task entirely:
+  // 1. Fill the title
+  // 2. Fill the description
+  // 3. Assign the task to a user
+  // 4. Sets a deadline
+  // 5. Selects the document target
+
+  // 1. Fill the title
+  await page.getByTestId('title-input').fill(taskName)
+  await expect(page.getByTestId('title-input')).toHaveText(taskName)
+
+  // 2. Fill the description
+  await page.getByTestId('comment-input-editable').fill('Created from navbar in test')
+  await expect(page.getByTestId('comment-input-editable')).toHaveText('Created from navbar in test')
+
+  // 3. Assign the task to a user
+  const selectAssigneeButton = await page.getByText('Select assignee')
+  await selectAssigneeButton.click()
+  await page.waitForSelector("[name='assigneeSearch']:focus") // Input should be in focus
+  await page.locator("[name='assigneeSearch']").fill('Pedro Bonamin') // Search for the user
+  await page.getByRole('menuitem', {name: 'Pedro Bonamin'}).click() // Select the user
+  await expect(page.getByTestId('assigned-user')).toHaveText('Pedro Bonamin') // The user should be displayed
+
+  // 4. Sets a deadline
+  await page.getByTestId('select-date-button').click()
+  await page.locator('div[aria-selected="true"][data-ui="CalendarDay"]').click() // Select the current date.
+  await page.getByTestId('select-date-button').click()
+  const inputValue = await page.inputValue("[data-testid='date-input']") // The date should be displayed
+  await expect(inputValue).toBeDefined()
+
+  // 5. Selects the document target
+  await page.getByText('Select target document').click()
+  await page.getByPlaceholder('Search').fill('Test - assign document')
+  const targetContent = await page.waitForSelector(
+    '[data-testid="default-preview__header"]:has-text("Test - assign document")',
+  )
+  await targetContent.click({force: true})
+
+  // Create the task
+  await page.getByRole('button', {name: 'Create Task'}).click()
+
+  // Should navigate back to the list view at subscribed tab
+  await page.waitForSelector('[id="subscribed-tab"][data-selected]')
+  // The task should be visible in the list
+  await page.getByRole('button', {name: taskName}).click()
+
+  await page.getByTestId('comment-input-editable').fill(' and edited')
+  await expect(page.getByTestId('comment-input-editable')).toHaveText(
+    'Created from navbar in test and edited',
+  )
+
+  // Remove the task to clean up
+  const taskMenuButton = await page.waitForSelector(`[id="edit-task-menu"]`)
+  await taskMenuButton.click()
+  await page.getByRole('menuitem', {name: 'Delete task'}).click()
+
+  // Confirmation modal shows
+  await expect(page.getByText('Delete this task?')).toBeVisible()
+  await page.getByRole('button', {name: 'Delete'}).click()
+  // Should navigate back to the list view at subscribed tab
+  await page.waitForSelector('[id="subscribed-tab"][data-selected]')
+})
+
+test('It is possible to create a task from the document action', async ({page, baseURL}) => {
+  const taskName = `Test task from document ${Math.floor(Math.random() * 10000)}`
+  const documentName = 'Test- do not remove'
+  const documentId = '945a97ac-e4b6-450e-a484-d0886f801461'
+  const documentType = 'book'
+  await page.goto(`${baseURL}/test/intent/edit/id=${documentId};type=${documentType}/`)
+  await page.waitForTimeout(2000)
+  await expect(page.getByTestId('document-panel-document-title')).toHaveText(documentName)
+
+  await page
+    .locator(
+      '[id="documentEditor-945a97ac-e4b6-450e-a484-d0886f801461-0"] >> [data-testid=pane-context-menu-button]',
+    )
+    .click()
+
+  await page.getByRole('menuitem', {name: 'Create new task'}).click()
+
+  // It should have the document as target in the target field.
+  await expect(page.getByTestId('task-target-field')).toContainText(documentName)
+  const targetField = await page.waitForSelector(
+    '[data-testid="task-target-field"] >> [data-testid="compact-preview__header"]',
+  )
+  expect(await targetField.textContent()).toBe(documentName)
+
+  await page.getByTestId('title-input').fill(taskName)
+  await expect(page.getByTestId('title-input')).toHaveText(taskName)
+  await page.getByTestId('comment-input-editable').fill('Created from document in test')
+  await expect(page.getByTestId('comment-input-editable')).toHaveText(
+    'Created from document in test',
+  )
+
+  await page.getByRole('button', {name: 'Create Task'}).click()
+  // Should navigate back to the list view at subscribed tab
+  await page.waitForSelector('[id="subscribed-tab"][data-selected]')
+  // The task should be visible in the list
+  const taskInList = await page.getByRole('button', {name: taskName})
+
+  // The document should show pending tasks.
+  await expect(page.getByTestId('tasks-footer-open-tasks')).toBeVisible()
+
+  // Remove the task to clean up
+  await taskInList.click()
+  const taskMenuButton = await page.waitForSelector(`[id="edit-task-menu"]`)
+  await taskMenuButton.click()
+  await page.getByRole('menuitem', {name: 'Delete task'}).click()
+  await expect(page.getByText('Delete this task?')).toBeVisible()
+  await page.getByRole('button', {name: 'Delete'}).click()
+  await page.waitForSelector('[id="subscribed-tab"][data-selected]')
+})


### PR DESCRIPTION
### Description

Adds e2e tests and some new integration tests to tasks to cover the critical paths.
- e2e tests added: 
  - Create a task from the sidebar (create new button)
    - Test all fields are working: 
      -  Title
      - Description
      - Assignee
      - Deadline
      - Target document.
    - Tests the task shows in the list
  - Edit the new task.
    - Changes values in the task, the change is reflected.
  - Deletes the task
  - Creates a task from the document action button.
  - Navigates to tasks from:
     - Document footer action.
     - Navbar toggle button.
     - Visiting the studio with a task url.  
 


- Fixes an issue in which when editing quickly through tasks and clicking create, the task was not created correctly.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is there something else considered critical that we are missing tests?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Adds e2e tests to tasks.
Fixes an issue in tasks in which in some cases tasks were not created.

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
