### PR TITLE
fix(core): skip reset presence selection on PTE blur

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -183,12 +183,6 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
     })
   }, [onPathFocus, portableTextMemberItems])
 
-  const resetSelectionPresence = useCallback(() => {
-    onPathFocus(props.path, {
-      selection: null,
-    })
-  }, [onPathFocus, props.path])
-
   const nextSelectionRef = useRef<EditorSelection | null>(null)
 
   // Handle editor changes
@@ -216,11 +210,6 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
         case 'blur':
           onBlur(change.event)
           setHasFocusWithin(false)
-
-          // When the editor blurs, we reset the presence selection
-          // in order to remove the presence cursor for the current user
-          // since they no longer have an active selection in the editor.
-          resetSelectionPresence()
           break
         case 'undo':
         case 'redo':
@@ -241,15 +230,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
         onEditorChange(change, editorRef.current)
       }
     },
-    [
-      editorRef,
-      onEditorChange,
-      onChange,
-      setFocusPathFromEditorSelection,
-      onBlur,
-      resetSelectionPresence,
-      toast,
-    ],
+    [editorRef, onEditorChange, onChange, setFocusPathFromEditorSelection, onBlur, toast],
   )
 
   useEffect(() => {


### PR DESCRIPTION
### Description

This pull request resolves an issue where the popover for editing objects in the PTE closes immediately after opening. This issue was introduced with the implementation of presence cursors, where the `onPathFocus` function is called to reset the `selection` presence state when the PTE input is blurred. The fix here is to avoid resetting the presence selection on blur, and instead, allow the selection to be reset when another input is focused, thereby updating the presence.

### What to review
- Ensure that editing objects in the PTE (such as links) is possible.

### Notes for release

N/A
