### PR TITLE
refactor(cli): use fs methods for reading package.json files

### DIFF
--- a/packages/@sanity/cli/src/actions/versions/findSanityModuleVersions.ts
+++ b/packages/@sanity/cli/src/actions/versions/findSanityModuleVersions.ts
@@ -1,4 +1,5 @@
-import path from 'node:path'
+import {readFileSync} from 'node:fs'
+import {join as joinPath} from 'node:path'
 
 import getLatestVersion from 'get-latest-version'
 import promiseProps from 'promise-props-recursive'
@@ -6,7 +7,6 @@ import semver from 'semver'
 import semverCompare from 'semver-compare'
 
 import {type CliCommandContext, type PackageJson} from '../../types'
-import {dynamicRequire} from '../../util/dynamicRequire'
 import {getCliVersion} from '../../util/getCliVersion'
 import {getLocalVersion} from '../../util/getLocalVersion'
 
@@ -92,7 +92,8 @@ export async function findSanityModuleVersions(
 
 function getLocalManifest(workDir: string): Partial<PackageJson> {
   try {
-    return dynamicRequire(path.join(workDir, 'package.json'))
+    const fileContent = readFileSync(joinPath(workDir, 'package.json'), 'utf8')
+    return JSON.parse(fileContent)
   } catch (err) {
     return {}
   }

--- a/packages/@sanity/cli/src/util/getLocalVersion.ts
+++ b/packages/@sanity/cli/src/util/getLocalVersion.ts
@@ -1,12 +1,11 @@
-import path from 'node:path'
+import {readFileSync} from 'node:fs'
+import {join as joinPath, normalize as normalizePath} from 'node:path'
 
 import resolveFrom from 'resolve-from'
 
-import {dynamicRequire} from './dynamicRequire'
-
 export function getLocalVersion(moduleId: string, workDir: string): string | undefined {
   const fromPath = workDir || process.cwd()
-  const modulePath = resolveFrom.silent(fromPath, path.join(moduleId, 'package.json'))
+  const modulePath = resolveFrom.silent(fromPath, joinPath(moduleId, 'package.json'))
   if (modulePath) {
     return tryGetVersion(modulePath)
   }
@@ -14,20 +13,22 @@ export function getLocalVersion(moduleId: string, workDir: string): string | und
   // In the case of packages with an `exports` key, we may not be able to resolve `package.json`.
   // If this happens, try to resolve the module itself and look for the last occurence of the
   // package name, then append `package.json` to that path
-  const pathSegment = path.normalize(moduleId)
+  const pathSegment = normalizePath(moduleId)
   const parentPath = resolveFrom.silent(fromPath, moduleId)
   if (!parentPath) {
     return undefined
   }
 
   const moduleRoot = parentPath.slice(0, parentPath.lastIndexOf(pathSegment) + pathSegment.length)
-  const manifestPath = path.join(moduleRoot, 'package.json')
+  const manifestPath = joinPath(moduleRoot, 'package.json')
   return tryGetVersion(manifestPath)
 }
 
 function tryGetVersion(modulePath: string): string | undefined {
   try {
-    return dynamicRequire(modulePath).version
+    const fileContent = readFileSync(modulePath, 'utf8')
+    const manifest = JSON.parse(fileContent)
+    return manifest.version
   } catch (err) {
     return undefined
   }


### PR DESCRIPTION
### Description

Background: gradually removing `require()` calls across the codebase in order to be more ready for an "ESM-first" world

Replaces a few `require()` calls for `.json` files with `fs.readFile` + `JSON.parse`.

### What to review

- CLI commands still work as expected
- Code refactorings look okay

### Notes for release

None
