### PR TITLE
fix(core): unify items to render in BundlesMenu

### DIFF
--- a/packages/sanity/src/core/bundles/components/BundleMenu.tsx
+++ b/packages/sanity/src/core/bundles/components/BundleMenu.tsx
@@ -30,9 +30,11 @@ interface BundleListProps {
  */
 export function BundleMenu(props: BundleListProps): JSX.Element {
   const {bundles, loading, actions, button} = props
-  const hasBundles = bundles && bundles.filter((b) => !isDraftOrPublished(b.slug)).length > 0
-
   const {currentGlobalBundle, setPerspective} = usePerspective()
+
+  const bundlesToDisplay =
+    bundles?.filter((b) => !isDraftOrPublished(b.slug) && !b.archivedAt) || []
+  const hasBundles = bundlesToDisplay.length > 0
 
   const handleBundleChange = useCallback(
     (bundle: Partial<BundleDocument>) => () => {
@@ -71,26 +73,24 @@ export function BundleMenu(props: BundleListProps): JSX.Element {
                   <>
                     <MenuDivider />
                     <StyledBox data-testid="bundles-list">
-                      {bundles
-                        .filter((b) => !isDraftOrPublished(b.slug) && !b.archivedAt)
-                        .map((b) => (
-                          <MenuItem
-                            key={b.slug}
-                            onClick={handleBundleChange(b)}
-                            padding={1}
-                            pressed={false}
-                            data-testid={`bundle-${b.slug}`}
-                          >
-                            <Flex>
-                              <BundleBadge hue={b.hue} icon={b.icon} padding={2} />
+                      {bundlesToDisplay.map((b) => (
+                        <MenuItem
+                          key={b.slug}
+                          onClick={handleBundleChange(b)}
+                          padding={1}
+                          pressed={false}
+                          data-testid={`bundle-${b.slug}`}
+                        >
+                          <Flex>
+                            <BundleBadge hue={b.hue} icon={b.icon} padding={2} />
 
-                              <Box flex={1} padding={2} style={{minWidth: 100}}>
-                                <Text size={1} weight="medium">
-                                  {b.title}
-                                </Text>
-                              </Box>
+                            <Box flex={1} padding={2} style={{minWidth: 100}}>
+                              <Text size={1} weight="medium">
+                                {b.title}
+                              </Text>
+                            </Box>
 
-                              {/*<Box padding={2}>
+                            {/*<Box padding={2}>
                                 <Text muted size={1}>
                                   {b.publishAt ? (
                                     <RelativeTime time={b.publishAt as Date} useTemporalPhrase />
@@ -100,17 +100,17 @@ export function BundleMenu(props: BundleListProps): JSX.Element {
                                 </Text>
                               </Box>*/}
 
-                              <Box padding={2}>
-                                <Text size={1}>
-                                  <CheckmarkIcon
-                                    style={{opacity: currentGlobalBundle.slug === b.slug ? 1 : 0}}
-                                    data-testid={`${b.slug}-checkmark-icon`}
-                                  />
-                                </Text>
-                              </Box>
-                            </Flex>
-                          </MenuItem>
-                        ))}
+                            <Box padding={2}>
+                              <Text size={1}>
+                                <CheckmarkIcon
+                                  style={{opacity: currentGlobalBundle.slug === b.slug ? 1 : 0}}
+                                  data-testid={`${b.slug}-checkmark-icon`}
+                                />
+                              </Text>
+                            </Box>
+                          </Flex>
+                        </MenuItem>
+                      ))}
                     </StyledBox>
                   </>
                 )}

--- a/packages/sanity/src/core/bundles/components/BundleMenu.tsx
+++ b/packages/sanity/src/core/bundles/components/BundleMenu.tsx
@@ -33,7 +33,7 @@ export function BundleMenu(props: BundleListProps): JSX.Element {
   const {currentGlobalBundle, setPerspective} = usePerspective()
 
   const bundlesToDisplay =
-    bundles?.filter((b) => !isDraftOrPublished(b.slug) && !b.archivedAt) || []
+    bundles?.filter((bundle) => !isDraftOrPublished(bundle.slug) && !bundle.archivedAt) || []
   const hasBundles = bundlesToDisplay.length > 0
 
   const handleBundleChange = useCallback(
@@ -73,27 +73,27 @@ export function BundleMenu(props: BundleListProps): JSX.Element {
                   <>
                     <MenuDivider />
                     <StyledBox data-testid="bundles-list">
-                      {bundlesToDisplay.map((b) => (
+                      {bundlesToDisplay.map((bundle) => (
                         <MenuItem
-                          key={b.slug}
-                          onClick={handleBundleChange(b)}
+                          key={bundle.slug}
+                          onClick={handleBundleChange(bundle)}
                           padding={1}
                           pressed={false}
-                          data-testid={`bundle-${b.slug}`}
+                          data-testid={`bundle-${bundle.slug}`}
                         >
                           <Flex>
-                            <BundleBadge hue={b.hue} icon={b.icon} padding={2} />
+                            <BundleBadge hue={bundle.hue} icon={bundle.icon} padding={2} />
 
                             <Box flex={1} padding={2} style={{minWidth: 100}}>
                               <Text size={1} weight="medium">
-                                {b.title}
+                                {bundle.title}
                               </Text>
                             </Box>
 
                             {/*<Box padding={2}>
                                 <Text muted size={1}>
-                                  {b.publishAt ? (
-                                    <RelativeTime time={b.publishAt as Date} useTemporalPhrase />
+                                  {bundle.publishAt ? (
+                                    <RelativeTime time={bundle.publishAt as Date} useTemporalPhrase />
                                   ) : (
                                     'No target date'
                                   )}
@@ -103,8 +103,10 @@ export function BundleMenu(props: BundleListProps): JSX.Element {
                             <Box padding={2}>
                               <Text size={1}>
                                 <CheckmarkIcon
-                                  style={{opacity: currentGlobalBundle.slug === b.slug ? 1 : 0}}
-                                  data-testid={`${b.slug}-checkmark-icon`}
+                                  style={{
+                                    opacity: currentGlobalBundle.slug === bundle.slug ? 1 : 0,
+                                  }}
+                                  data-testid={`${bundle.slug}-checkmark-icon`}
                                 />
                               </Text>
                             </Box>

--- a/packages/sanity/src/core/bundles/components/__tests__/BundleMenu.test.tsx
+++ b/packages/sanity/src/core/bundles/components/__tests__/BundleMenu.test.tsx
@@ -99,6 +99,24 @@ describe('BundleMenu', () => {
     })
   })
 
+  it('should render latest bundle menu item when bundles are archived', async () => {
+    const wrapper = await createWrapper()
+    const archivedBundles = mockBundles.map((bundle) => ({
+      ...bundle,
+      archivedAt: '2024-07-29T01:49:56.066Z',
+    }))
+    render(<BundleMenu button={ButtonTest} bundles={archivedBundles} loading={false} />, {
+      wrapper,
+    })
+
+    fireEvent.click(screen.getByRole('button', {name: 'Button Test'}))
+
+    act(() => {
+      expect(screen.getByTestId('latest-menu-item')).toBeInTheDocument()
+      expect(screen.queryByTestId('bundles-list')).not.toBeInTheDocument()
+    })
+  })
+
   it('should render latest bundle menu item as selected when currentGlobalBundle is LATEST', async () => {
     mockUsePerspective.mockReturnValue({
       currentGlobalBundle: LATEST,


### PR DESCRIPTION
### Description

The bundles menu component was showing an unnecessary divider when the bundles are archived.
Archived bundles are not rendered, but they were not considered for the `hasBundles` check.

By moving the list that is generated to the body of the component and reusing that to check the bundles length this issue is fixed.

#### Before
<img width="499" alt="Screenshot 2024-07-29 at 09 39 47" src="https://github.com/user-attachments/assets/8b6f3754-00ed-4bef-a040-36017d2ae800">

#### After
<img width="545" alt="Screenshot 2024-07-29 at 09 45 19" src="https://github.com/user-attachments/assets/d887255c-6ace-40ba-a41f-c65fc0cbe0dd">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Tests are updated.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
