### PR TITLE
docs(migrate): updating insert examples to showing always 3 args

### DIFF
--- a/packages/@sanity/migrate/src/mutations/operations/creators.ts
+++ b/packages/@sanity/migrate/src/mutations/operations/creators.ts
@@ -120,8 +120,8 @@ export const diffMatchPatch = (value: string): DiffMatchPatchOp => ({
  *
  * @example
  * ```ts
- * const prependFoo = insert(['foo'], 'before')
- * const appendFooAndBar = insert(['foo', 'bar'], 'after')
+ * const prependFoo = insert(['foo'], 'before', 0)
+ * const appendFooAndBar = insert(['foo', 'bar'], 'after', someArray.length -1)
  * const insertObjAfterXYZ = insert({name: 'foo'}, 'after', {_key: 'xyz'}])
  * ```
  */


### PR DESCRIPTION
### Description
The TSDoc for the `insert` method incorrectly gives examples of 2 provided args
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
