### PR TITLE
chore: add `dev:test-studio-production-profiling` script

### DIFF
--- a/dev/test-studio/turbo.json
+++ b/dev/test-studio/turbo.json
@@ -5,6 +5,11 @@
     "build": {
       "env": ["REACT_PRODUCTION_PROFILING"],
       "outputs": [".sanity/**", "dist/**", "workshop/scopes.js"]
+    },
+    "start": {
+      "dependsOn": ["build"],
+      "cache": false,
+      "persistent": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "dev:starter-studio": "pnpm --filter sanity-starter-studio dev",
     "dev:strict-studio": "pnpm --filter sanity-strict-studio dev",
     "dev:test-studio": "pnpm --filter sanity-test-studio dev",
+    "dev:test-studio-production-profiling": "REACT_PRODUCTION_PROFILING=true turbo run start --filter=sanity-test-studio",
     "dev:next-studio": "pnpm --filter sanity-test-next-studio dev",
     "dev:compiled-studio": "REACT_COMPILER=true pnpm dev:next-studio",
     "dev:turbo-studio": "pnpm dev:next-studio --turbo",


### PR DESCRIPTION
Run `pnpm dev:test-studio-production-profiling` to have a production build of the test studio on http://localhost:3333 that supports the React Profiler devtools :)

It's important to note that this mode does not have Hot Module Reloading, you'll need to restart the process when you make changes for them to apply 🙌 