### PR TITLE
fix(structure): don't replace url when navigating back to list after document deletion

### DIFF
--- a/packages/sanity/src/structure/components/paneRouter/PaneRouterProvider.tsx
+++ b/packages/sanity/src/structure/components/paneRouter/PaneRouterProvider.tsx
@@ -180,12 +180,9 @@ export function PaneRouterProvider(props: {
         if (expandLast && lastPane) {
           expand(lastPane.element)
         }
-        navigate(
-          {
-            panes: [...routerPaneGroups.slice(0, groupIndex)],
-          },
-          {replace: true},
-        )
+        navigate({
+          panes: [...routerPaneGroups.slice(0, groupIndex)],
+        })
       },
 
       // Duplicate the current pane, with optional overrides for payload, parameters


### PR DESCRIPTION
### Description
Before the fix in #6923 got merged, when deleting a document, you could always hit the back button to get back to the newly deleted document, and there you’d be given a way to undo/restore it. 

Now after this fix, if you delete a document you can no longer hit the back button to recover a deleted document if you realise you made a mistake (unless you remember the id, which you probably don’t). This is not great, and we want to leave a history entry in this case so you navigate back.

### What to review
Deleting a document should allow you to navigate back to restore it.

### Notes for release
n/a since the changes in #6923 has not been released yet
