### PR TITLE
chore: disallow and remove react default imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -325,6 +325,12 @@ const config = {
                 importNames: ['default'],
                 message: 'Please use `import {styled} from "styled-components"` instead.',
               },
+              {
+                name: 'react',
+                importNames: ['default'],
+                message:
+                  'Please use named imports, e.g. `import {useEffect, useMemo, type ComponentType} from "react"` instead.',
+              },
             ],
           },
         ],

--- a/packages/@sanity/cli/templates/.eslintrc
+++ b/packages/@sanity/cli/templates/.eslintrc
@@ -2,6 +2,7 @@
   "root": true,
   "extends": "@sanity/eslint-config-studio",
   "rules": {
-    "import/no-unresolved": "off"
+    "import/no-unresolved": "off",
+    "no-restricted-imports": "off"
   }
 }

--- a/packages/sanity/src/structure/__workshop__/ResolvePanesStory.tsx
+++ b/packages/sanity/src/structure/__workshop__/ResolvePanesStory.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable react/no-array-index-key */
 
 import {Box, Card, Code, Flex, Radio, Stack, Text} from '@sanity/ui'
-import type * as React from 'react'
-import {useCallback, useState} from 'react'
+import {type ChangeEvent, useCallback, useState} from 'react'
 
 import {LOADING_PANE} from '../constants'
 import {useResolvedPanes} from '../structureResolvers'
