### PR TITLE
fix: TS import paths importing index.ts twice incorrectly

### DIFF
--- a/dev/tsconfig.dev.json
+++ b/dev/tsconfig.dev.json
@@ -19,7 +19,13 @@
       "@sanity/util": ["./packages/@sanity/util/src/_exports/index.ts"],
       "@sanity/vision": ["./packages/@sanity/vision/src/index.ts"],
       "groq": ["./packages/groq/src/groq.ts"],
-      "sanity/*": ["./packages/sanity/src/_exports/*"],
+      "sanity/_internal": ["./packages/sanity/src/_exports/_internal.ts"],
+      "sanity/cli": ["./packages/sanity/src/_exports/cli.ts"],
+      "sanity/desk": ["./packages/sanity/src/_exports/desk.ts"],
+      "sanity/migrate": ["./packages/sanity/src/_exports/migrate.ts"],
+      "sanity/presentation": ["./packages/sanity/src/_exports/presentation.ts"],
+      "sanity/router": ["./packages/sanity/src/_exports/router.ts"],
+      "sanity/structure": ["./packages/sanity/src/_exports/structure.ts"],
       "sanity": ["./packages/sanity/src/_exports/index.ts"]
     }
   }

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -19,7 +19,13 @@
       "@sanity/util": ["./packages/@sanity/util/src/_exports/index.ts"],
       "@sanity/vision": ["./packages/@sanity/vision/src/index.ts"],
       "groq": ["./packages/groq/src/groq.ts"],
-      "sanity/*": ["./packages/sanity/src/_exports/*"],
+      "sanity/_internal": ["./packages/sanity/src/_exports/_internal.ts"],
+      "sanity/cli": ["./packages/sanity/src/_exports/cli.ts"],
+      "sanity/desk": ["./packages/sanity/src/_exports/desk.ts"],
+      "sanity/migrate": ["./packages/sanity/src/_exports/migrate.ts"],
+      "sanity/presentation": ["./packages/sanity/src/_exports/presentation.ts"],
+      "sanity/router": ["./packages/sanity/src/_exports/router.ts"],
+      "sanity/structure": ["./packages/sanity/src/_exports/structure.ts"],
       "sanity": ["./packages/sanity/src/_exports/index.ts"]
     }
   }

--- a/packages/@sanity/vision/tsconfig.json
+++ b/packages/@sanity/vision/tsconfig.json
@@ -35,7 +35,13 @@
       "@sanity/util/*": ["./node_modules/@sanity/util/src/_exports/*"],
       "@sanity/util": ["./node_modules/@sanity/util/src/_exports/index.ts"],
       "groq": ["./node_modules/groq/src/groq.ts"],
-      "sanity/*": ["./node_modules/sanity/src/_exports/*"],
+      "sanity/_internal": ["./node_modules/sanity/src/_exports/_internal.ts"],
+      "sanity/cli": ["./node_modules/sanity/src/_exports/cli.ts"],
+      "sanity/desk": ["./node_modules/sanity/src/_exports/desk.ts"],
+      "sanity/migrate": ["./node_modules/sanity/src/_exports/migrate.ts"],
+      "sanity/presentation": ["./node_modules/sanity/src/_exports/presentation.ts"],
+      "sanity/router": ["./node_modules/sanity/src/_exports/router.ts"],
+      "sanity/structure": ["./node_modules/sanity/src/_exports/structure.ts"],
       "sanity": ["./node_modules/sanity/src/_exports/index.ts"]
     }
   }

--- a/packages/sanity/tsconfig.json
+++ b/packages/sanity/tsconfig.json
@@ -37,7 +37,13 @@
       "@sanity/util/*": ["./node_modules/@sanity/util/src/_exports/*"],
       "@sanity/util": ["./node_modules/@sanity/util/src/_exports/index.ts"],
       "groq": ["./node_modules/groq/src/groq.ts"],
-      "sanity/*": ["./src/_exports/*"],
+      "sanity/_internal": ["./src/_exports/_internal.ts"],
+      "sanity/cli": ["./src/_exports/cli.ts"],
+      "sanity/desk": ["./src/_exports/desk.ts"],
+      "sanity/migrate": ["./src/_exports/migrate.ts"],
+      "sanity/presentation": ["./src/_exports/presentation.ts"],
+      "sanity/router": ["./src/_exports/router.ts"],
+      "sanity/structure": ["./src/_exports/structure.ts"],
       "sanity": ["./src/_exports/index.ts"]
     }
   }

--- a/packages/sanity/tsconfig.settings.json
+++ b/packages/sanity/tsconfig.settings.json
@@ -4,7 +4,13 @@
     "rootDir": ".",
     "outDir": "./lib",
     "paths": {
-      "sanity/*": ["./src/_exports/*"],
+      "sanity/_internal": ["./src/_exports/_internal.ts"],
+      "sanity/cli": ["./src/_exports/cli.ts"],
+      "sanity/desk": ["./src/_exports/desk.ts"],
+      "sanity/migrate": ["./src/_exports/migrate.ts"],
+      "sanity/presentation": ["./src/_exports/presentation.ts"],
+      "sanity/router": ["./src/_exports/router.ts"],
+      "sanity/structure": ["./src/_exports/structure.ts"],
       "sanity": ["./src/_exports/index.ts"]
     },
     // For import.meta.env/import.meta.hot definition and similar


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Problem: tsconfig using `/*` from exports was causing the `index.ts` getting imported twice causing IDEs to suggest incorrect `sanity/index` auto imports which is not correct as it would translate to `sanity/index.ts/index`. Although the wildcard imports are nice I think it's better to have more control here and avoid other issues in future. 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

`build` and `dev` works correctly. 

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
N/A
### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
N/A