### PR TITLE
feat: add hasSanityPackageInImportMap

### DIFF
--- a/packages/sanity/src/core/environment/hasSanityPackageInImportMap.test.ts
+++ b/packages/sanity/src/core/environment/hasSanityPackageInImportMap.test.ts
@@ -1,0 +1,31 @@
+import {describe, expect, it, jest} from '@jest/globals'
+
+import {hasSanityPackageInImportMap} from './hasSanityPackageInImportMap'
+
+const querySelectorAllSpy = jest.spyOn(document, 'querySelectorAll')
+
+describe('hasSanityPackageInImportMap', () => {
+  it('should return false if document is undefined', () => {
+    const documentSpy = jest.spyOn(global, 'document', 'get')
+    documentSpy.mockReturnValueOnce(undefined as any)
+    expect(hasSanityPackageInImportMap()).toBe(false)
+  })
+  it('should return false if no script with type importmap is found', () => {
+    querySelectorAllSpy.mockReturnValue([] as any)
+    expect(hasSanityPackageInImportMap()).toBe(false)
+  })
+
+  it('should return true if script with type importmap is found and contains sanity', () => {
+    querySelectorAllSpy.mockReturnValue([
+      {textContent: JSON.stringify({imports: {sanity: 'path/to/sanity'}})},
+    ] as any)
+    expect(hasSanityPackageInImportMap()).toBe(true)
+  })
+
+  it('should return false if script with type importmap is found but does not contain sanity', () => {
+    querySelectorAllSpy.mockReturnValue([
+      {textContent: JSON.stringify({imports: {other: 'path/to/other'}})},
+    ] as any)
+    expect(hasSanityPackageInImportMap()).toBe(false)
+  })
+})

--- a/packages/sanity/src/core/environment/hasSanityPackageInImportMap.ts
+++ b/packages/sanity/src/core/environment/hasSanityPackageInImportMap.ts
@@ -1,19 +1,17 @@
-/*
- * The presence of the sanity module in the importmap script
- * indicates that the studio was probably built with an auto-updates flag.
+/**
+ * Returns whether or not there is a `sanity` entry in an import map in the current document,
+ * which usually means that this studio is "auto updating".
+ * @internal
  */
-
-/** @internal */
 export const hasSanityPackageInImportMap = () => {
   if (typeof document === 'undefined' || !('querySelectorAll' in document)) {
     return false
   }
   const importMapEntries = document.querySelectorAll('script[type="importmap"]')
-  return Array.from(importMapEntries)
-    .some((entry) => {
-      if (!entry.textContent) return false
-      const importMap = JSON.parse(entry.textContent)
-      const imports = importMap.imports || {}
-      return 'sanity' in imports
-    })
+  return Array.from(importMapEntries).some((entry) => {
+    if (!entry.textContent) return false
+    const importMap = JSON.parse(entry.textContent)
+    const imports = importMap.imports || {}
+    return 'sanity' in imports
+  })
 }

--- a/packages/sanity/src/core/environment/hasSanityPackageInImportMap.ts
+++ b/packages/sanity/src/core/environment/hasSanityPackageInImportMap.ts
@@ -1,0 +1,19 @@
+/*
+ * The presence of the sanity module in the importmap script
+ * indicates that the studio was probably built with an auto-updates flag.
+ */
+
+/** @internal */
+export const hasSanityPackageInImportMap = () => {
+  if (typeof document === 'undefined' || !('querySelectorAll' in document)) {
+    return false
+  }
+  const importMapEntries = document.querySelectorAll('script[type="importmap"]')
+  return Array.from(importMapEntries)
+    .flatMap((entry) => {
+      if (!entry.textContent) return []
+      const entryImports = JSON.parse(entry.textContent)
+      return Object.keys(entryImports.imports || {})
+    })
+    .some((key) => key === 'sanity')
+}

--- a/packages/sanity/src/core/environment/hasSanityPackageInImportMap.ts
+++ b/packages/sanity/src/core/environment/hasSanityPackageInImportMap.ts
@@ -10,10 +10,10 @@ export const hasSanityPackageInImportMap = () => {
   }
   const importMapEntries = document.querySelectorAll('script[type="importmap"]')
   return Array.from(importMapEntries)
-    .flatMap((entry) => {
-      if (!entry.textContent) return []
-      const entryImports = JSON.parse(entry.textContent)
-      return Object.keys(entryImports.imports || {})
+    .some((entry) => {
+      if (!entry.textContent) return false
+      const importMap = JSON.parse(entry.textContent)
+      const imports = importMap.imports || {}
+      return 'sanity' in imports
     })
-    .some((key) => key === 'sanity')
 }

--- a/packages/sanity/src/core/environment/index.ts
+++ b/packages/sanity/src/core/environment/index.ts
@@ -4,3 +4,23 @@ export const isDev = process.env.NODE_ENV !== 'production'
 
 /** @internal */
 export const isProd = !isDev
+
+/*
+ * The presence of the sanity module in the importmap script
+ * indicates that the studio was probably built with an auto-updates flag.
+ */
+
+/** @internal */
+export const hasSanityPackageInImportMap = () => {
+  if (typeof document === 'undefined' || !('querySelectorAll' in document)) {
+    return false
+  }
+  const importMapEntries = document.querySelectorAll('script[type="importmap"]')
+  return Array.from(importMapEntries)
+    .flatMap((entry) => {
+      if (!entry.textContent) return []
+      const entryImports = JSON.parse(entry.textContent)
+      return Object.keys(entryImports.imports || {})
+    })
+    .some((key) => key === 'sanity')
+}

--- a/packages/sanity/src/core/environment/index.ts
+++ b/packages/sanity/src/core/environment/index.ts
@@ -4,23 +4,3 @@ export const isDev = process.env.NODE_ENV !== 'production'
 
 /** @internal */
 export const isProd = !isDev
-
-/*
- * The presence of the sanity module in the importmap script
- * indicates that the studio was probably built with an auto-updates flag.
- */
-
-/** @internal */
-export const hasSanityPackageInImportMap = () => {
-  if (typeof document === 'undefined' || !('querySelectorAll' in document)) {
-    return false
-  }
-  const importMapEntries = document.querySelectorAll('script[type="importmap"]')
-  return Array.from(importMapEntries)
-    .flatMap((entry) => {
-      if (!entry.textContent) return []
-      const entryImports = JSON.parse(entry.textContent)
-      return Object.keys(entryImports.imports || {})
-    })
-    .some((key) => key === 'sanity')
-}


### PR DESCRIPTION
### Description
Auto-updating studios include importmap scripts in their HTML. For a number of reasons, it's useful to determine whether or not the current studio is an auto-updating one (for metadata in error reporting, or to execute certain pieces of logic that are specific to these studios.

This PR adds a function that can be used to determine whether or not the current studio is an auto-updating one.

### What to review
The function -- anything that might slow things down or cause errors?

### Testing
I've added some unit tests but unsure how useful they are, since we have to mock a lot of the rendered HTML. I'm happy to remove them if they're not worth our while.