### PR TITLE
feat(releases): publish all documents in a bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check:deps": "pnpm --recursive --parallel exec depcheck",
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
-    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 27 .",
+    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 28 .",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",
     "chore:format:fix": "prettier --cache --write .",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check:deps": "pnpm --recursive --parallel exec depcheck",
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
-    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 28 .",
+    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 27 .",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",
     "chore:format:fix": "prettier --cache --write .",

--- a/packages/sanity/src/core/bundles/components/BundleBadge.tsx
+++ b/packages/sanity/src/core/bundles/components/BundleBadge.tsx
@@ -4,6 +4,7 @@ import {ChevronDownIcon, Icon, type IconSymbol} from '@sanity/icons'
 import {Box, Flex, rgba, Text, useTheme_v2} from '@sanity/ui'
 import {type CSSProperties} from 'react'
 
+import {Tooltip} from '../../../ui-components'
 import {type BundleDocument} from '../../store/bundles/types'
 
 /**
@@ -47,7 +48,17 @@ export function BundleBadge(
       )}
       {title && (
         <Box flex="none">
-          <Text size={1}>{title}</Text>
+          <Tooltip delay={1000} content={title} placement="bottom">
+            <Text
+              style={{
+                maxWidth: 100,
+              }}
+              textOverflow="ellipsis"
+              size={1}
+            >
+              {title}
+            </Text>
+          </Tooltip>
         </Box>
       )}
       {openButton && (

--- a/packages/sanity/src/core/releases/components/BundleMenuButton/BundleMenuButton.tsx
+++ b/packages/sanity/src/core/releases/components/BundleMenuButton/BundleMenuButton.tsx
@@ -5,11 +5,11 @@ import {
   TrashIcon,
   UnarchiveIcon,
 } from '@sanity/icons'
-import {Button, Menu, MenuButton, MenuItem, Spinner, Text, useToast} from '@sanity/ui'
+import {Button, Menu, MenuButton, Spinner, Text, useToast} from '@sanity/ui'
 import {useState} from 'react'
 import {useRouter} from 'sanity/router'
 
-import {Dialog} from '../../../../ui-components'
+import {Dialog, MenuItem} from '../../../../ui-components'
 import {BundleDetailsDialog} from '../../../bundles/components/dialog/BundleDetailsDialog'
 import {type BundleDocument} from '../../../store/bundles/types'
 import {useBundleOperations} from '../../../store/bundles/useBundleOperations'

--- a/packages/sanity/src/core/releases/components/ReleaseDocumentPreview.tsx
+++ b/packages/sanity/src/core/releases/components/ReleaseDocumentPreview.tsx
@@ -47,7 +47,7 @@ export function ReleaseDocumentPreview({
     [documentId, documentTypeName, releaseSlug],
   )
 
-  const presencePreview = useMemo(
+  const previewPresence = useMemo(
     () => documentPresence?.length > 0 && <DocumentPreviewPresence presence={documentPresence} />,
     [documentPresence],
   )
@@ -59,14 +59,14 @@ export function ReleaseDocumentPreview({
       radius={2}
       data-as="a"
     >
-      <SanityDefaultPreview {...previewValues} status={presencePreview} isPlaceholder={isLoading}>
+      <SanityDefaultPreview {...previewValues} status={previewPresence} isPlaceholder={isLoading}>
         {hasValidationError && (
           <Tooltip
             portal
             content={
               <Text muted size={1}>
                 {/* TODO: clarify copy */}
-                There are validation issues with this document
+                There are validation errors in this document
               </Text>
             }
           >

--- a/packages/sanity/src/core/releases/components/ReleaseDocumentPreview.tsx
+++ b/packages/sanity/src/core/releases/components/ReleaseDocumentPreview.tsx
@@ -1,6 +1,8 @@
+import {ErrorOutlineIcon} from '@sanity/icons'
 import {type PreviewValue} from '@sanity/types'
-import {Card} from '@sanity/ui'
+import {Card, Text, Tooltip} from '@sanity/ui'
 import {type ForwardedRef, forwardRef, useMemo} from 'react'
+import {DocumentPreviewPresence, useDocumentPresence} from 'sanity'
 import {IntentLink} from 'sanity/router'
 
 import {SanityDefaultPreview} from '../../preview/components/SanityDefaultPreview'
