### PR TITLE
fix(core): reactions menu open issue

### DIFF
--- a/packages/sanity/src/core/comments/components/reactions/CommentReactionsMenuButton.tsx
+++ b/packages/sanity/src/core/comments/components/reactions/CommentReactionsMenuButton.tsx
@@ -47,21 +47,27 @@ export function CommentReactionsMenuButton(props: CommentReactionsMenuButtonProp
 
     setOpen(false)
     onMenuClose?.()
+  }, [open, onMenuClose])
+
+  const handleCloseAndFocus = useCallback(() => {
+    if (!open) return
+
+    handleClose()
     buttonElement?.focus()
-  }, [buttonElement, onMenuClose, open])
+  }, [buttonElement, handleClose, open])
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       const {key, shiftKey} = event
 
       if ((shiftKey && key === 'Tab') || key === 'Escape' || key === 'Tab') {
-        handleClose()
+        handleCloseAndFocus()
       }
     },
-    [handleClose],
+    [handleCloseAndFocus],
   )
 
-  useClickOutside(handleClick, [popoverElement, buttonElement])
+  useClickOutside(handleClose, [popoverElement, buttonElement])
 
   const handleSelect = useCallback(
     (option: CommentReactionOption) => {


### PR DESCRIPTION
### Description

This pull request fixes an issue where the comment reactions popover menus would open when clicking outside of them.

### What to review

- Ensure that the comment reactions menus are correctly opened and closed.

### Notes for release

N/A