### PR TITLE
chore(ci): upgrade pnpm setup to use node20

### DIFF
--- a/.github/workflows/are-we-compiled-yet.yml
+++ b/.github/workflows/are-we-compiled-yet.yml
@@ -22,7 +22,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/are-we-compiled-yet.yml
+++ b/.github/workflows/are-we-compiled-yet.yml
@@ -22,7 +22,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/are-we-compiled-yet.yml
+++ b/.github/workflows/are-we-compiled-yet.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -41,7 +41,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -41,7 +41,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/depCheck.yml
+++ b/.github/workflows/depCheck.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/depCheck.yml
+++ b/.github/workflows/depCheck.yml
@@ -15,7 +15,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/depCheck.yml
+++ b/.github/workflows/depCheck.yml
@@ -15,7 +15,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/docReport.yml
+++ b/.github/workflows/docReport.yml
@@ -26,7 +26,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/docReport.yml
+++ b/.github/workflows/docReport.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/docReport.yml
+++ b/.github/workflows/docReport.yml
@@ -26,7 +26,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -22,7 +22,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -22,7 +22,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/e2e-pte.yml
+++ b/.github/workflows/e2e-pte.yml
@@ -29,7 +29,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/e2e-pte.yml
+++ b/.github/workflows/e2e-pte.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/e2e-pte.yml
+++ b/.github/workflows/e2e-pte.yml
@@ -29,7 +29,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:
@@ -128,7 +128,7 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:
@@ -231,7 +231,7 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory
@@ -132,7 +132,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory
@@ -235,7 +235,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory
@@ -132,7 +131,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory
@@ -235,7 +233,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -28,7 +28,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -28,7 +28,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/formatCheck.yml
+++ b/.github/workflows/formatCheck.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/formatCheck.yml
+++ b/.github/workflows/formatCheck.yml
@@ -20,7 +20,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/formatCheck.yml
+++ b/.github/workflows/formatCheck.yml
@@ -20,7 +20,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/lint-fix-if-needed.yml
+++ b/.github/workflows/lint-fix-if-needed.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: lts/*
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/lint-fix-if-needed.yml
+++ b/.github/workflows/lint-fix-if-needed.yml
@@ -29,7 +29,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/lint-fix-if-needed.yml
+++ b/.github/workflows/lint-fix-if-needed.yml
@@ -29,7 +29,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/lintPr.yml
+++ b/.github/workflows/lintPr.yml
@@ -22,7 +22,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/lintPr.yml
+++ b/.github/workflows/lintPr.yml
@@ -22,7 +22,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/lintPr.yml
+++ b/.github/workflows/lintPr.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -19,7 +19,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -19,7 +19,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/pnpm-if-needed.yml
+++ b/.github/workflows/pnpm-if-needed.yml
@@ -32,7 +32,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/pnpm-if-needed.yml
+++ b/.github/workflows/pnpm-if-needed.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/pnpm-if-needed.yml
+++ b/.github/workflows/pnpm-if-needed.yml
@@ -32,7 +32,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -24,7 +24,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory
@@ -72,7 +72,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -24,7 +24,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory
@@ -72,7 +71,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/prettier-if-needed.yml
+++ b/.github/workflows/prettier-if-needed.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: lts/*
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/prettier-if-needed.yml
+++ b/.github/workflows/prettier-if-needed.yml
@@ -29,7 +29,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/prettier-if-needed.yml
+++ b/.github/workflows/prettier-if-needed.yml
@@ -29,7 +29,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup pnpm and install dependencies
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 8
           run_install: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Setup pnpm and install dependencies
         uses: pnpm/action-setup@v4
         with:
-          version: 8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/testExports.yml
+++ b/.github/workflows/testExports.yml
@@ -18,7 +18,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/testExports.yml
+++ b/.github/workflows/testExports.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: lts/*
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/testExports.yml
+++ b/.github/workflows/testExports.yml
@@ -18,7 +18,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/typeCheck.yml
+++ b/.github/workflows/typeCheck.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/typeCheck.yml
+++ b/.github/workflows/typeCheck.yml
@@ -18,7 +18,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/typeCheck.yml
+++ b/.github/workflows/typeCheck.yml
@@ -18,7 +18,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 8.15.8
           run_install: false
 
       - name: Get pnpm store directory


### PR DESCRIPTION
### Description

This upgrades `pnpm/action-setup@v2` that uses Node 16 to v4 that uses Node 20. This gets rid of the deprecation warnings in GH actions. This version is also more strict and requires you to install the exact version if you have defined `packageManager` in package.json.

### What to review

Any downsides to upgrading? I know we do tests against Node 18 as well, but don't think this affects that in any way?

