### PR TITLE
chore: clean playwright-ct cache on each run

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -133,7 +133,7 @@
     "lint": "eslint .",
     "prepublishOnly": "turbo run build",
     "test": "pkg-utils --strict && jest",
-    "test:ct": "playwright test -c playwright-ct.config.ts",
+    "test:ct": "rimraf playwright-ct/template/.cache && playwright test -c playwright-ct.config.ts",
     "watch": "pkg-utils watch",
     "write:playwright-report-as-pr-comment": "node -r esbuild-register playwright-ct/scripts/parsePlaywrightReportJson.ts"
   },


### PR DESCRIPTION
### Description

When running playwright component tests locally we often have a problem with stale playwright cache, that is separate from the cache in the monorepo.

This change makes sure the cache is deleted every time you run `test:ct`.