### PR TITLE
fix(pte): don't render the PTE block extras container when not in use, disable pointer events on highlights

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/_common/ReviewChangesHighlightBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/_common/ReviewChangesHighlightBlock.tsx
@@ -13,5 +13,6 @@ export const ReviewChangesHighlightBlock = styled.div(({theme}) => {
     left: ${space[4] + space[1]}px;
     right: 0;
     background-color: ${bg};
+    pointer-events: none;
   `
 })

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.styles.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.styles.ts
@@ -41,6 +41,7 @@ function textBlockStyle(props: TextBlockStyleProps & {theme: Theme}) {
       background-color: var(--marker-bg-color);
       // This is to make sure the marker is always behind the text
       z-index: -1;
+      pointer-events: none;
     }
 
     &[data-markers] {

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
@@ -263,6 +263,9 @@ export function TextBlock(props: TextBlockProps) {
     [Markers, markers, renderCustomMarkers, tooltipEnabled, validation],
   )
 
+  const blockActionsVisible = renderBlockActions && focused && !readOnly
+  const changeIndicatorVisible = isFullscreen && memberItem
+
   return useMemo(
     () => (
       <Box
@@ -295,40 +298,47 @@ export function TextBlock(props: TextBlockProps) {
               </Tooltip>
             </Box>
 
-            <BlockExtrasContainer contentEditable={false}>
-              <BlockActionsOuter marginRight={1}>
-                <BlockActionsInner>
-                  {renderBlockActions && focused && !readOnly && (
-                    <BlockActions
-                      onChange={onChange}
-                      block={value}
-                      renderBlockActions={renderBlockActions}
+            {/*
+              Note that we only render this container if any children are present, as an
+              empty element will still occupy text space and display an invalid cursor on hover.
+            */}
+            {(blockActionsVisible || changeIndicatorVisible) && (
+              <BlockExtrasContainer contentEditable={false}>
+                {blockActionsVisible && (
+                  <BlockActionsOuter marginRight={1}>
+                    <BlockActionsInner>
+                      <BlockActions
+                        onChange={onChange}
+                        block={value}
+                        renderBlockActions={renderBlockActions}
+                      />
+                    </BlockActionsInner>
+                  </BlockActionsOuter>
+                )}
+                {changeIndicatorVisible && (
+                  <ChangeIndicatorWrapper
+                    $hasChanges={memberItem.member.item.changed}
+                    onMouseEnter={handleChangeIndicatorMouseEnter}
+                    onMouseLeave={handleChangeIndicatorMouseLeave}
+                  >
+                    <StyledChangeIndicatorWithProvidedFullPath
+                      hasFocus={focused}
+                      isChanged={memberItem.member.item.changed}
+                      path={memberItem.member.item.path}
+                      withHoverEffect={false}
                     />
-                  )}
-                </BlockActionsInner>
-              </BlockActionsOuter>
-
-              {isFullscreen && memberItem && (
-                <ChangeIndicatorWrapper
-                  $hasChanges={memberItem.member.item.changed}
-                  onMouseEnter={handleChangeIndicatorMouseEnter}
-                  onMouseLeave={handleChangeIndicatorMouseLeave}
-                >
-                  <StyledChangeIndicatorWithProvidedFullPath
-                    hasFocus={focused}
-                    isChanged={memberItem.member.item.changed}
-                    path={memberItem.member.item.path}
-                    withHoverEffect={false}
-                  />
-                </ChangeIndicatorWrapper>
-              )}
-            </BlockExtrasContainer>
+                  </ChangeIndicatorWrapper>
+                )}
+              </BlockExtrasContainer>
+            )}
             {reviewChangesHovered && <ReviewChangesHighlightBlock />}
           </Flex>
         </TextBlockFlexWrapper>
       </Box>
     ),
     [
+      blockActionsVisible,
+      changeIndicatorVisible,
       componentProps,
       focused,
       handleChangeIndicatorMouseEnter,
@@ -337,7 +347,6 @@ export function TextBlock(props: TextBlockProps) {
       hasMarkers,
       hasWarning,
       innerPaddingProps,
-      isFullscreen,
       memberItem,
       onChange,
       outerPaddingProps,


### PR DESCRIPTION
### Description

This PR makes some minor changes to text blocks and highlights.

**1. Disables `pointer-events` from the review changes highlight block**

Currently, it's possible to cause some render thrashing when hovering over the change indicator bar in fullscreen mode.

The highlight block doesn't contain any children, so it's safe for us to disable pointer events without having to fight z-index wars.

Before:

https://github.com/sanity-io/sanity/assets/209129/75ef6092-9736-464f-a68b-6fa336dd0183

After

https://github.com/sanity-io/sanity/assets/209129/39494504-a240-4c69-9233-fd5622fb8750


**2. Disables `pointer-events` from the validation highlight pseudo element**

_Really subtle_, but the presence of this would yield unwanted cursor changes when hovering over the periphery of text blocks.

Similar to the above, though this is rendered in a pseudo element so disabling pointer-events shouldn't affect children.

Before:

https://github.com/sanity-io/sanity/assets/209129/117c4452-51fb-489e-86de-d7fd2274ab79

After:

https://github.com/sanity-io/sanity/assets/209129/f9d9038d-0e15-4095-ac6f-58333c2c1cc8

**3. Don't render `BlockExtrasContainer`  in text blocks unless change indicators or (the now deprecated) block actions are present.**

The more significant change here – we now only render the block extras container if we can determine any (legacy) block actions exist, or if we need to display the change bar wrapper (in fullscreen mode)

This one is especially relevant to _Create_ as this container currently occupies space that could otherwise be used for text — like the above, it also shows a noticeable cursor change when hovering. This was especially noticeable in _Create_ given how much interaction happens on the RHS margins of PTE inputs.

Before (element highlighted for emphasis):

https://github.com/sanity-io/sanity/assets/209129/6d152b42-79ad-44a9-bacf-46063d0a5342

After:

https://github.com/sanity-io/sanity/assets/209129/0b93c786-87db-41f5-afb6-15bb9f677d52

### What to review

- Text block extras containers element should be hidden unless needed
- In general, mouse cursors shouldn't change when hovering around the periphery of text blocks in PTE

### Testing

No automated tests here – wasn't sure if it would be a bit overkill to create a playwright component test to validate cursor changes, happy to do so if needed!

### Notes for release

N/A