### PR TITLE
feat(sanity): use Actions API when restoring drafts

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -36,6 +36,7 @@ import {del as serverDel} from './serverOperations/delete'
 import {discardChanges as serverDiscardChanges} from './serverOperations/discardChanges'
 import {patch as serverPatch} from './serverOperations/patch'
 import {publish as serverPublish} from './serverOperations/publish'
+import {restore as serverRestore} from './serverOperations/restore'
 import {unpublish as serverUnpublish} from './serverOperations/unpublish'
 
 interface ExecuteArgs {
@@ -62,6 +63,7 @@ const operationImpls = {
 } as const
 
 //as we add server operations one by one, we can add them here
+// Note: Any changes must also be made to `createOperationsAPI`, which is defined in `packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts`.
 const serverOperationImpls = {
   ...operationImpls,
   del: serverDel,
@@ -70,6 +72,7 @@ const serverOperationImpls = {
   patch: serverPatch,
   publish: serverPublish,
   unpublish: serverUnpublish,
+  restore: serverRestore,
 }
 
 const execute = (

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
@@ -5,6 +5,7 @@ import {del as serverDel} from '../serverOperations/delete'
 import {discardChanges as serverDiscardChanges} from '../serverOperations/discardChanges'
 import {patch as serverPatch} from '../serverOperations/patch'
 import {publish as serverPublish} from '../serverOperations/publish'
+import {restore as serverRestore} from '../serverOperations/restore'
 import {unpublish as serverUnpublish} from '../serverOperations/unpublish'
 import {commit} from './commit'
 import {del} from './delete'
@@ -69,6 +70,7 @@ export function createOperationsAPI(args: OperationArgs): OperationsAPI {
   }
 
   //as we add server operations one by one, we can add them here
+  // Note: Any changes must also be made to `serverOperationImpls`, which is defined in `packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts`.
   if (args.serverActionsEnabled) {
     return {
       ...operationsAPI,
@@ -78,6 +80,7 @@ export function createOperationsAPI(args: OperationArgs): OperationsAPI {
       patch: wrap('patch', serverPatch, args),
       publish: wrap('publish', serverPublish, args),
       unpublish: wrap('unpublish', serverUnpublish, args),
+      restore: wrap('restore', serverRestore, args),
     }
   }
   return operationsAPI

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/restore.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/restore.ts
@@ -1,0 +1,12 @@
+import {type OperationImpl} from '../operations/types'
+import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
+
+export const restore: OperationImpl<[fromRevision: string]> = {
+  disabled: (): false => false,
+  execute: ({historyStore, schema, idPair, typeName}, fromRevision: string) => {
+    const targetId = isLiveEditEnabled(schema, typeName) ? idPair.publishedId : idPair.draftId
+    return historyStore.restore(idPair.publishedId, targetId, fromRevision, {
+      useServerDocumentActions: true,
+    })
+  },
+}

--- a/packages/sanity/src/structure/panes/document/timeline/timelineItem.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/timelineItem.tsx
@@ -70,6 +70,7 @@ export function TimelineItem({
     <Root
       $selected={isSelected}
       $disabled={!isSelectable}
+      data-testid="timeline-item-button"
       data-chunk-id={chunk.id}
       data-first={isFirst ? true : undefined}
       data-last={isLast ? true : undefined}

--- a/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
@@ -158,6 +158,7 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
 
   return (
     <Root
+      data-testid="timeline-menu"
       constrainSize
       content={open && content}
       data-ui="versionMenu"
@@ -167,6 +168,7 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
       ref={setPopover}
     >
       <Button
+        data-testid={open ? 'timeline-menu-close-button' : 'timeline-menu-open-button'}
         disabled={!ready}
         mode="bleed"
         iconRight={ChevronDownIcon}

--- a/test/e2e/tests/document-actions/restore.spec.ts
+++ b/test/e2e/tests/document-actions/restore.spec.ts
@@ -1,0 +1,46 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+test(`documents can be restored to an earlier revision`, async ({page, createDraftDocument}) => {
+  const titleA = 'Title A'
+  const titleB = 'Title B'
+
+  const documentStatus = page.getByTestId('pane-footer-document-status')
+  const publishButton = page.getByTestId('action-Publish')
+  const restoreButton = page.getByTestId('action-Restore')
+  const confirmButton = page.getByTestId('confirm-dialog-confirm-button')
+  const timelineMenuOpenButton = page.getByTestId('timeline-menu-open-button')
+  const timelineItemButton = page.getByTestId('timeline-item-button')
+  const previousRevisionButton = timelineItemButton.nth(2)
+  const title = page.getByTestId('document-panel-document-title')
+  const titleInput = page.getByTestId('field-title').getByTestId('string-input')
+
+  await createDraftDocument('/test/content/book')
+  await titleInput.fill(titleA)
+
+  // Wait for the document to be published.
+  await page.waitForTimeout(1_000)
+  await publishButton.click()
+  await expect(documentStatus).toContainText('Published just now')
+
+  // Change the title.
+  await titleInput.fill(titleB)
+  await expect(title).toHaveText(titleB)
+
+  // Wait for the document to be published.
+  await page.waitForTimeout(1_000)
+  await publishButton.click()
+  await expect(documentStatus).toContainText('Published just now')
+
+  // Pick the previous revision from the revision timeline.
+  await timelineMenuOpenButton.click()
+  await expect(previousRevisionButton).toBeVisible()
+  await previousRevisionButton.click({force: true})
+
+  await expect(titleInput).toHaveValue(titleA)
+
+  // Wait for the revision to be restored.
+  await restoreButton.click()
+  await confirmButton.click()
+  await expect(title).toHaveText(titleA)
+})


### PR DESCRIPTION
### Description

This branch adopts the Actions API for restoring revisions. This was made possible by the introduction of the `sanity.action.document.replaceDraft` action.

### What to review

Does everything look correct when restoring a previous revision of a document?

### Testing

Added an E2E test for revision restoration in `test/e2e/tests/document-actions/restore.spec.ts`.