### PR TITLE
chore: remove * as React imports

### DIFF
--- a/packages/sanity/src/router/IntentLink.tsx
+++ b/packages/sanity/src/router/IntentLink.tsx
@@ -1,5 +1,4 @@
-import type * as React from 'react'
-import {type ForwardedRef, forwardRef} from 'react'
+import {type ForwardedRef, forwardRef, type HTMLProps} from 'react'
 
 import {type IntentParameters} from './types'
 import {useIntentLink} from './useIntentLink'
@@ -41,7 +40,7 @@ export interface IntentLinkProps {
  * ```
  */
 export const IntentLink = forwardRef(function IntentLink(
-  props: IntentLinkProps & React.HTMLProps<HTMLAnchorElement>,
+  props: IntentLinkProps & HTMLProps<HTMLAnchorElement>,
   ref: ForwardedRef<HTMLAnchorElement>,
 ) {
   const {intent, params, target, ...restProps} = props

--- a/packages/sanity/src/router/Link.tsx
+++ b/packages/sanity/src/router/Link.tsx
@@ -1,5 +1,4 @@
-import type * as React from 'react'
-import {forwardRef} from 'react'
+import {type ForwardedRef, forwardRef, type HTMLProps} from 'react'
 
 import {useLink} from './useLink'
 
@@ -35,8 +34,8 @@ export interface LinkProps {
  * ```
  */
 export const Link = forwardRef(function Link(
-  props: LinkProps & React.HTMLProps<HTMLAnchorElement>,
-  ref: React.ForwardedRef<HTMLAnchorElement>,
+  props: LinkProps & HTMLProps<HTMLAnchorElement>,
+  ref: ForwardedRef<HTMLAnchorElement>,
 ) {
   const {onClick: onClickProp, href, target, replace, ...restProps} = props
   const {onClick} = useLink({onClick: onClickProp, href, target, replace})

--- a/packages/sanity/src/router/RouteScope.tsx
+++ b/packages/sanity/src/router/RouteScope.tsx
@@ -1,7 +1,5 @@
 /* eslint-disable camelcase */
-
-import type * as React from 'react'
-import {useCallback, useMemo, useRef} from 'react'
+import {type ReactElement, type ReactNode, useCallback, useMemo, useRef} from 'react'
 
 import {RouterContext} from './RouterContext'
 import {type RouterContextValue, type RouterState} from './types'
@@ -41,7 +39,7 @@ export interface RouteScopeProps {
   /**
    * The content to display inside the route scope.
    */
-  children: React.ReactNode
+  children: ReactNode
 }
 
 /**
@@ -65,7 +63,7 @@ export interface RouteScopeProps {
  * }
  * ```
  */
-export function RouteScope(props: RouteScopeProps): React.ReactElement {
+export function RouteScope(props: RouteScopeProps): ReactElement {
   const {children, scope, __unsafe_disableScopedSearchParams} = props
   const parentRouter = useRouter()
   const {resolvePathFromState: parent_resolvePathFromState, navigate: parent_navigate} =

--- a/packages/sanity/src/router/RouterProvider.tsx
+++ b/packages/sanity/src/router/RouterProvider.tsx
@@ -1,5 +1,4 @@
-import type * as React from 'react'
-import {useCallback, useMemo} from 'react'
+import {type ReactElement, type ReactNode, useCallback, useMemo} from 'react'
 
 import {RouterContext} from './RouterContext'
 import {
@@ -32,7 +31,7 @@ export interface RouterProviderProps {
   /**
    * The child elements to render.
    */
-  children: React.ReactNode
+  children: ReactNode
 }
 
 /**
@@ -77,7 +76,7 @@ export interface RouterProviderProps {
  *
  * @public
  */
-export function RouterProvider(props: RouterProviderProps): React.ReactElement {
+export function RouterProvider(props: RouterProviderProps): ReactElement {
   const {onNavigate, router: routerProp, state} = props
 
   const resolveIntentLink = useCallback(

--- a/packages/sanity/src/router/StateLink.tsx
+++ b/packages/sanity/src/router/StateLink.tsx
@@ -1,5 +1,4 @@
-import type * as React from 'react'
-import {forwardRef} from 'react'
+import {type ForwardedRef, forwardRef, type HTMLProps} from 'react'
 
 import {useStateLink} from './useStateLink'
 
@@ -43,8 +42,8 @@ export interface StateLinkProps {
  * ```
  */
 export const StateLink = forwardRef(function StateLink(
-  props: StateLinkProps & Omit<React.HTMLProps<HTMLAnchorElement>, 'href'>,
-  ref: React.ForwardedRef<HTMLAnchorElement>,
+  props: StateLinkProps & Omit<HTMLProps<HTMLAnchorElement>, 'href'>,
+  ref: ForwardedRef<HTMLAnchorElement>,
 ) {
   const {onClick: onClickProp, replace, state, target, toIndex = false, ...restProps} = props
   const {onClick, href} = useStateLink({

--- a/packages/sanity/src/router/useStateLink.ts
+++ b/packages/sanity/src/router/useStateLink.ts
@@ -1,5 +1,4 @@
-import type * as React from 'react'
-import {useMemo} from 'react'
+import {type MouseEventHandler, useMemo} from 'react'
 
 import {useLink} from './useLink'
 import {useRouter} from './useRouter'
@@ -13,7 +12,7 @@ export interface UseStateLinkOptions {
   /**
    * The click event handler for the link.
    */
-  onClick?: React.MouseEventHandler<HTMLElement>
+  onClick?: MouseEventHandler<HTMLElement>
   /**
    * Whether to replace the current history entry instead of adding a new one.
    */
@@ -46,7 +45,7 @@ export interface UseStateLinkOptions {
  * ```
  */
 export function useStateLink(options: UseStateLinkOptions): {
-  onClick: React.MouseEventHandler<HTMLElement>
+  onClick: MouseEventHandler<HTMLElement>
   href: string
 } {
   const {onClick: onClickProp, replace, state, target, toIndex = false} = options

--- a/packages/sanity/src/router/withRouter.tsx
+++ b/packages/sanity/src/router/withRouter.tsx
@@ -1,5 +1,4 @@
-import type * as React from 'react'
-import {type ComponentType, type FunctionComponent} from 'react'
+import {type ComponentType, type FunctionComponent, type ReactElement} from 'react'
 
 import {type RouterContextValue} from './types'
 import {useRouter} from './useRouter'
@@ -51,7 +50,7 @@ export interface WithRouterProps {
   /**
    * A function that renders the wrapped component with the `router` object as a parameter.
    */
-  children: (router: RouterContextValue) => React.ReactElement
+  children: (router: RouterContextValue) => ReactElement
 }
 
 /**

--- a/packages/sanity/src/structure/StructureToolProvider.tsx
+++ b/packages/sanity/src/structure/StructureToolProvider.tsx
@@ -1,5 +1,4 @@
-import type * as React from 'react'
-import {useMemo, useState} from 'react'
+import {type ReactElement, type ReactNode, useMemo, useState} from 'react'
 import {useConfigContextFromSource, useDocumentStore, useSource} from 'sanity'
 
 import {createStructureBuilder, type DefaultDocumentNodeResolver} from './structureBuilder'
@@ -14,7 +13,7 @@ import {
 export interface StructureToolProviderProps {
   structure?: StructureResolver
   defaultDocumentNode?: DefaultDocumentNodeResolver
-  children: React.ReactNode
+  children: ReactNode
 }
 
 /** @internal */
@@ -22,7 +21,7 @@ export function StructureToolProvider({
   defaultDocumentNode,
   structure: resolveStructure,
   children,
-}: StructureToolProviderProps): React.ReactElement {
+}: StructureToolProviderProps): ReactElement {
   const [layoutCollapsed, setLayoutCollapsed] = useState(false)
   const source = useSource()
   const configContext = useConfigContextFromSource(source)

--- a/packages/sanity/src/structure/comments/src/components/icons/CommentDisabledIcon.tsx
+++ b/packages/sanity/src/structure/comments/src/components/icons/CommentDisabledIcon.tsx
@@ -1,9 +1,8 @@
-import type * as React from 'react'
-import {forwardRef} from 'react'
+import {forwardRef, type Ref, type SVGProps} from 'react'
 
 export const CommentDisabledIcon = forwardRef(function Icon(
-  props: React.SVGProps<SVGSVGElement>,
-  ref: React.Ref<SVGSVGElement>,
+  props: SVGProps<SVGSVGElement>,
+  ref: Ref<SVGSVGElement>,
 ) {
   return (
     <svg

--- a/packages/sanity/src/structure/comments/src/components/icons/CommentIcon.tsx
+++ b/packages/sanity/src/structure/comments/src/components/icons/CommentIcon.tsx
@@ -1,11 +1,10 @@
-import type * as React from 'react'
-import {forwardRef} from 'react'
+import {forwardRef, type Ref, type SVGProps} from 'react'
 
 // A slightly (arguably) more optically centered version of the current <CommentIcon> provided by @sanity/icons
 // @todo: remove this and replace with an updated version from @sanity/icons
 export const CommentIcon = forwardRef(function Icon(
-  props: React.SVGProps<SVGSVGElement>,
-  ref: React.Ref<SVGSVGElement>,
+  props: SVGProps<SVGSVGElement>,
+  ref: Ref<SVGSVGElement>,
 ) {
   return (
     <svg

--- a/packages/sanity/src/structure/comments/src/components/icons/MentionIcon.tsx
+++ b/packages/sanity/src/structure/comments/src/components/icons/MentionIcon.tsx
@@ -1,9 +1,8 @@
-import type * as React from 'react'
-import {forwardRef} from 'react'
+import {forwardRef, type Ref, type SVGProps} from 'react'
 
 export const MentionIcon = forwardRef(function Icon(
-  props: React.SVGProps<SVGSVGElement>,
-  ref: React.Ref<SVGSVGElement>,
+  props: SVGProps<SVGSVGElement>,
+  ref: Ref<SVGSVGElement>,
 ) {
   return (
     <svg

--- a/packages/sanity/src/structure/comments/src/components/icons/SendIcon.tsx
+++ b/packages/sanity/src/structure/comments/src/components/icons/SendIcon.tsx
@@ -1,9 +1,8 @@
-import type * as React from 'react'
-import {forwardRef} from 'react'
+import {forwardRef, type Ref, type SVGProps} from 'react'
 
 export const SendIcon = forwardRef(function Icon(
-  props: React.SVGProps<SVGSVGElement>,
-  ref: React.Ref<SVGSVGElement>,
+  props: SVGProps<SVGSVGElement>,
+  ref: Ref<SVGSVGElement>,
 ) {
   return (
     <svg

--- a/packages/sanity/src/structure/comments/src/components/list/CommentThreadLayout.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentThreadLayout.tsx
@@ -6,8 +6,7 @@ import {
   Stack,
 } from '@sanity/ui'
 import {uuid} from '@sanity/uuid'
-import type * as React from 'react'
-import {useCallback, useMemo} from 'react'
+import {type MouseEvent, type ReactNode, useCallback, useMemo} from 'react'
 import {type UserListWithPermissionsHookValue, useTranslation} from 'sanity'
 import {css, styled} from 'styled-components'
 
@@ -41,7 +40,7 @@ const BreadcrumbsButton = styled(Button)(({theme}) => {
 interface CommentThreadLayoutProps {
   breadcrumbs?: CommentListBreadcrumbs
   canCreateNewThread: boolean
-  children: React.ReactNode
+  children: ReactNode
   currentUser: CurrentUser
   fieldPath: string
   isSelected: boolean
@@ -91,7 +90,7 @@ export function CommentThreadLayout(props: CommentThreadLayoutProps) {
   )
 
   const handleBreadcrumbsClick = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement>) => {
+    (e: MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation()
 
       onPathSelect?.({
@@ -104,7 +103,7 @@ export function CommentThreadLayout(props: CommentThreadLayoutProps) {
   )
 
   const handleNewThreadClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+    (e: MouseEvent<HTMLDivElement>) => {
       e.stopPropagation()
       // Skip if the click was triggered from "Enter" keydown.
       // This because we don't want to trigger `onPathSelect` when

--- a/packages/sanity/src/structure/comments/src/components/mentions/MentionsMenu.tsx
+++ b/packages/sanity/src/structure/comments/src/components/mentions/MentionsMenu.tsx
@@ -1,7 +1,14 @@
 import {Box, Flex, Stack, Text} from '@sanity/ui'
 import {deburr} from 'lodash'
-import {useCallback, useImperativeHandle, useMemo, useRef, useState} from 'react'
-import * as React from 'react'
+import {
+  forwardRef,
+  type Ref,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import {
   CommandList,
   type CommandListHandle,
@@ -38,9 +45,9 @@ interface MentionsMenuProps {
   options: UserWithPermission[] | null
 }
 
-export const MentionsMenu = React.forwardRef(function MentionsMenu(
+export const MentionsMenu = forwardRef(function MentionsMenu(
   props: MentionsMenuProps,
-  ref: React.Ref<MentionsMenuHandle>,
+  ref: Ref<MentionsMenuHandle>,
 ) {
   const {t} = useTranslation(commentsLocaleNamespace)
   const {loading, onSelect, options = [], inputElement} = props

--- a/packages/sanity/src/structure/comments/src/components/mentions/MentionsMenuItem.tsx
+++ b/packages/sanity/src/structure/comments/src/components/mentions/MentionsMenuItem.tsx
@@ -1,6 +1,5 @@
 import {Badge, Box, Card, Flex, Text, TextSkeleton} from '@sanity/ui'
-import type * as React from 'react'
-import {useCallback} from 'react'
+import {type CSSProperties, useCallback} from 'react'
 import {type UserWithPermission, useTranslation, useUser} from 'sanity'
 import {styled} from 'styled-components'
 
@@ -9,7 +8,7 @@ import {CommentsAvatar} from '../avatars'
 
 const InnerFlex = styled(Flex)``
 
-const SKELETON_INLINE_STYLE: React.CSSProperties = {width: '50%'}
+const SKELETON_INLINE_STYLE: CSSProperties = {width: '50%'}
 
 interface MentionsItemProps {
   user: UserWithPermission

--- a/packages/sanity/src/structure/comments/src/components/pte/blocks/NormalBlock.tsx
+++ b/packages/sanity/src/structure/comments/src/components/pte/blocks/NormalBlock.tsx
@@ -1,5 +1,5 @@
 import {Flex, Text} from '@sanity/ui'
-import type * as React from 'react'
+import {type ReactNode} from 'react'
 import {styled} from 'styled-components'
 
 const NormalText = styled(Text)`
@@ -7,7 +7,7 @@ const NormalText = styled(Text)`
 `
 
 interface NormalBlockProps {
-  children: React.ReactNode
+  children: ReactNode
 }
 
 export function NormalBlock(props: NormalBlockProps) {

--- a/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInput.tsx
+++ b/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInput.tsx
@@ -6,8 +6,18 @@ import {
 } from '@sanity/portable-text-editor'
 import {type CurrentUser, type PortableTextBlock} from '@sanity/types'
 import {type AvatarSize, focusFirstDescendant, focusLastDescendant, Stack} from '@sanity/ui'
-import type * as React from 'react'
-import {forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState} from 'react'
+import {
+  type FocusEvent,
+  type FormEvent,
+  forwardRef,
+  type KeyboardEvent,
+  type ReactNode,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import {type UserListWithPermissionsHookValue} from 'sanity'
 
 import {editorSchemaType} from '../config'
@@ -30,15 +40,15 @@ export interface CommentInputProps {
   focusLock?: boolean
   focusOnMount?: boolean
   mentionOptions: UserListWithPermissionsHookValue
-  onBlur?: (e: React.FormEvent<HTMLDivElement>) => void
+  onBlur?: (e: FormEvent<HTMLDivElement>) => void
   onChange: (value: PortableTextBlock[]) => void
   onDiscardCancel?: () => void
   onDiscardConfirm: () => void
-  onFocus?: (e: React.FormEvent<HTMLDivElement>) => void
-  onKeyDown?: (e: React.KeyboardEvent<Element>) => void
+  onFocus?: (e: FormEvent<HTMLDivElement>) => void
+  onKeyDown?: (e: KeyboardEvent<Element>) => void
   onMentionMenuOpenChange?: (open: boolean) => void
   onSubmit?: () => void
-  placeholder?: React.ReactNode
+  placeholder?: ReactNode
   readOnly?: boolean
   renderBlock?: RenderBlockFunction
   value: PortableTextBlock[] | null
@@ -185,7 +195,7 @@ export const CommentInput = forwardRef<CommentInputHandle, CommentInputProps>(
     )
 
     const handleFocus = useCallback(
-      (event: React.FocusEvent<HTMLDivElement>) => {
+      (event: FocusEvent<HTMLDivElement>) => {
         if (!focusLock) return
 
         const target = event.target

--- a/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInputDiscardDialog.tsx
+++ b/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInputDiscardDialog.tsx
@@ -1,6 +1,5 @@
 import {DialogProvider, Text, ThemeColorProvider} from '@sanity/ui'
-import type * as React from 'react'
-import {useCallback} from 'react'
+import {type MouseEvent, useCallback} from 'react'
 import {useTranslation} from 'sanity'
 
 import {Dialog} from '../../../../../../ui-components'
@@ -26,7 +25,7 @@ export function CommentInputDiscardDialog(props: CommentInputDiscardDialogProps)
   const {onClose, onConfirm} = props
 
   const handleCancelClick = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement>) => {
+    (e: MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation()
       onClose()
     },
@@ -34,7 +33,7 @@ export function CommentInputDiscardDialog(props: CommentInputDiscardDialogProps)
   )
 
   const handleConfirmClick = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement>) => {
+    (e: MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation()
       onConfirm()
     },

--- a/packages/sanity/src/structure/comments/src/context/enabled/CommentsEnabledProvider.tsx
+++ b/packages/sanity/src/structure/comments/src/context/enabled/CommentsEnabledProvider.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react'
+import {memo, type ReactNode} from 'react'
 
 import {useResolveCommentsEnabled} from '../../hooks'
 import {CommentsEnabledContext} from './CommentsEnabledContext'
 
 interface CommentsEnabledProviderProps {
-  children: React.ReactNode
+  children: ReactNode
   documentId: string
   documentType: string
 }
 
-export const CommentsEnabledProvider = React.memo(function CommentsEnabledProvider(
+export const CommentsEnabledProvider = memo(function CommentsEnabledProvider(
   props: CommentsEnabledProviderProps,
 ) {
   const {children, documentId, documentType} = props

--- a/packages/sanity/src/structure/comments/src/context/onboarding/CommentsOnboardingProvider.tsx
+++ b/packages/sanity/src/structure/comments/src/context/onboarding/CommentsOnboardingProvider.tsx
@@ -1,5 +1,4 @@
-import type * as React from 'react'
-import {useCallback, useMemo, useState} from 'react'
+import {type ReactNode, useCallback, useMemo, useState} from 'react'
 
 import {CommentsOnboardingContext} from './CommentsOnboardingContext'
 import {type CommentsOnboardingContextValue} from './types'
@@ -25,7 +24,7 @@ const getLocalStorage = (): boolean => {
 }
 
 interface CommentsOnboardingProviderProps {
-  children: React.ReactNode
+  children: ReactNode
 }
 
 export function CommentsOnboardingProvider(props: CommentsOnboardingProviderProps) {

--- a/packages/sanity/src/structure/components/Delay.tsx
+++ b/packages/sanity/src/structure/components/Delay.tsx
@@ -1,13 +1,12 @@
-import type * as React from 'react'
-import {useEffect, useState} from 'react'
+import {type ReactElement, useEffect, useState} from 'react'
 
 export function Delay({
   children,
   ms = 0,
 }: {
-  children?: React.ReactElement | (() => React.ReactElement)
+  children?: ReactElement | (() => ReactElement)
   ms?: number
-}): React.ReactElement {
+}): ReactElement {
   const [ready, setReady] = useState(ms <= 0)
 
   useEffect(() => {

--- a/packages/sanity/src/structure/components/IntentButton.tsx
+++ b/packages/sanity/src/structure/components/IntentButton.tsx
@@ -1,5 +1,4 @@
-import type * as React from 'react'
-import {forwardRef, useMemo} from 'react'
+import {type ComponentProps, type ForwardedRef, forwardRef, type ReactNode, useMemo} from 'react'
 import {IntentLink} from 'sanity/router'
 
 import {Button, type ButtonProps} from '../../ui-components'
@@ -11,8 +10,8 @@ export const IntentButton = forwardRef(function IntentButton(
   props: {
     intent: RouterIntent
   } & ButtonProps &
-    Omit<React.ComponentProps<typeof Button>, 'as' | 'href' | 'type'>,
-  ref: React.ForwardedRef<HTMLAnchorElement>,
+    Omit<ComponentProps<typeof Button>, 'as' | 'href' | 'type'>,
+  ref: ForwardedRef<HTMLAnchorElement>,
 ) {
   const {intent, ...restProps} = props
 
@@ -20,8 +19,8 @@ export const IntentButton = forwardRef(function IntentButton(
     () =>
       // eslint-disable-next-line @typescript-eslint/no-shadow
       forwardRef(function Link(
-        linkProps: {children: React.ReactNode},
-        linkRef: React.ForwardedRef<HTMLAnchorElement>,
+        linkProps: {children: ReactNode},
+        linkRef: ForwardedRef<HTMLAnchorElement>,
       ) {
         return (
           <IntentLink {...linkProps} intent={intent.type} params={intent.params} ref={linkRef} />
@@ -33,11 +32,6 @@ export const IntentButton = forwardRef(function IntentButton(
   return props.disabled ? (
     <Button {...restProps} as="a" role="link" aria-disabled="true" />
   ) : (
-    <Button
-      {...restProps}
-      as={Link}
-      data-as="a"
-      ref={ref as React.ForwardedRef<HTMLButtonElement>}
-    />
+    <Button {...restProps} as={Link} data-as="a" ref={ref as ForwardedRef<HTMLButtonElement>} />
   )
 })

--- a/packages/sanity/src/structure/components/RenderActionCollectionState.tsx
+++ b/packages/sanity/src/structure/components/RenderActionCollectionState.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react'
+import {type ReactNode} from 'react'
 import {
   type DocumentActionDescription,
   type DocumentActionGroup,
@@ -15,7 +15,7 @@ export interface Action<Args, Description> {
 export interface RenderActionCollectionProps {
   actions: Action<DocumentActionProps, DocumentActionDescription>[]
   actionProps: Omit<DocumentActionProps, 'onComplete'>
-  children: (props: {states: DocumentActionDescription[]}) => React.ReactNode
+  children: (props: {states: DocumentActionDescription[]}) => ReactNode
   onActionComplete?: () => void
   group?: DocumentActionGroup
 }

--- a/packages/sanity/src/structure/components/RenderBadgeCollectionState.tsx
+++ b/packages/sanity/src/structure/components/RenderBadgeCollectionState.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react'
+import {type ReactNode} from 'react'
 import {
   type DocumentBadgeDescription,
   type DocumentBadgeProps,
@@ -15,7 +15,7 @@ export interface Badge<Args, Description> {
 export interface RenderBadgeCollectionProps {
   badges: Badge<DocumentBadgeProps, DocumentBadgeDescription>[]
   badgeProps: EditStateFor
-  children: (props: {states: DocumentBadgeDescription[]}) => React.ReactNode
+  children: (props: {states: DocumentBadgeDescription[]}) => ReactNode
   onActionComplete?: () => void
 }
 

--- a/packages/sanity/src/structure/components/paneHeaderActions/InsufficientPermissionsMessageTooltip.tsx
+++ b/packages/sanity/src/structure/components/paneHeaderActions/InsufficientPermissionsMessageTooltip.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react'
+import {type ComponentProps, type ReactNode} from 'react'
 import {InsufficientPermissionsMessage, useCurrentUser, useTranslation} from 'sanity'
 
 import {Tooltip} from '../../../ui-components'
@@ -10,9 +10,9 @@ interface InsufficientPermissionsMessageTooltipProps {
    * delegates to `InsufficientPermissionsMessage`'s `context` prop
    * @see InsufficientPermissionsMessage
    */
-  context: React.ComponentProps<typeof InsufficientPermissionsMessage>['context']
+  context: ComponentProps<typeof InsufficientPermissionsMessage>['context']
   loading: boolean
-  children: React.ReactNode
+  children: ReactNode
 }
 
 export function InsufficientPermissionsMessageTooltip({

--- a/packages/sanity/src/structure/components/paneItem/PaneItem.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItem.tsx
@@ -6,8 +6,15 @@ import {
   type SchemaType,
 } from '@sanity/types'
 import {Box, type CardProps, Text} from '@sanity/ui'
-import type * as React from 'react'
-import {type ReactNode, useCallback, useEffect, useMemo, useState} from 'react'
+import {
+  type ComponentType,
+  type MouseEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import {
   type FIXME,
   type GeneralPreviewLayoutKey,
@@ -25,7 +32,7 @@ import {PaneItemPreview} from './PaneItemPreview'
 interface PaneItemProps {
   id: string
   layout?: GeneralPreviewLayoutKey
-  icon?: React.ComponentType<any> | false
+  icon?: ComponentType<any> | false
   pressed?: boolean
   selected?: boolean
   title?: string
@@ -41,10 +48,10 @@ interface PaneItemProps {
  * Otherwise return the passed icon or the schema type icon as a backup.
  */
 export function getIconWithFallback(
-  icon: React.ComponentType<any> | false | undefined,
+  icon: ComponentType<any> | false | undefined,
   schemaType: SchemaType | undefined,
-  defaultIcon: React.ComponentType<any>,
-): React.ComponentType<any> | false {
+  defaultIcon: ComponentType<any>,
+): ComponentType<any> | false {
   if (icon === false) {
     return false
   }
@@ -125,7 +132,7 @@ export function PaneItem(props: PaneItemProps) {
     [ChildLink, id],
   )
 
-  const handleClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
+  const handleClick = useCallback((e: MouseEvent<HTMLElement>) => {
     if (e.metaKey) {
       setClicked(false)
       return

--- a/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
@@ -1,8 +1,7 @@
 import {type SanityDocument, type SchemaType} from '@sanity/types'
 import {Flex} from '@sanity/ui'
 import {isNumber, isString} from 'lodash'
-import type * as React from 'react'
-import {isValidElement} from 'react'
+import {type ComponentType, isValidElement} from 'react'
 import {useMemoObservable} from 'react-rx'
 import {
   type DocumentPresence,
@@ -22,7 +21,7 @@ import {type PaneItemPreviewState} from './types'
 
 export interface PaneItemPreviewProps {
   documentPreviewStore: DocumentPreviewStore
-  icon: React.ComponentType | false
+  icon: ComponentType | false
   layout: GeneralPreviewLayoutKey
   presence?: DocumentPresence[]
   schemaType: SchemaType

--- a/packages/sanity/src/structure/components/paneItem/helpers.tsx
+++ b/packages/sanity/src/structure/components/paneItem/helpers.tsx
@@ -1,7 +1,7 @@
 import {WarningOutlineIcon} from '@sanity/icons'
 import {type PreviewValue, type SanityDocument, type SchemaType} from '@sanity/types'
 import {assignWith} from 'lodash'
-import type * as React from 'react'
+import {type ReactNode} from 'react'
 import {combineLatest, type Observable, of} from 'rxjs'
 import {map, startWith} from 'rxjs/operators'
 import {type DocumentPreviewStore, getDraftId, getPublishedId} from 'sanity'
@@ -40,7 +40,7 @@ export function getPreviewStateObservable(
   documentPreviewStore: DocumentPreviewStore,
   schemaType: SchemaType,
   documentId: string,
-  title: React.ReactNode,
+  title: ReactNode,
 ): Observable<PaneItemPreviewState> {
   const draft$ = isLiveEditEnabled(schemaType)
     ? of({snapshot: null})

--- a/packages/sanity/src/structure/components/paneRouter/BackLink.tsx
+++ b/packages/sanity/src/structure/components/paneRouter/BackLink.tsx
@@ -1,5 +1,4 @@
-import type * as React from 'react'
-import {forwardRef, useContext, useMemo} from 'react'
+import {type ComponentType, type ForwardedRef, forwardRef, useContext, useMemo} from 'react'
 import {StateLink} from 'sanity/router'
 
 import {PaneRouterContext} from './PaneRouterContext'
@@ -10,11 +9,11 @@ import {type BackLinkProps} from './types'
  */
 export const BackLink = forwardRef(function BackLink(
   props: BackLinkProps,
-  ref: React.ForwardedRef<HTMLAnchorElement>,
+  ref: ForwardedRef<HTMLAnchorElement>,
 ) {
   const {routerPanesState, groupIndex} = useContext(PaneRouterContext)
   const panes = useMemo(() => routerPanesState.slice(0, groupIndex), [groupIndex, routerPanesState])
   const state = useMemo(() => ({panes}), [panes])
 
   return <StateLink {...props} ref={ref} state={state} />
-}) as React.ComponentType<BackLinkProps>
+}) as ComponentType<BackLinkProps>

--- a/packages/sanity/src/structure/components/paneRouter/ChildLink.tsx
+++ b/packages/sanity/src/structure/components/paneRouter/ChildLink.tsx
@@ -1,5 +1,4 @@
-import type * as React from 'react'
-import {forwardRef, useContext} from 'react'
+import {type ForwardedRef, forwardRef, useContext} from 'react'
 import {StateLink} from 'sanity/router'
 
 import {PaneRouterContext} from './PaneRouterContext'
@@ -10,7 +9,7 @@ import {type ChildLinkProps} from './types'
  */
 export const ChildLink = forwardRef(function ChildLink(
   props: ChildLinkProps,
-  ref: React.ForwardedRef<HTMLAnchorElement>,
+  ref: ForwardedRef<HTMLAnchorElement>,
 ) {
   const {childId, childPayload, childParameters, ...rest} = props
   const {routerPanesState, groupIndex} = useContext(PaneRouterContext)

--- a/packages/sanity/src/structure/components/paneRouter/PaneRouterProvider.tsx
+++ b/packages/sanity/src/structure/components/paneRouter/PaneRouterProvider.tsx
@@ -1,7 +1,6 @@
 import {toString as pathToString} from '@sanity/util/paths'
 import {omit} from 'lodash'
-import type * as React from 'react'
-import {useCallback, useMemo} from 'react'
+import {type ReactNode, useCallback, useMemo} from 'react'
 import {useRouter, useRouterState} from 'sanity/router'
 
 import {type RouterPaneGroup, type RouterPanes, type RouterPaneSibling} from '../../types'
@@ -19,7 +18,7 @@ const emptyArray: never[] = []
  * @internal
  */
 export function PaneRouterProvider(props: {
-  children: React.ReactNode
+  children: ReactNode
   flatIndex: number
   index: number
   params: Record<string, string | undefined>

--- a/packages/sanity/src/structure/components/paneRouter/ParameterizedLink.tsx
+++ b/packages/sanity/src/structure/components/paneRouter/ParameterizedLink.tsx
@@ -1,5 +1,4 @@
-import type * as React from 'react'
-import {forwardRef, useContext, useMemo} from 'react'
+import {type ForwardedRef, forwardRef, type ReactNode, useContext, useMemo} from 'react'
 import {useUnique} from 'sanity'
 import {StateLink} from 'sanity/router'
 
@@ -8,7 +7,7 @@ import {PaneRouterContext} from './PaneRouterContext'
 interface ParameterizedLinkProps {
   params?: Record<string, string>
   payload?: unknown
-  children?: React.ReactNode
+  children?: ReactNode
 }
 
 /**
@@ -16,7 +15,7 @@ interface ParameterizedLinkProps {
  */
 export const ParameterizedLink = forwardRef(function ParameterizedLink(
   props: ParameterizedLinkProps,
-  ref: React.ForwardedRef<HTMLAnchorElement>,
+  ref: ForwardedRef<HTMLAnchorElement>,
 ) {
   const {routerPanesState: currentPanes, groupIndex, siblingIndex} = useContext(PaneRouterContext)
   const {params, payload, ...rest} = props

--- a/packages/sanity/src/structure/components/paneRouter/ReferenceChildLink.tsx
+++ b/packages/sanity/src/structure/components/paneRouter/ReferenceChildLink.tsx
@@ -1,13 +1,12 @@
 import {toString as pathToString} from '@sanity/util/paths'
-import type * as React from 'react'
-import {forwardRef} from 'react'
+import {type ForwardedRef, forwardRef} from 'react'
 
 import {ChildLink} from './ChildLink'
 import {type ReferenceChildLinkProps} from './types'
 
 export const ReferenceChildLink = forwardRef(function ReferenceChildLink(
   {documentId, documentType, parentRefPath, children, template, ...rest}: ReferenceChildLinkProps,
-  ref: React.ForwardedRef<HTMLAnchorElement>,
+  ref: ForwardedRef<HTMLAnchorElement>,
 ) {
   return (
     <ChildLink

--- a/packages/sanity/src/structure/panes/document/documentInspector/Resizer.tsx
+++ b/packages/sanity/src/structure/panes/document/documentInspector/Resizer.tsx
@@ -1,5 +1,4 @@
-import type * as React from 'react'
-import {useCallback, useRef} from 'react'
+import {type MouseEvent, useCallback, useRef} from 'react'
 import {styled} from 'styled-components'
 
 const Root = styled.div`
@@ -48,14 +47,14 @@ export function Resizer(props: {onResize: (delta: number) => void; onResizeStart
   const mouseXRef = useRef(0)
 
   const handleMouseDown = useCallback(
-    (event: React.MouseEvent) => {
+    (event: MouseEvent) => {
       event.preventDefault()
 
       mouseXRef.current = event.pageX
 
       onResizeStart()
 
-      const handleMouseMove = (e: MouseEvent) => {
+      const handleMouseMove = (e: globalThis.MouseEvent) => {
         e.preventDefault()
         onResize(e.pageX - mouseXRef.current)
       }

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/Banner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/Banner.tsx
@@ -1,19 +1,19 @@
 import {type ButtonTone, Card, type CardTone, Flex, Text} from '@sanity/ui'
-import type * as React from 'react'
+import {type ComponentType, type ElementType, type JSX, type ReactNode} from 'react'
 
 import {Button} from '../../../../../ui-components'
 import {SpacerButton} from '../../../../components/spacerButton'
 
 interface BannerProps {
   action?: {
-    as?: React.ElementType | keyof JSX.IntrinsicElements
-    icon?: React.ComponentType
+    as?: ElementType | keyof JSX.IntrinsicElements
+    icon?: ComponentType
     onClick?: () => void
     text: string
     tone?: ButtonTone
   }
-  content: React.ReactNode
-  icon?: React.ComponentType
+  content: ReactNode
+  icon?: ComponentType
   tone?: CardTone
 }
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import {Box, Container, Flex, focusFirstDescendant, Spinner, Text} from '@sanity/ui'
-import type * as React from 'react'
-import {forwardRef, useCallback, useEffect, useMemo, useState} from 'react'
+import {type FormEvent, forwardRef, useCallback, useEffect, useMemo, useState} from 'react'
 import {tap} from 'rxjs/operators'
 import {
   createPatchChannel,
@@ -29,7 +28,7 @@ interface FormViewProps {
   margins: [number, number, number, number]
 }
 
-const preventDefault = (ev: React.FormEvent) => ev.preventDefault()
+const preventDefault = (ev: FormEvent) => ev.preventDefault()
 
 export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormView(props, ref) {
   const {hidden, margins} = props
@@ -141,7 +140,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
   //   () =>
   //     Array.isArray(afterEditorComponents) &&
   //     afterEditorComponents.map(
-  //       (AfterEditorComponent: React.ComponentType<{documentId: string}>, idx: number) => (
+  //       (AfterEditorComponent: ComponentType<{documentId: string}>, idx: number) => (
   //         <AfterEditorComponent key={String(idx)} documentId={documentId} />
   //       )
   //     ),

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -1,7 +1,6 @@
 import {ArrowLeftIcon, CloseIcon, SplitVerticalIcon} from '@sanity/icons'
 import {Flex} from '@sanity/ui'
-import type * as React from 'react'
-import {createElement, forwardRef, memo, useMemo, useState} from 'react'
+import {createElement, type ForwardedRef, forwardRef, memo, useMemo, useState} from 'react'
 import {useFieldActions, useTimelineSelector, useTranslation} from 'sanity'
 
 import {Button, TooltipDelayGroupProvider} from '../../../../../ui-components'
@@ -31,7 +30,7 @@ export interface DocumentPanelHeaderProps {
 export const DocumentPanelHeader = memo(
   forwardRef(function DocumentPanelHeader(
     _props: DocumentPanelHeaderProps,
-    ref: React.ForwardedRef<HTMLDivElement>,
+    ref: ForwardedRef<HTMLDivElement>,
   ) {
     const {menuItems} = _props
     const {

--- a/packages/sanity/src/structure/panes/document/inspectDialog/Search.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectDialog/Search.tsx
@@ -1,7 +1,6 @@
 import {SearchIcon} from '@sanity/icons'
 import {TextInput} from '@sanity/ui'
-import type * as React from 'react'
-import {useCallback} from 'react'
+import {type ChangeEvent, useCallback} from 'react'
 import {useTranslation} from 'sanity'
 
 import {structureLocaleNamespace} from '../../../i18n'
@@ -10,7 +9,7 @@ export function Search(props: {onChange: (q: string) => void; query: string}) {
   const {onChange, query} = props
 
   const handleChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => onChange(event.target.value),
+    (event: ChangeEvent<HTMLInputElement>) => onChange(event.target.value),
     [onChange],
   )
   const {t} = useTranslation(structureLocaleNamespace)

--- a/packages/sanity/src/structure/panes/document/keyboardShortcuts/DocumentActionShortcuts.tsx
+++ b/packages/sanity/src/structure/panes/document/keyboardShortcuts/DocumentActionShortcuts.tsx
@@ -1,6 +1,14 @@
 import {isHotkey} from 'is-hotkey-esm'
-import * as React from 'react'
-import {createElement, type ElementType, useCallback, useMemo, useState} from 'react'
+import {
+  createElement,
+  type ElementType,
+  type HTMLProps,
+  memo,
+  type Ref,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react'
 import {type DocumentActionDescription, type DocumentActionProps, LegacyLayerProvider} from 'sanity'
 
 import {RenderActionCollectionState} from '../../../components'
@@ -16,12 +24,12 @@ export interface KeyboardShortcutResponderProps {
   id: string
   minWidth?: number
   onActionStart: (index: number) => void
-  rootRef: React.Ref<HTMLDivElement>
+  rootRef: Ref<HTMLDivElement>
   states: DocumentActionDescription[]
 }
 
 function KeyboardShortcutResponder(
-  props: KeyboardShortcutResponderProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height'>,
+  props: KeyboardShortcutResponderProps & Omit<HTMLProps<HTMLDivElement>, 'as' | 'height'>,
 ) {
   const {
     actionsBoxElement,
@@ -95,11 +103,11 @@ export interface DocumentActionShortcutsProps {
   flex: number
   id: string
   minWidth: number
-  rootRef: React.Ref<HTMLDivElement>
+  rootRef: Ref<HTMLDivElement>
 }
 
-export const DocumentActionShortcuts = React.memo(
-  (props: DocumentActionShortcutsProps & Omit<React.HTMLProps<HTMLDivElement>, 'as'>) => {
+export const DocumentActionShortcuts = memo(
+  (props: DocumentActionShortcutsProps & Omit<HTMLProps<HTMLDivElement>, 'as'>) => {
     const {actionsBoxElement, as = 'div', children, ...rest} = props
     const {actions, editState} = useDocumentPane()
     const [activeIndex, setActiveIndex] = useState(-1)

--- a/packages/sanity/src/structure/panes/document/statusBar/ActionStateDialog.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/ActionStateDialog.tsx
@@ -1,6 +1,5 @@
 import {PortalProvider, Text, usePortal} from '@sanity/ui'
-import type * as React from 'react'
-import {useId} from 'react'
+import {type ReactNode, useId} from 'react'
 import {type DocumentActionDialogProps} from 'sanity'
 
 import {Dialog} from '../../../../ui-components'
@@ -16,7 +15,7 @@ export interface ActionStateDialogProps {
 
 // A portal provider that uses the document panel portal element if it exists
 // as the portal element so that dialogs are scoped to the document panel
-function DocumentActionPortalProvider(props: {children: React.ReactNode}) {
+function DocumentActionPortalProvider(props: {children: ReactNode}) {
   const {children} = props
   const {element, elements} = usePortal()
   const portalElement = elements?.[DOCUMENT_PANEL_PORTAL_ELEMENT] || element

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPaneHeader.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPaneHeader.tsx
@@ -1,6 +1,5 @@
 import {ArrowLeftIcon} from '@sanity/icons'
-import type * as React from 'react'
-import {memo, useMemo} from 'react'
+import {memo, type ReactNode, useMemo} from 'react'
 import {type GeneralPreviewLayoutKey, type InitialValueTemplateItem} from 'sanity'
 
 import {Button, TooltipDelayGroupProvider} from '../../../ui-components'
@@ -14,7 +13,7 @@ import {useStructureTool} from '../../useStructureTool'
 import {type SortOrder} from './types'
 
 interface DocumentListPaneHeaderProps {
-  contentAfter?: React.ReactNode
+  contentAfter?: ReactNode
   index: number
   initialValueTemplates?: InitialValueTemplateItem[]
   menuItemGroups?: PaneMenuItemGroup[]

--- a/packages/sanity/src/structure/panes/userComponent/UserComponentPaneContent.tsx
+++ b/packages/sanity/src/structure/panes/userComponent/UserComponentPaneContent.tsx
@@ -1,11 +1,11 @@
 import {Box} from '@sanity/ui'
-import type * as React from 'react'
+import {type ReactNode} from 'react'
 import {styled} from 'styled-components'
 
 import {usePane} from '../../components'
 
 interface UserComponentPaneContentProps {
-  children: React.ReactNode
+  children: ReactNode
 }
 
 const Root = styled(Box)`

--- a/packages/sanity/src/tasks/src/tasks/components/form/fields/descriptionInput/blocks/DescriptionInputBlock.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/form/fields/descriptionInput/blocks/DescriptionInputBlock.tsx
@@ -1,5 +1,5 @@
 import {Box, Text} from '@sanity/ui'
-import type * as React from 'react'
+import {type ReactNode} from 'react'
 import {styled} from 'styled-components'
 
 const NormalText = styled(Text)`
@@ -7,7 +7,7 @@ const NormalText = styled(Text)`
 `
 
 interface NormalBlockProps {
-  children: React.ReactNode
+  children: ReactNode
 }
 
 export function DescriptionInputBlock(props: NormalBlockProps) {

--- a/packages/sanity/src/ui-components/dialog/Dialog.tsx
+++ b/packages/sanity/src/ui-components/dialog/Dialog.tsx
@@ -7,8 +7,7 @@ import {
   type DialogProps as UIDialogProps,
   Flex,
 } from '@sanity/ui'
-import type * as React from 'react'
-import {type ComponentProps, forwardRef} from 'react'
+import {type ComponentProps, forwardRef, type HTMLProps, type ReactNode, type Ref} from 'react'
 import {useTranslation} from 'react-i18next'
 
 /** @internal */
@@ -33,7 +32,7 @@ export type DialogProps = Pick<
    * and not trigger dynamic border visibility.
    */
   bodyHeight?: BoxHeight
-  children?: React.ReactNode
+  children?: ReactNode
   footer?: {
     cancelButton?: Omit<ComponentProps<typeof UIButton>, 'fontSize' | 'padding'>
     confirmButton?: Omit<ComponentProps<typeof UIButton>, 'fontSize' | 'padding'>
@@ -56,8 +55,8 @@ export const Dialog = forwardRef(function Dialog(
     footer,
     padding = true,
     ...props
-  }: DialogProps & Pick<React.HTMLProps<HTMLDivElement>, 'onDragEnter' | 'onDrop'>,
-  ref: React.Ref<HTMLDivElement>,
+  }: DialogProps & Pick<HTMLProps<HTMLDivElement>, 'onDragEnter' | 'onDrop'>,
+  ref: Ref<HTMLDivElement>,
 ) {
   const {t} = useTranslation()
 

--- a/packages/sanity/src/ui-components/menuButton/MenuButton.tsx
+++ b/packages/sanity/src/ui-components/menuButton/MenuButton.tsx
@@ -4,8 +4,7 @@ import {
   type MenuButtonProps as UIMenuButtonProps,
   type PopoverProps,
 } from '@sanity/ui'
-import type * as React from 'react'
-import {forwardRef} from 'react'
+import {type ForwardedRef, forwardRef} from 'react'
 
 /** @internal */
 export type MenuButtonProps = Omit<UIMenuButtonProps, 'popover'> & {
@@ -19,7 +18,7 @@ export type MenuButtonProps = Omit<UIMenuButtonProps, 'popover'> & {
  */
 export const MenuButton = forwardRef(function MenuButton(
   props: MenuButtonProps,
-  ref: React.ForwardedRef<HTMLButtonElement>,
+  ref: ForwardedRef<HTMLButtonElement>,
 ) {
   return (
     <UIMenuButton

--- a/packages/sanity/src/ui-components/menuGroup/MenuGroup.tsx
+++ b/packages/sanity/src/ui-components/menuGroup/MenuGroup.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import {MenuGroup as UIMenuGroup, type MenuGroupProps as UIMenuGroupProps} from '@sanity/ui'
-import type * as React from 'react'
+import {type HTMLProps} from 'react'
 
 /** @internal */
 export type MenuGroupProps = Pick<UIMenuGroupProps, 'icon' | 'popover' | 'text' | 'tone'>
@@ -11,8 +11,7 @@ export type MenuGroupProps = Pick<UIMenuGroupProps, 'icon' | 'popover' | 'text' 
  * @internal
  */
 export const MenuGroup = (
-  props: MenuGroupProps &
-    Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'ref' | 'tabIndex'>,
+  props: MenuGroupProps & Omit<HTMLProps<HTMLDivElement>, 'as' | 'height' | 'ref' | 'tabIndex'>,
 ) => {
   return <UIMenuGroup {...props} fontSize={1} padding={3} />
 }

--- a/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
+++ b/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
@@ -9,8 +9,17 @@ import {
   Stack,
   Text,
 } from '@sanity/ui'
-import type * as React from 'react'
-import {createElement, forwardRef, isValidElement, useCallback, useMemo} from 'react'
+import {
+  createElement,
+  forwardRef,
+  type HTMLProps,
+  isValidElement,
+  type JSX,
+  type ReactNode,
+  type Ref,
+  useCallback,
+  useMemo,
+} from 'react'
 import {isValidElementType} from 'react-is'
 import {styled} from 'styled-components'
 
@@ -41,11 +50,11 @@ export type MenuItemProps = Pick<
   /**
    * Previews should be 25x25.
    */
-  preview?: React.ReactNode
+  preview?: ReactNode
   /**
    * Optional render callback which receives menu item content.
    */
-  renderMenuItem?: (menuItemContent: React.JSX.Element) => React.ReactNode
+  renderMenuItem?: (menuItemContent: JSX.Element) => ReactNode
   text?: string
   tooltipProps?: TooltipProps | null
   /**
@@ -93,11 +102,8 @@ export const MenuItem = forwardRef(function MenuItem(
     __unstable_space,
     ...rest
   }: MenuItemProps &
-    Omit<
-      React.HTMLProps<HTMLDivElement>,
-      'as' | 'height' | 'ref' | 'selected' | 'tabIndex' | 'size'
-    >,
-  ref: React.Ref<HTMLDivElement>,
+    Omit<HTMLProps<HTMLDivElement>, 'as' | 'height' | 'ref' | 'selected' | 'tabIndex' | 'size'>,
+  ref: Ref<HTMLDivElement>,
 ) {
   const menuItemContent = useMemo(() => {
     return (

--- a/packages/sanity/src/ui-components/popover/Popover.tsx
+++ b/packages/sanity/src/ui-components/popover/Popover.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import {Popover as UIPopover, type PopoverProps as UIPopoverProps} from '@sanity/ui'
-import type * as React from 'react'
-import {forwardRef} from 'react'
+import {type ForwardedRef, forwardRef, type HTMLProps} from 'react'
 
 /** @internal */
 export type PopoverProps = Omit<UIPopoverProps, 'animate'>
@@ -14,9 +13,8 @@ export type PopoverProps = Omit<UIPopoverProps, 'animate'>
  * @internal
  */
 export const Popover = forwardRef(function Popover(
-  props: PopoverProps &
-    Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'children' | 'content' | 'width'>,
-  ref: React.ForwardedRef<HTMLDivElement>,
+  props: PopoverProps & Omit<HTMLProps<HTMLDivElement>, 'as' | 'children' | 'content' | 'width'>,
+  ref: ForwardedRef<HTMLDivElement>,
 ) {
   return <UIPopover {...props} animate ref={ref} />
 })

--- a/packages/sanity/src/ui-components/tab/Tab.tsx
+++ b/packages/sanity/src/ui-components/tab/Tab.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import {Tab as UITab, type TabProps as UITabProps} from '@sanity/ui'
-import type * as React from 'react'
-import {forwardRef} from 'react'
+import {type ForwardedRef, forwardRef, type HTMLProps} from 'react'
 
 /**
  * @internal
@@ -19,8 +18,8 @@ export type TabProps = Pick<
  * @internal
  */
 export const Tab = forwardRef(function Tab(
-  {tone = 'default', ...props}: TabProps & Omit<React.HTMLProps<HTMLButtonElement>, 'as' | 'size'>,
-  ref: React.ForwardedRef<HTMLButtonElement>,
+  {tone = 'default', ...props}: TabProps & Omit<HTMLProps<HTMLButtonElement>, 'as' | 'size'>,
+  ref: ForwardedRef<HTMLButtonElement>,
 ) {
   return <UITab {...props} muted padding={2} ref={ref} tone={tone} />
 })

--- a/packages/sanity/src/ui-components/tooltip/Tooltip.tsx
+++ b/packages/sanity/src/ui-components/tooltip/Tooltip.tsx
@@ -8,8 +8,7 @@ import {
   Tooltip as UITooltip,
   type TooltipProps as UITooltipProps,
 } from '@sanity/ui'
-import type * as React from 'react'
-import {forwardRef} from 'react'
+import {type ForwardedRef, forwardRef} from 'react'
 
 import {TOOLTIP_DELAY_PROPS} from './constants'
 
@@ -40,7 +39,7 @@ const TOOLTIP_SHARED_PROPS: UITooltipProps = {
  */
 export const Tooltip = forwardRef(function Tooltip(
   props: TooltipProps,
-  ref: React.ForwardedRef<HTMLDivElement>,
+  ref: ForwardedRef<HTMLDivElement>,
 ) {
   const {content, hotkeys, ...rest} = props
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Removes remaining `* as React` imports from the codebase, I thought there was a lint rule which prevent this 🤔 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Everything still works and there is no downside to this
