### PR TITLE
fix(core): apply create mutation only if draft doesn't exist locally

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.test.ts
@@ -318,7 +318,7 @@ describe('checkoutPair -- server actions', () => {
     const combined = merge(draft.events, published.events)
     const sub = combined.subscribe()
     await new Promise((resolve) => setTimeout(resolve, 0))
-
+    const logSpy = jest.spyOn(console, 'error')
     draft.mutate([
       draft.createIfNotExists({
         _id: 'draftId',
@@ -330,11 +330,16 @@ describe('checkoutPair -- server actions', () => {
     ])
     draft.commit()
 
+    // Note: server side actions should never need to use createIfNotExists patches, but if it does, a console error will be issued
+    // However – the createIfNotExist is mapped to an empty array of actions, which will be rejected by the server
     expect(mockedActionRequest).toHaveBeenCalledWith([], {
       tag: 'document.commit',
       transactionId: expect.any(String),
     })
 
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({message: 'Server actions should not be using createIfNotExists'}),
+    )
     sub.unsubscribe()
   })
 })

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -99,8 +99,10 @@ function toActions(idPair: IdPair, mutationParams: Mutation['params']): Action[]
     // This action is not always interoperable with the equivalent mutation. It will fail if the
     // published version of the document already exists.
     if (mutations.createIfNotExists) {
-      // ignore all createIfNotExists, as these should be covered by the actions api and only be done locally
-      throw new Error('Server side actions should not be using createIfNotExists')
+      console.error(new Error('Server actions should not be using createIfNotExists'))
+      // Note: we could throw an error here, but any error thrown here will propagate to the buffered document failure handler and ignored silently
+      // https://github.com/sanity-io/sanity/blob/b14622ed44899ad6da7bb0fd1d46f56c0186a04b/packages/@sanity/mutator/src/document/BufferedDocument.ts#L227
+      return []
     }
     if (mutations.create) {
       // the actions API requires attributes._id to be set, while it's optional in the mutation API
@@ -120,7 +122,10 @@ function toActions(idPair: IdPair, mutationParams: Mutation['params']): Action[]
         patch: omit(mutations.patch, 'id'),
       }
     }
-    throw new Error('Cannot map mutation to action')
+    // Note: we should ideally throw an error here, but any error thrown here will propagate to the buffered document failure handler and ignored silently
+    // https://github.com/sanity-io/sanity/blob/b14622ed44899ad6da7bb0fd1d46f56c0186a04b/packages/@sanity/mutator/src/document/BufferedDocument.ts#L227
+    console.error(new Error('Cannot map mutation to action'), mutations)
+    return []
   })
 }
 

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -100,7 +100,7 @@ function toActions(idPair: IdPair, mutationParams: Mutation['params']): Action[]
     // published version of the document already exists.
     if (mutations.createIfNotExists) {
       // ignore all createIfNotExists, as these should be covered by the actions api and only be done locally
-      return []
+      throw new Error('Server side actions should not be using createIfNotExists')
     }
     if (mutations.create) {
       // the actions API requires attributes._id to be set, while it's optional in the mutation API

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
@@ -29,6 +29,13 @@ export const patch: OperationImpl<[patches: any[], initialDocument?: Record<stri
 
     const patchMutation = draft.patch(patches)
 
+    if (snapshots.published && !snapshots.draft) {
+      // If there's a published version, but no draft version, editing the published version will
+      // ensure a draft version is created.
+      published.mutate(patchMutation)
+      return
+    }
+
     // If there's no draft, the user's edits will be based on the published document in the form in front of them
     // so before patching it we need to make sure it's created based on the current published version first.
     const ensureDraft = snapshots.draft
@@ -36,7 +43,6 @@ export const patch: OperationImpl<[patches: any[], initialDocument?: Record<stri
       : [
           draft.create({
             ...initialDocument,
-            ...(snapshots.published ? snapshots.published : {}),
             _id: idPair.draftId,
             _type: typeName,
           }),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
@@ -29,25 +29,14 @@ export const patch: OperationImpl<[patches: any[], initialDocument?: Record<stri
 
     const patchMutation = draft.patch(patches)
 
-    if (snapshots.published) {
-      draft.mutate([
-        // If there's no draft, the user's edits will be based on the published document in the form in front of them
-        // so before patching it we need to make sure it's created based on the current published version first.
-        draft.createIfNotExists({
-          ...initialDocument,
-          ...snapshots.published,
-          _id: idPair.draftId,
-          _type: typeName,
-        }),
-        ...patchMutation,
-      ])
-      return
-    }
+    // If there's no draft, the user's edits will be based on the published document in the form in front of them
+    // so before patching it we need to make sure it's created based on the current published version first.
     const ensureDraft = snapshots.draft
       ? []
       : [
           draft.create({
             ...initialDocument,
+            ...(snapshots.published ? snapshots.published : {}),
             _id: idPair.draftId,
             _type: typeName,
           }),


### PR DESCRIPTION
### Description

Currently, if a document has a published version, we would apply a `createIfNotExists` mutation locally in order to create the draft. Later on, when converting buffered document mutations to actions, we'd ignore `createIfNotExists` mutations, which could occationally lead to an empty array of actions, which again would be rejected by the server side document actions with an error saying "No actions provided".

However, if there is no published document, we'll currently apply a `create` mutation locally, which will then be converted to a `sanity.action.document.create`-action.

This PR fixes the issue of an empty actions array by using the same logic for `create` mutations no matter if there's a local published version or not.

### What to review

Does the changes make sense? Anything I'm missing here?

### Testing

I'm expecting some failing unit tests as a consequence of this change – ~will update tests accordingly~ Done.

### Notes for release

n/a