### PR TITLE
fix(core): correctly reset PTE list counts

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
@@ -104,7 +104,7 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $readOnly?:
 
     /* Reset the list count if the element is not a numbered list item */
     & > :not(.pt-list-item-number) {
-      counter-reset: ${TEXT_LEVELS.map((l) => createListName(l)).join(' ')};
+      counter-set: ${TEXT_LEVELS.map((l) => createListName(l)).join(' ')};
     }
 
     ${TEXT_LEVELS.slice(1).map((l) => {


### PR DESCRIPTION
### Description

I was reading the docs on [`counter-reset`](https://developer.mozilla.org/en-US/docs/Web/CSS/counter-reset#description) when this paragraph suddenly stood out:

> After creating a counter using `counter-reset`, you can adjust its value by
> using the `counter-set` property. This is counterintuitive because, despite
> its name, the `counter-reset` property is used for creating and initializing
> counters, while the `counter-set` property is used for resetting the value
> of an existing counter.

This made me realise that we probably used `content-reset` somewhere, incorrectly, where we actually meant to use `counter-set`.

Before this change, counters on each list level would not reset at all across a PTE document. Now, the counters reset properly.

Before:

```
1. This
  a. is
    i. nested
      1. list
This is a paragraph
      2. This
    ii. is
  b. another nested
2. list
```

After:

```
1. This
  a. is
    i. nested
      1. list
This is a paragraph
      1. This
    i. is
  a. another nested
1. list
```

---

**Studio screenshots**:

Before: 

![Screenshot 2024-07-31 at 10 41 04](https://github.com/user-attachments/assets/b502048e-4ce1-4c37-9903-2aaaa23f6d2a)

After:

![Screenshot 2024-07-31 at 10 40 37](https://github.com/user-attachments/assets/0f53b75b-83df-49dd-93fd-c909ebcced9e)


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->
If you know of some large documents with lots of content and lists at different levels, then that might be helpful when reviewing if this change has any adverse effects.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
I created various lists in a document broken up by various other elements and visually verified the list counts. Manual testing it the most practical method here.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
