### PR TITLE
refactor(migrate): import package name, version statically

### DIFF
--- a/packages/@sanity/migrate/src/fetch-utils/sanityRequestOptions.ts
+++ b/packages/@sanity/migrate/src/fetch-utils/sanityRequestOptions.ts
@@ -1,16 +1,11 @@
+// Named imports to "shake away" unnecessary props
+import {name as pkgName, version as pkgVersion} from '../../../mutator/package.json'
 import {type Endpoint} from './endpoints'
 import {type FetchOptions} from './fetchStream'
 
 function getUserAgent() {
-  if (typeof window === 'undefined') {
-    // only set UA if we're in a non-browser environment
-    try {
-      const pkg = require('../../package.json')
-      return `${pkg.name}@${pkg.version}`
-      // eslint-disable-next-line no-empty
-    } catch (err) {}
-  }
-  return null
+  // only set UA if we're in a non-browser environment
+  return typeof window === 'undefined' ? `${pkgName}@${pkgVersion}` : null
 }
 
 interface SanityRequestOptions {


### PR DESCRIPTION
### Description

Background: gradually removing `require()` calls across the codebase in order to be more ready for an "ESM-first" world

Loading the package.json file using an import seems to work fine with our build process, and tree-shakes really well. Output after change is:
```ts
var name = "@sanity/mutator", version = "3.37.2";
function getUserAgent() {
  return typeof window > "u" ? `${name}@${version}` : null;
}
```

### What to review

- Works as expected

### Testing

Don't think we need to, build looks alright.

### Notes for release

None
