### PR TITLE
refactor(sanity): remove "features"

### DIFF
--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -84,11 +84,9 @@ const sharedSettings = definePlugin({
     muxInput({mp4_support: 'standard'}),
     presenceTool(),
   ],
-  features: {
-    beta: {
-      treeArrayEditing: {
-        enabled: true,
-      },
+  beta: {
+    treeArrayEditing: {
+      enabled: true,
     },
   },
 })

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -73,11 +73,9 @@ const sharedSettings = definePlugin({
     bundles: testStudioLocaleBundles,
   },
 
-  features: {
-    beta: {
-      treeArrayEditing: {
-        enabled: true,
-      },
+  beta: {
+    treeArrayEditing: {
+      enabled: true,
     },
   },
 

--- a/packages/sanity/playwright-ct/tests/formBuilder/tree-editing/TreeEditingStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/tree-editing/TreeEditingStory.tsx
@@ -150,11 +150,9 @@ function getSchemaTypes(opts: GetSchemaTypesOpts) {
   ]
 }
 
-const FEATURES: WorkspaceOptions['features'] = {
-  beta: {
-    treeArrayEditing: {
-      enabled: true,
-    },
+const FEATURES: WorkspaceOptions['beta'] = {
+  treeArrayEditing: {
+    enabled: true,
   },
 }
 
@@ -170,7 +168,7 @@ export function TreeEditingStory(props: TreeEditingStoryProps): JSX.Element {
   const types = getSchemaTypes({legacyEditing})
 
   return (
-    <TestWrapper schemaTypes={types} features={FEATURES}>
+    <TestWrapper schemaTypes={types} betaFeatures={FEATURES}>
       <VirtualizerScrollInstanceProvider
         containerElement={{current: document.body}}
         scrollElement={document.body}

--- a/packages/sanity/playwright-ct/tests/formBuilder/utils/TestWrapper.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/utils/TestWrapper.tsx
@@ -19,7 +19,7 @@ import {getMockWorkspace} from '../../../../test/testUtils/getMockWorkspaceFromC
 
 interface TestWrapperProps {
   children?: ReactNode
-  features?: WorkspaceOptions['features']
+  betaFeatures?: WorkspaceOptions['beta']
   schemaTypes: SchemaTypeDefinition[]
 }
 
@@ -28,7 +28,7 @@ interface TestWrapperProps {
  * It provides a mock Sanity client and a mock workspace.
  */
 export const TestWrapper = (props: TestWrapperProps): JSX.Element | null => {
-  const {children, schemaTypes, features} = props
+  const {children, schemaTypes, betaFeatures} = props
   const [mockWorkspace, setMockWorkspace] = useState<Workspace | null>(null)
 
   useEffect(() => {
@@ -42,7 +42,7 @@ export const TestWrapper = (props: TestWrapperProps): JSX.Element | null => {
           types: schemaTypes,
         },
 
-        features,
+        beta: betaFeatures,
       })
 
       const workspace = await getMockWorkspace({client, config})
@@ -51,7 +51,7 @@ export const TestWrapper = (props: TestWrapperProps): JSX.Element | null => {
     }
 
     getWorkspace()
-  }, [schemaTypes, features])
+  }, [schemaTypes, betaFeatures])
 
   if (!mockWorkspace) {
     return null

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -318,13 +318,13 @@ export const arrayEditingReducer = (opts: {
   const flattenedConfig = flattenConfig(config, [])
 
   const result = flattenedConfig.reduce((acc, {config: innerConfig}) => {
-    const resolver = innerConfig.features?.beta?.treeArrayEditing?.enabled
+    const resolver = innerConfig.beta?.treeArrayEditing?.enabled
 
     if (!resolver && typeof resolver !== 'boolean') return acc
     if (typeof resolver === 'boolean') return resolver
 
     throw new Error(
-      `Expected \`features.beta.treeArrayEditing.enabled\` to be a boolean, but received ${getPrintableType(
+      `Expected \`beta.treeArrayEditing.enabled\` to be a boolean, but received ${getPrintableType(
         resolver,
       )}`,
     )

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -627,11 +627,9 @@ function resolveSource({
       staticInitialValueTemplateItems,
       options: config,
     },
-    features: {
-      beta: {
-        treeArrayEditing: {
-          enabled: arrayEditingReducer({config, initialValue: false}),
-        },
+    beta: {
+      treeArrayEditing: {
+        enabled: arrayEditingReducer({config, initialValue: false}),
       },
     },
   }

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -388,10 +388,10 @@ export interface PluginOptions {
      */
     enableLegacySearch?: boolean
   }
-  /** Configuration for studio features.
+  /** Configuration for studio beta features.
    * @internal
    */
-  features?: Features
+  beta?: BetaFeatures
 }
 
 /** @internal */
@@ -780,7 +780,7 @@ export interface Source {
   /** Configuration for studio features.
    * @internal
    */
-  features?: Features
+  beta?: BetaFeatures
 }
 
 /** @internal */
@@ -897,20 +897,15 @@ export type DefaultPluginsWorkspaceOptions = {
 /**
  * Configuration for studio features.
  * */
-interface Features {
+interface BetaFeatures {
   /**
-   * Configuration for beta features.
-   */
-  beta?: {
+   * @beta
+   * @hidden
+   * */
+  treeArrayEditing?: {
     /**
-     * @beta
-     * @hidden
-     * */
-    treeArrayEditing?: {
-      /**
-       * Enables the tree array editing feature.
-       */
-      enabled: boolean
-    }
+     * Enables the tree array editing feature.
+     */
+    enabled: boolean
   }
 }

--- a/packages/sanity/src/core/form/studio/tree-editing/__tests__/useTreeEditingEnabled.test.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/__tests__/useTreeEditingEnabled.test.tsx
@@ -27,11 +27,9 @@ const nestedWrapper = ({children}: PropsWithChildren) => (
 describe('useTreeEditingEnabled', () => {
   test('should return enabled: false when config is not enabled', () => {
     const features = {
-      features: {
-        beta: {
-          treeArrayEditing: {
-            enabled: false,
-          },
+      beta: {
+        treeArrayEditing: {
+          enabled: false,
         },
       },
     }
@@ -44,11 +42,9 @@ describe('useTreeEditingEnabled', () => {
 
   test('should return enabled: true when config is enabled', () => {
     const features = {
-      features: {
-        beta: {
-          treeArrayEditing: {
-            enabled: true,
-          },
+      beta: {
+        treeArrayEditing: {
+          enabled: true,
         },
       },
     }

--- a/packages/sanity/src/core/form/studio/tree-editing/context/enabled/TreeEditingEnabledProvider.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/context/enabled/TreeEditingEnabledProvider.tsx
@@ -12,7 +12,7 @@ interface TreeEditingEnabledProviderProps {
 export function TreeEditingEnabledProvider(props: TreeEditingEnabledProviderProps): JSX.Element {
   const {children, legacyEditing: legacyEditingProp} = props
 
-  const {features} = useSource()
+  const {beta} = useSource()
   const parentContextValue = useTreeEditingEnabled()
 
   const value = useMemo((): TreeEditingEnabledContextValue => {
@@ -26,14 +26,10 @@ export function TreeEditingEnabledProvider(props: TreeEditingEnabledProviderProp
       legacyEditingProp
 
     return {
-      enabled: features?.beta?.treeArrayEditing?.enabled === true,
+      enabled: beta?.treeArrayEditing?.enabled === true,
       legacyEditing: Boolean(legacyEditing),
     }
-  }, [
-    features?.beta?.treeArrayEditing?.enabled,
-    legacyEditingProp,
-    parentContextValue.legacyEditing,
-  ])
+  }, [beta?.treeArrayEditing?.enabled, legacyEditingProp, parentContextValue.legacyEditing])
 
   return (
     <TreeEditingEnabledContext.Provider value={value}>

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -27,7 +27,7 @@ function DocumentStatusBarActionsInner(props: DocumentStatusBarActionsInnerProps
   const {__internal_tasks, schemaType, openPath} = useDocumentPane()
   const [firstActionState, ...menuActionStates] = states
   const [buttonElement, setButtonElement] = useState<HTMLButtonElement | null>(null)
-  const isTreeArrayEditingEnabled = useSource().features?.beta?.treeArrayEditing?.enabled
+  const isTreeArrayEditingEnabled = useSource().beta?.treeArrayEditing?.enabled
 
   // Disable the main document action if the array dialog is open
   const isTreeArrayEditingEnabledOpen = useMemo(() => {


### PR DESCRIPTION
### Description

As spoken with Rune, remove the `features` object and rely instead on the `beta` object.

### What to review

- Make sure that the code makes sense
- Try out the feature and make sure that everything is still working as expected

### Testing

There are already automated tests for this (and of the feature itself)

### Notes for release

N/A shadow release related
