### PR TITLE
BUGFIX: Do not abort migration if user used `--no-dry-run` and `--no-confirm` flags together

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -195,7 +195,7 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
         type: 'confirm',
       }))
 
-    if (response === false) {
+    if (flags.confirm && response === false) {
       debug('User aborted migration')
       return
     }


### PR DESCRIPTION
### Description

Currently Sanity has a bug where using the flags `--no-dry-run` and `--no-confirm` at once quits the migration instead of foregoing the confirmation prompt. This PR fixes it.

The `flags.confirm` used to be called `shouldConfirm` ( https://github.com/sanity-io/sanity/commit/2dba20698361e74e1bd67b390e42384d26ee4a85#diff-5dd59c387c299ba5b1746c4c0a69aed0ec8a759c264d799e8462f6a03f7e4a91L200 ) which might have created the confusion.

### What to review

Run a migration with both `--no-dry-run` and `--no-confirm` flags.

### Testing

Run a migration with both `--no-dry-run` and `--no-confirm` flags.

### Notes for release

- Fixes the usage of `--no-dry-run` and `--no-confirm` flags together.
