### PR TITLE
refactor(core): cache fetchFeatureToggle by client

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/utils/fetchFeatureToggle.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/utils/fetchFeatureToggle.ts
@@ -5,31 +5,47 @@ import {catchError, concatMap, share} from 'rxjs/operators'
 interface ActionsFeatureToggle {
   actions: boolean
 }
+const CACHE = new WeakMap<SanityClient, Observable<boolean>>()
 
-//in the "real" code, this would be observable.request, to a URI
-export const fetchFeatureToggle = (client: SanityClient): Observable<boolean> => {
-  const dataset = client.config().dataset
-  return timer(0, 1000 * 120).pipe(
+// How often to refresh the feature toggle
+const REFRESH_INTERVAL = 1000 * 120
+
+// Timer used to reset the observable when it completes or it's refcount drops to zero
+const RESET_TIMER = timer(REFRESH_INTERVAL)
+
+function createFeatureToggle(client: SanityClient) {
+  const {dataset} = client.config()
+
+  return timer(0, REFRESH_INTERVAL).pipe(
     concatMap(() =>
-      client.observable.request({
-        uri: `/data/actions/${dataset}`,
-        withCredentials: true,
-      }),
-    ),
-    map((res: ActionsFeatureToggle) => res.actions),
-    timeout({first: 2000, with: () => of(false)}),
-    catchError(() =>
-      // If we fail to fetch the feature toggle, we'll just assume it's disabled and fallback to legacy mutations
-      of(false),
+      client.observable
+        .request({
+          uri: `/data/actions/${dataset}`,
+          withCredentials: true,
+        })
+        .pipe(
+          map((res: ActionsFeatureToggle) => res.actions),
+          timeout({first: 2000, with: () => of(false)}),
+          catchError(() =>
+            // If we fail to fetch the feature toggle, we'll just assume it's disabled and fallback to legacy mutations
+            of(false),
+          ),
+        ),
     ),
     share({
       // replay latest known state to new subscribers
       connector: () => new ReplaySubject(1),
       // this will typically be completed and unsubscribed from right after the answer is received, so we don't want to reset
-      resetOnRefCountZero: false,
-      // once the fetch has completed, we'll wait for 2 minutes before resetting the state.
-      // we'll then check again once a new subscriber comes in
-      resetOnComplete: () => timer(1000 * 120),
+      resetOnComplete: () => RESET_TIMER,
+      // keep it alive for some time after the last subscriber unsubscribes
+      resetOnRefCountZero: () => RESET_TIMER,
     }),
   )
+}
+
+export const fetchFeatureToggle = (client: SanityClient): Observable<boolean> => {
+  if (!CACHE.has(client)) {
+    CACHE.set(client, createFeatureToggle(client))
+  }
+  return CACHE.get(client)!
 }


### PR DESCRIPTION
### Description

This adds caching to the actions feature toggle, so we avoid refetching when switching between documents, etc.

### What to review

### Testing
In order to test this with the test-studio, this config flag has to be commented out here:
(note - it must be `undefined`, setting it to `false` will disable server actions entirely and skip fetching the flag from the backend):

https://github.com/sanity-io/sanity/blob/373af6a12047e16870fa03270a2452e822a37b55/dev/test-studio/sanity.config.ts#L153

### Notes for release
n/a
