### PR TITLE
fix(portable-text-editor): add autoresolving validations and fix normalization issues

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
@@ -310,7 +310,7 @@ describe('initialization', () => {
         _key: 'abc',
         _type: 'myTestBlockType',
         markDefs: [],
-        children: [{_key: 'def', _type: 'span', text: 'Test', marks: ['invalid']}],
+        children: [{_key: 'def', _type: 'span', marks: []}],
       },
     ]
     const initialSelection: EditorSelection = {
@@ -333,15 +333,15 @@ describe('initialization', () => {
           type: 'invalidValue',
           value: initialValue,
           resolution: {
-            action: 'Remove invalid marks',
+            action: 'Write an empty text property to the object',
             description:
-              "Block with _key 'abc' contains marks (invalid) not supported by the current content model.",
+              "Child with _key 'def' in block with key 'abc' has missing or invalid text property!",
             i18n: {
-              action: 'inputs.portable-text.invalid-value.orphaned-marks.action',
-              description: 'inputs.portable-text.invalid-value.orphaned-marks.description',
+              action: 'inputs.portable-text.invalid-value.invalid-span-text.action',
+              description: 'inputs.portable-text.invalid-value.invalid-span-text.description',
               values: {
                 key: 'abc',
-                orphanedMarks: ['invalid'],
+                childKey: 'def',
               },
             },
             item: {
@@ -351,8 +351,7 @@ describe('initialization', () => {
                 {
                   _key: 'def',
                   _type: 'span',
-                  marks: ['invalid'],
-                  text: 'Test',
+                  marks: [],
                 },
               ],
               markDefs: [],
@@ -367,10 +366,14 @@ describe('initialization', () => {
                   {
                     _key: 'def',
                   },
-                  'marks',
                 ],
                 type: 'set',
-                value: [],
+                value: {
+                  _key: 'def',
+                  _type: 'span',
+                  marks: [],
+                  text: '',
+                },
               },
             ],
           },

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/pteWarningsSelfSolving.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/pteWarningsSelfSolving.test.tsx
@@ -180,6 +180,123 @@ describe('when PTE would display warnings, instead it self solves', () => {
       }
     })
   })
+
+  it('removes orphaned marks', async () => {
+    const editorRef: RefObject<PortableTextEditor> = createRef()
+    const initialValue = [
+      {
+        _key: 'abc',
+        _type: 'myTestBlockType',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {
+            _key: 'def',
+            _type: 'span',
+            marks: ['ghi'],
+            text: 'Hello',
+          },
+        ],
+      },
+    ]
+
+    const onChange = jest.fn()
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
+    )
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({type: 'value', value: initialValue})
+      expect(onChange).toHaveBeenCalledWith({type: 'ready'})
+    })
+    await waitFor(() => {
+      if (editorRef.current) {
+        PortableTextEditor.focus(editorRef.current)
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          {
+            _key: 'abc',
+            _type: 'myTestBlockType',
+            children: [
+              {
+                _key: 'def',
+                _type: 'span',
+                text: 'Hello',
+                marks: [],
+              },
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ])
+      }
+    })
+  })
+
+  it('removes orphaned marksDefs', async () => {
+    const editorRef: RefObject<PortableTextEditor> = createRef()
+    const initialValue = [
+      {
+        _key: 'abc',
+        _type: 'myTestBlockType',
+        style: 'normal',
+        markDefs: [
+          {
+            _key: 'ghi',
+            _type: 'link',
+            href: 'https://sanity.io',
+          },
+        ],
+        children: [
+          {
+            _key: 'def',
+            _type: 'span',
+            marks: [],
+            text: 'Hello',
+          },
+        ],
+      },
+    ]
+
+    const onChange = jest.fn()
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
+    )
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({type: 'value', value: initialValue})
+      expect(onChange).toHaveBeenCalledWith({type: 'ready'})
+    })
+    await waitFor(() => {
+      if (editorRef.current) {
+        PortableTextEditor.focus(editorRef.current)
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          {
+            _key: 'abc',
+            _type: 'myTestBlockType',
+            children: [
+              {
+                _key: 'def',
+                _type: 'span',
+                text: 'Hello',
+                marks: [],
+              },
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ])
+      }
+    })
+  })
+
   it('allows missing .markDefs', async () => {
     const editorRef: RefObject<PortableTextEditor> = createRef()
     const initialValue = [

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
@@ -23,7 +23,6 @@ import {toPortableTextRange, toSlateRange} from '../../utils/ranges'
 import {fromSlateValue, isEqualToEmptyEditor, toSlateValue} from '../../utils/values'
 import {KEY_TO_VALUE_ELEMENT, SLATE_TO_PORTABLE_TEXT_RANGE} from '../../utils/weakMaps'
 import {type PortableTextEditor} from '../PortableTextEditor'
-import {normalizeMarkDefs} from './createWithPortableTextMarkModel'
 
 const debug = debugWithName('API:editable')
 
@@ -517,7 +516,6 @@ export function createWithEditableAPI(
                   })
                 }
               })
-              normalizeMarkDefs(editor, types)
             }
           })
           Editor.normalize(editor)


### PR DESCRIPTION
### Description

This will add two auto-resolving validations:

* Test a block for orphaned markDefs and remove obsolete ones (previously only done through editor normalization).
* Test a block for orphaned marks and remove obsolete ones (previously a hard validation error).

By introducing these new validations, I found two issues. The first was there before, and the other one occured introducing  the new normalization rules of markDefs. 

* Fix issue where deleting block 3, 2 and partially 1 where block 1 contains an remaining annotation (too many validation iterations error).
* Fix issue where copying an text fragment containing an annotation would not be valid with the new validation code.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Should be covered by unit tests.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Improve the validation of content in the Portable Text Editor.

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
