### PR TITLE
fix(core): make version check not depend on `process.env`

### DIFF
--- a/packages/sanity/src/core/studio/packageVersionStatus/checkForLatestVersions.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/checkForLatestVersions.ts
@@ -1,14 +1,14 @@
-//object like {sanity: '3.40.1'}
+// object like {sanity: '3.40.1'}
 interface VersionMap {
   [key: string]: string | undefined
 }
 
-//e2e tests also check for this URL pattern -- please update if it changes!
+// @ts-expect-error: __SANITY_STAGING__ is a global env variable set by the vite config
+const isStaging = typeof __SANITY_STAGING__ !== 'undefined' && __SANITY_STAGING__ === true
+
+// e2e tests also check for this URL pattern -- please update if it changes!
 const MODULES_URL_VERSION = 'v1'
-const MODULES_HOST =
-  process.env.SANITY_INTERNAL_ENV === 'staging'
-    ? 'https://sanity-cdn.work'
-    : 'https://sanity-cdn.com'
+const MODULES_HOST = isStaging ? 'https://sanity-cdn.work' : 'https://sanity-cdn.com'
 const MODULES_URL = `${MODULES_HOST}/${MODULES_URL_VERSION}/modules/`
 
 const fetchLatestVersionForPackage = async (pkg: string, version: string) => {
@@ -31,8 +31,6 @@ const fetchLatestVersionForPackage = async (pkg: string, version: string) => {
 export const checkForLatestVersions = async (
   packages: Record<string, string>,
 ): Promise<VersionMap | undefined> => {
-  const packageNames = Object.keys(packages)
-
   const results = await Promise.all(
     Object.entries(packages).map(async ([pkg, version]) => [
       pkg,


### PR DESCRIPTION
### Description

We recently introduced a version check for auto-updating studios that depend on `process.env` for telling if we're in staging or not - this doesn't work nicely across all environments, as some of them use `import.meta.env`, and others use `process.env`. To make things worse, we can't easily check for `process.env` and use `process.env[envVar]` as bundlers define these as "hard replacements" instead of actually defining an object.

This replaces the check with the same approach as we do in [createAuthStore](https://github.com/sanity-io/sanity/blob/next/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts#L147-L151), relying on the somewhat magic `__SANITY_STAGING__`  global defined in our [vite config](https://github.com/sanity-io/sanity/blob/next/packages/sanity/src/_internal/cli/server/getViteConfig.ts#L120).

This should be safe, as we only allow auto-updates on our own bundled studios for now.

### What to review

- Studio still runs as expected (does not crash when checking for the staging global)
- Still uses staging/production correctly (have tested this myself and it does work)

### Testing

We should add a test for this, but it needs to be run in a specific environment that does not have `process.env` defined, and we currently don't have an easy way of doing so. I'll make a note that we need to add some tests for multiple environments later.

### Notes for release

- Fixes a potential crash in certain javascript environments when trying to access `process.env`
