### PR TITLE
fix(form/inputs): Remove obsolete code for restoring selection

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -1,7 +1,14 @@
 import {PortableTextEditor, usePortableTextEditor} from '@sanity/portable-text-editor'
 import {type ObjectSchemaType, type Path, type PortableTextObject} from '@sanity/types'
 import {isEqual} from '@sanity/util/paths'
-import {type ComponentType, type ReactElement, useCallback, useMemo, useState} from 'react'
+import {
+  type ComponentType,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react'
 
 import {Tooltip} from '../../../../../ui-components'
 import {pathToString} from '../../../../field'
@@ -53,7 +60,7 @@ interface AnnotationProps {
   value: PortableTextObject
 }
 
-export function Annotation(props: AnnotationProps) {
+export function Annotation(props: AnnotationProps): ReactNode {
   const {
     children,
     editorNodeFocused,
@@ -84,7 +91,6 @@ export function Annotation(props: AnnotationProps) {
     [path, value._key],
   )
   const [spanElement, setSpanElement] = useState<HTMLSpanElement | null>(null)
-  const spanPath: Path = useMemo(() => path.slice(path.length - 3, path.length), [path])
   const memberItem = usePortableTextMemberItem(pathToString(markDefPath))
   const {validation} = useMemberValidation(memberItem?.node)
   const markers = usePortableTextMarkers(path)
@@ -105,19 +111,9 @@ export function Annotation(props: AnnotationProps) {
     onItemClose()
     if (isEmptyItem(value)) {
       PortableTextEditor.removeAnnotation(editor, schemaType)
-    } else {
-      // Keep track of any previous offsets on the spanNode before we select it.
-      const sel = PortableTextEditor.getSelection(editor)
-      const focusOffset = sel?.focus.path && isEqual(sel.focus.path, spanPath) && sel.focus.offset
-      const anchorOffset =
-        sel?.anchor.path && isEqual(sel.anchor.path, spanPath) && sel.anchor.offset
-      PortableTextEditor.select(editor, {
-        anchor: {path: spanPath, offset: anchorOffset || 0},
-        focus: {path: spanPath, offset: focusOffset || 0},
-      })
     }
     PortableTextEditor.focus(editor)
-  }, [editor, spanPath, onItemClose, schemaType, value])
+  }, [editor, onItemClose, schemaType, value])
 
   const onRemove = useCallback(() => {
     PortableTextEditor.removeAnnotation(editor, schemaType)


### PR DESCRIPTION
### Description

Previously it was necessary to restore the editor selection here, but it's no longer needed as our focus and blur handling has improved since then.

Should be removed to avoid confusion and noise.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That when selecting text (or just placing the cursor) inside an annotated text, for example a link, it should keep that exact selection after clicking the edit Annotation button, and closing the edit modal again. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
