### PR TITLE
fix: support field presence avatars on react 19

### DIFF
--- a/packages/sanity/src/core/presence/overlay/WithIntersection.tsx
+++ b/packages/sanity/src/core/presence/overlay/WithIntersection.tsx
@@ -21,5 +21,5 @@ export const WithIntersection = (props: WithIntersectionProps & HTMLProps<HTMLDi
       .subscribe()
     return () => subscription.unsubscribe()
   }, [io, id, onIntersection])
-  return <div ref={element} {...rest} />
+  return <div {...rest} ref={element} />
 }


### PR DESCRIPTION
### Description

[In React 19 it's possible to set a `ref` as a prop](https://react.dev/blog/2024/04/25/react-19#ref-as-a-prop), while in React 18 you must implement `React.forwardRef` for this.

Components that implement `React.forwardRef` isn't impacted by this change, and won't see that `ref` exists as a prop. But for components like `WithIntersection`, it's now important to have the right order when setting refs and spreading props:

```tsx
export default function Component(props) {
  // On React 19 this ref is never set
  const ref = useRef()

  return <div ref={ref} {...props} />
}
```

On React 18 this is fine, because `<Component ref={123} />` won't result in `props` containing `ref={123}`.
On React 19 it's not, because not only is `<Component ref={123} />` now possible and will result in `props.ref=123`, it also means that if a `ref` prop isn't defined, it'll be `null`.

In other words, on React 18 the resulting render is roughly: `<div {...props} ref={ref} />`, but on React 19 it's: `<div ref={ref} {...({
  ...props,
  ref: props.ref ?? null
})} />`.

The best way to mitigate this is to ensure that props are spread first, that way it's not possible to accidentally overriden:

```tsx
export default function Component(props) {
  const ref = useRef()

  return <div {...props} ref={ref} />
}
```

This behaviour can be verified with the React DevTools on the deployments:
#### [React 18](https://test-studio.sanity.dev/test/structure/input-standard;stringsTest;0e24d082-c111-4ed6-a7e5-c3fb7789df3b%2Ctemplate%3DstringsTest) (Hook 1 is set)
<img width="1120" alt="image" src="https://github.com/user-attachments/assets/adc55de8-9214-4281-8313-cbc080ce86eb">

#### [React 19](https://test-next-studio.sanity.dev/test/structure/input-standard;stringsTest;0e24d082-c111-4ed6-a7e5-c3fb7789df3b%2Ctemplate%3DstringsTest) (Hook 1 is `null`) 
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/010fad95-dfff-42bb-8e74-2414dc66e30d">
Note that the hook remains `null`, and that there's now a `ref` prop with `null`, which is causing it.

#### [React 19](https://test-next-studio-git-fix-field-presence-on-react-19.sanity.dev/test/structure/input-standard;stringsTest;0e24d082-c111-4ed6-a7e5-c3fb7789df3b%2Ctemplate%3DstringsTest) (with the fix applied)

<img width="1118" alt="image" src="https://github.com/user-attachments/assets/8d317836-aa90-4e61-9182-25a5103c28de">



### What to review

Does it make sense?

### Testing

Test on https://test-studio.sanity.dev/ for a working reference, use https://test-next-studio.sanity.dev/ to reproduce the bug, and finally https://test-next-studio-git-fix-field-presence-on-react-19.sanity.dev/ demonstrates the fix.

### Notes for release

Fixes an issue causing the Presence Avatar Overlays on form fields not to appear when the Studio is embedded in a React 19 app.