### PR TITLE
feat(codegen): generate SanityQueries interface in @sanity/codegen

### DIFF
--- a/packages/@sanity/codegen/src/readConfig.ts
+++ b/packages/@sanity/codegen/src/readConfig.ts
@@ -15,6 +15,7 @@ export const configDefintion = z.object({
   schema: z.string().default('./schema.json'),
   generates: z.string().default('./sanity.types.ts'),
   formatGeneratedCode: z.boolean().default(true),
+  overloadClientMethods: z.boolean().default(false),
 })
 
 export type CodegenConfig = z.infer<typeof configDefintion>

--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -2,7 +2,7 @@ import {describe, expect, test} from '@jest/globals'
 
 import {findQueriesInSource} from '../findQueriesInSource'
 
-describe('findQueries', () => {
+describe('findQueries with the groq template', () => {
   describe('should find queries in source', () => {
     test('plain string', () => {
       const source = `
@@ -153,6 +153,204 @@ describe('findQueries', () => {
       export const postQuery = groq\`*[_type == "foo"]\`
     `
 
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(0)
+  })
+})
+
+describe('findQueries with defineQuery', () => {
+  describe('should find queries in source', () => {
+    test('plain string', () => {
+      const source = `
+      import { defineQuery } from "groq";
+      const postQuery = defineQuery("*[_type == 'author']");
+      const res = sanity.fetch(postQuery);
+    `
+
+      const queries = findQueriesInSource(source, 'test.ts')
+      const queryResult = queries[0]
+
+      expect(queryResult?.result).toEqual("*[_type == 'author']")
+    })
+
+    test('template string', () => {
+      const source = `
+      import { defineQuery } from "groq";
+      const postQuery = defineQuery(\`*[_type == "author"]\`);
+      const res = sanity.fetch(postQuery);
+    `
+
+      const queries = findQueriesInSource(source, 'test.ts')
+      const queryResult = queries[0]
+
+      expect(queryResult?.result).toEqual('*[_type == "author"]')
+    })
+
+    test('with variables', () => {
+      const source = `
+      import { defineQuery } from "groq";
+      const type = "author";
+      const authorQuery = defineQuery(\`*[_type == "\${type}"]\`);
+      const res = sanity.fetch(authorQuery);
+    `
+
+      const queries = findQueriesInSource(source, 'test.ts')
+      const queryResult = queries[0]
+
+      expect(queryResult?.result).toEqual('*[_type == "author"]')
+    })
+
+    test('with function', () => {
+      const source = `
+      import { defineQuery } from "groq";
+      const getType = () => () => () => "author";
+      const query = defineQuery(\`*[_type == "\${getType()()()}"]\`);
+      const res = sanity.fetch(query);
+    `
+
+      const queries = findQueriesInSource(source, 'test.ts')
+
+      const queryResult = queries[0]
+
+      expect(queryResult?.result).toEqual('*[_type == "author"]')
+    })
+
+    test('with block comment', () => {
+      const source = `
+        import { defineQuery } from "groq";
+        const type = "author";
+        const query = /* groq */ defineQuery(\`*[_type == "\${type}"]\`);
+        const res = sanity.fetch(query);
+      `
+
+      const queries = findQueriesInSource(source, 'test.ts')
+      const queryResult = queries[0]
+
+      expect(queryResult?.result).toEqual('*[_type == "author"]')
+    })
+  })
+
+  test('should not find inline queries in source', () => {
+    const source = `
+        import { defineQuery } from "groq";
+        const res = sanity.fetch(defineQuery(\`*[_type == "author"]\`));
+      `
+
+    const queries = findQueriesInSource(source, 'test.ts')
+
+    expect(queries.length).toBe(0)
+  })
+
+  test('should import', () => {
+    const source = `
+      import {defineQuery} from "groq";
+      import {foo}  from "./fixtures/exportVar";
+      const postQuery = defineQuery(\`*[_type == "\${foo}"]\`);
+      const res = sanity.fetch(postQueryResult);
+    `
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(1)
+    expect(queries[0].result).toBe('*[_type == "foo"]')
+  })
+
+  test('should import, subdirectory', () => {
+    const source = `
+      import {defineQuery} from "groq";
+      import {foo}  from "../__tests__/fixtures/exportVar";
+      const postQuery = defineQuery(\`*[_type == "\${foo}"]\`);
+      const res = sanity.fetch(postQueryResult);
+    `
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(1)
+    expect(queries[0].result).toBe('*[_type == "foo"]')
+  })
+
+  test('can import sequence of files', () => {
+    const source = `
+      import {defineQuery} from "groq";
+      import {query}  from "../__tests__/fixtures/importSeq1";
+      const someQuery = defineQuery(\`$\{query}\`);
+    `
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(1)
+    expect(queries[0].result).toBe('*[_type == "foo bar"]')
+  })
+
+  test('should detect defineQuery calls that have been required', () => {
+    const source = `
+      const {defineQuery} = require("groq");
+      import {query}  from "../__tests__/fixtures/importSeq1";
+      const someQuery = defineQuery(\`$\{query}\`);
+    `
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(1)
+    expect(queries[0].result).toBe('*[_type == "foo bar"]')
+  })
+
+  test('will ignore declarations with ignore tag', () => {
+    const source = `
+      import {defineQuery} from "groq";
+
+      // @sanity-typegen-ignore
+      const postQuery = defineQuery(\`*[_type == "foo"]\`);
+    `
+
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(0)
+  })
+
+  test('will ignore export named declarations with ignore tag', () => {
+    const source = `
+      import {defineQuery} from "groq";
+
+      // @sanity-typegen-ignore
+      export const postQuery = defineQuery(\`*[_type == "foo"]\`);
+    `
+
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(0)
+  })
+
+  test('will ignore declarations with ignore tag, even with multiple comments above declaration', () => {
+    const source = `
+      import {defineQuery} from "groq";
+
+      // This is a query that queries posts
+      // @sanity-typegen-ignore
+      export const postQuery = groq\`*[_type == "foo"]\`
+    `
+
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(0)
+  })
+
+  test('will ignore declerations if any of the leading comments are ignore tags', () => {
+    const source = `
+      import {defineQuery} from "groq";
+
+      // @sanity-typegen-ignore
+      // This should be ignored because of the comment above
+      export const postQuery = defineQuery(\`*[_type == "foo"]\`);
+    `
+
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(0)
+  })
+
+  test('will ignore defineQuery calls that are not coming from the groq module', () => {
+    const source = `
+      import {defineQuery} from "another-module";
+      export const postQuery = defineQuery(\`*[_type == "foo"]\`);
+    `
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(0)
+  })
+
+  test('will ignore defineQuery calls that are not coming from the groq module when using require', () => {
+    const source = `
+      const {defineQuery} = require("another-module");
+      export const postQuery = defineQuery(\`*[_type == "foo"]\`);
+    `
     const queries = findQueriesInSource(source, __filename, undefined)
     expect(queries.length).toBe(0)
   })

--- a/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
+++ b/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
@@ -23,6 +23,7 @@ export interface NamedQueryResult {
 }
 
 const TAGGED_TEMPLATE_ALLOW_LIST = ['groq']
+const FUNCTION_WRAPPER_ALLOW_LIST = ['defineQuery']
 
 /**
  * resolveExpression takes a node and returns the resolved value of the expression.
@@ -122,6 +123,22 @@ export function resolveExpression({
       file,
       babelConfig,
       resolver,
+    })
+  }
+
+  if (
+    babelTypes.isCallExpression(node) &&
+    babelTypes.isIdentifier(node.callee) &&
+    FUNCTION_WRAPPER_ALLOW_LIST.includes(node.callee.name)
+  ) {
+    return resolveExpression({
+      node: node.arguments[0],
+      scope,
+      filename,
+      file,
+      resolver,
+      babelConfig,
+      params,
     })
   }
 

--- a/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
+++ b/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
@@ -1,6 +1,7 @@
 import {createRequire} from 'node:module'
 
 import {type NodePath, type TransformOptions, traverse} from '@babel/core'
+import {type Scope} from '@babel/traverse'
 import * as babelTypes from '@babel/types'
 
 import {getBabelConfig} from '../getBabelConfig'
@@ -10,6 +11,8 @@ import {parseSourceFile} from './parseSource'
 const require = createRequire(__filename)
 
 const groqTagName = 'groq'
+const defineQueryFunctionName = 'defineQuery'
+const groqModuleName = 'groq'
 
 const ignoreValue = '@sanity-typegen-ignore'
 
@@ -41,12 +44,17 @@ export function findQueriesInSource(
       const init = node.init
 
       // Look for tagged template expressions that are called with the `groq` tag
-      if (
+      const isGroqTemplateTag =
         babelTypes.isTaggedTemplateExpression(init) &&
         babelTypes.isIdentifier(init.tag) &&
-        babelTypes.isIdentifier(node.id) &&
         init.tag.name === groqTagName
-      ) {
+
+      // Look for strings wrapped in a defineQuery function call
+      const isDefineQueryCall =
+        babelTypes.isCallExpression(init) &&
+        isImportFrom(groqModuleName, defineQueryFunctionName, scope, init.callee)
+
+      if (babelTypes.isIdentifier(node.id) && (isGroqTemplateTag || isDefineQueryCall)) {
         // If we find a comment leading the decleration which macthes with ignoreValue we don't add
         // the query
         if (declarationLeadingCommentContains(path, ignoreValue)) {
@@ -137,6 +145,74 @@ function declarationLeadingCommentContains(path: NodePath, comment: string): boo
     )
   ) {
     return true
+  }
+
+  return false
+}
+
+function isImportFrom(
+  moduleName: string,
+  importName: string,
+  scope: Scope,
+  node: babelTypes.Expression | babelTypes.V8IntrinsicIdentifier,
+) {
+  if (babelTypes.isIdentifier(node)) {
+    const binding = scope.getBinding(node.name)
+    if (!binding) {
+      return false
+    }
+
+    const {path} = binding
+
+    // import { foo } from 'groq'
+    if (babelTypes.isImportSpecifier(path.node)) {
+      return (
+        path.node.importKind === 'value' &&
+        path.parentPath &&
+        babelTypes.isImportDeclaration(path.parentPath.node) &&
+        path.parentPath.node.source.value === moduleName &&
+        babelTypes.isIdentifier(path.node.imported) &&
+        path.node.imported.name === importName
+      )
+    }
+
+    // const { defineQuery } = require('groq')
+    if (babelTypes.isVariableDeclarator(path.node)) {
+      const {init} = path.node
+      return (
+        babelTypes.isCallExpression(init) &&
+        babelTypes.isIdentifier(init.callee) &&
+        init.callee.name === 'require' &&
+        babelTypes.isStringLiteral(init.arguments[0]) &&
+        init.arguments[0].value === moduleName
+      )
+    }
+  }
+
+  // import * as foo from 'groq'
+  // foo.defineQuery(...)
+  if (babelTypes.isMemberExpression(node)) {
+    const {object, property} = node
+
+    if (!babelTypes.isIdentifier(object)) {
+      return false
+    }
+
+    const binding = scope.getBinding(object.name)
+    if (!binding) {
+      return false
+    }
+    const {path} = binding
+
+    return (
+      babelTypes.isIdentifier(object) &&
+      babelTypes.isIdentifier(property) &&
+      property.name === importName &&
+      babelTypes.isImportNamespaceSpecifier(path.node) &&
+      path.parentPath &&
+      babelTypes.isImportDeclaration(path.parentPath.node) &&
+      path.parentPath.node.source.value === moduleName
+    )
   }
 
   return false

--- a/packages/groq/README.md
+++ b/packages/groq/README.md
@@ -20,6 +20,20 @@ import groq from 'groq'
 const query = groq`*[_type == 'products'][0...10]`
 ```
 
+## Automatic type inference
+
+If you are using `@sanity/codegen` you can use `defineQuery` instead of `groq` to
+get type inference out of the box:
+
+```ts
+import {defineQuery} from 'groq'
+
+const query = defineQuery(`*[_type == 'products'][0...10]`)
+```
+
+In the future we might merge `defineQuery` with `groq`, but this is currently [not
+100% supported by TypeScript](https://github.com/microsoft/TypeScript/issues/33304).
+
 ## What is Sanity? What is GROQ?
 
 [Sanity](https://www.sanity.io) is a real-time content infrastructure with a scalable, hosted backend featuring a Graph Oriented Query Language (GROQ), asset pipelines and fast edge caches.

--- a/packages/groq/package.config.ts
+++ b/packages/groq/package.config.ts
@@ -1,4 +1,11 @@
 import baseConfig from '@repo/package.config'
 import {defineConfig} from '@sanity/pkg-utils'
 
-export default defineConfig(baseConfig)
+export default defineConfig({
+  ...baseConfig,
+  legacyExports: false,
+  bundles: [
+    {source: './src/_exports.cts.ts', require: './lib/groq.cjs'},
+    {source: './src/_exports.mts.ts', import: './lib/groq.js'},
+  ],
+})

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -26,17 +26,16 @@
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",
   "sideEffects": false,
+  "type": "module",
   "exports": {
     ".": {
-      "source": "./src/groq.ts",
-      "import": "./lib/groq.mjs",
-      "require": "./lib/groq.js",
+      "require": "./lib/groq.cjs",
       "default": "./lib/groq.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "./lib/groq.js",
-  "module": "./lib/groq.esm.js",
+  "main": "./lib/groq.cjs",
+  "module": "./lib/groq.js",
   "types": "./lib/groq.d.ts",
   "files": [
     "lib",

--- a/packages/groq/src/_exports.cts.ts
+++ b/packages/groq/src/_exports.cts.ts
@@ -1,0 +1,11 @@
+import {defineQuery} from './define'
+import {groq} from './groq'
+
+module.exports = groq
+
+Object.assign(module.exports, {defineQuery})
+
+/**
+ * This is just to fix the typegen for the CJS export, as TS won't pick up on `module.exports` syntax when the package.json has `type: "module"`
+ */
+export type {groq as default, defineQuery}

--- a/packages/groq/src/_exports.mts.ts
+++ b/packages/groq/src/_exports.mts.ts
@@ -1,0 +1,2 @@
+export {defineQuery} from './define'
+export {groq as default} from './groq'

--- a/packages/groq/src/define.ts
+++ b/packages/groq/src/define.ts
@@ -1,0 +1,16 @@
+/**
+ * Define a GROQ query. This is a no-op, but it helps editor integrations
+ * understand that a string represents a GROQ query in order to provide syntax highlighting
+ * and other features.
+ *
+ * Ideally the `groq` template tag would be used, but we cannot infer types from it until
+ * microsoft/TypeScript#33304 is resolved. Otherwise, there is no difference between this
+ * and the `groq` template tag.
+ *
+ * @param query - The GROQ query
+ * @returns The same string as the input
+ * @public
+ */
+export function defineQuery<const Q extends string>(query: Q): Q {
+  return query
+}

--- a/packages/groq/src/groq.ts
+++ b/packages/groq/src/groq.ts
@@ -8,7 +8,7 @@
  * @returns The same string as the input
  * @public
  */
-export default function groq(strings: TemplateStringsArray, ...keys: any[]): string {
+export function groq(strings: TemplateStringsArray, ...keys: any[]): string {
   const lastIndex = strings.length - 1
   return (
     strings.slice(0, lastIndex).reduce((acc, str, i) => {

--- a/packages/groq/test/define.test.cjs
+++ b/packages/groq/test/define.test.cjs
@@ -1,0 +1,17 @@
+'use strict'
+// Integration test for the Node.js CJS runtime
+
+const {strict: assert} = require('node:assert')
+
+const {defineQuery} = require('groq')
+
+assert.equal(typeof defineQuery, 'function')
+
+assert.equal(defineQuery(`foo${'bar'}`), `foo${'bar'}`)
+assert.equal(defineQuery(`${'bar'}`), `${'bar'}`)
+assert.equal(defineQuery(``), ``)
+assert.equal(defineQuery(`${'foo'}`), `${'foo'}`)
+assert.equal(defineQuery(`${/foo/}bar`), `${/foo/}bar`)
+assert.equal(defineQuery(`${'foo'}bar${347}`), `${'foo'}bar${347}`)
+assert.equal(defineQuery(`${'foo'}bar${347}${/qux/}`), `${'foo'}bar${347}${/qux/}`)
+assert.equal(defineQuery(`${'foo'}${347}qux`), `${'foo'}${347}qux`)

--- a/packages/groq/test/define.test.mjs
+++ b/packages/groq/test/define.test.mjs
@@ -1,0 +1,16 @@
+// Integration test for the Node.js ESM runtime
+
+import {strict as assert} from 'node:assert'
+
+import {defineQuery} from 'groq'
+
+assert.equal(typeof defineQuery, 'function')
+
+assert.equal(defineQuery(`foo${'bar'}`), `foo${'bar'}`)
+assert.equal(defineQuery(`${'bar'}`), `${'bar'}`)
+assert.equal(defineQuery(``), ``)
+assert.equal(defineQuery(`${'foo'}`), `${'foo'}`)
+assert.equal(defineQuery(`${/foo/}bar`), `${/foo/}bar`)
+assert.equal(defineQuery(`${'foo'}bar${347}`), `${'foo'}bar${347}`)
+assert.equal(defineQuery(`${'foo'}bar${347}${/qux/}`), `${'foo'}bar${347}${/qux/}`)
+assert.equal(defineQuery(`${'foo'}${347}qux`), `${'foo'}${347}qux`)


### PR DESCRIPTION
### Description

This PR is just forwarding #6997 by @romeovs (with help from @sgulseth ), so that we can run all the CI testing flows that otherwise are skipped/fail on PRs from forked branches.

Check #6997 for all the deets, the gist of it is that it allows typegen that are much more ✨ **_magical_** ✨ and **easier** to use.

Today typegen requires you to instrument your `client.fetch` calls with the generated query response:
```tsx
import {createClient} from '@sanity/client'
import groq from 'groq'
// You have to manually import from the generated `sanity.types.ts` file
import type { SettingsQueryResult } from "~/sanity.types";

const client = createClient({ /* ... */ })

const settingsQuery = groq`*[_type == "settings"][0]`

// And also manually add the type for the response to the generic slot in `client.fetch`
const settings = await client.fetch<SettingsQueryResult>(settingsQuery)
```
This burden compounds as the `client.fetch` itself might be abstracted away in higher level functions. [For apps like on `next` it's common to define a `sanityFetch` function and must remember to forward the `QueryResponse` generic.](https://github.com/sanity-io/next.js/blob/44bac5100d0ae6afef2925c3d88810c63eaf3eba/examples/cms-sanity/sanity/lib/fetch.ts)

Now, given these requirements:
- `@sanity/client` is on a recent version (`v6.21.0` or later) [that has the new `SanityQueries` interface](https://github.com/sanity-io/client/pull/858).
- queries are defined with the new `defineQuery` utility from `groq` instead of `groq`
- `@sanity/codegen` is configured to generate the `SanityQueries` interface, it's opt-in by setting `"overloadClientMethods": true` in `sanity-typegen.json`
Then it's far less work to use the generated typings, and the DevEx is that it "just works"✨✨
```tsx
import {createClient} from '@sanity/client'
// You need to import `defineQuery` instead of `groq`
import {defineQuery} from 'groq'

const client = createClient({ /* ... */ })

// It's used as a function instead of a tagged template literal
const settingsQuery = defineQuery(`*[_type == "settings"][0]`)

// `settings` is typed, no generics needed, and it works well with custom wrapper functions that also no longer need to use generics
const settings = await client.fetch(settingsQuery)
```

### What to review

This feature brings a lot of value, and I struggle to find a use case where you want it disabled. Should we make `overloadClientMethods` true by default and rather opt-out if necessary?
The only cost to using this is potentially that typegen takes longer than needed if the feature isn't used for whatever reason, AFAIK.
If someone were to update `sanity` on a project that already use generics with `client.fetch` then the generic they pass takes precedence, so it shouldn't cause conflicts with codebases that already use typegen.

### Testing

I've made a canary release that can be used to e2e test in userland: `npm i --save-exact sanity@3.52.5-canary.18`.
To ensure that we don't regress any code that today rely on being able to import groq in ESM like:
```js
import groq from 'groq'
```
and in CJS:
```js
const groq = require('groq')
```
We added a testing suite that runtime checks these in node: https://github.com/sanity-io/sanity/tree/3b2329cf640954f308676a4b02f3fda701c65587/packages/groq/test
These tests makes us feel comfortable that we can introduce the new `defineQuery` utility as a named export in ESM:
```js
import {defineQuery} from 'groq'
```
and CJS:
```js
const {defineQuery} = require('groq')
```
You can even mix them:
```js
import groq, {defineQuery} from 'groq'
const groq = require('groq')
const {defineQuery} = groq

const legacyQuery = groq`count(*)`
const magicQuery = defineQuery(`count(*)`)
```

### Notes for release

It's now possible to use TypeGen without manually passing around generics into `client.fetch` calls 🥳
Update `@sanity/client` so you're on `v6.21.0` or later. Add `"overloadClientMethods": true` to your `sanity-typegen.json`, and wrap your query strings in the new `defineQuery` utility from `groq`:
```diff
import {createClient} from '@sanity/client'
-import groq from 'groq'
+import {defineQuery} from 'groq'
-import type { SettingsQueryResult } from "~/sanity.types";

const client = createClient({ /* ... */ })

-const settingsQuery = groq`
+const settingsQuery = defineQuery(`
  *[_type == "settings"][0]
-`
+`)

-const settings = await client.fetch<SettingsQueryResult>(settingsQuery)
+const settings = await client.fetch(settingsQuery)
```