### PR TITLE
fix(pte): improve text selection in fullscreen inputs

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 
-import {Card, Container, rem} from '@sanity/ui'
+import {Card, rem} from '@sanity/ui'
 import {getTheme_v2} from '@sanity/ui/theme'
 import {css, styled} from 'styled-components'
 
@@ -68,11 +68,6 @@ export const Scroller = styled(ScrollContainer)`
   }
 `
 
-export const EditableContainer = styled(Container)`
-  /* @todo: calculate from theme */
-  /* max-width: 728px; */
-`
-
 export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $readOnly?: boolean}>`
   height: 100%;
   width: 100%;
@@ -129,6 +124,11 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $readOnly?:
     }
 
     padding-bottom: ${({$isFullscreen, theme}) => theme.sanity.space[$isFullscreen ? 9 : 5]}px;
+
+    & > .pt-block {
+      margin: 0 auto;
+      max-width: ${(props) => getTheme_v2(props.theme).container[1]}px;
+    }
 
     /* & > .pt-block {
       & .pt-inline-object {

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -214,11 +214,16 @@ export function Editor(props: EditorProps): ReactNode {
 
       <EditableCard flex={1} tone={readOnly ? 'transparent' : 'default'}>
         <Scroller ref={setScrollElement}>
-          <EditableWrapper $isFullscreen={isFullscreen} tone={readOnly ? 'transparent' : 'default'}>
-            <BoundaryElementProvider element={isFullscreen ? scrollElement : boundaryElement}>
-              {editable}
-            </BoundaryElementProvider>
-          </EditableWrapper>
+          <div>
+            <EditableWrapper
+              $isFullscreen={isFullscreen}
+              tone={readOnly ? 'transparent' : 'default'}
+            >
+              <BoundaryElementProvider element={isFullscreen ? scrollElement : boundaryElement}>
+                {editable}
+              </BoundaryElementProvider>
+            </EditableWrapper>
+          </div>
         </Scroller>
 
         <div data-portal="" ref={setPortalElement} />

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -14,7 +14,13 @@ import {
   type RenderStyleFunction,
 } from '@sanity/portable-text-editor'
 import {type Path} from '@sanity/types'
-import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
+import {
+  BoundaryElementProvider,
+  Box,
+  useBoundaryElement,
+  useGlobalKeyDown,
+  useLayer,
+} from '@sanity/ui'
 // eslint-disable-next-line camelcase
 import {getTheme_v2} from '@sanity/ui/theme'
 import {omit} from 'lodash'
@@ -25,14 +31,7 @@ import {TooltipDelayGroupProvider} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
 import {type PortableTextInputProps} from '../../types/inputProps'
 import {useFormBuilder} from '../../useFormBuilder'
-import {
-  EditableCard,
-  EditableContainer,
-  EditableWrapper,
-  Root,
-  Scroller,
-  ToolbarCard,
-} from './Editor.styles'
+import {EditableCard, EditableWrapper, Root, Scroller, ToolbarCard} from './Editor.styles'
 import {useScrollSelectionIntoView} from './hooks/useScrollSelectionIntoView'
 import {useSpellCheck} from './hooks/useSpellCheck'
 import {Decorator} from './text'
@@ -221,7 +220,7 @@ export function Editor(props: EditorProps): ReactNode {
 
       <EditableCard flex={1} tone={readOnly ? 'transparent' : 'default'}>
         <Scroller ref={setScrollElement}>
-          <EditableContainer padding={isFullscreen ? 2 : 0} sizing="border" width={1}>
+          <Box>
             <EditableWrapper
               $isFullscreen={isFullscreen}
               tone={readOnly ? 'transparent' : 'default'}
@@ -230,7 +229,7 @@ export function Editor(props: EditorProps): ReactNode {
                 {editable}
               </BoundaryElementProvider>
             </EditableWrapper>
-          </EditableContainer>
+          </Box>
         </Scroller>
 
         <div data-portal="" ref={setPortalElement} />

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -14,13 +14,7 @@ import {
   type RenderStyleFunction,
 } from '@sanity/portable-text-editor'
 import {type Path} from '@sanity/types'
-import {
-  BoundaryElementProvider,
-  Box,
-  useBoundaryElement,
-  useGlobalKeyDown,
-  useLayer,
-} from '@sanity/ui'
+import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
 // eslint-disable-next-line camelcase
 import {getTheme_v2} from '@sanity/ui/theme'
 import {omit} from 'lodash'
@@ -220,16 +214,11 @@ export function Editor(props: EditorProps): ReactNode {
 
       <EditableCard flex={1} tone={readOnly ? 'transparent' : 'default'}>
         <Scroller ref={setScrollElement}>
-          <Box>
-            <EditableWrapper
-              $isFullscreen={isFullscreen}
-              tone={readOnly ? 'transparent' : 'default'}
-            >
-              <BoundaryElementProvider element={isFullscreen ? scrollElement : boundaryElement}>
-                {editable}
-              </BoundaryElementProvider>
-            </EditableWrapper>
-          </Box>
+          <EditableWrapper $isFullscreen={isFullscreen} tone={readOnly ? 'transparent' : 'default'}>
+            <BoundaryElementProvider element={isFullscreen ? scrollElement : boundaryElement}>
+              {editable}
+            </BoundaryElementProvider>
+          </EditableWrapper>
         </Scroller>
 
         <div data-portal="" ref={setPortalElement} />

--- a/packages/sanity/src/core/form/inputs/PortableText/_common/ReviewChangesHighlightBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/_common/ReviewChangesHighlightBlock.tsx
@@ -11,7 +11,7 @@ export const ReviewChangesHighlightBlock = styled.div(({theme}) => {
     top: -${space[2]}px;
     bottom: -${space[1] + space[1]}px;
     left: ${space[4] + space[1]}px;
-    right: 0;
+    right: ${space[2]}px;
     background-color: ${bg};
     pointer-events: none;
   `

