### PR TITLE
chore(renovate): only bump esbuild within `0.21.x`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,6 +77,11 @@
       ],
       "dependencyDashboardApproval": false,
       "schedule": ["every weekday"]
+    },
+    {
+      "description": "ESBuild 0.23 drops support for Windows 7 and 8, for now we don't want renovate to open PRs to bump them",
+      "allowedVersions": "<=0.21",
+      "matchPackageNames": ["esbuild"]
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
Following up on #7126 this changes renovate so it doesn't keep creating PRs that bump `esbuild` minor (minor are breaking btw) or major versions: https://github.com/sanity-io/sanity/pull/7127