### PR TITLE
feat(structure): Sheet List dropdown selects

### DIFF
--- a/packages/sanity/src/core/form/inputs/SelectInput.tsx
+++ b/packages/sanity/src/core/form/inputs/SelectInput.tsx
@@ -15,7 +15,11 @@ import {ChangeIndicator} from '../../changeIndicators'
 import {PatchEvent, set, unset} from '../patch'
 import {type StringInputProps} from '../types'
 
-function toSelectItem(
+/**
+ *
+ * @internal
+ */
+export function toSelectItem(
   option: TitledListValue<string | number> | string | number,
 ): TitledListValue<string | number> {
   return isTitledListValue(option) ? option : {title: capitalize(`${option}`), value: option}

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/string/StringList.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/string/StringList.tsx
@@ -1,8 +1,9 @@
 import {ChevronDownIcon} from '@sanity/icons'
-import {isTitledListValue, type StringOptions, type TitledListValue} from '@sanity/types'
+import {type StringOptions, type TitledListValue} from '@sanity/types'
 import {Menu} from '@sanity/ui'
-import {capitalize, uniq} from 'lodash'
+import {uniq} from 'lodash'
 import {useCallback, useId, useMemo} from 'react'
+import {toSelectItem} from 'sanity'
 
 import {Button, MenuButton, MenuItem} from '../../../../../../../../../../ui-components'
 import {useSchema} from '../../../../../../../../../hooks'
@@ -131,10 +132,4 @@ export function SearchFilterStringListInput({
       }}
     />
   )
-}
-
-function toSelectItem(
-  option: TitledListValue<string | number> | string | number,
-): TitledListValue<string | number> {
-  return isTitledListValue(option) ? option : {title: capitalize(`${option}`), value: option}
 }

--- a/packages/sanity/src/structure/panes/documentList/sheetList/DocumentSheetListProvider.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/DocumentSheetListProvider.tsx
@@ -14,15 +14,14 @@ type SelectedCellDetails = {
   state: 'focused' | 'selected'
 } | null
 
+export type CellState = 'focused' | 'selectedAnchor' | 'selectedRange' | null
+
 /** @internal */
 export interface DocumentSheetListContextValue {
   focusAnchorCell: () => void
   resetFocusSelection: () => void
   setSelectedAnchorCell: (colId: string, rowIndex: number) => void
-  getStateByCellId: (
-    colId: string,
-    rowIndex: number,
-  ) => 'focused' | 'selectedAnchor' | 'selectedRange' | null
+  getStateByCellId: (colId: string, rowIndex: number) => CellState
   submitFocusedCell: () => void
 }
 

--- a/packages/sanity/src/structure/panes/documentList/sheetList/SheetListCell.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/SheetListCell.tsx
@@ -204,15 +204,16 @@ export function SheetListCell(cell: Cell<DocumentSheetTableRow, unknown>) {
       // if cell is selected, paste events should be handled
       document.addEventListener('paste', handlePaste)
 
-    if (cellState === 'selectedAnchor')
-      // only allow copying when cell is selected anchor
+    if (cellState === 'selectedAnchor' || cellState === 'focused')
+      // only allow copying when cell is selected anchor or focused
       document.addEventListener('copy', handleCopy)
 
     return () => {
       if (cellState) document.removeEventListener('keydown', handleOnKeyDown)
       if (cellState === 'selectedAnchor' || cellState === 'selectedRange')
         document.removeEventListener('paste', handlePaste)
-      if (cellState === 'selectedAnchor') document.removeEventListener('copy', handleCopy)
+      if (cellState === 'selectedAnchor' || cellState === 'focused')
+        document.removeEventListener('copy', handleCopy)
     }
   }, [cellState, handleCopy, handleOnKeyDown, handlePaste])
 

