### PR TITLE
feat(preview): add support for live document id sets

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -251,6 +251,7 @@
     "rimraf": "^3.0.2",
     "rxjs": "^7.8.0",
     "rxjs-exhaustmap-with-trailing": "^2.1.1",
+    "rxjs-mergemap-array": "^0.1.0",
     "sanity-diff-patch": "^3.0.2",
     "scroll-into-view-if-needed": "^3.0.3",
     "semver": "^7.3.5",

--- a/packages/sanity/src/core/preview/createObserveDocument.ts
+++ b/packages/sanity/src/core/preview/createObserveDocument.ts
@@ -82,5 +82,6 @@ function applyMutationEvent(current: SanityDocument | undefined, event: Mutation
     )
   }
   const next = applyMendozaPatch(current, event.effects.apply)
-  return {...next, _rev: event.resultRev}
+  // next will be undefined in case of deletion
+  return next ? {...next, _rev: event.resultRev} : undefined
 }

--- a/packages/sanity/src/core/preview/documentPreviewStore.ts
+++ b/packages/sanity/src/core/preview/documentPreviewStore.ts
@@ -1,4 +1,9 @@
-import {type MutationEvent, type SanityClient, type WelcomeEvent} from '@sanity/client'
+import {
+  type MutationEvent,
+  type QueryParams,
+  type SanityClient,
+  type WelcomeEvent,
+} from '@sanity/client'
 import {type PrepareViewOptions, type SanityDocument} from '@sanity/types'
 import {pick} from 'lodash'
 import {combineLatest, type Observable} from 'rxjs'
@@ -11,6 +16,7 @@ import {createObserveDocument} from './createObserveDocument'
 import {createPathObserver} from './createPathObserver'
 import {createPreviewObserver} from './createPreviewObserver'
 import {create_preview_documentPair} from './documentPair'
