### PR TITLE
chore: enable production react profiling in test studios

### DIFF
--- a/dev/test-next-studio/next.config.mjs
+++ b/dev/test-next-studio/next.config.mjs
@@ -2,6 +2,10 @@ function requireResolve(id) {
   return import.meta.resolve(id).replace('file://', '')
 }
 
+const reactCompiler = process.env.REACT_COMPILER === 'true'
+const reactProductionProfiling = process.env.REACT_PRODUCTION_PROFILING === 'true'
+const productionBrowserSourceMaps = reactCompiler || reactProductionProfiling
+
 // eslint-disable-next-line tsdoc/syntax
 /** @type {import('next').NextConfig} */
 const config = {
@@ -80,9 +84,10 @@ const config = {
   },
   // Makes it much easier to see which component got memoized by the react compiler
   // when testing on https://test-next-studio.sanity.build
-  productionBrowserSourceMaps: true,
+  productionBrowserSourceMaps,
+  reactProductionProfiling,
   experimental: {
-    reactCompiler: process.env.REACT_COMPILER === 'true' ? true : false,
+    reactCompiler,
     turbo: {
       resolveAlias: {
         '@sanity/block-tools': '@sanity/block-tools/src/index.ts',

--- a/dev/test-next-studio/turbo.json
+++ b/dev/test-next-studio/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "env": ["REACT_COMPILER"],
+      "env": ["REACT_COMPILER", "REACT_PRODUCTION_PROFILING"],
       "outputs": [".next/**", "!.next/cache/**", "out/**"],
       "dependsOn": ["^build"]
     },

--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -14,6 +14,8 @@ export default defineCliConfig({
   // B) creating a `.env` file locally that sets the same env variable as above
   reactStrictMode: true,
   vite(viteConfig: UserConfig): UserConfig {
+    const reactProductionProfiling = process.env.REACT_PRODUCTION_PROFILING === 'true'
+
     return {
       ...viteConfig,
       optimizeDeps: {
@@ -26,8 +28,26 @@ export default defineCliConfig({
           'sanity',
         ],
       },
+      resolve: reactProductionProfiling
+        ? {
+            ...viteConfig.resolve,
+            alias: {
+              ...viteConfig.resolve?.alias,
+              'react-dom/client': require.resolve('react-dom/profiling'),
+            },
+          }
+        : viteConfig.resolve,
+      esbuild: reactProductionProfiling
+        ? {
+            ...viteConfig.esbuild,
+            // Makes it much easier to look through profiling traces
+            minifyIdentifiers: false,
+          }
+        : viteConfig.esbuild,
       build: {
         ...viteConfig.build,
+        // Enable production source maps to easier debug deployed test studios
+        sourcemap: reactProductionProfiling || viteConfig.build?.sourcemap,
         rollupOptions: {
           ...viteConfig.build?.rollupOptions,
           input: {

--- a/dev/test-studio/turbo.json
+++ b/dev/test-studio/turbo.json
@@ -3,6 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
+      "env": ["REACT_PRODUCTION_PROFILING"],
       "outputs": [".sanity/**", "dist/**", "workshop/scopes.js"]
     }
   }


### PR DESCRIPTION
### Description

This PR enables using the React Profiler on the production build of the studio.

In other words, instead of seeing this message on preview deployments [(like for this branch)](https://test-studio-git-react-production-profiling.sanity.build/test/structure):

<img width="1413" alt="image" src="https://github.com/user-attachments/assets/3ee2a5d6-404f-40c5-a757-e4cd2c6cc36b">

You'll be able to run the profiler:

<img width="1412" alt="image" src="https://github.com/user-attachments/assets/b475f5e1-0d9d-47d1-a516-210a44cd7fcd">

The main benefit of running the profiler in production, is that the perf overhead in React from running Strict Mode, as well as all the checks and instrumentation that is only used in local development (Hot Module Reload, checking if `key` is spread to attributes, checking if you're trying to set dom attributes that don't exist etc), all of that no longer interferes with the profiling results.

Additionally, since the regular components debugger is often used in conjunction with the profiler, I've made sure to disable esbuild's `minifyIdentifiers` setting and enabled source maps.

Without it the debugger becomes difficult to use:

<img width="1412" alt="image" src="https://github.com/user-attachments/assets/db180513-5734-42e9-a34a-a6f16e57944c">


Since they are enabled it's now almost as productive as when working locally in `sanity dev`:


<img width="1414" alt="image" src="https://github.com/user-attachments/assets/7fdd5b20-8a87-41c4-98be-5969dadb2750">

React production profiling is controlled by the new `REACT_PRODUCTION_PROFILING` env var, so to run the test studio this way locally you can:

```
cd dev/test-studio && REACT_PRODUCTION_PROFILING=true pnpm turbo run build && pnpm start
```

On our Vercel test studio projects the `REACT_PRODUCTION_PROFILING` is set for only preview deployments, not for production.
In other words merging this PR won't enable it for the production https://test-studio.sanity.build deployments.
**This is intentional.** There is still some overhead to enabling profiling in production.
Thus there's value in omitting it from the production test studios to ensure that the performance we see there matches userland as much as possible.
It also makes it much easier to do regular browser performance profiling: https://developer.chrome.com/docs/devtools/performance
As you often need a reference profile you can use to compare to changes in a PR to see its impact. Being able to quickly create that baseline on https://test-studio.sanity.build is really convenient.
If you need to use a react profiling in production reference frame you can always quickly branch off `next` and push it to have vercel create that reference deployment for you :)


### What to review

Does this make sense? Should we add a command in the root `package.json`, for example `dev:test-studio-production-profiling`?

### Testing

You can try the React profiler on the branch build with the regular React Devtools here: https://test-studio-git-react-production-profiling.sanity.build

And locally by running:
```
cd dev/test-studio && REACT_PRODUCTION_PROFILING=true pnpm turbo run build && pnpm start
```

### Notes for release

N/A only affects the test studios on the monorepo.
