### PR TITLE
fix(structure): fixing issue with shift mutli select of documents

### DIFF
--- a/packages/sanity/src/structure/panes/documentList/sheetList/DocumentSheetListSelect.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/DocumentSheetListSelect.tsx
@@ -15,15 +15,15 @@ export function DocumentSheetListSelect(props: CellContext<SanityDocument, unkno
         const lowerIndex = shiftClickIndex < selectedAnchor ? shiftClickIndex : selectedAnchor
         const upperIndex = shiftClickIndex < selectedAnchor ? selectedAnchor : shiftClickIndex
 
-        const additionalSelectedRows = Array.from(
-          {length: upperIndex - lowerIndex + 1},
-          (_, index) => lowerIndex + index,
-        )
+        const additionalSelectedRows = table
+          .getRowModel()
+          .flatRows.slice(lowerIndex, upperIndex + 1)
+          .map(({id}) => id)
 
-        const currentSelectedRows = table.getSelectedRowModel().rows.map(({index}) => index)
+        const currentSelectedRows = table.getSelectedRowModel().rows.map(({id}) => id)
         table.setRowSelection(() =>
           [...additionalSelectedRows, ...currentSelectedRows].reduce(
-            (nextSelectedRows, rowIndex) => ({...nextSelectedRows, [rowIndex]: true}),
+            (nextSelectedRows, rowId) => ({...nextSelectedRows, [rowId]: true}),
             {},
           ),
         )

--- a/packages/sanity/src/structure/panes/documentList/sheetList/__tests__/DocumentSheetListSelect.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/__tests__/DocumentSheetListSelect.test.tsx
@@ -12,8 +12,11 @@ const mockSetRowSelection = jest.fn()
 
 const props = {
   table: {
-    getSelectedRowModel: () => ({rows: [{index: 100}, {index: 122}]}),
+    getSelectedRowModel: () => ({rows: [{id: 'id-100'}, {id: 'id-122'}]}),
     setRowSelection: mockSetRowSelection,
+    getRowModel: () => ({
+      flatRows: [{id: 'id-0'}, {id: 'id-120'}, {id: 'id-121'}, {id: 'id-123'}],
+    }),
 
     options: {
       meta: {
@@ -23,7 +26,7 @@ const props = {
     },
   },
   row: {
-    index: 123,
+    index: 3,
     getCanSelect: () => true,
     getIsSelected: () => null,
     toggleSelected: mockToggleSelected,
@@ -51,7 +54,7 @@ describe('DocumentSheetListSelect', () => {
 
     fireEvent.click(checkbox)
     expect(mockToggleSelected).toHaveBeenCalledTimes(1)
-    expect(mockSetSelectedAnchor).toHaveBeenCalledWith(123)
+    expect(mockSetSelectedAnchor).toHaveBeenCalledWith(3)
   })
 
   it('unselected current checkbox', async () => {
@@ -84,24 +87,30 @@ describe('DocumentSheetListSelect', () => {
 
   it('resets the select anchor if shift not pressed on check', () => {
     const selectProps = {...props}
-    selectProps.table.options.meta!.selectedAnchor = 321
+    selectProps.table.options.meta!.selectedAnchor = 5
     renderTest(selectProps)
 
     const checkbox = screen.getByRole('checkbox')
 
     fireEvent.click(checkbox)
-    expect(mockSetSelectedAnchor).toHaveBeenCalledWith(123)
+    expect(mockSetSelectedAnchor).toHaveBeenCalledWith(3)
   })
 
   it('selects multiple rows when shift key is pressed and anchor exists', () => {
     const selectProps = {...props}
-    selectProps.table.options.meta!.selectedAnchor = 120
+    selectProps.table.options.meta!.selectedAnchor = 1
     renderTest(selectProps)
 
     const checkbox = screen.getByRole('checkbox')
 
     fireEvent.click(checkbox, {shiftKey: true})
     const setRowSelectionCall = mockSetRowSelection.mock.calls[0][0] as () => unknown
-    expect(setRowSelectionCall()).toEqual({100: true, 120: true, 121: true, 122: true, 123: true})
+    expect(setRowSelectionCall()).toEqual({
+      'id-100': true,
+      'id-120': true,
+      'id-121': true,
+      'id-122': true,
+      'id-123': true,
+    })
   })
 })


### PR DESCRIPTION
### Description
A regression came in around shift-selecting documents and selecting all in between. This was because the IDs of rows changed from being the row index to the document ID.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Updates to the Select tests also
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Nothing to note - this feature is not customer facing
<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
