### PR TITLE
fix(tasks): hide footer button until the active document is set

### DIFF
--- a/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.test.tsx
+++ b/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.test.tsx
@@ -1,0 +1,170 @@
+import {beforeAll, beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {LayerProvider, studioTheme, ThemeProvider, useMediaIndex} from '@sanity/ui'
+import {uuid} from '@sanity/uuid'
+import {render, screen, waitFor} from '@testing-library/react'
+import {act} from 'react'
+
+import {TasksEnabledProvider, TasksNavigationProvider, TasksProvider} from '../context'
+import {useTasksStore} from '../store'
+import {type TaskDocument} from '../types'
+import {SetActiveDocument} from './structure/SetActiveDocument'
+import {TasksFooterOpenTasks} from './TasksFooterOpenTasks'
+
+jest.mock('../../hooks/useFeatureEnabled', () => ({
+  useFeatureEnabled: jest.fn().mockReturnValue({enabled: true, isLoading: false}),
+}))
+jest.mock('../../studio/workspace', () => ({
+  useWorkspace: jest.fn().mockReturnValue({tasks: {enabled: true}}),
+}))
+jest.mock('../store', () => ({useTasksStore: jest.fn()}))
+jest.mock('../context/isLastPane/useIsLastPane', () => ({
+  useIsLastPane: jest.fn().mockReturnValue(true),
+}))
+jest.mock('@sanity/ui', () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual: typeof import('@sanity/ui') = jest.requireActual('@sanity/ui')
+  const useToastMock = jest.fn()
+  const useMediaIndexMock = jest.fn()
+  return new Proxy(actual, {
+    get: (target, property: keyof typeof actual) => {
+      if (property === 'useToast') return useToastMock
+      if (property === 'useMediaIndex') return useMediaIndexMock
+      return target[property]
+    },
+  })
+})
+jest.mock('sanity/router', () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual: typeof import('sanity/router') = jest.requireActual('sanity/router')
+  const mock = jest.fn().mockReturnValue({asPath: '/', state: {}})
+  return new Proxy(actual, {
+    get: (target, property: keyof typeof actual) => {
+      if (property === 'useRouter') return mock
+      return target[property]
+    },
+  })
+})
+
+const mockUseMediaIndex = useMediaIndex as jest.Mock
+const mockUseTasksStore = useTasksStore as jest.Mock<typeof useTasksStore>
+
+const createTaskMock = ({
+  targetDocumentId,
+  status = 'open',
+  title = 'Test task',
+}: {
+  targetDocumentId?: string
+  status?: TaskDocument['status']
+  title?: string
+}): TaskDocument => ({
+  _type: 'tasks.task',
+  _rev: uuid(),
+  _updatedAt: '2024-05-15T08:11:18Z',
+  _createdAt: '2024-05-15T08:08:26Z',
+  _id: uuid(),
+  createdByUser: '2024-05-15T08:11:21.103Z',
+  authorId: 'author1',
+  target: targetDocumentId
+    ? {
+        documentType: 'author',
+        document: {
+          _type: 'crossDatasetReference',
+          _dataset: 'test',
+          _projectId: 'ppsg7ml5',
+          _weak: true,
+          _ref: targetDocumentId,
+        },
+      }
+    : undefined,
+  title,
+  status,
+})
+
+describe('TasksFooterOpenTasks', () => {
+  const wrapper = ({children}: {children?: React.ReactNode}) => {
+    return (
+      <ThemeProvider theme={studioTheme}>
+        <LayerProvider>
+          <TasksEnabledProvider>
+            <TasksProvider>
+              <TasksNavigationProvider>{children}</TasksNavigationProvider>
+            </TasksProvider>
+          </TasksEnabledProvider>
+        </LayerProvider>
+      </ThemeProvider>
+    )
+  }
+
+  const setUpMocks = ({
+    tasks = [],
+    mediaIndex = 3,
+  }: {
+    tasks?: TaskDocument[]
+    mediaIndex?: number
+  }) => {
+    mockUseTasksStore.mockReturnValue({
+      data: tasks,
+      error: null,
+      isLoading: false,
+      dispatch: jest.fn(),
+    })
+    mockUseMediaIndex.mockReturnValue(mediaIndex)
+  }
+  beforeAll(() => {
+    jest.useFakeTimers()
+  })
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders null if there are no pending tasks', () => {
+    setUpMocks({tasks: []})
+    const {container} = render(<TasksFooterOpenTasks />, {wrapper})
+    expect(container).toBeEmptyDOMElement()
+  })
+  it('renders the button if it has tasks and an active document', async () => {
+    setUpMocks({tasks: [createTaskMock({targetDocumentId: 'doc1'})]})
+    render(
+      <>
+        <TasksFooterOpenTasks />
+        <SetActiveDocument documentId="doc1" documentType="author" />
+      </>,
+      {wrapper},
+    )
+
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+  })
+  it('should not render the button if it has tasks and no active document', async () => {
+    setUpMocks({tasks: [createTaskMock({targetDocumentId: 'doc1'})]})
+    const {container} = render(<TasksFooterOpenTasks />, {wrapper})
+
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders button with badge when mediaIndex is less than 3', async () => {
+    setUpMocks({tasks: [createTaskMock({targetDocumentId: 'doc1'})], mediaIndex: 2})
+    render(
+      <>
+        <TasksFooterOpenTasks />
+        <SetActiveDocument documentId="doc1" documentType="author" />
+      </>,
+      {wrapper},
+    )
+
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('button')).toBeInTheDocument()
+      expect(screen.getByText('1')).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.tsx
+++ b/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.tsx
@@ -31,7 +31,7 @@ export function TasksFooterOpenTasks() {
       activeDocument?.documentId
         ? data.filter((item) => {
             return (
-              item.target?.document._ref === activeDocument?.documentId &&
+              item.target?.document._ref === activeDocument.documentId &&
               item.status === 'open' &&
               item.createdByUser
             )

--- a/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.tsx
+++ b/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.tsx
@@ -5,7 +5,7 @@ import {styled} from 'styled-components'
 
 import {Button} from '../../../ui-components'
 import {useTranslation} from '../../i18n'
-import {useTasks, useTasksEnabled, useTasksNavigation} from '../context'
+import {useTasks, useTasksNavigation} from '../context'
 import {tasksLocaleNamespace} from '../i18n'
 
 const ButtonContainer = styled.div`
@@ -25,22 +25,20 @@ const ButtonContainer = styled.div`
 export function TasksFooterOpenTasks() {
   const {data, activeDocument} = useTasks()
   const {handleOpenTasks, setActiveTab} = useTasksNavigation()
-  const {enabled} = useTasksEnabled()
-
   const mediaIndex = useMediaIndex()
-
   const pendingTasks = useMemo(
     () =>
-      data.filter((item) => {
-        return (
-          item.target?.document._ref === activeDocument?.documentId &&
-          item.status === 'open' &&
-          item.createdByUser
-        )
-      }),
+      activeDocument?.documentId
+        ? data.filter((item) => {
+            return (
+              item.target?.document._ref === activeDocument?.documentId &&
+              item.status === 'open' &&
+              item.createdByUser
+            )
+          })
+        : [],
     [activeDocument, data],
   )
-
   const handleOnClick = useCallback(() => {
     handleOpenTasks()
     setActiveTab('document')
@@ -48,7 +46,7 @@ export function TasksFooterOpenTasks() {
 
   const {t} = useTranslation(tasksLocaleNamespace)
 
-  if (pendingTasks.length === 0 || !enabled) return null
+  if (pendingTasks.length === 0) return null
 
   if (mediaIndex < 3) {
     return (


### PR DESCRIPTION
### Description

The footer button was shown due to this condition being true in some documents which this value is undefined, until the active document value was correctly set.
`item.target?.document._ref === activeDocument?.documentId`  -> `undefined === undefined` 

By checking if the activeDocument is present before validating the values this issue is fixed.

The removal of the `enabled` check is intentional given the whole plugin won't be added if the plugin is not enabled, so this check is unnecessary. See [resolveDefaultPlugins](https://github.com/sanity-io/sanity/blob/next/packages/sanity/src/core/config/resolveDefaultPlugins.ts)

Added some tests.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
