### PR TITLE
chore(deps): update dependency @sanity/bifur-client to ^0.4.0

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -146,7 +146,7 @@
     "@portabletext/react": "^3.0.0",
     "@rexxars/react-json-inspector": "^8.0.1",
     "@sanity/asset-utils": "^1.2.5",
-    "@sanity/bifur-client": "^0.3.1",
+    "@sanity/bifur-client": "^0.4.0",
     "@sanity/block-tools": "3.43.0",
     "@sanity/cli": "3.43.0",
     "@sanity/client": "^6.18.3",

--- a/packages/sanity/src/core/store/_legacy/presence/message-transports/bifurTransport.ts
+++ b/packages/sanity/src/core/store/_legacy/presence/message-transports/bifurTransport.ts
@@ -61,7 +61,7 @@ const handleIncomingMessage = (event: IncomingBifurEvent<Location[]>): Transport
 
 export const createBifurTransport = (bifur: BifurClient, sessionId: string): Transport => {
   const incomingEvents$: Observable<TransportEvent> = bifur
-    .request<IncomingBifurEvent<Location[]>>('presence')
+    .listen<IncomingBifurEvent<Location[]>>('presence')
     .pipe(map(handleIncomingMessage))
 
   const dispatchMessage = (message: TransportMessage): Observable<undefined> => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1515,8 +1515,8 @@ importers:
         specifier: ^1.2.5
         version: 1.3.0
       '@sanity/bifur-client':
-        specifier: ^0.3.1
-        version: 0.3.1
+        specifier: ^0.4.0
+        version: 0.4.0
       '@sanity/block-tools':
         specifier: 3.43.0
         version: link:../@sanity/block-tools
@@ -6565,8 +6565,8 @@ packages:
       - react-is
     dev: false
 
-  /@sanity/bifur-client@0.3.1:
-    resolution: {integrity: sha512-GlY9+tUmM0Vye64BHwIYLOivuRL37ucW/sj/D9MYqBmjgBnTRrjfmg8NR7qoodZuJ5nYJ5qpGMsVIBLP4Plvnw==}
+  /@sanity/bifur-client@0.4.0:
+    resolution: {integrity: sha512-5aXovw6//IGF/xOFl4q9hoq5kwHzYH1eJ88IS0AwPZEHmGEj8nuaWVu5SWUUOLYTMph+bVqHaDjB33MhWJ3hzQ==}
     dependencies:
       nanoid: 3.3.7
       rxjs: 7.8.1


### PR DESCRIPTION
### Description

The new bifur client introduced a breaking change, where subscription based methods have to be called on the `listen()` method instead of on the `request()` method. This makes it more obvious that they're going to provide values over time and not a one-off response. Additionally, it allows reusing the same base method name for both subscriptions and one-off requests, eg `authorize` vs `authorize_subscribe`.

### What to review

Presence still work as before.

### Testing

Only a dependency upgrade, so should not be necessary.

### Notes for release

None