### PR TITLE
fix(deps): bump @sanity/ui ^2.6.7

### DIFF
--- a/dev/design-studio/package.json
+++ b/dev/design-studio/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@sanity/icons": "^3.3.0",
-    "@sanity/ui": "^2.6.6",
+    "@sanity/ui": "^2.6.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",

--- a/dev/embedded-studio/package.json
+++ b/dev/embedded-studio/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@sanity/ui": "^2.6.6",
+    "@sanity/ui": "^2.6.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",

--- a/dev/studio-e2e-testing/package.json
+++ b/dev/studio-e2e-testing/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@sanity/google-maps-input": "^4.0.0",
     "@sanity/icons": "^3.3.0",
-    "@sanity/ui": "^2.6.6",
+    "@sanity/ui": "^2.6.7",
     "@sanity/vision": "3.49.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -39,7 +39,7 @@
     "@sanity/react-loader": "^1.8.3",
     "@sanity/tsdoc": "1.0.83",
     "@sanity/types": "workspace:*",
-    "@sanity/ui": "^2.6.6",
+    "@sanity/ui": "^2.6.7",
     "@sanity/ui-workshop": "^1.0.0",
     "@sanity/util": "workspace:*",
     "@sanity/uuid": "^3.0.1",

--- a/examples/ecommerce-studio/package.json
+++ b/examples/ecommerce-studio/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@sanity/cli": "3.49.0",
-    "@sanity/ui": "^2.6.6",
+    "@sanity/ui": "^2.6.7",
     "react": "^18.3.1",
     "react-barcode": "^1.4.1",
     "react-dom": "^18.3.1",

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -63,7 +63,7 @@
     "@rexxars/react-split-pane": "^0.1.93",
     "@sanity/color": "^3.0.0",
     "@sanity/icons": "^3.3.0",
-    "@sanity/ui": "^2.6.6",
+    "@sanity/ui": "^2.6.7",
     "@uiw/react-codemirror": "^4.11.4",
     "is-hotkey-esm": "^1.0.0",
     "json-2-csv": "^5.5.1",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -167,7 +167,7 @@
     "@sanity/schema": "3.49.0",
     "@sanity/telemetry": "^0.7.7",
     "@sanity/types": "3.49.0",
-    "@sanity/ui": "^2.6.6",
+    "@sanity/ui": "^2.6.7",
     "@sanity/util": "3.49.0",
     "@sanity/uuid": "^3.0.1",
     "@sentry/react": "^8.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,8 +241,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0(react@18.3.1)
       '@sanity/ui':
-        specifier: ^2.6.6
-        version: 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+        specifier: ^2.6.7
+        version: 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -259,8 +259,8 @@ importers:
   dev/embedded-studio:
     dependencies:
       '@sanity/ui':
-        specifier: ^2.6.6
-        version: 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+        specifier: ^2.6.7
+        version: 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -368,8 +368,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0(react@18.3.1)
       '@sanity/ui':
-        specifier: ^2.6.6
-        version: 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+        specifier: ^2.6.7
+        version: 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       '@sanity/vision':
         specifier: 3.49.0
         version: link:../../packages/@sanity/vision
@@ -497,11 +497,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@sanity/types
       '@sanity/ui':
-        specifier: ^2.6.6
-        version: 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+        specifier: ^2.6.7
+        version: 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       '@sanity/ui-workshop':
         specifier: ^1.0.0
-        version: 1.2.11(@sanity/icons@3.3.0)(@sanity/ui@2.6.6)(@types/node@18.19.31)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+        version: 1.2.11(@sanity/icons@3.3.0)(@sanity/ui@2.6.7)(@types/node@18.19.31)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       '@sanity/util':
         specifier: workspace:*
         version: link:../../packages/@sanity/util
@@ -567,7 +567,7 @@ importers:
         version: link:../../packages/sanity
       sanity-plugin-hotspot-array:
         specifier: ^2.0.0
-        version: 2.0.0(@sanity/ui@2.6.6)(react-dom@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.11)
+        version: 2.0.0(@sanity/ui@2.6.7)(react-dom@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.11)
       sanity-plugin-mux-input:
         specifier: ^2.2.1
         version: 2.3.6(@types/react@18.3.3)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.11)
