### PR TITLE
chore(lint): fixes issue where boundaries lint rule was not working

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,7 +12,6 @@ const config = {
     browser: true,
   },
   extends: [
-    'plugin:boundaries/recommended',
     'sanity',
     'sanity/react',
     'sanity/import',
@@ -25,7 +24,6 @@ const config = {
   ],
   parser: '@typescript-eslint/parser',
   plugins: [
-    'boundaries',
     'import',
     'simple-import-sort',
     'unused-imports',
@@ -107,75 +105,7 @@ const config = {
     'sort-imports': 'off', // handled by simple-import-sort
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
-    'boundaries/element-types': [
-      'error',
-      {
-        default: 'disallow',
-        rules: [
-          {
-            // export
-            from: 'sanity/_internal',
-            allow: ['sanity/_internal__contents'],
-          },
-          {
-            from: 'sanity/_internal__contents',
-            allow: ['sanity', 'sanity/_internal__contents'],
-          },
-          {
-            // export
-            from: 'sanity/cli',
-            allow: ['sanity/cli__contents'],
-          },
-          {
-            from: 'sanity/cli__contents',
-            allow: ['sanity/cli__contents'],
-          },
-          {
-            // export
-            from: 'sanity',
-            allow: ['sanity__contents'],
-          },
-          {
-            from: 'sanity__contents',
-            allow: ['sanity__contents', 'sanity/router'],
-          },
-          {
-            // export (deprecated, aliases structure)
-            from: 'sanity/desk',
-            allow: ['sanity/desk__contents', 'sanity/structure', 'sanity/structure__contents'],
-          },
-          {
-            from: 'sanity/desk__contents',
-            allow: [
-              'sanity',
-              'sanity/desk__contents',
-              'sanity/router',
-              'sanity/_internal',
-              'sanity/structure',
-              'sanity/structure__contents',
-            ],
-          },
-          {
-            // export
-            from: 'sanity/router',
-            allow: ['sanity/router__contents'],
-          },
-          {
-            from: 'sanity/router__contents',
-            allow: ['sanity/router__contents'],
-          },
-          {
-            // export
-            from: 'sanity/structure',
-            allow: ['sanity/structure__contents'],
-          },
-          {
-            from: 'sanity/structure__contents',
-            allow: ['sanity', 'sanity/structure__contents', 'sanity/router'],
-          },
-        ],
-      },
-    ],
+
     'no-undef': 'off',
     'no-dupe-class-members': 'off', // doesn't work with TS overrides
     'no-shadow': 'off',
@@ -200,69 +130,6 @@ const config = {
         ],
       },
     },
-    'boundaries/include': ['packages/sanity/src/**/*.*'],
-    'boundaries/elements': [
-      {
-        type: 'sanity',
-        pattern: ['packages/sanity/src/_exports/index.ts'],
-        mode: 'full',
-      },
-      {
-        type: 'sanity__contents',
-        pattern: ['packages/sanity/src/core/**/*.*'],
-        mode: 'full',
-      },
-      {
-        type: 'sanity/_internal',
-        pattern: ['packages/sanity/src/_exports/_internal.ts'],
-        mode: 'full',
-      },
-      {
-        type: 'sanity/_internal__contents',
-        pattern: ['packages/sanity/src/_internal/**/*.*'],
-        mode: 'full',
-      },
-      {
-        type: 'sanity/cli',
-        pattern: ['packages/sanity/src/_exports/cli.ts'],
-        mode: 'full',
-      },
-      {
-        type: 'sanity/cli__contents',
-        pattern: ['packages/sanity/src/cli/**/*.*'],
-        mode: 'full',
-      },
-      {
-        type: 'sanity/desk',
-        pattern: ['packages/sanity/src/_exports/desk.ts'],
-        mode: 'file',
-      },
-      {
-        type: 'sanity/desk__contents',
-        pattern: ['packages/sanity/src/desk/**/*.*'],
-        mode: 'file',
-      },
-      {
-        type: 'sanity/router',
-        pattern: ['packages/sanity/src/_exports/router.ts'],
-        mode: 'full',
-      },
-      {
-        type: 'sanity/router__contents',
-        pattern: ['packages/sanity/src/router/**/*.*'],
-        mode: 'full',
-      },
-      {
-        type: 'sanity/structure',
-        pattern: ['packages/sanity/src/_exports/structure.ts'],
-        mode: 'file',
-      },
-      {
-        type: 'sanity/structure__contents',
-        pattern: ['packages/sanity/src/structure/**/*.*'],
-        mode: 'file',
-      },
-    ],
     react: {version: '18.0.0'},
   },
   overrides: [

--- a/packages/sanity/.depcheckrc.json
+++ b/packages/sanity/.depcheckrc.json
@@ -5,6 +5,7 @@
     "globby",
     "sanity",
     "@sanity/codegen",
-    "@types/react"
+    "@types/react",
+    "eslint-plugin-boundaries"
   ]
 }

