### PR TITLE
fix(cli): correct noop return value on esbuild-register in dev

### DIFF
--- a/packages/sanity/src/_internal/cli/server/renderDocument.ts
+++ b/packages/sanity/src/_internal/cli/server/renderDocument.ts
@@ -189,7 +189,7 @@ function renderDocumentFromWorkerData() {
   // Same as above, but we don't want to enforce a .jsx extension for anything with JSX
   debug('Registering esbuild for .js files using jsx loader')
   const {unregister: unregisterJs} = __DEV__
-    ? () => ({unregister: () => undefined})
+    ? {unregister: () => undefined}
     : require('esbuild-register/dist/node').register({
         target: `node${process.version.slice(1)}`,
         extensions: ['.js'],


### PR DESCRIPTION
### Description

Saw this randomly on [this test-next-studio build](https://vercel.com/sanity-io/test-next-studio/GmsQegGwVvZBMssTnGz94fYEwtDY?filter=errors) - in some cases the unregistration of the esbuild-register instance failed. After some investigation, it seems like we're returning a function where we should be returning an object.

Not quite sure why this popped up _now_, but worth fixing.

### Testing

- test-next-studio should build without errors (CI)

### Notes for release

None