### PR TITLE
feat(structure): add support for boolean inputs

### DIFF
--- a/packages/sanity/src/structure/panes/documentList/sheetList/fields/BooleanCellInput.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/fields/BooleanCellInput.tsx
@@ -27,13 +27,13 @@ export function BooleanCellInput(
   const layout = fieldType?.options?.layout || 'switch'
 
   const indeterminate = typeof cellValue !== 'boolean'
-  const checked = cellValue || false
+  const checked = typeof cellValue === 'boolean' ? cellValue : false
 
   const LayoutSpecificInput = layout === 'checkbox' ? Checkbox : Switch
 
   const tone: CardTone | undefined = readOnly ? 'transparent' : undefined
 
-  const handleOnMouseDown = useMemo(() => getOnMouseDownHandler(true), [getOnMouseDownHandler])
+  const handleOnMouseDown = useMemo(() => getOnMouseDownHandler(false), [getOnMouseDownHandler])
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/sanity/src/structure/panes/documentList/sheetList/fields/BooleanCellInput.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/fields/BooleanCellInput.tsx
@@ -1,0 +1,66 @@
+import {type BooleanSchemaType} from '@sanity/types'
+import {Card, type CardTone, Checkbox, Flex, Switch} from '@sanity/ui'
+import {type CellContext} from '@tanstack/react-table'
+import {useCallback, useMemo} from 'react'
+import {styled} from 'styled-components'
+
+import {type DocumentSheetTableRow} from '../types'
+
+const Root = styled(Card)`
+  width: 100%;
+`
+
+export function BooleanCellInput(
+  props: CellContext<DocumentSheetTableRow, unknown> & {
+    fieldType: BooleanSchemaType
+    readOnly?: boolean
+  },
+) {
+  const {
+    cellValue,
+    fieldType,
+    readOnly = false,
+    getOnMouseDownHandler,
+    setCellValue,
+    handlePatchField,
+  } = props
+  const layout = fieldType?.options?.layout || 'switch'
+
+  const indeterminate = typeof cellValue !== 'boolean'
+  const checked = cellValue || false
+
+  const LayoutSpecificInput = layout === 'checkbox' ? Checkbox : Switch
+
+  const tone: CardTone | undefined = readOnly ? 'transparent' : undefined
+
+  const handleOnMouseDown = useMemo(() => getOnMouseDownHandler(true), [getOnMouseDownHandler])
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.checked
+      setCellValue(value)
+      handlePatchField?.(value)
+    },
+    [setCellValue, handlePatchField],
+  )
+
+  return (
+    <Root
+      data-testid="boolean-input"
+      tone={tone}
+      onMouseDown={handleOnMouseDown}
+      height="fill"
+      width="full"
+    >
+      <Flex height="fill" justify="center" align="center">
+        <LayoutSpecificInput
+          label={fieldType?.title}
+          checked={checked}
+          readOnly={readOnly}
+          indeterminate={indeterminate}
+          onChange={handleChange}
+        />
+      </Flex>
+    </Root>
+  )
+}

--- a/packages/sanity/src/structure/panes/documentList/sheetList/fields/CellInput.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/fields/CellInput.tsx
@@ -1,18 +1,8 @@
 import {TextInput, type TextInputType} from '@sanity/ui'
 import {type CellContext} from '@tanstack/react-table'
-import {type MutableRefObject, useMemo} from 'react'
+import {useMemo} from 'react'
 
 import {type DocumentSheetTableRow} from '../types'
