### PR TITLE
fix(sanity): ensure Actions API client uses adequate API version

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.test.ts
@@ -19,6 +19,7 @@ const client = {
     action: mockedActionRequest,
   },
   dataRequest: mockedDataRequest,
+  withConfig: jest.fn(() => client),
 }
 
 const idPair = {publishedId: 'publishedId', draftId: 'draftId'}

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -14,6 +14,7 @@ import {
 } from '../buffered-doc'
 import {getPairListener, type ListenerEvent} from '../getPairListener'
 import {type IdPair, type PendingMutationsEvent, type ReconnectEvent} from '../types'
+import {actionsApiClient} from './utils/actionsApiClient'
 
 const isMutationEventForDocId =
   (id: string) =>
@@ -129,7 +130,7 @@ function commitActions(client: SanityClient, idPair: IdPair, mutationParams: Mut
     return commitMutations(client, mutationParams)
   }
 
-  return client.observable.action(toActions(idPair, mutationParams), {
+  return actionsApiClient(client).observable.action(toActions(idPair, mutationParams), {
     tag: 'document.commit',
     transactionId: mutationParams.transactionId,
   })

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/delete.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/delete.ts
@@ -1,4 +1,5 @@
 import {type OperationImpl} from '../operations/types'
+import {actionsApiClient} from '../utils/actionsApiClient'
 import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
 
 export const del: OperationImpl<[], 'NOTHING_TO_DELETE'> = {
@@ -11,7 +12,7 @@ export const del: OperationImpl<[], 'NOTHING_TO_DELETE'> = {
 
     //the delete action requires a published doc -- discard if not present
     if (!snapshots.published) {
-      return client.observable.action(
+      return actionsApiClient(client).observable.action(
         {
           actionType: 'sanity.action.document.discard',
           draftId: idPair.draftId,
@@ -20,7 +21,7 @@ export const del: OperationImpl<[], 'NOTHING_TO_DELETE'> = {
       )
     }
 
-    return client.observable.action(
+    return actionsApiClient(client).observable.action(
       {
         actionType: 'sanity.action.document.delete',
         includeDrafts: snapshots.draft ? [idPair.draftId] : [],

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/discardChanges.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/discardChanges.ts
@@ -1,4 +1,5 @@
 import {type OperationImpl} from '../operations/types'
+import {actionsApiClient} from '../utils/actionsApiClient'
 
 type DisabledReason = 'NO_CHANGES' | 'NOT_PUBLISHED'
 
@@ -13,7 +14,7 @@ export const discardChanges: OperationImpl<[], DisabledReason> = {
     return false
   },
   execute: ({client, idPair}) => {
-    return client.observable.action(
+    return actionsApiClient(client).observable.action(
       {
         actionType: 'sanity.action.document.discard',
         draftId: idPair.draftId,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.ts
@@ -1,4 +1,5 @@
 import {type OperationImpl} from '../operations/index'
+import {actionsApiClient} from '../utils/actionsApiClient'
 import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
 
 type DisabledReason = 'LIVE_EDIT_ENABLED' | 'ALREADY_PUBLISHED' | 'NO_CHANGES'
@@ -19,7 +20,7 @@ export const publish: OperationImpl<[], DisabledReason> = {
       throw new Error('cannot execute "publish" when draft is missing')
     }
 
-    return client.observable.action(
+    return actionsApiClient(client).observable.action(
       {
         actionType: 'sanity.action.document.publish',
         draftId: idPair.draftId,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/unpublish.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/unpublish.ts
@@ -1,4 +1,5 @@
 import {type OperationImpl} from '../operations/types'
+import {actionsApiClient} from '../utils/actionsApiClient'
 import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
 
 type DisabledReason = 'LIVE_EDIT_ENABLED' | 'NOT_PUBLISHED'
@@ -11,7 +12,7 @@ export const unpublish: OperationImpl<[], DisabledReason> = {
     return snapshots.published ? false : 'NOT_PUBLISHED'
   },
   execute: ({client, idPair}) =>
-    client.observable.action(
+    actionsApiClient(client).observable.action(
       {
         // This operation is run when "unpublish anyway" is clicked
         actionType: 'sanity.action.document.unpublish',

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/utils/actionsApiClient.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/utils/actionsApiClient.ts
@@ -1,0 +1,9 @@
+import {type SanityClient} from 'sanity'
+
+const ACTIONS_API_MINIMUM_VERSION = '2024-05-23'
+
+export function actionsApiClient(client: SanityClient): SanityClient {
+  return client.withConfig({
+    apiVersion: ACTIONS_API_MINIMUM_VERSION,
+  })
+}

--- a/packages/sanity/src/core/store/_legacy/history/createHistoryStore.ts
+++ b/packages/sanity/src/core/store/_legacy/history/createHistoryStore.ts
@@ -11,6 +11,7 @@ import {map, mergeMap} from 'rxjs/operators'
 
 import {isDev} from '../../../environment'
 import {getDraftId, getPublishedId, isRecord} from '../../../util'
+import {actionsApiClient} from '../document/document-pair/utils/actionsApiClient'
 import {Timeline, TimelineController} from './history'
 
 /**
@@ -215,7 +216,7 @@ function restore(
           publishedId: documentId,
           attributes: restoredDraft,
         }
-        return client.observable.action(
+        return actionsApiClient(client).observable.action(
           options.fromDeleted
             ? [
                 {


### PR DESCRIPTION
### Description

We observed that some Studios use an inadequate API version when calling the Actions API. It may be the case that developers are inadvertently mutating the client configuration object, however, we aren't certain. This change attempts to resolve the issue by explicitly setting all Actions API requests to use the minimally adequate API version.

### What to review

When performing actions on a document while the Actions API integration is enabled, the API requests produced should be exactly the same as before, but always use the minimally adequate API version (`2024-05-23`).

### Testing

I have not added tests, because we have not been able to replicate a scenario in which the API version used is anything other than the one required. For this change, I believe the existing tests are sufficient.