### PR TITLE
feat: add error boundary for form input components

### DIFF
--- a/dev/test-next-studio/next.config.mjs
+++ b/dev/test-next-studio/next.config.mjs
@@ -14,6 +14,10 @@ const config = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  env: {
+    // Support the ability to debug log the studio, for example `DEBUG="sanity:pte:* pnpm dev:next-studio"`
+    DEBUG: process.env.DEBUG,
+  },
   transpilePackages: [
     '@sanity/block-tools',
     '@sanity/cli',

--- a/dev/test-next-studio/turbo.json
+++ b/dev/test-next-studio/turbo.json
@@ -3,7 +3,13 @@
   "extends": ["//"],
   "pipeline": {
     "build": {
-      "env": ["NEXT_PUBLIC_SANITY_*", "NEXT_PUBLIC_VERCEL_ENV", "SANITY_*", "REACT_COMPILER", "DEBUG"],
+      "env": [
+        "NEXT_PUBLIC_SANITY_*",
+        "NEXT_PUBLIC_VERCEL_ENV",
+        "SANITY_*",
+        "REACT_COMPILER",
+        "DEBUG"
+      ],
       "outputs": [".next/**", "!.next/cache/**", "out/**"],
       "dependsOn": ["^build"]
     },

--- a/dev/test-next-studio/turbo.json
+++ b/dev/test-next-studio/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "pipeline": {
     "build": {
-      "env": ["NEXT_PUBLIC_SANITY_*", "NEXT_PUBLIC_VERCEL_ENV", "SANITY_*", "REACT_COMPILER"],
+      "env": ["NEXT_PUBLIC_SANITY_*", "NEXT_PUBLIC_VERCEL_ENV", "SANITY_*", "REACT_COMPILER", "DEBUG"],
       "outputs": [".next/**", "!.next/cache/**", "out/**"],
       "dependsOn": ["^build"]
     },

--- a/packages/sanity/src/core/form/studio/FormBuilder.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilder.tsx
@@ -33,6 +33,7 @@ import {
   type RenderPreviewCallbackProps,
 } from '../types'
 import {DocumentFieldActionsProvider} from './contexts/DocumentFieldActions'
+import {FormBuilderInputErrorBoundary} from './FormBuilderInputErrorBoundary'
 import {FormProvider} from './FormProvider'
 
 /**
@@ -145,7 +146,11 @@ export function FormBuilder(props: FormBuilderProps) {
   const Annotation = useAnnotationComponent()
 
   const renderInput = useCallback(
-    (inputProps: Omit<InputProps, 'renderDefault'>) => <Input {...inputProps} />,
+    (inputProps: Omit<InputProps, 'renderDefault'>) => (
+      <FormBuilderInputErrorBoundary>
+        <Input {...inputProps} />
+      </FormBuilderInputErrorBoundary>
+    ),
     [Input],
   )
   const renderField = useCallback(

--- a/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.tsx
@@ -1,16 +1,12 @@
-import {RefreshIcon} from '@sanity/icons'
-import {Card, Code, ErrorBoundary, Stack, Text} from '@sanity/ui'
+import {Box, Card, Code, ErrorBoundary, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo, useState} from 'react'
 import {useHotModuleReload} from 'use-hot-module-reload'
 
-import {Button} from '../../../ui-components'
 import {SchemaError} from '../../config'
-import {isDev} from '../../environment'
 import {useTranslation} from '../../i18n'
 import {CorsOriginError} from '../../store'
 import {isRecord} from '../../util'
 import {Alert} from '../components/Alert'
-import {Details} from '../components/Details'
 
 /**
  * @internal
@@ -68,25 +64,16 @@ function ErrorCard(props: {error: unknown; onRetry: () => void}) {
         <Text as="p" muted size={1}>
           <>{t('form.error.unhandled-runtime-error.error-message', {message})}</>
         </Text>
-        <Details open={isDev}>
-          <Stack space={4}>
+        <Box>
+          <Stack space={2}>
             <Text as="p" size={1}>
-              <>{t('form.error.unhandled-runtime-error.details.title')}</>
+              <>{t('form.error.unhandled-runtime-error.call-stack.title')}</>
             </Text>
             <Card border radius={2} overflow="auto" padding={4} tone="inherit">
               {stack && <Code size={1}>{stack}</Code>}
             </Card>
           </Stack>
-        </Details>
-        <div>
-          <Button
-            icon={RefreshIcon}
-            onClick={onRetry}
-            text={t('form.error.unhandled-runtime-error.retry-button-label')}
-            tone="caution"
-            mode="ghost"
-          />
-        </div>
+        </Box>
       </Stack>
     </Alert>
   )

--- a/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.tsx
@@ -1,0 +1,93 @@
+import {RefreshIcon} from '@sanity/icons'
+import {Card, Code, ErrorBoundary, Stack, Text} from '@sanity/ui'
+import {useCallback, useMemo, useState} from 'react'
+import {useHotModuleReload} from 'use-hot-module-reload'
+
+import {Button} from '../../../ui-components'
+import {SchemaError} from '../../config'
+import {isDev} from '../../environment'
+import {useTranslation} from '../../i18n'
+import {CorsOriginError} from '../../store'
+import {isRecord} from '../../util'
+import {Alert} from '../components/Alert'
+import {Details} from '../components/Details'
+
+/**
+ * @internal
+ */
+interface FormBuilderInputErrorBoundaryProps {
+  children: React.ReactNode
+}
+
+/**
+ * @internal
+ */
+export function FormBuilderInputErrorBoundary(
+  props: FormBuilderInputErrorBoundaryProps,
+): JSX.Element {
+  const {children} = props
+  const [{error}, setError] = useState<{error: unknown}>({error: null})
+  const handleRetry = useCallback(() => setError({error: null}), [])
+
+  if (!error) {
+    return <ErrorBoundary onCatch={setError}>{children}</ErrorBoundary>
+  }
+
+  return <ErrorCard error={error} onRetry={handleRetry} />
+}
+
+/**
+ * The error UI is in a separate component to keep the wrapper lightweight,
+ * it allows us to use hooks like useTranslation without incurring the cost of it on every form input
+ * when there are no errors.
+ * @internal
+ */
+function ErrorCard(props: {error: unknown; onRetry: () => void}) {
+  const {error, onRetry} = props
+
+  // If a CORS error, or a schema error, rethrow and let the StudioErrorBoundary handle it
+  if (error instanceof CorsOriginError || error instanceof SchemaError) {
+    throw error
+  }
+
+  const {t} = useTranslation()
+  const message = useMemo(
+    () => isRecord(error) && typeof error.message === 'string' && error.message,
+    [error],
+  )
+  const stack = useMemo(
+    () => isRecord(error) && typeof error.stack === 'string' && error.stack,
+    [error],
+  )
+
+  useHotModuleReload(onRetry)
+
+  return (
+    <Alert status="error" title={<>{t('form.error.unhandled-runtime-error.title')}</>}>
+      <Stack space={4}>
+        <Text as="p" muted size={1}>
+          <>{t('form.error.unhandled-runtime-error.error-message', {message})}</>
+        </Text>
+        <Details open={isDev}>
+          <Stack space={4}>
+            <Text as="p" size={1}>
+              <>{t('form.error.unhandled-runtime-error.details.title')}</>
+            </Text>
+            <Card border radius={2} overflow="auto" padding={4} tone="inherit">
+              {stack && <Code size={1}>{stack}</Code>}
+            </Card>
+          </Stack>
+        </Details>
+        <div>
+          <Button
+            icon={RefreshIcon}
+            onClick={onRetry}
+            text={t('form.error.unhandled-runtime-error.retry-button-label')}
+            tone="caution"
+            mode="ghost"
+          />
+        </div>
+      </Stack>
+    </Alert>
+  )
+}

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -397,12 +397,10 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Error text shown when form is unable to find an array item at a given keyed path */
   'form.error.no-array-item-at-key':
     'No array item with `_key` <code>"{{key}}"</code> found at path <code>{{path}}</code>',
-  /** The title for the error card rendered inside a field in place of a crashing input */
-  'form.error.unhandled-runtime-error.details.title': 'Call Stack',
+  /** The title above the error call stack output related to the crash */
+  'form.error.unhandled-runtime-error.call-stack.title': 'Call Stack:',
   /** The error message for the unhandled error that crashed the Input component during render */
   'form.error.unhandled-runtime-error.error-message': 'Error: {{message}}',
-  /** The label on the button that retries render in case the runtime error is transient */
-  'form.error.unhandled-runtime-error.retry-button-label': 'Retry',
   /** The title for the error card rendered inside a field in place of a crashing input */
   'form.error.unhandled-runtime-error.title': 'Unhandled Runtime Error',
   /** Form field deprecated label */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -397,6 +397,14 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Error text shown when form is unable to find an array item at a given keyed path */
   'form.error.no-array-item-at-key':
     'No array item with `_key` <code>"{{key}}"</code> found at path <code>{{path}}</code>',
+  /** The title for the error card rendered inside a field in place of a crashing input */
+  'form.error.unhandled-runtime-error.details.title': 'Call Stack',
+  /** The error message for the unhandled error that crashed the Input component during render */
+  'form.error.unhandled-runtime-error.error-message': 'Error: {{message}}',
+  /** The label on the button that retries render in case the runtime error is transient */
+  'form.error.unhandled-runtime-error.retry-button-label': 'Retry',
+  /** The title for the error card rendered inside a field in place of a crashing input */
+  'form.error.unhandled-runtime-error.title': 'Unhandled Runtime Error',
   /** Form field deprecated label */
   'form.field.deprecated-label': 'deprecated',
   /** Fallback title shown above field if it has no defined title */


### PR DESCRIPTION
### Description

While debugging issues in React 19, as well as React Compiler, I've frequently encountered crashes [that takes down the Structure Tool completely](https://test-compiled-studio-b8mfdmi85.sanity.build/test/structure/input-standard;portable-text;pt_allTheBellsAndWhistles;7455ba88-75d5-4a77-94a4-91738fa670c5):
![image](https://github.com/sanity-io/sanity/assets/81981/4c46cb2f-66a3-465a-9bc8-ed5458a6f788)

It's difficult to track down exactly what's causing it, the same is true when handling user reports of crashes, in Next v14 and v15 embedded studios in particular.
This PR adds an error boundary for input components, [which narrows down the crash to the input level](https://test-compiled-studio-git-add-input-error-boundary.sanity.build/test/structure/input-standard;portable-text;pt_allTheBellsAndWhistles;7455ba88-75d5-4a77-94a4-91738fa670c5):
![image](https://github.com/sanity-io/sanity/assets/81981/eb02c2ac-1c86-4fbf-89cf-c647df8a53c6)

In the image above only some of the Portable Text Editor inputs are crashing, significantly helping with narrowing down the cause. Fixes for the errors seen here will be done in follow up PRs.

### What to review

Does the language strings and the UI make sense?

### Testing

It's easiest to test on the compiled studio deployment, as it crashes early on race condition issues, instead of requiring tricky race condition reproduction steps: https://test-compiled-studio-git-add-input-error-boundary.sanity.build/test/structure/input-standard;portable-text;pt_allTheBellsAndWhistles;7455ba88-75d5-4a77-94a4-91738fa670c5


### Notes for release

Form input components now have their own error boundaries, limiting crashes to a field level on a document form, instead of taking down the entire Structure Tool.
