### PR TITLE
fix(cli): allow using auto-updates in unattended mode

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -42,6 +42,9 @@ export default async function buildSanityStudio(
     ...args.extOptions,
   }
 
+  /**
+   * Unattended mode means that if there are any prompts it will use `YES` for them but will no change anything that doesn't have a prompt
+   */
   const unattendedMode = Boolean(flags.yes || flags.y)
   const defaultOutputDir = path.resolve(path.join(workDir, 'dist'))
   const outputDir = path.resolve(args.argsWithoutOptions[0] || defaultOutputDir)
@@ -74,7 +77,8 @@ export default async function buildSanityStudio(
     try {
       const result = await compareStudioDependencyVersions(autoUpdatesImports, workDir)
 
-      if (result?.length) {
+      // If it is in unattended mode, we don't want to prompt
+      if (result?.length && !unattendedMode) {
         const shouldContinue = await prompt.single({
           type: 'confirm',
           message: chalk.yellow(

--- a/packages/sanity/src/_internal/cli/commands/build/buildCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/build/buildCommand.ts
@@ -5,7 +5,7 @@ const helpText = `
 Options
   --source-maps Enable source maps for built bundles (increases size of bundle)
   --no-minify Skip minifying built JavaScript (speeds up build, increases size of bundle)
-  -y, --yes Unattended mode, use 'y' for prompts and use only flags for choices
+  -y, --yes Unattended mode, answers "yes" to any "yes/no" prompt and otherwise uses defaults
 
 Examples
   sanity build

--- a/packages/sanity/src/_internal/cli/commands/build/buildCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/build/buildCommand.ts
@@ -5,7 +5,7 @@ const helpText = `
 Options
   --source-maps Enable source maps for built bundles (increases size of bundle)
   --no-minify Skip minifying built JavaScript (speeds up build, increases size of bundle)
-  -y, --yes Use unattended mode, accepting defaults and using only flags for choices
+  -y, --yes Unattended mode, use 'y' for prompts and use only flags for choices
 
 Examples
   sanity build


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Respects unattended mode when using `auto-updates` flag

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

`npx sanity build --auto-updates` 

If not using unattended mode it will default to no

`npx sanity build --auto-updates -y` 

If using unattended mode it will default to yes and not show the prompt

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Don't have specific tests for this, I will make a follow up PR to add tests for build command with auto-updates in general

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

N/A