### PR TITLE
fix: detect duplicate context errors

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -225,7 +225,11 @@ const config = {
     // Prefer createContext in _singletons
     {
       files: ['packages/sanity/src/**'],
-      excludedFiles: ['**/__workshop__/**', 'packages/sanity/src/_singletons/**'],
+      excludedFiles: [
+        '**/__workshop__/**',
+        'packages/sanity/src/_singletons/**',
+        'packages/sanity/src/_createContext/**',
+      ],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/dev/test-next-studio/next.config.mjs
+++ b/dev/test-next-studio/next.config.mjs
@@ -62,6 +62,9 @@ const config = {
       '@sanity/vision': requireResolve('../../packages/@sanity/vision/src/index.ts'),
       'sanity/_internal': requireResolve('../../packages/sanity/src/_exports/_internal.ts'),
       'sanity/_singletons': requireResolve('../../packages/sanity/src/_exports/_singletons.ts'),
+      'sanity/_createContext': requireResolve(
+        '../../packages/sanity/src/_exports/_createContext.ts',
+      ),
       'sanity/cli': requireResolve('../../packages/sanity/src/_exports/cli.ts'),
       'sanity/desk': requireResolve('../../packages/sanity/src/_exports/desk.ts'),
       'sanity/presentation': requireResolve('../../packages/sanity/src/_exports/presentation.ts'),
@@ -101,6 +104,7 @@ const config = {
         '@sanity/vision': '@sanity/vision/src/index.ts',
         'sanity/_internal': 'sanity/src/_exports/_internal.ts',
         'sanity/_singletons': 'sanity/src/_exports/_singletons.ts',
+        'sanity/_createContext': 'sanity/src/_exports/_createContext.ts',
         'sanity/cli': 'sanity/src/_exports/cli.ts',
         'sanity/desk': 'sanity/src/_exports/desk.ts',
         'sanity/presentation': 'sanity/src/_exports/presentation.ts',

--- a/dev/tsconfig.dev.json
+++ b/dev/tsconfig.dev.json
@@ -20,6 +20,7 @@
       "groq": ["./packages/groq/src/groq.ts"],
       "sanity/_internal": ["./packages/sanity/src/_exports/_internal.ts"],
       "sanity/_singletons": ["./packages/sanity/src/_exports/_singletons.ts"],
+      "sanity/_createContext": ["./packages/sanity/src/_exports/_createContext.ts"],
       "sanity/cli": ["./packages/sanity/src/_exports/cli.ts"],
       "sanity/desk": ["./packages/sanity/src/_exports/desk.ts"],
       "sanity/migrate": ["./packages/sanity/src/_exports/migrate.ts"],

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -20,6 +20,7 @@
       "groq": ["./packages/groq/src/groq.ts"],
       "sanity/_internal": ["./packages/sanity/src/_exports/_internal.ts"],
       "sanity/_singletons": ["./packages/sanity/src/_exports/_singletons.ts"],
+      "sanity/_createContext": ["./packages/sanity/src/_exports/_createContext.ts"],
       "sanity/cli": ["./packages/sanity/src/_exports/cli.ts"],
       "sanity/desk": ["./packages/sanity/src/_exports/desk.ts"],
       "sanity/migrate": ["./packages/sanity/src/_exports/migrate.ts"],

--- a/packages/@sanity/vision/tsconfig.json
+++ b/packages/@sanity/vision/tsconfig.json
@@ -35,6 +35,7 @@
       "groq": ["./node_modules/groq/src/groq.ts"],
       "sanity/_internal": ["./node_modules/sanity/src/_exports/_internal.ts"],
       "sanity/_singletons": ["./node_modules/sanity/src/_exports/_singletons.ts"],
+      "sanity/_createContext": ["./node_modules/sanity/src/_exports/_createContext.ts"],
       "sanity/cli": ["./node_modules/sanity/src/_exports/cli.ts"],
       "sanity/desk": ["./node_modules/sanity/src/_exports/desk.ts"],
       "sanity/migrate": ["./node_modules/sanity/src/_exports/migrate.ts"],

--- a/packages/sanity/.eslintignore
+++ b/packages/sanity/.eslintignore
@@ -1,5 +1,6 @@
 # legacy package exports
 _singletons.js
+_createContext.js
 desk.js
 form.js
 presentation.js

--- a/packages/sanity/.gitignore
+++ b/packages/sanity/.gitignore
@@ -20,6 +20,7 @@
 /router.js
 /structure.js
 /_singletons.js
+/_createContext.js
 
 # Playwright-ct artifacts
 /playwright-ct/report

--- a/packages/sanity/package.bundle.ts
+++ b/packages/sanity/package.bundle.ts
@@ -8,6 +8,7 @@ export default defineConfig(() => {
       lib: {
         entry: {
           _singletons: './src/_exports/_singletons.ts',
+          _createContext: './src/_exports/_createContext.ts',
           // 'sanity' module
           index: './src/_exports/index.ts',
           desk: './src/_exports/desk.ts',

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -39,6 +39,12 @@
       "require": "./lib/_singletons.js",
       "default": "./lib/_singletons.js"
     },
+    "./_createContext": {
+      "source": "./src/_exports/_createContext.ts",
+      "import": "./lib/_createContext.mjs",
+      "require": "./lib/_createContext.js",
+      "default": "./lib/_createContext.js"
+    },
     "./cli": {
       "source": "./src/_exports/cli.ts",
       "require": "./lib/cli.js",
@@ -86,6 +92,9 @@
       "_singletons": [
         "./lib/_singletons.d.ts"
       ],
+      "_createContext": [
+        "./lib/_createContext.d.ts"
+      ],
       "cli": [
         "./lib/cli.d.ts"
       ],
@@ -122,13 +131,14 @@
     "presentation.js",
     "router.js",
     "structure.js",
-    "_singletons.js"
+    "_singletons.js",
+    "_createContext.js"
   ],
   "scripts": {
     "build": "pkg-utils build --strict --check --clean",
     "build:bundle": "vite build --config package.bundle.ts",
     "check:types": "tsc --project tsconfig.lib.json",
-    "clean": "rimraf _internal.js _singletons.js cli.js desk.js migrate.js presentation.js router.js structure.js lib",
+    "clean": "rimraf _internal.js _singletons.js _createContext.js cli.js desk.js migrate.js presentation.js router.js structure.js lib",
     "coverage": "jest --coverage",
     "lint": "eslint .",
     "prepublishOnly": "turbo run build",

--- a/packages/sanity/src/_createContext/createGlobalScopedContext.ts
+++ b/packages/sanity/src/_createContext/createGlobalScopedContext.ts
@@ -1,0 +1,61 @@
+import {type Context, createContext} from 'react'
+
+import {SANITY_VERSION} from '../core/version'
+
+/**
+ * @internal
+ * @hidden
+ */
+export function createGlobalScopedContext<ContextType, const T extends ContextType = ContextType>(
+  /**
+   * It's important to prefix these keys as they are global
+   */
+  key: `sanity/_singletons/context/${string}`,
+  defaultValue: T,
+): Context<ContextType> {
+  const symbol = Symbol.for(key)
+
+  /**
+   * Prevent errors about re-renders on React SSR on Next.js App Router
+   */
+  if (typeof document === 'undefined') {
+    return createContext<ContextType>(defaultValue)
+  }
+
+  if (!globalScope[symbol]) {
+    globalScope[symbol] = {context: createContext<T>(defaultValue), version: SANITY_VERSION}
+  } else if (globalScope[symbol].version !== SANITY_VERSION) {
+    throw new TypeError(
+      `Duplicate instances of sanity context with incompatible versions detected: expected ${SANITY_VERSION}, got ${globalScope[symbol].version} on key "${key}"`,
+    )
+  } else if (!warned.has(SANITY_VERSION)) {
+    console.warn(
+      `Duplicate instances of sanity context on key "${key}" detected. This is likely a mistake and could lead to problems.`,
+    )
+    warned.add(SANITY_VERSION)
+  }
+
+  return globalScope[symbol].context
+}
+
+const warned = new Set<typeof SANITY_VERSION>()
+
+/**
+ * Gets the global scope instance in a given environment.
+ *
+ * The strategy is to return the most modern, and if not, the most common:
+ * - The `globalThis` variable is the modern approach to accessing the global scope
+ * - The `window` variable is the global scope in a web browser
+ * - The `self` variable is the global scope in workers and others
+ * - The `global` variable is the global scope in Node.js
+ */
+function getGlobalScope() {
+  if (typeof globalThis !== 'undefined') return globalThis
+  if (typeof window !== 'undefined') return window
+  if (typeof self !== 'undefined') return self
+  if (typeof global !== 'undefined') return global
+
+  throw new Error('sanity: could not locate global scope')
+}
+
+const globalScope = getGlobalScope() as any

--- a/packages/sanity/src/_createContext/createGlobalScopedContext.ts
+++ b/packages/sanity/src/_createContext/createGlobalScopedContext.ts
@@ -2,6 +2,8 @@ import {type Context, createContext} from 'react'
 
 import {SANITY_VERSION} from '../core/version'
 
+const MISSING_CONTEXT_HELP_URL = 'https://www.sanity.io/help/missing-context-error'
+
 /**
  * @internal
  * @hidden
@@ -26,11 +28,13 @@ export function createGlobalScopedContext<ContextType, const T extends ContextTy
     globalScope[symbol] = {context: createContext<T>(defaultValue), version: SANITY_VERSION}
   } else if (globalScope[symbol].version !== SANITY_VERSION) {
     throw new TypeError(
-      `Duplicate instances of sanity context with incompatible versions detected: expected ${SANITY_VERSION}, got ${globalScope[symbol].version} on key "${key}"`,
+      `Duplicate instances of context "${key}" with incompatible versions detected: Expected ${SANITY_VERSION} but got ${globalScope[symbol].version}.\n\n` +
+        `For more information, please visit ${MISSING_CONTEXT_HELP_URL}`,
     )
   } else if (!warned.has(SANITY_VERSION)) {
     console.warn(
-      `Duplicate instances of sanity context on key "${key}" detected. This is likely a mistake and could lead to problems.`,
+      `Duplicate instances of context "${key}" detected. This is likely a mistake and may cause unexpected behavior.\n\n` +
+        `For more information, please visit ${MISSING_CONTEXT_HELP_URL}`,
     )
     warned.add(SANITY_VERSION)
   }

--- a/packages/sanity/src/_createContext/index.ts
+++ b/packages/sanity/src/_createContext/index.ts
@@ -1,0 +1,1 @@
+export {createGlobalScopedContext as createContext} from './createGlobalScopedContext'

--- a/packages/sanity/src/_exports/_createContext.ts
+++ b/packages/sanity/src/_exports/_createContext.ts
@@ -1,0 +1,1 @@
+export * from '../_createContext'

--- a/packages/sanity/src/_singletons/core/form/FormValueContext.ts
+++ b/packages/sanity/src/_singletons/core/form/FormValueContext.ts
@@ -1,8 +1,11 @@
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 import type {FormValueContextValue} from '../../../core/form/contexts/FormValue'
 
 /**
  * @internal
  */
-export const FormValueContext = createContext<FormValueContextValue | null>(null)
+export const FormValueContext = createContext<FormValueContextValue | null>(
+  'sanity/_singletons/context/form-value',
+  null,
+)

--- a/packages/sanity/src/_singletons/core/form/GetFormValueContext.ts
+++ b/packages/sanity/src/_singletons/core/form/GetFormValueContext.ts
@@ -1,5 +1,5 @@
 import type {Path} from '@sanity/types'
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 /**
  * @internal
@@ -10,4 +10,7 @@ export type GetFormValueContextValue = (path: Path) => unknown
 /**
  * @internal
  */
-export const GetFormValueContext = createContext<GetFormValueContextValue | null>(null)
+export const GetFormValueContext = createContext<GetFormValueContextValue | null>(
+  'sanity/_singletons/context/get-form-value',
+  null,
+)

--- a/packages/sanity/src/_singletons/core/i18n/LocaleContext.ts
+++ b/packages/sanity/src/_singletons/core/i18n/LocaleContext.ts
@@ -1,5 +1,5 @@
 import type {i18n} from 'i18next'
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 import type {Locale} from '../../../core/i18n/types'
 
@@ -18,4 +18,7 @@ export interface LocaleContextValue {
  * @internal
  * @hidden
  */
-export const LocaleContext = createContext<LocaleContextValue | undefined>(undefined)
+export const LocaleContext = createContext<LocaleContextValue | undefined>(
+  'sanity/_singletons/context/locale',
+  undefined,
+)

--- a/packages/sanity/src/_singletons/core/store/_legacy/ResourceCacheContext.ts
+++ b/packages/sanity/src/_singletons/core/store/_legacy/ResourceCacheContext.ts
@@ -1,8 +1,11 @@
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 import type {ResourceCache} from '../../../../core/store/_legacy/ResourceCacheProvider'
 
 /**
  * @internal
  */
-export const ResourceCacheContext = createContext<ResourceCache | null>(null)
+export const ResourceCacheContext = createContext<ResourceCache | null>(
+  'sanity/_singletons/context/resource-cache',
+  null,
+)

--- a/packages/sanity/src/_singletons/core/studio/SourceContext.ts
+++ b/packages/sanity/src/_singletons/core/studio/SourceContext.ts
@@ -1,8 +1,8 @@
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 import type {Source} from '../../../core/config/types'
 
 /**
  * @internal
  */
-export const SourceContext = createContext<Source | null>(null)
+export const SourceContext = createContext<Source | null>('sanity/_singletons/context/source', null)

--- a/packages/sanity/src/_singletons/core/studio/WorkspaceContext.ts
+++ b/packages/sanity/src/_singletons/core/studio/WorkspaceContext.ts
@@ -1,8 +1,11 @@
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 import type {Workspace} from '../../../core/config/types'
 
 /**
  * @internal
  */
-export const WorkspaceContext = createContext<Workspace | null>(null)
+export const WorkspaceContext = createContext<Workspace | null>(
+  'sanity/_singletons/context/workspace',
+  null,
+)

--- a/packages/sanity/src/_singletons/core/studio/activeWorkspaceMatcher/ActiveWorkspaceMatcherContext.ts
+++ b/packages/sanity/src/_singletons/core/studio/activeWorkspaceMatcher/ActiveWorkspaceMatcherContext.ts
@@ -1,7 +1,10 @@
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 import type {ActiveWorkspaceMatcherContextValue} from '../../../../core/studio/activeWorkspaceMatcher/ActiveWorkspaceMatcherContext'
 
 /** @internal */
 export const ActiveWorkspaceMatcherContext =
-  createContext<ActiveWorkspaceMatcherContextValue | null>(null)
+  createContext<ActiveWorkspaceMatcherContextValue | null>(
+    'sanity/_singletons/context/active-workspace-matcher',
+    null,
+  )

--- a/packages/sanity/src/_singletons/core/studio/workspaces/WorkspacesContext.ts
+++ b/packages/sanity/src/_singletons/core/studio/workspaces/WorkspacesContext.ts
@@ -1,6 +1,9 @@
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 import type {WorkspacesContextValue} from '../../../../core/studio/workspaces/WorkspacesContext'
 
 /** @internal */
-export const WorkspacesContext = createContext<WorkspacesContextValue | null>(null)
+export const WorkspacesContext = createContext<WorkspacesContextValue | null>(
+  'sanity/_singletons/context/workspaces',
+  null,
+)

--- a/packages/sanity/src/_singletons/router/RouterContext.ts
+++ b/packages/sanity/src/_singletons/router/RouterContext.ts
@@ -1,8 +1,11 @@
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 import type {RouterContextValue} from '../../router/types'
 
 /**
  * @internal
  */
-export const RouterContext = createContext<RouterContextValue | null>(null)
+export const RouterContext = createContext<RouterContextValue | null>(
+  'sanity/_singletons/context/router',
+  null,
+)

--- a/packages/sanity/src/_singletons/structure/StructureToolContext.ts
+++ b/packages/sanity/src/_singletons/structure/StructureToolContext.ts
@@ -1,8 +1,11 @@
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 import type {StructureToolContextValue} from '../../structure/types'
 
 /**
  * @internal
  */
-export const StructureToolContext = createContext<StructureToolContextValue | null>(null)
+export const StructureToolContext = createContext<StructureToolContextValue | null>(
+  'sanity/_singletons/context/structure-tool',
+  null,
+)

--- a/packages/sanity/src/_singletons/structure/comments/intent/CommentsIntentContext.ts
+++ b/packages/sanity/src/_singletons/structure/comments/intent/CommentsIntentContext.ts
@@ -1,4 +1,4 @@
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 import type {CommentsIntentContextValue} from '../../../../core/comments/context/intent/types'
 
@@ -6,5 +6,6 @@ import type {CommentsIntentContextValue} from '../../../../core/comments/context
  * @internal
  */
 export const CommentsIntentContext = createContext<CommentsIntentContextValue | undefined>(
+  'sanity/_singletons/context/comments-intent',
   undefined,
 )

--- a/packages/sanity/src/_singletons/structure/components/pane/PaneContext.ts
+++ b/packages/sanity/src/_singletons/structure/components/pane/PaneContext.ts
@@ -1,8 +1,11 @@
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 import type {PaneContextValue} from '../../../../structure/components/pane/types'
 
 /**
  * @internal
  */
-export const PaneContext = createContext<PaneContextValue | null>(null)
+export const PaneContext = createContext<PaneContextValue | null>(
+  'sanity/_singletons/context/pane',
+  null,
+)

--- a/packages/sanity/src/_singletons/structure/components/pane/PaneLayoutContext.ts
+++ b/packages/sanity/src/_singletons/structure/components/pane/PaneLayoutContext.ts
@@ -1,8 +1,11 @@
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 import type {PaneLayoutContextValue} from '../../../../structure/components/pane/types'
 
 /**
  * @internal
  */
-export const PaneLayoutContext = createContext<PaneLayoutContextValue | null>(null)
+export const PaneLayoutContext = createContext<PaneLayoutContextValue | null>(
+  'sanity/_singletons/context/pane-layout',
+  null,
+)

--- a/packages/sanity/src/_singletons/structure/components/paneRouter/PaneRouterContext.tsx
+++ b/packages/sanity/src/_singletons/structure/components/paneRouter/PaneRouterContext.tsx
@@ -1,4 +1,4 @@
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 import type {PaneRouterContextValue} from '../../../../structure/components/paneRouter/types'
 
@@ -11,27 +11,30 @@ function missingContext<T = unknown>(): T {
  * @hidden
  * @beta
  */
-export const PaneRouterContext = createContext<PaneRouterContextValue>({
-  index: 0,
-  groupIndex: 0,
-  siblingIndex: 0,
-  payload: undefined,
-  params: {},
-  hasGroupSiblings: false,
-  groupLength: 0,
-  routerPanesState: [],
-  BackLink: () => missingContext(),
-  ChildLink: () => missingContext(),
-  ReferenceChildLink: () => missingContext(),
-  handleEditReference: () => missingContext(),
-  ParameterizedLink: () => missingContext(),
-  replaceCurrent: () => missingContext(),
-  closeCurrentAndAfter: () => missingContext(),
-  closeCurrent: () => missingContext(),
-  duplicateCurrent: () => missingContext(),
-  setView: () => missingContext(),
-  setParams: () => missingContext(),
-  setPayload: () => missingContext(),
-  navigateIntent: () => missingContext(),
-  createPathWithParams: () => missingContext(),
-})
+export const PaneRouterContext = createContext<PaneRouterContextValue>(
+  'sanity/_singletons/context/pane-router',
+  {
+    index: 0,
+    groupIndex: 0,
+    siblingIndex: 0,
+    payload: undefined,
+    params: {},
+    hasGroupSiblings: false,
+    groupLength: 0,
+    routerPanesState: [],
+    BackLink: () => missingContext(),
+    ChildLink: () => missingContext(),
+    ReferenceChildLink: () => missingContext(),
+    handleEditReference: () => missingContext(),
+    ParameterizedLink: () => missingContext(),
+    replaceCurrent: () => missingContext(),
+    closeCurrentAndAfter: () => missingContext(),
+    closeCurrent: () => missingContext(),
+    duplicateCurrent: () => missingContext(),
+    setView: () => missingContext(),
+    setParams: () => missingContext(),
+    setPayload: () => missingContext(),
+    navigateIntent: () => missingContext(),
+    createPathWithParams: () => missingContext(),
+  },
+)

--- a/packages/sanity/src/_singletons/structure/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/_singletons/structure/panes/document/DocumentPaneContext.ts
@@ -1,6 +1,9 @@
-import {createContext} from 'react'
+import {createContext} from 'sanity/_createContext'
 
 import type {DocumentPaneContextValue} from '../../../../structure/panes/document/DocumentPaneContext'
 
 /** @internal */
-export const DocumentPaneContext = createContext<DocumentPaneContextValue | null>(null)
+export const DocumentPaneContext = createContext<DocumentPaneContextValue | null>(
+  'sanity/_singletons/context/document-pane',
+  null,
+)

--- a/packages/sanity/src/core/form/contexts/GetFormValue.tsx
+++ b/packages/sanity/src/core/form/contexts/GetFormValue.tsx
@@ -48,7 +48,7 @@ export function GetFormValueProvider(props: {
 export function useGetFormValue() {
   const ctx = useContext(GetFormValueContext)
   if (!ctx) {
-    throw new Error('useFormValue must be used within a FormValueProvider')
+    throw new Error('useGetFormValue must be used within a GetFormValueProvider')
   }
   return ctx
 }

--- a/packages/sanity/tsconfig.json
+++ b/packages/sanity/tsconfig.json
@@ -37,6 +37,7 @@
       "groq": ["./node_modules/groq/src/groq.ts"],
       "sanity/_internal": ["./src/_exports/_internal.ts"],
       "sanity/_singletons": ["./src/_exports/_singletons.ts"],
+      "sanity/_createContext": ["./src/_exports/_createContext.ts"],
       "sanity/cli": ["./src/_exports/cli.ts"],
       "sanity/desk": ["./src/_exports/desk.ts"],
       "sanity/migrate": ["./src/_exports/migrate.ts"],

--- a/packages/sanity/tsconfig.settings.json
+++ b/packages/sanity/tsconfig.settings.json
@@ -6,6 +6,7 @@
     "paths": {
       "sanity/_internal": ["./src/_exports/_internal.ts"],
       "sanity/_singletons": ["./src/_exports/_singletons.ts"],
+      "sanity/_createContext": ["./src/_exports/_createContext.ts"],
       "sanity/cli": ["./src/_exports/cli.ts"],
       "sanity/desk": ["./src/_exports/desk.ts"],
       "sanity/migrate": ["./src/_exports/migrate.ts"],

--- a/packages/sanity/turbo.json
+++ b/packages/sanity/turbo.json
@@ -6,6 +6,7 @@
       "outputs": [
         "lib/**",
         "_singletons.js",
+        "_createContext.js",
         "desk.js",
         "presentation.js",
         "router.js",


### PR DESCRIPTION
### Description

When using monorepo setups it's very common to stumble upon errors such as:
- Workspace: missing context value
- Could not find `source` context
- Router: missing context value

What's effectively happening when these errors occur is that during bundling there are instances of `React.createContext` that should only happen once, that are now duplicated. There are many ways a repo can end up in this state, with monorepo setups like `pnpm workspaces` being especially suspectible.

Let's compare the simplified bundler output of a healthy build, and a broken one, to understand what's happening.

Let's say in your `sanity.config.ts` you're using the `useWorkspace` hook in a custom input component:
```tsx
import {useWorkspace} from 'sanity'

export function CustomInput() {
  const workspace = useWorkspace()

  // ...
}
```

#### Healthy bundle
```js
const WorkspaceContext = createContext(null)

function WorkspaceProvider({children, workspace}) {
  return <WorkspaceContext.Provider value={workspace}>{children}</WorkspaceContext.Provider>
}

function useWorkspace() {
  const workspace = useContext(WorkspaceContext)

  if (!workspace) throw new Error('Workspace: missing context value')

  return workspace
}

function CustomInput() {
  const workspace = useWorkspace()

  // ...
}
```

#### Broken bundle

Here's what the bundle looks like when we're in a failing state, where attempting to render `CustomInput`  throws  an `Workspace: missing context value` error

```js
const WorkspaceContext = createContext(null)

function WorkspaceProvider({children, workspace}) {
  return <WorkspaceContext.Provider value={workspace}>{children}</WorkspaceContext.Provider>
}

function useWorkspace() {
  const workspace = useContext(WorkspaceContext)

  if (!workspace) throw new Error('Workspace: missing context value')

  return workspace
}

// Instead of re-using the same hooks and context, hook deps are duplicated

const WorkspaceContext$0 = createContext(null)

function useWorkspace$0() {
  const workspace = useContext(WorkspaceContext$0)

  if (!workspace) throw new Error('Workspace: missing context value')

  return workspace
}

function CustomInput() {
  const workspace = useWorkspace$0()

  // ...
}
```

It's very difficult to resolve them, as their cause depends on userland package manager setup, workspace setup, symlinks and more.
This PR mitigates this problem by creating key react contexts in a global, versioned, scope, allowing us to:
a) if the context were come from different `sanity` versions we throw an error.
b) if duplicate contexts come from the same `sanity` versions we warn, and bridge them so it'll work in most cases.

#### Handling incompatible duplicates

When the globally scoped contexts detect duplicates on different versions [we throw an error](https://sanity-io-studio-kzvkc131s.sanity.build/):

![image](https://github.com/user-attachments/assets/4366c1ce-8521-4eb7-9980-beedbff2b420)

On next.js `next dev` ([here's the same error in production](https://sanity-i51vbv6h2.sanity.build/admin)):

![image](https://github.com/user-attachments/assets/86178538-1c83-40f9-a93d-14eef4ee8587)


#### Gracefully handling compatible duplicates

The way context is bridged when there are duplicates are based on the way `@sanity/ui` solves it: https://github.com/sanity-io/ui/blob/bad8b33cbfc801de7545b02e283c89fc38482d89/src/core/lib/createGlobalScopedContext.ts
We do warn when this happens though, as it's usually an indicator that the bundler might be doing other things it shouldn't be doing, in a way it's a bit of "undefined behaviour":

![image](https://github.com/user-attachments/assets/ff50a604-94e3-4dfa-84be-588841d51592)


### What to review

Does the error message, and console warnings make sense?
Should we link to a docs page for how to resolve duplicates (for example `pnpm dedupe sanity` is usually sufficient for `pnpm` workspaces)?
The contexts I added to the globally scoped contexts are based on [publicly documented hooks](https://www.sanity.io/docs/studio-react-hooks) and [on the hooks used by `@sanity/presentation`](https://github.com/sanity-io/visual-editing/blob/e8809f8131988af7888ea7d8e10524e55df52e9e/packages/presentation/src/internals.ts). Did I miss any?

### Testing

I made test releases that can be used to see the error messages:
- `sanity@3.50.1-detect-context-errors.12`
- `sanity@3.50.1-detect-context-errors.10`

### Notes for release

- improved error messages when duplicate instances of sanity in node_modules