### PR TITLE
feat(migrate): add `dryRun` to context

### DIFF
--- a/packages/@sanity/migrate/src/runner/dryRun.ts
+++ b/packages/@sanity/migrate/src/runner/dryRun.ts
@@ -5,7 +5,7 @@ import {decodeText} from '../it-utils'
 import {parse, stringify} from '../it-utils/ndjson'
 import {fromExportArchive} from '../sources/fromExportArchive'
 import {fromExportEndpoint, safeJsonParser} from '../sources/fromExportEndpoint'
-import {type APIConfig, type Migration} from '../types'
+import {type MigrationContext, type APIConfig, type Migration} from '../types'
 import {asyncIterableToStream} from '../utils/asyncIterableToStream'
 import {streamToAsyncIterator} from '../utils/streamToAsyncIterator'
 import {collectMigrationMutations} from './collectMigrationMutations'
@@ -43,9 +43,10 @@ export async function* dryRun(config: MigrationRunnerOptions, migration: Migrati
   const client = createContextClient({...config.api, useCdn: false})
 
   const filteredDocumentsClient = createFilteredDocumentsClient(createReader)
-  const context = {
+  const context: MigrationContext = {
     client,
     filtered: filteredDocumentsClient,
+    dryRun: true,
   }
 
   yield* collectMigrationMutations(

--- a/packages/@sanity/migrate/src/runner/run.ts
+++ b/packages/@sanity/migrate/src/runner/run.ts
@@ -13,7 +13,7 @@ import {mapAsync} from '../it-utils/mapAsync'
 import {parse, stringify} from '../it-utils/ndjson'
 import {tap} from '../it-utils/tap'
 import {fromExportEndpoint, safeJsonParser} from '../sources/fromExportEndpoint'
-import {type APIConfig, type Migration, type MigrationProgress} from '../types'
+import {type MigrationContext, type APIConfig, type Migration, type MigrationProgress} from '../types'
 import {asyncIterableToStream} from '../utils/asyncIterableToStream'
 import {streamToAsyncIterator} from '../utils/streamToAsyncIterator'
 import {collectMigrationMutations} from './collectMigrationMutations'
@@ -92,9 +92,10 @@ export async function run(config: MigrationRunnerConfig, migration: Migration) {
   })
 
   const filteredDocumentsClient = createFilteredDocumentsClient(createReader)
-  const context = {
+  const context: MigrationContext = {
     client,
     filtered: filteredDocumentsClient,
+    dryRun: false,
   }
 
   const documents = () =>

--- a/packages/@sanity/migrate/src/types.ts
+++ b/packages/@sanity/migrate/src/types.ts
@@ -61,6 +61,7 @@ export interface MigrationContext {
     getDocument<T extends SanityDocument>(id: string): Promise<T | undefined>
     getDocuments<T extends SanityDocument>(ids: string[]): Promise<T[]>
   }
+  dryRun: boolean
 }
 
 /**


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
When running a migration, there may be side-effects like calling a third-party API, or using client to make Sanity requests. A developer may wish to log those effects rather than actually executing them in a dry run.

```ts
import { defineMigration } from "sanity/migrate";

/**
 * Run this migration with
 * `npx sanity migration run my-migration`
 */
export default defineMigration({
  title: "my-migration",

  // pass whether the migration is a dry-run as context
  async *migrate(documents, { dryRun }) {
    for await (const document of documents()) {
      if(dryRun) {
        // Only log the effect
        console.log(`Something happened`)
      } else {
        // Execute the side-effect
        await thirdPartyRequest();
      }
      // ... do something with the document, maybe yield patches
    }
  },
});

```

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
I manually tested that the flag comes through the context in both async generator and object definition formats

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
Adds a `dryRun` flag to the context argument in migration scripts
