### PR TITLE
fix(structure): make sync document toast dismisable

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -67,14 +67,19 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
   const isLocked = editState?.transactionSyncLock?.enabled
   const {t} = useTranslation(structureLocaleNamespace)
 
-  useConditionalToast({
-    id: `sync-lock-${documentId}`,
-    status: 'warning',
-    enabled: isLocked,
-    title: t('document-view.form-view.sync-lock-toast.title'),
-    description: t('document-view.form-view.sync-lock-toast.description'),
-    closable: true,
-  })
+  const conditionalToastParams = useMemo(
+    () => ({
+      id: `sync-lock-${documentId}`,
+      status: 'warning' as const,
+      enabled: isLocked,
+      title: t('document-view.form-view.sync-lock-toast.title'),
+      description: t('document-view.form-view.sync-lock-toast.description'),
+      closable: true,
+    }),
+    [documentId, isLocked, t],
+  )
+
+  useConditionalToast(conditionalToastParams)
 
   useEffect(() => {
     const sub = documentStore.pair

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -69,14 +69,14 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
 
   const conditionalToastParams = useMemo(
     () => ({
-      id: `sync-lock-${documentId}`,
+      id: `sync-lock`,
       status: 'warning' as const,
       enabled: isLocked,
       title: t('document-view.form-view.sync-lock-toast.title'),
       description: t('document-view.form-view.sync-lock-toast.description'),
       closable: true,
     }),
-    [documentId, isLocked, t],
+    [isLocked, t],
   )
 
   useConditionalToast(conditionalToastParams)

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -73,6 +73,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     enabled: isLocked,
     title: t('document-view.form-view.sync-lock-toast.title'),
     description: t('document-view.form-view.sync-lock-toast.description'),
+    closable: true,
   })
 
   useEffect(() => {

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/useConditionalToast.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/useConditionalToast.ts
@@ -1,13 +1,5 @@
 import {type ToastParams, useToast} from '@sanity/ui'
-import {useEffect, useRef} from 'react'
-
-function usePrevious<T>(value: T) {
-  const ref = useRef<T>()
-  useEffect(() => {
-    ref.current = value
-  }, [value])
-  return ref.current
-}
+import {useEffect} from 'react'
 
 // https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
 const LONG_ENOUGH_BUT_NOT_TOO_LONG = 1000 * 60 * 60 * 24 * 24
@@ -18,19 +10,11 @@ const LONG_ENOUGH_BUT_NOT_TOO_LONG = 1000 * 60 * 60 * 24 * 24
 export function useConditionalToast(params: ToastParams & {id: string; enabled?: boolean}) {
   const toast = useToast()
 
-  const wasEnabled = usePrevious(params.enabled)
   // note1: there's a `duration || 0` in Sanity UI's pushToast(), so make it non-falsey
   // note2: cannot use `Infinity` as duration, since it exceeds setTimeout's maximum delay value
   useEffect(() => {
-    if (!wasEnabled && params.enabled) {
+    if (params.enabled) {
       toast.push({...params, duration: LONG_ENOUGH_BUT_NOT_TOO_LONG})
-    }
-    if (wasEnabled && !params.enabled) {
-      toast.push({
-        ...params,
-        // Note: @sanity/ui fallbacks to the default duration of 4s in case of falsey values
-        duration: 0.01,
-      })
     }
     return () => {
       if (params.enabled) {
@@ -41,5 +25,5 @@ export function useConditionalToast(params: ToastParams & {id: string; enabled?:
         })
       }
     }
-  }, [params, toast, wasEnabled])
+  }, [params, toast])
 }

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/useConditionalToast.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/useConditionalToast.ts
@@ -32,5 +32,14 @@ export function useConditionalToast(params: ToastParams & {id: string; enabled?:
         duration: 0.01,
       })
     }
+    return () => {
+      if (params.enabled) {
+        toast.push({
+          ...params,
+          // Note: @sanity/ui fallbacks to the default duration of 4s in case of falsey values
+          duration: 0.01,
+        })
+      }
+    }
   }, [params, toast, wasEnabled])
 }


### PR DESCRIPTION
### Description

An issue is present in structure in which sync toasts are forever present. 
For what was discussed with the internal team, is that the toast is persisted even though the condition for it is gone or and even if the document is not in view anymore. 

This seems to be caused because when the `FormView` component is unmounted, the toast doesn't trigger a close action, to solve this a cleanup function was added to the useEffect to close the toast if it is still shown.

This seems to be happening even if the `FormView` is not visually unmounted (document is still open), this seems to be caused because the `FormView` component takes a key [` key={documentId + (ready ? '_ready' : '_pending')}`](https://github.com/sanity-io/sanity/blob/dismissable-document-sync-toast/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx#L174-L175), so when the key changes, the form is unmounted and mounted again, but given there are no clean up functions in the conditional toast hook, the toast will be kept forever.


In this video two buttons were added to force the states that show or hide the toast.


https://github.com/user-attachments/assets/083e65d5-c157-45fd-8bda-090e1505adb4


It also adds support to close the **syncing document** toast.

<img width="682" alt="Screenshot 2024-07-19 at 16 06 47" src="https://github.com/user-attachments/assets/b4c3243a-7282-4dc3-a4bb-9442243226ed">



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
