### PR TITLE
build: remove `Version` step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       NPM_CONFIG_PROVENANCE: true
+      PKG_VERSION: ${{ inputs.version }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -59,6 +60,10 @@ jobs:
 
       - name: Pre-flight
         run: |
+          # Check if the incoming version exactly matches the format xx.xx.xx e.g. no `v` prefix
+          [[ "$PKG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            || { echo "PKG_VERSION must be an explicit semver version with no `v` prefix"; exit 1; }
+
           # Check incoming version is at or above the currently published version on NPM
           # Note: we allow the current version in the even that a publish partially fails
           npx semver ${{ inputs.version }} -r ">=$(npm show sanity version) 3.x"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,17 +92,6 @@ jobs:
           git checkout current
           git rebase ${{ github.ref }}
 
-      - name: Version
-        run: |
-          # Just bump the versions first, no push yet
-          lerna version           \
-            --no-git-tag-version  \
-            --no-push             \
-            --force-publish       \
-            --exact               \
-            --yes                 \
-            ${{ inputs.version }}
-
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped
 


### PR DESCRIPTION

### Description

The `Version` step in the release.yml workflow was added so that the build could be ran with updated `package.json` version but this was causing an issue with mismatched types and packages causing the build when installing after the version bump. it's not strictly necessary so we'll be removing this as a result.

![CleanShot 2024-06-26 at 17 10 31@2x](https://github.com/sanity-io/sanity/assets/10551026/c7c2a50a-b68c-40df-af90-9cc2d573a51b)

### What to review

~~Do we rely on the `Version` step at all? I believe we have measures in place that get the monorepo version in other ways so this version step should not be necessary.~~

Had a sync with @rexxars and we found that if the environment variable `PKG_VERSION` is set, it circumvents the needs to run `lerna version` prior to running the build.

### Testing

In order to test the above theory, I ran the build locally with the environment variable PKG_VERSION set to a different version than in the package.json and looked at the build result. All places where the version was referenced reflected the `PKG_VERSION` instead.

### Notes for release

N/A - internal build fix
