### PR TITLE
feat(corel): integrate bundles store

### DIFF
--- a/packages/sanity/src/core/store/bundles/__workshop__/BundlesStoreStory.tsx
+++ b/packages/sanity/src/core/store/bundles/__workshop__/BundlesStoreStory.tsx
@@ -1,0 +1,112 @@
+import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {type ComponentType, type FormEvent, useCallback, useState} from 'react'
+import {AddonDatasetProvider, LoadingBlock} from 'sanity'
+
+import {Button} from '../../../../ui-components'
+import {type BundleDocument} from '../types'
+import {useBundleOperations} from '../useBundleOperations'
+import {useBundlesStore} from '../useBundlesStore'
+import {ReleaseForm} from './ReleaseForm'
+
+const WithAddonDatasetProvider = <P extends object>(Component: ComponentType<P>): React.FC<P> => {
+  // Function that returns the wrapped component
+  const WrappedComponent: React.FC<P> = (props) => (
+    <AddonDatasetProvider>
+      <Component {...props} />
+    </AddonDatasetProvider>
+  )
+
+  // Setting a display name for the wrapped component
+  WrappedComponent.displayName = `WithAddonDatasetProvider(${Component.displayName || Component.name || 'Component'})`
+
+  return WrappedComponent
+}
+
+const initialValue = {name: '', title: '', tone: undefined, publishAt: undefined}
+const BundlesStoreStory = () => {
+  const {data, loading} = useBundlesStore()
+  const {createBundle, deleteBundle} = useBundleOperations()
+  const [creating, setCreating] = useState(false)
+  const [deleting, setDeleting] = useState<string | null>(null)
+  const [value, setValue] = useState<Partial<BundleDocument>>(initialValue)
+  const handleCreateBundle = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      try {
+        event.preventDefault()
+        setCreating(true)
+        await createBundle(value)
+        setValue(initialValue)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setCreating(false)
+      }
+    },
+    [createBundle, value],
+  )
+
+  const handleDeleteBundle = useCallback(
+    async (id: string) => {
+      try {
+        setDeleting(id)
+        await deleteBundle(id)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setDeleting(null)
+      }
+    },
+    [deleteBundle],
+  )
+
+  return (
+    <Stack space={3}>
+      <Flex gap={2}>
+        <Card margin={3} padding={3} border>
+          <form onSubmit={handleCreateBundle}>
+            <Stack space={4}>
+              <Text weight="medium">Create a new release</Text>
+              <ReleaseForm onChange={setValue} value={value} />
+              <Flex justify="flex-end">
+                <Button
+                  text="Create"
+                  tone="primary"
+                  type="submit"
+                  disabled={creating}
+                  loading={creating}
+                />
+              </Flex>
+            </Stack>
+          </form>
+        </Card>
+        <Card margin={3} border padding={3}>
+          <div style={{maxHeight: '400px', overflow: 'scroll'}}>
+            <Text>Data</Text>
+            {loading ? <LoadingBlock /> : <pre>{JSON.stringify(data, null, 2)}</pre>}
+          </div>
+        </Card>
+      </Flex>
+      <Card margin={3} border padding={3}>
+        <Stack space={3}>
+          {data?.map((bundle) => (
+            <Card key={bundle._id} padding={3} border radius={3}>
+              <Flex align="center" gap={3} justify={'space-between'}>
+                <Text>{bundle.name}</Text>
+                <Button
+                  text="Delete"
+                  tone="critical"
+                  // eslint-disable-next-line react/jsx-no-bind
+                  onClick={() => handleDeleteBundle(bundle._id)}
+                  disabled={deleting === bundle._id}
+                  loading={deleting === bundle._id}
+                />
+              </Flex>
+            </Card>
+          ))}
+        </Stack>
+      </Card>
+    </Stack>
+  )
+}
+
+export default WithAddonDatasetProvider(BundlesStoreStory)

--- a/packages/sanity/src/core/store/bundles/__workshop__/BundlesStoreStory.tsx
+++ b/packages/sanity/src/core/store/bundles/__workshop__/BundlesStoreStory.tsx
@@ -1,22 +1,20 @@
 import {Card, Flex, Stack, Text} from '@sanity/ui'
 import {type ComponentType, type FormEvent, useCallback, useState} from 'react'
