### PR TITLE
fix(preview): fix bug with replaying of welcome event to new subscribers

### DIFF
--- a/packages/sanity/src/core/preview/constants.tsx
+++ b/packages/sanity/src/core/preview/constants.tsx
@@ -4,6 +4,12 @@ import {type PreviewValue} from '@sanity/types'
 export const INCLUDE_FIELDS_QUERY = ['_id', '_rev', '_type']
 export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
 
+/**
+ * How long to wait after the last subscriber has unsubscribed before resetting the observable and disconnecting the listener
+ * We want to keep the listener alive for a short while after the last subscriber has unsubscribed to avoid unnecessary reconnects
+ */
+export const LISTENER_RESET_DELAY = 2000
+
 export const AVAILABILITY_READABLE = {
   available: true,
   reason: 'READABLE',

--- a/packages/sanity/src/core/preview/createGlobalListener.ts
+++ b/packages/sanity/src/core/preview/createGlobalListener.ts
@@ -1,18 +1,15 @@
-import {
-  type MutationEvent,
-  type ReconnectEvent,
-  type SanityClient,
-  type WelcomeEvent,
-} from '@sanity/client'
-import {merge, timer} from 'rxjs'
-import {filter, share, shareReplay} from 'rxjs/operators'
+import {type SanityClient} from '@sanity/client'
+import {timer} from 'rxjs'
+
+import {LISTENER_RESET_DELAY} from './constants'
+import {shareReplayLatest} from './utils/shareReplayLatest'
 
 /**
  * @internal
  * Creates a listener that will emit 'welcome' for all new subscribers immediately, and thereafter emit at every mutation event
  */
 export function createGlobalListener(client: SanityClient) {
-  const allEvents$ = client
+  return client
     .listen(
       '*[!(_id in path("_.**"))]',
       {},
@@ -27,37 +24,9 @@ export function createGlobalListener(client: SanityClient) {
       },
     )
     .pipe(
-      share({
-        resetOnRefCountZero: () => timer(2000),
+      shareReplayLatest({
+        predicate: (event) => event.type === 'welcome' || event.type === 'reconnect',
+        resetOnRefCountZero: () => timer(LISTENER_RESET_DELAY),
       }),
     )
-
-  // Reconnect events emitted in case the connection is lost
-  const reconnect = allEvents$.pipe(
-    filter((event): event is ReconnectEvent => event.type === 'reconnect'),
-  )
-
-  // Welcome events are emitted when the listener is (re)connected
-  const welcome = allEvents$.pipe(
-    filter((event): event is WelcomeEvent => event.type === 'welcome'),
-  )
-
-  // Mutation events coming from the listener
-  const mutations = allEvents$.pipe(
-    filter((event): event is MutationEvent => event.type === 'mutation'),
-  )
-
-  // Replay the latest connection event that was emitted either when the connection was disconnected ('reconnect'), established or re-established ('welcome')
-  const connectionEvent = merge(welcome, reconnect).pipe(
-    shareReplay({bufferSize: 1, refCount: true}),
-  )
-
-  // Emit the welcome event if the latest connection event was the 'welcome' event.
-  // Downstream subscribers will typically map the welcome event to an initial fetch
-  const replayWelcome = connectionEvent.pipe(
-    filter((latestConnectionEvent) => latestConnectionEvent.type === 'welcome'),
-  )
-
-  // Combine into a single stream
-  return merge(replayWelcome, mutations, reconnect)
 }

--- a/packages/sanity/src/core/preview/documentPreviewStore.ts
+++ b/packages/sanity/src/core/preview/documentPreviewStore.ts
@@ -115,7 +115,7 @@ export function createDocumentPreviewStore({
   const globalListener = createGlobalListener(versionedClient).pipe(
     filter(
       (event): event is MutationEvent | WelcomeEvent =>
-        // ignore reconnect events for now
+        // ignore reconnect events for now until we know that downstream consumers can handle them
         event.type === 'mutation' || event.type === 'welcome',
     ),
   )

--- a/packages/sanity/src/core/preview/utils/replayLatest.test.ts
+++ b/packages/sanity/src/core/preview/utils/replayLatest.test.ts
@@ -1,0 +1,37 @@
+import {expect, test} from '@jest/globals'
+import {concat, from, lastValueFrom, of, share, timer} from 'rxjs'
+import {concatMap, delay, mergeMap, take, toArray} from 'rxjs/operators'
+
+import {shareReplayLatest} from './shareReplayLatest'
+
+test('replayLatest() replays matching value to new subscribers', async () => {
+  const observable = from(['foo', 'bar', 'baz']).pipe(
+    concatMap((value) => of(value).pipe(delay(100))),
+    share(),
+    shareReplayLatest((v) => v === 'foo'),
+  )
+
+  const result = observable.pipe(
+    mergeMap((value) =>
+      value === 'bar' ? concat(of(value), observable.pipe(take(1))) : of(value),
+    ),
+    toArray(),
+  )
+  expect(await lastValueFrom(result)).toEqual(['foo', 'bar', 'foo', 'baz'])
+})
+
+test('replayLatest() doesnt keep the replay value after resets', async () => {
+  const observable = timer(0, 10).pipe(
+    shareReplayLatest({
+      resetOnRefCountZero: true,
+      resetOnComplete: true,
+      predicate: (v) => v < 2,
+    }),
+  )
+
+  const result = observable.pipe(take(5), toArray())
+  expect(await lastValueFrom(result)).toEqual([0, 1, 2, 3, 4])
+
+  const resultAfter = observable.pipe(take(5), toArray())
+  expect(await lastValueFrom(resultAfter)).toEqual([0, 1, 2, 3, 4])
+})

--- a/packages/sanity/src/core/preview/utils/shareReplayLatest.ts
+++ b/packages/sanity/src/core/preview/utils/shareReplayLatest.ts
@@ -1,0 +1,70 @@
+import {
+  finalize,
+  merge,
+  type MonoTypeOperatorFunction,
+  Observable,
+  share,
+  type ShareConfig,
+  tap,
+} from 'rxjs'
+
+export type ShareReplayLatestConfig<T> = ShareConfig<T> & {predicate: (value: T) => boolean}
+
+/**
+ * A variant of share that takes a predicate function to determine which value to replay to new subscribers
+ * @param predicate - Predicate function to determine which value to replay
+ */
+export function shareReplayLatest<T>(predicate: (value: T) => boolean): MonoTypeOperatorFunction<T>
+
+/**
+ * A variant of share that takes a predicate function to determine which value to replay to new subscribers
+ * @param config - ShareConfig with additional predicate function
+ */
+export function shareReplayLatest<T>(
+  config: ShareReplayLatestConfig<T>,
+): MonoTypeOperatorFunction<T>
+
+/**
+ * A variant of share that takes a predicate function to determine which value to replay to new subscribers
+ * @param configOrPredicate - Predicate function to determine which value to replay
+ * @param config - Optional ShareConfig
+ */
+export function shareReplayLatest<T>(
+  configOrPredicate: ShareReplayLatestConfig<T> | ShareReplayLatestConfig<T>['predicate'],
+  config?: ShareConfig<T>,
+) {
+  return _shareReplayLatest(
+    typeof configOrPredicate === 'function'
+      ? {predicate: configOrPredicate, ...config}
+      : configOrPredicate,
+  )
+}
+function _shareReplayLatest<T>(config: ShareReplayLatestConfig<T>): MonoTypeOperatorFunction<T> {
+  return (source: Observable<T>) => {
+    let latest: T | undefined
+    let emitted = false
+
+    const {predicate, ...shareConfig} = config
+
+    const wrapped = source.pipe(
+      tap((value) => {
+        if (config.predicate(value)) {
+          emitted = true
+          latest = value
+        }
+      }),
+      finalize(() => {
+        emitted = false
+        latest = undefined
+      }),
+      share(shareConfig),
+    )
+    const emitLatest = new Observable<T>((subscriber) => {
+      if (emitted) {
+        subscriber.next(latest)
+      }
+      subscriber.complete()
+    })
+    return merge(wrapped, emitLatest)
+  }
+}


### PR DESCRIPTION
### Description
fixes a regression introduced earlier in this branch (49591de54dc3788ddd3f97cfa7b9a4168f37362c to be specific) - where previews would sometimes stall. This PR fixes the issue by implementing a [share](https://rxjs.dev/api/operators/share)-based operator function that re-emits the latest event matching the provided predicate.

### What to review
Does the naming make sense?

### Testing
- Added unit tests with the `shareReplayLatest` operator

### Notes for release
n/a – internal