### PR TITLE
fix(typegen): move type new line separator into formatter

### DIFF
--- a/packages/@sanity/cli/src/actions/typegen/generateAction.ts
+++ b/packages/@sanity/cli/src/actions/typegen/generateAction.ts
@@ -146,7 +146,7 @@ export default async function typegenGenerateAction(
         stats.unknownTypeNodesGenerated += unknownTypeNodesGenerated
         stats.emptyUnionTypeNodesGenerated += emptyUnionTypeNodesGenerated
       }
-      typeFile.write(`${fileTypeString}\n`)
+      typeFile.write(fileTypeString)
       stats.size += Buffer.byteLength(fileTypeString)
     })
     worker.addListener('error', reject)

--- a/packages/@sanity/cli/src/actions/typegen/generateAction.ts
+++ b/packages/@sanity/cli/src/actions/typegen/generateAction.ts
@@ -124,7 +124,7 @@ export default async function typegenGenerateAction(
 
       if (msg.type === 'schema') {
         stats.schemaTypesCount += msg.length
-        fileTypeString += `${msg.schema}\n\n`
+        fileTypeString += msg.schema
         typeFile.write(fileTypeString)
         return
       }
@@ -140,7 +140,7 @@ export default async function typegenGenerateAction(
       } of msg.types) {
         fileTypeString += `// Variable: ${queryName}\n`
         fileTypeString += `// Query: ${query.replace(/(\r\n|\n|\r)/gm, '')}\n`
-        fileTypeString += `${type}\n`
+        fileTypeString += type
         stats.queriesCount++
         stats.typeNodesGenerated += typeNodesGenerated
         stats.unknownTypeNodesGenerated += unknownTypeNodesGenerated

--- a/packages/@sanity/cli/src/workers/typegenGenerate.ts
+++ b/packages/@sanity/cli/src/workers/typegenGenerate.ts
@@ -63,7 +63,7 @@ registerBabel()
 
 function maybeFormatCode(code: string, prettierConfig: PrettierOptions | null): Promise<string> {
   if (!prettierConfig) {
-    return Promise.resolve(code)
+    return Promise.resolve(`${code}\n`) // add an extra new newline, poor mans formatting
   }
 
   try {
@@ -82,7 +82,7 @@ async function main() {
 
   const typeGenerator = new TypeGenerator(schema)
   const schemaTypes = await maybeFormatCode(
-    [typeGenerator.generateSchemaTypes(), TypeGenerator.generateKnownTypes()].join('\n'),
+    [typeGenerator.generateSchemaTypes(), TypeGenerator.generateKnownTypes()].join('\n').trim(),
     opts.prettierConfig,
   )
   const resolver = getResolver()
@@ -125,7 +125,7 @@ async function main() {
         const queryTypes = typeEvaluate(ast, schema)
 
         const type = await maybeFormatCode(
-          typeGenerator.generateTypeNodeTypes(`${queryName}Result`, queryTypes),
+          typeGenerator.generateTypeNodeTypes(`${queryName}Result`, queryTypes).trim(),
           opts.prettierConfig,
         )
 

--- a/packages/@sanity/cli/test/__snapshots__/typegen.test.ts.snap
+++ b/packages/@sanity/cli/test/__snapshots__/typegen.test.ts.snap
@@ -32,13 +32,9 @@ export type Slug = {
   source?: string;
 };
 export declare const internalGroqTypeReferenceTo: unique symbol;
-
-
 // Source: ./src/queries.ts
 // Variable: PAGE_QUERY
 // Query: *[_type == \\"page\\" && slug.current == $slug][0]
 export type PAGE_QUERYResult = null;
-
-
 "
 `;

--- a/packages/@sanity/codegen/src/typescript/typeGenerator.ts
+++ b/packages/@sanity/codegen/src/typescript/typeGenerator.ts
@@ -70,7 +70,7 @@ export class TypeGenerator {
       type,
     )
 
-    return new CodeGenerator(t.exportNamedDeclaration(typeAlias)).generate().code
+    return new CodeGenerator(t.exportNamedDeclaration(typeAlias)).generate().code.trim()
   }
 
   static generateKnownTypes(): string {
@@ -82,7 +82,7 @@ export class TypeGenerator {
 
     const decleration = t.variableDeclaration('const', [t.variableDeclarator(identifier)])
     decleration.declare = true
-    return new CodeGenerator(t.exportNamedDeclaration(decleration)).generate().code
+    return new CodeGenerator(t.exportNamedDeclaration(decleration)).generate().code.trim()
   }
 
   /**


### PR DESCRIPTION
### Description

Prettier were adding a newline, and then we were adding an additional new line to each type. This moves new line into the maybeFormatCode to either rely on prettier adding it, or adding it manually if prettier is not found.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

We have test that checks a snapshot, these are updated

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

fixes a bug where typegen would add an additional new line between types.