### PR TITLE
fix(schedule-publishing): update flag used to check scheduledPublishing

### DIFF
--- a/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.test.tsx
@@ -90,4 +90,17 @@ describe('ScheduledPublishingEnabledProvider', () => {
 
     expect(value.result.current).toEqual({enabled: false, mode: null})
   })
+
+  it('should call "useFeatureEnabled" with "scheduledPublishing"', () => {
+    require('../../../studio').useWorkspace.mockReturnValue({scheduledPublishing: {enabled: false}})
+
+    const useFeatureEnabled = require('../../../hooks').useFeatureEnabled
+    useFeatureEnabled.mockReturnValue({enabled: false, isLoading: false})
+
+    renderHook(useScheduledPublishingEnabled, {
+      wrapper: ScheduledPublishingEnabledProvider,
+    })
+
+    expect(useFeatureEnabled).toHaveBeenCalledWith('scheduledPublishing')
+  })
 })

--- a/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx
@@ -26,7 +26,7 @@ interface TaksEnabledProviderProps {
  */
 
 export function ScheduledPublishingEnabledProvider({children}: TaksEnabledProviderProps) {
-  const {enabled, isLoading} = useFeatureEnabled('sanityTasks')
+  const {enabled, isLoading} = useFeatureEnabled('scheduledPublishing')
   const {scheduledPublishing} = useWorkspace()
 
   const isWorkspaceEnabled = scheduledPublishing.enabled

--- a/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.test.tsx
@@ -78,4 +78,14 @@ describe('TasksEnabledProvider', () => {
 
     expect(value.result.current).toEqual({enabled: false, mode: null})
   })
+
+  it('should call "useFeatureEnabled" with "sanityTasks"', () => {
+    require('../../../studio').useWorkspace.mockReturnValue({tasks: {enabled: false}})
+
+    const useFeatureEnabled = require('../../../hooks').useFeatureEnabled
+    useFeatureEnabled.mockReturnValue({enabled: false, isLoading: false})
+    renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
+
+    expect(useFeatureEnabled).toHaveBeenCalledWith('sanityTasks')
+  })
 })


### PR DESCRIPTION
### Description
The flag used to check the availability of scheduled publishing is incorrect, it should check `scheduledPublishing`, not `sanityTasks`

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in which users were incorrectly seeing the schedule publishing upsell ui.

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
