### PR TITLE
fix: portable text editor crash

### DIFF
--- a/.eslintignore.react-compiler
+++ b/.eslintignore.react-compiler
@@ -27,3 +27,4 @@ perf/*
 scripts/*
 test/*
 **/__workshop__/*
+packages/sanity/playwright-ct/**

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -253,6 +253,19 @@ const config = {
         'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
       },
     },
+
+    // Don't lint React Compiler rules on test code
+    {
+      files: [
+        `**/*/test/**/*`,
+        '**/*/__tests__/**/*',
+        '**/*.test.{js,ts,tsx}',
+        'packages/sanity/playwright-ct/**',
+      ],
+      rules: {
+        'react-compiler/react-compiler': 'off',
+      },
+    },
   ],
 }
 

--- a/dev/test-studio/components/workspaceLogos.tsx
+++ b/dev/test-studio/components/workspaceLogos.tsx
@@ -1,7 +1,7 @@
-import {useColorScheme} from 'sanity'
+import {useColorSchemeValue} from 'sanity'
 
 export const VercelLogo = () => {
-  const {scheme} = useColorScheme()
+  const scheme = useColorSchemeValue()
   const fill = scheme === 'dark' ? '#fff' : '#000'
 
   return (

--- a/dev/test-studio/workshop/WorkshopTool.tsx
+++ b/dev/test-studio/workshop/WorkshopTool.tsx
@@ -1,5 +1,5 @@
 import {Workshop} from '@sanity/ui-workshop'
-import {type Tool, useColorScheme, useWorkspace} from 'sanity'
+import {type Tool, useColorSchemeSetValue, useColorSchemeValue, useWorkspace} from 'sanity'
 
 import {config} from './config'
 import {type WorkshopOptions} from './types'
@@ -9,7 +9,8 @@ export function WorkshopTool(props: {tool: Tool<WorkshopOptions>}) {
   const {tool} = props
   const toolName = tool.options?.name || 'workshop'
 
-  const {scheme, setScheme} = useColorScheme()
+  const scheme = useColorSchemeValue()
+  const setScheme = useColorSchemeSetValue()
   const {basePath} = useWorkspace()
 
   const locationStore = useLocationStore({
@@ -20,7 +21,12 @@ export function WorkshopTool(props: {tool: Tool<WorkshopOptions>}) {
     <Workshop
       config={config}
       locationStore={locationStore}
-      onSchemeChange={setScheme}
+      onSchemeChange={
+        setScheme ||
+        (() => {
+          console.warn('Unable to change theme scheme')
+        })
+      }
       scheme={scheme}
     />
   )

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
     "check:react-exhaustive-deps": "turbo run lint --continue -- --quiet --rule 'react-hooks/exhaustive-deps: [error, {additionalHooks: \"(useAsync|useMemoObservable|useObservableCallback)\"}]'",
-    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 40 .",
+    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 38 .",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",
     "chore:format:fix": "prettier --cache --write .",

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/usePortableTextMembers.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/usePortableTextMembers.tsx
@@ -1,5 +1,5 @@
 import {isEqual, pathFor} from '@sanity/util/paths'
-import {createRef, type MutableRefObject, type ReactNode, useContext, useRef} from 'react'
+import {createRef, type MutableRefObject, type ReactNode, useContext, useMemo, useRef} from 'react'
 import {type FormPatch, type Path, set} from 'sanity'
 import {PortableTextMemberItemsContext} from 'sanity/_singletons'
 
@@ -38,23 +38,6 @@ export function usePortableTextMemberItems(): PortableTextMemberItem[] {
 export function usePortableTextMemberItemsFromProps(
   props: PortableTextInputProps,
 ): PortableTextMemberItem[] {
-  const portableTextMemberItemsRef: MutableRefObject<PortableTextMemberItem[]> = useRef([])
-  reconcilePortableTextMembers({props, ref: portableTextMemberItemsRef})
-  return portableTextMemberItemsRef.current
-}
-
-const reconcilePortableTextMembers = ({
-  props,
-  ref,
-}: {
-  props: PortableTextInputProps
-  ref: MutableRefObject<PortableTextMemberItem[]>
-}) => {
-  const result: {
-    kind: PortableTextMemberItem['kind']
-    member: ArrayOfObjectsItemMember
-    node: ObjectFormNode
-  }[] = []
   const {
     members,
     path,
@@ -66,154 +49,177 @@ const reconcilePortableTextMembers = ({
     renderItem,
     renderInlineBlock,
     renderPreview,
+    onPathFocus,
   } = props
-  for (const member of members) {
-    if (member.kind === 'item') {
-      const isObjectBlock = !isBlockType(member.item.schemaType)
-      if (isObjectBlock) {
-        result.push({kind: 'objectBlock', member, node: member.item})
-      } else {
-        // Also include regular text blocks with validation, presence, changes or that are open or focused.
-        // This is a performance optimization to avoid accounting for blocks that
-        // doesn't need to be re-rendered (which usually is most of the blocks).
-        if (
-          member.item.validation.length > 0 ||
-          member.item.changed ||
-          member.item.presence?.length ||
-          member.open ||
-          member.item.focusPath.length ||
-          member.item.focused
-        ) {
-          result.push({kind: 'textBlock', member, node: member.item})
-        }
-        // Inline objects
-        const childrenField = member.item.members.find(
-          (f) => f.kind === 'field' && f.name === 'children',
-        )
-        if (
-          childrenField &&
-          childrenField.kind === 'field' &&
-          isMemberArrayOfObjects(childrenField)
-        ) {
-          // eslint-disable-next-line max-depth
-          for (const child of childrenField.field.members) {
+
+  const portableTextMemberItemsRef: MutableRefObject<PortableTextMemberItem[]> = useRef([])
+  return useMemo(() => {
+    const result: {
+      kind: PortableTextMemberItem['kind']
+      member: ArrayOfObjectsItemMember
+      node: ObjectFormNode
+    }[] = []
+
+    for (const member of members) {
+      if (member.kind === 'item') {
+        const isObjectBlock = !isBlockType(member.item.schemaType)
+        if (isObjectBlock) {
+          result.push({kind: 'objectBlock', member, node: member.item})
+        } else {
+          // Also include regular text blocks with validation, presence, changes or that are open or focused.
+          // This is a performance optimization to avoid accounting for blocks that
+          // doesn't need to be re-rendered (which usually is most of the blocks).
+          if (
+            member.item.validation.length > 0 ||
+            member.item.changed ||
+            member.item.presence?.length ||
+            member.open ||
+            member.item.focusPath.length ||
+            member.item.focused
+          ) {
+            result.push({kind: 'textBlock', member, node: member.item})
+          }
+          // Inline objects
+          const childrenField = member.item.members.find(
+            (f) => f.kind === 'field' && f.name === 'children',
+          )
+          if (
+            childrenField &&
+            childrenField.kind === 'field' &&
+            isMemberArrayOfObjects(childrenField)
+          ) {
             // eslint-disable-next-line max-depth
-            if (child.kind === 'item' && child.item.schemaType.name !== 'span') {
-              result.push({kind: 'inlineObject', member: child, node: child.item})
+            for (const child of childrenField.field.members) {
+              // eslint-disable-next-line max-depth
+              if (child.kind === 'item' && child.item.schemaType.name !== 'span') {
+                result.push({kind: 'inlineObject', member: child, node: child.item})
+              }
             }
           }
-        }
-        // Markdefs
-        const markDefArrayMember = member.item.members
-          .filter(isArrayOfObjectsFieldMember)
-          .find((f) => f.name === 'markDefs')
-        if (markDefArrayMember) {
-          // eslint-disable-next-line max-depth
-          for (const child of markDefArrayMember.field.members) {
+          // Markdefs
+          const markDefArrayMember = member.item.members
+            .filter(isArrayOfObjectsFieldMember)
+            .find((f) => f.name === 'markDefs')
+          if (markDefArrayMember) {
             // eslint-disable-next-line max-depth
-            if (child.kind === 'item' && child.item.schemaType.jsonType === 'object') {
-              result.push({
-                kind: 'annotation',
-                member: child,
-                node: child.item,
-              })
+            for (const child of markDefArrayMember.field.members) {
+              // eslint-disable-next-line max-depth
+              if (child.kind === 'item' && child.item.schemaType.jsonType === 'object') {
+                result.push({
+                  kind: 'annotation',
+                  member: child,
+                  node: child.item,
+                })
+              }
             }
           }
         }
       }
     }
-  }
 
-  const items: PortableTextMemberItem[] = result.map((item) => {
-    const key = pathToString(item.node.path)
-    const existingItem = ref.current.find((refItem) => refItem.key === key)
-    const isObject = item.kind !== 'textBlock'
-    let input: ReactNode = null
+    const items: PortableTextMemberItem[] = result.map((item) => {
+      const key = pathToString(item.node.path)
+      const existingItem = portableTextMemberItemsRef.current.find((refItem) => refItem.key === key)
+      const isObject = item.kind !== 'textBlock'
+      let input: ReactNode = null
 
-    if ((isObject && item.member !== existingItem?.member) || item.node !== existingItem?.node) {
-      // No-op when calling elementProps.onFocus or calling onPathFocus with an empty focusPath
-      // This is to avoid closing the editing modal as it will focus the editor element itself.
-      const _elementProps = (renderInputProps: ObjectInputProps) => ({
-        ...renderInputProps.elementProps,
-        onFocus: () => {
-          // no-op
-        },
-      })
-      const _onPathFocus = (focusPath: Path) => {
-        const fullPath = item.member.item.path.concat(focusPath)
-        if (focusPath.length === 0) {
-          // no-op
-          return
-        }
-        props.onPathFocus(fullPath.slice(path.length, fullPath.length))
-      }
-
-      // When an Input is trying to remove itself (unset([])), we want instead to clear the values from the object,
-      // but keep the object itself. This is to avoid the array input to remove the array entirely when unsetting the last item (for instance with markDefs)
-      // We also want the (empty) object there in order to be able to control the closing of the object modal properly, cleaning up, normalizing through the editor etc.
-      const _onChangeDisableRemoveSelf = (objectFormRenderInputProps: ObjectInputProps) => {
-        return (patch: FormPatch) => {
-          // Special handling for unset([]) change
-          if (patch.type === 'unset' && patch.path.length === 0) {
-            objectFormRenderInputProps.onChange(
-              set({_type: item.member.item.schemaType.name, _key: item.member.key}, patch.path),
-            )
+      if ((isObject && item.member !== existingItem?.member) || item.node !== existingItem?.node) {
+        // No-op when calling elementProps.onFocus or calling onPathFocus with an empty focusPath
+        // This is to avoid closing the editing modal as it will focus the editor element itself.
+        const _elementProps = (renderInputProps: ObjectInputProps) => ({
+          ...renderInputProps.elementProps,
+          onFocus: () => {
+            // no-op
+          },
+        })
+        const _onPathFocus = (focusPath: Path) => {
+          const fullPath = item.member.item.path.concat(focusPath)
+          if (focusPath.length === 0) {
+            // no-op
             return
           }
-          // Original onChange
-          objectFormRenderInputProps.onChange(patch)
+          onPathFocus(fullPath.slice(path.length, fullPath.length))
         }
-      }
 
-      // Render object Input with no-ops for setting root focus, and unsetting the object.
-      const _renderInput = (renderInputProps: ObjectInputProps) => {
-        const isObjectInputPath = isEqual(renderInputProps.path, item.member.item.path)
-        if (isObjectInputPath) {
-          return renderInput({
-            ...renderInputProps,
-            onChange: _onChangeDisableRemoveSelf(renderInputProps),
-            onPathFocus: _onPathFocus,
-            elementProps: _elementProps(renderInputProps),
-          } as ObjectInputProps)
+        // When an Input is trying to remove itself (unset([])), we want instead to clear the values from the object,
+        // but keep the object itself. This is to avoid the array input to remove the array entirely when unsetting the last item (for instance with markDefs)
+        // We also want the (empty) object there in order to be able to control the closing of the object modal properly, cleaning up, normalizing through the editor etc.
+        const _onChangeDisableRemoveSelf = (objectFormRenderInputProps: ObjectInputProps) => {
+          return (patch: FormPatch) => {
+            // Special handling for unset([]) change
+            if (patch.type === 'unset' && patch.path.length === 0) {
+              objectFormRenderInputProps.onChange(
+                set({_type: item.member.item.schemaType.name, _key: item.member.key}, patch.path),
+              )
+              return
+            }
+            // Original onChange
+            objectFormRenderInputProps.onChange(patch)
+          }
         }
-        return renderInput(renderInputProps)
+
+        // Render object Input with no-ops for setting root focus, and unsetting the object.
+        const _renderInput = (renderInputProps: ObjectInputProps) => {
+          const isObjectInputPath = isEqual(renderInputProps.path, item.member.item.path)
+          if (isObjectInputPath) {
+            return renderInput({
+              ...renderInputProps,
+              onChange: _onChangeDisableRemoveSelf(renderInputProps),
+              onPathFocus: _onPathFocus,
+              elementProps: _elementProps(renderInputProps),
+            } as ObjectInputProps)
+          }
+          return renderInput(renderInputProps)
+        }
+        const inputProps = {
+          absolutePath: pathFor(item.node.path),
+          includeField: false,
+          members,
+          path: pathFor(path),
+          renderAnnotation,
+          renderBlock,
+          renderField,
+          renderInlineBlock,
+          renderInput: _renderInput,
+          renderItem,
+          renderPreview,
+          schemaType,
+        }
+        input = <FormInput {...(inputProps as FIXME)} />
       }
-      const inputProps = {
-        absolutePath: pathFor(item.node.path),
-        includeField: false,
-        members,
-        path: pathFor(path),
-        renderAnnotation,
-        renderBlock,
-        renderField,
-        renderInlineBlock,
-        renderInput: _renderInput,
-        renderItem,
-        renderPreview,
-        schemaType,
+
+      // Update existing item
+      if (existingItem) {
+        existingItem.member = item.member
+        existingItem.node = item.node
+        existingItem.input = input || existingItem.input
+        return existingItem
       }
-      input = <FormInput {...(inputProps as FIXME)} />
-    }
 
-    // Update existing item
-    if (existingItem) {
-      existingItem.member = item.member
-      existingItem.node = item.node
-      existingItem.input = input || existingItem.input
-      return existingItem
-    }
+      return {
+        kind: item.kind,
+        key,
+        member: item.member,
+        node: item.node,
+        elementRef: createRef<PortableTextEditorElement | null>(),
+        input,
+      }
+    })
 
-    return {
-      kind: item.kind,
-      key,
-      member: item.member,
-      node: item.node,
-      elementRef: createRef<PortableTextEditorElement | null>(),
-      input,
-    }
-  })
+    portableTextMemberItemsRef.current = items
 
-  ref.current = items
-
-  return items
+    return items
+  }, [
+    members,
+    onPathFocus,
+    path,
+    renderAnnotation,
+    renderBlock,
+    renderField,
+    renderInlineBlock,
+    renderInput,
+    renderItem,
+    renderPreview,
+    schemaType,
+  ])
 }

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -399,6 +399,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
     'No array item with `_key` <code>"{{key}}"</code> found at path <code>{{path}}</code>',
   /** The title above the error call stack output related to the crash */
   'form.error.unhandled-runtime-error.call-stack.title': 'Call Stack:',
+  /** The title above the error component stack provided by React's underlying ErrorBoundary component */
+  'form.error.unhandled-runtime-error.component-stack.title': 'Component Stack:',
   /** The error message for the unhandled error that crashed the Input component during render */
   'form.error.unhandled-runtime-error.error-message': 'Error: {{message}}',
   /** The title for the error card rendered inside a field in place of a crashing input */

--- a/packages/sanity/src/core/studio/colorScheme.tsx
+++ b/packages/sanity/src/core/studio/colorScheme.tsx
@@ -142,7 +142,7 @@ export function ColorSchemeCustomProvider({
   scheme,
 }: Pick<ColorSchemeProviderProps, 'children' | 'onSchemeChange'> & {
   scheme: StudioThemeColorSchemeKey
-}) {
+}): JSX.Element {
   return (
     <ColorSchemeSetValueContext.Provider
       value={typeof onSchemeChange === 'function' ? onSchemeChange : false}
@@ -155,14 +155,16 @@ export function ColorSchemeCustomProvider({
 }
 
 /** @alpha */
-export function useColorSchemeSetValue() {
+export function useColorSchemeSetValue():
+  | false
+  | ((nextScheme: StudioThemeColorSchemeKey) => void) {
   const setValue = useContext(ColorSchemeSetValueContext)
   if (setValue === null) throw new Error('Could not find `ColorSchemeSetValueContext` context')
   return setValue
 }
 
 /** @internal */
-export function _useColorSchemeInternalValue(): StudioThemeColorSchemeKey {
+export function useColorSchemeInternalValue(): StudioThemeColorSchemeKey {
   const value = useContext(ColorSchemeValueContext)
   if (value === null) throw new Error('Could not find `ColorSchemeValueContext` context')
   return value
@@ -170,7 +172,7 @@ export function _useColorSchemeInternalValue(): StudioThemeColorSchemeKey {
 
 /** @alpha */
 export function useColorSchemeValue(): ThemeColorSchemeKey {
-  const scheme = _useColorSchemeInternalValue()
+  const scheme = useColorSchemeInternalValue()
   const systemScheme = useSystemScheme()
   return scheme === 'system' ? systemScheme : scheme
 }
@@ -180,6 +182,12 @@ export function useColorSchemeValue(): ThemeColorSchemeKey {
  * @internal
  */
 export function useColorScheme() {
+  useEffect(() => {
+    console.warn(
+      'useColorScheme() is deprecated, use useColorSchemeValue() or useColorSchemeSetValue() instead',
+    )
+  }, [])
+
   const scheme = useColorSchemeValue()
   const setScheme = useColorSchemeSetValue()
   return useMemo(() => ({scheme, setScheme}), [scheme, setScheme])
@@ -200,7 +208,7 @@ export function useColorSchemeOptions(
   setScheme: (nextScheme: StudioThemeColorSchemeKey) => void,
   t: TFunction<'studio', undefined>,
 ) {
-  const scheme = _useColorSchemeInternalValue()
+  const scheme = useColorSchemeInternalValue()
 
   return useMemo(() => {
     return [

--- a/packages/sanity/src/core/studio/components/navbar/configIssues/ConfigIssuesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/configIssues/ConfigIssuesButton.tsx
@@ -7,7 +7,7 @@ import {Dialog} from '../../../../../ui-components'
 import {StatusButton} from '../../../../components'
 import {useSchema} from '../../../../hooks'
 import {useTranslation} from '../../../../i18n'
-import {useColorScheme} from '../../../colorScheme'
+import {useColorSchemeValue} from '../../../colorScheme'
 import {SchemaProblemGroups} from '../../../screens/schemaErrors/SchemaProblemGroups'
 
 export function ConfigIssuesButton() {
@@ -18,7 +18,7 @@ export function ConfigIssuesButton() {
     ) || []
 
   // get root scheme
-  const {scheme} = useColorScheme()
+  const scheme = useColorSchemeValue()
   const {t} = useTranslation()
 
   const dialogId = useId()

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
@@ -9,7 +9,7 @@ import {InsufficientPermissionsMessage} from '../../../../components'
 import {useSchema} from '../../../../hooks'
 import {useGetI18nText, useTranslation} from '../../../../i18n'
 import {useCurrentUser} from '../../../../store'
-import {useColorScheme} from '../../../colorScheme'
+import {useColorSchemeValue} from '../../../colorScheme'
 import {filterOptions} from './filter'
 import {
   DialogHeaderCard,
@@ -47,7 +47,7 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
   const {t} = useTranslation()
   const getI18nText = useGetI18nText(options)
 
-  const {scheme} = useColorScheme()
+  const scheme = useColorSchemeValue()
   const currentUser = useCurrentUser()
   const schema = useSchema()
 

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
@@ -7,7 +7,7 @@ import {MenuButton, type MenuButtonProps, MenuItem} from '../../../../../ui-comp
 import {StatusButton} from '../../../../components'
 import {useTranslation} from '../../../../i18n'
 import {useGlobalPresence} from '../../../../store'
-import {useColorScheme} from '../../../colorScheme'
+import {useColorSchemeValue} from '../../../colorScheme'
 import {useWorkspace} from '../../../workspace'
 import {PresenceMenuItem} from './PresenceMenuItem'
 
@@ -24,7 +24,7 @@ const FooterStack = styled(Stack)`
 export function PresenceMenu() {
   const presence = useGlobalPresence()
   const {projectId} = useWorkspace()
-  const {scheme} = useColorScheme()
+  const scheme = useColorSchemeValue()
   const {t} = useTranslation()
   const hasPresence = presence.length > 0
 

--- a/packages/sanity/src/core/studio/components/navbar/search/SearchDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/SearchDialog.tsx
@@ -3,9 +3,8 @@ import {useState} from 'react'
 import FocusLock from 'react-focus-lock'
 import {styled} from 'styled-components'
 
-import {useTranslation} from '../../../../i18n'
 import {supportsTouch} from '../../../../util'
-import {useColorScheme} from '../../../colorScheme'
+import {useColorSchemeValue} from '../../../colorScheme'
 import {SearchWrapper} from './components/common/SearchWrapper'
 import {Filters} from './components/filters/Filters'
 import {RecentSearches} from './components/recentSearches/RecentSearches'
@@ -45,8 +44,7 @@ const SearchDialogBox = styled(Box)`
  */
 export function SearchDialog({onClose, onOpen, open}: SearchDialogProps) {
   const [inputElement, setInputElement] = useState<HTMLInputElement | null>(null)
-  const {scheme} = useColorScheme()
-  const {t} = useTranslation()
+  const scheme = useColorSchemeValue()
 
   const {
     state: {filtersVisible, terms},

--- a/packages/sanity/src/core/studio/components/navbar/tools/ToolCollapseMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/tools/ToolCollapseMenu.tsx
@@ -6,7 +6,7 @@ import {Button} from '../../../../../ui-components'
 import {useRovingFocus} from '../../../../components'
 import {CollapseTabList} from '../../../../components/collapseTabList/CollapseTabList'
 import {type Tool} from '../../../../config'
-import {useColorScheme} from '../../../colorScheme'
+import {useColorSchemeValue} from '../../../colorScheme'
 import {ToolLink, type ToolLinkProps} from './ToolLink'
 
 interface ToolCollapseMenuProps {
@@ -16,7 +16,7 @@ interface ToolCollapseMenuProps {
 
 export function ToolCollapseMenu(props: ToolCollapseMenuProps) {
   const {activeToolName, tools} = props
-  const {scheme} = useColorScheme()
+  const scheme = useColorSchemeValue()
   const [collapseMenuEl, setCollapseMenuEl] = useState<HTMLDivElement | null>(null)
 
   useRovingFocus({

--- a/packages/sanity/src/core/tasks/context/tasks/TasksProvider.tsx
+++ b/packages/sanity/src/core/tasks/context/tasks/TasksProvider.tsx
@@ -1,5 +1,5 @@
 import {debounce} from 'lodash'
-import {useCallback, useMemo, useState} from 'react'
+import {useMemo, useState} from 'react'
 import {TasksContext} from 'sanity/_singletons'
 
 import {useTasksStore} from '../../store'
@@ -20,8 +20,7 @@ export function TasksProvider(props: TasksProviderProps) {
   const {data = EMPTY_ARRAY, isLoading} = useTasksStore({})
 
   // This change is debounced to wait until the next document loads if we are switching between documents.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debouncedSetActiveDocument = useCallback(debounce(setActiveDocument, 1000), [])
+  const debouncedSetActiveDocument = useMemo(() => debounce(setActiveDocument, 1000), [])
 
   const value: TasksContextValue = useMemo(
     () => ({

--- a/packages/sanity/src/core/user-color/provider.tsx
+++ b/packages/sanity/src/core/user-color/provider.tsx
@@ -1,7 +1,7 @@
 import {type ReactElement, type ReactNode, useMemo} from 'react'
 import {UserColorManagerContext} from 'sanity/_singletons'
 
-import {useColorScheme} from '../studio'
+import {useColorSchemeValue} from '../studio'
 import {createUserColorManager} from './manager'
 import {type UserColorManager} from './types'
 
@@ -16,7 +16,7 @@ export function UserColorManagerProvider({
   children,
   manager: managerFromProps,
 }: UserColorManagerProviderProps): ReactElement {
-  const {scheme} = useColorScheme()
+  const scheme = useColorSchemeValue()
 
   const manager = useMemo(() => {
     return managerFromProps || createUserColorManager({scheme})

--- a/packages/sanity/src/structure/panes/document/DocumentPane.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPane.tsx
@@ -115,6 +115,7 @@ function DocumentPaneInner(props: DocumentPaneProviderProps) {
               t={t}
               i18nKey="panes.document-pane.document-not-found.text"
               values={{id: options.id}}
+              components={{Code: ({children}) => <code>{children}</code>}}
             />
           </Text>
         </Stack>


### PR DESCRIPTION
### Description

On React 19 the Portable Text Editor sometimes ends up in an infinite render loop when there's no value yet, as demonstrated here: https://test-compiled-studio-b8mfdmi85.sanity.build/test/structure/input-standard;portable-text;pt_allTheBellsAndWhistles;7455ba88-75d5-4a77-94a4-91738fa670c5

This PR fixes it: https://test-compiled-studio-git-fix-portable-text-editor-crash.sanity.build/test/structure/input-standard;portable-text;pt_allTheBellsAndWhistles;7455ba88-75d5-4a77-94a4-91738fa670c5

The PR also contains a lot of other minor fixes related to React Compiler, improvements to how the color scheme state is passed around, adding the React Component stack to the form input error boundary etc.

### What to review

There shouldn't be any infinite render recursion loops happening in React 19 anymore for Portable Text Editor, try and break it 🙌 

### Testing

Beyond manual testing the existing e2e testing suite should be enough.

### Notes for release

Fixed React 19 causing Portable Text Editor to crash in some scenarios.
