### PR TITLE
feat(releases): default sorting version documents in release

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check:deps": "pnpm --recursive --parallel exec depcheck",
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
-    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 27 .",
+    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 28 .",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",
     "chore:format:fix": "prettier --cache --write .",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check:deps": "pnpm --recursive --parallel exec depcheck",
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
-    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 28 .",
+    "check:react-compiler": "eslint --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 27 .",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",
     "chore:format:fix": "prettier --cache --write .",

--- a/packages/sanity/src/_singletons/core/releases/ReleasesTableContext.ts
+++ b/packages/sanity/src/_singletons/core/releases/ReleasesTableContext.ts
@@ -10,7 +10,6 @@ export interface TableContextValue {
   setSearchTerm: (searchTerm: string) => void
   sort: TableSort | null
   setSortColumn: (column: string) => void
-  setDefaultSort: (sort: TableSort) => void
 }
 
 const DEFAULT_TABLE_CONTEXT: TableContextValue = {
@@ -18,7 +17,6 @@ const DEFAULT_TABLE_CONTEXT: TableContextValue = {
   setSearchTerm: () => null,
   sort: null,
   setSortColumn: () => null,
-  setDefaultSort: () => null,
 }
 
 /**

--- a/packages/sanity/src/_singletons/core/releases/ReleasesTableContext.ts
+++ b/packages/sanity/src/_singletons/core/releases/ReleasesTableContext.ts
@@ -1,20 +1,24 @@
 import {createContext, useContext} from 'react'
 
+import type {TableSort} from '../../../core/releases/components/Table/TableProvider'
+
 /**
  * @internal
  */
 export interface TableContextValue {
   searchTerm: string | null
   setSearchTerm: (searchTerm: string) => void
-  sort: {column: string; direction: 'asc' | 'desc'} | null
-  setSearchColumn: (column: string) => void
+  sort: TableSort | null
+  setSortColumn: (column: string) => void
+  setDefaultSort: (sort: TableSort) => void
 }
 
 const DEFAULT_TABLE_CONTEXT: TableContextValue = {
   searchTerm: null,
   setSearchTerm: () => null,
   sort: null,
-  setSearchColumn: () => null,
+  setSortColumn: () => null,
+  setDefaultSort: () => null,
 }
 
 /**

--- a/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
+++ b/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
@@ -1,6 +1,6 @@
 import {AddIcon, CheckmarkIcon} from '@sanity/icons'
 import {useToast} from '@sanity/ui'
-import {useCallback, useEffect, useState} from 'react'
+import {type ReactNode, useCallback, useEffect, useState} from 'react'
 import {filter, firstValueFrom} from 'rxjs'
 import {useDocumentOperation, useDocumentStore} from 'sanity'
 
@@ -18,9 +18,9 @@ interface BundleActionsProps {
 /**
  * @internal
  */
-export function BundleActions(props: BundleActionsProps): JSX.Element {
+export function BundleActions(props: BundleActionsProps): ReactNode {
   const {currentGlobalBundle, documentId, documentType, documentVersions} = props
-  const {slug, title} = currentGlobalBundle
+  const {slug, title, archivedAt} = currentGlobalBundle
   const documentStore = useDocumentStore()
 
   const [creatingVersion, setCreatingVersion] = useState<boolean>(false)
@@ -74,6 +74,8 @@ export function BundleActions(props: BundleActionsProps): JSX.Element {
   ])
 
   /** TODO what should happen when you add a version if we don't have the ready button */
+
+  if (archivedAt) return null
 
   return (
     <Button

--- a/packages/sanity/src/core/releases/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/components/Table/Table.tsx
@@ -1,13 +1,13 @@
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
 import {get} from 'lodash'
-import {Fragment, useMemo} from 'react'
+import {Fragment, useEffect, useMemo} from 'react'
 import {useTableContext} from 'sanity/_singletons'
 import {styled} from 'styled-components'
 
 import {TooltipDelayGroupProvider} from '../../../../ui-components'
 import {LoadingBlock} from '../../../components'
 import {TableHeader} from './TableHeader'
-import {TableProvider} from './TableProvider'
+import {TableProvider, type TableSort} from './TableProvider'
 import {type Column} from './types'
 
 type RowDatum<TableData, AdditionalRowTableData> = AdditionalRowTableData extends undefined
@@ -17,6 +17,7 @@ type RowDatum<TableData, AdditionalRowTableData> = AdditionalRowTableData extend
 export interface TableProps<TableData, AdditionalRowTableData> {
   columnDefs: Column<RowDatum<TableData, AdditionalRowTableData>>[]
   searchFilter?: (data: TableData[], searchTerm: string) => TableData[]
+  defaultSort?: TableSort
   Row?: ({
     datum,
     children,
@@ -50,6 +51,7 @@ const RowStack = styled(Stack)({
 
 const TableInner = <TableData, AdditionalRowTableData>({
   columnDefs,
+  defaultSort,
   data,
   emptyState,
   searchFilter,
@@ -58,7 +60,14 @@ const TableInner = <TableData, AdditionalRowTableData>({
   rowActions,
   loading = false,
 }: TableProps<TableData, AdditionalRowTableData>) => {
-  const {searchTerm, sort} = useTableContext()
+  const {searchTerm, sort, setDefaultSort} = useTableContext()
+
+  const {column: defaultSortColumn, direction: defaultSortDirection} = defaultSort || {}
+  useEffect(() => {
+    if (defaultSortColumn) {
+      setDefaultSort({column: defaultSortColumn, direction: defaultSortDirection || 'asc'})
+    }
+  }, [defaultSortColumn, defaultSortDirection, setDefaultSort])
 
   const filteredData = useMemo(() => {
     const filteredResult = searchTerm && searchFilter ? searchFilter(data, searchTerm) : data

--- a/packages/sanity/src/core/releases/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/components/Table/Table.tsx
@@ -1,6 +1,6 @@
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
 import {get} from 'lodash'
-import {Fragment, useEffect, useMemo} from 'react'
+import {Fragment, useMemo} from 'react'
 import {useTableContext} from 'sanity/_singletons'
 import {styled} from 'styled-components'
 
@@ -17,7 +17,6 @@ type RowDatum<TableData, AdditionalRowTableData> = AdditionalRowTableData extend
 export interface TableProps<TableData, AdditionalRowTableData> {
   columnDefs: Column<RowDatum<TableData, AdditionalRowTableData>>[]
   searchFilter?: (data: TableData[], searchTerm: string) => TableData[]
-  defaultSort?: TableSort
   Row?: ({
     datum,
     children,
@@ -51,7 +50,6 @@ const RowStack = styled(Stack)({
 
 const TableInner = <TableData, AdditionalRowTableData>({
   columnDefs,
-  defaultSort,
   data,
   emptyState,
   searchFilter,
@@ -60,14 +58,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
   rowActions,
   loading = false,
 }: TableProps<TableData, AdditionalRowTableData>) => {
-  const {searchTerm, sort, setDefaultSort} = useTableContext()
-
-  const {column: defaultSortColumn, direction: defaultSortDirection} = defaultSort || {}
-  useEffect(() => {
-    if (defaultSortColumn) {
-      setDefaultSort({column: defaultSortColumn, direction: defaultSortDirection || 'asc'})
-    }
-  }, [defaultSortColumn, defaultSortDirection, setDefaultSort])
+  const {searchTerm, sort} = useTableContext()
 
   const filteredData = useMemo(() => {
     const filteredResult = searchTerm && searchFilter ? searchFilter(data, searchTerm) : data
@@ -199,12 +190,13 @@ const TableInner = <TableData, AdditionalRowTableData>({
   )
 }
 
-export const Table = <TableData, AdditionalRowTableData = undefined>(
-  props: TableProps<TableData, AdditionalRowTableData>,
-) => {
+export const Table = <TableData, AdditionalRowTableData = undefined>({
+  defaultSort,
+  ...props
+}: TableProps<TableData, AdditionalRowTableData> & {defaultSort?: TableSort}) => {
   return (
     <TooltipDelayGroupProvider>
-      <TableProvider>
+      <TableProvider defaultSort={defaultSort}>
         <TableInner<TableData, AdditionalRowTableData> {...props} />
       </TableProvider>
     </TooltipDelayGroupProvider>

--- a/packages/sanity/src/core/releases/components/Table/TableHeader.tsx
+++ b/packages/sanity/src/core/releases/components/Table/TableHeader.tsx
@@ -5,13 +5,13 @@ import {useTableContext} from 'sanity/_singletons'
 import {type HeaderProps, type TableHeaderProps} from './types'
 
 const SortHeaderButton = ({header, text}: ButtonProps & HeaderProps) => {
-  const {sort, setSearchColumn} = useTableContext()
+  const {sort, setSortColumn} = useTableContext()
   const sortIcon = sort?.direction === 'asc' ? ArrowUpIcon : ArrowDownIcon
 
   return (
     <Button
       iconRight={header.sorting && sort?.column === header.id ? sortIcon : undefined}
-      onClick={() => setSearchColumn(String(header.id))}
+      onClick={() => setSortColumn(String(header.id))}
       mode="bleed"
       padding={2}
       radius={3}

--- a/packages/sanity/src/core/releases/components/Table/TableProvider.tsx
+++ b/packages/sanity/src/core/releases/components/Table/TableProvider.tsx
@@ -9,9 +9,12 @@ export interface TableSort {
 /**
  * @internal
  */
-export const TableProvider: ComponentType<PropsWithChildren> = ({children}) => {
+export const TableProvider: ComponentType<PropsWithChildren & {defaultSort?: TableSort}> = ({
+  children,
+  defaultSort,
+}) => {
   const [searchTerm, setSearchTerm] = useState<string | null>(null)
-  const [sort, setSort] = useState<TableSort | null>(null)
+  const [sort, setSort] = useState<TableSort | null>(defaultSort || null)
 
   const setSortColumn = useCallback((newColumn: string) => {
     setSort((s) => {
@@ -23,9 +26,7 @@ export const TableProvider: ComponentType<PropsWithChildren> = ({children}) => {
     })
   }, [])
 
-  const setDefaultSort = useCallback((defaultSort: TableSort) => setSort(defaultSort), [])
-
-  const contextValue = {searchTerm, setSearchTerm, sort, setSortColumn, setDefaultSort}
+  const contextValue = {searchTerm, setSearchTerm, sort, setSortColumn}
 
   return <TableContext.Provider value={contextValue}>{children}</TableContext.Provider>
 }

--- a/packages/sanity/src/core/releases/components/Table/TableProvider.tsx
+++ b/packages/sanity/src/core/releases/components/Table/TableProvider.tsx
@@ -1,14 +1,19 @@
-import {type ComponentType, type PropsWithChildren, useState} from 'react'
+import {type ComponentType, type PropsWithChildren, useCallback, useState} from 'react'
 import {TableContext} from 'sanity/_singletons'
+
+export interface TableSort {
+  column: string
+  direction: 'asc' | 'desc'
+}
 
 /**
  * @internal
  */
 export const TableProvider: ComponentType<PropsWithChildren> = ({children}) => {
   const [searchTerm, setSearchTerm] = useState<string | null>(null)
-  const [sort, setSort] = useState<{column: string; direction: 'asc' | 'desc'} | null>(null)
+  const [sort, setSort] = useState<TableSort | null>(null)
 
-  const setSearchColumn = (newColumn: string) => {
+  const setSortColumn = useCallback((newColumn: string) => {
     setSort((s) => {
       if (s?.column === newColumn) {
         return {...s, direction: s.direction === 'asc' ? 'desc' : 'asc'}
@@ -16,9 +21,11 @@ export const TableProvider: ComponentType<PropsWithChildren> = ({children}) => {
 
       return {column: String(newColumn), direction: 'desc'}
     })
-  }
+  }, [])
 
-  const contextValue = {searchTerm, setSearchTerm, sort, setSearchColumn}
+  const setDefaultSort = useCallback((defaultSort: TableSort) => setSort(defaultSort), [])
+
+  const contextValue = {searchTerm, setSearchTerm, sort, setSortColumn, setDefaultSort}
 
   return <TableContext.Provider value={contextValue}>{children}</TableContext.Provider>
 }

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -177,6 +177,7 @@ export function ReleasesOverview() {
             <Table<TableBundle>
               // for resetting filter and sort on table when mode changed
               key={bundleGroupMode}
+              defaultSort={{column: '_createdAt', direction: 'desc'}}
               loading={loading}
               data={groupedBundles[bundleGroupMode]}
               columnDefs={releasesOverviewColumnDefs}

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -8,6 +8,7 @@ import {BundleDetailsDialog} from '../../../bundles/components/dialog/BundleDeta
 import {type BundleDocument, useBundles} from '../../../store'
 import {BundleMenuButton} from '../../components/BundleMenuButton/BundleMenuButton'
 import {Table} from '../../components/Table/Table'
+import {type TableSort} from '../../components/Table/TableProvider'
 import {containsBundles} from '../../types/bundle'
 import {type BundlesMetadata, useBundlesMetadata} from '../useBundlesMetadata'
 import {releasesOverviewColumnDefs} from './ReleasesOverviewColumnDefs'
@@ -19,6 +20,7 @@ export interface TableBundle extends BundleDocument {
 }
 
 const EMPTY_BUNDLE_GROUPS = {open: [], archived: []}
+const DEFAULT_RELEASES_OVERVIEW_SORT: TableSort = {column: '_createdAt', direction: 'asc'}
 
 export function ReleasesOverview() {
   const {data: bundles, loading: loadingBundles} = useBundles()
@@ -177,7 +179,7 @@ export function ReleasesOverview() {
             <Table<TableBundle>
               // for resetting filter and sort on table when mode changed
               key={bundleGroupMode}
-              defaultSort={{column: '_createdAt', direction: 'desc'}}
+              defaultSort={DEFAULT_RELEASES_OVERVIEW_SORT}
               loading={loading}
               data={groupedBundles[bundleGroupMode]}
               columnDefs={releasesOverviewColumnDefs}

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -174,20 +174,21 @@ describe('ReleasesOverview', () => {
       // 2 open releases
       expect(bundleRows).toHaveLength(2)
 
-      const openBundles = [...bundles].slice(0, 2)
+      // reverse to match default sort order by _createdAt desc
+      const openBundles = [...bundles].slice(0, 2).reverse()
       openBundles.forEach((bundle, index) => {
         // bundle title
         within(bundleRows[index]).getByText(bundle.title)
         // document count
         within(bundleRows[index]).getByText('1')
         if (index === 0) {
-          // updated at & created at
-          expect(within(bundleRows[index]).getAllByText('yesterday')).toHaveLength(2)
-        } else if (index === 1) {
           // updated at
           within(bundleRows[index]).getByText('2 days ago')
           // created at
           within(bundleRows[index]).getByText('just now')
+        } else if (index === 1) {
+          // updated at & created at
+          expect(within(bundleRows[index]).getAllByText('yesterday')).toHaveLength(2)
         }
       })
     })
@@ -227,15 +228,15 @@ describe('ReleasesOverview', () => {
 
     it('sorts the list of releases', () => {
       const [unsortedFirstBundle, unsortedSecondBundle] = screen.getAllByTestId('table-row')
-      within(unsortedFirstBundle).getByText('Bundle 1')
-      within(unsortedSecondBundle).getByText('Bundle 2')
+      within(unsortedFirstBundle).getByText('Bundle 2')
+      within(unsortedSecondBundle).getByText('Bundle 1')
 
       // sort by asc created at
       fireEvent.click(screen.getByText('Created'))
       const [ascCreatedSortedFirstBundle, ascCreatedSortedSecondBundle] =
         screen.getAllByTestId('table-row')
-      within(ascCreatedSortedFirstBundle).getByText('Bundle 2')
-      within(ascCreatedSortedSecondBundle).getByText('Bundle 1')
+      within(ascCreatedSortedFirstBundle).getByText('Bundle 1')
+      within(ascCreatedSortedSecondBundle).getByText('Bundle 2')
 
       // searching retains sort order
       fireEvent.change(screen.getByPlaceholderText('Search releases'), {
@@ -243,15 +244,15 @@ describe('ReleasesOverview', () => {
       })
       const [ascCreatedSortedFirstBundleAfterSearch, ascCreatedSortedSecondBundleAfterSearch] =
         screen.getAllByTestId('table-row')
-      within(ascCreatedSortedFirstBundleAfterSearch).getByText('Bundle 2')
-      within(ascCreatedSortedSecondBundleAfterSearch).getByText('Bundle 1')
+      within(ascCreatedSortedFirstBundleAfterSearch).getByText('Bundle 1')
+      within(ascCreatedSortedSecondBundleAfterSearch).getByText('Bundle 2')
 
       // sort by desc created at
       fireEvent.click(screen.getByText('Created'))
       const [descCreatedSortedFirstBundle, descCreatedSortedSecondBundle] =
         screen.getAllByTestId('table-row')
-      within(descCreatedSortedFirstBundle).getByText('Bundle 1')
-      within(descCreatedSortedSecondBundle).getByText('Bundle 2')
+      within(descCreatedSortedFirstBundle).getByText('Bundle 2')
+      within(descCreatedSortedSecondBundle).getByText('Bundle 1')
 
       // sort by asc updated at
       fireEvent.click(screen.getByText('Edited'))
@@ -262,7 +263,7 @@ describe('ReleasesOverview', () => {
     })
 
     it('should navigate to release when row clicked', async () => {
-      const bundleRow = screen.getAllByTestId('table-row')[0]
+      const bundleRow = screen.getAllByTestId('table-row')[1]
       fireEvent.click(within(bundleRow).getByText('Bundle 1'))
 
       expect(useRouter().navigate).toHaveBeenCalledWith({bundleSlug: 'bundle-1'})

--- a/packages/sanity/src/core/store/bundles/reducer.ts
+++ b/packages/sanity/src/core/store/bundles/reducer.ts
@@ -1,10 +1,5 @@
 import {type BundleDocument} from './types'
 
-interface BundleAddedAction {
-  payload: BundleDocument
-  type: 'BUNDLE_ADDED'
-}
-
 interface BundleDeletedAction {
   id: string
   type: 'BUNDLE_DELETED'
@@ -34,7 +29,6 @@ interface LoadingStateChangedAction {
 }
 
 export type bundlesReducerAction =
-  | BundleAddedAction
   | BundleDeletedAction
   | BundleUpdatedAction
   | BundlesSetAction
@@ -74,17 +68,6 @@ export function bundlesReducer(
       return {
         ...state,
         bundles: bundlesById,
-      }
-    }
-
-    case 'BUNDLE_ADDED': {
-      const addedBundle = action.payload as BundleDocument
-      const currentBundles = new Map(state.bundles)
-      currentBundles.set(addedBundle._id, addedBundle)
-
-      return {
-        ...state,
-        bundles: currentBundles,
       }
     }
 


### PR DESCRIPTION
### Description
This PR sorts the list of documents in a bundle by default to show most recent first. This way, when new releases are created they immediately appear at the top of the list, rather than being added at the bottom
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* possible to now set a default sort col and direction on the `Table`
* Updated a mis-named setter
* Updated the `ReleaseSummary` tests
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
