### PR TITLE
fix: use `useImperativeHandle` instead of mutating a parent ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
     "check:react-exhaustive-deps": "turbo run lint --continue -- --quiet --rule 'react-hooks/exhaustive-deps: [error, {additionalHooks: \"(useAsync|useMemoObservable|useObservableCallback)\"}]'",
-    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 43 .",
+    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 42 .",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",
     "chore:format:fix": "prettier --cache --write .",

--- a/packages/sanity/src/structure/components/pane/Pane.tsx
+++ b/packages/sanity/src/structure/components/pane/Pane.tsx
@@ -1,11 +1,4 @@
-import {
-  BoundaryElementProvider,
-  Card,
-  type CardProps,
-  Code,
-  Flex,
-  useForwardedRef,
-} from '@sanity/ui'
+import {BoundaryElementProvider, Card, type CardProps, Code, Flex} from '@sanity/ui'
 import {
   type ForwardedRef,
   forwardRef,
@@ -13,6 +6,7 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useState,
 } from 'react'
@@ -81,18 +75,12 @@ export const Pane = forwardRef(function Pane(
   const expanded = expandedElement === rootElement
   const collapsed = layoutCollapsed ? false : pane?.collapsed || false
   const nextCollapsed = nextPane?.collapsed || false
-  const forwardedRef = useForwardedRef(ref)
   const flex = pane?.flex ?? flexProp
   const currentMinWidth = pane?.currentMinWidth ?? currentMinWidthProp
   const currentMaxWidth = pane?.currentMaxWidth ?? currentMaxWidthProp
 
-  const setRef = useCallback(
-    (refValue: HTMLDivElement | null) => {
-      setRootElement(refValue)
-      forwardedRef.current = refValue
-    },
-    [forwardedRef],
-  )
+  // Forward ref to parent
+  useImperativeHandle(ref, () => rootElement!, [rootElement])
 
   useEffect(() => {
     if (!rootElement) return undefined
@@ -211,7 +199,7 @@ export const Pane = forwardRef(function Pane(
               data-pane-collapsed={collapsed ? '' : undefined}
               data-pane-index={paneIndex}
               data-pane-selected={selected ? '' : undefined}
-              ref={setRef}
+              ref={setRootElement}
               style={style}
             >
               {PANE_DEBUG && (


### PR DESCRIPTION
### Description

React Compiler isn't able to optimize `<Pane>` when it mutates the `forwardedRef` value returned by `useForwardedRef`.
That's fine, because we can use `useImperativeHandle` to forward refs to the parent in a way that is sound, and that React Compiler is able to handle.
We should probably deprecate the `useForwardedRef` hook in `@sanity/ui` as `useImperativeHandle` is a much better alternative (`useForwardedRef` for example needs a `useEffect` cycle to handle forwarding):

```diff
-import {useForwardedRef} from '@sanity/ui'
-import {forwardRef} from 'react'
+import {forwardRef, useImperativeHandle} from 'react'

export default forwardRef(function Component(props, ref) {
-  const nodeRef = useForwardedRef(ref)
+  const nodeRef = useRef()
+  useImperativeHandle(ref, () => nodeRef.current)

  return <div ref={nodeRef} />
})
```

### What to review

Does it make sense?

### Testing

Existing tests should be sufficient, as the refactor doesn't have practical differences, beyond being slightly faster in general, and noticeably faster when React Compiler is enabled.

### Notes for release

N/A
