### PR TITLE
fix: remove circular reference to `usePaneRouter`

### DIFF
--- a/packages/sanity/src/structure/panes/document/comments/CommentsWrapper.tsx
+++ b/packages/sanity/src/structure/panes/document/comments/CommentsWrapper.tsx
@@ -5,8 +5,8 @@ import {
   CommentsProvider,
   useCommentsEnabled,
 } from 'sanity'
-import {usePaneRouter} from 'sanity/structure'
 
+import {usePaneRouter} from '../../../components'
 import {useDocumentPane} from '../useDocumentPane'
 
 interface CommentsWrapperProps {


### PR DESCRIPTION
### Description

When running `sanity build` this annoying warning happens:
```bash
✔ Clean output folder (3ms)
Export "P" of module "node_modules/sanity/lib/_chunks-es/StructureToolProvider.mjs" was reexported through module "node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/@sanity/presentation/dist/_chunks-es/PresentationTool.js" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
Export "S" of module "node_modules/sanity/lib/_chunks-es/StructureToolProvider.mjs" was reexported through module "node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/@sanity/presentation/dist/_chunks-es/PresentationTool.js" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
Export "g" of module "node_modules/sanity/lib/_chunks-es/StructureToolProvider.mjs" was reexported through module "node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/@sanity/presentation/dist/_chunks-es/PresentationTool.js" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
Export "h" of module "node_modules/sanity/lib/_chunks-es/StructureToolProvider.mjs" was reexported through module "node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/@sanity/presentation/dist/_chunks-es/PresentationTool.js" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
Export "R" of module "node_modules/sanity/lib/_chunks-es/StructureToolProvider.mjs" was reexported through module "node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/@sanity/presentation/dist/_chunks-es/BroadcastDisplayedDocument.js" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
✔ Build Sanity Studio (10895ms)
```

Turns out the root cause is that inside `node_modules/sanity/lib/_chunks-es/StructureToolProvider.mjs` there's this import:

```ts
import {usePaneRouter} from 'sanity/structure'
```
That's a problem, because `sanity/lib/structure.mjs` is re-exporting from `./_chunks-es/StructureToolProvider.mjs`.
This PR solves it by changing the import to the same relative imports used by other components that use `usePaneRouter`.

### What to review

If it builds it works, moving forward we should be careful not to introduce new circular references. `git blame` shows that this circular import were added less than a month ago.

### Testing

Existing tests are sufficient

### Notes for release

Fixes a circular import inside `sanity/structure` for `usePaneRouter`
