### PR TITLE
fix(sanity): do not order by `_updatedAt` when relevance ordering is used with Text Search API search strategy

### DIFF
--- a/packages/sanity/src/core/search/text-search/createTextSearch.ts
+++ b/packages/sanity/src/core/search/text-search/createTextSearch.ts
@@ -155,7 +155,7 @@ export const createTextSearch: SearchStrategyFactory<TextSearchResults> = (
         ...searchTerms.params,
       },
       types: getDocumentTypeConfiguration(searchOptions, searchTerms),
-      order: getOrder(searchOptions.sort),
+      ...(searchOptions.sort ? {order: getOrder(searchOptions.sort)} : {}),
       includeAttributes: ['_id', '_type'],
       fromCursor: searchOptions.cursor,
       limit: searchOptions.limit ?? DEFAULT_LIMIT,

--- a/packages/sanity/src/core/studio/components/navbar/search/components/SortMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/SortMenu.tsx
@@ -2,27 +2,18 @@ import {SortIcon} from '@sanity/icons'
 import {Card, Flex, Menu, MenuDivider} from '@sanity/ui'
 import {isEqual} from 'lodash'
 import {useCallback, useId, useMemo} from 'react'
+import {useWorkspace} from 'sanity'
 import {styled} from 'styled-components'
 
 import {Button, MenuButton, MenuItem} from '../../../../../../ui-components'
 import {useTranslation} from '../../../../../i18n'
 import {useSearchState} from '../contexts/search/useSearchState'
-import {ORDERINGS} from '../definitions/orderings'
+import {getOrderings} from '../definitions/getOrderings'
 import {type SearchOrdering} from '../types'
 
 interface SearchDivider {
   type: 'divider'
 }
