### PR TITLE
fix: remove `cleanStegaUnicode` helper

### DIFF
--- a/packages/@sanity/block-tools/src/HtmlDeserializer/helpers.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/helpers.ts
@@ -62,7 +62,7 @@ export function preprocess(
   parseHtml: HtmlParser,
   options: HtmlPreprocessorOptions,
 ): Document {
-  const cleanHTML = cleanStegaUnicode(html)
+  const cleanHTML = vercelStegaClean(html)
   const doc = parseHtml(normalizeHtmlBeforePreprocess(cleanHTML))
   preprocessors.forEach((processor) => {
     processor(cleanHTML, doc, options)
@@ -338,24 +338,6 @@ export function removeAllWhitespace(rootNode: Node) {
 
   // Remove the collected nodes
   nodesToRemove.forEach((node) => node.parentElement?.removeChild(node))
-}
-
-/**
- * This is a duplicate code from `@sanity/client/stega`
- * Unfortunately, as it stands, the e2e process is pulling in the node version of `@sanity/client` and so we don't have access to the utility as it stands
- * @todo remove once this utility is available in `@vercel/stega`
- *
- * Can take a `result` JSON from a `const {result} = client.fetch(query, params, {filterResponse: false})`
- * and remove all stega-encoded data from it.
- * @alpha
- * @hidden
- */
-export function cleanStegaUnicode(result: string): string {
-  try {
-    return vercelStegaClean(result)
-  } catch {
-    return result
-  }
 }
 
 function isWhitespaceBlock(elm: HTMLElement): boolean {


### PR DESCRIPTION
### Description

Version 1.0.2 of `@vercel/stega` removes the need to have a try/catch block around `vercelStegaClean`, so the `cleanStegaUnicode` utility is no longer needed.
The `@sanity/client` made the same change: https://github.com/sanity-io/client/pull/788

### What to review

Pasting stega into PTE should be stripped without any exceptions thrown just like before.

### Testing

Existing tests should be sufficient.

### Notes for release

N/A, it's a refactor without any user facing changes
