### PR TITLE
fix(tasks): reduce tasks sidebar zoffset

### DIFF
--- a/packages/sanity/src/core/tasks/plugin/TasksStudioActiveToolLayout.tsx
+++ b/packages/sanity/src/core/tasks/plugin/TasksStudioActiveToolLayout.tsx
@@ -77,7 +77,7 @@ function TasksStudioActiveToolLayoutInner(props: ActiveToolLayoutProps) {
         {isOpen && (
           <SidebarMotionLayer
             animate="visible"
-            zOffset={1000}
+            zOffset={100}
             height="fill"
             initial="hidden"
             transition={TRANSITION}


### PR DESCRIPTION
### Description

**Modals** have a z-index of 600.
**Popover** have a z-index of 400.
**Tooltips** have a z-index of 200

Reducing tasks sidebar to **100**, the same as the navbar to stay below modals, popovers and tooltips, it will still sit on top of the elements that were discovered as breaking on the previous fix when this was moved to 1000.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
