### PR TITLE
fix(structure): use case insensitive search for inspect dialog

### DIFF
--- a/packages/sanity/src/structure/panes/document/inspectDialog/InspectDialog.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectDialog/InspectDialog.tsx
@@ -111,6 +111,7 @@ export function InspectDialog(props: InspectDialogProps) {
                 isExpanded={isExpanded}
                 onClick={toggleExpanded}
                 search={Search}
+                filterOptions={{ignoreCase: true}}
               />
             </JSONInspectorWrapper>
           )}


### PR DESCRIPTION
### Description

The inspect dialog is currently case sensitive, which seems somewhat unnecessary. 

### What to review

Search is now case insensitive.

### Testing

I'd argue this is non-critical functionality, and is tested in the upstream component (`react-json-inspector`). 

### Notes for release

- Makes the search/filter in the document "Inspect" dialog case-insensitive
