### PR TITLE
fix: handle circular import issue in a compiler friendly way

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
     "check:react-exhaustive-deps": "turbo run lint --continue -- --quiet --rule 'react-hooks/exhaustive-deps: [error, {additionalHooks: \"(useAsync|useMemoObservable|useObservableCallback)\"}]'",
-    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 43 .",
+    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 42 .",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",
     "chore:format:fix": "prettier --cache --write .",

--- a/packages/sanity/src/core/components/previewCard/PreviewCard.tsx
+++ b/packages/sanity/src/core/components/previewCard/PreviewCard.tsx
@@ -47,3 +47,16 @@ export const PreviewCard = forwardRef(function PreviewCard(
     </StyledCard>
   )
 })
+
+/**
+ *  This is a workaround for a circular import issue.
+ * Calling `styled(PreviewCard)` at program load time triggered a build error with the commonjs bundle because it tried
+ * to access the PreviewCard variable/symbol before it was initialized.
+ * The workaround is to colocate the styled component with the component itself.
+ * @internal
+ */
+export const ReferenceInputPreviewCard = styled(PreviewCard)`
+  /* this is a hack to avoid layout jumps while previews are loading
+there's probably better ways of solving this */
+  min-height: 36px;
+`

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -1,21 +1,12 @@
 import {Stack, Text, useToast} from '@sanity/ui'
 import {uuid} from '@sanity/uuid'
-import {
-  type FocusEvent,
-  forwardRef,
-  type KeyboardEvent,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import {type FocusEvent, type KeyboardEvent, useCallback, useMemo, useRef, useState} from 'react'
 import {useObservableCallback} from 'react-rx'
 import {concat, type Observable, of} from 'rxjs'
 import {catchError, filter, map, scan, switchMap, tap} from 'rxjs/operators'
-import {styled} from 'styled-components'
 
 import {Button} from '../../../../ui-components'
-import {PreviewCard} from '../../../components'
+import {ReferenceInputPreviewCard} from '../../../components'
 import {Translate, useTranslation} from '../../../i18n'
 import {getPublishedId, isNonNullable} from '../../../util'
 import {Alert} from '../../components/Alert'
@@ -35,22 +26,6 @@ import {
 import {useReferenceInfo} from './useReferenceInfo'
 import {useReferenceInput} from './useReferenceInput'
 import {useReferenceItemRef} from './useReferenceItemRef'
-
-// This is a workaround for a circular import issue.
-// Calling `styled(PreviewCard)` at program load time triggered a build error with the commonjs bundle because it tried
-// to access the PreviewCard variable/symbol before it was initialized.
-// The workaround is to defer creating StyledPreviewCard until react render time
-let StyledPreviewCardImpl: undefined | typeof PreviewCard
-const StyledPreviewCard: typeof PreviewCard = forwardRef(function StyledPreviewCard(props, ref) {
-  if (!StyledPreviewCardImpl) {
-    StyledPreviewCardImpl = styled(PreviewCard)`
-      /* this is a hack to avoid layout jumps while previews are loading
-      there's probably better ways of solving this */
-      min-height: 36px;
-    `
-  }
-  return <StyledPreviewCardImpl ref={ref} {...props} />
-})
 
 const INITIAL_SEARCH_STATE: ReferenceSearchState = {
   hits: [],
@@ -225,14 +200,14 @@ export function ReferenceInput(props: ReferenceInputProps) {
       const documentId = option.hit.draft?._id || option.hit.published?._id || option.value
 
       return (
-        <StyledPreviewCard forwardedAs="button" type="button" radius={2} tone="inherit">
+        <ReferenceInputPreviewCard forwardedAs="button" type="button" radius={2} tone="inherit">
           <OptionPreview
             getReferenceInfo={getReferenceInfo}
             id={documentId}
             renderPreview={renderPreview}
             type={schemaType}
           />
-        </StyledPreviewCard>
+        </ReferenceInputPreviewCard>
       )
     },
     [schemaType, getReferenceInfo, renderPreview],


### PR DESCRIPTION
### Description

By moving the import to colocate with the `StyledCard` definition we're able to avoid the circular deps issue in CJS, and regain the benefit of declaring the `styled(PreviewCard)` on the top-level instead of at runtime in that the CSS is known ahead of time for `styled-components`.

### What to review

It makes sense what it's named and its internal warning.

### Testing

I tested it manually, but I'm not familiar with the original cjs bundle issue being referred to, can @bjoerge advice?

### Notes for release

N/A as it's an internal refactor that allows React Compiler but is otherwise the same as before
