### PR TITLE
fix: refactor checkoutPair to allow mutations for liveEdit documents

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/delete.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/delete.ts
@@ -1,8 +1,14 @@
 import {type OperationImpl} from '../operations/types'
+import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
 
 export const del: OperationImpl<[], 'NOTHING_TO_DELETE'> = {
   disabled: ({snapshots}) => (snapshots.draft || snapshots.published ? false : 'NOTHING_TO_DELETE'),
   execute: ({client: globalClient, schema, idPair, typeName}) => {
+    if (isLiveEditEnabled(schema, typeName)) {
+      const tx = globalClient.observable.transaction().delete(idPair.publishedId)
+      return tx.commit({tag: 'document.delete'})
+    }
+
     const vXClient = globalClient.withConfig({apiVersion: 'X'})
 
     const {dataset} = globalClient.config()

--- a/test/e2e/tests/document-actions/liveEdit.spec.ts
+++ b/test/e2e/tests/document-actions/liveEdit.spec.ts
@@ -1,0 +1,18 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+test(`liveEdited document can be created, edited, and deleted`, async ({
+  page,
+  createDraftDocument,
+}) => {
+  const name = 'Test Name'
+
+  await createDraftDocument('/test/content/playlist')
+  await page.getByTestId('field-name').getByTestId('string-input').fill(name)
+
+  await page.getByTestId('action-menu-button').click()
+  await page.getByTestId('action-Delete').click()
+  await page.getByRole('button', {name: 'Delete now'}).click()
+
+  await expect(page.getByText('The document was successfully deleted')).toBeVisible()
+})


### PR DESCRIPTION
### Description
We received confirmation from the backend team that the upcoming Actions API is not going to be able documents that have the liveEdit parameter. Using the Actions API with a liveEdited document led to undesirable behaviors.

This PR adds a check to checkoutPair to see if mutations are targeting the "published" (whatever that may mean in the future) document. As far as I can see, the only situation in which that would happen is if we are in a liveEdit situation. If that's the case, then checkoutPair falls back to using the mutations endpoint.

### What to review
Is my assumption correct? Or is it too naive to consider?

### Testing
I've added a case for this in our unit tests, and an additional e2e test that goes through the full end-to-end experience of a liveEdited document. I'm not sure how to guarantee the `playlist` document type will always have liveEdit set.
