### PR TITLE
fix(WorkspacesProvider): run `prepareConfig` in a passive effect

### DIFF
--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -1,5 +1,5 @@
 import {ToastProvider} from '@sanity/ui'
-import {type ReactNode} from 'react'
+import {type ReactNode, useMemo} from 'react'
 import Refractor from 'react-refractor'
 import bash from 'refractor/lang/bash.js'
 import javascript from 'refractor/lang/javascript.js'
@@ -62,17 +62,20 @@ export function StudioProvider({
   // mounted React component that is shared across embedded and standalone studios.
   errorReporter.initialize()
 
-  const _children = (
-    <WorkspaceLoader LoadingComponent={LoadingBlock} ConfigErrorsComponent={ConfigErrorsScreen}>
-      <StudioTelemetryProvider config={config}>
-        <LocaleProvider>
-          <PackageVersionStatusProvider>
-            <MaybeEnableErrorReporting errorReporter={errorReporter} />
-            <ResourceCacheProvider>{children}</ResourceCacheProvider>
-          </PackageVersionStatusProvider>
-        </LocaleProvider>
-      </StudioTelemetryProvider>
-    </WorkspaceLoader>
+  const _children = useMemo(
+    () => (
+      <WorkspaceLoader LoadingComponent={LoadingBlock} ConfigErrorsComponent={ConfigErrorsScreen}>
+        <StudioTelemetryProvider config={config}>
+          <LocaleProvider>
+            <PackageVersionStatusProvider>
+              <MaybeEnableErrorReporting errorReporter={errorReporter} />
+              <ResourceCacheProvider>{children}</ResourceCacheProvider>
+            </PackageVersionStatusProvider>
+          </LocaleProvider>
+        </StudioTelemetryProvider>
+      </WorkspaceLoader>
+    ),
+    [children, config],
   )
 
   return (
@@ -80,7 +83,7 @@ export function StudioProvider({
       <ToastProvider paddingY={7} zOffset={Z_OFFSET.toast}>
         <ErrorLogger />
         <StudioErrorBoundary>
-          <WorkspacesProvider config={config} basePath={basePath}>
+          <WorkspacesProvider config={config} basePath={basePath} LoadingComponent={LoadingBlock}>
             <ActiveWorkspaceMatcher
               unstable_history={history}
               NotFoundComponent={NotFoundScreen}

--- a/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
@@ -1,17 +1,33 @@
-import {type ReactNode, useMemo} from 'react'
+import {type ComponentType, type ReactNode, useEffect, useState} from 'react'
 import {WorkspacesContext} from 'sanity/_singletons'
 
 import {type Config, prepareConfig} from '../../config'
+import {type WorkspacesContextValue} from './WorkspacesContext'
 
 /** @internal */
 export interface WorkspacesProviderProps {
   config: Config
   children: ReactNode
   basePath?: string
+  LoadingComponent: ComponentType
 }
 
 /** @internal */
-export function WorkspacesProvider({config, children, basePath}: WorkspacesProviderProps) {
-  const {workspaces} = useMemo(() => prepareConfig(config, {basePath}), [config, basePath])
+export function WorkspacesProvider({
+  config,
+  children,
+  basePath,
+  LoadingComponent,
+}: WorkspacesProviderProps) {
+  const [workspaces, setWorkspaces] = useState<WorkspacesContextValue | null>(null)
+
+  useEffect(() => {
+    setWorkspaces(prepareConfig(config, {basePath}).workspaces)
+  }, [basePath, config])
+
+  if (workspaces === null) {
+    return <LoadingComponent />
+  }
+
   return <WorkspacesContext.Provider value={workspaces}>{children}</WorkspacesContext.Provider>
 }


### PR DESCRIPTION
### Description

Since `WorkspacesLoader` runs `prepareConfig` during render, without using React Suspense features, it winds up blocking render for quite some time on the first render of the Studio:


![image](https://github.com/user-attachments/assets/25e289c7-a548-4b98-a9d5-35317241a5f9)


You can repro this yourself here: https://test-studio-git-add-profiling-script.sanity.build/test/structure
By pressing "Reload and start profiling":
![image](https://github.com/user-attachments/assets/80bbddb1-4890-46b5-8017-3701c2db0ee3)

After scheduling it to run in a passive effect React is able to render the initial loading far more efficiently:

<img width="1636" alt="image" src="https://github.com/user-attachments/assets/94f3f70b-dcc7-40af-9ab4-66968fb7a024">


### What to review

You can load up these profiles yourself in the React Profiler to compare the before and after:

[before.workspaces.provider.fix.json.zip](https://github.com/user-attachments/files/16335990/before.workspaces.provider.fix.json.zip)
[after.workspaces.provider.fix.json.zip](https://github.com/user-attachments/files/16335994/after.workspaces.provider.fix.json.zip)


### Testing

You can test the profiler yourself directly on these deployments:
- [Before](https://test-studio-git-add-profiling-script.sanity.build/test/structure)
- [After](https://test-studio-git-fix-blocking-long-render-in-workspacesprovider.sanity.build/test/structure)

### Notes for release

N/A, it's not worth pointing out that the time from a white-empty-screen to the loading spinner is shorter than before. Especially not when it's less than a second.