### PR TITLE
chore(ci): tweak renovate preset to better align with branch rulesets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,7 +20,12 @@
     {
       "description": "Dependency updates to examples and the root should always use the chore scope as they aren't published to npm",
       "matchFileNames": ["package.json", "dev/**/package.json", "examples/**/package.json"],
-      "extends": [":semanticCommitTypeAll(chore)", "github>sanity-io/renovate-config:group-non-major"]
+      "extends": [":semanticCommitTypeAll(chore)"]
+    },
+    {
+      "description": "Group minor and patch deps in dev to a single PR",
+      "matchFileNames": ["dev/**/package.json"],
+      "extends": ["github>sanity-io/renovate-config:group-non-major"]
     },
     {
       "description": "Pin Presentation in Test Studio to the version that has the agressive focus path behavior that makes race conditions easier to debug",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,11 @@
   "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
   "packageRules": [
     {
+      "description": "Enable automerge with GitHub merge queues (note that this doesn't bypass required checks and code reviews)",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
       "description": "Slate upgrades are handled manually as they require extensive manual testing to verify it's safe to upgrade",
       "matchPackageNames": ["slate", "slate-react"],
       "enabled": false
@@ -15,7 +20,7 @@
     {
       "description": "Dependency updates to examples and the root should always use the chore scope as they aren't published to npm",
       "matchFileNames": ["package.json", "dev/**/package.json", "examples/**/package.json"],
-      "extends": [":semanticCommitTypeAll(chore)"]
+      "extends": [":semanticCommitTypeAll(chore)", "github>sanity-io/renovate-config:group-non-major"]
     },
     {
       "description": "Pin Presentation in Test Studio to the version that has the agressive focus path behavior that makes race conditions easier to debug",
@@ -36,6 +41,5 @@
       "semanticCommitType": "fix"
     }
   ],
-  "ignorePaths": ["packages/@sanity/cli/test/__fixtures__/v2/package.json"],
-  "rebaseWhen": "behind-base-branch"
+  "ignorePaths": ["packages/@sanity/cli/test/__fixtures__/v2/package.json"]
 }


### PR DESCRIPTION
This PR tweaks our Renovatebot preset to better align with changes to this repository settings since its introduction:
- Pull requests require code reviews from codeowners before merging.
- Pull requests require at least 1 code review from someone with write access before merging.
- GitHub Merge queues are enabled.
- If a rebase or a merge commit is pushed to a PR then existing PR review approvals are automatically dismissed and require re-approval to merge.

With those rules in mind these are the changes to our Renovate config:
- The `"rebaseWhen": "behind-base-branch"` rule is removed since it causes Renovatebot to always rebase a PR everytime someone pushes a commit to `next`. Removing this rule allows you to queue up Renovate PRs and batch them. It also greatly reduces the amount of Vercel deployments of the test studios as Renovatebot will only automatically rebase PRs if there's a merge conflict moving forward.
- The `automerge` is set to `true` for minor and patch updates. Note that this doesn't bypass any rules such as required code review. It has the same effect as pressing "Merge when ready" manually, and allows speeding up maintenance as PRs are queued the second they have the required approvals from code owners, without waiting for another maintainer to notice that it's ready to merge.

And as a bonus, for deps that live in `"dev/**/package.json"` we're now grouping deps that are minor and patch.
This way the Studio DX team will no longer have to deal with these deps bumping separately:
- `@sanity/react-loader`
- `@sanity/visual-editing`
- `next`
- `@sanity/assist`