-
-type Props = CellContext<DocumentSheetTableRow, unknown> & {
-  'cellValue': number | string
-  'setCellValue': (value: number | string) => void
-  'fieldRef': MutableRefObject<HTMLInputElement>
-  'getOnMouseDownHandler': (
-    suppressDefaultBehavior: boolean,
-  ) => (event: React.MouseEvent<HTMLElement>) => void
-  'data-testid': string
-}
 
 export const CellInput = ({
   cellValue,
@@ -21,7 +11,7 @@ export const CellInput = ({
   column,
   getOnMouseDownHandler,
   'data-testid': dataTestId,
-}: Props) => {
+}: CellContext<DocumentSheetTableRow, unknown>) => {
   const {fieldType} = column.columnDef.meta || {}
   const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setCellValue(event.target.value)

--- a/packages/sanity/src/structure/panes/documentList/sheetList/fields/CellInput.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/fields/CellInput.tsx
@@ -1,6 +1,6 @@
 import {TextInput, type TextInputType} from '@sanity/ui'
 import {type CellContext} from '@tanstack/react-table'
-import {useMemo} from 'react'
+import {useCallback, useMemo} from 'react'
 
 import {type DocumentSheetTableRow} from '../types'
 
@@ -13,15 +13,22 @@ export const CellInput = ({
   'data-testid': dataTestId,
 }: CellContext<DocumentSheetTableRow, unknown>) => {
   const {fieldType} = column.columnDef.meta || {}
-  const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setCellValue(event.target.value)
-  }
+  const value = cellValue as string
+  const handleOnChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setCellValue(event.target.value)
+    },
+    [setCellValue],
+  )
 
-  const setRef = (element: HTMLInputElement) => {
-    if (fieldRef) {
-      fieldRef.current = element
-    }
-  }
+  const setRef = useCallback(
+    (element: HTMLInputElement) => {
+      if (fieldRef) {
+        fieldRef.current = element
+      }
+    },
+    [fieldRef],
+  )
 
   const handleOnMouseDown = useMemo(
     () => getOnMouseDownHandler(fieldType?.name !== 'number'),
@@ -42,7 +49,7 @@ export const CellInput = ({
       style={{
         padding: '22px 16px',
       }}
-      value={cellValue}
+      value={value}
       data-testid={dataTestId}
       onChange={handleOnChange}
     />

--- a/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetColumns.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetColumns.tsx
@@ -17,6 +17,7 @@ import {useMemo} from 'react'
 
 import {DocumentSheetListSelect} from './DocumentSheetListSelect'
 import {PreviewCell} from './DocumentSheetPreviewCell'
+import {BooleanCellInput} from './fields/BooleanCellInput'
 import {CellInput} from './fields/CellInput'
 import {type DocumentSheetTableRow} from './types'
 
@@ -57,7 +58,7 @@ const getColsFromSchemaType = (schemaType: ObjectSchemaType, parentalField?: str
             }
 
             if (isBooleanSchemaType(fieldType)) {
-              return <div>{fieldType.options?.layout || 'boolean'}</div>
+              return <BooleanCellInput {...info} fieldType={fieldType} />
             }
 
             return null

--- a/packages/sanity/typings/tanstack-table.d.ts
+++ b/packages/sanity/typings/tanstack-table.d.ts
@@ -22,12 +22,20 @@ declare module '@tanstack/react-table' {
     disableCellFocus?: boolean
   }
   interface CellContext<TData extends RowData, TValue> {
-    'cellValue': number | string
-    'setCellValue': (value: number | string) => void
+    'cellValue': number | string | boolean
+    /**
+     * Changes the cell value but not the underlying data, the data will be changed when the user blurs the cell.
+     * For immediate change use `handlePatchField` from cell context
+     */
+    'setCellValue': (value: number | string | boolean) => void
     'fieldRef': MutableRefObject<HTMLElement>
     'getOnMouseDownHandler': (
       suppressDefaultBehavior: boolean,
     ) => (event: React.MouseEvent<HTMLElement>) => void
     'data-testid': string
+    /**
+     * Immediate change of the cell value, doing a server patch action.
+     */
+    'handlePatchField': (value: any) => void
   }
 }


### PR DESCRIPTION
### Description
Boolean input for the sheet list, with `switch` and `checbox`

Supports:
- Copy
- Paste
- Delete (transforms into undetermined value)
<img width="441" alt="Screenshot 2024-06-11 at 16 23 19" src="https://github.com/sanity-io/sanity/assets/46196328/d9c02f25-9401-4a3d-95cb-f8c5fce09662">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
