### PR TITLE
feat(typegen): add optout for prettier formatting

### DIFF
--- a/packages/@sanity/cli/src/actions/typegen/generateAction.ts
+++ b/packages/@sanity/cli/src/actions/typegen/generateAction.ts
@@ -62,10 +62,12 @@ export default async function typegenGenerateAction(
   const outputDir = dirname(outputPath)
   await mkdir(outputDir, {recursive: true})
 
-  const prettierConfig = await prettier.resolveConfig(outputPath).catch((err) => {
-    output.warn(`Failed to load prettier config: ${err.message}`)
-    return null
-  })
+  const prettierConfig = codegenConfig.formatGeneratedCode
+    ? await prettier.resolveConfig(outputPath).catch((err) => {
+        output.warn(`Failed to load prettier config: ${err.message}`)
+        return null
+      })
+    : null
   const workerPath = await getCliWorkerPath('typegenGenerate')
 
   const spinner = output.spinner({}).start('Generating types')

--- a/packages/@sanity/codegen/src/readConfig.ts
+++ b/packages/@sanity/codegen/src/readConfig.ts
@@ -14,6 +14,7 @@ export const configDefintion = z.object({
     ]),
   schema: z.string().default('./schema.json'),
   generates: z.string().default('./sanity.types.ts'),
+  formatGeneratedCode: z.boolean().default(true),
 })
 
 export type CodegenConfig = z.infer<typeof configDefintion>


### PR DESCRIPTION
### Description

We've gotten reports that formatting breaks between macos and windows, this adds a way to opt-out of the formatting

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Configuration flag looks sensible?

### Testing

we test generating both formatted and unformatted code already.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

n/a - no notes needed
