### PR TITLE
fix: regression causing a crash when presence overlays render

### DIFF
--- a/packages/sanity/src/core/presence/overlay/StickyOverlay.tsx
+++ b/packages/sanity/src/core/presence/overlay/StickyOverlay.tsx
@@ -137,11 +137,13 @@ function regionsWithComputedRects(
   regions: ReportedPresenceData[],
   parent: HTMLElement,
 ): ReportedRegionWithRect<FieldPresenceData>[] {
-  return regions.map(([id, region]) => ({
-    ...region,
-    id,
-    rect: getRelativeRect(region.element, parent),
-  }))
+  return return regions
+    .filter(([, region]) => region.element)
+    .map(([id, region]) => ({
+      ...region,
+      id,
+      rect: getRelativeRect(region.element, parent),
+    })
 }
 
 type Props = {margins: Margins; children: ReactNode}


### PR DESCRIPTION
### Description

When the presence menu appears it causes a crash:
```bash
Error: Cannot read properties of null (reading 'scrollTop')
```
You can reproduce this by opening this URL in two tabs and then focus the `Name` field:
https://test-studio.sanity.build/test/structure/author;ae3808f1-ecfc-4da5-8ff1-ea7be7888710

It seems to be caused by an update to `@sanity/ui` which has optimized how refs are forwarded, causing less re-renders. It seems like `StickyOverlay` has been implicitly relying on the efficient re-renders we've had previously.

I'll do a follow up PR that cleans up `StickyOverlay` properly, and its related `createTrackerScope` chain of deps. But this change should be sufficient as a hotfix.

### What to review

Does it make sense?

### Testing

In addition to existing tests, can you see the presence overlays again on this branch?

### Notes for release

Fixes a regression causing the Presence overlays to crash with a `Error: Cannot read properties of null (reading 'scrollTop')` error
