### PR TITLE
fix(form): fix issue where FormInput was not rendering field when passed 'includeField'

### DIFF
--- a/dev/test-studio/components/formBuilder/FormInputExample.tsx
+++ b/dev/test-studio/components/formBuilder/FormInputExample.tsx
@@ -1,0 +1,82 @@
+import {CloseIcon, EyeOpenIcon} from '@sanity/icons'
+import {Box, Button, Card, Checkbox, Flex, Inline, Stack, Text} from '@sanity/ui'
+import {useState} from 'react'
+import {
+  FormInput,
+  type ObjectInputProps,
+  type Path,
+  pathToString,
+  type RenderInputCallback,
+} from 'sanity'
+
+export function FormInputExample(props: ObjectInputProps) {
+  const [path, setPath] = useState<Path>([])
+
+  const [includeField, setIncludeField] = useState(false)
+  const [includeItem, setIncludeItem] = useState(false)
+
+  const renderDefaultForm = path.length === 0
+
+  const renderInput: RenderInputCallback = (inputProps) => {
+    // wraps each input with a button that allows rendering only the selected input
+    const selected = inputProps.path === path
+    return (
+      <Flex>
+        <Box flex={1}>{props.renderInput(inputProps)}</Box>
+        <Flex marginLeft={2}>
+          <Button
+            mode="ghost"
+            tone="primary"
+            fontSize={1}
+            onClick={() => setPath(selected ? [] : inputProps.path)}
+            icon={selected ? CloseIcon : EyeOpenIcon}
+          />
+        </Flex>
+      </Flex>
+    )
+  }
+
+  if (renderDefaultForm) {
+    return (
+      <Stack space={2}>
+        <Card shadow={2} margin={3} padding={4} radius={2}>
+          {props.renderDefault({...props, renderInput})}
+        </Card>
+      </Stack>
+    )
+  }
+  return (
+    <Stack space={2}>
+      <Card padding={3} radius={2}>
+        <Stack space={4}>
+          <Stack space={4}>
+            <Flex gap={2}>
+              <Text weight="semibold">
+                Input at <code>{pathToString(path)}</code>
+              </Text>
+            </Flex>
+            <Flex gap={4}>
+              <Inline space={2}>
+                <Checkbox checked={includeField} onChange={() => setIncludeField((v) => !v)} />{' '}
+                <Text>Include field</Text>
+              </Inline>
+              <Inline space={2}>
+                <Checkbox checked={includeItem} onChange={() => setIncludeItem((v) => !v)} />{' '}
+                <Text>Include item</Text>
+              </Inline>
+            </Flex>
+          </Stack>
+          <Card shadow={2} padding={3} radius={2}>
+            <FormInput
+              {...props}
+              renderInput={renderInput}
+              absolutePath={path}
+              includeField={includeField}
+              includeItem={includeItem}
+            />
+          </Card>
+        </Stack>
+      </Card>
+    </Stack>
+  )
+}

--- a/dev/test-studio/schema/docs/v3/form-components-api/formInputTest.tsx
+++ b/dev/test-studio/schema/docs/v3/form-components-api/formInputTest.tsx
@@ -1,0 +1,46 @@
+import {defineType} from '@sanity/types'
+
+import {FormInputExample} from '../../../../components/formBuilder/FormInputExample'
+import {structureGroupOptions} from '../../../../structure/groupByOption'
+
+export const formInputTest = defineType({
+  name: 'formInputTest',
+  title: 'FormInput Test',
+  type: 'document',
+  options: structureGroupOptions({
+    structureGroup: 'v3',
+  }),
+  components: {
+    input: FormInputExample,
+  },
+  fields: [
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+    },
+    {
+      name: 'array',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          fields: [
+            {name: 'title', type: 'string'},
+            {name: 'text', type: 'string'},
+          ],
+        },
+      ],
+    },
+    {
+      name: 'description',
+      title: 'Description',
+      type: 'text',
+    },
+    {
+      name: 'nested',
+      type: 'object',
+      fields: [{name: 'nested', type: 'string'}],
+    },
+  ],
+})

--- a/dev/test-studio/schema/docs/v3/form-components-api/index.ts
+++ b/dev/test-studio/schema/docs/v3/form-components-api/index.ts
@@ -1,1 +1,2 @@
+export * from './formInputTest'
 export * from './schema'

--- a/dev/test-studio/schema/docs/v3/index.ts
+++ b/dev/test-studio/schema/docs/v3/index.ts
@@ -1,7 +1,7 @@
 import {validationTest} from './async-functions/schemaType'
 import {example1SchemaType} from './example1'
-import {formComponentsSchema} from './form-components-api'
+import {formComponentsSchema, formInputTest} from './form-components-api'
 
 export const v3docs = {
-  types: [example1SchemaType, validationTest, formComponentsSchema],
+  types: [example1SchemaType, validationTest, formComponentsSchema, formInputTest],
 }