-import {AddonDatasetProvider, LoadingBlock} from 'sanity'
 
 import {Button} from '../../../../ui-components'
+import {LoadingBlock} from '../../../components/loadingBlock/LoadingBlock'
+import {AddonDatasetProvider} from '../../../studio/addonDataset/AddonDatasetProvider'
 import {type BundleDocument} from '../types'
 import {useBundleOperations} from '../useBundleOperations'
 import {useBundlesStore} from '../useBundlesStore'
 import {ReleaseForm} from './ReleaseForm'
 
 const WithAddonDatasetProvider = <P extends object>(Component: ComponentType<P>): React.FC<P> => {
-  // Function that returns the wrapped component
   const WrappedComponent: React.FC<P> = (props) => (
     <AddonDatasetProvider>
       <Component {...props} />
     </AddonDatasetProvider>
   )
-
-  // Setting a display name for the wrapped component
   WrappedComponent.displayName = `WithAddonDatasetProvider(${Component.displayName || Component.name || 'Component'})`
 
   return WrappedComponent

--- a/packages/sanity/src/core/store/bundles/__workshop__/ReleaseForm.tsx
+++ b/packages/sanity/src/core/store/bundles/__workshop__/ReleaseForm.tsx
@@ -11,15 +11,13 @@ import {
   TextArea,
   TextInput,
 } from '@sanity/ui'
+import speakingurl from 'speakingurl'
 
 import {Button} from '../../../../ui-components/button'
 import {type BundleDocument} from '../types'
 
 function toSlug(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
+  return speakingurl(value, {truncate: 200, symbols: true})
 }
 
 /**

--- a/packages/sanity/src/core/store/bundles/__workshop__/ReleaseForm.tsx
+++ b/packages/sanity/src/core/store/bundles/__workshop__/ReleaseForm.tsx
@@ -1,0 +1,135 @@
+import {COLOR_HUES} from '@sanity/color'
+import {CalendarIcon} from '@sanity/icons'
+import {
+  Box,
+  type ButtonTone,
+  Card,
+  Flex,
+  Select,
+  Stack,
+  Text,
+  TextArea,
+  TextInput,
+} from '@sanity/ui'
+
+import {Button} from '../../../../ui-components/button'
+import {type BundleDocument} from '../types'
+
+function toSlug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+/**
+ * Copy from Prototype, not a final or complete working implementation.
+ */
+export function ReleaseForm(props: {
+  onChange: (params: Partial<BundleDocument>) => void
+  value: Partial<BundleDocument>
+}) {
+  const {onChange, value} = props
+
+  const handleReleaseTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const v = event.target.value
+
+    onChange({...value, title: v, name: toSlug(v)})
+  }
+
+  const handleReleaseDescriptionChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const v = event.target.value
+
+    onChange({...value, description: v || undefined})
+  }
+
+  const handleReleaseToneChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    onChange({...value, tone: (event.target.value || undefined) as ButtonTone | undefined})
+  }
+
+  const handleReleasePublishAtChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const v = event.target.value
+
+    onChange({...value, publishAt: v})
+  }
+
+  return (
+    <Stack space={5}>
+      <Stack space={3}>
+        <Text size={1} weight="medium">
+          Title
+        </Text>
+        <TextInput fontSize={3} onChange={handleReleaseTitleChange} value={value.title} />
+      </Stack>
+
+      <Stack space={3}>
+        <Text size={1} weight="medium">
+          Description
+        </Text>
+        <TextArea onChange={handleReleaseDescriptionChange} value={value.description} />
+      </Stack>
+
+      <Stack hidden space={3}>
+        <Text size={1} weight="medium">
+          Schedule for publishing at
+        </Text>
+        <TextInput
+          onChange={handleReleasePublishAtChange}
+          suffix={
+            <Box padding={1} style={{border: '1px solid transparent'}}>
+              <Button icon={CalendarIcon} mode="bleed" />
+            </Box>
+          }
+          value={value.publishAt || ''}
+        />
+      </Stack>
+
+      <Stack space={3}>
+        <Text size={1} weight="medium">
+          Color
+        </Text>
+        <Flex>
+          <Card
+            borderTop
+            borderLeft
+            borderBottom
+            flex="none"
+            radius={2}
+            padding={2}
+            style={{
+              borderTopRightRadius: 0,
+              borderBottomRightRadius: 0,
+            }}
+          >
+            <div
+              style={{
+                borderRadius: 1,
+                width: 17,
+                height: 17,
+                backgroundColor: `var(--card-avatar-${value.tone || 'gray'}-bg-color)`,
+              }}
+            >
+              &nbsp;
+            </div>
+          </Card>
+          <Stack flex={1}>
+            <Select
+              onChange={handleReleaseToneChange}
+              style={{
+                borderTopLeftRadius: 0,
+                borderBottomLeftRadius: 0,
+              }}
+              value={value.tone || ''}
+            >
+              {COLOR_HUES.map((hue) => (
+                <option key={hue} value={hue === 'gray' ? '' : hue}>
+                  {hue}
+                </option>
+              ))}
+            </Select>
+          </Stack>
+        </Flex>
+      </Stack>
+    </Stack>
+  )
+}

