### PR TITLE
feat(core): add aliases to mitigate context issues

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -247,6 +247,7 @@
     "read-pkg-up": "^7.0.1",
     "refractor": "^3.6.0",
     "resolve-from": "^5.0.0",
+    "resolve.exports": "^2.0.2",
     "rimraf": "^3.0.2",
     "rxjs": "^7.8.0",
     "rxjs-exhaustmap-with-trailing": "^2.1.1",

--- a/packages/sanity/src/_internal/cli/server/__tests__/aliases.test.ts
+++ b/packages/sanity/src/_internal/cli/server/__tests__/aliases.test.ts
@@ -47,6 +47,15 @@ describe('browserCompatibleSanityPackageSpecifiers', () => {
 })
 
 describe('getAliases', () => {
+  // TODO: this test would be better if it called `vite.build` with fixtures
+  // but vite does not seem to be compatible in our jest environment.
+  // Error from trying to import vite:
+  //
+  // > Invariant violation: "new TextEncoder().encode("") instanceof Uint8Array" is incorrectly false
+  // >
+  // > This indicates that your JavaScript environment is broken. You cannot use
+  // > esbuild in this environment because esbuild relies on this invariant. This
+  // > is not a problem with esbuild. You need to fix your environment instead.
   it('returns the correct aliases for normal builds', () => {
     const aliases = getAliases({
       sanityPkgPath,

--- a/packages/sanity/src/_internal/cli/server/__tests__/aliases.test.ts
+++ b/packages/sanity/src/_internal/cli/server/__tests__/aliases.test.ts
@@ -1,0 +1,93 @@
+import path from 'node:path'
+
+import {describe, expect, it, jest} from '@jest/globals'
+import resolve from 'resolve.exports'
+
+import {browserCompatibleSanityPackageSpecifiers, getAliases} from '../aliases'
+
+const sanityPkgPath = path.resolve(__dirname, '../../../../../package.json')
+// eslint-disable-next-line import/no-dynamic-require
+const pkg = require(sanityPkgPath)
+
+describe('browserCompatibleSanityPackageSpecifiers', () => {
+  it('should have all specifiers listed in the package.json', () => {
+    const currentSpecifiers = Object.keys(pkg.exports)
+      .map((subpath) => path.join('sanity', subpath))
+      .sort()
+
+    // NOTE: this test is designed to fail if there are any changes to the
+    // package exports in the sanity package.json so you can stop and consider if that
+    // new subpath should also go into `browserCompatibleSanityPackageSpecifiers`.
+    // If there are changes, you may need to update this variable. New subpaths
+    // should go into `browserCompatibleSanityPackageSpecifiers` if that subpath
+    // is meant to be imported in the browser (e.g. a new subpath that is only meant
+    // for the CLI doesn't need to go into `browserCompatibleSanityPackageSpecifiers`).
+    expect(currentSpecifiers).toEqual([
+      'sanity',
+      'sanity/_createContext',
+      'sanity/_internal',
+      'sanity/_singletons',
+      'sanity/cli',
+      'sanity/desk',
+      'sanity/migrate',
+      'sanity/package.json',
+      'sanity/presentation',
+      'sanity/router',
+      'sanity/structure',
+    ])
+
+    expect(browserCompatibleSanityPackageSpecifiers).toHaveLength(8)
+
+    for (const specifier of browserCompatibleSanityPackageSpecifiers) {
+      expect(currentSpecifiers).toContain(specifier)
+    }
+  })
+})
+
+describe('getAliases', () => {
+  it('returns the correct aliases for normal builds', () => {
+    const aliases = getAliases({
+      sanityPkgPath,
+      conditions: ['import', 'browser'],
+      browser: true,
+    })
+
+    const expectedAliases = browserCompatibleSanityPackageSpecifiers.reduce<Record<string, string>>(
+      (acc, specifier) => {
+        const dest = resolve.exports(pkg, specifier, {
+          browser: true,
+          conditions: ['import', 'browser'],
+        })?.[0]
+        if (dest) {
+          acc[specifier] = path.resolve(path.dirname(sanityPkgPath), dest)
+        }
+        return acc
+      },
+      {},
+    )
+
+    expect(aliases).toMatchObject(expectedAliases)
+  })
+
+  it('returns the correct aliases for the monorepo', () => {
+    const monorepoPath = path.resolve(__dirname, '../../../../../monorepo')
+    const devAliases = {
+      'sanity/_singletons': 'packages/sanity/src/_singletons.ts',
+      'sanity/desk': 'packages/sanity/src/desk.ts',
+      'sanity/presentation': 'packages/sanity/src/presentation.ts',
+    }
+    jest.doMock(path.resolve(monorepoPath, 'dev/aliases.cjs'), () => devAliases, {virtual: true})
+
+    const aliases = getAliases({
+      monorepo: {path: monorepoPath},
+    })
+
+    const expectedAliases = Object.fromEntries(
+      Object.entries(devAliases).map(([key, modulePath]) => {
+        return [key, path.resolve(monorepoPath, modulePath)]
+      }),
+    )
+
+    expect(aliases).toMatchObject(expectedAliases)
+  })
+})

--- a/packages/sanity/src/_internal/cli/server/aliases.ts
+++ b/packages/sanity/src/_internal/cli/server/aliases.ts
@@ -1,32 +1,104 @@
 import path from 'node:path'
 
+import resolve from 'resolve.exports'
+import {type AliasOptions} from 'vite'
+
 import {type SanityMonorepo} from './sanityMonorepo'
 
 /**
- * Returns an object of aliases for vite to use
+ * @internal
+ */
+export interface GetAliasesOptions {
+  /** An optional monorepo configuration object. */
+  monorepo?: SanityMonorepo
+  /** The path to the sanity package.json file. */
+  sanityPkgPath?: string
+  /** The list of conditions to resolve package exports. */
+  conditions?: string[]
+}
+
+/**
+ * The following are the specifiers that are expected/allowed to be used within
+ * a built Sanity studio in the browser. These are used in combination with
+ * `resolve.exports` to determine the final entry point locations for each allowed specifier.
+ *
+ * There is also a corresponding test for this file that expects these to be
+ * included in the `sanity` package.json. That test is meant to keep this list
+ * in sync in the event we add another package subpath.
  *
  * @internal
  */
-export function getAliases(opts: {monorepo?: SanityMonorepo}): Record<string, string> {
-  const {monorepo} = opts
+export const browserCompatibleSanityPackageSpecifiers = [
+  'sanity',
+  'sanity/_createContext',
+  'sanity/_singletons',
+  'sanity/desk',
+  'sanity/presentation',
+  'sanity/router',
+  'sanity/structure',
+  'sanity/package.json',
+]
 
-  if (!monorepo?.path) {
-    return {}
+/**
+ * Returns an object of aliases for Vite to use.
+ *
+ * This function is used within our build tooling to prevent multiple context errors
+ * due to multiple instances of our library. It resolves the appropriate paths for
+ * modules based on whether the current project is inside the Sanity monorepo or not.
+ *
+ * If the project is within the monorepo, it uses the source files directly for a better
+ * development experience. Otherwise, it uses the `sanityPkgPath` and `conditions` to locate
+ * the entry points for each subpath the Sanity module exports.
+ *
+ * @internal
+ */
+export function getAliases({monorepo, sanityPkgPath, conditions}: GetAliasesOptions): AliasOptions {
+  // If the current Studio is located within the Sanity monorepo
+  if (monorepo?.path) {
+    // Load monorepo aliases. This ensures that the Vite server uses the source files
+    // instead of the compiled output, allowing for a better development experience.
+    const aliasesPath = path.resolve(monorepo.path, 'dev/aliases.cjs')
+
+    // Import the development aliases configuration
+    // eslint-disable-next-line import/no-dynamic-require
+    const devAliases: Record<string, string> = require(aliasesPath)
+
+    // Resolve each alias path relative to the monorepo path
+    const monorepoAliases = Object.fromEntries(
+      Object.entries(devAliases).map(([key, modulePath]) => {
+        return [key, path.resolve(monorepo.path, modulePath)]
+      }),
+    )
+
+    // Return the aliases configuration for monorepo
+    return monorepoAliases
   }
 
-  // Load monorepo aliases (if the current Studio is located within the sanity monorepo)
-  // This is done in order for the Vite server to use the source files instead of
-  // the compiled output, allowing for a better dev experience.
-  const aliasesPath = path.resolve(monorepo.path, 'dev/aliases.cjs')
+  // If not in the monorepo, use the `sanityPkgPath` and `conditions`
+  // to locate the entry points for each subpath the Sanity module exports
+  if (sanityPkgPath && conditions) {
+    // Load the package.json of the Sanity package
+    // eslint-disable-next-line import/no-dynamic-require
+    const pkg = require(sanityPkgPath)
+    const dirname = path.dirname(sanityPkgPath)
 
-  // eslint-disable-next-line import/no-dynamic-require
-  const devAliases: Record<string, string> = require(aliasesPath)
+    // Resolve the entry points for each allowed specifier
+    const unifiedSanityAliases = browserCompatibleSanityPackageSpecifiers.reduce<
+      Record<string, string>
+    >((acc, next) => {
+      // Resolve the export path for the specifier using resolve.exports
+      const dest = resolve.exports(pkg, next, {browser: true, conditions})?.[0]
+      if (!dest) return acc
 
-  const monorepoAliases = Object.fromEntries(
-    Object.entries(devAliases).map(([key, modulePath]) => {
-      return [key, path.resolve(monorepo.path, modulePath)]
-    }),
-  )
+      // Map the specifier to its resolved path
+      acc[next] = path.resolve(dirname, dest)
+      return acc
+    }, {})
 
-  return monorepoAliases
+    // Return the aliases configuration for external projects
+    return unifiedSanityAliases
+  }
+
+  // Return an empty aliases configuration if no conditions are met
+  return {}
 }

--- a/packages/sanity/src/_internal/cli/server/getViteConfig.ts
+++ b/packages/sanity/src/_internal/cli/server/getViteConfig.ts
@@ -86,6 +86,14 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
   const defaultFaviconsPath = path.join(path.dirname(sanityPkgPath), 'static', 'favicons')
   const staticPath = `${basePath}static`
 
+  const conditions = [
+    'import',
+    'browser',
+    // the `es2015` condition is primarily rxjs
+    // https://github.com/ReactiveX/rxjs/blob/4a2d0d29a7b17607e74afcb6fb8037fe58ef9021/package.json#L22
+    'es2015',
+  ]
+
   const viteConfig: InlineConfig = {
     // Define a custom cache directory so that sanity's vite cache
     // does not conflict with any potential local vite projects
@@ -113,7 +121,8 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     envPrefix: 'SANITY_STUDIO_',
     logLevel: mode === 'production' ? 'silent' : 'info',
     resolve: {
-      alias: getAliases({monorepo}),
+      alias: getAliases({monorepo, conditions, sanityPkgPath}),
+      conditions,
     },
     define: {
       // eslint-disable-next-line no-process-env

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,7 +440,7 @@ importers:
         version: 3.1.0(react@18.3.1)
       '@sanity/assist':
         specifier: ^3.0.2
-        version: 3.0.5(@sanity/mutator@packages+@sanity+mutator)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.12)
+        version: 3.0.4(@sanity/mutator@packages+@sanity+mutator)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.12)
       '@sanity/block-tools':
         specifier: 3.51.0
         version: link:../../packages/@sanity/block-tools
@@ -476,7 +476,7 @@ importers:
         version: 1.2.7(sanity@packages+sanity)
       '@sanity/logos':
         specifier: ^2.1.2
-        version: 2.1.13(@sanity/color@3.0.6)(react@18.3.1)
+        version: 2.1.12(@sanity/color@3.0.6)(react@18.3.1)
       '@sanity/migrate':
         specifier: workspace:*
         version: link:../../packages/@sanity/migrate
@@ -1219,7 +1219,7 @@ importers:
     dependencies:
       '@codemirror/autocomplete':
         specifier: ^6.1.0
-        version: 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.6)(@lezer/common@1.2.1)
+        version: 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.4)(@lezer/common@1.2.1)
       '@codemirror/commands':
         specifier: ^6.0.1
         version: 6.6.0
@@ -1237,7 +1237,7 @@ importers:
         version: 6.4.1
       '@codemirror/view':
         specifier: ^6.1.1
-        version: 6.28.6
+        version: 6.28.4
       '@juggle/resize-observer':
         specifier: ^3.3.1
         version: 3.4.0
@@ -1261,7 +1261,7 @@ importers:
         version: 2.8.8(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       '@uiw/react-codemirror':
         specifier: ^4.11.4
-        version: 4.21.25(@babel/runtime@7.24.8)(@codemirror/autocomplete@6.17.0)(@codemirror/language@6.10.2)(@codemirror/lint@6.8.1)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.28.6)(codemirror@6.0.1)(react-dom@18.3.1)(react@18.3.1)
+        version: 4.21.25(@babel/runtime@7.24.8)(@codemirror/autocomplete@6.17.0)(@codemirror/language@6.10.2)(@codemirror/lint@6.8.1)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.28.4)(codemirror@6.0.1)(react-dom@18.3.1)(react@18.3.1)
       is-hotkey-esm:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1409,7 +1409,7 @@ importers:
         version: 1.0.7(@sanity/types@packages+@sanity+types)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       '@sanity/logos':
         specifier: ^2.1.4
-        version: 2.1.13(@sanity/color@3.0.6)(react@18.3.1)
+        version: 2.1.12(@sanity/color@3.0.6)(react@18.3.1)
       '@sanity/migrate':
         specifier: 3.51.0
         version: link:../@sanity/migrate
@@ -1638,6 +1638,9 @@ importers:
       resolve-from:
         specifier: ^5.0.0
         version: 5.0.0
+      resolve.exports:
+        specifier: ^2.0.2
+        version: 2.0.2
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3306,7 +3309,7 @@ packages:
       hotscript: 1.0.13
       nanoid: 5.0.7
 
-  /@codemirror/autocomplete@6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.6)(@lezer/common@1.2.1):
+  /@codemirror/autocomplete@6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.4)(@lezer/common@1.2.1):
     resolution: {integrity: sha512-fdfj6e6ZxZf8yrkMHUSJJir7OJkHkZKaOZGzLWIYp2PZ3jd+d+UjG8zVPqJF6d3bKxkhvXTPan/UZ1t7Bqm0gA==}
     peerDependencies:
       '@codemirror/language': ^6.0.0
@@ -3316,7 +3319,7 @@ packages:
     dependencies:
       '@codemirror/language': 6.10.2
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.28.6
+      '@codemirror/view': 6.28.4
       '@lezer/common': 1.2.1
     dev: false
 
@@ -3325,18 +3328,18 @@ packages:
     dependencies:
       '@codemirror/language': 6.10.2
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.28.6
+      '@codemirror/view': 6.28.4
       '@lezer/common': 1.2.1
     dev: false
 
   /@codemirror/lang-javascript@6.2.2:
     resolution: {integrity: sha512-VGQfY+FCc285AhWuwjYxQyUQcYurWlxdKYT4bqwr3Twnd5wP5WSeu52t4tvvuWmljT4EmgEgZCqSieokhtY8hg==}
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.6)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.4)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.2
       '@codemirror/lint': 6.8.1
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.28.6
+      '@codemirror/view': 6.28.4
       '@lezer/common': 1.2.1
       '@lezer/javascript': 1.4.14
     dev: false
@@ -3345,7 +3348,7 @@ packages:
     resolution: {integrity: sha512-kgbTYTo0Au6dCSc/TFy7fK3fpJmgHDv1sG1KNQKJXVi+xBTEeBPY/M30YXiU6mMXeH+YIDLsbrT4ZwNRdtF+SA==}
     dependencies:
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.28.6
+      '@codemirror/view': 6.28.4
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
       '@lezer/lr': 1.4.1
@@ -3356,7 +3359,7 @@ packages:
     resolution: {integrity: sha512-IZ0Y7S4/bpaunwggW2jYqwLuHj0QtESf5xcROewY6+lDNwZ/NzvR4t+vpYgg9m7V8UXLPYqG+lu3DF470E5Oxg==}
     dependencies:
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.28.6
+      '@codemirror/view': 6.28.4
       crelt: 1.0.6
     dev: false
 
@@ -3364,7 +3367,7 @@ packages:
     resolution: {integrity: sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==}
     dependencies:
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.28.6
+      '@codemirror/view': 6.28.4
       crelt: 1.0.6
     dev: false
 
@@ -3377,12 +3380,12 @@ packages:
     dependencies:
       '@codemirror/language': 6.10.2
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.28.6
+      '@codemirror/view': 6.28.4
       '@lezer/highlight': 1.2.0
     dev: false
 
-  /@codemirror/view@6.28.6:
-    resolution: {integrity: sha512-bhwB1AZ6zU4M3dNKm8Aa2BXwj5mWDqE9IWpqxYKJoLCnx+AcwcMuLO01tLWgc1mx4vT1IVYVqx86YoqUsATrqQ==}
+  /@codemirror/view@6.28.4:
+    resolution: {integrity: sha512-QScv95fiviSQ/CaVGflxAvvvDy/9wi0RFyDl4LkHHWiMr/UPebyuTspmYSeN5Nx6eujcPYwsQzA6ZIZucKZVHQ==}
     dependencies:
       '@codemirror/state': 6.4.1
       style-mod: 4.1.2
@@ -6156,8 +6159,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /@sanity/assist@3.0.5(@sanity/mutator@packages+@sanity+mutator)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.12):
-    resolution: {integrity: sha512-u0lpStoI7RowDSqFIiHOmSRLzhhHKdp/QMn9SlKn7Zzh7E7dhbT/mQb1WQ0Rx7lYN0Hh3cLRMNlNV3seO/UupA==}
+  /@sanity/assist@3.0.4(@sanity/mutator@packages+@sanity+mutator)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.12):
+    resolution: {integrity: sha512-2UBznX9EjDwptMjby9x2zNQUoSR3sdgRSpD+AcnfTcnzjBytLTEnXxHr9hWzfRfPO4EDrr8UuxVaRTzHjnRb4Q==}
     engines: {node: '>=14'}
     peerDependencies:
       '@sanity/mutator': ^3.36.4
