### PR TITLE
test: adds jest config for CLI tests within the `sanity` module

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,15 +1,11 @@
 /* eslint-disable tsdoc/syntax */
-'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const globby = require('globby')
-const yaml = require('js-yaml')
-const fs = require('node:fs')
 
-const workspaces = yaml.load(fs.readFileSync('./pnpm-workspace.yaml', 'utf8'))
-const jestConfigFiles = globby.sync(
-  workspaces.packages.map((workspace) => path.join(__dirname, workspace, '/jest.config.cjs')),
-)
+const jestConfigFiles = globby.sync('**/*/jest.config.cjs', {
+  ignore: ['**/node_modules'],
+})
 
 const IGNORE_PROJECTS = []
 

--- a/packages/sanity/jest.config.cjs
+++ b/packages/sanity/jest.config.cjs
@@ -1,11 +1,19 @@
-'use strict'
-
+const path = require('node:path')
 const {createJestConfig} = require('../../test/config.cjs')
+
+const cliPath = path.resolve(__dirname, './src/_internal/cli')
 
 module.exports = createJestConfig({
   displayName: require('./package.json').name,
   globalSetup: '<rootDir>/test/setup/global.ts',
   setupFiles: ['<rootDir>/test/setup/environment.ts'],
   setupFilesAfterEnv: ['<rootDir>/test/setup/afterEnv.ts'],
-  modulePathIgnorePatterns: ['<rootDir>/playwright-ct'],
+  modulePathIgnorePatterns: [
+    '<rootDir>/playwright-ct',
+    cliPath, // the CLI has its own jest config
+  ],
+  projects: [
+    __dirname, // self
+    cliPath, // cli
+  ],
 })

--- a/packages/sanity/src/_internal/cli/actions/schema/__tests__/formatSchemaValidation.test.ts
+++ b/packages/sanity/src/_internal/cli/actions/schema/__tests__/formatSchemaValidation.test.ts
@@ -4,7 +4,7 @@ import {type SchemaValidationProblemGroup} from '@sanity/types'
 import {formatSchemaValidation} from '../formatSchemaValidation'
 
 // disables some terminal specific things that are typically auto detected
-jest.mock('tty', () => ({isatty: () => false}))
+jest.mock('node:tty', () => ({isatty: () => false}))
 
 describe('formatSchemaValidation', () => {
   it('formats incoming validation results', () => {

--- a/packages/sanity/src/_internal/cli/jest.config.cjs
+++ b/packages/sanity/src/_internal/cli/jest.config.cjs
@@ -1,0 +1,7 @@
+const {createJestConfig} = require('../../../../../test/config.cjs')
+const path = require('node:path')
+
+module.exports = createJestConfig({
+  displayName: `${require('../../../package.json').name}/${path.basename(__dirname)}`,
+  testEnvironment: 'node',
+})

--- a/packages/sanity/tsconfig.json
+++ b/packages/sanity/tsconfig.json
@@ -20,7 +20,7 @@
     "./node_modules/@sanity/util/src",
     "./node_modules/groq/src"
   ],
-  "exclude": ["./node_modules/@sanity/codegen/src/typescript/__tests__"],
+  "exclude": ["./node_modules/@sanity/codegen/src/typescript/__tests__", "**/jest.config.cjs"],
   "compilerOptions": {
     "paths": {
       "@sanity/block-tools": ["./node_modules/@sanity/block-tools/src/index.ts"],

--- a/packages/sanity/tsconfig.lib.json
+++ b/packages/sanity/tsconfig.lib.json
@@ -6,6 +6,7 @@
     "./src/**/__mocks__",
     "./src/**/__workshop__",
     "./src/**/*.test.ts",
-    "./src/**/*.test.tsx"
+    "./src/**/*.test.tsx",
+    "**/jest.config.cjs"
   ]
 }

--- a/packages/sanity/tsconfig.tsdoc.json
+++ b/packages/sanity/tsconfig.tsdoc.json
@@ -6,7 +6,8 @@
     "./src/**/__mocks__",
     "./src/**/__workshop__",
     "./src/**/*.test.ts",
-    "./src/**/*.test.tsx"
+    "./src/**/*.test.tsx",
+    "**/jest.config.cjs"
   ],
   "compilerOptions": {
     // Needed until `@microsoft/api-extractor`, as used by `@sanity/tsdoc`, supports `module: "Preserve"`

--- a/test/config.cjs
+++ b/test/config.cjs
@@ -1,8 +1,6 @@
-'use strict'
-
 /* eslint-disable tsdoc/syntax */
 
-const path = require('path')
+const path = require('node:path')
 const {escapeRegExp, omit} = require('lodash')
 const devAliases = require('../dev/aliases.cjs')
 
@@ -20,12 +18,12 @@ const defaultModuleNameMapper = resolveAliasPaths({
 })
 
 /**
- * @returns {import('@jest/types').Config.InitialOptions}
+ * Creates a Jest configuration object.
+ *
+ * @param {import('jest').Config} config - Initial Jest configuration options.
+ * @returns {import('jest').Config} The resulting Jest configuration options.
  */
-exports.createJestConfig = function createJestConfig(
-  /** @type {import('@jest/types').Config.InitialOptions */
-  config = {},
-) {
+exports.createJestConfig = function createJestConfig(config = {}) {
   const {
     testMatch = [],
     setupFiles = [],


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR introduces updates to the Jest configuration to align the environment settings with the CLI environment, which is a Node.js environment, instead of the previous browser-like environment. The key changes include:

- Updating the Jest configuration files to use `node:path` instead of `path`.
- Refactoring the way Jest config files are globbed to find all `jest.config.cjs` files instead of just the ones in workspaces.
- Adding new Jest configuration for the CLI within the `sanity` package.
- Adjusting TypeScript configuration files to exclude `jest.config.cjs` files from certain processes for the build

These changes are necessary to ensure that tests are running in the correct environment, reflecting the actual usage scenario of the new CLI. This is a prerequisite for another PR that introduces new CLI tests.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Reviewers should:
- Verify the changes in the Jest configuration to ensure they correctly set up the Node.js environment for CLI tests.
- Check the adjustments in the TypeScript configuration files to ensure they properly exclude the `jest.config.cjs` files where necessary.
- Ensure that all paths and configurations are correctly updated and there are no regressions in the existing tests.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
These changes primarily involve configuration updates, so no new tests were added. The existing tests should cover the impacted areas. Testing involved:
- Running the full test suite to ensure all tests pass in the updated Node.js environment.
- Manually verifying that the Jest configurations are correctly applied and tests are executed as expected.
- Ensuring the build still works.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

None. No changes to the user-facing functionality are included. This PR updates the Jest configuration to match the new Node.js environment for CLI testing.