### PR TITLE
chore: hide publish date

### DIFF
--- a/packages/sanity/src/core/bundles/components/BundleMenu.tsx
+++ b/packages/sanity/src/core/bundles/components/BundleMenu.tsx
@@ -1,7 +1,6 @@
 import {CheckmarkIcon} from '@sanity/icons'
 import {Box, Flex, Menu, MenuButton, MenuDivider, MenuItem, Spinner, Text} from '@sanity/ui'
 import {type ReactElement, useCallback} from 'react'
-import {RelativeTime} from 'sanity'
 import {styled} from 'styled-components'
 
 import {type BundleDocument} from '../../store/bundles/types'
@@ -91,16 +90,15 @@ export function BundleMenu(props: BundleListProps): JSX.Element {
                                 </Text>
                               </Box>
 
-                              <Box padding={2}>
+                              {/*<Box padding={2}>
                                 <Text muted size={1}>
                                   {b.publishAt ? (
                                     <RelativeTime time={b.publishAt as Date} useTemporalPhrase />
                                   ) : (
-                                    /* localize text */
                                     'No target date'
                                   )}
                                 </Text>
-                              </Box>
+                              </Box>*/}
 
                               <Box padding={2}>
                                 <Text size={1}>

--- a/packages/sanity/src/core/bundles/components/dialog/BundleForm.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/BundleForm.tsx
@@ -1,19 +1,18 @@
 /* eslint-disable i18next/no-literal-string */
-import {CalendarIcon} from '@sanity/icons'
-import {Box, Button, Flex, Popover, Stack, Text, TextArea, TextInput} from '@sanity/ui'
+//import {CalendarIcon} from '@sanity/icons'
+import {Flex, Stack, Text, TextArea, TextInput} from '@sanity/ui'
 import {useCallback, useMemo, useState} from 'react'
 import {
   FormFieldHeaderText,
   type FormNodeValidation,
   useBundles,
-  useDateTimeFormat,
-  useTranslation,
+  //useDateTimeFormat,
+  //useTranslation,
 } from 'sanity'
 import speakingurl from 'speakingurl'
 
-import {type CalendarLabels} from '../../../form/inputs/DateInputs/base/calendar/types'
-import {DatePicker} from '../../../form/inputs/DateInputs/base/DatePicker'
-import {getCalendarLabels} from '../../../form/inputs/DateInputs/utils'
+//import {type CalendarLabels} from '../../../form/inputs/DateInputs/base/calendar/types'
+//import {getCalendarLabels} from '../../../form/inputs/DateInputs/utils'
 import {type BundleDocument} from '../../../store/bundles/types'
 import {isDraftOrPublished} from '../../util/dummyGetters'
 import {BundleIconEditorPicker, type BundleIconEditorPickerValue} from './BundleIconEditorPicker'
