### PR TITLE
fix(structure): update PaneItemPreview to reflect when a document is in the current perspective

### DIFF
--- a/packages/sanity/src/core/bundles/util/util.test.ts
+++ b/packages/sanity/src/core/bundles/util/util.test.ts
@@ -1,0 +1,41 @@
+import {describe, expect, it} from '@jest/globals'
+
+import {getDocumentIsInPerspective} from './util'
+
+// * - document: `summer.my-document-id`, perspective: `bundle.summer` : **true**
+// * - document: `my-document-id`, perspective: `bundle.summer` : **false**
+// * - document: `summer.my-document-id`perspective: `bundle.winter` : **false**
+// * - document: `summer.my-document-id`, perspective: `undefined` : **false**
+// * - document: `my-document-id`, perspective: `undefined` : **true**
+// * - document: `drafts.my-document-id`, perspective: `undefined` : **true**
+
+describe('getDocumentIsInPerspective', () => {
+  it('should return true if document is in the current perspective', () => {
+    expect(getDocumentIsInPerspective('summer.my-document-id', 'bundle.summer')).toBe(true)
+  })
+
+  it('should return false if document is not a version  document a perspective is provided', () => {
+    expect(getDocumentIsInPerspective('my-document-id', 'bundle.summer')).toBe(false)
+  })
+
+  it('should return false if document is not in the current perspective', () => {
+    expect(getDocumentIsInPerspective('summer.my-document-id', 'bundle.winter')).toBe(false)
+  })
+
+  it('should return false if document is a version  document a no perspective is provided', () => {
+    expect(getDocumentIsInPerspective('summer.my-document-id', undefined)).toBe(false)
+  })
+
+  it("should return true if the document is in the 'Published' perspective, and no perspective is provided", () => {
+    expect(getDocumentIsInPerspective('my-document-id', undefined)).toBe(true)
+  })
+  it("should return true if the document is a draft document in the 'Published' perspective, and no perspective is provided", () => {
+    expect(getDocumentIsInPerspective('drafts.my-document-id', undefined)).toBe(true)
+  })
+
+  it('should handle complex document ids correctly', () => {
+    expect(
+      getDocumentIsInPerspective('complex-summer.my-document-id', 'bundle.complex-summer'),
+    ).toBe(true)
+  })
+})

--- a/packages/sanity/src/core/bundles/util/util.ts
+++ b/packages/sanity/src/core/bundles/util/util.ts
@@ -2,12 +2,14 @@ import speakingurl from 'speakingurl'
 
 import {type BundleDocument} from '../../store/bundles/types'
 
+const PUBLISHED_SLUG = 'Published'
+
 /**
  * @internal
  * @hidden
  */
 export function getBundleSlug(documentId: string): string {
-  if (documentId.indexOf('.') === -1) return 'Published'
+  if (documentId.indexOf('.') === -1) return PUBLISHED_SLUG
   const version = documentId.slice(0, documentId.indexOf('.'))
   return version
 }
