### PR TITLE
Fix(CLI): Set integration value for createProject directly in the createProject function

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -815,7 +815,7 @@ export default async function initSanity(
         displayName: projectName,
         organizationId: await getOrganizationId(organizations),
         subscription: selectedPlan ? {planId: selectedPlan} : undefined,
-        metadata: {coupon: intendedCoupon, integration: 'cli'},
+        metadata: {coupon: intendedCoupon},
       }).then((response) => ({
         ...response,
         isFirstProject: isUsersFirstProject,

--- a/packages/@sanity/cli/src/actions/project/createProject.ts
+++ b/packages/@sanity/cli/src/actions/project/createProject.ts
@@ -23,7 +23,7 @@ export function createProject(
       uri: '/projects',
       body: {
         ...options,
-        metadata: { ...options?.metadata, source: 'cli'},
+        metadata: { ...options?.metadata, integration: 'cli'},
       }
     })
     .then((response) => ({

--- a/packages/@sanity/cli/src/actions/project/createProject.ts
+++ b/packages/@sanity/cli/src/actions/project/createProject.ts
@@ -23,7 +23,10 @@ export function createProject(
       uri: '/projects',
       body: {
         ...options,
-        metadata: {...options?.metadata, integration: 'cli'},
+        metadata: {
+          ...options?.metadata,
+          integration: 'cli',
+        },
       }
     })
     .then((response) => ({

--- a/packages/@sanity/cli/src/actions/project/createProject.ts
+++ b/packages/@sanity/cli/src/actions/project/createProject.ts
@@ -21,7 +21,10 @@ export function createProject(
     .request({
       method: 'POST',
       uri: '/projects',
-      body: options,
+      body: {
+        ...options,
+        metadata: { ...options?.metadata, source: 'cli'},
+      }
     })
     .then((response) => ({
       projectId: response.projectId || response.id,

--- a/packages/@sanity/cli/src/actions/project/createProject.ts
+++ b/packages/@sanity/cli/src/actions/project/createProject.ts
@@ -27,7 +27,7 @@ export function createProject(
           ...options?.metadata,
           integration: 'cli',
         },
-      }
+      },
     })
     .then((response) => ({
       projectId: response.projectId || response.id,

--- a/packages/@sanity/cli/src/actions/project/createProject.ts
+++ b/packages/@sanity/cli/src/actions/project/createProject.ts
@@ -23,7 +23,7 @@ export function createProject(
       uri: '/projects',
       body: {
         ...options,
-        metadata: { ...options?.metadata, integration: 'cli'},
+        metadata: {...options?.metadata, integration: 'cli'},
       }
     })
     .then((response) => ({

--- a/packages/@sanity/cli/src/util/journeyConfig.ts
+++ b/packages/@sanity/cli/src/util/journeyConfig.ts
@@ -183,7 +183,6 @@ async function fetchJourneySchema(schemaUrl: string): Promise<DocumentOrObject[]
  */
 async function assembleJourneySchemaTypeFileContent(schemaType: DocumentOrObject): Promise<string> {
   const serialised = wrapSchemaTypeInHelpers(schemaType)
-  console.log('serialised', serialised)
   const imports = getImports(serialised)
   const prettifiedSchemaType = await format(serialised, {
     parser: 'typescript',

--- a/packages/@sanity/cli/src/util/journeyConfig.ts
+++ b/packages/@sanity/cli/src/util/journeyConfig.ts
@@ -183,6 +183,7 @@ async function fetchJourneySchema(schemaUrl: string): Promise<DocumentOrObject[]
  */
 async function assembleJourneySchemaTypeFileContent(schemaType: DocumentOrObject): Promise<string> {
   const serialised = wrapSchemaTypeInHelpers(schemaType)
+  console.log('serialised', serialised)
   const imports = getImports(serialised)
   const prettifiedSchemaType = await format(serialised, {
     parser: 'typescript',


### PR DESCRIPTION
### Description

Moving the position of where integration for a new project is defined, since createProject is called in multiple places throughout the CLI.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

- Create a new project though the cli
- Curl the `v1/projects/{projectId}` endpoint
- Verify that integration value is set to `cli`

### Notes for release

No notes