### PR TITLE
fix(sanity): only include create action when restoring a deleted document

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/restore.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/restore.ts
@@ -3,9 +3,10 @@ import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
 
 export const restore: OperationImpl<[fromRevision: string]> = {
   disabled: (): false => false,
-  execute: ({historyStore, schema, idPair, typeName}, fromRevision: string) => {
+  execute: ({snapshots, historyStore, schema, idPair, typeName}, fromRevision: string) => {
     const targetId = isLiveEditEnabled(schema, typeName) ? idPair.publishedId : idPair.draftId
     return historyStore.restore(idPair.publishedId, targetId, fromRevision, {
+      fromDeleted: !snapshots.draft && !snapshots.published,
       useServerDocumentActions: true,
     })
   },


### PR DESCRIPTION
### Description
This fixes an issue with using [API actions](https://www.sanity.io/docs/http-actions) causing a 409 error when restoring a document from history that already has a published version.

### What to review
Does it make sense?

### Testing
The e2e tests should cover this already


### Notes for release
- Fixes an issue that could cause a 409 error when restoring a document from history.