### PR TITLE
feat(cli): Add support for exporting dataset with cursor

### DIFF
--- a/packages/@sanity/cli/test/exportImport.test.ts
+++ b/packages/@sanity/cli/test/exportImport.test.ts
@@ -44,6 +44,35 @@ describeCliTest('CLI: `sanity dataset export` / `import`', () => {
       expect(filesTypes).toContain('.jpg')
     })
 
+    testConcurrent('export, with mode', async () => {
+      const result = await runSanityCmdCommand(version, [
+        'dataset',
+        'export',
+        'production',
+        testRunArgs.exportTarball,
+        '--overwrite',
+        '--mode cursor',
+      ])
+      expect(result.stdout).toMatch(/export finished/i)
+      expect(result.code).toBe(0)
+
+      const tarballPath = path.join(studiosPath, version, testRunArgs.exportTarball)
+
+      const stats = await stat(tarballPath)
+      expect(stats.isFile()).toBe(true)
+
+      // We're just checking for the existence of a few files here - the actual export
+      // functionality is fully tested in `@sanity/export`
+      const filesTypes: string[] = []
+      await tar.t({
+        file: tarballPath,
+        onentry: (entry) => filesTypes.push(path.extname(entry.path)),
+      })
+
+      expect(filesTypes).toContain('.ndjson')
+      expect(filesTypes).toContain('.jpg')
+    })
+
     testConcurrent('import', async () => {
       const result = await runSanityCmdCommand(version, [
         'dataset',

--- a/packages/sanity/src/_internal/cli/commands/dataset/exportDatasetCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/exportDatasetCommand.ts
@@ -20,6 +20,7 @@ Options
   --types                   Defines which document types to export
   --overwrite               Overwrite any file with the same name
   --asset-concurrency <num> Concurrent number of asset downloads
+  --mode <stream|cursor>    Uses a cursor when exporting, this might be more performant for larger datasets, but might not be as accurate if the dataset is being modified during export. Defaults to stream
 
 Examples
   sanity dataset export moviedb localPath.tar.gz
@@ -36,6 +37,7 @@ interface ExportFlags {
   'overwrite'?: boolean
   'types'?: string
   'asset-concurrency'?: string
+  'mode'?: string
 }
 
 interface ParsedExportFlags {
@@ -46,6 +48,7 @@ interface ParsedExportFlags {
   overwrite?: boolean
   types?: string[]
   assetConcurrency?: number
+  mode?: string
 }
 
 function parseFlags(rawFlags: ExportFlags): ParsedExportFlags {
@@ -76,6 +79,10 @@ function parseFlags(rawFlags: ExportFlags): ParsedExportFlags {
 
   if (typeof rawFlags.overwrite !== 'undefined') {
     flags.overwrite = Boolean(rawFlags.overwrite)
+  }
+
+  if (typeof rawFlags.mode !== 'undefined') {
+    flags.mode = rawFlags.mode
   }
 
   return flags


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

A new mode in the export endpoint allows streaming incrementally with a cursor

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Added a CLI test to make sure it picks it up 👍 

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->

Export: Add new export mode that can uses a cursor when exporting, this might be more performant for larger datasets, but might not be as accurate if the dataset is being modified during export. Defaults to stream