### PR TITLE
fix(bug): update to not add annotation in PTE if all fields are null

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -7,6 +7,7 @@ import {Tooltip} from '../../../../../ui-components'
 import {pathToString} from '../../../../field'
 import {useTranslation} from '../../../../i18n'
 import {EMPTY_ARRAY} from '../../../../util'
+import {isEmptyItem} from '../../../store/utils/isEmptyItem'
 import {useChildPresence} from '../../../studio/contexts/Presence'
 import {
   type BlockAnnotationProps,
@@ -101,16 +102,21 @@ export function Annotation(props: AnnotationProps) {
 
   const onClose = useCallback(() => {
     onItemClose()
-    // Keep track of any previous offsets on the spanNode before we select it.
-    const sel = PortableTextEditor.getSelection(editor)
-    const focusOffset = sel?.focus.path && isEqual(sel.focus.path, spanPath) && sel.focus.offset
-    const anchorOffset = sel?.anchor.path && isEqual(sel.anchor.path, spanPath) && sel.anchor.offset
-    PortableTextEditor.select(editor, {
-      anchor: {path: spanPath, offset: anchorOffset || 0},
-      focus: {path: spanPath, offset: focusOffset || 0},
-    })
+    if (isEmptyItem(value)) {
+      PortableTextEditor.removeAnnotation(editor, schemaType)
+    } else {
+      // Keep track of any previous offsets on the spanNode before we select it.
+      const sel = PortableTextEditor.getSelection(editor)
+      const focusOffset = sel?.focus.path && isEqual(sel.focus.path, spanPath) && sel.focus.offset
+      const anchorOffset =
+        sel?.anchor.path && isEqual(sel.anchor.path, spanPath) && sel.anchor.offset
+      PortableTextEditor.select(editor, {
+        anchor: {path: spanPath, offset: anchorOffset || 0},
+        focus: {path: spanPath, offset: focusOffset || 0},
+      })
+    }
     PortableTextEditor.focus(editor)
-  }, [editor, spanPath, onItemClose])
+  }, [editor, spanPath, onItemClose, schemaType, value])
 
   const onRemove = useCallback(() => {
     PortableTextEditor.removeAnnotation(editor, schemaType)


### PR DESCRIPTION
### Description

Fixes EDX-48

If you add an annotation but do not fill out any fields for it, we still mark the text as having the annotation. This change updates the logic so that if none of the fields are filled out, the annotation is removed.

Before:

https://github.com/sanity-io/sanity/assets/6889008/321f9367-88c5-4d23-a920-1e03831ce444


After:

https://github.com/sanity-io/sanity/assets/6889008/eabc930c-15f0-44ac-ae22-c43bbf597332


### What to review

Is this the right approach?

### Testing

Manual testing

