### PR TITLE
feat(corel): add search input to release review screen

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/ReleaseReview.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseReview.tsx
@@ -1,10 +1,16 @@
+import {SearchIcon} from '@sanity/icons'
 import {type SanityDocument} from '@sanity/types'
-import {Stack} from '@sanity/ui'
+import {Container, Flex, Stack, Text, TextInput} from '@sanity/ui'
+import {useState} from 'react'
+import {styled} from 'styled-components'
 
 import {type BundleDocument} from '../../../store/bundles/types'
 import {type DocumentHistory} from './documentTable/useReleaseHistory'
 import {DocumentDiffContainer} from './review/DocumentDiffContainer'
 
+const InputContainer = styled(Container)`
+  margin: 0;
+`
 export function ReleaseReview({
   documents,
   release,
@@ -14,16 +20,38 @@ export function ReleaseReview({
   release: BundleDocument
   documentsHistory: Map<string, DocumentHistory>
 }) {
+  const [searchTerm, setSearchTerm] = useState('')
+
   return (
-    <Stack space={[5, 6]}>
-      {documents.map((document) => (
-        <DocumentDiffContainer
-          key={document._id}
-          document={document}
-          release={release}
-          history={documentsHistory.get(document._id)}
-        />
-      ))}
+    <Stack space={5}>
+      <Flex justify="space-between" align="center">
+        <Text size={1} weight="semibold">
+          Changes to published documents
+        </Text>
+        <InputContainer width={0}>
+          <TextInput
+            fontSize={1}
+            icon={SearchIcon}
+            placeholder="Search documents"
+            radius={3}
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.currentTarget.value)}
+            onClear={() => setSearchTerm('')}
+            clearButton={!!searchTerm}
+          />
+        </InputContainer>
+      </Flex>
+      <Stack space={[5, 6]}>
+        {documents.map((document) => (
+          <DocumentDiffContainer
+            key={document._id}
+            searchTerm={searchTerm}
+            document={document}
+            release={release}
+            history={documentsHistory.get(document._id)}
+          />
+        ))}
+      </Stack>
     </Stack>
   )
 }

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseReview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseReview.test.tsx
@@ -1,6 +1,7 @@
 import {beforeEach, describe, expect, it, jest} from '@jest/globals'
-import {render, screen} from '@testing-library/react'
-import {ColorSchemeProvider, UserColorManagerProvider} from 'sanity'
+import {type SanityDocument} from '@sanity/client'
+import {act, fireEvent, render, screen} from '@testing-library/react'
+import {ColorSchemeProvider, getPublishedId, UserColorManagerProvider} from 'sanity'
 
 import {queryByDataUi} from '../../../../../../test/setup/customQueries'
 import {createWrapper} from '../../../../bundles'
@@ -10,45 +11,67 @@ import {useDocumentPreviewValues} from '../documentTable/useDocumentPreviewValue
 import {type DocumentHistory} from '../documentTable/useReleaseHistory'
 import {ReleaseReview} from '../ReleaseReview'
 
