### PR TITLE
feat(core): implement basic error reporting

### DIFF
--- a/dev/test-studio/plugins/error-reporting-test/ErrorReportingTest.tsx
+++ b/dev/test-studio/plugins/error-reporting-test/ErrorReportingTest.tsx
@@ -1,0 +1,73 @@
+import {Button, Card, Flex, Stack} from '@sanity/ui'
+import {useCallback, useState} from 'react'
+
+function triggerCustomErrorOnEvent() {
+  throw new Error('Custom error triggered')
+}
+
+function triggerTypeErrorOnEvent(evt: any) {
+  evt.someFunctionThatDoesntExist()
+}
+
+function triggerTimeoutError() {
+  setTimeout(() => {
+    throw new Error('Custom error in setTimeout')
+  }, 1000)
+}
+
+function triggerPromiseError() {
+  return new Promise((resolve, reject) => {
+    requestAnimationFrame(() => {
+      reject(new Error('Custom error in promise'))
+    })
+  })
+}
+
+export function ErrorReportingTest() {
+  const [doRenderError, setRenderError] = useState(false)
+  const handleShouldRenderWithError = useCallback(() => setRenderError(true), [])
+
+  return (
+    <Card padding={5}>
+      <Flex>
+        <Stack space={4}>
+          <Button
+            text="Trigger custom error on event handler"
+            onClick={triggerCustomErrorOnEvent}
+            tone="primary"
+          />
+
+          <Button
+            text="Trigger type error on event handler"
+            onClick={triggerTypeErrorOnEvent}
+            tone="primary"
+          />
+
+          <Button
+            text="Trigger async background error (timeout)"
+            onClick={triggerTimeoutError}
+            tone="primary"
+          />
+
+          <Button
+            text="Trigger unhandled rejection error"
+            onClick={triggerPromiseError}
+            tone="primary"
+          />
+
+          <Button
+            text="Trigger React render error"
+            onClick={handleShouldRenderWithError}
+            tone="primary"
+          />
+        </Stack>
+      </Flex>
+
+      {doRenderError && <WithRenderError />}
+    </Card>
+  )
+}
+
+function WithRenderError({text}: any) {
+  return <div>{text.toUpperCase()}</div>
+}

--- a/dev/test-studio/plugins/error-reporting-test/index.ts
+++ b/dev/test-studio/plugins/error-reporting-test/index.ts
@@ -1,0 +1,1 @@
+export * from './plugin'

--- a/dev/test-studio/plugins/error-reporting-test/plugin.tsx
+++ b/dev/test-studio/plugins/error-reporting-test/plugin.tsx
@@ -1,0 +1,20 @@
+import {AsteriskIcon} from '@sanity/icons'
+import {definePlugin} from 'sanity'
+import {route} from 'sanity/router'
+
+import {ErrorReportingTest} from './ErrorReportingTest'
+
+export const errorReportingTestPlugin = definePlugin(() => {
+  return {
+    name: 'error-reporting-test',
+    tools: [
+      {
+        name: 'error-reporting-test',
+        title: 'Errors test',
+        icon: AsteriskIcon,
+        component: ErrorReportingTest,
+        router: route.create('/'),
+      },
+    ],
+  }
+})

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -43,6 +43,7 @@ import {pasteAction} from './fieldActions/pasteAction'
 import {resolveInitialValueTemplates} from './initialValueTemplates'
 import {customInspector} from './inspectors/custom'
 import {testStudioLocaleBundles} from './locales'
+import {errorReportingTestPlugin} from './plugins/error-reporting-test'
 import {languageFilter} from './plugins/language-filter'
 import {presenceTool} from './plugins/presence'
 import {routerDebugTool} from './plugins/router-debug'
@@ -135,6 +136,7 @@ const sharedSettings = definePlugin({
     imageHotspotArrayPlugin(),
     presenceTool(),
     routerDebugTool(),
+    errorReportingTestPlugin(),
     tsdoc(),
   ],
 })

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -170,6 +170,7 @@
     "@sanity/ui": "^2.3.6",
     "@sanity/util": "3.46.1",
     "@sanity/uuid": "^3.0.1",
+    "@sentry/react": "^7.107.0",
     "@tanstack/react-table": "^8.16.0",
     "@tanstack/react-virtual": "3.0.0-beta.54",
     "@types/react-copy-to-clipboard": "^5.0.2",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -170,7 +170,7 @@
     "@sanity/ui": "^2.3.6",
     "@sanity/util": "3.46.1",
     "@sanity/uuid": "^3.0.1",
-    "@sentry/react": "^7.107.0",
+    "@sentry/react": "^8.7.0",
     "@tanstack/react-table": "^8.16.0",
     "@tanstack/react-virtual": "3.0.0-beta.54",
     "@types/react-copy-to-clipboard": "^5.0.2",

