### PR TITLE
feat(core): focus root array item when closing tree editing dialog

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/tree-editing/TreeEditing.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/tree-editing/TreeEditing.spec.tsx
@@ -305,4 +305,30 @@ test.describe('Tree editing', () => {
     const editPortalDialog = page.getByTestId('edit-portal-dialog')
     await expect(editPortalDialog).toBeVisible()
   })
+
+  test('should focus root array item when closing tree editing dialog', async ({mount, page}) => {
+    await mount(<TreeEditingStory value={DOCUMENT_VALUE} />)
+
+    const field = page.getByTestId('field-myArrayOfObjects')
+
+    // Click on the first item in the array inputs
+    const firstArrayItemButton = field.getByRole('button', {name: 'My object 1'})
+    await firstArrayItemButton.click()
+
+    // Expect the dialog to open
+    const dialog = page.getByTestId('tree-editing-dialog')
+    await expect(dialog).toBeVisible()
+
+    // Focus first field
+    await dialog.getByTestId('string-input').focus()
+
+    // Click done
+    await page.getByTestId('tree-editing-done').click()
+
+    // Wait for the dialog to be hidden
+    await expect(dialog).not.toBeVisible()
+
+    // Expect the first item in the array to be focused
+    await expect(firstArrayItemButton).toBeFocused()
+  })
 })

--- a/packages/sanity/src/core/form/studio/FormBuilder.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilder.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable camelcase */
-/* eslint-disable react/jsx-handler-names */
-
 import {type ObjectSchemaType, type Path, type ValidationMarker} from '@sanity/types'
 import {useCallback, useMemo, useRef} from 'react'
 
@@ -35,7 +32,12 @@ import {
 import {DocumentFieldActionsProvider} from './contexts/DocumentFieldActions'
 import {FormBuilderInputErrorBoundary} from './FormBuilderInputErrorBoundary'
 import {FormProvider} from './FormProvider'
-import {TreeEditingDialog, TreeEditingEnabledProvider, useTreeEditingEnabled} from './tree-editing'
+import {
+  shouldArrayDialogOpen,
+  TreeEditingDialog,
+  TreeEditingEnabledProvider,
+  useTreeEditingEnabled,
+} from './tree-editing'
 
 /**
  * @alpha
@@ -306,10 +308,16 @@ function RootInput(props: RootInputProps) {
   const {rootInputProps, onPathOpen, openPath, renderInput} = props
   const treeEditing = useTreeEditingEnabled()
 
+  const open = useMemo(
+    () => shouldArrayDialogOpen(rootInputProps.schemaType, openPath),
+    [openPath, rootInputProps.schemaType],
+  )
+
   const isRoot = rootInputProps.id === 'root'
 
-  const arrayEditingModal = treeEditing.enabled && isRoot && (
+  const arrayEditingModal = treeEditing.enabled && isRoot && open && (
     <TreeEditingDialog
+      // eslint-disable-next-line react/jsx-handler-names
       onPathFocus={rootInputProps.onPathFocus}
       onPathOpen={onPathOpen}
       openPath={openPath}
@@ -320,6 +328,7 @@ function RootInput(props: RootInputProps) {
 
   return renderInput({
     ...rootInputProps,
+    // eslint-disable-next-line camelcase
     __internal_arrayEditingModal: arrayEditingModal,
   })
 }

--- a/packages/sanity/src/core/form/studio/tree-editing/components/TreeEditingDialog.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/components/TreeEditingDialog.tsx
@@ -111,17 +111,11 @@ export function TreeEditingDialog(props: TreeEditingDialogProps): JSX.Element | 
   )
 
   const onClose = useCallback(() => {
-    // Focus the root array item when closing the dialog.
-    const firstKeySegmentIndex = openPath.findIndex(isKeySegment)
-    const rootFocusPath = openPath.slice(0, firstKeySegmentIndex + 1)
-
-    onPathFocus(rootFocusPath)
+    // Cancel any debounced state building when closing the dialog.
+    debouncedBuildTreeEditingState.cancel()
 
     // Reset the `openPath`
     onPathOpen(EMPTY_ARRAY)
-
-    // Cancel any debounced state building when closing the dialog.
-    debouncedBuildTreeEditingState.cancel()
 
     // Reset the tree state when closing the dialog.
     setTreeState(EMPTY_TREE_STATE)
@@ -133,6 +127,11 @@ export function TreeEditingDialog(props: TreeEditingDialogProps): JSX.Element | 
     // previous stored values.
     valueRef.current = undefined
     openPathRef.current = undefined
+
+    // Focus the root array item when closing the dialog.
+    const firstKeySegmentIndex = openPath.findIndex(isKeySegment)
+    const rootFocusPath = openPath.slice(0, firstKeySegmentIndex + 1)
+    onPathFocus(rootFocusPath)
   }, [debouncedBuildTreeEditingState, onPathFocus, onPathOpen, openPath])
 
   const onHandlePathSelect = useCallback(


### PR DESCRIPTION
### Description

This pull request ensures that the root array item is focused when the tree editing dialog is closed. It also adds animation to the tree editing dialog to be consistent with other dialogs in the studio.

Note: there is currently an issue with setting the correct `focusPath` when closing the tree editing dialog without having focused on any input in the form. This will be addressed as a separate issue.

### What to review

- Ensure that the changes are working as expected.

### Testing

- Component test for focusing the root array item when closing the tree editing dialog.

### Notes for release

N/A