-const baseDocument = {
-  name: 'William Faulkner',
-  role: 'developer',
-  awards: ['first award', 'second award'],
-  favoriteBooks: [
-    {
-      _ref: '0b229e82-48e4-4226-a36f-e6b3d874478a',
-      _type: 'reference',
-      _key: '23610d43d8e8',
+const DOCUMENTS_MOCKS = {
+  doc1: {
+    baseDocument: {
+      name: 'William Faulkner',
+      role: 'developer',
+      _id: 'doc1',
+      _rev: 'FvEfB9CaLlljeKWNkRBaf5',
+      _type: 'author',
+      _createdAt: '',
+      _updatedAt: '',
     },
-  ],
-  _id: '1f8caa96-4174-4c91-bb40-cbc96a737fcf',
-  _rev: 'FvEfB9CaLlljeKWNkRBaf5',
-  _type: 'author',
-  _createdAt: '',
-  _updatedAt: '',
-}
+    previewValues: {
+      _id: 'differences.doc1',
+      _type: 'author',
+      _createdAt: '2024-07-10T12:10:38Z',
+      _updatedAt: '2024-07-15T10:46:02Z',
+      _version: {},
+      title: 'William Faulkner added',
+      subtitle: 'Designer',
+    },
+  },
+  doc2: {
+    baseDocument: {
+      name: 'Virginia Woolf',
+      role: 'developer',
+      _id: 'doc2',
+      _rev: 'FvEfB9CaLlljeKWNkRBaf5',
+      _type: 'author',
+      _createdAt: '',
+      _updatedAt: '',
+    },
+    previewValues: {
+      _id: 'differences.doc2',
+      _type: 'author',
+      _createdAt: '2024-07-10T12:10:38Z',
+      _updatedAt: '2024-07-15T10:46:02Z',
+      _version: {},
+      title: 'Virginia Woolf test',
+      subtitle: 'Developer',
+    },
+  },
+} as const
 
 const MOCKED_PROPS = {
   documents: [
     {
-      favoriteBooks: [
-        {
-          _ref: '0daffd51-59c3-4dca-a9ee-1c4db54db87e',
-          _type: 'reference',
-          _key: '0d3f45004da0',
-        },
-      ],
-      _version: {},
-      bestFriend: {
-        _ref: '0c9d9135-0d20-44a1-9ec1-54ea41ce84d1',
-        _type: 'reference',
-      },
       _rev: 'FvEfB9CaLlljeKWNkQgpz9',
       _type: 'author',
       role: 'designer',
       _createdAt: '2024-07-10T12:10:38Z',
       name: 'William Faulkner added',
-      _id: 'differences.1f8caa96-4174-4c91-bb40-cbc96a737fcf',
+      _id: 'differences.doc1',
+      _updatedAt: '2024-07-15T10:46:02Z',
+    },
+    {
+      _rev: 'FvEfB9CaLlljeKWNkQg1232',
+      _type: 'author',
+      role: 'developer',
+      _createdAt: '2024-07-10T12:10:38Z',
+      name: 'Virginia Woolf test',
+      _id: 'differences.doc2',
       _updatedAt: '2024-07-15T10:46:02Z',
     },
   ],
@@ -67,7 +90,16 @@ const MOCKED_PROPS = {
   } as const,
   documentsHistory: new Map<string, DocumentHistory>([
     [
-      'differences.1f8caa96-4174-4c91-bb40-cbc96a737fcf',
+      'differences.doc1',
+      {
+        history: [],
+        createdBy: 'p8xDvUMxC',
+        lastEditedBy: 'p8xDvUMxC',
+        editors: ['p8xDvUMxC'],
+      },
+    ],
+    [
+      'differences.doc2',
       {
         history: [],
         createdBy: 'p8xDvUMxC',
@@ -104,16 +136,6 @@ const mockedUseDocumentPreviewValues = useDocumentPreviewValues as jest.Mock<
   typeof useDocumentPreviewValues
 >
 
-const previewValues = {
-  _id: 'differences.1f8caa96-4174-4c91-bb40-cbc96a737fcf',
-  _type: 'author',
-  _createdAt: '2024-07-10T12:10:38Z',
-  _updatedAt: '2024-07-15T10:46:02Z',
-  _version: {},
-  title: 'William Faulkner differences check 123 asklaks ',
-  subtitle: 'Designer',
-}
-
 describe('ReleaseReview', () => {
   describe('when loading baseDocument', () => {
     beforeEach(async () => {
@@ -121,11 +143,16 @@ describe('ReleaseReview', () => {
         document: null,
         loading: true,
       })
-      mockedUseDocumentPreviewValues.mockReturnValue({previewValues, isLoading: false})
+      mockedUseDocumentPreviewValues.mockReturnValue({
+        previewValues: DOCUMENTS_MOCKS.doc1.previewValues,
+        isLoading: false,
+      })
       const wrapper = await createWrapper({
         resources: [releasesUsEnglishLocaleBundle],
       })
-      render(<ReleaseReview {...MOCKED_PROPS} />, {wrapper})
+      render(<ReleaseReview {...MOCKED_PROPS} documents={MOCKED_PROPS.documents.slice(0, 1)} />, {
+        wrapper,
+      })
     })
     it("should show the loader when the base document hasn't loaded", () => {
       queryByDataUi(document.body, 'Spinner')
@@ -137,11 +164,16 @@ describe('ReleaseReview', () => {
         document: null,
         loading: false,
       })
-      mockedUseDocumentPreviewValues.mockReturnValue({previewValues, isLoading: false})
+      mockedUseDocumentPreviewValues.mockReturnValue({
+        previewValues: DOCUMENTS_MOCKS.doc1.previewValues,
+        isLoading: false,
+      })
       const wrapper = await createWrapper({
         resources: [releasesUsEnglishLocaleBundle],
       })
-      render(<ReleaseReview {...MOCKED_PROPS} />, {wrapper})
+      render(<ReleaseReview {...MOCKED_PROPS} documents={MOCKED_PROPS.documents.slice(0, 1)} />, {
+        wrapper,
+      })
     })
     it('should render the new document ui', async () => {
       expect(screen.getByText('New document')).toBeInTheDocument()
@@ -154,11 +186,16 @@ describe('ReleaseReview', () => {
         document: MOCKED_PROPS.documents[0],
         loading: false,
       })
-      mockedUseDocumentPreviewValues.mockReturnValue({previewValues, isLoading: false})
+      mockedUseDocumentPreviewValues.mockReturnValue({
+        previewValues: DOCUMENTS_MOCKS.doc1.previewValues,
+        isLoading: false,
+      })
       const wrapper = await createWrapper({
         resources: [releasesUsEnglishLocaleBundle],
       })
-      render(<ReleaseReview {...MOCKED_PROPS} />, {wrapper})
+      render(<ReleaseReview {...MOCKED_PROPS} documents={MOCKED_PROPS.documents.slice(0, 1)} />, {
+        wrapper,
+      })
     })
     it('should show that there are no changes', async () => {
       expect(screen.getByText('No changes')).toBeInTheDocument()
@@ -167,11 +204,22 @@ describe('ReleaseReview', () => {
 
   describe('when the base document is loaded and has changes', () => {
     beforeEach(async () => {
-      mockedUseObserveDocument.mockReturnValue({
-        document: baseDocument,
-        loading: false,
+      mockedUseObserveDocument.mockImplementation((docId: string) => {
+        return {
+          // @ts-expect-error - key is valid, ts won't infer it
+          document: DOCUMENTS_MOCKS[docId].baseDocument,
+          loading: false,
+        }
       })
-      mockedUseDocumentPreviewValues.mockReturnValue({previewValues, isLoading: false})
+      mockedUseDocumentPreviewValues.mockImplementation(
+        ({document}: {document: SanityDocument}) => {
+          return {
+            // @ts-expect-error - key is valid, ts won't infer it
+            previewValues: DOCUMENTS_MOCKS[getPublishedId(document._id, true)].previewValues,
+            isLoading: false,
+          }
+        },
+      )
       const wrapper = await createWrapper({
         resources: [releasesUsEnglishLocaleBundle],
       })
@@ -186,11 +234,56 @@ describe('ReleaseReview', () => {
     })
     it('should should show the changes', async () => {
       // Find an ins tag with the text "added"
-      const element = screen.getByText((content, el) => {
+      const firstDocumentChange = screen.getByText((content, el) => {
         return el?.tagName.toLowerCase() === 'ins' && content === 'added'
       })
 
-      expect(element).toBeInTheDocument()
+      expect(firstDocumentChange).toBeInTheDocument()
+
+      const secondDocumentChange = screen.getByText((content, el) => {
+        return el?.tagName.toLowerCase() === 'ins' && content === 'test'
+      })
+
+      expect(secondDocumentChange).toBeInTheDocument()
+    })
+  })
+  describe('filtering documents', () => {
+    beforeEach(async () => {
+      mockedUseObserveDocument.mockReturnValue({document: null, loading: false})
+
+      mockedUseDocumentPreviewValues.mockImplementation(
+        ({document}: {document: SanityDocument}) => {
+          return {
+            // @ts-expect-error - key is valid, ts won't infer it
+            previewValues: DOCUMENTS_MOCKS[getPublishedId(document._id, true)].previewValues,
+            isLoading: false,
+          }
+        },
+      )
+      const wrapper = await createWrapper({
+        resources: [releasesUsEnglishLocaleBundle],
+      })
+      render(<ReleaseReview {...MOCKED_PROPS} />, {wrapper})
+    })
+
+    it('should show all the documents when no filter is applied', () => {
+      expect(screen.queryByText(DOCUMENTS_MOCKS.doc1.previewValues.title)).toBeInTheDocument()
+      expect(screen.queryByText(DOCUMENTS_MOCKS.doc2.previewValues.title)).toBeInTheDocument()
+    })
+    it('should show support filtering by title', () => {
+      const searchInput = screen.getByPlaceholderText('Search documents')
+      act(() => {
+        fireEvent.change(searchInput, {target: {value: 'Virginia'}})
+      })
+
+      expect(screen.queryByText(DOCUMENTS_MOCKS.doc1.previewValues.title)).not.toBeInTheDocument()
+      expect(screen.queryByText(DOCUMENTS_MOCKS.doc2.previewValues.title)).toBeInTheDocument()
+
+      act(() => {
+        fireEvent.change(searchInput, {target: {value: ''}})
+      })
+      expect(screen.queryByText(DOCUMENTS_MOCKS.doc1.previewValues.title)).toBeInTheDocument()
+      expect(screen.queryByText(DOCUMENTS_MOCKS.doc2.previewValues.title)).toBeInTheDocument()
     })
   })
 })

--- a/packages/sanity/src/core/releases/tool/detail/review/DocumentDiffContainer.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/review/DocumentDiffContainer.tsx
@@ -15,10 +15,12 @@ export function DocumentDiffContainer({
   document,
   release,
   history,
+  searchTerm,
 }: {
   document: SanityDocument
   release: BundleDocument
   history?: DocumentHistory
+  searchTerm: string
 }) {
   const publishedId = getPublishedId(document._id, true)
   const schema = useSchema()
@@ -31,6 +33,13 @@ export function DocumentDiffContainer({
     schemaType,
   )
   const {previewValues, isLoading} = useDocumentPreviewValues({document, release})
+
+  if (searchTerm) {
+    // Early return to filter out documents that don't match the search term
+    const fallbackTitle = typeof document.title === 'string' ? document.title : 'Untitled'
+    const title = typeof previewValues.title === 'string' ? previewValues.title : fallbackTitle
+    if (!title.toLowerCase().includes(searchTerm.toLowerCase())) return null
+  }
 
   return (
     <Card border radius={3}>


### PR DESCRIPTION
### Description
Adds search input to review changes screen.

This search is using the preview values to search in the document, using only the document title. 
Is a low effort implementation, further implementation to be discussed if we want to use the seach api once text search lands.

<img width="875" alt="Screenshot 2024-07-19 at 17 18 51" src="https://github.com/user-attachments/assets/bd6a0ccb-b990-4734-b833-c6745fd66d2c">

--- 

<img width="856" alt="Screenshot 2024-07-19 at 17 18 56" src="https://github.com/user-attachments/assets/dccbc70b-eec0-4d80-af51-64c444332822">


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
