### PR TITLE
fix: ensure search context provider value is memoized

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/components/common/SearchWrapper.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/common/SearchWrapper.tsx
@@ -44,7 +44,11 @@ export function SearchWrapper({
    * Set shared `onClose` in search context
    */
   useEffect(() => {
-    setOnClose(handleClose)
+    /**
+     * When using useState you have to use the function callback version of setState,
+     *  otherwise it'll call your function and set the state to whatever your function return.
+     */
+    setOnClose(() => handleClose)
   }, [handleClose, setOnClose])
 
   /**

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
@@ -1,5 +1,5 @@
 import {isEqual} from 'lodash'
-import {type ReactNode, useCallback, useEffect, useMemo, useReducer, useRef, useState} from 'react'
+import {type ReactNode, useEffect, useMemo, useReducer, useRef, useState} from 'react'
 import {SearchContext} from 'sanity/_singletons'
 
 import {type CommandListHandle} from '../../../../../../components'
@@ -28,7 +28,7 @@ interface SearchProviderProps {
  * @internal
  */
 export function SearchProvider({children, fullscreen}: SearchProviderProps) {
-  const onCloseRef = useRef<(() => void) | null>(null)
+  const [onClose, setOnClose] = useState<(() => void) | null>(null)
   const [searchCommandList, setSearchCommandList] = useState<CommandListHandle | null>(null)
 
   const schema = useSchema()
@@ -102,10 +102,6 @@ export function SearchProvider({children, fullscreen}: SearchProviderProps) {
       operatorDefinitions,
     }),
   )
-
-  const handleSetOnClose = useCallback((onClose: () => void) => {
-    onCloseRef.current = onClose
-  }, [])
 
   /**
    * Trigger search when any terms (query or selected types) OR current pageIndex has changed
@@ -184,21 +180,20 @@ export function SearchProvider({children, fullscreen}: SearchProviderProps) {
     isMountedRef.current = true
   }, [dispatch, hasValidTerms, result.hits, terms.query, terms.types])
 
-  return (
-    <SearchContext.Provider
-      value={{
-        dispatch,
-        onClose: onCloseRef?.current,
-        searchCommandList,
-        setSearchCommandList,
-        setOnClose: handleSetOnClose,
-        state: {
-          ...state,
-          fullscreen,
-        },
-      }}
-    >
-      {children}
-    </SearchContext.Provider>
+  const value = useMemo(
+    () => ({
+      dispatch,
+      onClose,
+      searchCommandList,
+      setSearchCommandList,
+      setOnClose,
+      state: {
+        ...state,
+        fullscreen,
+      },
+    }),
+    [fullscreen, onClose, searchCommandList, state],
   )
+
+  return <SearchContext.Provider value={value}>{children}</SearchContext.Provider>
 }


### PR DESCRIPTION
### Description

Relates to #7199, read its description for all the deets. The SearchProvider warrants its own PR since it required more work than simply wrapping the context value in a `useMemo`.

### What to review

Does it make sense?

### Testing

If you can click outside the global search and it closes successfully then it works 🎉 

### Notes for release

N/A
