### PR TITLE
fix(pte): update to allow block styles to be hidden

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/blocks/block.ts
+++ b/packages/@sanity/schema/src/legacy/types/blocks/block.ts
@@ -108,13 +108,17 @@ function ensureNormalStyle(styles: any) {
     : [BLOCK_STYLES.normal, ...styles]
 }
 
+function filterHiddenStyles(styles: any) {
+  return styles.filter((style: any) => !style.hidden)
+}
+
 function createStyleField(styles: any) {
   return {
     name: 'style',
     title: 'Style',
     type: 'string',
     options: {
-      list: ensureNormalStyle(styles || DEFAULT_BLOCK_STYLES),
+      list: filterHiddenStyles(ensureNormalStyle(styles || DEFAULT_BLOCK_STYLES)),
     },
   }
 }

--- a/packages/@sanity/schema/src/sanity/validation/types/block.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/block.ts
@@ -20,7 +20,7 @@ const allowedKeys = [
   'validation',
 ]
 const allowedMarkKeys = ['decorators', 'annotations']
-const allowedStyleKeys = ['blockEditor', 'title', 'value', 'component']
+const allowedStyleKeys = ['blockEditor', 'title', 'value', 'component', 'hidden']
 const allowedDecoratorKeys = ['blockEditor', 'title', 'value', 'icon', 'component']
 const allowedListKeys = ['title', 'value', 'icon', 'component']
 const supportedBuiltInObjectTypes = ['file', 'image', 'object', 'reference']

--- a/packages/@sanity/types/src/schema/definition/type/block.ts
+++ b/packages/@sanity/types/src/schema/definition/type/block.ts
@@ -113,6 +113,7 @@ export interface BlockStyleDefinition {
   title: string
   value: string
   i18nTitleKey?: string
+  hidden?: boolean
 }
 
 /**


### PR DESCRIPTION
### Description

Fixes EDX-668

By default, we explicitly add in an entry for a Normal block style. This PR adds an option to hide block styles since there is no way to exclude a Normal style

Before:

```
styles: [{title: 'H1', value: 'h1'}, {title: 'H2', value: 'h2'}],
```

<img width="686" alt="image" src="https://github.com/sanity-io/sanity/assets/6889008/97005b75-cfcd-4822-a4a6-c7c0897d4c1b">


After:

```
styles: [{title: 'Normal', value: 'normal', hidden: true}, {title: 'H1', value: 'h1'}, {title: 'H2', value: 'h2'}],
```

<img width="646" alt="image" src="https://github.com/sanity-io/sanity/assets/6889008/459eab5a-339d-4ee8-b88b-a0c13d1c5d77">


### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->
I am not sure if this is the best way to solve this issue. This seemed to be the most natural since we were explicitly adding Normal styles before and I assume that was done intentionally. Removing that would be a breaking change. I also didn't want to add another property `noDefaultNormal` or something like that. Open to other suggestions.

### Testing

Manual testing for now, but will add tests once the approach is validated.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