-
-const MENU_ORDERINGS: (SearchDivider | SearchOrdering)[] = [
-  ORDERINGS.relevance,
-  {type: 'divider'},
-  ORDERINGS.createdAsc,
-  ORDERINGS.createdDesc,
-  {type: 'divider'},
-  ORDERINGS.updatedAsc,
-  ORDERINGS.updatedDesc,
-]
 
 const SortMenuContentFlex = styled(Flex)`
   box-sizing: border-box;
@@ -57,13 +48,27 @@ function CustomMenuItem({ordering}: {ordering: SearchOrdering}) {
 
 export function SortMenu() {
   const {t} = useTranslation()
+  const {enableLegacySearch = false} = useWorkspace().search
   const {
     state: {ordering},
   } = useSearchState()
 
   const menuButtonId = useId()
 
-  const currentMenuItem = MENU_ORDERINGS.find(
+  const menuOrderings: (SearchDivider | SearchOrdering)[] = useMemo(() => {
+    const orderings = getOrderings({enableLegacySearch})
+    return [
+      orderings.relevance,
+      {type: 'divider'},
+      orderings.createdAsc,
+      orderings.createdDesc,
+      {type: 'divider'},
+      orderings.updatedAsc,
+      orderings.updatedDesc,
+    ]
+  }, [enableLegacySearch])
+
+  const currentMenuItem = menuOrderings.find(
     (item): item is SearchOrdering => isEqual(ordering, item) && !isSearchDivider(item),
   )
 
@@ -79,7 +84,7 @@ export function SortMenu() {
           id={menuButtonId || ''}
           menu={
             <Menu>
-              {MENU_ORDERINGS.map((item, index) => {
+              {menuOrderings.map((item, index) => {
                 if (isSearchDivider(item)) {
                   // eslint-disable-next-line react/no-array-index-key
                   return <MenuDivider key={index} />

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
@@ -34,7 +34,7 @@ export function SearchProvider({children, fullscreen}: SearchProviderProps) {
   const schema = useSchema()
   const currentUser = useCurrentUser()
   const {
-    search: {operators, filters},
+    search: {operators, filters, enableLegacySearch},
   } = useSource()
 
   // Create field, filter and operator dictionaries
@@ -60,8 +60,16 @@ export function SearchProvider({children, fullscreen}: SearchProviderProps) {
           cursor: null,
           nextCursor: null,
         },
+        enableLegacySearch,
       }),
-    [currentUser, fieldDefinitions, filterDefinitions, fullscreen, operatorDefinitions],
+    [
+      currentUser,
+      fieldDefinitions,
+      filterDefinitions,
+      fullscreen,
+      operatorDefinitions,
+      enableLegacySearch,
+    ],
   )
   const [state, dispatch] = useReducer(searchReducer, initialState)
 
@@ -130,7 +138,7 @@ export function SearchProvider({children, fullscreen}: SearchProviderProps) {
           ],
           limit: SEARCH_LIMIT,
           skipSortByScore: ordering.ignoreScore,
-          sort: [ordering.sort],
+          ...(ordering.sort ? {sort: [ordering.sort]} : {}),
           cursor: cursor || undefined,
         },
         terms: {

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
@@ -120,9 +120,13 @@ export function SearchProvider({children, fullscreen}: SearchProviderProps) {
     const termsChanged = !isEqual(terms, previousTermsRef.current)
 
     if (orderingChanged || cursorChanged || termsChanged) {
-      // Use a custom label if provided, otherwise return field and direction, e.g. `_updatedAt desc`
-      const sortLabel =
-        ordering?.customMeasurementLabel || `${ordering.sort.field} ${ordering.sort.direction}`
+      let sortLabel = 'findability-sort:'
+
+      if (ordering?.customMeasurementLabel || ordering.sort) {
+        // Use a custom label if provided, otherwise return field and direction, e.g. `_updatedAt desc`
+        sortLabel +=
+          ordering?.customMeasurementLabel || `${ordering.sort?.field} ${ordering.sort?.direction}`
+      }
 
       handleSearch({
         options: {
@@ -132,7 +136,7 @@ export function SearchProvider({children, fullscreen}: SearchProviderProps) {
               ? [`findability-recent-search:${terms.__recent.index}`]
               : []),
             `findability-selected-types:${terms.types.length}`,
-            `findability-sort:${sortLabel}`,
+            sortLabel,
             `findability-source: global`,
             `findability-filter-count:${completeFilters.length}`,
           ],

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.ts
@@ -5,12 +5,12 @@ import {getPublishedId} from '../../../../../../util'
 import {type RecentSearch} from '../../datastores/recentSearches'
 import {type SearchFieldDefinitionDictionary} from '../../definitions/fields'
 import {type SearchFilterDefinitionDictionary} from '../../definitions/filters'
+import {getOrderings} from '../../definitions/getOrderings'
 import {
   getOperatorDefinition,
   getOperatorInitialValue,
   type SearchOperatorDefinitionDictionary,
 } from '../../definitions/operators'
-import {ORDERINGS} from '../../definitions/orderings'
 import {type SearchFilter, type SearchOrdering} from '../../types'
 import {debugWithName, isDebugMode} from '../../utils/debug'
 import {
@@ -40,6 +40,7 @@ export type SearchReducerState = PaginationState & {
   ordering: SearchOrdering
   result: SearchResult
   terms: RecentSearch | SearchTerms
+  enableLegacySearch?: boolean
 }
 
 export interface SearchDefinitions {
@@ -61,6 +62,7 @@ export interface InitialSearchState {
   fullscreen?: boolean
   definitions: SearchDefinitions
   pagination: PaginationState
+  enableLegacySearch?: boolean
 }
 
 export function initialSearchState({
@@ -68,6 +70,7 @@ export function initialSearchState({
   fullscreen,
   definitions,
   pagination,
+  enableLegacySearch,
 }: InitialSearchState): SearchReducerState {
   return {
     currentUser,
@@ -77,7 +80,7 @@ export function initialSearchState({
     filtersVisible: true,
     fullscreen,
     lastActiveIndex: -1,
-    ordering: ORDERINGS.relevance,
+    ordering: getOrderings({enableLegacySearch}).relevance,
     ...pagination,
     result: {
       error: null,
@@ -91,6 +94,7 @@ export function initialSearchState({
       types: [],
     },
     definitions,
+    enableLegacySearch,
   }
 }
 
@@ -173,7 +177,7 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
     case 'ORDERING_RESET':
       return {
         ...state,
-        ordering: ORDERINGS.relevance,
+        ordering: getOrderings({enableLegacySearch: state.enableLegacySearch}).relevance,
         terms: stripRecent(state.terms),
         result: {
           ...state.result,

--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/getOrderings.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/getOrderings.ts
@@ -1,6 +1,8 @@
 import {type SearchOrdering} from '../types'
 
-export const ORDERINGS: Record<string, SearchOrdering> = {
+export const getOrderings: (context: {
+  enableLegacySearch?: boolean
+}) => Record<string, SearchOrdering> = ({enableLegacySearch}) => ({
   createdAsc: {
     ignoreScore: true,
     sort: {direction: 'asc', field: '_createdAt'},
@@ -13,7 +15,7 @@ export const ORDERINGS: Record<string, SearchOrdering> = {
   },
   relevance: {
     customMeasurementLabel: 'relevance',
-    sort: {direction: 'desc', field: '_updatedAt'},
+    ...(enableLegacySearch ? {sort: {direction: 'desc', field: '_updatedAt'}} : {}),
     titleKey: 'search.ordering.best-match-label',
   },
   updatedAsc: {
@@ -26,4 +28,4 @@ export const ORDERINGS: Record<string, SearchOrdering> = {
     sort: {direction: 'desc', field: '_updatedAt'},
     titleKey: 'search.ordering.updated-descending-label',
   },
-}
+})

--- a/packages/sanity/src/core/studio/components/navbar/search/types.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/types.ts
@@ -72,7 +72,7 @@ export type SearchFilterValues = {
 export interface SearchOrdering {
   customMeasurementLabel?: string
   ignoreScore?: boolean
-  sort: SearchSort
+  sort?: SearchSort
   /**
    * i18n key for title
    */


### PR DESCRIPTION
### Description

**This branch relates only to global search.**

Ordering by relevance ("best match") when using the GROQ Query API search strategy causes the order `{direction: 'desc', field: '_updatedAt'}` to be applied. This is correct, because the results are subsequently ordered client-side.

**However, this is incorrect when using the Text Search API search strategy.** The Text Search API yields results ordered by relevance by default, and we do not apply any client-side ordering.

This branch eliminates the incorrectly applied `{direction: 'desc', field: '_updatedAt'}` ordering when the Text Search API search strategy is used.

### What to review

- `order(_updatedAt desc)` is still present in the GROQ Query API request when ordering by relevance using the GROQ Query API search strategy.
- `{order: [{"attribute": "_updatedAt", "direction": "desc"}]` is not present in the Text Search API request when ordering by relevance using the Text Search API search strategy.

### Testing

Added unit tests to `packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.test.ts`.