### PR TITLE
fix(cli): account for base path in the importmap

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -160,7 +160,7 @@ export default async function buildSanityStudio(
   if (autoUpdatesEnabled) {
     importMap = {
       imports: {
-        ...(await buildVendorDependencies({cwd: workDir, outputDir})),
+        ...(await buildVendorDependencies({cwd: workDir, outputDir, basePath})),
         ...autoUpdatesImports,
       },
     }

--- a/packages/sanity/src/_internal/cli/server/__tests__/buildVendorDependencies.test.ts
+++ b/packages/sanity/src/_internal/cli/server/__tests__/buildVendorDependencies.test.ts
@@ -22,234 +22,241 @@ describe('buildVendorDependencies', () => {
     vite.build.mockResolvedValue({})
   })
 
-  it('should throw if there is no matching entry in VENDOR_IMPORTS', () => {
-    const cwd = path.join(examplesRoot, 'prj-with-styled-components-5')
+  describe.each([
+    {basePath: '/', expectedPath: '/'},
+    {basePath: '//', expectedPath: '/'},
+    {basePath: 'some-path', expectedPath: '/some-path/'},
+    {basePath: '/some-path', expectedPath: '/some-path/'},
+  ])('basePath: $basePath', ({basePath, expectedPath}) => {
+    it('should throw if there is no matching entry in VENDOR_IMPORTS', () => {
+      const cwd = path.join(examplesRoot, 'prj-with-styled-components-5')
 
-    return expect(buildVendorDependencies({cwd, outputDir})).rejects.toThrow(
-      "Package 'styled-components' requires at least 6.1.0.",
-    )
-  })
-
-  it('should return the expected entry points for react 18', async () => {
-    const cwd = path.join(examplesRoot, 'prj-with-react-18')
-    const imports = await buildVendorDependencies({cwd, outputDir})
-
-    expect(imports).toEqual({
-      'react': '/vendor/react/index.mjs',
-      'react-dom': '/vendor/react-dom/index.mjs',
-      'react-dom/client': '/vendor/react-dom/client.mjs',
-      'react-dom/package.json': '/vendor/react-dom/package.json.mjs',
-      'react-dom/server': '/vendor/react-dom/server.mjs',
-      'react-dom/server.browser': '/vendor/react-dom/server.browser.mjs',
-      'react/jsx-dev-runtime': '/vendor/react/jsx-dev-runtime.mjs',
-      'react/jsx-runtime': '/vendor/react/jsx-runtime.mjs',
-      'react/package.json': '/vendor/react/package.json.mjs',
-      'styled-components': '/vendor/styled-components/index.mjs',
-      'styled-components/package.json': '/vendor/styled-components/package.json.mjs',
+      return expect(buildVendorDependencies({cwd, basePath: basePath, outputDir})).rejects.toThrow(
+        "Package 'styled-components' requires at least 6.1.0.",
+      )
     })
 
-    expect(build).toHaveBeenCalledTimes(1)
-    const [buildConfig] = build.mock.calls[0]
+    it('should return the expected entry points for react 18', async () => {
+      const cwd = path.join(examplesRoot, 'prj-with-react-18')
+      const imports = await buildVendorDependencies({cwd, basePath: basePath, outputDir})
 
-    expect(buildConfig).toMatchObject({
-      root: cwd,
-      configFile: false,
-      mode: 'production',
-      define: {'process.env.NODE_ENV': JSON.stringify('production')},
-      build: {
-        minify: true,
-        emptyOutDir: false,
-        outDir: path.join(outputDir, 'vendor'),
-        lib: {formats: ['es']},
-        rollupOptions: {
-          external: [
-            'react',
-            'react/jsx-runtime',
-            'react/jsx-dev-runtime',
-            'react/package.json',
-            'react-dom',
-            'react-dom/client',
-            'react-dom/server',
-            'react-dom/server.browser',
-            'react-dom/package.json',
-            'styled-components',
-            'styled-components/package.json',
-          ],
-          output: {exports: 'named', format: 'es'},
-          treeshake: {preset: 'recommended'},
+      expect(imports).toEqual({
+        'react': `${expectedPath}vendor/react/index.mjs`,
+        'react-dom': `${expectedPath}vendor/react-dom/index.mjs`,
+        'react-dom/client': `${expectedPath}vendor/react-dom/client.mjs`,
+        'react-dom/package.json': `${expectedPath}vendor/react-dom/package.json.mjs`,
+        'react-dom/server': `${expectedPath}vendor/react-dom/server.mjs`,
+        'react-dom/server.browser': `${expectedPath}vendor/react-dom/server.browser.mjs`,
+        'react/jsx-dev-runtime': `${expectedPath}vendor/react/jsx-dev-runtime.mjs`,
+        'react/jsx-runtime': `${expectedPath}vendor/react/jsx-runtime.mjs`,
+        'react/package.json': `${expectedPath}vendor/react/package.json.mjs`,
+        'styled-components': `${expectedPath}vendor/styled-components/index.mjs`,
+        'styled-components/package.json': `${expectedPath}vendor/styled-components/package.json.mjs`,
+      })
+
+      expect(build).toHaveBeenCalledTimes(1)
+      const [buildConfig] = build.mock.calls[0]
+
+      expect(buildConfig).toMatchObject({
+        root: cwd,
+        configFile: false,
+        mode: 'production',
+        define: {'process.env.NODE_ENV': JSON.stringify('production')},
+        build: {
+          minify: true,
+          emptyOutDir: false,
+          outDir: path.join(outputDir, 'vendor'),
+          lib: {formats: ['es']},
+          rollupOptions: {
+            external: [
+              'react',
+              'react/jsx-runtime',
+              'react/jsx-dev-runtime',
+              'react/package.json',
+              'react-dom',
+              'react-dom/client',
+              'react-dom/server',
+              'react-dom/server.browser',
+              'react-dom/package.json',
+              'styled-components',
+              'styled-components/package.json',
+            ],
+            output: {exports: 'named', format: 'es'},
+            treeshake: {preset: 'recommended'},
+          },
         },
-      },
+      })
+
+      const entry: Record<string, string> = buildConfig.build.lib.entry
+      const chunkNames = Object.keys(entry)
+      const resolvedEntries = Object.values(entry)
+
+      const {exports: reactExports} = JSON.parse(
+        await fs.promises.readFile(entry['react/package.json'], 'utf-8'),
+      )
+      const {exports: reactDomExports} = JSON.parse(
+        await fs.promises.readFile(entry['react-dom/package.json'], 'utf-8'),
+      )
+
+      // Verify the structure of the exports in the package.json files
+      // We're specifically checking the `exports` field of `react` and
+      // `react-dom` to see if there are any new subpath exports. Renovate
+      // automatically updates `react` and `react-dom`, so if a new subpath export
+      // is added, this test will fail. This failure acts as a signal for us to
+      // review and potentially add support for the new subpath if applicable.
+      expect(Object.keys(reactExports)).toEqual([
+        '.',
+        './package.json',
+        './jsx-runtime',
+        './jsx-dev-runtime',
+      ])
+      expect(Object.keys(reactDomExports)).toEqual([
+        '.',
+        './client',
+        './server',
+        './server.browser',
+        './server.node',
+        './profiling',
+        './test-utils',
+        './package.json',
+      ])
+
+      expect(chunkNames).toEqual([
+        'react/index',
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime',
+        'react/package.json',
+        'react-dom/index',
+        'react-dom/client',
+        'react-dom/server',
+        'react-dom/server.browser',
+        'react-dom/package.json',
+        'styled-components/index',
+        'styled-components/package.json',
+      ])
+
+      expect(resolvedEntries).toHaveLength(chunkNames.length)
+      expect(resolvedEntries.every(fs.existsSync)).toBe(true)
     })
 
-    const entry: Record<string, string> = buildConfig.build.lib.entry
-    const chunkNames = Object.keys(entry)
-    const resolvedEntries = Object.values(entry)
+    it('should return the expected entry points for react 19', async () => {
+      const cwd = path.join(examplesRoot, 'prj-with-react-19')
+      const imports = await buildVendorDependencies({cwd, basePath, outputDir})
 
-    const {exports: reactExports} = JSON.parse(
-      await fs.promises.readFile(entry['react/package.json'], 'utf-8'),
-    )
-    const {exports: reactDomExports} = JSON.parse(
-      await fs.promises.readFile(entry['react-dom/package.json'], 'utf-8'),
-    )
+      expect(imports).toEqual({
+        'react': `${expectedPath}vendor/react/index.mjs`,
+        'react-dom': `${expectedPath}vendor/react-dom/index.mjs`,
+        'react-dom/client': `${expectedPath}vendor/react-dom/client.mjs`,
+        'react-dom/package.json': `${expectedPath}vendor/react-dom/package.json.mjs`,
+        'react-dom/server': `${expectedPath}vendor/react-dom/server.mjs`,
+        'react-dom/server.browser': `${expectedPath}vendor/react-dom/server.browser.mjs`,
+        'react-dom/static': `${expectedPath}vendor/react-dom/static.mjs`,
+        'react-dom/static.browser': `${expectedPath}vendor/react-dom/static.browser.mjs`,
+        'react/compiler-runtime': `${expectedPath}vendor/react/compiler-runtime.mjs`,
+        'react/jsx-dev-runtime': `${expectedPath}vendor/react/jsx-dev-runtime.mjs`,
+        'react/jsx-runtime': `${expectedPath}vendor/react/jsx-runtime.mjs`,
+        'react/package.json': `${expectedPath}vendor/react/package.json.mjs`,
+        'styled-components': `${expectedPath}vendor/styled-components/index.mjs`,
+        'styled-components/package.json': `${expectedPath}vendor/styled-components/package.json.mjs`,
+      })
 
-    // Verify the structure of the exports in the package.json files
-    // We're specifically checking the `exports` field of `react` and
-    // `react-dom` to see if there are any new subpath exports. Renovate
-    // automatically updates `react` and `react-dom`, so if a new subpath export
-    // is added, this test will fail. This failure acts as a signal for us to
-    // review and potentially add support for the new subpath if applicable.
-    expect(Object.keys(reactExports)).toEqual([
-      '.',
-      './package.json',
-      './jsx-runtime',
-      './jsx-dev-runtime',
-    ])
-    expect(Object.keys(reactDomExports)).toEqual([
-      '.',
-      './client',
-      './server',
-      './server.browser',
-      './server.node',
-      './profiling',
-      './test-utils',
-      './package.json',
-    ])
+      expect(build).toHaveBeenCalledTimes(1)
+      const [buildConfig] = build.mock.calls[0]
 
-    expect(chunkNames).toEqual([
-      'react/index',
-      'react/jsx-runtime',
-      'react/jsx-dev-runtime',
-      'react/package.json',
-      'react-dom/index',
-      'react-dom/client',
-      'react-dom/server',
-      'react-dom/server.browser',
-      'react-dom/package.json',
-      'styled-components/index',
-      'styled-components/package.json',
-    ])
-
-    expect(resolvedEntries).toHaveLength(chunkNames.length)
-    expect(resolvedEntries.every(fs.existsSync)).toBe(true)
-  })
-
-  it('should return the expected entry points for react 19', async () => {
-    const cwd = path.join(examplesRoot, 'prj-with-react-19')
-    const imports = await buildVendorDependencies({cwd, outputDir})
-
-    expect(imports).toEqual({
-      'react': '/vendor/react/index.mjs',
-      'react-dom': '/vendor/react-dom/index.mjs',
-      'react-dom/client': '/vendor/react-dom/client.mjs',
-      'react-dom/package.json': '/vendor/react-dom/package.json.mjs',
-      'react-dom/server': '/vendor/react-dom/server.mjs',
-      'react-dom/server.browser': '/vendor/react-dom/server.browser.mjs',
-      'react-dom/static': '/vendor/react-dom/static.mjs',
-      'react-dom/static.browser': '/vendor/react-dom/static.browser.mjs',
-      'react/compiler-runtime': '/vendor/react/compiler-runtime.mjs',
-      'react/jsx-dev-runtime': '/vendor/react/jsx-dev-runtime.mjs',
-      'react/jsx-runtime': '/vendor/react/jsx-runtime.mjs',
-      'react/package.json': '/vendor/react/package.json.mjs',
-      'styled-components': '/vendor/styled-components/index.mjs',
-      'styled-components/package.json': '/vendor/styled-components/package.json.mjs',
-    })
-
-    expect(build).toHaveBeenCalledTimes(1)
-    const [buildConfig] = build.mock.calls[0]
-
-    expect(buildConfig).toMatchObject({
-      root: cwd,
-      configFile: false,
-      mode: 'production',
-      define: {'process.env.NODE_ENV': JSON.stringify('production')},
-      build: {
-        minify: true,
-        emptyOutDir: false,
-        outDir: path.join(outputDir, 'vendor'),
-        lib: {formats: ['es']},
-        rollupOptions: {
-          external: [
-            'react',
-            'react/jsx-runtime',
-            'react/jsx-dev-runtime',
-            'react/compiler-runtime',
-            'react/package.json',
-            'react-dom',
-            'react-dom/client',
-            'react-dom/server',
-            'react-dom/server.browser',
-            'react-dom/static',
-            'react-dom/static.browser',
-            'react-dom/package.json',
-            'styled-components',
-            'styled-components/package.json',
-          ],
-          output: {exports: 'named', format: 'es'},
-          treeshake: {preset: 'recommended'},
+      expect(buildConfig).toMatchObject({
+        root: cwd,
+        configFile: false,
+        mode: 'production',
+        define: {'process.env.NODE_ENV': JSON.stringify('production')},
+        build: {
+          minify: true,
+          emptyOutDir: false,
+          outDir: path.join(outputDir, 'vendor'),
+          lib: {formats: ['es']},
+          rollupOptions: {
+            external: [
+              'react',
+              'react/jsx-runtime',
+              'react/jsx-dev-runtime',
+              'react/compiler-runtime',
+              'react/package.json',
+              'react-dom',
+              'react-dom/client',
+              'react-dom/server',
+              'react-dom/server.browser',
+              'react-dom/static',
+              'react-dom/static.browser',
+              'react-dom/package.json',
+              'styled-components',
+              'styled-components/package.json',
+            ],
+            output: {exports: 'named', format: 'es'},
+            treeshake: {preset: 'recommended'},
+          },
         },
-      },
+      })
+
+      const entry: Record<string, string> = buildConfig.build.lib.entry
+      const chunkNames = Object.keys(entry)
+      const resolvedEntries = Object.values(entry)
+
+      // Verify the structure of the exports in the package.json files
+      // We're specifically checking the `exports` field of `react` and
+      // `react-dom` to see if there are any new subpath exports. Renovate
+      // automatically updates `react` and `react-dom`, so if a new subpath export
+      // is added, this test will fail. This failure acts as a signal for us to
+      // review and potentially add support for the new subpath if applicable.
+      const {exports: reactExports} = JSON.parse(
+        await fs.promises.readFile(entry['react/package.json'], 'utf-8'),
+      )
+      const {exports: reactDomExports} = JSON.parse(
+        await fs.promises.readFile(entry['react-dom/package.json'], 'utf-8'),
+      )
+
+      expect(Object.keys(reactExports)).toEqual([
+        '.',
+        './package.json',
+        './jsx-runtime',
+        './jsx-dev-runtime',
+        './compiler-runtime',
+      ])
+
+      expect(Object.keys(reactDomExports)).toEqual([
+        '.',
+        './client',
+        './server',
+        './server.browser',
+        './server.bun',
+        './server.edge',
+        './server.node',
+        './static',
+        './static.browser',
+        './static.edge',
+        './static.node',
+        './profiling',
+        './test-utils',
+        './package.json',
+      ])
+
+      expect(chunkNames).toEqual([
+        'react/index',
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime',
+        'react/compiler-runtime',
+        'react/package.json',
+        'react-dom/index',
+        'react-dom/client',
+        'react-dom/server',
+        'react-dom/server.browser',
+        'react-dom/static',
+        'react-dom/static.browser',
+        'react-dom/package.json',
+        'styled-components/index',
+        'styled-components/package.json',
+      ])
+
+      expect(resolvedEntries).toHaveLength(chunkNames.length)
+      expect(resolvedEntries.every(fs.existsSync)).toBe(true)
     })
-
-    const entry: Record<string, string> = buildConfig.build.lib.entry
-    const chunkNames = Object.keys(entry)
-    const resolvedEntries = Object.values(entry)
-
-    // Verify the structure of the exports in the package.json files
-    // We're specifically checking the `exports` field of `react` and
-    // `react-dom` to see if there are any new subpath exports. Renovate
-    // automatically updates `react` and `react-dom`, so if a new subpath export
-    // is added, this test will fail. This failure acts as a signal for us to
-    // review and potentially add support for the new subpath if applicable.
-    const {exports: reactExports} = JSON.parse(
-      await fs.promises.readFile(entry['react/package.json'], 'utf-8'),
-    )
-    const {exports: reactDomExports} = JSON.parse(
-      await fs.promises.readFile(entry['react-dom/package.json'], 'utf-8'),
-    )
-
-    expect(Object.keys(reactExports)).toEqual([
-      '.',
-      './package.json',
-      './jsx-runtime',
-      './jsx-dev-runtime',
-      './compiler-runtime',
-    ])
-
-    expect(Object.keys(reactDomExports)).toEqual([
-      '.',
-      './client',
-      './server',
-      './server.browser',
-      './server.bun',
-      './server.edge',
-      './server.node',
-      './static',
-      './static.browser',
-      './static.edge',
-      './static.node',
-      './profiling',
-      './test-utils',
-      './package.json',
-    ])
-
-    expect(chunkNames).toEqual([
-      'react/index',
-      'react/jsx-runtime',
-      'react/jsx-dev-runtime',
-      'react/compiler-runtime',
-      'react/package.json',
-      'react-dom/index',
-      'react-dom/client',
-      'react-dom/server',
-      'react-dom/server.browser',
-      'react-dom/static',
-      'react-dom/static.browser',
-      'react-dom/package.json',
-      'styled-components/index',
-      'styled-components/package.json',
-    ])
-
-    expect(resolvedEntries).toHaveLength(chunkNames.length)
-    expect(resolvedEntries.every(fs.existsSync)).toBe(true)
   })
 })

--- a/packages/sanity/src/_internal/cli/server/buildVendorDependencies.ts
+++ b/packages/sanity/src/_internal/cli/server/buildVendorDependencies.ts
@@ -106,6 +106,7 @@ const VENDOR_IMPORTS: VendorImports = {
 interface VendorBuildOptions {
   cwd: string
   outputDir: string
+  basePath: string
 }
 
 /**
@@ -115,6 +116,7 @@ interface VendorBuildOptions {
 export async function buildVendorDependencies({
   cwd,
   outputDir,
+  basePath,
 }: VendorBuildOptions): Promise<Record<string, string>> {
   // normalize the CWD to a relative dir for better error messages
   const dir = path.relative(process.cwd(), path.resolve(cwd))
@@ -197,7 +199,7 @@ export async function buildVendorDependencies({
       const chunkName = path.join(packageName, path.relative(packageName, specifier) || 'index')
 
       entry[chunkName] = entryPoint
-      imports[specifier] = path.join('/', VENDOR_DIR, `${chunkName}.mjs`)
+      imports[specifier] = path.join('/', basePath, VENDOR_DIR, `${chunkName}.mjs`)
     }
   }
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Accounts for basePath in the import map for vendor packages.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

How to test 

1. Add the following code in `dev/test-studio/sanity.cli.ts` 
```
project: { basePath: '/something' }
```
2. Run `pnpm sanity:build --auto-updates` 
3. Run `pnpm start` and notice the vendor packages are served from `/something/react/...` 

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I tried writing a test for build command with auto updates but it runs into an issue. Since the CLI is packaged and run as a whole there is no ability to mock anything. We would need to mock the getRemoteVersions function so it works and does not fail. I tried using `msw` and `nock` with no luck and I am curious if there is a better way to do this?

Did update the tests for buildVendorDependencies to account for basePath variations
### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

N/A 