### PR TITLE
fix(form): avoid spreading key prop

### DIFF
--- a/packages/sanity/src/core/form/studio/FormBuilder.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilder.tsx
@@ -153,7 +153,7 @@ export function FormBuilder(props: FormBuilderProps) {
     [Field],
   )
   const renderItem = useCallback(
-    (itemProps: Omit<ItemProps, 'renderDefault'>) => <Item {...itemProps} />,
+    ({key, ...itemProps}: Omit<ItemProps, 'renderDefault'>) => <Item key={key} {...itemProps} />,
     [Item],
   )
   const renderPreview = useCallback(


### PR DESCRIPTION
### Description

Before this change, React would throw a runtime error stating that `A props object containing a "key" prop is being spread into JSX`. Now, the `key` is passed to the JSX without using spread.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->
To test this you can run `pnpm dev` to spin up the test studio, and then open a document that has an array of objects. Verify that the error is gone.

![Screenshot 2024-05-28 at 13 00 03](https://github.com/sanity-io/sanity/assets/4602382/9bcad88a-93a8-4299-ba86-74b909f97ee2)


### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
Not practical to write an automated test for since it's a mitigation of a React render error.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
