### PR TITLE
refactor(renovate): group non major dev deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,7 +25,18 @@
     {
       "description": "Group minor and patch deps in dev to a single PR",
       "matchFileNames": ["dev/**/package.json"],
-      "extends": ["github>sanity-io/renovate-config:group-non-major"]
+      "groupName": "dev-non-major",
+      "matchUpdateTypes": [
+        "bump",
+        "digest",
+        "lockfileUpdate",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "replacement",
+        "rollback"
+      ]
     },
     {
       "description": "Pin Presentation in Test Studio to the version that has the agressive focus path behavior that makes race conditions easier to debug",


### PR DESCRIPTION
Follow up on #6648, the grouping didn't actually work as the `ignorePresets` directive takes presedence: https://github.com/sanity-io/sanity/blob/11dcb1ad9be866db21840b9868d6c23e934ac862/.github/renovate.json#L8
