### PR TITLE
fix(core/form): prohibit focus and unset on root input

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/DisableFocusAndUnset.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/DisableFocusAndUnset.spec.tsx
@@ -1,0 +1,51 @@
+/* eslint-disable max-nested-callbacks */
+import {expect, test} from '@playwright/experimental-ct-react'
+import {type Path, type SanityDocument} from '@sanity/types'
+
+import DisableFocusAndUnsetStory from './DisableFocusAndUnsetStory'
+
+export type UpdateFn = () => {focusPath: Path; document: SanityDocument}
+
+const document: SanityDocument = {
+  _id: '123',
+  _type: 'test',
+  _createdAt: new Date().toISOString(),
+  _updatedAt: new Date().toISOString(),
+  _rev: '123',
+  body: [
+    {
+      _key: 'a',
+      _type: 'block',
+      children: [{_key: 'b', _type: 'span', text: 'Foo', marks: ['123']}],
+      markDefs: [
+        {
+          _key: '123',
+          _type: 'link',
+          href: 'http://example.com',
+        },
+      ],
+    },
+  ],
+}
+
+test.describe('Portable Text Input', () => {
+  test.beforeEach(async ({page}) => {
+    await page.evaluate(() => {
+      window.localStorage.debug = 'sanity-pte:*'
+    })
+  })
+  test.describe('onPathFocus', () => {
+    test(`should not allow setting focus on the input itself`, async ({mount, page}) => {
+      await mount(
+        <DisableFocusAndUnsetStory
+          document={document}
+          focusPath={['body', {_key: 'a'}, 'markDefs', {_key: '123'}]}
+        />,
+      )
+      await expect(page.getByText('Edit Link')).toBeVisible()
+      await page.getByTestId('focusSelfButton').click()
+      await page.getByTestId('unsetSelfButton').click()
+      await expect(page.getByText('Edit Link')).toBeVisible()
+    })
+  })
+})

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/DisableFocusAndUnsetStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/DisableFocusAndUnsetStory.tsx
@@ -1,0 +1,110 @@
+/* eslint-disable react/jsx-no-bind */
+import {type SanityDocument} from '@sanity/client'
+import {defineArrayMember, defineField, defineType, type Path} from '@sanity/types'
+import {unset} from 'sanity'
+
+import {TestForm} from '../../utils/TestForm'
+import {TestWrapper} from '../../utils/TestWrapper'
+
+const SCHEMA_TYPES = [
+  defineType({
+    type: 'document',
+    name: 'test',
+    title: 'Test',
+    fields: [
+      defineField({
+        type: 'array',
+        name: 'body',
+        of: [
+          defineArrayMember({
+            type: 'block',
+            marks: {
+              annotations: [
+                defineArrayMember({
+                  name: 'link',
+                  title: 'Link',
+                  type: 'reference',
+                  components: {
+                    input: (inputProps) => (
+                      <div data-testid="annotationInput">
+                        <button
+                          type="button"
+                          data-testid="focusSelfButton"
+                          onClick={() => {
+                            inputProps.onPathFocus([])
+                          }}
+                        >
+                          Focus
+                        </button>
+                        <button
+                          type="button"
+                          data-testid="unsetSelfButton"
+                          onClick={() => {
+                            inputProps.onChange(unset())
+                          }}
+                        >
+                          Unset
+                        </button>
+                        {inputProps.renderDefault(inputProps)}
+                      </div>
+                    ),
+                  },
+                  to: {type: 'test'},
+                }),
+              ],
+            },
+            of: [
+              defineArrayMember({
+                type: 'object',
+                name: 'inlineObjectWithTextProperty',
+                fields: [
+                  defineField({
+                    type: 'string',
+                    name: 'text',
+                    components: {
+                      input: (inputProps) => (
+                        <div data-testid="inlineTextInputField">
+                          {inputProps.renderDefault(inputProps)}
+                        </div>
+                      ),
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+          defineArrayMember({
+            type: 'object',
+            name: 'testObjectBlock',
+            fields: [{type: 'string', name: 'text'}],
+            components: {
+              input: (inputProps) => (
+                <div data-testid="objectBlockInputField">
+                  {inputProps.renderDefault(inputProps)}
+                </div>
+              ),
+            },
+          }),
+        ],
+      }),
+    ],
+  }),
+]
+
+export function FocusTrackingStory({
+  focusPath,
+  onPathFocus,
+  document,
+}: {
+  focusPath?: Path
+  onPathFocus?: (path: Path) => void
+  document?: SanityDocument
+}) {
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm document={document} focusPath={focusPath} onPathFocus={onPathFocus} />
+    </TestWrapper>
+  )
+}
+
+export default FocusTrackingStory


### PR DESCRIPTION
### Description

<strike>NOTE: this PR builds on top of https://github.com/sanity-io/sanity/pull/6705 and this should be merged first.</strike>

This will prohibit that a input for a object modal inside the PT-input can call `onPathFocus` or `unset()` on itself.

Calling `onPathFocus([])` will focus the editor element and close the editing modal.

Also if the input calls `unset()` on itself (like the Reference Input) it will cause the modal to abruptly dissapear, and we might miss out on any cleanup and other expected functions in the editor when this happens.

This change will make sure that any input for the PT-content inside the editor will not be allowed to do this.
`onPathFocus([])` will be a no-op, and `unset([])` will instead reset the object (keeping `_key` and `_type`) allowing the editor to deal normally with the object (will be removed when the modal is closed and object it empty).

Also added test for this.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That it seems like a good idea and the proper solution.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Should be covered by automatic tests. See an example in the provided story if you want to test manually.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
* Fixed bugs that related to when the PT-input is using a Reference input directly as the annotation type (not wrapped in a object type).

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
