### PR TITLE
fix(migrate): forward possible API error response to error thrown for non 2xx

### DIFF
--- a/packages/@sanity/migrate/src/fetch-utils/__test__/assert2xx.test.ts
+++ b/packages/@sanity/migrate/src/fetch-utils/__test__/assert2xx.test.ts
@@ -1,0 +1,44 @@
+import {expect, test} from '@jest/globals'
+
+import {assert2xx} from '../fetchStream'
+
+test('server responds with 2xx', async () => {
+  const mockResponse = {
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        this: 'is fine',
+      }),
+  }
+  await expect(assert2xx(mockResponse as unknown as Response)).resolves.toBeUndefined()
+})
+
+test('server responds with 4xx and error response', () => {
+  const mockResponse = {
+    status: 400,
+    statusText: 'Request error',
+    json: () =>
+      Promise.resolve({
+        error: 'Error message',
+        status: 400,
+        message: 'More details',
+      }),
+  }
+  expect(assert2xx(mockResponse as unknown as Response)).rejects.toThrowError({
+    statusCode: 400,
+    message: 'Error message: More details',
+  })
+})
+
+test('server responds with 5xx and no json response', () => {
+  const mockResponse = {
+    status: 500,
+    statusText: 'Internal Server Error',
+    json: () => Promise.reject(new Error('Failed to parse JSON')),
+  }
+  expect(assert2xx(mockResponse as unknown as Response)).rejects.toThrowError({
+    statusCode: 500,
+    message: 'HTTP Error 500: Internal Server Error',
+  })
+})

--- a/packages/@sanity/migrate/src/fetch-utils/fetchStream.ts
+++ b/packages/@sanity/migrate/src/fetch-utils/fetchStream.ts
@@ -4,23 +4,24 @@ export interface FetchOptions {
   url: string | URL
   init: RequestInit
 }
-export interface HTTPError extends Error {
+export class HTTPError extends Error {
   statusCode: number
+
+  constructor(statusCode: number, message: string) {
+    super(message)
+    this.statusCode = statusCode
+  }
 }
 
 export async function assert2xx(res: Response): Promise<void> {
   if (res.status < 200 || res.status > 299) {
-    const response = await res.json().catch(() => {
-      throw new Error(`Error parsing JSON ${res.status}: ${res.statusText}`)
-    })
+    const jsonResponse = await res.json().catch(() => null)
 
-    const message = response.error
-      ? response.error.description
+    const message = jsonResponse?.error
+      ? `${jsonResponse.error}: ${jsonResponse.message}`
       : `HTTP Error ${res.status}: ${res.statusText}`
 
-    const err = new Error(message) as HTTPError
-    err.statusCode = res.status
-    throw err
+    throw new HTTPError(res.status, message)
   }
 }
 


### PR DESCRIPTION
### Description

Currently, when running a migration and the server responds with a non-2xx status, the error details from response body (e.g. in case of 4xx) is not properly forwarded to the error thrown by the migration command. This causes otherwise helpful details to be omitted from the error output.

Before:
```
npx sanity migration run some-migration

Running migration "some-migration" in dry mode

Project id:  some-project-id
Dataset:     doesnt-exist
Error
    at assert2xx (<snip>/fetchStream.ts:21:17)
   //…
```
After:

```
npx sanity migration run some-migration

Running migration "some-migration" in dry mode

Project id:  some-project-id
Dataset:     doesnt-exist
HTTPError: Dataset not found: Dataset "doesnt-exist" not found for project ID "some-project-id"
    at assert2xx (<snip>/fetchStream.ts:21:17)
   //…
```

### What to review

- Originally we were reading the error message from `error.description`. Is it a fair assumption that was a mistake and that API errors never have a `description` field? If not, I'll add a  fallback to description.
- If receiving a non-2xx and we could not parse the response as JSON we were currently throwing a separate JSON parse error. I believe this would prevent any HTTP errors _without_ a JSON-parseable body to be thrown as HTTP errors containing the status code and status message, so I've refactored this so we throw a HTTP error if we get a non-2xx and there's no JSON in the response body.

### Testing
Unit tests added.


### Notes for release
- Improved error handling when running migration against invalid project configurations
