### PR TITLE
feat: fetch feature toggle to enable serverside document actions

### DIFF
--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -95,4 +95,7 @@ export default defineConfig({
 
   plugins: [sharedSettings()],
   basePath: '/test',
+  unstable_serverActions: {
+    enabled: true,
+  },
 })

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -149,9 +149,8 @@ export default defineConfig([
     plugins: [sharedSettings()],
     basePath: '/test',
     icon: SanityMonogram,
-    unstable_serverActions: {
-      enabled: true,
-    },
+    // eslint-disable-next-line camelcase
+    __internal_serverDocumentActions: {},
     scheduledPublishing: {
       enabled: true,
       inputDateTimeFormat: 'MM/dd/yy h:mm a',

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -204,7 +204,8 @@ export function prepareConfig(
       __internal: {
         sources: resolvedSources,
       },
-      serverActions: rawWorkspace.unstable_serverActions ?? {enabled: false},
+      // eslint-disable-next-line camelcase
+      __internal_serverDocumentActions: rawWorkspace.__internal_serverDocumentActions,
       ...defaultPluginsOptions,
     }
     preparedWorkspaces.set(rawWorkspace, workspaceSummary)

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -448,10 +448,10 @@ export interface WorkspaceOptions extends SourceOptions {
 
   /**
    * @hidden
-   * @beta
+   * @internal
    */
-  unstable_serverActions?: {
-    enabled: boolean
+  __internal_serverDocumentActions?: {
+    enabled?: boolean
   }
 
   scheduledPublishing?: DefaultPluginsWorkspaceOptions['scheduledPublishing']
@@ -770,8 +770,9 @@ export interface Source {
   }
   /** @beta */
   tasks?: WorkspaceOptions['tasks']
-  /** @beta */
-  serverActions?: WorkspaceOptions['unstable_serverActions']
+
+  /** @internal */
+  __internal_serverDocumentActions?: WorkspaceOptions['__internal_serverDocumentActions']
 }
 
 /** @internal */
@@ -810,7 +811,7 @@ export interface WorkspaceSummary extends DefaultPluginsWorkspaceOptions {
       source: Observable<Source>
     }>
   }
-  serverActions: WorkspaceOptions['unstable_serverActions']
+  __internal_serverDocumentActions: WorkspaceOptions['__internal_serverDocumentActions']
 }
 
 /**

--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -134,11 +134,12 @@ export function useDocumentStore(): DocumentStore {
   const workspace = useWorkspace()
 
   const serverActionsEnabled = useMemo(() => {
-    // If it's explicitly disabled, we'll just return a stream that emits `false`
-    return workspace.serverActions?.enabled === false
-      ? of(false)
+    const configFlag = workspace.__internal_serverDocumentActions?.enabled
+    // If it's explicitly set, let it override the feature toggle
+    return typeof configFlag === 'boolean'
+      ? of(configFlag as boolean)
       : fetchFeatureToggle(getClient(DEFAULT_STUDIO_CLIENT_OPTIONS))
-  }, [getClient, workspace.serverActions?.enabled])
+  }, [getClient, workspace.__internal_serverDocumentActions?.enabled])
 
   return useMemo(() => {
     const documentStore =

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.test.ts
@@ -37,7 +37,7 @@ beforeEach(() => {
 
 describe('checkoutPair -- local actions', () => {
   test('patch', async () => {
-    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, false)
+    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, of(false))
     const combined = merge(draft.events, published.events)
     const sub = combined.subscribe()
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -62,7 +62,7 @@ describe('checkoutPair -- local actions', () => {
   })
 
   test('createIfNotExists', async () => {
-    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, false)
+    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, of(false))
     const combined = merge(draft.events, published.events)
     const sub = combined.subscribe()
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -104,7 +104,7 @@ describe('checkoutPair -- local actions', () => {
   })
 
   test('create', async () => {
-    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, false)
+    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, of(false))
     const combined = merge(draft.events, published.events)
     const sub = combined.subscribe()
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -146,7 +146,7 @@ describe('checkoutPair -- local actions', () => {
   })
 
   test('createOrReplace', async () => {
-    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, false)
+    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, of(false))
     const combined = merge(draft.events, published.events)
     const sub = combined.subscribe()
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -189,7 +189,7 @@ describe('checkoutPair -- local actions', () => {
   })
 
   test('delete', async () => {
-    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, false)
+    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, of(false))
     const combined = merge(draft.events, published.events)
     const sub = combined.subscribe()
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -223,7 +223,11 @@ describe('checkoutPair -- local actions', () => {
 
 describe('checkoutPair -- server actions', () => {
   test('patch', async () => {
-    const {draft, published} = checkoutPair(clientWithConfig as any as SanityClient, idPair, true)
+    const {draft, published} = checkoutPair(
+      clientWithConfig as any as SanityClient,
+      idPair,
+      of(true),
+    )
     const combined = merge(draft.events, published.events)
     const sub = combined.subscribe()
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -257,7 +261,11 @@ describe('checkoutPair -- server actions', () => {
   })
 
   test('published patch uses mutation endpoint', async () => {
-    const {draft, published} = checkoutPair(clientWithConfig as any as SanityClient, idPair, true)
+    const {draft, published} = checkoutPair(
+      clientWithConfig as any as SanityClient,
+      idPair,
+      of(true),
+    )
     const combined = merge(draft.events, published.events)
     const sub = combined.subscribe()
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -286,7 +294,11 @@ describe('checkoutPair -- server actions', () => {
   })
 
   test('create', async () => {
-    const {draft, published} = checkoutPair(clientWithConfig as any as SanityClient, idPair, true)
+    const {draft, published} = checkoutPair(
+      clientWithConfig as any as SanityClient,
+      idPair,
+      of(true),
+    )
     const combined = merge(draft.events, published.events)
     const sub = combined.subscribe()
     await new Promise((resolve) => setTimeout(resolve, 0))
@@ -327,7 +339,11 @@ describe('checkoutPair -- server actions', () => {
   })
 
   test('createIfNotExists', async () => {
-    const {draft, published} = checkoutPair(clientWithConfig as any as SanityClient, idPair, true)
+    const {draft, published} = checkoutPair(
+      clientWithConfig as any as SanityClient,
+      idPair,
+      of(true),
+    )
     const combined = merge(draft.events, published.events)
     const sub = combined.subscribe()
     await new Promise((resolve) => setTimeout(resolve, 0))

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -2,7 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {type Mutation} from '@sanity/mutator'
 import {type SanityDocument} from '@sanity/types'
 import {EMPTY, from, merge, type Observable, Subject} from 'rxjs'
-import {filter, map, mergeMap, share, take, tap} from 'rxjs/operators'
+import {filter, map, mergeMap, share, shareReplay, take, tap} from 'rxjs/operators'
 
 import {
   type BufferedDocumentEvent,
@@ -225,7 +225,9 @@ export function checkoutPair(
     filter((ev): ev is PendingMutationsEvent => ev.type === 'pending'),
   )
 
-  const serverActionFeatureToggle$ = featureToggleRequest(client, idPair, serverActionsEnabled)
+  const serverActionFeatureToggle$ = featureToggleRequest(client, serverActionsEnabled).pipe(
+    shareReplay(1),
+  )
 
   const commits$ = merge(draft.commitRequest$, published.commitRequest$).pipe(
     mergeMap((commitRequest) =>

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -225,7 +225,7 @@ export function checkoutPair(
     filter((ev): ev is PendingMutationsEvent => ev.type === 'pending'),
   )
 
-  const serverActionFeatureToggle$ = featureToggleRequest(client, serverActionsEnabled)
+  const serverActionFeatureToggle$ = featureToggleRequest(client, idPair, serverActionsEnabled)
 
   const commits$ = merge(draft.commitRequest$, published.commitRequest$).pipe(
     mergeMap((commitRequest) =>

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -14,7 +14,7 @@ import {
 import {getPairListener, type ListenerEvent} from '../getPairListener'
 import {type IdPair, type PendingMutationsEvent, type ReconnectEvent} from '../types'
 import {type HttpAction} from './actionTypes'
-import {featureToggleRequest} from './utils/featureToggleRequest'
+import {fetchFeatureToggle} from './utils/fetchFeatureToggle'
 
 const isMutationEventForDocId =
   (id: string) =>
@@ -225,7 +225,7 @@ export function checkoutPair(
     filter((ev): ev is PendingMutationsEvent => ev.type === 'pending'),
   )
 
-  const serverActionFeatureToggle$ = featureToggleRequest(client, serverActionsEnabled).pipe(
+  const serverActionFeatureToggle$ = fetchFeatureToggle(client, serverActionsEnabled).pipe(
     shareReplay(1),
   )
 

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/consistencyStatus.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/consistencyStatus.ts
@@ -13,9 +13,14 @@ export const consistencyStatus: (
   client: SanityClient,
   idPair: IdPair,
   typeName: string,
-  serverActionsEnabled: boolean,
+  serverActionsEnabled: Observable<boolean>,
 ) => Observable<boolean> = memoize(
-  (client: SanityClient, idPair: IdPair, typeName: string, serverActionsEnabled: boolean) => {
+  (
+    client: SanityClient,
+    idPair: IdPair,
+    typeName: string,
+    serverActionsEnabled: Observable<boolean>,
+  ) => {
     return memoizedPair(client, idPair, typeName, serverActionsEnabled).pipe(
       switchMap(({draft, published}) =>
         combineLatest([draft.consistency$, published.consistency$]),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/documentEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/documentEvents.ts
@@ -15,7 +15,7 @@ export const documentEvents = memoize(
     client: SanityClient,
     idPair: IdPair,
     typeName: string,
-    serverActionsEnabled: boolean,
+    serverActionsEnabled: Observable<boolean>,
   ): Observable<DocumentVersionEvent> => {
     return memoizedPair(client, idPair, typeName, serverActionsEnabled).pipe(
       switchMap(({draft, published}) => merge(draft.events, published.events)),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editOperations.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editOperations.ts
@@ -18,7 +18,7 @@ export const editOperations = memoize(
       client: SanityClient
       historyStore: HistoryStore
       schema: Schema
-      serverActionsEnabled: boolean
+      serverActionsEnabled: Observable<boolean>
     },
     idPair: IdPair,
     typeName: string,
@@ -34,5 +34,5 @@ export const editOperations = memoize(
       merge(operationEvents$.pipe(mergeMap(() => EMPTY)), operations$),
     ).pipe(shareReplay({refCount: true, bufferSize: 1}))
   },
-  (ctx, idPair, typeName) => memoizeKeyGen(ctx.client, idPair, typeName, ctx.serverActionsEnabled),
+  (ctx, idPair, typeName) => memoizeKeyGen(ctx.client, idPair, typeName),
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
@@ -34,7 +34,7 @@ export const editState = memoize(
     ctx: {
       client: SanityClient
       schema: Schema
-      serverActionsEnabled: boolean
+      serverActionsEnabled: Observable<boolean>
     },
     idPair: IdPair,
     typeName: string,
@@ -73,5 +73,5 @@ export const editState = memoize(
       refCount(),
     )
   },
-  (ctx, idPair, typeName) => memoizeKeyGen(ctx.client, idPair, typeName, ctx.serverActionsEnabled),
+  (ctx, idPair, typeName) => memoizeKeyGen(ctx.client, idPair, typeName),
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizeKeyGen.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizeKeyGen.ts
@@ -2,12 +2,7 @@ import {type SanityClient} from '@sanity/client'
 
 import {type IdPair} from '../types'
 
-export function memoizeKeyGen(
-  client: SanityClient,
-  idPair: IdPair,
-  typeName: string,
-  serverActionsEnabled: boolean,
-) {
+export function memoizeKeyGen(client: SanityClient, idPair: IdPair, typeName: string) {
   const config = client.config()
-  return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}${serverActionsEnabled ? '-serverActionsEnabled' : ''}`
+  return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}`
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
@@ -11,13 +11,13 @@ export const memoizedPair: (
   client: SanityClient,
   idPair: IdPair,
   typeName: string,
-  serverActionsEnabled: boolean,
+  serverActionsEnabled: Observable<boolean>,
 ) => Observable<Pair> = memoize(
   (
     client: SanityClient,
     idPair: IdPair,
     _typeName: string,
-    serverActionsEnabled: boolean,
+    serverActionsEnabled: Observable<boolean>,
   ): Observable<Pair> => {
     return new Observable<Pair>((subscriber) => {
       const pair = checkoutPair(client, idPair, serverActionsEnabled)

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable max-nested-callbacks */
 
 import {type SanityClient} from '@sanity/client'
 import {type Schema} from '@sanity/types'
 import {combineLatest, type Observable} from 'rxjs'
-import {map, publishReplay, refCount, switchMap} from 'rxjs/operators'
+import {map, publishReplay, refCount, switchMap, take} from 'rxjs/operators'
 
 import {type HistoryStore} from '../../history'
 import {type IdPair} from '../types'
@@ -11,6 +12,7 @@ import {memoize} from '../utils/createMemoizer'
 import {memoizeKeyGen} from './memoizeKeyGen'
 import {type OperationArgs} from './operations'
 import {snapshotPair} from './snapshotPair'
+import {featureToggleRequest} from './utils/featureToggleRequest'
 
 export const operationArgs = memoize(
   (
@@ -23,23 +25,29 @@ export const operationArgs = memoize(
     idPair: IdPair,
     typeName: string,
   ): Observable<OperationArgs> => {
-    return snapshotPair(ctx.client, idPair, typeName, ctx.serverActionsEnabled).pipe(
-      switchMap((versions) =>
-        combineLatest([versions.draft.snapshots$, versions.published.snapshots$]).pipe(
-          map(
-            ([draft, published]): OperationArgs => ({
-              ...ctx,
-              idPair,
-              typeName: typeName,
-              snapshots: {draft, published},
-              draft: versions.draft,
-              published: versions.published,
-            }),
+    return featureToggleRequest(ctx.client, ctx.serverActionsEnabled).pipe(
+      take(1), // Ensure we only take the first emission and complete
+      switchMap((canUseServerActions) =>
+        snapshotPair(ctx.client, idPair, typeName, canUseServerActions).pipe(
+          switchMap((versions) =>
+            combineLatest([versions.draft.snapshots$, versions.published.snapshots$]).pipe(
+              map(
+                ([draft, published]): OperationArgs => ({
+                  ...ctx,
+                  serverActionsEnabled: canUseServerActions,
+                  idPair,
+                  typeName,
+                  snapshots: {draft, published},
+                  draft: versions.draft,
+                  published: versions.published,
+                }),
+              ),
+            ),
           ),
+          publishReplay(1),
+          refCount(),
         ),
       ),
-      publishReplay(1),
-      refCount(),
     )
   },
   (ctx, idPair, typeName) => {

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
@@ -12,7 +12,7 @@ import {memoize} from '../utils/createMemoizer'
 import {memoizeKeyGen} from './memoizeKeyGen'
 import {type OperationArgs} from './operations'
 import {snapshotPair} from './snapshotPair'
-import {featureToggleRequest} from './utils/featureToggleRequest'
+import {fetchFeatureToggle} from './utils/fetchFeatureToggle'
 
 export const operationArgs = memoize(
   (
@@ -25,7 +25,7 @@ export const operationArgs = memoize(
     idPair: IdPair,
     typeName: string,
   ): Observable<OperationArgs> => {
-    return featureToggleRequest(ctx.client, ctx.serverActionsEnabled).pipe(
+    return fetchFeatureToggle(ctx.client, ctx.serverActionsEnabled).pipe(
       shareReplay(1),
       take(1),
       switchMap((canUseServerActions) =>

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
@@ -29,7 +29,7 @@ export const operationArgs = memoize(
       shareReplay(1),
       take(1),
       switchMap((canUseServerActions) =>
-        snapshotPair(ctx.client, idPair, typeName, canUseServerActions).pipe(
+        snapshotPair(ctx.client, idPair, typeName, ctx.serverActionsEnabled).pipe(
           switchMap((versions) =>
             combineLatest([versions.draft.snapshots$, versions.published.snapshots$]).pipe(
               map(

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
@@ -1,10 +1,9 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-/* eslint-disable max-nested-callbacks */
 
 import {type SanityClient} from '@sanity/client'
 import {type Schema} from '@sanity/types'
 import {combineLatest, type Observable} from 'rxjs'
-import {map, publishReplay, refCount, switchMap, take} from 'rxjs/operators'
+import {map, publishReplay, refCount, switchMap} from 'rxjs/operators'
 
 import {type HistoryStore} from '../../history'
 import {type IdPair} from '../types'
@@ -12,7 +11,6 @@ import {memoize} from '../utils/createMemoizer'
 import {memoizeKeyGen} from './memoizeKeyGen'
 import {type OperationArgs} from './operations'
 import {snapshotPair} from './snapshotPair'
-import {featureToggleRequest} from './utils/featureToggleRequest'
 
 export const operationArgs = memoize(
   (
@@ -25,29 +23,23 @@ export const operationArgs = memoize(
     idPair: IdPair,
     typeName: string,
   ): Observable<OperationArgs> => {
-    return featureToggleRequest(ctx.client, ctx.serverActionsEnabled).pipe(
-      take(1), // Ensure we only take the first emission and complete
-      switchMap((canUseServerActions) =>
-        snapshotPair(ctx.client, idPair, typeName, canUseServerActions).pipe(
-          switchMap((versions) =>
-            combineLatest([versions.draft.snapshots$, versions.published.snapshots$]).pipe(
-              map(
-                ([draft, published]): OperationArgs => ({
-                  ...ctx,
-                  serverActionsEnabled: canUseServerActions,
-                  idPair,
-                  typeName,
-                  snapshots: {draft, published},
-                  draft: versions.draft,
-                  published: versions.published,
-                }),
-              ),
-            ),
+    return snapshotPair(ctx.client, idPair, typeName, ctx.serverActionsEnabled).pipe(
+      switchMap((versions) =>
+        combineLatest([versions.draft.snapshots$, versions.published.snapshots$]).pipe(
+          map(
+            ([draft, published]): OperationArgs => ({
+              ...ctx,
+              idPair,
+              typeName: typeName,
+              snapshots: {draft, published},
+              draft: versions.draft,
+              published: versions.published,
+            }),
           ),
-          publishReplay(1),
-          refCount(),
         ),
       ),
+      publishReplay(1),
+      refCount(),
     )
   },
   (ctx, idPair, typeName) => {

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable max-nested-callbacks */
 
 import {type SanityClient} from '@sanity/client'
 import {type Schema} from '@sanity/types'
 import {combineLatest, type Observable} from 'rxjs'
-import {map, publishReplay, refCount, switchMap} from 'rxjs/operators'
+import {map, publishReplay, refCount, shareReplay, switchMap, take} from 'rxjs/operators'
 
 import {type HistoryStore} from '../../history'
 import {type IdPair} from '../types'
@@ -11,6 +12,7 @@ import {memoize} from '../utils/createMemoizer'
 import {memoizeKeyGen} from './memoizeKeyGen'
 import {type OperationArgs} from './operations'
 import {snapshotPair} from './snapshotPair'
+import {featureToggleRequest} from './utils/featureToggleRequest'
 
 export const operationArgs = memoize(
   (
@@ -23,23 +25,30 @@ export const operationArgs = memoize(
     idPair: IdPair,
     typeName: string,
   ): Observable<OperationArgs> => {
-    return snapshotPair(ctx.client, idPair, typeName, ctx.serverActionsEnabled).pipe(
-      switchMap((versions) =>
-        combineLatest([versions.draft.snapshots$, versions.published.snapshots$]).pipe(
-          map(
-            ([draft, published]): OperationArgs => ({
-              ...ctx,
-              idPair,
-              typeName: typeName,
-              snapshots: {draft, published},
-              draft: versions.draft,
-              published: versions.published,
-            }),
+    return featureToggleRequest(ctx.client, ctx.serverActionsEnabled).pipe(
+      shareReplay(1),
+      take(1),
+      switchMap((canUseServerActions) =>
+        snapshotPair(ctx.client, idPair, typeName, canUseServerActions).pipe(
+          switchMap((versions) =>
+            combineLatest([versions.draft.snapshots$, versions.published.snapshots$]).pipe(
+              map(
+                ([draft, published]): OperationArgs => ({
+                  ...ctx,
+                  serverActionsEnabled: canUseServerActions,
+                  idPair,
+                  typeName,
+                  snapshots: {draft, published},
+                  draft: versions.draft,
+                  published: versions.published,
+                }),
+              ),
+            ),
           ),
+          publishReplay(1),
+          refCount(),
         ),
       ),
-      publishReplay(1),
-      refCount(),
     )
   },
   (ctx, idPair, typeName) => {

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
@@ -4,7 +4,7 @@
 import {type SanityClient} from '@sanity/client'
 import {type Schema} from '@sanity/types'
 import {combineLatest, type Observable} from 'rxjs'
-import {map, publishReplay, refCount, shareReplay, switchMap, take} from 'rxjs/operators'
+import {map, publishReplay, refCount, switchMap} from 'rxjs/operators'
 
 import {type HistoryStore} from '../../history'
 import {type IdPair} from '../types'
@@ -12,7 +12,6 @@ import {memoize} from '../utils/createMemoizer'
 import {memoizeKeyGen} from './memoizeKeyGen'
 import {type OperationArgs} from './operations'
 import {snapshotPair} from './snapshotPair'
-import {fetchFeatureToggle} from './utils/fetchFeatureToggle'
 
 export const operationArgs = memoize(
   (
@@ -20,38 +19,36 @@ export const operationArgs = memoize(
       client: SanityClient
       historyStore: HistoryStore
       schema: Schema
-      serverActionsEnabled: boolean
+      serverActionsEnabled: Observable<boolean>
     },
     idPair: IdPair,
     typeName: string,
   ): Observable<OperationArgs> => {
-    return fetchFeatureToggle(ctx.client, ctx.serverActionsEnabled).pipe(
-      shareReplay(1),
-      take(1),
-      switchMap((canUseServerActions) =>
-        snapshotPair(ctx.client, idPair, typeName, ctx.serverActionsEnabled).pipe(
-          switchMap((versions) =>
-            combineLatest([versions.draft.snapshots$, versions.published.snapshots$]).pipe(
-              map(
-                ([draft, published]): OperationArgs => ({
-                  ...ctx,
-                  serverActionsEnabled: canUseServerActions,
-                  idPair,
-                  typeName,
-                  snapshots: {draft, published},
-                  draft: versions.draft,
-                  published: versions.published,
-                }),
-              ),
-            ),
+    return snapshotPair(ctx.client, idPair, typeName, ctx.serverActionsEnabled).pipe(
+      switchMap((versions) =>
+        combineLatest([
+          versions.draft.snapshots$,
+          versions.published.snapshots$,
+          ctx.serverActionsEnabled,
+        ]).pipe(
+          map(
+            ([draft, published, canUseServerActions]): OperationArgs => ({
+              ...ctx,
+              serverActionsEnabled: canUseServerActions,
+              idPair,
+              typeName,
+              snapshots: {draft, published},
+              draft: versions.draft,
+              published: versions.published,
+            }),
           ),
-          publishReplay(1),
-          refCount(),
         ),
       ),
+      publishReplay(1),
+      refCount(),
     )
   },
   (ctx, idPair, typeName) => {
-    return memoizeKeyGen(ctx.client, idPair, typeName, ctx.serverActionsEnabled)
+    return memoizeKeyGen(ctx.client, idPair, typeName)
   },
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -38,7 +38,7 @@ import {discardChanges as serverDiscardChanges} from './serverOperations/discard
 import {patch as serverPatch} from './serverOperations/patch'
 import {publish as serverPublish} from './serverOperations/publish'
 import {unpublish as serverUnpublish} from './serverOperations/unpublish'
-import {featureToggleRequest} from './utils/featureToggleRequest'
+import {fetchFeatureToggle} from './utils/fetchFeatureToggle'
 
 interface ExecuteArgs {
   operationName: keyof OperationsAPI
@@ -143,7 +143,7 @@ export const operationEvents = memoize(
     schema: Schema
     serverActionsEnabled: boolean
   }) => {
-    const serverActionFeatureToggle$ = featureToggleRequest(
+    const serverActionFeatureToggle$ = fetchFeatureToggle(
       ctx.client,
       ctx.serverActionsEnabled,
     ).pipe(shareReplay(1))

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -37,7 +37,6 @@ import {discardChanges as serverDiscardChanges} from './serverOperations/discard
 import {patch as serverPatch} from './serverOperations/patch'
 import {publish as serverPublish} from './serverOperations/publish'
 import {unpublish as serverUnpublish} from './serverOperations/unpublish'
-import {featureToggleRequest} from './utils/featureToggleRequest'
 
 interface ExecuteArgs {
   operationName: keyof OperationsAPI
@@ -142,47 +141,43 @@ export const operationEvents = memoize(
     schema: Schema
     serverActionsEnabled: boolean
   }) => {
-    const serverActionFeatureToggle$ = featureToggleRequest(ctx.client, ctx.serverActionsEnabled)
-
     const result$: Observable<IntermediarySuccess | IntermediaryError> = operationCalls$.pipe(
       groupBy((op) => op.idPair.publishedId),
       mergeMap((groups$) =>
         groups$.pipe(
+          // although it might look like a bug, dropping pending async operations here is actually a feature
+          // E.g. if the user types `publish` which is async and then starts patching (sync) then the publish
+          // should be cancelled
           switchMap((args) =>
-            serverActionFeatureToggle$.pipe(
+            operationArgs(ctx, args.idPair, args.typeName).pipe(
               take(1),
-              switchMap((canUseServerActions) =>
-                operationArgs(ctx, args.idPair, args.typeName).pipe(
-                  take(1),
-                  switchMap((operationArguments) => {
-                    const requiresConsistency = REQUIRES_CONSISTENCY.includes(args.operationName)
-                    if (requiresConsistency) {
-                      operationArguments.published.commit()
-                      operationArguments.draft.commit()
-                    }
-                    const isConsistent$ = consistencyStatus(
-                      ctx.client,
-                      args.idPair,
-                      args.typeName,
-                      canUseServerActions,
-                    ).pipe(filter(Boolean))
-                    const ready$ = requiresConsistency ? isConsistent$.pipe(take(1)) : of(true)
-                    return ready$.pipe(
-                      switchMap(() =>
-                        execute(
-                          args.operationName,
-                          operationArguments,
-                          args.extraArgs,
-                          canUseServerActions,
-                        ),
-                      ),
-                    )
-                  }),
-                  map((): IntermediarySuccess => ({type: 'success', args})),
-                  catchError(
-                    (err): Observable<IntermediaryError> => of({type: 'error', args, error: err}),
+              switchMap((operationArguments) => {
+                const requiresConsistency = REQUIRES_CONSISTENCY.includes(args.operationName)
+                if (requiresConsistency) {
+                  operationArguments.published.commit()
+                  operationArguments.draft.commit()
+                }
+                const isConsistent$ = consistencyStatus(
+                  ctx.client,
+                  args.idPair,
+                  args.typeName,
+                  ctx.serverActionsEnabled,
+                ).pipe(filter(Boolean))
+                const ready$ = requiresConsistency ? isConsistent$.pipe(take(1)) : of(true)
+                return ready$.pipe(
+                  switchMap(() =>
+                    execute(
+                      args.operationName,
+                      operationArguments,
+                      args.extraArgs,
+                      ctx.serverActionsEnabled,
+                    ),
                   ),
-                ),
+                )
+              }),
+              map((): IntermediarySuccess => ({type: 'success', args})),
+              catchError(
+                (err): Observable<IntermediaryError> => of({type: 'error', args, error: err}),
               ),
             ),
           ),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -12,6 +12,7 @@ import {
   mergeMap,
   mergeMapTo,
   share,
+  shareReplay,
   switchMap,
   take,
   tap,
@@ -37,6 +38,7 @@ import {discardChanges as serverDiscardChanges} from './serverOperations/discard
 import {patch as serverPatch} from './serverOperations/patch'
 import {publish as serverPublish} from './serverOperations/publish'
 import {unpublish as serverUnpublish} from './serverOperations/unpublish'
+import {featureToggleRequest} from './utils/featureToggleRequest'
 
 interface ExecuteArgs {
   operationName: keyof OperationsAPI
@@ -141,43 +143,50 @@ export const operationEvents = memoize(
     schema: Schema
     serverActionsEnabled: boolean
   }) => {
+    const serverActionFeatureToggle$ = featureToggleRequest(
+      ctx.client,
+      ctx.serverActionsEnabled,
+    ).pipe(shareReplay(1))
+
     const result$: Observable<IntermediarySuccess | IntermediaryError> = operationCalls$.pipe(
       groupBy((op) => op.idPair.publishedId),
       mergeMap((groups$) =>
         groups$.pipe(
-          // although it might look like a bug, dropping pending async operations here is actually a feature
-          // E.g. if the user types `publish` which is async and then starts patching (sync) then the publish
-          // should be cancelled
           switchMap((args) =>
-            operationArgs(ctx, args.idPair, args.typeName).pipe(
+            serverActionFeatureToggle$.pipe(
               take(1),
-              switchMap((operationArguments) => {
-                const requiresConsistency = REQUIRES_CONSISTENCY.includes(args.operationName)
-                if (requiresConsistency) {
-                  operationArguments.published.commit()
-                  operationArguments.draft.commit()
-                }
-                const isConsistent$ = consistencyStatus(
-                  ctx.client,
-                  args.idPair,
-                  args.typeName,
-                  ctx.serverActionsEnabled,
-                ).pipe(filter(Boolean))
-                const ready$ = requiresConsistency ? isConsistent$.pipe(take(1)) : of(true)
-                return ready$.pipe(
-                  switchMap(() =>
-                    execute(
-                      args.operationName,
-                      operationArguments,
-                      args.extraArgs,
-                      ctx.serverActionsEnabled,
-                    ),
+              switchMap((canUseServerActions) =>
+                operationArgs(ctx, args.idPair, args.typeName).pipe(
+                  take(1),
+                  switchMap((operationArguments) => {
+                    const requiresConsistency = REQUIRES_CONSISTENCY.includes(args.operationName)
+                    if (requiresConsistency) {
+                      operationArguments.published.commit()
+                      operationArguments.draft.commit()
+                    }
+                    const isConsistent$ = consistencyStatus(
+                      ctx.client,
+                      args.idPair,
+                      args.typeName,
+                      canUseServerActions,
+                    ).pipe(filter(Boolean))
+                    const ready$ = requiresConsistency ? isConsistent$.pipe(take(1)) : of(true)
+                    return ready$.pipe(
+                      switchMap(() =>
+                        execute(
+                          args.operationName,
+                          operationArguments,
+                          args.extraArgs,
+                          canUseServerActions,
+                        ),
+                      ),
+                    )
+                  }),
+                  map((): IntermediarySuccess => ({type: 'success', args})),
+                  catchError(
+                    (err): Observable<IntermediaryError> => of({type: 'error', args, error: err}),
                   ),
-                )
-              }),
-              map((): IntermediarySuccess => ({type: 'success', args})),
-              catchError(
-                (err): Observable<IntermediaryError> => of({type: 'error', args, error: err}),
+                ),
               ),
             ),
           ),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -37,6 +37,7 @@ import {discardChanges as serverDiscardChanges} from './serverOperations/discard
 import {patch as serverPatch} from './serverOperations/patch'
 import {publish as serverPublish} from './serverOperations/publish'
 import {unpublish as serverUnpublish} from './serverOperations/unpublish'
+import {featureToggleRequest} from './utils/featureToggleRequest'
 
 interface ExecuteArgs {
   operationName: keyof OperationsAPI
@@ -141,43 +142,47 @@ export const operationEvents = memoize(
     schema: Schema
     serverActionsEnabled: boolean
   }) => {
+    const serverActionFeatureToggle$ = featureToggleRequest(ctx.client, ctx.serverActionsEnabled)
+
     const result$: Observable<IntermediarySuccess | IntermediaryError> = operationCalls$.pipe(
       groupBy((op) => op.idPair.publishedId),
       mergeMap((groups$) =>
         groups$.pipe(
-          // although it might look like a bug, dropping pending async operations here is actually a feature
-          // E.g. if the user types `publish` which is async and then starts patching (sync) then the publish
-          // should be cancelled
           switchMap((args) =>
-            operationArgs(ctx, args.idPair, args.typeName).pipe(
+            serverActionFeatureToggle$.pipe(
               take(1),
-              switchMap((operationArguments) => {
-                const requiresConsistency = REQUIRES_CONSISTENCY.includes(args.operationName)
-                if (requiresConsistency) {
-                  operationArguments.published.commit()
-                  operationArguments.draft.commit()
-                }
-                const isConsistent$ = consistencyStatus(
-                  ctx.client,
-                  args.idPair,
-                  args.typeName,
-                  ctx.serverActionsEnabled,
-                ).pipe(filter(Boolean))
-                const ready$ = requiresConsistency ? isConsistent$.pipe(take(1)) : of(true)
-                return ready$.pipe(
-                  switchMap(() =>
-                    execute(
-                      args.operationName,
-                      operationArguments,
-                      args.extraArgs,
-                      ctx.serverActionsEnabled,
-                    ),
+              switchMap((canUseServerActions) =>
+                operationArgs(ctx, args.idPair, args.typeName).pipe(
+                  take(1),
+                  switchMap((operationArguments) => {
+                    const requiresConsistency = REQUIRES_CONSISTENCY.includes(args.operationName)
+                    if (requiresConsistency) {
+                      operationArguments.published.commit()
+                      operationArguments.draft.commit()
+                    }
+                    const isConsistent$ = consistencyStatus(
+                      ctx.client,
+                      args.idPair,
+                      args.typeName,
+                      canUseServerActions,
+                    ).pipe(filter(Boolean))
+                    const ready$ = requiresConsistency ? isConsistent$.pipe(take(1)) : of(true)
+                    return ready$.pipe(
+                      switchMap(() =>
+                        execute(
+                          args.operationName,
+                          operationArguments,
+                          args.extraArgs,
+                          canUseServerActions,
+                        ),
+                      ),
+                    )
+                  }),
+                  map((): IntermediarySuccess => ({type: 'success', args})),
+                  catchError(
+                    (err): Observable<IntermediaryError> => of({type: 'error', args, error: err}),
                   ),
-                )
-              }),
-              map((): IntermediarySuccess => ({type: 'success', args})),
-              catchError(
-                (err): Observable<IntermediaryError> => of({type: 'error', args, error: err}),
+                ),
               ),
             ),
           ),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -12,7 +12,6 @@ import {
   mergeMap,
   mergeMapTo,
   share,
-  shareReplay,
   switchMap,
   take,
   tap,
@@ -38,7 +37,6 @@ import {discardChanges as serverDiscardChanges} from './serverOperations/discard
 import {patch as serverPatch} from './serverOperations/patch'
 import {publish as serverPublish} from './serverOperations/publish'
 import {unpublish as serverUnpublish} from './serverOperations/unpublish'
-import {fetchFeatureToggle} from './utils/fetchFeatureToggle'
 
 interface ExecuteArgs {
   operationName: keyof OperationsAPI
@@ -141,52 +139,45 @@ export const operationEvents = memoize(
     client: SanityClient
     historyStore: HistoryStore
     schema: Schema
-    serverActionsEnabled: boolean
+    serverActionsEnabled: Observable<boolean>
   }) => {
-    const serverActionFeatureToggle$ = fetchFeatureToggle(
-      ctx.client,
-      ctx.serverActionsEnabled,
-    ).pipe(shareReplay(1))
-
     const result$: Observable<IntermediarySuccess | IntermediaryError> = operationCalls$.pipe(
       groupBy((op) => op.idPair.publishedId),
       mergeMap((groups$) =>
         groups$.pipe(
+          // although it might look like a bug, dropping pending async operations here is actually a feature
+          // E.g. if the user types `publish` which is async and then starts patching (sync) then the publish
+          // should be cancelled
           switchMap((args) =>
-            serverActionFeatureToggle$.pipe(
+            operationArgs(ctx, args.idPair, args.typeName).pipe(
               take(1),
-              switchMap((canUseServerActions) =>
-                operationArgs(ctx, args.idPair, args.typeName).pipe(
-                  take(1),
-                  switchMap((operationArguments) => {
-                    const requiresConsistency = REQUIRES_CONSISTENCY.includes(args.operationName)
-                    if (requiresConsistency) {
-                      operationArguments.published.commit()
-                      operationArguments.draft.commit()
-                    }
-                    const isConsistent$ = consistencyStatus(
-                      ctx.client,
-                      args.idPair,
-                      args.typeName,
-                      canUseServerActions,
-                    ).pipe(filter(Boolean))
-                    const ready$ = requiresConsistency ? isConsistent$.pipe(take(1)) : of(true)
-                    return ready$.pipe(
-                      switchMap(() =>
-                        execute(
-                          args.operationName,
-                          operationArguments,
-                          args.extraArgs,
-                          canUseServerActions,
-                        ),
-                      ),
-                    )
-                  }),
-                  map((): IntermediarySuccess => ({type: 'success', args})),
-                  catchError(
-                    (err): Observable<IntermediaryError> => of({type: 'error', args, error: err}),
+              switchMap((operationArguments) => {
+                const requiresConsistency = REQUIRES_CONSISTENCY.includes(args.operationName)
+                if (requiresConsistency) {
+                  operationArguments.published.commit()
+                  operationArguments.draft.commit()
+                }
+                const isConsistent$ = consistencyStatus(
+                  ctx.client,
+                  args.idPair,
+                  args.typeName,
+                  ctx.serverActionsEnabled,
+                ).pipe(filter(Boolean))
+                const ready$ = requiresConsistency ? isConsistent$.pipe(take(1)) : of(true)
+                return ready$.pipe(
+                  switchMap(() =>
+                    execute(
+                      args.operationName,
+                      operationArguments,
+                      args.extraArgs,
+                      operationArguments.serverActionsEnabled,
+                    ),
                   ),
-                ),
+                )
+              }),
+              map((): IntermediarySuccess => ({type: 'success', args})),
+              catchError(
+                (err): Observable<IntermediaryError> => of({type: 'error', args, error: err}),
               ),
             ),
           ),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/remoteSnapshots.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/remoteSnapshots.ts
@@ -14,7 +14,7 @@ export const remoteSnapshots = memoize(
     client: SanityClient,
     idPair: IdPair,
     typeName: string,
-    serverActionsEnabled: boolean,
+    serverActionsEnabled: Observable<boolean>,
   ): Observable<RemoteSnapshotVersionEvent> => {
     return memoizedPair(client, idPair, typeName, serverActionsEnabled).pipe(
       switchMap(({published, draft}) => merge(published.remoteSnapshot$, draft.remoteSnapshot$)),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/snapshotPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/snapshotPair.ts
@@ -65,7 +65,7 @@ export const snapshotPair = memoize(
     client: SanityClient,
     idPair: IdPair,
     typeName: string,
-    serverActionsEnabled: boolean,
+    serverActionsEnabled: Observable<boolean>,
   ): Observable<SnapshotPair> => {
     return memoizedPair(client, idPair, typeName, serverActionsEnabled).pipe(
       map(({published, draft, transactionsPendingEvents$}): SnapshotPair => {

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/utils/featureToggleRequest.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/utils/featureToggleRequest.ts
@@ -3,25 +3,15 @@
 import {type SanityClient} from '@sanity/client'
 import {map, type Observable, of} from 'rxjs'
 
-import {type IdPair} from '../../types'
-import {memoize} from '../../utils/createMemoizer'
-
 //in the "real" code, this would be observable.request, to a URI
-export const featureToggleRequest: (
+export const featureToggleRequest = (
   client: SanityClient,
-  idPair: IdPair,
   serverActionsEnabled: boolean,
-) => Observable<boolean> = memoize(
-  (client: SanityClient, idPair: IdPair, serverActionsEnabled: boolean): Observable<boolean> => {
-    if (!serverActionsEnabled) {
-      return of(false)
-    }
-    return client.observable
-      .fetch('*[_id == $id][0]', {id: '20449512-1e9c-44f0-a509-417c901fbbbd'})
-      .pipe(map((doc) => doc.name.split('CONTROL FOR SERVER ACTIONS: ')[1] === 'enabled'))
-  },
-  (client: SanityClient, idPair: IdPair, serverActionsEnabled: boolean) => {
-    const config = client.config()
-    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${serverActionsEnabled ? '-serverActionsEnabled' : ''}`
-  },
-)
+): Observable<boolean> => {
+  if (!serverActionsEnabled) {
+    return of(false)
+  }
+  return client.observable
+    .fetch('*[_id == $id][0]', {id: '20449512-1e9c-44f0-a509-417c901fbbbd'})
+    .pipe(map((doc) => doc.name.split('CONTROL FOR SERVER ACTIONS: ')[1] === 'enabled'))
+}

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/utils/featureToggleRequest.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/utils/featureToggleRequest.ts
@@ -3,15 +3,25 @@
 import {type SanityClient} from '@sanity/client'
 import {map, type Observable, of} from 'rxjs'
 
+import {type IdPair} from '../../types'
+import {memoize} from '../../utils/createMemoizer'
+
 //in the "real" code, this would be observable.request, to a URI
-export const featureToggleRequest = (
+export const featureToggleRequest: (
   client: SanityClient,
+  idPair: IdPair,
   serverActionsEnabled: boolean,
-): Observable<boolean> => {
-  if (!serverActionsEnabled) {
-    return of(false)
-  }
-  return client.observable
-    .fetch('*[_id == $id][0]', {id: '20449512-1e9c-44f0-a509-417c901fbbbd'})
-    .pipe(map((doc) => doc.name.split('CONTROL FOR SERVER ACTIONS: ')[1] === 'enabled'))
-}
+) => Observable<boolean> = memoize(
+  (client: SanityClient, idPair: IdPair, serverActionsEnabled: boolean): Observable<boolean> => {
+    if (!serverActionsEnabled) {
+      return of(false)
+    }
+    return client.observable
+      .fetch('*[_id == $id][0]', {id: '20449512-1e9c-44f0-a509-417c901fbbbd'})
+      .pipe(map((doc) => doc.name.split('CONTROL FOR SERVER ACTIONS: ')[1] === 'enabled'))
+  },
+  (client: SanityClient, idPair: IdPair, serverActionsEnabled: boolean) => {
+    const config = client.config()
+    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${serverActionsEnabled ? '-serverActionsEnabled' : ''}`
+  },
+)

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/utils/featureToggleRequest.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/utils/featureToggleRequest.ts
@@ -1,0 +1,17 @@
+//this is an example function -- we're just calling a document
+
+import {type SanityClient} from '@sanity/client'
+import {map, type Observable, of} from 'rxjs'
+
+//in the "real" code, this would be observable.request, to a URI
+export const featureToggleRequest = (
+  client: SanityClient,
+  serverActionsEnabled: boolean,
+): Observable<boolean> => {
+  if (!serverActionsEnabled) {
+    return of(false)
+  }
+  return client.observable
+    .fetch('*[_id == $id][0]', {id: '20449512-1e9c-44f0-a509-417c901fbbbd'})
+    .pipe(map((doc) => doc.name.split('CONTROL FOR SERVER ACTIONS: ')[1] === 'enabled'))
+}

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/utils/fetchFeatureToggle.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/utils/fetchFeatureToggle.ts
@@ -4,7 +4,7 @@ import {type SanityClient} from '@sanity/client'
 import {map, type Observable, of} from 'rxjs'
 
 //in the "real" code, this would be observable.request, to a URI
-export const featureToggleRequest = (
+export const fetchFeatureToggle = (
   client: SanityClient,
   serverActionsEnabled: boolean,
 ): Observable<boolean> => {

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/utils/fetchFeatureToggle.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/utils/fetchFeatureToggle.ts
@@ -1,5 +1,5 @@
 import {type SanityClient} from '@sanity/client'
-import {map, type Observable, of, ReplaySubject, timer} from 'rxjs'
+import {map, type Observable, of, ReplaySubject, timeout, timer} from 'rxjs'
 import {catchError, share} from 'rxjs/operators'
 
 interface ActionsFeatureToggle {
@@ -18,6 +18,7 @@ export const fetchFeatureToggle = (defaultClient: SanityClient): Observable<bool
     })
     .pipe(
       map((res: ActionsFeatureToggle) => res.actions),
+      timeout({first: 2000, with: () => of(false)}),
       catchError(() =>
         // If we fail to fetch the feature toggle, we'll just assume it's disabled and fallback to legacy mutations
         of(false),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/utils/fetchFeatureToggle.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/utils/fetchFeatureToggle.ts
@@ -1,17 +1,27 @@
 //this is an example function -- we're just calling a document
 
 import {type SanityClient} from '@sanity/client'
-import {map, type Observable, of} from 'rxjs'
+import {map, type Observable, of, ReplaySubject, timer} from 'rxjs'
+import {catchError, share} from 'rxjs/operators'
 
 //in the "real" code, this would be observable.request, to a URI
-export const fetchFeatureToggle = (
-  client: SanityClient,
-  serverActionsEnabled: boolean,
-): Observable<boolean> => {
-  if (!serverActionsEnabled) {
-    return of(false)
-  }
+export const fetchFeatureToggle = (client: SanityClient): Observable<boolean> => {
   return client.observable
     .fetch('*[_id == $id][0]', {id: '20449512-1e9c-44f0-a509-417c901fbbbd'})
-    .pipe(map((doc) => doc.name.split('CONTROL FOR SERVER ACTIONS: ')[1] === 'enabled'))
+    .pipe(
+      map((doc) => doc.name.split('CONTROL FOR SERVER ACTIONS: ')[1] === 'enabled'),
+      catchError(() =>
+        // If we fail to fetch the feature toggle, we'll just assume it's disabled and fallback to legacy mutations
+        of(false),
+      ),
+      share({
+        // replay latest known state to new subscribers
+        connector: () => new ReplaySubject(1),
+        // this will typically be completed and unsubscribed from right after the answer is received, so we don't want to reset
+        resetOnRefCountZero: false,
+        // once the fetch has completed, we'll wait for 2 minutes before resetting the state.
+        // we'll then check again once a new subscriber comes in
+        resetOnComplete: () => timer(1000 * 120),
+      }),
+    )
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/utils/fetchFeatureToggle.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/utils/fetchFeatureToggle.ts
@@ -1,5 +1,3 @@
-//this is an example function -- we're just calling a document
-
 import {type SanityClient} from '@sanity/client'
 import {map, type Observable, of, ReplaySubject, timer} from 'rxjs'
 import {catchError, share} from 'rxjs/operators'

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/utils/fetchFeatureToggle.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/utils/fetchFeatureToggle.ts
@@ -4,7 +4,7 @@ import {type SanityClient} from '@sanity/client'
 import {map, type Observable, of, ReplaySubject, timer} from 'rxjs'
 import {catchError, share} from 'rxjs/operators'
 
-interface FeatureToggle {
+interface ActionsFeatureToggle {
   actions: boolean
 }
 
@@ -19,7 +19,7 @@ export const fetchFeatureToggle = (defaultClient: SanityClient): Observable<bool
       withCredentials: true,
     })
     .pipe(
-      map((res: FeatureToggle) => res.actions),
+      map((res: ActionsFeatureToggle) => res.actions),
       catchError(() =>
         // If we fail to fetch the feature toggle, we'll just assume it's disabled and fallback to legacy mutations
         of(false),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
@@ -95,7 +95,7 @@ export const validation = memoize(
       observeDocumentPairAvailability: ObserveDocumentPairAvailability
       schema: Schema
       i18n: LocaleSource
-      serverActionsEnabled: boolean
+      serverActionsEnabled: Observable<boolean>
     },
     {draftId, publishedId}: IdPair,
     typeName: string,
@@ -191,6 +191,6 @@ export const validation = memoize(
     )
   },
   (ctx, idPair, typeName) => {
-    return memoizeKeyGen(ctx.client, idPair, typeName, ctx.serverActionsEnabled)
+    return memoizeKeyGen(ctx.client, idPair, typeName)
   },
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-store.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-store.ts
@@ -80,7 +80,7 @@ export interface DocumentStoreOptions {
   schema: Schema
   initialValueTemplates: Template[]
   i18n: LocaleSource
-  serverActionsEnabled: boolean
+  serverActionsEnabled: Observable<boolean>
 }
 
 /** @internal */
@@ -91,7 +91,7 @@ export function createDocumentStore({
   initialValueTemplates,
   schema,
   i18n,
-  serverActionsEnabled = false,
+  serverActionsEnabled,
 }: DocumentStoreOptions): DocumentStore {
   const observeDocumentPairAvailability =
     documentPreviewStore.unstable_observeDocumentPairAvailability
@@ -100,6 +100,7 @@ export function createDocumentStore({
   // internal operations, and a `getClient` method that we expose to user-land
   // for things like validations
   const client = getClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+
   const ctx = {
     client,
     getClient,
@@ -154,7 +155,12 @@ export function createDocumentStore({
         return editState(ctx, getIdPairFromPublished(publishedId), type)
       },
       operationEvents(publishedId, type) {
-        return operationEvents({client, historyStore, schema, serverActionsEnabled}).pipe(
+        return operationEvents({
+          client,
+          historyStore,
+          schema,
+          serverActionsEnabled,
+        }).pipe(
           filter(
             (result) =>
               result.args.idPair.publishedId === publishedId && result.args.typeName === type,

--- a/packages/sanity/src/core/store/_legacy/grants/documentPairPermissions.ts
+++ b/packages/sanity/src/core/store/_legacy/grants/documentPairPermissions.ts
@@ -299,9 +299,10 @@ export function useDocumentPairPermissions({
   )
 
   const serverActionsEnabled = useMemo(() => {
-    // If it's explicitly disabled, we'll just return a stream that emits `false`
-    return workspace.serverActions?.enabled === false ? of(false) : fetchFeatureToggle(client)
-  }, [client, workspace.serverActions?.enabled])
+    const configFlag = workspace.__internal_serverDocumentActions?.enabled
+    // If it's explicitly set, let it override the feature toggle
+    return typeof configFlag === 'boolean' ? of(configFlag as boolean) : fetchFeatureToggle(client)
+  }, [client, workspace.__internal_serverDocumentActions?.enabled])
 
   return useDocumentPairPermissionsFromHookFactory(
     useMemo(

--- a/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
+++ b/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
@@ -160,9 +160,10 @@ export function useTimelineStore({
   }, [rev, since, controller, timelineController$])
 
   const serverActionsEnabled = useMemo(() => {
-    // If it's explicitly disabled, we'll just return a stream that emits `false`
-    return workspace.serverActions?.enabled === false ? of(false) : fetchFeatureToggle(client)
-  }, [client, workspace.serverActions?.enabled])
+    const configFlag = workspace.__internal_serverDocumentActions?.enabled
+    // If it's explicitly set, let it override the feature toggle
+    return typeof configFlag === 'boolean' ? of(configFlag as boolean) : fetchFeatureToggle(client)
+  }, [client, workspace.__internal_serverDocumentActions?.enabled])
 
   /**
    * Fetch document snapshots and update the mutable controller.

--- a/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
+++ b/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
@@ -22,6 +22,7 @@ import {
 import {useClient} from '../../../hooks'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
 import {remoteSnapshots, type RemoteSnapshotVersionEvent} from '../document'
+import {fetchFeatureToggle} from '../document/document-pair/utils/fetchFeatureToggle'
 
 interface UseTimelineControllerOpts {
   documentId: string
@@ -103,8 +104,6 @@ export function useTimelineStore({
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const workspace = useWorkspace()
 
-  const serverActionsEnabled = useMemo(() => !!workspace.serverActions?.enabled, [workspace])
-
   /**
    * The mutable TimelineController, used internally
    */
@@ -159,6 +158,11 @@ export function useTimelineStore({
     controller.resume()
     return () => controller.suspend()
   }, [rev, since, controller, timelineController$])
+
+  const serverActionsEnabled = useMemo(() => {
+    // If it's explicitly disabled, we'll just return a stream that emits `false`
+    return workspace.serverActions?.enabled === false ? of(false) : fetchFeatureToggle(client)
+  }, [client, workspace.serverActions?.enabled])
 
   /**
    * Fetch document snapshots and update the mutable controller.

--- a/test/e2e/tests/document-actions/fetchFeatureToggle.spec.ts
+++ b/test/e2e/tests/document-actions/fetchFeatureToggle.spec.ts
@@ -1,0 +1,53 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+interface ActionsFeatureToggle {
+  actions: boolean
+}
+
+test(`document actions follow appropriate logic after receiving response from feature toggle endpoint`, async ({
+  page,
+  createDraftDocument,
+}) => {
+  await createDraftDocument('/test/content/book')
+
+  const featureToggleRequest = page.waitForResponse(async (response) => {
+    return response.url().includes('/data/actions') && response.request().method() === 'GET'
+  })
+
+  const featureToggleResponse: ActionsFeatureToggle = await (await featureToggleRequest).json()
+
+  await page.getByTestId('field-title').getByTestId('string-input').fill('Test title')
+
+  if (featureToggleResponse.actions) {
+    const actionsEditRequest = page.waitForResponse(async (response) => {
+      return response.url().includes('/data/actions') && response.request().method() === 'POST'
+    })
+
+    const actionsEditResponse = await (await actionsEditRequest).json()
+
+    expect(actionsEditResponse).toEqual(
+      expect.objectContaining({
+        transactionId: expect.any(String),
+      }),
+    )
+  } else {
+    const mutateEditRequest = page.waitForResponse(async (response) => {
+      return response.url().includes('/data/mutate') && response.request().method() === 'POST'
+    })
+
+    const mutateEditResponse = await (await mutateEditRequest).json()
+
+    expect(mutateEditResponse).toEqual(
+      expect.objectContaining({
+        transactionId: expect.any(String),
+        results: [
+          {
+            id: expect.any(String),
+            operation: expect.any(String),
+          },
+        ],
+      }),
+    )
+  }
+})


### PR DESCRIPTION
### Description
As we move toward transitioning to server-side document actions, we'd like to have some ability to have a remote way to configure whether or not our end users' document actions should be utilizing the Actions API endpoint, in case there's some risk or problem in content creation.

This PR introduces a remote check used in those places that code paths might diverge based on whether or not to use server actions. This way, we can shut off server actions and revert to old and tested functionality if needed.

This is done through the following:
1. Continuing to use the `sanity.config.ts` flag. If it is set to false, then the old mutations endpoint should be used, no matter what.
2. Introducing a HTTP request that is fed into `document-store`. This HTTP request lasts, at most, two minutes (thanks very much to @bjoerge  for refining this).
3. Because the `serverActionsEnabled` parameter is observable, it is no longer included in memoization.

### What to review
Any gotchas. As of this writing, the `/data/actions` GET request is returning a `false` -- so even if the config flag is set, users should continue to see the mutations endpoint being used.

### Testing
There were already tests in place to ensure that `checkoutPair` sent the correct requests based on the `serverActionsEnabled` parameter. These have been updated to respect that it is now an observable.

An additional end-to-end test was added to spy on requests made on document load and edit -- to ensure that the actions we send follow what we receive from the feature toggle endpoint.