### PR TITLE
fix(core): fix issue with nested preview fields not being included in legacy text search

### DIFF
--- a/dev/test-studio/schema/standard/crossDatasetReference.ts
+++ b/dev/test-studio/schema/standard/crossDatasetReference.ts
@@ -159,6 +159,33 @@ export default defineType({
       ],
     },
     {
+      title:
+        'Cross dataset reference with custom filter, only returning books with a norwegian title',
+      description: 'Repro case for https://linear.app/sanity/issue/SDX-1367',
+      name: 'bookWithTitle',
+      type: 'crossDatasetReference',
+      dataset: 'playground',
+      studioUrl: ({id, type}) => {
+        return type
+          ? `${document.location.protocol}//${document.location.host}/playground/structure/${type};${id}`
+          : null
+      },
+      options: {
+        filter: `defined(translations.no)`,
+      },
+      to: [
+        {
+          type: 'book',
+          icon: BookIcon,
+          preview: {
+            select: {
+              title: 'translations.no',
+            },
+          },
+        },
+      ],
+    },
+    {
       title: 'Cross Dataset reference in PTE',
       name: 'portableText',
       type: 'array',

--- a/packages/sanity/src/core/search/common/deriveSearchWeightsFromType.ts
+++ b/packages/sanity/src/core/search/common/deriveSearchWeightsFromType.ts
@@ -157,13 +157,14 @@ const getPreviewWeights = (
 
   if (isCrossDataset) {
     return Object.fromEntries(
-      Object.values(selectionKeysBySelectionPath).map((path) => {
+      Object.entries(selectionKeysBySelectionPath).map(([path, previewFieldName]) => {
         return [
           path,
           {
             path,
             type: 'string',
-            weight: PREVIEW_FIELD_WEIGHT_MAP[path as keyof typeof PREVIEW_FIELD_WEIGHT_MAP],
+            weight:
+              PREVIEW_FIELD_WEIGHT_MAP[previewFieldName as keyof typeof PREVIEW_FIELD_WEIGHT_MAP],
           },
         ]
       }),


### PR DESCRIPTION
### Description
This fixes a regression introduced by #5948 which caused nested preview fields defined on cross dataset references to be included by their preview key instead of their actual path.

E.g. the following cross dataset reference eould produce a query that looked for keyword matches in `title`, which would yield no results, and should instead be `translations.no`.
```
{
  title: 'Example',
  name: 'exampleCrossDatasetReference',
  type: 'crossDatasetReference',
  dataset: 'other-dataset',
  to: [
    {
      type: 'book',
      preview: {
        select: {
          title: 'translations.no',
        },
      },
    },
  ],
},
```

### What to review

This PR includes:
 - 👀 an added repro case to our dev/test studio (d7dd3bc64c319d8bfb00b747ba96cdb730ce3921)
 - 🔴 a (failing) unit test covering the particular case (997a020a811efdfe86fa8a761212d1b33da1a4a9)
 - 🟢 the fix (8c40a7b713ad9a1e5c4e69cf681483b31c6c509a)

### Testing
The issue can be demostrated **before** the fix [here](https://test-studio-ke6jk03nx.sanity.build/test/structure/crossDatasetReferenceTest;14109b82-f9a6-4393-9499-633286dc3dcd%2Ctemplate%3DcrossDatasetReferenceTest) by scrolling down to the "Cross dataset reference with custom filter, only returning books with a norwegian title" field and typing "NORSK".

Compare with a deployment that has the fix applied [here](https://test-studio-git-sdx-1367.sanity.build/test/structure/crossDatasetReferenceTest;14109b82-f9a6-4393-9499-633286dc3dcd)


### Notes for release
- Fix issue causing cross dataset reference search not returning hits in certain cases