### PR TITLE
feat: add cliInitializedAt field to project metadata

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -610,6 +610,17 @@ export default async function initSanity(
     print(`sanity help - to explore the CLI manual`)
   }
 
+  try {
+    await apiClient({api: {projectId}}).request({
+      method: 'PATCH',
+      uri: `/projects/${projectId}`,
+      body: {metadata: {cliInitializedAt: new Date().toISOString()}},
+    })
+  } catch (err: unknown) {
+    // Non-critical update
+    debug('Failed to update cliInitializedAt metadata')
+  }
+
   const sendInvite =
     isFirstProject &&
     (await prompt.single({


### PR DESCRIPTION
### Description

Updates project metadata to indicate the project has been initialized locally

### What to review

Backend errors should not interrupt project init flow under any circumstances
