### PR TITLE
fix(form): activate PTE input when dragging files

### DIFF
--- a/packages/sanity/src/core/form/components/ActivateOnFocus/ActivateOnFocus.tsx
+++ b/packages/sanity/src/core/form/components/ActivateOnFocus/ActivateOnFocus.tsx
@@ -52,6 +52,15 @@ export function ActivateOnFocus(props: ActivateOnFocusProps) {
     [isOverlayActive, onActivate],
   )
 
+  const handleDragEnter = useCallback(() => {
+    if (!isOverlayActive) {
+      return
+    }
+    if (onActivate) {
+      onActivate()
+    }
+  }, [isOverlayActive, onActivate])
+
   const handleOnFocus = useCallback(() => {
     setFocused(true)
   }, [])
@@ -86,6 +95,7 @@ export function ActivateOnFocus(props: ActivateOnFocusProps) {
       onClick={handleClick}
       onFocus={handleOnFocus}
       onKeyDown={handleKeyDown}
+      onDragEnter={handleDragEnter}
     >
       {isOverlayActive && (
         <FlexContainer data-testid="activate-overlay" tabIndex={0} align="center" justify="center">


### PR DESCRIPTION
### Description

After the change in #6867 you have to activate the PTE before you are able to drag files into the PTE.

This change fixes that situation by activating the PTE whenever the drag starts.

### What to review

- That the PTE activates when you start dragging files into it.

### Notes for release

- Fixes a issue where the PTE won't activate when you start dragging files into it
