### PR TITLE
fix(cli): remove `conditions` to prevent CJS interop errors

### DIFF
--- a/packages/sanity/src/_internal/cli/server/__tests__/aliases.test.ts
+++ b/packages/sanity/src/_internal/cli/server/__tests__/aliases.test.ts
@@ -57,10 +57,7 @@ describe('getAliases', () => {
   // > esbuild in this environment because esbuild relies on this invariant. This
   // > is not a problem with esbuild. You need to fix your environment instead.
   it('returns the correct aliases for normal builds', () => {
-    const aliases = getAliases({
-      sanityPkgPath,
-      conditions: ['import', 'browser'],
-    })
+    const aliases = getAliases({sanityPkgPath})
 
     // Prepare expected aliases
     const dirname = path.dirname(sanityPkgPath)
@@ -68,7 +65,6 @@ describe('getAliases', () => {
       (acc, next) => {
         const dest = resolve.exports(pkg, next, {
           browser: true,
-          conditions: ['import', 'browser'],
         })?.[0]
         if (dest) {
           acc.push({

--- a/packages/sanity/src/_internal/cli/server/aliases.ts
+++ b/packages/sanity/src/_internal/cli/server/aliases.ts
@@ -14,8 +14,6 @@ export interface GetAliasesOptions {
   monorepo?: SanityMonorepo
   /** The path to the sanity package.json file. */
   sanityPkgPath?: string
-  /** The list of conditions to resolve package exports. */
-  conditions?: string[]
 }
 
 /**
@@ -41,6 +39,14 @@ export const browserCompatibleSanityPackageSpecifiers = [
 ]
 
 /**
+ * These conditions should align with the conditions present in the
+ * `package.json` of the `'sanity'` module. they are given to `resolve.exports`
+ * in order to determine the correct entrypoint for the browser-compatible
+ * package specifiers listed above.
+ */
+const conditions = ['import', 'browser', 'default']
+
+/**
  * Returns an object of aliases for Vite to use.
  *
  * This function is used within our build tooling to prevent multiple context errors
@@ -53,7 +59,7 @@ export const browserCompatibleSanityPackageSpecifiers = [
  *
  * @internal
  */
-export function getAliases({monorepo, sanityPkgPath, conditions}: GetAliasesOptions): AliasOptions {
+export function getAliases({monorepo, sanityPkgPath}: GetAliasesOptions): AliasOptions {
   // If the current Studio is located within the Sanity monorepo
   if (monorepo?.path) {
     // Load monorepo aliases. This ensures that the Vite server uses the source files
@@ -75,9 +81,9 @@ export function getAliases({monorepo, sanityPkgPath, conditions}: GetAliasesOpti
     return monorepoAliases
   }
 
-  // If not in the monorepo, use the `sanityPkgPath` and `conditions`
+  // If not in the monorepo, use the `sanityPkgPath`
   // to locate the entry points for each subpath the Sanity module exports
-  if (sanityPkgPath && conditions) {
+  if (sanityPkgPath) {
     // Load the package.json of the Sanity package
     // eslint-disable-next-line import/no-dynamic-require
     const pkg = require(sanityPkgPath)

--- a/packages/sanity/src/_internal/cli/server/getViteConfig.ts
+++ b/packages/sanity/src/_internal/cli/server/getViteConfig.ts
@@ -86,8 +86,6 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
   const defaultFaviconsPath = path.join(path.dirname(sanityPkgPath), 'static', 'favicons')
   const staticPath = `${basePath}static`
 
-  const conditions = ['import', 'browser']
-
   const viteConfig: InlineConfig = {
     // Define a custom cache directory so that sanity's vite cache
     // does not conflict with any potential local vite projects
@@ -115,8 +113,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     envPrefix: 'SANITY_STUDIO_',
     logLevel: mode === 'production' ? 'silent' : 'info',
     resolve: {
-      alias: getAliases({monorepo, conditions, sanityPkgPath}),
-      conditions,
+      alias: getAliases({monorepo, sanityPkgPath}),
     },
     define: {
       // eslint-disable-next-line no-process-env


### PR DESCRIPTION
### Description

The following PR removes the [`conditions`](https://vitejs.dev/config/shared-options#resolve-conditions) configuration in the `getViteConfig` function in order to preserve previous behavior.

The `conditions` configuration appears to have caused an issue with a third-party dependency, resulting in Vite failing to start properly due to incorrect interoperability with a CJS module.

### What to review

Make sure I didn't miss anything.

### Testing

I removed this configuration in a reproduction that involved the third-party plugin `sanity-plugin-icon-picker` and it seemed to work as normal.

### Notes for release

- Resolves a build configuration issue that led to interoperability problems with CJS modules, causing the error `Uncaught error: _interopRequireDefault2 is not a function`.