### PR TITLE
fix(migrate): fixes error message to be more helpful

### DIFF
--- a/packages/@sanity/migrate/src/fetch-utils/__test__/assert2xx.test.ts
+++ b/packages/@sanity/migrate/src/fetch-utils/__test__/assert2xx.test.ts
@@ -42,3 +42,22 @@ test('server responds with 5xx and no json response', () => {
     message: 'HTTP Error 500: Internal Server Error',
   })
 })
+
+test('server responds with 5xx and json response', () => {
+  const mockResponse = {
+    status: 500,
+    statusText: 'Internal Server Error',
+    json: () =>
+      Promise.resolve({
+        error: {
+          type: 'validationError',
+          description: 'Document is not of valid type',
+        },
+        status: 500,
+      }),
+  }
+  expect(assert2xx(mockResponse as unknown as Response)).rejects.toThrowError({
+    statusCode: 500,
+    message: 'validationError: Document is not of valid type',
+  })
+})

--- a/packages/@sanity/migrate/src/fetch-utils/fetchStream.ts
+++ b/packages/@sanity/migrate/src/fetch-utils/fetchStream.ts
@@ -18,9 +18,17 @@ export async function assert2xx(res: Response): Promise<void> {
   if (res.status < 200 || res.status > 299) {
     const jsonResponse = await res.json().catch(() => null)
 
-    const message = jsonResponse?.error
-      ? `${jsonResponse.error}: ${jsonResponse.message}`
-      : `HTTP Error ${res.status}: ${res.statusText}`
+    let message: string
+
+    if (jsonResponse?.error) {
+      if (jsonResponse?.error?.description) {
+        message = `${jsonResponse?.error?.type || res.status}: ${jsonResponse.error.description}`
+      } else {
+        message = `${jsonResponse.error}: ${jsonResponse.message}`
+      }
+    } else {
+      message = `HTTP Error ${res.status}: ${res.statusText}`
+    }
 
     throw new HTTPError(res.status, message)
   }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Seems like the error response from backend is in the shape below

```ts
{ error: { type: string, description: string }
```

When we receive error in this shape we don't properly log that message making it hard for folks to debug. See screenshots below 

#### Before
![Screenshot 2024-06-18 at 2 49 06 PM](https://github.com/sanity-io/sanity/assets/6476108/72042cff-2849-4bca-9e62-e5348fc6cf4b)


#### After
![Screenshot 2024-06-18 at 2 49 32 PM](https://github.com/sanity-io/sanity/assets/6476108/ae36afcb-a47f-45d1-abae-8fbe70719e24)

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Copy and change makes sense, I checked the repo and there seems to be other places checking `error.description` so I am not sure if error will not be an object but I added a conditional to keep backwards compatibility

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Updated the test

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

- Migration error messages provide more details