### PR TITLE
chore: remove agressive npmrc options

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -13,6 +13,3 @@ public-hoist-pattern[]=prettier-plugin-packagejson
 
 prefer-workspace-packages = true
 link-workspace-packages = deep
-dedupe-injected-deps = false
-hoist-workspace-packages = false
-enable-pre-post-scripts = false


### PR DESCRIPTION
### Description

Looks like some of the options we set doesn't play too nice with `pnpm dedupe`, as seen in https://github.com/sanity-io/sanity/pull/7281.
I've removed them and set us to trust the defaults, except for `prefer-workspace-packages` and `link-workspace-packages = deep` as they make a lot of sense for our monorepo setup.

### What to review

It makes sense?

### Testing

Existing tests should be enough. I ran `pnpm dedupe && pnpm install --fix-lockfile` locally before pushing.

### Notes for release

N/A
