### PR TITLE
fix(preview): remove full document preview support

### DIFF
--- a/packages/sanity/src/core/preview/createGlobalListener.ts
+++ b/packages/sanity/src/core/preview/createGlobalListener.ts
@@ -21,7 +21,7 @@ export function createGlobalListener(client: SanityClient) {
         includeResult: false,
         includePreviousRevision: false,
         includeMutations: false,
-        visibility: 'transaction',
+        visibility: 'query',
         effectFormat: 'mendoza',
         tag: 'preview.global',
       },


### PR DESCRIPTION
This was an interesting thing to explore, but it doesn't scale well, so turning this off for now (it's only been enabled in this branch, fwiw).
