### PR TITLE
fix: deprecate @sanity/portable-text-editor

### DIFF
--- a/packages/@sanity/portable-text-editor/README.md
+++ b/packages/@sanity/portable-text-editor/README.md
@@ -1,3 +1,3 @@
-# @sanity/portable-text-editor
+# ⚠ This package is deprecated ️
 
-More info to come!
+Please note that this package is deprecated and has been replaced by [@portabletext/editor](https://www.npmjs.com/package/@portabletext/editor).


### PR DESCRIPTION
I think it would be good to update the README of https://www.npmjs.com/package/@sanity/portable-text-editor to state that it has been deprecated. 

I'm a little unsure about the correct procedure though. Do we need to merge this PR which updates the README, wait until next week until a new Studio release and first then we can merge https://github.com/sanity-io/sanity/pull/7001 which deletes the package from this repo?

Or can the process be sped up somehow? I would love to merge #7001 soon-ish.