@@ -621,8 +621,8 @@ importers:
         specifier: 3.49.0
         version: link:../../packages/@sanity/cli
       '@sanity/ui':
-        specifier: ^2.6.6
-        version: 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+        specifier: ^2.6.7
+        version: 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1276,8 +1276,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0(react@18.3.1)
       '@sanity/ui':
-        specifier: ^2.6.6
-        version: 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+        specifier: ^2.6.7
+        version: 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       '@uiw/react-codemirror':
         specifier: ^4.11.4
         version: 4.21.25(@babel/runtime@7.24.8)(@codemirror/autocomplete@6.17.0)(@codemirror/language@6.10.2)(@codemirror/lint@6.8.1)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.28.4)(codemirror@6.0.1)(react-dom@18.3.1)(react@18.3.1)
@@ -1448,8 +1448,8 @@ importers:
         specifier: 3.49.0
         version: link:../@sanity/types
       '@sanity/ui':
-        specifier: ^2.6.6
-        version: 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+        specifier: ^2.6.7
+        version: 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       '@sanity/util':
         specifier: 3.49.0
         version: link:../@sanity/util
@@ -1732,7 +1732,7 @@ importers:
         version: 1.0.83(@types/node@18.19.31)(debug@4.3.5)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.11)
       '@sanity/ui-workshop':
         specifier: ^1.2.11
-        version: 1.2.11(@sanity/icons@3.3.0)(@sanity/ui@2.6.6)(@types/node@18.19.31)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+        version: 1.2.11(@sanity/icons@3.3.0)(@sanity/ui@2.6.7)(@types/node@18.19.31)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       '@sentry/types':
         specifier: ^8.12.0
         version: 8.12.0
@@ -6709,7 +6709,7 @@ packages:
       '@sanity/icons': 2.11.8(react@18.3.1)
       '@sanity/incompatible-plugin': 1.0.4(react-dom@18.3.1)(react@18.3.1)
       '@sanity/mutator': link:packages/@sanity/mutator
-      '@sanity/ui': 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+      '@sanity/ui': 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       date-fns: 3.6.0
       lodash: 4.17.21
       lodash-es: 4.17.21
@@ -6860,7 +6860,7 @@ packages:
     dependencies:
       '@sanity/icons': 2.11.8(react@18.3.1)
       '@sanity/incompatible-plugin': 1.0.4(react-dom@18.3.1)(react@18.3.1)
-      '@sanity/ui': 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+      '@sanity/ui': 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       lodash: 4.17.21
       react: 18.3.1
       sanity: link:packages/sanity
@@ -6953,7 +6953,7 @@ packages:
     dependencies:
       '@sanity/icons': 3.3.0(react@18.3.1)
       '@sanity/types': link:packages/@sanity/types
-      '@sanity/ui': 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+      '@sanity/ui': 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       lodash.startcase: 4.4.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -7145,7 +7145,7 @@ packages:
       '@sanity/client': 6.21.0(debug@4.3.5)
       '@sanity/icons': 3.3.0(react@18.3.1)
       '@sanity/preview-url-secret': 1.6.18(@sanity/client@6.21.0)
-      '@sanity/ui': 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+      '@sanity/ui': 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       '@sanity/uuid': 3.0.2
       '@types/lodash.isequal': 4.5.8
       fast-deep-equal: 3.1.3
@@ -7239,7 +7239,7 @@ packages:
       '@sanity/color': 3.0.6
       '@sanity/icons': 3.3.0(react@18.3.1)
       '@sanity/pkg-utils': 6.10.2(@types/node@18.19.31)(debug@4.3.5)(typescript@5.5.3)
-      '@sanity/ui': 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+      '@sanity/ui': 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       '@types/cpx': 1.5.5
       '@vitejs/plugin-react': 4.3.1(vite@5.3.3)
       cac: 6.7.14
@@ -7297,7 +7297,7 @@ packages:
       - debug
     dev: false
 
-  /@sanity/ui-workshop@1.2.11(@sanity/icons@3.3.0)(@sanity/ui@2.6.6)(@types/node@18.19.31)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.11):
+  /@sanity/ui-workshop@1.2.11(@sanity/icons@3.3.0)(@sanity/ui@2.6.7)(@types/node@18.19.31)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.11):
     resolution: {integrity: sha512-vzj7upIF7wq2W1HEA0D5VSkR8axaH4Rt07yNTAaas7CLgjSE9r2d+Gnkrq4FIbIuN1GYhhCD+D3/s60GaZrpQw==}
     hasBin: true
     peerDependencies:
