### PR TITLE
fix(test-studio): add repro case for using server actions with custom publish document action

### DIFF
--- a/dev/test-studio/documentActions/actions/createCustomPublishAction.ts
+++ b/dev/test-studio/documentActions/actions/createCustomPublishAction.ts
@@ -1,0 +1,19 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import {type DocumentActionComponent, type DocumentActionProps, useDocumentOperation} from 'sanity'
+
+export function createCustomPublishAction(originalAction: DocumentActionComponent) {
+  return function CustomPublishAction(props: DocumentActionProps) {
+    const defaultPublishAction = originalAction(props)
+    const documentOperations = useDocumentOperation(props.id, props.type)
+
+    return {
+      ...defaultPublishAction,
+      label: 'Custom publish that sets publishedAt to now',
+      onHandle: () => {
+        documentOperations.patch.execute([{set: {publishedAt: new Date().toISOString()}}])
+
+        defaultPublishAction?.onHandle?.()
+      },
+    }
+  }
+}

--- a/dev/test-studio/documentActions/index.ts
+++ b/dev/test-studio/documentActions/index.ts
@@ -1,5 +1,6 @@
 import {type DocumentActionsResolver} from 'sanity'
 
+import {createCustomPublishAction} from './actions/createCustomPublishAction'
 import {TestConfirmDialogAction} from './actions/TestConfirmDialogAction'
 import {TestCustomComponentAction} from './actions/TestCustomComponentAction'
 import {TestCustomRestoreAction} from './actions/TestCustomRestoreAction'
@@ -18,7 +19,9 @@ export const resolveDocumentActions: DocumentActionsResolver = (prev, {schemaTyp
       if (action.action === 'restore') {
         return TestCustomRestoreAction(action)
       }
-
+      if (action.action === 'publish') {
+        return createCustomPublishAction(action)
+      }
       return action
     })
   }

--- a/dev/test-studio/schema/debug/documentActions.js
+++ b/dev/test-studio/schema/debug/documentActions.js
@@ -8,5 +8,6 @@ export default {
       name: 'title',
       title: 'Title',
     },
+    {type: 'datetime', name: 'publishedAt', title: 'Published at'},
   ],
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/__snapshots__/publish.test.ts.snap
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/__snapshots__/publish.test.ts.snap
@@ -9,7 +9,6 @@ Object {
         "actions": Object {
           "actionType": "sanity.action.document.publish",
           "draftId": "drafts.my-id",
-          "ifDraftRevisionId": "exampleRev",
           "ifPublishedRevisionId": "exampleRev",
           "publishedId": "my-id",
         },
@@ -37,7 +36,6 @@ Object {
         "actions": Object {
           "actionType": "sanity.action.document.publish",
           "draftId": "drafts.my-id",
-          "ifDraftRevisionId": "exampleRev",
           "ifPublishedRevisionId": undefined,
           "publishedId": "my-id",
         },
@@ -65,7 +63,6 @@ Object {
         "actions": Object {
           "actionType": "sanity.action.document.publish",
           "draftId": "drafts.my-id",
-          "ifDraftRevisionId": "exampleRev",
           "ifPublishedRevisionId": undefined,
           "publishedId": "my-id",
         },

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.ts
@@ -24,11 +24,11 @@ export const publish: OperationImpl<[], DisabledReason> = {
         actionType: 'sanity.action.document.publish',
         draftId: idPair.draftId,
         publishedId: idPair.publishedId,
-        // The editor must be able to see the latest state of both the draft document they are
-        // publishing, and the published document they are choosing to replace. Optimistic
-        // locking using `ifDraftRevisionId` and `ifPublishedRevisionId` ensures the client and
-        // server are synchronised.
-        ifDraftRevisionId: snapshots.draft._rev,
+        // Optimistic locking using `ifPublishedRevisionId` ensures that concurrent publish action
+        // invocations do not override each other.
+        //
+        // Note: for custom publish actions, `snapshots.draft._rev` may be stale, which means the
+        // `ifDraftRevisionId` optimistic lock cannot currently be used.
         ifPublishedRevisionId: snapshots.published?._rev,
       },
       {

--- a/test/e2e/tests/document-actions/publish.spec.ts
+++ b/test/e2e/tests/document-actions/publish.spec.ts
@@ -20,3 +20,30 @@ test(`document panel displays correct title for published document`, async ({
   // Ensure the correct title is displayed after publishing.
   expect(page.getByTestId('document-panel-document-title')).toHaveText(title)
 })
+
+test(`custom publish action can patch document before publication`, async ({
+  page,
+  createDraftDocument,
+}) => {
+  const title = 'Test Title'
+
+  const publishKeypress = () => page.locator('body').press('Control+Alt+p')
+  const documentStatus = page.getByTestId('pane-footer-document-status')
+  const titleInput = page.getByTestId('field-title').getByTestId('string-input')
+  const publishedAtInput = page.getByTestId('field-publishedAt').getByTestId('date-input')
+
+  await createDraftDocument('/test/content/input-debug;documentActionsTest')
+  await titleInput.fill(title)
+
+  // Wait for the document to be published.
+  //
+  // Note: This is invoked using the publish keyboard shortcut, because the publish document action
+  // has been overridden for the `documentActionsTest` type, and is not visible without opening the
+  // document actions menu.
+  await page.waitForTimeout(1_000)
+  await publishKeypress()
+  await expect(documentStatus).toContainText('Published just now')
+
+  // Ensure the custom publish action succeeded in setting the `publishedAt` field.
+  await expect(publishedAtInput).toHaveValue(/.*/)
+})


### PR DESCRIPTION
### Description

This branch removes usage of the `ifDraftRevisionId` optimistic lock when publishing documents using the Actions API. For custom publish document actions, `snapshots.draft._rev` may be stale, which means the `ifDraftRevisionId` optimistic lock cannot currently be used.

This is less safe, because it means it's technically possible for a user publishing a document via Studio to cause the publication of a draft that has not yet been synced to them. However, it's important to note this same issue exists with the Mutations API integration today. When the underlying staleness bug is fixed in the future, we should switch `ifDraftRevisionId` back on.

We still make use of `ifPublishedRevisionId` to ensure concurrent publish action invocations do not override each other.

### What to review

That removing the `ifDraftRevisionId` optimistic lock does not introduce any failure points that do not already exist in the Mutations API integration.

### Testing

Ensure that the "Custom publish that sets publishedAt to now" action (`test/structure/input-debug;documentActionsTest`) works as expected.