### PR TITLE
fix(portable-text-editor): fix issue with decorating inline objects

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -585,8 +585,10 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
         ]
       }
       const result = rangeDecorationState.filter((item) => {
-        // Only children are supported for now
-        if (path.length !== 2) {
+        // Only text children and inline objects are supported for now
+        // The editor node will have a path like [], a block node [0], a span node [0, 0] and a inline object node [0, 0, 0]
+        // Return false if the path is less than 2, as it's not a text node or inline object text node
+        if (path.length < 2) {
           return false
         }
         if (


### PR DESCRIPTION
### Description

There was a bug where if the range decoration included an inline object, if would get stuck in a render loop causing the browser to freeze up.

The oversight was not accounting for that inline objects have a path length of 3 inside Slate when returning matching nodes to decorate.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
