### PR TITLE
fix(bundles): handling latest bundle having no name

### DIFF
--- a/packages/sanity/src/core/bundles/components/BundleMenu.tsx
+++ b/packages/sanity/src/core/bundles/components/BundleMenu.tsx
@@ -75,7 +75,7 @@ export function BundleMenu(props: BundleListProps): JSX.Element {
                         .filter((b) => !isDraftOrPublished(b.name) && !b.archivedAt)
                         .map((b) => (
                           <MenuItem
-                            key={b.name}
+                            key={b._id}
                             onClick={handleBundleChange(b)}
                             padding={1}
                             pressed={false}

--- a/packages/sanity/src/core/releases/contexts/BundlesMetadataProvider.tsx
+++ b/packages/sanity/src/core/releases/contexts/BundlesMetadataProvider.tsx
@@ -37,8 +37,10 @@ const BundlesMetadataProviderInner = ({children}: {children: React.ReactNode}) =
     [observedResult.data],
   )
 
-  const addBundleSlugsToListener = useCallback((addBundleSlugs: string[]) => {
-    setListenerBundleSlugs((prevSlugs) => [...prevSlugs, ...addBundleSlugs])
+  const addBundleSlugsToListener = useCallback((addBundleSlugs: (string | undefined)[]) => {
+    const isString = (slug: string | undefined): slug is string => !!slug
+
+    setListenerBundleSlugs((prevSlugs) => [...prevSlugs, ...addBundleSlugs.filter(isString)])
   }, [])
 
   const removeBundleSlugsFromListener = useCallback((removeBundleSlugs: string[]) => {


### PR DESCRIPTION
### Description
Latest 'bundle' now doesn't have a name (slug). This was causing a warning due to undefined being used for `key` in a `map` for BundleMenu`; and was causing an error when trying to listen to bundle metadata
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
