### PR TITLE
fix(cli): allow no-confirm no-dry-run migrations

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -186,18 +186,18 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
       `To adjust them, launch the management interface with ${chalk.cyan('sanity manage')}, navigate to the API settings, and toggle the webhooks before and after the migration as needed.\n`,
     )
 
-    const response =
-      flags.confirm &&
-      (await prompt.single<boolean>({
+    if (flags.confirm) {
+      const response = await prompt.single<boolean>({
         message: `This migration will run on the ${chalk.yellow(
           chalk.bold(apiConfig.dataset),
         )} dataset in ${chalk.yellow(chalk.bold(apiConfig.projectId))} project. Are you sure?`,
         type: 'confirm',
-      }))
+      })
 
-    if (response === false) {
-      debug('User aborted migration')
-      return
+      if (!response) {
+        debug('User aborted migration')
+        return
+      }
     }
 
     const spinner = output.spinner(`Running migration "${id}"`).start()


### PR DESCRIPTION
### Description

Supersedes #7016 but has the same outcome.

### What to review

Does this allow `--no-dry-run` and `--no-confirm` together?

### Testing

https://github.com/sanity-io/sanity/assets/10551026/73708788-b698-4063-b34e-8debc6ad5978

### Notes for release

Fixes a bug where `--no-dry-run` and `--no-confirm` could not be used together.

Big thanks to @pawelngei
