### PR TITLE
fix(structure): resolve static types in document list filters

### DIFF
--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -229,7 +229,6 @@ export const structure: StructureResolver = (S, {schema, documentStore, i18n}) =
                     id: 'authors-and-books',
                     title: 'Authors & Books',
                     options: {
-                      apiVersion: '2023-07-28',
                       filter: '_type == "author" || _type == "book"',
                     },
                   }),
@@ -341,7 +340,6 @@ export const structure: StructureResolver = (S, {schema, documentStore, i18n}) =
                 child: () =>
                   S.documentTypeList('author')
                     .title('Developers')
-                    .apiVersion('2023-07-27')
                     .filter('_type == $type && role == $role')
                     .params({type: 'author', role: 'developer'})
                     .initialValueTemplates(S.initialValueTemplateItem('author-developer')),

--- a/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
+++ b/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
@@ -30,7 +30,7 @@ interface ListenQueryOptions {
   schema: Schema
   searchQuery: string
   sort: SortOrder
-  staticTypeNames?: string[]
+  staticTypeNames?: string[] | null
   maxFieldDepth?: number
   enableLegacySearch?: boolean
 }

--- a/packages/sanity/src/structure/panes/documentList/useDocumentList.ts
+++ b/packages/sanity/src/structure/panes/documentList/useDocumentList.ts
@@ -10,7 +10,7 @@ import {
 } from 'sanity'
 
 import {DEFAULT_ORDERING, FULL_LIST_LIMIT, PARTIAL_PAGE_LIMIT} from './constants'
-import {getTypeNameFromSingleTypeFilter, removePublishedWithDrafts} from './helpers'
+import {findStaticTypesInFilter, removePublishedWithDrafts} from './helpers'
 import {listenSearchQuery} from './listenSearchQuery'
 import {type DocumentListPaneItem, type QueryResult, type SortOrder} from './types'
 
@@ -82,7 +82,7 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
 
   // Get the type name from the filter, if it is a simple type filter.
   const typeNameFromFilter = useMemo(
-    () => getTypeNameFromSingleTypeFilter(filter, paramsProp),
+    () => findStaticTypesInFilter(filter, paramsProp),
     [filter, paramsProp],
   )
 
@@ -158,7 +158,7 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
       schema,
       searchQuery: searchQuery || '',
       sort,
-      staticTypeNames: typeNameFromFilter ? [typeNameFromFilter] : undefined,
+      staticTypeNames: typeNameFromFilter,
       maxFieldDepth,
       enableLegacySearch,
     }).pipe(


### PR DESCRIPTION
### Description

There was a bug where the regex used to match static types that would eagerly match type filters that included more than one type. This would cause the document listener to not grab the search config for all the types in certain filter expressions.

For example, the search filter expression:

```
_type == 'testDocument'  || (_type == 'webhookDocument' && isActive != true
``` 

would only grab the search config for the `'testDocument` instead of both the `testDocument` and `webhookDocument`.

### What to review

Does the structure tool still work? Can you provide any filter and it finds all the appropriate types?

### Testing

I added a few unit tests and double checked the "Authors & Books"` custom pane.

### Notes for release

Fixes a bug that caused types to be incorrectly parsed from filter statements.