### PR TITLE
chore(renovate): add fixtures to `ignorePaths`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,7 +24,6 @@
       "matchUpdateTypes": [
         "bump",
         "digest",
-        "lockfileUpdate",
         "minor",
         "patch",
         "pin",
@@ -47,5 +46,10 @@
       "semanticCommitType": "fix"
     }
   ],
-  "ignorePaths": ["packages/@sanity/cli/test/__fixtures__/v2/package.json"]
+  "ignorePaths": [
+    "packages/@sanity/cli/test/__fixtures__/v2/package.json",
+    "packages/sanity/fixtures/examples/prj-with-react-18/package.json",
+    "packages/sanity/fixtures/examples/prj-with-react-19/package.json",
+    "packages/sanity/fixtures/examples/prj-with-styled-components-5/package.json"
+  ]
 }


### PR DESCRIPTION
When https://github.com/sanity-io/sanity/pull/6920 were closed it didn't turn off `styled-components` renovation for just [that particular `package.json`](packages/sanity/fixtures/examples/prj-with-styled-components-5/package.json), it also disabled `styled-components` updates for the rest of this repo.
The rules in this PR will instead opt-out the fixture `package.json` files from being part of the manifests that renovate maintains, allowing us to see future updates to `styled-components`