### PR TITLE
feat(sanity): memoize initial value resolver

### DIFF
--- a/packages/sanity/src/core/store/_legacy/grants/templatePermissions.ts
+++ b/packages/sanity/src/core/store/_legacy/grants/templatePermissions.ts
@@ -76,6 +76,9 @@ export function getTemplatePermissions({
           template,
           item.parameters,
           context,
+          {
+            useCache: true,
+          },
         )
 
         return {template, item, resolvedInitialValue}

--- a/packages/sanity/src/core/templates/resolve.ts
+++ b/packages/sanity/src/core/templates/resolve.ts
@@ -21,10 +21,19 @@ export type Serializeable<T> = {
   serialize(): T
 }
 
+interface Options {
+  useCache?: boolean
+}
+
 /** @internal */
 export function isBuilder(template: unknown): template is Serializeable<Template> {
   return isRecord(template) && typeof template.serialize === 'function'
 }
+
+const cache = new WeakMap<
+  InitialValueResolver<unknown, unknown>,
+  Record<string, unknown | Promise<unknown>>
+>()
 
 /** @internal */
 // returns the "resolved" value from an initial value property (e.g. type.initialValue)
@@ -33,10 +42,35 @@ export async function resolveValue<Params, InitialValue>(
   initialValueOpt: InitialValueProperty<Params, InitialValue>,
   params: Params | undefined,
   context: InitialValueResolverContext,
+  options?: Options,
 ): Promise<InitialValue | undefined> {
-  return typeof initialValueOpt === 'function'
-    ? (initialValueOpt as InitialValueResolver<Params, InitialValue>)(params, context)
-    : initialValueOpt
+  const useCache = options?.useCache
+
+  if (typeof initialValueOpt === 'function') {
+    const cached = cache.get(initialValueOpt as InitialValueResolver<unknown, unknown>)
+
+    const key = JSON.stringify([
+      params,
+      [context.projectId, context.dataset, context.currentUser?.id],
+    ])
+
+    if (useCache && cached?.[key]) {
+      return cached[key] as InitialValue | Promise<InitialValue>
+    }
+
+    const value = (initialValueOpt as InitialValueResolver<Params, InitialValue>)(params, context)
+
+    if (useCache) {
+      cache.set(initialValueOpt as InitialValueResolver<unknown, unknown>, {
+        ...cached,
+        [key]: value,
+      })
+    }
+
+    return value
+  }
+
+  return initialValueOpt
 }
 
 /** @internal */
@@ -45,10 +79,11 @@ export async function resolveInitialValue(
   template: Template,
   params: {[key: string]: any} = {},
   context: InitialValueResolverContext,
+  options?: Options,
 ): Promise<{[key: string]: any}> {
   // Template builder?
   if (isBuilder(template)) {
-    return resolveInitialValue(schema, template.serialize(), params, context)
+    return resolveInitialValue(schema, template.serialize(), params, context, options)
   }
 
   const {id, schemaType: schemaTypeName, value} = template
@@ -56,7 +91,7 @@ export async function resolveInitialValue(
     throw new Error(`Template "${id}" has invalid "value" property`)
   }
 
-  let resolvedValue = await resolveValue(value, params, context)
+  let resolvedValue = await resolveValue(value, params, context, options)
 
   if (!isRecord(resolvedValue)) {
     throw new Error(
@@ -79,8 +114,13 @@ export async function resolveInitialValue(
   }
 
   const newValue = deepAssign(
-    (await resolveInitialValueForType(schemaType, params, DEFAULT_MAX_RECURSION_DEPTH, context)) ||
-      {},
+    (await resolveInitialValueForType(
+      schemaType,
+      params,
+      DEFAULT_MAX_RECURSION_DEPTH,
+      context,
+      options,
+    )) || {},
     resolvedValue as Record<string, unknown>,
   )
 
@@ -120,20 +160,21 @@ export function resolveInitialValueForType<Params extends Record<string, unknown
    */
   maxDepth = DEFAULT_MAX_RECURSION_DEPTH,
   context: InitialValueResolverContext,
+  options?: Options,
 ): Promise<any> {
   if (maxDepth <= 0) {
     return Promise.resolve(undefined)
   }
 
   if (isObjectSchemaType(type)) {
-    return resolveInitialObjectValue(type, params, maxDepth, context)
+    return resolveInitialObjectValue(type, params, maxDepth, context, options)
   }
 
   if (isArraySchemaType(type)) {
-    return resolveInitialArrayValue(type, params, maxDepth, context)
+    return resolveInitialArrayValue(type, params, maxDepth, context, options)
   }
 
-  return resolveValue(type.initialValue, params, context)
+  return resolveValue(type.initialValue, params, context, options)
 }
 
 async function resolveInitialArrayValue<Params extends Record<string, unknown>>(
@@ -141,8 +182,9 @@ async function resolveInitialArrayValue<Params extends Record<string, unknown>>(
   params: Params,
   maxDepth: number,
   context: InitialValueResolverContext,
+  options?: Options,
 ): Promise<any> {
-  const initialArray = await resolveValue(type.initialValue, undefined, context)
+  const initialArray = await resolveValue(type.initialValue, undefined, context, options)
 
   if (!Array.isArray(initialArray)) {
     return undefined
@@ -154,7 +196,7 @@ async function resolveInitialArrayValue<Params extends Record<string, unknown>>(
       return isObjectSchemaType(itemType)
         ? {
             ...initialItem,
-            ...(await resolveInitialValueForType(itemType, params, maxDepth - 1, context)),
+            ...(await resolveInitialValueForType(itemType, params, maxDepth - 1, context, options)),
             _key: randomKey(),
           }
         : initialItem
@@ -168,9 +210,10 @@ export async function resolveInitialObjectValue<Params extends Record<string, un
   params: Params,
   maxDepth: number,
   context: InitialValueResolverContext,
+  options?: Options,
 ): Promise<any> {
   const initialObject: Record<string, unknown> = {
-    ...((await resolveValue(type.initialValue, params, context)) || {}),
+    ...((await resolveValue(type.initialValue, params, context, options)) || {}),
   }
 
   const fieldValues: Record<string, any> = {}
@@ -181,6 +224,7 @@ export async function resolveInitialObjectValue<Params extends Record<string, un
         params,
         maxDepth - 1,
         context,
+        options,
       )
       if (initialFieldValue !== undefined && initialFieldValue !== null) {
         fieldValues[field.name] = initialFieldValue

--- a/packages/sanity/src/core/templates/resolve.ts
+++ b/packages/sanity/src/core/templates/resolve.ts
@@ -51,7 +51,9 @@ export async function resolveValue<Params, InitialValue>(
 
     const key = JSON.stringify([
       params,
-      [context.projectId, context.dataset, context.currentUser?.id],
+      context.projectId,
+      context.dataset,
+      context.currentUser?.id,
     ])
 
     if (useCache && cached?.[key]) {


### PR DESCRIPTION
### Description

Wherever Studio allows users to create new documents, it runs `getTemplatePermissions`, which subsequently resolves the initial value of every schema type. It's troublesome for schema types that use an `initialValue` function (especially async function that may call an HTTP API), because it causes that function to be called at multiple unexpected times.

- When rendering a document list containing a type with an `initialValue` function, a `PaneHeaderCreateButton` is rendered.
- When the Studio navbar renders.
- When rendering the document pane for any type of document, `ReferenceInputOptionsProvider` is rendered.

We cannot simply remove initial value resolution. Studio must resolve initial values before allowing the user to create a new document in case those values would preclude the user from viewing the document they just created. e.g. if the user is prohibited from viewing documents where the `secret` field is `true`, they should not be given the option to create such documents.

In order to minimise unnecessary calls to the `initialValue` function, this branch memoizes the `initialValue` function when it's called from `getTemplatePermissions`.

**When a document is created, memoization isn't applied.** This ensures newly created documents aren't given stale values. A contrived example of when this would be an issue is if an `initialValue` function returns the current time. _This does mean it would be possible for the user to create a document they don't have permission to view if some piece of data controlling this changed since the initial `getTemplatePermissions` call, but this scenario seems unlikely_.

***

To see this for yourself, try tracking how many times an `initialValue` function is called when loading Studio with the document pane visible.

#### Before change: 42 calls 

<img width="1676" alt="Screenshot 2024-05-10 at 23 12 40" src="https://github.com/sanity-io/sanity/assets/1454914/66b221b7-01a9-4569-9df4-fef800744959">

#### After change: 3 calls (once for the global document creation UI, once for the document list document creation UI, and once to populate the new document)

<img width="1676" alt="Screenshot 2024-05-10 at 23 13 29" src="https://github.com/sanity-io/sanity/assets/1454914/169c4a51-82a5-4a94-ab29-39e3d8107cfd">

### What to review

Does this approach make sense? Are there any scenarios I've missed (such as various initial value template configurations)?

### Testing

Added tests in `packages/sanity/src/core/templates/__tests__/resolve.test.ts`.

### Notes for release

Adds memoization to minimise initial value function calls.