### PR TITLE
fix(search): include `text` type fields in search queries

### DIFF
--- a/packages/sanity/src/core/search/common/__tests__/deriveSearchWeightsFromType.test.ts
+++ b/packages/sanity/src/core/search/common/__tests__/deriveSearchWeightsFromType.test.ts
@@ -23,6 +23,8 @@ describe('deriveSearchWeightsFromType', () => {
           preview: {select: {}},
           fields: [
             defineField({name: 'simpleStringField', type: 'string'}),
+            defineField({name: 'descriptionTextField', type: 'text'}),
+            defineField({name: 'markdownField', type: 'markdown'}),
             defineField({
               name: 'simplePtField',
               type: 'array',
@@ -83,6 +85,10 @@ describe('deriveSearchWeightsFromType', () => {
             }),
           ],
         }),
+        defineType({
+          name: 'markdown',
+          type: 'text',
+        }),
       ],
     })
 
@@ -97,6 +103,8 @@ describe('deriveSearchWeightsFromType', () => {
         {path: '_id', weight: 1},
         {path: '_type', weight: 1},
         {path: 'simpleStringField', weight: 1},
+        {path: 'descriptionTextField', weight: 1},
+        {path: 'markdownField', weight: 1},
         {path: 'simplePtField', weight: 1, mapWith: 'pt::text'},
         {path: 'simpleObject.nestedStringField', weight: 1},
         {path: 'simpleObject.nestedPtField', weight: 1, mapWith: 'pt::text'},

--- a/packages/sanity/src/core/search/common/deriveSearchWeightsFromType.ts
+++ b/packages/sanity/src/core/search/common/deriveSearchWeightsFromType.ts
@@ -29,8 +29,8 @@ const isPtField = (type: SchemaType | undefined) =>
   type?.jsonType === 'array' &&
   type.of.some((arrType) => getTypeChain(arrType).some(({name}) => name === 'block'))
 
-const isStringField = (schemaType: SchemaType | undefined) =>
-  getTypeChain(schemaType).some((type) => type.name === 'string')
+const isStringField = (schemaType: SchemaType | undefined): boolean =>
+  schemaType ? schemaType?.jsonType === 'string' : false
 
 const isSearchConfiguration = (options: unknown): options is SearchConfiguration =>
   isRecord(options) && 'search' in options && isRecord(options.search)


### PR DESCRIPTION
### Description

It seems we do not include fields of type `text` in the list of fields to search for. 
Upon some investigation, it seems like we are traversing the type chain in order to find any type that extends from `string`. This isn't strictly necessary, as there is a `jsonType` property that allows us to more easily tell this. The `text` type does not actually "extend" `string` in the same way as user-defined types does, so it did not pass the previous check.

This PR changes to use `jsonType` for determining the string fields.

See #6698

### What to review

- Searching for text in string fields work
- Searching for text in text fields work
- Searching for text in portable text fields work
 
### Testing

Added a test to the function that derives weights from types that checks that both `text` fields and fields of types that _extend_ `text` are included in the search.

### Notes for release

- Fixes an issue where searching for text within fields of type `text` (not `string`) would not yield results
