### PR TITLE
fix(sanity): respect Studio configuration when rendering "restore" document action

### DIFF
--- a/dev/test-studio/documentActions/actions/TestCustomRestoreAction.tsx
+++ b/dev/test-studio/documentActions/actions/TestCustomRestoreAction.tsx
@@ -1,0 +1,16 @@
+import {RocketIcon} from '@sanity/icons'
+import {type DocumentActionComponent} from 'sanity'
+
+export const TestCustomRestoreAction: (
+  action: DocumentActionComponent,
+) => DocumentActionComponent = (restoreAction) => {
+  const action: DocumentActionComponent = (props) => ({
+    ...restoreAction(props),
+    label: 'Custom restore',
+    tone: 'positive',
+    icon: RocketIcon,
+  })
+
+  action.action = 'restore'
+  return action
+}

--- a/dev/test-studio/documentActions/index.ts
+++ b/dev/test-studio/documentActions/index.ts
@@ -2,6 +2,7 @@ import {type DocumentActionsResolver} from 'sanity'
 
 import {TestConfirmDialogAction} from './actions/TestConfirmDialogAction'
 import {TestCustomComponentAction} from './actions/TestCustomComponentAction'
+import {TestCustomRestoreAction} from './actions/TestCustomRestoreAction'
 import {TestModalDialogAction} from './actions/TestModalDialogAction'
 import {TestPopoverDialogAction} from './actions/TestPopoverDialogAction'
 
@@ -13,7 +14,13 @@ export const resolveDocumentActions: DocumentActionsResolver = (prev, {schemaTyp
       TestPopoverDialogAction,
       TestCustomComponentAction,
       ...prev,
-    ]
+    ].map((action) => {
+      if (action.action === 'restore') {
+        return TestCustomRestoreAction(action)
+      }
+
+      return action
+    })
   }
 
   return prev

--- a/dev/test-studio/documentActions/index.ts
+++ b/dev/test-studio/documentActions/index.ts
@@ -23,5 +23,9 @@ export const resolveDocumentActions: DocumentActionsResolver = (prev, {schemaTyp
     })
   }
 
+  if (schemaType === 'removeRestoreActionTest') {
+    return prev.filter(({action}) => action !== 'restore')
+  }
+
   return prev
 }

--- a/dev/test-studio/schema/debug/removeRestoreAction.ts
+++ b/dev/test-studio/schema/debug/removeRestoreAction.ts
@@ -1,0 +1,12 @@
+export default {
+  type: 'document',
+  name: 'removeRestoreActionTest',
+  title: 'Remove Restore Action',
+  fields: [
+    {
+      type: 'string',
+      name: 'title',
+      title: 'Title',
+    },
+  ],
+}

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -62,6 +62,7 @@ import recursive from './debug/recursive'
 import recursiveArray from './debug/recursiveArray'
 import recursiveObjectTest, {recursiveObject} from './debug/recursiveObject'
 import recursivePopover from './debug/recursivePopover'
+import removeRestoreAction from './debug/removeRestoreAction'
 import reservedFieldNames from './debug/reservedFieldNames'
 import review from './debug/review'
 import * as scrollBugTypes from './debug/scrollBug'
