### PR TITLE
fix(sanity): make config flag override server document actions

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -149,9 +149,8 @@ export default defineConfig([
     plugins: [sharedSettings()],
     basePath: '/test',
     icon: SanityMonogram,
-    unstable_serverActions: {
-      enabled: true,
-    },
+    // eslint-disable-next-line camelcase
+    __internal_serverDocumentActions: {},
     scheduledPublishing: {
       enabled: true,
       inputDateTimeFormat: 'MM/dd/yy h:mm a',

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -204,7 +204,8 @@ export function prepareConfig(
       __internal: {
         sources: resolvedSources,
       },
-      serverActions: rawWorkspace.unstable_serverActions ?? {enabled: false},
+      // eslint-disable-next-line camelcase
+      __internal_serverDocumentActions: rawWorkspace.__internal_serverDocumentActions,
       ...defaultPluginsOptions,
     }
     preparedWorkspaces.set(rawWorkspace, workspaceSummary)

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -448,10 +448,10 @@ export interface WorkspaceOptions extends SourceOptions {
 
   /**
    * @hidden
-   * @beta
+   * @internal
    */
-  unstable_serverActions?: {
-    enabled: boolean
+  __internal_serverDocumentActions?: {
+    enabled?: boolean
   }
 
   scheduledPublishing?: DefaultPluginsWorkspaceOptions['scheduledPublishing']
@@ -770,8 +770,9 @@ export interface Source {
   }
   /** @beta */
   tasks?: WorkspaceOptions['tasks']
-  /** @beta */
-  serverActions?: WorkspaceOptions['unstable_serverActions']
+
+  /** @internal */
+  __internal_serverDocumentActions?: WorkspaceOptions['__internal_serverDocumentActions']
 }
 
 /** @internal */
@@ -810,7 +811,7 @@ export interface WorkspaceSummary extends DefaultPluginsWorkspaceOptions {
       source: Observable<Source>
     }>
   }
-  serverActions: WorkspaceOptions['unstable_serverActions']
+  __internal_serverDocumentActions: WorkspaceOptions['__internal_serverDocumentActions']
 }
 
 /**

--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -136,7 +136,7 @@ export function useDocumentStore(): DocumentStore {
   const serverActionsEnabled = useMemo(() => {
     const configFlag = workspace.__internal_serverDocumentActions?.enabled
     // If it's explicitly set, let it override the feature toggle
-    return typeof workspace.__internal_serverDocumentActions?.enabled === 'boolean'
+    return typeof configFlag === 'boolean'
       ? of(configFlag as boolean)
       : fetchFeatureToggle(getClient(DEFAULT_STUDIO_CLIENT_OPTIONS))
   }, [getClient, workspace.__internal_serverDocumentActions?.enabled])

--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -134,11 +134,12 @@ export function useDocumentStore(): DocumentStore {
   const workspace = useWorkspace()
 
   const serverActionsEnabled = useMemo(() => {
-    // If it's explicitly disabled, we'll just return a stream that emits `false`
-    return workspace.serverActions?.enabled === false
-      ? of(false)
+    const configFlag = workspace.__internal_serverDocumentActions?.enabled
+    // If it's explicitly set, let it override the feature toggle
+    return typeof workspace.__internal_serverDocumentActions?.enabled === 'boolean'
+      ? of(configFlag as boolean)
       : fetchFeatureToggle(getClient(DEFAULT_STUDIO_CLIENT_OPTIONS))
-  }, [getClient, workspace.serverActions?.enabled])
+  }, [getClient, workspace.__internal_serverDocumentActions?.enabled])
 
   return useMemo(() => {
     const documentStore =

--- a/packages/sanity/src/core/store/_legacy/grants/documentPairPermissions.ts
+++ b/packages/sanity/src/core/store/_legacy/grants/documentPairPermissions.ts
@@ -299,10 +299,9 @@ export function useDocumentPairPermissions({
   )
 
   const serverActionsEnabled = useMemo(() => {
-    // If it's explicitly disabled, we'll just return a stream that emits `false`
-    return workspace.__internal_serverDocumentActions?.enabled === false
-      ? of(false)
-      : fetchFeatureToggle(client)
+    const configFlag = workspace.__internal_serverDocumentActions?.enabled
+    // If it's explicitly set, let it override the feature toggle
+    return typeof configFlag === 'boolean' ? of(configFlag as boolean) : fetchFeatureToggle(client)
   }, [client, workspace.__internal_serverDocumentActions?.enabled])
 
   return useDocumentPairPermissionsFromHookFactory(

--- a/packages/sanity/src/core/store/_legacy/grants/documentPairPermissions.ts
+++ b/packages/sanity/src/core/store/_legacy/grants/documentPairPermissions.ts
@@ -300,8 +300,10 @@ export function useDocumentPairPermissions({
 
   const serverActionsEnabled = useMemo(() => {
     // If it's explicitly disabled, we'll just return a stream that emits `false`
-    return workspace.serverActions?.enabled === false ? of(false) : fetchFeatureToggle(client)
-  }, [client, workspace.serverActions?.enabled])
+    return workspace.__internal_serverDocumentActions?.enabled === false
+      ? of(false)
+      : fetchFeatureToggle(client)
+  }, [client, workspace.__internal_serverDocumentActions?.enabled])
 
   return useDocumentPairPermissionsFromHookFactory(
     useMemo(

--- a/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
+++ b/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
@@ -160,10 +160,9 @@ export function useTimelineStore({
   }, [rev, since, controller, timelineController$])
 
   const serverActionsEnabled = useMemo(() => {
-    // If it's explicitly disabled, we'll just return a stream that emits `false`
-    return workspace.__internal_serverDocumentActions?.enabled === false
-      ? of(false)
-      : fetchFeatureToggle(client)
+    const configFlag = workspace.__internal_serverDocumentActions?.enabled
+    // If it's explicitly set, let it override the feature toggle
+    return typeof configFlag === 'boolean' ? of(configFlag as boolean) : fetchFeatureToggle(client)
   }, [client, workspace.__internal_serverDocumentActions?.enabled])
 
   /**

--- a/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
+++ b/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
@@ -161,8 +161,10 @@ export function useTimelineStore({
 
   const serverActionsEnabled = useMemo(() => {
     // If it's explicitly disabled, we'll just return a stream that emits `false`
-    return workspace.serverActions?.enabled === false ? of(false) : fetchFeatureToggle(client)
-  }, [client, workspace.serverActions?.enabled])
+    return workspace.__internal_serverDocumentActions?.enabled === false
+      ? of(false)
+      : fetchFeatureToggle(client)
+  }, [client, workspace.__internal_serverDocumentActions?.enabled])
 
   /**
    * Fetch document snapshots and update the mutable controller.


### PR DESCRIPTION
### Description
While reviewing #6418 I realized that we probably want a way to enable server actions (e.g. to test intenrally) even in the case it's turned off for most users.

I think it also makes sense to make it very clear that it's internal, and not meant for studio developers.

### What to review
Does it make sense?

### Testing
- Might need to update some tests - opening as draft PR for now to gauge.

### Notes for release

n/a – not public facing