### PR TITLE
Add support for @sanity-typegen-ignore to ignore queries

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -143,4 +143,17 @@ describe('findQueries', () => {
     const queries = findQueriesInSource(source, __filename, undefined)
     expect(queries.length).toBe(0)
   })
+
+  test('will ignore declerations if any of the leading comments are ignore tags', () => {
+    const source = `
+      import { groq } from "groq";
+
+      // @sanity-typegen-ignore
+      // This should be ignored because of the comment above
+      export const postQuery = groq\`*[_type == "foo"]\`
+    `
+
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(0)
+  })
 })

--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -106,4 +106,41 @@ describe('findQueries', () => {
     expect(queries.length).toBe(1)
     expect(queries[0].result).toBe('*[_type == "foo bar"]')
   })
+
+  test('will ignore declarations with ignore tag', () => {
+    const source = `
+      import { groq } from "groq";
+
+      // @sanity-typegen-ignore
+      const postQuery = groq\`*[_type == "foo"]\`
+    `
+
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(0)
+  })
+
+  test('will ignore export named declarations with ignore tag', () => {
+    const source = `
+      import { groq } from "groq";
+
+      // @sanity-typegen-ignore
+      export const postQuery = groq\`*[_type == "foo"]\`
+    `
+
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(0)
+  })
+
+  test('will ignore declarations with ignore tag, even with multiple comments above declaration', () => {
+    const source = `
+      import { groq } from "groq";
+
+      // This is a query that queries posts
+      // @sanity-typegen-ignore
+      export const postQuery = groq\`*[_type == "foo"]\`
+    `
+
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(0)
+  })
 })

--- a/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
+++ b/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
@@ -1,6 +1,6 @@
 import {createRequire} from 'node:module'
 
-import {type TransformOptions, traverse} from '@babel/core'
+import {type NodePath, type TransformOptions, traverse} from '@babel/core'
 import * as babelTypes from '@babel/types'
 
 import {getBabelConfig} from '../getBabelConfig'
@@ -10,6 +10,8 @@ import {parseSourceFile} from './parseSource'
 const require = createRequire(__filename)
 
 const groqTagName = 'groq'
+
+const ignoreValue = '@sanity-typegen-ignore'
 
 /**
  * findQueriesInSource takes a source string and returns all GROQ queries in it.
@@ -33,8 +35,11 @@ export function findQueriesInSource(
   traverse(file, {
     // Look for variable declarations, e.g. `const myQuery = groq`... and extract the query.
     // The variable name is used as the name of the query result type
-    VariableDeclarator({node, scope}) {
+    VariableDeclarator(path) {
+      const {node, scope} = path
+
       const init = node.init
+
       // Look for tagged template expressions that are called with the `groq` tag
       if (
         babelTypes.isTaggedTemplateExpression(init) &&
@@ -42,6 +47,10 @@ export function findQueriesInSource(
         babelTypes.isIdentifier(node.id) &&
         init.tag.name === groqTagName
       ) {
+        if (getDeclarationLeadingComment(path)?.trim() === ignoreValue) {
+          return
+        }
+
         const queryName = `${node.id.name}`
         const queryResult = resolveExpression({
           node: init,
@@ -51,10 +60,80 @@ export function findQueriesInSource(
           filename,
           resolver,
         })
+
         queries.push({name: queryName, result: queryResult})
       }
     },
   })
 
   return queries
+}
+
+function getDeclarationLeadingComment(
+  path: NodePath<babelTypes.VariableDeclarator>,
+): string | null {
+  /*
+   * We have to consider these cases:
+   *
+   * // @sanity-typegen-ignore
+   * const query = groq`...`
+   *
+   * // AST
+   * VariableDeclaration {
+   *   declarations: [
+   *     VariableDeclarator: {init: tag: {name: "groq"}}
+   *   ],
+   *   leadingComments: ...
+   * }
+   *
+   * // @sanity-typegen-ignore
+   * const query1 = groq`...`, query2 = groq`...`
+   *
+   * // AST
+   * VariableDeclaration {
+   *   declarations: [
+   *     VariableDeclarator: {init: tag: {name: "groq"}}
+   *     VariableDeclarator: {init: tag: {name: "groq"}}
+   *   ],
+   *   leadingComments: ...
+   * }
+   *
+   * // @sanity-typegen-ignore
+   * export const query = groq`...`
+   *
+   * // AST
+   * ExportNamedDeclaration {
+   *   declaration: VariableDeclaration {
+   *     declarations: [
+   *       VariableDeclarator: {init: tag: {name: "groq"}}
+   *       VariableDeclarator: {init: tag: {name: "groq"}}
+   *     ],
+   *   },
+   *   leadingComments: ...
+   * }
+   *
+   * In the case where multiple variables are under the same VariableDeclaration the leadingComments
+   * will still be on the VariableDeclaration
+   *
+   * In the case where the variable is exported, the leadingComments are on the
+   * ExportNamedDeclaration which includes the VariableDeclaration in its own declaration property
+   */
+
+  const variableDeclaration = path.find((node) => node.isVariableDeclaration())
+  if (!variableDeclaration) return null
+
+  if (variableDeclaration.node.leadingComments) {
+    return getLastInArray(variableDeclaration.node.leadingComments)?.value || null
+  }
+
+  // If the declaration is exported, the comment lies on the parent of the export declaration
+  if (variableDeclaration.parent.leadingComments) {
+    return getLastInArray(variableDeclaration.parent.leadingComments)?.value || null
+  }
+
+  return null
+}
+
+function getLastInArray<T>(arr: T[]) {
+  return arr[arr.length - 1]
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Added functionality in `findQueriesInSource.ts` to ignore queries which are prefixed with the comment `@sanity-typegen-ignore`.

In some cases you want to extract a single use query to its own value:

```ts
const query = `
  *[_type == "post"]
`

const posts = await client.fetch(query)
```

Now if you validate the posts with zod you will have to explicitly write the result anyway

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

If there are any other cases than the ones specified in the function `getDeclarationLeadingComment`, please let me know and I will add them

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Added tests for const declarations, export const and making sure it chooses the correct comment if there are multiple leading comments

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