--- a/packages/sanity/src/core/error/errorReporter.ts
+++ b/packages/sanity/src/core/error/errorReporter.ts
@@ -1,0 +1,36 @@
+import {type ErrorInfo as ReactErrorInfo} from 'react'
+
+import {getSentryErrorReporter} from './sentry/sentryErrorReporter'
+
+/**
+ * @internal
+ */
+export interface ErrorInfo {
+  reactErrorInfo?: ReactErrorInfo
+  errorBoundary?: string
+}
+
+/**
+ * @internal
+ */
+export interface ErrorReporter {
+  /** Call to prepare the error reporter for use */
+  initialize: () => void
+
+  /**
+   * Reports an error, as caught by an error handler or a React boundary.
+   *
+   * @param error - The error that is caught. Note that while typed as `Error` by Reacts `componentDidCatch`, it can also be invoked with non-error objects.
+   * @param options - Additional options for the error report
+   * @returns An object containing information on the reported error, or `null` if ignored
+   */
+  reportError: (error: Error, options?: ErrorInfo) => {eventId: string} | null
+}
+
+/**
+ * Singleton instance of an error reporter, that will send errors encountered during execution or
+ * rendering to Sanity (potentially to a third party error tracking service).
+ *
+ * @internal
+ */
+export const errorReporter = getSentryErrorReporter()

--- a/packages/sanity/src/core/error/sentry/README.md
+++ b/packages/sanity/src/core/error/sentry/README.md
@@ -1,0 +1,3 @@
+This may be moved into a separate package in the future, in order for us to provide a more generic error reporter that may be swapped for a different service if need be.
+
+For now, we keep it in-module to keep things simple.

--- a/packages/sanity/src/core/error/sentry/sentryErrorReporter.ts
+++ b/packages/sanity/src/core/error/sentry/sentryErrorReporter.ts
@@ -34,12 +34,14 @@ const IS_EMBEDDED_STUDIO = !('__sanityErrorChannel' in globalScope)
 
 const DEBUG_ERROR_REPORTING = Boolean(process.env.SANITY_STUDIO_DEBUG_ERROR_REPORTING)
 
