### PR TITLE
feat: include hashes in vendor builds

### DIFF
--- a/packages/sanity/src/_internal/cli/server/__tests__/buildVendorDependencies.test.ts
+++ b/packages/sanity/src/_internal/cli/server/__tests__/buildVendorDependencies.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {type InlineConfig} from 'vite'
 
 import {buildVendorDependencies} from '../buildVendorDependencies'
 
@@ -19,7 +20,17 @@ describe('buildVendorDependencies', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     const vite = require('vite')
-    vite.build.mockResolvedValue({})
+    vite.build.mockImplementation((input: InlineConfig) => {
+      const libOptions = input.build?.lib
+      if (!libOptions) throw new Error(`Expected lib in inline config`)
+
+      const output = Object.keys(libOptions.entry).map((entry) => ({
+        type: 'chunk',
+        name: entry,
+        fileName: `${entry.replace('/', '-')}-12345.mjs`,
+      }))
+      return Promise.resolve({output})
+    })
   })
 
   describe.each([
@@ -41,17 +52,17 @@ describe('buildVendorDependencies', () => {
       const imports = await buildVendorDependencies({cwd, basePath: basePath, outputDir})
 
       expect(imports).toEqual({
-        'react': `${expectedPath}vendor/react/index.mjs`,
-        'react-dom': `${expectedPath}vendor/react-dom/index.mjs`,
-        'react-dom/client': `${expectedPath}vendor/react-dom/client.mjs`,
-        'react-dom/package.json': `${expectedPath}vendor/react-dom/package.json.mjs`,
-        'react-dom/server': `${expectedPath}vendor/react-dom/server.mjs`,
-        'react-dom/server.browser': `${expectedPath}vendor/react-dom/server.browser.mjs`,
-        'react/jsx-dev-runtime': `${expectedPath}vendor/react/jsx-dev-runtime.mjs`,
-        'react/jsx-runtime': `${expectedPath}vendor/react/jsx-runtime.mjs`,
-        'react/package.json': `${expectedPath}vendor/react/package.json.mjs`,
-        'styled-components': `${expectedPath}vendor/styled-components/index.mjs`,
-        'styled-components/package.json': `${expectedPath}vendor/styled-components/package.json.mjs`,
+        'react': `${expectedPath}vendor/react-index-12345.mjs`,
+        'react-dom': `${expectedPath}vendor/react-dom-index-12345.mjs`,
+        'react-dom/client': `${expectedPath}vendor/react-dom-client-12345.mjs`,
+        'react-dom/package.json': `${expectedPath}vendor/react-dom-package.json-12345.mjs`,
+        'react-dom/server': `${expectedPath}vendor/react-dom-server-12345.mjs`,
+        'react-dom/server.browser': `${expectedPath}vendor/react-dom-server.browser-12345.mjs`,
+        'react/jsx-dev-runtime': `${expectedPath}vendor/react-jsx-dev-runtime-12345.mjs`,
+        'react/jsx-runtime': `${expectedPath}vendor/react-jsx-runtime-12345.mjs`,
+        'react/package.json': `${expectedPath}vendor/react-package.json-12345.mjs`,
+        'styled-components': `${expectedPath}vendor/styled-components-index-12345.mjs`,
+        'styled-components/package.json': `${expectedPath}vendor/styled-components-package.json-12345.mjs`,
       })
 
       expect(build).toHaveBeenCalledTimes(1)
@@ -144,20 +155,20 @@ describe('buildVendorDependencies', () => {
       const imports = await buildVendorDependencies({cwd, basePath, outputDir})
 
       expect(imports).toEqual({
-        'react': `${expectedPath}vendor/react/index.mjs`,
-        'react-dom': `${expectedPath}vendor/react-dom/index.mjs`,
-        'react-dom/client': `${expectedPath}vendor/react-dom/client.mjs`,
-        'react-dom/package.json': `${expectedPath}vendor/react-dom/package.json.mjs`,
-        'react-dom/server': `${expectedPath}vendor/react-dom/server.mjs`,
-        'react-dom/server.browser': `${expectedPath}vendor/react-dom/server.browser.mjs`,
-        'react-dom/static': `${expectedPath}vendor/react-dom/static.mjs`,
-        'react-dom/static.browser': `${expectedPath}vendor/react-dom/static.browser.mjs`,
-        'react/compiler-runtime': `${expectedPath}vendor/react/compiler-runtime.mjs`,
-        'react/jsx-dev-runtime': `${expectedPath}vendor/react/jsx-dev-runtime.mjs`,
-        'react/jsx-runtime': `${expectedPath}vendor/react/jsx-runtime.mjs`,
-        'react/package.json': `${expectedPath}vendor/react/package.json.mjs`,
-        'styled-components': `${expectedPath}vendor/styled-components/index.mjs`,
-        'styled-components/package.json': `${expectedPath}vendor/styled-components/package.json.mjs`,
+        'react': `${expectedPath}vendor/react-index-12345.mjs`,
+        'react-dom': `${expectedPath}vendor/react-dom-index-12345.mjs`,
+        'react-dom/client': `${expectedPath}vendor/react-dom-client-12345.mjs`,
+        'react-dom/package.json': `${expectedPath}vendor/react-dom-package.json-12345.mjs`,
+        'react-dom/server': `${expectedPath}vendor/react-dom-server-12345.mjs`,
+        'react-dom/server.browser': `${expectedPath}vendor/react-dom-server.browser-12345.mjs`,
+        'react-dom/static': `${expectedPath}vendor/react-dom-static-12345.mjs`,
+        'react-dom/static.browser': `${expectedPath}vendor/react-dom-static.browser-12345.mjs`,
+        'react/compiler-runtime': `${expectedPath}vendor/react-compiler-runtime-12345.mjs`,
+        'react/jsx-dev-runtime': `${expectedPath}vendor/react-jsx-dev-runtime-12345.mjs`,
+        'react/jsx-runtime': `${expectedPath}vendor/react-jsx-runtime-12345.mjs`,
+        'react/package.json': `${expectedPath}vendor/react-package.json-12345.mjs`,
+        'styled-components': `${expectedPath}vendor/styled-components-index-12345.mjs`,
+        'styled-components/package.json': `${expectedPath}vendor/styled-components-package.json-12345.mjs`,
       })
 
       expect(build).toHaveBeenCalledTimes(1)

--- a/packages/sanity/src/_internal/cli/server/buildVendorDependencies.ts
+++ b/packages/sanity/src/_internal/cli/server/buildVendorDependencies.ts
@@ -206,8 +206,11 @@ export async function buildVendorDependencies({
     }
   }
 
+  // removes the `RollupWatcher` type
+  type BuildResult = Exclude<Awaited<ReturnType<typeof build>>, {close: unknown}>
+
   // Use Vite to build the packages into the output directory
-  await build({
+  let buildResult = (await build({
     // Define a custom cache directory so that sanity's vite cache
     // does not conflict with any potential local vite projects
     cacheDir: 'node_modules/.sanity/vite-vendor',
@@ -226,11 +229,32 @@ export async function buildVendorDependencies({
       lib: {entry, formats: ['es']},
       rollupOptions: {
         external: createExternalFromImportMap({imports}),
-        output: {exports: 'named', format: 'es'},
+        output: {
+          entryFileNames: '[name]-[hash].mjs',
+          chunkFileNames: '[name]-[hash].mjs',
+          exports: 'named',
+          format: 'es',
+        },
         treeshake: {preset: 'recommended'},
       },
     },
-  })
+  })) as BuildResult
 
-  return imports
+  buildResult = Array.isArray(buildResult) ? buildResult : [buildResult]
+
+  // Create a map of the original import specifiers to their hashed filenames
+  const hashedImports: Record<string, string> = {}
+  const output = buildResult.flatMap((i) => i.output)
+
+  for (const chunk of output) {
+    if (chunk.type === 'asset') continue
+
+    for (const [specifier, originalPath] of Object.entries(imports)) {
+      if (originalPath.endsWith(`${chunk.name}.mjs`)) {
+        hashedImports[specifier] = path.posix.join('/', basePath, VENDOR_DIR, chunk.fileName)
+      }
+    }
+  }
+
+  return hashedImports
 }


### PR DESCRIPTION
### Description

This PR updates the `buildVendorDependencies` function to correctly handle and return hashed filenames in the import map. The changes involve modifying the Vite build configuration to include hashes in the output filenames and then updating the function to map the original import specifiers to their hashed filenames. This ensures that the import map reflects the hashed filenames produced by the Vite build process, improving cache management and consistency.

### What to review

- Review the changes in `buildVendorDependencies.ts` to ensure the correct handling of hashed filenames in the import map.
- Check the test file `buildVendorDependencies.test.ts` to confirm that the tests accurately reflect the new behavior and correctly mock the Vite build process.
- Ensure that the implementation correctly maps original specifiers to the hashed output from the Vite build.

### Testing

- The existing tests in `buildVendorDependencies.test.ts` have been updated to mock the Vite build process and generate hashed filenames.
- New checks have been added to verify that the returned import map includes the correct hashed filenames.

### Notes for release

N/A - this feature has not been announced yet and changes to it aren't relevant