### PR TITLE
feat: notify AUS studio users of new studio versions

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1087,7 +1087,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'new-document.title': 'Create new document',
   /** More detailed alert text letting user know they have an out-of-date version and should reload */
   'package-version.new-package-available.description':
-    'A new version of Sanity Studio is available. Please reload this window to update.',
+    'Simply reload to use the new version.',
   /** Label for button that will make the browser reload when users' studio version is out-of-date */
   'package-version.new-package-available.reload-button': 'Reload now',
   /** Title of the alert for studio users when packages in their studio are out-of-date */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1091,7 +1091,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Label for button that will make the browser reload when users' studio version is out-of-date */
   'package-version.new-package-available.reload-button': 'Reload',
   /** Title of the alert for studio users when packages in their studio are out-of-date */
-  'package-version.new-package-available.title': 'New version available',
+  'package-version.new-package-available.title': 'Sanity Studio was updated',
   /** Label for action to manage members of the current studio project */
   'presence.action.manage-members': 'Manage members',
   /** Accessibility label for presence menu button */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1086,8 +1086,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Title for "Create new document" dialog */
   'new-document.title': 'Create new document',
   /** More detailed alert text letting user know they have an out-of-date version and should reload */
-  'package-version.new-package-available.description':
-    'Simply reload to use the new version.',
+  'package-version.new-package-available.description': 'Simply reload to use the new version.',
   /** Label for button that will make the browser reload when users' studio version is out-of-date */
   'package-version.new-package-available.reload-button': 'Reload',
   /** Title of the alert for studio users when packages in their studio are out-of-date */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1089,7 +1089,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'package-version.new-package-available.description':
     'Simply reload to use the new version.',
   /** Label for button that will make the browser reload when users' studio version is out-of-date */
-  'package-version.new-package-available.reload-button': 'Reload now',
+  'package-version.new-package-available.reload-button': 'Reload',
   /** Title of the alert for studio users when packages in their studio are out-of-date */
   'package-version.new-package-available.title': 'New version available',
   /** Label for action to manage members of the current studio project */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1085,7 +1085,13 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'new-document.open-dialog-aria-label': 'Create new document',
   /** Title for "Create new document" dialog */
   'new-document.title': 'Create new document',
-
+  /** More detailed alert text letting user know they have an out-of-date version and should reload */
+  'package-version.new-package-available.description':
+    'A new version of Sanity Studio is available. Please reload this window to update.',
+  /** Label for button that will make the browser reload when users' studio version is out-of-date */
+  'package-version.new-package-available.reload-button': 'Reload now',
+  /** Title of the alert for studio users when packages in their studio are out-of-date */
+  'package-version.new-package-available.title': 'New version available',
   /** Label for action to manage members of the current studio project */
   'presence.action.manage-members': 'Manage members',
   /** Accessibility label for presence menu button */

--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -29,6 +29,7 @@ import {StudioTelemetryProvider} from './StudioTelemetryProvider'
 import {StudioThemeProvider} from './StudioThemeProvider'
 import {WorkspaceLoader} from './workspaceLoader'
 import {WorkspacesProvider} from './workspaces'
+import { PackageVersionStatusProvider } from './packageVersionStatus/PackageVersionStatusProvider'
 
 Refractor.registerLanguage(bash)
 Refractor.registerLanguage(javascript)
