### PR TITLE
fix(core): add retry to image observer and loading state

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
@@ -1,5 +1,5 @@
 import {CropIcon} from '@sanity/icons'
-import {Inline, Menu, useClickOutside, useGlobalKeyDown} from '@sanity/ui'
+import {Inline, Menu, Skeleton, useClickOutside, useGlobalKeyDown} from '@sanity/ui'
 import {type MouseEventHandler, type ReactNode, useCallback, useEffect, useState} from 'react'
 import {styled} from 'styled-components'
 
@@ -12,6 +12,12 @@ export const MenuActionsWrapper = styled(Inline)`
   top: 0;
   right: 0;
 `
+
+export const ImageActionsMenuWaitPlaceholder = () => (
+  <MenuActionsWrapper padding={2}>
+    <Skeleton style={{width: '25px', height: '25px'}} animated />
+  </MenuActionsWrapper>
+)
 
 interface ImageActionsMenuProps {
   children: ReactNode

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -49,7 +49,7 @@ import {UploadProgress} from '../common/UploadProgress'
 import {UploadWarning} from '../common/UploadWarning'
 import {ImageToolInput} from '../ImageToolInput'
 import {type ImageUrlBuilder} from '../types'
-import {ImageActionsMenu} from './ImageActionsMenu'
+import {ImageActionsMenu, ImageActionsMenuWaitPlaceholder} from './ImageActionsMenu'
 import {ImagePreview} from './ImagePreview'
 import {InvalidImageWarning} from './InvalidImageWarning'
 
@@ -510,7 +510,11 @@ export class BaseImageInput extends PureComponent<BaseImageInputProps, BaseImage
     }
 
     return (
-      <WithReferencedAsset observeAsset={observeAsset} reference={asset}>
+      <WithReferencedAsset
+        observeAsset={observeAsset}
+        reference={asset}
+        waitPlaceholder={<ImageActionsMenuWaitPlaceholder />}
+      >
         {({_id, originalFilename, extension}) => {
           let copyUrl: string | undefined
           let downloadUrl: string | undefined

--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/assets.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/assets.ts
@@ -78,6 +78,10 @@ export const uploadImageAsset = (
 export const uploadFileAsset = (client: SanityClient, file: File | Blob, options?: UploadOptions) =>
   uploadAsset(client, 'file', file, options)
 
+/**
+ *
+ *
+ */
 // note: there's currently 100% overlap between the ImageAsset document and the FileAsset documents as per interface required by the image and file input
 function observeAssetDoc(documentPreviewStore: DocumentPreviewStore, id: string) {
   return documentPreviewStore
@@ -93,6 +97,13 @@ function observeAssetDoc(documentPreviewStore: DocumentPreviewStore, id: string)
       'size',
     ])
     .pipe(
+      /**
+       * In some cases when uploading large media file we are getting an stale `null` response from content lake when fetching the reference that was just uploaded,
+       * making the UI not to react as it should.
+       * This retry logic is added to handle the case where the asset is not found in the initial fetch to the documentPreviewStore but it will eventually be found,
+       * because the asset has been just added.
+       * It has the downside that if this is being used to check if an asset exists, it will retry 5 times before returning null.
+       */
       switchMap((result) => {
         // If the result is null, throw an error to trigger retry
         if (result === null) {


### PR DESCRIPTION
### Description

We have a racing condition in the `BaseImageInput` component, in some cases, specially with big images the fetch request to resolve the reference is happening before the reference exists. Making the image input to persist in a "loading" state which nothing indicates it. 
Also, there was no retry option when the reference was not properly resolved.

With this changes, a retry option is added to the  `observeAssetDoc` function, fixing this problem.
Also, a loading state was included in the image input.

How to reproduce this issue:
- Go to https://test-studio-git-next.sanity.build/test/structure/
- Open any document with an image input.
- Add a large image which is not in the client assets, see if it stales, if not, remove the image and try with another one.
- Retry previous step until you can see the issue.

#### Reproducing the issue in next
https://github.com/sanity-io/sanity/assets/46196328/bed7456e-f5de-472a-a28c-e4d2fffdc29a

#### After fix
After the fix I was not able to reproduce this issue anymore.


https://github.com/sanity-io/sanity/assets/46196328/dad16eb0-6a1a-4664-875c-c12cc3a2e878



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manual testing of the issue, couldn't reproduce it. 

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
