### PR TITLE
fix: check for telemetry consent before error reporting

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -264,6 +264,7 @@
     "@sanity/pkg-utils": "6.9.3",
     "@sanity/tsdoc": "1.0.72",
     "@sanity/ui-workshop": "^1.2.11",
+    "@sentry/types": "^8.12.0",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.0.16",

--- a/packages/sanity/src/core/error/errorReporter.ts
+++ b/packages/sanity/src/core/error/errorReporter.ts
@@ -25,6 +25,13 @@ export interface ErrorReporter {
    * @returns An object containing information on the reported error, or `null` if ignored
    */
   reportError: (error: Error, options?: ErrorInfo) => {eventId: string} | null
+  /**
+   * In some cases (for example, when we are respecting telemetry consent and not sending data to 3rd parties),
+   * we may start the error reporter in a disabled state, where it will not report errors.
+   * This method can be used to activate the error reporter.
+   */
+  enable: () => void
+  disable: () => void
 }
 
 /**

--- a/packages/sanity/src/core/error/errorReporter.ts
+++ b/packages/sanity/src/core/error/errorReporter.ts
@@ -27,7 +27,7 @@ export interface ErrorReporter {
   reportError: (error: Error, options?: ErrorInfo) => {eventId: string} | null
   /**
    * In some cases (for example, when we are respecting telemetry consent and not sending data to 3rd parties),
-   * we may start the error reporter in a disabled state, where it will not report errors.
+   * we may start the error reporter in a pending state, where it will not report errors.
    * This method can be used to activate the error reporter.
    */
   enable: () => void

--- a/packages/sanity/src/core/error/sentry/makeBufferedTransport.ts
+++ b/packages/sanity/src/core/error/sentry/makeBufferedTransport.ts
@@ -1,0 +1,55 @@
+import {makeFetchTransport} from '@sentry/react'
+import {type EventEnvelope, type Transport, type TransportMakeRequestResponse} from '@sentry/types'
+
+type BufferedTransport = Transport & {
+  setConsent: (consentGiven: boolean) => Promise<void>
+}
+
+/*
+ * Because we want to buffer events until the user has given consent to telemetry,
+ * we need to implement a custom transport, but mostly wrap the fetch transport.
+ */
+export function makeBufferedTransport(options: any): BufferedTransport {
+  let buffer: EventEnvelope[] = []
+  let consentGiven: boolean | undefined
+  const fetchTransport = makeFetchTransport(options)
+
+  const send = async (event: EventEnvelope) => {
+    if (consentGiven) {
+      return sendImmediately(event)
+    }
+    //we may not have received consent yet. Buffer the event until we know what to do.
+    else if (typeof consentGiven === 'undefined') {
+      buffer.push(event)
+    }
+    return {}
+  }
+
+  const sendImmediately = async (event: EventEnvelope): Promise<TransportMakeRequestResponse> => {
+    return fetchTransport.send(event)
+  }
+
+  const setConsent = async (consent: boolean) => {
+    consentGiven = consent
+    //we clear the buffer if consent is given (since we've sent the buffered events)
+    //and we clear the buffer if consent is revoked (since the events should not be sent)
+    if (consent) {
+      await flushBuffer()
+    }
+    buffer = []
+  }
+
+  const flushBuffer = async () => {
+    buffer.map(sendImmediately)
+  }
+
+  const flush = async () => {
+    return fetchTransport.flush()
+  }
+
+  return {
+    flush,
+    send,
+    setConsent,
+  }
+}

