### PR TITLE
refactor(sanity): use openPath & update ImageInput and FileInput

### DIFF
--- a/dev/test-studio/schema/debug/objectsDebug.ts
+++ b/dev/test-studio/schema/debug/objectsDebug.ts
@@ -319,6 +319,11 @@ const arrayOfMixedTypes = defineField({
       title: 'Image',
     },
     {
+      type: 'file',
+      name: 'file',
+      title: 'File',
+    },
+    {
       name: 'author',
       type: 'reference',
       title: 'Author',

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -4,6 +4,8 @@ import {Stack, useToast} from '@sanity/ui'
 import {get} from 'lodash'
 import {type FocusEvent, memo, type ReactNode, useCallback, useMemo, useRef, useState} from 'react'
 import {type Subscription} from 'rxjs'
+import {shouldArrayDialogOpen} from 'sanity'
+import {useDocumentPane} from 'sanity/structure'
 
 import {useTranslation} from '../../../../i18n'
 import {FormInput} from '../../../components'
@@ -64,6 +66,8 @@ function BaseImageInputComponent(props: BaseImageInputProps): JSX.Element {
   // it when closing the dialog (see `handleAssetSourceClosed`)
   const [menuButtonElement, setMenuButtonElement] = useState<HTMLButtonElement | null>(null)
   const [isMenuOpen, setMenuOpen] = useState(false)
+
+  const {schemaType: documentSchemaType} = useDocumentPane()
 
   const uploadSubscription = useRef<null | Subscription>(null)
 
@@ -260,12 +264,15 @@ function BaseImageInputComponent(props: BaseImageInputProps): JSX.Element {
       // Background: https://github.com/facebook/react/issues/6410#issuecomment-671915381
       if (
         event.currentTarget === event.target &&
-        event.currentTarget === elementProps.ref?.current
+        event.currentTarget === elementProps.ref?.current &&
+        // when opening the array editing dialog, we don't want to focus to be on the element itself
+        // (the array) vs the item itself
+        !shouldArrayDialogOpen(documentSchemaType, path)
       ) {
         elementProps.onFocus(event)
       }
     },
-    [elementProps],
+    [elementProps, path, documentSchemaType],
   )
   const handleFilesOver = useCallback((nextHoveringFiles: FileInfo[]) => {
     setHoveringFiles(nextHoveringFiles.filter((file) => file.kind !== 'string'))

--- a/packages/sanity/src/core/form/studio/tree-editing/components/TreeEditingDialog.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/components/TreeEditingDialog.tsx
@@ -129,12 +129,7 @@ export function TreeEditingDialog(props: TreeEditingDialogProps): JSX.Element | 
     openPathRef.current = undefined
   }, [debouncedBuildTreeEditingState, onPathOpen])
 
-  // if the path is outside of the current window, we want to use the openPath
-  const pathToUse = openPath.some((path) => treeState.relativePath.includes(path))
-    ? treeState.relativePath
-    : openPath
-
-  const open = useMemo(() => shouldArrayDialogOpen(schemaType, pathToUse), [schemaType, pathToUse])
+  const open = useMemo(() => shouldArrayDialogOpen(schemaType, openPath), [schemaType, openPath])
 
   const onHandlePathSelect = useCallback(
     (path: Path) => {


### PR DESCRIPTION
### Description

Have opening method rely solely on openPath

Issue:
- HandleFocus on ImageInput and FileInput handle the focus in a particular manner due to a bubbling event in react

To dos
- Write component test for opening image and file items in input
- Add solution to fileInput (move to functionalcomponent)


### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
