### PR TITLE
don't prepend message about .env.local if creating .env.local

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -1281,8 +1281,7 @@ export default async function initSanity(
       '# Warning: Do not add secrets (API keys and similar) to this file, as it source controlled!',
       '# Use `.env.local` for any secrets, and ensure it is not added to source control',
     ].join('\n')
-    const shouldPrependWarning = !existingEnv.includes(warningComment)
-    // prepend warning comment to the env vars if one does not exist
+    const shouldPrependWarning = filename !== '.env.local' && !existingEnv.includes(warningComment)
     if (shouldPrependWarning) {
       await fs.writeFile(fileOutputPath, `${warningComment}\n\n${updatedEnv}`, {
         encoding: 'utf8',


### PR DESCRIPTION
### Description

You can init a new Sanity project to just create an .env file like so

```
npx sanity init --env
```

But you can also stipulate the name of the file, like

```
npx sanity init --env=.env.local
```

Currently we always prepend a message in the file about using an `.env.local` file instead for secrets, which is confusing if that's exactly what you **are** creating.

### Notes for release

Fixed default messaging in `.env` file created by `sanity init --env` if creating a `.env.local` file