### PR TITLE
fix: use discard in delete action when document is not published

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/delete.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/delete.ts
@@ -3,15 +3,32 @@ import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
 
 export const del: OperationImpl<[], 'NOTHING_TO_DELETE'> = {
   disabled: ({snapshots}) => (snapshots.draft || snapshots.published ? false : 'NOTHING_TO_DELETE'),
-  execute: ({client: globalClient, schema, idPair, typeName}) => {
+  execute: ({client: globalClient, schema, idPair, typeName, snapshots}) => {
     if (isLiveEditEnabled(schema, typeName)) {
       const tx = globalClient.observable.transaction().delete(idPair.publishedId)
       return tx.commit({tag: 'document.delete'})
     }
 
     const vXClient = globalClient.withConfig({apiVersion: 'X'})
-
     const {dataset} = globalClient.config()
+
+    //the delete action requires a published doc -- discard if not present
+    if (!snapshots.published) {
+      return vXClient.observable.request({
+        url: `/data/actions/${dataset}`,
+        method: 'post',
+        tag: 'document.discard',
+        body: {
+          actions: [
+            {
+              actionType: 'sanity.action.document.discard',
+              draftId: idPair.draftId,
+              publishedId: idPair.publishedId,
+            },
+          ],
+        },
+      })
+    }
 
     return vXClient.observable.request({
       url: `/data/actions/${dataset}`,

--- a/test/e2e/tests/document-actions/delete.spec.ts
+++ b/test/e2e/tests/document-actions/delete.spec.ts
@@ -1,0 +1,29 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+const name = 'Test Name'
+
+test(`unpublished documents can be deleted`, async ({page, createDraftDocument}) => {
+  await createDraftDocument('/test/content/author')
+  await page.getByTestId('field-name').getByTestId('string-input').fill(name)
+
+  await page.getByTestId('action-menu-button').click()
+  await page.getByTestId('action-Delete').click()
+  await page.getByRole('button', {name: 'Delete now'}).click()
+
+  await expect(page.getByText('The document was successfully deleted')).toBeVisible()
+})
+
+test(`published documents can be deleted`, async ({page, createDraftDocument}) => {
+  await createDraftDocument('/test/content/author')
+  await page.getByTestId('field-name').getByTestId('string-input').fill(name)
+
+  await page.getByTestId('action-Publish').click()
+  await expect(page.getByText('was published')).toBeVisible()
+
+  await page.getByTestId('action-menu-button').click()
+  await page.getByTestId('action-Delete').click()
+  await page.getByRole('button', {name: 'Delete now'}).click()
+
+  await expect(page.getByText('The document was successfully deleted')).toBeVisible()
+})


### PR DESCRIPTION
### Description
The `delete` action in server side document actions requires a published document. In those cases when there is not a published document, we can't use this endpoint.

This PR adds logic for those cases by using the discard endpoint instead, and adds a few tests.

### What to review
That the logic makes sense and this is how we want to proceed. We can always work with other teams to ensure we're doing something semantic that won't hinder us later.

### Testing
This PR adds two tests for the delete action.