--- a/packages/sanity/src/structure/panes/documentList/sheetList/SheetListCell.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/SheetListCell.tsx
@@ -163,7 +163,7 @@ export function SheetListCell(cell: Cell<DocumentSheetTableRow, unknown>) {
   // child field inputs can control whether default behavior is stopped or preserved
   const getOnMouseDownHandler = useCallback(
     (suppressDefaultBehavior: boolean) => (event: React.MouseEvent<HTMLElement>) => {
-      if (event.detail === 2) {
+      if (suppressDefaultBehavior && event.detail === 2) {
         handleProgrammaticFocus()
       } else {
         if (suppressDefaultBehavior) event.preventDefault()

--- a/packages/sanity/src/structure/panes/documentList/sheetList/__tests__/DocumentSheetListSelect.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/__tests__/DocumentSheetListSelect.test.tsx
@@ -1,10 +1,10 @@
 import {beforeEach, describe, expect, it, jest} from '@jest/globals'
-import {type SanityDocument} from '@sanity/types'
 import {studioTheme, ThemeProvider} from '@sanity/ui'
 import {type CellContext} from '@tanstack/react-table'
 import {fireEvent, render, screen} from '@testing-library/react'
 
 import {DocumentSheetListSelect} from '../DocumentSheetListSelect'
+import {type DocumentSheetTableRow} from '../types'
 
 const mockToggleSelected = jest.fn()
 const mockSetSelectedAnchor = jest.fn()
@@ -31,9 +31,9 @@ const props = {
     getIsSelected: () => null,
     toggleSelected: mockToggleSelected,
   },
-} as unknown as CellContext<SanityDocument, unknown>
+} as unknown as CellContext<DocumentSheetTableRow, unknown>
 
-const renderTest = (renderProps?: Partial<CellContext<SanityDocument, unknown>>) =>
+const renderTest = (renderProps?: Partial<CellContext<DocumentSheetTableRow, unknown>>) =>
   render(
     <ThemeProvider theme={studioTheme}>
       <DocumentSheetListSelect {...{...props, ...(renderProps || {})}} />

--- a/packages/sanity/src/structure/panes/documentList/sheetList/fields/BooleanCellInput.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/fields/BooleanCellInput.tsx
@@ -1,29 +1,20 @@
 import {type BooleanSchemaType} from '@sanity/types'
 import {Card, type CardTone, Checkbox, Flex, Switch} from '@sanity/ui'
-import {type CellContext} from '@tanstack/react-table'
-import {useCallback, useMemo} from 'react'
+import {useCallback} from 'react'
 import {styled} from 'styled-components'
 
-import {type DocumentSheetTableRow} from '../types'
+import {type CellInputType} from '../SheetListCell'
 
 const Root = styled(Card)`
   width: 100%;
 `
 
 export function BooleanCellInput(
-  props: CellContext<DocumentSheetTableRow, unknown> & {
-    fieldType: BooleanSchemaType
+  props: CellInputType<BooleanSchemaType> & {
     readOnly?: boolean
   },
 ) {
-  const {
-    cellValue,
-    fieldType,
-    readOnly = false,
-    getOnMouseDownHandler,
-    setCellValue,
-    handlePatchField,
-  } = props
+  const {cellValue, fieldType, readOnly = false, setCellValue, handlePatchField} = props
   const layout = fieldType?.options?.layout || 'switch'
 
   const indeterminate = typeof cellValue !== 'boolean'
@@ -33,25 +24,17 @@ export function BooleanCellInput(
 
   const tone: CardTone | undefined = readOnly ? 'transparent' : undefined
 
-  const handleOnMouseDown = useMemo(() => getOnMouseDownHandler(false), [getOnMouseDownHandler])
-
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.checked
       setCellValue(value)
-      handlePatchField?.(value)
+      handlePatchField(value)
     },
     [setCellValue, handlePatchField],
   )
 
   return (
-    <Root
-      data-testid="boolean-input"
-      tone={tone}
-      onMouseDown={handleOnMouseDown}
-      height="fill"
-      width="full"
-    >
+    <Root data-testid="boolean-input" tone={tone} height="fill" width="full">
       <Flex height="fill" justify="center" align="center">
         <LayoutSpecificInput
           label={fieldType?.title}

--- a/packages/sanity/src/structure/panes/documentList/sheetList/fields/BooleanCellInput.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/fields/BooleanCellInput.tsx
@@ -14,7 +14,7 @@ export function BooleanCellInput(
     readOnly?: boolean
   },
 ) {
-  const {cellValue, fieldType, readOnly = false, setCellValue, handlePatchField} = props
+  const {cellValue, fieldType, readOnly = false, setCellValue, handlePatchField, fieldRef} = props
   const layout = fieldType?.options?.layout || 'switch'
 
   const indeterminate = typeof cellValue !== 'boolean'
@@ -42,6 +42,7 @@ export function BooleanCellInput(
           readOnly={readOnly}
           indeterminate={indeterminate}
           onChange={handleChange}
+          ref={fieldRef}
         />
       </Flex>
     </Root>

--- a/packages/sanity/src/structure/panes/documentList/sheetList/fields/CellInput.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/fields/CellInput.tsx
@@ -1,52 +1,48 @@
 import {TextInput, type TextInputType} from '@sanity/ui'
 import {type CellContext} from '@tanstack/react-table'
-import React, {useCallback, useMemo} from 'react'
+import {useCallback, useMemo} from 'react'
 
 import {type DocumentSheetTableRow} from '../types'
 
-export const CellInput = React.forwardRef(
-  ({
-    cellValue,
-    setCellValue,
-    fieldRef,
-    column,
-    getOnMouseDownHandler,
-    'data-testid': dataTestId,
-  }: CellContext<DocumentSheetTableRow, unknown>) => {
-    const {fieldType} = column.columnDef.meta || {}
-    const value = cellValue as string
-    const handleOnChange = useCallback(
-      (event: React.ChangeEvent<HTMLInputElement>) => {
-        setCellValue(event.target.value)
-      },
-      [setCellValue],
-    )
+export const CellInput = ({
+  cellValue,
+  setCellValue,
+  fieldRef,
+  column,
+  getOnMouseDownHandler,
+  'data-testid': dataTestId,
+}: CellContext<DocumentSheetTableRow, unknown>) => {
+  const {fieldType} = column.columnDef.meta || {}
+  const value = cellValue as string
+  const handleOnChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setCellValue(event.target.value)
+    },
+    [setCellValue],
+  )
 
-    const handleOnMouseDown = useMemo(
-      () => getOnMouseDownHandler(fieldType?.name !== 'number'),
-      [fieldType?.name, getOnMouseDownHandler],
-    )
+  const handleOnMouseDown = useMemo(
+    () => getOnMouseDownHandler(fieldType?.name !== 'number'),
+    [fieldType?.name, getOnMouseDownHandler],
+  )
 
-    const inputType = (fieldType?.name !== 'string' && (fieldType?.name as TextInputType)) || 'text'
+  const inputType = (fieldType?.name !== 'string' && (fieldType?.name as TextInputType)) || 'text'
 
-    return (
-      <TextInput
-        size={0}
-        radius={0}
-        border={false}
-        type={inputType}
-        onMouseDown={handleOnMouseDown}
-        ref={fieldRef}
-        __unstable_disableFocusRing
-        style={{
-          padding: '22px 16px',
-        }}
-        value={value}
-        data-testid={dataTestId}
-        onChange={handleOnChange}
-      />
-    )
-  },
-)
-
-CellInput.displayName = 'CellInput'
+  return (
+    <TextInput
+      size={0}
+      radius={0}
+      border={false}
+      type={inputType}
+      onMouseDown={handleOnMouseDown}
+      ref={fieldRef}
+      __unstable_disableFocusRing
+      style={{
+        padding: '22px 16px',
+      }}
+      value={value}
+      data-testid={dataTestId}
+      onChange={handleOnChange}
+    />
+  )
+}

--- a/packages/sanity/src/structure/panes/documentList/sheetList/fields/CellInput.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/fields/CellInput.tsx
@@ -1,57 +1,52 @@
 import {TextInput, type TextInputType} from '@sanity/ui'
 import {type CellContext} from '@tanstack/react-table'
-import {useCallback, useMemo} from 'react'
+import React, {useCallback, useMemo} from 'react'
 
 import {type DocumentSheetTableRow} from '../types'
 
-export const CellInput = ({
-  cellValue,
-  setCellValue,
-  fieldRef,
-  column,
-  getOnMouseDownHandler,
-  'data-testid': dataTestId,
-}: CellContext<DocumentSheetTableRow, unknown>) => {
-  const {fieldType} = column.columnDef.meta || {}
-  const value = cellValue as string
-  const handleOnChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      setCellValue(event.target.value)
-    },
-    [setCellValue],
-  )
+export const CellInput = React.forwardRef(
+  ({
+    cellValue,
+    setCellValue,
+    fieldRef,
+    column,
+    getOnMouseDownHandler,
+    'data-testid': dataTestId,
+  }: CellContext<DocumentSheetTableRow, unknown>) => {
+    const {fieldType} = column.columnDef.meta || {}
+    const value = cellValue as string
+    const handleOnChange = useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        setCellValue(event.target.value)
+      },
+      [setCellValue],
+    )
 
-  const setRef = useCallback(
-    (element: HTMLInputElement) => {
-      if (fieldRef) {
-        fieldRef.current = element
-      }
-    },
-    [fieldRef],
-  )
+    const handleOnMouseDown = useMemo(
+      () => getOnMouseDownHandler(fieldType?.name !== 'number'),
+      [fieldType?.name, getOnMouseDownHandler],
+    )
 
-  const handleOnMouseDown = useMemo(
-    () => getOnMouseDownHandler(fieldType?.name !== 'number'),
-    [fieldType?.name, getOnMouseDownHandler],
-  )
+    const inputType = (fieldType?.name !== 'string' && (fieldType?.name as TextInputType)) || 'text'
 
-  const inputType = (fieldType?.name !== 'string' && (fieldType?.name as TextInputType)) || 'text'
+    return (
+      <TextInput
+        size={0}
+        radius={0}
+        border={false}
+        type={inputType}
+        onMouseDown={handleOnMouseDown}
+        ref={fieldRef}
+        __unstable_disableFocusRing
+        style={{
+          padding: '22px 16px',
+        }}
+        value={value}
+        data-testid={dataTestId}
+        onChange={handleOnChange}
+      />
+    )
+  },
+)
 
-  return (
-    <TextInput
-      size={0}
-      radius={0}
-      border={false}
-      type={inputType}
-      onMouseDown={handleOnMouseDown}
-      ref={setRef}
-      __unstable_disableFocusRing
-      style={{
-        padding: '22px 16px',
-      }}
-      value={value}
-      data-testid={dataTestId}
-      onChange={handleOnChange}
-    />
-  )
-}
+CellInput.displayName = 'CellInput'

--- a/packages/sanity/src/structure/panes/documentList/sheetList/fields/CellInput.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/fields/CellInput.tsx
@@ -1,17 +1,17 @@
+import {type NumberSchemaType, type StringSchemaType} from '@sanity/types'
 import {TextInput, type TextInputType} from '@sanity/ui'
-import {type CellContext} from '@tanstack/react-table'
-import {useCallback, useMemo} from 'react'
+import {useCallback, useEffect} from 'react'
 
-import {type DocumentSheetTableRow} from '../types'
+import {type CellInputType} from '../SheetListCell'
 
 export const CellInput = ({
   cellValue,
   setCellValue,
   fieldRef,
   column,
-  getOnMouseDownHandler,
+  setShouldPreventDefaultMouseDown,
   'data-testid': dataTestId,
-}: CellContext<DocumentSheetTableRow, unknown>) => {
+}: CellInputType<StringSchemaType | NumberSchemaType>) => {
   const {fieldType} = column.columnDef.meta || {}
   const value = cellValue as string
   const handleOnChange = useCallback(
@@ -21,10 +21,9 @@ export const CellInput = ({
     [setCellValue],
   )
 
-  const handleOnMouseDown = useMemo(
-    () => getOnMouseDownHandler(fieldType?.name !== 'number'),
-    [fieldType?.name, getOnMouseDownHandler],
-  )
+  useEffect(() => {
+    if (fieldType?.name !== 'number') setShouldPreventDefaultMouseDown(true)
+  }, [fieldType?.name, setShouldPreventDefaultMouseDown])
 
   const inputType = (fieldType?.name !== 'string' && (fieldType?.name as TextInputType)) || 'text'
 
@@ -34,7 +33,6 @@ export const CellInput = ({
       radius={0}
       border={false}
       type={inputType}
-      onMouseDown={handleOnMouseDown}
       ref={fieldRef}
       __unstable_disableFocusRing
       style={{

--- a/packages/sanity/src/structure/panes/documentList/sheetList/fields/CellInput.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/fields/CellInput.tsx
@@ -38,7 +38,7 @@ export const CellInput = ({
       style={{
         padding: '22px 16px',
       }}
-      value={value}
+      value={value ?? ''}
       data-testid={dataTestId}
       onChange={handleOnChange}
     />

--- a/packages/sanity/src/structure/panes/documentList/sheetList/fields/DropdownCellInput.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/fields/DropdownCellInput.tsx
@@ -42,6 +42,7 @@ export function DropdownCellInput({
       }}
       value={cellValue}
     >
+      <option value={undefined} selected={!cellValue} />
       {options.map(toSelectItem).map((option) => (
         <option key={option.title} value={option.value}>
           {option.title}

--- a/packages/sanity/src/structure/panes/documentList/sheetList/fields/DropdownCellInput.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/fields/DropdownCellInput.tsx
@@ -1,0 +1,52 @@
+import {Select} from '@sanity/ui'
+import {
+  isNumberSchemaType,
+  isStringSchemaType,
+  type NumberSchemaType,
+  type StringSchemaType,
+  toSelectItem,
+} from 'sanity'
+
+import {type CellInputType} from '../SheetListCell'
+
+export const shouldDropdownRender = (fieldType: StringSchemaType | NumberSchemaType) =>
+  (isNumberSchemaType(fieldType) || isStringSchemaType(fieldType)) &&
+  (fieldType.options?.list ||
+    fieldType.options?.layout === 'radio' ||
+    fieldType.options?.layout === 'dropdown')
+
+export function DropdownCellInput({
+  fieldType,
+  handlePatchField,
+  cellValue,
+  setCellValue,
+}: CellInputType<StringSchemaType | NumberSchemaType>) {
+  const handleOnChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value: boolean | string | number = e.target.value
+
+    // update and patch document immediately whenever value is changed manually
+    setCellValue(value)
+    handlePatchField(value)
+  }
+
+  const options = fieldType.options?.list
+
+  if (!options || typeof cellValue === 'boolean') return null
+
+  return (
+    <Select
+      onChange={handleOnChange}
+      radius={0}
+      style={{
+        boxShadow: 'none',
+      }}
+      value={cellValue}
+    >
+      {options.map(toSelectItem).map((option) => (
+        <option key={option.title} value={option.value}>
+          {option.title}
+        </option>
+      ))}
+    </Select>
+  )
+}

--- a/packages/sanity/src/structure/panes/documentList/sheetList/fields/DropdownCellInput.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/fields/DropdownCellInput.tsx
@@ -20,6 +20,7 @@ export function DropdownCellInput({
   handlePatchField,
   cellValue,
   setCellValue,
+  fieldRef,
 }: CellInputType<StringSchemaType | NumberSchemaType>) {
   const handleOnChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value: boolean | string | number = e.target.value
@@ -42,6 +43,7 @@ export function DropdownCellInput({
       style={{
         boxShadow: 'none',
       }}
+      ref={fieldRef}
       value={cellValue}
     >
       {/* only allow unset open when field is NOT a radio selection */}

--- a/packages/sanity/src/structure/panes/documentList/sheetList/fields/DropdownCellInput.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/fields/DropdownCellInput.tsx
@@ -33,6 +33,8 @@ export function DropdownCellInput({
 
   if (!options || typeof cellValue === 'boolean') return null
 
+  const isUnsetOptionAllowed = !cellValue || fieldType.options?.layout !== 'radio'
+
   return (
     <Select
       onChange={handleOnChange}
@@ -42,7 +44,8 @@ export function DropdownCellInput({
       }}
       value={cellValue}
     >
-      <option value={undefined} selected={!cellValue} />
+      {/* only allow unset open when field is NOT a radio selection */}
+      {isUnsetOptionAllowed && <option value={undefined} selected={!cellValue} />}
       {options.map(toSelectItem).map((option) => (
         <option key={option.title} value={option.value}>
           {option.title}

--- a/packages/sanity/src/structure/panes/documentList/sheetList/types.ts
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/types.ts
@@ -1,5 +1,11 @@
 import {type Table} from '@tanstack/react-table'
-import {type IdPair, type SanityDocument} from 'sanity'
+import {
+  type BooleanSchemaType,
+  type IdPair,
+  type NumberSchemaType,
+  type SanityDocument,
+  type StringSchemaType,
+} from 'sanity'
 
 /**
  * Type definition for the row values in the sheet list
@@ -18,3 +24,7 @@ export type DocumentSheetTableRow = SanityDocument & {
  * Type definition for the table instance used in the sheet list
  */
 export type DocumentSheetListTable = Table<DocumentSheetTableRow>
+
+export type DocumentSheetListValueTypes = string | number | boolean
+
+export type DocumentSheetListSchemaTypes = StringSchemaType | NumberSchemaType | BooleanSchemaType

--- a/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetColumns.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetColumns.tsx
@@ -19,6 +19,7 @@ import {DocumentSheetListSelect} from './DocumentSheetListSelect'
 import {PreviewCell} from './DocumentSheetPreviewCell'
 import {BooleanCellInput} from './fields/BooleanCellInput'
 import {CellInput} from './fields/CellInput'
+import {DropdownCellInput, shouldDropdownRender} from './fields/DropdownCellInput'
 import {type DocumentSheetTableRow} from './types'
 
 export const VISIBLE_COLUMN_LIMIT = 5
@@ -46,15 +47,10 @@ const getColsFromSchemaType = (schemaType: ObjectSchemaType, parentalField?: str
           },
           cell: (info) => {
             if (isNumberSchemaType(fieldType) || isStringSchemaType(fieldType)) {
-              if (
-                fieldType.options?.list ||
-                fieldType.options?.layout === 'radio' ||
-                fieldType.options?.layout === 'dropdown'
-              )
-                // eslint-disable-next-line i18next/no-literal-string
-                return <div>Select</div>
+              if (shouldDropdownRender(fieldType))
+                return <DropdownCellInput {...info} fieldType={fieldType} />
 
-              return <CellInput {...info} />
+              return <CellInput {...info} fieldType={fieldType} />
             }
 
             if (isBooleanSchemaType(fieldType)) {

--- a/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetListStore.ts
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetListStore.ts
@@ -78,20 +78,12 @@ function documentsReducer(
     case 'DOCUMENT_UPDATED': {
       const updatedDocument = action.payload
       const id = updatedDocument._id as string
-      const document = state.documents[id]
-
-      const nextDocument = {
-        // Add existing document data
-        ...document,
-        // Add incoming document data
-        ...updatedDocument,
-      } satisfies SanityDocument
 
       return {
         ...state,
         documents: {
           ...state.documents,
-          [id]: nextDocument,
+          [id]: updatedDocument,
         },
       }
     }

--- a/packages/sanity/src/structure/panes/documentList/sheetList/useOnMouseDownCell.ts
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/useOnMouseDownCell.ts
@@ -1,0 +1,23 @@
+import {useCallback, useState} from 'react'
+
+/** @internal */
+export const useOnMouseDownCell = (
+  handleProgrammaticFocus: () => void,
+  setCellAsSelectedAnchor: () => void,
+) => {
+  const [shouldPreventDefaultMouseDown, setShouldPreventDefaultMouseDown] = useState(false)
+
+  const handleOnMouseDown = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      if (shouldPreventDefaultMouseDown && event.detail === 2) {
+        handleProgrammaticFocus()
+      } else {
+        if (shouldPreventDefaultMouseDown) event.preventDefault()
+        setCellAsSelectedAnchor()
+      }
+    },
+    [handleProgrammaticFocus, setCellAsSelectedAnchor, shouldPreventDefaultMouseDown],
+  )
+
+  return {setShouldPreventDefaultMouseDown, handleOnMouseDown}
+}

--- a/packages/sanity/typings/tanstack-table.d.ts
+++ b/packages/sanity/typings/tanstack-table.d.ts
@@ -1,6 +1,10 @@
 import {type RowData} from '@tanstack/react-table'
 
-import {type BaseStructureToolPaneProps} from '../src/structure/panes/types'
+import {type DocumentSheetListSchemaTypes} from '../src/structure/panes/documentList/sheetList/types'
+import {
+  type BaseStructureToolPaneProps,
+  type DocumentSheetListValueTypes,
+} from '../src/structure/panes/types'
 
 declare module '@tanstack/react-table' {
   interface TableMeta<TData extends RowData> {

--- a/packages/sanity/typings/tanstack-table.d.ts
+++ b/packages/sanity/typings/tanstack-table.d.ts
@@ -1,4 +1,3 @@
-import {type BooleanSchemaType, type NumberSchemaType, type StringSchemaType} from '@sanity/types'
 import {type RowData} from '@tanstack/react-table'
 
 import {type BaseStructureToolPaneProps} from '../src/structure/panes/types'
@@ -18,20 +17,18 @@ declare module '@tanstack/react-table' {
      */
     customHeader?: boolean
     borderWidth?: number
-    fieldType?: StringSchemaType | NumberSchemaType | BooleanSchemaType
+    fieldType?: DocumentSheetListSchemaTypes
     disableCellFocus?: boolean
   }
   interface CellContext<TData extends RowData, TValue> {
-    'cellValue': number | string | boolean
+    'cellValue': DocumentSheetListValueTypes
     /**
      * Changes the cell value but not the underlying data, the data will be changed when the user blurs the cell.
      * For immediate change use `handlePatchField` from cell context
      */
-    'setCellValue': (value: number | string | boolean) => void
+    'setCellValue': (value: DocumentSheetListValueTypes) => void
     'fieldRef': MutableRefObject<HTMLElement>
-    'getOnMouseDownHandler': (
-      suppressDefaultBehavior: boolean,
-    ) => (event: React.MouseEvent<HTMLElement>) => void
+    'setShouldPreventDefaultMouseDown': (shouldSuppressDefaultMouseDown: boolean) => void
     'data-testid': string
     /**
      * Immediate change of the cell value, doing a server patch action.

--- a/packages/sanity/typings/tanstack-table.d.ts
+++ b/packages/sanity/typings/tanstack-table.d.ts
@@ -27,6 +27,10 @@ declare module '@tanstack/react-table' {
      * For immediate change use `handlePatchField` from cell context
      */
     'setCellValue': (value: DocumentSheetListValueTypes) => void
+    /**
+     * `fieldRef` should be assigned as `ref` to the input element in the cell
+     * to allow for focus controls
+     */
     'fieldRef': MutableRefObject<HTMLElement>
     'setShouldPreventDefaultMouseDown': (shouldSuppressDefaultMouseDown: boolean) => void
     'data-testid': string


### PR DESCRIPTION
### Description
* Supporting Dropdown selection for string and number selects and radio button groups
* Fixing issue where unsetting a value in document form would not propagate to sheet list
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* New `DropdownCellInput` renders for dropdown selects
* `useOnMouseDownCell` hook to group the logic around whether a cell should require dbl click to focus or not
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
I'll add more wider tests for all the sheet list inputs in a separate branch
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Nothing relevant to note- no user facing changes
<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
