### PR TITLE
chore(structure): disable sheet list view if no schemaType is found

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -403,6 +403,10 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text for the "Open preview" action for a document */
   'production-preview.menu-item.title': 'Open preview',
 
+  /** The message that will be shown to users when the table view is not supported the list has no schema type */
+  'sheet-list.not-supported.no-schema-type':
+    'Table view is only supported using the <code>S.documentTypeListItems</code> builder',
+
   /** Label for button when status is saved */
   'status-bar.document-status-pulse.status.saved.text': 'Saved',
   /** Label for button when status is syncing */

--- a/packages/sanity/src/structure/panes/documentList/sheetList/DocumentSheetListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/DocumentSheetListPane.tsx
@@ -8,9 +8,10 @@ import {
   useReactTable,
 } from '@tanstack/react-table'
 import {useCallback, useEffect, useState} from 'react'
-import {SearchProvider, useSchema, useSearchState} from 'sanity'
+import {SearchProvider, Translate, useSchema, useSearchState, useTranslation} from 'sanity'
 import {styled} from 'styled-components'
 
+import {structureLocaleNamespace} from '../../../i18n'
 import {type BaseStructureToolPaneProps} from '../../types'
 import {ColumnsControl} from './ColumnsControl'
 import {DocumentSheetListFilter} from './DocumentSheetListFilter'
@@ -150,10 +151,19 @@ function DocumentSheetListPaneInner({
 export function DocumentSheetListPane(props: DocumentSheetListPaneProps) {
   const schema = useSchema()
   const typeName = props.pane.schemaTypeName
+  const {t} = useTranslation(structureLocaleNamespace)
 
   const schemaType = schema.get(typeName)
   if (!schemaType || !isDocumentSchemaType(schemaType)) {
-    throw new Error(`Schema type "${typeName}" not found or not a document schema`)
+    console.error(`Schema type "${typeName}" not found`)
+
+    return (
+      <Box padding={4}>
+        <Text>
+          <Translate t={t} i18nKey="sheet-list.not-supported.no-schema-type" />
+        </Text>
+      </Box>
+    )
   }
   return (
     <SearchProvider>


### PR DESCRIPTION
### Description

Sheet list view has the limitation of working only with 1 document type. For that, users will need to use the `DocumentTypeListBuilder` to expose the `schemaType` property in the pane. 
If that property is not present or the type was not found, the following message will be shown.
![screencapture-localhost-3333-test-structure-custom-authorsBooks-2024-06-12-11_24_25](https://github.com/sanity-io/sanity/assets/46196328/061b4066-8bc5-4dd4-a56b-d7891dfcc98e)

<img width="643" alt="Screenshot 2024-06-12 at 11 30 14" src="https://github.com/sanity-io/sanity/assets/46196328/f288a1cd-75ab-4e9e-91bf-4847263ab044">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

