### PR TITLE
refactor(typegen): use typenode to lookup referencing type names

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/__snapshots__/typeGenerator.test.ts.snap
+++ b/packages/@sanity/codegen/src/typescript/__tests__/__snapshots__/typeGenerator.test.ts.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`generateSchemaTypes Adds a comment when missing referenced inline type 1`] = `
+"export type MyObject = unknown // Unable to locate the referenced type \\"test\\" in schema
+;"
+`;
+
 exports[`generateSchemaTypes can generate well known types 1`] = `"export declare const internalGroqTypeReferenceTo: unique symbol;"`;
 
 exports[`generateSchemaTypes generateTypeNodeTypes should be able to generate types for type nodes: boolean 1`] = `"export type Test_2 = boolean;"`;

--- a/packages/@sanity/codegen/src/typescript/__tests__/typeGenerator.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/typeGenerator.test.ts
@@ -415,7 +415,16 @@ export type AllSanitySchemaTypes = OptionalData;"
       },
     } satisfies TypeNode
 
-    const typeGenerator = new TypeGenerator([])
+    const typeGenerator = new TypeGenerator([
+      {
+        type: 'type',
+        name: 'test',
+        value: {
+          type: 'object',
+          attributes: {test: {type: 'objectAttribute', value: {type: 'string'}}},
+        },
+      },
+    ])
     const objectNodeOut = typeGenerator.generateTypeNodeTypes('myObject', objectNode)
     expect(objectNodeOut).toMatchSnapshot()
 
@@ -424,5 +433,25 @@ export type AllSanitySchemaTypes = OptionalData;"
       name: 'myObject',
     })
     expect(someOtherTypeOut).toMatchSnapshot()
+  })
+
+  test('Adds a comment when missing referenced inline type', () => {
+    const objectNode = {
+      type: 'object',
+      attributes: {
+        test: {
+          type: 'objectAttribute',
+          value: {type: 'string'},
+        },
+      },
+      rest: {
+        type: 'inline',
+        name: 'test',
+      },
+    } satisfies TypeNode
+
+    const typeGenerator = new TypeGenerator([])
+    const objectNodeOut = typeGenerator.generateTypeNodeTypes('myObject', objectNode)
+    expect(objectNodeOut).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
### Description

When we generate the types we hold the generated type name in case it's referenced later. This was needed primarily because we, earlier, wanted to support multiple queries having the same name etc. Since we now doesn't allow this, it's not a big case. However, in https://github.com/sanity-io/sanity/pull/6997 we need to later reference all the names by the type nodes.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Correctness: The outputted types should be 100% identical to the previous.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Tests should still pass, I added a test for the case where it's referencing a type node we haven't seen.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

n/a - no notes needed

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
