### PR TITLE
fix(i18n): remove extraneous curly brace

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -32,7 +32,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'asset-source.delete-dialog.loading': 'Loading…',
   /** Message confirming to delete *named* file */
   'asset-source.delete-dialog.usage-list.confirm-delete-file_named':
-    'You are about to delete the file <strong>{{filename}}}</strong> and its metadata. Are you sure?',
+    'You are about to delete the file <strong>{{filename}}</strong> and its metadata. Are you sure?',
   /** Message confirming to delete *unnamed* file */
   'asset-source.delete-dialog.usage-list.confirm-delete-file_unnamed':
     'You are about to delete the file and its metadata. Are you sure?',


### PR DESCRIPTION
### Description
Tiny one, removes an extraneous curly brace when confirming image deletion: 
<img width="724" alt="image" src="https://github.com/sanity-io/sanity/assets/876086/ede22dca-6184-4379-915a-d3bac4ad3ef0">

### What to review
- the diff :)

### Testing
- should be fine to not have a separate test for this one

### Notes for release
- removes an extraneous curly brace from delete asset confirmation dialog
