### PR TITLE
chore(core): prevent extra work on preview prepare

### DIFF
--- a/packages/sanity/src/core/preview/utils/prepareForPreview.ts
+++ b/packages/sanity/src/core/preview/utils/prepareForPreview.ts
@@ -294,7 +294,7 @@ export function prepareForPreview(
     return withErrors(prepareResult, type, selectedValue)
   }
 
-  const returnValueResult = validateReturnedPreview(invokePrepare(type, selectedValue, viewOptions))
+  const returnValueResult = validateReturnedPreview(prepareResult)
   return returnValueResult.errors.length > 0
     ? withErrors(returnValueResult, type, selectedValue)
     : {...pick(rawValue, PRESERVE_KEYS), ...prepareResult.returnValue}


### PR DESCRIPTION
### Description

While validating some preview behaviour, I noticed the `invokePrepare` func being called a second time in the same scope.
This is just a quick amend to use the assignment from the first call.

### What to review

Ensure the system wasn't relying on it being called twice in succession

### Testing

Tests and typesafety should remain the same

### Notes for release

Prevent extra work on preview prepare
