### PR TITLE
fix(test): remove hydrateroot warning test

### DIFF
--- a/packages/sanity/src/core/studio/Studio.test.tsx
+++ b/packages/sanity/src/core/studio/Studio.test.tsx
@@ -18,9 +18,7 @@ import {describe, expect, it, jest} from '@jest/globals'
  * c) https://styled-components.com/docs/advanced#server-side-rendering
  */
 import {type SanityClient} from '@sanity/client'
-import {hydrateRoot} from 'react-dom/client'
 import {renderToStaticMarkup, renderToString} from 'react-dom/server'
-import {act} from 'react-dom/test-utils'
 import {ServerStyleSheet} from 'styled-components'
 
 import {createMockSanityClient} from '../../../test/mocks/mockSanityClient'
@@ -64,29 +62,6 @@ describe('Studio', () => {
       expect(html).toMatchInlineSnapshot(
         `"<div class=\\"sc-iftxFb wOspp\\"><div data-ui=\\"Spinner\\" class=\\"sc-irLvIq kqiGuJ sc-ktwOfi bQiRGJ sc-bOcqSQ hqXpkL\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
-    } finally {
-      sheet.seal()
-    }
-
-    expect(console.error).not.toHaveBeenCalled()
-
-    spy.mockReset()
-    spy.mockRestore()
-  })
-  it('SSR hydrateRoot finishes without warnings', () => {
-    const spy = jest.spyOn(console, 'error')
-    const node = document.createElement('div')
-    document.body.appendChild(node)
-    const sheet = new ServerStyleSheet()
-    try {
-      const html = renderToString(sheet.collectStyles(<Studio config={config} />))
-      node.innerHTML = html
-      expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-iftxFb wOspp\\"><div data-ui=\\"Spinner\\" class=\\"sc-irLvIq kqiGuJ sc-ktwOfi bQiRGJ sc-bOcqSQ hqXpkL\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
-      )
-      document.head.innerHTML += sheet.getStyleTags()
-
-      act(() => hydrateRoot(node, <Studio config={config} />))
     } finally {
       sheet.seal()
     }


### PR DESCRIPTION
### Description

Removes a test asserting SSR hydrateRoot finishes without warnings. This test started failing after upgrading to React 18.3 due to a deprecation warning when importing `act` react/test-utils.

Now that #6487 is merged we have a next build of the entire test studio which should cover a lot more SSR/hydration issues, so removing this test for now.

### What to review

- Do we still need the other tests here?

### Testing
n/a

### Notes for release
n/a