### PR TITLE
feat(scheduled-publishing): add warning for deprecated plugin

### DIFF
--- a/packages/sanity/src/core/config/flattenConfig.ts
+++ b/packages/sanity/src/core/config/flattenConfig.ts
@@ -1,9 +1,11 @@
+import {deprecatedScheduledPublishingPlugin} from '../deprecatedPlugins/DeprecatedScheduledPublishing'
 import {type PluginOptions} from './types'
 
 const DEPRECATED_PLUGINS = [
   // Scheduled publishing is added by default, we are filtering to avoid duplicates
   'scheduled-publishing',
 ]
+
 /**
  * @internal
  *
@@ -20,6 +22,17 @@ export const flattenConfig = (
   const allPlugins = plugins.flatMap((plugin) =>
     flattenConfig(plugin, [...path, currentConfig.name]),
   )
+
+  const deprecatedScheduledPublishing = allPlugins.find(
+    (p) => p.config.name === 'scheduled-publishing',
+  )
+  if (deprecatedScheduledPublishing) {
+    // Add the deprecated plugin error to the plugins list, to show the error to users.
+    allPlugins.push({
+      path: deprecatedScheduledPublishing.path,
+      config: deprecatedScheduledPublishingPlugin(),
+    })
+  }
 
   const resolved = [
     ...allPlugins.filter((plugin) => !DEPRECATED_PLUGINS.includes(plugin.config.name)),

--- a/packages/sanity/src/core/deprecatedPlugins/DeprecatedScheduledPublishing.tsx
+++ b/packages/sanity/src/core/deprecatedPlugins/DeprecatedScheduledPublishing.tsx
@@ -1,0 +1,39 @@
+import {useToast} from '@sanity/ui'
+import {useEffect} from 'react'
+
+import {definePlugin, type LayoutProps} from '../config'
+
+function SchedulePublishingStudioLayout(props: LayoutProps) {
+  const toast = useToast()
+  useEffect(() => {
+    console.error(
+      `Scheduled publishing plugin is added by default, please remove this plugin from your config. 
+        \nIf you have a custom date config, you can use the scheduledPublishing API to customize the date input.
+        \nSee: https://www.sanity.io/docs/scheduled-publishing.
+        `,
+    )
+    toast.push({
+      closable: true,
+      duration: 60000,
+      status: 'error',
+      title: 'Scheduled publishing plugin is deprecated',
+      description:
+        'The scheduled publishing plugin is now deprecated, you should remove the plugin from your configuration. If you have a custom date config, you can use the scheduledPublishing API to customize the date input. See: https://www.sanity.io/docs/scheduled-publishing.',
+    })
+  }, [toast])
+
+  return props.renderDefault(props)
+}
+
+/**
+ * Shows an error in console and a toast to prevent users from importing the deprecated plugin.
+ * Gives information about how to upgrade to the new version.
+ */
+export const deprecatedScheduledPublishingPlugin = definePlugin({
+  name: 'sanity/deprecated/scheduled-publishing',
+  studio: {
+    components: {
+      layout: SchedulePublishingStudioLayout,
+    },
+  },
+})


### PR DESCRIPTION
### Description
🟡 Before merging, remove the import for scheduled-publishing plugin in the test studio 🟡 

Shows a warning to users if they are adding a deprecated plugin in their studio config.

![image](https://github.com/sanity-io/sanity/assets/46196328/677897c2-2e23-4614-85b6-63d43c2d4234)


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
