### PR TITLE
fix(sanity): hybrid Text Search API search strategy

### DIFF
--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -29,7 +29,9 @@ const sharedSettings = definePlugin({
       assetSources: [imageAssetSource],
     },
   },
-
+  search: {
+    enableLegacySearch: false,
+  },
   document: {
     actions: documentActions,
     inspectors: (prev, ctx) => {

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -67,6 +67,9 @@ const sharedSettings = definePlugin({
       assetSources: [imageAssetSource],
     },
   },
+  search: {
+    enableLegacySearch: false,
+  },
 
   i18n: {
     bundles: testStudioLocaleBundles,

--- a/dev/test-studio/schema/standard/references.ts
+++ b/dev/test-studio/schema/standard/references.ts
@@ -251,6 +251,15 @@ export default defineType({
         },
       }),
     },
+    {
+      name: 'referenceWithSubqueryFilter',
+      title: 'Subquery filter',
+      type: 'reference',
+      to: [{type: 'book'}],
+      options: {
+        filter: 'author->name match "*e*"',
+      },
+    },
   ],
   preview: {
     select: {

--- a/packages/sanity/src/core/search/search.ts
+++ b/packages/sanity/src/core/search/search.ts
@@ -1,9 +1,12 @@
+import {parse} from 'groq-js'
+
 import {
   type SearchStrategyFactory,
   type TextSearchResults,
   type WeightedSearchResults,
 } from './common'
 import {createTextSearch} from './text-search'
+import {groqExpressionIsTextSearchCompatible} from './utils/groq'
 import {createWeightedSearch} from './weighted'
 
 /** @internal */
@@ -12,6 +15,27 @@ export const createSearch: SearchStrategyFactory<TextSearchResults | WeightedSea
   client,
   options,
 ) => {
-  const factory = options.enableLegacySearch ? createWeightedSearch : createTextSearch
+  // Studio's filtering APIs allow developers to use any GROQ operation, but unfortunately, the
+  // Text Search API does not provide a full GROQ implementation for filtering. Notably, it
+  // currently lacks support for dereferences, subqueries, and some function calls.
+  //
+  // If the filter includes any such operation, the legacy search strategy will instead be used.
+  //
+  // This does have some implications for the end user. For example, the legacy search API doesn't
+  // support negations (e.g. `-word`). We warn in the console to make developers aware.
+  const isTextSearchApiCompatible =
+    !options.filter || groqExpressionIsTextSearchCompatible(parse(options.filter))
+
+  if (!options.enableLegacySearch && !isTextSearchApiCompatible) {
+    console.warn(
+      `Using legacy search because custom filter contains subquery: \`${options.filter}\`.`,
+    )
+  }
+
+  const factory =
+    options.enableLegacySearch || !isTextSearchApiCompatible
+      ? createWeightedSearch
+      : createTextSearch
+
   return factory(searchableTypes, client, options)
 }

--- a/packages/sanity/src/core/search/utils/groq.test.ts
+++ b/packages/sanity/src/core/search/utils/groq.test.ts
@@ -1,0 +1,120 @@
+import {describe, expect, it} from '@jest/globals'
+import {type ExprNode, parse} from 'groq-js'
+
+import {groqExpressionContainsType, groqExpressionIsTextSearchCompatible} from './groq'
+
+describe('groqExpressionIsTextSearchCompatible', () => {
+  it.each([
+    {
+      expression: 'fieldA',
+      expected: true,
+    },
+    {
+      expression: 'fieldA->fieldB',
+      expected: false,
+    },
+    {
+      expression: `{
+        "documents": ^.documentReferences->
+      }`,
+      expected: false,
+    },
+    {
+      expression: `{
+        "count": count(fieldA->fieldB)
+      }`,
+      expected: false,
+    },
+    {
+      expression: `{
+        "value": {
+          "innerValue": global::coalesce(fieldA->fieldB, fieldA)
+        }.innerValue
+      }`,
+      expected: false,
+    },
+    {
+      expression: `{
+        "documents": *[_type == "type"]
+      }`,
+      expected: false,
+    },
+    {
+      expression: `{
+        "documents": *[_type == "type"] { _id }
+      }`,
+      expected: false,
+    },
+    {
+      expression: `{
+        "count": count(*[_type == "type"])
+      }`,
+      expected: false,
+    },
+    {
+      expression: `{
+        "value": {
+          "innerValue": *[0...2]
+        }.innerValue
+      }`,
+      expected: false,
+    },
+    {
+      expression: `coalesce(null, true)`,
+      expected: false,
+    },
+  ])(
+    'identifies operations at any level that are incompatible with the Text Search API %#',
+    ({expression, expected}) => {
+      expect(groqExpressionIsTextSearchCompatible(parse(expression))).toBe(expected)
+    },
+  )
+})
+
+describe('groqExpressionContainsType', () => {
+  it.each<{
+    expression: string
+    type: ExprNode['type'][]
+    expected: boolean
+  }>([
+    {
+      expression: 'fieldA->fieldB',
+      type: ['Deref'],
+      expected: true,
+    },
+    {
+      expression: 'fieldA',
+      type: ['Deref'],
+      expected: false,
+    },
+    {
+      expression: `{
+        "array": ["a", "b", "c"]
+      }`,
+      type: ['Array'],
+      expected: true,
+    },
+    {
+      expression: `{
+        "notArray": 1
+      }`,
+      type: ['Array'],
+      expected: false,
+    },
+    {
+      expression: `{
+        "value": "a",
+        "maybeValue": fieldA && fieldB
+      }`,
+      type: ['Value', 'And'],
+      expected: true,
+    },
+    {
+      expression: '*',
+      type: ['Value', 'And'],
+      expected: false,
+    },
+  ])('identifies specified types at any level %#', ({expression, type, expected}) => {
+    expect(groqExpressionContainsType(parse(expression), type)).toBe(expected)
+  })
+})

--- a/packages/sanity/src/core/search/utils/groq.ts
+++ b/packages/sanity/src/core/search/utils/groq.ts
@@ -1,0 +1,56 @@
+import {type ExprNode} from 'groq-js'
+
+/**
+ * Check whether the provided GROQ expression contains any unsupported operations at any level.
+ *
+ * The Text Search API doesn't support:
+ *
+ * - Subqueries & dereferences
+ * - Function calls
+ */
+export function groqExpressionIsTextSearchCompatible(expression: ExprNode): boolean {
+  return !groqExpressionContainsType(expression, ['Deref', 'Everything', 'FuncCall'])
+}
+
+/**
+ * Check whether any of the provided GROQ expression types appear within the provided GROQ
+ * expression at any level.
+ */
+export function groqExpressionContainsType(
+  expression: ExprNode,
+  type: ExprNode['type'][],
+): boolean {
+  if (type.includes(expression.type)) {
+    return true
+  }
+
+  return Object.values(expression).some((value) => {
+    if (Array.isArray(value)) {
+      return value
+        .filter(isGroqExpressionNode)
+        .some((entry) => groqExpressionContainsType(entry, type))
+    }
+
+    if (isGroqExpressionNode(value)) {
+      return groqExpressionContainsType(value, type)
+    }
+
+    return false
+  })
+}
+
+/**
+ * Check whether a value appears to be a GROQ expression node.
+ *
+ * Note: This simply verifies the value is an object with a `type` property. It does not check
+ * whether the type—nor the rest of the object—is valid.
+ */
+export function isGroqExpressionNode(
+  maybeGroqExpressionNode: unknown,
+): maybeGroqExpressionNode is ExprNode {
+  return (
+    typeof maybeGroqExpressionNode === 'object' &&
+    maybeGroqExpressionNode !== null &&
+    'type' in maybeGroqExpressionNode
+  )
+}

--- a/test/e2e/tests/desk/documentList.spec.ts
+++ b/test/e2e/tests/desk/documentList.spec.ts
@@ -85,3 +85,30 @@ test(`navigating document creates only one listener connection`, async ({page}) 
   expect(bookListenersCount).toBe(1)
   await bookRequest
 })
