### PR TITLE
chore: add a newline to the extracted schema.json

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/schema/extractAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/schema/extractAction.ts
@@ -82,7 +82,7 @@ export default async function extractAction(
 
     spinner.text = `Writing schema to ${path}`
 
-    await writeFile(path, JSON.stringify(schema, null, 2))
+    await writeFile(path, `${JSON.stringify(schema, null, 2)}\n`)
 
     trace.complete()
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds a new line to generated schema json file, this is expected by most formatters

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

We don't have any test for this specific part of the code as all it does is json.stringify the extracted schema. The extracted schema part is well tested already.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

schema extraction: add a trailing new line to the generated schema.json file


