### PR TITLE
test(COREL): add core tests

### DIFF
--- a/packages/sanity/src/core/bundles/components/BundleMenu.tsx
+++ b/packages/sanity/src/core/bundles/components/BundleMenu.tsx
@@ -48,27 +48,30 @@ export function BundleMenu(props: BundleListProps): JSX.Element {
     <>
       <MenuButton
         button={button}
-        id="global-version-menu"
+        id="bundle-menu"
         menu={
-          <StyledMenu>
+          <StyledMenu data-testid="bundle-menu">
             {loading ? (
-              <Flex padding={4} justify="center">
+              <Flex padding={4} justify="center" data-testid="spinner">
                 <Spinner muted />
               </Flex>
             ) : (
               <>
                 <MenuItem
                   iconRight={
-                    currentGlobalBundle.name === LATEST.name ? <CheckmarkIcon /> : undefined
+                    currentGlobalBundle.name === LATEST.name ? (
+                      <CheckmarkIcon data-testid="latest-checkmark-icon" />
+                    ) : undefined
                   }
                   onClick={handleBundleChange(LATEST)}
                   pressed={false}
                   text={LATEST.title}
+                  data-testid="latest-menu-item"
                 />
                 {hasBundles && (
                   <>
                     <MenuDivider />
-                    <StyledBox>
+                    <StyledBox data-testid="bundles-list">
                       {bundles
                         .filter((b) => !isDraftOrPublished(b.name) && !b.archivedAt)
                         .map((b) => (
@@ -77,6 +80,7 @@ export function BundleMenu(props: BundleListProps): JSX.Element {
                             onClick={handleBundleChange(b)}
                             padding={1}
                             pressed={false}
+                            data-testid={`bundle-${b.name}`}
                           >
                             <Flex>
                               <BundleBadge hue={b.hue} icon={b.icon} padding={2} />
@@ -102,6 +106,7 @@ export function BundleMenu(props: BundleListProps): JSX.Element {
                                 <Text size={1}>
                                   <CheckmarkIcon
                                     style={{opacity: currentGlobalBundle.name === b.name ? 1 : 0}}
+                                    data-testid={`${b.name}-checkmark-icon`}
                                   />
                                 </Text>
                               </Box>

--- a/packages/sanity/src/core/bundles/components/__tests__/BundleMenu.test.tsx
+++ b/packages/sanity/src/core/bundles/components/__tests__/BundleMenu.test.tsx
@@ -1,0 +1,192 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {Button} from '@sanity/ui'
+import {fireEvent, render, screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {act} from 'react'
+import {type BundleDocument} from 'sanity'
+
+import {usePerspective} from '../../hooks/usePerspective'
+import {LATEST} from '../../util/const'
+import {createWrapper} from '../../util/tests/createWrapper'
+import {BundleMenu} from '../BundleMenu'
+
+jest.mock('../../hooks/usePerspective', () => ({
+  usePerspective: jest.fn().mockReturnValue({
+    currentGlobalBundle: {},
+    setPerspective: jest.fn(),
+  }),
+}))
+
+jest.mock('../../util/dummyGetters', () => ({
+  isDraftOrPublished: jest.fn(),
+}))
+
+describe('BundleMenu', () => {
+  const mockUsePerspective = usePerspective as jest.Mock
+  const ButtonTest = <Button>Button Test</Button>
+  const mockBundles: BundleDocument[] = [
+    {
+      hue: 'magenta',
+      _id: 'db76c50e-358b-445c-a57c-8344c588a5d5',
+      _type: 'bundle',
+      name: 'spring-drop',
+      _rev: '6z08CvvPnPe5pWSKJ5zPRR',
+      icon: 'heart-filled',
+      description: 'What a spring drop, allergies galore 🌸',
+      title: 'Spring Drop',
+      _updatedAt: '2024-07-02T11:37:51Z',
+      _createdAt: '2024-07-02T11:37:51Z',
+      authorId: '',
+    },
+    {
+      icon: 'drop',
+      title: 'Autumn Drop',
+      _type: 'bundle',
+      hue: 'yellow',
+      _id: '0e87530e-4378-45ff-9d6f-58207e89f3ed',
+      _createdAt: '2024-07-02T11:37:06Z',
+      _rev: '6z08CvvPnPe5pWSKJ5zJiK',
+      _updatedAt: '2024-07-02T11:37:06Z',
+      name: 'autumn-drop',
+      authorId: '',
+    },
+    {
+      _createdAt: '2024-07-02T11:36:00Z',
+      _rev: '22LTUf6tptoEq53N9U5CzE',
+      icon: 'sun',
+      description: 'What a summer drop woo hoo! ☀️',
+      _updatedAt: '2024-07-02T11:36:00Z',
+      title: 'Summer Drop',
+      _type: 'bundle',
+      hue: 'red',
+      _id: 'f6b2c2cc-1732-4465-bfb3-dd205b5d78e9',
+      name: 'summer-drop',
+      authorId: '',
+    },
+  ]
+
+  beforeEach(() => {
+    mockUsePerspective.mockClear()
+  })
+
+  it('should render loading spinner when loading is true', async () => {
+    const wrapper = await createWrapper()
+    render(<BundleMenu button={ButtonTest} bundles={[]} loading />, {
+      wrapper,
+    })
+
+    expect(screen.getByRole('button', {name: 'Button Test'})).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', {name: 'Button Test'}))
+
+    act(() => {
+      expect(screen.getByTestId('bundle-menu')).toBeInTheDocument()
+      expect(screen.getByTestId('spinner')).toBeInTheDocument()
+    })
+  })
+
+  it('should render latest bundle menu item when bundles are null', async () => {
+    const wrapper = await createWrapper()
+    render(<BundleMenu button={ButtonTest} bundles={null} loading={false} />, {
+      wrapper,
+    })
+
+    fireEvent.click(screen.getByRole('button', {name: 'Button Test'}))
+
+    act(() => {
+      expect(screen.getByTestId('latest-menu-item')).toBeInTheDocument()
+      expect(screen.queryByTestId('bundles-list')).not.toBeInTheDocument()
+    })
+  })
+
+  it('should render latest bundle menu item as selected when currentGlobalBundle is LATEST', async () => {
+    mockUsePerspective.mockReturnValue({
+      currentGlobalBundle: LATEST,
+      setPerspective: jest.fn(),
+    })
+
+    const wrapper = await createWrapper()
+    render(<BundleMenu button={ButtonTest} bundles={[]} loading={false} />, {
+      wrapper,
+    })
+
+    fireEvent.click(screen.getByRole('button', {name: 'Button Test'}))
+
+    act(() => {
+      expect(screen.getByTestId('latest-menu-item')).toBeInTheDocument()
+      expect(screen.getByTestId('latest-checkmark-icon')).toBeInTheDocument()
+    })
+  })
+
+  it('should render bundle as selected when currentGlobalBundle is that bundle', async () => {
+    mockUsePerspective.mockReturnValue({
+      currentGlobalBundle: mockBundles[0],
+      setPerspective: jest.fn(),
+    })
+
+    const wrapper = await createWrapper()
+    render(<BundleMenu button={ButtonTest} bundles={mockBundles} loading={false} />, {
+      wrapper,
+    })
+
+    fireEvent.click(screen.getByRole('button', {name: 'Button Test'}))
+
+    act(() => {
+      expect(screen.getByText(mockBundles[0].title)).toBeInTheDocument()
+      expect(screen.getByTestId(`${mockBundles[0].name}-checkmark-icon`)).toBeInTheDocument()
+    })
+  })
+
+  it('should render bundle menu items when bundles are provided', async () => {
+    const wrapper = await createWrapper()
+    render(<BundleMenu button={ButtonTest} bundles={mockBundles} loading={false} />, {
+      wrapper,
+    })
+
+    fireEvent.click(screen.getByRole('button', {name: 'Button Test'}))
+
+    act(() => {
+      expect(screen.getByText('Spring Drop')).toBeInTheDocument()
+      expect(screen.getByText('Autumn Drop')).toBeInTheDocument()
+      expect(screen.getByText('Summer Drop')).toBeInTheDocument()
+    })
+  })
+
+  it('should call setPerspective when a bundle menu item is clicked', async () => {
+    const setPerspective = jest.fn()
+    mockUsePerspective.mockReturnValue({
+      currentGlobalBundle: LATEST,
+      setPerspective,
+    })
+
+    const wrapper = await createWrapper()
+    render(<BundleMenu button={ButtonTest} bundles={mockBundles} loading={false} />, {
+      wrapper,
+    })
+
+    fireEvent.click(screen.getByRole('button', {name: 'Button Test'}))
+
+    act(() => {
+      userEvent.click(screen.getByTestId('bundle-spring-drop'))
+      expect(setPerspective).toHaveBeenCalledWith('spring-drop')
+    })
+  })
+
+  it('should render actions when actions prop is provided', async () => {
+    const actions = <Button>Actions</Button>
+
+    const wrapper = await createWrapper()
+    render(
+      <BundleMenu button={ButtonTest} bundles={mockBundles} loading={false} actions={actions} />,
+      {
+        wrapper,
+      },
+    )
+
+    fireEvent.click(screen.getByRole('button', {name: 'Button Test'}))
+
+    act(() => {
+      expect(screen.getByRole('button', {name: 'Actions'})).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/sanity/src/core/bundles/components/dialog/BundleForm.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/BundleForm.tsx
@@ -82,16 +82,18 @@ export function BundleForm(props: {
 
   const handlePublishAtInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
+      const dateValue = event.target.value.trim()
+
       // there's likely a better way of doing this
       // needs to check that the date is not invalid & not empty
       // in which case it can update the input value but not the actual bundle value
-      if (new Date(event.target.value).toString() === 'Invalid Date' && event.target.value !== '') {
+      if (new Date(event.target.value).toString() === 'Invalid Date' && dateValue !== '') {
         setShowDateValidation(true)
-        setDisplayDate(event.target.value)
+        setDisplayDate(dateValue)
       } else {
         setShowDateValidation(false)
-        setDisplayDate(event.target.value)
-        onChange({...value, publishAt: event.target.value})
+        setDisplayDate(dateValue)
+        onChange({...value, publishAt: dateValue})
       }
     },
     [onChange, value],

--- a/packages/sanity/src/core/bundles/components/dialog/BundleForm.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/BundleForm.tsx
@@ -124,7 +124,11 @@ export function BundleForm(props: {
           {/* localize text */}
           Title
         </Text>
-        <TextInput onChange={handleBundleTitleChange} value={title} />
+        <TextInput
+          onChange={handleBundleTitleChange}
+          value={title}
+          data-testid="bundle-form-title"
+        />
       </Stack>
 
       <Stack space={3}>
@@ -132,7 +136,11 @@ export function BundleForm(props: {
           {/* localize text */}
           Description
         </Text>
-        <TextArea onChange={handleBundleDescriptionChange} value={description} />
+        <TextArea
+          onChange={handleBundleDescriptionChange}
+          value={description}
+          data-testid="bundle-form-description"
+        />
       </Stack>
 
       <Stack space={3}>
@@ -179,6 +187,7 @@ export function BundleForm(props: {
           }
           value={displayDate}
           onChange={handlePublishAtInputChange}
+          data-testid="bundle-form-publish-at"
         />
       </Stack>
     </Stack>

--- a/packages/sanity/src/core/bundles/components/dialog/BundleIconEditorPicker.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/BundleIconEditorPicker.tsx
@@ -1,6 +1,16 @@
 import {COLOR_HUES, type ColorHueKey} from '@sanity/color'
 import {icons, type IconSymbol, SearchIcon} from '@sanity/icons'
-import {Avatar, Box, Button, Flex, Popover, Stack, TextInput, useClickOutside} from '@sanity/ui'
+import {
+  Avatar,
+  Box,
+  Button,
+  Container,
+  Flex,
+  Popover,
+  Stack,
+  TextInput,
+  useClickOutside,
+} from '@sanity/ui'
 import {useCallback, useState} from 'react'
 import {styled} from 'styled-components'
 
@@ -60,7 +70,7 @@ export function BundleIconEditorPicker(props: {
   return (
     <Popover
       content={
-        <>
+        <Container data-testid="popover-content">
           <Flex gap={1} padding={1}>
             {COLOR_HUES.map((hue) => (
               <Button
@@ -69,6 +79,7 @@ export function BundleIconEditorPicker(props: {
                 onClick={handleHueChange(hue)}
                 padding={1}
                 selected={value.hue === hue}
+                data-testid={`hue-button-${hue}`}
               >
                 <Avatar color={hue} size={0} />
               </Button>
@@ -96,11 +107,12 @@ export function BundleIconEditorPicker(props: {
                     mode="bleed"
                     onClick={handleIconChange(key as IconSymbol)}
                     padding={2}
+                    data-testId={`icon-button-${key}`}
                   />
                 ))}
             </IconPickerFlex>
           </StyledStack>
-        </>
+        </Container>
       }
       open={open}
       placement="bottom-start"
@@ -115,6 +127,7 @@ export function BundleIconEditorPicker(props: {
           ref={setButton}
           selected={open}
           radius="full"
+          data-testid="icon-picker-button"
         >
           <BundleBadge hue={value.hue} icon={value.icon} />
         </Button>

--- a/packages/sanity/src/core/bundles/components/dialog/CreateBundleDialog.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/CreateBundleDialog.tsx
@@ -74,6 +74,7 @@ export function CreateBundleDialog(props: CreateBundleDialogProps): JSX.Element 
             // localize Text
             text="Create release"
             loading={isCreating}
+            data-testid="create-release-button"
           />
         </Flex>
       </form>

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleForm.test.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleForm.test.tsx
@@ -6,14 +6,9 @@ import {createWrapper} from '../../../util/tests/createWrapper'
 import {BundleForm} from '../BundleForm'
 
 jest.mock('sanity', () => ({
-  ...(jest.requireActual('sanity') || {}),
   useDateTimeFormat: jest.fn().mockReturnValue({format: jest.fn().mockReturnValue('Mocked date')}),
+  useTranslation: jest.fn().mockReturnValue({t: jest.fn().mockReturnValue('Mocked translation')}),
 }))
-
-const renderBundleForm = async (onChangeMock: jest.Mock, valueMock: Partial<BundleDocument>) => {
-  const wrapper = await createWrapper()
-  render(<BundleForm onChange={onChangeMock} value={valueMock} />, {wrapper})
-}
 
 describe('BundleForm', () => {
   const onChangeMock = jest.fn()
@@ -25,10 +20,11 @@ describe('BundleForm', () => {
     publishAt: undefined,
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     onChangeMock.mockClear()
 
-    renderBundleForm(onChangeMock, valueMock)
+    const wrapper = await createWrapper()
+    render(<BundleForm onChange={onChangeMock} value={valueMock} />, {wrapper})
   })
 
   it('should render the form fields', async () => {
@@ -38,30 +34,30 @@ describe('BundleForm', () => {
   })
 
   it('should call onChange when title input value changes', () => {
-    const titleInput = screen.getByLabelText('Title')
+    const titleInput = screen.getByTestId('bundle-form-title')
     fireEvent.change(titleInput, {target: {value: 'Bundle 1'}})
 
     expect(onChangeMock).toHaveBeenCalledWith({...valueMock, title: 'Bundle 1', name: 'bundle-1'})
   })
 
   it('should call onChange when description textarea value changes', () => {
-    const descriptionTextarea = screen.getByLabelText('Description')
+    const descriptionTextarea = screen.getByTestId('bundle-form-description')
     fireEvent.change(descriptionTextarea, {target: {value: 'New Description'}})
 
     expect(onChangeMock).toHaveBeenCalledWith({...valueMock, description: 'New Description'})
   })
 
   it('should call onChange when publishAt input value changes', () => {
-    const publishAtInput = screen.getByLabelText('Schedule for publishing at')
+    const publishAtInput = screen.getByTestId('bundle-form-publish-at')
     fireEvent.change(publishAtInput, {target: {value: '2022-01-01'}})
 
     expect(onChangeMock).toHaveBeenCalledWith({...valueMock, publishAt: '2022-01-01'})
   })
 
   it('should call onChange with undefined when publishAt input value is empty', () => {
-    const publishAtInput = screen.getByLabelText('Schedule for publishing at')
-    fireEvent.change(publishAtInput, {target: {value: ''}})
+    const publishAtInput = screen.getByTestId('bundle-form-publish-at')
+    fireEvent.change(publishAtInput, {target: {value: ' '}})
 
-    expect(onChangeMock).toHaveBeenCalledWith({...valueMock, publishAt: undefined})
+    expect(onChangeMock).toHaveBeenCalledWith({...valueMock, publishAt: ''})
   })
 })

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleForm.test.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleForm.test.tsx
@@ -1,5 +1,7 @@
 import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {studioTheme, ThemeProvider} from '@sanity/ui'
 import {render, screen} from '@testing-library/react'
+import {type ReactNode} from 'react'
 import {type BundleDocument} from 'sanity'
 
 import {BundleForm} from '../BundleForm'
@@ -29,8 +31,15 @@ describe('BundleForm', () => {
     onChangeMock.mockClear()
   })
 
+  const createWrapper = async () => {
+    return function Wrapper({children}: {children: ReactNode}) {
+      return <ThemeProvider theme={studioTheme}>{children}</ThemeProvider>
+    }
+  }
+
   it('should render the form fields', async () => {
-    render(<BundleForm onChange={onChangeMock} value={valueMock} />)
+    const wrapper = await createWrapper()
+    render(<BundleForm onChange={onChangeMock} value={valueMock} />, {wrapper})
 
     expect(screen.getByLabelText('Title')).toBeInTheDocument()
     expect(screen.getByLabelText('Description')).toBeInTheDocument()

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleForm.test.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleForm.test.tsx
@@ -2,7 +2,7 @@ import {beforeEach, describe, expect, it, jest} from '@jest/globals'
 import {fireEvent, render, screen} from '@testing-library/react'
 import {type BundleDocument} from 'sanity'
 
-import {createWrapper} from '../../../util/__tests__/createWrapper'
+import {createWrapper} from '../../../util/tests/createWrapper'
 import {BundleForm} from '../BundleForm'
 
 jest.mock('sanity', () => ({

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleForm.test.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleForm.test.tsx
@@ -1,0 +1,75 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {render, screen} from '@testing-library/react'
+import {type BundleDocument} from 'sanity'
+
+import {BundleForm} from '../BundleForm'
+
+jest.mock('sanity', () => ({
+  ...(jest.requireActual('sanity') || {}),
+  useDateTimeFormat: jest.fn().mockReturnValue({format: jest.fn().mockReturnValue('Mocked date')}),
+}))
+
+jest.mock('@sanity/ui', () => ({
+  ...(jest.requireActual('@sanity/ui') || {}),
+  // eslint-disable-next-line camelcase
+  useTheme_v2: jest.fn().mockReturnValue({color: {}}),
+}))
+
+describe('BundleForm', () => {
+  const onChangeMock = jest.fn()
+  const valueMock: Partial<BundleDocument> = {
+    title: '',
+    description: '',
+    icon: 'cube',
+    hue: 'gray',
+    publishAt: undefined,
+  }
+
+  beforeEach(() => {
+    onChangeMock.mockClear()
+  })
+
+  it('should render the form fields', async () => {
+    render(<BundleForm onChange={onChangeMock} value={valueMock} />)
+
+    expect(screen.getByLabelText('Title')).toBeInTheDocument()
+    expect(screen.getByLabelText('Description')).toBeInTheDocument()
+    expect(screen.getByLabelText('Schedule for publishing at')).toBeInTheDocument()
+  })
+
+  /*it('should call onChange when title input value changes', () => {
+    renderBundleForm()
+
+    const titleInput = screen.getByLabelText('Title')
+    fireEvent.change(titleInput, {target: {value: 'Bundle 1'}})
+
+    expect(onChangeMock).toHaveBeenCalledWith({...valueMock, title: 'Bundle 1', name: 'bundle-1'})
+  })
+
+  it('should call onChange when description textarea value changes', () => {
+    renderBundleForm()
+
+    const descriptionTextarea = screen.getByLabelText('Description')
+    fireEvent.change(descriptionTextarea, {target: {value: 'New Description'}})
+
+    expect(onChangeMock).toHaveBeenCalledWith({...valueMock, description: 'New Description'})
+  })
+
+  it('should call onChange when publishAt input value changes', () => {
+    renderBundleForm()
+
+    const publishAtInput = screen.getByLabelText('Schedule for publishing at')
+    fireEvent.change(publishAtInput, {target: {value: '2022-01-01'}})
+
+    expect(onChangeMock).toHaveBeenCalledWith({...valueMock, publishAt: '2022-01-01'})
+  })
+
+  it('should call onChange with undefined when publishAt input value is empty', () => {
+    renderBundleForm()
+
+    const publishAtInput = screen.getByLabelText('Schedule for publishing at')
+    fireEvent.change(publishAtInput, {target: {value: ''}})
+
+    expect(onChangeMock).toHaveBeenCalledWith({...valueMock, publishAt: undefined})
+  })*/
+})

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleForm.test.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleForm.test.tsx
@@ -1,9 +1,8 @@
 import {beforeEach, describe, expect, it, jest} from '@jest/globals'
-import {studioTheme, ThemeProvider} from '@sanity/ui'
-import {render, screen} from '@testing-library/react'
-import {type ReactNode} from 'react'
+import {fireEvent, render, screen} from '@testing-library/react'
 import {type BundleDocument} from 'sanity'
 
+import {createWrapper} from '../../../util/__tests__/createWrapper'
 import {BundleForm} from '../BundleForm'
 
 jest.mock('sanity', () => ({
@@ -11,11 +10,10 @@ jest.mock('sanity', () => ({
   useDateTimeFormat: jest.fn().mockReturnValue({format: jest.fn().mockReturnValue('Mocked date')}),
 }))
 
-jest.mock('@sanity/ui', () => ({
-  ...(jest.requireActual('@sanity/ui') || {}),
-  // eslint-disable-next-line camelcase
-  useTheme_v2: jest.fn().mockReturnValue({color: {}}),
-}))
+const renderBundleForm = async (onChangeMock: jest.Mock, valueMock: Partial<BundleDocument>) => {
+  const wrapper = await createWrapper()
+  render(<BundleForm onChange={onChangeMock} value={valueMock} />, {wrapper})
+}
 
 describe('BundleForm', () => {
   const onChangeMock = jest.fn()
@@ -29,26 +27,17 @@ describe('BundleForm', () => {
 
   beforeEach(() => {
     onChangeMock.mockClear()
-  })
 
-  const createWrapper = async () => {
-    return function Wrapper({children}: {children: ReactNode}) {
-      return <ThemeProvider theme={studioTheme}>{children}</ThemeProvider>
-    }
-  }
+    renderBundleForm(onChangeMock, valueMock)
+  })
 
   it('should render the form fields', async () => {
-    const wrapper = await createWrapper()
-    render(<BundleForm onChange={onChangeMock} value={valueMock} />, {wrapper})
-
-    expect(screen.getByLabelText('Title')).toBeInTheDocument()
-    expect(screen.getByLabelText('Description')).toBeInTheDocument()
-    expect(screen.getByLabelText('Schedule for publishing at')).toBeInTheDocument()
+    expect(screen.getByTestId('bundle-form-title')).toBeInTheDocument()
+    expect(screen.getByTestId('bundle-form-description')).toBeInTheDocument()
+    expect(screen.getByTestId('bundle-form-publish-at')).toBeInTheDocument()
   })
 
-  /*it('should call onChange when title input value changes', () => {
-    renderBundleForm()
-
+  it('should call onChange when title input value changes', () => {
     const titleInput = screen.getByLabelText('Title')
     fireEvent.change(titleInput, {target: {value: 'Bundle 1'}})
 
@@ -56,8 +45,6 @@ describe('BundleForm', () => {
   })
 
   it('should call onChange when description textarea value changes', () => {
-    renderBundleForm()
-
     const descriptionTextarea = screen.getByLabelText('Description')
     fireEvent.change(descriptionTextarea, {target: {value: 'New Description'}})
 
@@ -65,8 +52,6 @@ describe('BundleForm', () => {
   })
 
   it('should call onChange when publishAt input value changes', () => {
-    renderBundleForm()
-
     const publishAtInput = screen.getByLabelText('Schedule for publishing at')
     fireEvent.change(publishAtInput, {target: {value: '2022-01-01'}})
 
@@ -74,11 +59,9 @@ describe('BundleForm', () => {
   })
 
   it('should call onChange with undefined when publishAt input value is empty', () => {
-    renderBundleForm()
-
     const publishAtInput = screen.getByLabelText('Schedule for publishing at')
     fireEvent.change(publishAtInput, {target: {value: ''}})
 
     expect(onChangeMock).toHaveBeenCalledWith({...valueMock, publishAt: undefined})
-  })*/
+  })
 })

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleIconEditorPicker.test.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleIconEditorPicker.test.tsx
@@ -1,0 +1,49 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {fireEvent, render, screen} from '@testing-library/react'
+import {type BundleDocument} from 'sanity'
+
+import {createWrapper} from '../../../util/__tests__/createWrapper'
+import {BundleIconEditorPicker} from '../BundleIconEditorPicker'
+
+describe('BundleIconEditorPicker', () => {
+  const onChangeMock = jest.fn()
+  const valueMock: Partial<BundleDocument> = {
+    hue: 'gray',
+    icon: 'cube',
+  }
+
+  beforeEach(async () => {
+    onChangeMock.mockClear()
+
+    const wrapper = await createWrapper()
+    render(<BundleIconEditorPicker onChange={onChangeMock} value={valueMock} />, {wrapper})
+  })
+
+  it('should render the icon picker button', () => {
+    const iconPickerButton = screen.getByTestId('icon-picker-button')
+    expect(iconPickerButton).toBeInTheDocument()
+  })
+
+  it('should open the popover when the icon picker button is clicked', () => {
+    const iconPickerButton = screen.getByTestId('icon-picker-button')
+    fireEvent.click(iconPickerButton)
+    const popoverContent = screen.getByTestId('popover-content')
+    expect(popoverContent).toBeInTheDocument()
+  })
+
+  it('should call onChange with the selected hue when a hue button is clicked', () => {
+    const iconPickerButton = screen.getByTestId('icon-picker-button')
+    fireEvent.click(iconPickerButton)
+    const hueButton = screen.getByTestId('hue-button-magenta')
+    fireEvent.click(hueButton)
+    expect(onChangeMock).toHaveBeenCalledWith({...valueMock, hue: 'magenta'})
+  })
+
+  it('should call onChange with the selected icon when an icon button is clicked', () => {
+    const iconPickerButton = screen.getByTestId('icon-picker-button')
+    fireEvent.click(iconPickerButton)
+    const iconButton = screen.getByTestId('icon-button-circle')
+    fireEvent.click(iconButton)
+    expect(onChangeMock).toHaveBeenCalledWith({...valueMock, icon: 'circle'})
+  })
+})

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleIconEditorPicker.test.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleIconEditorPicker.test.tsx
@@ -2,7 +2,7 @@ import {beforeEach, describe, expect, it, jest} from '@jest/globals'
 import {fireEvent, render, screen} from '@testing-library/react'
 import {type BundleDocument} from 'sanity'
 
-import {createWrapper} from '../../../util/__tests__/createWrapper'
+import {createWrapper} from '../../../util/tests/createWrapper'
 import {BundleIconEditorPicker} from '../BundleIconEditorPicker'
 
 describe('BundleIconEditorPicker', () => {

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/CreateBundleDialog.test.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/CreateBundleDialog.test.tsx
@@ -1,0 +1,69 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {fireEvent, render, screen} from '@testing-library/react'
+import {type BundleDocument} from 'sanity'
+
+import {useBundleOperations} from '../../../../store/bundles/useBundleOperations'
+import {usePerspective} from '../../../hooks/usePerspective'
+import {createWrapper} from '../../../util/tests/createWrapper'
+import {CreateBundleDialog} from '../CreateBundleDialog'
+
+jest.mock('sanity', () => ({
+  useDateTimeFormat: jest.fn().mockReturnValue({format: jest.fn().mockReturnValue('Mocked date')}),
+  useTranslation: jest.fn().mockReturnValue({t: jest.fn().mockReturnValue('Mocked translation')}),
+}))
+
+jest.mock('../../../../store/bundles/useBundleOperations', () => ({
+  useBundleOperations: jest.fn().mockReturnValue({
+    createBundle: jest.fn(),
+  }),
+}))
+
+jest.mock('../../../hooks/usePerspective', () => ({
+  usePerspective: jest.fn().mockReturnValue({
+    setPerspective: jest.fn(),
+  }),
+}))
+
+describe('CreateBundleDialog', () => {
+  const onCancelMock = jest.fn()
+  const onCreateMock = jest.fn()
+
+  beforeEach(async () => {
+    onCancelMock.mockClear()
+    onCreateMock.mockClear()
+
+    const wrapper = await createWrapper()
+    render(<CreateBundleDialog onCancel={onCancelMock} onCreate={onCreateMock} />, {wrapper})
+  })
+
+  it('should render the dialog', () => {
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('should call onCancel when dialog is closed', () => {
+    fireEvent.click(screen.getByRole('button', {name: /close/i}))
+
+    expect(onCancelMock).toHaveBeenCalled()
+  })
+
+  it('should call createBundle, setPerspective, and onCreate when form is submitted with a valid name', async () => {
+    const value: Partial<BundleDocument> = {
+      name: 'bundle-1',
+      title: 'Bundle 1',
+      hue: 'gray',
+      icon: 'cube',
+      publishAt: undefined,
+    }
+
+    const titleInput = screen.getByTestId('bundle-form-title')
+    fireEvent.change(titleInput, {target: {value: value.title}})
+
+    const submitButton = screen.getByTestId('create-release-button')
+    fireEvent.click(submitButton)
+
+    await expect(useBundleOperations().createBundle).toHaveBeenCalledWith(value)
+
+    expect(usePerspective().setPerspective).toHaveBeenCalledWith(value.name)
+    expect(onCreateMock).toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/core/bundles/index.ts
+++ b/packages/sanity/src/core/bundles/index.ts
@@ -1,4 +1,5 @@
 export * from './components'
 export * from './hooks'
+export * from './util/__tests__/createWrapper'
 export * from './util/const'
 export * from './util/dummyGetters'

--- a/packages/sanity/src/core/bundles/index.ts
+++ b/packages/sanity/src/core/bundles/index.ts
@@ -1,5 +1,5 @@
 export * from './components'
 export * from './hooks'
-export * from './util/__tests__/createWrapper'
 export * from './util/const'
 export * from './util/dummyGetters'
+export * from './util/tests/createWrapper'

--- a/packages/sanity/src/core/bundles/util/__tests__/createWrapper.tsx
+++ b/packages/sanity/src/core/bundles/util/__tests__/createWrapper.tsx
@@ -1,0 +1,18 @@
+import {studioTheme, ThemeProvider} from '@sanity/ui'
+import {type ReactNode} from 'react'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {releasesUsEnglishLocaleBundle} from '../../../releases/i18n'
+
+export const createWrapper = async () => {
+  const TestProvider = await createTestProvider({
+    resources: [releasesUsEnglishLocaleBundle],
+  })
+  return function Wrapper({children}: {children: ReactNode}): JSX.Element {
+    return (
+      <ThemeProvider theme={studioTheme}>
+        <TestProvider>{children}</TestProvider>
+      </ThemeProvider>
+    )
+  }
+}

--- a/packages/sanity/src/core/bundles/util/tests/createWrapper.tsx
+++ b/packages/sanity/src/core/bundles/util/tests/createWrapper.tsx
@@ -2,12 +2,9 @@ import {studioTheme, ThemeProvider} from '@sanity/ui'
 import {type ReactNode} from 'react'
 
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
-import {releasesUsEnglishLocaleBundle} from '../../../releases/i18n'
 
 export const createWrapper = async () => {
-  const TestProvider = await createTestProvider({
-    resources: [releasesUsEnglishLocaleBundle],
-  })
+  const TestProvider = await createTestProvider()
   return function Wrapper({children}: {children: ReactNode}): JSX.Element {
     return (
       <ThemeProvider theme={studioTheme}>

--- a/packages/sanity/src/core/bundles/util/tests/createWrapper.tsx
+++ b/packages/sanity/src/core/bundles/util/tests/createWrapper.tsx
@@ -1,10 +1,13 @@
 import {studioTheme, ThemeProvider} from '@sanity/ui'
 import {type ReactNode} from 'react'
 
-import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {
+  createTestProvider,
+  type TestProviderOptions,
+} from '../../../../../test/testUtils/TestProvider'
 
-export const createWrapper = async () => {
-  const TestProvider = await createTestProvider()
+export const createWrapper = async (options?: TestProviderOptions) => {
+  const TestProvider = await createTestProvider(options)
   return function Wrapper({children}: {children: ReactNode}): JSX.Element {
     return (
       <ThemeProvider theme={studioTheme}>

--- a/packages/sanity/src/core/releases/tool/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/__tests__/ReleasesOverview.test.tsx
@@ -1,9 +1,8 @@
 import {beforeEach, describe, expect, it, jest} from '@jest/globals'
 import {fireEvent, render, screen, waitFor} from '@testing-library/react'
-import {type ReactNode} from 'react'
 
 import {queryByDataUi} from '../../../../../test/setup/customQueries'
-import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {createWrapper} from '../../../bundles/util/tests/createWrapper'
 import {useBundles} from '../../../store/bundles'
 import {type BundleDocument} from '../../../store/bundles/types'
 import {releasesUsEnglishLocaleBundle} from '../../i18n'
@@ -23,15 +22,6 @@ jest.mock('sanity/router', () => ({
   useRouter: jest.fn().mockReturnValue({state: {}, navigate: jest.fn()}),
 }))
 
-const createWrapper = async () => {
-  const TestProvider = await createTestProvider({
-    resources: [releasesUsEnglishLocaleBundle],
-  })
-  return function Wrapper({children}: {children: ReactNode}) {
-    return <TestProvider>{children}</TestProvider>
-  }
-}
-
 const mockUseBundleStore = useBundles as jest.Mock<typeof useBundles>
 
 describe('ReleasesOverview', () => {
@@ -43,7 +33,9 @@ describe('ReleasesOverview', () => {
         dispatch: jest.fn(),
       })
 
-      const wrapper = await createWrapper()
+      const wrapper = await createWrapper({
+        resources: [releasesUsEnglishLocaleBundle],
+      })
 
       return render(<ReleasesOverview />, {wrapper})
     })

--- a/packages/sanity/test/testUtils/TestProvider.tsx
+++ b/packages/sanity/test/testUtils/TestProvider.tsx
@@ -16,7 +16,7 @@ import {studioDefaultLocaleResources} from '../../src/core/i18n/bundles/studio'
 import {prepareI18n} from '../../src/core/i18n/i18nConfig'
 import {getMockWorkspace} from './getMockWorkspaceFromConfig'
 
-interface TestProviderOptions {
+export interface TestProviderOptions {
   config?: SingleWorkspace
   client?: SanityClient
   resources?: LocaleResourceBundle[]


### PR DESCRIPTION
### Description

- Add createWrapper in core (with resource options)
- Add bundleForm test
- Add BundleIconEditorPicker test
- Add createBundleDialog test
- Add BundleMenu test
- Replace createWrapper in the releases tool with the new one.

Left some components out since they were either:
- Too simple / UI focused
- Will eventually change

### What to review
- Make sure that the changes to the releases plugin makes sense

A lot of these were taken with inspiration from the tests that Jordan has been writing, so thank you 🙏 🥺 