--- a/packages/sanity/.eslintrc.cjs
+++ b/packages/sanity/.eslintrc.cjs
@@ -1,11 +1,145 @@
-'use strict'
-
 const path = require('path')
 
 const ROOT_PATH = path.resolve(__dirname, '../..')
 
 module.exports = {
+  extends: ['plugin:boundaries/recommended'],
+  plugins: ['boundaries'],
   rules: {
     'import/no-extraneous-dependencies': ['error', {packageDir: [ROOT_PATH, __dirname]}],
+    'boundaries/element-types': [
+      'error',
+      {
+        default: 'disallow',
+        rules: [
+          {
+            // export
+            from: 'sanity/_internal',
+            allow: ['sanity/_internal__contents'],
+          },
+          {
+            from: 'sanity/_internal__contents',
+            allow: ['sanity', 'sanity/_internal__contents'],
+          },
+          {
+            // export
+            from: 'sanity/cli',
+            allow: ['sanity/cli__contents'],
+          },
+          {
+            from: 'sanity/cli__contents',
+            allow: ['sanity/cli__contents'],
+          },
+          {
+            // export
+            from: 'sanity',
+            allow: ['sanity__contents'],
+          },
+          {
+            from: 'sanity__contents',
+            allow: ['sanity__contents', 'sanity/router'],
+          },
+          {
+            // export (deprecated, aliases structure)
+            from: 'sanity/desk',
+            allow: ['sanity/desk__contents', 'sanity/structure', 'sanity/structure__contents'],
+          },
+          {
+            from: 'sanity/desk__contents',
+            allow: [
+              'sanity',
+              'sanity/desk__contents',
+              'sanity/router',
+              'sanity/_internal',
+              'sanity/structure',
+              'sanity/structure__contents',
+            ],
+          },
+          {
+            // export
+            from: 'sanity/router',
+            allow: ['sanity/router__contents'],
+          },
+          {
+            from: 'sanity/router__contents',
+            allow: ['sanity/router__contents'],
+          },
+          {
+            // export
+            from: 'sanity/structure',
+            allow: ['sanity/structure__contents'],
+          },
+          {
+            from: 'sanity/structure__contents',
+            allow: ['sanity', 'sanity/structure__contents', 'sanity/router'],
+          },
+        ],
+      },
+    ],
+  },
+  settings: {
+    'boundaries/include': ['src/**/*.*'],
+    'boundaries/elements': [
+      {
+        type: 'sanity',
+        pattern: ['src/_exports/index.ts'],
+        mode: 'full',
+      },
+      {
+        type: 'sanity__contents',
+        pattern: ['src/core/**/*.*'],
+        mode: 'full',
+      },
+      {
+        type: 'sanity/_internal',
+        pattern: ['src/_exports/_internal.ts'],
+        mode: 'full',
+      },
+      {
+        type: 'sanity/_internal__contents',
+        pattern: ['src/_internal/**/*.*'],
+        mode: 'full',
+      },
+      {
+        type: 'sanity/cli',
+        pattern: ['src/_exports/cli.ts'],
+        mode: 'full',
+      },
+      {
+        type: 'sanity/cli__contents',
+        pattern: ['src/cli/**/*.*'],
+        mode: 'full',
+      },
+      {
+        type: 'sanity/desk',
+        pattern: ['src/_exports/desk.ts'],
+        mode: 'file',
+      },
+      {
+        type: 'sanity/desk__contents',
+        pattern: ['src/desk/**/*.*'],
+        mode: 'file',
+      },
+      {
+        type: 'sanity/router',
+        pattern: ['src/_exports/router.ts'],
+        mode: 'full',
+      },
+      {
+        type: 'sanity/router__contents',
+        pattern: ['src/router/**/*.*'],
+        mode: 'full',
+      },
+      {
+        type: 'sanity/structure',
+        pattern: ['src/_exports/structure.ts'],
+        mode: 'file',
+      },
+      {
+        type: 'sanity/structure__contents',
+        pattern: ['src/structure/**/*.*'],
+        mode: 'file',
+      },
+    ],
   },
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Fixes an issue where the boundaries eslint plugin was not actually enforcing boundaries

Why?
> When we run lint in the monorepo, we use turbo, turbo runs lint script in each package.json and the eslintrc gets merged with the root to create a final config and the linting runs scoped to that working directory. The issue happens is at the root config we define the glob paths relative to the root and now the working directory of the package which causes the glob pattern to not match any of the paths and get ignored

What's Changed?

I have moved the boundary configuration to the `.eslintrc.cjs` in `packages/sanity` as the glob can be relative to that package and it reads much better than using relative glob at the root level 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

If it's linting and change makes sense

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

N/A