### PR TITLE
fix(tasks): close the form only after the task is created

### DIFF
--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/FormCreate.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/FormCreate.tsx
@@ -70,7 +70,7 @@ export function FormCreate(props: ObjectInputProps) {
 
   useEffect(() => {
     // If after 10 seconds the task is still in the "creating" state, show an error and reset the creating state.
-    let timeoutId: NodeJS.Timeout | null = null
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
     if (creating) {
       timeoutId = setTimeout(() => {
         setCreating(false)

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/FormCreate.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/FormCreate.tsx
@@ -1,13 +1,13 @@
 import {TrashIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Box, Flex, Switch, Text, useToast} from '@sanity/ui'
-import {useCallback, useState} from 'react'
+import {useCallback, useEffect, useState} from 'react'
 
 import {Button} from '../../../../../ui-components'
 import {type ObjectInputProps, set} from '../../../../form'
 import {useTranslation} from '../../../../i18n'
 import {TaskCreated} from '../../../__telemetry__/tasks.telemetry'
-import {useTasksNavigation} from '../../../context'
+import {useTasks, useTasksNavigation} from '../../../context'
 import {useRemoveTask} from '../../../hooks'
 import {tasksLocaleNamespace} from '../../../i18n'
 import {type TaskDocument} from '../../../types'
@@ -29,12 +29,9 @@ const getTaskSubscribers = (task: TaskDocument): string[] => {
   return subscribers
 }
 export function FormCreate(props: ObjectInputProps) {
+  const [creating, setCreating] = useState(false)
   const {onChange} = props
-  const {
-    setViewMode,
-    setActiveTab,
-    state: {viewMode},
-  } = useTasksNavigation()
+  const {setViewMode, setActiveTab} = useTasksNavigation()
   const toast = useToast()
   const telemetry = useTelemetry()
 
@@ -47,7 +44,52 @@ export function FormCreate(props: ObjectInputProps) {
   }, [setViewMode])
   const {handleRemove, removeStatus} = useRemoveTask({id: value._id, onRemoved: onRemove})
   const {t} = useTranslation(tasksLocaleNamespace)
-  const handleCreate = useCallback(() => {
+  const {data} = useTasks()
+  const savedTask = data.find((task) => task._id === value._id)
+
+  useEffect(() => {
+    // This useEffect takes care of closing the form when a task entered the "creation" state.
+    // That action is async and we don't have access to the promise, once the value is updated in the form we will close the form.
+    if (creating && savedTask?.createdByUser) {
+      telemetry.log(TaskCreated)
+      toast.push({
+        closable: true,
+        status: 'success',
+        title: t('form.status.success'),
+      })
+
+      setCreating(false)
+      if (createMore) {
+        setViewMode({type: 'create'})
+      } else {
+        setActiveTab('subscribed')
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [creating, savedTask?.createdByUser])
+
+  useEffect(() => {
+    // If after 10 seconds the task is still in the "creating" state, show an error and reset the creating state.
+    let timeoutId: NodeJS.Timeout | null = null
+    if (creating) {
+      timeoutId = setTimeout(() => {
+        setCreating(false)
+        toast.push({
+          closable: true,
+          status: 'error',
+          title: t('form.status.error.creation-failed'),
+        })
+      }, 10000)
+    }
+    // Cleanup function to clear the timeout
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [creating])
+
+  const handleCreate = useCallback(async () => {
+    setCreating(true)
     if (!value?.title) {
       toast.push({
         closable: true,
@@ -60,21 +102,7 @@ export function FormCreate(props: ObjectInputProps) {
       set(getTaskSubscribers(value), ['subscribers']),
       set(new Date().toISOString(), ['createdByUser']),
     ])
-
-    if (createMore) {
-      setViewMode({type: 'create'})
-    } else {
-      setActiveTab('subscribed')
-    }
-
-    telemetry.log(TaskCreated)
-
-    toast.push({
-      closable: true,
-      status: 'success',
-      title: t('form.status.success'),
-    })
-  }, [value, onChange, createMore, telemetry, toast, t, setViewMode, setActiveTab])
+  }, [value, onChange, t, toast])
 
   return (
     <>
@@ -102,7 +130,12 @@ export function FormCreate(props: ObjectInputProps) {
             </Text>
           </Flex>
 
-          <Button text={t('buttons.create.text')} onClick={handleCreate} />
+          <Button
+            text={t('buttons.create.text')}
+            onClick={handleCreate}
+            disabled={creating}
+            loading={creating}
+          />
         </Flex>
       </Box>
     </>


### PR DESCRIPTION
### Description

Fixes an issue in which tasks are kept in draft mode after clicking on the "create" button. 
The on change action triggered by the form doesn't provides a way to validate that the transaction ended, so in this case we will persist the form in `creating` state until the task store is updated with the correct values.
The task store fetches the latest task values when a task is updated, so if the value has been updated in the store it means the transaction has ended.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is there a better way to do this? 
Is there any way to access the transaction from the form onChange or from any form action?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
fixes an issue in tasks in which the UI showed that they were created but the transaction was didn't ended.
