### PR TITLE
Update sanity UI use click outside

### DIFF
--- a/examples/ecommerce-studio/package.json
+++ b/examples/ecommerce-studio/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@sanity/cli": "3.51.0",
-    "@sanity/ui": "^2.7.0",
+    "@sanity/ui": "^2.8.0",
     "react": "^18.3.1",
     "react-barcode": "^1.4.1",
     "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@sanity/prettier-config": "^1.0.2",
     "@sanity/test": "0.0.1-alpha.1",
     "@sanity/tsdoc": "1.0.83",
-    "@sanity/ui": "^2.7.0",
+    "@sanity/ui": "^2.8.0",
     "@sanity/uuid": "^3.0.2",
     "@types/glob": "^7.2.0",
     "@types/lodash": "^4.14.149",

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -63,7 +63,7 @@
     "@rexxars/react-split-pane": "^0.1.93",
     "@sanity/color": "^3.0.0",
     "@sanity/icons": "^3.3.0",
-    "@sanity/ui": "^2.7.0",
+    "@sanity/ui": "^2.8.0",
     "@uiw/react-codemirror": "^4.11.4",
     "is-hotkey-esm": "^1.0.0",
     "json-2-csv": "^5.5.1",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -167,7 +167,7 @@
     "@sanity/schema": "3.51.0",
     "@sanity/telemetry": "^0.7.7",
     "@sanity/types": "3.51.0",
