### PR TITLE
fix(core): fix lint warning in WithAddonDatasetProvider

### DIFF
--- a/packages/sanity/src/core/store/bundles/__workshop__/BundlesStoreStory.tsx
+++ b/packages/sanity/src/core/store/bundles/__workshop__/BundlesStoreStory.tsx
@@ -9,7 +9,7 @@ import {type BundleDocument} from '../types'
 import {useBundleOperations} from '../useBundleOperations'
 import {useBundles} from '../useBundles'
 
-const WithAddonDatasetProvider = <P extends object>(Component: ComponentType<P>): React.FC<P> => {
+const withAddonDatasetProvider = <P extends object>(Component: ComponentType<P>): React.FC<P> => {
   const WrappedComponent: React.FC<P> = (props) => (
     <AddonDatasetProvider>
       <Component {...props} />
@@ -163,4 +163,4 @@ const BundlesStoreStory = () => {
   )
 }
 
-export default WithAddonDatasetProvider(BundlesStoreStory)
+export default withAddonDatasetProvider(BundlesStoreStory)


### PR DESCRIPTION
### Description

HOC WithAddonDatasetProvider is read as a component instead of a HOC because it starts with a capital letter, so react compiler exposes an error because of the name mutation.
Changing the `WithAddonDatasetProvider` to lowercase `withAddonDatasetProvider` fixes the issue


[
<img width="1034" alt="Screenshot 2024-07-24 at 16 00 27" src="https://github.com/user-attachments/assets/7610a497-629d-42b8-8b29-425fe56e4753">
<img width="881" alt="Screenshot 2024-07-24 at 16 00 35" src="https://github.com/user-attachments/assets/c29b66f6-8ea6-4b57-973e-48932b9b0054">
](url)
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
