### PR TITLE
fix(cli): mock matchMedia window function

### DIFF
--- a/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
+++ b/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
@@ -63,6 +63,13 @@ const getFakeGlobals = (basePath: string) => ({
   InputEvent: global.window?.InputEvent,
   customElements: global.window?.customElements,
   ResizeObserver: global.window?.ResizeObserver || ResizeObserver,
+  matchMedia:
+    global.window?.matchMedia ||
+    (() => ({
+      matches: false,
+      media: '',
+      onchange: null,
+    })),
 })
 
 function provideFakeGlobals(basePath: string): () => void {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

The mux video plugin uses `matchMedia`, which throws an error since matchMedia is missing:

```

» pnpm sanity schema extract                                                                                                                                                                                          1 ↵ 
✖ Failed to extract schema                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                             
TypeError: Failed to load configuration file "/Users/sgulseth/workspace/src/sindre.dev/scratch/mux-mvp/sanity.config.ts":                                                                                                                                    
l.matchMedia is not a function                                                                                                                                                                                                                               
    at el (~/workspace/src/sindre.dev/scratch/mux-mvp/node_modules/.pnpm/@mux+mux-player@2.5.0/node_modules/@mux/mux-player/dist/index.cjs.js:145:8374)                                                                                                      
    at Object.<anonymous> (~/workspace/src/sindre.dev/scratch/mux-mvp/node_modules/.pnpm/@mux+mux-player@2.5.0/node_modules/@mux/mux-player/dist/index.cjs.js:145:8586)                                                                                      
    at Object.newLoader [as .js] (~/workspace/src/sindre.dev/scratch/mux-mvp/node_modules/.pnpm/esbuild-register@3.5.0_esbuild@0.20.2/node_modules/esbuild-register/dist/node.js:2262:9)                                                                     
    at extensions..js (~/workspace/src/sindre.dev/scratch/mux-mvp/node_modules/.pnpm/esbuild-register@3.5.0_esbuild@0.20.2/node_modules/esbuild-register/dist/node.js:4838:24)     
» pnpm sanity schema validate                                                                                                                                                                                             
⠙ Validating schema…                                                                                                                                                                                                                                         
TypeError: Failed to load configuration file "/Users/sgulseth/workspace/src/sindre.dev/scratch/mux-mvp/sanity.config.ts":                                                                                                                                    
l.matchMedia is not a function                                                                                                                                                                                                                               
    at el (~/workspace/src/sindre.dev/scratch/mux-mvp/node_modules/.pnpm/@mux+mux-player@2.5.0/node_modules/@mux/mux-player/dist/index.cjs.js:145:8374)                                                                                                      
    at Object.<anonymous> (~/workspace/src/sindre.dev/scratch/mux-mvp/node_modules/.pnpm/@mux+mux-player@2.5.0/node_modules/@mux/mux-player/dist/index.cjs.js:145:8586)                                                                                      
    at Object.newLoader [as .js] (~/workspace/src/sindre.dev/scratch/mux-mvp/node_modules/.pnpm/esbuild-register@3.5.0_esbuild@0.20.2/node_modules/esbuild-register/dist/node.js:2262:9)                                                                     
    at extensions..js (~/workspace/src/sindre.dev/scratch/mux-mvp/node_modules/.pnpm/esbuild-register@3.5.0_esbuild@0.20.2/node_modules/esbuild-register/dist/node.js:4838:24) ```

```

### What to review

Is this the correct way to add a mock?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Tested manually on a repo using the `sanity-plugin-mux-input`

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

fixes a bug where we could not extract or validate a schema using the `sanity-plugin-mux-input` plugin.

Fixes https://github.com/sanity-io/sanity-plugin-mux-input/issues/359
