### PR TITLE
test(core): add test to ensures that only one listener is open when navigating list

### DIFF
--- a/packages/sanity/src/structure/components/paneItem/PaneItem.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItem.tsx
@@ -146,6 +146,7 @@ export function PaneItem(props: PaneItemProps) {
 
   return (
     <PreviewCard
+      data-testid={`pane-item-${title}`}
       __unstable_focusRing
       as={Link as FIXME}
       data-as="a"

--- a/test/e2e/tests/desk/documentList.spec.ts
+++ b/test/e2e/tests/desk/documentList.spec.ts
@@ -1,0 +1,87 @@
+import {expect, type Request} from '@playwright/test'
+import {test} from '@sanity/test'
+
+function getListenEventType(request: Request): string | null | undefined {
+  if (request.url().includes('data/listen')) {
+    const url = new URL(request.url())
+    return url.searchParams.get('$type')
+  }
+
+  return undefined
+}
+
+test(`navigating document creates only one listener connection`, async ({page}) => {
+  await page.goto('/test/content')
+
+  let authorListenersCount = 0
+  let bookListenersCount = 0
+
+  /**
+   * We listen for requests to the listen endpoint to keep track of how many listeners are active
+   * for each type.
+   */
+  page.on('request', (request) => {
+    const type = getListenEventType(request)
+
+    if (type === '"author"') {
+      authorListenersCount++
+    } else if (type === '"book"') {
+      bookListenersCount++
+    }
+  })
+
+  /**
+   * There is not really a good way for playwright to tell if an EventSource request is cancelled
+   * It marks requests as failed when it's cancelled
+   *
+   * We use this to decrement the counter so for the context of the test we should always have one active listener
+   */
+  page.on('requestfailed', (request) => {
+    const type = getListenEventType(request)
+
+    if (type === '"author"') {
+      authorListenersCount--
+    } else if (type === '"book"') {
+      bookListenersCount--
+    }
+  })
+
+  await page.waitForSelector('[data-testid="structure-tool-list-pane"]')
+
+  const authorRequest = page.waitForRequest(
+    (request) => request.url().includes('data/listen') && request.url().includes('author'),
+  )
+  const bookRequest = page.waitForRequest(
+    (request) => request.url().includes('data/listen') && request.url().includes('book'),
+  )
+  const keyValueRequest = page.waitForResponse((response) => response.url().includes('keyvalue'))
+
+  await page.getByTestId('pane-item-Author').click({force: true})
+  await page.waitForSelector('#author-author-0')
+  await authorRequest
+  expect(bookListenersCount).toBe(0)
+  expect(authorListenersCount).toBe(1)
+
+  // We change the sort order to not be default, to ensure that the listener is not re-created
+  await page.getByTestId('pane-context-menu-button').click()
+  await page.getByRole('menuitem', {name: 'Sort by Name'}).click()
+  await keyValueRequest
+
+  await page.getByTestId('pane-item-Book').click({force: true})
+  await page.waitForSelector('#book-book-0')
+  expect(authorListenersCount).toBe(0)
+  expect(bookListenersCount).toBe(1)
+  await bookRequest
+
+  await page.getByTestId('pane-item-Author').click({force: true})
+  await page.waitForSelector('#author-author-0')
+  expect(bookListenersCount).toBe(0)
+  expect(authorListenersCount).toBe(1)
+  await authorRequest
+
+  await page.getByTestId('pane-item-Book').click({force: true})
+  await page.waitForSelector('#book-book-0')
+  expect(authorListenersCount).toBe(0)
+  expect(bookListenersCount).toBe(1)
+  await bookRequest
+})


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds a test that only one listener is open when navigating document lists

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Changes makes sense

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I did write a test to assert that only one connection is kept open but it is not very ideal way but this is a limitation of playwright that it does not support connection close event for long polling request. Fortunately they get marked as failed requests when they get closed which helps us write some assertions around it.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

- N/A