### PR TITLE
refactor: change memoization of margins to support the rule of hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check:deps": "pnpm --recursive --parallel exec depcheck",
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
-    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 32 .",
+    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 31 .",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",
     "chore:format:fix": "prettier --cache --write .",

--- a/packages/sanity/src/core/presence/overlay/RegionsWithIntersections.tsx
+++ b/packages/sanity/src/core/presence/overlay/RegionsWithIntersections.tsx
@@ -46,13 +46,20 @@ export const RegionsWithIntersections = forwardRef(function RegionsWithIntersect
   props: RegionsWithIntersectionsProps,
   ref: ForwardedRef<HTMLDivElement>,
 ) {
-  const {regions, render, children, margins: marginsProp} = props
+  const {
+    regions,
+    render,
+    children,
+    margins: [mt, mr, mb, ml],
+  } = props
 
   const overlayRef = useRef<HTMLDivElement | null>(null)
 
   // Make sure `margins` is memoized
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const margins = useMemo(() => marginsProp, [JSON.stringify(marginsProp)])
+  const margins = useMemo<[number, number, number, number]>(
+    () => [mt, mr, mb, ml],
+    [mt, mr, mb, ml],
+  )
 
   const io = useMemo(
     () =>


### PR DESCRIPTION
### Description

By destructuring the array, which is guaranteed to always be a `[number, number, number, number]` tuple, the memoization is no longer violating the rules of hooks by overriding how deps are specified in `useMemo`. And it no longer calls `JSON.stringify` on every single render.
Thus it can also be compiled by React Compiler.

### What to review

Presence circles should work like before in general, and slightly faster in https://test-compiled-studio.sanity.build

### Testing

Existing tests should cover it.

### Notes for release

N/A
