### PR TITLE
fix(pte): insert empty text block after removing void block 

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/components/SlateContainer.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/components/SlateContainer.tsx
@@ -64,7 +64,7 @@ export function SlateContainer(props: SlateContainerProps) {
   }, [keyGenerator, portableTextEditor, maxBlocks, readOnly, patches$, slateEditor])
 
   const initialValue = useMemo(() => {
-    return [slateEditor.createPlaceholderBlock()]
+    return [slateEditor.pteCreateEmptyBlock()]
   }, [slateEditor])
 
   useEffect(() => {

--- a/packages/@sanity/portable-text-editor/src/editor/hooks/useSyncValue.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/hooks/useSyncValue.ts
@@ -106,7 +106,7 @@ export function useSyncValue(
                   at: [childrenLength - 1 - index],
                 })
               })
-              Transforms.insertNodes(slateEditor, slateEditor.createPlaceholderBlock(), {at: [0]})
+              Transforms.insertNodes(slateEditor, slateEditor.pteCreateEmptyBlock(), {at: [0]})
               // Add a new selection in the top of the document
               if (hadSelection) {
                 Transforms.select(slateEditor, [0, 0])

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withPlaceholderBlock.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withPlaceholderBlock.test.tsx
@@ -1,0 +1,133 @@
+import {describe, expect, it, jest} from '@jest/globals'
+/* eslint-disable max-nested-callbacks */
+import {render, waitFor} from '@testing-library/react'
+import {createRef, type RefObject} from 'react'
+
+import {PortableTextEditorTester, schemaType} from '../../__tests__/PortableTextEditorTester'
+import {PortableTextEditor} from '../../PortableTextEditor'
+
+describe('plugin:withPlaceholderBlock', () => {
+  describe('removing nodes', () => {
+    it("should insert an empty text block if it's removing the only block", async () => {
+      const editorRef: RefObject<PortableTextEditor> = createRef()
+      const initialValue = [
+        {
+          _key: '5fc57af23597',
+          _type: 'someObject',
+        },
+      ]
+      const onChange = jest.fn()
+      await waitFor(() => {
+        render(
+          <PortableTextEditorTester
+            onChange={onChange}
+            ref={editorRef}
+            schemaType={schemaType}
+            value={initialValue}
+          />,
+        )
+      })
+
+      await waitFor(() => {
+        if (editorRef.current) {
+          PortableTextEditor.focus(editorRef.current)
+
+          PortableTextEditor.delete(
+            editorRef.current,
+            {
+              focus: {path: [{_key: '5fc57af23597'}], offset: 0},
+              anchor: {path: [{_key: '5fc57af23597'}], offset: 0},
+            },
+            {mode: 'blocks'},
+          )
+
+          const value = PortableTextEditor.getValue(editorRef.current)
+
+          expect(value).toEqual([
+            {
+              _type: 'myTestBlockType',
+              _key: '3',
+              style: 'normal',
+              markDefs: [],
+              children: [
+                {
+                  _type: 'span',
+                  _key: '2',
+                  text: '',
+                  marks: [],
+                },
+              ],
+            },
+          ])
+        }
+      })
+    })
+    it('should not insert a new block if we have more blocks available', async () => {
+      const editorRef: RefObject<PortableTextEditor> = createRef()
+      const initialValue = [
+        {
+          _key: '5fc57af23597',
+          _type: 'someObject',
+        },
+        {
+          _type: 'myTestBlockType',
+          _key: 'existingBlock',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {
+              _type: 'span',
+              _key: '2',
+              text: '',
+              marks: [],
+            },
+          ],
+        },
+      ]
+      const onChange = jest.fn()
+      await waitFor(() => {
+        render(
+          <PortableTextEditorTester
+            onChange={onChange}
+            ref={editorRef}
+            schemaType={schemaType}
+            value={initialValue}
+          />,
+        )
+      })
+
+      await waitFor(() => {
+        if (editorRef.current) {
+          PortableTextEditor.focus(editorRef.current)
+
+          PortableTextEditor.delete(
+            editorRef.current,
+            {
+              focus: {path: [{_key: '5fc57af23597'}], offset: 0},
+              anchor: {path: [{_key: '5fc57af23597'}], offset: 0},
+            },
+            {mode: 'blocks'},
+          )
+
+          const value = PortableTextEditor.getValue(editorRef.current)
+          expect(value).toEqual([
+            {
+              _type: 'myTestBlockType',
+              _key: 'existingBlock',
+              style: 'normal',
+              markDefs: [],
+              children: [
+                {
+                  _type: 'span',
+                  _key: '2',
+                  text: '',
+                  marks: [],
+                },
+              ],
+            },
+          ])
+        }
+      })
+    })
+  })
+})

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withPortableTextMarkModel.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withPortableTextMarkModel.test.tsx
@@ -1145,4 +1145,128 @@ describe('plugin:withPortableTextMarksModel', () => {
       })
     })
   })
