### PR TITLE
fix(core): remove id from patch when using server actions

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -149,7 +149,9 @@ export default defineConfig([
     basePath: '/test',
     icon: SanityMonogram,
     // eslint-disable-next-line camelcase
-    __internal_serverDocumentActions: {},
+    __internal_serverDocumentActions: {
+      enabled: true,
+    },
     scheduledPublishing: {
       enabled: true,
       inputDateTimeFormat: 'MM/dd/yy h:mm a',

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/actionTypes.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/actionTypes.ts
@@ -20,7 +20,7 @@ export interface HttpEditAction {
   actionType: 'sanity.action.document.edit'
   draftId: string
   publishedId: string
-  patch: PatchMutation['patch']
+  patch: Omit<PatchMutation['patch'], 'id'>
 }
 
 export type HttpAction = HttpCreateAction | HttpDeleteAction | HttpEditAction

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.test.ts
@@ -247,7 +247,6 @@ describe('checkoutPair -- server actions', () => {
             draftId: 'draftId',
             publishedId: 'publishedId',
             patch: {
-              id: 'draftId',
               set: {
                 title: 'new title',
               },

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -1,6 +1,7 @@
 import {type SanityClient} from '@sanity/client'
 import {type Mutation} from '@sanity/mutator'
 import {type SanityDocument} from '@sanity/types'
+import {omit} from 'lodash'
 import {EMPTY, from, merge, type Observable, Subject} from 'rxjs'
 import {filter, map, mergeMap, share, take, tap} from 'rxjs/operators'
 
@@ -121,7 +122,7 @@ function toActions(idPair: IdPair, mutationParams: Mutation['params']) {
         actionType: 'sanity.action.document.edit',
         draftId: idPair.draftId,
         publishedId: idPair.publishedId,
-        patch: mutations.patch,
+        patch: omit(mutations.patch, 'id'),
       }
     }
     throw new Error('Todo: implement')


### PR DESCRIPTION
### Description
When using server actions, we forwarded the patch mutations as-is, but that means they would also include the document id. The doucment ID is alredy provided as part of the actions payload, and should not be part of the action's patch here.


### What to review
The diff :)

### Testing
This was already covered by a test that I've updated.

### Notes for release

N/A