### PR TITLE
feat: add and use prefersLatestPublished parameter in DocumentPaneProvider

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -146,6 +146,22 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const [timelineMode, setTimelineMode] = useState<'since' | 'rev' | 'closed'>('closed')
 
   const [timelineError, setTimelineError] = useState<Error | null>(null)
+
+  /**
+   * The `preferLatestPublished` parameter can be used to "force" viewing the revision
+   * of the last published document. This is not a permanent function, and will likely
+   * be removed when we move to a more robust way of viewing "releases".
+   */
+  useEffect(() => {
+    if (params.prefersLatestPublished && editState.published) {
+      setPaneParams({
+        //ensure we only run on first load
+        ...omit(params, 'prefersLatestPublished'),
+        rev: `${editState.published._updatedAt}/${editState.published._rev}`,
+      })
+    }
+  }, [editState, setPaneParams, params])
+
   /**
    * Create an intermediate store which handles document Timeline + TimelineController
    * creation, and also fetches pre-requsite document snapshots. Compatible with `useSyncExternalStore`


### PR DESCRIPTION
### Description
In Presentation, users were having a somewhat misleading experience when clicking on a popover (which used an intent link) to load a document in the side pane. The document pane would show the latest revision, even if the users were looking at the "published" perspective.

This PR adds a parameter that can be read from an intent link (e.g., `https://example.sanity.studio/production/intent/edit/id=the-page-id;type=page;prefersLatestPublished=true`) which sets the revision of the latest published document on first load.

The document will then load in a readOnly state to that last published revision. Users can then switch revisions if needed.

### What to review
You can test this out by running the studio locally and using an intent link like: [http://localhost:3333/test/intent/edit/id=grrm;type=author;prefersLatestPublished=true](http://localhost:3333/test/intent/edit/id=grrm;type=author;prefersLatestPublished=true)

For documents that have never been published, or have been unpublished, it should default to the draft.

This is a bit of a blunt hammer. `useEffect` here might be a bit inelegant or intensive, and there may be more precautions to take to ensure we're not resetting state unnecessarily.

However, `DocumentPaneProvider` seems to be the only place where we have easy access to a document's `_rev` parameter. It might be more overhead to have the timelineStore look it up from history, and it doesn't seem to be available earlier in routing. 

### Testing
I unfortunately did not see a testing suite for the DocumentPaneProvider. Please let me know if I should add this in Storybook.
