### PR TITLE
fix(cli): dedupe `styled-components` in vite config

### DIFF
--- a/packages/sanity/src/_internal/cli/server/getViteConfig.ts
+++ b/packages/sanity/src/_internal/cli/server/getViteConfig.ts
@@ -114,6 +114,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     logLevel: mode === 'production' ? 'silent' : 'info',
     resolve: {
       alias: getAliases({monorepo, sanityPkgPath}),
+      dedupe: ['styled-components'],
     },
     define: {
       // eslint-disable-next-line no-process-env


### PR DESCRIPTION
### Description

This PR supersedes #7298 in favor of just adding `styled-components` into the vite's `resolve.dedupe` option.

### Testing

- Tested this out in the test studio and vision no longer crashes due to two versions of styled-components.
- Also tested this out in our admin studio and it built with no issues.

### Notes for release

- Dedupes `styled-components` in our build config to prevent errors related to different context instances.
