### PR TITLE
fix(structure): remove useEffect and set table columns as initial state

### DIFF
--- a/packages/sanity/src/structure/panes/documentList/ColumnsControl.tsx
+++ b/packages/sanity/src/structure/panes/documentList/ColumnsControl.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @sanity/i18n/no-attribute-string-literals */
 /* eslint-disable i18next/no-literal-string */
 import {Box, Button, Card, Checkbox, Flex, Menu, MenuButton, Stack, Text} from '@sanity/ui'
-import {type Column, type Table, type VisibilityState} from '@tanstack/react-table'
+import {type Column, type Table} from '@tanstack/react-table'
 import {useCallback} from 'react'
 import {type SanityDocument} from 'sanity'
 
@@ -9,16 +9,15 @@ import {VISIBLE_COLUMN_LIMIT} from './useDocumentSheetColumns'
 
 type Props = {
   table: Table<SanityDocument>
-  initialState: VisibilityState
 }
 
-export function ColumnsControl({table, initialState}: Props) {
+export function ColumnsControl({table}: Props) {
   const isVisibleLimitReached =
     table.getVisibleLeafColumns().filter((col) => col.getCanHide()).length >= VISIBLE_COLUMN_LIMIT
 
   const setInitialColumns = useCallback(() => {
-    table.setColumnVisibility(initialState)
-  }, [table, initialState])
+    table.resetColumnVisibility()
+  }, [table])
 
   const handleColumnOnChange = (column: Column<SanityDocument, unknown>) => () => {
     column.toggleVisibility()

--- a/packages/sanity/src/structure/panes/documentList/DocumentSheetListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentSheetListPane.tsx
@@ -139,7 +139,7 @@ function DocumentSheetListPaneInner({
         </Text>
       </Flex>
       <TableContainer>
-        <ColumnsControl table={table} initialState={initialColumnsVisibility} />
+        <ColumnsControl table={table} />
         <Table>
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (

--- a/packages/sanity/src/structure/panes/documentList/DocumentSheetListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentSheetListPane.tsx
@@ -68,7 +68,7 @@ function DocumentSheetListPaneInner({
   schemaType,
 }: DocumentSheetListPaneProps & {schemaType: SchemaType}) {
   const {dispatch, state} = useSearchState()
-  const columns = useDocumentSheetColumns(schemaType)
+  const {columns, initialColumnsVisibility} = useDocumentSheetColumns(schemaType)
   const {data} = useDocumentSheetList({
     typeName: schemaType.name,
   })
@@ -84,6 +84,7 @@ function DocumentSheetListPaneInner({
     autoResetPageIndex: false,
     initialState: {
       pagination: {pageSize: 25},
+      columnVisibility: initialColumnsVisibility,
     },
     meta: {
       updateData: () => {
@@ -138,7 +139,7 @@ function DocumentSheetListPaneInner({
         </Text>
       </Flex>
       <TableContainer>
-        <ColumnsControl table={table} />
+        <ColumnsControl table={table} initialState={initialColumnsVisibility} />
         <Table>
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (

--- a/packages/sanity/src/structure/panes/documentList/__tests__/ColumnsControl.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/ColumnsControl.test.tsx
@@ -1,4 +1,6 @@
-import {beforeEach, describe, expect, it} from '@jest/globals'
+import {afterEach} from 'node:test'
+
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
 import {studioTheme, ThemeProvider} from '@sanity/ui'
 import {useReactTable} from '@tanstack/react-table'
 import {fireEvent, render, screen} from '@testing-library/react'
@@ -7,15 +9,27 @@ import {type SanityDocument} from 'sanity'
 import {ColumnsControl} from '../ColumnsControl'
 
 const TableHarness = ({columns}) => {
+  const initialVisibilityState = {
+    'First Column': true,
+    'Second Column': true,
+    'Third Column': true,
+    'Nested First Column': true,
+    'Nested Second Column': true,
+    'Fifth Column': true,
+    'Sixth Column': false,
+  }
   const table = useReactTable<SanityDocument>({
     columns,
     data: [],
     getCoreRowModel: () => {
       throw new Error('getCoreRowModel not implemented.')
     },
+    initialState: {
+      columnVisibility: initialVisibilityState,
+    },
   })
 
-  return <ColumnsControl table={table} />
+  return <ColumnsControl table={table} initialState={initialVisibilityState} />
 }
 
 describe('ColumnsControl', () => {
@@ -41,6 +55,10 @@ describe('ColumnsControl', () => {
         />
       </ThemeProvider>,
     )
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   it('should set default column visibilities', () => {

--- a/packages/sanity/src/structure/panes/documentList/__tests__/ColumnsControl.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/ColumnsControl.test.tsx
@@ -29,7 +29,7 @@ const TableHarness = ({columns}) => {
     },
   })
 
-  return <ColumnsControl table={table} initialState={initialVisibilityState} />
+  return <ColumnsControl table={table} />
 }
 
 describe('ColumnsControl', () => {


### PR DESCRIPTION
### Description

Suggestion to use columns initial state rather than setting them later in a useEffect.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
