### PR TITLE
feat(pte): expose data-attributes on PTE Text + Object blocks

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -282,7 +282,12 @@ export function BlockObject(props: BlockObjectProps) {
         ref={memberItem?.elementRef as RefObject<HTMLDivElement> | undefined}
         contentEditable={false}
       >
-        <Flex paddingBottom={1} marginY={3} style={debugRender()}>
+        <Flex
+          data-object-block="" // used by create
+          paddingBottom={1}
+          marginY={3}
+          style={debugRender()}
+        >
           <InnerFlex flex={1}>
             <Tooltip
               placement="top"
@@ -291,7 +296,10 @@ export function BlockObject(props: BlockObjectProps) {
               disabled={isOpen ? true : !tooltipEnabled}
               content={toolTipContent}
             >
-              <PreviewContainer {...innerPaddingProps}>
+              <PreviewContainer
+                data-object-block-inner="" // used by create
+                {...innerPaddingProps}
+              >
                 {renderBlock && renderBlock(componentProps)}
               </PreviewContainer>
             </Tooltip>

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
@@ -270,12 +270,13 @@ export function TextBlock(props: TextBlockProps) {
     () => (
       <Box
         data-testid="text-block"
+        data-text-block=""
         {...outerPaddingProps}
         style={debugRender()}
         ref={memberItem?.elementRef as RefObject<HTMLDivElement>}
       >
         <TextBlockFlexWrapper data-testid="text-block__wrapper">
-          <Flex flex={1} {...innerPaddingProps}>
+          <Flex data-text-block-inner="" flex={1} {...innerPaddingProps}>
             <Box flex={1}>
               <Tooltip
                 content={toolTipContent}

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
@@ -269,14 +269,18 @@ export function TextBlock(props: TextBlockProps) {
   return useMemo(
     () => (
       <Box
-        data-testid="text-block"
-        data-text-block=""
         {...outerPaddingProps}
-        style={debugRender()}
+        data-testid="text-block"
+        data-text-block="" // used by create
         ref={memberItem?.elementRef as RefObject<HTMLDivElement>}
+        style={debugRender()}
       >
         <TextBlockFlexWrapper data-testid="text-block__wrapper">
-          <Flex data-text-block-inner="" flex={1} {...innerPaddingProps}>
+          <Flex
+            data-text-block-inner="" // used by create
+            flex={1}
+            {...innerPaddingProps}
+          >
             <Box flex={1}>
               <Tooltip
                 content={toolTipContent}


### PR DESCRIPTION
### Description

This tiny PR adds data attributes to PTE text + object blocks, as well as their children which have styles applied in JS (via `innerPaddingProps`)

These have been added in order for _Create_ to be able to safely target and override styles applied on these elements without resorting to sketchy CSS selectors.

There's definitely a greater question of how we could look to render `<PortableTextInput>` in a style-agnostic fashion in future. For now, this is very much a short term solve.

### What to review 

Nothing – this doesn't impact the studio...

### Questions

.. but does lead to some interesting questions!

- **When it comes to exposing arbitrary (non-test) data-attributes, is there a convention we should use to denote certain attributes as protected and in use externally?** 
  - E.g. I could easily see a future where someone searches for instances of these data attrs, finds none within the studio and then marks them for deletion.
  - If there isn't an existing convention, is it worth just attaching inline comments to these?
- As above, how customisable should PTE and all rendered output be? Perhaps a convention could be made where if we are applying styles-in-js, that we provide a data-attr / escape hatch for users to override these externally. 
Nothing that needs to be actioned any time soon, but perhaps worth formalising eventually (especially as we start to see more PTE usage within the studio _outside_ of document forms)

### Testing

N/A

### Notes for release

N/A