### PR TITLE
fix: resolve type error by inlining DocumentComponents definition

### DIFF
--- a/packages/sanity/src/core/form/types/definitionExtensions.test.ts
+++ b/packages/sanity/src/core/form/types/definitionExtensions.test.ts
@@ -12,29 +12,55 @@ import {
   type ReferenceValue,
   type SlugValue,
 } from '@sanity/types'
+// NOTE:
+// Fix: Addressed type error caused by missing 'preview' property in
+// 'DocumentComponents'. The error "Object literal may only specify known
+// properties, and 'preview' does not exist in type 'DocumentComponents'"
+// was resolved by extending the 'DocumentComponents' type within a module
+// augmentation.
+//
+// See: https://github.com/sanity-io/sanity/issues/6542
+//
+// This involves moving the component type definitions from
+// './definitionExtensions' into the '@sanity/types' module,
+// ensuring TypeScript properly recognizes the 'preview' property as part of
+// 'DocumentComponents'.
+//
+// This fix helps avoid cyclical dependencies by extending all type definitions
+// in one place, maintaining consistency across the codebase.
+//
+// Additionally, this issue also relates to how the build process creates the
+// `.d.ts` files. We had a naming collision with 'DocumentComponents' which
+// caused the type error. By inlining the type definitions within the module
+// augmentation, we ensure the build prefers the correct type instead of the type it collided with.
+//
+// We use a type import to ensure this change does not affect the runtime.
+// The 'sanity' package re-exports the '@sanity/types' module, which is why this
+// approach works.
+// eslint-disable-next-line import/consistent-type-specifier-style
+import type {
+  ArrayOfObjectsComponents,
+  ArrayOfPrimitivesComponents,
+  BooleanComponents,
+  CrossDatasetReferenceComponents,
+  DateComponents,
+  DatetimeComponents,
+  DocumentComponents,
+  EmailComponents,
+  FileComponents,
+  GeopointComponents,
+  ImageComponents,
+  NumberComponents,
+  ObjectComponents,
+  ReferenceComponents,
+  SlugComponents,
+  StringComponents,
+  TextComponents,
+  UrlComponents,
+} from 'sanity'
 
 import {type PreviewProps} from '../../components'
 import {type CrossDatasetReferenceInputProps, type ReferenceInputProps} from '../studio'