+
+  describe('removing nodes', () => {
+    it("should insert an empty text block if it's removing the only block", async () => {
+      const editorRef: RefObject<PortableTextEditor> = createRef()
+      const initialValue = [
+        {
+          _key: '5fc57af23597',
+          _type: 'someObject',
+        },
+      ]
+      const onChange = jest.fn()
+      await waitFor(() => {
+        render(
+          <PortableTextEditorTester
+            onChange={onChange}
+            ref={editorRef}
+            schemaType={schemaType}
+            value={initialValue}
+          />,
+        )
+      })
+
+      await waitFor(() => {
+        if (editorRef.current) {
+          PortableTextEditor.focus(editorRef.current)
+
+          PortableTextEditor.delete(
+            editorRef.current,
+            {
+              focus: {path: [{_key: '5fc57af23597'}], offset: 0},
+              anchor: {path: [{_key: '5fc57af23597'}], offset: 0},
+            },
+            {mode: 'blocks'},
+          )
+
+          const value = PortableTextEditor.getValue(editorRef.current)
+
+          expect(value).toEqual([
+            {
+              _type: 'myTestBlockType',
+              _key: '3',
+              style: 'normal',
+              markDefs: [],
+              children: [
+                {
+                  _type: 'span',
+                  _key: '2',
+                  text: '',
+                  marks: [],
+                },
+              ],
+            },
+          ])
+        }
+      })
+    })
+    it('should not insert a new block if we have more blocks available', async () => {
+      const editorRef: RefObject<PortableTextEditor> = createRef()
+      const initialValue = [
+        {
+          _key: '5fc57af23597',
+          _type: 'someObject',
+        },
+        {
+          _type: 'myTestBlockType',
+          _key: 'existingBlock',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {
+              _type: 'span',
+              _key: '2',
+              text: '',
+              marks: [],
+            },
+          ],
+        },
+      ]
+      const onChange = jest.fn()
+      await waitFor(() => {
+        render(
+          <PortableTextEditorTester
+            onChange={onChange}
+            ref={editorRef}
+            schemaType={schemaType}
+            value={initialValue}
+          />,
+        )
+      })
+
+      await waitFor(() => {
+        if (editorRef.current) {
+          PortableTextEditor.focus(editorRef.current)
+
+          PortableTextEditor.delete(
+            editorRef.current,
+            {
+              focus: {path: [{_key: '5fc57af23597'}], offset: 0},
+              anchor: {path: [{_key: '5fc57af23597'}], offset: 0},
+            },
+            {mode: 'blocks'},
+          )
+
+          const value = PortableTextEditor.getValue(editorRef.current)
+          expect(value).toEqual([
+            {
+              _type: 'myTestBlockType',
+              _key: 'existingBlock',
+              style: 'normal',
+              markDefs: [],
+              children: [
+                {
+                  _type: 'span',
+                  _key: '2',
+                  text: '',
+                  marks: [],
+                },
+              ],
+            },
+          ])
+        }
+      })
+    })
+  })
 })

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
@@ -426,7 +426,7 @@ export function createWithEditableAPI(
             // that would insert the placeholder into the actual value
             // which should remain empty)
             if (editor.children.length === 0) {
-              editor.children = [editor.createPlaceholderBlock()]
+              editor.children = [editor.pteCreateEmptyBlock()]
             }
             editor.onChange()
           }

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPortableTextMarkModel.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPortableTextMarkModel.ts
@@ -23,6 +23,7 @@ import {
   type PortableTextMemberSchemaTypes,
   type PortableTextSlateEditor,
 } from '../../types/editor'
+import {type SlateTextBlock, type VoidElement} from '../../types/slate'
 import {debugWithName} from '../../utils/debug'
 import {toPortableTextRange} from '../../utils/ranges'
 
