### PR TITLE
refactor(core): use new value transfer function for copy/paste + tests

### DIFF
--- a/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
+++ b/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
@@ -14,14 +14,6 @@ export const CopyPasteProvider: React.FC<{
   const documentMetaRef = useRef<DocumentMeta | null>(null)
   const [copyResult, setCopyResult] = useState<CopyActionResult | null>(null)
 
-  const isValidTargetType = useCallback(
-    (target: string) => {
-      const source = copyResult?.schemaTypeName
-      return source === target
-    },
-    [copyResult],
-  )
-
   const setDocumentMeta = useCallback(
     ({documentId, documentType, schemaType, onChange}: Required<DocumentMeta>) => {
       documentMetaRef.current = {
@@ -43,9 +35,8 @@ export const CopyPasteProvider: React.FC<{
       getDocumentMeta,
       setCopyResult,
       setDocumentMeta,
-      isValidTargetType,
     }),
-    [copyResult, getDocumentMeta, setDocumentMeta, isValidTargetType],
+    [copyResult, getDocumentMeta, setDocumentMeta],
   )
 
   return <CopyPasteContext.Provider value={contextValue}>{children}</CopyPasteContext.Provider>

--- a/packages/sanity/src/core/studio/copyPaste/__test__/schema.tsx
+++ b/packages/sanity/src/core/studio/copyPaste/__test__/schema.tsx
@@ -1,8 +1,6 @@
-import {defineField, defineType, type Schema} from '@sanity/types'
+import {defineType, type Schema} from '@sanity/types'
 
 import {createSchema} from '../../../schema'
-
-const Icon = () => null
 
 const linkType = defineType({
   type: 'object',
@@ -17,242 +15,172 @@ const linkType = defineType({
   validation: (Rule) => Rule.required(),
 })
 
-const myStringType = defineType({
+const myStringObjectType = defineType({
   type: 'object',
-  name: 'test',
-  fields: [{type: 'string', name: 'mystring', validation: (Rule) => Rule.required()}],
+  name: 'myStringObject',
+  fields: [{type: 'string', name: 'myString', validation: (Rule) => Rule.required()}],
+})
+
+const nestedObjectType = defineType({
+  type: 'object',
+  name: 'nestedObject',
+  fields: [
+    {
+      name: 'title',
+      type: 'string',
+    },
+    {
+      type: 'array',
+      name: 'objectList',
+      of: [{type: 'nestedObject'}],
+    },
+  ],
 })
 
 export const schema = createSchema({
   name: 'default',
   types: [
     linkType,
-    myStringType,
-    // {
-    //   name: 'customNamedBlock',
-    //   type: 'block',
-    //   title: 'A named custom block',
-    //   marks: {
-    //     annotations: [linkType, myStringType],
-    //   },
-    //   of: [
-    //     {type: 'image'},
-    //     {
-    //       type: 'object',
-    //       name: 'test',
-    //       fields: [myStringType],
-    //     },
-    //     {
-    //       type: 'reference',
-    //       name: 'strongAuthorRef',
-    //       title: 'A strong author ref',
-    //       to: {type: 'author'},
-    //     },
-    //   ],
-    // },
-    defineType({
+    myStringObjectType,
+    nestedObjectType,
+    {
+      name: 'customNamedBlock',
+      type: 'block',
+      title: 'A named custom block',
+      marks: {
+        annotations: [linkType, myStringObjectType],
+      },
+      of: [
+        {
+          type: 'object',
+          name: 'test',
+          fields: [myStringObjectType],
+        },
+        {
+          type: 'reference',
+          name: 'strongAuthorRef',
+          title: 'A strong author ref',
+          to: {type: 'author'},
+        },
+      ],
+    },
+    {
       name: 'author',
       title: 'Author',
       type: 'document',
-      //icon: Icon,
       fields: [
         {
           name: 'name',
           type: 'string',
         },
         {
-          name: 'role',
-          type: 'string',
+          name: 'born',
+          type: 'number',
         },
-        // {
-        //   name: 'bio',
-        //   type: 'array',
-        //   of: [{type: 'customNamedBlock'}],
-        // },
-        defineField({
+        {
+          name: 'favoriteNumbers',
+          type: 'array',
+          of: [{type: 'number'}],
+        },
+        {type: 'image', name: 'profileImage'},
+        {
+          type: 'object',
+          name: 'socialLinks',
+          fields: [
+            {type: 'string', name: 'twitter'},
+            {type: 'string', name: 'linkedin'},
+          ],
+        },
+        {
+          name: 'nestedTest',
+          type: 'nestedObject',
+        },
+        {
+          name: 'bio',
+          type: 'array',
+          of: [{type: 'customNamedBlock'}, {type: 'myStringObject'}],
+        },
+        {
+          name: 'friends',
+          type: 'array',
+          of: [{type: 'reference', to: [{type: 'author'}]}],
+        },
+        {
           name: 'bestFriend',
           type: 'reference',
           to: [{type: 'author'}],
-        }),
-      ],
-      initialValue: () => ({
-        role: 'Developer',
-      }),
-    }),
-    defineType({
-      name: 'address',
-      title: 'Address',
-      type: 'object',
-      fields: [
-        {
-          name: 'street',
-          type: 'string',
-          initialValue: 'one old street',
-        },
-        {
-          name: 'streetNo',
-          type: 'string',
-          initialValue: '123',
-        },
-      ],
-    }),
-    {
-      name: 'contact',
-      title: 'Contact',
-      type: 'object',
-      fields: [
-        {
-          name: 'email',
-          type: 'string',
-        },
-        {
-          name: 'phone',
-          type: 'string',
         },
       ],
     },
     {
-      name: 'person',
-      title: 'Person',
+      name: 'editor',
+      title: 'Editor',
       type: 'document',
-      icon: Icon,
       fields: [
         {
-          name: 'address',
-          type: 'address',
+          name: 'name',
+          type: 'string',
         },
         {
-          name: 'contact',
-          type: 'contact',
+          name: 'born',
+          type: 'number',
+        },
+        {type: 'image', name: 'profileImage'},
+        {
+          name: 'bio',
+          type: 'array',
+          of: [{type: 'customNamedBlock'}],
+        },
+        {
+          name: 'favoriteNumbers',
+          type: 'array',
+          of: [{type: 'number'}],
+        },
+        {
+          name: 'nestedTest',
+          type: 'nestedObject',
+        },
+        {
+          name: 'profile',
+          type: 'object',
+          fields: [
+            {type: 'string', name: 'email'},
+            {type: 'image', name: 'avatar'},
+            {
+              type: 'object',
+              name: 'social',
+              fields: [
+                {type: 'string', name: 'twitter'},
+                {type: 'string', name: 'linkedin'},
+              ],
+            },
+          ],
+        },
+        {
+          name: 'friends',
+          type: 'array',
+          of: [{type: 'reference', to: [{type: 'editor'}, {type: 'author'}]}],
         },
       ],
     },
-
     {
       name: 'post',
       title: 'Post',
       type: 'document',
-      icon: Icon,
       fields: [
         {
           name: 'title',
           type: 'string',
         },
-        // {
-        //   name: 'body',
-        //   type: 'array',
-        //   of: [{type: 'customNamedBlock'}],
-        // },
+        {
+          name: 'body',
+          type: 'array',
+          of: [{type: 'customNamedBlock'}],
+        },
         {
           name: 'author',
           type: 'reference',
           to: [{type: 'author'}],
-        },
-      ],
-    },
-
-    {
-      name: 'captionedImage',
-      type: 'object',
-      fields: [
-        // {
-        //   // This doesn't have a default value, so shouldn't be present,
-        //   // not even with a `_type` stub
-        //   name: 'asset',
-        //   type: 'reference',
-        //   to: [{type: 'sanity.imageAsset'}],
-        // },
-        {
-          name: 'caption',
-          type: 'string',
-        },
-      ],
-      initialValue: {caption: 'Default caption!'},
-    },
-
-    {
-      name: 'recursiveObject',
-      type: 'object',
-      fields: [
-        {
-          name: 'name',
-          type: 'string',
-        },
-        {
-          name: 'child',
-          type: 'recursiveObject',
-        },
-      ],
-      initialValue: {
-        name: '∞ recursion is ∞',
-      },
-    },
-
-    {
-      name: 'developer',
-      type: 'document',
-      initialValue: () => ({
-        name: 'A default name!',
-
-        // Should clear the default value below (but ideally not actually be part
-        // of the value, eg no `undefined` in the resolved value)
-        numberOfCats: undefined,
-      }),
-      fields: [
-        {
-          name: 'name',
-          type: 'string',
-        },
-        {
-          name: 'hasPet',
-          type: 'boolean',
-          initialValue: false,
-        },
-        {
-          name: 'age',
-          type: 'number',
-          initialValue: 30,
-        },
-        {
-          name: 'numberOfCats',
-          type: 'number',
-          initialValue: 3,
-        },
-        {
-          name: 'heroImage',
-          type: 'captionedImage',
-        },
-        {
-          name: 'awards',
-          type: 'array',
-          of: [{type: 'string'}],
-          initialValue: () => ['TypeScript Wizard of the Year'],
-        },
-        {
-          name: 'tasks',
-          type: 'array',
-          of: [
-            {
-              name: 'task',
-              type: 'object',
-              fields: [
-                {name: 'description', type: 'string'},
-                {name: 'isDone', type: 'boolean', initialValue: false},
-              ],
-            },
-          ],
-          initialValue: () => [
-            {
-              _type: 'task',
-              description: 'Mark as done',
-              isDone: false,
-            },
-          ],
-        },
-        {
-          name: 'recursive',
-          type: 'recursiveObject',
-          // Initial value set on it's actual type
         },
       ],
     },

--- a/packages/sanity/src/core/studio/copyPaste/__test__/valueTransfer.test.ts
+++ b/packages/sanity/src/core/studio/copyPaste/__test__/valueTransfer.test.ts
@@ -1,6 +1,7 @@
 import {beforeEach, describe, expect, jest, test} from '@jest/globals'
-import {type CopyActionResult} from 'sanity'
+import {omit} from 'lodash'
 
+import {resolveSchemaTypeForPath} from '../resolveSchemaTypeForPath'
 import {transferValue} from '../valueTransfer'
 import {schema} from './schema'
 
@@ -10,9 +11,11 @@ beforeEach(() => {
 })
 
 describe('transferValue', () => {
-  test('can copy portable text field', () => {
-    const docValue = {
-      body: [
+  test('cannot copy from one type to another if the schema json type is different', () => {
+    const sourceValue = {
+      _type: 'author',
+      _id: 'xxx',
+      bio: [
         {
           _key: 'someKey',
           _type: 'customNamedBlock',
@@ -20,21 +23,112 @@ describe('transferValue', () => {
         },
       ],
     }
-    const copyActionResult: CopyActionResult = {
-      _type: 'copyResult',
-      documentId: '123',
-      documentType: 'author',
-      schemaTypeName: 'author',
-      path: ['bio'],
-      docValue,
-      isDocument: true,
-      isArray: false,
-      isObject: false,
-    }
-    const targetValue = transferValue(copyActionResult, {
-      targetDocumentType: 'author',
-      targetSchemaType: schema.get('author')!,
+    const transferValueResult = transferValue({
+      sourceRootSchemaType: schema.get('author')!,
+      sourcePath: [],
+      sourceValue,
+      targetRootSchemaType: schema.get('editor')!,
+      targetPath: ['bio'],
     })
-    expect(targetValue).toEqual(docValue)
+    expect(transferValueResult.errors.length).toEqual(1)
+    expect(transferValueResult.errors[0].message).toEqual(
+      'Source and target schema types are not compatible',
+    )
   })
+
+  describe('objects', () => {
+    test('can copy object', () => {
+      const sourceValue = {
+        _type: 'author',
+        _id: 'xxx',
+        bio: [
+          {
+            _key: 'someKey',
+            _type: 'customNamedBlock',
+            children: [{_key: 'someOtherKey', _type: 'span', text: 'Hello'}],
+          },
+        ],
+      }
+      const transferValueResult = transferValue({
+        sourceRootSchemaType: schema.get('author')!,
+        sourcePath: [],
+        sourceValue,
+        targetRootSchemaType: schema.get('editor')!,
+        targetPath: [],
+      })
+      expect(transferValueResult?.targetValue).toEqual({
+        ...omit(sourceValue, ['_id']),
+        _type: 'editor',
+      })
+    })
+
+    test('can copy array of numbers', () => {
+      const sourceValue = {
+        _type: 'author',
+        _id: 'xxx',
+        favoriteNumbers: [1, 2, 3, 4, 'foo'],
+      }
+      const transferValueResult = transferValue({
+        sourceRootSchemaType: schema.get('author')!,
+        sourcePath: ['favoriteNumbers'],
+        sourceValue,
+        targetRootSchemaType: schema.get('editor')!,
+        targetPath: ['favoriteNumbers'],
+      })
+      expect(transferValueResult?.targetValue).toEqual([1, 2, 3, 4])
+    })
+
+    test('can copy nested objects', () => {
+      const sourceValue = {_type: 'nestedObject', _key: 'yyy', title: 'item', items: []}
+      const schemaTypeAtPath = resolveSchemaTypeForPath(schema.get('author')!, ['nestedTest'])
+      const transferValueResult = transferValue({
+        sourceRootSchemaType: schemaTypeAtPath!,
+        sourcePath: [],
+        sourceValue,
+        targetRootSchemaType: schema.get('editor')!,
+        targetPath: ['nestedTest'],
+      })
+      expect(transferValueResult?.targetValue).toEqual({_type: 'nestedObject', title: 'item'})
+    })
+
+    test('can copy image objects', () => {
+      const sourceValue = {
+        _type: 'image',
+        asset: {
+          _ref: 'image-e4be7fa20bb20c271060a46bca82b9e84907a13a-320x320-jpg',
+          _type: 'reference',
+        },
+      }
+      const schemaTypeAtPath = resolveSchemaTypeForPath(schema.get('author')!, ['profileImage'])
+      const transferValueResult = transferValue({
+        sourceRootSchemaType: schemaTypeAtPath!,
+        sourcePath: [],
+        sourceValue,
+        targetRootSchemaType: schema.get('editor')!,
+        targetPath: ['profileImage'],
+      })
+      expect(transferValueResult?.targetValue).toEqual(sourceValue)
+    })
+  })
+  // test.only('can copy nested objects', () => {
+  //   const sourceValue = {
+  //     _type: 'nestedObject',
+  //     title: 'root',
+  //     objectList: [{_type: 'nestedObject', _key: 'yyy', title: 'item', items: []}],
+  //   }
+  //   const transferValueResult = transferValue({
+  //     sourceRootSchemaType: schema.get('author')!,
+  //     sourcePath: ['nestedTest', 'objectList', {_key: 'yyy'}],
+  //     sourceValue,
+  //     targetRootSchemaType: schema.get('editor')!,
+  //     targetPath: ['nestedTest'],
+  //   })
+  //   expect(transferValueResult.errors.length).toEqual(0)
+  //   expect(transferValueResult?.targetValue).toEqual({
+  //     _type: 'nestedObject',
+  //     _key: 'yyy',
+  //     title: 'item',
+  //     items: [],
+  //   })
+  // })
 })

--- a/packages/sanity/src/core/studio/copyPaste/types.ts
+++ b/packages/sanity/src/core/studio/copyPaste/types.ts
@@ -1,4 +1,4 @@
-import {type ObjectSchemaType, type PatchEvent} from 'sanity'
+import {type ObjectSchemaType, type PatchEvent, type Path} from 'sanity'
 
 /**
  * @beta
@@ -19,13 +19,13 @@ export interface CopyActionResult {
   _type: 'copyResult'
   documentId?: string
   documentType?: string
+  documentPath: Path
+  value: unknown
+  isArray: boolean
+  isDocument: boolean
+  isObject: boolean
   schemaTypeName: string
   schemaTypeTitle?: string
-  path: any[]
-  docValue: any // Adjust the type based on your actual data structure
-  isDocument: boolean
-  isArray: boolean
-  isObject: boolean
 }
 
 /**
@@ -37,5 +37,4 @@ export interface CopyPasteContextType {
   copyResult: CopyActionResult | null
   setCopyResult: (result: CopyActionResult) => void
   setDocumentMeta: (meta: Required<DocumentMeta>) => void
-  isValidTargetType: (targetType: string) => boolean
 }

--- a/packages/sanity/src/core/studio/copyPaste/valueTransfer.ts
+++ b/packages/sanity/src/core/studio/copyPaste/valueTransfer.ts
@@ -1,46 +1,329 @@
-// const {schemaTypeName: sourceSchemaTypeName, isDocument, isArray} = value
+import {
+  type ArraySchemaType,
+  type BooleanSchemaType,
+  isArrayOfObjectsSchemaType,
+  isArrayOfPrimitivesSchemaType,
+  isArraySchemaType,
+  isObjectSchemaType,
+  isPrimitiveSchemaType,
+  isReferenceSchemaType,
+  type NumberSchemaType,
+  type ObjectSchemaType,
+  type StringSchemaType,
+  type TypedObject,
+} from '@sanity/types'
+import {type Path, type SchemaType} from 'sanity'
 
-import {normalizeBlock} from '@sanity/block-tools'
-import {pickBy} from 'lodash'
-import {type SchemaType} from 'sanity'
+import {getValueAtPath} from '../../field/paths/helpers'
+import {isEmptyValue, tryResolveSchemaTypeForPath} from './utils'
 
-import {type CopyActionResult} from './types'
-
-export interface TransferValueOptions {
-  targetSchemaType: SchemaType
-  targetDocumentType?: string
+export interface TransferValueError {
+  level: 'warning' | 'error'
+  message: string
+  sourceValue: unknown
 }
 
-export function transferValue(
-  value: CopyActionResult,
-  {targetDocumentType, targetSchemaType}: TransferValueOptions,
-): CopyActionResult {
-  const {schemaTypeName: sourceSchemaTypeName, isDocument, isArray} = value
-  const keysToDelete = ['_id', '_type', '_createdAt', '_updatedAt', '_rev']
-  const isArrayValue = Array.isArray(value.docValue)
-  const isPrimitiveValue = typeof value.docValue !== 'object'
+export function transferValue({
+  sourceRootSchemaType,
+  sourcePath,
+  sourceValue,
+  targetRootSchemaType,
+  targetPath,
+}: {
+  sourceRootSchemaType: SchemaType
+  sourcePath: Path
+  sourceValue: unknown
+  targetRootSchemaType: SchemaType
+  targetPath: Path
+}): {
+  targetValue: unknown
+  errors: TransferValueError[]
+} {
+  const errors: TransferValueError[] = []
 
-  let targetValue =
-    isArrayValue || isPrimitiveValue
-      ? value.docValue
-      : pickBy(
-          value.docValue as object,
-          (_value, key) => !keysToDelete.includes(key) && !key.startsWith('_'),
-        )
-  const isTargetDocument = targetSchemaType.type?.name === 'document'
-  const targetName = targetSchemaType.name
-  const targetTypeLabel = isTargetDocument ? 'document' : 'field'
+  const sourceSchemaTypeAtPath = tryResolveSchemaTypeForPath(sourceRootSchemaType, sourcePath)
+  const targetSchemaTypeAtPath = tryResolveSchemaTypeForPath(targetRootSchemaType, targetPath)
 
-  if (isArrayValue || isArray) {
-    // Reset/normalize array object keys
-    targetValue = [...targetValue].map((item) => {
-      return normalizeBlock(item)
+  if (!sourceSchemaTypeAtPath) {
+    throw new Error('Could not find source schema type at path')
+  }
+  if (!targetSchemaTypeAtPath) {
+    throw new Error('Could not find target schema type at path')
+  }
+
+  // Test that the target schematypes are compatible
+  if (
+    sourceSchemaTypeAtPath &&
+    targetSchemaTypeAtPath &&
+    sourceSchemaTypeAtPath.jsonType !== targetSchemaTypeAtPath.jsonType
+  ) {
+    return {
+      targetValue: undefined,
+      errors: [
+        {
+          level: 'error',
+          message: 'Source and target schema types are not compatible',
+          sourceValue,
+        },
+      ],
+    }
+  }
+
+  const sourceValueAtPath = getValueAtPath(sourceValue as TypedObject, sourcePath)
+
+  // Objects
+  if (
+    sourceSchemaTypeAtPath.jsonType === 'object' &&
+    targetSchemaTypeAtPath.jsonType === 'object'
+  ) {
+    // Special handling for reference objects to ensure that (some) common references exists
+    // I think this is the best effort we can do without fetching and inspecting the actual referenced data,
+    if (
+      isReferenceSchemaType(sourceSchemaTypeAtPath) &&
+      isReferenceSchemaType(targetSchemaTypeAtPath)
+    ) {
+      const sourceReferenceTypes = sourceSchemaTypeAtPath.to.map((type) => type.name)
+      const targetReferenceTypes = targetSchemaTypeAtPath.to.map((type) => type.name)
+      if (!targetReferenceTypes.some((type) => sourceReferenceTypes.includes(type))) {
+        errors.push({
+          level: 'error',
+          message: `References of type ${sourceReferenceTypes.join(', ')} is not allowed in reference field to types ${sourceReferenceTypes.join(', ')}`,
+          sourceValue,
+        })
+        return {
+          targetValue: undefined,
+          errors,
+        }
+      }
+    }
+
+    return collateObjectValue({
+      sourceValue: sourceValueAtPath as TypedObject,
+      targetSchemaType: targetSchemaTypeAtPath as ObjectSchemaType,
+      targetPath: [],
+      errors,
     })
   }
-  if (isDocument && (!isTargetDocument || targetDocumentType !== sourceSchemaTypeName)) {
-    throw new Error(
-      `Cannot paste document of type ${sourceSchemaTypeName} into ${targetTypeLabel} of type ${targetName}`,
-    )
+
+  // Arrays
+  if (sourceSchemaTypeAtPath.jsonType === 'array' && targetSchemaTypeAtPath.jsonType === 'array') {
+    return collateArrayValue({
+      sourceValue: sourceValueAtPath as unknown[],
+      targetSchemaType: targetSchemaTypeAtPath as ArraySchemaType,
+      errors,
+    })
   }
-  return targetValue
+
+  // Primitives
+  const primitiveSchemaType = targetSchemaTypeAtPath as
+    | NumberSchemaType
+    | StringSchemaType
+    | BooleanSchemaType
+
+  return collatePrimitiveValue({
+    sourceValue: sourceValueAtPath as unknown,
+    targetSchemaType: primitiveSchemaType,
+    errors,
+  })
+}
+
+function collateObjectValue({
+  sourceValue,
+  targetSchemaType,
+  targetPath,
+  errors,
+}: {
+  sourceValue: unknown
+  targetSchemaType: ObjectSchemaType
+  targetPath: Path
+  errors: TransferValueError[]
+}) {
+  const targetValue = {_type: targetSchemaType.name} as TypedObject
+  const objectMembers = targetSchemaType.fields
+
+  objectMembers.forEach((member) => {
+    const memberSchemaType = member.type
+    const memberIsArray = isArraySchemaType(memberSchemaType)
+    const memberIsObject = isObjectSchemaType(memberSchemaType)
+    const memberIsPrimitive = isPrimitiveSchemaType(memberSchemaType)
+    // Primitive field
+    if (memberIsPrimitive) {
+      const genericValue = sourceValue
+        ? ((sourceValue as TypedObject)[member.name] as unknown)
+        : undefined
+      const collated = collatePrimitiveValue({
+        sourceValue: genericValue,
+        targetSchemaType: memberSchemaType,
+        errors,
+      })
+      if (!isEmptyValue(collated.targetValue)) {
+        targetValue[member.name] = collated.targetValue
+      }
+      // Object field
+    } else if (memberIsObject) {
+      const collated = collateObjectValue({
+        sourceValue: getValueAtPath(
+          sourceValue as TypedObject,
+          targetPath.concat(member.name),
+        ) as TypedObject,
+        targetPath: [],
+        targetSchemaType: memberSchemaType,
+        errors,
+      })
+      if (!isEmptyValue(collated.targetValue)) {
+        targetValue[member.name] = collated.targetValue
+      }
+      // Array field
+    } else if (memberIsArray) {
+      const genericValue = sourceValue
+        ? ((sourceValue as TypedObject)[member.name] as unknown)
+        : undefined
+      const collated = collateArrayValue({
+        sourceValue: genericValue,
+        targetSchemaType: memberSchemaType as ArraySchemaType,
+        errors,
+      })
+      if (!isEmptyValue(collated.targetValue)) {
+        targetValue[member.name] = collated.targetValue
+      }
+    }
+  })
+  const valueAtTargetPath = getValueAtPath(targetValue, targetPath)
+  return {
+    targetValue: valueAtTargetPath,
+    errors,
+  }
+}
+
+function collateArrayValue({
+  sourceValue,
+  targetSchemaType,
+  errors,
+}: {
+  sourceValue: unknown
+  targetSchemaType: ArraySchemaType
+  errors: TransferValueError[]
+}): {
+  targetValue: unknown
+  errors: TransferValueError[]
+} {
+  let targetValue: unknown[] | undefined = undefined
+
+  const genericValue = sourceValue as unknown[]
+
+  if (!genericValue || !Array.isArray(genericValue)) {
+    return {
+      targetValue: undefined,
+      errors: [
+        {
+          level: 'error',
+          message: `Value of type ${typeof genericValue}, is not allowed in this array field`,
+          sourceValue,
+        },
+      ],
+    }
+  }
+  const isArrayOfPrimitivesMember = isArrayOfPrimitivesSchemaType(targetSchemaType)
+  const isArrayOfObjectsMember = isArrayOfObjectsSchemaType(targetSchemaType)
+
+  // Primitive array
+  if (isArrayOfPrimitivesMember) {
+    const transferredItems = genericValue.filter(
+      (item) =>
+        (typeof item === 'number' &&
+          targetSchemaType.of.map((type) => type.jsonType).includes('number')) ||
+        (typeof item === 'string' &&
+          targetSchemaType.of.map((type) => type.jsonType).includes('string')) ||
+        (typeof item === 'boolean' &&
+          targetSchemaType.of.map((type) => type.jsonType).includes('boolean')),
+    )
+    const nonTransferredItems = genericValue.filter((item) => !transferredItems.includes(item))
+    if (nonTransferredItems.length > 0) {
+      nonTransferredItems.forEach((item) => {
+        errors.push({
+          level: transferredItems.length > 0 ? 'warning' : 'error',
+          message: `Value of type ${typeof item}, is not allowed in this array field`,
+          sourceValue: item,
+        })
+      })
+    }
+    if (transferredItems.length > 0) {
+      targetValue = transferredItems
+    }
+  }
+
+  // Object array
+  if (isArrayOfObjectsMember) {
+    const value = sourceValue as TypedObject[]
+    const transferredItems = value.filter((item) =>
+      targetSchemaType.of.some((type) => type.name === item._type),
+    )
+    const nonTransferredItems = value.filter(
+      (item) => !targetSchemaType.of.some((type) => type.name === item._type),
+    )
+    targetValue =
+      transferredItems.length > 0
+        ? transferredItems.map((item) => cleanObjectKeys(item))
+        : undefined
+    if (nonTransferredItems.length > 0) {
+      nonTransferredItems.forEach((item) => {
+        errors.push({
+          level: transferredItems.length > 0 ? 'warning' : 'error',
+          message: `Value of type '${item._type || typeof item}' is not allowed in this array field`,
+          sourceValue: item,
+        })
+      })
+    }
+  }
+
+  return {
+    targetValue,
+    errors,
+  }
+}
+
+function collatePrimitiveValue({
+  sourceValue,
+  targetSchemaType,
+  errors,
+}: {
+  sourceValue: unknown
+  targetSchemaType: NumberSchemaType | StringSchemaType | BooleanSchemaType
+  errors: TransferValueError[]
+}): {
+  targetValue: unknown
+  errors: TransferValueError[]
+} {
+  let targetValue: unknown
+  const primitiveValue = sourceValue as unknown
+  if (typeof primitiveValue === 'undefined') {
+    return {
+      targetValue: undefined,
+      errors,
+    }
+  }
+  const isSamePrimitiveType = targetSchemaType.jsonType === typeof primitiveValue
+  if (isSamePrimitiveType) {
+    targetValue = primitiveValue
+  } else {
+    errors.push({
+      level: 'error',
+      message: `Value of type ${typeof primitiveValue}, is not allowed in this field`,
+      sourceValue: primitiveValue,
+    })
+  }
+  return {
+    targetValue,
+    errors,
+  }
+}
+
+function cleanObjectKeys(obj: TypedObject) {
+  const disallowedKeys = ['_id', '_createdAt', '_updatedAt', '_rev']
+  return Object.keys(obj).reduce((acc, key) => {
+    if (disallowedKeys.includes(key)) {
+      return acc
+    }
+    return {...acc, [key]: obj[key]}
+  }, {})
 }


### PR DESCRIPTION
### Description

This is a new and improved version of the transferValue function.

It's made more generic so that it's not too tightly coupled to the CopyPasteAction.

It will also work recursively in objects and array values, besides collecting warnings / errors for the result.

I have hooked it up with the copy/paste functionality for the studio.

Also made some new tests for the function.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
