### PR TITLE
fix(sanity): ignore sticky overlay regions with a falsey DOM node

### DIFF
--- a/packages/sanity/src/core/presence/overlay/StickyOverlay.tsx
+++ b/packages/sanity/src/core/presence/overlay/StickyOverlay.tsx
@@ -137,11 +137,17 @@ function regionsWithComputedRects(
   regions: ReportedPresenceData[],
   parent: HTMLElement,
 ): ReportedRegionWithRect<FieldPresenceData>[] {
-  return regions.map(([id, region]) => ({
-    ...region,
-    id,
-    rect: getRelativeRect(region.element, parent),
-  }))
+  return (
+    regions
+      // Note: This filter shouldn't be necessary, but some developers have experienced regions
+      // being passed to the function with a `null` element.
+      .filter(([, region]) => Boolean(region.element))
+      .map(([id, region]) => ({
+        ...region,
+        id,
+        rect: getRelativeRect(region.element, parent),
+      }))
+  )
 }
 
 type Props = {margins: Margins; children: ReactNode}


### PR DESCRIPTION
### Description

There have been some reports that the `StickyOverlay` component is being given regions that have no DOM node (instead, the `element` property is `null`). This causes an error when we attempt to read the `scrollTop` property of the element inside `getOffsetsTo`.

For affected users, this crashes the entire structure tool when it occurs.

I haven't yet been able to replicate this issue, nor determine the cause. We have a hook named `useReporter` that we use to track the position of field presence indicators. It passes up the value of a ref attached to a DOM node. That ref is read inside a layout effect, so it should never be `null` as far as I understand.

As an exploratory fix, I've added a condition to `StickyOverlay` to ignore any region that has a falsey DOM node. My hope is this will fix the immediate issue, and once verified, allow us to investigate the underlying cause.

### What to review

Does this seem like a reasonable interim step to solve and confirm the problem?

### Testing

In this instance, I haven't added or changed tests. I don't believe there is an existing test suite for the sticky presence indicators.

However, this branch only adds a filter to ignore any region that has a falsey DOM node. It's defensive and should only have an impact for affected Studios. In all other cases where sticky presence indicators were working, that should remain the case.

You can test this out by making sure the sticky presence indicators still work as expected.