### PR TITLE
fix(core): tree editing dialog open issue

### DIFF
--- a/packages/sanity/src/core/form/studio/tree-editing/components/TreeEditingDialog.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/components/TreeEditingDialog.tsx
@@ -129,12 +129,7 @@ export function TreeEditingDialog(props: TreeEditingDialogProps): JSX.Element | 
     openPathRef.current = undefined
   }, [debouncedBuildTreeEditingState, onPathOpen])
 
-  // if the path is outside of the current window, we want to use the openPath
-  const pathToUse = openPath.some((path) => treeState.relativePath.includes(path))
-    ? treeState.relativePath
-    : openPath
-
-  const open = useMemo(() => shouldArrayDialogOpen(schemaType, pathToUse), [schemaType, pathToUse])
+  const open = useMemo(() => shouldArrayDialogOpen(schemaType, openPath), [schemaType, openPath])
 
   const onHandlePathSelect = useCallback(
     (path: Path) => {
@@ -196,7 +191,7 @@ export function TreeEditingDialog(props: TreeEditingDialogProps): JSX.Element | 
     })
 
     return () => {
-      // Cancel any debounced state building when navigating.
+      // Cancel any debounced state building on unmount.
       debouncedBuildTreeEditingState.cancel()
     }
   }, [schemaType, value, debouncedBuildTreeEditingState, openPath, handleBuildTreeEditingState])

--- a/packages/sanity/src/core/form/studio/tree-editing/utils/getRootPath.ts
+++ b/packages/sanity/src/core/form/studio/tree-editing/utils/getRootPath.ts
@@ -6,14 +6,14 @@ import {type Path} from 'sanity'
  *
  * Example:
  * ```js
- * const rootPath = getRootPath(['object', 'array', { _key: '123'}])
+ * const rootPath = getRootPath(['object', 'array', { _key: '123' }])
  * // => ['object','array']
  * ```
  */
 export function getRootPath(path: Path): Path {
   const keyedSegmentIndex = path.findIndex((seg) => seg?.hasOwnProperty('_key'))
 
-  if (!keyedSegmentIndex) return path
+  if (keyedSegmentIndex === -1) return path
 
   return path.slice(0, keyedSegmentIndex)
 }


### PR DESCRIPTION
### Description

This pull request fixes an issue with `getRootPath`, which caused the tree editing dialog to not open correctly using `shouldArrayDialogOpen`. The function incorrectly returned an empty array when no `_key` was present in the path.

**Before**: `['array']` => `[]`  
**After**: `['array']` => `['array']`

The fix changes the condition to `if (keyedSegmentIndex === -1)`, ensuring the entire path is returned if no `_key` is found.


### What to review

- Make sure that the tree editing dialog opens correctly

### Notes for release

N/A
