### PR TITLE
POC(typegen): Add ability to format schematype names

### DIFF
--- a/packages/@sanity/cli/src/actions/typegen/generateAction.ts
+++ b/packages/@sanity/cli/src/actions/typegen/generateAction.ts
@@ -76,6 +76,7 @@ export default async function typegenGenerateAction(
       schemaPath: codegenConfig.schema,
       searchPath: codegenConfig.path,
       prettierConfig,
+      format: codegenConfig.format,
     } satisfies TypegenGenerateTypesWorkerData,
     // eslint-disable-next-line no-process-env
     env: process.env,

--- a/packages/@sanity/cli/src/workers/typegenGenerate.ts
+++ b/packages/@sanity/cli/src/workers/typegenGenerate.ts
@@ -21,6 +21,16 @@ export interface TypegenGenerateTypesWorkerData {
   schemaPath: string
   searchPath: string | string[]
   prettierConfig: PrettierOptions | null
+  format?: {
+    schemaTypes: {
+      literal: string
+      nameCase: 'camel' | 'pascal' | 'snake'
+    }
+    queries: {
+      literal: string
+      nameCase: 'camel' | 'pascal' | 'snake'
+    }
+  }
 }
 
 export type TypegenGenerateTypesWorkerMessage =
@@ -80,7 +90,7 @@ function maybeFormatCode(code: string, prettierConfig: PrettierOptions | null): 
 async function main() {
   const schema = await readSchema(opts.schemaPath)
 
-  const typeGenerator = new TypeGenerator(schema)
+  const typeGenerator = new TypeGenerator(schema, {format: opts.format?.schemaTypes})
   const schemaTypes = await maybeFormatCode(
     [typeGenerator.generateSchemaTypes(), TypeGenerator.generateKnownTypes()].join('\n'),
     opts.prettierConfig,

--- a/packages/@sanity/codegen/src/readConfig.ts
+++ b/packages/@sanity/codegen/src/readConfig.ts
@@ -42,7 +42,7 @@ export const configDefintion = z.object({
           literal: z.string().default(defaultFormat.queries.literal),
           nameCase: caseString.default(defaultFormat.queries.nameCase),
         })
-        .default(defaultFormat.schemaTypes),
+        .default(defaultFormat.queries),
     })
     .default(defaultFormat),
 })

--- a/packages/@sanity/codegen/src/readConfig.ts
+++ b/packages/@sanity/codegen/src/readConfig.ts
@@ -3,6 +3,21 @@ import {readFile} from 'node:fs/promises'
 import * as json5 from 'json5'
 import * as z from 'zod'
 
+export type Case = 'camel' | 'pascal' | 'snake'
+
+const defaultFormat = {
+  schemaTypes: {
+    literal: '{name}',
+    nameCase: 'pascal',
+  },
+  queries: {
+    literal: '{name}Result',
+    nameCase: 'pascal',
+  },
+} as const
+
+const caseString = z.union([z.literal('camel'), z.literal('pascal'), z.literal('snake')])
+
 export const configDefintion = z.object({
   path: z
     .string()
@@ -14,7 +29,22 @@ export const configDefintion = z.object({
     ]),
   schema: z.string().default('./schema.json'),
   generates: z.string().default('./sanity.types.ts'),
-  schemaTypeFormat: z.string().includes('{name}').default('{name}'),
+  format: z
+    .object({
+      schemaTypes: z
+        .object({
+          literal: z.string().default(defaultFormat.schemaTypes.literal),
+          nameCase: caseString.default(defaultFormat.schemaTypes.nameCase),
+        })
+        .default(defaultFormat.schemaTypes),
+      queries: z
+        .object({
+          literal: z.string().default(defaultFormat.queries.literal),
+          nameCase: caseString.default(defaultFormat.queries.nameCase),
+        })
+        .default(defaultFormat.schemaTypes),
+    })
+    .default(defaultFormat),
 })
 
 export type CodegenConfig = z.infer<typeof configDefintion>

--- a/packages/@sanity/codegen/src/readConfig.ts
+++ b/packages/@sanity/codegen/src/readConfig.ts
@@ -14,6 +14,7 @@ export const configDefintion = z.object({
     ]),
   schema: z.string().default('./schema.json'),
   generates: z.string().default('./sanity.types.ts'),
+  schemaTypeFormat: z.string().includes('{name}').default('{name}'),
 })
 
 export type CodegenConfig = z.infer<typeof configDefintion>


### PR DESCRIPTION
### Description

Extra config property for customizing type names on schema types.

Feedback on this feature would be appriciated

Example:
```typescript
//sanity-typegen.json

{
  "path": "'./**/*.{ts,tsx,js,jsx}'",
  "schema": "schema.json",
  "generates": "sanity.types.ts",
  "format": {
    "schemaTypes": {
      "literal": "i{name}Schema",
      "nameCase": "pascal"
    },
    "queries": {
      "literal": "i{name}query",
      "nameCase": "pascal"
    }
  }
}
```

```typescript
// schema.ts

defineType({
  name: "documentName",
  type: "document"
})
```

```typescript
// Old result

export type DocumentName = {...}
```

```typescript
// New result

export type iDocumentNameSchema = {...}
```

### What to review

The way the formatting is done, I don't know if it is the best way to do it.
@sanity/cli @sanity/codegen is affected

### Testing

No, this is only a proof of concept

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
