### PR TITLE
fix(structure): allow search/list ignored types when explicitly requested

### DIFF
--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -377,6 +377,10 @@ export const structure: StructureResolver = (S, {schema, documentStore, i18n}) =
               S.divider(),
 
               S.documentTypeListItem('sanity.imageAsset').title('Images').icon(ImagesIcon),
+
+              S.divider(),
+
+              S.listItem().title('All document types').child(S.defaults()),
             ]),
         ),
 

--- a/packages/sanity/src/core/search/common/__tests__/getSearchableTypes.test.ts
+++ b/packages/sanity/src/core/search/common/__tests__/getSearchableTypes.test.ts
@@ -1,0 +1,91 @@
+import {describe, expect, it} from '@jest/globals'
+import {defineType, type Schema} from '@sanity/types'
+
+import {createSchema} from '../../../schema'
+import {getSearchableTypes} from '../getSearchableTypes'
+
+const getSearchableTypeNames = (schema: Schema, explicitlyAllowedTypes?: string[]) =>
+  getSearchableTypes(schema, explicitlyAllowedTypes)
+    .map((type) => type.name)
+    .sort()
+
+describe('getSearchableTypes', () => {
+  it('finds no searchable types in an empty schema', () => {
+    const schema = createSchema({
+      name: 'default',
+      types: [],
+    })
+
+    const searchable = getSearchableTypeNames(schema)
+    expect(searchable).toEqual([])
+  })
+
+  it('finds all non-core document types by default', () => {
+    const schema = createSchema({
+      name: 'default',
+      types: [
+        defineType({name: 'author', type: 'document', fields: [{name: 'name', type: 'string'}]}),
+        defineType({name: 'address', type: 'object', fields: [{name: 'street', type: 'string'}]}),
+      ],
+    })
+
+    const searchable = getSearchableTypeNames(schema)
+    expect(searchable).toEqual(['author'])
+  })
+
+  it('allows "preview url secrets"', () => {
+    const schema = createSchema({
+      name: 'default',
+      types: [
+        defineType({
+          name: 'sanity.previewUrlSecret',
+          type: 'document',
+          fields: [{name: 'key', type: 'string'}],
+        }),
+      ],
+    })
+
+    const searchable = getSearchableTypeNames(schema)
+    expect(searchable).toEqual(['sanity.previewUrlSecret'])
+  })
+
+  it('allows explicitly allowing certain types, if sanity types', () => {
+    const schema = createSchema({
+      name: 'default',
+      types: [],
+    })
+
+    const searchable = getSearchableTypeNames(schema, ['sanity.imageAsset', 'sanity.fileAsset'])
+    expect(searchable).toEqual(['sanity.fileAsset', 'sanity.imageAsset'])
+  })
+
+  it('allows explicitly allowing certain types, does not include non-existant ones', () => {
+    const schema = createSchema({
+      name: 'default',
+      types: [],
+    })
+
+    const searchable = getSearchableTypeNames(schema, ['foobar', 'sanity.imageAsset'])
+    expect(searchable).toEqual(['sanity.imageAsset'])
+  })
+
+  it('allows explicitly allowing certain types, if object types', () => {
+    const schema = createSchema({
+      name: 'default',
+      types: [
+        defineType({
+          name: 'wasPreviouslyADocument',
+          type: 'object',
+          fields: [{name: 'name', type: 'string'}],
+        }),
+        defineType({
+          name: 'myLink',
+          type: 'string',
+        }),
+      ],
+    })
+
+    const searchable = getSearchableTypeNames(schema, ['wasPreviouslyADocument', 'myLink'])
+    expect(searchable).toEqual(['wasPreviouslyADocument'])
+  })
+})

--- a/packages/sanity/src/core/search/common/getSearchableTypes.ts
+++ b/packages/sanity/src/core/search/common/getSearchableTypes.ts
@@ -5,16 +5,30 @@ import {isNonNullable} from '../../util/isNonNullable'
 const isDocumentType = (type: SchemaType): type is ObjectSchemaType =>
   Boolean(type.type && type.type.name === 'document')
 
+const isObjectType = (type: SchemaType): type is ObjectSchemaType => type.jsonType === 'object'
+
 const isIgnoredType = (type: SchemaType): boolean =>
   type.name.startsWith('sanity.') && type.name !== 'sanity.previewUrlSecret'
 
 /**
+ * Get all defined document types from the schema that are searchable
+ *
+ * @param schema - The schema to get searchable types from
+ * @param explicitlyAllowedTypes - Array of type names to explicitly allow, even if they are otherwise ignored. This is useful for cases where you want to allow say `sanity.imageAsset` explicitly, or an object type that was _previously_ defined as a document type, and thus still have documents.
+ *
  * @internal
  */
-export const getSearchableTypes = (schema: Schema): ObjectSchemaType[] =>
+export const getSearchableTypes = (
+  schema: Schema,
+  explicitlyAllowedTypes: string[] = [],
+): ObjectSchemaType[] =>
   schema
     .getTypeNames()
     .map((typeName) => schema.get(typeName))
     .filter(isNonNullable)
-    .filter(isDocumentType)
-    .filter((type) => !isIgnoredType(type))
+    .filter(
+      (type) =>
+        (isDocumentType(type) && !isIgnoredType(type)) ||
+        explicitlyAllowedTypes.includes(type.name),
+    )
+    .filter(isObjectType)

--- a/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
+++ b/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
@@ -96,7 +96,7 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Sanit
       // Use the type names to create a search query and fetch the documents that match the query.
       return typeNames$.pipe(
         mergeMap((typeNames: string[]) => {
-          const types = getSearchableTypes(schema).filter((type) => {
+          const types = getSearchableTypes(schema, staticTypeNames || []).filter((type) => {
             if (typeNames.includes(type.name)) {
               // make a call to getExtendedProjection in strict mode to verify that all fields are
               // known. This method will throw an exception if there are any unknown fields specified


### PR DESCRIPTION
### Description

We previously allowed users to list assets in the structure tool by using a `S.documentTypeList('sanity.imageAsset')`, but during search refactoring this seems to no longer be possible.

This reintroduces the ability, by ensuring that the `getSearchableTypes()` does not remove explicitly declared types.

### What to review

- In the test studio, observe that in `next`, the document list under `Custom panes > Images` does not list images, and that the preview deploy of this _does_
- Check that the ["all document types"](https://test-studio-git-fix-structure-explicit-allow-types.sanity.build/test/structure/custom;allDocumentTypes) custom pane in test studio does not list image and file asset types, as well as the global search not including these types.

### Testing

I attempted to test the actual `listenSearchQuery()` function, but it has a _lot_ of dependencies and was not easy to mock out a client for. An alternative would be to do an e2e test, but I would prefer us to have a more stable environment we can test against, to ensure we have assets that can be listed. I'll make a note of it for future iterations of the E2E suite.

For now, I added some tests for the `getSearchableTypes` function, which at least increases test coverage of _that_ part of the codebase. 

### Notes for release

- Fixes an issue where structure lists would not list image/file assets if told to do so
