### PR TITLE
fix(structure): fixing incorrect way of setting col visibility

### DIFF
--- a/packages/sanity/src/structure/panes/documentList/__tests__/useDocumentSheetColumns.test.ts
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/useDocumentSheetColumns.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it, jest} from '@jest/globals'
+import {type ObjectSchemaType} from '@sanity/types'
 import {renderHook} from '@testing-library/react'
 
 import {useDocumentSheetColumns} from '../useDocumentSheetColumns'
@@ -20,7 +21,7 @@ describe('useDocumentSheetColumns', () => {
         {name: 'email', type: {name: 'string'}},
         {name: 'age', type: {name: 'number'}},
         {
-          name: 'address',
+          name: 'address.place',
           type: {
             name: 'object',
             jsonType: 'object',
@@ -33,18 +34,17 @@ describe('useDocumentSheetColumns', () => {
         {name: 'phone number', type: {name: 'number'}},
         {name: 'has pet', type: {name: 'boolean'}},
       ],
-    }
+    } as unknown as ObjectSchemaType
 
     const {result} = renderHook(() => useDocumentSheetColumns(mockSchemaType))
     expect(result.current.initialColumnsVisibility).toEqual({
       'Preview': true,
-      'selected': true,
       'name': true,
       'nickname': true,
       'email': true,
       'age': true,
-      'address.street': true,
-      'address.country': false,
+      'address.place_street': true,
+      'address.place_country': false,
       'phone number': false,
       'has pet': false,
     })

--- a/packages/sanity/src/structure/panes/documentList/__tests__/useDocumentSheetColumns.test.ts
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/useDocumentSheetColumns.test.ts
@@ -21,7 +21,7 @@ describe('useDocumentSheetColumns', () => {
         {name: 'email', type: {name: 'string'}},
         {name: 'age', type: {name: 'number'}},
         {
-          name: 'address.place',
+          name: 'address',
           type: {
             name: 'object',
             jsonType: 'object',
@@ -43,8 +43,8 @@ describe('useDocumentSheetColumns', () => {
       'nickname': true,
       'email': true,
       'age': true,
-      'address.place_street': true,
-      'address.place_country': false,
+      'address_street': true,
+      'address_country': false,
       'phone number': false,
       'has pet': false,
     })

--- a/packages/sanity/src/structure/panes/documentList/useDocumentSheetColumns.tsx
+++ b/packages/sanity/src/structure/panes/documentList/useDocumentSheetColumns.tsx
@@ -65,8 +65,10 @@ const getColsFromSchemaType = (schemaType: ObjectSchemaType, parentalField?: str
     const {type, name} = field
     if (SUPPORTED_FIELDS.includes(type.name)) {
       const nextCol = columnHelper.accessor(
+        // accessor must use dot notation for internal tanstack method of reading cell data
         parentalField ? `${parentalField}.${field.name}` : field.name,
         {
+          id: parentalField ? `${parentalField}_${field.name}` : field.name,
           header: field.type.title,
           enableHiding: true,
           cell: (info) => <SheetListCell {...info} fieldType={type} />,
@@ -120,7 +122,8 @@ export function useDocumentSheetColumns(documentSchemaType?: ObjectSchemaType) {
       return []
     }
     return [
-      columnHelper.accessor('selected', {
+      columnHelper.display({
+        id: 'selected',
         enableHiding: false,
         header: (info) => (
           <Checkbox
@@ -138,6 +141,7 @@ export function useDocumentSheetColumns(documentSchemaType?: ObjectSchemaType) {
       }),
       columnHelper.accessor('Preview', {
         enableHiding: false,
+        id: 'Preview',
         cell: (info) => {
           return (
             <PreviewCell
@@ -156,17 +160,19 @@ export function useDocumentSheetColumns(documentSchemaType?: ObjectSchemaType) {
     () =>
       flatColumns(columns).reduce<[VisibilityState, number]>(
         ([accCols, countAllowedVisible], column) => {
+          const visibilityKey = String(column.id)
+
           // this column is always visible
           if (!column.enableHiding) {
-            return [{...accCols, [column.accessorKey]: true}, countAllowedVisible]
+            return [{...accCols, [visibilityKey]: true}, countAllowedVisible]
           }
 
           // have already reached column visibility limit, hide column by default
           if (countAllowedVisible === VISIBLE_COLUMN_LIMIT) {
-            return [{...accCols, [column.accessorKey]: false}, countAllowedVisible]
+            return [{...accCols, [visibilityKey]: false}, countAllowedVisible]
           }
 
-          return [{...accCols, [column.accessorKey]: true}, countAllowedVisible + 1]
+          return [{...accCols, [visibilityKey]: true}, countAllowedVisible + 1]
         },
         [{}, 0],
       ),

--- a/packages/sanity/src/structure/panes/documentList/useDocumentSheetColumns.tsx
+++ b/packages/sanity/src/structure/panes/documentList/useDocumentSheetColumns.tsx
@@ -160,7 +160,8 @@ export function useDocumentSheetColumns(documentSchemaType?: ObjectSchemaType) {
     () =>
       flatColumns(columns).reduce<[VisibilityState, number]>(
         ([accCols, countAllowedVisible], column) => {
-          const visibilityKey = String(column.id)
+          if (!column.id) throw new Error('Column must have an id')
+          const visibilityKey = column.id
 
           // this column is always visible
           if (!column.enableHiding) {


### PR DESCRIPTION
### Description
Fixes an issue introduced in EDX-1308 (https://github.com/sanity-io/sanity/pull/6661) where tanstack col visibility expects field separator as `_` but incorrectly `.` was being used for our definitions

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Defining an id for all cols which is used in flatColumns.
Selected column now a display column

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Updated test case
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Not relevant - this feature is not yet user facing
<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
