### PR TITLE
perf(portable-text-editor): improve range deocration render perf

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -1,5 +1,5 @@
 import {type PortableTextBlock} from '@sanity/types'
-import {noop} from 'lodash'
+import {isEqual, noop} from 'lodash'
 import {
   type ClipboardEvent,
   type CSSProperties,
@@ -13,6 +13,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react'
 import {
@@ -244,8 +245,14 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     }
   }, [propsSelection, slateEditor, blockTypeName, change$])
 
+  const previousRangeDecorations = useRef(rangeDecorations)
+
   const syncRangeDecorations = useCallback(
     (operation?: Operation) => {
+      if (isEqual(previousRangeDecorations.current, rangeDecorations)) {
+        previousRangeDecorations.current = rangeDecorations
+        return
+      }
       if (rangeDecorations && rangeDecorations.length > 0) {
         const newSlateRanges: BaseRangeWithDecoration[] = []
         rangeDecorations.forEach((rangeDecorationItem) => {
@@ -285,6 +292,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
         })
         if (newSlateRanges.length > 0) {
           setRangeDecorationsState(newSlateRanges)
+          previousRangeDecorations.current = rangeDecorations
           return
         }
       }

--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -584,8 +584,16 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
         ]
       }
       const result = rangeDecorationState.filter((item) => {
-        if (SlateRange.isCollapsed(item)) {
-          return Path.equals(item.focus.path, path) && Path.equals(item.anchor.path, path)
+        // Only children are supported for now
+        if (path.length !== 2) {
+          return false
+        }
+        if (
+          SlateRange.isCollapsed(item) &&
+          Path.equals(item.focus.path, path) &&
+          Path.equals(item.anchor.path, path)
+        ) {
+          return true
         }
         return SlateRange.includes(item, path)
       })

--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -141,6 +141,8 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
   const [rangeDecorationState, setRangeDecorationsState] =
     useState<BaseRangeWithDecoration[]>(EMPTY_DECORATIONS_STATE)
 
+  const rangeDecorationsRef = useRef(rangeDecorations)
+
   const {change$, schemaTypes} = portableTextEditor
   const slateEditor = useSlate()
 
@@ -330,7 +332,6 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []) // Empty here! We only want to run this once at mount
 
