### PR TITLE
fix: update `@sanity/presentation` and remove deprecated internal exports no longer in use

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,28 +71,28 @@ packages/sanity/src/core/studio/upsell/ @sanity-io/studio-ex
 
 # Internals used by @sanity/presentation
 # See https://github.com/sanity-io/visual-editing/blob/main/packages/presentation/src/internals.ts for exactly which exports
-/packages/sanity/src/_singletons/structure/components/paneRouter/PaneRouterContext.tsx @sanity-io/ecosystem
-/packages/sanity/src/core/comments/context/intent/CommentsIntentProvider.tsx @sanity-io/ecosystem
-/packages/sanity/src/core/comments/types.ts @sanity-io/ecosystem
-/packages/sanity/src/core/config/document/fieldActions/define.ts @sanity-io/ecosystem
-/packages/sanity/src/core/config/document/fieldActions/types.ts @sanity-io/ecosystem
-/packages/sanity/src/core/field/paths/helpers.ts @sanity-io/ecosystem
-/packages/sanity/src/core/hooks/useEditState.ts @sanity-io/ecosystem
-/packages/sanity/src/core/preview/components/Preview.tsx @sanity-io/ecosystem
-/packages/sanity/src/core/store/_legacy/datastores.ts @sanity-io/ecosystem
-/packages/sanity/src/core/store/_legacy/document/document-store.ts @sanity-io/ecosystem
-/packages/sanity/src/core/studio/activeWorkspaceMatcher/useActiveWorkspace.ts @sanity-io/ecosystem
-/packages/sanity/src/core/studio/workspace.tsx @sanity-io/ecosystem
-/packages/sanity/src/core/util/draftUtils.ts @sanity-io/ecosystem
-/packages/sanity/src/core/util/isRecord.ts @sanity-io/ecosystem
-/packages/sanity/src/core/util/useUnique.ts @sanity-io/ecosystem
-/packages/sanity/src/router/utils/jsonParamsEncoding.ts @sanity-io/ecosystem
-/packages/sanity/src/structure/components/pane/PaneLayout.tsx @sanity-io/ecosystem
-/packages/sanity/src/structure/components/paneRouter/types.ts @sanity-io/ecosystem
-/packages/sanity/src/structure/panes/document/DocumentPane.tsx @sanity-io/ecosystem
-/packages/sanity/src/structure/panes/document/useDocumentPane.tsx @sanity-io/ecosystem
-/packages/sanity/src/structure/panes/documentList/index.ts @sanity-io/ecosystem
-/packages/sanity/src/structure/panes/documentList/pane.ts @sanity-io/ecosystem
-/packages/sanity/src/structure/panes/documentList/PaneContainer.tsx @sanity-io/ecosystem
-/packages/sanity/src/structure/StructureToolProvider.tsx @sanity-io/ecosystem
-/packages/sanity/src/structure/types.ts @sanity-io/ecosystem
+/packages/sanity/src/_singletons/structure/components/paneRouter/PaneRouterContext.tsx @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/core/comments/context/intent/CommentsIntentProvider.tsx @sanity-io/ecosystem @sanity-io/studio-ex
+/packages/sanity/src/core/comments/types.ts @sanity-io/ecosystem @sanity-io/studio-ex
+/packages/sanity/src/core/config/document/fieldActions/define.ts @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/core/config/document/fieldActions/types.ts @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/core/field/paths/helpers.ts @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/core/hooks/useEditState.ts @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/core/preview/components/Preview.tsx @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/core/store/_legacy/datastores.ts @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/core/store/_legacy/document/document-store.ts @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/core/studio/activeWorkspaceMatcher/useActiveWorkspace.ts @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/core/studio/workspace.tsx @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/core/util/draftUtils.ts @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/core/util/isRecord.ts @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/core/util/useUnique.ts @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/router/utils/jsonParamsEncoding.ts @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/structure/components/pane/PaneLayout.tsx @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/structure/components/paneRouter/types.ts @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/structure/panes/document/DocumentPane.tsx @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/structure/panes/document/useDocumentPane.tsx @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/structure/panes/documentList/index.ts @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/structure/panes/documentList/pane.ts @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/structure/panes/documentList/PaneContainer.tsx @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/structure/StructureToolProvider.tsx @sanity-io/ecosystem @sanity-io/studio-dx
+/packages/sanity/src/structure/types.ts @sanity-io/ecosystem @sanity-io/studio-dx

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,6 +70,7 @@ packages/sanity/src/core/studio/upsell/ @sanity-io/studio-ex
 /packages/@sanity/cli/src/workers/typegenGenerate.ts @sanity-io/content-lake-dx
 
 # Internals used by @sanity/presentation
