### PR TITLE
fix(core): fix issue with pasting mixed content (files and text) for PT-input

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -354,6 +354,17 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   const handlePaste: OnPasteFn = useCallback(
     (input) => {
       const {event} = input
+
+      // Some applications may put both text and files on the clipboard when content is copied.
+      // If we have both text and html on the clipboard, just ignore the files if this is a paste event.
+      // Drop events will most probably be files so skip this test for those.
+      const eventType = event.type === 'paste' ? 'paste' : 'drop'
+      const hasHtml = !!event.clipboardData.getData('text/html')
+      const hasText = !!event.clipboardData.getData('text/plain')
+      if (eventType === 'paste' && hasHtml && hasText) {
+        return onPaste?.(input)
+      }
+
       extractPastedFiles(event.clipboardData)
         .then((files) => {
           return files.length > 0 ? files : []


### PR DESCRIPTION
### Description

If we have html and text on the clipboard, don't include any files into the pasted content.

Word is putting a preview image of the text on the clipboard for instance, when you copy text from the application.

If the intention is to paste a an image or file, there will be no text and html version on the clipboard as far as  I can tell, testing different scenarios on my machine (Mac).


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That this assumption holds water. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing


<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fix issue where a text preview image would be included into the Portable Text input, when pasting text from Word.

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