@@ -7308,7 +7308,7 @@ packages:
       styled-components: ^5.2 || ^6
     dependencies:
       '@sanity/icons': 3.3.0(react@18.3.1)
-      '@sanity/ui': 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+      '@sanity/ui': 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       '@vitejs/plugin-react': 4.3.1(vite@4.5.3)
       axe-core: 4.9.0
       cac: 6.7.14
@@ -7336,8 +7336,8 @@ packages:
       - supports-color
       - terser
 
-  /@sanity/ui@2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11):
-    resolution: {integrity: sha512-y4iw7f0oZ0MZOR94JyXgihMr+xjgN39ei5TLrZXYWgEoL2eAnN2V3IZojOYHDAIFHIc8WhO1AeGkluKTN8EGpg==}
+  /@sanity/ui@2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11):
+    resolution: {integrity: sha512-+vUE7xuXUzo5kSkr8NrEluLOvdyvUReWQOciUiv2dqeT/AZ6wo4gnJNujUIakIe0Y7HdGAAs0spBVSssX2PGUQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '*'
@@ -7355,7 +7355,6 @@ packages:
       react-is: 18.3.1
       react-refractor: 2.2.0(react@18.3.1)
       styled-components: 6.1.11(react-dom@18.3.1)(react@18.3.1)
-      use-effect-event: 1.0.2(react@18.3.1)
 
   /@sanity/util@3.37.2(debug@4.3.5):
     resolution: {integrity: sha512-hq0eLjyV2iaOm9ivtPw12YTQ4QsE3jnV/Ui0zhclEhu8Go5JiaEhFt2+WM2lLGRH6qcSA414QbsCNCcyhJL6rA==}
@@ -18074,7 +18073,7 @@ packages:
       '@sanity/diff-match-patch': 3.1.1
     dev: false
 
-  /sanity-plugin-hotspot-array@2.0.0(@sanity/ui@2.6.6)(react-dom@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.11):
+  /sanity-plugin-hotspot-array@2.0.0(@sanity/ui@2.6.7)(react-dom@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.11):
     resolution: {integrity: sha512-y+FP4JgRaIKO17cBMyzCCVcxwl3fh7DXEp99QlvZSWUFi3NJJg2ZXFIXc2Om66HNkprfH2ORzEmEZMuDShtlTg==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -18086,7 +18085,7 @@ packages:
       '@sanity/asset-utils': 1.3.0
       '@sanity/image-url': 1.0.2
       '@sanity/incompatible-plugin': 1.0.4(react-dom@18.3.1)(react@18.3.1)
-      '@sanity/ui': 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+      '@sanity/ui': 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       '@sanity/util': 3.49.0
       '@types/lodash-es': 4.17.12
       framer-motion: 11.0.8(react-dom@18.3.1)(react@18.3.1)
@@ -18112,7 +18111,7 @@ packages:
       '@mux/upchunk': 3.4.0
       '@sanity/icons': 3.3.0(react@18.3.1)
       '@sanity/incompatible-plugin': 1.0.4(react-dom@18.3.1)(react@18.3.1)
-      '@sanity/ui': 2.6.6(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
+      '@sanity/ui': 2.6.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       '@sanity/uuid': 3.0.2
       iso-639-1: 3.1.2
       jsonwebtoken-esm: 1.0.5
@@ -19935,6 +19934,7 @@ packages:
       react: '*'
     dependencies:
       react: 18.3.1
+    dev: false
 
   /use-error-boundary@2.0.6(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-AWCVKSAanLe6R/on/ZkHYtGKfXs8BQX6z/TUGYqtvkajLqQyrGKJJscbahtq8OyN8L3LqTRjJWx4gCOLmfIObw==}


### PR DESCRIPTION
### Description

Bumps sanity ui to 2.6.7 to prevent a regression that was introduce in previous sanity ui version. See https://github.com/sanity-io/ui/pull/1372

### What to review

Do the e2e tests pass now?

### Testing

This bump was a simple revert so if the e2e tests, we should be good!

### Notes for release

N/A