### PR TITLE
test(e2e): update timeouts for opening popovers

### DIFF
--- a/test/e2e/tests/document-actions/discardChanges.spec.ts
+++ b/test/e2e/tests/document-actions/discardChanges.spec.ts
@@ -33,7 +33,7 @@ test(`is possible to discard changes if a changed document has a published versi
 
   await titleInput.fill('This is a book')
 
-  publishButton.click()
+  publishButton.click({timeout: 10000})
   await expect(paneFooter).toContainText('Published just now')
 
   await titleInput.fill('This is not a book')
@@ -57,7 +57,7 @@ test(`displays the published document state after discarding changes`, async ({
 
   await titleInput.fill('This is a book')
 
-  publishButton.click()
+  publishButton.click({timeout: 10000})
   await expect(paneFooter).toContainText('Published just now')
 
   // Change the title.

--- a/test/e2e/tests/document-actions/discardChanges.spec.ts
+++ b/test/e2e/tests/document-actions/discardChanges.spec.ts
@@ -33,7 +33,7 @@ test(`is possible to discard changes if a changed document has a published versi
 
   await titleInput.fill('This is a book')
 
-  publishButton.click({timeout: 15000})
+  publishButton.click({timeout: 40000})
   await expect(paneFooter).toContainText('Published just now')
 
   await titleInput.fill('This is not a book')
@@ -57,7 +57,7 @@ test(`displays the published document state after discarding changes`, async ({
 
   await titleInput.fill('This is a book')
 
-  publishButton.click({timeout: 15000})
+  publishButton.click({timeout: 40000})
   await expect(paneFooter).toContainText('Published just now')
 
   // Change the title.

--- a/test/e2e/tests/document-actions/discardChanges.spec.ts
+++ b/test/e2e/tests/document-actions/discardChanges.spec.ts
@@ -34,7 +34,7 @@ test(`is possible to discard changes if a changed document has a published versi
   await titleInput.fill('This is a book')
 
   publishButton.click()
-  await expect(paneFooter).toContainText('Published just now', {timeout: 40000})
+  await expect(paneFooter).toContainText('Published just now', {timeout: 50000})
 
   await titleInput.fill('This is not a book')
 
@@ -58,7 +58,7 @@ test(`displays the published document state after discarding changes`, async ({
   await titleInput.fill('This is a book')
 
   publishButton.click()
-  await expect(paneFooter).toContainText('Published just now', {timeout: 40000})
+  await expect(paneFooter).toContainText('Published just now', {timeout: 50000})
 
   // Change the title.
   await titleInput.fill('This is not a book')

--- a/test/e2e/tests/document-actions/discardChanges.spec.ts
+++ b/test/e2e/tests/document-actions/discardChanges.spec.ts
@@ -33,7 +33,7 @@ test(`is possible to discard changes if a changed document has a published versi
 
   await titleInput.fill('This is a book')
 
-  publishButton.click({timeout: 10000})
+  publishButton.click({timeout: 15000})
   await expect(paneFooter).toContainText('Published just now')
 
   await titleInput.fill('This is not a book')
@@ -57,7 +57,7 @@ test(`displays the published document state after discarding changes`, async ({
 
   await titleInput.fill('This is a book')
 
-  publishButton.click({timeout: 10000})
+  publishButton.click({timeout: 15000})
   await expect(paneFooter).toContainText('Published just now')
 
   // Change the title.

--- a/test/e2e/tests/document-actions/discardChanges.spec.ts
+++ b/test/e2e/tests/document-actions/discardChanges.spec.ts
@@ -33,8 +33,8 @@ test(`is possible to discard changes if a changed document has a published versi
 
   await titleInput.fill('This is a book')
 
-  publishButton.click({timeout: 40000})
-  await expect(paneFooter).toContainText('Published just now')
+  publishButton.click()
+  await expect(paneFooter).toContainText('Published just now', {timeout: 40000})
 
   await titleInput.fill('This is not a book')
 
@@ -57,8 +57,8 @@ test(`displays the published document state after discarding changes`, async ({
 
   await titleInput.fill('This is a book')
 
-  publishButton.click({timeout: 40000})
-  await expect(paneFooter).toContainText('Published just now')
+  publishButton.click()
+  await expect(paneFooter).toContainText('Published just now', {timeout: 40000})
 
   // Change the title.
   await titleInput.fill('This is not a book')

--- a/test/e2e/tests/inputs/reference.spec.ts
+++ b/test/e2e/tests/inputs/reference.spec.ts
@@ -51,7 +51,7 @@ withDefaultClient((context) => {
     await page.locator('#author-menuButton').click()
     await page.getByRole('menuitem').getByText('Replace').click()
     await referenceInput.getByLabel('Open').click()
-    await expect(authorListbox).toBeVisible()
+    await expect(authorListbox).toBeVisible({timeout: 50000})
 
     // Select the next document in the list.
     await page.keyboard.press('ArrowDown')

--- a/test/e2e/tests/pte/Toolbar.spec.ts
+++ b/test/e2e/tests/pte/Toolbar.spec.ts
@@ -28,7 +28,7 @@ test.describe('Portable Text Input - Open Block Style Select', () => {
     // wait for PTE to be full screen
     await waitForFullScreen(page)
 
-    await page.locator('[data-testid="block-style-select"]').click()
+    await page.locator('[data-testid="block-style-select"]').click({timeout: 3000})
 
     await expect(await page.locator('[data-ui="MenuButton__popover"]')).toBeVisible()
   })
@@ -63,7 +63,10 @@ test.describe('Portable Text Input - Open Block Style Select', () => {
     // click the block style select
     await page.locator('[data-testid="block-style-select"]').nth(1).click()
 
-    await page.waitForSelector('[data-ui="MenuButton__popover"]', {state: 'attached'})
+    await page.waitForSelector('[data-ui="MenuButton__popover"]', {
+      state: 'attached',
+      timeout: 3000,
+    })
 
     await expect(await page.locator('[data-ui="MenuButton__popover"]')).toBeVisible()
   })

--- a/test/e2e/tests/pte/Toolbar.spec.ts
+++ b/test/e2e/tests/pte/Toolbar.spec.ts
@@ -28,7 +28,7 @@ test.describe('Portable Text Input - Open Block Style Select', () => {
     // wait for PTE to be full screen
     await waitForFullScreen(page)
 
-    await page.locator('[data-testid="block-style-select"]').click({timeout: 3000})
+    await page.locator('[data-testid="block-style-select"]').click()
 
     await expect(await page.locator('[data-ui="MenuButton__popover"]')).toBeVisible()
   })
@@ -65,7 +65,7 @@ test.describe('Portable Text Input - Open Block Style Select', () => {
 
     await page.waitForSelector('[data-ui="MenuButton__popover"]', {
       state: 'attached',
-      timeout: 3000,
+      timeout: 15000,
     })
 
     await expect(await page.locator('[data-ui="MenuButton__popover"]')).toBeVisible()

--- a/test/e2e/tests/pte/Toolbar.spec.ts
+++ b/test/e2e/tests/pte/Toolbar.spec.ts
@@ -17,7 +17,7 @@ test.describe('Portable Text Input - Open Block Style Select', () => {
   })
 
   test('on a simple editor', async ({page}) => {
-    await pteInput.getByTestId('block-style-select').click()
+    await pteInput.getByTestId('block-style-select').click({timeout: 15000})
 
     expect(await page.locator('[data-ui="MenuButton__popover"]')).toBeVisible()
   })


### PR DESCRIPTION
### Description
- Update two e2e tests that tend to be flaky on next because the timeout runs out

<image src="https://github.com/sanity-io/sanity/assets/6951139/2383f308-d771-4a73-93f6-961a82948a48" width=500>


