### PR TITLE
fix(presentation): regression causing a crash when in an embedded studio

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -162,7 +162,7 @@
     "@sanity/migrate": "3.41.0",
     "@sanity/mutator": "3.41.0",
     "@sanity/portable-text-editor": "3.41.0",
-    "@sanity/presentation": "1.15.0",
+    "@sanity/presentation": "1.15.1",
     "@sanity/schema": "3.41.0",
     "@sanity/telemetry": "^0.7.6",
     "@sanity/types": "3.41.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1530,8 +1530,8 @@ importers:
         specifier: 3.41.0
         version: link:../@sanity/portable-text-editor
       '@sanity/presentation':
-        specifier: 1.15.0
-        version: 1.15.0(@sanity/client@6.18.0)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.10)
+        specifier: 1.15.1
+        version: 1.15.1(@sanity/client@6.18.0)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.10)
       '@sanity/schema':
         specifier: 3.41.0
         version: link:../@sanity/schema
@@ -6585,11 +6585,11 @@ packages:
       - styled-components
     dev: false
 
-  /@sanity/presentation@1.15.0(@sanity/client@6.18.0)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.10):
-    resolution: {integrity: sha512-iu75zesZ++jjSdc5Z7uD0l332rKd9lvp9G5lhiSDogBIz11hU7lLOnAqsa4RjjznemNnEkefqSUHy3rkfZpP4g==}
+  /@sanity/presentation@1.15.1(@sanity/client@6.18.0)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.10):
+    resolution: {integrity: sha512-bFghEY8rlUneLR5lWFXxdn52oMUwOrNucKrwinzykH9/m3NxrHA5ObvwoSu02lu+ebVLk0KY8ptczfoz6WDlWA==}
     engines: {node: '>=16.14'}
     peerDependencies:
-      '@sanity/client': ^6.17.2
+      '@sanity/client': ^6.18.0
     dependencies:
       '@sanity/client': 6.18.0(debug@4.3.4)
       '@sanity/icons': 2.11.8(react@18.3.1)


### PR DESCRIPTION
### Description

In `v3.41.0` we have a regression in `@sanity/presentation` causing it to crash when used in an embedded Studio: 
![image](https://github.com/sanity-io/sanity/assets/81981/c4ebc496-a479-4ff6-b67d-ca1ec33c8359)
We fixed it in `@sanity/presentation` `v1.15.1` and it's sufficient to just bump the depedency to fix the issue.

### What to review

It's already reviewed here: https://github.com/sanity-io/visual-editing/pull/1482

### Testing

We've tested the fix on affected repos already by using `@sanity/presentation` and confirmed it works.

### Notes for release

Fixes a regression in Presentation Tool introduced in `v3.41.0` that causes it to crash in embedded studios.
