### PR TITLE
feat(corel): remove version documents when deleting bundle

### DIFF
--- a/packages/sanity/src/core/releases/components/BundleMenuButton/__tests__/BundleMenuButton.test.tsx
+++ b/packages/sanity/src/core/releases/components/BundleMenuButton/__tests__/BundleMenuButton.test.tsx
@@ -101,8 +101,13 @@ describe('BundleMenuButton', () => {
     await act(() => {
       fireEvent.click(screen.getByText('Delete'))
     })
+    expect(useBundleOperations().deleteBundle).not.toHaveBeenCalled()
 
-    expect(useBundleOperations().deleteBundle).toHaveBeenCalledWith(activeBundle._id)
+    await act(() => {
+      fireEvent.click(screen.getByText('Confirm'))
+    })
+
+    expect(useBundleOperations().deleteBundle).toHaveBeenCalledWith(activeBundle)
     expect(useRouter().navigate).not.toHaveBeenCalled()
   })
 })

--- a/packages/sanity/src/core/store/bundles/useBundleOperations.ts
+++ b/packages/sanity/src/core/store/bundles/useBundleOperations.ts
@@ -1,12 +1,16 @@
+import {type SanityDocument} from '@sanity/client'
 import {uuid} from '@sanity/uuid'
 import {useCallback} from 'react'
 
+import {useClient} from '../../hooks'
 import {useAddonDataset} from '../../studio/addonDataset/useAddonDataset'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {type BundleDocument} from './types'
 
 // WIP - Raw implementation for initial testing purposes
 export function useBundleOperations() {
   const {client} = useAddonDataset()
+  const studioClient = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
 
   const handleCreateBundle = useCallback(
     async (bundle: Partial<BundleDocument>) => {
@@ -22,11 +26,22 @@ export function useBundleOperations() {
   )
 
   const handleDeleteBundle = useCallback(
-    async (id: string) => {
-      const res = await client?.delete(id)
+    async (bundle: BundleDocument) => {
+      // Fetch the related version documents from the main dataset, this documents will be removed
+      const versionDocuments = await studioClient.fetch<SanityDocument[]>(
+        `*[defined(_version) && _id in path("${bundle.name}.*")]`,
+      )
+      // Starts the transaction to remove the documents.
+      const transaction = studioClient.transaction()
+      versionDocuments.forEach((doc) => {
+        transaction.delete(doc._id)
+      })
+      await transaction.commit()
+      // Remove the bundle metadata document from the addon dataset
+      const res = await client?.delete(bundle._id)
       return res
     },
-    [client],
+    [client, studioClient],
   )
 
   const handleUpdateBundle = useCallback(


### PR DESCRIPTION
### Description
When a bundle document is removed the related version documents in the main dataset should also be removed.
This PR adds that functionality and implements a confirmation modal before deleting everything, given this is a destructive operation.

<img width="600" alt="Screenshot 2024-07-09 at 17 18 33" src="https://github.com/sanity-io/sanity/assets/46196328/5afadfca-f5e4-491b-a5b7-88d4eef9b7ba">


🟡 Missing changes due to the listener updates for the related documents count 🟡 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
If this is PR is a partial implementation of a feature and is not enabled by default, please
call this out explicitly here so that it does not get included in the release notes.
-->
