### PR TITLE
fix(cli): add `styled-components` aliasing.

### DIFF
--- a/packages/sanity/src/_internal/cli/server/__tests__/aliases.test.ts
+++ b/packages/sanity/src/_internal/cli/server/__tests__/aliases.test.ts
@@ -61,7 +61,7 @@ describe('getAliases', () => {
 
     // Prepare expected aliases
     const dirname = path.dirname(sanityPkgPath)
-    const expectedAliases = browserCompatibleSanityPackageSpecifiers.reduce<Alias[]>(
+    const resolvedSanityAliases = browserCompatibleSanityPackageSpecifiers.reduce<Alias[]>(
       (acc, next) => {
         const dest = resolve.exports(pkg, next, {
           browser: true,
@@ -77,7 +77,18 @@ describe('getAliases', () => {
       [],
     )
 
-    expect(aliases).toEqual(expectedAliases)
+    const styledComponentsAliases = [
+      {
+        find: /^styled-components\/package\.json$/,
+        replacement: expect.stringContaining('styled-components/package.json'),
+      },
+      {
+        find: /^styled-components$/,
+        replacement: expect.stringContaining('styled-components.esm.js'),
+      },
+    ]
+
+    expect(aliases).toEqual([...resolvedSanityAliases, ...styledComponentsAliases])
   })
 
   it('returns the correct aliases for the monorepo', () => {
@@ -93,13 +104,17 @@ describe('getAliases', () => {
       monorepo: {path: monorepoPath},
     })
 
-    const expectedAliases = Object.fromEntries(
+    const resolvedDevAliases = Object.fromEntries(
       Object.entries(devAliases).map(([key, modulePath]) => {
         return [key, path.resolve(monorepoPath, modulePath)]
       }),
     )
 
-    expect(aliases).toMatchObject(expectedAliases)
+    expect(aliases).toMatchObject({
+      ...resolvedDevAliases,
+      'styled-components/package.json': expect.stringContaining('styled-components/package.json'),
+      'styled-components': expect.stringContaining('styled-components.esm.js'),
+    })
   })
 
   it('returns an empty object if no conditions are met', () => {


### PR DESCRIPTION
### Description

The following PR adds additional aliasing for styled-components for both the internal build in the monorepo and any user builds.

### What to review

Do the changes make sense? Are the updated tests adequate?

### Testing

- Unit tests were updated
- I built the `test-studio` with the new styled-component aliases and without. See below.
- I also packed this new version of sanity and tried it out in the admin studio to check the non-monorepo alises of styled-components.

https://github.com/user-attachments/assets/0d2f4275-4d44-4914-bdce-046094c5603f


### Notes for release

- Adds aliases for `styled-components` to prevent missing context errors.
