### PR TITLE
fix(structure): when documents are added, add them to sheet list

### DIFF
--- a/packages/sanity/src/structure/panes/documentList/__tests__/PaneContainer.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/PaneContainer.test.tsx
@@ -20,8 +20,8 @@ jest.mock('../../../components/pane/usePaneLayout', () => ({
   usePaneLayout: jest.fn().mockReturnValue({panes: [], mount: jest.fn()}),
 }))
 
-jest.mock('../sheetList/useDocumentSheetList', () => ({
-  useDocumentSheetList: jest.fn().mockReturnValue({data: [], isLoading: false}),
+jest.mock('../sheetList/useDocumentSheetListStore', () => ({
+  useDocumentSheetListStore: jest.fn().mockReturnValue({data: [], isLoading: false, documents: []}),
 }))
 
 jest.mock('sanity', () => {

--- a/packages/sanity/src/structure/panes/documentList/sheetList/DocumentSheetListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/DocumentSheetListPane.tsx
@@ -9,14 +9,13 @@ import {
   type Row,
   useReactTable,
 } from '@tanstack/react-table'
-import React, {useCallback, useEffect, useMemo, useState} from 'react'
+import React, {useCallback, useMemo, useState} from 'react'
 import {
   SearchProvider,
   set,
   toMutationPatches,
   unset,
   useSchema,
-  useSearchState,
   useValidationStatus,
   ValidationProvider,
 } from 'sanity'
@@ -127,15 +126,12 @@ function DocumentSheetListPaneInner(
   props: DocumentSheetListPaneProps & {documentSchemaType: ObjectSchemaType},
 ) {
   const {documentSchemaType, ...paneProps} = props
-  const {dispatch, state} = useSearchState()
   const {columns, initialColumnsVisibility} = useDocumentSheetColumns(documentSchemaType)
 
-  const {data} = useDocumentSheetList({
-    typeName: documentSchemaType.name,
-  })
+  const {data} = useDocumentSheetList(documentSchemaType)
   const [selectedAnchor, setSelectedAnchor] = useState<number | null>(null)
 
-  const totalRows = state.result.hits.length
+  const totalRows = data.length
   const meta = {
     selectedAnchor,
     setSelectedAnchor,
@@ -229,13 +225,6 @@ function DocumentSheetListPaneInner(
       return nextOptions
     })
   }
-
-  useEffect(() => {
-    dispatch({type: 'TERMS_TYPE_ADD', schemaType: documentSchemaType})
-    return () => {
-      dispatch({type: 'TERMS_TYPE_REMOVE', schemaType: documentSchemaType})
-    }
-  }, [documentSchemaType, dispatch])
 
   const renderRow = useCallback(
     (row: Row<DocumentSheetTableRow>) => {

--- a/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetList.ts
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetList.ts
@@ -1,25 +1,42 @@
-import {useMemo} from 'react'
-import {getDraftId, getPublishedId, useSearchState} from 'sanity'
+import {type ObjectSchemaType} from '@sanity/types'
+import {useCallback, useEffect, useMemo} from 'react'
+import {getDraftId, getPublishedId, type SanityDocument, useSearchState} from 'sanity'
 
 import {type DocumentSheetTableRow} from './types'
 import {useDocumentSheetListStore} from './useDocumentSheetListStore'
 
-interface DocumentSheetListOptions {
-  /**The schemaType.name  */
-  typeName: string
-}
-
-export function useDocumentSheetList({typeName}: DocumentSheetListOptions): {
+export function useDocumentSheetList(schemaType: ObjectSchemaType): {
   data: DocumentSheetTableRow[]
   isLoading: boolean
 } {
-  const {state} = useSearchState()
+  const typeName = schemaType.name
+  const {state, dispatch} = useSearchState()
+
+  useEffect(() => {
+    dispatch({type: 'TERMS_TYPE_ADD', schemaType})
+    return () => {
+      dispatch({type: 'TERMS_TYPE_REMOVE', schemaType})
+    }
+  }, [schemaType, dispatch])
 
   const items = useMemo(() => {
     const map = new Map()
     state.result.hits.forEach((h) => map.set(getPublishedId(h.hit._id), h.hit))
     return map
   }, [state.result.hits])
+
+  const handleDocumentAdded = useCallback(
+    (document: SanityDocument) => {
+      items.set(getPublishedId(document._id), document)
+    },
+    [items],
+  )
+  const handleDocumentDeleted = useCallback(
+    (id: string) => {
+      items.delete(getPublishedId(id))
+    },
+    [items],
+  )
 
   // The store is listening to all the documents that match with the _type filter.
   const {
@@ -28,6 +45,8 @@ export function useDocumentSheetList({typeName}: DocumentSheetListOptions): {
     documents: allDocuments,
   } = useDocumentSheetListStore({
     filter: `_type == "${typeName}"`,
+    onDocumentDeleted: handleDocumentDeleted,
+    onDocumentAdded: handleDocumentAdded,
   })
 
   // Only return the documents that match with the serverSide filter items.

--- a/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetListStore.ts
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetListStore.ts
@@ -117,12 +117,16 @@ export function useDocumentSheetListStore({
   filter,
   params,
   apiVersion,
+  onDocumentDeleted,
+  onDocumentAdded,
 }: {
   filter: string
   params?: Record<string, unknown>
   apiVersion?: string
+  onDocumentDeleted?: (id: string) => void
+  onDocumentAdded?: (document: SanityDocument) => void
 }) {
-  const QUERY = `*[${filter}][0...2000]`
+  const QUERY = `*[${filter}][0...1000]`
   const client = useClient({
     ...DEFAULT_STUDIO_CLIENT_OPTIONS,
     apiVersion: apiVersion || DEFAULT_STUDIO_CLIENT_OPTIONS.apiVersion,
@@ -175,11 +179,13 @@ export function useDocumentSheetListStore({
               type: 'DOCUMENT_RECEIVED',
               payload: nextDocument,
             })
+            onDocumentAdded?.(nextDocument)
           }
         }
 
         if (event.transition === 'disappear') {
           dispatch({type: 'DOCUMENT_DELETED', id: event.documentId})
+          onDocumentDeleted?.(event.documentId)
         }
 
         if (event.transition === 'update') {
@@ -194,7 +200,7 @@ export function useDocumentSheetListStore({
         }
       }
     },
-    [initialFetch],
+    [initialFetch, onDocumentAdded, onDocumentDeleted],
   )
 
   const listener$ = useMemo(() => {


### PR DESCRIPTION
When a document for the type is added it is received in the sheet list store, but the search is not updated because we are not triggering a new search.
Producing the effect of not adding the document into the sheet view.

With this changes when either a document is added or removed, the sheet list view will react accordingly, because the items map is updated.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
