### PR TITLE
chore(structure): move useDocumentVersions to PaneProvider

### DIFF
--- a/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
+++ b/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
@@ -2,7 +2,7 @@ import {AddIcon, CheckmarkIcon} from '@sanity/icons'
 import {useToast} from '@sanity/ui'
 import {useCallback, useEffect, useState} from 'react'
 import {filter, firstValueFrom} from 'rxjs'
-import {useDocumentOperation, useDocumentStore, useDocumentVersions} from 'sanity'
+import {useDocumentOperation, useDocumentStore} from 'sanity'
 
 import {Button} from '../../../../ui-components'
 import {type BundleDocument} from '../../../store/bundles/types'
@@ -12,15 +12,15 @@ interface BundleActionsProps {
   currentGlobalBundle: BundleDocument
   documentId: string
   documentType: string
+  documentVersions: BundleDocument[] | null
 }
 
 /**
  * @internal
  */
 export function BundleActions(props: BundleActionsProps): JSX.Element {
-  const {currentGlobalBundle, documentId, documentType} = props
+  const {currentGlobalBundle, documentId, documentType, documentVersions} = props
   const {slug, title} = currentGlobalBundle
-  const {data: documentVersions} = useDocumentVersions({documentId})
   const documentStore = useDocumentStore()
 
   const [creatingVersion, setCreatingVersion] = useState<boolean>(false)

--- a/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
@@ -6,6 +6,7 @@ import {
   type ValidationMarker,
 } from '@sanity/types'
 import {
+  type BundleDocument,
   type DocumentActionComponent,
   type DocumentBadgeComponent,
   type DocumentFieldAction,
@@ -38,6 +39,7 @@ export interface DocumentPaneContextValue {
   documentId: string
   documentIdRaw: string
   documentType: string
+  documentVersions: BundleDocument[] | null
   editState: EditStateFor | null
   fieldActions: DocumentFieldAction[]
   focusPath: Path

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -31,6 +31,7 @@ import {
   useDocumentOperation,
   useDocumentStore,
   useDocumentValuePermissions,
+  useDocumentVersions,
   useEditState,
   useFormState,
   useInitialValue,
@@ -149,6 +150,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const editState = useEditState(documentId, documentType, 'default')
   const {validation: validationRaw} = useValidationStatus(documentId, documentType)
   const connectionState = useConnectionState(documentId, documentType)
+  const {data: documentVersions} = useDocumentVersions({documentId})
 
   // When a bundle is checked out and the document being viewed either comes into existence or is
   // removed from the bundle, switch to the version or the default document accordingly.
@@ -690,6 +692,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       documentId,
       documentIdRaw,
       documentType,
+      documentVersions,
       editState,
       fieldActions,
       focusPath,
@@ -751,6 +754,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       documentId,
       documentIdRaw,
       documentType,
+      documentVersions,
       editState,
       fieldActions,
       focusPath,

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveMenu.tsx
@@ -1,9 +1,11 @@
 import {ChevronDownIcon} from '@sanity/icons'
 import {Box, Button} from '@sanity/ui'
 import {useCallback} from 'react'
-import {BundleBadge, BundleMenu, getBundleSlug, useDocumentVersions, usePerspective} from 'sanity'
+import {BundleBadge, BundleMenu, getBundleSlug, usePerspective} from 'sanity'
 import {useRouter} from 'sanity/router'
 import {styled} from 'styled-components'
+
+import {useDocumentPane} from '../../../useDocumentPane'
 
 const BadgeButton = styled(Button)({
   cursor: 'pointer',
@@ -15,7 +17,7 @@ export function DocumentPerspectiveMenu(props: {documentId: string}): JSX.Elemen
 
   const existsInBundle = getBundleSlug(documentId) === currentGlobalBundle?.slug
   const {title, hue, icon, slug} = currentGlobalBundle
-  const {data: documentVersions} = useDocumentVersions({documentId})
+  const {documentVersions} = useDocumentPane()
 
   const router = useRouter()
 

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -31,7 +31,8 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
   props: DocumentStatusBarActionsInnerProps,
 ) {
   const {disabled, showMenu, states} = props
-  const {__internal_tasks, schemaType, openPath, documentId, documentType} = useDocumentPane()
+  const {__internal_tasks, schemaType, openPath, documentId, documentType, documentVersions} =
+    useDocumentPane()
 
   const [firstActionState, ...menuActionStates] = states
   const [buttonElement, setButtonElement] = useState<HTMLButtonElement | null>(null)
@@ -99,6 +100,7 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
                         currentGlobalBundle={currentGlobalBundle}
                         documentId={documentId}
                         documentType={documentType}
+                        documentVersions={documentVersions}
                       />
                     ) : (
                       <div>


### PR DESCRIPTION
### Description

This moves the invocation of `useDocumentVersions` to the PaneProvider, deduplicating it invocation and making it available for any consumer inside the Pane. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
