### PR TITLE
feat(core): document diff review for new documents

### DIFF
--- a/packages/sanity/src/core/field/__workshop__/ChangeListStory.tsx
+++ b/packages/sanity/src/core/field/__workshop__/ChangeListStory.tsx
@@ -88,6 +88,7 @@ export default function ChangeListStory() {
       rootDiff: diff,
       schemaType,
       value: {name: 'Test'},
+      showFromValue: true,
     }),
     [diff, documentId, FieldWrapper, schemaType],
   )

--- a/packages/sanity/src/core/field/__workshop__/ChangeResolverStory.tsx
+++ b/packages/sanity/src/core/field/__workshop__/ChangeResolverStory.tsx
@@ -103,6 +103,7 @@ export default function ChangeResolverStory() {
       rootDiff: diff,
       schemaType,
       value: {name: 'Test'},
+      showFromValue: true,
     }),
     [diff, documentId, FieldWrapper, schemaType],
   )

--- a/packages/sanity/src/core/field/diff/contexts/DocumentChangeContext.tsx
+++ b/packages/sanity/src/core/field/diff/contexts/DocumentChangeContext.tsx
@@ -11,4 +11,9 @@ export type DocumentChangeContextInstance = {
   isComparingCurrent: boolean
   FieldWrapper: ComponentType<{path: Path; children: ReactNode; hasHover: boolean}>
   value: Partial<SanityDocument>
+  /**
+   * When comparing two values it decides if it shows the original "from" value in the Diff components.
+   * Useful for the DocumentDiff in releases when showing the diff for a new document.
+   */
+  showFromValue: boolean
 }

--- a/packages/sanity/src/core/field/types/boolean/diff/BooleanFieldDiff.tsx
+++ b/packages/sanity/src/core/field/types/boolean/diff/BooleanFieldDiff.tsx
@@ -1,6 +1,6 @@
 import {Box, Flex, Text} from '@sanity/ui'
 
-import {DiffTooltip, FromToArrow, useDiffAnnotationColor} from '../../../diff'
+import {DiffTooltip, FromToArrow, useDiffAnnotationColor, useDocumentChange} from '../../../diff'
 import {type BooleanDiff, type DiffComponent} from '../../../types'
 import {Checkbox, Switch} from '../preview'
 
@@ -9,20 +9,22 @@ export const BooleanFieldDiff: DiffComponent<BooleanDiff> = ({diff, schemaType})
   const {title, options} = schemaType
   const Preview = options?.layout === 'checkbox' ? Checkbox : Switch
   const userColor = useDiffAnnotationColor(diff, [])
