### PR TITLE
fix(core): prevent transformation of negation tokens into wildcard prefix tokens

### DIFF
--- a/packages/sanity/src/core/search/text-search/createTextSearch.test.ts
+++ b/packages/sanity/src/core/search/text-search/createTextSearch.test.ts
@@ -2,7 +2,14 @@ import {describe, expect, it} from '@jest/globals'
 import {Schema} from '@sanity/schema'
 import {defineField, defineType} from '@sanity/types'
 
-import {getDocumentTypeConfiguration, getOrder, getQueryString} from './createTextSearch'
+import {
+  getDocumentTypeConfiguration,
+  getOrder,
+  getQueryString,
+  isNegationToken,
+  isPrefixToken,
+  prefixLast,
+} from './createTextSearch'
 
 const testType = Schema.compile({
   types: [
@@ -233,5 +240,52 @@ describe('getQueryString', () => {
   it('appends no wildcard to search query when `queryType` is `prefixNone`', () => {
     expect(getQueryString('test', {queryType: 'prefixNone'})).toEqual('test')
     expect(getQueryString('', {queryType: 'prefixNone'})).toEqual('')
+  })
+})
+
+describe('isNegationToken', () => {
+  it('identifies negation tokens', () => {
+    expect(isNegationToken('-test')).toBe(true)
+    expect(isNegationToken('test')).toBe(false)
+    expect(isNegationToken('test-')).toBe(false)
+    expect(isNegationToken(undefined)).toBe(false)
+  })
+})
+
+describe('isPrefixToken', () => {
+  it('identifies prefix tokens', () => {
+    expect(isPrefixToken('test*')).toBe(true)
+    expect(isPrefixToken('test')).toBe(false)
+    expect(isPrefixToken('*test')).toBe(false)
+    expect(isPrefixToken(undefined)).toBe(false)
+  })
+})
+
+describe('prefixLast', () => {
+  it('transforms the final non-negation token into a wildcard prefix', () => {
+    expect(prefixLast('a')).toBe('a*')
+    expect(prefixLast('a b')).toBe('a b*')
+    expect(prefixLast('a -b')).toBe('a* -b')
+    expect(prefixLast('a "bc" d')).toBe('a "bc" d*')
+    expect(prefixLast('ab "cd"')).toBe('ab "cd"*')
+  })
+
+  it('does not transform the final non-negation token if it is already a wildcard prefix', () => {
+    expect(prefixLast('a*')).toBe('a*')
+    expect(prefixLast('a* -b')).toBe('a* -b')
+  })
+
+  it('does not transform any tokens if only negation tokens are present', () => {
+    expect(prefixLast('-a -b')).toBe('-a -b')
+  })
+
+  it('trims tokens', () => {
+    expect(prefixLast('a   "ab   c"   d')).toBe('a "ab   c" d*')
+  })
+
+  it('preserves quoted tokens', () => {
+    expect(prefixLast('"a b" c d')).toBe('"a b" c d*')
+    expect(prefixLast('"a   b"   c d  "ef" "g  "')).toBe('"a   b" c d "ef" "g  "*')
+    expect(prefixLast('"a " b" c d')).toBe('"a " b c d*')
   })
 })

--- a/packages/sanity/src/core/search/text-search/createTextSearch.test.ts
+++ b/packages/sanity/src/core/search/text-search/createTextSearch.test.ts
@@ -246,6 +246,7 @@ describe('getQueryString', () => {
 describe('isNegationToken', () => {
   it('identifies negation tokens', () => {
     expect(isNegationToken('-test')).toBe(true)
+    expect(isNegationToken('--')).toBe(true)
     expect(isNegationToken('test')).toBe(false)
     expect(isNegationToken('test-')).toBe(false)
     expect(isNegationToken(undefined)).toBe(false)
@@ -268,6 +269,7 @@ describe('prefixLast', () => {
     expect(prefixLast('a -b')).toBe('a* -b')
     expect(prefixLast('a "bc" d')).toBe('a "bc" d*')
     expect(prefixLast('ab "cd"')).toBe('ab "cd"*')
+    expect(prefixLast('a --')).toBe('a* --')
   })
 
   it('does not transform the final non-negation token if it is already a wildcard prefix', () => {
@@ -277,6 +279,7 @@ describe('prefixLast', () => {
 
   it('does not transform any tokens if only negation tokens are present', () => {
     expect(prefixLast('-a -b')).toBe('-a -b')
+    expect(prefixLast('--')).toBe('--')
   })
 
   it('trims tokens', () => {

--- a/packages/sanity/src/core/search/text-search/createTextSearch.ts
+++ b/packages/sanity/src/core/search/text-search/createTextSearch.ts
@@ -18,6 +18,9 @@ import {
 } from '../common'
 
 const DEFAULT_LIMIT = 1000
+const WILDCARD_TOKEN = '*'
+const NEGATION_TOKEN = '-'
+const TOKEN_REGEX = /(?:[^\s"]+|"[^"]*")+/g
 
 function normalizeSearchTerms(
   searchParams: string | SearchTerms,
@@ -83,12 +86,38 @@ export function getOrder(sort: SearchSort[] = []): TextSearchOrder[] {
   )
 }
 
+export function isNegationToken(token: string | undefined): boolean {
+  return typeof token !== 'undefined' && token.trim().at(0) === NEGATION_TOKEN
+}
+
+export function isPrefixToken(token: string | undefined): boolean {
+  return typeof token !== 'undefined' && token.trim().at(-1) === WILDCARD_TOKEN
+}
+
+export function prefixLast(query: string): string {
+  const tokens = (query.match(TOKEN_REGEX) ?? []).map((token) => token.trim())
+  const finalNonNegationTokenIndex = tokens.findLastIndex((token) => !isNegationToken(token))
+  const finalNonNegationToken = tokens[finalNonNegationTokenIndex]
+
+  if (tokens.length === 0) {
+    return WILDCARD_TOKEN
+  }
+
+  if (isPrefixToken(finalNonNegationToken) || typeof finalNonNegationToken === 'undefined') {
+    return tokens.join(' ')
+  }
+
+  return tokens
+    .toSpliced(finalNonNegationTokenIndex, 1, `${finalNonNegationToken}${WILDCARD_TOKEN}`)
+    .join(' ')
+}
+
 export function getQueryString(
   query: string,
   {queryType = 'prefixLast'}: Pick<SearchOptions, 'queryType'>,
 ): string {
   if (queryType === 'prefixLast') {
-    return `${query}*`
+    return prefixLast(query)
   }
 
   return query

--- a/packages/sanity/src/core/search/text-search/createTextSearch.ts
+++ b/packages/sanity/src/core/search/text-search/createTextSearch.ts
@@ -107,9 +107,9 @@ export function prefixLast(query: string): string {
     return tokens.join(' ')
   }
 
-  return tokens
-    .toSpliced(finalNonNegationTokenIndex, 1, `${finalNonNegationToken}${WILDCARD_TOKEN}`)
-    .join(' ')
+  const prefixedTokens = [...tokens]
+  prefixedTokens.splice(finalNonNegationTokenIndex, 1, `${finalNonNegationToken}${WILDCARD_TOKEN}`)
+  return prefixedTokens.join(' ')
 }
 
 export function getQueryString(


### PR DESCRIPTION
### Description

Search requests fail if the query ends with a negation token (e.g. `monstera -deliciosa`). This is because the query is automatically transformed into `monstera -deliciosa*` to support prefix searching, but Text Search API doesn't currently support wildcards inside negations (and, even if it did, it's unlikely to be what the user intended).

This branch prevents this occurring by instead converting the final *non-negation* token to a wildcard prefix. e.g.  `monstera -deliciosa` is now transformed into `monstera* -deliciosa`.

It also ensures a wildcard token is never appended if the user has explicitly added one already (e.g. `monstera del*`).

### What to review

Search works as expected. Especially that it is now possible to successfully search when the query ends in a negation token (e.g.  `monstera -deliciosa`).

### Testing

Added tests for this behaviour in `packages/sanity/src/core/search/text-search/createTextSearch.test.ts`.

### Notes for release

Fixes a bug that caused search requests to fail if they ended with a negation token (e.g. `monstera -deliciosa`).