--- a/packages/sanity/src/core/form/components/FormInput.tsx
+++ b/packages/sanity/src/core/form/components/FormInput.tsx
@@ -40,6 +40,7 @@ export const FormInput = memo(function FormInput(
        * Whether to include the field around the input. Defaults to false
        */
       includeField?: boolean
+      includeItem?: boolean
     },
 ) {
   const absolutePath = useMemo(() => {
@@ -101,6 +102,34 @@ const FormInputInner = memo(function FormInputInner(
 
   const {t} = useTranslation()
 
+  const renderField: RenderFieldCallback = useCallback(
+    (fieldProps) => {
+      // we want to render the field around the input if either of these are true:
+      // 1. we have reached the destination path and the `includeField`-prop is passed as true
+      // 2. we are currently at a node somewhere below/inside the destination path
+      const atDestination = isEqual(absolutePath, fieldProps.path)
+      const shouldRenderField = atDestination
+        ? props.includeField
+        : startsWith(absolutePath, fieldProps.path)
+      return shouldRenderField ? destinationRenderField(fieldProps) : pass(fieldProps)
+    },
+    [absolutePath, destinationRenderField, props.includeField],
+  )
+
+  const renderItem: RenderArrayOfObjectsItemCallback = useCallback(
+    (itemProps) => {
+      // we want to render the item around the input if either of these are true:
+      // 1. we have reached the destination path and the `includeItem`-prop is passed as true
+      // 2. we are currently at a node somewhere below/inside the destination path
+      const atDestination = isEqual(absolutePath, itemProps.path)
+      const shouldRenderItem = atDestination
+        ? props.includeItem
+        : startsWith(absolutePath, itemProps.path)
+      return shouldRenderItem ? destinationRenderItem(itemProps) : pass(itemProps)
+    },
+    [absolutePath, destinationRenderItem, props.includeItem],
+  )
+
   const renderInput: RenderInputCallback = useCallback(
     (inputProps) => {
       const isDestinationReached =
@@ -120,6 +149,8 @@ const FormInputInner = memo(function FormInputInner(
       return (
         <FormInputInner
           {...inputProps}
+          includeField={props.includeField}
+          includeItem={props.includeItem}
           absolutePath={absolutePath}
           destinationRenderAnnotation={destinationRenderAnnotation}
           destinationRenderBlock={destinationRenderBlock}
@@ -140,33 +171,9 @@ const FormInputInner = memo(function FormInputInner(
       destinationRenderInput,
       destinationRenderItem,
       destinationRenderPreview,
+      props.includeField,
+      props.includeItem,
     ],
-  )
-
-  const renderField: RenderFieldCallback = useCallback(
-    (fieldProps) => {
-      // we want to render the field around the input if either of these are true:
-      // 1. we have reached the destination path and the `includeField`-prop is passed as true
-      // 2. we are currently at a node somewhere below/inside the destination path
-      const shouldRenderField =
-        startsWith(absolutePath, fieldProps.path) &&
-        (props.includeField || !isEqual(absolutePath, fieldProps.path))
-      return shouldRenderField ? destinationRenderField(fieldProps) : pass(fieldProps)
-    },
-    [absolutePath, destinationRenderField, props.includeField],
-  )
-
-  const renderItem: RenderArrayOfObjectsItemCallback = useCallback(
-    (itemProps) => {
-      // we want to render the item around the input if either of these are true:
-      // 1. we have reached the destination path and the `includeItem`-prop is passed as true
-      // 2. we are currently at a node somewhere below/inside the destination path
-      const shouldRenderField =
-        startsWith(absolutePath, itemProps.path) &&
-        (props.includeItem || !isEqual(absolutePath, itemProps.path))
-      return shouldRenderField ? destinationRenderItem(itemProps) : pass(itemProps)
-    },
-    [absolutePath, destinationRenderItem, props.includeItem],
   )
 
   const renderBlock: RenderBlockCallback = useCallback(


### PR DESCRIPTION
### Description
Currently using `FormInput` with `includeField` does not work for nested fields. This PR fixes the issue, and also adds proper support for `includeItem` so fields and array items works the same way.

### What to review

Repro steps, current (broken) behavior:
- Go to the playground in the preview build _without_ the fix [here](https://test-studio-4orv430uh.sanity.dev/test/structure/v3;formInputTest;9108e390-aa8f-4ac4-ba1c-d655ddba7347)
- Scroll down to the `Nested` -> `Nested` field and click the "eye"-icon to put it in "attention mode"
- Then hit the "Include Field" checkbox
- Observe that the field is _not_ rendered (bad)

Repro steps with fix applied:
- Go to the playground in the preview build with the fix _included_ [here](https://test-studio-git-sdx-1527.sanity.dev/test/structure/v3;formInputTest;9108e390-aa8f-4ac4-ba1c-d655ddba7347)
- Scroll down to the `Nested` -> `Nested` field and click the "eye"-icon to put it in "attention mode"
- Then hit the "Include Field" checkbox
- Observe that the field is rendered (good)

Note: during testing I found that `includeItem` didn't quite work as expected with `treeArrayEditing` enabled, assuming it's due to the beta status of that feature.

### Testing
Included a test document type named `formInputTest` that is placed under `V3 APIs` in the test-studio structure ([link](https://test-studio-git-sdx-1527.sanity.dev/test/structure/v3;formInputTest)).

### Notes for release
- Fixes an issue with `FormInput` causing `includeField` to not have any effect for nested paths.