### PR TITLE
fix: remove "a key prop is spread into JSX" warning

### DIFF
--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
@@ -140,8 +140,9 @@ export class ArrayOfPrimitivesInput extends PureComponent<ArrayOfPrimitivesInput
 
   renderArrayItem = (props: Omit<PrimitiveItemProps, 'renderDefault'>) => {
     const {schemaType} = this.props
+    const {key, ...rest} = props
     const sortable = schemaType.options?.sortable !== false
-    return <ItemRow {...props} sortable={sortable} insertableTypes={schemaType.of} />
+    return <ItemRow key={key} {...rest} sortable={sortable} insertableTypes={schemaType.of} />
   }
 
   render() {

--- a/packages/sanity/src/core/form/studio/FormProvider.tsx
+++ b/packages/sanity/src/core/form/studio/FormProvider.tsx
@@ -108,7 +108,7 @@ export function FormProvider(props: FormProviderProps) {
     [Field],
   )
   const renderItem = useCallback(
-    (itemProps: Omit<ItemProps, 'renderDefault'>) => <Item {...itemProps} />,
+    ({key, ...itemProps}: Omit<ItemProps, 'renderDefault'>) => <Item key={key} {...itemProps} />,
     [Item],
   )
   const renderPreview = useCallback(


### PR DESCRIPTION
### Description

During `sanity dev` this warning happens all the time, it's very chonky and annoying:
<img width="1404" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/c168677a-4fe0-4c3f-abc6-273b0b95ac18">

This PR solves them. To repro, checkout `next` and `pnpm i && pnpm dev` and open http://localhost:3333/test/structure/author;pedro-summer.bd673136-a8dc-46f6-8cc2-d79bc32477ca to see the same error.

### What to review

When checking out this branch, opening http://localhost:3333/test/structure/author;pedro-summer.bd673136-a8dc-46f6-8cc2-d79bc32477ca should no longer trigger the warning.

### Testing

Existing tests are enough.

### Notes for release

N/A, unless this happens in userland?