### PR TITLE
chore(ci): set a shorter cache on manifest

### DIFF
--- a/scripts/uploadBundles.ts
+++ b/scripts/uploadBundles.ts
@@ -160,6 +160,10 @@ async function updateManifest(newVersions: Map<string, string>) {
     const options = {
       destination: 'modules/v1/manifest-v1.json',
       contentType: 'application/json',
+      metadata: {
+        // 10 mins cache
+        cacheControl: 'public, max-age=600',
+      },
     }
 
     await bucket.upload('manifest-v1.json', options)

--- a/scripts/uploadBundles.ts
+++ b/scripts/uploadBundles.ts
@@ -71,6 +71,10 @@ async function copyPackages() {
           destination: `modules/${appVersion}/${cleanDir}/${version}/bare/${fileName}`,
           gzip: true,
           contentType: 'application/javascript',
+          metadata: {
+            // 1 year cache
+            cacheControl: 'public, max-age=31536000, immutable',
+          },
         }
 
         // Upload files to the proper bucket destination
@@ -161,8 +165,8 @@ async function updateManifest(newVersions: Map<string, string>) {
       destination: 'modules/v1/manifest-v1.json',
       contentType: 'application/json',
       metadata: {
-        // 10 mins cache
-        cacheControl: 'public, max-age=600',
+        // 10 seconds
+        cacheControl: 'public, max-age=10',
       },
     }
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
Update the cache header on the manifest to be 10s and JS files to 1 year immutable

FIXES SDX-1343

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Changes makes sense

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

N/A

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

N/A (internal)