@@ -6460,8 +6463,8 @@ packages:
       sanity: link:packages/sanity
     dev: false
 
-  /@sanity/logos@2.1.13(@sanity/color@3.0.6)(react@18.3.1):
-    resolution: {integrity: sha512-PKAbPbM4zn+6wHYjCVwuhmlZnFqyZ9lT/O7OT3BVd2SGAqXoZTimfBOHrVPifytuazdoQ1T2M5eYJTtW/VXLyA==}
+  /@sanity/logos@2.1.12(@sanity/color@3.0.6)(react@18.3.1):
+    resolution: {integrity: sha512-2cj3EwTTyAN9OurOYpcQi5f3OFZURdhxmTcKFOou3I8JSzxLqEuY9EywArekwgrUMDfZ+sSorv4UEu9rMtqatQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@sanity/color': ^2.0 || ^3.0 || ^3.0.0-beta
@@ -6710,7 +6713,7 @@ packages:
       esbuild-register: 3.5.0(esbuild@0.23.0)
       express: 4.19.2
       globby: 11.1.0
-      groq: 3.51.0
+      groq: 3.50.0
       groq-js: 1.10.0
       history: 5.3.0
       jsonc-parser: 3.3.1
@@ -7866,7 +7869,7 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@uiw/codemirror-extensions-basic-setup@4.21.25(@codemirror/autocomplete@6.17.0)(@codemirror/commands@6.6.0)(@codemirror/language@6.10.2)(@codemirror/lint@6.8.1)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/view@6.28.6):
+  /@uiw/codemirror-extensions-basic-setup@4.21.25(@codemirror/autocomplete@6.17.0)(@codemirror/commands@6.6.0)(@codemirror/language@6.10.2)(@codemirror/lint@6.8.1)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/view@6.28.4):
     resolution: {integrity: sha512-eeUKlmEE8aSoSgelS8OR2elcPGntpRo669XinAqPCLa0eKorT2B0d3ts+AE+njAeGk744tiyAEbHb2n+6OQmJw==}
     peerDependencies:
       '@codemirror/autocomplete': '>=6.0.0'
