### PR TITLE
fix(core): inability to remove image and file blocks in PTE when preview bypasses modal

### DIFF
--- a/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
+++ b/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
@@ -115,22 +115,6 @@ export default defineType({
             spellCheck: true,
           },
         }),
-
-        defineArrayMember({
-          type: 'image',
-          name: 'Render Image Component Preview',
-          // Replace the preview of all block images
-          // with the edit form for that object, bypassing
-          // the modal step.
-          components: {
-            block: (props) => {
-              return props.renderDefault({
-                ...props,
-                renderPreview: () => props.children,
-              })
-            },
-          },
-        }),
         {
           type: 'image',
           name: 'image',
@@ -187,6 +171,48 @@ export default defineType({
             },
           ],
         },
+      ],
+    },
+    {
+      name: 'blockPreview',
+      title: 'Block Preview body',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          type: 'block',
+          of: [{type: 'image', name: 'image'}],
+        }),
+
+        defineArrayMember({
+          type: 'image',
+          name: 'Render Image Component Preview',
+          // Replace the preview of all block images
+          // with the edit form for that object, bypassing
+          // the modal step.
+          components: {
+            block: (props) => {
+              return props.renderDefault({
+                ...props,
+                renderPreview: () => props.children,
+              })
+            },
+          },
+        }),
+        defineArrayMember({
+          type: 'file',
+          name: 'Render File Component Preview',
+          // Replace the preview of all block images
+          // with the edit form for that object, bypassing
+          // the modal step.
+          components: {
+            block: (props) => {
+              return props.renderDefault({
+                ...props,
+                renderPreview: () => props.children,
+              })
+            },
+          },
+        }),
       ],
     },
     {

--- a/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
+++ b/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
@@ -115,6 +115,22 @@ export default defineType({
             spellCheck: true,
           },
         }),
+
+        defineArrayMember({
+          type: 'image',
+          name: 'Render Image Component Preview',
+          // Replace the preview of all block images
+          // with the edit form for that object, bypassing
+          // the modal step.
+          components: {
+            block: (props) => {
+              return props.renderDefault({
+                ...props,
+                renderPreview: () => props.children,
+              })
+            },
+          },
+        }),
         {
           type: 'image',
           name: 'image',

--- a/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
+++ b/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
@@ -180,12 +180,17 @@ export default defineType({
       of: [
         defineArrayMember({
           type: 'block',
-          of: [{type: 'image', name: 'image'}],
+          of: [
+            defineArrayMember({
+              type: 'image',
+              name: 'image',
+            }),
+          ],
         }),
 
         defineArrayMember({
           type: 'image',
-          name: 'Render Image Component Preview',
+          name: 'Image Component Preview',
           // Replace the preview of all block images
           // with the edit form for that object, bypassing
           // the modal step.
@@ -200,7 +205,7 @@ export default defineType({
         }),
         defineArrayMember({
           type: 'file',
-          name: 'Render File Component Preview',
+          name: 'File Component Preview',
           // Replace the preview of all block images
           // with the edit form for that object, bypassing
           // the modal step.

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
@@ -324,6 +324,9 @@ export class BaseFileInput extends PureComponent<BaseFileInputProps, BaseFileInp
 
   renderAsset() {
     const {value, changed, readOnly, elementProps} = this.props
+
+    // removed onBlur as part of a solution to allow for FileInput to be removed within PTE
+    const {onBlur, ...rest} = elementProps
     const {hoveringFiles, isStale} = this.state
     const hasValueOrUpload = Boolean(value?._upload || value?.asset)
 
@@ -350,7 +353,7 @@ export class BaseFileInput extends PureComponent<BaseFileInputProps, BaseFileInp
             this.renderUploadState(value._upload)
           ) : (
             <FileTarget
-              {...elementProps}
+              {...rest}
               onFocus={this.handleFileTargetFocus}
               tabIndex={0}
               disabled={Boolean(readOnly)}

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -729,6 +729,9 @@ export class BaseImageInput extends PureComponent<BaseImageInputProps, BaseImage
   renderAsset() {
     const {value, readOnly, elementProps} = this.props
 
+    // removed onBlur as part of a solution to allow for FileInput to be removed within PTE
+    const {onBlur, ...rest} = elementProps
+
     const {hoveringFiles, isStale} = this.state
 
     const hasValueOrUpload = Boolean(value?._upload || value?.asset)
@@ -756,7 +759,7 @@ export class BaseImageInput extends PureComponent<BaseImageInputProps, BaseImage
             this.renderUploadState(value._upload)
           ) : (
             <FileTarget
-              {...elementProps}
+              {...rest}
               onFocus={this.handleFileTargetFocus}
               tabIndex={0}
               disabled={Boolean(readOnly)}

--- a/test/e2e/tests/pte/HotKeyTest.spec.ts
+++ b/test/e2e/tests/pte/HotKeyTest.spec.ts
@@ -1,0 +1,38 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+test.describe('When pressing backspace with a block with a custom renderPreview', () => {
+  test('an image block will be deleted', async ({page, createDraftDocument}) => {
+    await createDraftDocument('/test/content/input-standard;portable-text;simpleBlock')
+
+    // set up the portable text editor
+    await page.getByTestId('field-blockPreview').focus()
+    await page.getByTestId('field-blockPreview').click()
+
+    await page.getByTestId('insert-menu-button').click()
+    await page.getByTestId('document-panel-portal').getByLabel('Insert Image Component').click()
+
+    await page.getByTestId('pte-block-object').click()
+    await page.keyboard.down('Backspace')
+
+    // check that the block is no longer in the input
+    await expect(await page.getByTestId('pte-block-object')).not.toBeVisible()
+  })
+
+  test('a file block will be deleted', async ({page, createDraftDocument}) => {
+    await createDraftDocument('/test/content/input-standard;portable-text;simpleBlock')
+
+    // set up the portable text editor
+    await page.getByTestId('field-blockPreview').focus()
+    await page.getByTestId('field-blockPreview').click()
+
+    await page.getByTestId('insert-menu-button').click()
+    await page.getByTestId('document-panel-portal').getByLabel('Insert File Component').click()
+
+    await page.getByTestId('pte-block-object').click()
+    await page.keyboard.down('Backspace')
+
+    // check that the block is no longer in the input
+    await expect(await page.getByTestId('pte-block-object')).not.toBeVisible()
+  })
+})


### PR DESCRIPTION
### Description

There was an issue where when adding an image input within PTE, when pressing backspace the image block wasn't being removed. The solution is a bit finicky but better than before (where they were unable to delete it all together)

Before:

https://github.com/sanity-io/sanity/assets/6951139/d92e9712-561c-4c0e-b810-08397b2b0602

After

https://github.com/sanity-io/sanity/assets/6951139/5ec31dc2-a363-42df-9d6a-82254064fa24


### What to review

Make sure there are no unintended side effects to the solution.

### Testing

There are blocks set up (for the e2e tests) in the [test-studio](https://test-studio-ggki2v88o.sanity.build/test/structure/input-standard;portable-text;simpleBlock;bee46755-70c3-4cd8-85d6-3193e3398315%2Ctemplate%3DsimpleBlock) specifically on "Block Preview body" input

### Notes for release

Fixes issue where Image and File blocks in PTE with custom preview weren't being able to be removed
