### PR TITLE
feat(cli): remove is-builtin-module

### DIFF
--- a/packages/@sanity/cli/package.config.ts
+++ b/packages/@sanity/cli/package.config.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-sync */
 import fs from 'node:fs'
+import {isBuiltin} from 'node:module'
 import path from 'node:path'
 
 import baseConfig from '@repo/package.config'
 import {nodeResolve} from '@rollup/plugin-node-resolve'
 import {defineConfig} from '@sanity/pkg-utils'
-import isBuiltin from 'is-builtin-module'
 
 const workersDir = path.join(__dirname, 'src', 'workers')
 
@@ -17,13 +17,6 @@ const workerNames = fs
 export default defineConfig({
   ...baseConfig,
 
-  // This is a workaround for an issue where the `readable-stream` package imports
-  // from `string_decoder/` instead of `string_decoder` (note the trailing slash),
-  // which _should_ tell rollup not to use the built-in `string_decoder` module,
-  // which it unfortunately does not. Hoping we can get rid of this hack soon:
-  // https://github.com/rollup/plugins/issues/1211
-  // https://github.com/sindresorhus/is-builtin-module/issues/7
-  // https://github.com/sindresorhus/builtin-modules/pull/17
   rollup: {
     plugins: (plugins) => [
       ...plugins.filter((plugin) => plugin.name !== 'node-resolve'),
@@ -31,7 +24,7 @@ export default defineConfig({
         browser: false,
         extensions: ['.cjs', '.mjs', '.js', '.jsx', '.json', '.node'],
         preferBuiltins: false,
-        resolveOnly: (moduleName) => moduleName === 'string_decoder' || !isBuiltin(moduleName),
+        resolveOnly: (moduleName) => !isBuiltin(moduleName),
       }),
     ],
   },

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -111,7 +111,6 @@
     "get-latest-version": "^5.0.0",
     "git-user-info": "^2.0.3",
     "inquirer": "^6.0.0",
-    "is-builtin-module": "^3.2.0",
     "is-installed-globally": "^0.4.0",
     "leven": "^3.1.0",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -890,9 +890,6 @@ importers:
       inquirer:
         specifier: ^6.0.0
         version: 6.5.2
-      is-builtin-module:
-        specifier: ^3.2.0
-        version: 3.2.1
       is-installed-globally:
         specifier: ^0.4.0
         version: 0.4.0


### PR DESCRIPTION
This removes the `is-builtin-module` package since all node versions within our `engine` constraint already have such a function built in.

This also allows us to remove the temporary workaround we had around `string_decoder/` since the built in function will not have such a bug.

### What to review

The CLI should be the only affected package.

### Testing

Existing tests should cover this.

### Notes for release

N/A