@@ -7877,16 +7880,16 @@ packages:
       '@codemirror/state': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.6)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.4)(@lezer/common@1.2.1)
       '@codemirror/commands': 6.6.0
       '@codemirror/language': 6.10.2
       '@codemirror/lint': 6.8.1
       '@codemirror/search': 6.5.6
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.28.6
+      '@codemirror/view': 6.28.4
     dev: false
 
-  /@uiw/react-codemirror@4.21.25(@babel/runtime@7.24.8)(@codemirror/autocomplete@6.17.0)(@codemirror/language@6.10.2)(@codemirror/lint@6.8.1)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.28.6)(codemirror@6.0.1)(react-dom@18.3.1)(react@18.3.1):
+  /@uiw/react-codemirror@4.21.25(@babel/runtime@7.24.8)(@codemirror/autocomplete@6.17.0)(@codemirror/language@6.10.2)(@codemirror/lint@6.8.1)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.28.4)(codemirror@6.0.1)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-mBrCoiffQ+hbTqV1JoixFEcH7BHXkS3PjTyNH7dE8Gzf3GSBRazhtSM5HrAFIiQ5FIRGFs8Gznc4UAdhtevMmw==}
     peerDependencies:
       '@babel/runtime': '>=7.11.0'
@@ -7901,8 +7904,8 @@ packages:
       '@codemirror/commands': 6.6.0
       '@codemirror/state': 6.4.1
       '@codemirror/theme-one-dark': 6.1.2
