### PR TITLE
fix(core): update useDocumentVersions to restore breaking tests

### DIFF
--- a/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
@@ -87,9 +87,17 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
       }
 
       if (event.type === 'mutation') {
+        if (event.transition === 'disappear') {
+          const removedDocumentId = getPublishedId(event.documentId)
+          const updatedBundles = state?.filter(
+            (b) => b._id !== removedDocumentId,
+          ) as BundleDocument[]
+          setState(updatedBundles)
+        }
         const prev = event.result
         const exists = state?.find((b) => b.slug === getBundleSlug(prev?._id || ''))
 
+        if (!prev) return
         if (exists) {
           const updatedBundles = state?.map((b: BundleDocument) =>
             exists ? prev : b,
@@ -111,7 +119,6 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
       sub?.unsubscribe()
     }
   }, [handleListenerEvent, listener$, initialFetch])
-
   return {
     data: state,
     error,


### PR DESCRIPTION
### Description

Fixes an issue that is crashing the Form when removing a document and making tests fail. 

The return value of the `useVersionDocument` hook was. `{data: [undefined]}` and this is making the ui crash because it doesn't handle undefined values inside the array of bundles

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
