### PR TITLE
refactor(cli): allow all properties from ClientConfig in `getCliClient`

### DIFF
--- a/packages/@sanity/cli/src/__test__/cliCient.test.ts
+++ b/packages/@sanity/cli/src/__test__/cliCient.test.ts
@@ -1,0 +1,77 @@
+import {afterAll, beforeAll, describe, expect, it, jest} from '@jest/globals'
+
+import {getCliClient} from '../cliClient'
+import {type CliConfig} from '../types'
+import {resolveRootDir} from '../util/resolveRootDir'
+
+jest.mock('@sanity/client', () => ({
+  // create a mock that only implements the `config()` method
+  createClient: jest.fn((config) => ({config: () => config})),
+}))
+
+jest.mock('../util/resolveRootDir', () => ({
+  resolveRootDir: jest.fn((dir) => dir || 'MOCK_ROOT_DIR'),
+}))
+
+jest.mock('../util/getCliConfig', () => {
+  const mockCliConfig: CliConfig = {
+    api: {
+      dataset: 'dataset-from-mock-config',
+      projectId: 'project-from-mock-config',
+    },
+  }
+
+  return {
+    getCliConfigSync: jest.fn((rootDir: string) => ({
+      config: mockCliConfig,
+      path: `${rootDir}/sanity.cli.ts`,
+      version: 3,
+    })),
+  }
+})
+
+beforeAll(() => {
+  // eslint-disable-next-line camelcase
+  Object.assign(getCliClient, {__internal__getToken: () => 'test-token'})
+})
+
+afterAll(() => {
+  jest.resetAllMocks()
+})
+
+describe('getCliClient', () => {
+  it('creates a sanity client with defaults for useCdn, apiVersion, and token if projectId and dataset are provided', () => {
+    const client = getCliClient({
+      projectId: 'myproject',
+      dataset: 'test',
+      perspective: 'published',
+    })
+
+    expect(client.config()).toMatchObject({
+      projectId: 'myproject',
+      dataset: 'test',
+      perspective: 'published',
+      apiVersion: '2022-06-06',
+      useCdn: false,
+      token: 'test-token',
+    })
+  })
+
+  it('creates a sanity client using the config file if no projectId or dataset was provided', () => {
+    const client = getCliClient({
+      perspective: 'published',
+      cwd: 'ANOTHER_ROOT_DIR',
+    })
+
+    expect(resolveRootDir).toHaveBeenCalledWith('ANOTHER_ROOT_DIR')
+
+    expect(client.config()).toMatchObject({
+      projectId: 'project-from-mock-config',
+      dataset: 'dataset-from-mock-config',
+      perspective: 'published',
+      apiVersion: '2022-06-06',
+      useCdn: false,
+      token: 'test-token',
+    })
+  })
+})

--- a/packages/@sanity/cli/src/cliClient.ts
+++ b/packages/@sanity/cli/src/cliClient.ts
@@ -1,16 +1,20 @@
-import {createClient, type SanityClient} from '@sanity/client'
+import {type ClientConfig, createClient, type SanityClient} from '@sanity/client'
 
 import {getCliConfigSync} from './util/getCliConfig'
 import {resolveRootDir} from './util/resolveRootDir'
 
-export interface CliClientOptions {
+/**
+ * `getCliClient` accepts all options the `ClientConfig` does but provides
+ * `projectId` and `dataset` from the `sanity.cli.ts` configuration file along
+ * with a token in certain scenarios (e.g. `sanity exec SCRIPT -with-user-token`)
+ */
+export interface CliClientOptions extends ClientConfig {
+  /**
+   * If no `projectId` or `dataset` is provided, `getCliClient` will try to
+   * resolve these from the `sanity.cli.ts` configuration file. Use this option
+   * to specify the directory to look for this file.
+   */
   cwd?: string
-
-  projectId?: string
-  dataset?: string
-  useCdn?: boolean
-  token?: string
-  apiVersion?: string
 }
 
 export function getCliClient(options: CliClientOptions = {}): SanityClient {
@@ -26,10 +30,11 @@ export function getCliClient(options: CliClientOptions = {}): SanityClient {
     projectId,
     dataset,
     token = getCliClient.__internal__getToken(),
+    ...restOfOptions
   } = options
 
   if (projectId && dataset) {
-    return createClient({projectId, dataset, apiVersion, useCdn, token})
+    return createClient({projectId, dataset, apiVersion, useCdn, token, ...restOfOptions})
   }
 
   const rootDir = resolveRootDir(cwd)
@@ -49,6 +54,7 @@ export function getCliClient(options: CliClientOptions = {}): SanityClient {
     apiVersion,
     useCdn,
     token,
+    ...restOfOptions,
   })
 }
 


### PR DESCRIPTION
### Description

Allows all options from `createClient` in `getCliClient`. There doesn't seem to be any breaking changes here. Closes sdx-1323

### What to review

Everything look good? Any unexpected changes here?

### Testing

I added a unit test that mocks what it calls but it does not do any integration testing.

### Notes for release

Allows all `@sanity/client` `ClientOptions` in `getCliClient`.
