### PR TITLE
refactor(core): rename InsertMenu->InsertMenuGroups

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -30,7 +30,7 @@ import {set, unset} from '../../patch'
 import {type ObjectItem, type ObjectItemProps} from '../../types'
 import {randomKey} from '../../utils/randomKey'
 import {createProtoArrayValue} from '../arrays/ArrayOfObjectsInput/createProtoArrayValue'
-import {InsertMenu} from '../arrays/ArrayOfObjectsInput/InsertMenu'
+import {InsertMenuGroups} from '../arrays/ArrayOfObjectsInput/InsertMenuGroups'
 import {RowLayout} from '../arrays/layouts/RowLayout'
 import {PreviewReferenceValue} from './PreviewReferenceValue'
 import {ReferenceFinalizeAlertStrip} from './ReferenceFinalizeAlertStrip'
@@ -216,7 +216,7 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
                     icon={DuplicateIcon}
                     onClick={handleDuplicate}
                   />
-                  <InsertMenu onInsert={handleInsert} types={insertableTypes} />
+                  <InsertMenuGroups onInsert={handleInsert} types={insertableTypes} />
                 </>
               )}
 

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
@@ -22,7 +22,7 @@ import {type ObjectItem, type ObjectItemProps} from '../../../../types'
 import {randomKey} from '../../../../utils/randomKey'
 import {CellLayout} from '../../layouts/CellLayout'
 import {createProtoArrayValue} from '../createProtoArrayValue'
-import {InsertMenu} from '../InsertMenu'
+import {InsertMenuGroups} from '../InsertMenuGroups'
 
 type GridItemProps<Item extends ObjectItem> = Omit<ObjectItemProps<Item>, 'renderDefault'>
 
@@ -154,7 +154,7 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
                 icon={DuplicateIcon}
                 onClick={handleDuplicate}
               />
-              <InsertMenu types={insertableTypes} onInsert={handleInsert} />
+              <InsertMenuGroups types={insertableTypes} onInsert={handleInsert} />
             </Menu>
           }
           popover={MENU_POPOVER_PROPS}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/InsertMenuGroups.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/InsertMenuGroups.tsx
@@ -18,7 +18,7 @@ const MENU_POPOVER_PROPS: PopoverProps = {
   constrainSize: true,
 } as const
 
-export const InsertMenu = memo(function InsertMenu(props: Props) {
+export const InsertMenuGroups = memo(function InsertMenuGroups(props: Props) {
   const {types, onInsert} = props
   const {t} = useTranslation()
   return (

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -20,7 +20,7 @@ import {type ObjectItem, type ObjectItemProps} from '../../../../types'
 import {randomKey} from '../../../../utils/randomKey'
 import {RowLayout} from '../../layouts/RowLayout'
 import {createProtoArrayValue} from '../createProtoArrayValue'
-import {InsertMenu} from '../InsertMenu'
+import {InsertMenuGroups} from '../InsertMenuGroups'
 
 type PreviewItemProps<Item extends ObjectItem> = Omit<ObjectItemProps<Item>, 'renderDefault'>
 
@@ -137,7 +137,7 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
                 icon={DuplicateIcon}
                 onClick={handleDuplicate}
               />
-              <InsertMenu types={insertableTypes} onInsert={handleInsert} />
+              <InsertMenuGroups types={insertableTypes} onInsert={handleInsert} />
             </Menu>
           }
           popover={MENU_POPOVER_PROPS}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
@@ -9,7 +9,7 @@ import {useTranslation} from '../../../../i18n'
 import {FieldPresence} from '../../../../presence'
 import {FormFieldValidationStatus} from '../../../components/formField'
 import {type PrimitiveItemProps} from '../../../types/itemProps'
-import {InsertMenu} from '../ArrayOfObjectsInput/InsertMenu'
+import {InsertMenuGroups} from '../ArrayOfObjectsInput/InsertMenuGroups'
 import {RowLayout} from '../layouts/RowLayout'
 import {getEmptyValue} from './getEmptyValue'
 
@@ -83,7 +83,7 @@ export const ItemRow = forwardRef(function ItemRow(
             icon={DuplicateIcon}
             onClick={handleDuplicate}
           />
-          <InsertMenu types={insertableTypes} onInsert={handleInsert} />
+          <InsertMenuGroups types={insertableTypes} onInsert={handleInsert} />
         </Menu>
       }
     />


### PR DESCRIPTION
### Description

I want to introduce a new `InsertMenu` abstraction and this component's name is conflicting with that. At the same time, I think this component is wrongly named. It does not return an "insert menu", it returns two menu groups that can be used as sub menus in an existing menul.

### What to review

Is this new name good?

### Testing

No testing needed.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
