### PR TITLE
chore: turn server actions on by default in test-studio

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -150,9 +150,9 @@ export default defineConfig([
     plugins: [sharedSettings()],
     basePath: '/test',
     icon: SanityMonogram,
-    // unstable_serverActions: {
-    //   enabled: true,
-    // },
+    unstable_serverActions: {
+      enabled: true,
+    },
   },
   {
     name: 'partialIndexing',


### PR DESCRIPTION
### Description

This enables server actions for the dev/test studio

### What to review
- The diff for this particular PR is miniscule as it only enables the server actions in the dev/test-studio in order for us to dogfood and catch potential errors.

### Testing
- Unit tests has been included in prior work.
- I've done a bit of manual testing and haven't found any issues.

### Notes for release
n/a - internal