### PR TITLE
fix: prevent looping requests to keyvalue in recent searches

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/datastores/useStoredSearch.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/datastores/useStoredSearch.ts
@@ -36,6 +36,9 @@ export function useStoredSearch(): [StoredSearch, (_value: StoredSearch) => void
       .pipe(
         startWith(defaultValue as any),
         map((data: StoredSearch) => {
+          if (!data) {
+            return defaultValue
+          }
           // Check if the version matches RECENT_SEARCH_VERSION
           if (data?.version !== RECENT_SEARCH_VERSION) {
             // If not, return the default object and mutate the store (per original verifySearchVersionNumber logic)


### PR DESCRIPTION
### Description
A bit of logic was transplanted from the old localStorage recent searches store that did not translate well to an async request format. Certain users, who are not able to reach the `/users/me/keyvalue` endpoint for various reasons, would get stuck in a loop while they were trying to fetch recent searches:
1. They would open the search bar and request recent searches, which returned a null because they were not able to access it
2. The default logic would see that there was an empty search with an invalid version and set an empty object
3. Because they were not able to set the value, they would end up at step 1 of the process again.

This PR short-circuits that process by checking if there is data at all and returns a default value, rather than trying to set it immediately, as the old `recentSearches.ts` did.

### What to review
Anything else we're missing?

### Testing
There is already a test case for an empty result from the backend, which should result in this behavior. It's a bit difficult to simulate the looping behavior caused by valid error codes, unfortunately.