### PR TITLE
fix(migrate): properly decode chunks of multibyte unicode strings

### DIFF
--- a/packages/@sanity/migrate/src/it-utils/__test__/decodeText.test.ts
+++ b/packages/@sanity/migrate/src/it-utils/__test__/decodeText.test.ts
@@ -1,0 +1,26 @@
+import {expect, test} from '@jest/globals'
+
+import {decodeText} from '../decodeText'
+import {toArray} from '../toArray'
+
+const encoder = new TextEncoder()
+
+const str = [
+  '載ウルフホ権行エヌカク日対ぼれ途権うつじば面川ソニ禁碁ッ脅詳いク提場ノ継検ム聞権もおな辞女れかまひ守就ごどす爆白ヒ体91捜ルッば集作ソモネ相生どほ三5竜宿則廟びる。欲帯げ引寺ぱリ帯屋十ヘシニラ戒量ア耐部面ちさ特見離ロ政変1界がょせぞ向度そおまご劇選モヘ上抱動ゃわ認者キメセミ図午品漫ぜま。',
+  '香国モツホ家済びづじ下法ドぽけえ巨供ユ続読ざるドさ検公ざ条詳ヒロハ升氏ハ協会テ明襲ス本索ヨアネラ問83希譜助ゃ水果当号財ょのッね。麻ケイロ動閣りすを受済文節ぞゃく例略ラ方6宿クトリマ存動ヌテチツ聞可ん月諭安しド体入タ胆外90因おぽでち玲料反念ぱ。手すばゃん護込ほ社道断ーへふや著拠フさーず版年ル遣告ン勤投ッのる可解ぐむそび房類ロニヨ僚25王4護刊キ担注拍らゃの。',
+  '終ユテカ委死クょ見4老ドご絶実ぴそ院地ロホ将6駆セホヲヒ欠式ユリフヲ変打ド延職測池闘へや態発サノエ作形近偵ぜ。結求牛ムホ馬56牧風みよ刑一アメニナ医講つみクづ手通問戸にかド転集べひレ衛壁政普河つにイク。演ぜょべし海殿カヲヱラ留出レドほ報憲こ異記ネノ過頁作こぐぶ賢田キ社推エラス勢92政ねラご台簿ンび府制モツニケ合瞥てさょ手発かぞリな精7第カシヱト桑企リソナ原贈マ隅局っょろ岐東め。',
+  '権都案入ねつろ春垣予昇よほせ注高テ含初ツチフ社組アスサ手裁っは煙国ミオウ索写セヱウ市錦ごでレ捕必ゅさた海歩こく材自え番真ラア能委ゃせ全投交まさドで。除ヌコ揮市チ件合つさきラ参約クキユ報注ホモスク卒片64明キセツロ水約療きぱ学行う捕界ヲソケク組43都と真5禁ゃいル更理よて立政ねい記83覧働迎2乞ゅスり。',
+].join('')
+
+const bytes = encoder.encode(str)
+
+async function* chunk(array: Uint8Array, chunkSize: number) {
+  for (let i = 0; i < array.length; i += chunkSize) {
+    yield array.slice(i, i + chunkSize)
+  }
+}
+
+test('decodeText() works with chunks of unicode strings', async () => {
+  const decoded = await toArray(decodeText(chunk(bytes, 10)))
+  expect(decoded.join('')).toEqual(str)
+})

--- a/packages/@sanity/migrate/src/it-utils/__test__/decodeText.test.ts
+++ b/packages/@sanity/migrate/src/it-utils/__test__/decodeText.test.ts
@@ -20,7 +20,7 @@ async function* chunk(array: Uint8Array, chunkSize: number) {
   }
 }
 
