### PR TITLE
fix(scheduled-publishing): export EditScheduleForm from core

### DIFF
--- a/packages/sanity/src/core/scheduledPublishing/components/editScheduleForm/EditScheduleForm.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/components/editScheduleForm/EditScheduleForm.tsx
@@ -10,6 +10,7 @@ interface Props {
 }
 
 /**
+ * @internal
  * Form for editing a schedule for a document when scheduled publishing is enabled.
  */
 export function EditScheduleForm(props: PropsWithChildren<Props>) {

--- a/packages/sanity/src/core/scheduledPublishing/components/editScheduleForm/EditScheduleForm.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/components/editScheduleForm/EditScheduleForm.tsx
@@ -10,8 +10,8 @@ interface Props {
 }
 
 /**
- * @internal
  * Form for editing a schedule for a document when scheduled publishing is enabled.
+ * @internal
  */
 export function EditScheduleForm(props: PropsWithChildren<Props>) {
   const {onChange, value} = props

--- a/packages/sanity/src/core/scheduledPublishing/components/editScheduleForm/EditScheduleForm.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/components/editScheduleForm/EditScheduleForm.tsx
@@ -9,6 +9,9 @@ interface Props {
   value?: ScheduleFormData | null
 }
 
+/**
+ * Form for editing a schedule for a document when scheduled publishing is enabled.
+ */
 export function EditScheduleForm(props: PropsWithChildren<Props>) {
   const {onChange, value} = props
 

--- a/packages/sanity/src/core/scheduledPublishing/index.ts
+++ b/packages/sanity/src/core/scheduledPublishing/index.ts
@@ -1,2 +1,3 @@
+export * from './components/editScheduleForm/EditScheduleForm'
 export * from './plugin/documentActions/schedule/ScheduleAction'
 export * from './plugin/documentBadges/scheduled/ScheduledBadge'


### PR DESCRIPTION
### Description

Some users are depending on the `EditScheduleForm` for custom scheduled publishing  integrations, this was previously exported from the [plugin](https://github.com/sanity-io/sanity-plugin-scheduled-publishing/blob/main/src/index.ts#L13) but when the plugin was moved into core this export was not included.  

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is this correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Export EditScheduleForm from core

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
