### PR TITLE
fix: call dynamic hooks in a way that can be compiled

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
     "check:react-exhaustive-deps": "turbo run lint --continue -- --quiet --rule 'react-hooks/exhaustive-deps: [error, {additionalHooks: \"(useAsync|useMemoObservable|useObservableCallback)\"}]'",
-    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 41 .",
+    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 40 .",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",
     "chore:format:fix": "prettier --cache --write .",

--- a/packages/sanity/src/core/form/field/actions/FieldActionsResolver.tsx
+++ b/packages/sanity/src/core/form/field/actions/FieldActionsResolver.tsx
@@ -1,5 +1,5 @@
 import {type Path, type SchemaType} from '@sanity/types'
-import {memo, useCallback, useEffect, useRef, useState} from 'react'
+import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 
 import {type DocumentFieldAction, type DocumentFieldActionNode} from '../../../config'
 import {useUnique} from '../../../util'
@@ -34,7 +34,7 @@ export interface FieldActionsProps {
  *
  * @internal
  */
-export const FieldActionsResolver = memo(function FieldActions(props: FieldActionsProps) {
+export const FieldActionsResolver = memo(function FieldActionsResolver(props: FieldActionsProps) {
   const {actions, documentId, documentType, onActions, path, schemaType} = props
 
   const len = actions.length
@@ -76,26 +76,41 @@ export const FieldActionsResolver = memo(function FieldActions(props: FieldActio
     }
   }, [len])
 
+  const FieldActions = useMemo(() => {
+    return actions.map((action, index) => {
+      return defineFieldActionComponent({
+        action,
+        documentId,
+        documentType,
+        index,
+        path,
+        schemaType,
+        setFieldAction,
+      })
+    })
+  }, [actions, documentId, documentType, path, schemaType, setFieldAction])
+
   return (
     <>
-      {actions.map((a, aIdx) => (
+      {FieldActions.map((FieldAction, key) => (
         <FieldAction
-          action={a}
-          index={aIdx}
           // eslint-disable-next-line react/no-array-index-key
-          key={aIdx}
-          documentId={documentId}
-          documentType={documentType}
-          path={path}
-          schemaType={schemaType}
-          setFieldAction={setFieldAction}
+          key={key}
         />
       ))}
     </>
   )
 })
 
-interface FieldActionProps {
+function defineFieldActionComponent({
+  action,
+  documentId,
+  documentType,
+  index,
+  path,
+  schemaType,
+  setFieldAction,
+}: {
   action: DocumentFieldAction
   documentId: string
   documentType: string
@@ -103,23 +118,21 @@ interface FieldActionProps {
   path: Path
   schemaType: SchemaType
   setFieldAction: (index: number, node: DocumentFieldActionNode) => void
-}
-
-const FieldAction = memo(function FieldAction(props: FieldActionProps) {
-  const {action, documentId, documentType, index, path, schemaType, setFieldAction} = props
-
-  const node = useUnique(
-    action.useAction({
+}) {
+  const {useAction} = action
+  return memo(function FieldAction() {
+    const _action = useAction({
       documentId,
       documentType,
       path,
       schemaType,
-    }),
-  )
+    })
+    const node = useUnique(_action)
 
-  useEffect(() => {
-    setFieldAction(index, node)
-  }, [index, node, setFieldAction])
+    useEffect(() => {
+      setFieldAction(index, node)
+    }, [node])
 
-  return null
-})
+    return null
+  })
+}


### PR DESCRIPTION
### Description

Refactors `FieldAction` and `InspectorMenuItem` components so they're no longer calling hooks that come from props. Instead, the components themselves are dynamically defined, allowing React to call said underlying hooks in a dynamic way.
It upholds the guarantee that no matter how many times, say, `FieldAction` re-renders, it'll never suddenly see `props.action.useAction()` change identity, because if it changes a new component is created instead.

### What to review

It should make sense. There's another linter warning in `DocumentInspectorMenuItemsResolver.tsx` that will be handled in a follow up.

### Testing

Existing tests should be enough.

### Notes for release

N/A