-      '@codemirror/view': 6.28.6
-      '@uiw/codemirror-extensions-basic-setup': 4.21.25(@codemirror/autocomplete@6.17.0)(@codemirror/commands@6.6.0)(@codemirror/language@6.10.2)(@codemirror/lint@6.8.1)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/view@6.28.6)
+      '@codemirror/view': 6.28.4
+      '@uiw/codemirror-extensions-basic-setup': 4.21.25(@codemirror/autocomplete@6.17.0)(@codemirror/commands@6.6.0)(@codemirror/language@6.10.2)(@codemirror/lint@6.8.1)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/view@6.28.4)
       codemirror: 6.0.1(@lezer/common@1.2.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -9274,13 +9277,13 @@ packages:
   /codemirror@6.0.1(@lezer/common@1.2.1):
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.6)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.4)(@lezer/common@1.2.1)
       '@codemirror/commands': 6.6.0
       '@codemirror/language': 6.10.2
       '@codemirror/lint': 6.8.1
       '@codemirror/search': 6.5.6
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.28.6
+      '@codemirror/view': 6.28.4
     transitivePeerDependencies:
       - '@lezer/common'
     dev: false
@@ -12298,8 +12301,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /groq@3.51.0:
-    resolution: {integrity: sha512-4wkxG/YIl3KMyr4e1WD727JOkZ3a3MZj+tnT3dqlSQBwi+yy+ne7X4pgbCMT6wvO9CvF3y1pbRblbqQD1rZqlg==}
+  /groq@3.50.0:
+    resolution: {integrity: sha512-nnlnjqmGbi5G9dSWmgObVMBh/3nZgA1jhj8lHuMzGfpXkQuI1gR+X4MwyvOq96PSk50XQX1lCm0N0zRcHbiskg==}
     engines: {node: '>=18'}
 
   /growly@1.3.0:
