### PR TITLE
fix(scheduled-publishing): don't include it if it's the only plugin available

### DIFF
--- a/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
@@ -4,6 +4,7 @@ import {firstValueFrom, lastValueFrom, of} from 'rxjs'
 import {bufferTime} from 'rxjs/operators'
 
 import {createMockAuthStore} from '../../store'
+import {definePlugin} from '../definePlugin'
 import {createSourceFromConfig, createWorkspaceFromConfig, resolveConfig} from '../resolveConfig'
 
 describe('resolveConfig', () => {
@@ -134,6 +135,59 @@ describe('resolveConfig', () => {
           },
         ],
       },
+    ])
+  })
+
+  it('includes all the default plugins', async () => {
+    const projectId = 'ppsg7ml5'
+    const dataset = 'production'
+    const client = createClient({
+      projectId,
+      apiVersion: '2021-06-07',
+      dataset,
+      useCdn: false,
+    })
+    const mockPlugin = definePlugin({name: 'sanity/mock-plugin'})
+    const [workspace] = await firstValueFrom(
+      resolveConfig({
+        name: 'default',
+        dataset,
+        projectId,
+        auth: createMockAuthStore({client, currentUser: null}),
+        plugins: [mockPlugin()],
+      }),
+    )
+    expect(workspace.__internal.options.plugins).toMatchObject([
+      {name: 'sanity/mock-plugin'},
+      {name: 'sanity/comments'},
+      {name: 'sanity/tasks'},
+      {name: 'sanity/scheduled-publishing'},
+    ])
+  })
+
+  it('wont include scheduled publishing default plugin', async () => {
+    // Schedule publishing should not be included when none other plugin is included in the user config.
+    const projectId = 'ppsg7ml5'
+    const dataset = 'production'
+    const client = createClient({
+      projectId,
+      apiVersion: '2021-06-07',
+      dataset,
+      useCdn: false,
+    })
+    const [workspace] = await firstValueFrom(
+      resolveConfig({
+        name: 'default',
+        dataset,
+        projectId,
+        auth: createMockAuthStore({client, currentUser: null}),
+        plugins: [], // No plugins
+      }),
+    )
+
+    expect(workspace.__internal.options.plugins).toMatchObject([
+      {name: 'sanity/comments'},
+      {name: 'sanity/tasks'},
     ])
   })
 })

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -118,7 +118,10 @@ export function prepareConfig(
 
     const {unstable_sources: nestedSources = [], ...rootSource} = rawWorkspace
     const sources = [rootSource as SourceOptions, ...nestedSources].map(({plugins, ...source}) => {
-      return {...source, plugins: [...(plugins ?? []), ...getDefaultPlugins(defaultPluginsOptions)]}
+      return {
+        ...source,
+        plugins: [...(plugins ?? []), ...getDefaultPlugins(defaultPluginsOptions, plugins)],
+      }
     })
 
     const resolvedSources = sources.map((source): InternalSource => {

--- a/packages/sanity/src/core/config/resolveDefaultPlugins.ts
+++ b/packages/sanity/src/core/config/resolveDefaultPlugins.ts
@@ -4,16 +4,21 @@ import {SCHEDULED_PUBLISHING_NAME, scheduledPublishing} from '../scheduledPublis
 import {tasks, TASKS_NAME} from '../tasks/plugin'
 import {
   type DefaultPluginsWorkspaceOptions,
+  type PluginOptions,
   type SingleWorkspace,
   type WorkspaceOptions,
 } from './types'
 
 const defaultPlugins = [comments(), tasks(), scheduledPublishing()]
 
-export function getDefaultPlugins(options: DefaultPluginsWorkspaceOptions) {
+export function getDefaultPlugins(
+  options: DefaultPluginsWorkspaceOptions,
+  plugins?: PluginOptions[],
+) {
   return defaultPlugins.filter((plugin) => {
     if (plugin.name === SCHEDULED_PUBLISHING_NAME) {
-      return options.scheduledPublishing.enabled
+      // The scheduled publishing plugin is only included if other plugin is included by the user.
+      return options.scheduledPublishing.enabled && !!plugins?.length
     }
     if (plugin.name === TASKS_NAME) {
       return options.tasks.enabled


### PR DESCRIPTION
Before the implementation of scheduled publishing as a default feature, when visiting the studio with no plugins added users were seeing the following screen:

<img width="997" alt="Screenshot 2024-04-30 at 13 05 32" src="https://github.com/sanity-io/sanity/assets/46196328/ac7835ea-3b2d-4df0-9e1e-a454d5f78240">


Once scheduled publishing was implemented, users no longer see that screen and instead are seeing the schedule publishing tool.
This PR fixes that, and only includes into the plugins array the scheduled publishing tool if other plugins have been added to the source.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