-
+  const {showFromValue} = useDocumentChange()
   const showToValue = toValue !== undefined && toValue !== null
 
   return (
     <Flex align="center">
       <DiffTooltip diff={diff}>
         <Flex align="center">
-          <Preview checked={fromValue} color={userColor} />
+          {showFromValue && <Preview checked={fromValue} color={userColor} />}
 
           {showToValue && (
             <>
-              <Box marginX={2}>
-                <FromToArrow />
-              </Box>
+              {showFromValue && (
+                <Box marginX={2}>
+                  <FromToArrow />
+                </Box>
+              )}
               <Preview checked={toValue} color={userColor} />
             </>
           )}

--- a/packages/sanity/src/core/field/types/image/diff/ImageFieldDiff.tsx
+++ b/packages/sanity/src/core/field/types/image/diff/ImageFieldDiff.tsx
@@ -2,7 +2,13 @@ import {type Image} from '@sanity/types'
 import {Box, Card, Text} from '@sanity/ui'
 
 import {type TFunction, useTranslation} from '../../../../i18n'
-import {ChangeList, DiffCard, DiffTooltip, getAnnotationAtPath} from '../../../diff'
+import {
+  ChangeList,
+  DiffCard,
+  DiffTooltip,
+  getAnnotationAtPath,
+  useDocumentChange,
+} from '../../../diff'
 import {FromTo} from '../../../diff/components'
 import {type DiffComponent, type ObjectDiff} from '../../../types'
 import {ImagePreview, NoImagePreview} from './ImagePreview'
@@ -16,7 +22,7 @@ const CARD_STYLES = {
 
 export const ImageFieldDiff: DiffComponent<ObjectDiff<Image>> = ({diff, schemaType}) => {
   const {t} = useTranslation()
-
+  const {showFromValue} = useDocumentChange()
   const {fromValue, toValue, fields, isChanged} = diff
   const fromRef = fromValue?.asset?._ref
   const toRef = toValue?.asset?._ref
@@ -96,7 +102,9 @@ export const ImageFieldDiff: DiffComponent<ObjectDiff<Image>> = ({diff, schemaTy
     ) : null
   }
 
-  const imageDiff = <FromTo align="center" from={from} layout="grid" to={to} />
+  const imageDiff = (
+    <FromTo align="center" from={showFromValue ? from : undefined} layout="grid" to={to} />
+  )
 
   return (
     <>

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -38,8 +38,6 @@ const releasesLocaleStrings = {
   'delete.warning_other': 'This will also delete {{count}} document versions.',
   /** Header for deleting a release dialog */
   'delete-dialog.header': 'Are you sure you want to delete the release "{{title}}"?',
-  /** Text for when there's a new document in a release diff */
-  'diff.new-document': 'New document',
   /** Text for when there's no changes in a release diff */
   'diff.no-changes': 'No changes',
   /** Text for when there's no changes in a release diff */

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseReview.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseReview.tsx
@@ -91,23 +91,25 @@ export function ReleaseReview({
       </Flex>
       <VirtualizerRoot style={{height: virtualizer.getTotalSize()}}>
         <VirtualizerTrack style={{transform: `translateY(${items[0]?.start ?? 0}px)`}}>
-          {items.map((virtualItem) => {
-            const {document} = filteredList[virtualItem.index]
+          {items.map((virtualRow) => {
+            const item = filteredList[virtualRow.index]
+            const documentId = item.document._id
+
             return (
               <Box
                 paddingBottom={[5, 6]}
-                key={virtualItem.key}
-                data-index={virtualItem.index}
+                key={virtualRow.key}
+                data-index={virtualRow.index}
                 ref={virtualizer.measureElement}
               >
                 <DocumentDiffContainer
-                  key={document._id}
-                  item={filteredList[virtualItem.index]}
+                  key={documentId}
+                  item={item}
                   releaseSlug={release.slug}
-                  history={documentsHistory[document._id]}
-                  isExpanded={expandedItems[document._id] ?? true}
+                  history={documentsHistory[documentId]}
+                  isExpanded={expandedItems[documentId] ?? true}
                   // eslint-disable-next-line react/jsx-no-bind
-                  toggleIsExpanded={() => toggleIsExpanded(document._id)}
+                  toggleIsExpanded={() => toggleIsExpanded(documentId)}
                 />
               </Box>
             )

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseReview.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseReview.tsx
@@ -91,23 +91,20 @@ export function ReleaseReview({
       </Flex>
       <VirtualizerRoot style={{height: virtualizer.getTotalSize()}}>
         <VirtualizerTrack style={{transform: `translateY(${items[0]?.start ?? 0}px)`}}>
-          {items.map((virtualRow) => {
-            const {document, validation, previewValues} = filteredList[virtualRow.index]
-
+          {items.map((virtualItem) => {
+            const {document} = filteredList[virtualItem.index]
             return (
               <Box
                 paddingBottom={[5, 6]}
-                key={virtualRow.key}
-                data-index={virtualRow.index}
+                key={virtualItem.key}
+                data-index={virtualItem.index}
                 ref={virtualizer.measureElement}
               >
                 <DocumentDiffContainer
                   key={document._id}
-                  release={release}
+                  item={filteredList[virtualItem.index]}
+                  releaseSlug={release.slug}
                   history={documentsHistory[document._id]}
-                  document={document}
-                  validation={validation}
-                  previewValues={previewValues}
                   isExpanded={expandedItems[document._id] ?? true}
                   // eslint-disable-next-line react/jsx-no-bind
                   toggleIsExpanded={() => toggleIsExpanded(document._id)}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -10,7 +10,7 @@ import {RelativeTime} from '../../../components/RelativeTime'
 import {UserAvatar} from '../../../components/userAvatar/UserAvatar'
 import {Translate, useTranslation} from '../../../i18n'
 import {type BundleDocument} from '../../../store/bundles/types'
-import {useAddonDataset} from '../../../studio/addonDataset/useAddonDataset'
+import {useBundleOperations} from '../../../store/bundles/useBundleOperations'
 import {Chip} from '../../components/Chip'
 import {Table} from '../../components/Table/Table'
 import {releasesLocaleNamespace} from '../../i18n'
@@ -40,26 +40,17 @@ const setIconHue = ({hue, icon}: {hue: BundleDocument['hue']; icon: BundleDocume
 export function ReleaseSummary(props: ReleaseSummaryProps) {
   const {documents, documentsHistory, release, collaborators, scrollContainerRef} = props
   const {hue, icon} = release
-  const {client} = useAddonDataset()
+
   const {t} = useTranslation(releasesLocaleNamespace)
+  const {updateBundle} = useBundleOperations()
 
   const [iconValue, setIconValue] = useState<BundleIconEditorPickerValue>(setIconHue({hue, icon}))
   const toast = useToast()
   const handleIconValueChange = useCallback(
     async (value: {hue: BundleDocument['hue']; icon: BundleDocument['icon']}) => {
-      if (!client) {
-        toast.push({
-          closable: true,
-          status: 'error',
-          title: 'Failed to save changes',
-          description: 'AddonDataset client not found',
-        })
-        return
-      }
-
       setIconValue(value)
       try {
-        await client?.patch(release._id).set(value).commit()
+        await updateBundle({...value, _id: release._id})
       } catch (e) {
         toast.push({
           closable: true,
@@ -68,7 +59,7 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
         })
       }
     },
-    [client, release._id, toast],
+    [toast, updateBundle, release._id],
   )
 
   const aggregatedData = useMemo(

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
@@ -215,6 +215,7 @@ describe('after bundles have loaded', () => {
           loading: false,
           results: [
             {
+              memoKey: 'key123',
               document: {
                 _id: 'test-id',
                 _type: 'document',
@@ -251,6 +252,7 @@ describe('after bundles have loaded', () => {
           loading: false,
           results: [
             {
+              memoKey: 'key123',
               document: {
                 _id: 'test-id',
                 _type: 'document',
@@ -314,6 +316,7 @@ describe('after bundles have loaded', () => {
           loading: false,
           results: [
             {
+              memoKey: 'key123',
               document: {
                 _id: '123',
                 _type: 'test',

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseReview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseReview.test.tsx
@@ -1,5 +1,6 @@
 import {beforeEach, describe, expect, it, jest} from '@jest/globals'
 import {act, fireEvent, render, screen, within} from '@testing-library/react'
+import {type ReactNode} from 'react'
 import {ColorSchemeProvider, UserColorManagerProvider} from 'sanity'
 
 import {queryByDataUi} from '../../../../../../test/setup/customQueries'
@@ -32,6 +33,7 @@ const BASE_DOCUMENTS_MOCKS = {
 
 const MOCKED_DOCUMENTS: DocumentInBundleResult[] = [
   {
+    memoKey: 'key123',
     document: {
       _rev: 'FvEfB9CaLlljeKWNkQgpz9',
       _type: 'author',
@@ -59,6 +61,7 @@ const MOCKED_DOCUMENTS: DocumentInBundleResult[] = [
     },
   },
   {
+    memoKey: 'key123',
     document: {
       _rev: 'FvEfB9CaLlljeKWNkQg1232',
       _type: 'author',

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
@@ -27,6 +27,7 @@ const timeNow = new Date()
 
 const releaseDocuments: DocumentInBundleResult[] = [
   {
+    memoKey: 'key123',
     document: {
       _id: '123',
       _type: 'document',
@@ -51,6 +52,7 @@ const releaseDocuments: DocumentInBundleResult[] = [
     },
   },
   {
+    memoKey: 'key123',
     document: {
       _id: '456',
       _type: 'document',

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -1,6 +1,6 @@
 import {CloseIcon} from '@sanity/icons'
 import {Card, Menu, Text, useToast} from '@sanity/ui'
-import {useState} from 'react'
+import {memo, useState} from 'react'
 import {SanityDefaultPreview, Translate, useTranslation} from 'sanity'
 
 import {Dialog, MenuButton, MenuItem} from '../../../../../ui-components'
@@ -10,82 +10,86 @@ import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../../studioClient'
 import {releasesLocaleNamespace} from '../../../i18n'
 import {type BundleDocumentRow} from '../ReleaseSummary'
 
-export function DocumentActions({
-  document,
-  bundleTitle,
-}: {
-  document: BundleDocumentRow
-  bundleTitle: string
-}) {
-  const [showDiscardDialog, setShowDiscardDialog] = useState(false)
-  const [discardStatus, setDiscardStatus] = useState<'idle' | 'discarding' | 'error'>('idle')
-  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
-  const toast = useToast()
-  const {t} = useTranslation(releasesLocaleNamespace)
+export const DocumentActions = memo(
+  function DocumentActions({
+    document,
+    bundleTitle,
+  }: {
+    document: BundleDocumentRow
+    bundleTitle: string
+  }) {
+    const [showDiscardDialog, setShowDiscardDialog] = useState(false)
+    const [discardStatus, setDiscardStatus] = useState<'idle' | 'discarding' | 'error'>('idle')
+    const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+    const toast = useToast()
+    const {t} = useTranslation(releasesLocaleNamespace)
 
-  const handleDiscardVersion = async () => {
-    try {
-      setDiscardStatus('discarding')
-      await client.delete(document.document._id)
-      setDiscardStatus('idle')
-    } catch (e) {
-      setDiscardStatus('error')
-      toast.push({
-        closable: true,
-        status: 'error',
-        title: 'Failed to discard version',
-      })
-    } finally {
-      setShowDiscardDialog(false)
+    const handleDiscardVersion = async () => {
+      try {
+        setDiscardStatus('discarding')
+        await client.delete(document.document._id)
+        setDiscardStatus('idle')
+      } catch (e) {
+        setDiscardStatus('error')
+        toast.push({
+          closable: true,
+          status: 'error',
+          title: 'Failed to discard version',
+        })
+      } finally {
+        setShowDiscardDialog(false)
+      }
     }
-  }
-  return (
-    <>
-      <Card tone="default" display="flex">
-        <MenuButton
-          id="document-actions"
-          button={<ContextMenuButton />}
-          menu={
-            <Menu>
-              <MenuItem
-                text={t('action.discard-version')}
-                icon={CloseIcon}
-                onClick={() => setShowDiscardDialog(true)}
+    return (
+      <>
+        <Card tone="default" display="flex">
+          <MenuButton
+            id="document-actions"
+            button={<ContextMenuButton />}
+            menu={
+              <Menu>
+                <MenuItem
+                  text={t('action.discard-version')}
+                  icon={CloseIcon}
+                  onClick={() => setShowDiscardDialog(true)}
+                />
+              </Menu>
+            }
+          />
+        </Card>
+        {showDiscardDialog && (
+          <Dialog
+            id="discard-version-dialog"
+            header={t('discard-version-dialog.header')}
+            onClose={() => setShowDiscardDialog(false)}
+            footer={{
+              confirmButton: {
+                text: t('discard-version-dialog.title'),
+                tone: 'default',
+                onClick: handleDiscardVersion,
+                loading: discardStatus === 'discarding',
+                disabled: discardStatus === 'discarding',
+              },
+            }}
+          >
+            <Card marginBottom={4} radius={2} border>
+              <SanityDefaultPreview
+                {...document.previewValues}
+                isPlaceholder={document.previewValues.isLoading}
               />
-            </Menu>
-          }
-        />
-      </Card>
-      {showDiscardDialog && (
-        <Dialog
-          id="discard-version-dialog"
-          header={t('discard-version-dialog.header')}
-          onClose={() => setShowDiscardDialog(false)}
-          footer={{
-            confirmButton: {
-              text: t('discard-version-dialog.title'),
-              tone: 'default',
-              onClick: handleDiscardVersion,
-              loading: discardStatus === 'discarding',
-              disabled: discardStatus === 'discarding',
-            },
-          }}
-        >
-          <Card marginBottom={4} radius={2} border>
-            <SanityDefaultPreview
-              {...document.previewValues}
-              isPlaceholder={document.previewValues.isLoading}
-            />
-          </Card>
-          <Text muted size={1}>
-            <Translate
-              t={t}
-              i18nKey={'discard-version-dialog.description'}
-              values={{title: bundleTitle}}
-            />
-          </Text>
-        </Dialog>
-      )}
-    </>
-  )
-}
+            </Card>
+            <Text muted size={1}>
+              <Translate
+                t={t}
+                i18nKey={'discard-version-dialog.description'}
+                values={{title: bundleTitle}}
+              />
+            </Text>
+          </Dialog>
+        )}
+      </>
+    )
+  },
+  (prev, next) =>
+    prev.document.memoKey === next.document.memoKey && prev.bundleTitle === next.bundleTitle,
+)

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -1,4 +1,5 @@
 import {AvatarStack, Box, Flex, Text} from '@sanity/ui'
+import {memo} from 'react'
 import {type BundleDocument, type TFunction, UserAvatar} from 'sanity'
 
 import {RelativeTime} from '../../../../components/RelativeTime'
@@ -6,6 +7,29 @@ import {ReleaseDocumentPreview} from '../../../components/ReleaseDocumentPreview
 import {Headers} from '../../../components/Table/TableHeader'
 import {type Column} from '../../../components/Table/types'
 import {type BundleDocumentRow} from '../ReleaseSummary'
+import {type DocumentInBundleResult} from '../useBundleDocuments'
+
+const MemoReleaseDocumentPreview = memo(
+  function MemoReleaseDocumentPreview({
+    item,
+    releaseSlug,
+  }: {
+    item: DocumentInBundleResult
+    releaseSlug: string
+  }) {
+    return (
+      <ReleaseDocumentPreview
+        documentId={item.document._id}
+        documentTypeName={item.document._type}
+        releaseSlug={releaseSlug}
+        previewValues={item.previewValues.values}
+        isLoading={item.previewValues.isLoading}
+        hasValidationError={item.validation?.hasError}
+      />
+    )
+  },
+  (prev, next) => prev.item.memoKey === next.item.memoKey && prev.releaseSlug === next.releaseSlug,
+)
 
 export const getDocumentTableColumnDefs: (
   releaseSlug: BundleDocument['slug'],
@@ -17,16 +41,9 @@ export const getDocumentTableColumnDefs: (
     header: (props) => (
       <Headers.TableHeaderSearch {...props} placeholder={t('search-documents-placeholder')} />
     ),
-    cell: ({cellProps, datum: {document, previewValues, validation}}) => (
+    cell: ({cellProps, datum}) => (
       <Box {...cellProps} flex={1} padding={1}>
-        <ReleaseDocumentPreview
-          documentId={document._id}
-          documentTypeName={document._type}
-          releaseSlug={releaseSlug}
-          previewValues={previewValues.values}
-          isLoading={!!document.isLoading || !!previewValues.isLoading}
-          hasValidationError={validation?.hasError}
-        />
+        <MemoReleaseDocumentPreview item={datum} releaseSlug={releaseSlug} />
       </Box>
     ),
   },

--- a/packages/sanity/src/core/releases/tool/detail/review/DocumentDiff.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/review/DocumentDiff.tsx
@@ -11,7 +11,7 @@ import {type ObjectDiff} from '../../../../field/types'
 import {releasesLocaleNamespace} from '../../../i18n'
 import {ChangesWrapper, FieldWrapper} from './DocumentDiff.styled'
 
-const buildDocumentForDiffInput = (document: SanityDocument) => {
+const buildDocumentForDiffInput = (document: Partial<SanityDocument>) => {
   // Remove internal fields and undefined values
   const {_id, _rev, _createdAt, _updatedAt, _type, _version, ...rest} = JSON.parse(
     JSON.stringify(document),
@@ -34,9 +34,8 @@ export function DocumentDiff({
   schemaType: ObjectSchemaType
 }) {
   const {changesList, rootDiff} = useMemo(() => {
-    if (!baseDocument) return {changesList: [], rootDiff: null}
     const diff = diffInput(
-      wrap(buildDocumentForDiffInput(baseDocument), null),
+      wrap(buildDocumentForDiffInput(baseDocument ?? {}), null),
       wrap(buildDocumentForDiffInput(document), null),
     ) as ObjectDiff
 
@@ -47,10 +46,6 @@ export function DocumentDiff({
   const {t} = useTranslation(releasesLocaleNamespace)
 
   const isChanged = !!rootDiff?.isChanged
-
-  if (!baseDocument) {
-    return <Text>{t('diff.new-document')}</Text>
-  }
 
   if (!isChanged) {
     return <Text>{t('diff.no-changes')}</Text>
@@ -67,6 +62,7 @@ export function DocumentDiff({
           return <FieldWrapper>{props.children}</FieldWrapper>
         },
         value: document,
+        showFromValue: !!baseDocument,
       }}
     >
       <ChangesWrapper width={1}>

--- a/packages/sanity/src/core/releases/tool/detail/review/DocumentDiffContainer.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/review/DocumentDiffContainer.tsx
@@ -1,66 +1,74 @@
 import {type ObjectSchemaType} from '@sanity/types'
 import {Card, Flex} from '@sanity/ui'
+import {memo} from 'react'
 
 import {LoadingBlock} from '../../../../components/loadingBlock/LoadingBlock'
 import {useSchema} from '../../../../hooks/useSchema'
 import {useObserveDocument} from '../../../../preview/useObserveDocument'
-import {type BundleDocument} from '../../../../store/bundles/types'
 import {getPublishedId} from '../../../../util/draftUtils'
 import {type DocumentHistory} from '../documentTable/useReleaseHistory'
 import {DocumentReviewHeader} from '../review/DocumentReviewHeader'
 import {type DocumentInBundleResult} from '../useBundleDocuments'
 import {DocumentDiff} from './DocumentDiff'
 
-function DocumentDiffExpanded({document}: {document: DocumentInBundleResult['document']}) {
-  const publishedId = getPublishedId(document._id, true)
+const DocumentDiffExpanded = memo(
+  function DocumentDiffExpanded({document}: {document: DocumentInBundleResult['document']}) {
+    const publishedId = getPublishedId(document._id, true)
 
-  const schema = useSchema()
-  const schemaType = schema.get(document._type) as ObjectSchemaType
-  if (!schemaType) {
-    throw new Error(`Schema type "${document._type}" not found`)
-  }
+    const schema = useSchema()
+    const schemaType = schema.get(document._type) as ObjectSchemaType
+    if (!schemaType) {
+      throw new Error(`Schema type "${document._type}" not found`)
+    }
 
-  const {document: baseDocument, loading: baseDocumentLoading} = useObserveDocument(publishedId)
+    const {document: baseDocument, loading: baseDocumentLoading} = useObserveDocument(publishedId)
 
-  if (baseDocumentLoading) return <LoadingBlock />
+    if (baseDocumentLoading) return <LoadingBlock />
 
-  return <DocumentDiff baseDocument={baseDocument} document={document} schemaType={schemaType} />
-}
+    return <DocumentDiff baseDocument={baseDocument} document={document} schemaType={schemaType} />
+  },
+  (prev, next) => prev.document._rev === next.document._rev,
+)
 
-export function DocumentDiffContainer({
-  document,
-  history,
-  release,
-  previewValues,
-  validation,
-  isExpanded,
-  toggleIsExpanded,
-}: {
-  document: DocumentInBundleResult['document']
-  history?: DocumentHistory
-  release: BundleDocument
-  previewValues: DocumentInBundleResult['previewValues']
-  validation?: DocumentInBundleResult['validation']
-  isExpanded: boolean
-  toggleIsExpanded: () => void
-}) {
-  return (
-    <Card border radius={3} data-testid={`doc-differences-${document._id}`}>
-      <DocumentReviewHeader
-        document={document}
-        isLoading={previewValues.isLoading}
-        previewValues={previewValues.values}
-        history={history}
-        release={release}
-        validation={validation}
-        isExpanded={isExpanded}
-        toggleIsExpanded={toggleIsExpanded}
-      />
-      {isExpanded && (
-        <Flex justify="center" padding={4}>
-          <DocumentDiffExpanded document={document} />
-        </Flex>
-      )}
-    </Card>
-  )
-}
+export const DocumentDiffContainer = memo(
+  function DocumentDiffContainer({
+    item,
+    history,
+    releaseSlug,
+    isExpanded,
+    toggleIsExpanded,
+  }: {
+    history?: DocumentHistory
+    releaseSlug: string
+    item: DocumentInBundleResult
+    isExpanded: boolean
+    toggleIsExpanded: () => void
+  }) {
+    return (
+      <Card border radius={3} data-testid={`doc-differences-${item.document._id}`}>
+        <DocumentReviewHeader
+          document={item.document}
+          isLoading={item.previewValues.isLoading}
+          previewValues={item.previewValues.values}
+          history={history}
+          releaseSlug={releaseSlug}
+          validation={item.validation}
+          isExpanded={isExpanded}
+          toggleIsExpanded={toggleIsExpanded}
+        />
+        {isExpanded && (
+          <Flex justify="center" padding={4}>
+            <DocumentDiffExpanded document={item.document} />
+          </Flex>
+        )}
+      </Card>
+    )
+  },
+  (prev, next) => {
+    return (
+      prev.item.memoKey === next.item.memoKey &&
+      prev.isExpanded === next.isExpanded &&
+      prev.history?.lastEditedBy === next.history?.lastEditedBy
+    )
+  },
+)

--- a/packages/sanity/src/core/releases/tool/detail/review/DocumentReviewHeader.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/review/DocumentReviewHeader.tsx
@@ -6,7 +6,6 @@ import {Translate, useTranslation} from 'sanity'
 import {Button} from '../../../../../ui-components'
 import {RelativeTime} from '../../../../components/RelativeTime'
 import {UserAvatar} from '../../../../components/userAvatar/UserAvatar'
-import {type BundleDocument} from '../../../../store/bundles/types'
 import {Chip} from '../../../components/Chip'
 import {ReleaseDocumentPreview} from '../../../components/ReleaseDocumentPreview'
 import {releasesLocaleNamespace} from '../../../i18n'
@@ -17,7 +16,7 @@ export function DocumentReviewHeader({
   document,
   isLoading,
   history,
-  release,
+  releaseSlug,
   validation,
   isExpanded,
   toggleIsExpanded,
@@ -25,7 +24,7 @@ export function DocumentReviewHeader({
   document: SanityDocument
   previewValues: PreviewValue
   isLoading: boolean
-  release: BundleDocument
+  releaseSlug: string
   validation?: DocumentValidationStatus
   isExpanded: boolean
   toggleIsExpanded: () => void
@@ -53,7 +52,7 @@ export function DocumentReviewHeader({
           <ReleaseDocumentPreview
             documentId={document._id}
             documentTypeName={document._type}
-            releaseSlug={release.slug}
+            releaseSlug={releaseSlug}
             previewValues={previewValues}
             isLoading={isLoading}
             hasValidationError={validation?.hasError}

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -1,4 +1,5 @@
 import {isValidationErrorMarker, type SanityDocument} from '@sanity/types'
+import {uuid} from '@sanity/uuid'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
 import {combineLatest} from 'rxjs'
@@ -16,6 +17,7 @@ export interface DocumentValidationStatus extends ValidationStatus {
 }
 
 export interface DocumentInBundleResult {
+  memoKey: string
   document: SanityDocument
   validation: DocumentValidationStatus
   previewValues: {isLoading: boolean; values: ReturnType<typeof prepareForPreview>}
@@ -83,6 +85,7 @@ export function useBundleDocuments(bundle: string): {
             document,
             validation,
             previewValues,
+            memoKey: uuid(),
           })),
         )
       }),

--- a/packages/sanity/src/core/store/_legacy/__workshop__/HistoryTimelineStory.tsx
+++ b/packages/sanity/src/core/store/_legacy/__workshop__/HistoryTimelineStory.tsx
@@ -89,6 +89,7 @@ export default function HistoryTimelineStory() {
       rootDiff: diff,
       isComparingCurrent,
       value,
+      showFromValue: true,
     }),
     [diff, documentId, isComparingCurrent, schemaType, value],
   )

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/ChangesInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/ChangesInspector.tsx
@@ -55,6 +55,7 @@ export function ChangesInspector(props: DocumentInspectorProps): ReactElement {
       rootDiff: diff,
       isComparingCurrent,
       value,
+      showFromValue: true,
     }),
     [documentId, diff, isComparingCurrent, schemaType, value],
   )

--- a/packages/sanity/test/testUtils/TestProvider.tsx
+++ b/packages/sanity/test/testUtils/TestProvider.tsx
@@ -2,9 +2,9 @@ import {type SanityClient} from '@sanity/client'
 import {LayerProvider, studioTheme, ThemeProvider, ToastProvider} from '@sanity/ui'
 import {noop} from 'lodash'
 import {type ReactNode} from 'react'
+import {AddonDatasetContext} from 'sanity/_singletons'
 
 import {
-  AddonDatasetProvider,
   LocaleProviderBase,
   type LocaleResourceBundle,
   ResourceCacheProvider,
@@ -53,7 +53,16 @@ export async function createTestProvider({
                 <WorkspaceProvider workspace={workspace}>
                   <SourceProvider source={workspace.unstable_sources[0]}>
                     <ResourceCacheProvider>
-                      <AddonDatasetProvider>{children}</AddonDatasetProvider>
+                      <AddonDatasetContext.Provider
+                        value={{
+                          createAddonDataset: async () => Promise.resolve(null),
+                          isCreatingDataset: false,
+                          client: null,
+                          ready: true,
+                        }}
+                      >
+                        {children}
+                      </AddonDatasetContext.Provider>
                     </ResourceCacheProvider>
                   </SourceProvider>
                 </WorkspaceProvider>


### PR DESCRIPTION
### Description
This PR introduces some changes to address the use case of reviewing a new document in a release.
Replaces the `new document` view for a difference showing all the fields as added with the corresponding value.
![image](https://github.com/user-attachments/assets/a6550164-cfbf-4ff6-8546-d92c7e235a4b)
<img width="995" alt="image" src="https://github.com/user-attachments/assets/18bb4753-7d00-4d63-b8d9-332af2dd8f17">

To generate this difference it:
- Calculates the diff of the element with an empty object as initial value, all new fields will be calculated as "added".
- Adds new `showFromValue` property to the `DocumentDiff` context which will be used to define if the original value needs to be shown or not, some components, like the image, show an empty image placeholder when no initial `from` value is provided.
- Updates the necessary Diff components to check for the `showFromValue` and avoid rendering empty or placeholder values.

#### Other changes
- Adds a `memoKey` property to the `BundleInDocumentResult` object, which is useful to define if some components should re render or not, this key will be recreated every time something in that result changes, so we can ensure that by checking only that key, if it's the same value, nothing has changed in the inner object, this allows us to memoize components by checking it `prev.item.memoKey === next.item.memoKey` 

- Updates [ReleaseSummary](packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx) to use the bundleOperations hook instead of defining it's own patch action.

- Updates [TestProvider.tsx](https://github.com/sanity-io/sanity/compare/corel...corel-62?expand=1#diff-8902abb51209aa1c27ce7d6593109b4df4291d4c360eb125d89e71b60775c04b) to mock the `AddonDatasetContext` which was re rendering the components and printing console.errors making it hard to debug the existing tests. 
 Example: 

```
console.error
    Warning: An update to AddonDatasetProviderInner inside a test was not wrapped in act(...).
    When testing, code that causes React state updates should be wrapped into act(...):
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
        at children (/Users/pedrobonamin/code/sanity/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx:17:10)
        at AddonDatasetProvider (/Users/pedrobonamin/code/sanity/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx:139:29)
        at children (/Users/pedrobonamin/code/sanity/packages/sanity/src/core/store/_legacy/ResourceCacheProvider.tsx:18:40)
        at children (/Users/pedrobonamin/code/sanity/packages/sanity/src/core/studio/source.tsx:13:33)
        at children (/Users/pedrobonamin/code/sanity/packages/sanity/src/core/studio/workspace.tsx:13:36)
        at LayerProvider (/Users/pedrobonamin/code/sanity/node_modules/.pnpm/@sanity+ui@2.8.8_react-dom@18.3.1_react@18.3.1__react-is@18.3.1_react@18.3.1_styled-component_fbogie77evuot6l34mwfts4wai/node_modules/@sanity/ui/src/core/utils/layer/layerProvider.tsx:19:10)

```
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is the `memoKey` approach correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Related tests have been updated.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
