### PR TITLE
fix(typegen): pass resolved path instead of the imported path

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -95,4 +95,15 @@ describe('findQueries', () => {
     expect(queries.length).toBe(1)
     expect(queries[0].result).toBe('*[_type == "foo"]')
   })
+
+  test('can import sequence of files', () => {
+    const source = `
+      import { groq } from "groq";
+      import {query}  from "../__tests__/fixtures/importSeq1";
+      const someQuery = groq\`$\{query}\`
+    `
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(1)
+    expect(queries[0].result).toBe('*[_type == "foo bar"]')
+  })
 })

--- a/packages/@sanity/codegen/src/typescript/__tests__/fixtures/importSeq1.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/fixtures/importSeq1.ts
@@ -1,0 +1,5 @@
+import groq from 'groq'
+
+import {fragment1} from './importSeq2'
+
+export const query = groq`*[_type == "${fragment1}"]`

--- a/packages/@sanity/codegen/src/typescript/__tests__/fixtures/importSeq2.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/fixtures/importSeq2.ts
@@ -1,0 +1,3 @@
+import {fragment2} from './importSeq3'
+
+export const fragment1 = `foo ${fragment2}`

--- a/packages/@sanity/codegen/src/typescript/__tests__/fixtures/importSeq3.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/fixtures/importSeq3.ts
@@ -1,0 +1,1 @@
+export const fragment2 = 'bar'

--- a/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
+++ b/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
@@ -352,7 +352,7 @@ function resolveImportSpecifier({
       file: tree,
       scope: newScope,
       babelConfig,
-      filename: importFileName,
+      filename: resolvedFile,
       resolver,
     })
   }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
We were passing the relative imported file path instead of the resolved file path, this prevents imported modules from importing other relative files

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Added 👍 

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

typegen: Fixed bug where importing a variable inside an imported file would fail