--- a/packages/sanity/src/core/error/sentry/makeBufferedTransport.ts
+++ b/packages/sanity/src/core/error/sentry/makeBufferedTransport.ts
@@ -8,6 +8,7 @@ export type BufferedTransport = Transport & {
 /*
  * Because we want to buffer events until the user has given consent to telemetry,
  * we need to implement a custom transport, but mostly wrap the fetch transport.
+  @internal
  */
 export function makeBufferedTransport(options: any): BufferedTransport {
   let buffer: EventEnvelope[] = []
@@ -22,6 +23,7 @@ export function makeBufferedTransport(options: any): BufferedTransport {
     else if (typeof consentGiven === 'undefined') {
       buffer.push(event)
     }
+    // consent not given, skip sending the event
     return {}
   }
 

--- a/packages/sanity/src/core/error/sentry/makeBufferedTransport.ts
+++ b/packages/sanity/src/core/error/sentry/makeBufferedTransport.ts
@@ -1,14 +1,17 @@
 import {makeFetchTransport} from '@sentry/react'
 import {type EventEnvelope, type Transport, type TransportMakeRequestResponse} from '@sentry/types'
 
+/**
+ * @internal
+ */
 export type BufferedTransport = Transport & {
   setConsent: (consentGiven: boolean) => Promise<void>
 }
 
-/*
+/**
  * Because we want to buffer events until the user has given consent to telemetry,
  * we need to implement a custom transport, but mostly wrap the fetch transport.
-  @internal
+ * @internal
  */
 export function makeBufferedTransport(options: any): BufferedTransport {
   let buffer: EventEnvelope[] = []
@@ -19,8 +22,9 @@ export function makeBufferedTransport(options: any): BufferedTransport {
     if (consentGiven) {
       return sendImmediately(event)
     }
+
     //we may not have received consent yet. Buffer the event until we know what to do.
-    else if (typeof consentGiven === 'undefined') {
+    if (typeof consentGiven === 'undefined') {
       buffer.push(event)
     }
     // consent not given, skip sending the event

--- a/packages/sanity/src/core/error/sentry/makeBufferedTransport.ts
+++ b/packages/sanity/src/core/error/sentry/makeBufferedTransport.ts
@@ -1,7 +1,7 @@
 import {makeFetchTransport} from '@sentry/react'
 import {type EventEnvelope, type Transport, type TransportMakeRequestResponse} from '@sentry/types'
 
-type BufferedTransport = Transport & {
+export type BufferedTransport = Transport & {
   setConsent: (consentGiven: boolean) => Promise<void>
 }
 
@@ -40,7 +40,9 @@ export function makeBufferedTransport(options: any): BufferedTransport {
   }
 
   const flushBuffer = async () => {
-    buffer.map(sendImmediately)
+    await Promise.all(buffer.map(sendImmediately)).catch((err) => {
+      console.error('Failed to send buffered events from transport: ', err)
+    })
   }
 
   const flush = async () => {

--- a/packages/sanity/src/core/error/sentry/sentryErrorReporter.ts
+++ b/packages/sanity/src/core/error/sentry/sentryErrorReporter.ts
@@ -179,13 +179,15 @@ export function getSentryErrorReporter(): ErrorReporter {
   }
 
   function enable() {
-    if (isBufferedTransport(client?.getTransport())) {
-      ;(client?.getTransport() as BufferedTransport).setConsent(true)
+    const transport = client?.getTransport()
+    if (isBufferedTransport(transport)) {
+      transport.setConsent(true)
     }
   }
   function disable() {
-    if (isBufferedTransport(client?.getTransport())) {
-      ;(client?.getTransport() as BufferedTransport).setConsent(false)
+    const transport = client?.getTransport()
+    if (isBufferedTransport(transport)) {
+      transport.setConsent(false)
     }
   }
 

--- a/packages/sanity/src/core/error/sentry/sentryErrorReporter.ts
+++ b/packages/sanity/src/core/error/sentry/sentryErrorReporter.ts
@@ -2,7 +2,6 @@ import {
   breadcrumbsIntegration,
   browserApiErrorsIntegration,
   BrowserClient,
-  type BrowserOptions,
   captureException,
   dedupeIntegration,
   defaultStackParser,
@@ -39,7 +38,7 @@ const DEBUG_ERROR_REPORTING =
 
 const IS_BROWSER = typeof window !== 'undefined'
 
-const clientOptions: BrowserOptions = {
+const clientOptions = {
   dsn: SANITY_DSN,
   release: SANITY_VERSION,
   environment: isDev ? 'development' : 'production',
@@ -103,7 +102,6 @@ export function getSentryErrorReporter(): ErrorReporter {
     if (hasThirdPartySentry) {
       client = new BrowserClient({
         ...clientOptions,
-        transport: makeBufferedTransport,
         stackParser: defaultStackParser,
         integrations,
         beforeSend,

--- a/packages/sanity/src/core/error/sentry/sentryErrorReporter.ts
+++ b/packages/sanity/src/core/error/sentry/sentryErrorReporter.ts
@@ -2,6 +2,7 @@ import {
   breadcrumbsIntegration,
   browserApiErrorsIntegration,
   BrowserClient,
+  type BrowserOptions,
   captureException,
   dedupeIntegration,
   defaultStackParser,
@@ -38,7 +39,7 @@ const DEBUG_ERROR_REPORTING =
 
 const IS_BROWSER = typeof window !== 'undefined'
 
-const clientOptions = {
+const clientOptions: BrowserOptions = {
   dsn: SANITY_DSN,
   release: SANITY_VERSION,
   environment: isDev ? 'development' : 'production',
@@ -105,6 +106,7 @@ export function getSentryErrorReporter(): ErrorReporter {
         stackParser: defaultStackParser,
         integrations,
         beforeSend,
+        transport: makeBufferedTransport,
       })
 
       scope = new Scope()

--- a/packages/sanity/src/core/studio/EnableErrorReporting.ts
+++ b/packages/sanity/src/core/studio/EnableErrorReporting.ts
@@ -19,6 +19,8 @@ export function EnableErrorReporting() {
 
         if (res?.status === 'granted' || res?.status === 'unset') {
           errorReporter.enable()
+        } else {
+          errorReporter.disable()
         }
       } catch (e) {
         console.error('Error fetching telemetry status', e)

--- a/packages/sanity/src/core/studio/EnableErrorReporting.ts
+++ b/packages/sanity/src/core/studio/EnableErrorReporting.ts
@@ -17,7 +17,7 @@ export function EnableErrorReporting() {
       try {
         const res = await fetchTelemetryConsent(client)
 
-        if (res?.status === 'granted' || res?.status === 'unset') {
+        if (res?.status === 'granted') {
           errorReporter.enable()
         } else {
           errorReporter.disable()

--- a/packages/sanity/src/core/studio/EnableErrorReporting.tsx
+++ b/packages/sanity/src/core/studio/EnableErrorReporting.tsx
@@ -1,0 +1,32 @@
+import {type SanityClient} from '@sanity/client'
+import {useEffect} from 'react'
+
+import {errorReporter} from '../error/errorReporter'
+import {useClient} from '../hooks'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../studioClient'
+
+async function fetchTelemetryConsent(client: SanityClient) {
+  return client.request({uri: '/intake/telemetry-status'})
+}
+
+export function EnableErrorReporting() {
+  const client = useClient().withConfig(DEFAULT_STUDIO_CLIENT_OPTIONS)
+
+  useEffect(() => {
+    async function checkConsent() {
+      try {
+        const res = await fetchTelemetryConsent(client)
+
+        if (res?.status === 'granted' || res?.status === 'unset') {
+          errorReporter.enable()
+        }
+      } catch (e) {
+        console.error('Error fetching telemetry status', e)
+      }
+    }
+
+    checkConsent()
+  }, [client])
+
+  return null
+}

--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -17,6 +17,7 @@ import {ActiveWorkspaceMatcher} from './activeWorkspaceMatcher'
 import {AuthBoundary} from './AuthBoundary'
 import {ColorSchemeProvider} from './colorScheme'
 import {Z_OFFSET} from './constants'
+import {EnableErrorReporting} from './EnableErrorReporting'
 import {PackageVersionStatusProvider} from './packageVersionStatus/PackageVersionStatusProvider'
 import {
   AuthenticateScreen,
@@ -66,6 +67,7 @@ export function StudioProvider({
       <StudioTelemetryProvider config={config}>
         <LocaleProvider>
           <PackageVersionStatusProvider>
+            <EnableErrorReporting />
             <ResourceCacheProvider>{children}</ResourceCacheProvider>
           </PackageVersionStatusProvider>
         </LocaleProvider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1730,6 +1730,9 @@ importers:
       '@sanity/ui-workshop':
         specifier: ^1.2.11
         version: 1.2.11(@sanity/icons@3.2.0)(@sanity/ui@2.4.0)(@types/node@18.19.31)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+      '@sentry/types':
+        specifier: ^8.12.0
+        version: 8.12.0
       '@testing-library/jest-dom':
         specifier: ^6.2.0
         version: 6.4.2(@jest/globals@29.7.0)(jest@29.7.0)
@@ -7290,7 +7293,7 @@ packages:
       esbuild-register: 3.5.0(esbuild@0.21.5)
       express: 4.19.2
       globby: 11.1.0
-      groq: 3.46.1
+      groq: 3.48.0
       groq-js: 1.9.0
       history: 5.3.0
       jsonc-parser: 3.2.1
@@ -7351,7 +7354,7 @@ packages:
       esbuild-register: 3.5.0(esbuild@0.21.5)
       express: 4.19.2
       globby: 11.1.0
-      groq: 3.46.1
+      groq: 3.48.0
       groq-js: 1.9.0
       history: 5.3.0
       jsonc-parser: 3.2.1
@@ -7649,6 +7652,11 @@ packages:
       '@sentry/utils': 8.9.2
       hoist-non-react-statics: 3.3.2
       react: 18.3.1
+
+  /@sentry/types@8.12.0:
+    resolution: {integrity: sha512-pKuW64IjgcklWAOHzPJ02Ej480hyL25TLnYCAfl2TDMrYc+N0bbbH1N7ZxqJpTSVK9IxZPY/t2TRxpQBiyPEcg==}
+    engines: {node: '>=14.18'}
+    dev: true
 
   /@sentry/types@8.9.2:
     resolution: {integrity: sha512-+LFOyQGl+zk5SZRGZD2MEURf7i5RHgP/mt3s85Rza+vz8M211WJ0YsjkIGUJFSY842nged5QLx4JysLaBlLymg==}
@@ -13109,14 +13117,9 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /groq@3.46.1:
-    resolution: {integrity: sha512-IHKiK2LjTQkaBteXxvxJi3fQz4uyjfxgzcXa8mWxhe4oZjWMRi0p9mNe8//aK/UA0d3u5j0oepID5g0cS0Enww==}
-    engines: {node: '>=18'}
-
   /groq@3.48.0:
     resolution: {integrity: sha512-0l4wqGpaT4JPiVD34hlhQ9fV3I6tcj0O1tieJcOF33NcgjhrW7uXYEzWWQ8aHXzGDWhP7kMAz1HGaXNqTo+s4Q==}
     engines: {node: '>=18'}
-    dev: true
 
   /growly@1.3.0:
     resolution: {integrity: sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==}


### PR DESCRIPTION
### Description
In order to respect our users' telemetry consent, it's become necessary to ensure we don't send events to Sentry when consent has not been granted.

We are somewhat changing the paradigm of error reporting, where error reporters are assumed to be in a "disabled" state until otherwise enabled. We're doing so by:

1. Adding an `enable` and `disable` function on the errorReporter.
2. Adding a component to StudioProvider at an appropriate depth where the client can check the user's consent status.
3. In our specific Sentry implementation, initializing Sentry with a custom transport that buffers events until consent is received.

### What to review
Are we satisfied with this? Any caveats about in-memory issues or fragility?

### Testing
I'd like to incorporate tests for this in my other PR (#7002) -- possibly by intercepting the telemetry status call, since it happens later in the application.