### PR TITLE
test: add sanity-plugin-hotspot-array

### DIFF
--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -63,6 +63,7 @@
     "refractor": "^3.6.0",
     "rxjs": "^7.8.0",
     "sanity": "workspace:*",
+    "sanity-plugin-hotspot-array": "^2.0.0",
     "sanity-plugin-mux-input": "^2.2.1",
     "styled-components": "^6.1.0",
     "three": "^0.157.0",

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -14,6 +14,7 @@ import {visionTool} from '@sanity/vision'
 import {defineConfig, definePlugin, type WorkspaceOptions} from 'sanity'
 import {presentationTool} from 'sanity/presentation'
 import {structureTool} from 'sanity/structure'
+import {imageHotspotArrayPlugin} from 'sanity-plugin-hotspot-array'
 import {muxInput} from 'sanity-plugin-mux-input'
 
 import {imageAssetSource} from './assetSources'
@@ -133,6 +134,7 @@ const sharedSettings = definePlugin({
     }),
     // eslint-disable-next-line camelcase
     muxInput({mp4_support: 'standard'}),
+    imageHotspotArrayPlugin(),
     presenceTool(),
     routerDebugTool(),
     tsdoc(),

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -82,6 +82,7 @@ import playlistTrack from './playlistTrack'
 import code from './plugins/code'
 import color from './plugins/color'
 import geopoint from './plugins/geopoint'
+import {hotspot, hotspotArrayTest} from './plugins/hotspotArray'
 import species from './species'
 import arrays, {topLevelArrayType, topLevelPrimitiveArrayType} from './standard/arrays'
 import booleans from './standard/booleans'
@@ -253,6 +254,8 @@ export const schemaTypes = [
   codeInputType,
   color,
   geopoint,
+  hotspot,
+  hotspotArrayTest,
 
   // Test documents with 3rd party plugin inputs
   markdown,

--- a/dev/test-studio/schema/plugins/hotspotArray.tsx
+++ b/dev/test-studio/schema/plugins/hotspotArray.tsx
@@ -1,0 +1,61 @@
+import {defineField, defineType, type Rule} from 'sanity'
+
+export const hotspot = defineType({
+  name: 'hotspot',
+  type: 'object',
+  fieldsets: [{name: 'position', options: {columns: 2}}],
+  fields: [
+    {name: 'details', type: 'text', rows: 2},
+    {
+      name: 'x',
+      type: 'number',
+      readOnly: true,
+      fieldset: 'position',
+      initialValue: 50,
+      validation: (Rule: Rule) => Rule.required().min(0).max(100),
+    },
+    {
+      name: 'y',
+      type: 'number',
+      readOnly: true,
+      fieldset: 'position',
+      initialValue: 50,
+      validation: (Rule: Rule) => Rule.required().min(0).max(100),
+    },
+  ],
+  preview: {
+    select: {
+      title: 'details',
+      x: 'x',
+      y: 'y',
+    },
+    prepare({title, x, y}: any) {
+      return {
+        title,
+        subtitle: x && y ? `${x}% x ${y}%` : `No position set`,
+      }
+    },
+  },
+})
+
+export const hotspotArrayTest = defineType({
+  name: 'hotspotArrayTest',
+  type: 'document',
+  fields: [
+    defineField({name: 'title', type: 'string'}),
+    defineField({name: 'featureImage', type: 'image'}),
+    defineField({
+      name: 'hotspots',
+      type: 'array',
+      of: [{type: 'hotspot'}],
+      options: {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore nbd
+        imageHotspot: {
+          imagePath: 'featureImage',
+          descriptionPath: 'details',
+        },
+      },
+    }),
+  ],
+})

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -29,6 +29,7 @@ export const PLUGIN_INPUT_TYPES = [
   'codeTest',
   'colorTest',
   'geopointTest',
+  'hotspotArrayTest',
   //'orderableCategory',
   //'orderableTag',
 ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,6 +518,9 @@ importers:
       sanity:
         specifier: workspace:*
         version: link:../../packages/sanity
+      sanity-plugin-hotspot-array:
+        specifier: ^2.0.0
+        version: 2.0.0(@sanity/ui@2.1.4)(react-dom@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@6.1.8)
       sanity-plugin-mux-input:
         specifier: ^2.2.1
         version: 2.3.4(@types/react@18.2.78)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@6.1.8)
@@ -6611,6 +6614,15 @@ packages:
       - debug
     dev: false
 
+  /@sanity/types@3.38.0:
+    resolution: {integrity: sha512-eBMnX21GJ2+aUAFC4Ddg+RhsyBjRGQXs/DfiDp50FctHn9MngCFoPQjExFet3TkoBg4jy6PJfjFzsUat0/Dyng==}
+    dependencies:
+      '@sanity/client': 6.15.17
+      '@types/react': 18.2.78
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /@sanity/ui-workshop@1.2.11(@sanity/icons@2.11.8)(@sanity/ui@2.1.4)(@types/node@18.19.31)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.1.8):
     resolution: {integrity: sha512-vzj7upIF7wq2W1HEA0D5VSkR8axaH4Rt07yNTAaas7CLgjSE9r2d+Gnkrq4FIbIuN1GYhhCD+D3/s60GaZrpQw==}
     hasBin: true
