### PR TITLE
refactor(core): abstract `getSchemaTypeIcon`

### DIFF
--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions.tsx
@@ -1,5 +1,5 @@
 import {AddIcon} from '@sanity/icons'
-import {type ArraySchemaType, isReferenceSchemaType} from '@sanity/types'
+import {type ArraySchemaType} from '@sanity/types'
 import {Grid, Menu} from '@sanity/ui'
 import {useCallback, useId} from 'react'
 
@@ -12,6 +12,7 @@ import {
 } from '../../../../../ui-components'
 import {useTranslation} from '../../../../i18n'
 import {type ArrayInputFunctionsProps, type ObjectItem} from '../../../types'
+import {getSchemaTypeIcon} from './getSchemaTypeIcon'
 
 const POPOVER_PROPS: MenuButtonProps['popover'] = {
   constrainSize: true,
@@ -93,19 +94,12 @@ export function ArrayOfObjectsFunctions<
           menu={
             <Menu>
               {schemaType.of.map((memberDef, i) => {
-                // Use reference icon if reference is to one schemaType only
-                const referenceIcon =
-                  isReferenceSchemaType(memberDef) &&
-                  (memberDef.to || []).length === 1 &&
-                  memberDef.to[0].icon
-
-                const icon = memberDef.icon || memberDef.type?.icon || referenceIcon
                 return (
                   <MenuItem
                     key={i}
                     text={memberDef.title || memberDef.type?.name}
                     onClick={() => insertItem(memberDef)}
-                    icon={icon}
+                    icon={getSchemaTypeIcon(memberDef)}
                   />
                 )
               })}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/getSchemaTypeIcon.ts
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/getSchemaTypeIcon.ts
@@ -1,0 +1,12 @@
+import {isReferenceSchemaType, type SchemaType} from '@sanity/types'
+import {type ComponentType} from 'react'
+
+export function getSchemaTypeIcon(schemaType: SchemaType): ComponentType | undefined {
+  // Use reference icon if reference is to one schemaType only
+  const referenceIcon =
+    isReferenceSchemaType(schemaType) && (schemaType.to ?? []).length === 1
+      ? schemaType.to[0].icon
+      : undefined
+
+  return schemaType.icon ?? schemaType.type?.icon ?? referenceIcon
+}


### PR DESCRIPTION
### Description

I need the same logic in a new component in a subsequent PR so I'm abstracting it beforehand. `||` and `&&` have been changed to `??` and `?:` to avoid returning `| false` from the function. Now, it just returns `ComponentType | undefined`.

### What to review

Do you like the function name and placement in the repo?

### Testing

I verified in the test studio that array insert menu icons still show up: 
<img width="2237" alt="Screenshot 2024-06-04 at 09 16 43" src="https://github.com/sanity-io/sanity/assets/4602382/4b77ad9b-f9a1-40d4-bd31-b954884fe296">



### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