--- a/packages/sanity/src/core/store/bundles/__workshop__/index.ts
+++ b/packages/sanity/src/core/store/bundles/__workshop__/index.ts
@@ -1,0 +1,14 @@
+import {defineScope} from '@sanity/ui-workshop'
+import {lazy} from 'react'
+
+export default defineScope({
+  name: 'core/bundles',
+  title: 'bundles',
+  stories: [
+    {
+      name: 'bundles-store',
+      title: 'BundlesStore',
+      component: lazy(() => import('./BundlesStoreStory')),
+    },
+  ],
+})

--- a/packages/sanity/src/core/store/bundles/index.ts
+++ b/packages/sanity/src/core/store/bundles/index.ts
@@ -1,0 +1,1 @@
+export * from './useBundlesStore'

--- a/packages/sanity/src/core/store/bundles/reducer.ts
+++ b/packages/sanity/src/core/store/bundles/reducer.ts
@@ -1,0 +1,109 @@
+import {type BundleDocument} from './types'
+
+interface BundleAddedAction {
+  payload: BundleDocument
+  type: 'BUNDLE_ADDED'
+}
+
+interface BundleDeletedAction {
+  id: string
+  type: 'BUNDLE_DELETED'
+}
+
+interface BundleUpdatedAction {
+  payload: BundleDocument
+  type: 'BUNDLE_UPDATED'
+}
+
+interface BundlesSetAction {
+  bundles: BundleDocument[]
+  type: 'BUNDLES_SET'
+}
+
+interface BundleReceivedAction {
+  payload: BundleDocument
+  type: 'BUNDLE_RECEIVED'
+}
+
+export type bundlesReducerAction =
+  | BundleAddedAction
+  | BundleDeletedAction
+  | BundleUpdatedAction
+  | BundlesSetAction
+  | BundleReceivedAction
+
+export interface bundlesReducerState {
+  bundles: Map<string, BundleDocument>
+}
+
+function createBundlesSet(bundles: BundleDocument[]) {
+  const bundlesById = bundles.reduce((acc, bundle) => {
+    acc.set(bundle._id, bundle)
+    return acc
+  }, new Map<string, BundleDocument>())
+  return bundlesById
+}
+
+export function bundlesReducer(
+  state: bundlesReducerState,
+  action: bundlesReducerAction,
+): bundlesReducerState {
+  switch (action.type) {
+    case 'BUNDLES_SET': {
+      // Create an object with the BUNDLE id as key
+      const bundlesById = createBundlesSet(action.bundles)
+
+      return {
+        ...state,
+        bundles: bundlesById,
+      }
+    }
+
+    case 'BUNDLE_ADDED': {
+      const addedBundle = action.payload as BundleDocument
+      const currentBundles = new Map(state.bundles)
+      currentBundles.set(addedBundle._id, addedBundle)
+
+      return {
+        ...state,
+        bundles: currentBundles,
+      }
+    }
+
+    case 'BUNDLE_RECEIVED': {
+      const receivedBundle = action.payload as BundleDocument
+      const currentBundles = new Map(state.bundles)
+      currentBundles.set(receivedBundle._id, receivedBundle)
+
+      return {
+        ...state,
+        bundles: currentBundles,
+      }
+    }
+
+    case 'BUNDLE_DELETED': {
+      const currentBundles = new Map(state.bundles)
+      currentBundles.delete(action.id)
+
+      return {
+        ...state,
+        bundles: currentBundles,
+      }
+    }
+
+    case 'BUNDLE_UPDATED': {
+      const updatedBundle = action.payload
+      const id = updatedBundle._id as string
+      const currentBundles = new Map(state.bundles)
+      currentBundles.set(id, updatedBundle)
+
+      return {
+        ...state,
+        bundles: currentBundles,
+      }
+    }
+
+    default:
+      return state
+  }
+}