-import {
-  type ArrayOfObjectsComponents,
-  type ArrayOfPrimitivesComponents,
-  type BooleanComponents,
-  type CrossDatasetReferenceComponents,
-  type DateComponents,
-  type DatetimeComponents,
-  type DocumentComponents,
-  type EmailComponents,
-  type FileComponents,
-  type GeopointComponents,
-  type ImageComponents,
-  type NumberComponents,
-  type ObjectComponents,
-  type ReferenceComponents,
-  type SlugComponents,
-  type StringComponents,
-  type TextComponents,
-  type UrlComponents,
-} from './definitionExtensions'
 import {
   type ArrayFieldProps,
   type ArrayOfPrimitivesFieldProps,

--- a/packages/sanity/src/core/form/types/definitionExtensions.ts
+++ b/packages/sanity/src/core/form/types/definitionExtensions.ts
@@ -35,276 +35,276 @@ import {
 } from './inputProps'
 import {type ObjectItem, type ObjectItemProps, type PrimitiveItemProps} from './itemProps'
 
-/**
- *
- * @hidden
- * @beta
- */
-export interface ArrayOfObjectsComponents {
-  annotation?: ComponentType<BlockAnnotationProps>
-  block?: ComponentType<BlockProps>
-  diff?: ComponentType<any>
-  field?: ComponentType<ArrayFieldProps>
-  inlineBlock?: ComponentType<BlockProps>
-  input?: ComponentType<ArrayOfObjectsInputProps>
-  item?: ComponentType<ObjectItemProps>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface ArrayOfPrimitivesComponents {
-  diff?: ComponentType<any>
-  field?: ComponentType<ArrayOfPrimitivesFieldProps>
-  input?: ComponentType<ArrayOfPrimitivesInputProps>
-  item?: ComponentType<PrimitiveItemProps>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface BooleanComponents {
-  diff?: ComponentType<any>
-  field?: ComponentType<BooleanFieldProps>
-  input?: ComponentType<BooleanInputProps>
-  item?: ComponentType<PrimitiveItemProps>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface DateComponents {
-  diff?: ComponentType<any>
-  field?: ComponentType<StringFieldProps>
-  input?: ComponentType<StringInputProps>
-  item?: ComponentType<PrimitiveItemProps>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface DatetimeComponents {
-  diff?: ComponentType<any>
-  field?: ComponentType<StringFieldProps>
-  input?: ComponentType<StringInputProps>
-  item?: ComponentType<PrimitiveItemProps>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface DocumentComponents {
-  diff?: ComponentType<any>
-  field?: ComponentType<ObjectFieldProps>
-  input?: ComponentType<ObjectInputProps>
-  item?: ComponentType<ObjectItemProps>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface FileComponents {
-  annotation?: ComponentType<BlockAnnotationProps>
-  block?: ComponentType<BlockProps>
-  diff?: ComponentType<any>
-  field?: ComponentType<ObjectFieldProps<FileValue>>
-  inlineBlock?: ComponentType<BlockProps>
-  input?: ComponentType<ObjectInputProps<FileValue>>
-  item?: ComponentType<ObjectItemProps<FileValue & ObjectItem>>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface GeopointComponents {
-  annotation?: ComponentType<BlockAnnotationProps>
-  block?: ComponentType<BlockProps>
-  diff?: ComponentType<any>
-  field?: ComponentType<ObjectFieldProps<GeopointValue>>
-  inlineBlock?: ComponentType<BlockProps>
-  input?: ComponentType<ObjectInputProps<GeopointValue>>
-  item?: ComponentType<ObjectItemProps<GeopointValue & ObjectItem>>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface ImageComponents {
-  annotation?: ComponentType<BlockAnnotationProps>
-  block?: ComponentType<BlockProps>
-  diff?: ComponentType<any>
-  field?: ComponentType<ObjectFieldProps<ImageValue>>
-  inlineBlock?: ComponentType<BlockProps>
-  input?: ComponentType<ObjectInputProps<ImageValue>>
-  item?: ComponentType<ObjectItemProps<ImageValue & ObjectItem>>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface NumberComponents {
-  diff?: ComponentType<any>
-  field?: ComponentType<NumberFieldProps>
-  input?: ComponentType<NumberInputProps>
-  item?: ComponentType<PrimitiveItemProps>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface ObjectComponents {
-  annotation?: ComponentType<BlockAnnotationProps>
-  block?: ComponentType<BlockProps>
-  diff?: ComponentType<any>
-  field?: ComponentType<ObjectFieldProps>
-  inlineBlock?: ComponentType<BlockProps>
-  input?: ComponentType<ObjectInputProps>
-  item?: ComponentType<ObjectItemProps>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface ReferenceComponents {
-  annotation?: ComponentType<BlockAnnotationProps>
-  block?: ComponentType<BlockProps>
-  diff?: ComponentType<any>
-  field?: ComponentType<ObjectFieldProps<ReferenceValue>>
-  inlineBlock?: ComponentType<BlockProps>
-  input?: ComponentType<ReferenceInputProps>
-  item?: ComponentType<ObjectItemProps<ReferenceValue & ObjectItem>>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface CrossDatasetReferenceComponents {
-  annotation?: ComponentType<BlockAnnotationProps>
-  block?: ComponentType<BlockProps>
-  diff?: ComponentType<any>
-  field?: ComponentType<ObjectFieldProps<CrossDatasetReferenceValue>>
-  inlineBlock?: ComponentType<BlockProps>
-  input?: ComponentType<CrossDatasetReferenceInputProps>
-  item?: ComponentType<ObjectItemProps<CrossDatasetReferenceValue & ObjectItem>>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface SlugComponents {
-  diff?: ComponentType<any>
-  field?: ComponentType<ObjectFieldProps<SlugValue>>
-  input?: ComponentType<ObjectInputProps<SlugValue>>
-  item?: ComponentType<ObjectItemProps<SlugValue & ObjectItem>>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface SpanComponents {
-  diff?: ComponentType<any>
-  field?: ComponentType<ObjectFieldProps>
-  input?: ComponentType<ObjectInputProps>
-  item?: ComponentType<ObjectItemProps>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface StringComponents {
-  diff?: ComponentType<any>
-  field?: ComponentType<StringFieldProps>
-  input?: ComponentType<StringInputProps>
-  item?: ComponentType<PrimitiveItemProps>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface TextComponents {
-  diff?: ComponentType<any>
-  field?: ComponentType<StringFieldProps>
-  input?: ComponentType<StringInputProps>
-  item?: ComponentType<PrimitiveItemProps>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface UrlComponents {
-  diff?: ComponentType<any>
-  field?: ComponentType<StringFieldProps>
-  input?: ComponentType<StringInputProps>
-  item?: ComponentType<PrimitiveItemProps>
-  preview?: ComponentType<PreviewProps>
-}
-
-/**
- *
- * @hidden
- * @beta
- */
-export interface EmailComponents {
-  diff?: ComponentType<any>
-  field?: ComponentType<StringFieldProps>
-  input?: ComponentType<StringInputProps>
-  item?: ComponentType<PrimitiveItemProps>
-  preview?: ComponentType<PreviewProps>
-}
-
 /* To avoid cyclic dependencies on Props, we extend all type definitions here, to add the correct component props */
 declare module '@sanity/types' {
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface ArrayOfObjectsComponents {
+    annotation?: ComponentType<BlockAnnotationProps>
+    block?: ComponentType<BlockProps>
+    diff?: ComponentType<any>
+    field?: ComponentType<ArrayFieldProps>
+    inlineBlock?: ComponentType<BlockProps>
+    input?: ComponentType<ArrayOfObjectsInputProps>
+    item?: ComponentType<ObjectItemProps>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface ArrayOfPrimitivesComponents {
+    diff?: ComponentType<any>
+    field?: ComponentType<ArrayOfPrimitivesFieldProps>
+    input?: ComponentType<ArrayOfPrimitivesInputProps>
+    item?: ComponentType<PrimitiveItemProps>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface BooleanComponents {
+    diff?: ComponentType<any>
+    field?: ComponentType<BooleanFieldProps>
+    input?: ComponentType<BooleanInputProps>
+    item?: ComponentType<PrimitiveItemProps>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface DateComponents {
+    diff?: ComponentType<any>
+    field?: ComponentType<StringFieldProps>
+    input?: ComponentType<StringInputProps>
+    item?: ComponentType<PrimitiveItemProps>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface DatetimeComponents {
+    diff?: ComponentType<any>
+    field?: ComponentType<StringFieldProps>
+    input?: ComponentType<StringInputProps>
+    item?: ComponentType<PrimitiveItemProps>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface DocumentComponents {
+    diff?: ComponentType<any>
+    field?: ComponentType<ObjectFieldProps>
+    input?: ComponentType<ObjectInputProps>
+    item?: ComponentType<ObjectItemProps>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface FileComponents {
+    annotation?: ComponentType<BlockAnnotationProps>
+    block?: ComponentType<BlockProps>
+    diff?: ComponentType<any>
+    field?: ComponentType<ObjectFieldProps<FileValue>>
+    inlineBlock?: ComponentType<BlockProps>
+    input?: ComponentType<ObjectInputProps<FileValue>>
+    item?: ComponentType<ObjectItemProps<FileValue & ObjectItem>>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface GeopointComponents {
+    annotation?: ComponentType<BlockAnnotationProps>
+    block?: ComponentType<BlockProps>
+    diff?: ComponentType<any>
+    field?: ComponentType<ObjectFieldProps<GeopointValue>>
+    inlineBlock?: ComponentType<BlockProps>
+    input?: ComponentType<ObjectInputProps<GeopointValue>>
+    item?: ComponentType<ObjectItemProps<GeopointValue & ObjectItem>>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface ImageComponents {
+    annotation?: ComponentType<BlockAnnotationProps>
+    block?: ComponentType<BlockProps>
+    diff?: ComponentType<any>
+    field?: ComponentType<ObjectFieldProps<ImageValue>>
+    inlineBlock?: ComponentType<BlockProps>
+    input?: ComponentType<ObjectInputProps<ImageValue>>
+    item?: ComponentType<ObjectItemProps<ImageValue & ObjectItem>>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface NumberComponents {
+    diff?: ComponentType<any>
+    field?: ComponentType<NumberFieldProps>
+    input?: ComponentType<NumberInputProps>
+    item?: ComponentType<PrimitiveItemProps>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface ObjectComponents {
+    annotation?: ComponentType<BlockAnnotationProps>
+    block?: ComponentType<BlockProps>
+    diff?: ComponentType<any>
+    field?: ComponentType<ObjectFieldProps>
+    inlineBlock?: ComponentType<BlockProps>
+    input?: ComponentType<ObjectInputProps>
+    item?: ComponentType<ObjectItemProps>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface ReferenceComponents {
+    annotation?: ComponentType<BlockAnnotationProps>
+    block?: ComponentType<BlockProps>
+    diff?: ComponentType<any>
+    field?: ComponentType<ObjectFieldProps<ReferenceValue>>
+    inlineBlock?: ComponentType<BlockProps>
+    input?: ComponentType<ReferenceInputProps>
+    item?: ComponentType<ObjectItemProps<ReferenceValue & ObjectItem>>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface CrossDatasetReferenceComponents {
+    annotation?: ComponentType<BlockAnnotationProps>
+    block?: ComponentType<BlockProps>
+    diff?: ComponentType<any>
+    field?: ComponentType<ObjectFieldProps<CrossDatasetReferenceValue>>
+    inlineBlock?: ComponentType<BlockProps>
+    input?: ComponentType<CrossDatasetReferenceInputProps>
+    item?: ComponentType<ObjectItemProps<CrossDatasetReferenceValue & ObjectItem>>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface SlugComponents {
+    diff?: ComponentType<any>
+    field?: ComponentType<ObjectFieldProps<SlugValue>>
+    input?: ComponentType<ObjectInputProps<SlugValue>>
+    item?: ComponentType<ObjectItemProps<SlugValue & ObjectItem>>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface SpanComponents {
+    diff?: ComponentType<any>
+    field?: ComponentType<ObjectFieldProps>
+    input?: ComponentType<ObjectInputProps>
+    item?: ComponentType<ObjectItemProps>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface StringComponents {
+    diff?: ComponentType<any>
+    field?: ComponentType<StringFieldProps>
+    input?: ComponentType<StringInputProps>
+    item?: ComponentType<PrimitiveItemProps>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface TextComponents {
+    diff?: ComponentType<any>
+    field?: ComponentType<StringFieldProps>
+    input?: ComponentType<StringInputProps>
+    item?: ComponentType<PrimitiveItemProps>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface UrlComponents {
+    diff?: ComponentType<any>
+    field?: ComponentType<StringFieldProps>
+    input?: ComponentType<StringInputProps>
+    item?: ComponentType<PrimitiveItemProps>
+    preview?: ComponentType<PreviewProps>
+  }
+
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  export interface EmailComponents {
+    diff?: ComponentType<any>
+    field?: ComponentType<StringFieldProps>
+    input?: ComponentType<StringInputProps>
+    item?: ComponentType<PrimitiveItemProps>
+    preview?: ComponentType<PreviewProps>
+  }
+
   export interface ArrayDefinition {
     /**
      *

--- a/packages/sanity/src/core/form/types/index.ts
+++ b/packages/sanity/src/core/form/types/index.ts
@@ -1,10 +1,13 @@
 export * from './_transitional'
 export * from './asserters'
 export * from './blockProps'
-export * from './definitionExtensions'
 export * from './event'
 export * from './fieldProps'
 export * from './formDocumentValue'
 export * from './inputProps'
 export * from './itemProps'
 export * from './renderCallback'
+
+// this file doesn't have any exports because it just augments a module
+// eslint-disable-next-line import/export
+export * from './definitionExtensions'


### PR DESCRIPTION
### Description

This PR addresses a type error caused by the missing 'preview' property in 'DocumentComponents'. The error, "Object literal may only specify known properties, and 'preview' does not exist in type 'DocumentComponents'", was resolved by inlining the type definitions within the module augmentation. This ensures TypeScript recognizes the 'preview' property as part of 'DocumentComponents' and avoids naming collisions that were causing the build process to prefer the incorrect type.

Note that this should not change the public API of the package at all due to the re-export but I may be missing something. An alternative would be to rename the `DocumentComponents` interface to something that doesn't collide.

Closes #6542

The fix involves:
- Moving the component type definitions from './definitionExtensions' into the '@sanity/types' module.
- Inlining type definitions to ensure the build process creates the correct `.d.ts` files.
- Using a type import to prevent any impact on runtime.

This change was necessary to maintain consistency across the codebase and to resolve the type error encountered during the build process.

### What to review

- Verify that the type definitions for `DocumentComponents` are correctly inlined within the module augmentation.
- Check that the type error related to the 'preview' property is resolved.
- Ensure there are no cyclical dependencies introduced by this change.
- Review the build process to confirm that the `.d.ts` files are correctly generated.

Added @stipsan as a reviewer to verify this has no affect on the build and to give insight on how the build outputs declaration files.

### Testing

I manually tested the result by running the build and copying the resulting `.d.ts` files into a fresh project that previously showed the issue. The type error was gone, confirming that the fix works as intended.

### Notes for release

Resolves a type error caused by the missing 'preview' property in 'DocumentComponents'.