### PR TITLE
fixup! feat(preview): add `unstable_observeDocument(s)` to preview store (#7176)

### DIFF
--- a/packages/sanity/src/core/preview/documentPreviewStore.ts
+++ b/packages/sanity/src/core/preview/documentPreviewStore.ts
@@ -107,7 +107,7 @@ export function createDocumentPreviewStore({
   function getObserveFields() {
     if (PREVIEW_FETCH_FULL_DOCUMENTS) {
       return function observeFields(id: string, fields: string[], apiConfig?: ApiConfig) {
-        return observeDocument(id, apiConfig).pipe(map((doc) => pick(doc, fields)))
+        return observeDocument(id, apiConfig).pipe(map((doc) => (doc ? pick(doc, fields) : null)))
       }
     }
     return createObserveFields({client: versionedClient, invalidationChannel})


### PR DESCRIPTION
Note: I've left fixup! in the commit/PR title so it can be squashed with the earlier commit at next rebase of this branch

Note2: also snuck in a [tiny fix](https://github.com/sanity-io/sanity/pull/7246/commits/333ee5861dbf8ffcddd273e484f0d003cd3e3c1a) that caused previews always to show "Undefined" when there was only a published version

### Description

#7176 introduced a regression in that the `welcome`-event would not be emitted to new subscribers of the preview listener, causing previews to show the loading skeleton infinitely. This PR refactors the preview listener event stream so that:

- The `welcome` is emitted immediately to new subscribers. This is typically when downstream subscribers will do the initial fetch
- In case of a connection loss (e.g. the last connection event was `reconnecting`, the `welcome` event will not be emitted to new subscribers.
- When the connetion is reestablished, all subscribers will receive the welcome event again

Note: This change also passes through `reconnect` events coming in via `client.listen()`. This is the event emitted when the connection is lost (we do [filter it out later on](https://github.com/sanity-io/sanity/compare/corel...corel-fix-preview-loading-issue?expand=1#diff-acbbc80a279373f54730a2c7212c35bbab783d127e201ebbb027b5c8f4817009R95), but I suspect we might find a use for to signal connection loss in the future) 

### What to review
- Does the logic seem right?
- Is it easier to follow the flow in here than it used to be?

### Testing
- Previews should load consistently when navigating around in the studio
- In case of connection loss (try e.g. to disconnect wifi and turn it back on), the listeners should reconnect (there might be some error screens appearing in the studio that makes this hard to test)


### Notes for release
n/a - fixes an earlier regression in this branch