### PR TITLE
fix(e2e): support headless/headful env var toggle

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,7 @@ import {readBoolEnv, readEnv} from './test/e2e/helpers/envVars'
 loadEnvFiles()
 
 const CI = readBoolEnv('CI', false)
+const HEADLESS = readBoolEnv('HEADLESS', true)
 
 /**
  * Excludes the GitHub reporter until https://github.com/microsoft/playwright/issues/19817 is resolved, since it creates a lot of noise in our PRs.
@@ -22,13 +23,14 @@ function excludeGithub(reporters: PlaywrightTestConfig['reporter']) {
 const playwrightConfig = createPlaywrightConfig({
   projectId: readEnv('SANITY_E2E_PROJECT_ID'),
   token: readEnv('SANITY_E2E_SESSION_TOKEN'),
-  playwrightOptions(config) {
+  playwrightOptions(config): PlaywrightTestConfig {
     return {
       ...config,
       reporter: excludeGithub(config.reporter),
       use: {
         ...config.use,
         baseURL: 'http://localhost:3339',
+        headless: HEADLESS,
       },
       webServer: {
         ...config.webServer,

--- a/test/e2e/helpers/envVars.ts
+++ b/test/e2e/helpers/envVars.ts
@@ -3,6 +3,7 @@ type KnownEnvVar =
   | 'SANITY_E2E_PROJECT_ID'
   | 'SANITY_E2E_DATASET'
   | 'CI'
+  | 'HEADLESS'
 
 /**
  * Read an environment variable, parsing the response as a boolean, using loose


### PR DESCRIPTION
### Description
adds ability to run e2e tests headful by specifying `HEADLESS=false pnpm run test:e2e`. This is useful for debugging and provides insight into what the e2e tests actually do and can tell you what parts of the studio are actually covered, etc.

### What to review
- Is this supported by other means/existing env vars already? :)
- Is it sensible to use an env var for this?

### Testing
This is for the test runner

### Notes for release
n/a internal