### PR TITLE
feat(cli): enable autoUpdates by default on new projects

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/createCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init-project/createCliConfig.ts
@@ -9,7 +9,12 @@ export default defineCliConfig({
   api: {
     projectId: '%projectId%',
     dataset: '%dataset%'
-  }
+  },
+  /**
+   * Enable auto-updates for studios.
+   * Learn more at https://www.sanity.io/docs/cli#auto-updates
+   */
+  autoUpdates: true,
 })
 `
 

--- a/packages/@sanity/cli/test/init.test.ts
+++ b/packages/@sanity/cli/test/init.test.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import {describe, expect} from '@jest/globals'
+
+import templates from '../src/actions/init-project/templates'
+import {describeCliTest, testConcurrent} from './shared/describe'
+import {baseTestPath, cliProjectId, getTestRunArgs, runSanityCmdCommand} from './shared/environment'
+
+describeCliTest('CLI: `sanity init v3`', () => {
+  describe.each(Object.keys(templates))('for template %s', (template) => {
+    testConcurrent('adds autoUpdates: true to cli config', async () => {
+      const version = 'v3'
+      const testRunArgs = getTestRunArgs(version)
+      const outpath = `test-template-${template}-${version}`
+
+      await runSanityCmdCommand(version, [
+        'init',
+        '--y',
+        '--project',
+        cliProjectId,
+        '--dataset',
+        testRunArgs.dataset,
+        '--template',
+        template,
+        '--output-path',
+        `${baseTestPath}/${outpath}`,
+        '--package-manager',
+        'manual',
+      ])
+
+      const cliConfig = await fs.readFile(
+        path.join(baseTestPath, outpath, 'sanity.cli.ts'),
+        'utf-8',
+      )
+
+      expect(cliConfig).toContain(`projectId: '${cliProjectId}'`)
+      expect(cliConfig).toContain(`dataset: '${testRunArgs.dataset}'`)
+      expect(cliConfig).toContain(`autoUpdates: true`)
+    })
+  })
+
+  testConcurrent('adds autoUpdate: true to cli config for javascript projects', async () => {
+    const version = 'v3'
+    const testRunArgs = getTestRunArgs(version)
+    const outpath = `test-template-${version}`
+
+    await runSanityCmdCommand(version, [
+      'init',
+      '--y',
+      '--project',
+      cliProjectId,
+      '--dataset',
+      testRunArgs.dataset,
+      '--output-path',
+      `${baseTestPath}/${outpath}`,
+      '--package-manager',
+      'manual',
+      '--no-typescript',
+    ])
+
+    const cliConfig = await fs.readFile(path.join(baseTestPath, outpath, 'sanity.cli.js'), 'utf-8')
+
+    expect(cliConfig).toContain(`projectId: '${cliProjectId}'`)
+    expect(cliConfig).toContain(`dataset: '${testRunArgs.dataset}'`)
+    expect(cliConfig).toContain(`autoUpdates: true`)
+  })
+})


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This enables autoUpdates flag by default for all new studios

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

The change makes sense, I don't believe this will be case reading the code but it should not add it for embedded studio's.

Ways to test

1. In the monorepo, run `pnpm build` at the root
2. Navigate to another folder `dev` for instance (just to make it easy deleting the changes but not a requirement)
3. run `npx sanity init` follow the prompts
4. Check if `autoUpdates: true` is in the `sanity.cli.ts` 

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I have added some tests to cover init command, in general it requires more thorough testing but this should at least test all templates that it sets the flag correctly.

I would be way more comfortable if I am able to test init inside a nextjs application but the setup and time investment is much greater. It would have to be a follow up PR if anything

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

(Double check if needs to be mentioned)
- Enables auto updates in studio for new projects
