### PR TITLE
test(cli): use separate tarball location for cursor export test

### DIFF
--- a/packages/@sanity/cli/test/exportImport.test.ts
+++ b/packages/@sanity/cli/test/exportImport.test.ts
@@ -45,18 +45,19 @@ describeCliTest('CLI: `sanity dataset export` / `import`', () => {
     })
 
     testConcurrent('export, with mode', async () => {
+      const filename = `cursor-${testRunArgs.exportTarball}.tar.gz`
       const result = await runSanityCmdCommand(version, [
         'dataset',
         'export',
         'production',
-        testRunArgs.exportTarball,
+        filename,
         '--overwrite',
         '--mode cursor',
       ])
       expect(result.stdout).toMatch(/export finished/i)
       expect(result.code).toBe(0)
 
-      const tarballPath = path.join(studiosPath, version, testRunArgs.exportTarball)
+      const tarballPath = path.join(studiosPath, version, filename)
 
       const stats = await stat(tarballPath)
       expect(stats.isFile()).toBe(true)


### PR DESCRIPTION
### Description

We're seeing some [new failures](https://github.com/sanity-io/sanity/actions/runs/9865117760/job/27241410606?pr=7117) in the CLI tests intermittently. After some brief investigation, I think perhaps it is caused by the same tarball location being used for both the regular and cursor based export tests, which can run concurrently.

This PR changes the filename used by the cursor based export test, to ensure they do not interfere with eachother.

### Testing

Tests should still pass, but be more stable

### Notes for release

None
