### PR TITLE
chore: add eslint rule for disabling createContext outside _singletons

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -217,6 +217,26 @@ const config = {
       },
     },
 
+    // Prefer createContext in _singletons
+    {
+      files: ['packages/sanity/src/**'],
+      excludedFiles: ['**/__workshop__/**', 'packages/sanity/src/_singletons/**'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: 'react',
+                importNames: ['createContext'],
+                message: 'Please place context in _singletons',
+              },
+            ],
+          },
+        ],
+      },
+    },
+
     // Prefer top-level type imports in singletons because boundaries plugin doesn't support named typed imports
     {
       files: ['packages/sanity/src/_singletons/**'],

--- a/packages/sanity/src/core/components/react-track-elements/createTrackerScope.tsx
+++ b/packages/sanity/src/core/components/react-track-elements/createTrackerScope.tsx
@@ -1,4 +1,5 @@
 import {
+  // eslint-disable-next-line no-restricted-imports
   createContext,
   type ReactNode,
   useContext,


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds an eslint rule that complains about using `createContext` from react in `structure`, `core` or `router`

requires https://github.com/sanity-io/sanity/pull/6350

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Linting passes

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

N/A
