### PR TITLE
feat(core): add support for copying objects and reference fields

### DIFF
--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -7,8 +7,6 @@ import {muxInput} from 'sanity-plugin-mux-input'
 import {imageAssetSource} from 'sanity-test-studio/assetSources'
 import {resolveDocumentActions as documentActions} from 'sanity-test-studio/documentActions'
 import {assistFieldActionGroup} from 'sanity-test-studio/fieldActions/assistFieldActionGroup'
-import {copyAction} from 'sanity-test-studio/fieldActions/copyAction'
-import {pasteAction} from 'sanity-test-studio/fieldActions/pasteAction'
 import {resolveInitialValueTemplates} from 'sanity-test-studio/initialValueTemplates'
 import {customInspector} from 'sanity-test-studio/inspectors/custom'
 import {languageFilter} from 'sanity-test-studio/plugins/language-filter'
@@ -41,7 +39,7 @@ const sharedSettings = definePlugin({
     },
     unstable_fieldActions: (prev, ctx) => {
       if (['fieldActionsTest', 'stringsTest'].includes(ctx.documentType)) {
-        return [...prev, assistFieldActionGroup, copyAction, pasteAction]
+        return [...prev, assistFieldActionGroup]
       }
 
       return prev

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -38,8 +38,6 @@ import {
 import {GoogleLogo, TailwindLogo, VercelLogo} from './components/workspaceLogos'
 import {resolveDocumentActions as documentActions} from './documentActions'
 import {assistFieldActionGroup} from './fieldActions/assistFieldActionGroup'
-import {copyAction} from './fieldActions/copyAction'
-import {pasteAction} from './fieldActions/pasteAction'
 import {resolveInitialValueTemplates} from './initialValueTemplates'
 import {customInspector} from './inspectors/custom'
 import {testStudioLocaleBundles} from './locales'
@@ -82,7 +80,7 @@ const sharedSettings = definePlugin({
       return prev
     },
     unstable_fieldActions: (prev, ctx) => {
-      const defaultActions = [...prev, copyAction, pasteAction]
+      const defaultActions = [...prev]
 
       if (['fieldActionsTest', 'stringsTest'].includes(ctx.documentType)) {
         return [...defaultActions, assistFieldActionGroup]

--- a/dev/test-studio/schema/standard/portableText/allTheBellsAndWhistles.ts
+++ b/dev/test-studio/schema/standard/portableText/allTheBellsAndWhistles.ts
@@ -230,6 +230,26 @@ export const ptAllTheBellsAndWhistlesType = defineType({
               of: [{type: 'block'}],
               validation: (rule) => rule.required().error('Must have content'),
             }),
+            defineField({
+              title: 'Nested object',
+              name: 'nestedObject',
+              type: 'object',
+              fields: [
+                defineField({
+                  name: 'title',
+                  title: 'Title',
+                  type: 'string',
+                  validation: (rule) => rule.required().warning('Should have a title'),
+                }),
+                defineField({
+                  title: 'Box Content',
+                  name: 'body',
+                  type: 'array',
+                  of: [{type: 'block'}],
+                  validation: (rule) => rule.required().error('Must have content'),
+                }),
+              ],
+            }),
           ],
           components: {
             preview: InfoBoxPreview as any,

--- a/packages/sanity/src/core/config/document/fieldActions/index.ts
+++ b/packages/sanity/src/core/config/document/fieldActions/index.ts
@@ -1,3 +1,5 @@
+import {copyAction} from '../../../form/field/actions/copyAction'
+import {pasteAction} from '../../../form/field/actions/pasteAction'
 import {type DocumentFieldAction} from './types'
 
 export * from './define'
@@ -5,4 +7,4 @@ export * from './reducer'
 export * from './types'
 
 /** @internal */
-export const initialDocumentFieldActions: DocumentFieldAction[] = []
+export const initialDocumentFieldActions: DocumentFieldAction[] = [copyAction, pasteAction]

--- a/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
@@ -84,15 +84,18 @@ const Content = styled(Box)<{
    * https://styled-components.com/docs/api#transient-props
    */
   $borderLeft: boolean
+  $focused?: boolean
   theme: Theme
 }>((props) => {
-  const {$borderLeft, theme} = props
+  const {$borderLeft, $focused, theme} = props
   const {focusRing} = theme.sanity
   const {base} = theme.sanity.color
 
   return css`
     outline: none;
     border-left: ${$borderLeft ? '1px solid var(--card-border-color)' : undefined};
+
+    ${$borderLeft && $focused && `border-left: 1px solid var(--card-focus-ring-color);`}
 
     &:focus {
       box-shadow: ${focusRingStyle({base, focusRing: {...focusRing, offset: 2}})};
@@ -225,6 +228,7 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
 
       <Content
         $borderLeft={level > 0}
+        $focused={Boolean(focused)}
         hidden={collapsed}
         paddingLeft={level === 0 ? 0 : 3}
         onFocus={typeof tabIndex === 'number' && tabIndex > -1 ? handleFocus : undefined}

--- a/packages/sanity/src/core/form/field/actions/copyAction.ts
+++ b/packages/sanity/src/core/form/field/actions/copyAction.ts
@@ -1,13 +1,11 @@
 import {CopyIcon} from '@sanity/icons'
+import {type Path} from '@sanity/types'
 import {useCallback} from 'react'
-import {
-  defineDocumentFieldAction,
-  type FormDocumentValue,
-  type Path,
-  useCopyPasteAction,
-  useGetFormValue,
-} from 'sanity'
 
+import {defineDocumentFieldAction} from '../../../config/document/fieldActions/define'
+import {useCopyPasteAction} from '../../../studio/copyPaste/useCopyPasteAction'
+import {useGetFormValue} from '../../contexts/GetFormValue'
+import {type FormDocumentValue} from '../../types/formDocumentValue'
 import {defineActionItem} from './define'
 
 export interface CopyActionResult {

--- a/packages/sanity/src/core/form/field/actions/copyAction.ts
+++ b/packages/sanity/src/core/form/field/actions/copyAction.ts
@@ -35,7 +35,7 @@ export const copyAction = defineDocumentFieldAction({
       type: 'action',
       icon: CopyIcon,
       onAction,
-      title: 'Copy',
+      title: 'Copy field',
       hidden: path.length === 0,
     })
   },

--- a/packages/sanity/src/core/form/field/actions/copyAction.ts
+++ b/packages/sanity/src/core/form/field/actions/copyAction.ts
@@ -26,7 +26,9 @@ export const copyAction = defineDocumentFieldAction({
     const {onCopy} = useCopyPasteAction()
     const onAction = useCallback(() => {
       const value = getFormValue([]) as FormDocumentValue
-      onCopy(path, value)
+      onCopy(path, value, {
+        context: {source: 'fieldAction'},
+      })
     }, [path, onCopy, getFormValue])
 
     return defineActionItem({

--- a/packages/sanity/src/core/form/field/actions/copyAction.ts
+++ b/packages/sanity/src/core/form/field/actions/copyAction.ts
@@ -20,7 +20,7 @@ export interface CopyActionResult {
 }
 
 export const copyAction = defineDocumentFieldAction({
-  name: 'test/copy',
+  name: 'copyField',
   useAction({path}) {
     const getFormValue = useGetFormValue()
     const {onCopy} = useCopyPasteAction()

--- a/packages/sanity/src/core/form/field/actions/define.ts
+++ b/packages/sanity/src/core/form/field/actions/define.ts
@@ -1,0 +1,9 @@
+import {type DocumentFieldActionGroup, type DocumentFieldActionItem} from 'sanity'
+
+export function defineActionItem(node: DocumentFieldActionItem): DocumentFieldActionItem {
+  return node
+}
+
+export function defineActionGroup(node: DocumentFieldActionGroup): DocumentFieldActionGroup {
+  return node
+}

--- a/packages/sanity/src/core/form/field/actions/pasteAction.ts
+++ b/packages/sanity/src/core/form/field/actions/pasteAction.ts
@@ -1,7 +1,8 @@
 import {ClipboardIcon} from '@sanity/icons'
 import {useCallback} from 'react'
-import {defineDocumentFieldAction, useCopyPasteAction} from 'sanity'
 
+import {defineDocumentFieldAction} from '../../../config/document/fieldActions/define'
+import {useCopyPasteAction} from '../../../studio/copyPaste/useCopyPasteAction'
 import {defineActionItem} from './define'
 
 export const pasteAction = defineDocumentFieldAction({

--- a/packages/sanity/src/core/form/field/actions/pasteAction.ts
+++ b/packages/sanity/src/core/form/field/actions/pasteAction.ts
@@ -16,7 +16,7 @@ export const pasteAction = defineDocumentFieldAction({
       type: 'action',
       icon: ClipboardIcon,
       onAction,
-      title: 'Paste',
+      title: 'Paste field',
       hidden: path.length === 0,
     })
   },

--- a/packages/sanity/src/core/form/field/actions/pasteAction.ts
+++ b/packages/sanity/src/core/form/field/actions/pasteAction.ts
@@ -10,7 +10,9 @@ export const pasteAction = defineDocumentFieldAction({
   useAction({path}) {
     const {onPaste} = useCopyPasteAction()
     const onAction = useCallback(() => {
-      onPaste(path)
+      onPaste(path, {
+        context: {source: 'fieldAction'},
+      })
     }, [path, onPaste])
 
     return defineActionItem({

--- a/packages/sanity/src/core/form/field/actions/pasteAction.ts
+++ b/packages/sanity/src/core/form/field/actions/pasteAction.ts
@@ -6,7 +6,7 @@ import {useCopyPasteAction} from '../../../studio/copyPaste/useCopyPasteAction'
 import {defineActionItem} from './define'
 
 export const pasteAction = defineDocumentFieldAction({
-  name: 'test/paste',
+  name: 'pasteField',
   useAction({path}) {
     const {onPaste} = useCopyPasteAction()
     const onAction = useCallback(() => {

--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferenceInput.tsx
@@ -2,7 +2,6 @@
 import {ResetIcon as ClearIcon, SyncIcon as ReplaceIcon} from '@sanity/icons'
 import {type CrossDatasetReferenceSchemaType, type CrossDatasetReferenceValue} from '@sanity/types'
 import {Box, Card, Flex, Inline, Menu, Stack, useToast} from '@sanity/ui'
-import {FOCUS_TERMINATOR} from '@sanity/util/paths'
 import {
   type FocusEvent,
   type KeyboardEvent,
@@ -177,7 +176,7 @@ export function CrossDatasetReferenceInput(props: CrossDatasetReferenceInputProp
   const handleFocus = useCallback(
     (event: FocusEvent<HTMLDivElement>) => {
       if (event.currentTarget === elementProps.ref.current) {
-        onPathFocus?.([FOCUS_TERMINATOR])
+        onPathFocus?.([])
       }
     },
     [elementProps.ref, onPathFocus],

--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferenceInput.tsx
@@ -182,6 +182,8 @@ export function CrossDatasetReferenceInput(props: CrossDatasetReferenceInputProp
     [elementProps.ref, onPathFocus],
   )
 
+  const handleBlur = useCallback((event: FocusEvent) => elementProps.onBlur(event), [elementProps])
+
   const handleAutocompleteFocus = useCallback(
     (event: FocusEvent<HTMLInputElement>) => {
       if (event.currentTarget === elementProps.ref.current) {
@@ -345,6 +347,7 @@ export function CrossDatasetReferenceInput(props: CrossDatasetReferenceInputProp
                       __unstable_focusRing
                       tabIndex={0}
                       onFocus={handleFocus}
+                      onBlur={handleBlur}
                       ref={elementProps.ref}
                     >
                       <PreviewReferenceValue
@@ -365,6 +368,7 @@ export function CrossDatasetReferenceInput(props: CrossDatasetReferenceInputProp
                       __unstable_focusRing
                       tabIndex={0}
                       onFocus={handleFocus}
+                      onBlur={handleBlur}
                       ref={elementProps.ref}
                     >
                       <PreviewReferenceValue

--- a/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
@@ -1,6 +1,7 @@
 import {Stack} from '@sanity/ui'
+import {last} from 'lodash'
 import {type FocusEvent, Fragment, memo, useCallback, useMemo, useRef} from 'react'
-import {useFormCallbacks} from 'sanity'
+import {isKeySegment, useFormCallbacks} from 'sanity'
 import styled from 'styled-components'
 
 import {ObjectInputMembers} from '../../members'
@@ -43,6 +44,12 @@ export const ObjectInput = memo(function ObjectInput(props: ObjectInputProps) {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const {columns} = schemaType.options || {}
 
+  // Object inputs should only be focusable if they are not the root object input
+  // This includes if they are in the root of a array block
+  const isFocusable = useMemo(() => {
+    return id !== 'root' && !(path.length > 0 && isKeySegment(last(path)!))
+  }, [id, path])
+
   const renderedUnknownFields = useMemo(() => {
     if (!schemaType.fields) {
       return null
@@ -66,7 +73,7 @@ export const ObjectInput = memo(function ObjectInput(props: ObjectInputProps) {
 
   const handleBlur = useCallback(
     (event: FocusEvent) => {
-      if (id === 'root') {
+      if (!isFocusable) {
         return
       }
 
@@ -75,12 +82,12 @@ export const ObjectInput = memo(function ObjectInput(props: ObjectInputProps) {
         onPathBlur(path)
       }
     },
-    [id, path, onPathBlur],
+    [isFocusable, onPathBlur, path],
   )
 
   const handleFocus = useCallback(
     (event: FocusEvent) => {
-      if (id === 'root') {
+      if (!isFocusable) {
         return
       }
 
@@ -89,7 +96,7 @@ export const ObjectInput = memo(function ObjectInput(props: ObjectInputProps) {
         onPathFocus(path)
       }
     },
-    [id, path, onPathFocus],
+    [isFocusable, onPathFocus, path],
   )
 
   const renderObjectMembers = useCallback(
@@ -124,7 +131,7 @@ export const ObjectInput = memo(function ObjectInput(props: ObjectInputProps) {
   return (
     <RootStack
       space={6}
-      tabIndex={id === 'root' ? undefined : 0}
+      tabIndex={isFocusable ? 0 : undefined}
       onFocus={handleFocus}
       onBlur={handleBlur}
       ref={wrapperRef}

--- a/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
@@ -10,10 +10,10 @@ import {AlignedBottomGrid, FieldGroupTabsWrapper} from './ObjectInput.styled'
 import {UnknownFields} from './UnknownFields'
 
 const RootStack = styled(Stack)`
-  &:-moz-focusring,
-  &:focus-visible {
-    outline: 0px !important;
-    box-shadow: 0 0 0 1em var(--card-focus-ring-color);
+  // Disable focus ring for the object block. We instead highlight the left border on the fieldset
+  // for level > 0 to signal that you have focused on the object
+  &:focus {
+    outline: none;
   }
 `
 

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
@@ -3,6 +3,7 @@ import {type Reference, type ReferenceSchemaType} from '@sanity/types'
 import {Box, Card, type CardTone, Flex, Menu, MenuDivider, Stack} from '@sanity/ui'
 import {
   type ComponentProps,
+  type FocusEvent,
   type ForwardedRef,
   forwardRef,
   useCallback,
@@ -222,6 +223,12 @@ export function ReferenceField(props: ReferenceFieldProps) {
     [handleClear, handleReplace, inputId, OpenLink, readOnly, t, value?._ref],
   )
 
+  const handleFocus = useCallback(() => inputProps.onPathFocus([]), [inputProps])
+  const handleBlur = useCallback(
+    (event: FocusEvent) => inputProps.elementProps.onBlur(event),
+    [inputProps.elementProps],
+  )
+
   return (
     <>
       {documentId && props.actions && props.actions.length > 0 && (
@@ -271,6 +278,8 @@ export function ReferenceField(props: ReferenceFieldProps) {
                       ref={elementRef}
                       selected={selected}
                       tone="inherit"
+                      onFocus={handleFocus}
+                      onBlur={handleBlur}
                     >
                       <PreviewReferenceValue
                         value={value}

--- a/packages/sanity/src/core/hooks/useGlobalCopyPasteElementHandler.ts
+++ b/packages/sanity/src/core/hooks/useGlobalCopyPasteElementHandler.ts
@@ -51,6 +51,13 @@ export function useGlobalCopyPasteElementHandler({
         return
       }
 
+      if (!isInputElement(targetElement)) {
+        const selection = window.getSelection()
+        if (selection && selection?.toString().length > 0) {
+          return
+        }
+      }
+
       onCopy(focusPathRef.current, valueRef.current)
     },
     [onCopy, focusPathRef],
@@ -64,6 +71,13 @@ export function useGlobalCopyPasteElementHandler({
         // Prevent event propogation if we have a selection within an input element
         if (isSelectionWithinInputElement(targetElement as HTMLElement)) {
           return
+        }
+
+        if (!isInputElement(targetElement)) {
+          const selection = window.getSelection()
+          if (selection && selection?.toString().length > 0) {
+            return
+          }
         }
 
         event.preventDefault()

--- a/packages/sanity/src/core/hooks/useGlobalCopyPasteElementHandler.ts
+++ b/packages/sanity/src/core/hooks/useGlobalCopyPasteElementHandler.ts
@@ -58,7 +58,9 @@ export function useGlobalCopyPasteElementHandler({
         }
       }
 
-      onCopy(focusPathRef.current, valueRef.current)
+      onCopy(focusPathRef.current, valueRef.current, {
+        context: {source: 'keyboardShortcut'},
+      })
     },
     [onCopy, focusPathRef],
   )
@@ -82,7 +84,9 @@ export function useGlobalCopyPasteElementHandler({
 
         event.preventDefault()
         event.stopPropagation()
-        onCopy(focusPathRef.current, valueRef.current)
+        onCopy(focusPathRef.current, valueRef.current, {
+          context: {source: 'keyboardShortcut'},
+        })
       }
 
       if (isPasteHotKey(event)) {
@@ -92,7 +96,9 @@ export function useGlobalCopyPasteElementHandler({
         }
 
         event.preventDefault()
-        onPaste(focusPathRef.current)
+        onPaste(focusPathRef.current, {
+          context: {source: 'keyboardShortcut'},
+        })
       }
     },
     [onCopy, onPaste, focusPathRef, valueRef],
@@ -118,7 +124,9 @@ export function useGlobalCopyPasteElementHandler({
             // We insert the value here instead of natively because we need to transform the value above
             insertTextAtCursor(targetElement, `${targetValue}`)
           } else {
-            onPaste(focusPathRef.current)
+            onPaste(focusPathRef.current, {
+              context: {source: 'keyboardShortcut'},
+            })
           }
         } else {
           // If we don't have a copy/paste result in clipboard, pass through the event

--- a/packages/sanity/src/core/studio/copyPaste/__telemetry__/copyPaste.telemetry.ts
+++ b/packages/sanity/src/core/studio/copyPaste/__telemetry__/copyPaste.telemetry.ts
@@ -1,0 +1,37 @@
+import {defineEvent} from '@sanity/telemetry'
+
+interface FieldCopiedInfo {
+  /**
+   * The context the action was triggered from
+   */
+  context: 'fieldAction' | 'keyboardShortcut' | 'unknown'
+  /**
+   * The schema type(s) that was copied
+   */
+  schemaTypes: string[]
+}
+
+interface FieldPastedInfo {
+  /**
+   * The context the action was triggered from
+   */
+  context: 'fieldAction' | 'keyboardShortcut' | 'unknown'
+  /**
+   * The schema(s) type that was copied
+   */
+  schemaTypes: string[]
+}
+
+export const FieldCopied = defineEvent<FieldCopiedInfo>({
+  name: 'Field Copied',
+  version: 1,
+  description:
+    'User clicked the "Copy field" button in the field action menu or used the Ctrl+C shortcut',
+})
+
+export const FieldPasted = defineEvent<FieldPastedInfo>({
+  name: 'Field Pasted',
+  version: 1,
+  description:
+    'User clicked the "Paste field" button in the field action menu or used the Ctrl+V shortcut',
+})

--- a/packages/sanity/src/core/studio/copyPaste/types.ts
+++ b/packages/sanity/src/core/studio/copyPaste/types.ts
@@ -42,3 +42,25 @@ export interface CopyPasteContextType {
   setCopyResult: (result: CopyActionResult) => void
   setDocumentMeta: (meta: Required<DocumentMeta>) => void
 }
+
+/**
+ * @beta
+ * @hidden
+ */
+export interface BaseOptions {
+  context?: {
+    source: 'fieldAction' | 'keyboardShortcut' | 'unknown'
+  }
+}
+
+/**
+ * @beta
+ * @hidden
+ */
+export interface CopyOptions extends BaseOptions {}
+
+/**
+ * @beta
+ * @hidden
+ */
+export interface PasteOptions extends BaseOptions {}


### PR DESCRIPTION
### Description

- Adds support for focusing and copying objects
- Add support for focusing and copying selected references (already works on empty reference fields)
- Fixes focus path for CDR inputs
- Adds telemetry
- Makes labels on field actions explicit (`Copy field` & `Paste field`)