+
+test.describe('search strategy', () => {
+  test('uses Text Search API search strategy if filter is supported', async ({page}) => {
+    // Wait for Text Search API request.
+    const searchRequest = page.waitForRequest((request) =>
+      request.url().includes('data/textsearch'),
+    )
+
+    await page.goto('/test/content/book')
+    await expect(page.locator('#book-book-0')).toBeVisible()
+    await searchRequest
+  })
+
+  test('falls back to GROQ Query API search strategy if filter is not supported by Text Search API', async ({
+    page,
+  }) => {
+    // Wait for GROQ Query API request.
+    const searchRequest = page.waitForRequest(
+      (request) =>
+        request.url().includes('data/query') && request.url().includes('*%5Bdefined%28title%29%5D'),
+    )
+
+    await page.goto('/test/content/custom;anythingWithATitle')
+    await expect(page.locator('#title-list-anythingWithATitle-0')).toBeVisible()
+    await searchRequest
+  })
+})


### PR DESCRIPTION
### Description

This branch adopts a hybrid approach for supporting the Text Search API alongside the GROQ Query API when searching for documents. This is applicable for parts of Studio that support custom GROQ filters, such as document lists and reference fields. Studio's filtering APIs allow developers to use any GROQ operation, but unfortunately, the Text Search API does not provide a full GROQ implementation for filtering. Notably, it currently lacks support for dereferences, subqueries, and some function calls.

With this change, Studio will fall back to the GROQ Query API if it detects any operation in the filter GROQ that is incompatible with the Text Search API. This makes it possible to enable Text Search API for Studios without the filter configuration leading to errors.

**Note:**  The Text Search API search strategy must still be explicitly enabled by setting the `search.enableLegacySearch` Studio configuration property to `false`. The changes introduced in this branch won't have any impact for Studios using legacy search.

### What to review

- Does the incompatible GROQ operation detection seem reasonable?
- We currently log a warning to the console when Text Search API is enabled and an incompatible GROQ operation causes Studio to fall back to the GROQ Query API. Should we consider a more prominent warning?

### Testing

 - Unit tests for incompatible GROQ detection have been added in `packages/sanity/src/core/search/utils/groq.test.ts`.
 - E2E tests for document lists have been added in `test/e2e/tests/desk/documentList.spec.ts`.
 - E2E tests for reference fields have been added in `test/e2e/tests/inputs/reference.spec.ts`.

In a Studio that has the Text Search API search strategy enabled, try using a document list or reference field that has an incompatible GROQ filter configured. _You can enable the Text Search API search strategy by setting the `search.enableLegacySearch` Studio configuration property to `false`._

When navigating Studio, you should see data is generally sourced using the Text Search API (`data/textsearch`). When a document list or reference field uses an incompatible GROQ filter, the GROQ Query API (`data/query`) should instead be used.

There is an example of an incompatible reference field in the test-studio named `referenceWithSubqueryFilter`. You can find it by navigating to http://localhost:3333/test/structure/input-standard;referenceTest;c5a278ae-f38c-47aa-b95f-f038db7d9c9f and scrolling to the "Subquery filter" field.