--- a/packages/sanity/src/core/store/bundles/reducer.ts
+++ b/packages/sanity/src/core/store/bundles/reducer.ts
@@ -16,7 +16,7 @@ interface BundleUpdatedAction {
 }
 
 interface BundlesSetAction {
-  bundles: BundleDocument[]
+  payload: BundleDocument[]
   type: 'BUNDLES_SET'
 }
 
@@ -51,7 +51,7 @@ export function bundlesReducer(
   switch (action.type) {
     case 'BUNDLES_SET': {
       // Create an object with the BUNDLE id as key
-      const bundlesById = createBundlesSet(action.bundles)
+      const bundlesById = createBundlesSet(action.payload)
 
       return {
         ...state,

--- a/packages/sanity/src/core/store/bundles/types.ts
+++ b/packages/sanity/src/core/store/bundles/types.ts
@@ -1,0 +1,10 @@
+import {type SanityDocument} from '@sanity/types'
+
+export interface BundleDocument extends SanityDocument {
+  _type: 'bundle'
+  title: string
+  description?: string
+  color?: string
+  icon?: string
+  authorId: string
+}

--- a/packages/sanity/src/core/store/bundles/types.ts
+++ b/packages/sanity/src/core/store/bundles/types.ts
@@ -1,10 +1,12 @@
 import {type SanityDocument} from '@sanity/types'
+import {type ButtonTone} from '@sanity/ui'
 
 export interface BundleDocument extends SanityDocument {
   _type: 'bundle'
   title: string
+  name: string
   description?: string
-  color?: string
+  tone?: ButtonTone
   icon?: string
   authorId: string
 }

--- a/packages/sanity/src/core/store/bundles/useBundleOperations.ts
+++ b/packages/sanity/src/core/store/bundles/useBundleOperations.ts
@@ -1,7 +1,7 @@
 import {uuid} from '@sanity/uuid'
 import {useCallback} from 'react'
-import {useAddonDataset} from 'sanity'
 
+import {useAddonDataset} from '../../studio/addonDataset/useAddonDataset'
 import {type BundleDocument} from './types'
 
 // WIP - Raw implementation for initial testing purposes

--- a/packages/sanity/src/core/store/bundles/useBundleOperations.ts
+++ b/packages/sanity/src/core/store/bundles/useBundleOperations.ts
@@ -1,0 +1,50 @@
+import {uuid} from '@sanity/uuid'
+import {useCallback} from 'react'
+import {useAddonDataset} from 'sanity'
+
+import {type BundleDocument} from './types'
+
+// WIP - Raw implementation for initial testing purposes
+export function useBundleOperations() {
+  const {client} = useAddonDataset()
+
+  const handleCreateBundle = useCallback(
+    async (bundle: Partial<BundleDocument>) => {
+      const document = {
+        ...bundle,
+        _type: 'bundle',
+        _id: bundle._id ?? uuid(),
+      } as BundleDocument
+      const res = await client?.createIfNotExists(document)
+      return res
+    },
+    [client],
+  )
+
+  const handleDeleteBundle = useCallback(
+    async (id: string) => {
+      const res = await client?.delete(id)
+      return res
+    },
+    [client],
+  )
+
+  const handleUpdateBundle = useCallback(
+    async (bundle: BundleDocument) => {
+      const document = {
+        ...bundle,
+        _type: 'bundle',
+      } as BundleDocument
+
+      const res = await client?.patch(bundle._id).set(document).commit()
+      return res
+    },
+    [client],
+  )
+
+  return {
+    createBundle: handleCreateBundle,
+    deleteBundle: handleDeleteBundle,
+    updateBundle: handleUpdateBundle,
+  }
+}

--- a/packages/sanity/src/core/store/bundles/useBundlesStore.ts
+++ b/packages/sanity/src/core/store/bundles/useBundlesStore.ts
@@ -1,0 +1,147 @@
+import {type ListenEvent, type ListenOptions} from '@sanity/client'
+import {useCallback, useEffect, useMemo, useReducer, useRef, useState} from 'react'
+import {catchError, of} from 'rxjs'
+
+import {useAddonDataset} from '../../studio/addonDataset/useAddonDataset'
+import {bundlesReducer, type bundlesReducerAction, type bundlesReducerState} from './reducer'
+import {type BundleDocument} from './types'
+
+interface BundlesStoreReturnType {
+  data: BundleDocument[] | null
+  error: Error | null
+  loading: boolean
+  dispatch: React.Dispatch<bundlesReducerAction>
+}
+
+const INITIAL_STATE: bundlesReducerState = {
+  bundles: new Map(),
+}
+
+const LISTEN_OPTIONS: ListenOptions = {
+  events: ['welcome', 'mutation', 'reconnect'],
+  includeResult: true,
+  visibility: 'query',
+}
+
+export const SORT_FIELD = '_createdAt'
+export const SORT_ORDER = 'desc'
+
+const QUERY_FILTERS = [`_type == "bundle"`]
+
+// TODO: Extend the projection with the fields needed
+const QUERY_PROJECTION = `{
+  ...,
+}`
+
+// Newest bundles first
+const QUERY_SORT_ORDER = `order(${SORT_FIELD} ${SORT_ORDER})`
+
+const QUERY = `*[${QUERY_FILTERS.join(' && ')}] ${QUERY_PROJECTION} | ${QUERY_SORT_ORDER}`
+
+export function useBundlesStore(): BundlesStoreReturnType {
+  const {client} = useAddonDataset()
+
+  const [state, dispatch] = useReducer(bundlesReducer, INITIAL_STATE)
+  const [loading, setLoading] = useState<boolean>(client !== null)
+  const [error, setError] = useState<Error | null>(null)
+
+  const didInitialFetch = useRef<boolean>(false)
+
+  const initialFetch = useCallback(async () => {
+    if (!client) {
+      setLoading(false)
+      return
+    }
+
+    try {
+      const res = await client.fetch(QUERY)
+      dispatch({type: 'BUNDLES_SET', bundles: res})
+      setLoading(false)
+    } catch (err) {
+      setError(err)
+    }
+  }, [client])
+
+  const handleListenerEvent = useCallback(
+    async (event: ListenEvent<Record<string, BundleDocument>>) => {
+      // Fetch all bundles on initial connection
+      if (event.type === 'welcome' && !didInitialFetch.current) {
+        setLoading(true)
+        await initialFetch()
+        setLoading(false)
+        didInitialFetch.current = true
+      }
+
+      // The reconnect event means that we are trying to reconnect to the realtime listener.
+      // In this case we set loading to true to indicate that we're trying to
+      // reconnect. Once a connection has been established, the welcome event
+      // will be received and we'll fetch all bundles again (above)
+      if (event.type === 'reconnect') {
+        setLoading(true)
+        didInitialFetch.current = false
+      }
+
+      // Handle mutations (create, update, delete) from the realtime listener
+      // and update the bundles store accordingly
+      if (event.type === 'mutation') {
+        if (event.transition === 'appear') {
+          const nextBundle = event.result as BundleDocument | undefined
+
+          if (nextBundle) {
+            dispatch({
+              type: 'BUNDLE_RECEIVED',
+              payload: nextBundle,
+            })
+          }
+        }
+
+        if (event.transition === 'disappear') {
+          dispatch({type: 'BUNDLE_DELETED', id: event.documentId})
+        }
+
+        if (event.transition === 'update') {
+          const updatedBundle = event.result as BundleDocument | undefined
+
+          if (updatedBundle) {
+            dispatch({
+              type: 'BUNDLE_UPDATED',
+              payload: updatedBundle,
+            })
+          }
+        }
+      }
+    },
+    [initialFetch],
+  )
+
+  const listener$ = useMemo(() => {
+    if (!client) return of()
+
+    const events$ = client.observable.listen(QUERY, {}, LISTEN_OPTIONS).pipe(
+      catchError((err) => {
+        setError(err)
+        return of(err)
+      }),
+    )
+
+    return events$
+  }, [client])
+
+  useEffect(() => {
+    const sub = listener$.subscribe(handleListenerEvent)
+
+    return () => {
+      sub?.unsubscribe()
+    }
+  }, [handleListenerEvent, listener$])
+
+  // Transform bundles object to array
+  const bundlesAsArray = useMemo(() => Array.from(state.bundles.values()), [state.bundles])
+
+  return {
+    data: bundlesAsArray,
+    dispatch,
+    error,
+    loading,
+  }
+}

--- a/packages/sanity/src/core/store/bundles/useBundlesStore.ts
+++ b/packages/sanity/src/core/store/bundles/useBundlesStore.ts
@@ -54,7 +54,7 @@ export function useBundlesStore(): BundlesStoreReturnType {
     return client.observable.fetch(QUERY).pipe(
       timeout(10000), // 10s timeout
       map((res) => {
-        dispatch({type: 'BUNDLES_SET', bundles: res})
+        dispatch({type: 'BUNDLES_SET', payload: res})
         didInitialFetch.current = true
         setLoading(false)
       }),

--- a/packages/sanity/src/core/store/bundles/useBundlesStore.ts
+++ b/packages/sanity/src/core/store/bundles/useBundlesStore.ts
@@ -1,5 +1,6 @@
 import {type ListenEvent, type ListenOptions} from '@sanity/client'
-import {useCallback, useEffect, useMemo, useReducer, useRef, useState} from 'react'
+import {useCallback, useMemo, useReducer, useRef, useState} from 'react'
+import {useObservable} from 'react-rx'
 import {catchError, concatMap, map, of, retry, timeout} from 'rxjs'
 
 import {useAddonDataset} from '../../studio/addonDataset/useAddonDataset'
@@ -71,6 +72,7 @@ export function useBundlesStore(): BundlesStoreReturnType {
       }),
     )
   }, [client])
+
   const handleListenerEvent = useCallback(
     (event: ListenEvent<Record<string, BundleDocument>>) => {
       // Fetch all bundles on initial connection
@@ -129,17 +131,12 @@ export function useBundlesStore(): BundlesStoreReturnType {
     return events$ // as Observable<ListenEvent<Record<string, BundleDocument>>>
   }, [client, handleListenerEvent])
 
-  useEffect(() => {
-    if (!client) return
-    const subscription = initialFetch$()
-      .pipe(concatMap(() => listener$))
-      .subscribe()
-
-    // eslint-disable-next-line consistent-return
-    return () => {
-      subscription.unsubscribe()
-    }
+  const observable = useMemo(() => {
+    if (!client) return of(null) // emits null and completes if no client
+    return initialFetch$().pipe(concatMap(() => listener$))
   }, [initialFetch$, listener$, client])
+
+  useObservable(observable)
 
   const bundlesAsArray = useMemo(() => Array.from(state.bundles.values()), [state.bundles])
 


### PR DESCRIPTION
### Description

Introduces `bundlesStore` allowing to fetch bundles metadata from the `addon-dataset`.
Also, introduces a minimal implementation for `bundlesOperations` for testing purposes.

It can be tested in the following story:
https://test-studio-git-corel-6.sanity.build/test/workshop/core;bundles;bundles-store

<img width="1579" alt="Screenshot 2024-06-28 at 14 31 05" src="https://github.com/sanity-io/sanity/assets/46196328/35803977-f64b-411b-859f-2e164af8c4b1">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
