### PR TITLE
fix: document perspective menu test fix

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveMenu.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveMenu.test.tsx
@@ -23,6 +23,7 @@ type GetAllVersionsOfDocumentType = (
 ) => Promise<Partial<BundleDocument>[]>
 
 jest.mock('sanity', () => ({
+  ...(jest.requireActual('sanity') || {}),
   useClient: jest.fn(),
   usePerspective: jest.fn().mockReturnValue({
     currentGlobalBundle: {},


### PR DESCRIPTION
### Description
sanity import was being mocked in `DocumentPerspectiveMenu`, but `createWrapper` therefore wasn't available.
This PR uses the actual sanity package and mocks additions
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
