### PR TITLE
feat(core): enable Text Search API search strategy by default

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -67,9 +67,6 @@ const sharedSettings = definePlugin({
       assetSources: [imageAssetSource],
     },
   },
-  search: {
-    unstable_enableNewSearch: true,
-  },
 
   i18n: {
     bundles: testStudioLocaleBundles,

--- a/packages/@sanity/types/src/reference/types.ts
+++ b/packages/@sanity/types/src/reference/types.ts
@@ -27,7 +27,7 @@ export type ReferenceFilterSearchOptions = {
   params?: Record<string, unknown>
   tag?: string
   maxFieldDepth?: number
-  unstable_enableNewSearch?: boolean
+  enableLegacySearch?: boolean
 }
 
 /** @public */

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -361,8 +361,8 @@ export const newSearchEnabledReducer: ConfigPropertyReducer<boolean, ConfigConte
   prev,
   {search},
 ): boolean => {
-  if (typeof search?.unstable_enableNewSearch !== 'undefined') {
-    return search.unstable_enableNewSearch
+  if (typeof search?.enableLegacySearch !== 'undefined') {
+    return search.enableLegacySearch
   }
 
   return prev

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -361,5 +361,9 @@ export const newSearchEnabledReducer: ConfigPropertyReducer<boolean, ConfigConte
   prev,
   {search},
 ): boolean => {
-  return prev || search?.unstable_enableNewSearch || false
+  if (typeof search?.unstable_enableNewSearch !== 'undefined') {
+    return search.unstable_enableNewSearch
+  }
+
+  return prev
 }

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -357,7 +357,7 @@ export const partialIndexingEnabledReducer = (opts: {
   return result
 }
 
-export const newSearchEnabledReducer: ConfigPropertyReducer<boolean, ConfigContext> = (
+export const legacySearchEnabledReducer: ConfigPropertyReducer<boolean, ConfigContext> = (
   prev,
   {search},
 ): boolean => {

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -578,12 +578,12 @@ function resolveSource({
           initialValue: config.search?.unstable_partialIndexing?.enabled ?? false,
         }),
       },
-      unstable_enableNewSearch: resolveConfigProperty({
+      enableLegacySearch: resolveConfigProperty({
         config,
         context,
         reducer: newSearchEnabledReducer,
-        propertyName: 'search.unstable_enableNewSearch',
-        initialValue: true,
+        propertyName: 'enableLegacySearch',
+        initialValue: false,
       }),
       // we will use this when we add search config to PluginOptions
       /*filters: resolveConfigProperty({

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -30,8 +30,8 @@ import {
   initialDocumentBadges,
   initialLanguageFilter,
   internalTasksReducer,
+  legacySearchEnabledReducer,
   newDocumentOptionsResolver,
-  newSearchEnabledReducer,
   partialIndexingEnabledReducer,
   resolveProductionUrlReducer,
   schemaTemplatesReducer,
@@ -581,7 +581,7 @@ function resolveSource({
       enableLegacySearch: resolveConfigProperty({
         config,
         context,
-        reducer: newSearchEnabledReducer,
+        reducer: legacySearchEnabledReducer,
         propertyName: 'enableLegacySearch',
         initialValue: false,
       }),

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -583,7 +583,7 @@ function resolveSource({
         context,
         reducer: newSearchEnabledReducer,
         propertyName: 'search.unstable_enableNewSearch',
-        initialValue: false,
+        initialValue: true,
       }),
       // we will use this when we add search config to PluginOptions
       /*filters: resolveConfigProperty({

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -378,15 +378,9 @@ export interface PluginOptions {
       enabled: boolean
     }
     /**
-     * Enables the experimental new search API as an opt-in feature. This flag
-     * allows you to test and provide feedback on the new search capabilities
-     * before they become the default search mechanism. It is part of an
-     * experimental set of features that are subject to change. Users should be
-     * aware that while this feature is in use, they may encounter
-     * inconsistencies or unexpected behavior compared to the stable search
-     * functionality.
+     * Enables the legacy Query API search strategy.
      */
-    unstable_enableNewSearch?: boolean
+    enableLegacySearch?: boolean
   }
 }
 
@@ -740,7 +734,7 @@ export interface Source {
       enabled: boolean
     }
 
-    unstable_enableNewSearch?: boolean
+    enableLegacySearch?: boolean
   }
 
   /** @internal */

--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
@@ -192,11 +192,11 @@ export function referenceSearch(
   textTerm: string,
   type: ReferenceSchemaType,
   options: ReferenceFilterSearchOptions,
-  unstable_enableNewSearch: boolean,
+  enableLegacySearch: boolean,
 ): Observable<ReferenceSearchHit[]> {
   const search = createSearch(type.to, client, {
     ...options,
-    unstable_enableNewSearch,
+    enableLegacySearch,
     maxDepth: options.maxFieldDepth || DEFAULT_MAX_FIELD_DEPTH,
   })
   return search(textTerm, {includeDrafts: true}).pipe(

--- a/packages/sanity/src/core/form/studio/inputs/crossDatasetReference/StudioCrossDatasetReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/crossDatasetReference/StudioCrossDatasetReferenceInput.tsx
@@ -81,7 +81,7 @@ export function StudioCrossDatasetReferenceInput(props: StudioCrossDatasetRefere
   const client = source.getClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const documentPreviewStore = useDocumentPreviewStore()
   const getClient = source.getClient
-  const {unstable_enableNewSearch = false} = source.search
+  const {enableLegacySearch = false} = source.search
 
   const crossDatasetClient = useMemo(() => {
     return (
@@ -110,7 +110,7 @@ export function StudioCrossDatasetReferenceInput(props: StudioCrossDatasetRefere
             params,
             tag: 'search.cross-dataset-reference',
             maxFieldDepth,
-            unstable_enableNewSearch,
+            enableLegacySearch,
           }),
         ),
 
@@ -130,7 +130,7 @@ export function StudioCrossDatasetReferenceInput(props: StudioCrossDatasetRefere
       getClient,
       crossDatasetClient,
       maxFieldDepth,
-      unstable_enableNewSearch,
+      enableLegacySearch,
     ],
   )
 

--- a/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
@@ -95,7 +95,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
   const {path, schemaType} = props
   const {EditReferenceLinkComponent, onEditReference, activePath, initialValueTemplateItems} =
     useReferenceInputOptions()
-  const {unstable_enableNewSearch = false} = source.search
+  const {enableLegacySearch = false} = source.search
 
   const documentValue = useFormValue([]) as FIXME
   const documentRef = useValueRef(documentValue)
@@ -122,7 +122,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
               tag: 'search.reference',
               maxFieldDepth,
             },
-            unstable_enableNewSearch,
+            enableLegacySearch,
           ),
         ),
 
@@ -135,15 +135,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
         }),
       ),
 