-    "@sanity/ui": "^2.7.0",
+    "@sanity/ui": "^2.8.0",
     "@sanity/util": "3.51.0",
     "@sanity/uuid": "^3.0.1",
     "@sentry/react": "^8.7.0",

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/InsertMenuPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/InsertMenuPopover.tsx
@@ -34,12 +34,9 @@ export function useInsertMenuPopover(props: {
   const [popoverElement, setPopoverElement] = useState<HTMLDivElement | null>(null)
   const referenceElement = props.popoverProps.referenceElement ?? null
 
-  useClickOutside(
-    useCallback(() => {
-      send({type: 'close'})
-    }, []),
-    [popoverElement, referenceElement],
-  )
+  useClickOutside(() => {
+    send({type: 'close'})
+  }, [popoverElement, referenceElement])
 
   useGlobalKeyDown(
     useCallback(

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileActionsMenu.tsx
@@ -51,14 +51,11 @@ export function FileActionsMenu(props: Props) {
   // Close menu when clicking outside of it
   // Not when clicking on the button
   useClickOutside(
-    useCallback(
-      (event) => {
-        if (!buttonElement?.contains(event.target as Node)) {
-          onMenuOpen(false)
-        }
-      },
-      [buttonElement, onMenuOpen],
-    ),
+    (event) => {
+      if (!buttonElement?.contains(event.target as Node)) {
+        onMenuOpen(false)
+      }
+    },
     [menuElement],
   )
 

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
@@ -60,14 +60,11 @@ export function ImageActionsMenu(props: ImageActionsMenuProps) {
   // Close menu when clicking outside of it
   // Not when clicking on the button
   useClickOutside(
-    useCallback(
-      (event) => {
-        if (!buttonElement?.contains(event.target as Node)) {
-          onMenuOpen(false)
-        }
-      },
-      [buttonElement, onMenuOpen],
-    ),
+    (event) => {
+      if (!buttonElement?.contains(event.target as Node)) {
+        onMenuOpen(false)
+      }
+    },
     [menuElement],
   )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@npmcli/arborist': ^7.5.4
-  '@sanity/ui@2': ^2.7.0
+  '@sanity/ui@2': ^2.8.0
   '@typescript-eslint/eslint-plugin': ^7.11.0
   '@typescript-eslint/parser': ^7.11.0
 
@@ -70,8 +70,8 @@ importers:
         specifier: 1.0.83
         version: 1.0.83(@types/node@18.19.31)(debug@4.3.5)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.12)
       '@sanity/ui':
-        specifier: ^2.7.0
-        version: 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+        specifier: ^2.8.0
+        version: 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       '@sanity/uuid':
         specifier: ^3.0.2
         version: 3.0.2
@@ -246,8 +246,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0(react@18.3.1)
       '@sanity/ui':
-        specifier: ^2.7.0
-        version: 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+        specifier: ^2.8.0
+        version: 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -264,8 +264,8 @@ importers:
   dev/embedded-studio:
     dependencies:
       '@sanity/ui':
-        specifier: ^2.7.0
-        version: 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+        specifier: ^2.8.0
+        version: 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -373,8 +373,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0(react@18.3.1)
       '@sanity/ui':
-        specifier: ^2.7.0
-        version: 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+        specifier: ^2.8.0
+        version: 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       '@sanity/vision':
         specifier: 3.51.0
         version: link:../../packages/@sanity/vision
@@ -493,11 +493,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@sanity/types
       '@sanity/ui':
-        specifier: ^2.7.0
-        version: 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+        specifier: ^2.8.0
+        version: 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       '@sanity/ui-workshop':
         specifier: ^1.0.0
-        version: 1.2.11(@sanity/icons@3.3.0)(@sanity/ui@2.7.0)(@types/node@18.19.31)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+        version: 1.2.11(@sanity/icons@3.3.0)(@sanity/ui@2.8.0)(@types/node@18.19.31)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       '@sanity/util':
         specifier: workspace:*
         version: link:../../packages/@sanity/util
@@ -554,7 +554,7 @@ importers:
         version: link:../../packages/sanity
       sanity-plugin-hotspot-array:
         specifier: ^2.0.0
-        version: 2.0.0(@sanity/ui@2.7.0)(react-dom@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.12)
+        version: 2.0.0(@sanity/ui@2.8.0)(react-dom@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.12)
       sanity-plugin-mux-input:
         specifier: ^2.2.1
         version: 2.3.6(@types/react@18.3.3)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.12)
@@ -602,8 +602,8 @@ importers:
         specifier: 3.51.0
         version: link:../../packages/@sanity/cli
       '@sanity/ui':
-        specifier: ^2.7.0
-        version: 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+        specifier: ^2.8.0
+        version: 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1257,8 +1257,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0(react@18.3.1)
       '@sanity/ui':
-        specifier: ^2.7.0
-        version: 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+        specifier: ^2.8.0
+        version: 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       '@uiw/react-codemirror':
         specifier: ^4.11.4
         version: 4.21.25(@babel/runtime@7.24.8)(@codemirror/autocomplete@6.17.0)(@codemirror/language@6.10.2)(@codemirror/lint@6.8.1)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.28.5)(codemirror@6.0.1)(react-dom@18.3.1)(react@18.3.1)
@@ -1429,8 +1429,8 @@ importers:
         specifier: 3.51.0
         version: link:../@sanity/types
       '@sanity/ui':
-        specifier: ^2.7.0
-        version: 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+        specifier: ^2.8.0
+        version: 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       '@sanity/util':
         specifier: 3.51.0
         version: link:../@sanity/util
@@ -1713,7 +1713,7 @@ importers:
         version: 1.0.83(@types/node@18.19.31)(debug@4.3.5)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.12)
       '@sanity/ui-workshop':
         specifier: ^1.2.11
-        version: 1.2.11(@sanity/icons@3.3.0)(@sanity/ui@2.7.0)(@types/node@18.19.31)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+        version: 1.2.11(@sanity/icons@3.3.0)(@sanity/ui@2.8.0)(@types/node@18.19.31)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       '@sentry/types':
         specifier: ^8.12.0
         version: 8.12.0
@@ -6168,7 +6168,7 @@ packages:
       '@sanity/icons': 2.11.8(react@18.3.1)
       '@sanity/incompatible-plugin': 1.0.4(react-dom@18.3.1)(react@18.3.1)
       '@sanity/mutator': link:packages/@sanity/mutator
-      '@sanity/ui': 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+      '@sanity/ui': 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       date-fns: 3.6.0
       lodash: 4.17.21
       lodash-es: 4.17.21
@@ -6319,7 +6319,7 @@ packages:
     dependencies:
       '@sanity/icons': 2.11.8(react@18.3.1)
       '@sanity/incompatible-plugin': 1.0.4(react-dom@18.3.1)(react@18.3.1)
-      '@sanity/ui': 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+      '@sanity/ui': 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       lodash: 4.17.21
       react: 18.3.1
       sanity: link:packages/sanity
@@ -6412,7 +6412,7 @@ packages:
     dependencies:
       '@sanity/icons': 3.3.0(react@18.3.1)
       '@sanity/types': link:packages/@sanity/types
-      '@sanity/ui': 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+      '@sanity/ui': 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       lodash.startcase: 4.4.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -6604,7 +6604,7 @@ packages:
       '@sanity/client': 6.21.0(debug@4.3.5)
       '@sanity/icons': 3.3.0(react@18.3.1)
       '@sanity/preview-url-secret': 1.6.18(@sanity/client@6.21.0)
-      '@sanity/ui': 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+      '@sanity/ui': 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       '@sanity/uuid': 3.0.2
       '@types/lodash.isequal': 4.5.8
       fast-deep-equal: 3.1.3
@@ -6698,7 +6698,7 @@ packages:
       '@sanity/color': 3.0.6
       '@sanity/icons': 3.3.0(react@18.3.1)
       '@sanity/pkg-utils': 6.10.2(@types/node@18.19.31)(debug@4.3.5)(typescript@5.5.3)
-      '@sanity/ui': 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+      '@sanity/ui': 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       '@types/cpx': 1.5.5
       '@vitejs/plugin-react': 4.3.1(vite@5.3.3)
       cac: 6.7.14
@@ -6756,7 +6756,7 @@ packages:
       - debug
     dev: false
 
-  /@sanity/ui-workshop@1.2.11(@sanity/icons@3.3.0)(@sanity/ui@2.7.0)(@types/node@18.19.31)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.12):
+  /@sanity/ui-workshop@1.2.11(@sanity/icons@3.3.0)(@sanity/ui@2.8.0)(@types/node@18.19.31)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.12):
     resolution: {integrity: sha512-vzj7upIF7wq2W1HEA0D5VSkR8axaH4Rt07yNTAaas7CLgjSE9r2d+Gnkrq4FIbIuN1GYhhCD+D3/s60GaZrpQw==}
     hasBin: true
     peerDependencies:
