### PR TITLE
fix(cli): fixes importmap path on windows

### DIFF
--- a/packages/sanity/src/_internal/cli/server/buildVendorDependencies.ts
+++ b/packages/sanity/src/_internal/cli/server/buildVendorDependencies.ts
@@ -195,11 +195,14 @@ export async function buildVendorDependencies({
         )
       }
 
-      const specifier = path.join(packageName, subpath)
-      const chunkName = path.join(packageName, path.relative(packageName, specifier) || 'index')
+      const specifier = path.posix.join(packageName, subpath)
+      const chunkName = path.posix.join(
+        packageName,
+        path.relative(packageName, specifier) || 'index',
+      )
 
       entry[chunkName] = entryPoint
-      imports[specifier] = path.join('/', basePath, VENDOR_DIR, `${chunkName}.mjs`)
+      imports[specifier] = path.posix.join('/', basePath, VENDOR_DIR, `${chunkName}.mjs`)
     }
   }
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Fixes import map path on windows since we are using join to create specifier it is using windows style in output

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

change makes sense.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

~My attempt to simply add windows to actions testing list was not successful. I am not what really is the best way to test this, would love to some suggestions~ - Will be fixed in future PRs

Manually tested in windows and it works

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

N/A