--- a/packages/sanity/src/core/form/inputs/PortableText/_common/ReviewChangesHighlightBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/_common/ReviewChangesHighlightBlock.tsx
@@ -11,7 +11,7 @@ export const ReviewChangesHighlightBlock = styled.div(({theme}) => {
     top: -${space[2]}px;
     bottom: -${space[1] + space[1]}px;
     left: ${space[4] + space[1]}px;
-    right: ${space[2]}px;
+    right: ${space[1]}px;
     background-color: ${bg};
     pointer-events: none;
   `

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.styles.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.styles.ts
@@ -70,8 +70,9 @@ export const Root = styled(Card)((props: {theme: Theme}) => {
   `
 })
 
-export const PreviewContainer = styled(Box)`
+export const PreviewContainer = styled(Flex)`
   display: block;
+  position: relative;
   width: 100%;
   user-select: none;
   pointer-events: all;
@@ -88,6 +89,7 @@ export const ChangeIndicatorWrapper = styled.div<{$hasChanges: boolean}>(
       top: 0;
       bottom: 0;
       padding-left: ${space[1]}px;
+      padding-right: ${space[2]}px;
       user-select: none;
 
       ${!$hasChanges &&
@@ -113,6 +115,8 @@ export const InnerFlex = styled(Flex)`
 export const BlockActionsOuter = styled(Box)`
   width: 25px;
   position: relative;
+  flex-shrink: 0;
+  user-select: none;
 
   [data-dragged] & {
     visibility: hidden;

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -46,7 +46,6 @@ import {
   BlockActionsInner,
   BlockActionsOuter,
   ChangeIndicatorWrapper,
-  InnerFlex,
   PreviewContainer,
   Root,
   TooltipBox,
@@ -122,8 +121,8 @@ export function BlockObject(props: BlockObjectProps) {
     [relativePath],
   )
 
-  const handleMouseOver = useCallback(() => setReviewChangesHovered(true), [])
-  const handleMouseOut = useCallback(() => setReviewChangesHovered(false), [])
+  const handleChangeIndicatorMouseEnter = useCallback(() => setReviewChangesHovered(true), [])
+  const handleChangeIndicatorMouseLeave = useCallback(() => setReviewChangesHovered(false), [])
 
   const onOpen = useCallback(() => {
     if (memberItem) {
@@ -276,6 +275,9 @@ export function BlockObject(props: BlockObjectProps) {
     ],
   )
 
+  const blockActionsEnabled = renderBlockActions && value && !readOnly
+  const changeIndicatorVisible = isFullscreen && memberItem
+
   return useMemo(
     () => (
       <Box
@@ -288,38 +290,42 @@ export function BlockObject(props: BlockObjectProps) {
           marginY={3}
           style={debugRender()}
         >
-          <InnerFlex flex={1}>
-            <Tooltip
-              placement="top"
-              portal="editor"
-              // If the object modal is open, disable the tooltip to avoid it rerendering the inner items when the validation changes.
-              disabled={isOpen ? true : !tooltipEnabled}
-              content={toolTipContent}
-            >
-              <PreviewContainer
-                data-object-block-inner="" // used by create
-                {...innerPaddingProps}
+          <PreviewContainer
+            data-object-block-inner="" // used by create
+            {...innerPaddingProps}
+          >
+            <Box flex={1}>
+              <Tooltip
+                placement="top"
+                portal="editor"
+                // If the object modal is open, disable the tooltip to avoid it rerendering the inner items when the validation changes.
+                disabled={isOpen ? true : !tooltipEnabled}
+                content={toolTipContent}
               >
-                {renderBlock && renderBlock(componentProps)}
-              </PreviewContainer>
-            </Tooltip>
-            <BlockActionsOuter marginRight={1}>
-              <BlockActionsInner>
-                {renderBlockActions && value && focused && !readOnly && (
-                  <BlockActions
-                    block={value}
-                    onChange={onChange}
-                    renderBlockActions={renderBlockActions}
-                  />
-                )}
-              </BlockActionsInner>
-            </BlockActionsOuter>
+                <div>{renderBlock && renderBlock(componentProps)}</div>
+              </Tooltip>
+            </Box>
 
-            {isFullscreen && memberItem && (
+            {blockActionsEnabled && (
+              <BlockActionsOuter contentEditable={false} marginRight={3}>
+                <BlockActionsInner>
+                  {focused && (
+                    <BlockActions
+                      block={value}
+                      onChange={onChange}
+                      renderBlockActions={renderBlockActions}
+                    />
+                  )}
+                </BlockActionsInner>
+              </BlockActionsOuter>
+            )}
+
+            {changeIndicatorVisible && (
               <ChangeIndicatorWrapper
                 $hasChanges={memberItem.member.item.changed}
-                onMouseOut={handleMouseOut}
-                onMouseOver={handleMouseOver}
+                contentEditable={false}
+                onMouseEnter={handleChangeIndicatorMouseEnter}
+                onMouseLeave={handleChangeIndicatorMouseLeave}
               >
                 <StyledChangeIndicatorWithProvidedFullPath
                   hasFocus={focused}
@@ -329,22 +335,21 @@ export function BlockObject(props: BlockObjectProps) {
                 />
               </ChangeIndicatorWrapper>
             )}
-
             {reviewChangesHovered && <ReviewChangesHighlightBlock />}
-          </InnerFlex>
+          </PreviewContainer>
         </Flex>
       </Box>
     ),
     [
+      blockActionsEnabled,
+      changeIndicatorVisible,
       componentProps,
       focused,
-      handleMouseOut,
-      handleMouseOver,
+      handleChangeIndicatorMouseLeave,
+      handleChangeIndicatorMouseEnter,
       innerPaddingProps,
-      isFullscreen,
       memberItem,
       onChange,
-      readOnly,
       renderBlock,
       renderBlockActions,
       reviewChangesHovered,

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.styles.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.styles.ts
@@ -168,6 +168,7 @@ export const ChangeIndicatorWrapper = styled.div<{$hasChanges: boolean}>(
       top: 0;
       bottom: 0;
       padding-left: ${space[1]}px;
+      padding-right: ${space[3]}px;
       user-select: none;
 
       ${!$hasChanges &&

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.styles.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.styles.ts
@@ -116,10 +116,6 @@ export const ListPrefixWrapper = styled.div`
   white-space: nowrap;
 `
 
-export const BlockExtrasContainer = styled(Box)`
-  user-select: none;
-`
-
 export const BlockActionsOuter = styled(Box)`
   line-height: 0;
   width: 25px;
@@ -168,7 +164,7 @@ export const ChangeIndicatorWrapper = styled.div<{$hasChanges: boolean}>(
       top: 0;
       bottom: 0;
       padding-left: ${space[1]}px;
-      padding-right: ${space[3]}px;
+      padding-right: ${space[2]}px;
       user-select: none;
 
       ${!$hasChanges &&

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
@@ -35,7 +35,6 @@ import {TEXT_STYLE_PADDING} from './constants'
 import {
   BlockActionsInner,
   BlockActionsOuter,
-  BlockExtrasContainer,
   ChangeIndicatorWrapper,
   ListPrefixWrapper,
   TextBlockFlexWrapper,
@@ -263,7 +262,7 @@ export function TextBlock(props: TextBlockProps) {
     [Markers, markers, renderCustomMarkers, tooltipEnabled, validation],
   )
 
-  const blockActionsVisible = renderBlockActions && focused && !readOnly
+  const blockActionsEnabled = renderBlockActions && !readOnly
   const changeIndicatorVisible = isFullscreen && memberItem
 
   return useMemo(
@@ -303,38 +302,34 @@ export function TextBlock(props: TextBlockProps) {
               </Tooltip>
             </Box>
 
-            {/*
-              Note that we only render this container if any children are present, as an
-              empty element will still occupy text space and display an invalid cursor on hover.
-            */}
-            {(blockActionsVisible || changeIndicatorVisible) && (
-              <BlockExtrasContainer contentEditable={false}>
-                {blockActionsVisible && (
-                  <BlockActionsOuter marginRight={1}>
-                    <BlockActionsInner>
-                      <BlockActions
-                        onChange={onChange}
-                        block={value}
-                        renderBlockActions={renderBlockActions}
-                      />
-                    </BlockActionsInner>
-                  </BlockActionsOuter>
-                )}
-                {changeIndicatorVisible && (
-                  <ChangeIndicatorWrapper
-                    $hasChanges={memberItem.member.item.changed}
-                    onMouseEnter={handleChangeIndicatorMouseEnter}
-                    onMouseLeave={handleChangeIndicatorMouseLeave}
-                  >
-                    <StyledChangeIndicatorWithProvidedFullPath
-                      hasFocus={focused}
-                      isChanged={memberItem.member.item.changed}
-                      path={memberItem.member.item.path}
-                      withHoverEffect={false}
+            {blockActionsEnabled && (
+              <BlockActionsOuter contentEditable={false} marginRight={3}>
+                <BlockActionsInner>
+                  {focused && (
+                    <BlockActions
+                      block={value}
+                      onChange={onChange}
+                      renderBlockActions={renderBlockActions}
                     />
-                  </ChangeIndicatorWrapper>
-                )}
-              </BlockExtrasContainer>
+                  )}
+                </BlockActionsInner>
+              </BlockActionsOuter>
+            )}
+
+            {changeIndicatorVisible && (
+              <ChangeIndicatorWrapper
+                $hasChanges={memberItem.member.item.changed}
+                contentEditable={false}
+                onMouseEnter={handleChangeIndicatorMouseEnter}
+                onMouseLeave={handleChangeIndicatorMouseLeave}
+              >
+                <StyledChangeIndicatorWithProvidedFullPath
+                  hasFocus={focused}
+                  isChanged={memberItem.member.item.changed}
+                  path={memberItem.member.item.path}
+                  withHoverEffect={false}
+                />
+              </ChangeIndicatorWrapper>
             )}
             {reviewChangesHovered && <ReviewChangesHighlightBlock />}
           </Flex>
@@ -342,7 +337,7 @@ export function TextBlock(props: TextBlockProps) {
       </Box>
     ),
     [
-      blockActionsVisible,
+      blockActionsEnabled,
       changeIndicatorVisible,
       componentProps,
       focused,

--- a/packages/sanity/src/core/studio/Studio.test.tsx
+++ b/packages/sanity/src/core/studio/Studio.test.tsx
@@ -43,7 +43,7 @@ describe('Studio', () => {
       const html = renderToStaticMarkup(sheet.collectStyles(<Studio config={config} />))
 
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-cbekWb bumVOU\\"><div data-ui=\\"Spinner\\" class=\\"sc-dAlxHm iMZvQo sc-cPiJYC ifYoiP sc-ifjxUM sIQhr\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-fGdjyZ dFEnsq\\"><div data-ui=\\"Spinner\\" class=\\"sc-dAlxHm iMZvQo sc-cPiJYC ifYoiP sc-iUHVUy dnCWXc\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
     } finally {
       sheet.seal()
@@ -60,7 +60,7 @@ describe('Studio', () => {
     try {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-cbekWb bumVOU\\"><div data-ui=\\"Spinner\\" class=\\"sc-dAlxHm iMZvQo sc-cPiJYC ifYoiP sc-ifjxUM sIQhr\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-fGdjyZ dFEnsq\\"><div data-ui=\\"Spinner\\" class=\\"sc-dAlxHm iMZvQo sc-cPiJYC ifYoiP sc-iUHVUy dnCWXc\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
     } finally {
       sheet.seal()


### PR DESCRIPTION
### Description

This PR sets `max-width` on PTE blocks, rather than the editable container.

This enables block margins to be clickable and improve ergonomics of focusing and selecting text, especially in fullscreen mode.

This is useful for _Create_ as there effectively all PTE inputs are in fullscreen by default and this was especially noticeable, as often these margins occupy much of the screen!

This change especially improves text selection in this context, as you can now start selections directly in the margins – fairly standard behaviour across various editors.

Before:

https://github.com/sanity-io/sanity/assets/209129/5ccac024-add5-446d-9ce6-032126113ea8

After:

https://github.com/sanity-io/sanity/assets/209129/e14d0e73-3235-482d-8ab9-5478e7e42ab3

**Other minor changes:**
1. Remove padding in fullscreen mode (not terribly noticeable, but this also ensures that we don't have a slight 'dead zone' around text where the cursor switches from `text` to `default`)
2. Slightly tweaks spacing of change highlight bars to look a little better on constrained viewports:

  Before:
  <img width="497" alt="image" src="https://github.com/sanity-io/sanity/assets/209129/cf6ffc14-809a-43f0-83a1-fa84d0752c69">

  After:
  <img width="495" alt="image" src="https://github.com/sanity-io/sanity/assets/209129/8f988859-8297-4dca-8f63-8e076a9f3dfc">

### What to review

- General text selection and focusing of collapsed / default PTE inputs in the Studio should be unaffected
- When in 'fullscreen' mode, it should be possible to focus and select text directly in the margins

### Testing

No new tests. This would be a fantastic candidate to test in playwright-ct (clicking block margins and double checking PTE selections), though unfortunately don't have the bandwidth to add right now 😓 

### Notes for release

Improves text selection of full screen Portable Text inputs