### PR TITLE
feat(typegen): add location of discovered query

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -14,7 +14,12 @@ describe('findQueries with the groq template', () => {
       const queries = findQueriesInSource(source, 'test.ts')
       const queryResult = queries[0]
 
+      expect(queryResult?.name).toEqual('postQuery')
       expect(queryResult?.result).toEqual('*[_type == "author"]')
+      expect(queryResult?.location).toStrictEqual({
+        end: {line: 3, column: 50, index: 86},
+        start: {line: 3, column: 12, index: 48},
+      })
     })
 
     test('with variables', () => {
@@ -29,6 +34,10 @@ describe('findQueries with the groq template', () => {
       const queryResult = queries[0]
 
       expect(queryResult?.result).toEqual('*[_type == "author"]')
+      expect(queryResult?.location).toStrictEqual({
+        end: {line: 4, column: 53, index: 118},
+        start: {line: 4, column: 12, index: 77},
+      })
     })
 
     test('with function', () => {

--- a/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
+++ b/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
@@ -20,6 +20,20 @@ export interface NamedQueryResult {
   name: string
   /** result is a groq query */
   result: resolveExpressionReturnType
+
+  /** location is the location of the query in the source */
+  location: {
+    start?: {
+      line: number
+      column: number
+      index: number
+    }
+    end?: {
+      line: number
+      column: number
+      index: number
+    }
+  }
 }
 
 const TAGGED_TEMPLATE_ALLOW_LIST = ['groq']

--- a/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
+++ b/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
@@ -71,7 +71,18 @@ export function findQueriesInSource(
           resolver,
         })
 
-        queries.push({name: queryName, result: queryResult})
+        const location = node.loc
+          ? {
+              start: {
+                ...node.loc?.start,
+              },
+              end: {
+                ...node.loc?.end,
+              },
+            }
+          : {}
+
+        queries.push({name: queryName, result: queryResult, location})
       }
     },
   })


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds a location object to the discovered queries, this is practical when using codegen to parse a source file and find location of queries. Ie in vscode-sanity

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Does the start/end interface make sense?

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Added

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

N/A - no notes needed
