### PR TITLE
chore(cli): pin next-sanity to v9

### DIFF
--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -22,7 +22,7 @@
     "@react-three/fiber": "^8.13.6",
     "@sanity/assist": "^3.0.2",
     "@sanity/block-tools": "3.41.1",
-    "@sanity/client": "^6.17.2",
+    "@sanity/client": "^6.18.0",
     "@sanity/color": "^3.0.0",
     "@sanity/google-maps-input": "^4.0.0",
     "@sanity/icons": "^2.11.0",

--- a/dev/test-studio/schema/standard/booleans.ts
+++ b/dev/test-studio/schema/standard/booleans.ts
@@ -20,10 +20,22 @@ export default defineType({
       title: 'Title',
     },
     {
-      name: 'switchTest',
+      name: 'switch_doesnt_exist',
       type: 'boolean',
       title: `I'm a switch`,
       description: 'Try toggling me! This is the new switch design',
+    },
+    {
+      name: 'switchTest',
+      type: 'boolean',
+      title: `true & Read only`,
+      readOnly: true,
+    },
+    {
+      name: 'switch',
+      type: 'boolean',
+      title: `false & Read only`,
+      readOnly: true,
     },
     {
       name: 'switchIndeterminate2',
@@ -41,12 +53,6 @@ export default defineType({
       options: {
         layout: 'checkbox',
       },
-    },
-    {
-      name: 'switch',
-      type: 'boolean',
-      description: 'Should be either true or false',
-      title: 'Check me?',
     },
     {
       name: 'checkbox',

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@playwright/test": "1.41.2",
     "@repo/package.config": "workspace:*",
     "@repo/tsconfig": "workspace:*",
-    "@sanity/client": "^6.17.2",
+    "@sanity/client": "^6.18.0",
     "@sanity/eslint-config-i18n": "1.0.0",
     "@sanity/eslint-config-studio": "^4.0.0",
     "@sanity/pkg-utils": "6.8.13",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@babel/traverse": "^7.23.5",
-    "@sanity/client": "^6.17.2",
+    "@sanity/client": "^6.18.0",
     "@sanity/codegen": "3.41.1",
     "@sanity/telemetry": "^0.7.6",
     "@sanity/util": "3.41.1",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -66,7 +66,7 @@
     "decompress": "^4.2.0",
     "esbuild": "^0.21.0",
     "esbuild-register": "^3.4.1",
-    "get-it": "^8.4.28",
+    "get-it": "^8.4.29",
     "groq-js": "^1.8.0",
     "node-machine-id": "^1.1.12",
     "pkg-dir": "^5.0.0",

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -451,11 +451,11 @@ export default async function initSanity(
     }
 
     if (chosen === 'npm') {
-      await execa('npm', ['install', 'next-sanity@7'], execOptions)
+      await execa('npm', ['install', 'next-sanity@9'], execOptions)
     } else if (chosen === 'yarn') {
-      await execa('npx', ['install-peerdeps', '--yarn', 'next-sanity@7'], execOptions)
+      await execa('npx', ['install-peerdeps', '--yarn', 'next-sanity@9'], execOptions)
     } else if (chosen === 'pnpm') {
-      await execa('pnpm', ['install', 'next-sanity@7'], execOptions)
+      await execa('pnpm', ['install', 'next-sanity@9'], execOptions)
     }
 
     print(

--- a/packages/@sanity/migrate/package.json
+++ b/packages/@sanity/migrate/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@bjoerge/mutiny": "^0.5.1",
-    "@sanity/client": "^6.17.2",
+    "@sanity/client": "^6.18.0",
     "@sanity/types": "3.41.1",
     "@sanity/util": "3.41.1",
     "arrify": "^2.0.1",

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -49,7 +49,7 @@
     "watch": "pkg-utils watch"
   },
   "dependencies": {
-    "@sanity/client": "^6.17.2",
+    "@sanity/client": "^6.18.0",
     "@types/react": "^18.0.25"
   },
   "devDependencies": {

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -122,7 +122,7 @@
     "watch": "pkg-utils watch"
   },
   "dependencies": {
-    "@sanity/client": "^6.17.2",
+    "@sanity/client": "^6.18.0",
     "@sanity/types": "3.41.1",
     "get-random-values-esm": "1.0.2",
     "moment": "^2.29.4",

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -74,7 +74,7 @@
     "@repo/package.config": "workspace:*",
     "@sanity/block-tools": "workspace:*",
     "@sanity/cli": "workspace:*",
-    "@sanity/client": "^6.17.2",
+    "@sanity/client": "^6.18.0",
     "@sanity/codegen": "workspace:*",
     "@sanity/diff": "workspace:*",
     "@sanity/migrate": "workspace:*",

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -66,6 +66,7 @@
     "@sanity/ui": "^2.1.6",
     "@uiw/react-codemirror": "^4.11.4",
     "is-hotkey-esm": "^1.0.0",
+    "json-2-csv": "^5.5.1",
     "json5": "^2.2.3",
     "lodash": "^4.17.21",
     "quick-lru": "^5.1.1"

--- a/packages/@sanity/vision/src/components/SaveResultButtons.tsx
+++ b/packages/@sanity/vision/src/components/SaveResultButtons.tsx
@@ -1,0 +1,57 @@
+import {DocumentSheetIcon} from '@sanity/icons'
+import {Button, Tooltip} from '@sanity/ui'
+import {type MouseEvent} from 'react'
+import {useTranslation} from 'sanity'
+
+import {visionLocaleNamespace} from '../i18n'
+
+interface SaveButtonProps {
+  blobUrl: string | undefined
+}
+
+function preventSave(evt: MouseEvent<HTMLButtonElement>) {
+  return evt.preventDefault()
+}
+
+export function SaveCsvButton({blobUrl}: SaveButtonProps) {
+  const {t} = useTranslation(visionLocaleNamespace)
+  const isDisabled = !blobUrl
+
+  const button = (
+    <Button
+      as="a"
+      disabled={isDisabled}
+      download={isDisabled ? undefined : 'query-result.csv'}
+      href={blobUrl}
+      icon={DocumentSheetIcon}
+      mode="ghost"
+      onClick={isDisabled ? preventSave : undefined}
+      // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
+      text="CSV" // String is a File extension
+      tone="default"
+    />
+  )
+
+  return isDisabled ? (
+    <Tooltip content={t('result.save-result-as-csv.not-csv-encodable')} placement="top">
+      {button}
+    </Tooltip>
+  ) : (
+    button
+  )
+}
+
+export function SaveJsonButton({blobUrl}: SaveButtonProps) {
+  return (
+    <Button
+      as="a"
+      download={'query-result.json'}
+      href={blobUrl}
+      icon={DocumentSheetIcon}
+      mode="ghost"
+      // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
+      text="JSON" // String is a File extension
+      tone="default"
+    />
+  )
+}

--- a/packages/@sanity/vision/src/components/VisionGui.styled.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.styled.tsx
@@ -1,4 +1,4 @@
-import {Box, Card, Flex, Label, rem} from '@sanity/ui'
+import {Box, Card, Flex, Label, rem, Text} from '@sanity/ui'
 import {css, styled} from 'styled-components'
 
 export const Root = styled(Flex)`
@@ -127,7 +127,7 @@ export const Result = styled(Box)`
   z-index: 20;
 `
 
-export const TimingsFooter = styled(Box)`
+export const ResultFooter = styled(Flex)`
   border-top: 1px solid var(--card-border-color);
 `
 
@@ -149,6 +149,23 @@ export const TimingsTextContainer = styled(Flex)`
         theme.sanity.fonts.text.sizes[2].ascenderHeight -
         theme.sanity.fonts.text.sizes[2].descenderHeight,
     )};
+`
+
+export const DownloadsCard = styled(Card)`
+  position: relative;
+`
+
+export const SaveResultLabel = styled(Text)`
+  transform: initial;
+  &:before,
+  &:after {
+    content: none;
+  }
+  > span {
+    display: flex !important;
+    gap: ${({theme}) => rem(theme.sanity.space[3])};
+    align-items: center;
+  }
 `
 
 export const ControlsContainer = styled(Box)`

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -24,13 +24,14 @@ import {
 } from '@sanity/ui'
 import {isHotkey} from 'is-hotkey-esm'
 import {type ChangeEvent, createRef, PureComponent, type RefObject} from 'react'
-import {type TFunction} from 'sanity'
+import {type TFunction, Translate} from 'sanity'
 
 import {API_VERSIONS, DEFAULT_API_VERSION} from '../apiVersions'
 import {VisionCodeMirror} from '../codemirror/VisionCodeMirror'
 import {DEFAULT_PERSPECTIVE, isPerspective, PERSPECTIVES} from '../perspectives'
 import {type VisionProps} from '../types'
 import {encodeQueryString} from '../util/encodeQueryString'
+import {getCsvBlobUrl, getJsonBlobUrl} from '../util/getBlobUrl'
 import {getLocalStorage, type LocalStorageish} from '../util/localStorage'
 import {parseApiQueryString, type ParsedApiQueryString} from '../util/parseApiQueryString'
 import {prefixApiVersion} from '../util/prefixApiVersion'
@@ -42,8 +43,10 @@ import {ParamsEditor, type ParamsEditorChangeEvent} from './ParamsEditor'
 import {PerspectivePopover} from './PerspectivePopover'
 import {QueryErrorDialog} from './QueryErrorDialog'
 import {ResultView} from './ResultView'
+import {SaveCsvButton, SaveJsonButton} from './SaveResultButtons'
 import {
   ControlsContainer,
+  DownloadsCard,
   Header,
   InputBackgroundContainer,
   InputBackgroundContainerLeft,
@@ -51,13 +54,14 @@ import {
   QueryCopyLink,
   Result,
   ResultContainer,
+  ResultFooter,
   ResultInnerContainer,
   ResultOuterContainer,
   Root,
+  SaveResultLabel,
   SplitpaneContainer,
   StyledLabel,
   TimingsCard,
-  TimingsFooter,
   TimingsTextContainer,
 } from './VisionGui.styled'
 
@@ -669,6 +673,8 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
       url,
     } = this.state
     const hasResult = !error && !queryInProgress && typeof queryResult !== 'undefined'
+    const jsonUrl = hasResult ? getJsonBlobUrl(queryResult) : ''
+    const csvUrl = hasResult ? getCsvBlobUrl(queryResult) : ''
 
     return (
       <Root
@@ -948,7 +954,7 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
                 </ResultContainer>
               </ResultInnerContainer>
               {/* Execution time */}
-              <TimingsFooter>
+              <ResultFooter justify="space-between" direction={['column', 'column', 'row']}>
                 <TimingsCard paddingX={4} paddingY={3} sizing="border">
                   <TimingsTextContainer align="center">
                     <Box>
@@ -969,7 +975,26 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
                     </Box>
                   </TimingsTextContainer>
                 </TimingsCard>
-              </TimingsFooter>
+
+                {hasResult && (
+                  <DownloadsCard paddingX={4} paddingY={3} sizing="border">
+                    <SaveResultLabel muted>
+                      <Translate
+                        components={{
+                          SaveResultButtons: () => (
+                            <>
+                              <SaveJsonButton blobUrl={jsonUrl} />
+                              <SaveCsvButton blobUrl={csvUrl} />
+                            </>
+                          ),
+                        }}
+                        i18nKey="result.save-result-as-format"
+                        t={t}
+                      />
+                    </SaveResultLabel>
+                  </DownloadsCard>
+                )}
+              </ResultFooter>
             </ResultOuterContainer>
           </SplitPane>
         </SplitpaneContainer>

--- a/packages/@sanity/vision/src/i18n/resources.ts
+++ b/packages/@sanity/vision/src/i18n/resources.ts
@@ -44,6 +44,10 @@ const visionLocaleStrings = defineLocalesResources('vision', {
   'result.execution-time-label': 'Execution',
   /** Label for "Result" explorer/view */
   'result.label': 'Result',
+  /** Tooltip text shown when the query result is not encodable as CSV */
+  'result.save-result-as-csv.not-csv-encodable': 'Result cannot be encoded as CSV',
+  /** Label for "Save result as" result action */
+  'result.save-result-as-format': 'Save result as <SaveResultButtons/>',
   /**
    * "Not applicable" message for when there is no Execution time or End to End time information
    * available for the query (eg when the query has not been executed, or errored)

--- a/packages/@sanity/vision/src/util/getBlobUrl.ts
+++ b/packages/@sanity/vision/src/util/getBlobUrl.ts
@@ -1,0 +1,42 @@
+import {json2csv} from 'json-2-csv'
+
+function getBlobUrl(content: string, mimeType: string): string {
+  return URL.createObjectURL(
+    new Blob([content], {
+      type: mimeType,
+    }),
+  )
+}
+
+function getMemoizedBlobUrlResolver(mimeType: string, stringEncoder: (input: any) => string) {
+  return (() => {
+    let prevResult = ''
+    let prevContent = ''
+    return (input: unknown) => {
+      const content = stringEncoder(input)
+      if (typeof content !== 'string' || content === '') {
+        return undefined
+      }
+
+      if (content === prevContent) {
+        return prevResult
+      }
+
+      prevContent = content
+      if (prevResult) {
+        URL.revokeObjectURL(prevResult)
+      }
+
+      prevResult = getBlobUrl(content, mimeType)
+      return prevResult
+    }
+  })()
+}
+
+export const getJsonBlobUrl = getMemoizedBlobUrlResolver('application/json', (input) =>
+  JSON.stringify(input, null, 2),
+)
+
+export const getCsvBlobUrl = getMemoizedBlobUrlResolver('text/csv', (input) => {
+  return json2csv(Array.isArray(input) ? input : [input]).trim()
+})

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -195,7 +195,7 @@
     "execa": "^2.0.0",
     "exif-component": "^1.0.1",
     "framer-motion": "11.0.8",
-    "get-it": "^8.4.28",
+    "get-it": "^8.4.29",
     "get-random-values-esm": "1.0.2",
     "groq-js": "^1.8.0",
     "history": "^5.3.0",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -149,7 +149,7 @@
     "@sanity/bifur-client": "^0.3.1",
     "@sanity/block-tools": "3.41.1",
     "@sanity/cli": "3.41.1",
-    "@sanity/client": "^6.17.2",
+    "@sanity/client": "^6.18.0",
     "@sanity/color": "^3.0.0",
     "@sanity/diff": "3.41.1",
     "@sanity/diff-match-patch": "^3.1.1",

--- a/packages/sanity/src/core/form/inputs/BooleanInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/BooleanInput.test.tsx
@@ -1,5 +1,6 @@
 import {describe, expect, it} from '@jest/globals'
 import {defineField} from '@sanity/types'
+import {fireEvent, screen, waitFor} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import {renderBooleanInput} from '../../../../test/form/renderBooleanInput'
@@ -169,6 +170,18 @@ describe('readOnly property', () => {
     // Keyboard event
     userEvent.tab()
     expect(input).not.toHaveFocus()
+  })
+
+  it('renders a tooltip on the switch', async () => {
+    const {container} = await renderBooleanInput({
+      fieldDefinition: defs.booleanReadOnly,
+      render: (inputProps) => <BooleanInput {...inputProps} readOnly />,
+    })
+
+    const input = container.querySelector('input[id="booleanReadOnly"]')
+    fireEvent.mouseEnter(input!)
+
+    await waitFor(() => screen.getByText('Disabled'))
   })
 
   it('does not make field read-only with callback', async () => {

--- a/packages/sanity/src/core/form/inputs/BooleanInput.tsx
+++ b/packages/sanity/src/core/form/inputs/BooleanInput.tsx
@@ -1,6 +1,8 @@
 import {Box, Card, type CardTone, Checkbox, Flex, Switch} from '@sanity/ui'
 import {styled} from 'styled-components'
 
+import {Tooltip} from '../../../ui-components'
+import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {FormFieldHeaderText} from '../components/formField/FormFieldHeaderText'
 import {FormFieldStatus} from '../components/formField/FormFieldStatus'
 import {type BooleanInputProps} from '../types'
@@ -23,6 +25,7 @@ const ZeroLineHeightBox = styled(Box)`
  * @beta
  */
 export function BooleanInput(props: BooleanInputProps) {
+  const {t} = useTranslation()
   const {id, value, schemaType, readOnly, elementProps, validation} = props
   const layout = schemaType.options?.layout || 'switch'
 
@@ -33,19 +36,23 @@ export function BooleanInput(props: BooleanInputProps) {
 
   const tone: CardTone | undefined = readOnly ? 'transparent' : undefined
 
+  const input = (
+    <ZeroLineHeightBox padding={3}>
+      <LayoutSpecificInput
+        label={schemaType.title}
+        {...elementProps}
+        checked={checked}
+        readOnly={readOnly}
+        indeterminate={indeterminate}
+        style={{margin: -4}}
+      />
+    </ZeroLineHeightBox>
+  )
+
   return (
     <Root border data-testid="boolean-input" radius={2} tone={tone}>
       <Flex>
-        <ZeroLineHeightBox padding={3}>
-          <LayoutSpecificInput
-            label={schemaType.title}
-            {...elementProps}
-            checked={checked}
-            disabled={readOnly}
-            indeterminate={indeterminate}
-            style={{margin: -4}}
-          />
-        </ZeroLineHeightBox>
+        {readOnly ? <Tooltip content={t('inputs.boolean.disabled')}>{input}</Tooltip> : input}
         <Box flex={1} paddingY={2}>
           <FormFieldHeaderText
             deprecated={schemaType.deprecated}

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -506,6 +506,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'inputs.array.read-only-label': 'This field is read-only',
   /** Label for when the array input is resolving the initial value for the item */
   'inputs.array.resolving-initial-value': 'Resolving initial value…',
+  /** Tooltip content when boolean input is disabled */
+  'inputs.boolean.disabled': 'Disabled',
   /** Placeholder value for datetime input */
   'inputs.datetime.placeholder': 'e.g. {{example}}',
   /** Acessibility label for button to open file options menu */

--- a/packages/sanity/src/structure/panes/document/inspectDialog/InspectDialog.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectDialog/InspectDialog.tsx
@@ -111,6 +111,7 @@ export function InspectDialog(props: InspectDialogProps) {
                 isExpanded={isExpanded}
                 onClick={toggleExpanded}
                 search={Search}
+                filterOptions={{ignoreCase: true}}
               />
             </JSONInspectorWrapper>
           )}

--- a/packages/sanity/src/structure/structureBuilder/Component.ts
+++ b/packages/sanity/src/structure/structureBuilder/Component.ts
@@ -1,5 +1,6 @@
 import {type I18nTextRecord} from 'sanity'
 
+import {type IntentChecker} from './Intent'
 import {maybeSerializeMenuItem, type MenuItem, type MenuItemBuilder} from './MenuItem'
 import {
   maybeSerializeMenuItemGroup,
@@ -34,6 +35,7 @@ export interface Component extends StructureNode {
   menuItemGroups: MenuItemGroup[]
   /** Component options */
   options: {[key: string]: unknown}
+  canHandleIntent?: IntentChecker
 }
 
 /**
@@ -70,6 +72,7 @@ export interface BuildableComponent extends Partial<StructureNode> {
   menuItems?: (MenuItem | MenuItemBuilder)[]
   /** Component menu item groups. See {@link MenuItemGroup} and {@link MenuItemGroupBuilder} */
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
+  canHandleIntent?: IntentChecker
 }
 
 /**
@@ -205,6 +208,10 @@ export class ComponentBuilder implements Serializable<Component> {
     return this.spec.menuItemGroups
   }
 
+  canHandleIntent(canHandleIntent: IntentChecker): ComponentBuilder {
+    return this.clone({canHandleIntent})
+  }
+
   /** Serialize component
    * @param options - serialization options
    * @returns component object based on path provided in options
@@ -234,6 +241,7 @@ export class ComponentBuilder implements Serializable<Component> {
       type: 'component',
       child,
       component,
+      canHandleIntent: this.spec.canHandleIntent,
       options: componentOptions || {},
       menuItems: (this.spec.menuItems || []).map((item, i) =>
         maybeSerializeMenuItem(item, i, options.path),

--- a/perf/tests/package.json
+++ b/perf/tests/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@playwright/test": "1.41.2",
-    "@sanity/client": "^6.17.2",
+    "@sanity/client": "^6.18.0",
     "@sanity/uuid": "^3.0.1",
     "dotenv": "^16.0.3",
     "execa": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         specifier: workspace:*
         version: link:packages/@repo/tsconfig
       '@sanity/client':
-        specifier: ^6.17.2
+        specifier: ^6.18.0
         version: 6.18.0
       '@sanity/eslint-config-i18n':
         specifier: 1.0.0
@@ -410,7 +410,7 @@ importers:
         specifier: 3.41.1
         version: link:../../packages/@sanity/block-tools
       '@sanity/client':
-        specifier: ^6.17.2
+        specifier: ^6.18.0
         version: 6.18.0
       '@sanity/color':
         specifier: ^3.0.0
@@ -734,7 +734,7 @@ importers:
         specifier: ^7.23.5
         version: 7.24.5
       '@sanity/client':
-        specifier: ^6.17.2
+        specifier: ^6.18.0
         version: 6.18.0(debug@4.3.4)
       '@sanity/codegen':
         specifier: 3.41.1
@@ -1040,7 +1040,7 @@ importers:
         specifier: ^0.5.1
         version: 0.5.3
       '@sanity/client':
-        specifier: ^6.17.2
+        specifier: ^6.18.0
         version: 6.18.0(debug@4.3.4)
       '@sanity/types':
         specifier: 3.41.1
@@ -1284,7 +1284,7 @@ importers:
   packages/@sanity/types:
     dependencies:
       '@sanity/client':
-        specifier: ^6.17.2
+        specifier: ^6.18.0
         version: 6.18.0
       '@types/react':
         specifier: ^18.0.25
@@ -1303,7 +1303,7 @@ importers:
   packages/@sanity/util:
     dependencies:
       '@sanity/client':
-        specifier: ^6.17.2
+        specifier: ^6.18.0
         version: 6.18.0
       '@sanity/types':
         specifier: 3.41.1
@@ -1401,7 +1401,7 @@ importers:
         specifier: workspace:*
         version: link:../cli
       '@sanity/client':
-        specifier: ^6.17.2
+        specifier: ^6.18.0
         version: 6.18.0
       '@sanity/codegen':
         specifier: workspace:*
@@ -1491,7 +1491,7 @@ importers:
         specifier: 3.41.1
         version: link:../@sanity/cli
       '@sanity/client':
-        specifier: ^6.17.2
+        specifier: ^6.18.0
         version: 6.18.0(debug@4.3.4)
       '@sanity/color':
         specifier: ^3.0.0
@@ -1918,7 +1918,7 @@ importers:
         specifier: 1.41.2
         version: 1.41.2
       '@sanity/client':
-        specifier: ^6.17.2
+        specifier: ^6.18.0
         version: 6.18.0
       '@sanity/uuid':
         specifier: ^3.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1381,6 +1381,9 @@ importers:
       is-hotkey-esm:
         specifier: ^1.0.0
         version: 1.0.0
+      json-2-csv:
+        specifier: ^5.5.1
+        version: 5.5.1
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -9948,6 +9951,11 @@ packages:
         optional: true
     dev: true
 
+  /deeks@3.1.0:
+    resolution: {integrity: sha512-e7oWH1LzIdv/prMQ7pmlDlaVoL64glqzvNgkgQNgyec9ORPHrT2jaOqMtRyqJuwWjtfb6v+2rk9pmaHj+F137A==}
+    engines: {node: '>= 16'}
+    dev: false
+
   /deep-equal@2.2.3:
     resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
     engines: {node: '>= 0.4'}
@@ -10155,6 +10163,11 @@ packages:
   /direction@1.0.4:
     resolution: {integrity: sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==}
     hasBin: true
+    dev: false
+
+  /doc-path@4.1.1:
+    resolution: {integrity: sha512-h1ErTglQAVv2gCnOpD3sFS6uolDbOKHDU1BZq+Kl3npPqroU3dYL42lUgMfd5UimlwtRgp7C9dLGwqQ5D2HYgQ==}
+    engines: {node: '>=16'}
     dev: false
 
   /doctrine@2.1.0:
@@ -13986,6 +13999,14 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
     dev: true
+
+  /json-2-csv@5.5.1:
+    resolution: {integrity: sha512-KgAtAXTQopRwe90gh8SgjRSxgt9bUWbGAPMo9W0TZLA8SqiQH7khtagFfeEUjG3NBPwJu/+9uX5pMvunKaPvrQ==}
+    engines: {node: '>= 16'}
+    dependencies:
+      deeks: 3.1.0
+      doc-path: 4.1.1
+    dev: false
 
   /json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -761,7 +761,7 @@ importers:
         specifier: ^3.4.1
         version: 3.5.0(esbuild@0.21.1)
       get-it:
-        specifier: ^8.4.28
+        specifier: ^8.4.29
         version: 8.4.29(debug@4.3.4)
       groq-js:
         specifier: ^1.8.0
@@ -1629,7 +1629,7 @@ importers:
         specifier: 11.0.8
         version: 11.0.8(react-dom@18.3.1)(react@18.3.1)
       get-it:
-        specifier: ^8.4.28
+        specifier: ^8.4.29
         version: 8.4.29(debug@4.3.4)
       get-random-values-esm:
         specifier: 1.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6796,8 +6796,8 @@ packages:
       - debug
     dev: false
 
-  /@sanity/types@3.41.0:
-    resolution: {integrity: sha512-sE7A8+76sBR6YsI8liiwkEdAy3GZh9JjY+dnCzJziSqK1Sl1Iobguh2G4FkSzit1oggLM2trJTkWOmaQl4witQ==}
+  /@sanity/types@3.41.1:
+    resolution: {integrity: sha512-29pRfXQ6a89ozbZFQaUI/ldHde4bl/DL634CBj0gxTMYuFY7x/wLgCsjjDnMcJsB9Eiq+8enV8LNKdChGhW0Hg==}
     dependencies:
       '@sanity/client': 6.18.0
       '@types/react': 18.3.1
@@ -6877,12 +6877,12 @@ packages:
       - debug
     dev: false
 
-  /@sanity/util@3.41.0:
-    resolution: {integrity: sha512-u3PxtlJPpZXUeVq1op49V1teV1dDkLVjL3iomyyJt/YA72WgxFIHzy9Ib/3YIET5YJsnQj2x+gFEJYxGnYbIzQ==}
+  /@sanity/util@3.41.1:
+    resolution: {integrity: sha512-rMOKJqXiJwLvGXx91SiAiBwV1pm4MelAfLOuld3wDWc4XANKSicfX2jcfLhgU3WprOM4aaOEumiA1JEnqdanaQ==}
     engines: {node: '>=18'}
     dependencies:
       '@sanity/client': 6.18.0
-      '@sanity/types': 3.41.0
+      '@sanity/types': 3.41.1
       get-random-values-esm: 1.0.2
       moment: 2.30.1
       rxjs: 7.8.1
@@ -17301,7 +17301,7 @@ packages:
       '@sanity/image-url': 1.0.2
       '@sanity/incompatible-plugin': 1.0.4(react-dom@18.3.1)(react@18.3.1)
       '@sanity/ui': 2.1.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.10)
-      '@sanity/util': 3.41.0
+      '@sanity/util': 3.41.1
       '@types/lodash-es': 4.17.12
       framer-motion: 11.0.8(react-dom@18.3.1)(react@18.3.1)
       lodash-es: 4.17.21

--- a/test/e2e/tests/document-actions/delete.spec.ts
+++ b/test/e2e/tests/document-actions/delete.spec.ts
@@ -17,9 +17,15 @@ test(`unpublished documents can be deleted`, async ({page, createDraftDocument})
 test(`published documents can be deleted`, async ({page, createDraftDocument}) => {
   await createDraftDocument('/test/content/author')
   await page.getByTestId('field-name').getByTestId('string-input').fill(name)
+  const paneFooter = page.getByTestId('pane-footer-document-status')
 
+  // `.fill` and `.click` can cause the draft creation and publish to happen at the same exact time.
+  // We are waiting for 1s to make sure the draft actually gets created and click action is not too eager
+  await page.waitForTimeout(1000)
+
+  // Wait for the document to be published.
   await page.getByTestId('action-Publish').click()
-  await expect(page.getByText('was published')).toBeVisible()
+  expect(await paneFooter.textContent()).toMatch(/published/i)
 
   await page.getByTestId('action-menu-button').click()
   await page.getByTestId('action-Delete').click()


### PR DESCRIPTION
### Description

This branch updates the version of `next-sanity` installed when using the Sanity CLI to initialise a Next.js project. We're currently pinned to `next-sanity@7`, which is two major versions old.

### What to review

The version change is correct.

### Testing

`next-sanity@9` can run successfully in Next.js projects. This should already be well established, because it's the latest stable release and already used widely.
