### PR TITLE
fix(search): revert to old search API for now

### DIFF
--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -588,7 +588,7 @@ function resolveSource({
         context,
         reducer: legacySearchEnabledReducer,
         propertyName: 'enableLegacySearch',
-        initialValue: false,
+        initialValue: true,
       }),
       // we will use this when we add search config to PluginOptions
       /*filters: resolveConfigProperty({


### PR DESCRIPTION
### Description

We've got some reports about a subpar search experience with the new API, as well as certain GROQ functions and features that may be used in custom document lists and reference search filters that do not work with the new API.

We need to have a proper look at addressing this, but for now we've decided to roll back to using the old search API for now. This PR ensures that we can still explicitly _enable_ the new search if we want, but by default it is disabled.

### What to review

Studio uses old search API by default

### Notes for release

- Disabled the new search API introduced in [v3.38.0](https://github.com/sanity-io/sanity/releases/tag/v3.38.0) by default
