### PR TITLE
chore(test-studio): bump vercel stega version

### DIFF
--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -49,7 +49,7 @@
     "@turf/helpers": "^6.0.1",
     "@turf/points-within-polygon": "^5.1.5",
     "@types/three": "^0.150.0",
-    "@vercel/stega": "0.1.0",
+    "@vercel/stega": "0.1.1",
     "chokidar": "^3.5.3",
     "globby": "^10.0.0",
     "history": "^5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,8 +482,8 @@ importers:
         specifier: ^0.150.0
         version: 0.150.2
       '@vercel/stega':
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: 0.1.1
+        version: 0.1.1
       chokidar:
         specifier: ^3.5.3
         version: 3.6.0
@@ -7519,7 +7519,7 @@ packages:
     resolution: {integrity: sha512-gKmTNwZnblUdnTIJu3e9kmeRRzV2j1a/LUO27KNNAnIC5zjy1aSvXSRp4rVNlmAoHlQ7HzX42NbKpcSr4jF80A==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^7.5.0
+      '@typescript-eslint/parser': ^7.0.0
       eslint: ^8.56.0
       typescript: '*'
     peerDependenciesMeta:
@@ -7749,7 +7749,6 @@ packages:
 
   /@vercel/stega@0.1.1:
     resolution: {integrity: sha512-YdlhbgFdUAKYPlLaAhCUL10U/DdeNwp2fSJR0Wdi2c0DYdYQZbamdxizr4Lj9mxv2+/FxMWaMK7eW6BskKEZLw==}
-    dev: true
 
   /@vitejs/plugin-react@4.2.1(vite@4.5.3):
     resolution: {integrity: sha512-oojO9IDc4nCUUi8qIR11KoQm0XFFLIwsRBwHRR4d/88IWghn1y6ckz/bJ8GHDCsYEJee8mDzqtJxh15/cisJNQ==}
@@ -10433,8 +10432,8 @@ packages:
     resolution: {integrity: sha512-7Na1kh3OiteeFmeQkUqtIjThsKWIIiK/TLNUby0pOkGHhWV3AKYFsMEIhH7VuOIEOeTE53Ix/04Z6XWyvsHcuQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^7.5.0
-      '@typescript-eslint/parser': ^7.5.0
+      '@typescript-eslint/eslint-plugin': ^6.7.5 || ^7.0.0
+      '@typescript-eslint/parser': ^6.7.5 || ^7.0.0
       eslint: ^8.51.0
       eslint-plugin-import: ^2.28.1
       eslint-plugin-react: ^7.33.2
@@ -10743,7 +10742,7 @@ packages:
     resolution: {integrity: sha512-9l1YFCzXKkw1qtAru1RWUtG2EVDZY0a0eChKXcL+EZ5jitG7qxdctu4RnvhOJHv4xfmUf7h+JJPINlVpGhZMrw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^7.5.0
+      '@typescript-eslint/eslint-plugin': 6 - 7
       eslint: '8'
     peerDependenciesMeta:
       '@typescript-eslint/eslint-plugin':


### PR DESCRIPTION
### Description
Test studio is crashing due to having  different @vercel/stega version , required due to this change https://github.com/sanity-io/sanity/pull/6544
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