+import {createDocumentIdSetObserver, type DocumentIdSetObserverState} from './liveDocumentIdSet'
 import {createObserveFields} from './observeFields'
 import {
   type ApiConfig,
@@ -58,6 +64,31 @@ export interface DocumentPreviewStore {
     id: string,
     paths: PreviewPath[],
   ) => Observable<DraftsModelDocument<T>>
+
+  /**
+   * Observes a set of document IDs that matches the given groq-filter. The document ids are returned in ascending order and will update in real-time
+   * Whenever a document appears or disappears from the set, a new array with the updated set of IDs will be pushed to subscribers.
+   * The query is performed once, initially, and thereafter the set of ids are patched based on the `appear` and `disappear`
+   * transitions on the received listener events.
+   * This provides a lightweight way of subscribing to a list of ids for simple cases where you just want to subscribe to a set of documents ids
+   * that matches a particular filter.
+   * @hidden
+   * @beta
+   * @param filter - A groq filter to use for the document set
+   * @param params - Parameters to use with the groq filter
+   * @param options - Options for the observer
+   * @param options - Options for the observer
+   */
+  unstable_observeDocumentIdSet: (
+    filter: string,
+    params?: QueryParams,
+    options?: {
+      /**
+       * Where to insert new items into the set. Defaults to 'sorted' which is based on the lexicographic order of the id
+       */
+      insert?: 'sorted' | 'prepend' | 'append'
+    },
+  ) => Observable<DocumentIdSetObserverState>
 
   /**
    * Observe a complete document with the given ID
@@ -127,6 +158,10 @@ export function createDocumentPreviewStore({
     )
   }
 
+  const observeDocumentIdSet = createDocumentIdSetObserver(
+    versionedClient.withConfig({apiVersion: '2024-07-22'}),
+  )
+
   const observeForPreview = createPreviewObserver({observeDocumentTypeFromId, observePaths})
   const {observeDocumentPairAvailability} = createPreviewAvailabilityObserver(
     versionedClient,
@@ -141,6 +176,7 @@ export function createDocumentPreviewStore({
     observeForPreview,
     observeDocumentTypeFromId,
 
+    unstable_observeDocumentIdSet: observeDocumentIdSet,
     unstable_observeDocument: observeDocument,
     unstable_observeDocuments: (ids: string[]) =>
       combineLatest(ids.map((id) => observeDocument(id))),

--- a/packages/sanity/src/core/preview/documentPreviewStore.ts
+++ b/packages/sanity/src/core/preview/documentPreviewStore.ts
@@ -77,7 +77,6 @@ export interface DocumentPreviewStore {
    * @param filter - A groq filter to use for the document set
    * @param params - Parameters to use with the groq filter
    * @param options - Options for the observer
-   * @param options - Options for the observer
    */
   unstable_observeDocumentIdSet: (
     filter: string,

--- a/packages/sanity/src/core/preview/liveDocumentIdSet.ts
+++ b/packages/sanity/src/core/preview/liveDocumentIdSet.ts
@@ -23,7 +23,7 @@ export function createDocumentIdSetObserver(client: SanityClient) {
     const query = `*[${queryFilter}]._id`
     function fetchFilter() {
       return client.observable
-        .fetch(`*[${queryFilter}]._id`, params, {
+        .fetch(query, params, {
           tag: 'preview.observe-document-set.fetch',
         })
         .pipe(

--- a/packages/sanity/src/core/preview/liveDocumentIdSet.ts
+++ b/packages/sanity/src/core/preview/liveDocumentIdSet.ts
@@ -1,0 +1,112 @@
+import {type QueryParams, type SanityClient} from '@sanity/client'
+import {sortedIndex} from 'lodash'
+import {of} from 'rxjs'
+import {distinctUntilChanged, filter, map, mergeMap, scan, tap} from 'rxjs/operators'
+
+export type DocumentIdSetObserverState = {
+  status: 'reconnecting' | 'connected'
+  documentIds: string[]
+}
+
+interface LiveDocumentIdSetOptions {
+  insert?: 'sorted' | 'prepend' | 'append'
+}
+
+export function createDocumentIdSetObserver(client: SanityClient) {
+  return function observe(
+    queryFilter: string,
+    params?: QueryParams,
+    options: LiveDocumentIdSetOptions = {},
+  ) {
+    const {insert: insertOption = 'sorted'} = options
+
+    const query = `*[${queryFilter}]._id`
+    function fetchFilter() {
+      return client.observable
+        .fetch(`*[${queryFilter}]._id`, params, {
+          tag: 'preview.observe-document-set.fetch',
+        })
+        .pipe(
+          tap((result) => {
+            if (!Array.isArray(result)) {
+              throw new Error(
+                `Expected query to return array of documents, but got ${typeof result}`,
+              )
+            }
+          }),
+        )
+    }
+    return client.observable
+      .listen(query, params, {
+        visibility: 'transaction',
+        events: ['welcome', 'mutation', 'reconnect'],
+        includeResult: false,
+        includeMutations: false,
+        tag: 'preview.observe-document-set.listen',
+      })
+      .pipe(
+        mergeMap((event) => {
+          return event.type === 'welcome'
+            ? fetchFilter().pipe(map((result) => ({type: 'fetch' as const, result})))
+            : of(event)
+        }),
+        scan(
+          (
+            state: DocumentIdSetObserverState | undefined,
+            event,
+          ): DocumentIdSetObserverState | undefined => {
+            if (event.type === 'reconnect') {
+              return {
+                documentIds: state?.documentIds || [],
+                ...state,
+                status: 'reconnecting' as const,
+              }
+            }
+            if (event.type === 'fetch') {
+              return {...state, status: 'connected' as const, documentIds: event.result}
+            }
+            if (event.type === 'mutation') {
+              if (event.transition === 'update') {
+                // ignore updates, as we're only interested in documents appearing and disappearing from the set
+                return state
+              }
+              if (event.transition === 'appear') {
+                return {
+                  status: 'connected',
+                  documentIds: insert(state?.documentIds || [], event.documentId, insertOption),
+                }
+              }
+              if (event.transition === 'disappear') {
+                return {
+                  status: 'connected',
+                  documentIds: state?.documentIds
+                    ? state.documentIds.filter((id) => id !== event.documentId)
+                    : [],
+                }
+              }
+            }
+            return state
+          },
+          undefined,
+        ),
+        distinctUntilChanged(),
+        filter(
+          (state: DocumentIdSetObserverState | undefined): state is DocumentIdSetObserverState =>
+            state !== undefined,
+        ),
+      )
+  }
+}
+
+function insert<T>(array: T[], element: T, strategy: 'sorted' | 'prepend' | 'append') {
+  let index
+  if (strategy === 'prepend') {
+    index = 0
+  } else if (strategy === 'append') {
+    index = array.length
+  } else {
+    index = sortedIndex(array, element)
+  }
+
+  return array.toSpliced(index, 0, element)
+}

--- a/packages/sanity/src/core/preview/useLiveDocumentIdSet.ts
+++ b/packages/sanity/src/core/preview/useLiveDocumentIdSet.ts
@@ -1,0 +1,45 @@
+import {type QueryParams} from '@sanity/client'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {scan} from 'rxjs/operators'
+
+import {useDocumentPreviewStore} from '../store/_legacy/datastores'
+import {type DocumentIdSetObserverState} from './liveDocumentIdSet'
+
+const INITIAL_STATE = {status: 'loading' as const, documentIds: []}
+
+export type LiveDocumentSetState =
+  | {status: 'loading'; documentIds: string[]}
+  | DocumentIdSetObserverState
+
+/**
+ * @internal
+ * @beta
+ *
+ * Observes a document by its ID and returns the document and loading state
+ * it will listen to the document changes.
+ */
+export function useLiveDocumentIdSet(
+  filter: string,
+  params?: QueryParams,
+  options: {
+    // how to insert new document ids. Defaults to `sorted`
+    insert?: 'sorted' | 'prepend' | 'append'
+  } = {},
+) {
+  const documentPreviewStore = useDocumentPreviewStore()
+  const observable = useMemo(
+    () =>
+      documentPreviewStore.unstable_observeDocumentIdSet(filter, params, options).pipe(
+        scan(
+          (currentState: LiveDocumentSetState, nextState) => ({
+            ...currentState,
+            ...nextState,
+          }),
+          INITIAL_STATE,
+        ),
+      ),
+    [documentPreviewStore, filter, params, options],
+  )
+  return useObservable(observable, INITIAL_STATE)
+}

--- a/packages/sanity/src/core/preview/useLiveDocumentIdSet.ts
+++ b/packages/sanity/src/core/preview/useLiveDocumentIdSet.ts
@@ -15,9 +15,11 @@ export type LiveDocumentSetState =
 /**
  * @internal
  * @beta
- *
- * Observes a document by its ID and returns the document and loading state
- * it will listen to the document changes.
+ * Returns document ids that matches the provided GROQ-filter, and loading state
+ * The document ids are returned in ascending order and will update in real-time
+ * Whenever a document appears or disappears from the set, a new array with the updated set of IDs will be returned.
+ * This provides a lightweight way of subscribing to a list of ids for simple cases where you just want the documents ids
+ * that matches a particular filter.
  */
 export function useLiveDocumentIdSet(
   filter: string,

--- a/packages/sanity/src/core/preview/useLiveDocumentSet.ts
+++ b/packages/sanity/src/core/preview/useLiveDocumentSet.ts
@@ -1,0 +1,32 @@
+import {type QueryParams} from '@sanity/client'
+import {type SanityDocument} from '@sanity/types'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {map} from 'rxjs/operators'
+import {mergeMapArray} from 'rxjs-mergemap-array'
+
+import {useDocumentPreviewStore} from '../store'
+
+/**
+ * @internal
+ * @beta
+ *
+ * Observes a set of documents matching the filter and returns an array of complete documents
+ * A new array will be pushed whenever a document in the set changes
+ * Document ids are returned in ascending order
+ * Any sorting beyond that must happen client side
+ */
+export function useLiveDocumentSet(
+  groqFilter: string,
+  params?: QueryParams,
+): {loading: boolean; documents: SanityDocument[]} {
+  const documentPreviewStore = useDocumentPreviewStore()
+  const observable = useMemo(() => {
+    return documentPreviewStore.unstable_observeDocumentIdSet(groqFilter, params).pipe(
+      map((state) => (state.documentIds || []) as string[]),
+      mergeMapArray((id) => documentPreviewStore.unstable_observeDocument(id)),
+      map((docs) => ({loading: false, documents: docs as SanityDocument[]})),
+    )
+  }, [documentPreviewStore, groqFilter, params])
+  return useObservable(observable, {loading: true, documents: []})
+}

--- a/packages/sanity/src/core/preview/useLiveDocumentSet.ts
+++ b/packages/sanity/src/core/preview/useLiveDocumentSet.ts
@@ -7,6 +7,8 @@ import {mergeMapArray} from 'rxjs-mergemap-array'
 
 import {useDocumentPreviewStore} from '../store'
 
+const INITIAL_VALUE = {loading: true, documents: []}
+
 /**
  * @internal
  * @beta
@@ -28,5 +30,5 @@ export function useLiveDocumentSet(
       map((docs) => ({loading: false, documents: docs as SanityDocument[]})),
     )
   }, [documentPreviewStore, groqFilter, params])
-  return useObservable(observable, {loading: true, documents: []})
+  return useObservable(observable, INITIAL_VALUE)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1653,6 +1653,9 @@ importers:
       rxjs-exhaustmap-with-trailing:
         specifier: ^2.1.1
         version: 2.1.1(rxjs@7.8.1)
+      rxjs-mergemap-array:
+        specifier: ^0.1.0
+        version: 0.1.0(rxjs@7.8.1)
       sanity-diff-patch:
         specifier: ^3.0.2
         version: 3.0.2
@@ -6873,8 +6876,8 @@ packages:
       - debug
     dev: false
 
-  /@sanity/types@3.52.0:
-    resolution: {integrity: sha512-Dqjh8vOWEdnKeLr9ss3ETqAlDff6LChNNFXo71q1eOWqUHoKOD3R0o2qUfNfDl1dWC+T5Frp7MwFC5flAj73xA==}
+  /@sanity/types@3.52.2:
+    resolution: {integrity: sha512-4ONLnYCwNvmkC8Z0LmJmPqMSDX+fNW8J+c/Zg1/kOjoa99gQfl9543mY1jG+ei7FROnWfF36+dv2jagSnGYunQ==}
     dependencies:
       '@sanity/client': 6.21.1(debug@4.3.5)
       '@types/react': 18.3.3
@@ -6955,12 +6958,12 @@ packages:
       - debug
     dev: false
 
-  /@sanity/util@3.52.0:
-    resolution: {integrity: sha512-UsoQ7LDG8HiCGwn60/+hfz3D2Wl02wxHZz5IJ9EyADQ4fJAQ6spFEehsOVywtZPzqNTAZkjJ5h3AmJbEuZzF1w==}
+  /@sanity/util@3.52.2:
+    resolution: {integrity: sha512-G432RERxYop1MjqpyreKn3qrQOkAiNSo6Mc+cF9vm036Ts/pAepW/IUCYfAnARZlGezg4TSAqg9l7WnH1s+v+w==}
     engines: {node: '>=18'}
     dependencies:
       '@sanity/client': 6.21.1(debug@4.3.5)
-      '@sanity/types': 3.52.0
+      '@sanity/types': 3.52.2
       get-random-values-esm: 1.0.2
       moment: 2.30.1
       rxjs: 7.8.1
@@ -17397,6 +17400,15 @@ packages:
       rxjs: 7.8.1
     dev: false
 
+  /rxjs-mergemap-array@0.1.0(rxjs@7.8.1):
+    resolution: {integrity: sha512-19fXxPXN4X8LPWu7fg/nyX+nr0G97qSNXhEvF32cdgWuoyUVQ4MrFr+UL4HGip6iO5kbZOL4puAjPeQ/D5qSlA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      rxjs: 7.x
+    dependencies:
+      rxjs: 7.8.1
+    dev: false
+
   /rxjs@6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
     engines: {npm: '>=2.0.0'}
@@ -17461,7 +17473,7 @@ packages:
       '@sanity/image-url': 1.0.2
       '@sanity/incompatible-plugin': 1.0.4(react-dom@18.3.1)(react@18.3.1)
       '@sanity/ui': 2.8.8(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.12)
-      '@sanity/util': 3.52.0
+      '@sanity/util': 3.52.2
       '@types/lodash-es': 4.17.12
       framer-motion: 11.0.8(react-dom@18.3.1)(react@18.3.1)
       lodash-es: 4.17.21


### PR DESCRIPTION
### Description
Adds a new (unstable) method to the preview store that supports subscribing to a set of document ids that matches a given groq-filter. The set of document ids are returned in ascending order and will update in real-time as documents appear or disappear from the set.
A query based on the given filter is performed once, initially, and thereafter the set of ids are patched based on the listener events `appear` and `disappear` transition.

This provides a lightweight way of subscribing to a list of ids for simple cases where you just want to subscribe to a set of documents ids that matches a particular filter.

### What to review
- Implementation and accompanying hooks

### Testing
TBD

### Notes for release

n/a - internal (for now)