### PR TITLE
fix(portable-text-editor): support collapsed range decorations

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -20,6 +20,7 @@ import {
   Editor,
   type NodeEntry,
   type Operation,
+  Path,
   Range as SlateRange,
   type Text,
   Transforms,
@@ -574,7 +575,12 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
           },
         ]
       }
-      const result = rangeDecorationState.filter((item) => SlateRange.includes(item, path))
+      const result = rangeDecorationState.filter((item) => {
+        if (SlateRange.isCollapsed(item)) {
+          return Path.equals(item.focus.path, path) && Path.equals(item.anchor.path, path)
+        }
+        return SlateRange.includes(item, path)
+      })
       if (result.length > 0) {
         return result
       }

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/RangeDecoration.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/RangeDecoration.spec.tsx
@@ -60,6 +60,24 @@ test.describe('Portable Text Input', () => {
       await expect($pte).toHaveText("123 Hello there worldIt's a beautiful day on planet earth")
       // Assert that the same word is decorated after the edit
       await expect(page.getByTestId('range-decoration')).toHaveText('there')
+      expect(await page.getByTestId('range-decoration').count()).toBe(1)
+    })
+    test(`Let's us render single point decorations correctly`, async ({mount, page}) => {
+      const {getFocusedPortableTextEditor} = testHelpers({page})
+      const singlePointDecorationData: DecorationData[] = [
+        {
+          selection: {
+            anchor: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 6},
+            focus: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 6},
+          },
+          word: '',
+        },
+      ]
+      await mount(
+        <RangeDecorationStory document={document} decorationData={singlePointDecorationData} />,
+      )
+      await getFocusedPortableTextEditor('field-body')
+      expect(await page.getByTestId('range-decoration').count()).toBe(1)
     })
   })
 })


### PR DESCRIPTION
### Description

This will fix a bug where a range decoration for a single point (collapsed) range would be rendered three times.

This is because we can't do a Range include check on those collapsed ranges, we must equality check the points.

Added test for this.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That  collapsed range decorations aren't rendered multiple times.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Covered by automatic tests.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
