### PR TITLE
fix(scheduled-publishing): deprecated error toast shows multiple times

### DIFF
--- a/packages/sanity/src/core/deprecatedPlugins/DeprecatedScheduledPublishing.tsx
+++ b/packages/sanity/src/core/deprecatedPlugins/DeprecatedScheduledPublishing.tsx
@@ -13,6 +13,7 @@ function SchedulePublishingStudioLayout(props: LayoutProps) {
         `,
     )
     toast.push({
+      id: 'scheduled-publishing-deprecated',
       closable: true,
       duration: 60000,
       status: 'error',


### PR DESCRIPTION
### Description
The deprecated `scheduledPublishing` toast in some cases shows multiple times, adding an id to it fixes it and ensures it will only show once. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
