### PR TITLE
feat: add canHandleIntent to Structure Builder component

### DIFF
--- a/packages/sanity/src/structure/structureBuilder/Component.ts
+++ b/packages/sanity/src/structure/structureBuilder/Component.ts
@@ -1,5 +1,6 @@
 import {type I18nTextRecord} from 'sanity'
 
+import {type IntentChecker} from './Intent'
 import {maybeSerializeMenuItem, type MenuItem, type MenuItemBuilder} from './MenuItem'
 import {
   maybeSerializeMenuItemGroup,
@@ -34,7 +35,7 @@ export interface Component extends StructureNode {
   menuItemGroups: MenuItemGroup[]
   /** Component options */
   options: {[key: string]: unknown}
-  canHandleIntent: any
+  canHandleIntent?: IntentChecker
 }
 
 /**
@@ -71,7 +72,7 @@ export interface BuildableComponent extends Partial<StructureNode> {
   menuItems?: (MenuItem | MenuItemBuilder)[]
   /** Component menu item groups. See {@link MenuItemGroup} and {@link MenuItemGroupBuilder} */
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
-  canHandleIntent?: any
+  canHandleIntent?: IntentChecker
 }
 
 /**

--- a/packages/sanity/src/structure/structureBuilder/Component.ts
+++ b/packages/sanity/src/structure/structureBuilder/Component.ts
@@ -34,6 +34,7 @@ export interface Component extends StructureNode {
   menuItemGroups: MenuItemGroup[]
   /** Component options */
   options: {[key: string]: unknown}
+  canHandleIntent: any
 }
 
 /**
@@ -70,6 +71,7 @@ export interface BuildableComponent extends Partial<StructureNode> {
   menuItems?: (MenuItem | MenuItemBuilder)[]
   /** Component menu item groups. See {@link MenuItemGroup} and {@link MenuItemGroupBuilder} */
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
+  canHandleIntent?: any
 }
 
 /**
@@ -205,6 +207,10 @@ export class ComponentBuilder implements Serializable<Component> {
     return this.spec.menuItemGroups
   }
 
+  canHandleIntent(canHandleIntent: any): ComponentBuilder {
+    return this.clone({canHandleIntent})
+  }
+
   /** Serialize component
    * @param options - serialization options
    * @returns component object based on path provided in options
@@ -234,6 +240,7 @@ export class ComponentBuilder implements Serializable<Component> {
       type: 'component',
       child,
       component,
+      canHandleIntent: this.spec.canHandleIntent,
       options: componentOptions || {},
       menuItems: (this.spec.menuItems || []).map((item, i) =>
         maybeSerializeMenuItem(item, i, options.path),

--- a/packages/sanity/src/structure/structureBuilder/Component.ts
+++ b/packages/sanity/src/structure/structureBuilder/Component.ts
@@ -208,7 +208,7 @@ export class ComponentBuilder implements Serializable<Component> {
     return this.spec.menuItemGroups
   }
 
-  canHandleIntent(canHandleIntent: any): ComponentBuilder {
+  canHandleIntent(canHandleIntent: IntentChecker): ComponentBuilder {
     return this.clone({canHandleIntent})
   }
 


### PR DESCRIPTION
### Description
Some users would like to implement their own custom component within Structure, rather than just a desk list. However, this becomes difficult when trying to route to this component from other parts of the Studio, because there was no way for us to signal that this component could indeed handle that intent.

This PR takes the `canHandleIntent` argument available on lists and makes it available on components.

### What to review
Is this a valid approach? Does it break inheritance of Structure Builder items in any way? Are there any gotchas?

### Testing
This can be tried out in the test studio by adding a `canHandleIntent` to an `S.component`, like so:
```javascript
      S.listItem()
        .id('translate')
        .title('Translate Test')
        .child(S.component(TranslateExample).id('example')
          .canHandleIntent((intent, params, context) =>  {
            console.log(intent, params, context)
            return true
          }
        )),
```

You should be able to run the Studio without crashing. When searching for a document, you should land on the `canHandleIntent` component.

A unit test is also included as part of this PR.

### Notes for release
Custom components included in Structure (like `S.component(MyCustomComponent)`) can now be routed to from global search results or other links by using a `canHandleIntent` parameter.