### PR TITLE
fix(cli): allow styled-component as dev dependency

### DIFF
--- a/packages/sanity/src/_internal/cli/util/checkRequiredDependencies.ts
+++ b/packages/sanity/src/_internal/cli/util/checkRequiredDependencies.ts
@@ -49,7 +49,10 @@ export async function checkRequiredDependencies(context: CliCommandContext): Pro
   // The studio _must_ now declare `styled-components` as a dependency. If it's not there,
   // we'll want to automatically _add it_ to the manifest and tell the user to reinstall
   // dependencies before running whatever command was being run
-  const declaredStyledComponentsVersion = studioPackageManifest.dependencies['styled-components']
+  const declaredStyledComponentsVersion =
+    studioPackageManifest.dependencies['styled-components'] ||
+    studioPackageManifest.devDependencies['styled-components']
+
   if (!declaredStyledComponentsVersion) {
     const [file, ...args] = process.argv
     const deps = {'styled-components': wantedStyledComponentsVersionRange}


### PR DESCRIPTION
### Description

Bit of an edge case, but; in some settings (like plugin development) you might have a studio installed to test the plugin. In those settings, styled-components shouldn't be a dependency - instead it should be a _dev_ dependency, in order to not cause multiple versions to be installed (dev + peer, to be exact). Currently the CLI will complain that it can't find the package declared in `dependencies` and attempt to install it, which leads to an infinite install loop, as npm already sees it listed and installed - and then re-runs the same command again.

This change should ensure that it can exist in `devDependencies` _or_ `dependencies`. Don't believe this to be an issue for regular users either, since strictly speaking in an app setting it is only a _build time_ dependency.

### What to review

- Running `sanity dev` in a studio folder without `styled-components` declared in `dependencies` _or_ `devDependencies` should cause it to be installed
- Running `sanity dev` in a studio folder with `styled-components` declared in `dependencies` should _not_ cause it to be installed
- Running `sanity dev` in a studio folder with `styled-components` declared in `devDependencies` should _not_ cause it to be installed

### Testing

Not adding tests for this, unfortunately, but I'll take the blame on this.

### Notes for release

- Fixes an issue where having `styled-components` listed in `devDependencies` instead of `dependencies` would cause the CLI to try to install it as a dependency in a loop
