### PR TITLE
fix: add back `FieldPresenceWithOverlay` export

### DIFF
--- a/packages/sanity/src/core/presence/FieldPresence.tsx
+++ b/packages/sanity/src/core/presence/FieldPresence.tsx
@@ -107,3 +107,10 @@ export function FieldPresence(props: FieldPresenceProps) {
     </PresenceTooltip>
   )
 }
+
+/**
+ * @internal
+ * @hidden
+ * @deprecated Use `FieldPresence` instead
+ */
+export const FieldPresenceWithOverlay = FieldPresence


### PR DESCRIPTION
### Description

Fixes #7261. Some third party plugins rely on this export. The `FieldPresence` and `FieldPresenceWithOverlay` have always been identical, but the theory is that the naming have created the assumption that `FieldPresence` doesn't implement presence overlays, leading third party plugin authors to import `FieldPresenceWithOverlay`.
This PR adds it back, with a TSDOC `@deprecated` tag noting that `FieldPresence` should be used instead. It also has `@hidden` so that it's excluded from the generated API docs.

### What to review

I've only added back `FieldPresenceWithOverlay`. The original PR (#6946) also removed `EnabledChangeConnectorRoot`, but I'm not adding it back here as its name isn't as ambiguous as `FieldPresenceWithOverlay` and it's usage is far less likely from third parties than `FieldPresence` is.
The `DisabledChangeConnectorRoot` and `FieldPresenceWithoutOverlay` are also not added back here as they were never officially supported ways of using the Studio. They have always been marked as `@internal` and there are other ways of rendering fields that doesn't have change connectors or presence overlays. E.g. one can override the rendering of the `field` itself and render the input directly instead of using `props.renderDefault()`.

### Testing

Existing tests should be enough.

### Notes for release

The `FieldPresenceWithOverlay` export is added back to fix a regression happening in some third party plugins. Plugin authors should use the `FieldPresence` export instead, as the two have always been identical, and there isn't any benefit to using `FieldPresenceWithOverlay`.
