### PR TITLE
fix(cli): prevent crash when no package.json found in studio folder

### DIFF
--- a/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
+++ b/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
@@ -4,6 +4,7 @@ import {generateHelpUrl} from '@sanity/generate-help-url'
 import resolveFrom from 'resolve-from'
 import semver, {type SemVer} from 'semver'
 
+import {findClosestPackageJson} from './findClosestPackageJson'
 import {readPackageJson} from './readPackageJson'
 
 interface PackageInfo {
@@ -26,7 +27,11 @@ const PACKAGES = [
 ]
 
 export function checkStudioDependencyVersions(workDir: string): void {
-  const manifest = readPackageJson(path.join(workDir, 'package.json'))
+  const packageJsonPath = findClosestPackageJson(workDir)
+  const manifest = packageJsonPath
+    ? readPackageJson(packageJsonPath)
+    : {dependencies: {}, devDependencies: {}}
+
   const dependencies = {...manifest.dependencies, ...manifest.devDependencies}
 
   const packageInfo = PACKAGES.map((pkg): PackageInfo | false => {

--- a/packages/sanity/src/_internal/cli/util/findClosestPackageJson.ts
+++ b/packages/sanity/src/_internal/cli/util/findClosestPackageJson.ts
@@ -1,0 +1,23 @@
+import {existsSync} from 'node:fs'
+import {join as joinPath, resolve as resolvePath} from 'node:path'
+
+/**
+ * Find the closest `package.json` file to the given directory
+ *
+ * @param startDir - The directory to start searching from
+ * @returns The path to the closest `package.json` file, or `undefined` if none was found
+ * @internal
+ */
+export function findClosestPackageJson(startDir: string): string | undefined {
+  const packageJsonPath = joinPath(startDir, 'package.json')
+  if (existsSync(packageJsonPath)) {
+    return packageJsonPath
+  }
+
+  const parentDir = resolvePath(startDir, '..')
+  if (parentDir === startDir) {
+    return undefined
+  }
+
+  return findClosestPackageJson(parentDir)
+}


### PR DESCRIPTION
### Description

If you have the following folder structure:
```
.
├── node_modules
│   └── sanity
├── package.json
└── studios
    ├── studio-1
    │   └── sanity.config.ts
    └── studio-2
        └── sanity.config.ts
```

Running `sanity dev`, `sanity build` or `sanity deploy` from within `studios/studio-1` will currently crash, because we attempt to read `package.json` from the "work directory", which is resolved to `studios/studio-1`.

The folder structure does make sense, since you may want to reuse the same dependencies for multiple studios.

Additionally, if you happen to be missing required dependencies (`styled-components`), it will install to the studio folder, not the "dependency root" (eg in folder containing `package.json`). Attempted to fix this too.

Marked as draft since I have yet to write tests.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
