### PR TITLE
refactor: remove `prefersLatestPublished` handling

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -151,21 +151,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const [timelineError, setTimelineError] = useState<Error | null>(null)
 
   /**
-   * The `preferLatestPublished` parameter can be used to "force" viewing the revision
-   * of the last published document. This is not a permanent function, and will likely
-   * be removed when we move to a more robust way of viewing "releases".
-   */
-  useEffect(() => {
-    if (params.prefersLatestPublished && editState.published) {
-      setPaneParams({
-        //ensure we only run on first load
-        ...omit(params, 'prefersLatestPublished'),
-        rev: `${editState.published._updatedAt}/${editState.published._rev}`,
-      })
-    }
-  }, [editState, setPaneParams, params])
-
-  /**
    * Create an intermediate store which handles document Timeline + TimelineController
    * creation, and also fetches pre-requsite document snapshots. Compatible with `useSyncExternalStore`
    * and made available to child components via DocumentPaneContext.


### PR DESCRIPTION
### Description

With #7302 `@sanity/presentation` now takes full ownership of how it opens the "latest published" document when needed, and no longer use or need the `prefersLatestPublished` parameter and its related handling in the Studio core 😌 

### What to review

This param was always something that were implement only for usage in `@sanity/presentation`, with the intention of it to be a temporary escape hatch. Removing it doesn't affect the public API in any way and isn't considering a breaking change.
`sanity/presentation` has always been using a pinned version of `@sanity/presentation` to allow us to do these kinds of cleanups and internal changes.

### Testing

This can be tested [manually in the Presentation Studio](https://test-studio-git-preferslatestpublished.sanity.dev/presentation/presentation/simpleBlock/eed1de44-4731-48f5-ab77-ea50a82dfef9?preview=%2Fpreview),
selecting `Published` in the Perspectives dropdown should result in opening the last published revision of the document:
![image](https://github.com/user-attachments/assets/f9d8e1a8-bf2e-4a0e-ae98-9f143fe5aa93)



### Notes for release

N/A
