### PR TITLE
fix(cli): remove comments from moviedb template, hide location field

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/templates/moviedb.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/moviedb.ts
@@ -4,7 +4,6 @@ const configTemplate = `
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
-//import {googleMapsInput} from '@sanity/google-maps-input'
 import {schemaTypes} from './schemaTypes'
 
 export default defineConfig({
@@ -17,7 +16,6 @@ export default defineConfig({
   plugins: [
     structureTool(),
     visionTool(),
-    //googleMapsInput(),
   ],
 
   schema: {
@@ -31,7 +29,6 @@ const movieTemplate: ProjectTemplate = {
   importPrompt: 'Add a sampling of sci-fi movies to your dataset on the hosted backend?',
   datasetUrl: 'https://public.sanity.io/moviesdb-2018-03-06.tar.gz',
   dependencies: {
-    //'@sanity/google-maps-input': '^2.27.0',
     'react-icons': '^3.11.0',
   },
 }

--- a/packages/@sanity/cli/templates/moviedb/schemaTypes/screening.js
+++ b/packages/@sanity/cli/templates/moviedb/schemaTypes/screening.js
@@ -31,6 +31,7 @@ export default defineType({
       title: 'Location',
       type: 'geopoint',
       description: 'Where will the screening take place?',
+      hidden: true,
     }),
     defineField({
       name: 'beginAt',


### PR DESCRIPTION
### Description

There's an issue I am struggling to find the cause of, where `npm create sanity@latest` will crash when trying to create the configuration file for the movie db template.

Reading the stack trace, it appears as part of the comments handling in recast, but I am struggling to easily reproduce it in testing. I modified the template to not include any comments, by simply removing the google maps input references. It was a bit of an oversight that it had stayed commented out since v3 was launched, and it looks a bit unprofessional in my opinion.

I also chose to hide the location field in the schema, since showing plain lat/lng fields seems... not very user friendly, but the data exists in the tarball that we provide, so I'd rather not show warnings on data for missing fields.

We can reintroduce the google maps plugin (or similar) later, but we should make sure it works with little to no configuration. Currently it's a bit of a setup in terms of getting the necessary API keys etc.

### What to review

The changes appears safe and sane

### Testing

This one is hard to test - I wasn't actually able to easily reproduce outside of modifying the built version in my local node_modules, unfortunately. It may be that it was built with a dependency that had a bug that I am not seeing locally for some reason.

Regardless, the changes here are somewhat useful even without the bugfix, so we can do a release and see if it goes away after these changes.

### Notes for release

- Fixes an issue that caused `npm create sanity` to crash when using the movie database template