@@ -6676,6 +6688,19 @@ packages:
     dependencies:
       '@sanity/client': 6.15.17(debug@4.3.4)
       '@sanity/types': 3.37.2(debug@4.3.4)
+      get-random-values-esm: 1.0.2
+      moment: 2.30.1
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /@sanity/util@3.38.0:
+    resolution: {integrity: sha512-9LeZWNtpgdWBu5MWzeNtLNtf/EU04+Cno5/DOaxxSLlP76f9iRGCmCPdEViU1GupIuDRRC3itJstjvCWFIs7Vg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@sanity/client': 6.15.17
+      '@sanity/types': 3.38.0
       get-random-values-esm: 1.0.2
       moment: 2.30.1
       rxjs: 7.8.1
@@ -7216,6 +7241,12 @@ packages:
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
+
+  /@types/lodash-es@4.17.12:
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+    dependencies:
+      '@types/lodash': 4.17.0
+    dev: false
 
   /@types/lodash.isequal@4.5.8:
     resolution: {integrity: sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==}
@@ -16982,6 +17013,31 @@ packages:
     engines: {node: '>=14.18'}
     dependencies:
       '@sanity/diff-match-patch': 3.1.1
+    dev: false
+
+  /sanity-plugin-hotspot-array@2.0.0(@sanity/ui@2.1.4)(react-dom@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@6.1.8):
+    resolution: {integrity: sha512-y+FP4JgRaIKO17cBMyzCCVcxwl3fh7DXEp99QlvZSWUFi3NJJg2ZXFIXc2Om66HNkprfH2ORzEmEZMuDShtlTg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@sanity/ui': ^2.0.0
+      react: ^18
+      sanity: ^3.0.0
+      styled-components: ^6.1
+    dependencies:
+      '@sanity/asset-utils': 1.3.0
+      '@sanity/image-url': 1.0.2
+      '@sanity/incompatible-plugin': 1.0.4(react-dom@18.2.0)(react@18.2.0)
+      '@sanity/ui': 2.1.4(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8)
+      '@sanity/util': 3.38.0
+      '@types/lodash-es': 4.17.12
+      framer-motion: 11.0.8(react-dom@18.2.0)(react@18.2.0)
+      lodash-es: 4.17.21
+      react: 18.2.0
+      sanity: link:packages/sanity
+      styled-components: 6.1.8(react-dom@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - debug
+      - react-dom
     dev: false
 
   /sanity-plugin-mux-input@2.3.4(@types/react@18.2.78)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@6.1.8):


### PR DESCRIPTION
### Description

The following PR adds the `sanity-plugin-hotspot-array` to our test studio just so we don't completely forget about it. I believe we own this plugin now and have to maintain it 😳

![CleanShot 2024-04-17 at 17 07 59@2x](https://github.com/sanity-io/sanity/assets/10551026/ba8742c7-c1bd-4da7-b012-1af0c9d99c2f)

### What to review

Does it work?

### Testing

I added the plugin to the test studio structure.

### Notes for release

N/A