@@ -6767,7 +6767,7 @@ packages:
       styled-components: ^5.2 || ^6
     dependencies:
       '@sanity/icons': 3.3.0(react@18.3.1)
-      '@sanity/ui': 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+      '@sanity/ui': 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       '@vitejs/plugin-react': 4.3.1(vite@4.5.3)
       axe-core: 4.9.0
       cac: 6.7.14
@@ -6795,8 +6795,8 @@ packages:
       - supports-color
       - terser
 
-  /@sanity/ui@2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12):
-    resolution: {integrity: sha512-WqKDXr8CLkkVqX8RcG6+O2giR30Rbew5sdpJMp3zIXIeLEBAYx00k/8ObRmeSLJe4NUMEisVUriV8i4iV2nJHQ==}
+  /@sanity/ui@2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12):
+    resolution: {integrity: sha512-/SSGW62uGcegyKZYx+Exl/W1qzMYrhu6FYmg5GU/thom4P52v7BTpmSV8BysdYqvNwYb/jSUlG6CSIp1JIrYYQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '*'
@@ -17162,11 +17162,11 @@ packages:
       '@sanity/diff-match-patch': 3.1.1
     dev: false
 
-  /sanity-plugin-hotspot-array@2.0.0(@sanity/ui@2.7.0)(react-dom@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.12):
+  /sanity-plugin-hotspot-array@2.0.0(@sanity/ui@2.8.0)(react-dom@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.12):
     resolution: {integrity: sha512-y+FP4JgRaIKO17cBMyzCCVcxwl3fh7DXEp99QlvZSWUFi3NJJg2ZXFIXc2Om66HNkprfH2ORzEmEZMuDShtlTg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@sanity/ui': ^2.7.0
+      '@sanity/ui': ^2.8.0
       react: '*'
       sanity: ^3.0.0
       styled-components: ^6.1
@@ -17174,7 +17174,7 @@ packages:
       '@sanity/asset-utils': 1.3.0
       '@sanity/image-url': 1.0.2
       '@sanity/incompatible-plugin': 1.0.4(react-dom@18.3.1)(react@18.3.1)
-      '@sanity/ui': 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+      '@sanity/ui': 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       '@sanity/util': 3.51.0
       '@types/lodash-es': 4.17.12
       framer-motion: 11.0.8(react-dom@18.3.1)(react@18.3.1)
@@ -17200,7 +17200,7 @@ packages:
       '@mux/upchunk': 3.4.0
       '@sanity/icons': 3.3.0(react@18.3.1)
       '@sanity/incompatible-plugin': 1.0.4(react-dom@18.3.1)(react@18.3.1)
-      '@sanity/ui': 2.7.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
+      '@sanity/ui': 2.8.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
       '@sanity/uuid': 3.0.2
       iso-639-1: 3.1.2
       jsonwebtoken-esm: 1.0.5


### PR DESCRIPTION
### Description

Fixes the type errors failing the build for #7185.
In v2.8.0 of `@sanity/ui` the implementation of `useClickOutside` were updated to allow using react refs, and to no longer require `useCallback` wrapping on the handler. See https://github.com/sanity-io/ui/pull/1390 for more details.
As a result of this it seems TypeScript is no longer able to infer the type of the `event` argument, when the handler is wrapped in `useCallback`.
Inference works just fine and the type of `event` winds up being `MouseEvent` when the `useCallback` wrapping is removed, and the handler is passed to `useClickOutside` directly.
Since `useCallback` isn't needed anymore in any case it seemed like the best way to resolve the typescript errors.

There are other improvements to `useClickOutside` but they'll be implemented in separate follow-up PRs 🙌 

### What to review

Does the change make sense?

### Testing

Existing builds and tests should be sufficient. `@sanity/ui` already ran the studio E2E testing suite before releasing v2.8.0: https://github.com/sanity-io/ui/actions/runs/9978840730/job/27576866642

### Notes for release

N/A


Closes #7185