### PR TITLE
fix(core): restore platform-aware keyboard shortcuts

### DIFF
--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable camelcase */
-import {Flex, Hotkeys, LayerProvider, Stack, Text} from '@sanity/ui'
+import {Flex, LayerProvider, Stack, Text} from '@sanity/ui'
 import {memo, useMemo, useState} from 'react'
 import {
   type DocumentActionComponent,
   type DocumentActionDescription,
+  Hotkeys,
   shouldArrayDialogOpen,
   useSource,
   useTimelineSelector,
@@ -45,6 +46,7 @@ function DocumentStatusBarActionsInner(props: DocumentStatusBarActionsInnerProps
         {firstActionState.title && <Text size={1}>{firstActionState.title}</Text>}
         {firstActionState.shortcut && (
           <Hotkeys
+            data-testid="document-status-bar-hotkeys"
             fontSize={1}
             style={{marginTop: -4, marginBottom: -4}}
             keys={String(firstActionState.shortcut)

--- a/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
+++ b/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
@@ -3,7 +3,6 @@ import {
   Badge,
   Box,
   Flex,
-  Hotkeys,
   MenuItem as UIMenuItem,
   type MenuItemProps as UIMenuItemProps,
   Stack,
@@ -23,6 +22,7 @@ import {
 import {isValidElementType} from 'react-is'
 import {styled} from 'styled-components'
 
+import {Hotkeys} from '../../core/components/Hotkeys'
 import {Tooltip, type TooltipProps} from '..'
 import {
   ConditionalWrapper,

--- a/packages/sanity/src/ui-components/tooltip/Tooltip.tsx
+++ b/packages/sanity/src/ui-components/tooltip/Tooltip.tsx
@@ -1,8 +1,6 @@
-/* eslint-disable no-restricted-imports */
 import {
   Box,
   Flex,
-  Hotkeys,
   type HotkeysProps,
   Text,
   Tooltip as UITooltip,
@@ -10,9 +8,11 @@ import {
 } from '@sanity/ui'
 import {type ForwardedRef, forwardRef} from 'react'
 
+import {Hotkeys} from '../../core/components/Hotkeys'
 import {TOOLTIP_DELAY_PROPS} from './constants'
 
 /** @internal */
+
 export type TooltipProps = Omit<UITooltipProps, 'arrow' | 'padding' | 'shadow'> & {
   hotkeys?: HotkeysProps['keys']
 }

--- a/test/e2e/tests/document-actions/publish.spec.ts
+++ b/test/e2e/tests/document-actions/publish.spec.ts
@@ -13,6 +13,20 @@ test(`document panel displays correct title for published document`, async ({
   // Ensure the correct title is displayed before publishing.
   await expect(page.getByTestId('document-panel-document-title')).toHaveText(title)
 
+  // Focus the publish button to trigger the tooltip showing the keyboard shortcut
+  page.getByTestId('action-Publish').focus()
+
+  // There is a delay before the tooltip opens, let's explicitly wait for it
+  await page.waitForTimeout(300)
+
+  // Now look for the tooltip to appear, with platform-aware keyboard shortcuts
+  // It'll have a data-testid of 'document-status-bar-hotkeys'
+  await page.waitForSelector('[data-testid="document-status-bar-hotkeys"]')
+  const hotkeys = page.getByTestId('document-status-bar-hotkeys')
+
+  const isMac = await page.evaluate(() => /Mac|iPod|iPhone|iPad/.test(navigator.platform || ''))
+  expect(hotkeys).toHaveText(isMac ? 'CtrlOptionP' : 'CtrlAltP')
+
   // Wait for the document to be published.
   page.getByTestId('action-Publish').click()
   await expect(page.getByText('Published just now')).toBeVisible()


### PR DESCRIPTION
### Description

Seems the facelift PR caused a regression that basically reverted [this PR](https://github.com/sanity-io/sanity/pull/5065) in terms of end result.

This PR reverts to using the `<Hotkeys>` component from the sanity core, which is platform aware.

### What to review

- Shows `Ctrl + Option + P` on publish and similar, when on Mac
- Shows `Ctrl + Alt + P` on publish and similar, when _not_ on Mac

(This should be uncovered by the test suite, fwiw)

### Testing

I added one test for this in the publish action. Ideally I would test all the different locations that use any kind of hotkeys that _may_ involve the `Alt` key, but that would be a lot of tests in a lot of different places. I may introduce an ESLint rule to disallow the use of `<Hotkeys>` from `@sanity/ui` later.

### Notes for release

- Fixes a regression causing platform-aware hotkeys not to be displayed in tooltips