-  const rangeDecorationsRef = useRef(rangeDecorations)
   useEffect(() => {
     if (!isEqual(rangeDecorations, rangeDecorationsRef.current)) {
       syncRangeDecorations()

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditorTester.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditorTester.tsx
@@ -1,7 +1,7 @@
 import {jest} from '@jest/globals'
 import {Schema} from '@sanity/schema'
 import {defineArrayMember, defineField} from '@sanity/types'
-import {type ForwardedRef, forwardRef, useCallback, useEffect} from 'react'
+import {type ForwardedRef, forwardRef, useCallback, useEffect, useMemo} from 'react'
 
 import {
   PortableTextEditable,
@@ -87,15 +87,16 @@ export const PortableTextEditorTester = forwardRef(function PortableTextEditorTe
 ) {
   useEffect(() => {
     key = 0
-  })
+  }, [])
   const _keyGenerator = useCallback(() => {
     key++
     return `${key}`
   }, [])
+  const onChange = useMemo(() => props.onChange || jest.fn(), [props.onChange])
   return (
     <PortableTextEditor
       schemaType={props.schemaType}
-      onChange={props.onChange || jest.fn()}
+      onChange={onChange}
       value={props.value || undefined}
       keyGenerator={_keyGenerator}
       ref={ref}

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditorTester.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditorTester.tsx
@@ -76,11 +76,12 @@ let key = 0
 
 export const PortableTextEditorTester = forwardRef(function PortableTextEditorTester(
   props: Partial<Omit<PortableTextEditorProps, 'type' | 'onChange' | 'value'>> & {
-    schemaType: PortableTextEditorProps['schemaType']
-    value?: PortableTextEditorProps['value']
     onChange?: PortableTextEditorProps['onChange']
-    selection?: PortableTextEditableProps['selection']
+    rangeDecorations?: PortableTextEditableProps['rangeDecorations']
     renderPlaceholder?: PortableTextEditableProps['renderPlaceholder']
+    schemaType: PortableTextEditorProps['schemaType']
+    selection?: PortableTextEditableProps['selection']
+    value?: PortableTextEditorProps['value']
   },
   ref: ForwardedRef<PortableTextEditor>,
 ) {
@@ -101,6 +102,7 @@ export const PortableTextEditorTester = forwardRef(function PortableTextEditorTe
     >
       <PortableTextEditable
         selection={props.selection || undefined}
+        rangeDecorations={props.rangeDecorations}
         renderPlaceholder={props.renderPlaceholder}
         aria-describedby="desc_foo"
       />

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/RangeDecorations.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/RangeDecorations.test.tsx
@@ -1,0 +1,115 @@
+import {describe, expect, it, jest} from '@jest/globals'
+/* eslint-disable no-irregular-whitespace */
+import {type PortableTextBlock} from '@sanity/types'
+import {render, waitFor} from '@testing-library/react'
+import {createRef, type ReactNode, type RefObject} from 'react'
+
+import {type RangeDecoration} from '../..'
+import {type PortableTextEditor} from '../PortableTextEditor'
+import {PortableTextEditorTester, schemaType} from './PortableTextEditorTester'
+
+const helloBlock: PortableTextBlock = {
+  _key: '123',
+  _type: 'myTestBlockType',
+  markDefs: [],
+  children: [{_key: '567', _type: 'span', text: 'Hello', marks: []}],
+}
+
+let rangeDecorationIteration = 0
+
+const RangeDecorationTestComponent = ({children}: {children?: ReactNode}) => {
+  rangeDecorationIteration++
+  return <span data-testid="range-decoration">{children}</span>
+}
+
+describe('RangeDecorations', () => {
+  it('reconciles range decorations', async () => {
+    const editorRef: RefObject<PortableTextEditor> = createRef()
+    const onChange = jest.fn()
+    const value = [helloBlock]
+    let rangeDecorations: RangeDecoration[] = [
+      {
+        component: RangeDecorationTestComponent,
+        selection: {
+          anchor: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 0},
+          focus: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 2},
+        },
+      },
+    ]
+    const {rerender} = render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        rangeDecorations={rangeDecorations}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={value}
+      />,
+    )
+    await waitFor(() => {
+      expect([rangeDecorationIteration, 'initial']).toEqual([0, 'initial'])
+    })
+    // Re-render with the same range decorations
+    rerender(
+      <PortableTextEditorTester
+        onChange={onChange}
+        rangeDecorations={rangeDecorations}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={value}
+      />,
+    )
+    await waitFor(() => {
+      expect([rangeDecorationIteration, 'initial']).toEqual([0, 'initial'])
+    })
+    // Update the range decorations, a new object with identical values
+    rangeDecorations = [
+      {
+        component: RangeDecorationTestComponent,
+        selection: {
+          anchor: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 0},
+          focus: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 2},
+        },
+      },
+    ]
+    rerender(
+      <PortableTextEditorTester
+        onChange={onChange}
+        rangeDecorations={rangeDecorations}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={value}
+      />,
+    )
+    await waitFor(() => {
+      expect([rangeDecorationIteration, 'updated-with-equal-values']).toEqual([
+        0,
+        'updated-with-equal-values',
+      ])
+    })
+    // Update the range decorations with a new offset
+    rangeDecorations = [
+      {
+        component: RangeDecorationTestComponent,
+        selection: {
+          anchor: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 2},
+          focus: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 4},
+        },
+      },
+    ]
+    rerender(
+      <PortableTextEditorTester
+        onChange={onChange}
+        rangeDecorations={rangeDecorations}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={value}
+      />,
+    )
+    await waitFor(() => {
+      expect([rangeDecorationIteration, 'updated-with-different']).toEqual([
+        1,
+        'updated-with-different',
+      ])
+    })
+  })
+})

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/RangeDecorations.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/RangeDecorations.test.tsx
@@ -23,7 +23,7 @@ const RangeDecorationTestComponent = ({children}: {children?: ReactNode}) => {
 }
 
 describe('RangeDecorations', () => {
-  it('reconciles range decorations', async () => {
+  it.only('only render range decorations as necessary', async () => {
     const editorRef: RefObject<PortableTextEditor> = createRef()
     const onChange = jest.fn()
     const value = [helloBlock]


### PR DESCRIPTION
### Description

This will skip unnecessary re-renders of range decorations when the previous values are the same (but the object might be different). 

Also added a test for this.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Will there be a situation where we did want to re-render even though the values are the same, but the object is different? I can't think of anything, but perhaps give this an extra thought.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Covered by automatic tests

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
