### PR TITLE
fix(cli): don't create default apps on deploy

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/deploy/__tests__/helpers.test.ts
+++ b/packages/sanity/src/_internal/cli/actions/deploy/__tests__/helpers.test.ts
@@ -122,12 +122,11 @@ describe('getOrCreateUserApplication', () => {
     expect(result).toEqual(newApp)
   })
 
-  it('creates a default user application by prompting the user for a name', async () => {
+  it('creates a user application by prompting the user for a name', async () => {
     const newApp = {
       id: 'default-app',
       appHost: 'default.sanity.studio',
       urlType: 'internal',
-      isDefaultForDeployment: true,
     }
     mockClientRequest.mockResolvedValueOnce(null) // Simulate no existing app
     ;(mockPrompt.single as jest.Mock<any>).mockImplementationOnce(

--- a/packages/sanity/src/_internal/cli/actions/deploy/helpers.ts
+++ b/packages/sanity/src/_internal/cli/actions/deploy/helpers.ts
@@ -66,7 +66,6 @@ function createUserApplication(
   client: SanityClient,
   body: Pick<UserApplication, 'appHost' | 'urlType'> & {
     title?: string
-    isDefaultForDeployment?: boolean
   },
 ): Promise<UserApplication> {
   return client.request({uri: '/user-applications', method: 'POST', body})
@@ -121,7 +120,6 @@ export async function getOrCreateUserApplication({
       try {
         const response = await createUserApplication(client, {
           appHost,
-          isDefaultForDeployment: true,
           urlType: 'internal',
         })
         resolve(response)


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Doesn't create default apps on new CLI version. DM for more context if needed

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Changes make sense, there shouldn't be any instance of `isDefaultForDeployment` 

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Updated

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

N/A
