### PR TITLE
chore(core): refactor useDocumentVersion to use ListenQuery

### DIFF
--- a/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
@@ -1,14 +1,15 @@
-import {type ListenEvent, type ListenOptions} from '@sanity/client'
-import {useCallback, useEffect, useMemo, useState} from 'react'
-import {catchError, of} from 'rxjs'
-import {
-  type BundleDocument,
-  DEFAULT_STUDIO_CLIENT_OPTIONS,
-  getBundleSlug,
-  getPublishedId,
-  useBundles,
-  useClient,
-} from 'sanity'
+import {type SanityDocument} from '@sanity/types'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {type Observable} from 'rxjs'
+import {type BundleDocument} from 'sanity'
+
+import {useClient} from '../../hooks/useClient'
+import {listenQuery} from '../../store/_legacy/document/listenQuery'
+import {useBundles} from '../../store/bundles/useBundles'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
+import {getPublishedId} from '../../util/draftUtils'
+import {getBundleSlug} from '../util/util'
 
 export interface DocumentPerspectiveProps {
   documentId: string
@@ -16,13 +17,6 @@ export interface DocumentPerspectiveProps {
 
 export interface DocumentPerspectiveState {
   data: BundleDocument[] | null
-  error?: Error
-}
-
-const LISTEN_OPTIONS: ListenOptions = {
-  events: ['welcome', 'mutation', 'reconnect'],
-  includeResult: true,
-  visibility: 'query',
 }
 
 /**
@@ -35,92 +29,31 @@ const LISTEN_OPTIONS: ListenOptions = {
 export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPerspectiveState {
   const {documentId} = props
 
-  const [state, setState] = useState<BundleDocument[] | null>(null)
-
-  const [error, setError] = useState<Error | undefined>(undefined)
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const {data: bundles} = useBundles()
   const publishedId = getPublishedId(documentId, documentId.includes('.'))
 
-  const QUERY = `*[sanity::versionOf("${publishedId}")]`
+  const QUERY = `*[sanity::versionOf("${publishedId}")]{_id, _version}`
 
-  const initialFetch = useCallback(async () => {
-    if (!client) {
-      return
-    }
-
-    try {
-      const res = await client.fetch(QUERY)
-
-      // build the document bundles
-      const documentBundles = res
-        ?.map((r: BundleDocument) =>
-          bundles?.find((b) => r._version && getBundleSlug(r._id) === b.slug),
-        )
-        .filter((b: BundleDocument) => b !== undefined)
-
-      setState(documentBundles)
-    } catch (err) {
-      setError(err)
-    }
-  }, [QUERY, bundles, client])
-
-  const listener$ = useMemo(() => {
-    if (!client) return of()
-
-    const events$ = client.observable.listen(QUERY, {}, LISTEN_OPTIONS).pipe(
-      catchError((err) => {
-        setError(err)
-        return of() // return an empty observable on error
-      }),
-    )
-
-    return events$
-  }, [QUERY, client])
-
-  const handleListenerEvent = useCallback(
-    async (event: ListenEvent<Record<string, BundleDocument[]>>) => {
-      if (event.type === 'welcome') {
-        if (!state) {
-          await initialFetch()
-        }
-      }
-
-      if (event.type === 'mutation') {
-        if (event.transition === 'disappear') {
-          const removedDocumentId = getPublishedId(event.documentId)
-          const updatedBundles = state?.filter(
-            (b) => b._id !== removedDocumentId,
-          ) as BundleDocument[]
-          setState(updatedBundles)
-        }
-        const prev = event.result
-        const exists = state?.find((b) => b.slug === getBundleSlug(prev?._id || ''))
-
-        if (!prev) return
-        if (exists) {
-          const updatedBundles = state?.map((b: BundleDocument) =>
-            exists ? prev : b,
-          ) as BundleDocument[]
-          setState(updatedBundles || [])
-        } else {
-          const newBundles = [...(state || []), prev] as BundleDocument[]
-          setState(newBundles)
-        }
-      }
-    },
-    [initialFetch, state],
+  const observable = useMemo(
+    () => listenQuery(client, QUERY) as Observable<Pick<SanityDocument, '_id' | '_version'>[]>,
+    [QUERY, client],
   )
 
-  useEffect(() => {
-    const sub = listener$.subscribe(handleListenerEvent)
+  // This will return the sanity documents that are a version of the published document.
+  const versions = useObservable(observable, null)
 
-    return () => {
-      sub?.unsubscribe()
-    }
-  }, [handleListenerEvent, listener$, initialFetch])
+  const state = useMemo(
+    () =>
+      versions
+        ? (versions
+            .map((r) => bundles?.find((b) => r._version && getBundleSlug(r._id) === b.slug))
+            .filter(Boolean) as BundleDocument[])
+        : null,
+    [versions, bundles],
+  )
+
   return {
     data: state,
-    error,
   }
 }

--- a/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
@@ -43,15 +43,19 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
   // This will return the sanity documents that are a version of the published document.
   const versions = useObservable(observable, null)
 
-  const state = useMemo(
-    () =>
-      versions
-        ? (versions
-            .map((r) => bundles?.find((b) => r._version && getBundleSlug(r._id) === b.slug))
-            .filter(Boolean) as BundleDocument[])
-        : null,
-    [versions, bundles],
-  )
+  const state = useMemo(() => {
+    if (!versions) return null
+
+    const validBundles = versions
+      .map(({_id, _version}) => {
+        if (!_version) return null
+        const bundleSlug = getBundleSlug(_id)
+        return bundles?.find((bundle) => bundle.slug === bundleSlug) || null
+      })
+      .filter(Boolean) as BundleDocument[]
+
+    return validBundles
+  }, [versions, bundles])
 
   return {
     data: state,


### PR DESCRIPTION
### Description
refactor useDocumentVersion to use `ListenQuery` observable. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Existing tests updated and new tests added. 
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
