### PR TITLE
chore(dev): add groq package to monorepo aliases

### DIFF
--- a/dev/aliases.cjs
+++ b/dev/aliases.cjs
@@ -26,6 +26,7 @@ const devAliases = {
   '@sanity/util': './packages/@sanity/util/src/_exports',
   '@sanity/vision': './packages/@sanity/vision/src',
   'sanity': './packages/sanity/src/_exports',
+  'groq': './packages/groq/src/_exports.mts',
 }
 
 module.exports = devAliases


### PR DESCRIPTION
### Description
Currently, if checking out this repo, running `pnpm install` and then `pnpm run dev` you get the following error:

```
Failed to resolve entry for package "groq". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-pre-bundle]
```
This PR fixes it so that it works by adding a dev alias.

### What to review
Is this the right way to fix it?

### Testing

Do a clean checkout, install dependencies and run `pnpm run dev` and the studio should start without having to run build first.

### Notes for release
n/a – internal