### PR TITLE
feat: create import map w/ installed sanity version

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -123,11 +123,10 @@ export default async function buildSanityStudio(
   if (enableAutoUpdates) {
     const version = encodeURIComponent(`^${installedSanityVersion}`)
     const autoUpdatesImports = {
-      // /:packageName/:channel/:minVersion/:file?
-      'sanity': `https://api.sanity.work/v1/sanity/default/${version}`,
-      'sanity/': `https://api.sanity.work/v1/sanity/default/${version}/`,
-      '@sanity/vision': `https://api.sanity.work/v1/@sanity__vision/default/${version}`,
-      '@sanity/vision/': `https://api.sanity.work/v1/@sanity__vision/default/${version}/`,
+      'sanity': `https://api.sanity.work/v1/modules/sanity/default/${version}`,
+      'sanity/': `https://api.sanity.work/v1/modules/sanity/default/${version}/`,
+      '@sanity/vision': `https://api.sanity.work/v1/modules/@sanity__vision/default/${version}`,
+      '@sanity/vision/': `https://api.sanity.work/v1/modules/@sanity__vision/default/${version}/`,
     }
 
     importMap = {


### PR DESCRIPTION
### Description

This PR adds the minimum version to the import map grabbed from the installed sanity version.

### What to review

Try the build action out, try the deploy action out with auto updates.

### Testing

Tested it in by building the test-studio with --enable-auto-updates (flag needs to be renamed but will come in another PR)

### Notes for release

N/A