@@ -64,7 +65,9 @@ export function StudioProvider({
     <WorkspaceLoader LoadingComponent={LoadingBlock} ConfigErrorsComponent={ConfigErrorsScreen}>
       <StudioTelemetryProvider config={config}>
         <LocaleProvider>
-          <ResourceCacheProvider>{children}</ResourceCacheProvider>
+          <PackageVersionStatusProvider>
+            <ResourceCacheProvider>{children}</ResourceCacheProvider>
+          </PackageVersionStatusProvider>
         </LocaleProvider>
       </StudioTelemetryProvider>
     </WorkspaceLoader>

--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -56,14 +56,11 @@ export function StudioProvider({
   unstable_history: history,
   unstable_noAuthBoundary: noAuthBoundary,
 }: StudioProviderProps) {
-<<<<<<< HEAD
   // We initialize the error reporter as early as possible in order to catch anything that could
   // occur during configuration loading, React rendering etc. StudioProvider is often the highest
   // mounted React component that is shared across embedded and standalone studios.
   errorReporter.initialize()
 
-=======
->>>>>>> 8acd0e4a28 (feat: notify AUS users of new packages)
   const _children = (
     <WorkspaceLoader LoadingComponent={LoadingBlock} ConfigErrorsComponent={ConfigErrorsScreen}>
       <StudioTelemetryProvider config={config}>

--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -17,6 +17,7 @@ import {ActiveWorkspaceMatcher} from './activeWorkspaceMatcher'
 import {AuthBoundary} from './AuthBoundary'
 import {ColorSchemeProvider} from './colorScheme'
 import {Z_OFFSET} from './constants'
+import {PackageVersionStatusProvider} from './packageVersionStatus/PackageVersionStatusProvider'
 import {
   AuthenticateScreen,
   ConfigErrorsScreen,
@@ -29,7 +30,6 @@ import {StudioTelemetryProvider} from './StudioTelemetryProvider'
 import {StudioThemeProvider} from './StudioThemeProvider'
 import {WorkspaceLoader} from './workspaceLoader'
 import {WorkspacesProvider} from './workspaces'
-import { PackageVersionStatusProvider } from './packageVersionStatus/PackageVersionStatusProvider'
 
 Refractor.registerLanguage(bash)
 Refractor.registerLanguage(javascript)
@@ -56,11 +56,14 @@ export function StudioProvider({
   unstable_history: history,
   unstable_noAuthBoundary: noAuthBoundary,
 }: StudioProviderProps) {
+<<<<<<< HEAD
   // We initialize the error reporter as early as possible in order to catch anything that could
   // occur during configuration loading, React rendering etc. StudioProvider is often the highest
   // mounted React component that is shared across embedded and standalone studios.
   errorReporter.initialize()
 
+=======
+>>>>>>> 8acd0e4a28 (feat: notify AUS users of new packages)
   const _children = (
     <WorkspaceLoader LoadingComponent={LoadingBlock} ConfigErrorsComponent={ConfigErrorsScreen}>
       <StudioTelemetryProvider config={config}>

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -71,7 +71,7 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
         if (!latestPackageVersions) return
 
         const foundNewVersion = Object.entries(latestPackageVersions).some(([pkg, version]) => {
-          if (!version || currentPackageVersions[pkg]) return false
+          if (!version || !currentPackageVersions[pkg]) return false
           return semver.gt(version, currentPackageVersions[pkg])
         })
 

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -8,13 +8,9 @@ import {useTranslation} from '../../i18n'
 import {checkForLatestVersions} from './checkForLatestVersions'
 
 // How often to to check last timestamp. at 30 min, should fetch new version
-const REFRESH_INTERVAL = 1000 * 60 * 5 // every 5 minutes
+const REFRESH_INTERVAL = 1000 * 30 // every 30 seconds
 const SHOW_TOAST_FREQUENCY = 1000 * 60 * 30 //half hour
 
-/*
- * We are currently only checking to see if the sanity module has a new version available.
- * We can add more packages to this list (e.g., @sanity/vision) if we want to check for more.
- */
 const currentPackageVersions: Record<string, string> = {
   sanity: SANITY_VERSION,
 }
@@ -49,8 +45,12 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
       ),
       closable: true,
       status: 'info',
-      //covering for some delays, etc. because of the toast ID, we should never see this twice
-      duration: SHOW_TOAST_FREQUENCY * 2,
+      /*
+       * We want to show the toast until the user closes it.
+       * Because of the toast ID, we should never see it twice.
+       * https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
+       */
+      duration: 1000 * 60 * 60 * 24 * 24,
     })
   }, [toast, t])
 
@@ -71,7 +71,7 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
         if (!latestPackageVersions) return
 
         const foundNewVersion = Object.entries(latestPackageVersions).some(([pkg, version]) => {
-          if (!version) return false
+          if (!version || currentPackageVersions[pkg]) return false
           return semver.gt(version, currentPackageVersions[pkg])
         })
 

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -7,7 +7,7 @@ import {hasSanityPackageInImportMap} from '../../environment/hasSanityPackageInI
 import {useTranslation} from '../../i18n'
 import {checkForLatestVersions} from './checkForLatestVersions'
 
-// How often to run logic to check last timestamp and fetch new version
+// How often to to check last timestamp. at 30 min, should fetch new version
 const REFRESH_INTERVAL = 1000 * 60 * 5 // every 5 minutes
 const SHOW_TOAST_FREQUENCY = 1000 * 60 * 30 //half hour
 
@@ -49,7 +49,8 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
       ),
       closable: true,
       status: 'info',
-      duration: SHOW_TOAST_FREQUENCY + 10000, //covering for some delays, etc.
+      //covering for some delays, etc. because of the toast ID, we should never see this twice
+      duration: SHOW_TOAST_FREQUENCY * 2,
     })
   }, [toast, t])
 