@@ -31,7 +33,7 @@ export function getDocumentIsInPerspective(
 ): boolean {
   const bundleSlug = getBundleSlug(documentId)
 
-  if (!perspective) return bundleSlug === 'Published' || bundleSlug === 'drafts'
+  if (!perspective) return bundleSlug === PUBLISHED_SLUG || bundleSlug === 'drafts'
 
   if (!perspective.startsWith('bundle.')) return false
   // perspective is `bundle.${bundleSlug}`

--- a/packages/sanity/src/core/bundles/util/util.ts
+++ b/packages/sanity/src/core/bundles/util/util.ts
@@ -12,6 +12,34 @@ export function getBundleSlug(documentId: string): string {
   return version
 }
 
+/**
+ * @beta
+ * @param documentId - The document id, e.g. `my-document-id` or `drafts.my-document-id` or `summer.my-document-id`
+ * @param perspective - The current perspective, e.g. `bundle.summer` or undefined, it can be obtained from `useRouter().stickyParams.perspective`
+ * @returns boolean - `true` if the document is in the current perspective.
+ * e.g:
+ * - document: `summer.my-document-id`, perspective: `bundle.summer` : **true**
+ * - document: `my-document-id`, perspective: `bundle.summer` : **false**
+ * - document: `summer.my-document-id`perspective: `bundle.winter` : **false**
+ * - document: `summer.my-document-id`, perspective: `undefined` : **false**
+ * - document: `my-document-id`, perspective: `undefined` : **true**
+ * - document: `drafts.my-document-id`, perspective: `undefined` : **true**
+ */
+export function getDocumentIsInPerspective(
+  documentId: string,
+  perspective: string | undefined,
+): boolean {
+  const bundleSlug = getBundleSlug(documentId)
+
+  if (!perspective) return bundleSlug === 'Published' || bundleSlug === 'drafts'
+
+  if (!perspective.startsWith('bundle.')) return false
+  // perspective is `bundle.${bundleSlug}`
+
+  if (bundleSlug === 'Published') return false
+  return bundleSlug === perspective.replace('bundle.', '')
+}
+
 export function versionDocumentExists(
   documentVersions: BundleDocument[] = [],
   slug: string,

--- a/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
@@ -9,7 +9,6 @@ interface DocumentStatusProps {
   absoluteDate?: boolean
   draft?: PreviewValue | Partial<SanityDocument> | null
   published?: PreviewValue | Partial<SanityDocument> | null
-  version?: PreviewValue | Partial<SanityDocument> | null
   singleLine?: boolean
 }
 
@@ -27,17 +26,9 @@ const StyledText = styled(Text)`
  *
  * @internal
  */
-export function DocumentStatus({
-  absoluteDate,
-  draft,
-  published,
-  version,
-  singleLine,
-}: DocumentStatusProps) {
+export function DocumentStatus({absoluteDate, draft, published, singleLine}: DocumentStatusProps) {
   const {t} = useTranslation()
-  const checkedOutVersion = version ?? draft
-  const draftUpdatedAt =
-    checkedOutVersion && '_updatedAt' in checkedOutVersion ? checkedOutVersion._updatedAt : ''
+  const draftUpdatedAt = draft && '_updatedAt' in draft ? draft._updatedAt : ''
   const publishedUpdatedAt = published && '_updatedAt' in published ? published._updatedAt : ''
 
   const intlDateFormat = useDateTimeFormat({
@@ -69,12 +60,12 @@ export function DocumentStatus({
       gap={2}
       wrap="nowrap"
     >
-      {!version && !publishedDate && (
+      {!publishedDate && (
         <StyledText size={1} weight="medium">
           {t('document-status.not-published')}
         </StyledText>
       )}
-      {!version && publishedDate && (
+      {publishedDate && (
         <StyledText size={1} weight="medium">
           {t('document-status.published', {date: publishedDate})}
         </StyledText>

--- a/packages/sanity/src/core/components/documentStatusIndicator/DocumentStatusIndicator.tsx
+++ b/packages/sanity/src/core/components/documentStatusIndicator/DocumentStatusIndicator.tsx
@@ -7,10 +7,8 @@ import {styled} from 'styled-components'
 interface DocumentStatusProps {
   draft?: PreviewValue | Partial<SanityDocument> | null
   published?: PreviewValue | Partial<SanityDocument> | null
-  version?: PreviewValue | Partial<SanityDocument> | null
 }
 
-// TODO: `version` style is only for debugging.
 const Root = styled(Text)`
   &[data-status='edited'] {
     --card-icon-color: var(--card-badge-caution-dot-color);
@@ -18,9 +16,6 @@ const Root = styled(Text)`
   &[data-status='unpublished'] {
     --card-icon-color: var(--card-badge-default-dot-color);
     opacity: 0.5 !important;
-  }
-  &[data-status='version'] {
-    --card-icon-color: lime;
   }
 `
 
@@ -34,29 +29,25 @@ const Root = styled(Text)`
  *
  * @internal
  */
-export function DocumentStatusIndicator({draft, published, version}: DocumentStatusProps) {
-  const $version = Boolean(version)
+export function DocumentStatusIndicator({draft, published}: DocumentStatusProps) {
   const $draft = Boolean(draft)
   const $published = Boolean(published)
 
   const status = useMemo(() => {
-    if ($version) return 'version'
     if ($draft && !$published) return 'unpublished'
     return 'edited'
-  }, [$draft, $published, $version])
+  }, [$draft, $published])
 
   // Return null if the document is:
-  // - Not a version
   // - Published without edits
   // - Neither published or without edits (this shouldn't be possible)
-  if (!$version && ((!$draft && !$published) || (!$draft && $published))) {
+  if ((!$draft && !$published) || (!$draft && $published)) {
     return null
   }
 
   // TODO: Remove debug `status[0]` output.
   return (
     <Root data-status={status} size={1}>
-      <span>{status[0]}</span>
       <DotIcon />
     </Root>
   )

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -3,6 +3,7 @@ export {
   BundleBadge,
   BundleMenu,
   getBundleSlug,
+  getDocumentIsInPerspective,
   LATEST,
   useDocumentVersions,
   usePerspective,

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/useReleaseHistory.ts
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/useReleaseHistory.ts
@@ -51,7 +51,6 @@ export function useReleaseHistory(bundleDocuments: SanityDocument[]): {
   useEffect(() => {
     fetchAndParseAll()
     // When revision changes, update the history.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchAndParseAll])
 
   return useMemo(() => {

--- a/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
@@ -1,5 +1,5 @@
 import {type SanityDocument, type SchemaType} from '@sanity/types'
-import {Flex, Text} from '@sanity/ui'
+import {Flex} from '@sanity/ui'
 import {isNumber, isString} from 'lodash'
 import {type ComponentType, isValidElement, useMemo} from 'react'
 import {useObservable} from 'react-rx'
@@ -10,13 +10,19 @@ import {
   DocumentStatus,
   DocumentStatusIndicator,
   type GeneralPreviewLayoutKey,
+  getDocumentIsInPerspective,
   getPreviewStateObservable,
   getPreviewValueWithFallback,
   isRecord,
   SanityDefaultPreview,
 } from 'sanity'
+import {styled} from 'styled-components'
 
 import {TooltipDelayGroupProvider} from '../../../ui-components'
+
+const Root = styled.div<{$isInPerspective: boolean}>`
+  opacity: ${(props) => (props.$isInPerspective ? 1 : 0.5)};
+`
 
 export interface PaneItemPreviewProps {
   documentPreviewStore: DocumentPreviewStore
@@ -62,28 +68,24 @@ export function PaneItemPreview(props: PaneItemPreviewProps) {
     published: null,
   })
 
+  const isInPerspective = useMemo(
+    () => getDocumentIsInPerspective(value._id, perspective),
+    [perspective, value._id],
+  )
+
   const status = isLoading ? null : (
     <TooltipDelayGroupProvider>
       <Flex align="center" gap={3}>
         {presence && presence.length > 0 && <DocumentPreviewPresence presence={presence} />}
-        <DocumentStatusIndicator draft={draft} published={published} version={version} />
+        <DocumentStatusIndicator draft={draft} published={published} />
       </Flex>
     </TooltipDelayGroupProvider>
   )
 
-  const tooltip = <DocumentStatus draft={draft} published={published} version={version} />
+  const tooltip = <DocumentStatus draft={draft} published={published} />
 
-  // TODO: Remove debug `_id` output.
   return (
-    <>
-      <Text size={1} muted>
-        {
-          // This is temporary, will be removed.
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          //@ts-expect-error
-          (version ?? draft ?? published)?._id
-        }
-      </Text>
+    <Root $isInPerspective={isInPerspective}>
       <SanityDefaultPreview
         {...getPreviewValueWithFallback({value, draft, published, version, perspective})}
         isPlaceholder={isLoading}
@@ -92,6 +94,6 @@ export function PaneItemPreview(props: PaneItemPreviewProps) {
         status={status}
         tooltip={tooltip}
       />
-    </>
+    </Root>
   )
 }


### PR DESCRIPTION
### Description

It adds to `core` a new function `getDocumentIsInPerspective` which can be used to know when a document belongs to the current perspective.
```
- document: `summer.my-document-id`, perspective: `bundle.summer` : **true**
- document: `my-document-id`, perspective: `bundle.summer` : **false**
- document: `summer.my-document-id`perspective: `bundle.winter` : **false**
- document: `summer.my-document-id`, perspective: `undefined` : **false**
- document: `my-document-id`, perspective: `undefined` : **true**
- document: `drafts.my-document-id`, perspective: `undefined` : **true**
```

It uses that function in `PaneItemPreview` to create a distinction between documents that are part of the release or not.

<img width="367" alt="Screenshot 2024-07-24 at 09 37 17" src="https://github.com/user-attachments/assets/383fc0f8-6ac8-4a53-8fe2-08c6cfc10b7b">
<img width="367" alt="Screenshot 2024-07-24 at 09 37 07" src="https://github.com/user-attachments/assets/b14b7340-8bc9-4013-89fb-d6bb57e914fb">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Tests included for the new function added. 

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