+const IS_BROWSER = typeof window !== 'undefined'
+
 const clientOptions: BrowserOptions = {
   dsn: SANITY_DSN,
   release: SANITY_VERSION,
   environment: isDev ? 'development' : 'production',
   debug: DEBUG_ERROR_REPORTING,
-  enabled: !isDev || DEBUG_ERROR_REPORTING,
+  enabled: IS_BROWSER && (!isDev || DEBUG_ERROR_REPORTING),
 }
 
 const integrations = [

--- a/packages/sanity/src/core/error/sentry/sentryErrorReporter.ts
+++ b/packages/sanity/src/core/error/sentry/sentryErrorReporter.ts
@@ -1,0 +1,373 @@
+import {
+  breadcrumbsIntegration,
+  browserApiErrorsIntegration,
+  BrowserClient,
+  type BrowserOptions,
+  captureException,
+  dedupeIntegration,
+  defaultStackParser,
+  type Event,
+  type Exception,
+  functionToStringIntegration,
+  getClient,
+  getCurrentScope,
+  globalHandlersIntegration,
+  httpContextIntegration,
+  inboundFiltersIntegration,
+  init,
+  isInitialized as sentryIsInitialized,
+  linkedErrorsIntegration,
+  makeFetchTransport,
+  Scope,
+  withScope,
+} from '@sentry/react'
+
+import {isDev} from '../../environment'
+import {isRecord} from '../../util'
+import {globalScope} from '../../util/globalScope'
+import {SANITY_VERSION} from '../../version'
+import {type ErrorInfo, type ErrorReporter} from '../errorReporter'
+
+const SANITY_DSN =
+  'https://8914c8dde7e1ebce191f15af8bf6b7b9@o131006.ingest.us.sentry.io/4507342122123264'
+
+const IS_EMBEDDED_STUDIO = !('__sanityErrorChannel' in globalScope)
+
+const DEBUG_ERROR_REPORTING = Boolean(process.env.SANITY_STUDIO_DEBUG_ERROR_REPORTING)
+
+const clientOptions: BrowserOptions = {
+  dsn: SANITY_DSN,
+  release: SANITY_VERSION,
+  environment: isDev ? 'development' : 'production',
+  debug: DEBUG_ERROR_REPORTING,
+  enabled: !isDev || DEBUG_ERROR_REPORTING,
+}
+
+const integrations = [
+  inboundFiltersIntegration(),
+  functionToStringIntegration(),
+  browserApiErrorsIntegration({eventTarget: false}),
+  breadcrumbsIntegration({console: false}),
+  globalHandlersIntegration({onerror: true, onunhandledrejection: true}),
+  linkedErrorsIntegration(),
+  dedupeIntegration(),
+  sanityDedupeIntegration(),
+  httpContextIntegration(),
+]
+
+/**
+ * Get an instance of the Sentry error reporter
+ *
+ * @internal
+ */
+export function getSentryErrorReporter(): ErrorReporter {
+  let client: BrowserClient | undefined
+  let scope: Scope | undefined
+  let prevMessage: string | undefined
+  let isInitialized = false
+
+  function initialize() {
+    if (isInitialized) {
+      return
+    }
+
+    if (IS_EMBEDDED_STUDIO) {
+      client = new BrowserClient({
+        ...clientOptions,
+        transport: makeFetchTransport,
+        stackParser: defaultStackParser,
+        integrations,
+        beforeSend,
+      })
+
+      scope = new Scope()
+      scope.setClient(client)
+
+      // Initializing has to be done after setting the client on the scope
+      client.init()
+    } else if (!sentryIsInitialized()) {
+      init({
+        ...clientOptions,
+        defaultIntegrations: false,
+        integrations,
+        beforeSend,
+      })
+      client = getClient()
+      scope = getCurrentScope()
+    }
+
+    // By this point, Sentry will already have registered a global error handler if not in an
+    // embedded studio (only the root hub reports errors on the global scope)
+    isInitialized = true
+  }
+
+  function assertInitialized() {
+    if (!isInitialized) {
+      console.warn('Error reporter is not initialized')
+    }
+  }
+
+  function reportError(error: Error, options: ErrorInfo = {}) {
+    assertInitialized()
+    if (!client) {
+      return null
+    }
+
+    // Skip reporting duplicate errors
+    const errMessage = getMessage(error)
+    if (errMessage && errMessage === prevMessage) {
+      return null
+    }
+
+    const {reactErrorInfo = {}, errorBoundary} = options
+    const {componentStack} = reactErrorInfo
+
+    // Decorate the error report with relevant context and tags
+    const contexts: Record<string, Record<string, unknown> | undefined> = {}
+    if (componentStack) {
+      contexts.react = {componentStack}
+    }
+
+    const tags: {[key: string]: number | string | boolean | null | undefined} = {
+      handled: 'no',
+    }
+
+    if (errorBoundary) {
+      tags.errorBoundary = errorBoundary
+    }
+
+    let eventId: string | null = null
+    withScope(() => {
+      if (componentStack && isError(error)) {
+        const errorBoundaryError = new Error(error.message)
+        errorBoundaryError.name = `${errorBoundary || 'ErrorBoundary'} ${error.name}`
+        errorBoundaryError.stack = componentStack
+
+        // Using the `LinkedErrors` integration to link the errors together.
+        setCause(error, errorBoundaryError)
+      }
+
+      eventId = captureException(error, {
+        mechanism: {handled: false},
+        captureContext: {contexts, tags},
+      })
+    })
+
+    return eventId ? {eventId} : null
+  }
+
+  return {
+    initialize,
+    reportError,
+  }
+}
+
+const objectToString = Object.prototype.toString
+
+/**
+ * Checks whether given value's type is one of a few Error or Error-like
+ *
+ * @param thing - A value to be checked
+ * @returns A boolean representing the result
+ * @internal
+ */
+function isError(thing: unknown): thing is Error & {cause?: Error} {
+  switch (objectToString.call(thing)) {
+    case '[object Error]':
+    case '[object Exception]':
+    case '[object DOMException]':
+      return true
+    default:
+      return isInstanceOf(thing, Error)
+  }
+}
+
+/**
+ * Checks whether given value's type is an instance of provided constructor.
+ *
+ * @param thing - A value to be checked.
+ * @param base - A constructor to be used in a check.
+ * @returns A boolean representing the result.
+ * @internal
+ */
+function isInstanceOf(thing: unknown, base: any): boolean {
+  try {
+    return thing instanceof base
+  } catch (_e) {
+    return false
+  }
+}
+
+/**
+ * Set the `cause` property on an error object
+ *
+ * @param error - The error to set the cause on
+ * @param cause - The cause of the error
+ * @internal
+ */
+function setCause(error: Error & {cause?: Error}, cause: Error): void {
+  const seenErrors = new WeakMap<Error, boolean>()
+
+  function recurse(err: Error & {cause?: Error | unknown}, subCause: Error): void {
+    // If we've already seen the error, there is a recursive loop somewhere in the error's
+    // cause chain. Let's just bail out then to prevent a stack overflow.
+    if (seenErrors.has(err)) {
+      return
+    }
+
+    if (isError(err.cause)) {
+      seenErrors.set(err, true)
+      recurse(err.cause, subCause)
+      return
+    }
+    err.cause = subCause
+  }
+
+  recurse(error, cause)
+}
+
+/**
+ * Tries to extract the `message` property from an error-like object, if it exists
+ *
+ * @param error - The error-like object to extract the message from
+ * @returns A string representing the message, or `null` if not found
+ * @internal
+ */
+function getMessage(error: Error | null): string | null {
+  return isRecord(error) && typeof error.message === 'string' ? error.message : null
+}
+
+/**
+ * Sentry treats errors that are caught in an error boundary as "handled", which we don't want.
+ * It gives a false sense of security, as the error is only caught to show a more helpful error
+ * than a blank page. This function sets the `handled` prop on the error's mechanism to `false`.
+ * Note: This _mutates_ the event, in order to avoid having to deep-clone.
+ *
+ * @param event - The event to mark as unhandled
+ * @internal
+ */
+function setAsUnhandled(event: {exception?: {values?: Exception[]}}) {
+  for (const exception of event.exception?.values || []) {
+    if (exception.mechanism) {
+      exception.mechanism.handled = false
+    }
+  }
+}
+
+/**
+ * "Before send" event handler, which sets the error as unhandled.
+ * @see setAsUnhandled for a clearer rationale.
+ *
+ * @param event - The event to be sent
+ * @returns The event to be sent
+ * @internal
+ */
+function beforeSend(event: {exception?: {values?: Exception[]}}) {
+  setAsUnhandled(event)
+  return event
+}
+
+/**
+ * We'll want a more aggressive dedupe strategy than the default one, as the default is very
+ * fine grained, needing the same exact stack and message to be considered a duplicate.
+ * We want to be more conservative.
+ *
+ * @internal
+ */
+function sanityDedupeIntegration() {
+  const previousEvents: Event[] = []
+
+  return {
+    name: 'SanityDedupe',
+    setupOnce() {
+      // intentionally empty - required to not crash Sentry
+    },
+    processEvent(currentEvent: Event): Event | null | PromiseLike<Event | null> {
+      // We want to ignore any non-error type events, e.g. transactions or replays
+      // These should never be deduped, and also not be compared against _previousEvent.
+      if (currentEvent.type) {
+        return currentEvent
+      }
+
+      // Juuust in case something goes wrong
+      try {
+        if (shouldDropEvent(currentEvent, previousEvents)) {
+          if (DEBUG_ERROR_REPORTING) {
+            console.warn(
+              '[sanity/sentry] Dropping error from being reported because it is a duplicate',
+            )
+          }
+          return null
+        }
+      } catch (_) {
+        /* empty */
+      }
+
+      // Keep the last 10 events around for comparison
+      if (previousEvents.length > 10) {
+        previousEvents.shift()
+      }
+
+      previousEvents.push(currentEvent)
+      return currentEvent
+    },
+  }
+}
+
+/**
+ * Determines wether or not the given event should be dropped or not, based on a window of
+ * previously reported events.
+ *
+ * @param currentEvent - The event to check
+ * @param previousEvents - An array of previously reported events
+ * @returns True if event should be dropped, false otherwise
+ * @internal
+ */
+function shouldDropEvent(currentEvent: Event, previousEvents: Event[]): boolean {
+  for (const previousEvent of previousEvents) {
+    const currentMessage = getMessageFromEvent(currentEvent)
+    const previousMessage = getMessageFromEvent(previousEvent)
+
+    if (currentMessage && previousMessage && currentMessage !== previousMessage) {
+      continue
+    }
+
+    // Sentry timestamps are in fractional seconds, not milliseconds
+    const currentTimestamp = Math.floor(currentEvent.timestamp || 0)
+    const previousTimestamp = Math.floor(previousEvent.timestamp || 0)
+
+    // If the events are within 5 minutes of each other, we consider them duplicates.
+    // 5 minutes is a bit much, but if an error occurs every 5 minutes, we better be
+    // investigating it - and reporting the same error from the same user every 5 minutes
+    // is not really helpful.
+    if (Math.abs(currentTimestamp - previousTimestamp) < 300) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Extract the `message` string from a Sentry event. Sometimes this is not available on the `event`
+ * itself, but buried inside of the `event.exception` property.
+ *
+ * @param event - The Sentry event to extract the message from
+ * @returns A string representing the message, or `undefined` if not found
+ * @internal
+ */
+function getMessageFromEvent(event: Event): string | undefined {
+  if (event.message) {
+    return event.message
+  }
+
+  if (event.exception) {
+    for (const exception of event.exception.values || []) {
+      if (exception.value) {
+        return exception.value
+      }
+    }
+  }
+
+  return undefined
+}

--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -9,6 +9,7 @@ import typescript from 'refractor/lang/typescript.js'
 
 import {LoadingBlock} from '../components/loadingBlock'
 import {ErrorLogger} from '../error/ErrorLogger'
+import {errorReporter} from '../error/errorReporter'
 import {LocaleProvider} from '../i18n'
 import {ResourceCacheProvider} from '../store'
 import {UserColorManagerProvider} from '../user-color'
@@ -54,6 +55,11 @@ export function StudioProvider({
   unstable_history: history,
   unstable_noAuthBoundary: noAuthBoundary,
 }: StudioProviderProps) {
+  // We initialize the error reporter as early as possible in order to catch anything that could
+  // occur during configuration loading, React rendering etc. StudioProvider is often the highest
+  // mounted React component that is shared across embedded and standalone studios.
+  errorReporter.initialize()
+
   const _children = (
     <WorkspaceLoader LoadingComponent={LoadingBlock} ConfigErrorsComponent={ConfigErrorsScreen}>
       <StudioTelemetryProvider config={config}>

--- a/packages/sanity/src/core/version.ts
+++ b/packages/sanity/src/core/version.ts
@@ -1,6 +1,8 @@
+import {version} from '../../package.json'
+
 /**
  * This version is provided by `@sanity/pkg-utils` at build time
  * @hidden
  * @beta
  */
-export const SANITY_VERSION = process.env.PKG_VERSION || ('0.0.0-development' as string)
+export const SANITY_VERSION = process.env.PKG_VERSION || `${version}-development`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1510,7 +1510,7 @@ importers:
         version: 1.3.0
       '@sanity/bifur-client':
         specifier: ^0.4.0
-        version: 0.4.1
+        version: 0.4.0
       '@sanity/block-tools':
         specifier: 3.46.1
         version: link:../@sanity/block-tools
@@ -1580,6 +1580,9 @@ importers:
       '@sanity/uuid':
         specifier: ^3.0.1
         version: 3.0.2
+      '@sentry/react':
+        specifier: ^7.107.0
+        version: 7.117.0(react@18.3.1)
       '@tanstack/react-table':
         specifier: ^8.16.0
         version: 8.16.0(react-dom@18.3.1)(react@18.3.1)
@@ -8229,8 +8232,8 @@ packages:
       - react-is
     dev: false
 
-  /@sanity/bifur-client@0.4.1:
-    resolution: {integrity: sha512-mHM8WR7pujbIw2qxuV0lzinS1izOoyLza/ejWV6quITTLpBhUoPIQGPER3Ar0SON5JV0VEEqkJGa1kjiYYgx2w==}
+  /@sanity/bifur-client@0.4.0:
+    resolution: {integrity: sha512-5aXovw6//IGF/xOFl4q9hoq5kwHzYH1eJ88IS0AwPZEHmGEj8nuaWVu5SWUUOLYTMph+bVqHaDjB33MhWJ3hzQ==}
     dependencies:
       nanoid: 3.3.7
       rxjs: 7.8.1
@@ -8980,6 +8983,102 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       scroll-into-view-if-needed: 3.1.0
       valibot: 0.31.1
+    dev: false
+
+  /@sentry-internal/feedback@7.117.0:
+    resolution: {integrity: sha512-4X+NnnY17W74TymgLFH7/KPTVYpEtoMMJh8HzVdCmHTOE6j32XKBeBMRaXBhmNYmEgovgyRKKf2KvtSfgw+V1Q==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@sentry/core': 7.117.0
+      '@sentry/types': 7.117.0
+      '@sentry/utils': 7.117.0
+    dev: false
+
+  /@sentry-internal/replay-canvas@7.117.0:
+    resolution: {integrity: sha512-7hjIhwEcoosr+BIa0AyEssB5xwvvlzUpvD5fXu4scd3I3qfX8gdnofO96a8r+LrQm3bSj+eN+4TfKEtWb7bU5A==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@sentry/core': 7.117.0
+      '@sentry/replay': 7.117.0
+      '@sentry/types': 7.117.0
+      '@sentry/utils': 7.117.0
+    dev: false
+
+  /@sentry-internal/tracing@7.117.0:
+    resolution: {integrity: sha512-fAIyijNvKBZNA12IcKo+dOYDRTNrzNsdzbm3DP37vJRKVQu19ucqP4Y6InvKokffDP2HZPzFPDoGXYuXkDhUZg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/core': 7.117.0
+      '@sentry/types': 7.117.0
+      '@sentry/utils': 7.117.0
+    dev: false
+
+  /@sentry/browser@7.117.0:
+    resolution: {integrity: sha512-29X9HlvDEKIaWp6XKlNPPSNND0U6P/ede5WA2nVHfs1zJLWdZ7/ijuMc0sH/CueEkqHe/7gt94hBcI7HOU/wSw==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry-internal/feedback': 7.117.0
+      '@sentry-internal/replay-canvas': 7.117.0
+      '@sentry-internal/tracing': 7.117.0
+      '@sentry/core': 7.117.0
+      '@sentry/integrations': 7.117.0
+      '@sentry/replay': 7.117.0
+      '@sentry/types': 7.117.0
+      '@sentry/utils': 7.117.0
+    dev: false
+
+  /@sentry/core@7.117.0:
+    resolution: {integrity: sha512-1XZ4/d/DEwnfM2zBMloXDwX+W7s76lGKQMgd8bwgPJZjjEztMJ7X0uopKAGwlQcjn242q+hsCBR6C+fSuI5kvg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.117.0
+      '@sentry/utils': 7.117.0
+    dev: false
+
+  /@sentry/integrations@7.117.0:
+    resolution: {integrity: sha512-U3suSZysmU9EiQqg0ga5CxveAyNbi9IVdsapMDq5EQGNcVDvheXtULs+BOc11WYP3Kw2yWB38VDqLepfc/Fg2g==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/core': 7.117.0
+      '@sentry/types': 7.117.0
+      '@sentry/utils': 7.117.0
+      localforage: 1.10.0
+    dev: false
+
+  /@sentry/react@7.117.0(react@18.3.1):
+    resolution: {integrity: sha512-aK+yaEP2esBhaczGU96Y7wkqB4umSIlRAzobv7ER88EGHzZulRaocTpQO8HJJGDHm4D8rD+E893BHnghkoqp4Q==}
+    engines: {node: '>=8'}
+    peerDependencies:
+      react: '*'
+    dependencies:
+      '@sentry/browser': 7.117.0
+      '@sentry/core': 7.117.0
+      '@sentry/types': 7.117.0
+      '@sentry/utils': 7.117.0
+      hoist-non-react-statics: 3.3.2
+      react: 18.3.1
+    dev: false
+
+  /@sentry/replay@7.117.0:
+    resolution: {integrity: sha512-V4DfU+x4UsA4BsufbQ8jHYa5H0q5PYUgso2X1PR31g1fpx7yiYguSmCfz1UryM6KkH92dfTnqXapDB44kXOqzQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@sentry-internal/tracing': 7.117.0
+      '@sentry/core': 7.117.0
+      '@sentry/types': 7.117.0
+      '@sentry/utils': 7.117.0
+    dev: false
+
+  /@sentry/types@7.117.0:
+    resolution: {integrity: sha512-5dtdulcUttc3F0Te7ekZmpSp/ebt/CA71ELx0uyqVGjWsSAINwskFD77sdcjqvZWek//WjiYX1+GRKlpJ1QqsA==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /@sentry/utils@7.117.0:
+    resolution: {integrity: sha512-KkcLY8643SGBiDyPvMQOubBkwVX5IPknMHInc7jYC8pDVncGp7C65Wi506bCNPpKCWspUd/0VDNWOOen51/qKA==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.117.0
     dev: false
 
   /@sideway/address@4.1.5:
@@ -16809,6 +16908,12 @@ packages:
       - supports-color
     dev: true
 
+  /lie@3.1.1:
+    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
+    dependencies:
+      immediate: 3.0.6
+    dev: false
+
   /lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
     dependencies:
@@ -16899,6 +17004,12 @@ packages:
       pify: 4.0.1
       strip-bom: 3.0.0
     dev: true
+
+  /localforage@1.10.0:
+    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
+    dependencies:
+      lie: 3.1.1
+    dev: false
 
   /locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1581,8 +1581,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.2
       '@sentry/react':
-        specifier: ^7.107.0
-        version: 7.117.0(react@18.3.1)
+        specifier: ^8.7.0
+        version: 8.9.2(react@18.3.1)
       '@tanstack/react-table':
         specifier: ^8.16.0
         version: 8.16.0(react-dom@18.3.1)(react@18.3.1)
@@ -8985,100 +8985,89 @@ packages:
       valibot: 0.31.1
     dev: false
 
-  /@sentry-internal/feedback@7.117.0:
-    resolution: {integrity: sha512-4X+NnnY17W74TymgLFH7/KPTVYpEtoMMJh8HzVdCmHTOE6j32XKBeBMRaXBhmNYmEgovgyRKKf2KvtSfgw+V1Q==}
-    engines: {node: '>=12'}
+  /@sentry-internal/browser-utils@8.9.2:
+    resolution: {integrity: sha512-2A0A6TnfzFDvYCRWS9My3t+JKG6KlslhyaN35BTiOTlYDauEekyJP7BFFyeTJXCHm2BQgI8aRZhBKm+oR9QuYw==}
+    engines: {node: '>=14.18'}
     dependencies:
-      '@sentry/core': 7.117.0
-      '@sentry/types': 7.117.0
-      '@sentry/utils': 7.117.0
+      '@sentry/core': 8.9.2
+      '@sentry/types': 8.9.2
+      '@sentry/utils': 8.9.2
     dev: false
 
-  /@sentry-internal/replay-canvas@7.117.0:
-    resolution: {integrity: sha512-7hjIhwEcoosr+BIa0AyEssB5xwvvlzUpvD5fXu4scd3I3qfX8gdnofO96a8r+LrQm3bSj+eN+4TfKEtWb7bU5A==}
-    engines: {node: '>=12'}
+  /@sentry-internal/feedback@8.9.2:
+    resolution: {integrity: sha512-v04Q+08ohwautwmiDfK5hI+nFW2B/IYhBz7pZM9x1srkwmNA69XOFyo5u34TeVHhYOPbMM2Ubs0uNEcSWHgbbQ==}
+    engines: {node: '>=14.18'}
     dependencies:
-      '@sentry/core': 7.117.0
-      '@sentry/replay': 7.117.0
-      '@sentry/types': 7.117.0
-      '@sentry/utils': 7.117.0
+      '@sentry/core': 8.9.2
+      '@sentry/types': 8.9.2
+      '@sentry/utils': 8.9.2
     dev: false
 
-  /@sentry-internal/tracing@7.117.0:
-    resolution: {integrity: sha512-fAIyijNvKBZNA12IcKo+dOYDRTNrzNsdzbm3DP37vJRKVQu19ucqP4Y6InvKokffDP2HZPzFPDoGXYuXkDhUZg==}
-    engines: {node: '>=8'}
+  /@sentry-internal/replay-canvas@8.9.2:
+    resolution: {integrity: sha512-vu9TssSjO+XbZjnoyYxMrBI4KgXG+zyqw3ThfPqG6o7O0BGa54fFwtZiMdGq/BHz017FuNiEz4fgtzuDd4gZJQ==}
+    engines: {node: '>=14.18'}
     dependencies:
-      '@sentry/core': 7.117.0
-      '@sentry/types': 7.117.0
-      '@sentry/utils': 7.117.0
+      '@sentry-internal/replay': 8.9.2
+      '@sentry/core': 8.9.2
+      '@sentry/types': 8.9.2
+      '@sentry/utils': 8.9.2
     dev: false
 
-  /@sentry/browser@7.117.0:
-    resolution: {integrity: sha512-29X9HlvDEKIaWp6XKlNPPSNND0U6P/ede5WA2nVHfs1zJLWdZ7/ijuMc0sH/CueEkqHe/7gt94hBcI7HOU/wSw==}
-    engines: {node: '>=8'}
+  /@sentry-internal/replay@8.9.2:
+    resolution: {integrity: sha512-YPnrnXJd6mJpJspJ8pI8hd1KTMOxw+BARP5twiDwXlij1RTotwnNoX9UGaSm+ZPTexPD++6Zyp6xQf4vKKP3yg==}
+    engines: {node: '>=14.18'}
     dependencies:
-      '@sentry-internal/feedback': 7.117.0
-      '@sentry-internal/replay-canvas': 7.117.0
-      '@sentry-internal/tracing': 7.117.0
-      '@sentry/core': 7.117.0
-      '@sentry/integrations': 7.117.0
-      '@sentry/replay': 7.117.0
-      '@sentry/types': 7.117.0
-      '@sentry/utils': 7.117.0
+      '@sentry-internal/browser-utils': 8.9.2
+      '@sentry/core': 8.9.2
+      '@sentry/types': 8.9.2
+      '@sentry/utils': 8.9.2
     dev: false
 
-  /@sentry/core@7.117.0:
-    resolution: {integrity: sha512-1XZ4/d/DEwnfM2zBMloXDwX+W7s76lGKQMgd8bwgPJZjjEztMJ7X0uopKAGwlQcjn242q+hsCBR6C+fSuI5kvg==}
-    engines: {node: '>=8'}
+  /@sentry/browser@8.9.2:
+    resolution: {integrity: sha512-jI5XY4j8Sa+YteokI+4SW+A/ErZxPDnspjvV3dm5pIPWvEFhvDyXWZSepqaoqwo3L7fdkRMzXY8Bi4T7qDVMWg==}
+    engines: {node: '>=14.18'}
     dependencies:
-      '@sentry/types': 7.117.0
-      '@sentry/utils': 7.117.0
+      '@sentry-internal/browser-utils': 8.9.2
+      '@sentry-internal/feedback': 8.9.2
+      '@sentry-internal/replay': 8.9.2
+      '@sentry-internal/replay-canvas': 8.9.2
+      '@sentry/core': 8.9.2
+      '@sentry/types': 8.9.2
+      '@sentry/utils': 8.9.2
     dev: false
 
-  /@sentry/integrations@7.117.0:
-    resolution: {integrity: sha512-U3suSZysmU9EiQqg0ga5CxveAyNbi9IVdsapMDq5EQGNcVDvheXtULs+BOc11WYP3Kw2yWB38VDqLepfc/Fg2g==}
-    engines: {node: '>=8'}
+  /@sentry/core@8.9.2:
+    resolution: {integrity: sha512-ixm8NISFlPlEo3FjSaqmq4nnd13BRHoafwJ5MG+okCz6BKGZ1SexEggP42/QpGvDprUUHnfncG6WUMgcarr1zA==}
+    engines: {node: '>=14.18'}
     dependencies:
-      '@sentry/core': 7.117.0
-      '@sentry/types': 7.117.0
-      '@sentry/utils': 7.117.0
-      localforage: 1.10.0
+      '@sentry/types': 8.9.2
+      '@sentry/utils': 8.9.2
     dev: false
 
-  /@sentry/react@7.117.0(react@18.3.1):
-    resolution: {integrity: sha512-aK+yaEP2esBhaczGU96Y7wkqB4umSIlRAzobv7ER88EGHzZulRaocTpQO8HJJGDHm4D8rD+E893BHnghkoqp4Q==}
-    engines: {node: '>=8'}
+  /@sentry/react@8.9.2(react@18.3.1):
+    resolution: {integrity: sha512-RK4tnkmGg1U9bAjMkY7iyKvZf1diGHYi5o8eOIrJ29OTg3c73C3/MyEuqAlP386tLglcQBn22u9JeP6g4yfiFg==}
+    engines: {node: '>=14.18'}
     peerDependencies:
       react: '*'
     dependencies:
-      '@sentry/browser': 7.117.0
-      '@sentry/core': 7.117.0
-      '@sentry/types': 7.117.0
-      '@sentry/utils': 7.117.0
+      '@sentry/browser': 8.9.2
+      '@sentry/core': 8.9.2
+      '@sentry/types': 8.9.2
+      '@sentry/utils': 8.9.2
       hoist-non-react-statics: 3.3.2
       react: 18.3.1
     dev: false
 
-  /@sentry/replay@7.117.0:
-    resolution: {integrity: sha512-V4DfU+x4UsA4BsufbQ8jHYa5H0q5PYUgso2X1PR31g1fpx7yiYguSmCfz1UryM6KkH92dfTnqXapDB44kXOqzQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@sentry-internal/tracing': 7.117.0
-      '@sentry/core': 7.117.0
-      '@sentry/types': 7.117.0
-      '@sentry/utils': 7.117.0
+  /@sentry/types@8.9.2:
+    resolution: {integrity: sha512-+LFOyQGl+zk5SZRGZD2MEURf7i5RHgP/mt3s85Rza+vz8M211WJ0YsjkIGUJFSY842nged5QLx4JysLaBlLymg==}
+    engines: {node: '>=14.18'}
     dev: false
 
-  /@sentry/types@7.117.0:
-    resolution: {integrity: sha512-5dtdulcUttc3F0Te7ekZmpSp/ebt/CA71ELx0uyqVGjWsSAINwskFD77sdcjqvZWek//WjiYX1+GRKlpJ1QqsA==}
-    engines: {node: '>=8'}
-    dev: false
-
-  /@sentry/utils@7.117.0:
-    resolution: {integrity: sha512-KkcLY8643SGBiDyPvMQOubBkwVX5IPknMHInc7jYC8pDVncGp7C65Wi506bCNPpKCWspUd/0VDNWOOen51/qKA==}
-    engines: {node: '>=8'}
+  /@sentry/utils@8.9.2:
+    resolution: {integrity: sha512-A4srR9mEBFdVXwSEKjQ94msUbVkMr8JeFiEj9ouOFORw/Y/ux/WV2bWVD/ZI9wq0TcTNK8L1wBgU8UMS5lIq3A==}
+    engines: {node: '>=14.18'}
     dependencies:
-      '@sentry/types': 7.117.0
+      '@sentry/types': 8.9.2
     dev: false
 
   /@sideway/address@4.1.5:
@@ -16908,12 +16897,6 @@ packages:
       - supports-color
     dev: true
 
-  /lie@3.1.1:
-    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
-    dependencies:
-      immediate: 3.0.6
-    dev: false
-
   /lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
     dependencies:
@@ -17004,12 +16987,6 @@ packages:
       pify: 4.0.1
       strip-bom: 3.0.0
     dev: true
-
-  /localforage@1.10.0:
-    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
-    dependencies:
-      lie: 3.1.1
-    dev: false
 
   /locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}


### PR DESCRIPTION
### Description

This introduces an error reporter using Sentry, for auto-updating, non-embedded studios. In the future, we may extend this to other studio types/configurations.

### Review notes

- Can be reviewed as a whole - I'll squash on merge
- The only (seemingly) unrelated commit here is the first one, which changes the `SANITY_VERSION` constant from being a static `0.0.0-development` to say `3.15.3-development`. This is really only relevant for the monorepo, but is helpful in the context of error reporting to see what the "base" version is.
- The Sentry relay is currently not working due to some CORS issues I am working to figure out, but the _code_ aspect of this is ready for review.
- I am aware of a few locations in the code that needs a few comments to clarify the purpose/rationale for them - I'll see if I can find the time to add them soon.
- There is a new "Errors test" tool in the test studio that has five different error "causes", and can be triggered by clicking the respective buttons. Each of these should cause an error to be reported to Sentry (once the relay is working).
  - Thrown errors in event handlers (something that runs on click, for instance, and is not executed during _rendering_)
  - Type errors in event handlers (eg calling a method on `undefined` or similar)
  - Errors in timeouts (`setTimeout`/`setImmediate`/`setInterval`)
  - Unhandled rejections (promises without a catch handler)
  - Errors during React render cycle
- Known limitations/areas to improve on:
  - Filtering errors that is not caused by Sanity. This needs more investigation in introspecting the stack trace etc - just have not had time to look at this yet, and can be added later.
  - (Potentially) add a flag to opt-out of error reporting
  - Add more context to reported errors - knowing more about the state of the application would help debug issues

### Testing

We're currently missing tests. I'd like to add some playwright tests that trigger an error and verify that a network request to the Sentry relay is triggered, but have not had time yet. Will see if I can find time before merging this.

### Notes for release

None, I think. Will double check if this should be called out or not.
