### PR TITLE
feat: add disableArrayWarning option to SlugOptions

### DIFF
--- a/packages/@sanity/types/src/schema/definition/type/slug.ts
+++ b/packages/@sanity/types/src/schema/definition/type/slug.ts
@@ -25,6 +25,7 @@ export interface SlugOptions extends SearchConfiguration, BaseSchemaTypeOptions 
   maxLength?: number
   slugify?: SlugifierFn
   isUnique?: SlugIsUniqueValidator
+  disableArrayWarning?: boolean
 }
 
 /** @public */

--- a/packages/sanity/src/core/validation/validators/slugValidator.ts
+++ b/packages/sanity/src/core/validation/validators/slugValidator.ts
@@ -32,7 +32,7 @@ function serializePath(path: Path): string {
 
 const defaultIsUnique: SlugIsUniqueValidator = (slug, context) => {
   const {getClient, document, path, type} = context
-  const schemaOptions = type?.options as {disableArrayWarning?: boolean} | undefined
+  const schemaOptions = type?.options
 
   if (!document) {
     throw new Error(`\`document\` was not provided in validation context.`)


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
Adds `disableArrayWarning` to the `SlugOptions` interface. Purpose is to allow users to disable the automatic array warning for slug fields within arrays.

Below is warning seen in the console.
![image](https://github.com/user-attachments/assets/4009e575-11f0-4aa0-a0d3-6e57dd122cdf)

Following the steps suggested by the warning works and stops the warning from showing up. However, if the developer creating the schema is using TypeScript they are hit with the following error
![image](https://github.com/user-attachments/assets/d4fb9e7f-3f25-4389-b637-026172d0499c)

So adding `disableArrayWarning` removes that TS error.

Also a change to the `schemaOptions` `const` within the `slugValidator.ts` file as its type assertion is not needed due to `disableArrayWarning` is now included within the `SlugOptions` interface.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->
Review the changes to the `SlugOptions` interface found in the `slug.ts` file and to the `defaultIsUnique` function, specifically the `schemaOptions` variable`. Ensure that when enabling `disableArrayWarning` no TS error appears.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
I did not add testing, I honestly do not know how but checking out the other slug functions and options I believe there is none. I have tested it with my own repos where I have used a slug field within an array.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
This PR adds the `disableArrayWarning` option to the `SlugOptions` interface removing the TS error that appears when `disableArrayWarning` does not exist within the interface.