### PR TITLE
fix(core): chunk user loading into batches of max 400 items

### DIFF
--- a/packages/sanity/src/core/store/_legacy/user/__tests__/userStore.test.ts
+++ b/packages/sanity/src/core/store/_legacy/user/__tests__/userStore.test.ts
@@ -1,11 +1,12 @@
 import {describe, expect, it, jest} from '@jest/globals'
 import {type SanityClient} from '@sanity/client'
+import {type CurrentUser} from 'sanity'
 
 import {createUserStore} from '../userStore'
 
 export class HttpError extends Error {
-  constructor() {
-    super()
+  constructor(message: string) {
+    super(message)
     this.name = 'HttpError'
   }
 
@@ -13,26 +14,108 @@ export class HttpError extends Error {
 }
 
 // Mock client which always throws 403 Forbidden errors on `request`
-const client = {
+const failingClient = {
   request: jest.fn(() => {
     const error = new HttpError('Forbidden')
     error.statusCode = 403
     throw error
   }),
-  withConfig: () => client,
+  withConfig: () => failingClient,
 } as unknown as SanityClient
 
-const userStore = createUserStore({client, currentUser: null})
+// Mock client which always throws 403 Forbidden errors on `request`
+const getClient = () => {
+  const client = {
+    request: jest.fn((options: {uri: string}) => {
+      const userIds = options.uri.slice(options.uri.lastIndexOf('/') + 1).split(',')
+      return Promise.resolve(
+        userIds
+          // Skip IDs that do not start with a `p`, to allow us to test the case where some users are not returned
+          .filter((id) => id.startsWith('p'))
+          .map((id) => ({id, displayName: `User ${id}`})),
+      )
+    }),
+    withConfig: () => client,
+  } as unknown as SanityClient
+  return client
+}
+
+const failingUserStore = createUserStore({client: failingClient, currentUser: null})
+const getUserStore = ({
+  currentUser,
+  client,
+}: {currentUser?: CurrentUser | null; client?: SanityClient} = {}) =>
+  createUserStore({client: client || getClient(), currentUser: currentUser || null})
 
 describe('userStore', () => {
   describe('getUser()', () => {
     it(`resolves with null on 403 responses`, async () => {
-      await expect(userStore.getUser('foo')).resolves.toEqual(null)
+      await expect(failingUserStore.getUser('foo')).resolves.toEqual(null)
     })
   })
   describe('getUsers()', () => {
     it(`resolves with an empty array on 403 responses`, async () => {
-      await expect(userStore.getUsers(['foo', 'bar'])).resolves.toStrictEqual([])
+      await expect(failingUserStore.getUsers(['foo', 'bar'])).resolves.toStrictEqual([])
+    })
+
+    it('fetches correctly when passing single user', async () => {
+      await expect(getUserStore().getUsers(['p3t3rh0fs'])).resolves.toEqual([
+        {id: 'p3t3rh0fs', displayName: 'User p3t3rh0fs'},
+      ])
+    })
+
+    it('fetches correctly when passing multiple users', async () => {
+      await expect(getUserStore().getUsers(['p3sp3nh0v', 'pr1v47e00'])).resolves.toEqual([
+        {id: 'p3sp3nh0v', displayName: 'User p3sp3nh0v'},
+        {id: 'pr1v47e00', displayName: 'User pr1v47e00'},
+      ])
+    })
+
+    it('skips (not throws) when passing users that do not exist', async () => {
+      await expect(getUserStore().getUsers(['p3sp3nh0v', 'f00b4r', 'pr1v47e00'])).resolves.toEqual([
+        {id: 'p3sp3nh0v', displayName: 'User p3sp3nh0v'},
+        {id: 'pr1v47e00', displayName: 'User pr1v47e00'},
+      ])
+    })
+
+    it('does not refetch current user if passed when constructing user store, normalizes', async () => {
+      const currentUser: CurrentUser = {
+        id: 'pl0l3sp3n',
+        name: 'Espen',
+        email: 'e5p3n@sanity.io',
+        role: 'admin',
+        roles: [{name: 'admin', title: 'Administrator'}],
+      }
+      await expect(getUserStore({currentUser}).getUsers([currentUser.id])).resolves.toEqual([
+        {
+          id: currentUser.id,
+          displayName: currentUser.name,
+        },
+      ])
+    })
+
+    it('does not refetch users that already have been fetched', async () => {
+      const client = getClient()
+      const userStore = getUserStore({client})
+
+      await expect(userStore.getUsers(['pAbC', 'pDeF'])).resolves.toHaveLength(2)
+      expect(client.request).toHaveBeenCalledTimes(1) // Should fetch those users one time
+
+      await expect(userStore.getUsers(['pDeF', 'pAbC'])).resolves.toHaveLength(2)
+      expect(client.request).toHaveBeenCalledTimes(1) // Should not refetch those users
+    })
+
+    it('fetches correctly when passing a huge amount of users - splits batches', async () => {
+      const client = getClient()
+      const userIds = Array.from({length: 1500}, (_, i) => `p50m3u53r${i}`)
+      const lastBatch = userIds.slice(-300)
+      await expect(getUserStore({client}).getUsers(userIds)).resolves.toHaveLength(userIds.length)
+      expect(client.request).toHaveBeenCalledTimes(4) // Math.ceil(1500 / 400) = 4, eg 4 batches
+      expect(client.request).toHaveBeenLastCalledWith({
+        uri: `/users/${lastBatch.join(',')}`,
+        tag: 'users.get',
+        withCredentials: true,
+      })
     })
   })
 })

--- a/packages/sanity/src/core/store/_legacy/user/userStore.ts
+++ b/packages/sanity/src/core/store/_legacy/user/userStore.ts
@@ -55,7 +55,15 @@ export function createUserStore({client: _client, currentUser}: UserStoreOptions
       )
       return userIds.map((id) => users[id] || null)
     },
-    {batchScheduleFn: (cb) => raf(cb)},
+    {
+      batchScheduleFn: (cb) => raf(cb),
+      /**
+       * User IDs are generally 9 bytes long, but external user IDs may be longer.
+       * In order to keep the HTTP header size below ~8KB, we limit the batch size.
+       * ~4kB for user IDs in paths should allow for plenty of headers, if need be.
+       */
+      maxBatchSize: 400,
+    },
   )
 
   const userFromCurrentUser: User | null = currentUser && {


### PR DESCRIPTION
### Description

Fixes a case where passing a large number of users to retrieve from the user store would cause too large of a request to be sent. This chunks the number of users to fetch into batches of 400.

### What to review

- User fetching works as intended

### Testing

Added tests for the user store in general, there was previously only tests for the 403 case - now it should have the majority of the functionality covered (some missing tests for the `getUser` function, but it calls `getUsers` internally - can add those later)

### Notes for release

- Fixes an issue where projects with a large amount of users would sometimes get a request error when loading user info
