### PR TITLE
chore(page-building): configure build outputs

### DIFF
--- a/dev/page-building-studio/turbo.json
+++ b/dev/page-building-studio/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "pipeline": {
+    "build": {
+      "outputs": ["./sanity/**", "dist/**"]
+    }
+  }
+}


### PR DESCRIPTION
When deploying on Vercel, this studio fails with `Error: No Output Directory named "dist" found after the Build completed.` whenever there is a cache hit. Hopefully, specifying the `outputs` of the `build` pipeline makes sure that `dist` can in fact be found in these instances.