@@ -197,6 +198,7 @@ export const schemaTypes = [
   fieldActionsTest,
   fieldComponentsTest,
   fieldsets,
+  removeRestoreAction,
 
   fieldValidationInferReproSharedObject,
   fieldValidationInferReproDoc,

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -74,6 +74,7 @@ export const DEBUG_INPUT_TYPES = [
   'recursiveDocument',
   'recursiveObjectTest',
   'recursivePopoverTest',
+  'removeRestoreActionTest',
   'reservedKeywordsTest',
   'scrollBug',
   'select',

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -17,6 +17,7 @@ import {isMenuNodeButton, isNotMenuNodeButton, resolveMenuNodes} from '../../../
 import {type PaneMenuItem} from '../../../../types'
 import {useStructureTool} from '../../../../useStructureTool'
 import {ActionDialogWrapper, ActionMenuListItem} from '../../statusBar/ActionMenuButton'
+import {isRestoreAction} from '../../statusBar/DocumentStatusBarActions'
 import {TimelineMenu} from '../../timeline'
 import {useDocumentPane} from '../../useDocumentPane'
 import {DocumentHeaderTabs} from './DocumentHeaderTabs'
@@ -34,7 +35,7 @@ export const DocumentPanelHeader = memo(
   ) {
     const {menuItems} = _props
     const {
-      actions,
+      actions: allActions,
       editState,
       onMenuAction,
       onPaneClose,
@@ -50,6 +51,13 @@ export const DocumentPanelHeader = memo(
     const {index, BackLink, hasGroupSiblings} = usePaneRouter()
     const {actions: fieldActions} = useFieldActions()
     const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null)
+
+    // The restore action has a dedicated place in the UI; it's only visible when the user is
+    // viewing a different document revision. It must be omitted from this collection.
+    const actions = useMemo(
+      () => (allActions ?? []).filter((action) => !isRestoreAction(action)),
+      [allActions],
+    )
 
     const menuNodes = useMemo(
       () =>
@@ -135,7 +143,7 @@ export const DocumentPanelHeader = memo(
               ))}
               {editState && (
                 <RenderActionCollectionState
-                  actions={actions || []}
+                  actions={actions}
                   actionProps={editState}
                   group="paneActions"
                 >

--- a/test/e2e/tests/document-actions/restore.spec.ts
+++ b/test/e2e/tests/document-actions/restore.spec.ts
@@ -44,3 +44,56 @@ test(`documents can be restored to an earlier revision`, async ({page, createDra
   await confirmButton.click()
   await expect(title).toHaveText(titleA)
 })
+
+test(`respects overridden restore action`, async ({page, createDraftDocument}) => {
+  const titleA = 'Title A'
+  const titleB = 'Title B'
+
+  const publishKeypress = () => page.locator('body').press('Control+Alt+p')
+  const documentStatus = page.getByTestId('pane-footer-document-status')
+  const restoreButton = page.getByTestId('action-Restore')
+  const customRestoreButton = page.getByRole('button').getByText('Custom restore')
+  const confirmButton = page.getByTestId('confirm-dialog-confirm-button')
+  const timelineMenuOpenButton = page.getByTestId('timeline-menu-open-button')
+  const timelineItemButton = page.getByTestId('timeline-item-button')
+  const previousRevisionButton = timelineItemButton.nth(2)
+  const titleInput = page.getByTestId('field-title').getByTestId('string-input')
+
+  await createDraftDocument('/test/content/input-debug;documentActionsTest')
+  const title = page.getByTestId('document-panel-document-title')
+  await titleInput.fill(titleA)
+
+  // Wait for the document to be published.
+  //
+  // Note: This is invoked using the publish keyboard shortcut, because the publish document action
+  // has been overridden for the `documentActionsTest` type, and is not visible without opening the
+  // document actions menu.
+  await page.waitForTimeout(1_000)
+  await publishKeypress()
+  await expect(documentStatus).toContainText('Published just now')
+
+  // Change the title.
+  await titleInput.fill(titleB)
+  await expect(title).toHaveText(titleB)
+
+  // Wait for the document to be published.
+  await page.waitForTimeout(1_000)
+  await publishKeypress()
+  await expect(documentStatus).toContainText('Published just now')
+
+  // Pick the previous revision from the revision timeline.
+  await timelineMenuOpenButton.click()
+  await expect(previousRevisionButton).toBeVisible()
+  await previousRevisionButton.click({force: true})
+
+  await expect(titleInput).toHaveValue(titleA)
+
+  // Ensure the custom restore button is rendered instead of the default restore button.
+  await expect(customRestoreButton).toBeVisible()
+  await expect(restoreButton).not.toBeVisible()
+
+  // Ensure the custom restore action can invoke the system restore action.
+  await customRestoreButton.click()
+  await confirmButton.click()
+  await expect(title).toHaveText(titleA)
+})

--- a/test/e2e/tests/document-actions/restore.spec.ts
+++ b/test/e2e/tests/document-actions/restore.spec.ts
@@ -138,3 +138,19 @@ test(`respects removed restore action`, async ({page, createDraftDocument}) => {
   // Ensure the restore button is not displayed.
   await expect(restoreButton).not.toBeVisible()
 })
+
+test(`user defined restore actions should not appear in any other document action group UI`, async ({
+  page,
+  createDraftDocument,
+}) => {
+  const actionMenuButton = page.getByTestId('action-menu-button')
+  const customRestoreButton = page.getByTestId('action-Customrestore')
+  const paneContextMenu = page.locator('[data-ui="MenuButton__popover"]')
+
+  await createDraftDocument('/test/content/input-debug;documentActionsTest')
+
+  await actionMenuButton.click()
+
+  await expect(paneContextMenu).toBeVisible()
+  await expect(customRestoreButton).not.toBeVisible()
+})

--- a/test/e2e/tests/document-actions/restore.spec.ts
+++ b/test/e2e/tests/document-actions/restore.spec.ts
@@ -97,3 +97,44 @@ test(`respects overridden restore action`, async ({page, createDraftDocument}) =
   await confirmButton.click()
   await expect(title).toHaveText(titleA)
 })
+
+test(`respects removed restore action`, async ({page, createDraftDocument}) => {
+  const titleA = 'Title A'
+  const titleB = 'Title B'
+
+  const documentStatus = page.getByTestId('pane-footer-document-status')
+  const publishButton = page.getByTestId('action-Publish')
+  const restoreButton = page.getByTestId('action-Restore')
+  const timelineMenuOpenButton = page.getByTestId('timeline-menu-open-button')
+  const timelineItemButton = page.getByTestId('timeline-item-button')
+  const previousRevisionButton = timelineItemButton.nth(2)
+  const title = page.getByTestId('document-panel-document-title')
+  const titleInput = page.getByTestId('field-title').getByTestId('string-input')
+
+  await createDraftDocument('/test/content/input-debug;removeRestoreActionTest')
+  await titleInput.fill(titleA)
+
+  // Wait for the document to be published.
+  await page.waitForTimeout(1_000)
+  await publishButton.click()
+  await expect(documentStatus).toContainText('Published just now')
+
+  // Change the title.
+  await titleInput.fill(titleB)
+  await expect(title).toHaveText(titleB)
+
+  // Wait for the document to be published.
+  await page.waitForTimeout(1_000)
+  await publishButton.click()
+  await expect(documentStatus).toContainText('Published just now')
+
+  // Pick the previous revision from the revision timeline.
+  await timelineMenuOpenButton.click()
+  await expect(previousRevisionButton).toBeVisible()
+  await previousRevisionButton.click({force: true})
+
+  await expect(titleInput).toHaveValue(titleA)
+
+  // Ensure the restore button is not displayed.
+  await expect(restoreButton).not.toBeVisible()
+})


### PR DESCRIPTION
### Description

The Studio document actions configuration is not currently respected when rendering the "Restore" document action.

#### For example, given a document actions resolver that removes the "Restore" document action:

``` ts
actions.filter((action) => action.action !== 'restore')
```

#### Studio will render it anyway:

<img width="1331" alt="Screenshot 2024-05-13 at 16 33 42" src="https://github.com/sanity-io/sanity/assets/1454914/1c0b6b94-2ce1-49b7-ad91-fe08b57b1135">

#### With this change in place, the document actions resolver is respected, allowing developers to remove or replace the action:

<img width="1331" alt="Screenshot 2024-05-13 at 16 35 43" src="https://github.com/sanity-io/sanity/assets/1454914/33831325-879e-4bd7-9fca-f4da0e155bcf">

#### Impact on public API

In order to replace the restore action, developers **must** set the `action` property to `"restore"` on their `DocumentActionComponent`.

```diff
import {RocketIcon} from '@sanity/icons'
import {type DocumentActionComponent} from 'sanity'

export const TestCustomRestoreAction: (
  action: DocumentActionComponent,
) => DocumentActionComponent = (restoreAction) => {
  const action: DocumentActionComponent = (props) => ({
    ...restoreAction(props),
    label: 'Custom restore',
    tone: 'positive',
    icon: RocketIcon,
  })

+ action.action = 'restore'
  return action
}
```

This is because the restore action is specially handled by Studio. It does not appear alongside the other document actions, but rather, appears only when a different revision of the document is being viewed. The `action` property allows Studio to identify the restore action.

I think we should begin recommending setting the `action` property [when developers replace _any_ built-in document actions](https://www.sanity.io/docs/document-actions#b34d4d68c564). Not only does this make things more consistent, it makes it easier for us to specially handled other document actions in the future.

We may wish to consider introducing a new helper to simplify this (e.g. `defineDocumentAction`). In the future, it could do other helpful things beyond setting the `action` property, such as automatically calling the built-in action's `onHandle` function if the developer is _extending_ a built-in action.

### What to review

- That we _should_ allow developers to customise the "restore" action.
- That the approach taken seems reasonable.
- That the proposed change to the public API seems reasonable.

### Testing

Added E2E tests in `test/e2e/tests/document-actions/restore.spec.ts`.

### Notes for release

Fixes a bug preventing developers removing or customising the "restore" document action using the `document.actions` Studio configuration property.

Studio will now respect changes you make to the "restore" document action, but please note that you **must** set the `action` property to `"restore"` on your `DocumentActionComponent`. The `action` property allows Studio to identify the restore action.

#### Example

```diff
import {RocketIcon} from '@sanity/icons'
import {type DocumentActionComponent} from 'sanity'

export const TestCustomRestoreAction: (
  action: DocumentActionComponent,
) => DocumentActionComponent = (restoreAction) => {
  const action: DocumentActionComponent = (props) => ({
    ...restoreAction(props),
    label: 'Custom restore',
    tone: 'positive',
    icon: RocketIcon,
  })

+ action.action = 'restore'
  return action
}
```
