### PR TITLE
chore(test-studio): add workspace for us based dataset

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -147,26 +147,35 @@ const sharedSettings = definePlugin({
   ],
 })
 
+const defaultWorkspace = {
+  name: 'default',
+  title: 'Test Studio',
+  projectId: 'ppsg7ml5',
+  dataset: 'test',
+  plugins: [sharedSettings()],
+  basePath: '/test',
+  icon: SanityMonogram,
+  // eslint-disable-next-line camelcase
+  __internal_serverDocumentActions: {
+    enabled: true,
+  },
+  scheduledPublishing: {
+    enabled: true,
+    inputDateTimeFormat: 'MM/dd/yy h:mm a',
+  },
+  tasks: {
+    enabled: true,
+  },
+}
+
 export default defineConfig([
+  defaultWorkspace,
   {
-    name: 'default',
-    title: 'Test Studio',
-    projectId: 'ppsg7ml5',
-    dataset: 'test',
-    plugins: [sharedSettings()],
-    basePath: '/test',
-    icon: SanityMonogram,
-    // eslint-disable-next-line camelcase
-    __internal_serverDocumentActions: {
-      enabled: true,
-    },
-    scheduledPublishing: {
-      enabled: true,
-      inputDateTimeFormat: 'MM/dd/yy h:mm a',
-    },
-    tasks: {
-      enabled: true,
-    },
+    ...defaultWorkspace,
+    name: 'us',
+    title: 'Test Studio (US)',
+    dataset: 'test-us',
+    basePath: '/us',
   },
   {
     name: 'partialIndexing',


### PR DESCRIPTION
### Description

Adds a US-based dataset so it is easier to test things like latency etc

### What to review

See that there are requests going to the `test-us` dataset when selecting the US workspace

### Testing

👆

### Notes for release

None.
