### PR TITLE
fix(core/inputs): fix issues with focus handling

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -11,7 +11,7 @@ import {
 } from '@sanity/portable-text-editor'
 import {type Path, type PortableTextBlock, type PortableTextTextBlock} from '@sanity/types'
 import {Box, Portal, PortalProvider, useBoundaryElement, usePortal} from '@sanity/ui'
-import {useCallback, useMemo, useState} from 'react'
+import {type ReactNode, useCallback, useMemo, useState} from 'react'
 
 import {ChangeIndicator} from '../../../changeIndicators'
 import {EMPTY_ARRAY} from '../../../util'
@@ -28,6 +28,7 @@ import {InlineObject} from './object/InlineObject'
 import {TextBlock} from './text'
 
 interface InputProps extends ArrayOfObjectsInputProps<PortableTextBlock> {
+  elementRef: React.RefObject<HTMLDivElement>
   hasFocusWithin: boolean
   hotkeys?: HotkeyOptions
   isActive: boolean
@@ -46,9 +47,10 @@ interface InputProps extends ArrayOfObjectsInputProps<PortableTextBlock> {
 export type PortableTextEditorElement = HTMLDivElement | HTMLSpanElement
 
 /** @internal */
-export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunctions'>) {
+export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunctions'>): ReactNode {
   const {
     changed,
+    elementRef,
     focused,
     focusPath = EMPTY_ARRAY,
     hasFocusWithin,
@@ -388,6 +390,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     () => (
       <Editor
         ariaDescribedBy={ariaDescribedBy}
+        elementRef={elementRef}
         initialSelection={initialSelection}
         hotkeys={editorHotkeys}
         isActive={isActive}
@@ -411,6 +414,8 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     // Keep only stable ones here!
     [
       ariaDescribedBy,
+      elementRef,
+      initialSelection,
       editorHotkeys,
       isActive,
       isFullscreen,
@@ -424,7 +429,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       editorRenderAnnotation,
       editorRenderBlock,
       editorRenderChild,
-      initialSelection,
       scrollElement,
     ],
   )

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -16,7 +16,7 @@ import {type Path} from '@sanity/types'
 import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
 // eslint-disable-next-line camelcase
 import {getTheme_v2} from '@sanity/ui/theme'
-import {useCallback, useMemo, useRef} from 'react'
+import {type ReactNode, useCallback, useMemo} from 'react'
 import {css, styled} from 'styled-components'
 
 import {TooltipDelayGroupProvider} from '../../../../ui-components'
@@ -51,6 +51,7 @@ const PlaceholderWrapper = styled.span((props) => {
 })
 
 interface EditorProps {
+  elementRef: React.RefObject<HTMLDivElement>
   hotkeys: HotkeyOptions
   initialSelection?: EditorSelection
   isActive: boolean
@@ -85,8 +86,9 @@ const renderListItem: RenderListItemFunction = (props) => {
 /**
  * @internal
  */
-export function Editor(props: EditorProps) {
+export function Editor(props: EditorProps): ReactNode {
   const {
+    elementRef,
     hotkeys,
     initialSelection,
     isActive,
@@ -109,7 +111,6 @@ export function Editor(props: EditorProps) {
   const {id} = useFormBuilder()
   const {t} = useTranslation()
   const {isTopLayer} = useLayer()
-  const editableRef = useRef<HTMLDivElement | null>(null)
 
   const {element: boundaryElement} = useBoundaryElement()
 
@@ -147,7 +148,7 @@ export function Editor(props: EditorProps) {
         hotkeys={hotkeys}
         onCopy={onCopy}
         onPaste={onPaste}
-        ref={editableRef}
+        ref={elementRef}
         rangeDecorations={rangeDecorations}
         renderAnnotation={renderAnnotation}
         renderBlock={renderBlock}
@@ -164,6 +165,7 @@ export function Editor(props: EditorProps) {
     ),
     [
       ariaDescribedBy,
+      elementRef,
       hotkeys,
       initialSelection,
       onCopy,

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -14,7 +14,6 @@ import {
   startTransition,
   useCallback,
   useEffect,
-  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -85,17 +84,6 @@ export function PortableTextInput(props: PortableTextInputProps) {
   const defaultEditorRef = useRef<PortableTextEditor | null>(null)
   const editorRef = editorRefProp || defaultEditorRef
 
-  // This handle will allow for natively calling .focus
-  // on the returned component and have the PortableTextEditor focused,
-  // simulating a native input element (like with an string input)
-  useImperativeHandle(elementProps.ref, () => ({
-    focus() {
-      if (editorRef.current) {
-        PortableTextEditor.focus(editorRef.current)
-      }
-    },
-  }))
-
   const {subscribe} = usePatches({path})
   const [ignoreValidationError, setIgnoreValidationError] = useState(false)
   const [invalidValue, setInvalidValue] = useState<InvalidValue | null>(null)
@@ -113,8 +101,6 @@ export function PortableTextInput(props: PortableTextInputProps) {
     snapshot: PortableTextBlock[] | undefined
   }> = useMemo(() => new Subject(), [])
   const patches$ = useMemo(() => patchSubject.asObservable(), [patchSubject])
-
-  const innerElementRef = useRef<HTMLDivElement | null>(null)
 
   const handleToggleFullscreen = useCallback(() => {
     setIsFullscreen((v) => {
@@ -266,7 +252,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
   }, [editorRef, isActive])
 
   return (
-    <Box ref={innerElementRef}>
+    <Box ref={elementProps.ref}>
       {!ignoreValidationError && respondToInvalidContent}
       {(!invalidValue || ignoreValidationError) && (
         <PortableTextMarkersProvider markers={markers}>

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -57,7 +57,7 @@ export interface PortableTextMemberItem {
  * @public
  * @param props - {@link PortableTextInputProps} component props.
  */
-export function PortableTextInput(props: PortableTextInputProps) {
+export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   const {
     editorRef: editorRefProp,
     elementProps,
@@ -80,7 +80,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
     value,
   } = props
 
-  const {onBlur} = elementProps
+  const {onBlur, onFocus, ref: elementRef} = elementProps
   const defaultEditorRef = useRef<PortableTextEditor | null>(null)
   const editorRef = editorRefProp || defaultEditorRef
 
@@ -268,6 +268,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
             >
               <Compositor
                 {...props}
+                elementRef={elementRef}
                 hasFocusWithin={hasFocusWithin}
                 hotkeys={hotkeys}
                 isActive={isActive}

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/usePortableTextMembers.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/usePortableTextMembers.tsx
@@ -80,7 +80,8 @@ const reconcilePortableTextMembers = ({
           member.item.changed ||
           member.item.presence?.length ||
           member.open ||
-          member.item.focusPath.length
+          member.item.focusPath.length ||
+          member.item.focused
         ) {
           result.push({kind: 'textBlock', member, node: member.item})
         }

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -16,7 +16,7 @@ interface Props {
   onItemClose: () => void
 }
 
-// This hook will track the focusPath and make sure editor content is visible and focused accordingly.
+// This hook will track the form focusPath and make sure editor content is visible (opened), scrolled to, and (potentially) focused accordingly.
 export function useTrackFocusPath(props: Props): void {
   const {focusPath, boundaryElement, onItemClose} = props
   const portableTextMemberItems = usePortableTextMemberItems()
@@ -24,15 +24,21 @@ export function useTrackFocusPath(props: Props): void {
   const selection = usePortableTextEditorSelection()
 
   useLayoutEffect(() => {
-    // Don't do anything if no focusPath
+    // Don't do anything if no focusPath to track
     if (focusPath.length === 0) {
       return
     }
 
-    // Find the opened member item
+    // Find the focused editor member item (if any)
+    const focusedItem = portableTextMemberItems.find((m) => m.member.item.focused)
+
+    // Find the opened member item (if any)
     const openItem = portableTextMemberItems.find((m) => m.member.open)
 
-    if (openItem && openItem.elementRef?.current) {
+    // The related editor member to scroll to, or focus, according to the given focusPath
+    const relatedEditorItem = focusedItem || openItem
+
+    if (relatedEditorItem && relatedEditorItem.elementRef?.current) {
       // Don't do anything if the selection focus path is already equal to the focusPath
       if (
         selection?.focus.path &&
@@ -49,7 +55,7 @@ export function useTrackFocusPath(props: Props): void {
           inline: 'start',
         })
         // Scroll the member into view (the member within the scroll-boundary)
-        scrollIntoView(openItem.elementRef.current, {
+        scrollIntoView(relatedEditorItem.elementRef.current, {
           scrollMode: 'if-needed',
           boundary: boundaryElement,
           block: 'start',
@@ -57,7 +63,7 @@ export function useTrackFocusPath(props: Props): void {
         })
       }
 
-      const isTextBlock = openItem.kind === 'textBlock'
+      const isTextBlock = relatedEditorItem.kind === 'textBlock'
       const isBlockFocusPath = focusPath.length === 1
 
       // Track focus and selection for focusPaths that are either inside text blocks,
@@ -66,8 +72,8 @@ export function useTrackFocusPath(props: Props): void {
         const textBlockChildKey =
           isTextBlock && isKeyedObject(focusPath[2]) ? focusPath[2]._key : undefined
         const child =
-          textBlockChildKey && Array.isArray(openItem.node.value?.children)
-            ? (openItem.node.value?.children.find((c) => c._key === textBlockChildKey) as
+          textBlockChildKey && Array.isArray(relatedEditorItem.node.value?.children)
+            ? (relatedEditorItem.node.value?.children.find((c) => c._key === textBlockChildKey) as
                 | KeyedObject
                 | undefined)
             : undefined
@@ -94,12 +100,12 @@ export function useTrackFocusPath(props: Props): void {
           // Known text block, but unknown child. Select first child in that block.
           isTextBlock &&
           isBlockFocusPath &&
-          Array.isArray(openItem.node.value?.children)
+          Array.isArray(relatedEditorItem.node.value?.children)
         ) {
-          path = [focusPath[0], 'children', {_key: openItem.node.value?.children[0]._key}]
+          path = [focusPath[0], 'children', {_key: relatedEditorItem.node.value?.children[0]._key}]
           // Directly pointing to a non-text block
         } else if (isBlockFocusPath) {
-          path = [{_key: openItem.key}]
+          path = [{_key: relatedEditorItem.key}]
         }
 
         // Select and focus the editor if we produced a path

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -33,6 +33,14 @@ export function useTrackFocusPath(props: Props): void {
     const openItem = portableTextMemberItems.find((m) => m.member.open)
 
     if (openItem && openItem.elementRef?.current) {
+      // Don't do anything if the selection focus path is already equal to the focusPath
+      if (
+        selection?.focus.path &&
+        isEqual(selection.focus.path, focusPath.slice(0, selection.focus.path.length))
+      ) {
+        return
+      }
+
       if (boundaryElement) {
         // Scroll the boundary element into view (the scrollable element itself)
         scrollIntoView(boundaryElement, {
@@ -47,14 +55,6 @@ export function useTrackFocusPath(props: Props): void {
           block: 'start',
           inline: 'start',
         })
-      }
-
-      // Don't do anything if the selection focus path is already equal to the focusPath
-      if (
-        selection?.focus.path &&
-        isEqual(selection.focus.path, focusPath.slice(0, selection.focus.path.length))
-      ) {
-        return
       }
 
       const isTextBlock = openItem.kind === 'textBlock'

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -92,12 +92,13 @@ export function Annotation(props: AnnotationProps) {
 
   const onOpen = useCallback(() => {
     if (memberItem) {
-      // Take focus away from the editor so that it doesn't propagate a new focusPath and interfere here.
+      // Take focus away from the editor so it doesn't accidentally propagate a new focusPath
+      // for the text node that the annotation is attached to.
       PortableTextEditor.blur(editor)
-      onPathFocus(memberItem.node.focusPath) // Set the focus path to be the markDef here as we currently have focus on the text node
+      // Open the annotation item (markDef object)
       onItemOpen(memberItem.node.path)
     }
-  }, [editor, memberItem, onItemOpen, onPathFocus])
+  }, [editor, memberItem, onItemOpen])
 
   const onClose = useCallback(() => {
     onItemClose()

--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
@@ -102,12 +102,7 @@ export function ArrayOfObjectsField(props: {
       // blur, not when a child element receives blur, but React has decided
       // to let focus events bubble, so this workaround is needed
       // Background: https://github.com/facebook/react/issues/6410#issuecomment-671915381
-      if (
-        event.currentTarget === event.target &&
-        (event.currentTarget === focusRef.current ||
-          // PortableTextInput forwarded ref is a custom handle, i.e. not an HTMLElement
-          !(focusRef.current instanceof HTMLElement))
-      ) {
+      if (event.currentTarget === event.target && event.currentTarget === focusRef.current) {
         onPathBlur(member.field.path)
       }
     },

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -10,7 +10,6 @@ import {useToast} from '@sanity/ui'
 import {fromString as pathFromString, resolveKeyedPath} from '@sanity/util/paths'
 import {omit} from 'lodash'
 import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react'
-import deepEquals from 'react-fast-compare'
 import {
   type DocumentFieldAction,
   type DocumentInspector,
@@ -141,7 +140,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     params.path ? pathFromString(params.path) : EMPTY_ARRAY,
   )
   const focusPathRef = useRef(focusPath)
-  const openPathRef = useRef<Path>([])
   const activeViewId = params.view || (views[0] && views[0].id) || null
   const [timelineMode, setTimelineMode] = useState<'since' | 'rev' | 'closed'>('closed')
 
@@ -262,6 +260,46 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       })
     },
     [params, setPaneParams],
+  )
+
+  const handleFocus = useCallback(
+    (nextFocusPath: Path) => {
+      setFocusPath(nextFocusPath)
+
+      if (focusPathRef.current !== nextFocusPath) {
+        focusPathRef.current = nextFocusPath
+        onFocusPath?.(nextFocusPath)
+      }
+
+      presenceStore.setLocation([
+        {
+          type: 'document',
+          documentId,
+          path: nextFocusPath,
+          lastActiveAt: new Date().toISOString(),
+        },
+      ])
+    },
+    [documentId, onFocusPath, presenceStore, setFocusPath],
+  )
+
+  const handleBlur = useCallback(
+    (blurredPath: Path) => {
+      if (disableBlurRef.current) {
+        return
+      }
+
+      setFocusPath(EMPTY_ARRAY)
+
+      if (focusPathRef.current !== EMPTY_ARRAY) {
+        focusPathRef.current = EMPTY_ARRAY
+        onFocusPath?.(EMPTY_ARRAY)
+      }
+
+      // note: we're deliberately not syncing presence here since it would make the user avatar disappear when a
+      // user clicks outside a field without focusing another one
+    },
+    [onFocusPath, setFocusPath],
   )
 
   const patchRef = useRef<(event: PatchEvent) => void>(() => {
@@ -529,45 +567,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     [formStateRef],
   )
 
-  const handleFocus = useCallback(
-    (nextFocusPath: Path) => {
-      if (!deepEquals(focusPathRef.current, nextFocusPath)) {
-        setFocusPath(nextFocusPath)
-        focusPathRef.current = nextFocusPath
-        openPathRef.current = nextFocusPath
-        onFocusPath?.(nextFocusPath)
-      }
-
-      presenceStore.setLocation([
-        {
-          type: 'document',
-          documentId,
-          path: nextFocusPath,
-          lastActiveAt: new Date().toISOString(),
-        },
-      ])
-    },
-    [documentId, onFocusPath, presenceStore, setFocusPath],
-  )
-
-  const handleBlur = useCallback(
-    (blurredPath: Path) => {
-      if (disableBlurRef.current) {
-        return
-      }
-
-      setFocusPath(EMPTY_ARRAY)
-
-      if (focusPathRef.current !== EMPTY_ARRAY) {
-        focusPathRef.current = EMPTY_ARRAY
-        onFocusPath?.(EMPTY_ARRAY)
-      }
-
-      // note: we're deliberately not syncing presence here since it would make the user avatar disappear when a
-      // user clicks outside a field without focusing another one
-    },
-    [onFocusPath, setFocusPath],
-  )
   const documentPane: DocumentPaneContextValue = useMemo(
     () => ({
       actions,
@@ -707,13 +706,9 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
       // Reset focus path when url params path changes
       setFocusPath(pathFromUrl)
+      setOpenPath(pathFromUrl)
 
-      if (!deepEquals(openPathRef.current, pathFromUrl)) {
-        openPathRef.current = pathFromUrl
-        setOpenPath(pathFromUrl)
-      }
-
-      if (!deepEquals(focusPathRef.current, pathFromUrl)) {
+      if (focusPathRef.current !== pathFromUrl) {
         focusPathRef.current = pathFromUrl
         onFocusPath?.(pathFromUrl)
       }

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -262,27 +262,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     [params, setPaneParams],
   )
 
-  const handleFocus = useCallback(
-    (nextFocusPath: Path) => {
-      setFocusPath(nextFocusPath)
-
-      if (focusPathRef.current !== nextFocusPath) {
-        focusPathRef.current = nextFocusPath
-        onFocusPath?.(nextFocusPath)
-      }
-
-      presenceStore.setLocation([
-        {
-          type: 'document',
-          documentId,
-          path: nextFocusPath,
-          lastActiveAt: new Date().toISOString(),
-        },
-      ])
-    },
-    [documentId, onFocusPath, presenceStore, setFocusPath],
-  )
-
   const handleBlur = useCallback(
     (blurredPath: Path) => {
       if (disableBlurRef.current) {
@@ -565,6 +544,27 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       onSetOpenPath(path)
     },
     [formStateRef],
+  )
+
+  const handleFocus = useCallback(
+    (nextFocusPath: Path) => {
+      setFocusPath(nextFocusPath)
+      setOpenPath(nextFocusPath.slice(0, -1))
+      if (focusPathRef.current !== nextFocusPath) {
+        focusPathRef.current = nextFocusPath
+        onFocusPath?.(nextFocusPath)
+      }
+
+      presenceStore.setLocation([
+        {
+          type: 'document',
+          documentId,
+          path: nextFocusPath,
+          lastActiveAt: new Date().toISOString(),
+        },
+      ])
+    },
+    [documentId, onFocusPath, presenceStore, setOpenPath],
   )
 
   const documentPane: DocumentPaneContextValue = useMemo(

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -10,6 +10,7 @@ import {useToast} from '@sanity/ui'
 import {fromString as pathFromString, resolveKeyedPath} from '@sanity/util/paths'
 import {omit} from 'lodash'
 import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import deepEquals from 'react-fast-compare'
 import {
   type DocumentFieldAction,
   type DocumentInspector,
@@ -549,8 +550,8 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const handleFocus = useCallback(
     (nextFocusPath: Path) => {
       setFocusPath(nextFocusPath)
-      setOpenPath(nextFocusPath.slice(0, -1))
-      if (focusPathRef.current !== nextFocusPath) {
+      if (!deepEquals(focusPathRef.current, nextFocusPath)) {
+        setOpenPath(nextFocusPath.slice(0, -1))
         focusPathRef.current = nextFocusPath
         onFocusPath?.(nextFocusPath)
       }
@@ -705,10 +706,9 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       disableBlurRef.current = true
 
       // Reset focus path when url params path changes
-      setFocusPath(pathFromUrl)
-      setOpenPath(pathFromUrl)
-
-      if (focusPathRef.current !== pathFromUrl) {
+      if (!deepEquals(focusPathRef.current, pathFromUrl)) {
+        setFocusPath(pathFromUrl)
+        setOpenPath(pathFromUrl)
         focusPathRef.current = pathFromUrl
         onFocusPath?.(pathFromUrl)
       }

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -139,7 +139,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const [focusPath, setFocusPath] = useState<Path>(() =>
     params.path ? pathFromString(params.path) : EMPTY_ARRAY,
   )
-  const focusPathRef = useRef(focusPath)
+  const focusPathRef = useRef<Path>([])
   const activeViewId = params.view || (views[0] && views[0].id) || null
   const [timelineMode, setTimelineMode] = useState<'since' | 'rev' | 'closed'>('closed')
 


### PR DESCRIPTION
### Description
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
This will fix some issues with focus handling in form inputs and the document pane that are problematic with the presentation tool (and potential causing problems in other situations as well).

* Fixes an issue where the PT-input wasn't properly calling formBuilder onBlur, or called a synthetic onBlur through imperative handling. This caused some issues because the event targets would not be the same elements as the inputElement ref had (imperative handle).  The PT-Input is now using the editable element as the inputElement ref, so that the blur and focus functions are now the native ones with the correct targets. The imperative handle that previously was used for this is now removed.

*  DocumentPaneProvider will now automatically open the path up to the focusPath. So when something is focused, it should also open everything up to that path.

* Changed it so that the PT-Input will not scroll to focus again when a focusPath is set and it's the same path that is currently focused in the PTE.
 
* Improved tracking of focusPath in the PT-Input. The current function didn't take into account that some members should be handled on their 'open' status while others must be handled on their 'focused' status (for instance an annotation which have what is visible in the editor (the text) on a different (block root) path than where the focus is (the markDef).

### What to review

That the Presentation tool now works like it's supposed to regarding navigating around inside Portable Text.

That the Structure tool handles focus correctly, especially for PT-Inputs and Array Inputs.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
PT-focus should be tested automatically by component tests.

The Presentation Tool functionality should be tested manually. See the "Presentation Tool" from the workspace menu in the Test Studio.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Improves focus handling inside the Presentation Tool when working with Portable Text.

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
