### PR TITLE
feat(cli): allow the ability to specify package manager in init command

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -22,6 +22,7 @@ import {
 } from '../../packageManager'
 import {
   ALLOWED_PACKAGE_MANAGERS,
+  allowedPackageManagersString,
   getPartialEnvWithNpmPath,
   type PackageManager,
 } from '../../packageManager/packageManagerChoice'
@@ -460,8 +461,6 @@ export default async function initSanity(
 
     // eslint-disable-next-line no-process-exit
     process.exit(0)
-
-    return
   }
 
   // eslint-disable-next-line @typescript-eslint/no-shadow
@@ -557,6 +556,16 @@ export default async function initSanity(
         interactive: unattended ? false : isInteractive,
       })
     ).chosen
+
+    // only log warning if a package manager flag is passed
+    if (packageManager) {
+      output.warn(
+        chalk.yellow(
+          `Given package manager "${packageManager}" is not supported. Supported package managers are ${allowedPackageManagersString}.`,
+        ),
+      )
+      output.print(`Using ${pkgManager} as package manager`)
+    }
   }
 
   trace.log({step: 'selectPackageManager', selectedOption: pkgManager})

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -4,12 +4,10 @@ import {detectFrameworkRecord, LocalFileSystemDetector} from '@vercel/fs-detecto
 import initPlugin from '../../actions/init-plugin/initPlugin'
 import initProject from '../../actions/init-project/initProject'
 import {
-  ALLOWED_PACKAGE_MANAGERS,
+  allowedPackageManagersString,
   type PackageManager,
 } from '../../packageManager/packageManagerChoice'
 import {type CliCommandDefinition} from '../../types'
-
-const allowedPms = ALLOWED_PACKAGE_MANAGERS.map((pm) => `"${pm}"`).join(' | ')
 
 const helpText = `
 Options
@@ -28,7 +26,7 @@ Options
   --project-plan <name> Optionally select a plan for a new project
   --coupon <name> Optionally select a coupon for a new project (cannot be used with --project-plan)
   --no-typescript Do not use TypeScript for template files
-  --package-manager <manager> Specify which package manager to use [allowed: ${allowedPms}]
+  --package-manager <manager> Specify which package manager to use [allowed: ${allowedPackageManagersString}]
 
 Examples
   # Initialize a new project, prompt for required information along the way

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -26,7 +26,7 @@ Options
   --project-plan <name> Optionally select a plan for a new project
   --coupon <name> Optionally select a coupon for a new project (cannot be used with --project-plan)
   --no-typescript Do not use TypeScript for template files
-  --package-manager <manager> Specify which package manager to use [allowed: ${allowedPackageManagersString}]
+  --package-manager <name> Specify which package manager to use [allowed: ${allowedPackageManagersString}]
 
 Examples
   # Initialize a new project, prompt for required information along the way

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -3,6 +3,7 @@ import {detectFrameworkRecord, LocalFileSystemDetector} from '@vercel/fs-detecto
 
 import initPlugin from '../../actions/init-plugin/initPlugin'
 import initProject from '../../actions/init-project/initProject'
+import {type PackageManager} from '../../packageManager/packageManagerChoice'
 import {type CliCommandDefinition} from '../../types'
 
 const helpText = `
@@ -22,6 +23,7 @@ Options
   --project-plan <name> Optionally select a plan for a new project
   --coupon <name> Optionally select a coupon for a new project (cannot be used with --project-plan)
   --no-typescript Do not use TypeScript for template files
+  --package-manager <manager> Specify which package manager to use [allowed: "npm" | "yarn" | "pnpm" | "bun" | "manual"]
 
 Examples
   # Initialize a new project, prompt for required information along the way
@@ -80,6 +82,8 @@ export interface InitFlags {
   'reconfigure'?: boolean
 
   'organization'?: string
+
+  'package-manager'?: PackageManager
 }
 
 export const initCommand: CliCommandDefinition<InitFlags> = {

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -3,8 +3,13 @@ import {detectFrameworkRecord, LocalFileSystemDetector} from '@vercel/fs-detecto
 
 import initPlugin from '../../actions/init-plugin/initPlugin'
 import initProject from '../../actions/init-project/initProject'
-import {type PackageManager} from '../../packageManager/packageManagerChoice'
+import {
+  ALLOWED_PACKAGE_MANAGERS,
+  type PackageManager,
+} from '../../packageManager/packageManagerChoice'
 import {type CliCommandDefinition} from '../../types'
+
+const allowedPms = ALLOWED_PACKAGE_MANAGERS.map((pm) => `"${pm}"`).join(' | ')
 
 const helpText = `
 Options
@@ -23,7 +28,7 @@ Options
   --project-plan <name> Optionally select a plan for a new project
   --coupon <name> Optionally select a coupon for a new project (cannot be used with --project-plan)
   --no-typescript Do not use TypeScript for template files
-  --package-manager <manager> Specify which package manager to use [allowed: "npm" | "yarn" | "pnpm" | "bun" | "manual"]
+  --package-manager <manager> Specify which package manager to use [allowed: ${allowedPms}]
 
 Examples
   # Initialize a new project, prompt for required information along the way

--- a/packages/@sanity/cli/src/packageManager/packageManagerChoice.ts
+++ b/packages/@sanity/cli/src/packageManager/packageManagerChoice.ts
@@ -9,6 +9,8 @@ import {isInteractive} from '../util/isInteractive'
 
 export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun' | 'manual'
 
+export const ALLOWED_PACKAGE_MANAGERS: PackageManager[] = ['npm', 'yarn', 'pnpm', 'bun', 'manual']
+
 const EXPERIMENTAL = ['bun']
 
 /**

--- a/packages/@sanity/cli/src/packageManager/packageManagerChoice.ts
+++ b/packages/@sanity/cli/src/packageManager/packageManagerChoice.ts
@@ -10,6 +10,9 @@ import {isInteractive} from '../util/isInteractive'
 export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun' | 'manual'
 
 export const ALLOWED_PACKAGE_MANAGERS: PackageManager[] = ['npm', 'yarn', 'pnpm', 'bun', 'manual']
+export const allowedPackageManagersString = ALLOWED_PACKAGE_MANAGERS.map((pm) => `"${pm}"`).join(
+  ' | ',
+)
 
 const EXPERIMENTAL = ['bun']
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds `--package-manager` flag to the init command. If passed and valid, it will use this flag as the package manager when installing dependencies. 

Note: I have not touched the nextjs init package manager choosing piece not sure if it should or not. 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Changes and copy makes sense. You can still create new projects with and without this flag.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I manually tested different scenarios, this PR will unblock future PRs for testing the init command

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

- Adds `--package-manager` flag to init command to choose a package manager