### PR TITLE
 fix(core): fix autocomplete for `defineType` in VSCode

### DIFF
--- a/packages/@sanity/types/src/schema/define.ts
+++ b/packages/@sanity/types/src/schema/define.ts
@@ -9,6 +9,7 @@ import {
   type WidenValidation,
 } from './defineTypes'
 import {type FieldDefinitionBase, type IntrinsicTypeName} from './definition'
+import {type AllowOtherStrings} from './types'
 
 /**
  * Helper function for defining a Sanity type definition. This function does not do anything on its own;
@@ -170,7 +171,7 @@ import {type FieldDefinitionBase, type IntrinsicTypeName} from './definition'
  * @beta
  */
 export function defineType<
-  const TType extends string | IntrinsicTypeName, // IntrinsicTypeName here improves autocompletion in _some_ IDEs (not VS Code atm)
+  const TType extends IntrinsicTypeName | AllowOtherStrings,
   const TName extends string,
   TSelect extends Record<string, string> | undefined,
   TPrepareValue extends Record<keyof TSelect, any> | undefined,

--- a/packages/@sanity/types/src/schema/define.ts
+++ b/packages/@sanity/types/src/schema/define.ts
@@ -9,7 +9,7 @@ import {
   type WidenValidation,
 } from './defineTypes'
 import {type FieldDefinitionBase, type IntrinsicTypeName} from './definition'
-import {type AllowOtherStrings} from './types'
+import {type AutocompleteString} from './types'
 
 /**
  * Helper function for defining a Sanity type definition. This function does not do anything on its own;
@@ -171,7 +171,7 @@ import {type AllowOtherStrings} from './types'
  * @beta
  */
 export function defineType<
-  const TType extends IntrinsicTypeName | AllowOtherStrings,
+  const TType extends IntrinsicTypeName | AutocompleteString,
   const TName extends string,
   TSelect extends Record<string, string> | undefined,
   TPrepareValue extends Record<keyof TSelect, any> | undefined,
@@ -212,7 +212,7 @@ export function defineType<
  * @beta
  */
 export function defineField<
-  const TType extends string | IntrinsicTypeName, // IntrinsicTypeName here improves autocompletion in _some_ IDEs (not VS Code atm)
+  const TType extends IntrinsicTypeName | AutocompleteString,
   const TName extends string,
   TSelect extends Record<string, string> | undefined,
   TPrepareValue extends Record<keyof TSelect, any> | undefined,
@@ -255,7 +255,7 @@ export function defineField<
  * @beta
  */
 export function defineArrayMember<
-  const TType extends string | IntrinsicTypeName, // IntrinsicTypeName here improves autocompletion in _some_ IDEs (not VS Code atm)
+  const TType extends IntrinsicTypeName | AutocompleteString,
   const TName extends string,
   TSelect extends Record<string, string> | undefined,
   TPrepareValue extends Record<keyof TSelect, any> | undefined,

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -24,6 +24,10 @@ import {type PreviewConfig} from './preview'
 
 export {defineArrayMember, defineField, defineType, typed} from './define'
 
+// Necessary since this is the only way to include all string literals and all other strings
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type AllowOtherStrings = string & {}
+
 /**
  * Note: you probably want `SchemaTypeDefinition` instead
  * @see SchemaTypeDefinition

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -24,9 +24,20 @@ import {type PreviewConfig} from './preview'
 
 export {defineArrayMember, defineField, defineType, typed} from './define'
 
-// Necessary since this is the only way to include all string literals and all other strings
+/**
+ * Enhances VSCode autocomplete by using a distinct type for strings.
+ *
+ * `AllowOtherStrings` is defined as `string & {}`, an intersection that behaves
+ * like `string` but is treated differently by TypeScript's type system for
+ * internal processing. This helps in improving the specificity and relevance of
+ * autocomplete suggestions by potentially prioritizing `IntrinsicTypeName`
+ * over general string inputs, addressing issues where `string` type suggestions
+ * might overshadow more useful specific literals.
+ *
+ * @beta
+ */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type AllowOtherStrings = string & {}
+export type AutocompleteString = string & {}
 
 /**
  * Note: you probably want `SchemaTypeDefinition` instead


### PR DESCRIPTION
### Description

Supersedes #6426 by @GregorGabric. Include the original commit by @GregorGabric.

This pull request introduces a small but crucial change to the typing of the `defineType` function to improve the autocomplete experience in VSCode.

The original implementation used a type parameter that extended `string | IntrinsicTypeName`, which caused VSCode's autocomplete to not effectively prioritize or sometimes display the specific string literals defined under `IntrinsicTypeName`. This was due to the broad nature of the `string` type overwhelming the specific suggestions that `IntrinsicTypeName` could provide.

By introducing an intersection type `AllowOtherStrings = string & {}`, we differentiate the generic string type from our specific string type (`IntrinsicTypeName`). This subtle change encourages TypeScript's type inference system to handle these types distinctly, thereby improving the relevance and prioritization of autocomplete suggestions in VSCode.

### What to review

Does the change make sense? Does it affect more than it should?

### Testing

- Ran the build and tried it in a studio. It's a great improvement!

### Notes for release

Improves autocomplete in VSCode for `defineType` and `defineField` with more relevant suggestions. Thanks @GregorGabric!