### PR TITLE
fix(core): put back select button for single-asset source

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputBrowser.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputBrowser.tsx
@@ -64,5 +64,20 @@ function ImageInputBrowserComponent(
       />
     )
   }
+
+  return (
+    <Button
+      text={t('inputs.image.browse-menu.text')}
+      icon={SearchIcon}
+      mode="bleed"
+      // eslint-disable-next-line react/jsx-no-bind
+      onClick={() => {
+        setMenuOpen(false)
+        handleSelectImageFromAssetSource(assetSources[0])
+      }}
+      data-testid="file-input-browse-button"
+      disabled={readOnly}
+    />
+  )
 }
 export const ImageInputBrowser = memo(forwardRef(ImageInputBrowserComponent))


### PR DESCRIPTION
### Description

Seems like there was a regression in #6930 where the Select/Browse button would not render if there was only a single asset source.

### What to review

Does the button show up now for a single asset source?

### Testing

I removed the custom asset source so that there would only be one in the test studio, observed the bug, then fixed it.

### Notes for release

Fixes a regression that caused the Select button to not appear.
