### PR TITLE
fix(core): fix dragging existing blocks in pte

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithInsertData.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithInsertData.ts
@@ -170,15 +170,7 @@ export function createWithInsertData(
       const html = data.getData('text/html')
       const text = data.getData('text/plain')
 
-      const {files} = data
-      const hasFiles = files && files.length > 0
-
-      if (hasFiles) {
-        const plural = files.length === 1 ? 'file' : 'files'
-        debug(`Inserting ${plural}`, data)
-      }
-
-      if (!hasFiles && (html || text)) {
+      if (html || text) {
         debug('Inserting data', data)
         let portableText: PortableTextBlock[]
         let fragment: Node[]
@@ -190,6 +182,10 @@ export function createWithInsertData(
           }).map((block) => normalizeBlock(block, {blockTypeName})) as PortableTextBlock[]
           fragment = toSlateValue(portableText, {schemaTypes})
           insertedType = 'HTML'
+
+          if (portableText.length === 0) {
+            return false
+          }
         } else {
           // plain text
           const blocks = escapeHtml(text)

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/DragAndDrop.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/DragAndDrop.spec.tsx
@@ -1,0 +1,95 @@
+/* eslint-disable max-nested-callbacks */
+import {expect, test} from '@playwright/experimental-ct-react'
+import {type Path, type SanityDocument} from '@sanity/types'
+
+import {testHelpers} from '../../../utils/testHelpers'
+import DragAndDropStory from './DragAndDropStory'
+
+export type UpdateFn = () => {focusPath: Path; document: SanityDocument}
+
+const document: SanityDocument = {
+  _id: '123',
+  _type: 'test',
+  _createdAt: new Date().toISOString(),
+  _updatedAt: new Date().toISOString(),
+  _rev: '123',
+  body: [
+    {
+      _type: 'block',
+      _key: 'a',
+      children: [{_type: 'span', _key: 'b', text: 'Foo'}],
+      markDefs: [],
+    },
+    {
+      _type: 'block',
+      _key: 'c',
+      children: [{_type: 'span', _key: 'd', text: 'Bar'}],
+      markDefs: [],
+    },
+    {
+      _type: 'block',
+      _key: 'e',
+      children: [{_type: 'span', _key: 'f', text: 'Baz'}],
+      markDefs: [],
+    },
+    {
+      _type: 'block',
+      _key: 'g',
+      children: [
+        {_type: 'span', _key: 'h', text: 'Hello '},
+        {_type: 'inlineObjectWithTextProperty', _key: 'i', text: 'there'},
+        {_type: 'span', _key: 'j', text: ' playwright'},
+      ],
+      markDefs: [],
+    },
+    {
+      _type: 'testObjectBlock',
+      _key: 'k',
+      text: 'Hello world',
+    },
+  ],
+}
+
+test.describe('Portable Text Input', () => {
+  test.beforeEach(async ({page}) => {
+    await page.evaluate(() => {
+      window.localStorage.debug = 'sanity-pte:*'
+    })
+  })
+
+  test.describe('Should be able to drag and drop blocks', () => {
+    test(`drag and drop blocks`, async ({mount, page}) => {
+      await mount(
+        <DragAndDropStory
+          document={document}
+          focusPath={['body', {_key: 'c'}, 'children', {_key: 'd'}, 'text']}
+        />,
+      )
+      const {dragAndDrop} = testHelpers({page})
+      // Drag and drop the 'Hello world' block to the position of 'Baz'
+      await dragAndDrop(
+        '.pt-block.pt-object-block [draggable="true"]',
+        '.pt-block.pt-text-block:nth-child(3)',
+      )
+
+      await expect(page.locator('.pt-block:nth-child(4)')).toContainText('Baz')
+    })
+
+    test(`drag and drop blocks without warning overlay`, async ({mount, page}) => {
+      await mount(
+        <DragAndDropStory
+          document={document}
+          focusPath={['body', {_key: 'c'}, 'children', {_key: 'd'}, 'text']}
+        />,
+      )
+      const {dragWithoutDrop} = testHelpers({page})
+      // Drag and drop the 'Hello world' block to the position of 'Baz' without dropping it
+      await dragWithoutDrop(
+        '.pt-block.pt-object-block [draggable="true"]',
+        '.pt-block.pt-text-block:nth-child(3)',
+      )
+
+      await expect(page.getByText(`Can't upload this file here`)).not.toBeVisible()
+    })
+  })
+})

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/DragAndDropStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/DragAndDropStory.tsx
@@ -1,0 +1,74 @@
+/* eslint-disable react/jsx-no-bind */
+import {type SanityDocument} from '@sanity/client'
+import {defineArrayMember, defineField, defineType, type Path} from '@sanity/types'
+
+import {TestForm} from '../../utils/TestForm'
+import {TestWrapper} from '../../utils/TestWrapper'
+
+const SCHEMA_TYPES = [
+  defineType({
+    type: 'document',
+    name: 'test',
+    title: 'Test',
+    fields: [
+      defineField({
+        type: 'array',
+        name: 'body',
+        of: [
+          defineArrayMember({
+            type: 'block',
+            of: [
+              defineArrayMember({
+                type: 'object',
+                name: 'inlineObjectWithTextProperty',
+                fields: [
+                  defineField({
+                    type: 'string',
+                    name: 'text',
+                    components: {
+                      input: (inputProps) => (
+                        <div data-testid="inlineTextInputField">
+                          {inputProps.renderDefault(inputProps)}
+                        </div>
+                      ),
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+          defineArrayMember({
+            type: 'object',
+            name: 'testObjectBlock',
+            fields: [{type: 'string', name: 'text'}],
+            components: {
+              input: (inputProps) => (
+                <div data-testid="objectBlockInputField">
+                  {inputProps.renderDefault(inputProps)}
+                </div>
+              ),
+            },
+          }),
+        ],
+      }),
+    ],
+  }),
+]
+
+export function DragAndDropStory({
+  focusPath,
+  onPathFocus,
+  document,
+}: {
+  focusPath?: Path
+  onPathFocus?: (path: Path) => void
+  document?: SanityDocument
+}) {
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm document={document} focusPath={focusPath} onPathFocus={onPathFocus} />
+    </TestWrapper>
+  )
+}
+
+export default DragAndDropStory

--- a/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
+++ b/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
@@ -16,6 +16,53 @@ export function testHelpers({page}: {page: PlaywrightTestArgs['page']}) {
   }
   return {
     /**
+     * Drags and drops the source element to the target element position
+     *
+     * @param testId The data-testid attribute of the Portable Text Input
+     * @returns The Portable Text Input element
+     */
+    dragAndDrop: async (sourceSelector: string, targetSelector: string) => {
+      const source = await page.locator(sourceSelector)
+      const target = await page.locator(targetSelector)
+
+      const box = await source.boundingBox()
+      if (box) {
+        const {x, y, width, height} = box
+        await page.mouse.move(x + width / 2, y + height / 2)
+        await page.mouse.down()
+      }
+
+      const targetBox = await target.boundingBox()
+      if (targetBox) {
+        const {x, y, width, height} = targetBox
+        await page.mouse.move(x + width / 2, y + height / 2)
+        await page.mouse.up()
+      }
+    },
+    /**
+     * Drags the source element to the target element position without dropping
+     *
+     * @param testId The data-testid attribute of the Portable Text Input
+     * @returns The Portable Text Input element
+     */
+    dragWithoutDrop: async (sourceSelector: string, targetSelector: string) => {
+      const source = await page.locator(sourceSelector)
+      const target = await page.locator(targetSelector)
+
+      const box = await source.boundingBox()
+      if (box) {
+        const {x, y, width, height} = box
+        await page.mouse.move(x + width / 2, y + height / 2)
+        await page.mouse.down()
+      }
+
+      const targetBox = await target.boundingBox()
+      if (targetBox) {
+        const {x, y, width, height} = targetBox
+        await page.mouse.move(x + width / 2, y + height / 2)
+      }
+    },
+    /**
      * Returns the DOM element of a focused Portable Text Input ready to typed into
      *
      * @param testId The data-testid attribute of the Portable Text Input

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.styles.tsx
@@ -56,4 +56,8 @@ export const ExpandedLayer = styled(Layer)`
   left: 0;
   right: 0;
   bottom: 0;
+
+  & > div {
+    height: 100%;
+  }
 `

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -22,6 +22,7 @@ import {
   type RenderCustomMarkers,
 } from '../../types'
 import {type RenderBlockActionsCallback} from '../../types/_transitional'
+import {UploadTargetCard} from '../arrays/common/UploadTargetCard'
 import {ExpandedLayer, Root} from './Compositor.styles'
 import {Editor} from './Editor'
 import {useHotkeys} from './hooks/useHotKeys'
@@ -395,34 +396,43 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
 
   const editorNode = useMemo(
     () => (
-      <Editor
-        ariaDescribedBy={ariaDescribedBy}
-        elementRef={elementRef}
-        initialSelection={initialSelection}
-        hideToolbar={hideToolbar}
-        hotkeys={editorHotkeys}
-        isActive={isActive}
-        isFullscreen={isFullscreen}
-        onItemOpen={onItemOpen}
-        onCopy={onCopy}
-        onPaste={onPaste}
-        onToggleFullscreen={handleToggleFullscreen}
-        path={path}
-        rangeDecorations={rangeDecorations}
-        readOnly={readOnly}
-        renderAnnotation={editorRenderAnnotation}
-        renderBlock={editorRenderBlock}
-        renderChild={editorRenderChild}
-        renderEditable={renderEditable}
-        setPortalElement={setPortalElement}
-        scrollElement={scrollElement}
-        setScrollElement={setScrollElement}
-      />
+      <UploadTargetCard
+        types={editor.schemaTypes.portableText.of}
+        resolveUploader={props.resolveUploader}
+        onUpload={props.onUpload}
+        {...props.elementProps}
+        tabIndex={-1}
+      >
+        <Editor
+          ariaDescribedBy={ariaDescribedBy}
+          elementRef={elementRef}
+          initialSelection={initialSelection}
+          hideToolbar={hideToolbar}
+          hotkeys={editorHotkeys}
+          isActive={isActive}
+          isFullscreen={isFullscreen}
+          onItemOpen={onItemOpen}
+          onCopy={onCopy}
+          onPaste={onPaste}
+          onToggleFullscreen={handleToggleFullscreen}
+          path={path}
+          rangeDecorations={rangeDecorations}
+          readOnly={readOnly}
+          renderAnnotation={editorRenderAnnotation}
+          renderBlock={editorRenderBlock}
+          renderChild={editorRenderChild}
+          renderEditable={renderEditable}
+          setPortalElement={setPortalElement}
+          scrollElement={scrollElement}
+          setScrollElement={setScrollElement}
+        />
+      </UploadTargetCard>
     ),
 
     // Keep only stable ones here!
     [
       ariaDescribedBy,
+      editor.schemaTypes.portableText.of,
       editorHotkeys,
       editorRenderAnnotation,
       editorRenderBlock,
@@ -437,6 +447,9 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       onItemOpen,
       onPaste,
       path,
+      props.elementProps,
+      props.onUpload,
+      props.resolveUploader,
       rangeDecorations,
       readOnly,
       renderEditable,

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -37,7 +37,6 @@ import {type ArrayOfObjectsItemMember, type ObjectFormNode} from '../../store'
 import {immutableReconcile} from '../../store/utils/immutableReconcile'
 import {type ResolvedUploader} from '../../studio/uploads/types'
 import {type PortableTextInputProps} from '../../types'
-import {UploadTargetCard} from '../arrays/common/UploadTargetCard'
 import {extractPastedFiles} from '../common/fileTarget/utils/extractFiles'
 import {Compositor, type PortableTextEditorElement} from './Compositor'
 import {PortableTextMarkersProvider} from './contexts/PortableTextMarkers'
@@ -369,49 +368,41 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
 
   return (
     <Box>
-      <UploadTargetCard
-        types={schemaType.of}
-        resolveUploader={props.resolveUploader}
-        onUpload={props.onUpload}
-        {...elementProps}
-        tabIndex={-1}
-      >
-        {!ignoreValidationError && respondToInvalidContent}
-        {(!invalidValue || ignoreValidationError) && (
-          <PortableTextMarkersProvider markers={markers}>
-            <PortableTextMemberItemsProvider memberItems={portableTextMemberItems}>
-              <PortableTextEditor
-                patches$={patches$}
-                onChange={handleEditorChange}
-                maxBlocks={undefined} // TODO: from schema?
-                ref={editorRef}
-                readOnly={isOffline || readOnly}
-                schemaType={schemaType}
-                value={value}
-              >
-                <Compositor
-                  {...props}
-                  elementRef={elementRef}
-                  hasFocusWithin={hasFocusWithin}
-                  hotkeys={hotkeys}
-                  isActive={isActive}
-                  isFullscreen={isFullscreen}
-                  onActivate={handleActivate}
-                  onItemRemove={onItemRemove}
-                  onCopy={onCopy}
-                  onInsert={onInsert}
-                  onPaste={handlePaste}
-                  onToggleFullscreen={handleToggleFullscreen}
-                  rangeDecorations={rangeDecorations}
-                  renderBlockActions={renderBlockActions}
-                  renderCustomMarkers={renderCustomMarkers}
-                  renderEditable={renderEditable}
-                />
-              </PortableTextEditor>
-            </PortableTextMemberItemsProvider>
-          </PortableTextMarkersProvider>
-        )}
-      </UploadTargetCard>
+      {!ignoreValidationError && respondToInvalidContent}
+      {(!invalidValue || ignoreValidationError) && (
+        <PortableTextMarkersProvider markers={markers}>
+          <PortableTextMemberItemsProvider memberItems={portableTextMemberItems}>
+            <PortableTextEditor
+              patches$={patches$}
+              onChange={handleEditorChange}
+              maxBlocks={undefined} // TODO: from schema?
+              ref={editorRef}
+              readOnly={isOffline || readOnly}
+              schemaType={schemaType}
+              value={value}
+            >
+              <Compositor
+                {...props}
+                elementRef={elementRef}
+                hasFocusWithin={hasFocusWithin}
+                hotkeys={hotkeys}
+                isActive={isActive}
+                isFullscreen={isFullscreen}
+                onActivate={handleActivate}
+                onItemRemove={onItemRemove}
+                onCopy={onCopy}
+                onInsert={onInsert}
+                onPaste={handlePaste}
+                onToggleFullscreen={handleToggleFullscreen}
+                rangeDecorations={rangeDecorations}
+                renderBlockActions={renderBlockActions}
+                renderCustomMarkers={renderCustomMarkers}
+                renderEditable={renderEditable}
+              />
+            </PortableTextEditor>
+          </PortableTextMemberItemsProvider>
+        </PortableTextMarkersProvider>
+      )}
     </Box>
   )
 }

--- a/packages/sanity/src/core/form/inputs/arrays/common/UploadTargetCard.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/common/UploadTargetCard.tsx
@@ -1,6 +1,11 @@
 import {Card} from '@sanity/ui'
+import styled from 'styled-components'
 
 import {withFocusRing} from '../../../components/withFocusRing'
 import {uploadTarget} from './uploadTarget/uploadTarget'
 
-export const UploadTargetCard = withFocusRing(uploadTarget(Card))
+const StyledCard = styled(Card)`
+  height: 100%;
+`
+
+export const UploadTargetCard = withFocusRing(uploadTarget(StyledCard))

--- a/packages/sanity/src/core/form/inputs/common/fileTarget/fileTarget.tsx
+++ b/packages/sanity/src/core/form/inputs/common/fileTarget/fileTarget.tsx
@@ -132,6 +132,17 @@ export function fileTarget<ComponentProps>(Component: ComponentType<ComponentPro
 
     const handleDragEnter = useCallback(
       (event: DragEvent) => {
+        const fileTypes = Array.from(event.dataTransfer.items).map((item) => ({
+          type: item.type,
+          kind: item.kind,
+        }))
+
+        // Skip items that is PTE blocks
+        const isPortableTextBlock = fileTypes.some((item) => isPortableTextItem(item))
+
+        if (isPortableTextBlock) {
+          return
+        }
         event.stopPropagation()
 
         if (onFilesOver && forwardedRef.current === event.currentTarget) {
@@ -141,13 +152,6 @@ export function fileTarget<ComponentProps>(Component: ComponentType<ComponentPro
         */
           enteredElements.current = [...new Set(enteredElements.current), event.currentTarget]
 
-          const fileTypes = Array.from(event.dataTransfer.items)
-            .map((item) => ({
-              type: item.type,
-              kind: item.kind,
-            }))
-            // Remove portable text files from the list of files so we don't interfere with the PTE block drag and drop
-            .filter((item) => !isPortableTextItem(item))
           onFilesOver(fileTypes)
         }
       },
@@ -189,6 +193,7 @@ export function fileTarget<ComponentProps>(Component: ComponentType<ComponentPro
           onDragEnter={disabled ? undefined : handleDragEnter}
           onDragLeave={disabled ? undefined : handleDragLeave}
           onDrop={disabled ? undefined : handleDrop}
+          data-test-id="file-target"
         />
         {!disabled && showPasteInput && (
           <div contentEditable onPaste={handlePaste} ref={pasteInput} style={PASTE_INPUT_STYLE} />

--- a/packages/sanity/src/core/form/inputs/common/fileTarget/fileTarget.tsx
+++ b/packages/sanity/src/core/form/inputs/common/fileTarget/fileTarget.tsx
@@ -12,7 +12,7 @@ import {
   useState,
 } from 'react'
 
-import {extractDroppedFiles, extractPastedFiles} from './utils/extractFiles'
+import {extractDroppedFiles, extractPastedFiles, isPortableTextItem} from './utils/extractFiles'
 import {imageUrlToBlob} from './utils/imageUrlToBlob'
 
 export type FileInfo = {
@@ -141,10 +141,13 @@ export function fileTarget<ComponentProps>(Component: ComponentType<ComponentPro
         */
           enteredElements.current = [...new Set(enteredElements.current), event.currentTarget]
 
-          const fileTypes = Array.from(event.dataTransfer.items).map((item) => ({
-            type: item.type,
-            kind: item.kind,
-          }))
+          const fileTypes = Array.from(event.dataTransfer.items)
+            .map((item) => ({
+              type: item.type,
+              kind: item.kind,
+            }))
+            // Remove portable text files from the list of files so we don't interfere with the PTE block drag and drop
+            .filter((item) => !isPortableTextItem(item))
           onFilesOver(fileTypes)
         }
       },

--- a/packages/sanity/src/core/form/inputs/common/fileTarget/utils/extractFiles.ts
+++ b/packages/sanity/src/core/form/inputs/common/fileTarget/utils/extractFiles.ts
@@ -106,3 +106,7 @@ function walk(entry: Entry): Promise<File[]> {
   }
   return Promise.resolve([])
 }
+
+export function isPortableTextItem(item: {type: string; kind: string}) {
+  return item.type === 'application/portable-text'
+}


### PR DESCRIPTION
### Description

This fixes an issue preventing blocks in the PTE from being re-arranged after we added support for drag-n-drop of images/files to the PTE in #6534.

It also fixes some adjacent issues:
- Styling of info/error overlay when dragging files was not styled correctly in fullscreen mode (fixes EDX-1408, fixes EDX-1405)

### What to review

- That the logic change makes sense
- That dragging PTE blocks works without showing any error messages
- That both drag-n-drop and pasting of images and files works

### Testing

Playwright tests for this has been added.

### Notes for release

- Fixes an issue when dragging PTE blocks
- Fixes an visual regression in PTE fullscreen mode where the _Drop to upload n files_ message would be position incorrectly