### PR TITLE
feat(cli): show prompt if local version doesn't match remote

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -59,20 +59,12 @@ export default async function buildSanityStudio(
   const autoUpdatesEnabled =
     flags['auto-updates'] ||
     (cliConfig && 'autoUpdates' in cliConfig && cliConfig.autoUpdates === true)
-  let importMap
+
+  const version = encodeURIComponent(`^${installedSanityVersion}`)
+  const autoUpdatesImports = getAutoUpdateImportMap(version)
 
   if (autoUpdatesEnabled) {
     output.print(`${info} Building with auto-updates enabled`)
-
-    const version = encodeURIComponent(`^${installedSanityVersion}`)
-    const autoUpdatesImports = getAutoUpdateImportMap(version)
-
-    importMap = {
-      imports: {
-        ...(await buildVendorDependencies({cwd: workDir, outputDir})),
-        ...autoUpdatesImports,
-      },
-    }
 
     // Check the versions
     try {
@@ -154,6 +146,17 @@ export default async function buildSanityStudio(
 
   const trace = telemetry.trace(BuildTrace)
   trace.start()
+
+  let importMap
+
+  if (autoUpdatesEnabled) {
+    importMap = {
+      imports: {
+        ...(await buildVendorDependencies({cwd: workDir, outputDir})),
+        ...autoUpdatesImports,
+      },
+    }
+  }
 
   try {
     timer.start('bundleStudio')

--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -3,10 +3,9 @@ import {promisify} from 'node:util'
 
 import chalk from 'chalk'
 import {info} from 'log-symbols'
+import semver from 'semver'
 import {noopLogger} from '@sanity/telemetry'
 import rimrafCallback from 'rimraf'
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore This may not yet be built.
 import type {CliCommandArguments, CliCommandContext} from '@sanity/cli'
 
 import {buildStaticFiles, ChunkModule, ChunkStats} from '../../server'
@@ -60,7 +59,12 @@ export default async function buildSanityStudio(
     flags['auto-updates'] ||
     (cliConfig && 'autoUpdates' in cliConfig && cliConfig.autoUpdates === true)
 
-  const version = encodeURIComponent(`^${installedSanityVersion}`)
+  // Get the version without any tags if any
+  const coercedSanityVersion = semver.coerce(installedSanityVersion)?.version
+  if (autoUpdatesEnabled && !coercedSanityVersion) {
+    throw new Error(`Failed to parse installed Sanity version: ${installedSanityVersion}`)
+  }
+  const version = encodeURIComponent(`^${coercedSanityVersion}`)
   const autoUpdatesImports = getAutoUpdateImportMap(version)
 
   if (autoUpdatesEnabled) {

--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -70,9 +70,10 @@ export default async function buildSanityStudio(
         const shouldContinue = await prompt.single({
           type: 'confirm',
           message: chalk.yellow(
-            `The following versions are different from the versions available with auto updates enabled. \n` +
-              `This may lead to issues in the studio. \n\n` +
-              `${result.map((mod) => ` - ${mod.pkg} (installed: ${mod.installed}, want: ${mod.remote})`).join('\n')}`,
+            `The following local package versions are different from the versions currently served at runtime.\n` +
+              `When using auto updates, we recommend that you test locally with the most recent versions before deploying. \n\n` +
+              `${result.map((mod) => ` - ${mod.pkg} (local version: ${mod.installed}, runtime version: ${mod.remote})`).join('\n')} \n\n` +
+              `Deploy anyway?`,
           ),
           default: false,
         })

--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -66,19 +66,19 @@ export default async function buildSanityStudio(
     try {
       const result = await compareStudioDependencyVersions(workDir)
 
-      if (result?.error) {
-        const {pkg, installed, remote} = result.error
+      if (result?.length) {
         const shouldContinue = await prompt.single({
           type: 'confirm',
           message: chalk.yellow(
-            `The version of ${chalk.underline(pkg)} installed (${chalk.underline(installed)}) does not match the version on the remote (${chalk.underline(remote)}).\n` +
-              `Do you want to continue anyway?`,
+            `The following versions are different from the versions available with auto updates enabled. \n` +
+              `This may lead to issues in the studio. \n\n` +
+              `${result.map((mod) => ` - ${mod.pkg} (installed: ${mod.installed}, want: ${mod.remote})`).join('\n')}`,
           ),
           default: false,
         })
 
         if (!shouldContinue) {
-          process.exit(0)
+          return process.exit(0)
         }
       }
     } catch (err) {

--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -79,9 +79,9 @@ export default async function buildSanityStudio(
           type: 'confirm',
           message: chalk.yellow(
             `The following local package versions are different from the versions currently served at runtime.\n` +
-              `When using auto updates, we recommend that you test locally with the most recent versions before deploying. \n\n` +
+              `When using auto updates, we recommend that you test locally with the same versions before deploying. \n\n` +
               `${result.map((mod) => ` - ${mod.pkg} (local version: ${mod.installed}, runtime version: ${mod.remote})`).join('\n')} \n\n` +
-              `Deploy anyway?`,
+              `Continue anyway?`,
           ),
           default: false,
         })

--- a/packages/sanity/src/_internal/cli/server/buildVendorDependencies.ts
+++ b/packages/sanity/src/_internal/cli/server/buildVendorDependencies.ts
@@ -123,7 +123,7 @@ export async function buildVendorDependencies({
 
   // Iterate over each package and its version ranges in VENDOR_IMPORTS
   for (const [packageName, ranges] of Object.entries(VENDOR_IMPORTS)) {
-    const packageJsonPath = resolveFrom.silent(cwd, `./node_modules/${packageName}/package.json`)
+    const packageJsonPath = resolveFrom.silent(cwd, path.join(packageName, 'package.json'))
     if (!packageJsonPath) {
       throw new Error(
         `Could not find package.json for package '${packageName}' from directory '${dir}'. Is it installed?`,
@@ -184,10 +184,8 @@ export async function buildVendorDependencies({
 
     // Iterate over each subpath and its corresponding entry point
     for (const [subpath, relativeEntryPoint] of Object.entries(subpaths)) {
-      const entryPoint = resolveFrom.silent(
-        cwd,
-        `./node_modules/${path.join(packageName, relativeEntryPoint)}`,
-      )
+      const packagePath = path.dirname(packageJsonPath)
+      const entryPoint = resolveFrom.silent(packagePath, relativeEntryPoint)
 
       if (!entryPoint) {
         throw new Error(

--- a/packages/sanity/src/_internal/cli/util/__tests__/compareStudioDependencyVersions.test.ts
+++ b/packages/sanity/src/_internal/cli/util/__tests__/compareStudioDependencyVersions.test.ts
@@ -1,0 +1,177 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+import resolveFrom from 'resolve-from'
+
+import {compareStudioDependencyVersions} from '../compareStudioDependencyVersions'
+import {readPackageJson} from '../readPackageJson'
+
+jest.mock('resolve-from')
+jest.mock('../readPackageJson')
+
+global.fetch = jest.fn() as jest.MockedFunction<typeof fetch>
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockedFetch = global.fetch as jest.MockedFunction<any>
+const mockedResolveFrom = resolveFrom as jest.MockedFunction<typeof resolveFrom>
+const mockedReadPackageJson = readPackageJson as jest.MockedFunction<typeof readPackageJson>
+
+const autoUpdatesImports = {
+  'sanity': 'v1/modules/sanity',
+  'sanity/': 'v1/modules/sanity/',
+  '@sanity/vision': 'v1/modules/@sanity__vision',
+  '@sanity/vision/': 'v1/modules/@sanity__vision/',
+}
+
+describe('compareStudioDependencyVersions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return empty array if versions match', async () => {
+    mockedFetch.mockResolvedValue({
+      headers: {
+        get: jest.fn<(name: string) => string | null>().mockReturnValue('3.40.0'),
+      },
+    })
+    mockedResolveFrom.silent
+      .mockReturnValueOnce('/test/workdir/node_modules/sanity/package.json')
+      .mockReturnValueOnce('/test/workdir/node_modules/@sanity/vision/package.json')
+    mockedReadPackageJson
+      .mockReturnValueOnce({
+        dependencies: {
+          'sanity': '^3.40.0',
+          '@sanity/vision': '^3.40.0',
+        },
+        devDependencies: {},
+        name: 'test-package',
+        version: '0.0.0',
+      })
+      .mockReturnValueOnce({
+        name: 'sanity',
+        version: '3.40.0',
+      })
+      .mockReturnValueOnce({
+        name: '@sanity/vision',
+        version: '3.40.0',
+      })
+
+    const result = await compareStudioDependencyVersions(autoUpdatesImports, '/test/workdir')
+
+    expect(result).toEqual([])
+  })
+
+  it('should return one item in array if versions mismatches for one pkg', async () => {
+    mockedFetch.mockResolvedValue({
+      headers: {
+        get: jest.fn<(name: string) => string | null>().mockReturnValue('3.40.0'),
+      },
+    })
+    mockedResolveFrom.silent
+      .mockReturnValueOnce('/test/workdir/node_modules/sanity/package.json')
+      .mockReturnValueOnce('/test/workdir/node_modules/@sanity/vision/package.json')
+    mockedReadPackageJson
+      .mockReturnValueOnce({
+        dependencies: {
+          'sanity': '^3.40.0',
+          '@sanity/vision': '^3.40.0',
+        },
+        devDependencies: {},
+        name: 'test-package',
+        version: '0.0.0',
+      })
+      .mockReturnValueOnce({
+        name: 'sanity',
+        version: '3.30.0',
+      })
+      .mockReturnValueOnce({
+        name: '@sanity/vision',
+        version: '3.40.0',
+      })
+
+    const result = await compareStudioDependencyVersions(autoUpdatesImports, '/test/workdir')
+
+    expect(result).toEqual([
+      {
+        pkg: 'sanity',
+        installed: '3.30.0',
+        remote: '3.40.0',
+      },
+    ])
+  })
+  it('should return multiple items in array if versions mismatches for more pkg', async () => {
+    mockedFetch.mockResolvedValue({
+      headers: {
+        get: jest.fn<(name: string) => string | null>().mockReturnValue('3.40.0'),
+      },
+    })
+    mockedResolveFrom.silent
+      .mockReturnValueOnce('/test/workdir/node_modules/sanity/package.json')
+      .mockReturnValueOnce('/test/workdir/node_modules/@sanity/vision/package.json')
+    mockedReadPackageJson
+      .mockReturnValueOnce({
+        dependencies: {
+          'sanity': '^3.40.0',
+          '@sanity/vision': '^3.40.0',
+        },
+        devDependencies: {},
+        name: 'test-package',
+        version: '0.0.0',
+      })
+      .mockReturnValueOnce({
+        name: 'sanity',
+        version: '3.30.0',
+      })
+      .mockReturnValueOnce({
+        name: '@sanity/vision',
+        version: '3.30.0',
+      })
+
+    const result = await compareStudioDependencyVersions(autoUpdatesImports, '/test/workdir')
+
+    expect(result).toEqual([
+      {
+        pkg: 'sanity',
+        installed: '3.30.0',
+        remote: '3.40.0',
+      },
+      {
+        pkg: '@sanity/vision',
+        installed: '3.30.0',
+        remote: '3.40.0',
+      },
+    ])
+  })
+
+  it("should read from user's package.json if resolveFrom fails to find package.json in node_modules", async () => {
+    mockedFetch.mockResolvedValue({
+      headers: {
+        get: jest.fn<(name: string) => string | null>().mockReturnValue('3.40.0'),
+      },
+    })
+    mockedReadPackageJson.mockReturnValueOnce({
+      dependencies: {
+        'sanity': '^3.20.0',
+        '@sanity/vision': '^3.20.0',
+      },
+      devDependencies: {},
+      name: 'test-package',
+      version: '0.0.0',
+    })
+
+    const result = await compareStudioDependencyVersions(autoUpdatesImports, '/test/workdir')
+
+    expect(readPackageJson).toHaveBeenCalledTimes(1)
+
+    expect(result).toEqual([
+      {
+        pkg: 'sanity',
+        installed: '3.20.0',
+        remote: '3.40.0',
+      },
+      {
+        pkg: '@sanity/vision',
+        installed: '3.20.0',
+        remote: '3.40.0',
+      },
+    ])
+  })
+})

--- a/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
+++ b/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
@@ -1,10 +1,10 @@
-import fs from 'node:fs'
 import path from 'node:path'
 
-import {type PackageJson} from '@sanity/cli'
 import {generateHelpUrl} from '@sanity/generate-help-url'
 import resolveFrom from 'resolve-from'
 import semver, {type SemVer} from 'semver'
+
+import {readPackageJson} from './readPackageJson'
 
 interface PackageInfo {
   name: string
@@ -173,13 +173,4 @@ function getDowngradeInstructions(pkgs: PackageInfo[]) {
   or
 
   pnpm install ${inst}`
-}
-
-function readPackageJson(filePath: string): PackageJson {
-  try {
-    // eslint-disable-next-line no-sync
-    return JSON.parse(fs.readFileSync(filePath, 'utf8'))
-  } catch (err) {
-    throw new Error(`Failed to read "${filePath}": ${err.message}`)
-  }
 }

--- a/packages/sanity/src/_internal/cli/util/compareStudioDependencyVersions.ts
+++ b/packages/sanity/src/_internal/cli/util/compareStudioDependencyVersions.ts
@@ -46,7 +46,7 @@ export async function compareStudioDependencyVersions(
     const manifestPath = resolveFrom.silent(workDir, path.join(pkg, 'package.json'))
 
     const installed = semver.coerce(
-      manifestPath ? readPackageJson(manifestPath).version : dependency.replace(/[\D.]/g, ''),
+      manifestPath ? readPackageJson(manifestPath).version : dependency,
     )
 
     if (!installed) {

--- a/packages/sanity/src/_internal/cli/util/compareStudioDependencyVersions.ts
+++ b/packages/sanity/src/_internal/cli/util/compareStudioDependencyVersions.ts
@@ -31,13 +31,14 @@ interface CompareStudioDependencyVersions {
  * The failed dependencies are anything that does not strictly match the remote version.
  * This means that if a version is lower or greater by even a patch it will be marked as failed.
  *
- * @param AutoUpdatesImportMap - An object mapping package names to their remote import URLs.
- * @param string - The path to the working directory containing the package.json file.
+ * @param autoUpdatesImports - An object mapping package names to their remote import URLs.
+ * @param workDir - The path to the working directory containing the package.json file.
+ * @param fetchFn - Optional {@link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API | Fetch}-compatible function to use for requesting the current remote version of a module
  *
- * @returns Promise\<Array\<CompareStudioDependencyVersions\>\> - A promise that resolves to an array of objects, each containing
+ * @returns A promise that resolves to an array of objects, each containing
  * the name of a package whose local and remote versions do not match, along with the local and remote versions.
  *
- * @throws Error - Throws an error if the remote version of a package cannot be fetched, or if the local version of a package
+ * @throws Throws an error if the remote version of a package cannot be fetched, or if the local version of a package
  * cannot be parsed.
  */
 export async function compareStudioDependencyVersions(

--- a/packages/sanity/src/_internal/cli/util/compareStudioDependencyVersions.ts
+++ b/packages/sanity/src/_internal/cli/util/compareStudioDependencyVersions.ts
@@ -1,0 +1,93 @@
+import path from 'node:path'
+
+import resolveFrom from 'resolve-from'
+import semver from 'semver'
+
+import {readPackageJson} from './readPackageJson'
+
+// TODO: support custom hostname
+const AUTO_UPDATE_PACKAGES = {
+  'react': {
+    url: 'https://api.sanity.work/v1/modules/react/^18',
+    shouldAddPathPrefix: true,
+  },
+  'react-dom': {url: 'https://api.sanity.work/v1/modules/react-dom/^18', shouldAddPathPrefix: true},
+  'styled-components': {
+    url: 'https://api.sanity.work/v1/modules/styled-components/^6',
+    shouldAddPathPrefix: false,
+  },
+  'sanity': {url: 'https://api.sanity.work/v1/modules/sanity/^3', shouldAddPathPrefix: true},
+  '@sanity/vision': {
+    url: 'https://api.sanity.work/v1/modules/@sanity__vision/^3',
+    shouldAddPathPrefix: false,
+  },
+}
+
+// TODO: replace this with a manifest somewhere
+export const AUTO_UPDATES_IMPORTMAP = {
+  imports: Object.keys(AUTO_UPDATE_PACKAGES).reduce<Record<string, string>>((acc, curr) => {
+    const key = curr as keyof typeof AUTO_UPDATE_PACKAGES
+    const pkg = AUTO_UPDATE_PACKAGES[key]
+
+    acc[key] = pkg.url
+    if (pkg.shouldAddPathPrefix) {
+      acc[`${key}/`] = `${pkg.url}/`
+    }
+
+    return acc
+  }, {}),
+}
+
+async function getRemoteResolvedVersion(url: string) {
+  try {
+    const res = await fetch(url, {method: 'HEAD', redirect: 'manual'})
+    return res.headers.get('x-resolved-version')
+  } catch (err) {
+    throw new Error(`Failed to fetch remote version for ${url}: ${err.message}`)
+  }
+}
+
+export async function compareStudioDependencyVersions(workDir: string): Promise<
+  | {
+      error?: {
+        pkg: string
+        installed: string
+        remote: string
+      }
+    }
+  | undefined
+> {
+  const manifest = readPackageJson(path.join(workDir, 'package.json'))
+  const dependencies = {...manifest.dependencies, ...manifest.devDependencies}
+
+  for (const [pkg, value] of Object.entries(AUTO_UPDATE_PACKAGES)) {
+    const resolvedVersion = await getRemoteResolvedVersion(value.url)
+
+    if (!resolvedVersion) {
+      throw new Error(`Failed to fetch remote version for ${value.url}`)
+    }
+
+    const dependency = dependencies[pkg]
+    const manifestPath = resolveFrom.silent(workDir, path.join(pkg, 'package.json'))
+
+    const installed = semver.coerce(
+      manifestPath ? readPackageJson(manifestPath).version : dependency.replace(/[\D.]/g, ''),
+    )
+
+    if (!installed) {
+      throw new Error(`Failed to parse installed version for ${pkg}`)
+    }
+
+    if (!semver.eq(resolvedVersion, installed.version)) {
+      return {
+        error: {
+          pkg,
+          installed: installed.version,
+          remote: resolvedVersion,
+        },
+      }
+    }
+  }
+
+  return undefined
+}

--- a/packages/sanity/src/_internal/cli/util/getAutoUpdatesImportMap.ts
+++ b/packages/sanity/src/_internal/cli/util/getAutoUpdatesImportMap.ts
@@ -8,7 +8,10 @@ export interface AutoUpdatesImportMap {
   '@sanity/vision/': string
 }
 
-const MODULES_HOST = 'https://sanity-cdn.work'
+const MODULES_HOST =
+  process.env.SANITY_INTERNAL_ENV === 'staging'
+    ? 'https://sanity-cdn.work'
+    : 'https://sanity-cdn.com'
 
 /**
  * @internal

--- a/packages/sanity/src/_internal/cli/util/getAutoUpdatesImportMap.ts
+++ b/packages/sanity/src/_internal/cli/util/getAutoUpdatesImportMap.ts
@@ -1,0 +1,25 @@
+/**
+ * @internal
+ */
+export interface AutoUpdatesImportMap {
+  'sanity': string
+  'sanity/': string
+  '@sanity/vision': string
+  '@sanity/vision/': string
+}
+
+const MODULES_HOST = 'https://api.sanity.work'
+
+/**
+ * @internal
+ */
+export function getAutoUpdateImportMap(version: string): AutoUpdatesImportMap {
+  const autoUpdatesImports = {
+    'sanity': `${MODULES_HOST}/v1/modules/sanity/default/${version}`,
+    'sanity/': `${MODULES_HOST}/v1/modules/sanity/default/${version}/`,
+    '@sanity/vision': `${MODULES_HOST}/v1/modules/@sanity__vision/default/${version}`,
+    '@sanity/vision/': `${MODULES_HOST}/v1/modules/@sanity__vision/default/${version}/`,
+  }
+
+  return autoUpdatesImports
+}

--- a/packages/sanity/src/_internal/cli/util/getAutoUpdatesImportMap.ts
+++ b/packages/sanity/src/_internal/cli/util/getAutoUpdatesImportMap.ts
@@ -8,7 +8,7 @@ export interface AutoUpdatesImportMap {
   '@sanity/vision/': string
 }
 
-const MODULES_HOST = 'https://api.sanity.work'
+const MODULES_HOST = 'https://sanity-cdn.work'
 
 /**
  * @internal

--- a/packages/sanity/src/_internal/cli/util/readPackageJson.ts
+++ b/packages/sanity/src/_internal/cli/util/readPackageJson.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs'
+
+import {type PackageJson} from '@sanity/cli'
+
+/**
+ * Read the `package.json` file at the given path
+ *
+ * @param filePath - Path to package.json to read
+ * @returns The parsed package.json
+ */
+export function readPackageJson(filePath: string): PackageJson {
+  try {
+    // eslint-disable-next-line no-sync
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+  } catch (err) {
+    throw new Error(`Failed to read "${filePath}": ${err.message}`)
+  }
+}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Shows a prompt if the installed version of importmap deps are different then what it would resolve to.

FIXES SDX-1342

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Updates makes sense.

To test no error case in test-studio

1. cd `dev/test-studio/` 
2. run `pnpm sanity:build --auto-updates` 

Expected: No warning

To test error case in test-studio

1. Update the `sanity` and/or `@sanity/vision` version to something older in `dev/test-studio/package.json` and run `pnpm install`
2. cd `dev/test-studio` 
3. run `pnpm sanity:build --auto-updates` 

Expect: will show copy with different versions

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

It's probably very hard to do a more integration level test for this, I wrote a unit test for the compare function at least

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

N/A
