### PR TITLE
fix(form): avoid spreading key prop

### DIFF
--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
@@ -56,9 +56,9 @@ export function GridArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
 
   const sortable = schemaType.options?.sortable !== false
 
-  const renderItem = useCallback((itemProps: Omit<ObjectItemProps, 'renderDefault'>) => {
+  const renderItem = useCallback(({key, ...itemProps}: Omit<ObjectItemProps, 'renderDefault'>) => {
     // todo: consider using a different item component for references
-    return <GridItem {...itemProps} />
+    return <GridItem key={key} {...itemProps} />
   }, [])
 
   const memberKeys = useMemo(() => members.map((member) => member.key), [members])


### PR DESCRIPTION
Before this change, React would throw a runtime error stating that `A props object containing a "key" prop is being spread into JSX`. Now, the `key` is passed to the JSX without using spread.
