### PR TITLE
fix: change `useListFormat` to no longer violate the rule of hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check:deps": "pnpm --recursive --parallel exec depcheck",
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
-    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 32 .",
+    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 31 .",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",
     "chore:format:fix": "prettier --cache --write .",

--- a/packages/sanity/src/core/hooks/useListFormat.ts
+++ b/packages/sanity/src/core/hooks/useListFormat.ts
@@ -1,4 +1,6 @@
-import {useCurrentLocale} from '../i18n/hooks/useLocale'
+import {useContext} from 'react'
+import {LocaleContext} from 'sanity/_singletons'
+
 import {intlCache} from '../i18n/intlCache'
 
 /**
@@ -39,10 +41,8 @@ export function useListFormat(options: UseListFormatOptions = {}): Intl.ListForm
    * may not have access to the LocaleProvider that lets us use useCurrentLocale.
    * In that case, we fall back to a default, unobstrusive list format.
    */
-  try {
-    const currentLocale = useCurrentLocale().id
-    return intlCache.listFormat(currentLocale, options)
-  } catch {
-    return intlCache.listFormat('en-US', {...options, style: 'narrow'})
-  }
+  const currentLocale = useContext(LocaleContext)?.currentLocale.id
+  return currentLocale
+    ? intlCache.listFormat(currentLocale, options)
+    : intlCache.listFormat('en-US', {...options, style: 'narrow'})
 }


### PR DESCRIPTION
### Description

Calling a hook inside a try/catch boundary is violating the [rules of hooks](https://19.react.dev/warnings/invalid-hook-call-warning).
React relies on call order for core hooks (`useState`, `useMemo`, all the hooks that come from `react`) and that they are consistent on every re-render.
The fact that this currently works for `useListFormat` is a hack, and has downsides:
- [v8 and other browser engines have to deopt a lot of JIT perf boosts when catch boundaries are used, and errors thrown](https://blog.dubbelboer.com/2012/04/16/node-try-catch.html).
- if other errors than a missing context is thrown then the hook swallow said errors, for example what if calling `intlCache.listFormat` throws a unhandled runtime error?
- React Compiler is unable to optimize components that have hooks that are called within conditions, it requires them to be top-level.

The fix is to instead read the context directly `useContext(LocaleContext)`, and not throw if it's undefined. In this case it's the simplest fix since we're dealing with internals.
If the logic is crossing package boundaries, for example if `useListFormat` lived in a different package on a different repo, then the recommend solution would've been to add an option to `useLocale` that lets you opt-out of throwing an error if the context is `null`.

A reference implementation of that pattern, with good TypeScript overloads, is `usePresentationParams` in `@sanity/presentation`: https://github.com/sanity-io/visual-editing/blob/147c5f6f08eb9f34e6665254677852a6e2d8a084/packages/presentation/src/usePresentationParams.ts#L6-L19


### What to review

Hopefully the refactor makes sense, and the logic is sound 🙌 

### Testing

Existing tests should be enough.

### Notes for release

N/A
