### PR TITLE
feat(sanity): use optimistic locking when publishing documents

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/__snapshots__/publish.test.ts.snap
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/__snapshots__/publish.test.ts.snap
@@ -92,3 +92,17 @@ Object {
   "transaction": Array [],
 }
 `;
+
+exports[`publish execute throws an error if the client has no draft snaphot 1`] = `
+Object {
+  "listen": Array [],
+  "observable": Object {
+    "fetch": Array [],
+    "getDocuments": Array [],
+    "listen": Array [],
+    "request": Array [],
+  },
+  "request": Array [],
+  "transaction": Array [],
+}
+`;

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/__snapshots__/publish.test.ts.snap
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/__snapshots__/publish.test.ts.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`publish execute calls createOrReplace with _revision_lock_pseudo_field_ if there is an already published document 1`] = `
+Object {
+  "listen": Array [],
+  "observable": Object {
+    "fetch": Array [],
+    "getDocuments": Array [],
+    "listen": Array [],
+    "request": Array [
+      Object {
+        "body": Object {
+          "actions": Array [
+            Object {
+              "actionType": "sanity.action.document.publish",
+              "draftId": "drafts.my-id",
+              "ifDraftRevisionId": "exampleRev",
+              "ifPublishedRevisionId": "exampleRev",
+              "publishedId": "my-id",
+            },
+          ],
+        },
+        "method": "post",
+        "tag": "document.publish",
+        "url": "/data/actions/mock-data-set",
+      },
+    ],
+  },
+  "request": Array [],
+  "transaction": Array [],
+}
+`;
+
+exports[`publish execute removes the \`_updatedAt\` field 1`] = `
+Object {
+  "listen": Array [],
+  "observable": Object {
+    "fetch": Array [],
+    "getDocuments": Array [],
+    "listen": Array [],
+    "request": Array [
+      Object {
+        "body": Object {
+          "actions": Array [
+            Object {
+              "actionType": "sanity.action.document.publish",
+              "draftId": "drafts.my-id",
+              "ifDraftRevisionId": "exampleRev",
+              "ifPublishedRevisionId": undefined,
+              "publishedId": "my-id",
+            },
+          ],
+        },
+        "method": "post",
+        "tag": "document.publish",
+        "url": "/data/actions/mock-data-set",
+      },
+    ],
+  },
+  "request": Array [],
+  "transaction": Array [],
+}
+`;
+
+exports[`publish execute takes in any and strengthens references where _strengthenOnPublish is true 1`] = `
+Object {
+  "listen": Array [],
+  "observable": Object {
+    "fetch": Array [],
+    "getDocuments": Array [],
+    "listen": Array [],
+    "request": Array [
+      Object {
+        "body": Object {
+          "actions": Array [
+            Object {
+              "actionType": "sanity.action.document.publish",
+              "draftId": "drafts.my-id",
+              "ifDraftRevisionId": "exampleRev",
+              "ifPublishedRevisionId": undefined,
+              "publishedId": "my-id",
+            },
+          ],
+        },
+        "method": "post",
+        "tag": "document.publish",
+        "url": "/data/actions/mock-data-set",
+      },
+    ],
+  },
+  "request": Array [],
+  "transaction": Array [],
+}
+`;

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.test.ts
@@ -1,0 +1,181 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {type SanityDocument} from 'sanity'
+
+import {createMockSanityClient} from '../../../../../../../test/mocks/mockSanityClient'
+import {type OperationArgs} from '../operations/types'
+import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
+import {publish} from './publish'
+
+jest.mock('../utils/isLiveEditEnabled', () => ({isLiveEditEnabled: jest.fn()}))
+
+beforeEach(() => {
+  ;(isLiveEditEnabled as jest.Mock).mockClear()
+})
+
+describe('publish', () => {
+  describe('disabled', () => {
+    it('returns with LIVE_EDIT_ENABLED if isLiveEditEnabled', () => {
+      ;(isLiveEditEnabled as jest.Mock).mockImplementation(
+        // eslint-disable-next-line max-nested-callbacks
+        () => true,
+      )
+
+      expect(
+        publish.disabled(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          {} as any,
+        ),
+      ).toBe('LIVE_EDIT_ENABLED')
+    })
+
+    it('returns ALREADY_PUBLISHED if there is no draft and there is a published version', () => {
+      ;(isLiveEditEnabled as jest.Mock).mockImplementation(
+        // eslint-disable-next-line max-nested-callbacks
+        () => false,
+      )
+
+      expect(
+        publish.disabled({
+          typeName: 'blah',
+          snapshots: {
+            draft: undefined,
+            published: {} as SanityDocument,
+          },
+        } as unknown as OperationArgs),
+      ).toBe('ALREADY_PUBLISHED')
+    })
+
+    it("otherwise the operation isn't disabled", () => {
+      ;(isLiveEditEnabled as jest.Mock).mockImplementation(
+        // eslint-disable-next-line max-nested-callbacks
+        () => false,
+      )
+
+      expect(
+        publish.disabled({
+          typeName: 'blah',
+          snapshots: {
+            draft: {} as SanityDocument,
+            published: {} as SanityDocument,
+          },
+        } as unknown as OperationArgs),
+      ).toBe(false)
+    })
+  })
+
+  describe('execute', () => {
+    it('removes the `_updatedAt` field', () => {
+      const client = createMockSanityClient()
+
+      publish.execute({
+        client,
+        idPair: {
+          draftId: 'drafts.my-id',
+          publishedId: 'my-id',
+        },
+        snapshots: {
+          draft: {
+            _createdAt: '2021-09-14T22:48:02.303Z',
+            _rev: 'exampleRev',
+            _id: 'drafts.my-id',
+            _type: 'example',
+            _updatedAt: '2021-09-14T22:48:02.303Z',
+            newValue: 'hey',
+          },
+        },
+      } as unknown as OperationArgs)
+
+      expect(client.$log).toMatchSnapshot()
+    })
+
+    it('calls createOrReplace with _revision_lock_pseudo_field_ if there is an already published document', () => {
+      const client = createMockSanityClient()
+
+      publish.execute({
+        client,
+        idPair: {
+          draftId: 'drafts.my-id',
+          publishedId: 'my-id',
+        },
+        snapshots: {
+          draft: {
+            _createdAt: '2021-09-14T22:48:02.303Z',
+            _rev: 'exampleRev',
+            _id: 'drafts.my-id',
+            _type: 'example',
+            _updatedAt: '2021-09-14T22:48:02.303Z',
+            newValue: 'hey',
+          },
+          published: {
+            _createdAt: '2021-09-14T22:48:02.303Z',
+            _rev: 'exampleRev',
+            _id: 'drafts.my-id',
+            _type: 'example',
+            _updatedAt: '2021-09-14T22:48:02.303Z',
+          },
+        },
+      } as unknown as OperationArgs)
+
+      expect(client.$log).toMatchSnapshot()
+    })
+
+    it('takes in any and strengthens references where _strengthenOnPublish is true', () => {
+      const client = createMockSanityClient()
+
+      publish.execute({
+        client,
+        idPair: {
+          draftId: 'drafts.my-id',
+          publishedId: 'my-id',
+        },
+        snapshots: {
+          draft: {
+            _createdAt: '2021-09-14T22:48:02.303Z',
+            _id: 'drafts.my-id',
+            _rev: 'exampleRev',
+            _type: 'my-type',
+            _updatedAt: '2021-09-14T22:48:02.303Z',
+            simpleRef: {
+              _type: 'reference',
+              _weak: true,
+              _ref: 'my-ref',
+              _strengthenOnPublish: true,
+            },
+            notToBeStrengthened: {
+              _type: 'reference',
+              _weak: true,
+              _ref: 'my-ref',
+            },
+            inAn: [
+              {
+                _type: 'reference',
+                _weak: true,
+                _ref: 'my-ref-in-an-',
+                _strengthenOnPublish: true,
+                _key: 'my-key',
+              },
+              {
+                _key: 'my-other-key',
+                _type: 'nestedObj',
+                myRef: {
+                  _weak: true,
+                  _ref: 'my-ref-in-an--nested',
+                  _strengthenOnPublish: true,
+                },
+              },
+              {
+                _type: 'reference',
+                _weak: true,
+                _ref: 'my-ref-in-an--no-key',
+                _strengthenOnPublish: true,
+              },
+            ],
+          },
+          published: null,
+        },
+      } as unknown as OperationArgs)
+
+      expect(client.$log).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.test.ts
@@ -177,5 +177,31 @@ describe('publish', () => {
 
       expect(client.$log).toMatchSnapshot()
     })
+
+    it('throws an error if the client has no draft snaphot', () => {
+      const client = createMockSanityClient()
+
+      // eslint-disable-next-line max-nested-callbacks
+      expect(() => {
+        publish.execute({
+          client,
+          idPair: {
+            draftId: 'drafts.my-id',
+            publishedId: 'my-id',
+          },
+          snapshots: {
+            published: {
+              _createdAt: '2021-09-14T22:48:02.303Z',
+              _rev: 'exampleRev',
+              _id: 'drafts.my-id',
+              _type: 'example',
+              _updatedAt: '2021-09-14T22:48:02.303Z',
+            },
+          },
+        } as unknown as OperationArgs)
+      }).toThrow('cannot execute "publish" when draft is missing')
+
+      expect(client.$log).toMatchSnapshot()
+    })
   })
 })

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.ts
@@ -32,6 +32,12 @@ export const publish: OperationImpl<[], DisabledReason> = {
             actionType: 'sanity.action.document.publish',
             draftId: idPair.draftId,
             publishedId: idPair.publishedId,
+            // The editor must be able to see the latest state of both the draft document they are
+            // publishing, and the published document they are choosing to replace. Optimistic
+            // locking using `ifDraftRevisionId` and `ifPublishedRevisionId` ensures the client and
+            // server are synchronised.
+            ifDraftRevisionId: snapshots.draft._rev,
+            ifPublishedRevisionId: snapshots.published?._rev,
           },
         ],
       },

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.ts
@@ -13,9 +13,14 @@ export const publish: OperationImpl<[], DisabledReason> = {
     }
     return false
   },
