### PR TITLE
refactor(core): change revision history label from 'Version' to the more accurate 'Revision'

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1580,7 +1580,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'timeline.latest-revision': 'Latest revision',
   /**
    * Label for latest revision for timeline menu dropdown
-   * @deprecated use `timeline.latest-revision` instead
+   * @deprecated as of `v3.47.0` `timeline.latest-revision` should be used instead. Note: _usage_ of this key is deprecated, but Studios on `< v3.47.0` still require this key to be _defined_
    * */
   'timeline.latest-version': 'Latest revision',
   /** The aria-label for the list of revisions in the timeline */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1575,8 +1575,14 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'timeline.error.unable-to-load-revision': 'Unable to load revision',
   /** Label for when the timeline item is the latest in the history */
   'timeline.latest': 'Latest',
-  /** Label for latest version for timeline menu dropdown */
-  'timeline.latest-version': 'Latest version',
+
+  /** Label for latest revision for timeline menu dropdown */
+  'timeline.latest-revision': 'Latest revision',
+  /**
+   * Label for latest revision for timeline menu dropdown
+   * @deprecated use `timeline.latest-revision` instead
+   * */
+  'timeline.latest-version': 'Latest revision',
   /** The aria-label for the list of revisions in the timeline */
   'timeline.list.aria-label': 'Document revisions',
   /** Label for loading history */

--- a/packages/sanity/src/core/store/_legacy/history/history/Aligner.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/Aligner.ts
@@ -79,7 +79,7 @@ function startFromSnapshot(state: VersionState, doc: SanityDocument) {
  * - Internally this class will then try to align the history event to the received
  *   mutations and then dispatch to the timeline.
  *
- * - The aligner also maintains the latest version for both the draft and the published version.
+ * - The aligner also maintains the latest revision for both the draft and the published version.
  *
  *
  */

--- a/packages/sanity/src/structure/documentActions/HistoryRestoreAction.tsx
+++ b/packages/sanity/src/structure/documentActions/HistoryRestoreAction.tsx
@@ -56,10 +56,10 @@ export const HistoryRestoreAction: DocumentActionComponent = ({id, type, revisio
     return null
   }, [handleConfirm, isConfirmDialogOpen, onComplete, t])
 
-  const isRevisionInitialVersion = revision === '@initial'
-  const isRevisionLatestVersion = revision === undefined // undefined means latest version
+  const isRevisionInitial = revision === '@initial'
+  const isRevisionLatest = revision === undefined // undefined means latest revision
 
-  if (isRevisionLatestVersion) {
+  if (isRevisionLatest) {
     return null
   }
 
@@ -68,13 +68,13 @@ export const HistoryRestoreAction: DocumentActionComponent = ({id, type, revisio
     color: 'primary',
     onHandle: handle,
     title: t(
-      isRevisionInitialVersion
+      isRevisionInitial
         ? 'action.restore.disabled.cannot-restore-initial'
         : 'action.restore.tooltip',
     ),
     icon: RestoreIcon,
     dialog,
-    disabled: isRevisionInitialVersion,
+    disabled: isRevisionInitial,
   }
 }
 

--- a/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
@@ -145,7 +145,7 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
         timestamp: new Date(chunk?.endTimestamp),
         formatParams,
       })
-    : t('timeline.latest-version')
+    : t('timeline.latest-revision')
 
   const sinceLabel = chunk
     ? t('timeline.since', {


### PR DESCRIPTION
### Description

This makes our labeling of revision to be more consistent. We are calling it revision in someplaces but not everywhere. Also updated the code to be more consistent too.

### What to review

- Is the way I've deprecate the old i18n key ok?
- Would it be better to leave the key as-is and instead just change the label?

### Testing
Don't think it makes all that much sense to add automated testing for this one

### Notes for release

n/a - should just make the studio terminology more consistent.