@@ -234,6 +235,17 @@ export function createWithPortableTextMarkModel(
             )
             debug('Inserting text at end of annotation')
             return
+          }
+        }
+      }
+      if (op.type === 'remove_node') {
+        const node = op.node as SlateTextBlock | VoidElement
+        if (op.path[0] === 0 && Editor.isVoid(editor, node)) {
+          // Check next path, if it exists, do nothing
+          const nextPath = Path.next(op.path)
+          // Is removing the first block which is a void (not a text block), add a new empty text block in it, if there is no other element in the next path
+          if (!editor.children[nextPath[0]]) {
+            Editor.insertNode(editor, editor.pteCreateEmptyBlock())
           }
         }
       }

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPortableTextMarkModel.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPortableTextMarkModel.ts
@@ -23,7 +23,6 @@ import {
   type PortableTextMemberSchemaTypes,
   type PortableTextSlateEditor,
 } from '../../types/editor'
-import {type SlateTextBlock, type VoidElement} from '../../types/slate'
 import {debugWithName} from '../../utils/debug'
 import {toPortableTextRange} from '../../utils/ranges'
 
@@ -235,17 +234,6 @@ export function createWithPortableTextMarkModel(
             )
             debug('Inserting text at end of annotation')
             return
-          }
-        }
-      }
-      if (op.type === 'remove_node') {
-        const node = op.node as SlateTextBlock | VoidElement
-        if (op.path[0] === 0 && Editor.isVoid(editor, node)) {
-          // Check next path, if it exists, do nothing
-          const nextPath = Path.next(op.path)
-          // Is removing the first block which is a void (not a text block), add a new empty text block in it, if there is no other element in the next path
-          if (!editor.children[nextPath[0]]) {
-            Editor.insertNode(editor, editor.pteCreateEmptyBlock())
           }
         }
       }

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithUtils.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithUtils.ts
@@ -60,7 +60,7 @@ export function createWithUtils({schemaTypes, keyGenerator, portableTextEditor}:
           {
             _type: schemaTypes.block.name,
             _key: keyGenerator(),
-            style: 'normal',
+            style: schemaTypes.styles[0].value || 'normal',
             markDefs: [],
             children: [
               {

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/index.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/index.ts
@@ -81,10 +81,7 @@ export const withPlugins = <T extends Editor>(
   const withPortableTextMarkModel = createWithPortableTextMarkModel(schemaTypes, change$)
   const withPortableTextBlockStyle = createWithPortableTextBlockStyle(schemaTypes)
 
-  const withPlaceholderBlock = createWithPlaceholderBlock({
-    keyGenerator,
-    schemaTypes,
-  })
+  const withPlaceholderBlock = createWithPlaceholderBlock()
 
   const withInsertBreak = createWithInsertBreak()
 

--- a/packages/@sanity/portable-text-editor/src/utils/applyPatch.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/applyPatch.ts
@@ -297,7 +297,7 @@ function unsetPatch(editor: PortableTextSlateEditor, patch: UnsetPatch, previous
     editor.children.forEach((c, i) => {
       Transforms.removeNodes(editor, {at: [i]})
     })
-    Transforms.insertNodes(editor, editor.createPlaceholderBlock())
+    Transforms.insertNodes(editor, editor.pteCreateEmptyBlock())
     if (previousSelection) {
       Transforms.select(editor, {
         anchor: {path: [0, 0], offset: 0},


### PR DESCRIPTION
### Description

#### Issue
After clearing a PTE field with blocks, there is a very short period where attempting to input text after manually re-focusing will yield errors `(Cannot get the start point in the node at path [] because it has no start text node)` as well as rendering text incorrectly.

<img width="479" alt="Screenshot 2024-05-02 at 18 22 16" src="https://github.com/sanity-io/sanity/assets/46196328/35554bb6-23a0-4594-8b55-4366958014dc">

This is caused because the editor gets an "empty" state, which is later restored to the placeholder state with an empty text block.

#### Fix

Instead of waiting on the editor to restore itself after getting the empty state, avoid going to that state by inmediately adding an empty text block when removing the non text block if it's necessary.
It is necessary when this block is the only available. 
If we have another void or text block the editor won't be empty.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is this change correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manual testing of the changes.
Unit tests covering the case.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