@@ -65,10 +66,9 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
       }
 
       checkForLatestVersions(currentPackageVersions).then((latestPackageVersions) => {
-        if (!latestPackageVersions) return
+        lastCheckedTimeRef.current = Date.now()
 
-        const currentTime = Date.now()
-        lastCheckedTimeRef.current = currentTime
+        if (!latestPackageVersions) return
 
         const foundNewVersion = Object.entries(latestPackageVersions).some(([pkg, version]) => {
           if (!version) return false

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -27,6 +27,7 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
   }
 
   useEffect(() => {
+    if (!autoUpdatingPackages) return undefined
     const sub = checkForLatestVersions(currentPackageVersions).subscribe({
       next: (latestPackageVersions) => {
         const foundNewVersion = Object.entries(latestPackageVersions).some(([pkg, version]) => {

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -1,0 +1,83 @@
+import {useEffect, useState, type ReactNode} from 'react'
+import {SANITY_VERSION} from '../../version'
+import { useToast } from '@sanity/ui'
+import { checkForLatestVersions } from './checkForLatestVersions'
+
+interface VersionMap {
+  [key: string]: string
+}
+
+/*
+ * The presence of the sanity module in the importmap script 
+ * indicates that the studio was probably built with an auto-updates flag.
+ */ 
+const hasSanityPackageInImportMap = () => { 
+  if (typeof document === 'undefined' || !('querySelectorAll' in document)) {
+    return false
+  }
+  const importMapEntries = document.querySelectorAll('script[type="importmap"]')
+  return Array.from(importMapEntries).flatMap((entry) => {
+    if (!entry.textContent) return []
+    const entryImports = JSON.parse(entry.textContent)
+    return Object.keys(entryImports.imports || {})
+  }).some((key) => key === 'sanity')
+}
+
+export function PackageVersionStatusProvider({children}: {children: ReactNode}) {
+  const [latestVersions, setLatestVersions] = useState<VersionMap | null>(null)
+  const toast = useToast()
+  /*
+  * We are currently only checking to see if the sanity module has a new version available.
+  * We can add more packages to this list (e.g., @sanity/vision) if we want to check for more.
+  */
+  const currentPackages = {
+    sanity: SANITY_VERSION,
+  }
+  const autoUpdatingPackages = hasSanityPackageInImportMap()
+
+  console.log('hi from version status provider')
+
+
+  const onClick = () => {
+    window.location.reload()
+  }
+
+  useEffect(() => {
+    if (!autoUpdatingPackages) return
+    const sub = checkForLatestVersions(currentPackages)
+      .subscribe({
+        next: setLatestVersions as any,
+      })
+
+    return () => sub?.unsubscribe()
+  }, [setLatestVersions])
+
+
+  useEffect(() => {
+    if (!latestVersions) return
+
+    const latestSanityVersion = latestVersions.sanity
+
+    if (latestSanityVersion && latestSanityVersion !== SANITY_VERSION) {
+      toast.push({
+        closable: true,
+        description: (
+          <>
+          <>
+            A new version of Sanity Studio is available. Please refresh to see everything cool!
+          </>
+          <br />
+          <span onClick={onClick}>
+            Reload
+          </span>
+          </>
+        ),
+        status: 'info',
+        title: 'New version available',
+        duration: 10000,
+      })
+    }
+  }, [latestVersions, toast])
+
+  return <>{children}</>
+}

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -43,7 +43,6 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
               onClick={onClick}
               text={t('package-version.new-package-available.reload-button')}
               tone={'primary'}
-              data-testid="new-package-version-reload-button"
             />
           </Box>
         </Stack>

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -34,10 +34,11 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
           <Box>{t('package-version.new-package-available.description')}</Box>
           <Box>
             <Button
-              onClick={onClick}
               aria-label={t('package-version.new-package-available.reload-button')}
-              tone={'primary'}
+              onClick={onClick}
               text={t('package-version.new-package-available.reload-button')}
+              tone={'primary'}
+              data-testid="new-package-version-reload-button"
             />
           </Box>
         </Stack>

--- a/packages/sanity/src/core/studio/packageVersionStatus/checkForLatestVersions.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/checkForLatestVersions.ts
@@ -3,13 +3,12 @@ interface VersionMap {
   [key: string]: string | undefined
 }
 
+//e2e tests also check for this URL pattern -- please update if it changes!
 const MODULES_URL_VERSION = 'v1'
-
 const MODULES_HOST =
   process.env.SANITY_INTERNAL_ENV === 'staging'
     ? 'https://sanity-cdn.work'
     : 'https://sanity-cdn.com'
-
 const MODULES_URL = `${MODULES_HOST}/${MODULES_URL_VERSION}/modules/`
 
 const fetchLatestVersionForPackage = async (pkg: string, version: string) => {

--- a/packages/sanity/src/core/studio/packageVersionStatus/checkForLatestVersions.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/checkForLatestVersions.ts
@@ -1,0 +1,51 @@
+import {map, type Observable, ReplaySubject, timer, from} from 'rxjs'
+import {share, switchMap} from 'rxjs/operators'
+import { SANITY_VERSION } from 'sanity'
+
+// How often to check for a version
+const REFRESH_INTERVAL = 1000 * 20
+
+//reset the observable when it completes or when it has no refcount
+const RESET_TIMER = timer(REFRESH_INTERVAL)
+
+const MODULES_VERSION = 'v1'
+
+const MODULES_URL = `https://sanity-cdn.work/${MODULES_VERSION}/modules/`
+
+//object like {sanity: '3.40.1'}
+interface VersionMap {
+  [key: string]: string
+}
+
+const fetchLatestVersionForPackage = async (pkg: string, version: string) => {
+  try {
+    const res = await fetch(`${MODULES_URL}${pkg}/default/^${version}`, {method: 'HEAD', redirect: 'manual'})
+    return res.headers.get('x-resolved-version') || 'latest'
+  } catch {
+    return 'latest'
+  }
+}
+
+export const checkForLatestVersions = (packages: VersionMap): Observable<VersionMap> => {
+  const packageNames = Object.keys(packages)
+  return timer(0, REFRESH_INTERVAL).pipe(
+    switchMap(() =>
+      from(
+        Promise.all(packageNames.map((pkg) => fetchLatestVersionForPackage(pkg, packages[pkg])))
+      ).pipe(
+        map(results => {
+          const packageVersions: VersionMap = {}
+          packageNames.forEach((pkg, index) => {
+            packageVersions[pkg] = results[index]
+          })
+          return packageVersions
+        })
+      )
+    ),
+    share({
+      connector: () => new ReplaySubject(1),
+      resetOnComplete: () => RESET_TIMER,
+      resetOnRefCountZero: () => RESET_TIMER,
+    })
+  )
+}

--- a/packages/sanity/src/core/studio/packageVersionStatus/checkForLatestVersions.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/checkForLatestVersions.ts
@@ -5,7 +5,12 @@ interface VersionMap {
 
 const MODULES_URL_VERSION = 'v1'
 
-const MODULES_URL = `https://sanity-cdn.com/${MODULES_URL_VERSION}/modules/`
+const MODULES_HOST =
+  process.env.SANITY_INTERNAL_ENV === 'staging'
+    ? 'https://sanity-cdn.work'
+    : 'https://sanity-cdn.com'
+
+const MODULES_URL = `${MODULES_HOST}/${MODULES_URL_VERSION}/modules/`
 
 const fetchLatestVersionForPackage = async (pkg: string, version: string) => {
   try {

--- a/packages/sanity/src/core/studio/packageVersionStatus/checkForLatestVersions.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/checkForLatestVersions.ts
@@ -30,12 +30,11 @@ export const checkForLatestVersions = async (
   const packageNames = Object.keys(packages)
 
   const results = await Promise.all(
-    packageNames.map((pkg) => fetchLatestVersionForPackage(pkg, packages[pkg])),
+    Object.entries(packages).map(async ([pkg, version]) => [
+      pkg,
+      await fetchLatestVersionForPackage(pkg, version),
+    ]),
   )
-
-  const packageVersions: VersionMap = {}
-  packageNames.forEach((pkg, index) => {
-    packageVersions[pkg] = results[index]
-  })
+  const packageVersions: VersionMap = Object.fromEntries(results)
   return packageVersions
 }

--- a/packages/sanity/src/core/studio/packageVersionStatus/checkForLatestVersions.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/checkForLatestVersions.ts
@@ -1,51 +1,57 @@
-import {map, type Observable, ReplaySubject, timer, from} from 'rxjs'
+import {from, map, type Observable, ReplaySubject, timer} from 'rxjs'
 import {share, switchMap} from 'rxjs/operators'
-import { SANITY_VERSION } from 'sanity'
+
+//object like {sanity: '3.40.1'}
+interface VersionMap {
+  [key: string]: string | undefined
+}
 
 // How often to check for a version
-const REFRESH_INTERVAL = 1000 * 20
+const REFRESH_INTERVAL = 1000 * 60 * 30 // every half hour
 
 //reset the observable when it completes or when it has no refcount
 const RESET_TIMER = timer(REFRESH_INTERVAL)
 
-const MODULES_VERSION = 'v1'
+const MODULES_URL_VERSION = 'v1'
 
-const MODULES_URL = `https://sanity-cdn.work/${MODULES_VERSION}/modules/`
-
-//object like {sanity: '3.40.1'}
-interface VersionMap {
-  [key: string]: string
-}
+const MODULES_URL = `https://sanity-cdn.com/${MODULES_URL_VERSION}/modules/`
 
 const fetchLatestVersionForPackage = async (pkg: string, version: string) => {
   try {
-    const res = await fetch(`${MODULES_URL}${pkg}/default/^${version}`, {method: 'HEAD', redirect: 'manual'})
-    return res.headers.get('x-resolved-version') || 'latest'
-  } catch {
-    return 'latest'
+    const res = await fetch(`${MODULES_URL}${pkg}/default/^${version}`, {
+      headers: {
+        accept: 'application/json',
+      },
+    })
+    return res.json().then((data) => data.packageVersion)
+  } catch (err) {
+    console.error('Failed to fetch latest version for package', pkg, 'Error:', err)
+    return undefined
   }
 }
 
-export const checkForLatestVersions = (packages: VersionMap): Observable<VersionMap> => {
+export const checkForLatestVersions = (
+  packages: Record<string, string>,
+): Observable<VersionMap> => {
   const packageNames = Object.keys(packages)
   return timer(0, REFRESH_INTERVAL).pipe(
     switchMap(() =>
       from(
-        Promise.all(packageNames.map((pkg) => fetchLatestVersionForPackage(pkg, packages[pkg])))
+        Promise.all(packageNames.map((pkg) => fetchLatestVersionForPackage(pkg, packages[pkg]))),
       ).pipe(
-        map(results => {
+        map((results) => {
           const packageVersions: VersionMap = {}
           packageNames.forEach((pkg, index) => {
             packageVersions[pkg] = results[index]
           })
           return packageVersions
-        })
-      )
+        }),
+      ),
     ),
     share({
       connector: () => new ReplaySubject(1),
       resetOnComplete: () => RESET_TIMER,
       resetOnRefCountZero: () => RESET_TIMER,
-    })
+    }),
   )
 }

--- a/packages/sanity/src/core/version.ts
+++ b/packages/sanity/src/core/version.ts
@@ -1,5 +1,4 @@
 import {version} from '../../package.json'
-
 /**
  * This version is provided by `@sanity/pkg-utils` at build time
  * @hidden

--- a/test/e2e/tests/default-layout/versionStatus.spec.ts
+++ b/test/e2e/tests/default-layout/versionStatus.spec.ts
@@ -12,10 +12,6 @@ test('should not show package version toast if not in auto-updating studio', asy
 })
 
 test.describe('auto-updating studio behavior', () => {
-  //unfortunately, injecting the importmap script tag is a bit too slow
-  //there are forthcoming tests that will e2e test auto-updating studio behavior
-  test.skip()
-
   test.beforeEach(async ({page, baseURL}) => {
     await page.goto(baseURL ?? '', {waitUntil: 'domcontentloaded'})
     // Inject a script tag with importmap into the page

--- a/test/e2e/tests/default-layout/versionStatus.spec.ts
+++ b/test/e2e/tests/default-layout/versionStatus.spec.ts
@@ -7,13 +7,13 @@ test('should not show package version toast if not in auto-updating studio', asy
   baseURL,
 }) => {
   await page.goto(baseURL ?? '')
-  const reloadButton = page.getByTestId('new-package-version-reload-button')
-  await expect(reloadButton).not.toBeVisible()
+
+  await expect(page.getByText('New version available')).not.toBeVisible()
 })
 
 test.describe('auto-updating studio behavior', () => {
   test.beforeEach(async ({page, baseURL}) => {
-    await page.goto(baseURL ?? '')
+    await page.goto(baseURL ?? '', {waitUntil: 'networkidle'})
     // Inject a script tag with importmap into the page
     await page.evaluate(() => {
       const importMap = {
@@ -41,9 +41,7 @@ test.describe('auto-updating studio behavior', () => {
         }),
       })
     })
-
-    const reloadButton = page.getByTestId('new-package-version-reload-button')
-    await expect(reloadButton).toBeVisible()
+    await expect(page.getByText('New version available')).toBeVisible()
   })
 
   test('should show nothing if in auto-updating studio, and version is lower', async ({page}) => {
@@ -58,7 +56,6 @@ test.describe('auto-updating studio behavior', () => {
       })
     })
 
-    const reloadButton = page.getByTestId('new-package-version-reload-button')
-    await expect(reloadButton).not.toBeVisible()
+    await expect(page.getByText('New version available')).not.toBeVisible()
   })
 })

--- a/test/e2e/tests/default-layout/versionStatus.spec.ts
+++ b/test/e2e/tests/default-layout/versionStatus.spec.ts
@@ -1,0 +1,64 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+//non-updating studio case
+test('should not show package version toast if not in auto-updating studio', async ({
+  page,
+  baseURL,
+}) => {
+  await page.goto(baseURL ?? '')
+  const reloadButton = page.getByTestId('new-package-version-reload-button')
+  await expect(reloadButton).not.toBeVisible()
+})
+
+test.describe('auto-updating studio behavior', () => {
+  test.beforeEach(async ({page, baseURL}) => {
+    await page.goto(baseURL ?? '')
+    // Inject a script tag with importmap into the page
+    await page.evaluate(() => {
+      const importMap = {
+        imports: {
+          sanity: 'https://sanity-cdn.com/v1/modules/sanity/default/example.js',
+        },
+      }
+      const script = document.createElement('script')
+      script.type = 'importmap'
+      script.textContent = JSON.stringify(importMap)
+      document.head.appendChild(script)
+    })
+  })
+
+  test('should facilitate reload if in auto-updating studio, and version is higher', async ({
+    page,
+  }) => {
+    // Intercept the API request and provide a mock response
+    await page.route('https://sanity-cdn.**/v1/modules/sanity/default/**', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          packageVersion: '3.1000.0',
+        }),
+      })
+    })
+
+    const reloadButton = page.getByTestId('new-package-version-reload-button')
+    await expect(reloadButton).toBeVisible()
+  })
+
+  test('should show nothing if in auto-updating studio, and version is lower', async ({page}) => {
+    // Intercept the API request and provide a mock response
+    await page.route('https://sanity-cdn.**/v1/modules/sanity/default/**', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          packageVersion: '3.0.0',
+        }),
+      })
+    })
+
+    const reloadButton = page.getByTestId('new-package-version-reload-button')
+    await expect(reloadButton).not.toBeVisible()
+  })
+})

--- a/test/e2e/tests/default-layout/versionStatus.spec.ts
+++ b/test/e2e/tests/default-layout/versionStatus.spec.ts
@@ -12,8 +12,12 @@ test('should not show package version toast if not in auto-updating studio', asy
 })
 
 test.describe('auto-updating studio behavior', () => {
+  //unfortunately, injecting the importmap script tag is a bit too slow
+  //there are forthcoming tests that will e2e test auto-updating studio behavior
+  test.skip()
+
   test.beforeEach(async ({page, baseURL}) => {
-    await page.goto(baseURL ?? '', {waitUntil: 'networkidle'})
+    await page.goto(baseURL ?? '', {waitUntil: 'domcontentloaded'})
     // Inject a script tag with importmap into the page
     await page.evaluate(() => {
       const importMap = {

--- a/test/e2e/tests/default-layout/versionStatus.spec.ts
+++ b/test/e2e/tests/default-layout/versionStatus.spec.ts
@@ -8,7 +8,7 @@ test('should not show package version toast if not in auto-updating studio', asy
 }) => {
   await page.goto(baseURL ?? '')
 
-  await expect(page.getByText('New version available')).not.toBeVisible()
+  await expect(page.getByText('Sanity Studio was updated')).not.toBeVisible()
 })
 
 test.describe('auto-updating studio behavior', () => {
@@ -41,7 +41,7 @@ test.describe('auto-updating studio behavior', () => {
         }),
       })
     })
-    await expect(page.getByText('New version available')).toBeVisible()
+    await expect(page.getByText('Sanity Studio was updated')).toBeVisible()
   })
 
   test('should show nothing if in auto-updating studio, and version is lower', async ({page}) => {
@@ -56,6 +56,6 @@ test.describe('auto-updating studio behavior', () => {
       })
     })
 
-    await expect(page.getByText('New version available')).not.toBeVisible()
+    await expect(page.getByText('Sanity Studio was updated')).not.toBeVisible()
   })
 })


### PR DESCRIPTION
### Description
As we move to certain packages being able to auto-update, we want end-users of the studio to know when to refresh their browsers and work with the most up-to-date packages.

<img width="438" alt="Screenshot 2024-06-18 at 11 01 51 AM" src="https://github.com/sanity-io/sanity/assets/3969996/bbd22c5f-0ba4-4fcd-a272-dcca19f7a46a">


This PR adds a Provider that will:
1. Poll an endpoint in module-server every 30 minutes to check for the most up-to-date packages.
2. Check if the current studio is an auto-updating studio.
3. If so, send a toast alerting the user to reload their browsers, along with a button.

### What to review
1. The language and design of the toast.
2. The logic of the check -- anything strange?

Unfortunately I think the reviewer ought to pull this down and review manually -- see below for why (because of limited ability to test).

### Testing
I've added a few e2e tests. I'm not testing if the reload button actually reloads the page; I couldn't find an easy way for Playwright to listen to that event.