@@ -12,6 +14,7 @@ interface ReleaseDocumentPreviewProps {
   releaseSlug: string
   previewValues: PreviewValue
   isLoading: boolean
+  hasValidationError?: boolean
 }
 
 export function ReleaseDocumentPreview({
@@ -20,7 +23,10 @@ export function ReleaseDocumentPreview({
   releaseSlug,
   previewValues,
   isLoading,
+  hasValidationError,
 }: ReleaseDocumentPreviewProps) {
+  const documentPresence = useDocumentPresence(documentId)
+
   const LinkComponent = useMemo(
     () =>
       // eslint-disable-next-line @typescript-eslint/no-shadow
@@ -41,9 +47,33 @@ export function ReleaseDocumentPreview({
     [documentId, documentTypeName, releaseSlug],
   )
 
+  const presencePreview = useMemo(
+    () => documentPresence?.length > 0 && <DocumentPreviewPresence presence={documentPresence} />,
+    [documentPresence],
+  )
+
   return (
-    <Card as={LinkComponent} radius={2} data-as="a">
-      <SanityDefaultPreview {...previewValues} isPlaceholder={isLoading} />
+    <Card
+      tone={hasValidationError ? 'critical' : 'default'}
+      as={LinkComponent}
+      radius={2}
+      data-as="a"
+    >
+      <SanityDefaultPreview {...previewValues} status={presencePreview} isPlaceholder={isLoading}>
+        {hasValidationError && (
+          <Tooltip
+            portal
+            content={
+              <Text muted size={1}>
+                {/* TODO: clarify copy */}
+                There are validation issues with this document
+              </Text>
+            }
+          >
+            <ErrorOutlineIcon />
+          </Tooltip>
+        )}
+      </SanityDefaultPreview>
     </Card>
   )
 }

--- a/packages/sanity/src/core/releases/components/ReleasePublishAllButton/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/components/ReleasePublishAllButton/ReleasePublishAllButton.tsx
@@ -33,10 +33,11 @@ export const ReleasePublishAllButton = ({
   const isValidatingDocuments = Object.values(validation).some(({isValidating}) => isValidating)
   const hasDocumentValidationErrors = Object.values(validation).some(({hasError}) => hasError)
 
-  const isPublishButtonDisabled = disabled || isValidatingDocuments || hasDocumentValidationErrors
+  const isPublishButtonDisabled =
+    disabled || isValidatingDocuments || hasDocumentValidationErrors || !publishedDocumentsRevisions
 
   const handleConfirmPublishAll = useCallback(async () => {
-    if (!bundle) return
+    if (!bundle || !publishedDocumentsRevisions) return
 
     try {
       setPublishBundleStatus('publishing')

--- a/packages/sanity/src/core/releases/components/ReleasePublishAllButton/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/components/ReleasePublishAllButton/ReleasePublishAllButton.tsx
@@ -1,0 +1,133 @@
+import {ErrorOutlineIcon, PublishIcon} from '@sanity/icons'
+import {type SanityDocument} from '@sanity/types'
+import {Flex, Text, useToast} from '@sanity/ui'
+import {useCallback, useMemo, useState} from 'react'
+import {type BundleDocument} from 'sanity'
+
+import {Button, Dialog} from '../../../../ui-components'
+import {useBundleOperations} from '../../../store/bundles/useBundleOperations'
+import {type useBundleDocumentsValidation} from '../../tool/detail/useBundleDocumentsValidation'
+
+interface ReleasePublishAllButtonProps {
+  bundle: BundleDocument
+  bundleDocuments: SanityDocument[]
+  disabled?: boolean
+  validation: ReturnType<typeof useBundleDocumentsValidation>
+}
+
+export const ReleasePublishAllButton = ({
+  bundle,
+  bundleDocuments,
+  disabled,
+  validation,
+}: ReleasePublishAllButtonProps) => {
+  const toast = useToast()
+  const {publishBundle} = useBundleOperations()
+  const [publishBundleStatus, setPublishBundleStatus] = useState<'idle' | 'confirm' | 'publishing'>(
+    'idle',
+  )
+
+  const isValidatingDocuments = Object.values(validation).some(({isValidating}) => isValidating)
+  const hasDocumentValidationErrors = Object.values(validation).some(({hasError}) => hasError)
+
+  const isPublishButtonDisabled = disabled || isValidatingDocuments || hasDocumentValidationErrors
+
+  const handleConfirmPublishAll = useCallback(async () => {
+    if (!bundle) return
+
+    try {
+      setPublishBundleStatus('publishing')
+      await publishBundle(bundle._id, bundleDocuments)
+      toast.push({
+        closable: true,
+        status: 'success',
+        title: (
+          <Text muted size={1}>
+            The <strong>{bundle.title}</strong> release was published
+          </Text>
+        ),
+      })
+    } catch (publishingError) {
+      toast.push({
+        status: 'error',
+        title: (
+          <Text muted size={1}>
+            Failed to publish the <strong>{bundle.title}</strong> release
+          </Text>
+        ),
+      })
+      console.error(publishingError)
+    } finally {
+      setPublishBundleStatus('idle')
+    }
+  }, [bundle, bundleDocuments, publishBundle, toast])
+
+  const confirmPublishDialog = useMemo(() => {
+    if (publishBundleStatus === 'idle') return null
+
+    return (
+      <Dialog
+        id="confirm-publish-dialog"
+        header="Are you sure you want to publish the release and all document versions?"
+        onClose={() => setPublishBundleStatus('idle')}
+        footer={{
+          confirmButton: {
+            text: 'Publish',
+            tone: 'default',
+            onClick: handleConfirmPublishAll,
+            loading: publishBundleStatus === 'publishing',
+            disabled: publishBundleStatus === 'publishing',
+          },
+        }}
+      >
+        <Text muted size={1}>
+          The <strong>{bundle?.title}</strong> release and its {bundleDocuments.length} document
+          version{bundleDocuments.length > 1 ? 's' : ''} will be published.
+        </Text>
+      </Dialog>
+    )
+  }, [bundle?.title, bundleDocuments.length, handleConfirmPublishAll, publishBundleStatus])
+
+  const publishTooltipContent = useMemo(() => {
+    if (!hasDocumentValidationErrors && !isValidatingDocuments) return null
+
+    const tooltipText = () => {
+      if (isValidatingDocuments) {
+        return 'Validating documents...'
+      }
+
+      if (hasDocumentValidationErrors) {
+        return 'Some documents have validation errors'
+      }
+
+      return null
+    }
+
+    return (
+      <Flex gap={1} align="center">
+        <ErrorOutlineIcon />
+        <Text muted size={1}>
+          {tooltipText()}
+        </Text>
+      </Flex>
+    )
+  }, [hasDocumentValidationErrors, isValidatingDocuments])
+
+  return (
+    <>
+      <Button
+        tooltipProps={{
+          disabled: !isPublishButtonDisabled,
+          content: publishTooltipContent,
+          placement: 'bottom',
+        }}
+        icon={PublishIcon}
+        disabled={isPublishButtonDisabled || publishBundleStatus === 'publishing'}
+        text="Publish all"
+        onClick={() => setPublishBundleStatus('confirm')}
+        loading={publishBundleStatus === 'publishing'}
+      />
+      {confirmPublishDialog}
+    </>
+  )
+}

--- a/packages/sanity/src/core/releases/components/ReleasePublishAllButton/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/components/ReleasePublishAllButton/ReleasePublishAllButton.tsx
@@ -7,6 +7,7 @@ import {type BundleDocument} from 'sanity'
 import {Button, Dialog} from '../../../../ui-components'
 import {useBundleOperations} from '../../../store/bundles/useBundleOperations'
 import {type useBundleDocumentsValidation} from '../../tool/detail/useBundleDocumentsValidation'
+import {useObserveDocumentRevisions} from './useObserveDocumentRevisions'
 
 interface ReleasePublishAllButtonProps {
   bundle: BundleDocument
@@ -27,6 +28,8 @@ export const ReleasePublishAllButton = ({
     'idle',
   )
 
+  const publishedDocumentsRevisions = useObserveDocumentRevisions(bundleDocuments)
+
   const isValidatingDocuments = Object.values(validation).some(({isValidating}) => isValidating)
   const hasDocumentValidationErrors = Object.values(validation).some(({hasError}) => hasError)
 
@@ -37,7 +40,7 @@ export const ReleasePublishAllButton = ({
 
     try {
       setPublishBundleStatus('publishing')
-      await publishBundle(bundle._id, bundleDocuments)
+      await publishBundle(bundle._id, bundleDocuments, publishedDocumentsRevisions)
       toast.push({
         closable: true,
         status: 'success',
@@ -60,7 +63,7 @@ export const ReleasePublishAllButton = ({
     } finally {
       setPublishBundleStatus('idle')
     }
-  }, [bundle, bundleDocuments, publishBundle, toast])
+  }, [bundle, bundleDocuments, publishBundle, publishedDocumentsRevisions, toast])
 
   const confirmPublishDialog = useMemo(() => {
     if (publishBundleStatus === 'idle') return null

--- a/packages/sanity/src/core/releases/components/ReleasePublishAllButton/useObserveDocumentRevisions.ts
+++ b/packages/sanity/src/core/releases/components/ReleasePublishAllButton/useObserveDocumentRevisions.ts
@@ -1,0 +1,34 @@
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {map} from 'rxjs/operators'
+import {
+  getPublishedId,
+  isSanityDocument,
+  type SanityDocument,
+  useDocumentPreviewStore,
+} from 'sanity'
+
+export const useObserveDocumentRevisions = (documents: SanityDocument[]) => {
+  const previewStore = useDocumentPreviewStore()
+  const publishedDocumentIds = documents.map(({_id}) => getPublishedId(_id, true))
+
+  const memoObservable = useMemo(
+    () =>
+      previewStore.unstable_observeDocuments(publishedDocumentIds).pipe(
+        map((publishedDocuments) =>
+          publishedDocuments
+            .filter(isSanityDocument)
+            .reduce<Record<SanityDocument['_id'], SanityDocument['_rev']>>(
+              (accPublishedDocs, {_id, _rev}) => ({
+                ...accPublishedDocs,
+                [_id]: _rev,
+              }),
+              {},
+            ),
+        ),
+      ),
+    [previewStore, publishedDocumentIds],
+  )
+
+  return useObservable(memoObservable)
+}

--- a/packages/sanity/src/core/releases/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/components/Table/Table.tsx
@@ -4,6 +4,7 @@ import {Fragment, useMemo} from 'react'
 import {useTableContext} from 'sanity/_singletons'
 import {styled} from 'styled-components'
 
+import {TooltipDelayGroupProvider} from '../../../../ui-components'
 import {LoadingBlock} from '../../../components'
 import {TableHeader} from './TableHeader'
 import {TableProvider} from './TableProvider'
@@ -193,8 +194,10 @@ export const Table = <TableData, AdditionalRowTableData = undefined>(
   props: TableProps<TableData, AdditionalRowTableData>,
 ) => {
   return (
-    <TableProvider>
-      <TableInner<TableData, AdditionalRowTableData> {...props} />
-    </TableProvider>
+    <TooltipDelayGroupProvider>
+      <TableProvider>
+        <TableInner<TableData, AdditionalRowTableData> {...props} />
+      </TableProvider>
+    </TooltipDelayGroupProvider>
   )
 }

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
@@ -1,12 +1,13 @@
-import {ArrowLeftIcon, PublishIcon} from '@sanity/icons'
-import {Box, Card, Container, Flex, Heading, Stack, Text} from '@sanity/ui'
-import {useCallback, useMemo} from 'react'
+import {ArrowLeftIcon, ErrorOutlineIcon, PublishIcon} from '@sanity/icons'
+import {Box, Card, Container, Flex, Heading, Stack, Text, useToast} from '@sanity/ui'
+import {useCallback, useEffect, useMemo, useState} from 'react'
 import {LoadingBlock, useClient} from 'sanity'
 import {type RouterContextValue, useRouter} from 'sanity/router'
 
-import {Button} from '../../../../ui-components'
+import {Button, Dialog} from '../../../../ui-components'
 import {useListener} from '../../../hooks/useListener'
 import {useBundles} from '../../../store/bundles'
+import {useBundleOperations} from '../../../store/bundles/useBundleOperations'
 import {API_VERSION} from '../../../tasks/constants'
 import {BundleMenuButton} from '../../components/BundleMenuButton/BundleMenuButton'
 import {type ReleasesRouterState} from '../../types/router'
@@ -20,7 +21,7 @@ type Screen = (typeof SUPPORTED_SCREENS)[number]
 
 const useFetchBundleDocuments = (bundleSlug: string) => {
   const client = useClient({apiVersion: API_VERSION})
-  const query = `*[defined(_version) &&  _id in path("${bundleSlug}.*")]`
+  const query = `*[defined(_version) && _id in path("${bundleSlug}.*")]`
   return useListener({query, client})
 }
 
@@ -43,15 +44,29 @@ export const ReleaseDetail = () => {
   const {bundleSlug}: ReleasesRouterState = router.state
   const parsedSlug = decodeURIComponent(bundleSlug || '')
   const {data, loading} = useBundles()
+  const {publishBundle} = useBundleOperations()
   const {documents: bundleDocuments, loading: documentsLoading} =
     useFetchBundleDocuments(parsedSlug)
+  const [publishBundleStatus, setPublishBundleStatus] = useState<'idle' | 'confirm' | 'publishing'>(
+    'idle',
+  )
   const history = useReleaseHistory(bundleDocuments)
   const validation = useBundleDocumentsValidation(bundleDocuments)
 
   const bundle = data?.find((storeBundle) => storeBundle.slug === parsedSlug)
   const bundleHasDocuments = !!bundleDocuments.length
   const showPublishButton = loading || !bundle?.publishedAt
-  const isPublishButtonDisabled = loading || !bundle || !bundleHasDocuments
+  const isValidatingDocuments = Object.values(validation).some(({isValidating}) => isValidating)
+  const hasDocumentValidationErrors = Object.values(validation).some(({hasError}) => hasError)
+  const isPublishButtonDisabled =
+    loading ||
+    !bundle ||
+    !bundleHasDocuments ||
+    publishBundleStatus === 'publishing' ||
+    hasDocumentValidationErrors ||
+    isValidatingDocuments
+
+  const toast = useToast()
 
   const navigateToReview = useCallback(() => {
     router.navigate({
@@ -66,6 +81,96 @@ export const ReleaseDetail = () => {
       _searchParams: [],
     })
   }, [router])
+
+  const publishTooltipContent = useMemo(() => {
+    if (!hasDocumentValidationErrors && !isValidatingDocuments) return null
+
+    const tooltipText = () => {
+      if (isValidatingDocuments) {
+        return 'Validating documents...'
+      }
+
+      if (hasDocumentValidationErrors) {
+        return 'Some documents have validation errors'
+      }
+
+      return null
+    }
+
+    return (
+      <Flex gap={1} align="center">
+        <ErrorOutlineIcon />
+        <Text muted size={1}>
+          {tooltipText()}
+        </Text>
+      </Flex>
+    )
+  }, [hasDocumentValidationErrors, isValidatingDocuments])
+
+  // review screen will not be available once published
+  // so redirect to summary screen
+  useEffect(() => {
+    if (activeScreen === 'review' && bundle?.publishedAt) {
+      navigateToSummary()
+    }
+  }, [activeScreen, bundle?.publishedAt, navigateToSummary])
+
+  const handleConfirmPublishAll = useCallback(async () => {
+    if (!bundle) return
+
+    try {
+      setPublishBundleStatus('publishing')
+      await publishBundle(bundle._id, bundleDocuments)
+      toast.push({
+        closable: true,
+        status: 'success',
+        title: (
+          <Text muted size={1}>
+            The <strong>{bundle.title}</strong> release was published
+          </Text>
+        ),
+      })
+    } catch (publishingError) {
+      toast.push({
+        status: 'error',
+        title: (
+          <Text muted size={1}>
+            Failed to publish the <strong>{bundle.title}</strong> release
+          </Text>
+        ),
+      })
+      console.error(publishingError)
+    } finally {
+      setPublishBundleStatus('idle')
+    }
+  }, [bundle, bundleDocuments, publishBundle, toast])
+
+  const confirmPublishDialog = useMemo(() => {
+    if (publishBundleStatus === 'idle') return null
+
+    return (
+      <Dialog
+        id="confirm-publish-dialog"
+        header="Are you sure you want to publish the release and all document versions?"
+        onClose={() => setPublishBundleStatus('idle')}
+        footer={{
+          confirmButton: {
+            text: 'Publish',
+            tone: 'default',
+            onClick: handleConfirmPublishAll,
+            loading: publishBundleStatus === 'publishing',
+            disabled: publishBundleStatus === 'publishing',
+          },
+        }}
+      >
+        <Text muted size={1}>
+          The <strong>{bundle?.title}</strong> release and its {bundleDocuments.length} document
+          version{bundleDocuments.length > 1 ? 's' : ''} will be published.
+        </Text>
+      </Dialog>
+    )
+  }, [bundle?.title, bundleDocuments.length, handleConfirmPublishAll, publishBundleStatus])
+
   const header = useMemo(
     () => (
       <Card
@@ -106,25 +211,38 @@ export const ReleaseDetail = () => {
                 text="Summary"
               />
               {/* StudioButton supports tooltip when button is disabled */}
-              <Button
-                tooltipProps={{
-                  disabled: bundleHasDocuments,
-                  content: 'Add documents to this release to review changes',
-                  placement: 'bottom',
-                }}
-                key="review"
-                disabled={!bundleHasDocuments}
-                mode="bleed"
-                onClick={navigateToReview}
-                selected={activeScreen === 'review'}
-                text="Review changes"
-              />
+              {!bundle?.publishedAt && (
+                <Button
+                  tooltipProps={{
+                    disabled: bundleHasDocuments,
+                    content: 'Add documents to this release to review changes',
+                    placement: 'bottom',
+                  }}
+                  key="review"
+                  disabled={!bundleHasDocuments}
+                  mode="bleed"
+                  onClick={navigateToReview}
+                  selected={activeScreen === 'review'}
+                  text="Review changes"
+                />
+              )}
             </Flex>
           </Flex>
 
           <Flex flex="none" gap={2}>
             {showPublishButton && (
-              <Button icon={PublishIcon} disabled={isPublishButtonDisabled} text="Publish all" />
+              <Button
+                tooltipProps={{
+                  disabled: !isPublishButtonDisabled,
+                  content: publishTooltipContent,
+                  placement: 'bottom',
+                }}
+                icon={PublishIcon}
+                disabled={isPublishButtonDisabled}
+                text="Publish all"
+                onClick={() => setPublishBundleStatus('confirm')}
+                loading={publishBundleStatus === 'publishing'}
+              />
             )}
             <BundleMenuButton bundle={bundle} documentCount={bundleDocuments.length} />
           </Flex>
@@ -139,10 +257,46 @@ export const ReleaseDetail = () => {
       isPublishButtonDisabled,
       navigateToReview,
       navigateToSummary,
+      publishBundleStatus,
+      publishTooltipContent,
       router,
       showPublishButton,
     ],
   )
+
+  const detailContent = useMemo(() => {
+    if (!bundle) return null
+
+    if (activeScreen === 'summary') {
+      return (
+        <ReleaseSummary
+          documents={bundleDocuments}
+          release={bundle}
+          documentsHistory={history.documentsHistory}
+          collaborators={history.collaborators}
+          validation={validation}
+        />
+      )
+    }
+    if (activeScreen === 'review') {
+      return (
+        <ReleaseReview
+          documents={bundleDocuments}
+          release={bundle}
+          documentsHistory={history.documentsHistory}
+          validation={validation}
+        />
+      )
+    }
+    return null
+  }, [
+    activeScreen,
+    bundle,
+    bundleDocuments,
+    history.collaborators,
+    history.documentsHistory,
+    validation,
+  ])
 
   if (loading) {
     return <LoadingBlock title="Loading release" fill data-testid="bundle-documents-table-loader" />
@@ -167,32 +321,11 @@ export const ReleaseDetail = () => {
       <Card flex={1} overflow="auto">
         <Container width={2}>
           <Box paddingX={4} paddingY={6}>
-            {documentsLoading ? (
-              <LoadingBlock title="Loading documents" />
-            ) : (
-              <>
-                {activeScreen === 'summary' && (
-                  <ReleaseSummary
-                    documents={bundleDocuments}
-                    release={bundle}
-                    documentsHistory={history.documentsHistory}
-                    collaborators={history.collaborators}
-                    validation={validation}
-                  />
-                )}
-              </>
-            )}
-            {activeScreen === 'review' && (
-              <ReleaseReview
-                documents={bundleDocuments}
-                release={bundle}
-                documentsHistory={history.documentsHistory}
-                validation={validation}
-              />
-            )}
+            {documentsLoading ? <LoadingBlock title="Loading documents" /> : detailContent}
           </Box>
         </Container>
       </Card>
+      {confirmPublishDialog}
     </Flex>
   )
 }

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -158,7 +158,7 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
             />
 
             {/* Published */}
-            {!release.archivedAt && (
+            {
               <Chip
                 avatar={
                   release.publishedBy ? <UserAvatar size={0} user={release.publishedBy} /> : null
@@ -173,7 +173,7 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
                   )
                 }
               />
-            )}
+            }
 
             {/* Contributors */}
             <Box padding={1}>

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
@@ -5,10 +5,18 @@ import {route, RouterProvider} from 'sanity/router'
 import {createWrapper} from '../../../../../../test/testUtils/createWrapper'
 import {useListener} from '../../../../hooks/useListener'
 import {useBundles} from '../../../../store/bundles'
+import {useBundleOperations} from '../../../../store/bundles/useBundleOperations'
 import {ReleaseDetail} from '../ReleaseDetail'
+import {useBundleDocumentsValidation} from '../useBundleDocumentsValidation'
 
 jest.mock('../../../../store/bundles', () => ({
   useBundles: jest.fn().mockReturnValue({data: [], loading: false}),
+}))
+
+jest.mock('../../../../store/bundles/useBundleOperations', () => ({
+  useBundleOperations: jest.fn().mockReturnValue({
+    publishBundle: jest.fn(),
+  }),
 }))
 
 jest.mock('../../../../hooks/useListener', () => ({
@@ -35,8 +43,15 @@ jest.mock('../documentTable/useReleaseHistory', () => ({
   }),
 }))
 
+jest.mock('../useBundleDocumentsValidation', () => ({
+  useBundleDocumentsValidation: jest.fn().mockReturnValue({}),
+}))
+
 const mockUseBundles = useBundles as jest.Mock<typeof useBundles>
 const mockUseListener = useListener as jest.Mock<typeof useListener>
+const mockUseBundleDocumentsValidation = useBundleDocumentsValidation as jest.Mock<
+  typeof useBundleDocumentsValidation
+>
 const mockRouterNavigate = jest.fn()
 
 const renderTest = async () => {
@@ -67,14 +82,6 @@ const publishAgnosticTests = () => {
   it('should default to showing summary screen', () => {
     expect(screen.getByText('Summary').closest('button')).toHaveAttribute('data-selected', '')
   })
-
-  it('should navigate to release review changes screen', () => {
-    expect(screen.getByText('Review changes').closest('button')).not.toBeDisabled()
-    fireEvent.click(screen.getByText('Review changes'))
-    expect(mockRouterNavigate).toHaveBeenCalledWith({
-      path: '/test-bundle-slug?screen=review',
-    })
-  })
 }
 
 describe('ReleaseDetail', () => {
@@ -88,127 +95,261 @@ describe('ReleaseDetail', () => {
       screen.getByTestId('mocked-loading-block')
     })
 
-    describe('when loaded bundles but still loading bundle documents', () => {
-      beforeEach(async () => {
-        mockUseBundles.mockReturnValue({data: [], loading: false, dispatch: jest.fn()})
-        mockUseListener.mockReturnValue({
-          documents: [],
-          loading: true,
-          error: null,
-          dispatch: jest.fn(),
-        })
-        await renderTest()
-      })
-
-      it('should show loading spinner', () => {
-        screen.getByTestId('mocked-loading-block')
-      })
+    it('does not show the rest of the screen ui', () => {
+      expect(screen.queryByText('Publish all')).toBeNull()
+      expect(screen.queryByText('Summary')).toBeNull()
+      expect(screen.queryByText('Review changes')).toBeNull()
+      expect(screen.queryByLabelText('Release menu')).toBeNull()
     })
   })
 
-  describe('after bundles have loaded', () => {
-    describe('with unpublished release', () => {
-      beforeEach(async () => {
-        mockUseBundles.mockReturnValue({
-          data: [
-            {
-              title: 'Test bundle',
-              publishedAt: undefined,
-              archivedAt: undefined,
-              _id: 'test-id',
-              _createdAt: new Date().toISOString(),
-              _type: 'bundle',
-              slug: 'test-bundle-slug',
-              hue: 'blue',
-              icon: 'string',
-              authorId: 'author-id',
-              _updatedAt: new Date().toISOString(),
-              _rev: 'abc',
-            },
-          ],
-          loading: false,
-          dispatch: jest.fn(),
-        })
-        mockUseListener.mockReturnValue({
-          documents: [
-            {
-              _id: 'test-id',
-              _type: 'document',
-              _rev: 'abc',
-              _createdAt: new Date().toISOString(),
-              _updatedAt: new Date().toISOString(),
-            },
-          ],
-          loading: false,
-          dispatch: jest.fn(),
-          error: null,
-        })
-
-        await renderTest()
+  describe('when loaded bundles but still loading bundle documents', () => {
+    beforeEach(async () => {
+      mockUseBundles.mockReturnValue({
+        data: [
+          {
+            title: 'Test bundle',
+            publishedAt: undefined,
+            archivedAt: undefined,
+            _id: 'test-id',
+            _createdAt: new Date().toISOString(),
+            _type: 'bundle',
+            slug: 'test-bundle-slug',
+            hue: 'blue',
+            icon: 'string',
+            authorId: 'author-id',
+            _updatedAt: new Date().toISOString(),
+            _rev: 'abc',
+          },
+        ],
+        loading: false,
+        dispatch: jest.fn(),
       })
-
-      publishAgnosticTests()
-
-      it('should show publish button when release not published', () => {
-        expect(screen.getByText('Publish all').closest('button')).not.toBeDisabled()
+      mockUseListener.mockReturnValue({
+        documents: [],
+        loading: true,
+        error: null,
+        dispatch: jest.fn(),
       })
+      await renderTest()
+    })
 
+    it('should show loading spinner', () => {
+      screen.getByTestId('mocked-loading-block')
+    })
+
+    it('should show the header', () => {
+      screen.getByText('Test bundle')
+      screen.getByText('Summary')
+      expect(screen.getByText('Review changes').closest('button')).toBeDisabled()
+      screen.getByLabelText('Release menu')
+      expect(screen.getByText('Publish all').closest('button')).toBeDisabled()
+    })
+  })
+})
+
+describe('after bundles have loaded', () => {
+  describe('with unpublished release', () => {
+    const currentDate = new Date().toISOString()
+    beforeEach(async () => {
+      mockUseBundles.mockReturnValue({
+        data: [
+          {
+            title: 'Test bundle',
+            publishedAt: undefined,
+            archivedAt: undefined,
+            _id: 'test-id',
+            _createdAt: currentDate,
+            _type: 'bundle',
+            slug: 'test-bundle-slug',
+            hue: 'blue',
+            icon: 'string',
+            authorId: 'author-id',
+            _updatedAt: currentDate,
+            _rev: 'abc',
+          },
+        ],
+        loading: false,
+        dispatch: jest.fn(),
+      })
+      mockUseListener.mockReturnValue({
+        documents: [
+          {
+            _id: 'test-id',
+            _type: 'document',
+            _rev: 'abc',
+            _createdAt: currentDate,
+            _updatedAt: currentDate,
+          },
+        ],
+        loading: false,
+        dispatch: jest.fn(),
+        error: null,
+      })
+    })
+
+    const loadedBundleAndDocumentsTests = () => {
       it('should allow for the release to be archived', () => {
         fireEvent.click(screen.getByLabelText('Release menu'))
         screen.getByText('Archive')
       })
-    })
 
-    describe('with published release', () => {
+      it('should navigate to release review changes screen', () => {
+        expect(screen.getByText('Review changes').closest('button')).not.toBeDisabled()
+        fireEvent.click(screen.getByText('Review changes'))
+        expect(mockRouterNavigate).toHaveBeenCalledWith({
+          path: '/test-bundle-slug?screen=review',
+        })
+      })
+    }
+
+    describe('with pending document validation', () => {
       beforeEach(async () => {
-        mockUseBundles.mockReturnValue({
-          data: [
-            {
-              title: 'Test bundle',
-              publishedAt: new Date().toISOString(),
-              archivedAt: new Date().toISOString(),
-              _id: 'test-id',
-              _createdAt: new Date().toISOString(),
-              _type: 'bundle',
-              slug: 'test-bundle-slug',
-              hue: 'blue',
-              icon: 'string',
-              authorId: 'author-id',
-              _updatedAt: new Date().toISOString(),
-              _rev: 'abc',
-            },
-          ],
-          loading: false,
-          dispatch: jest.fn(),
+        mockUseBundleDocumentsValidation.mockReturnValue({
+          'test-bundle-slug': {
+            documentId: '123',
+            hasError: false,
+            isValidating: true,
+            validation: [],
+          },
         })
-        mockUseListener.mockReturnValue({
-          documents: [
-            {
-              _id: 'test-id',
-              _type: 'document',
-              _rev: 'abc',
-              _createdAt: new Date().toISOString(),
-              _updatedAt: new Date().toISOString(),
-            },
-          ],
-          loading: false,
-          dispatch: jest.fn(),
-          error: null,
-        })
-
         await renderTest()
       })
 
       publishAgnosticTests()
+      loadedBundleAndDocumentsTests()
 
-      it('should not show the publish button', () => {
-        expect(screen.queryByText('Publish all')).toBeNull()
+      it('should disable publish all button', () => {
+        expect(screen.getByText('Publish all').closest('button')).toBeDisabled()
+      })
+    })
+
+    describe('with passing document validation', () => {
+      beforeEach(async () => {
+        mockUseBundleDocumentsValidation.mockReturnValue({
+          'test-bundle-slug': {
+            documentId: '123',
+            hasError: false,
+            isValidating: false,
+            validation: [],
+          },
+        })
+        await renderTest()
       })
 
-      it('should allow for the release to be unarchived', () => {
-        fireEvent.click(screen.getByLabelText('Release menu'))
-        screen.getByText('Unarchive')
+      publishAgnosticTests()
+      loadedBundleAndDocumentsTests()
+
+      it('should show publish all button when release not published', () => {
+        expect(screen.getByText('Publish all').closest('button')).not.toBeDisabled()
       })
+
+      it('should require confirmation to publish', () => {
+        fireEvent.click(screen.getByText('Publish all'))
+        screen.getByText('Are you sure you want to publish the release and all document versions?')
+        fireEvent.click(screen.getByText('Cancel'))
+
+        expect(screen.getByText('Publish all').closest('button')).not.toBeDisabled()
+      })
+
+      it('should perform publish', () => {
+        fireEvent.click(screen.getByText('Publish all'))
+        fireEvent.click(screen.getByText('Publish'))
+
+        expect(useBundleOperations().publishBundle).toHaveBeenCalledWith('test-id', [
+          {
+            _createdAt: currentDate,
+            _id: 'test-id',
+            _rev: 'abc',
+            _type: 'document',
+            _updatedAt: currentDate,
+          },
+        ])
+      })
+    })
+
+    describe('with failing document validation', () => {
+      beforeEach(async () => {
+        mockUseBundleDocumentsValidation.mockReturnValue({
+          'test-bundle-slug': {
+            documentId: '123',
+            hasError: true,
+            isValidating: false,
+            validation: [
+              {
+                message: 'title validation message',
+                level: 'error',
+                path: ['title'],
+              },
+            ],
+          },
+        })
+        await renderTest()
+      })
+
+      publishAgnosticTests()
+      loadedBundleAndDocumentsTests()
+
+      it('should disable publish all button', () => {
+        expect(screen.getByText('Publish all').closest('button')).toBeDisabled()
+        fireEvent.mouseOver(screen.getByText('Publish all'))
+      })
+    })
+  })
+
+  describe('with published release', () => {
+    beforeEach(async () => {
+      mockUseBundles.mockReturnValue({
+        data: [
+          {
+            title: 'Test bundle',
+            publishedAt: new Date().toISOString(),
+            archivedAt: new Date().toISOString(),
+            _id: 'test-id',
+            _createdAt: new Date().toISOString(),
+            _type: 'bundle',
+            slug: 'test-bundle-slug',
+            hue: 'blue',
+            icon: 'string',
+            authorId: 'author-id',
+            _updatedAt: new Date().toISOString(),
+            _rev: 'abc',
+          },
+        ],
+        loading: false,
+        dispatch: jest.fn(),
+      })
+      mockUseListener.mockReturnValue({
+        documents: [
+          {
+            _id: 'test-id',
+            _type: 'document',
+            _rev: 'abc',
+            _createdAt: new Date().toISOString(),
+            _updatedAt: new Date().toISOString(),
+          },
+        ],
+        loading: false,
+        dispatch: jest.fn(),
+        error: null,
+      })
+
+      await renderTest()
+    })
+
+    publishAgnosticTests()
+
+    it('should not show the publish button', () => {
+      expect(screen.queryByText('Publish all')).toBeNull()
+    })
+
+    it('should allow for the release to be unarchived', () => {
+      fireEvent.click(screen.getByLabelText('Release menu'))
+      screen.getByText('Unarchive')
+    })
+
+    it('should not show the review changes button', () => {
+      expect(screen.queryByText('Review changes')).toBeNull()
     })
   })
 })

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
@@ -33,6 +33,12 @@ jest.mock('sanity', () => ({
   useCurrentUser: jest.fn().mockReturnValue({id: 'test-user-id'}),
 }))
 
+jest.mock('../../../components/ReleasePublishAllButton/useObserveDocumentRevisions', () => ({
+  useObserveDocumentRevisions: jest.fn().mockReturnValue({
+    '123': 'mock revision id',
+  }),
+}))
+
 jest.mock('../ReleaseSummary', () => ({
   ReleaseSummary: () => <div data-testid="mocked-release-summary" />,
 }))
@@ -256,15 +262,19 @@ describe('after bundles have loaded', () => {
         fireEvent.click(screen.getByText('Publish all'))
         fireEvent.click(screen.getByText('Publish'))
 
-        expect(useBundleOperations().publishBundle).toHaveBeenCalledWith('test-id', [
-          {
-            _createdAt: currentDate,
-            _id: 'test-id',
-            _rev: 'abc',
-            _type: 'document',
-            _updatedAt: currentDate,
-          },
-        ])
+        expect(useBundleOperations().publishBundle).toHaveBeenCalledWith(
+          'test-id',
+          [
+            {
+              _createdAt: currentDate,
+              _id: 'test-id',
+              _rev: 'abc',
+              _type: 'document',
+              _updatedAt: currentDate,
+            },
+          ],
+          {'123': 'mock revision id'},
+        )
       })
     })
 

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -39,19 +39,21 @@ export function DocumentActions({
   }
   return (
     <>
-      <MenuButton
-        id="document-actions"
-        button={<ContextMenuButton />}
-        menu={
-          <Menu>
-            <MenuItem
-              text="Discard version"
-              icon={CloseIcon}
-              onClick={() => setShowDiscardDialog(true)}
-            />
-          </Menu>
-        }
-      />
+      <Card tone="default" display="flex">
+        <MenuButton
+          id="document-actions"
+          button={<ContextMenuButton />}
+          menu={
+            <Menu>
+              <MenuItem
+                text="Discard version"
+                icon={CloseIcon}
+                onClick={() => setShowDiscardDialog(true)}
+              />
+            </Menu>
+          }
+        />
+      </Card>
       {showDiscardDialog && (
         <Dialog
           id="discard-version-dialog"

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -22,6 +22,7 @@ export const getDocumentTableColumnDefs: (
           releaseSlug={releaseSlug}
           previewValues={document.previewValues}
           isLoading={!!document.isLoading}
+          hasValidationError={document.validation?.hasError}
         />
       </Box>
     ),

--- a/packages/sanity/src/core/store/bundles/useBundleOperations.ts
+++ b/packages/sanity/src/core/store/bundles/useBundleOperations.ts
@@ -78,7 +78,7 @@ export function useBundleOperations() {
     async (
       bundleId: string,
       bundleDocuments: SanityDocument[],
-      publishedDocumentsRevisions: Record<string, string> = {},
+      publishedDocumentsRevisions: Record<string, string>,
     ) => {
       if (!addOnClient) return null
 


### PR DESCRIPTION
### Description
Clicking 'Publish all' on a release with all valid documents will not publish the version documents, and update the bundle metadata with the publish date

https://www.loom.com/share/94911ea76b484457aca3ffa31ceca78f?sid=1851e5b8-fb86-4052-ae3f-0ff9958b97e8
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* Presence added to `ReleaseDocumentPreview`
* `handlePublishBundle` added to `useBundleOperations`
* validation of documents used to control disabled state of publish all in `ReleaseDetail`
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
* Tests in `ReleaseDetail.test` updated for new publish all calls
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
