### PR TITLE
fix: regression in #6813

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
     "check:react-exhaustive-deps": "turbo run lint --continue -- --quiet --rule 'react-hooks/exhaustive-deps: [error, {additionalHooks: \"(useAsync|useMemoObservable|useObservableCallback)\"}]'",
-    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 42 .",
+    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 41 .",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",
     "chore:format:fix": "prettier --cache --write .",

--- a/packages/sanity/src/structure/components/pane/Pane.tsx
+++ b/packages/sanity/src/structure/components/pane/Pane.tsx
@@ -8,6 +8,7 @@ import {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useRef,
   useState,
 } from 'react'
 import {IsLastPaneProvider, LegacyLayerProvider} from 'sanity'
@@ -46,7 +47,7 @@ export const Pane = forwardRef(function Pane(
   props: PaneProps &
     Omit<CardProps, 'as' | 'overflow'> &
     Omit<HTMLProps<HTMLDivElement>, 'as' | 'height' | 'hidden' | 'id' | 'style'>,
-  ref: ForwardedRef<HTMLDivElement>,
+  forwardedRef: ForwardedRef<HTMLDivElement>,
 ) {
   const {
     children,
@@ -75,12 +76,18 @@ export const Pane = forwardRef(function Pane(
   const expanded = expandedElement === rootElement
   const collapsed = layoutCollapsed ? false : pane?.collapsed || false
   const nextCollapsed = nextPane?.collapsed || false
+  const ref = useRef<HTMLDivElement | null>(null)
   const flex = pane?.flex ?? flexProp
   const currentMinWidth = pane?.currentMinWidth ?? currentMinWidthProp
   const currentMaxWidth = pane?.currentMaxWidth ?? currentMaxWidthProp
 
   // Forward ref to parent
-  useImperativeHandle(ref, () => rootElement!, [rootElement])
+  useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(forwardedRef, () => ref.current)
+
+  const setRef = useCallback((refValue: HTMLDivElement | null) => {
+    setRootElement(refValue)
+    ref.current = refValue
+  }, [])
 
   useEffect(() => {
     if (!rootElement) return undefined
@@ -199,7 +206,7 @@ export const Pane = forwardRef(function Pane(
               data-pane-collapsed={collapsed ? '' : undefined}
               data-pane-index={paneIndex}
               data-pane-selected={selected ? '' : undefined}
-              ref={setRootElement}
+              ref={setRef}
               style={style}
             >
               {PANE_DEBUG && (


### PR DESCRIPTION
The change in #6813 caused some regressions.

For example previously this would log `HTMLDivElement` on the first render:

```tsx
function MyComponent() {
  const ref = React.useRef(null)
  React.useEffect(() => {
    console.log(ref?.current)
  }, [])

  return <Pane ref={ref} />
}
```
But in #6813  it's `null`, forcing you to use this pattern for it to be safe:
```tsx
function MyComponent() {
  const [el, setEl] = React.useState(null)
  React.useEffect(() => {
    console.log(el) // eventually logs `HTMLDivElement`
  }, [el])

  return <Pane ref={setEl} />
}
```
In this PR we regain the behaviour that it's `HTMLDivElement` on the first render, while preserving the ability for React Compiler to compile `<Pane />` since it still uses `useImperativeHandle` instead of `useForwardedRef` 🙌 

It also preserves the behaviour that `rootElement` has a value on the first render of `useEffect` hooks inside `Pane`.