+# See https://github.com/sanity-io/visual-editing/blob/main/packages/presentation/src/internals.ts for exactly which exports
 /packages/sanity/src/_singletons/structure/components/paneRouter/PaneRouterContext.tsx @sanity-io/ecosystem
 /packages/sanity/src/core/comments/context/intent/CommentsIntentProvider.tsx @sanity-io/ecosystem
 /packages/sanity/src/core/comments/types.ts @sanity-io/ecosystem

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 /.vscode
+/.github/CODEOWNERS
 
 /dev/*/.next
 /dev/*/.sanity

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -162,7 +162,7 @@
     "@sanity/migrate": "3.42.1",
     "@sanity/mutator": "3.42.1",
     "@sanity/portable-text-editor": "3.42.1",
-    "@sanity/presentation": "1.15.5",
+    "@sanity/presentation": "1.15.6",
     "@sanity/schema": "3.42.1",
     "@sanity/telemetry": "^0.7.6",
     "@sanity/types": "3.42.1",

--- a/packages/sanity/src/structure/index.ts
+++ b/packages/sanity/src/structure/index.ts
@@ -1,26 +1,3 @@
-/**
- * These are provided from `sanity/structure` for backwards compatibility;
- * `@sanity/presentation` depends/depended on them from `sanity/structure` originially.
- *
- * Do not remove until next major version at the earliest (eg v4)
- */
-import {
-  type CommentIntentGetter as _CommentIntentGetter,
-  CommentsIntentProvider as _CommentsIntentProvider,
-} from 'sanity'
-
-/**
- * @deprecated Import from `sanity` instead of `sanity/structure`
- * @internal
- */
-export type CommentIntentGetter = _CommentIntentGetter
-
-/**
- * @deprecated Import from `sanity` instead of `sanity/structure`
- * @internal
- */
-export const CommentsIntentProvider = _CommentsIntentProvider
-
 export type {
   BackLinkProps,
   ChildLinkProps,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1533,8 +1533,8 @@ importers:
         specifier: 3.42.1
         version: link:../@sanity/portable-text-editor
       '@sanity/presentation':
-        specifier: 1.15.5
-        version: 1.15.5(@sanity/client@6.18.2)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+        specifier: 1.15.6
+        version: 1.15.6(@sanity/client@6.18.2)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       '@sanity/schema':
         specifier: 3.42.1
         version: link:../@sanity/schema
@@ -6604,8 +6604,8 @@ packages:
       - debug
       - supports-color
 
-  /@sanity/presentation@1.15.5(@sanity/client@6.18.2)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11):
-    resolution: {integrity: sha512-Xsd4NCMc0Ft9iVs8L8qlPuzu1NVgCh4AXQ4UiF7iUQ8jIIP8/31NmVc2ynl3FV7IGbON5lF8Kki5z1XetvzJQw==}
+  /@sanity/presentation@1.15.6(@sanity/client@6.18.2)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11):
+    resolution: {integrity: sha512-Ktl8OWOf3dvFY+dsIndifBMGuLGzXckYJCtMBqigNTmPAWqFMk5jivgZSbPObxbrQ1LJ6HKEjsVdkIaIeWryxg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       '@sanity/client': ^6.18.2


### PR DESCRIPTION
### Description

Follows up on https://github.com/sanity-io/sanity/pull/6684.
It adds back the original CODEOWNERS on file paths that CDX want to review to ensure backwards compatibility. This allows the Studio DX and EX teams to continue to receive code review requests in the same way as before #6684 merged.

It also bumps `@sanity/presentation` to a new version that no longer use the deprecated imports:
```
import {
  type CommentIntentGetter,
  CommentsIntentProvider,
} from 'sanity/structure'
```
Internally it now uses:
```
import {
  type CommentIntentGetter,
  CommentsIntentProvider,
} from 'sanity'
```
And it's tested working on https://visual-editing-studio.sanity.build already 🙌 

### What to review

If presentation continues to work as it does here https://test-studio.sanity.build/presentation/presentation then we're good to go.

### Testing

Existing tests are sufficient

### Notes for release

N/A as it's an internals refactor that makes no difference to userland.
