### PR TITLE
fix(schema): use base type title if no subtype title or name is given

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/file.ts
+++ b/packages/@sanity/schema/src/legacy/types/file.ts
@@ -37,7 +37,7 @@ export const FileType = {
 
     const parsed = Object.assign(pick(FILE_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: FILE_CORE,
-      title: subTypeDef.title || (subTypeDef.name ? startCase(subTypeDef.name) : ''),
+      title: subTypeDef.title || (subTypeDef.name ? startCase(subTypeDef.name) : FILE_CORE.title),
       options: options,
       fields: subTypeDef.fields.map((fieldDef: any) => {
         const {name, fieldset, ...rest} = fieldDef

--- a/packages/@sanity/schema/src/legacy/types/image.ts
+++ b/packages/@sanity/schema/src/legacy/types/image.ts
@@ -34,7 +34,7 @@ export const ImageType = {
 
     const parsed = Object.assign(pick(this.get(), OVERRIDABLE_FIELDS), subTypeDef, {
       type: IMAGE_CORE,
-      title: subTypeDef.title || (subTypeDef.name ? startCase(subTypeDef.name) : ''),
+      title: subTypeDef.title || (subTypeDef.name ? startCase(subTypeDef.name) : IMAGE_CORE.title),
       options: options,
       fields: subTypeDef.fields.map((fieldDef: any) => {
         const {name, fieldset, ...rest} = fieldDef

--- a/packages/@sanity/schema/src/legacy/types/object.ts
+++ b/packages/@sanity/schema/src/legacy/types/object.ts
@@ -38,7 +38,7 @@ export const ObjectType = {
     const options = {...(subTypeDef.options || {})}
     const parsed = Object.assign(pick(this.get(), OVERRIDABLE_FIELDS), subTypeDef, {
       type: this.get(),
-      title: subTypeDef.title || (subTypeDef.name ? startCase(subTypeDef.name) : ''),
+      title: subTypeDef.title || (subTypeDef.name ? startCase(subTypeDef.name) : 'Object'),
       options: options,
       orderings: subTypeDef.orderings || guessOrderingConfig(subTypeDef),
       fields: subTypeDef.fields.map((fieldDef: any) => {
@@ -104,7 +104,7 @@ export const ObjectType = {
             title:
               extensionDef.title ||
               subTypeDef.title ||
-              (subTypeDef.name ? startCase(subTypeDef.name) : ''),
+              (subTypeDef.name ? startCase(subTypeDef.name) : 'Object'),
             type: parent,
           })
           lazyGetter(current, '__experimental_search', () => parent.__experimental_search)

--- a/packages/@sanity/schema/test/legacy/fixtures/schemas/arrays.ts
+++ b/packages/@sanity/schema/test/legacy/fixtures/schemas/arrays.ts
@@ -127,5 +127,47 @@ export default {
         },
       ],
     },
+    {
+      name: 'withAnonymousMemberSubtypes',
+      type: 'object',
+      fields: [
+        {
+          name: 'assets',
+          type: 'array',
+          title: 'Array of assets',
+          of: [{type: 'image'}, {type: 'file'}],
+        },
+      ],
+    },
+    {
+      name: 'withNamedMemberSubtypes',
+      type: 'object',
+      fields: [
+        {
+          name: 'assets',
+          type: 'array',
+          title: 'Array of assets',
+          of: [
+            {type: 'image', name: 'myImage'},
+            {type: 'file', name: 'myFile'},
+          ],
+        },
+      ],
+    },
+    {
+      name: 'withTitledMemberSubtypes',
+      type: 'object',
+      fields: [
+        {
+          name: 'assets',
+          type: 'array',
+          title: 'Array of assets',
+          of: [
+            {type: 'image', name: 'myImage', title: 'My beautiful image'},
+            {type: 'file', name: 'myFile', title: 'My wonderful file'},
+          ],
+        },
+      ],
+    },
   ],
 }

--- a/packages/@sanity/schema/test/legacy/schemas.test.ts
+++ b/packages/@sanity/schema/test/legacy/schemas.test.ts
@@ -15,3 +15,27 @@ Object.keys(rawSchemas).forEach((name) => {
     expect(() => parseSchema((rawSchemas as any)[name])).not.toThrow()
   })
 })
+
+test('anonymous image and file subtypes inherit title', () => {
+  const withSubtypes = new Schema(rawSchemas.arrays).get('withAnonymousMemberSubtypes')
+  const assetsField = withSubtypes.fields.find((field: any) => field.name === 'assets')
+  const [imageSubtype, fileSubtype] = assetsField.type.of
+  expect(imageSubtype).toHaveProperty('title', 'Image')
+  expect(fileSubtype).toHaveProperty('title', 'File')
+})
+
+test('named image and file subtypes infer title', () => {
+  const withSubtypes = new Schema(rawSchemas.arrays).get('withNamedMemberSubtypes')
+  const assetsField = withSubtypes.fields.find((field: any) => field.name === 'assets')
+  const [imageSubtype, fileSubtype] = assetsField.type.of
+  expect(imageSubtype).toHaveProperty('title', 'My Image')
+  expect(fileSubtype).toHaveProperty('title', 'My File')
+})
+
+test('titled image and file subtypes use defined title', () => {
+  const withSubtypes = new Schema(rawSchemas.arrays).get('withTitledMemberSubtypes')
+  const assetsField = withSubtypes.fields.find((field: any) => field.name === 'assets')
+  const [imageSubtype, fileSubtype] = assetsField.type.of
+  expect(imageSubtype).toHaveProperty('title', 'My beautiful image')
+  expect(fileSubtype).toHaveProperty('title', 'My wonderful file')
+})


### PR DESCRIPTION
### Description

In certain UI locations, especially for array members, image and files would be listed without a title, or using the type name (`image`) when the member declaration is simply: `{type: 'image'}`.

This PR ensures that we fall back to the base types' title.

I also modified the _object_ to use the same approach, but I think this one is more theoretical, since we require a name for  objects.

### What to review

- Code looks good
- "Add item" menus lists images and files correctly (there's a "Array of multiple types" field that has this in the test studio)

### Testing

Added new tests to ensure no regressions.
Also did some manual testing.

### Notes for release

- Fixes a case where image and file types might be listed in their lowercase variant in array insert menus