### PR TITLE
fix(sanity): prevent empty actions being executed

### DIFF
--- a/dev/test-studio/documentActions/actions/createCustomPublishAction.ts
+++ b/dev/test-studio/documentActions/actions/createCustomPublishAction.ts
@@ -1,7 +1,9 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import {type DocumentActionComponent, type DocumentActionProps, useDocumentOperation} from 'sanity'
 
-export function createCustomPublishAction(originalAction: DocumentActionComponent) {
+export function createCustomPublishAction(
+  originalAction: DocumentActionComponent,
+): DocumentActionComponent {
   return function CustomPublishAction(props: DocumentActionProps) {
     const defaultPublishAction = originalAction(props)
     const documentOperations = useDocumentOperation(props.id, props.type)
@@ -11,7 +13,24 @@ export function createCustomPublishAction(originalAction: DocumentActionComponen
       label: 'Custom publish that sets publishedAt to now',
       onHandle: () => {
         documentOperations.patch.execute([{set: {publishedAt: new Date().toISOString()}}])
+        defaultPublishAction?.onHandle?.()
+      },
+    }
+  }
+}
 
+export function createNoopPatchPublishAction(
+  originalAction: DocumentActionComponent,
+): DocumentActionComponent {
+  return function NoopPatchPublishAction(props) {
+    const defaultPublishAction = originalAction(props)
+    const documentOperations = useDocumentOperation(props.id, props.type)
+
+    return {
+      ...defaultPublishAction,
+      label: 'Custom publish that sets someBoolean to true',
+      onHandle: () => {
+        documentOperations.patch.execute([{set: {someBoolean: true}}])
         defaultPublishAction?.onHandle?.()
       },
     }

--- a/dev/test-studio/documentActions/index.ts
+++ b/dev/test-studio/documentActions/index.ts
@@ -1,6 +1,9 @@
 import {type DocumentActionsResolver} from 'sanity'
 
-import {createCustomPublishAction} from './actions/createCustomPublishAction'
+import {
+  createCustomPublishAction,
+  createNoopPatchPublishAction,
+} from './actions/createCustomPublishAction'
 import {TestConfirmDialogAction} from './actions/TestConfirmDialogAction'
 import {TestCustomComponentAction} from './actions/TestCustomComponentAction'
 import {TestCustomRestoreAction} from './actions/TestCustomRestoreAction'
@@ -15,12 +18,12 @@ export const resolveDocumentActions: DocumentActionsResolver = (prev, {schemaTyp
       TestPopoverDialogAction,
       TestCustomComponentAction,
       ...prev,
-    ].map((action) => {
+    ].flatMap((action) => {
       if (action.action === 'restore') {
         return TestCustomRestoreAction(action)
       }
       if (action.action === 'publish') {
-        return createCustomPublishAction(action)
+        return [createCustomPublishAction(action), createNoopPatchPublishAction(action)]
       }
       return action
     })

--- a/dev/test-studio/schema/debug/documentActions.js
+++ b/dev/test-studio/schema/debug/documentActions.js
@@ -9,5 +9,10 @@ export default {
       title: 'Title',
     },
     {type: 'datetime', name: 'publishedAt', title: 'Published at'},
+    {
+      name: 'someBoolean',
+      title: 'Some Boolean',
+      type: 'boolean',
+    },
   ],
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.test.ts
@@ -331,10 +331,22 @@ describe('checkoutPair -- server actions', () => {
     ])
     draft.commit()
 
-    expect(mockedActionRequest).toHaveBeenCalledWith([], {
-      tag: 'document.commit',
-      transactionId: expect.any(String),
-    })
+    expect(mockedActionRequest).toHaveBeenCalledWith(
+      [
+        {
+          actionType: 'sanity.action.document.edit',
+          draftId: idPair.draftId,
+          publishedId: idPair.publishedId,
+          patch: {
+            unset: ['_empty_action_guard_pseudo_field_'],
+          },
+        },
+      ],
+      {
+        tag: 'document.commit',
+        transactionId: expect.any(String),
+      },
+    )
 
     sub.unsubscribe()
   })


### PR DESCRIPTION
### Description

This branch fixes an issue arising when Studio executes an empty array of actions using the Actions API. This usage is permitted by Content Lake, but is effectively a noop, with no transaction being executed and propagated through the system.

Although this scenario doesn't occur in Studio code, it can occur in user code. For example: if a custom document action patches a document, but the value it sets is unchanged from the current value. This can cause Studio to become stuck in a "saving" state, because it expected a transaction to be executed.

This branch fixes the issue by adding a fake `unset: ['_empty_action_guard_pseudo_field_']` patch when executing an array of actions that would otherwise be empty. This is similar to the approach employed elsewhere to emulate optimistic locking.

### What to review

Does this approach make sense?

### Testing

- Added replication to Test Studio. This can be accessed by navigating to [a document with custom document actions](http://localhost:3333/test/structure/input-debug;documentActionsTest;8655b5c5-ea4c-4d01-8874-a37d2e2c6cd0), and  executing the "Custom publish that sets someBoolean to true" document action. Prior to this fix, Studio would become stuck in a "saving" state, and the document would never be published.
- Updated unit test.