### PR TITLE
fix(comments): inline comment creation issue in Safari

### DIFF
--- a/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -78,6 +78,11 @@ export const CommentsPortableTextInputInner = memo(function CommentsPortableText
   const editorRef = useRef<PortableTextEditor | null>(null)
   const mouseDownRef = useRef<boolean>(false)
 
+  // A reference to the authoring decoration element that highlights the selected text
+  // when starting to author a comment.
+  const [authoringDecorationElement, setAuthoringDecorationElement] =
+    useState<HTMLSpanElement | null>(null)
+
   const [nextCommentValue, setNextCommentValue] = useState<CommentMessage | null>(null)
   const [nextCommentSelection, setNextCommentSelection] = useState<EditorSelection | null>(null)
 
@@ -106,6 +111,7 @@ export const CommentsPortableTextInputInner = memo(function CommentsPortableText
     setNextCommentSelection(null)
     setNextCommentValue(null)
     setCanSubmit(false)
+    setAuthoringDecorationElement(null)
   }, [])
 
   // Set the next comment selection to the current selection so that we can
@@ -396,7 +402,9 @@ export const CommentsPortableTextInputInner = memo(function CommentsPortableText
 
     return {
       component: ({children}) => (
-        <CommentInlineHighlightSpan isAuthoring>{children}</CommentInlineHighlightSpan>
+        <CommentInlineHighlightSpan isAuthoring ref={setAuthoringDecorationElement}>
+          {children}
+        </CommentInlineHighlightSpan>
       ),
       selection: nextCommentSelection,
     }
@@ -450,7 +458,7 @@ export const CommentsPortableTextInputInner = memo(function CommentsPortableText
 
   const popoverAuthoringReferenceElement = useAuthoringReferenceElement({
     scrollElement,
-    disabled: !nextCommentSelection,
+    disabled: !nextCommentSelection || !authoringDecorationElement,
     selector: '[data-inline-comment-state="authoring"]',
   })
 

--- a/packages/sanity/src/core/comments/plugin/input/helpers.ts
+++ b/packages/sanity/src/core/comments/plugin/input/helpers.ts
@@ -40,25 +40,16 @@ function useRectFromElements(props: RectFromElementsHookOptions): DOMRect | null
   const [rect, setRect] = useState<DOMRect | null>(null)
 
   const handleSetRect = useCallback(() => {
+    if (disabled) return
     const elements = document?.querySelectorAll(selector)
     if (!elements) return
 
     const nextRect = createDomRectFromElements(Array.from(elements))
 
     setRect(nextRect)
-  }, [selector])
+  }, [disabled, selector])
 
-  useEffect(() => {
-    if (disabled) return undefined
-
-    const timeout = setTimeout(() => {
-      handleSetRect()
-    }, 1)
-
-    return () => {
-      clearTimeout(timeout)
-    }
-  }, [handleSetRect, disabled])
+  useEffect(handleSetRect, [handleSetRect])
 
   useEffect(() => {
     if (disabled || !scrollElement) return undefined


### PR DESCRIPTION
### Description

This pull request fixes an issue where the comment input fails to appear when clicking the "Add Comment" button to create an inline comment in Safari.

### What to review

- Ensure that the comment input appears in Safari

### Notes for release

N/A