-  execute: ({client: globalClient, idPair}) => {
+  execute: ({client: globalClient, idPair, snapshots}) => {
     const vXClient = globalClient.withConfig({apiVersion: 'X'})
     const {dataset} = globalClient.config()
+
+    // The editor must be able to see the draft they are choosing to publish.
+    if (!snapshots.draft) {
+      throw new Error('cannot execute "publish" when draft is missing')
+    }
 
     return vXClient.observable.request({
       url: `/data/actions/${dataset}`,


### PR DESCRIPTION
### Description

This branch adds optimistic locking when publishing documents via the Actions API by adopting its `ifDraftRevisionId` and `ifPublishedRevisionId` guards. These guards are a recent addition to the Actions API.

Optimistic locking ensures the editor can see the latest state of both the draft document they are publishing, and the published document they are choosing to replace.

Additionally, this branch adds a check prior to publishing that ensures Studio has a draft snapshot. This check is already in place when publishing via the Mutations API. It stands to reason that the editor must be able to see the draft they are choosing to publish.

### What to review

Is the usage of the `ifDraftRevisionId` and `ifPublishedRevisionId` guards correct?

### Testing

- I've copied the existing unit tests from the Mutations API based publish operation to the Actions API based publish operation.
- These tests use snapshots to ensure the expected revision guards are used.
- I've added a test to ensure `execute` throws if the client has no draft snapshot.
- You can find these tests in `packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.test.ts`.
