### PR TITLE
Feat(CLI): Add "cli" as an integration when creating a new project through the CLI

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -815,7 +815,7 @@ export default async function initSanity(
         displayName: projectName,
         organizationId: await getOrganizationId(organizations),
         subscription: selectedPlan ? {planId: selectedPlan} : undefined,
-        metadata: {coupon: intendedCoupon},
+        metadata: {coupon: intendedCoupon, integration: 'cli'},
       }).then((response) => ({
         ...response,
         isFirstProject: isUsersFirstProject,

--- a/packages/@sanity/cli/src/actions/project/createProject.ts
+++ b/packages/@sanity/cli/src/actions/project/createProject.ts
@@ -4,7 +4,10 @@ export interface CreateProjectOptions {
   displayName: string
   organizationId?: string
   subscription?: {planId: string}
-  metadata?: {coupon?: string}
+  metadata?: {
+    coupon?: string
+    integration?: string
+  }
 }
 
 export function createProject(


### PR DESCRIPTION
### Description

Adding "cli" as integration to `metadata.integration` field to better track where a project is created. This follows the pattern we already use for Manage and our onboarding flow.

### What to review

Tbd

### Testing

Tbd

### Notes for release

None
