### PR TITLE
fix(router): pass options on scoped router navigation

### DIFF
--- a/packages/sanity/src/router/RouteScope.tsx
+++ b/packages/sanity/src/router/RouteScope.tsx
@@ -2,7 +2,7 @@
 import {type ReactElement, type ReactNode, useCallback, useMemo, useRef} from 'react'
 import {RouterContext} from 'sanity/_singletons'
 
-import {type RouterContextValue, type RouterState} from './types'
+import {type NavigateOptions, type RouterContextValue, type RouterState} from './types'
 import {useRouter} from './useRouter'
 
 function addScope(
@@ -94,7 +94,8 @@ export function RouteScope(props: RouteScopeProps): ReactElement {
   )
 
   const navigate = useCallback(
-    (nextState: RouterState) => parent_navigate(resolveNextParentState(nextState)),
+    (nextState: RouterState, options?: NavigateOptions) =>
+      parent_navigate(resolveNextParentState(nextState), options),
     [parent_navigate, resolveNextParentState],
   )
 


### PR DESCRIPTION
### Description

Scoped routers implement their own `navigate` function which wraps that of the parent router and calls it with some new resolved state.

Currently this wrapper function does not pass an options param to the parent function call. As far as I can tell this means scoped routers can only push, not replace history state. I suspect this is an oversight as for example the `PaneRouter` [attempts to replace using an options param](https://github.com/sanity-io/sanity/blob/a8270d224d55e052608fa21e0ce0d1f440279db7/packages/sanity/src/structure/components/paneRouter/PaneRouterProvider.tsx#L183-L188).

Similarly, in the Presentation tool, we can't currently replace history state as we implement our own scoped router (`PresentationPaneRouterProvider`), I believe this PR would fix that issue for us.

### What to review

1. Navigate to the test studio Structure tool root.
2. Navigate to "Book".
3. Create and publish a new "Book" document.
4. Delete the document.
5. Navigate back in your browser.

#### Before this PR:
You will navigate back to the deleted document. The code linked to above suggests this shouldn't be the case.

#### After this PR:
You will navigate back to the Structure tool root.

### Testing

### Notes for release

Pass navigation options when calling a scoped router's navigate function.