@@ -32,7 +31,7 @@ function ResolvePanesStory() {
   const {paneDataItems, resolvedPanes, routerPanes} = useResolvedPanes()
   const [testKey, setTestKey] = useState('0')
 
-  const handleChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
     const inputValue = event.currentTarget.value
 
     setTestKey(inputValue)

--- a/packages/sanity/src/structure/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/structure/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -11,7 +11,7 @@ import * as PathUtils from '@sanity/util/paths'
 import {uuid} from '@sanity/uuid'
 import {AnimatePresence} from 'framer-motion'
 import {debounce} from 'lodash'
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {isPortableTextTextBlock, type PortableTextInputProps, useCurrentUser} from 'sanity'
 
 import {
@@ -56,7 +56,7 @@ export function CommentsPortableTextInput(props: PortableTextInputProps) {
   return <CommentsPortableTextInputInner {...props} mode={mode} />
 }
 
-export const CommentsPortableTextInputInner = React.memo(function CommentsPortableTextInputInner(
+export const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputInner(
   props: PortableTextInputProps & {mode: CommentsUIMode},
 ) {
   const {mode} = props

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItem.tsx
@@ -1,7 +1,16 @@
 import {ChevronDownIcon} from '@sanity/icons'
 import {type CurrentUser} from '@sanity/types'
 import {type AvatarSize, Flex, Stack, type StackProps, useLayer} from '@sanity/ui'
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {
+  type KeyboardEvent,
+  memo,
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import {type UserListWithPermissionsHookValue, useTranslation} from 'sanity'
 import {css, styled} from 'styled-components'
 
@@ -99,7 +108,7 @@ export interface CommentsListItemProps {
   onCreateRetry: (id: string) => void
   onDelete: (id: string) => void
   onEdit: (id: string, payload: CommentUpdatePayload) => void
-  onKeyDown?: (event: React.KeyboardEvent<Element>) => void
+  onKeyDown?: (event: KeyboardEvent<Element>) => void
   onPathSelect?: (nextPath: CommentsSelectedPath) => void
   onReactionSelect?: (id: string, reaction: CommentReactionOption) => void
   onReply: (payload: CommentBaseCreatePayload) => void
@@ -109,7 +118,7 @@ export interface CommentsListItemProps {
   replies: CommentDocument[] | undefined
 }
 
-export const CommentsListItem = React.memo(function CommentsListItem(props: CommentsListItemProps) {
+export const CommentsListItem = memo(function CommentsListItem(props: CommentsListItemProps) {
   const {
     avatarConfig = DEFAULT_AVATAR_CONFIG,
     canReply,
@@ -183,7 +192,7 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
   }, [hasValue])
 
   const handleInputKeyDown = useCallback(
-    (event: React.KeyboardEvent<Element>) => {
+    (event: KeyboardEvent<Element>) => {
       // Don't act if the input already prevented this event
       if (event.isDefaultPrevented()) {
         return
@@ -209,7 +218,7 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
   }, [])
 
   const handleThreadRootClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+    (e: MouseEvent<HTMLDivElement>) => {
       e.stopPropagation()
 
       // Don't act if the click was caused by clicking
@@ -225,7 +234,7 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
     [isTopLayer, onPathSelect, parentComment.target.path?.field, parentComment.threadId],
   )
 
-  const handleExpand = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleExpand = useCallback((e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
     setCollapsed(false)
     didExpand.current = true

--- a/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInputProvider.tsx
+++ b/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInputProvider.tsx
@@ -4,7 +4,7 @@ import {
   usePortableTextEditor,
 } from '@sanity/portable-text-editor'
 import {isPortableTextSpan, type Path} from '@sanity/types'
-import React, {useCallback, useMemo, useState} from 'react'
+import {createContext, type ReactNode, useCallback, useMemo, useState} from 'react'
 import {useDidUpdate, type UserListWithPermissionsHookValue} from 'sanity'
 
 import {hasCommentMessageValue, useCommentHasChanged} from '../../../helpers'
@@ -30,10 +30,10 @@ export interface CommentInputContextValue {
   value: CommentMessage
 }
 
-export const CommentInputContext = React.createContext<CommentInputContextValue | null>(null)
+export const CommentInputContext = createContext<CommentInputContextValue | null>(null)
 
 interface CommentInputProviderProps {
-  children: React.ReactNode
+  children: ReactNode
   expandOnFocus?: boolean
   focused: boolean
   focusOnMount?: boolean

--- a/packages/sanity/src/structure/comments/src/components/reactions/CommentReactionsBar.tsx
+++ b/packages/sanity/src/structure/comments/src/components/reactions/CommentReactionsBar.tsx
@@ -5,7 +5,7 @@ import {
   Flex,
   Text,
 } from '@sanity/ui'
-import React, {useCallback, useMemo, useRef} from 'react'
+import {memo, useCallback, useMemo, useRef} from 'react'
 
 import {Tooltip, TooltipDelayGroupProvider} from '../../../../../ui-components'
 import {COMMENT_REACTION_EMOJIS, COMMENT_REACTION_OPTIONS} from '../../constants'
@@ -82,7 +82,7 @@ interface CommentReactionsBarProps {
   mode: CommentsUIMode
 }
 
-export const CommentReactionsBar = React.memo(function CommentReactionsBar(
+export const CommentReactionsBar = memo(function CommentReactionsBar(
   props: CommentReactionsBarProps,
 ) {
   const {currentUser, onSelect, reactions, readOnly, mode} = props

--- a/packages/sanity/src/structure/comments/src/context/selected-path/CommentsSelectedPathProvider.tsx
+++ b/packages/sanity/src/structure/comments/src/context/selected-path/CommentsSelectedPathProvider.tsx
@@ -1,5 +1,5 @@
 import {isEqual} from 'lodash'
-import React, {useCallback, useMemo, useState} from 'react'
+import {memo, useCallback, useMemo, useState} from 'react'
 
 import {CommentsSelectedPathContext} from './CommentsSelectedPathContext'
 import {type CommentsSelectedPath, type CommentsSelectedPathContextValue} from './types'
@@ -8,7 +8,7 @@ interface CommentsSelectedPathProviderProps {
   children: React.ReactNode
 }
 
-export const CommentsSelectedPathProvider = React.memo(function CommentsSelectedPathProvider(
+export const CommentsSelectedPathProvider = memo(function CommentsSelectedPathProvider(
   props: CommentsSelectedPathProviderProps,
 ) {
   const {children} = props

--- a/packages/sanity/src/structure/components/pane/__workshop__/SplitPanesStory/DocumentPane/DocumentPane.tsx
+++ b/packages/sanity/src/structure/components/pane/__workshop__/SplitPanesStory/DocumentPane/DocumentPane.tsx
@@ -1,6 +1,5 @@
 import {Flex} from '@sanity/ui'
-import type * as React from 'react'
-import {useCallback, useEffect, useState} from 'react'
+import {type Dispatch, type SetStateAction, useCallback, useEffect, useState} from 'react'
 
 import {Pane} from '../../../Pane'
 import {usePaneLayout} from '../../../usePaneLayout'
@@ -11,7 +10,7 @@ import {ReviewChangesPanel} from './ReviewChangesPanel'
 export function DocumentPane(props: {
   index: number
   node: DocumentPaneNode
-  setPath: React.Dispatch<React.SetStateAction<string[]>>
+  setPath: Dispatch<SetStateAction<string[]>>
 }) {
   const {index, node, setPath} = props
   const {collapsed: layoutCollapsed} = usePaneLayout()

--- a/packages/sanity/src/structure/components/pane/__workshop__/SplitPanesStory/ListPane/ListPane.tsx
+++ b/packages/sanity/src/structure/components/pane/__workshop__/SplitPanesStory/ListPane/ListPane.tsx
@@ -1,7 +1,6 @@
 import {ArrowLeftIcon, ChevronRightIcon} from '@sanity/icons'
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
-import type * as React from 'react'
-import {useCallback} from 'react'
+import {type Dispatch, type SetStateAction, useCallback} from 'react'
 import {ContextMenuButton} from 'sanity'
 
 import {Button} from '../../../../../../ui-components'
@@ -16,7 +15,7 @@ export function ListPane(props: {
   childId?: string
   index: number
   node: ListPaneNode
-  setPath: React.Dispatch<React.SetStateAction<string[]>>
+  setPath: Dispatch<SetStateAction<string[]>>
 }) {
   const {active, childId, index, node, setPath} = props
   const {collapsed: layoutCollapsed} = usePaneLayout()

--- a/packages/sanity/src/structure/components/paneRouter/types.ts
+++ b/packages/sanity/src/structure/components/paneRouter/types.ts
@@ -1,5 +1,5 @@
 import {type Path} from '@sanity/types'
-import type React from 'react'
+import {type ComponentType, type ReactNode} from 'react'
 
 import {type RouterPanes, type RouterPaneSibling} from '../../types'
 
@@ -10,14 +10,14 @@ export interface ChildLinkProps {
   childId: string
   childParameters?: Record<string, string>
   childPayload?: unknown
-  children?: React.ReactNode
+  children?: ReactNode
 }
 
 /**
  * @hidden
  * @beta */
 export interface BackLinkProps {
-  children?: React.ReactNode
+  children?: ReactNode
 }
 
 /**
@@ -28,7 +28,7 @@ export interface ReferenceChildLinkProps {
   documentType: string
   parentRefPath: Path
   template?: {id: string; params?: Record<string, string | number | boolean>}
-  children: React.ReactNode
+  children: ReactNode
 }
 
 /**
@@ -96,18 +96,18 @@ export interface PaneRouterContextValue {
   /**
    * Curried StateLink that passes the correct state automatically
    */
-  ChildLink: React.ComponentType<ChildLinkProps>
+  ChildLink: ComponentType<ChildLinkProps>
 
   /**
    * Curried StateLink that pops off the last pane group
    */
-  BackLink?: React.ComponentType<BackLinkProps>
+  BackLink?: ComponentType<BackLinkProps>
 
   /**
    * A specialized `ChildLink` that takes in the needed props to open a
    * referenced document to the right
    */
-  ReferenceChildLink: React.ComponentType<ReferenceChildLinkProps>
+  ReferenceChildLink: ComponentType<ReferenceChildLinkProps>
 
   /**
    * Similar to `ReferenceChildLink` expect without the wrapping component
@@ -117,7 +117,7 @@ export interface PaneRouterContextValue {
   /**
    * Curried StateLink that passed the correct state, but merges params/payload
    */
-  ParameterizedLink: React.ComponentType<ParameterizedLinkProps>
+  ParameterizedLink: ComponentType<ParameterizedLinkProps>
 
   /**
    * Replaces the current pane with a new one

--- a/packages/sanity/test/form/renderArrayOfObjectsInput.tsx
+++ b/packages/sanity/test/form/renderArrayOfObjectsInput.tsx
@@ -1,6 +1,6 @@
 import {jest} from '@jest/globals'
 import {type ArraySchemaType, type FieldDefinition} from '@sanity/types'
-import type * as React from 'react'
+import {type ReactElement} from 'react'
 
 import {
   type ArrayOfObjectsFormNode,
@@ -22,7 +22,7 @@ const noopRenderDefault = () => <></>
 
 export type TestRenderArrayOfObjectInputCallback = (
   inputProps: ArrayOfObjectsInputProps,
-) => React.ReactElement
+) => ReactElement
 
 export async function renderArrayOfObjectsInput(options: {
   fieldDefinition: FieldDefinition<'array'>

--- a/packages/sanity/test/form/renderBooleanInput.tsx
+++ b/packages/sanity/test/form/renderBooleanInput.tsx
@@ -1,5 +1,5 @@
 import {type BooleanSchemaType, type FieldDefinition} from '@sanity/types'
-import type * as React from 'react'
+import {type ReactElement} from 'react'
 
 import {type BooleanInputProps, type PrimitiveInputElementProps} from '../../src/core'
 import {renderInput, type RenderInputResult, type TestRenderInputProps} from './renderInput'
@@ -7,7 +7,7 @@ import {type TestRenderProps} from './types'
 
 const noopRenderDefault = () => <></>
 
-export type TestRenderBooleanInputCallback = (inputProps: BooleanInputProps) => React.ReactElement
+export type TestRenderBooleanInputCallback = (inputProps: BooleanInputProps) => ReactElement
 
 export async function renderBooleanInput(options: {
   fieldDefinition: FieldDefinition<'boolean'>

--- a/packages/sanity/test/form/renderCrossDatasetReferenceInput.tsx
+++ b/packages/sanity/test/form/renderCrossDatasetReferenceInput.tsx
@@ -3,7 +3,7 @@ import {
   type FieldDefinition,
   type SchemaTypeDefinition,
 } from '@sanity/types'
-import type * as React from 'react'
+import {type ReactElement} from 'react'
 import {of} from 'rxjs'
 
 import {type ObjectInputProps} from '../../src/core'
@@ -17,7 +17,7 @@ const EMPTY_SEARCH = () => of([])
 export type TestRenderCrossDatasetReferenceInputCallback = (
   inputProps: CrossDatasetReferenceInputProps,
   context: TestRenderInputContext,
-) => React.ReactElement
+) => ReactElement
 
 export async function renderCrossDatasetReferenceInput(options: {
   fieldDefinition: SchemaTypeDefinition<'reference'>

--- a/packages/sanity/test/form/renderFileInput.tsx
+++ b/packages/sanity/test/form/renderFileInput.tsx
@@ -4,7 +4,7 @@ import {
   type FileSchemaType,
   type SchemaTypeDefinition,
 } from '@sanity/types'
-import type * as React from 'react'
+import {type ReactElement} from 'react'
 import {EMPTY} from 'rxjs'
 
 import {type ObjectInputProps} from '../../src/core'
@@ -27,7 +27,7 @@ const STUB_RESOLVE_UPLOADER = () => ({
 export type TestRenderFileInputCallback = (
   inputProps: BaseFileInputProps,
   context: TestRenderInputContext,
-) => React.ReactElement
+) => ReactElement
 
 export async function renderFileInput(options: {
   assetSources?: BaseFileInputProps['assetSources']

--- a/packages/sanity/test/form/renderImageInput.tsx
+++ b/packages/sanity/test/form/renderImageInput.tsx
@@ -4,7 +4,7 @@ import {
   type ImageSchemaType,
   type SchemaTypeDefinition,
 } from '@sanity/types'
-import type * as React from 'react'
+import {type ReactElement} from 'react'
 import {EMPTY} from 'rxjs'
 
 import {type ImageUrlBuilder, type ObjectInputProps} from '../../src/core'
@@ -16,7 +16,7 @@ import {type TestRenderProps} from './types'
 export type TestRenderImageInputCallback = (
   inputProps: BaseImageInputProps,
   context: TestRenderInputContext,
-) => React.ReactElement
+) => ReactElement
 
 export async function renderImageInput(options: {
   fieldDefinition: SchemaTypeDefinition<'image'>

--- a/packages/sanity/test/form/renderInput.tsx
+++ b/packages/sanity/test/form/renderInput.tsx
@@ -9,8 +9,7 @@ import {
   type SchemaType,
 } from '@sanity/types'
 import {render} from '@testing-library/react'
-import type * as React from 'react'
-import {type FocusEvent} from 'react'
+import {type FocusEvent, type ReactElement, type RefObject} from 'react'
 
 import {
   createPatchChannel,
@@ -55,11 +54,11 @@ export interface TestRenderInputProps<ElementProps> {
 export type TestRenderInputCallback<ElementProps> = (
   inputProps: TestRenderInputProps<ElementProps>,
   context: TestRenderInputContext,
-) => React.ReactElement
+) => ReactElement
 
 export type RenderInputResult = {
   container: Element
-  focusRef: React.RefObject<HTMLElement>
+  focusRef: RefObject<HTMLElement>
   onBlur: jest.Mock<(event: FocusEvent) => void>
   onFocus: jest.Mock<(event: FocusEvent) => void>
   onChange: jest.Mock<(path: PatchArg | PatchEvent) => void>

--- a/packages/sanity/test/form/renderObjectInput.tsx
+++ b/packages/sanity/test/form/renderObjectInput.tsx
@@ -1,6 +1,6 @@
 import {jest} from '@jest/globals'
 import {type FieldDefinition, type ObjectSchemaType} from '@sanity/types'
-import type * as React from 'react'
+import {type ReactElement} from 'react'
 
 import {
   type ComplexElementProps,
@@ -23,7 +23,7 @@ const noopRenderDefault = () => <></>
 export type TestRenderObjectInputCallback = (
   inputProps: ObjectInputProps,
   context: TestRenderInputContext,
-) => React.ReactElement
+) => ReactElement
 
 export async function renderObjectInput(options: {
   fieldDefinition: FieldDefinition<'object'>

--- a/packages/sanity/test/form/renderStringInput.tsx
+++ b/packages/sanity/test/form/renderStringInput.tsx
@@ -1,5 +1,5 @@
 import {type FieldDefinition, type StringSchemaType} from '@sanity/types'
-import type * as React from 'react'
+import {type ReactElement} from 'react'
 
 import {type PrimitiveInputElementProps, type StringInputProps} from '../../src/core'
 import {renderInput, type TestRenderInputContext, type TestRenderInputProps} from './renderInput'
@@ -10,7 +10,7 @@ const noopRenderDefault = () => <></>
 export type TestRenderStringInputCallback = (
   inputProps: StringInputProps,
   context: TestRenderInputContext,
-) => React.ReactElement
+) => ReactElement
 
 export async function renderStringInput(options: {
   fieldDefinition: FieldDefinition<'date' | 'datetime' | 'string' | 'url'>


### PR DESCRIPTION
### Description

Disallows and removes usage of the React default export from the code base:

These will now give a lint error:
- `import React from 'react'`
- `import * as React from 'react'`
- `import type * as React from 'react'`


### What to review
- Do you agree with this change? The main benefit of doing it is consistency, and that not using default imports may give some ESM/tree-shaking benefits down the line.
- I'm deliberately ignoring this rule in CLI templates as I find it hard to reason about what impact removing default imports may have there.

### Notes for release
n/a - internal