-    [
-      schemaType,
-      documentRef,
-      path,
-      getClient,
-      searchClient,
-      maxFieldDepth,
-      unstable_enableNewSearch,
-    ],
+    [schemaType, documentRef, path, getClient, searchClient, maxFieldDepth, enableLegacySearch],
   )
 
   const template = props.value?._strengthenOnPublish?.template

--- a/packages/sanity/src/core/search/common/types.ts
+++ b/packages/sanity/src/core/search/common/types.ts
@@ -64,7 +64,7 @@ export interface SearchFactoryOptions {
   tag?: string
   /* only return unique documents (e.g. not both draft and published) */
   unique?: boolean
-  unstable_enableNewSearch?: boolean
+  enableLegacySearch?: boolean
 }
 
 /**

--- a/packages/sanity/src/core/search/search.ts
+++ b/packages/sanity/src/core/search/search.ts
@@ -12,6 +12,6 @@ export const createSearch: SearchStrategyFactory<TextSearchResults | WeightedSea
   client,
   options,
 ) => {
-  const factory = options.unstable_enableNewSearch ? createTextSearch : createWeightedSearch
+  const factory = options.enableLegacySearch ? createWeightedSearch : createTextSearch
   return factory(searchableTypes, client, options)
 }

--- a/packages/sanity/src/core/studio/components/navbar/search/hooks/useSearch.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/hooks/useSearch.ts
@@ -82,17 +82,17 @@ export function useSearch({
   const [searchState, setSearchState] = useState(initialState)
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const maxFieldDepth = useSearchMaxFieldDepth()
-  const {unstable_enableNewSearch = false} = useWorkspace().search
+  const {enableLegacySearch = false} = useWorkspace().search
 
   const search = useMemo(
     () =>
       createSearch(getSearchableOmnisearchTypes(schema), client, {
         tag: 'search.global',
         unique: true,
-        unstable_enableNewSearch,
+        enableLegacySearch,
         maxDepth: maxFieldDepth,
       }),
-    [client, maxFieldDepth, schema, unstable_enableNewSearch],
+    [client, maxFieldDepth, schema, enableLegacySearch],
   )
 
   const handleQueryChange = useObservableCallback(

--- a/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
+++ b/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
@@ -33,7 +33,7 @@ interface ListenQueryOptions {
   sort: SortOrder
   staticTypeNames?: string[]
   maxFieldDepth?: number
-  unstable_enableNewSearch?: boolean
+  enableLegacySearch?: boolean
 }
 
 export function listenSearchQuery(options: ListenQueryOptions): Observable<SanityDocumentLike[]> {
@@ -47,7 +47,7 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Sanit
     searchQuery,
     staticTypeNames,
     maxFieldDepth,
-    unstable_enableNewSearch,
+    enableLegacySearch,
   } = options
   const sortBy = sort.by
   const extendedProjection = sort?.extendedProjection
@@ -111,7 +111,7 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Sanit
           const search = createSearch(types, client, {
             filter,
             params,
-            unstable_enableNewSearch,
+            enableLegacySearch,
             maxDepth: maxFieldDepth,
           })
 

--- a/packages/sanity/src/structure/panes/documentList/useDocumentList.ts
+++ b/packages/sanity/src/structure/panes/documentList/useDocumentList.ts
@@ -50,7 +50,7 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
     ...DEFAULT_STUDIO_CLIENT_OPTIONS,
     apiVersion: apiVersion || DEFAULT_STUDIO_CLIENT_OPTIONS.apiVersion,
   })
-  const {unstable_enableNewSearch = false} = useWorkspace().search
+  const {enableLegacySearch = false} = useWorkspace().search
   const schema = useSchema()
   const maxFieldDepth = useSearchMaxFieldDepth()
 
@@ -155,7 +155,7 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
       sort,
       staticTypeNames: typeNameFromFilter ? [typeNameFromFilter] : undefined,
       maxFieldDepth,
-      unstable_enableNewSearch,
+      enableLegacySearch,
     }).pipe(
       map((results) => ({
         result: {documents: results},
@@ -190,7 +190,7 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
     searchQuery,
     typeNameFromFilter,
     maxFieldDepth,
-    unstable_enableNewSearch,
+    enableLegacySearch,
   ])
 
   useEffect(() => {


### PR DESCRIPTION
### Description

This branch enables the Text Search API for all search surfaces by default. It can still be switched off by setting the `search.enableLegacySearch` configuration option to `true`.

### What to review

- The Text Search API is used by default.
- The Text Search API can be switched off by setting the `search.enableLegacySearch` configuration option to `true`

### Testing

Testing is already in place for the flagged search functionality.

### Notes for release

Enabled new search for all Studios by default. Global search, document list search, and reference search are now faster; especially for workspaces with large schemas. Additionally, wildcard (`*`) and negation (`-`) tokens can now be used in search queries.