### PR TITLE
fix(core): account for dateFormat when parsing initialValue

### DIFF
--- a/dev/test-studio/schema/debug/dateValidation.ts
+++ b/dev/test-studio/schema/debug/dateValidation.ts
@@ -9,5 +9,13 @@ export default defineType({
       type: 'date',
       validation: (Rule) => Rule.min('2024-01-01').required(),
     }),
+    defineField({
+      name: 'initialValue',
+      type: 'date',
+      options: {
+        dateFormat: 'YYYY.MM.DD.',
+      },
+      initialValue: '2024.04.29.',
+    }),
   ],
 })

--- a/packages/sanity/src/core/form/inputs/DateInputs/DateInput.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/DateInput.tsx
@@ -13,9 +13,6 @@ import {getCalendarLabels} from './utils'
  * @beta */
 export type DateInputProps = StringInputProps
 
-const deserialize = (value: string) => parse(value, DEFAULT_DATE_FORMAT)
-const serialize = (date: Date) => format(date, DEFAULT_DATE_FORMAT)
-
 /**
  * @hidden
  * @beta */
@@ -39,6 +36,10 @@ export function DateInput(props: DateInputProps) {
   )
 
   const calendarLabels: CalendarLabels = useMemo(() => getCalendarLabels(t), [t])
+
+  const deserialize = useCallback((v: string) => parse(v, dateFormat), [dateFormat])
+  const serialize = useCallback((date: Date) => format(date, dateFormat), [dateFormat])
+
   return (
     <CommonDateTimeInput
       {...elementProps}

--- a/test/e2e/tests/inputs/date.spec.ts
+++ b/test/e2e/tests/inputs/date.spec.ts
@@ -1,5 +1,5 @@
-import {test} from '@sanity/test'
 import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
 
 test(`date input shows validation on selecting date from datepicker`, async ({
   page,
@@ -70,4 +70,21 @@ test(`date input shows validation on entering date in the textfield and onBlur`,
   ).toBeVisible()
 
   await expect(page.getByTestId('action-Publish')).toBeDisabled()
+})
+
+test('date input does not show an error when passing an initialValue with a custom format', async ({
+  page,
+  createDraftDocument,
+}) => {
+  await createDraftDocument('/test/content/input-debug;dateValidation')
+
+  await page.waitForSelector(`data-testid=field-initialValue`)
+
+  await expect(page.getByTestId('field-initialValue').getByTestId('date-input')).toHaveValue(
+    // Defined in dev/test-studio/schema/debug/dateValidation.ts
+    '2024.04.29.',
+  )
+
+  const invalidInput = page.locator(`[data-testid=date-input]:invalid`)
+  expect(await invalidInput.count()).toBe(0)
 })


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

When a dateFormat is used for `date` type component and when the `initialValue` is passed to it via the correct format. The component would try to convert that to default format and show an error. The makes it that the initialValue gets parsed correctly using the provided date format and not default date format/

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Changes makes sense 

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Added an e2e test

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

- Fixes an issue where `dateFormat` in `date` type input would show an error for correct `initialValue` 