### PR TITLE
fix(core):  open PTE dialogs in tree editing dialog with `openPath`

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/tree-editing/TreeEditing.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/tree-editing/TreeEditing.spec.tsx
@@ -28,6 +28,48 @@ const DOCUMENT_VALUE: SanityDocument = {
       _key: 'key-3',
       title: 'My object 3',
     },
+    {
+      _type: 'myObject',
+      _key: 'key-4',
+      title: 'My object 4',
+      pte: [
+        {
+          _key: 'key-4-1',
+          _type: 'myBlockObject',
+          myBlockObjectArray: [
+            {
+              _type: 'myBlockObjectArrayItem',
+              _key: 'key-4-1-1',
+              title: 'My block object array item 1',
+            },
+            {
+              _type: 'myBlockObjectArrayItem',
+              _key: 'key-4-1-2',
+              title: 'My block object array item 2',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+
+  pte: [
+    {
+      _key: 'key-1',
+      _type: 'myBlockObject',
+      myBlockObjectArray: [
+        {
+          _type: 'myBlockObjectArrayItem',
+          _key: 'key-2-1',
+          title: 'My block object array item 1',
+        },
+        {
+          _type: 'myBlockObjectArrayItem',
+          _key: 'key-2-2',
+          title: 'My block object array item 2',
+        },
+      ],
+    },
   ],
 
   myFieldsetArray: [
@@ -45,7 +87,7 @@ const DOCUMENT_VALUE: SanityDocument = {
 }
 
 test.describe('Tree editing', () => {
-  test('should open dialog when adding an item and close it when clicking done', async ({
+  test('should open tree editing dialog when adding an item and close it when clicking done', async ({
     mount,
     page,
   }) => {
@@ -174,7 +216,10 @@ test.describe('Tree editing', () => {
     await expect(thirdObjectStringInput).toHaveValue('My object 3')
   })
 
-  test('should open dialog with correct form view based on the openPath', async ({mount, page}) => {
+  test('should open tree editing dialog with correct form view based on the openPath', async ({
+    mount,
+    page,
+  }) => {
     await mount(
       <TreeEditingStory value={DOCUMENT_VALUE} openPath={['myArrayOfObjects', {_key: 'key-2'}]} />,
     )
@@ -214,5 +259,50 @@ test.describe('Tree editing', () => {
 
     const dialog = page.getByTestId('tree-editing-dialog')
     await expect(dialog).not.toBeVisible()
+  })
+
+  test('should open both tree editing dialog and portable text dialog when the openPath points to an array field nested inside a portable text field', async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TreeEditingStory
+        value={DOCUMENT_VALUE}
+        openPath={[
+          'myArrayOfObjects',
+          {_key: 'key-4'},
+          'pte',
+          {_key: 'key-4-1'},
+          'myBlockObjectArray',
+          {_key: 'key-4-1-1'},
+        ]}
+      />,
+    )
+    const dialog = page.getByTestId('tree-editing-dialog')
+    await expect(dialog).toBeVisible()
+
+    const editPortalDialog = page.getByTestId('edit-portal-dialog')
+    await expect(editPortalDialog).toBeVisible()
+
+    const stringInput = editPortalDialog.getByTestId('string-input')
+    await expect(stringInput).toHaveValue('My block object array item 1')
+  })
+
+  test('should open only the portable text dialog when the openPath points directly to an array field inside a portable text field', async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TreeEditingStory
+        value={DOCUMENT_VALUE}
+        openPath={['pte', {_key: 'key-1'}, 'myBlockObjectArray', {_key: 'key-2-2'}]}
+      />,
+    )
+
+    const dialog = page.getByTestId('tree-editing-dialog')
+    await expect(dialog).not.toBeVisible()
+
+    const editPortalDialog = page.getByTestId('edit-portal-dialog')
+    await expect(editPortalDialog).toBeVisible()
   })
 })

--- a/packages/sanity/playwright-ct/tests/formBuilder/tree-editing/TreeEditingStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/tree-editing/TreeEditingStory.tsx
@@ -8,6 +8,41 @@ interface GetSchemaTypesOpts {
   legacyEditing?: boolean
 }
 
+const blockField = defineField({
+  type: 'array',
+  name: 'pte',
+  title: 'PTE',
+  of: [
+    {type: 'block'},
+    {
+      type: 'object',
+      name: 'myBlockObject',
+      title: 'My block object',
+      fields: [
+        {
+          type: 'array',
+          name: 'myBlockObjectArray',
+          title: 'My block object array',
+          of: [
+            {
+              type: 'object',
+              name: 'myBlockObjectArrayItem',
+              title: 'My block object array item',
+              fields: [
+                {
+                  type: 'string',
+                  name: 'title',
+                  title: 'Title',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
 function getSchemaTypes(opts: GetSchemaTypesOpts) {
   const {legacyEditing} = opts
 
@@ -18,23 +53,19 @@ function getSchemaTypes(opts: GetSchemaTypesOpts) {
       type: 'document',
       name: 'test',
       title: 'Test',
-
       fieldsets: [
         {
           name: 'fieldset',
         },
       ],
-
       fields: [
         defineField({
           type: 'array',
           name: 'myArrayOfObjects',
           title: 'My array of objects',
-
           options: {
             treeEditing: treeEditingEnabled,
           },
-
           of: [
             {
               type: 'object',
@@ -45,17 +76,16 @@ function getSchemaTypes(opts: GetSchemaTypesOpts) {
                   name: 'title',
                   title: 'Title',
                 },
+                blockField,
               ],
             },
           ],
         }),
-
         defineField({
           type: 'array',
           name: 'myFieldsetArray',
           title: 'My fieldset array',
           fieldset: 'fieldset',
-
           of: [
             {
               type: 'object',
@@ -66,10 +96,12 @@ function getSchemaTypes(opts: GetSchemaTypesOpts) {
                   name: 'title',
                   title: 'Title',
                 },
+                blockField,
               ],
             },
           ],
         }),
+        blockField,
       ],
     }),
   ]

--- a/packages/sanity/src/core/form/studio/tree-editing/utils/build-tree-editing-state/buildArrayState.ts
+++ b/packages/sanity/src/core/form/studio/tree-editing/utils/build-tree-editing-state/buildArrayState.ts
@@ -1,3 +1,4 @@
+import {toString} from '@sanity/util/paths'
 import {
   type ArraySchemaType,
   EMPTY_ARRAY,
@@ -122,6 +123,19 @@ export function buildArrayState(props: BuildArrayState): TreeEditingState {
           schemaType: childField as ObjectSchemaType,
           value: childValue,
         })
+
+        return
+      }
+
+      // If `openPath` points to an array field within a portable text field,
+      // set `relativePath` to the parent of the portable text field.
+      // This ensures that the tree editing dialog opens at the parent level
+      // of the portable text field.
+      // Portable text fields manage their own dialogs, so we open the tree editing
+      // dialog for the parent item and let the portable text field handle its
+      // dialogs via `openPath`.
+      if (isPortableText && toString(openPath).startsWith(toString(childPath))) {
+        relativePath = getRelativePath(childPath)
       }
     })
 


### PR DESCRIPTION
### Description

This pull request fixes an issue where the tree editing dialog does not open correctly when the `openPath` points to an array item inside a portable text block. This can occur, for example, when navigating to a field with presence, from a comment, or using the validation menu.

Steps to reproduce the issue:

1. Open the tree editing dialog.
2. Open an array item inside a portable text editor.
3. Add a comment to a field in the array item.
4. Close all dialogs.
5. Click the comment in the inspector.
6. Notice that the dialog(s) do not open.

### What to review

- General code review
- Ensure that the PTE dialogs are opening correctly inside the tree editing dialog when setting the `openPath`

### Testing

- Component tests added to cover this particular situation

### Notes for release

N/A
