### PR TITLE
fix(structure): update DocumentPerspective menu test

### DIFF
--- a/packages/sanity/src/core/bundles/components/BundleBadge.tsx
+++ b/packages/sanity/src/core/bundles/components/BundleBadge.tsx
@@ -1,12 +1,27 @@
 import {type ColorHueKey, hues} from '@sanity/color'
 import {ChevronDownIcon, Icon, type IconSymbol} from '@sanity/icons'
+import {Box, Flex, rgba, Text} from '@sanity/ui'
 // eslint-disable-next-line camelcase
-import {Box, Flex, rgba, Text, useTheme_v2} from '@sanity/ui'
-import {type CSSProperties} from 'react'
+import {getTheme_v2} from '@sanity/ui/theme'
+import {css, styled} from 'styled-components'
 
 import {Tooltip} from '../../../ui-components'
 import {type BundleDocument} from '../../store/bundles/types'
 
+const BadgeRoot = styled(Flex)<{
+  $hue: ColorHueKey
+}>((props) => {
+  const {color} = getTheme_v2(props.theme)
+  const hue: ColorHueKey = props.$hue
+
+  return css`
+    --card-bg-color: ${rgba(hues[hue][color._dark ? 700 : 300].hex, 0.2)};
+    --card-fg-color: ${hues[hue][color._dark ? 400 : 600].hex};
+    --card-icon-color: ${hues[hue][color._dark ? 400 : 600].hex};
+    background-color: var(--card-bg-color);
+    border-radius: 9999px;
+  `
+})
 /**
  * @internal
  */
@@ -22,23 +37,9 @@ export function BundleBadge(
   >,
 ): JSX.Element {
   const {hue = 'gray', icon, openButton, padding = 3, title} = props
-  const {color} = useTheme_v2()
 
   return (
-    <Flex
-      gap={padding}
-      padding={padding}
-      data-testid={`bundle-badge-color-${hue}`}
-      style={
-        {
-          '--card-bg-color': rgba(hues[hue][color._dark ? 700 : 300].hex, 0.2),
-          '--card-fg-color': hues[hue][color._dark ? 400 : 600].hex,
-          '--card-icon-color': hues[hue][color._dark ? 400 : 600].hex,
-          'backgroundColor': 'var(--card-bg-color)',
-          'borderRadius': '9999px',
-        } as CSSProperties
-      }
-    >
+    <BadgeRoot gap={padding} padding={padding} data-testid={`bundle-badge-color-${hue}`} $hue={hue}>
       {icon && (
         <Box flex="none">
           <Text size={1}>
@@ -68,6 +69,6 @@ export function BundleBadge(
           </Text>
         </Box>
       )}
-    </Flex>
+    </BadgeRoot>
   )
 }

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveMenu.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveMenu.test.tsx
@@ -1,18 +1,12 @@
 import {beforeEach, describe, expect, it, jest} from '@jest/globals'
 import {fireEvent, render, screen} from '@testing-library/react'
-import {
-  BundleBadge,
-  type BundleDocument,
-  getBundleSlug,
-  useDocumentVersions,
-  usePerspective,
-} from 'sanity'
+import {type BundleDocument, usePerspective} from 'sanity'
 import {useRouter} from 'sanity/router'
 
 import {createWrapper} from '../../../../../../../../test/testUtils/createWrapper'
+import {type DocumentPaneContextValue} from '../../../../DocumentPaneContext'
+import {useDocumentPane} from '../../../../useDocumentPane'
 import {DocumentPerspectiveMenu} from '../DocumentPerspectiveMenu'
-
-type getBundleSlugType = (documentId: string) => string
 
 jest.mock('sanity', () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -24,9 +18,6 @@ jest.mock('sanity', () => {
       currentGlobalBundle: {},
       setPerspective: jest.fn(),
     }),
-    BundleBadge: jest.fn(),
-    getBundleSlug: jest.fn(() => ''),
-    useDocumentVersions: jest.fn(),
   }
 })
 
@@ -40,16 +31,15 @@ jest.mock('sanity/router', () => ({
   IntentLink: jest.fn(),
 }))
 
+jest.mock('../../../../useDocumentPane')
+
+const mockUseDocumentPane = useDocumentPane as jest.MockedFunction<
+  () => Partial<DocumentPaneContextValue>
+>
 const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
 const navigateIntent = mockUseRouter().navigateIntent as jest.Mock
 
 const mockUsePerspective = usePerspective as jest.Mock
-const mockGetBundleSlug = getBundleSlug as jest.MockedFunction<getBundleSlugType>
-const mockUseDocumentVersions = useDocumentVersions as jest.MockedFunction<
-  typeof useDocumentVersions
->
-
-const mockBundleBadge = BundleBadge as jest.Mock
 
 describe('DocumentPerspectiveMenu', () => {
   const mockCurrent: BundleDocument = {
@@ -68,28 +58,19 @@ describe('DocumentPerspectiveMenu', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-
-    mockBundleBadge.mockImplementation(() => <div>"test"</div>)
-
     mockUsePerspective.mockReturnValue({
       currentGlobalBundle: mockCurrent,
       setPerspective: jest.fn(),
     })
 
-    mockUseDocumentVersions.mockImplementationOnce(() => ({
-      data: [],
+    mockUseDocumentPane.mockImplementationOnce(() => ({
+      documentVersions: [],
     }))
   })
 
   it('should render the bundle badge if the document exists in the global bundle', async () => {
-    // Dummy Getters
-    mockGetBundleSlug.mockReturnValue('spring-drop')
-
-    mockUseDocumentVersions.mockImplementationOnce(() => ({
-      data: [
+    mockUseDocumentPane.mockImplementationOnce(() => ({
+      documentVersions: [
         {
           slug: 'spring-drop',
           title: 'Spring Drop',
@@ -112,9 +93,6 @@ describe('DocumentPerspectiveMenu', () => {
   })
 
   it('should not render the bundle badge if the document does not exist in the bundle', async () => {
-    // Dummy Getters
-    mockGetBundleSlug.mockReturnValue('no-bundle')
-
     const wrapper = await createWrapper()
     render(<DocumentPerspectiveMenu documentId="document-id" />, {wrapper})
 
@@ -122,11 +100,8 @@ describe('DocumentPerspectiveMenu', () => {
   })
 
   it('should navigate to the release intent when the bundle badge is clicked', async () => {
-    // Dummy Getters
-    mockGetBundleSlug.mockReturnValue('spring-drop')
-
-    mockUseDocumentVersions.mockImplementationOnce(() => ({
-      data: [
+    mockUseDocumentPane.mockImplementationOnce(() => ({
+      documentVersions: [
         {
           slug: 'spring-drop',
           title: 'Spring Drop',


### PR DESCRIPTION
### Description
With the introduction of https://github.com/sanity-io/sanity/pull/7237 the DocumentPerspectiveMenu tests failed and it was not detected on time.
This PR updates those tests to pass

It also updates the `BundleBadge` to use a styled component to define it's styles instead of inline styles, not specifically related to this PR but caught that while reviewing the changes needed for the tests.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Are the changes correct? 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Tests have been updated to pass
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
