### PR TITLE
fix(structure): fix incorrect i18n key for discard changes button "no changes" status

### DIFF
--- a/packages/sanity/src/structure/documentActions/DiscardChangesAction.tsx
+++ b/packages/sanity/src/structure/documentActions/DiscardChangesAction.tsx
@@ -15,7 +15,7 @@ import {
 import {structureLocaleNamespace} from '../i18n'
 
 const DISABLED_REASON_KEY = {
-  NO_CHANGES: 'action.discard-changes.disabled.no-changes',
+  NO_CHANGES: 'action.discard-changes.disabled.no-change',
   NOT_PUBLISHED: 'action.discard-changes.disabled.not-published',
   NOT_READY: 'action.discard-changes.disabled.not-ready',
 } as const


### PR DESCRIPTION

### Description

Old: `action.discard-changes.disabled.no-changes`
New: `action.discard-changes.disabled.no-change`

This is to match what is in https://github.com/sanity-io/locales/

### What to review

Localization key for the alt text on the "Discard Changes" action when it is disabled. 

### Testing

https://github.com/sanity-io/locales/blob/main/locales/fr-FR/src/structure.ts#L17 for an example of the key translated / used


### Notes for release

None
