### PR TITLE
fix: unify externals in auto-updating builds

### DIFF
--- a/packages/@repo/package.bundle/.depcheckrc.json
+++ b/packages/@repo/package.bundle/.depcheckrc.json
@@ -1,3 +1,3 @@
 {
-  "ignores": ["vite", "vite-tsconfig-paths", "@vitejs/plugin-react"]
+  "ignores": ["lodash", "vite", "vite-tsconfig-paths", "@vitejs/plugin-react"]
 }

--- a/packages/@repo/package.bundle/src/package.bundle.ts
+++ b/packages/@repo/package.bundle/src/package.bundle.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react'
+import {escapeRegExp} from 'lodash'
 import {type UserConfig} from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
@@ -19,7 +20,16 @@ export const defaultConfig: UserConfig = {
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['react', /^react-dom/, 'react/jsx-runtime', 'styled-components'],
+      // self-externals are required here in order to ensure that the presentation
+      // tool and future transitive dependencies that require sanity do not
+      // re-include sanity in their bundle
+      external: ['react', 'react-dom', 'styled-components', 'sanity', '@sanity/vision'].flatMap(
+        (dependency) => [
+          dependency,
+          // this matches `react/jsx-runtime`, `sanity/presentation` etc
+          new RegExp(`^${escapeRegExp(dependency)}\\/`),
+        ],
+      ),
       output: {
         exports: 'named',
         dir: 'dist',

--- a/packages/@sanity/vision/package.bundle.ts
+++ b/packages/@sanity/vision/package.bundle.ts
@@ -10,9 +10,6 @@ export default defineConfig(() => {
           index: './src/index.ts',
         },
       },
-      rollupOptions: {
-        external: ['sanity'],
-      },
     },
   })
 })


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This pull request addresses an issue where the sanity build with auto-update was breaking the sanity presentation. The issue was due to the package bundle configuration not including externals. The changes introduced include adding externals to the build configuration for the sanity module, ensuring that external dependencies are properly handled in the import map. This resolves the issue of the presentation tool crashing.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

The reviewer should:
1. Review the changes made to the build configuration, specifically the inclusion of externals.
2. Verify that the local setup with the module server and localhost URLs is correctly implemented.
3. Test the presentation tool to ensure it no longer crashes with the new configuration.
4. Consider the architectural suggestion regarding the handling of external dependencies in the import map.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Manual testing was conducted by setting up the module server locally, replacing module server URLs with localhost ones, and verifying that the presentation tool works correctly after including externals in the build configuration. Automated testing was not added due to the complexity of the setup, but the fix was validated through thorough manual testing.

See [this](https://sanity-io.slack.com/archives/C06QRTY1R16/p1721246345043359?thread_ts=1721059108.241229&cid=C06QRTY1R16) slack thread.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

* **What changed:** The build configuration for the sanity module was updated to include externals.
* **How to use it:** No changes in usage for end users, but developers should ensure that external dependencies are included in the import map.
