### PR TITLE
fix(typegen): fixes a bug where we imported the wrong relative path

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 import {describe, expect, test} from '@jest/globals'
 
 import {findQueriesInSource} from '../findQueriesInSource'
@@ -81,18 +79,19 @@ describe('findQueries', () => {
       const postQuery = groq\`*[_type == "\${foo}"]\`
       const res = sanity.fetch(postQueryResult);
     `
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(1)
+    expect(queries[0].result).toBe('*[_type == "foo"]')
+  })
 
-    const resolver: NodeJS.RequireResolve = (id) => {
-      if (id === 'foo') {
-        return path.resolve(__dirname, 'fixtures', 'exportVar')
-      }
-      return require.resolve(id)
-    }
-    resolver.paths = (request: string): string[] | null => {
-      return require.resolve.paths(request)
-    }
-
-    const queries = findQueriesInSource(source, 'test.ts', undefined, resolver)
+  test('should import, subdirectory', () => {
+    const source = `
+      import { groq } from "groq";
+      import {foo}  from "../__tests__/fixtures/exportVar";
+      const postQuery = groq\`*[_type == "\${foo}"]\`
+      const res = sanity.fetch(postQueryResult);
+    `
+    const queries = findQueriesInSource(source, __filename, undefined)
     expect(queries.length).toBe(1)
     expect(queries[0].result).toBe('*[_type == "foo"]')
   })

--- a/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
+++ b/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
@@ -323,12 +323,14 @@ function resolveImportSpecifier({
     throw new Error(`Could not find import declaration for ${node.local.name}`)
   }
 
-  const importName = node.local.name
-  const importFileName = importDeclaration.source.value
-  // const importPath = path.resolve(path.dirname(filename), importFileName);
-  const importPath = importName.startsWith('./')
-    ? path.resolve(path.dirname(filename), importFileName)
-    : importFileName
+  const importName = node.local.name // the name of the variable to import
+  const importFileName = importDeclaration.source.value // the file to import from
+
+  const importPath =
+    importFileName.startsWith('./') || importFileName.startsWith('../')
+      ? path.resolve(path.dirname(filename), importFileName)
+      : importFileName
+
   const resolvedFile = resolver(importPath)
   const source = fs.readFileSync(resolvedFile)
   const tree = parseSourceFile(source.toString(), resolvedFile, babelConfig)


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

We we're checking the wrong variable for relative imports. importName is the variable being imported, but we want to check the actual path. The tests were also wrong...

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Tests fixed

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

typegen: fixes a bug where relative imports would fail.

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

Fixes #6297