@@ -12339,7 +12342,7 @@ packages:
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.19.0
+      uglify-js: 3.18.0
     dev: true
 
   /hard-rejection@2.1.0:
@@ -16915,7 +16918,6 @@ packages:
   /resolve.exports@2.0.2:
     resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
     engines: {node: '>=10'}
-    dev: true
 
   /resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
@@ -18734,8 +18736,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /uglify-js@3.19.0:
-    resolution: {integrity: sha512-wNKHUY2hYYkf6oSFfhwwiHo4WCHzHmzcXsqXYTN9ja3iApYIFbb2U6ics9hBcYLHcYGQoAlwnZlTrf3oF+BL/Q==}
+  /uglify-js@3.18.0:
+    resolution: {integrity: sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true


### PR DESCRIPTION
### Description

This pull request enhances the `sanity` React library's build tooling by adding comprehensive comments and JSDoc annotations to improve maintainability and understanding of the code. Specifically, it elaborates on package exports, conditions, and the `getAliases` function. Additionally, it completes the associated test file to ensure the `getAliases` function operates correctly in both monorepo and normal build scenarios.

**Key changes:**
- Added detailed comments and JSDoc annotations to `aliases.ts` to explain the purpose and functionality of the code.
- Completed the test file `aliases.test.ts` with test cases for normal builds and monorepo builds.
- Mocked monorepo development aliases in the test to ensure accurate alias resolution.

**Why these changes were introduced:**
- To prevent multiple context errors due to multiple instances of the library.
- To improve code readability and maintainability.
- To ensure comprehensive testing coverage for the alias resolution functionality.

### What to review

- Review the added comments and JSDoc annotations in `aliases.ts` for accuracy and clarity.
- Review the test cases in `aliases.test.ts` to ensure they cover the expected scenarios and edge cases.
- Ensure that the monorepo aliases are correctly mocked and resolved in the tests.

### Testing

- Added test cases for both normal builds and monorepo builds in `aliases.test.ts`.
- Verified that the dynamic resolution logic in the tests mirrors the resolution logic used in `getAliases`.
- Testing manually by packing and linking this in the admin studio.

Demo:


https://github.com/user-attachments/assets/a66fc0a2-cc63-4fcb-9bcd-be06feabdf7f



### Notes for release

- Adds aliases to internal vite config used by `sanity build` and `sanity deploy` to prevent missing React context issues.