### PR TITLE
feat(schema): add icon to BlockStyleDefinition

### DIFF
--- a/packages/@sanity/schema/src/sanity/validation/types/block.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/block.ts
@@ -20,7 +20,7 @@ const allowedKeys = [
   'validation',
 ]
 const allowedMarkKeys = ['decorators', 'annotations']
-const allowedStyleKeys = ['blockEditor', 'title', 'value', 'component']
+const allowedStyleKeys = ['blockEditor', 'title', 'value', 'icon', 'component']
 const allowedDecoratorKeys = ['blockEditor', 'title', 'value', 'icon', 'component']
 const allowedListKeys = ['title', 'value', 'icon', 'component']
 const supportedBuiltInObjectTypes = ['file', 'image', 'object', 'reference']

--- a/packages/@sanity/schema/test/validation/validation.test.ts
+++ b/packages/@sanity/schema/test/validation/validation.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, test} from '@jest/globals'
+import {SquareIcon} from '@sanity/icons'
 import {flatten} from 'lodash'
 
 import {validateSchema} from '../../src/sanity/validateSchema'
@@ -170,5 +171,36 @@ describe('Validation test', () => {
       severity: 'error',
       helpId: 'schema-array-of-type-builtin-type-conflict',
     })
+  })
+
+  test('accepts blocks with a style icon', () => {
+    const schemaDef = [
+      {
+        name: 'testBlock',
+        type: 'block',
+        styles: [{icon: SquareIcon, title: 'Normal text', value: 'normal'}],
+      },
+    ]
+
+    const validation = validateSchema(schemaDef).get('testBlock')
+    const validationErrors = validation._problems.filter(
+      (problem: any) => problem.severity === 'error',
+    )
+    expect(validationErrors).toHaveLength(0)
+  })
+  test('accepts blocks without a style icon', () => {
+    const schemaDef = [
+      {
+        name: 'testBlock',
+        type: 'block',
+        styles: [{title: 'Normal text', value: 'normal'}],
+      },
+    ]
+
+    const validation = validateSchema(schemaDef).get('testBlock')
+    const validationErrors = validation._problems.filter(
+      (problem: any) => problem.severity === 'error',
+    )
+    expect(validationErrors).toHaveLength(0)
   })
 })

--- a/packages/@sanity/types/src/schema/definition/type/block.ts
+++ b/packages/@sanity/types/src/schema/definition/type/block.ts
@@ -113,6 +113,7 @@ export interface BlockStyleDefinition {
   title: string
   value: string
   i18nTitleKey?: string
+  icon?: ReactNode | ComponentType
 }
 
 /**


### PR DESCRIPTION
### Description

This PR adds support for specifying a custom `icon` to block styles (similar to `lists` and `annotations`). 

Whilst not immediately useful to the Studio right now, this is helpful for _Create_ as it employs a block-level slash command palette which displays a list of available _text_ and _list_ styles (and other custom blocks / actions) available in the current schema.

<img width="342" alt="image" src="https://github.com/sanity-io/sanity/assets/209129/97988648-2819-4e2e-8483-8d1911f31cc9">

Whilst we could hard-code icons for text styles, it felt more idiomatic to make these customisable at the schema level (which is already possible for lists and annotations). 

These could come into play for Studio users if a similar slash command palette is added here – or if we look to change the look of the block style dropdown to be a little more streamlined.

### What to review

Adding an `icon` to a custom block style shouldn't throw validation errors in the studio.

### Testing

A simple unit test was added to check that `validateSchema` doesn't return errors when specifying a custom style `icon`.

### Notes for release

N/A