### PR TITLE
fix(core): change padding to fix tab box

### DIFF
--- a/packages/sanity/src/core/tasks/components/list/TasksList.tsx
+++ b/packages/sanity/src/core/tasks/components/list/TasksList.tsx
@@ -42,7 +42,7 @@ function TaskList(props: TaskListProps) {
 
   return (
     <DetailsFlex forwardedAs="details" direction="column" open={status === 'open'}>
-      <SummaryBox forwardedAs="summary">
+      <SummaryBox forwardedAs="summary" paddingY={1}>
         <Flex align="center" gap={1} paddingY={1}>
           <Text size={1} weight="medium" muted>
             {getLabelForStatus(status)}
@@ -54,7 +54,7 @@ function TaskList(props: TaskListProps) {
         </Flex>
       </SummaryBox>
 
-      <Stack space={4} marginTop={4} paddingBottom={5}>
+      <Stack space={4} marginTop={3} paddingBottom={5}>
         {tasks?.length > 0 ? (
           tasks.map((task, index) => {
             const showDivider = index < tasks.length - 1


### PR DESCRIPTION
### Description
Small UI fix when tabbing in tasks

Before: 
![Screenshot 2024-06-20 at 10 55 23](https://github.com/sanity-io/sanity/assets/44635000/6415c337-e80f-4970-9741-23a3945483c1)
After: 
![Screenshot 2024-06-20 at 10 55 17](https://github.com/sanity-io/sanity/assets/44635000/b37866e8-3282-4e41-8023-4fb5459f409e)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Tab box in tasks
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
