### PR TITLE
chore(lint): continue linting on error

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "check": "npm-run-all build --parallel check:*",
     "check:deps": "pnpm --recursive --parallel exec depcheck",
     "check:format": "prettier . --check",
-    "check:lint": "turbo run lint -- --quiet",
+    "check:lint": "turbo run lint --continue -- --quiet",
     "check:react-exhaustive-deps": "run-s check:lint -- --quiet --rule 'react-hooks/exhaustive-deps: [error, {additionalHooks: \"(useAsync|useMemoObservable|useObservableCallback)\"}]'",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",

--- a/packages/@sanity/migrate/.eslintignore
+++ b/packages/@sanity/migrate/.eslintignore
@@ -1,0 +1,2 @@
+# legacy package exports
+mutations.js


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Currently, if you run `pnpm lint` locally it bails on the first error and does not catch all the errors. The change makes it so it continues on error and reports all the linting issues at once

Also fixes lint issue with `@sanity/migrate` 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

linting still works

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
N/A
