### PR TITLE
feat(typegen): add all schema types exported union

### DIFF
--- a/packages/@sanity/cli/test/__snapshots__/typegen.test.ts.snap
+++ b/packages/@sanity/cli/test/__snapshots__/typegen.test.ts.snap
@@ -31,6 +31,8 @@ export type Slug = {
   current?: string;
   source?: string;
 };
+
+export type AllSanitySchemaTypes = Person | Slug;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ./src/queries.ts
 // Variable: PAGE_QUERY

--- a/packages/@sanity/codegen/src/typescript/__tests__/__snapshots__/typeGenerator.test.ts.snap
+++ b/packages/@sanity/codegen/src/typescript/__tests__/__snapshots__/typeGenerator.test.ts.snap
@@ -208,7 +208,9 @@ export type SanityImagePaletteSwatch = {
   population?: number;
   title?: string;
   _type: \\"sanity.imagePaletteSwatch\\";
-};"
+};
+
+export type AllSanitySchemaTypes = Author | Post | Ghost | BlockContent | SanityAssetSourceData | Slug | Geopoint | SanityImageAsset | SanityFileAsset | SanityImageCrop | SanityImageHotspot | SanityImageMetadata | SanityImageDimensions | SanityImagePalette | SanityImagePaletteSwatch;"
 `;
 
 exports[`generateSchemaTypes should generate correct types for document schema with inline fields 1`] = `

--- a/packages/@sanity/codegen/src/typescript/__tests__/typeGenerator.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/typeGenerator.test.ts
@@ -56,7 +56,9 @@ describe('generateSchemaTypes', () => {
 "export type Author = {
   _id: string;
   name?: string;
-};"
+};
+
+export type AllSanitySchemaTypes = Author;"
 `)
   })
 
@@ -80,7 +82,9 @@ describe('generateSchemaTypes', () => {
     expect(actualOutput).toMatchInlineSnapshot(`
 "export type Product = {
   price: number;
-};"
+};
+
+export type AllSanitySchemaTypes = Product;"
 `)
   })
 
@@ -103,7 +107,9 @@ describe('generateSchemaTypes', () => {
     expect(actualOutput).toMatchInlineSnapshot(`
 "export type Task = {
   completed: boolean;
-};"
+};
+
+export type AllSanitySchemaTypes = Task;"
 `)
   })
 
@@ -142,7 +148,9 @@ describe('generateSchemaTypes', () => {
     street: string;
     city: string;
   };
-};"
+};
+
+export type AllSanitySchemaTypes = User;"
 `)
   })
 
@@ -169,7 +177,9 @@ describe('generateSchemaTypes', () => {
     expect(actualOutput).toMatchInlineSnapshot(`
 "export type BlogPost = {
   tags: Array<string>;
-};"
+};
+
+export type AllSanitySchemaTypes = BlogPost;"
 `)
   })
 
@@ -193,7 +203,9 @@ describe('generateSchemaTypes', () => {
     expect(actualOutput).toMatchInlineSnapshot(`
 "export type DynamicData = {
   metadata: unknown;
-};"
+};
+
+export type AllSanitySchemaTypes = DynamicData;"
 `)
   })
 
@@ -217,7 +229,9 @@ describe('generateSchemaTypes', () => {
     expect(actualOutput).toMatchInlineSnapshot(`
 "export type Impossible = {
   willNotHappen: null;
-};"
+};
+
+export type AllSanitySchemaTypes = Impossible;"
 `)
   })
 
@@ -259,7 +273,9 @@ describe('generateSchemaTypes', () => {
 
 export type Author = {
   name: string;
-};"
+};
+
+export type AllSanitySchemaTypes = BlogPost | Author;"
 `)
   })
 
@@ -286,7 +302,9 @@ export type Author = {
     expect(actualOutput).toMatchInlineSnapshot(`
 "export type MixedContent = {
   content: string | number;
-};"
+};
+
+export type AllSanitySchemaTypes = MixedContent;"
 `)
   })
 
@@ -310,7 +328,9 @@ export type Author = {
     expect(actualOutput).toMatchInlineSnapshot(`
 "export type OptionalData = {
   obsoleteField: null;
-};"
+};
+
+export type AllSanitySchemaTypes = OptionalData;"
 `)
   })
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds a union that exports all the potential schemas to the generated file. This can be useful in mocks/testing environments and used by third party tools to get a list of potential types.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Name of the exported variable `allSchemaTypes`, should it be prefixed with anything? `_`? Anything else to indicate that this is a "special" type?

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Already test schema generation, so updated the snapshots

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

TypeGen: Added a type export of all the the discovered Sanity Schema variants.