@@ -24,29 +23,26 @@ export function BundleForm(props: {
   value: Partial<BundleDocument>
 }): JSX.Element {
   const {onChange, onError, value} = props
-  const {title, description, icon, hue, publishAt} = value
+  const {title, description, icon, hue /*, publishAt*/} = value
 
-  const dateFormatter = useDateTimeFormat()
+  //const dateFormatter = useDateTimeFormat()
 
-  const [showDateValidation, setShowDateValidation] = useState(false)
   const [showDatePicker, setShowDatePicker] = useState(false)
-  const [showBundleExists, setShowBundleExists] = useState(false)
-  const [showIsDraftPublishError, setShowIsDraftPublishError] = useState(false)
 
   const [isInitialRender, setIsInitialRender] = useState(true)
   const {data} = useBundles()
 
   const [titleErrors, setTitleErrors] = useState<FormNodeValidation[]>([])
-  const [dateErrors, setDateErrors] = useState<FormNodeValidation[]>([])
+  /*const [dateErrors, setDateErrors] = useState<FormNodeValidation[]>([])
 
-  const publishAtDisplayValue = useMemo(() => {
+  /*const publishAtDisplayValue = useMemo(() => {
     if (!publishAt) return ''
     return dateFormatter.format(new Date(publishAt as Date))
   }, [dateFormatter, publishAt])
 
   const [displayDate, setDisplayDate] = useState(publishAtDisplayValue)
   const {t: coreT} = useTranslation()
-  const calendarLabels: CalendarLabels = useMemo(() => getCalendarLabels(coreT), [coreT])
+  const calendarLabels: CalendarLabels = useMemo(() => getCalendarLabels(coreT), [coreT])*/
 
   const iconValue: BundleIconEditorPickerValue = useMemo(
     () => ({
@@ -112,7 +108,7 @@ export function BundleForm(props: {
     setShowDatePicker(!showDatePicker)
   }, [showDatePicker])
 
-  const handleBundlePublishAtChange = useCallback(
+  /*const handleBundlePublishAtChange = useCallback(
     (nextDate: Date | undefined) => {
       onChange({...value, publishAt: nextDate})
       setDisplayDate(dateFormatter.format(new Date(nextDate as Date)))
@@ -131,7 +127,6 @@ export function BundleForm(props: {
       // in which case it can update the input value but not the actual bundle value
       if (new Date(event.target.value).toString() === 'Invalid Date' && dateValue !== '') {
         // if the date is invalid, show an error
-        // TODO localize text
         setDateErrors([
           {
             level: 'error',
@@ -149,7 +144,7 @@ export function BundleForm(props: {
       }
     },
     [onChange, value, onError],
-  )
+  )*/
 
   const handleIconValueChange = useCallback(
     (pickedIcon: BundleIconEditorPickerValue) => {
@@ -186,8 +181,7 @@ export function BundleForm(props: {
         />
       </Stack>
 
-      <Stack space={3}>
-        {/* localize text */}
+      {/*<Stack space={3}>
         <FormFieldHeaderText title="Schedule for publishing at" validation={dateErrors} />
 
         <TextInput
@@ -223,7 +217,7 @@ export function BundleForm(props: {
           data-testid="bundle-form-publish-at"
           customValidity={dateErrors.length > 0 ? 'error' : undefined}
         />
-      </Stack>
+      </Stack>*/}
     </Stack>
   )
 }

--- a/packages/sanity/src/core/bundles/components/dialog/CreateBundleDialog.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/CreateBundleDialog.tsx
@@ -22,7 +22,7 @@ export function CreateBundleDialog(props: CreateBundleDialogProps): JSX.Element 
     title: '',
     hue: 'gray',
     icon: 'cube',
-    publishAt: undefined,
+    //publishAt: undefined,
   })
   const [isCreating, setIsCreating] = useState(false)
 

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleForm.test.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleForm.test.tsx
@@ -25,7 +25,7 @@ describe('BundleForm', () => {
     description: '',
     icon: 'cube',
     hue: 'gray',
-    publishAt: undefined,
+    //publishAt: undefined,
   }
 
   beforeEach(async () => {
@@ -62,7 +62,7 @@ describe('BundleForm', () => {
   it('should render the form fields', () => {
     expect(screen.getByTestId('bundle-form-title')).toBeInTheDocument()
     expect(screen.getByTestId('bundle-form-description')).toBeInTheDocument()
-    expect(screen.getByTestId('bundle-form-publish-at')).toBeInTheDocument()
+    //expect(screen.getByTestId('bundle-form-publish-at')).toBeInTheDocument()
   })
 
   it('should call onChange when title input value changes', () => {
@@ -79,7 +79,7 @@ describe('BundleForm', () => {
     expect(onChangeMock).toHaveBeenCalledWith({...valueMock, description: 'New Description'})
   })
 
-  it('should call onChange when publishAt input value changes', () => {
+  /*it('should call onChange when publishAt input value changes', () => {
     const publishAtInput = screen.getByTestId('bundle-form-publish-at')
     fireEvent.change(publishAtInput, {target: {value: '2022-01-01'}})
 
@@ -91,7 +91,7 @@ describe('BundleForm', () => {
     fireEvent.change(publishAtInput, {target: {value: ' '}})
 
     expect(onChangeMock).toHaveBeenCalledWith({...valueMock, publishAt: ''})
-  })
+  })*/
 
   it('should show an error when the title is "drafts"', () => {
     const titleInput = screen.getByTestId('bundle-form-title')
@@ -123,10 +123,10 @@ describe('BundleForm', () => {
     expect(screen.getByTestId('input-validation-icon-error')).toBeInTheDocument()
   })
 
-  it('should show an error when the publishAt input value is invalid', () => {
+  /*it('should show an error when the publishAt input value is invalid', () => {
     const publishAtInput = screen.getByTestId('bundle-form-publish-at')
     fireEvent.change(publishAtInput, {target: {value: 'invalid-date'}})
 
     expect(screen.getByTestId('input-validation-icon-error')).toBeInTheDocument()
-  })
+  })*/
 })

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/CreateBundleDialog.test.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/CreateBundleDialog.test.tsx
@@ -1,15 +1,15 @@
 import {beforeEach, describe, expect, it, jest} from '@jest/globals'
 import {fireEvent, render, screen} from '@testing-library/react'
-import {type BundleDocument, useBundles, useDateTimeFormat} from 'sanity'
+import {type BundleDocument, useBundles} from 'sanity'
 
 import {useBundleOperations} from '../../../../store/bundles/useBundleOperations'
 import {usePerspective} from '../../../hooks/usePerspective'
 import {createWrapper} from '../../../util/tests/createWrapper'
 import {CreateBundleDialog} from '../CreateBundleDialog'
 
-jest.mock('../../../../../core/hooks/useDateTimeFormat', () => ({
+/*jest.mock('../../../../../core/hooks/useDateTimeFormat', () => ({
   useDateTimeFormat: jest.fn(),
-}))
+}))*/
 
 jest.mock('../../../../store/bundles', () => ({
   useBundles: jest.fn(),
@@ -28,7 +28,7 @@ jest.mock('../../../hooks/usePerspective', () => ({
 }))
 
 const mockUseBundleStore = useBundles as jest.Mock<typeof useBundles>
-const mockUseDateTimeFormat = useDateTimeFormat as jest.Mock
+//const mockUseDateTimeFormat = useDateTimeFormat as jest.Mock
 
 describe('CreateBundleDialog', () => {
   const onCancelMock = jest.fn()
@@ -44,7 +44,7 @@ describe('CreateBundleDialog', () => {
       dispatch: jest.fn(),
     })
 
-    mockUseDateTimeFormat.mockReturnValue({format: jest.fn().mockReturnValue('Mocked date')})
+    //mockUseDateTimeFormat.mockReturnValue({format: jest.fn().mockReturnValue('Mocked date')})
 
     const wrapper = await createWrapper()
     render(<CreateBundleDialog onCancel={onCancelMock} onCreate={onCreateMock} />, {wrapper})
@@ -66,7 +66,7 @@ describe('CreateBundleDialog', () => {
       title: 'Bundle 1',
       hue: 'gray',
       icon: 'cube',
-      publishAt: undefined,
+      //publishAt: undefined,
     }
 
     const titleInput = screen.getByTestId('bundle-form-title')

--- a/packages/sanity/src/core/bundles/util/const.ts
+++ b/packages/sanity/src/core/bundles/util/const.ts
@@ -10,5 +10,5 @@ export const LATEST: Partial<BundleDocument> = {
   title: 'Latest',
   icon: undefined,
   tone: 'gray',
-  publishAt: '',
+  //publishAt: '',
 }

--- a/packages/sanity/src/core/bundles/util/dummyGetters.ts
+++ b/packages/sanity/src/core/bundles/util/dummyGetters.ts
@@ -32,7 +32,7 @@ export async function getAllVersionsOfDocument(
         title: bundle?.title || sluggedName,
         hue: bundle?.hue || 'gray',
         icon: bundle?.icon || 'cube',
-        publishAt: bundle?.publishAt,
+        //publishAt: bundle?.publishAt,
       }
     })
   })

--- a/packages/sanity/src/core/store/bundles/__workshop__/BundlesStoreStory.tsx
+++ b/packages/sanity/src/core/store/bundles/__workshop__/BundlesStoreStory.tsx
@@ -20,7 +20,7 @@ const WithAddonDatasetProvider = <P extends object>(Component: ComponentType<P>)
   return WrappedComponent
 }
 
-const initialValue = {name: '', title: '', tone: undefined, publishAt: undefined}
+const initialValue = {name: '', title: '', tone: undefined /*, publishAt: undefined*/}
 
 const BundlesStoreStory = () => {
   const {data, loading} = useBundles()


### PR DESCRIPTION
### Description

- Hide all publishAt mentions
  - BundleMenu
  - CreateBundleDialog
  - Update tests

I commented them out instead of removing them because I feel the publish type will likely be a pretty swift follow up after the first mvi? Let me know if you all prefer that I remove them completely