-test('decodeText() works with chunks of unicode strings', async () => {
+test('decodeText() works with chunks of multibyte unicode strings', async () => {
   const decoded = await toArray(decodeText(chunk(bytes, 10)))
   expect(decoded.join('')).toEqual(str)
 })

--- a/packages/@sanity/migrate/src/it-utils/decodeText.ts
+++ b/packages/@sanity/migrate/src/it-utils/decodeText.ts
@@ -1,6 +1,6 @@
 export async function* decodeText(it: AsyncIterableIterator<Uint8Array>) {
   const decoder = new TextDecoder()
   for await (const chunk of it) {
-    yield decoder.decode(chunk)
+    yield decoder.decode(chunk, {stream: true})
   }
 }


### PR DESCRIPTION
### Description

Migration tooling is currently decoding chunks of strings using TextDecoder without passing `{stream: true}`, which sometimes caused malformed strings appearing in documents passed to migration scripts. This PR fixes the issue by always passing `{stream: true}` to the text decoder ([docs](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/decode#stream)).

### What to review
- Does it make sense?

### Testing
- Added a unit test, which prior to this fix failed with the following error:
```
Error: expect(received).toEqual(expected) // deep equality

Expected: "載ウルフホ権行エヌカク日対ぼれ途権うつじば面川ソニ禁碁ッ脅詳いク提場ノ継検ム聞権もおな辞女れかまひ守就ごどす爆白ヒ体91捜ルッば集作ソモネ相生どほ三5竜宿則廟びる。欲帯げ引寺ぱリ帯屋十ヘシニラ戒量ア耐部面ちさ特見離ロ政変1界がょせぞ向度そおまご劇選モヘ上抱動ゃわ認者キメセミ図午品漫ぜま。香国モツホ家済びづじ下法ドぽけえ巨供ユ続読ざるドさ検公ざ条詳ヒロハ升氏ハ協会テ明襲ス本索ヨアネラ問83希譜助ゃ水果当号財ょのッね。麻ケイロ動閣りすを受済文節ぞゃく例略ラ方6宿クトリマ存動ヌテチツ聞可ん月諭安しド体入タ胆外90因おぽでち玲料反念ぱ。手すばゃん護込ほ社道断ーへふや著拠フさーず版年ル遣告ン勤投ッのる可解ぐむそび房類ロニヨ僚25王4護刊キ担注拍らゃの。終ユテカ委死クょ見4老ドご絶実ぴそ院地ロホ将6駆セホヲヒ欠式ユリフヲ変打ド延職測池闘へや態発サノエ作形近偵ぜ。結求牛ムホ馬56牧風みよ刑一アメニナ医講つみクづ手通問戸にかド転集べひレ衛壁政普河つにイク。演ぜょべし海殿カヲヱラ留出レドほ報憲こ異記ネノ過頁作こぐぶ賢田キ社推エラス勢92政ねラご台簿ンび府制モツニケ合瞥てさょ手発かぞリな精7第カシヱト桑企リソナ原贈マ隅局っょろ岐東め。権都案入ねつろ春垣予昇よほせ注高テ含初ツチフ社組アスサ手裁っは煙国ミオウ索写セヱウ市錦ごでレ捕必ゅさた海歩こく材自え番真ラア能委ゃせ全投交まさドで。除ヌコ揮市チ件合つさきラ参約クキユ報注ホモスク卒片64明キセツロ水約療きぱ学行う捕界ヲソケク組43都と真5禁ゃいル更理よて立政ねい記83覧働迎2乞ゅスり。"
Received: "載ウル���ホ権��エヌカク日対���れ途��うつじば面川���ニ禁��ッ脅詳いク提���ノ継��ム聞権もおな���女れ��まひ守就ごど���爆白��体91捜���ッば��作ソモネ相生���ほ三5���宿則��びる。欲帯げ���寺ぱ��帯屋十ヘシニ���戒量��耐部面ちさ特���離ロ��変1界��ょせぞ向度そ���まご��選モヘ上抱動���わ認��キメセミ図午���漫ぜ��。香国モツホ���済び��じ下法ドぽけ���巨供��続読ざるドさ���公ざ��詳ヒロハ升氏���協会��明襲ス本索ヨ���ネラ��83希譜���ゃ水��当号財ょのッ���。麻��イロ動閣りす���受済��節ぞゃく例略���方6宿���トリ��存動ヌテチツ���可ん��諭安しド体入���胆外90因おぽ���ち玲��反念ぱ。手す���ゃん��込ほ社道断ー���ふや��拠フさーず版���ル遣��ン勤投ッのる���解ぐ��そび房類ロニ���僚25王4護刊キ担注拍���ゃの��終ユテカ委死���ょ見4���ドご��実ぴそ院地ロ���将6駆���ホヲ��欠式ユリフヲ���打ド��職測池闘へや���発サ��エ作形近偵ぜ���結求��ムホ馬56牧風��よ刑一アメニ���医講��みクづ手通問���にか��転集べひレ衛���政普��つにイク。演���ょべ��海殿カヲヱラ���出レ��ほ報憲こ異記���ノ過��作こぐぶ賢田���社推��ラス勢92政ね��ご台簿ンび府���モツ��ケ合瞥てさょ���発か��リな精7第カシヱト桑���リソ��原贈マ隅局っ���ろ岐��め。権都案入���つろ��垣予昇よほせ���高テ��初ツチフ社組���スサ��裁っは煙国ミ���ウ索��セヱウ市錦ご���レ捕��ゅさた海歩こ���材自��番真ラア能委���せ全��交まさドで。���ヌコ��市チ件合つさ���ラ参��クキユ報注ホ���スク��片64明���セツ��水約療きぱ学���う捕��ヲソケク組43��と真5��ゃいル更理よ���立政��い記83���働迎2���ゅス��。"
```

### Notes for release
- Fixes an issue that could cause malformed strings to appear in documents passed to migration scripts
