### PR TITLE
fix(core): add focus ring to useravatar

### DIFF
--- a/packages/sanity/src/core/components/userAvatar/UserAvatar.tsx
+++ b/packages/sanity/src/core/components/userAvatar/UserAvatar.tsx
@@ -88,6 +88,7 @@ const StaticUserAvatar = forwardRef(function StaticUserAvatar(
 
   return (
     <Avatar
+      as="button"
       __unstable_hideInnerStroke
       animateArrowFrom={animateArrowFrom}
       arrowPosition={position}

--- a/packages/sanity/src/core/studio/components/navbar/userMenu/UserMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/userMenu/UserMenu.tsx
@@ -58,7 +58,7 @@ export function UserMenu() {
   return (
     <MenuButton
       button={
-        <Button mode="bleed" padding={0} radius="full">
+        <Button mode="bleed" padding={0} radius="full" tabIndex={-1}>
           <UserAvatar size={1} user="me" />
         </Button>
       }


### PR DESCRIPTION
### Description
From one of the accessibility reports there's a remark that the `UserAvatar` in the navbar doesn't have a focus ring when tabbing over it. 

This PR attempts to fix this, but since the `UserAvatar` is a button within the `UserMenu`, I had some difficulties with the tabbing and ended up with this solution where I've just added a `tabIndex={-1}` to the wrapper `Button`, and` as={button} `to the UserAvatar to get the focus ring. However, when opening the Menu, the focus will go to the wrapper button, resulting in the tab index to be off by one. 

If anyone has suggestions for a better fix, I appreciate feedback 🙇 


https://github.com/sanity-io/sanity/assets/44635000/e2e5a93d-e68c-4b07-8425-e2efcc21fee2


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
