### PR TITLE
feat(pte): create new text blocks if needed

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -19,6 +19,7 @@ import {
 import {
   type BaseRange,
   Editor,
+  Node,
   type NodeEntry,
   type Operation,
   Path,
@@ -50,6 +51,7 @@ import {
   type ScrollSelectionIntoViewFunction,
 } from '../types/editor'
 import {type HotkeyOptions} from '../types/options'
+import {type SlateTextBlock, type VoidElement} from '../types/slate'
 import {debugWithName} from '../utils/debug'
 import {moveRangeByOperation, toPortableTextRange, toSlateRange} from '../utils/ranges'
 import {normalizeSelection} from '../utils/selection'
@@ -118,6 +120,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     onBeforeInput,
     onPaste,
     onCopy,
+    onClick,
     rangeDecorations,
     renderAnnotation,
     renderBlock,
@@ -444,6 +447,30 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     [onFocus, portableTextEditor, change$, slateEditor],
   )
 
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+      if (onClick) {
+        onClick(event)
+      }
+      // Inserts a new block if it's clicking on the editor, focused on the last block and it's a void element
+      if (slateEditor.selection && event.target === event.currentTarget) {
+        const [lastBlock, path] = Node.last(slateEditor, [])
+        const focusPath = slateEditor.selection.focus.path.slice(0, 1)
+        const lastPath = path.slice(0, 1)
+        if (Path.equals(focusPath, lastPath)) {
+          const node = Node.descendant(slateEditor, path.slice(0, 1)) as
+            | SlateTextBlock
+            | VoidElement
+          if (lastBlock && Editor.isVoid(slateEditor, node)) {
+            Transforms.insertNodes(slateEditor, slateEditor.pteCreateEmptyBlock())
+            slateEditor.onChange()
+          }
+        }
+      }
+    },
+    [onClick, slateEditor],
+  )
+
   const handleOnBlur: FocusEventHandler<HTMLDivElement> = useCallback(
     (event) => {
       if (onBlur) {
@@ -626,6 +653,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
       decorate={decorate}
       onBlur={handleOnBlur}
       onCopy={handleCopy}
+      onClick={handleClick}
       onDOMBeforeInput={handleOnBeforeInput}
       onFocus={handleOnFocus}
       onKeyDown={handleKeyDown}

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/handleClick.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/handleClick.test.tsx
@@ -1,0 +1,218 @@
+import {describe, expect, it, jest} from '@jest/globals'
+import {fireEvent, render, waitFor} from '@testing-library/react'
+import {createRef, type RefObject} from 'react'
+
+import {PortableTextEditor} from '../PortableTextEditor'
+import {PortableTextEditorTester, schemaType} from './PortableTextEditorTester'
+import {getEditableElement} from './utils'
+
+describe('adds empty text block if its needed', () => {
+  const newBlock = {
+    _type: 'myTestBlockType',
+    _key: '3',
+    style: 'normal',
+    markDefs: [],
+    children: [
+      {
+        _type: 'span',
+        _key: '2',
+        text: '',
+        marks: [],
+      },
+    ],
+  }
+  it('adds a new block at the bottom, when clicking on the portable text editor, because the only block is void and user is focused on that one', async () => {
+    const initialValue = [
+      {
+        _key: 'b',
+        _type: 'someObject',
+      },
+    ]
+
+    const initialSelection = {
+      focus: {path: [{_key: 'b'}], offset: 0},
+      anchor: {path: [{_key: 'b'}], offset: 0},
+    }
+
+    const editorRef: RefObject<PortableTextEditor> = createRef()
+    const onChange = jest.fn()
+    const component = render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
+    )
+    const element = await getEditableElement(component)
+
+    const editor = editorRef.current
+    const inlineType = editor?.schemaTypes.inlineObjects.find((t) => t.name === 'someObject')
+    await waitFor(async () => {
+      if (editor && inlineType && element) {
+        PortableTextEditor.focus(editor)
+        PortableTextEditor.select(editor, initialSelection)
+        fireEvent.click(element)
+        expect(PortableTextEditor.getValue(editor)).toEqual([initialValue[0], newBlock])
+      }
+    })
+  })
+  it('should not add blocks if the last element is a text block', async () => {
+    const initialValue = [
+      {
+        _key: 'b',
+        _type: 'someObject',
+      },
+      {
+        _type: 'myTestBlockType',
+        _key: '3',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {
+            _type: 'span',
+            _key: '2',
+            text: '',
+            marks: [],
+          },
+        ],
+      },
+    ]
+
+    const initialSelection = {
+      focus: {path: [{_key: 'b'}], offset: 0},
+      anchor: {path: [{_key: 'b'}], offset: 0},
+    }
+
+    const editorRef: RefObject<PortableTextEditor> = createRef()
+    const onChange = jest.fn()
+    const component = render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
+    )
+    const element = await getEditableElement(component)
+
+    const editor = editorRef.current
+    const inlineType = editor?.schemaTypes.inlineObjects.find((t) => t.name === 'someObject')
+    await waitFor(async () => {
+      if (editor && inlineType && element) {
+        PortableTextEditor.focus(editor)
+        PortableTextEditor.select(editor, initialSelection)
+        fireEvent.click(element)
+        expect(PortableTextEditor.getValue(editor)).toEqual(initialValue)
+      }
+    })
+  })
+  it('should not add blocks if the last element is void, but its not focused on that one', async () => {
+    const initialValue = [
+      {
+        _key: 'a',
+        _type: 'someObject',
+      },
+      {
+        _type: 'myTestBlockType',
+        _key: 'b',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {
+            _type: 'span',
+            _key: 'b1',
+            text: '',
+            marks: [],
+          },
+        ],
+      },
+      {
+        _key: 'c',
+        _type: 'someObject',
+      },
+    ]
+
+    const initialSelection = {
+      focus: {path: [{_key: 'b'}, 'children', {_key: 'b1'}], offset: 2},
+      anchor: {path: [{_key: 'b'}, 'children', {_key: 'b1'}], offset: 2},
+    }
+
+    const editorRef: RefObject<PortableTextEditor> = createRef()
+    const onChange = jest.fn()
+    const component = render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
+    )
+    const element = await getEditableElement(component)
+
+    const editor = editorRef.current
+    const inlineType = editor?.schemaTypes.inlineObjects.find((t) => t.name === 'someObject')
+    await waitFor(async () => {
+      if (editor && inlineType && element) {
+        PortableTextEditor.focus(editor)
+        PortableTextEditor.select(editor, initialSelection)
+        fireEvent.click(element)
+        expect(PortableTextEditor.getValue(editor)).toEqual(initialValue)
+      }
+    })
+  })
+  it('should not add blocks if the last element is void, and its focused on that one when clicking', async () => {
+    const initialValue = [
+      {
+        _key: 'a',
+        _type: 'someObject',
+      },
+      {
+        _type: 'myTestBlockType',
+        _key: 'b',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {
+            _type: 'span',
+            _key: 'b1',
+            text: '',
+            marks: [],
+          },
+        ],
+      },
+      {
+        _key: 'c',
+        _type: 'someObject',
+      },
+    ]
+
+    const initialSelection = {
+      focus: {path: [{_key: 'c'}], offset: 0},
+      anchor: {path: [{_key: 'c'}], offset: 0},
+    }
+
+    const editorRef: RefObject<PortableTextEditor> = createRef()
+    const onChange = jest.fn()
+    const component = render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
+    )
+    const element = await getEditableElement(component)
+
+    const editor = editorRef.current
+    const inlineType = editor?.schemaTypes.inlineObjects.find((t) => t.name === 'someObject')
+    await waitFor(async () => {
+      if (editor && inlineType && element) {
+        PortableTextEditor.focus(editor)
+        PortableTextEditor.select(editor, initialSelection)
+        fireEvent.click(element)
+        expect(PortableTextEditor.getValue(editor)).toEqual(initialValue.concat(newBlock))
+      }
+    })
+  })
+})

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/utils.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/utils.ts
@@ -1,0 +1,39 @@
+// This utils are inspired from https://github.dev/mwood23/slate-test-utils/blob/master/src/buildTestHarness.tsx
+import {act, fireEvent, type render} from '@testing-library/react'
+import {parseHotkey} from 'is-hotkey-esm'
+
+export async function triggerKeyboardEvent(hotkey: string, element: Element): Promise<void> {
+  return act(async () => {
+    const eventProps = parseHotkey(hotkey)
+    const values = hotkey.split('+')
+
+    fireEvent(
+      element,
+      new window.KeyboardEvent('keydown', {
+        key: values[values.length - 1],
+        code: `${eventProps.which}`,
+        keyCode: eventProps.which,
+        bubbles: true,
+        ...eventProps,
+      }),
+    )
+  })
+}
+
+export async function getEditableElement(component: ReturnType<typeof render>): Promise<Element> {
+  await act(async () => component)
+  const element = component.container.querySelector('[data-slate-editor="true"]')
+  if (!element) {
+    throw new Error('Could not find element')
+  }
+  /**
+   * Manually add this because JSDom doesn't implement this and Slate checks for it
+   * internally before doing stuff.
+   *
+   * https://github.com/jsdom/jsdom/issues/1670
+   */
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  element.isContentEditable = true
+  return element
+}

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withHotkeys.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withHotkeys.test.tsx
@@ -1,0 +1,212 @@
+import {describe, expect, it, jest} from '@jest/globals'
+import {render, waitFor} from '@testing-library/react'
+import {createRef, type RefObject} from 'react'
+
+import {PortableTextEditorTester, schemaType} from '../../__tests__/PortableTextEditorTester'
+import {getEditableElement, triggerKeyboardEvent} from '../../__tests__/utils'
+import {PortableTextEditor} from '../../PortableTextEditor'
+
+const newBlock = {
+  _type: 'myTestBlockType',
+  _key: '3',
+  style: 'normal',
+  markDefs: [],
+  children: [
+    {
+      _type: 'span',
+      _key: '2',
+      text: '',
+      marks: [],
+    },
+  ],
+}
+describe('plugin:withHotkeys: .ArrowDown', () => {
+  it('a new block is added if the user is focused on the only block which is void, and presses arrow down.', async () => {
+    const initialValue = [
+      {
+        _key: 'a',
+        _type: 'someObject',
+      },
+    ]
+
+    const initialSelection = {
+      focus: {path: [{_key: 'a'}], offset: 0},
+      anchor: {path: [{_key: 'a'}], offset: 0},
+    }
+
+    const editorRef: RefObject<PortableTextEditor> = createRef()
+    const onChange = jest.fn()
+    const component = render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
+    )
+    const element = await getEditableElement(component)
+
+    const editor = editorRef.current
+    const inlineType = editor?.schemaTypes.inlineObjects.find((t) => t.name === 'someObject')
+    await waitFor(async () => {
+      if (editor && inlineType && element) {
+        PortableTextEditor.focus(editor)
+        PortableTextEditor.select(editor, initialSelection)
+        PortableTextEditor.insertBreak(editor)
+        await triggerKeyboardEvent('ArrowDown', element)
+
+        const value = PortableTextEditor.getValue(editor)
+        expect(value).toEqual([initialValue[0], newBlock])
+      }
+    })
+  })
+  it('a new block is added if the user is focused on the last block which is void, and presses arrow down.', async () => {
+    const initialValue = [
+      {
+        _type: 'myTestBlockType',
+        _key: 'a',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {
+            _type: 'span',
+            _key: 'a1',
+            text: 'This is the first block',
+            marks: [],
+          },
+        ],
+      },
+      {
+        _key: 'b',
+        _type: 'someObject',
+      },
+    ]
+    const initialSelection = {
+      focus: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 2},
+      anchor: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 2},
+    }
+
+    const editorRef: RefObject<PortableTextEditor> = createRef()
+    const onChange = jest.fn()
+    const component = render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
+    )
+    const element = await getEditableElement(component)
+
+    const editor = editorRef.current
+    const inlineType = editor?.schemaTypes.inlineObjects.find((t) => t.name === 'someObject')
+    await waitFor(async () => {
+      if (editor && inlineType && element) {
+        PortableTextEditor.focus(editor)
+        PortableTextEditor.select(editor, initialSelection)
+        await triggerKeyboardEvent('ArrowDown', element)
+        const value = PortableTextEditor.getValue(editor)
+        // Arrow down on the text block should not add a new block
+        expect(value).toEqual(initialValue)
+        // Focus on the object block
+        PortableTextEditor.select(editor, {
+          focus: {path: [{_key: 'b'}], offset: 0},
+          anchor: {path: [{_key: 'b'}], offset: 0},
+        })
+        await triggerKeyboardEvent('ArrowDown', element)
+        const value2 = PortableTextEditor.getValue(editor)
+        expect(value2).toEqual([
+          initialValue[0],
+          initialValue[1],
+          {
+            _type: 'myTestBlockType',
+            _key: '3',
+            style: 'normal',
+            markDefs: [],
+            children: [
+              {
+                _type: 'span',
+                _key: '2',
+                text: '',
+                marks: [],
+              },
+            ],
+          },
+        ])
+      }
+    })
+  })
+})
+describe('plugin:withHotkeys: .ArrowUp', () => {
+  it('a new block is added at the top, when pressing arrow up, because first block is void, the new block can be deleted with backspace.', async () => {
+    const initialValue = [
+      {
+        _key: 'b',
+        _type: 'someObject',
+      },
+      {
+        _type: 'myTestBlockType',
+        _key: 'a',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {
+            _type: 'span',
+            _key: 'a1',
+            text: 'This is the first block',
+            marks: [],
+          },
+        ],
+      },
+    ]
+
+    const initialSelection = {
+      focus: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 2},
+      anchor: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 2},
+    }
+
+    const editorRef: RefObject<PortableTextEditor> = createRef()
+    const onChange = jest.fn()
+    const component = render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
+    )
+    const element = await getEditableElement(component)
+
+    const editor = editorRef.current
+    const inlineType = editor?.schemaTypes.inlineObjects.find((t) => t.name === 'someObject')
+    await waitFor(async () => {
+      if (editor && inlineType && element) {
+        PortableTextEditor.focus(editor)
+        PortableTextEditor.select(editor, initialSelection)
+        await triggerKeyboardEvent('ArrowUp', element)
+        // Arrow down on the text block should not add a new block
+        expect(PortableTextEditor.getValue(editor)).toEqual(initialValue)
+        // Focus on the object block
+        PortableTextEditor.select(editor, {
+          focus: {path: [{_key: 'b'}], offset: 0},
+          anchor: {path: [{_key: 'b'}], offset: 0},
+        })
+        await triggerKeyboardEvent('ArrowUp', element)
+        expect(PortableTextEditor.getValue(editor)).toEqual([
+          newBlock,
+          initialValue[0],
+          initialValue[1],
+        ])
+        // Pressing arrow up again won't add a new block
+        await triggerKeyboardEvent('ArrowUp', element)
+        expect(PortableTextEditor.getValue(editor)).toEqual([
+          newBlock,
+          initialValue[0],
+          initialValue[1],
+        ])
+        await triggerKeyboardEvent('Backspace', element)
+        expect(PortableTextEditor.getValue(editor)).toEqual(initialValue)
+      }
+    })
+  })
+})

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
@@ -128,9 +128,7 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $readOnly?:
       padding-top: ${({$isFullscreen, theme}) => theme.sanity.space[$isFullscreen ? 5 : 3]}px;
     }
 
-    & > :last-child {
-      padding-bottom: ${({$isFullscreen, theme}) => theme.sanity.space[$isFullscreen ? 9 : 5]}px;
-    }
+    padding-bottom: ${({$isFullscreen, theme}) => theme.sanity.space[$isFullscreen ? 9 : 5]}px;
 
     /* & > .pt-block {
       & .pt-inline-object {


### PR DESCRIPTION
### Description

This changes improve the editor experience by adding empty text blocks into PTE when needed.
####  A new block is added if the user is focused on the last block which is void, and clicks in the editor.

https://github.com/sanity-io/sanity/assets/46196328/623e28aa-f5e6-47b2-89e2-64142c1995bd

#### A new block is added if the user is focused on the last block which is void, and presses arrow down.

https://github.com/sanity-io/sanity/assets/46196328/0425bee3-4de8-4f7b-ab7f-e6e62c2fdb4a


####  A new block is added at the top, when pressing arrow up, because first block is void, the new block can be deleted with backspace.

https://github.com/sanity-io/sanity/assets/46196328/a241fdf4-50ee-49c1-81c9-354321dc848c




<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
