### PR TITLE
test(e2e): fix unawaited assertion

### DIFF
--- a/test/e2e/tests/desk/deprecatedFields.spec.ts
+++ b/test/e2e/tests/desk/deprecatedFields.spec.ts
@@ -28,10 +28,10 @@ for (const type of allTypes) {
 
     await page.waitForSelector(`data-testid=deprecated-badge-${type}`)
 
-    const deprecatedBadge = await page.getByTestId(`deprecated-badge-${type}`)
-    const deprecatedMessage = await page.getByTestId(`deprecated-message-${type}`)
+    const deprecatedBadge = page.getByTestId(`deprecated-badge-${type}`)
+    const deprecatedMessage = page.getByTestId(`deprecated-message-${type}`)
 
-    expect(deprecatedBadge).toHaveText('deprecated')
-    expect(deprecatedMessage).toBeVisible()
+    await expect(deprecatedMessage).toBeVisible()
+    await expect(deprecatedBadge).toHaveText('deprecated')
   })
 }


### PR DESCRIPTION
### Description

Fixes an e2e test that was improperly awaiting its assertions, sometimes causing the test to timeout.

### What to review

That the `test/e2e/tests/desk/deprecatedFields.spec.ts` test runs correctly.