### PR TITLE
refactor(sanity): update version id to match `versions.[bundle].[id]`

### DIFF
--- a/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
+++ b/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
@@ -2,7 +2,13 @@ import {AddIcon, CheckmarkIcon} from '@sanity/icons'
 import {useToast} from '@sanity/ui'
 import {type ReactNode, useCallback, useState} from 'react'
 import {filter, firstValueFrom} from 'rxjs'
-import {getPublishedId, useDocumentOperation, useDocumentStore, useTranslation} from 'sanity'
+import {
+  getPublishedId,
+  getVersionId,
+  useDocumentOperation,
+  useDocumentStore,
+  useTranslation,
+} from 'sanity'
 
 import {Button} from '../../../../ui-components'
 import {type BundleDocument} from '../../../store/bundles/types'
@@ -52,7 +58,7 @@ export function BundleActions(props: BundleActionsProps): ReactNode {
       return
     }
 
-    const bundleId = `versions.${slug}.${documentId}`
+    const bundleId = getVersionId(documentId, slug)
 
     setCreatingVersion(true)
 
@@ -68,7 +74,7 @@ export function BundleActions(props: BundleActionsProps): ReactNode {
     // only change if the version was created successfully
     await createVersionSuccess
     setIsInVersion(true)
-  }, [documentId, slug, publishedId, documentStore.pair, documentType, newVersion, toast, title])
+  }, [documentId, slug, documentStore.pair, documentType, newVersion, toast, title])
 
   /** TODO what should happen when you add a version if we don't have the ready button */
 

--- a/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
+++ b/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
@@ -52,8 +52,7 @@ export function BundleActions(props: BundleActionsProps): ReactNode {
       return
     }
 
-    // TODO: Replace for getVersionId function
-    const bundleId = `${slug}.${publishedId}`
+    const bundleId = `versions.${slug}.${documentId}`
 
     setCreatingVersion(true)
 

--- a/packages/sanity/src/core/bundles/hooks/__tests__/useDocumentVersions.test.tsx
+++ b/packages/sanity/src/core/bundles/hooks/__tests__/useDocumentVersions.test.tsx
@@ -4,6 +4,7 @@ import {of} from 'rxjs'
 
 import {type DocumentPreviewStore} from '../../../preview'
 import {type BundleDocument} from '../../../store'
+import {type PublishedId} from '../../../util/draftUtils'
 import {useDocumentVersions} from '../useDocumentVersions'
 
 // Mock the entire module
@@ -61,8 +62,18 @@ async function setupMocks({
   const useDocumentPreviewStore = sanityModule.useDocumentPreviewStore as jest.Mock<
     typeof sanityModule.useDocumentPreviewStore
   >
+  const getPublishedId = sanityModule.getPublishedId as jest.Mock<
+    typeof sanityModule.getPublishedId
+  >
 
-  useBundles.mockReturnValue({data: bundles, loading: false, dispatch: jest.fn()})
+  useBundles.mockReturnValue({
+    data: bundles,
+    loading: false,
+    dispatch: jest.fn(),
+    deletedBundles: {},
+  })
+
+  getPublishedId.mockReturnValue('document-1' as PublishedId)
 
   useDocumentPreviewStore.mockReturnValue({
     unstable_observeDocumentIdSet: jest
@@ -89,7 +100,7 @@ describe('useDocumentVersions', () => {
   it('should return the bundles if versions are found', async () => {
     await setupMocks({
       bundles: [mockBundles[0]],
-      versionIds: ['spring-drop.document-1'],
+      versionIds: ['versions.spring-drop.document-1'],
     })
     const {result} = renderHook(() => useDocumentVersions({documentId: 'document-1'}))
     expect(result.current.data).toEqual([mockBundles[0]])

--- a/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
@@ -43,7 +43,7 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
 
   const observable = useMemo(() => {
     return documentPreviewStore
-      .unstable_observeDocumentIdSet(`sanity::versionOf("${publishedId}")`)
+      .unstable_observeDocumentIdSet(`_id in path("versions.**") && _id match '*.${publishedId}'`)
       .pipe(
         map(({documentIds}) => {
           return documentIds.flatMap((id) => {

--- a/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
@@ -37,7 +37,7 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
   const {documentId} = props
 
   const {data: bundles} = useBundles()
-  const publishedId = getPublishedId(documentId, documentId.includes('.'))
+  const publishedId = getPublishedId(documentId)
 
   const documentPreviewStore = useDocumentPreviewStore()
 

--- a/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
@@ -42,24 +42,27 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
   const documentPreviewStore = useDocumentPreviewStore()
 
   const observable = useMemo(() => {
-    return documentPreviewStore
-      .unstable_observeDocumentIdSet(`_id in path("versions.**") && _id match '*.${publishedId}'`)
-      .pipe(
-        map(({documentIds}) => {
-          return documentIds.flatMap((id) => {
-            // eslint-disable-next-line max-nested-callbacks
-            const matchingBundle = bundles?.find((bundle) => getBundleSlug(id) === bundle.slug)
-            return matchingBundle || []
-          })
-        }),
-        map((data) => ({data})),
-        catchError((error) => {
-          return of({error})
-        }),
-        scan((state, result) => {
-          return {...state, ...result}
-        }, INITIAL_STATE),
-      )
+    return (
+      documentPreviewStore
+        // TODO - re-add versionOf once CL has it ready
+        .unstable_observeDocumentIdSet(`_id in path("versions.**") && _id match '*.${publishedId}'`)
+        .pipe(
+          map(({documentIds}) => {
+            return documentIds.flatMap((id) => {
+              // eslint-disable-next-line max-nested-callbacks
+              const matchingBundle = bundles?.find((bundle) => getBundleSlug(id) === bundle.slug)
+              return matchingBundle || []
+            })
+          }),
+          map((data) => ({data})),
+          catchError((error) => {
+            return of({error})
+          }),
+          scan((state, result) => {
+            return {...state, ...result}
+          }, INITIAL_STATE),
+        )
+    )
   }, [bundles, documentPreviewStore, publishedId])
 
   return useObservable(observable, INITIAL_STATE)

--- a/packages/sanity/src/core/bundles/util/util.test.ts
+++ b/packages/sanity/src/core/bundles/util/util.test.ts
@@ -7,11 +7,11 @@ describe('getBundleSlug', () => {
     expect(getBundleSlug('versions.summer.my-document-id')).toBe('summer')
   })
 
-  it('should return the undefined if no bundle slug is found / is published id', () => {
+  it('should return the undefined if no bundle slug is found and document is a draft', () => {
     expect(getBundleSlug('drafts.my-document-id')).toBe(undefined)
   })
 
-  it('should return the undefined if no bundle slug is found', () => {
+  it('should return the undefined if no bundle slug is found and document is published', () => {
     expect(getBundleSlug('my-document-id')).toBe(undefined)
   })
 })

--- a/packages/sanity/src/core/bundles/util/util.test.ts
+++ b/packages/sanity/src/core/bundles/util/util.test.ts
@@ -7,8 +7,12 @@ describe('getBundleSlug', () => {
     expect(getBundleSlug('versions.summer.my-document-id')).toBe('summer')
   })
 
-  it('should return the PUBLISHED_SLUG if no bundle slug is found', () => {
-    expect(getBundleSlug('my-document-id')).toBe('Published')
+  it('should return the undefined if no bundle slug is found / is published id', () => {
+    expect(getBundleSlug('drafts.my-document-id')).toBe(undefined)
+  })
+
+  it('should return the undefined if no bundle slug is found', () => {
+    expect(getBundleSlug('my-document-id')).toBe(undefined)
   })
 })
 

--- a/packages/sanity/src/core/bundles/util/util.test.ts
+++ b/packages/sanity/src/core/bundles/util/util.test.ts
@@ -38,7 +38,7 @@ describe('getDocumentIsInPerspective', () => {
     )
   })
 
-  it('should return false if document is a version  document a no perspective is provided', () => {
+  it('should return false if document is a version document a no perspective is provided', () => {
     expect(getDocumentIsInPerspective('versions.summer.my-document-id', undefined)).toBe(false)
   })
 

--- a/packages/sanity/src/core/bundles/util/util.test.ts
+++ b/packages/sanity/src/core/bundles/util/util.test.ts
@@ -1,6 +1,16 @@
 import {describe, expect, it} from '@jest/globals'
 
-import {getDocumentIsInPerspective} from './util'
+import {getBundleSlug, getDocumentIsInPerspective} from './util'
+
+describe('getBundleSlug', () => {
+  it('should return the bundle slug', () => {
+    expect(getBundleSlug('versions.summer.my-document-id')).toBe('summer')
+  })
+
+  it('should return the PUBLISHED_SLUG if no bundle slug is found', () => {
+    expect(getBundleSlug('my-document-id')).toBe('Published')
+  })
+})
 
 // * - document: `summer.my-document-id`, perspective: `bundle.summer` : **true**
 // * - document: `my-document-id`, perspective: `bundle.summer` : **false**

--- a/packages/sanity/src/core/bundles/util/util.test.ts
+++ b/packages/sanity/src/core/bundles/util/util.test.ts
@@ -21,7 +21,7 @@ describe('getBundleSlug', () => {
 
 describe('getDocumentIsInPerspective', () => {
   it('should return true if document is in the current perspective', () => {
-    expect(getDocumentIsInPerspective('summer.my-document-id', 'bundle.summer')).toBe(true)
+    expect(getDocumentIsInPerspective('versions.summer.my-document-id', 'bundle.summer')).toBe(true)
   })
 
   it('should return false if document is not a version  document a perspective is provided', () => {
@@ -29,11 +29,13 @@ describe('getDocumentIsInPerspective', () => {
   })
 
   it('should return false if document is not in the current perspective', () => {
-    expect(getDocumentIsInPerspective('summer.my-document-id', 'bundle.winter')).toBe(false)
+    expect(getDocumentIsInPerspective('versions.summer.my-document-id', 'bundle.winter')).toBe(
+      false,
+    )
   })
 
   it('should return false if document is a version  document a no perspective is provided', () => {
-    expect(getDocumentIsInPerspective('summer.my-document-id', undefined)).toBe(false)
+    expect(getDocumentIsInPerspective('versions.summer.my-document-id', undefined)).toBe(false)
   })
 
   it("should return true if the document is in the 'Published' perspective, and no perspective is provided", () => {
@@ -45,7 +47,7 @@ describe('getDocumentIsInPerspective', () => {
 
   it('should handle complex document ids correctly', () => {
     expect(
-      getDocumentIsInPerspective('complex-summer.my-document-id', 'bundle.complex-summer'),
+      getDocumentIsInPerspective('versions.complex-summer.my-document-id', 'bundle.complex-summer'),
     ).toBe(true)
   })
 })

--- a/packages/sanity/src/core/bundles/util/util.ts
+++ b/packages/sanity/src/core/bundles/util/util.ts
@@ -4,6 +4,7 @@ import {type BundleDocument} from '../../store/bundles/types'
 import {isVersionId} from '../../util'
 
 const PUBLISHED_SLUG = 'Published'
+const DRAFTS_SLUG = 'Drafts'
 
 /**
  * @internal
@@ -17,7 +18,7 @@ export function getBundleSlug(documentId: string): string {
     return bundleSlug
   }
 
-  return 'drafts'
+  return DRAFTS_SLUG
 }
 
 /**

--- a/packages/sanity/src/core/bundles/util/util.ts
+++ b/packages/sanity/src/core/bundles/util/util.ts
@@ -1,7 +1,7 @@
-import {isVersionId} from 'sanity'
 import speakingurl from 'speakingurl'
 
 import {type BundleDocument} from '../../store/bundles/types'
+import {isVersionId} from '../../util'
 
 const PUBLISHED_SLUG = 'Published'
 

--- a/packages/sanity/src/core/bundles/util/util.ts
+++ b/packages/sanity/src/core/bundles/util/util.ts
@@ -14,7 +14,7 @@ export function getBundleSlug(documentId: string): string {
   if (documentId.indexOf('.') === -1) return PUBLISHED_SLUG
 
   if (isVersionId(documentId)) {
-    const [_, bundleSlug, ...PublishedId] = documentId.split('.')
+    const [_, bundleSlug] = documentId.split('.')
     return bundleSlug
   }
 

--- a/packages/sanity/src/core/bundles/util/util.ts
+++ b/packages/sanity/src/core/bundles/util/util.ts
@@ -10,8 +10,9 @@ const PUBLISHED_SLUG = 'Published'
  */
 export function getBundleSlug(documentId: string): string {
   if (documentId.indexOf('.') === -1) return PUBLISHED_SLUG
-  const version = documentId.slice(0, documentId.indexOf('.'))
-  return version
+
+  const [_, bundleSlug, ...PublishedId] = documentId.split('.')
+  return bundleSlug
 }
 
 /**

--- a/packages/sanity/src/core/bundles/util/util.ts
+++ b/packages/sanity/src/core/bundles/util/util.ts
@@ -40,7 +40,7 @@ export function getDocumentIsInPerspective(
 ): boolean {
   const bundleSlug = getBundleSlug(documentId)
 
-  if (!perspective) return bundleSlug === PUBLISHED_SLUG || bundleSlug === 'drafts'
+  if (!perspective) return bundleSlug === PUBLISHED_SLUG || bundleSlug === DRAFTS_SLUG
 
   if (!perspective.startsWith('bundle.')) return false
   // perspective is `bundle.${bundleSlug}`

--- a/packages/sanity/src/core/bundles/util/util.ts
+++ b/packages/sanity/src/core/bundles/util/util.ts
@@ -38,7 +38,7 @@ export function getDocumentIsInPerspective(
 ): boolean {
   const bundleSlug = getBundleSlug(documentId)
 
-  if (!perspective) return true
+  if (!perspective) return !isVersionId(documentId)
 
   if (!perspective.startsWith('bundle.')) return false
   // perspective is `bundle.${bundleSlug}`

--- a/packages/sanity/src/core/bundles/util/util.ts
+++ b/packages/sanity/src/core/bundles/util/util.ts
@@ -1,3 +1,4 @@
+import {isVersionId} from 'sanity'
 import speakingurl from 'speakingurl'
 
 import {type BundleDocument} from '../../store/bundles/types'
@@ -11,8 +12,12 @@ const PUBLISHED_SLUG = 'Published'
 export function getBundleSlug(documentId: string): string {
   if (documentId.indexOf('.') === -1) return PUBLISHED_SLUG
 
-  const [_, bundleSlug, ...PublishedId] = documentId.split('.')
-  return bundleSlug
+  if (isVersionId(documentId)) {
+    const [_, bundleSlug, ...PublishedId] = documentId.split('.')
+    return bundleSlug
+  }
+
+  return 'drafts'
 }
 
 /**

--- a/packages/sanity/src/core/bundles/util/util.ts
+++ b/packages/sanity/src/core/bundles/util/util.ts
@@ -11,8 +11,7 @@ export function getBundleSlug(documentId: string): string | undefined {
   if (documentId.indexOf('.') === -1) return undefined
 
   if (isVersionId(documentId)) {
-    // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
-    const [_versionPrefix, bundleSlug] = documentId.split('.')
+    const [, bundleSlug] = documentId.split('.')
     return bundleSlug
   }
 

--- a/packages/sanity/src/core/bundles/util/util.ts
+++ b/packages/sanity/src/core/bundles/util/util.ts
@@ -3,15 +3,12 @@ import speakingurl from 'speakingurl'
 import {type BundleDocument} from '../../store/bundles/types'
 import {isVersionId} from '../../util'
 
-const PUBLISHED_SLUG = 'Published'
-const DRAFTS_SLUG = 'Drafts'
-
 /**
  * @internal
  * @hidden
  */
-export function getBundleSlug(documentId: string): string {
-  if (documentId.indexOf('.') === -1) return PUBLISHED_SLUG
+export function getBundleSlug(documentId: string): string | undefined {
+  if (documentId.indexOf('.') === -1) return undefined
 
   if (isVersionId(documentId)) {
     // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
@@ -19,7 +16,7 @@ export function getBundleSlug(documentId: string): string {
     return bundleSlug
   }
 
-  return DRAFTS_SLUG
+  return undefined
 }
 
 /**
@@ -41,7 +38,7 @@ export function getDocumentIsInPerspective(
 ): boolean {
   const bundleSlug = getBundleSlug(documentId)
 
-  if (!perspective) return bundleSlug === PUBLISHED_SLUG || bundleSlug === DRAFTS_SLUG
+  if (!perspective) return true
 
   if (!perspective.startsWith('bundle.')) return false
   // perspective is `bundle.${bundleSlug}`

--- a/packages/sanity/src/core/bundles/util/util.ts
+++ b/packages/sanity/src/core/bundles/util/util.ts
@@ -14,7 +14,8 @@ export function getBundleSlug(documentId: string): string {
   if (documentId.indexOf('.') === -1) return PUBLISHED_SLUG
 
   if (isVersionId(documentId)) {
-    const [_, bundleSlug] = documentId.split('.')
+    // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
+    const [_versionPrefix, bundleSlug] = documentId.split('.')
     return bundleSlug
   }
 

--- a/packages/sanity/src/core/preview/availability.ts
+++ b/packages/sanity/src/core/preview/availability.ts
@@ -6,7 +6,7 @@ import {combineLatest, defer, from, type Observable, of} from 'rxjs'
 import {distinctUntilChanged, map, mergeMap, reduce, switchMap} from 'rxjs/operators'
 import shallowEquals from 'shallow-equals'
 
-import {getDraftId, getPublishedId, isRecord} from '../util'
+import {getDraftId, getPublishedId, getVersionId, isRecord, isVersionId} from '../util'
 import {
   AVAILABILITY_NOT_FOUND,
   AVAILABILITY_PERMISSION_DENIED,
@@ -85,7 +85,7 @@ export function createPreviewAvailabilityObserver(
   ): Observable<DraftsModelDocumentAvailability> {
     const draftId = getDraftId(id)
     const publishedId = getPublishedId(id)
-    const versionId = version ? [version, publishedId].join('.') : undefined
+    const versionId = isVersionId(id) && version ? getVersionId(id, version) : undefined
     return combineLatest([
       observeDocumentAvailability(draftId),
       observeDocumentAvailability(publishedId),

--- a/packages/sanity/src/core/preview/utils/getPreviewStateObservable.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewStateObservable.ts
@@ -3,7 +3,7 @@ import {type ReactNode} from 'react'
 import {combineLatest, type Observable, of} from 'rxjs'
 import {map, startWith} from 'rxjs/operators'
 
-import {getDraftId, getPublishedId} from '../../util/draftUtils'
+import {getDraftId, getPublishedId, getVersionId} from '../../util/draftUtils'
 import {type DocumentPreviewStore} from '../documentPreviewStore'
 
 export interface PreviewState {
@@ -34,10 +34,9 @@ export function getPreviewStateObservable(
         schemaType,
       )
 
-  // TODO: Create `getVersionId` abstraction
   const version$ = bundlePerspective
     ? documentPreviewStore.observeForPreview(
-        {_type: 'reference', _ref: [bundlePerspective, getPublishedId(documentId, true)].join('.')},
+        {_type: 'reference', _ref: getVersionId(documentId, bundlePerspective)},
         schemaType,
       )
     : of({snapshot: null})
@@ -45,7 +44,7 @@ export function getPreviewStateObservable(
   const published$ = documentPreviewStore.observeForPreview(
     {
       _type: 'reference',
-      _ref: getPublishedId(documentId, documentId.startsWith(`${bundlePerspective}.`)),
+      _ref: getPublishedId(documentId),
     },
     schemaType,
   )

--- a/packages/sanity/src/core/releases/components/ReleaseDocumentPreview.tsx
+++ b/packages/sanity/src/core/releases/components/ReleaseDocumentPreview.tsx
@@ -39,7 +39,7 @@ export function ReleaseDocumentPreview({
             {...linkProps}
             intent="edit"
             params={{
-              id: getPublishedId(documentId, true),
+              id: getPublishedId(documentId),
               type: documentTypeName,
             }}
             searchParams={[['perspective', `bundle.${releaseSlug}`]]}

--- a/packages/sanity/src/core/releases/components/ReleasePublishAllButton/useObserveDocumentRevisions.ts
+++ b/packages/sanity/src/core/releases/components/ReleasePublishAllButton/useObserveDocumentRevisions.ts
@@ -10,7 +10,7 @@ import {
 
 export const useObserveDocumentRevisions = (documents: SanityDocument[]) => {
   const previewStore = useDocumentPreviewStore()
-  const publishedDocumentIds = documents.map(({_id}) => getPublishedId(_id, true))
+  const publishedDocumentIds = documents.map(({_id}) => getPublishedId(_id))
 
   const memoObservable = useMemo(
     () =>

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseReview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseReview.test.tsx
@@ -40,7 +40,7 @@ const MOCKED_DOCUMENTS: DocumentInBundleResult[] = [
       role: 'designer',
       _createdAt: '2024-07-10T12:10:38Z',
       name: 'William Faulkner added',
-      _id: 'differences.doc1',
+      _id: 'versions.differences.doc1',
       _updatedAt: '2024-07-15T10:46:02Z',
     },
     previewValues: {
@@ -68,7 +68,7 @@ const MOCKED_DOCUMENTS: DocumentInBundleResult[] = [
       role: 'developer',
       _createdAt: '2024-07-10T12:10:38Z',
       name: 'Virginia Woolf test',
-      _id: 'differences.doc2',
+      _id: 'versions.differences.doc2',
       _updatedAt: '2024-07-15T10:46:02Z',
     },
     previewValues: {

--- a/packages/sanity/src/core/releases/tool/detail/review/DocumentDiffContainer.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/review/DocumentDiffContainer.tsx
@@ -13,7 +13,7 @@ import {DocumentDiff} from './DocumentDiff'
 
 const DocumentDiffExpanded = memo(
   function DocumentDiffExpanded({document}: {document: DocumentInBundleResult['document']}) {
-    const publishedId = getPublishedId(document._id, true)
+    const publishedId = getPublishedId(document._id)
 
     const schema = useSchema()
     const schemaType = schema.get(document._type) as ObjectSchemaType

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -27,7 +27,7 @@ export function useBundleDocuments(bundle: string): {
   loading: boolean
   results: DocumentInBundleResult[]
 } {
-  const groqFilter = `defined(_version) &&  _id in path("${bundle}.*")`
+  const groqFilter = `_id in path("versions.${bundle}.*")`
   const documentPreviewStore = useDocumentPreviewStore()
   const {getClient, i18n} = useSource()
   const schema = useSchema()

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/newVersion.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/newVersion.ts
@@ -22,7 +22,6 @@ export const newVersion: OperationImpl<[baseDocumentId: string], 'NO_NEW_VERSION
         // we have guardrails for this on the front
         _id: dupeId,
         _type: source._type,
-        _version: {},
       },
       {
         tag: 'document.newVersion',

--- a/packages/sanity/src/core/store/_legacy/document/useInitialValue.ts
+++ b/packages/sanity/src/core/store/_legacy/document/useInitialValue.ts
@@ -3,7 +3,7 @@ import {useEffect, useMemo, useState} from 'react'
 
 import {useDataset, useProjectId, useSchema} from '../../../hooks'
 import {useSource} from '../../../studio'
-import {useUnique} from '../../../util'
+import {getVersionId, useUnique} from '../../../util'
 import {useCurrentUser} from '../../user'
 import {useDocumentStore} from '../datastores'
 import {type InitialValueState} from './initialValue/types'
@@ -26,10 +26,7 @@ export function useInitialValue(props: {
   const defaultValue: SanityDocumentLike = useMemo(() => {
     const base: SanityDocumentLike = {_id: documentId, _type: documentType}
     if (version) {
-      // TODO: this would need to be updated once the CL changes land for the new id format.
-      base._version = {}
-      // TODO: Use getVersionId function.
-      base._id = `${version}.${documentId}`
+      base._id = getVersionId(documentId, version)
     }
     return base
   }, [documentId, documentType, version])

--- a/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
+++ b/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
@@ -17,6 +17,8 @@ import {
   type Annotation,
   type Chunk,
   DRAFTS_FOLDER,
+  getVersionId,
+  isVersionId,
   remoteSnapshots,
   type RemoteSnapshotVersionEvent,
   type SelectionState,
@@ -117,7 +119,8 @@ export function useTimelineStore({
     () =>
       historyStore.getTimelineController({
         client,
-        documentId: version ? [version, documentId].join('.') : documentId,
+        documentId:
+          isVersionId(documentId) && version ? getVersionId(documentId, version) : documentId,
         documentType,
       }),
     [client, documentId, documentType, historyStore, version],
@@ -184,7 +187,7 @@ export function useTimelineStore({
           publishedId: documentId,
           ...(version
             ? {
-                versionId: [version, documentId].join('.'),
+                versionId: getVersionId(documentId, version),
               }
             : {}),
         },

--- a/packages/sanity/src/core/store/bundles/createBundlesMetadataAggregator.ts
+++ b/packages/sanity/src/core/store/bundles/createBundlesMetadataAggregator.ts
@@ -26,7 +26,7 @@ const getFetchQuery = (bundleSlugs: string[]) => {
     ({subquery: accSubquery, projection: accProjection}, bundleSlug) => {
       const safeSlug = getSafeSlug(bundleSlug)
 
-      const subquery = `${accSubquery}"${safeSlug}": *[_id in path("${bundleSlug}.*")]{_updatedAt } | order(_updatedAt desc),`
+      const subquery = `${accSubquery}"${safeSlug}": *[_id in path("versions.${bundleSlug}.*")]{_updatedAt } | order(_updatedAt desc),`
 
       // conforms to BundlesMetadata
       const projection = `${accProjection}"${bundleSlug}": {
@@ -83,9 +83,9 @@ export const createBundlesMetadataAggregator = (client: SanityClient | null) => 
 
     return client.observable
       .listen(
-        `*[defined(_version) && (${bundleSlugs.reduce(
+        `(${bundleSlugs.reduce(
           (accQuery, bundleSlug, index) =>
-            `${accQuery}${index === 0 ? '' : '||'} _id in path("${bundleSlug}.*")`,
+            `${accQuery}${index === 0 ? '' : '||'} _id in path("versions.${bundleSlug}.*")`,
           '',
         )})]`,
         {},

--- a/packages/sanity/src/core/store/bundles/useBundleOperations.ts
+++ b/packages/sanity/src/core/store/bundles/useBundleOperations.ts
@@ -61,7 +61,7 @@ export function useBundleOperations() {
 
       // Fetch the related version documents from the main dataset, this documents will be removed
       const versionDocuments = await studioClient.fetch<SanityDocument[]>(
-        `*[defined(_version) && _id in path("${bundle.slug}.*")]`,
+        `_id in path("versions.${bundle.slug}.*")]`,
       )
       // Starts the transaction to remove the documents.
       const transaction = studioClient.transaction()

--- a/packages/sanity/src/core/store/bundles/useBundleOperations.ts
+++ b/packages/sanity/src/core/store/bundles/useBundleOperations.ts
@@ -109,7 +109,7 @@ export function useBundleOperations() {
 
       const transaction = studioClient.transaction()
       bundleDocuments.forEach((bundleDocument) => {
-        const publishedDocumentId = getPublishedId(bundleDocument._id, true)
+        const publishedDocumentId = getPublishedId(bundleDocument._id)
         const versionDocument = omit(bundleDocument, ['_version']) as SanityDocument
         const publishedDocumentRevisionId = publishedDocumentsRevisions[publishedDocumentId]
 

--- a/packages/sanity/src/core/util/draftUtils.test.ts
+++ b/packages/sanity/src/core/util/draftUtils.test.ts
@@ -57,6 +57,7 @@ test.each([
   ['from published id', 'agot', 'agot'],
   ['from draft id', 'drafts.agot', 'agot'],
   ['from version id', 'versions.summer-drop.agot', 'agot'],
+  ['from complex id with version', 'versions.summer-drop.foo.agot', 'foo.agot'],
 ])('getPublishedId(): %s', (_, documentId, shouldEqual) => {
   expect(getPublishedId(documentId)).toEqual(shouldEqual)
 })

--- a/packages/sanity/src/core/util/draftUtils.test.ts
+++ b/packages/sanity/src/core/util/draftUtils.test.ts
@@ -1,7 +1,7 @@
 import {expect, test} from '@jest/globals'
 import {type SanityDocument} from '@sanity/types'
 
-import {collate, documentIdEquals, removeDupes} from './draftUtils'
+import {collate, documentIdEquals, getPublishedId, getVersionId, removeDupes} from './draftUtils'
 
 test('collate()', () => {
   const foo = {_type: 'foo', _id: 'foo'}
@@ -37,4 +37,26 @@ test.each([
   ['rhs non-draft prefix, otherwise equality', 'agot', 'notes.agot', false],
 ])('documentIdEquals(): %s', (_, documentId, equalsDocumentId, shouldEqual) => {
   expect(documentIdEquals(documentId, equalsDocumentId)).toEqual(shouldEqual)
+})
+
+test.each([
+  ['From published id', 'agot', 'summer-drop', 'versions.summer-drop.agot'],
+  ['From draft id', 'drafts.agot', 'summer-drop', 'versions.summer-drop.agot'],
+  ['From same version id', 'versions.summer-drop.agot', 'summer-drop', 'versions.summer-drop.agot'],
+  [
+    'From other version id',
+    'versions.winter-drop.agot',
+    'summer-drop',
+    'versions.summer-drop.agot',
+  ],
+])('getVersionId(): %s', (_, documentId, equalsDocumentId, shouldEqual) => {
+  expect(getVersionId(documentId, equalsDocumentId)).toEqual(shouldEqual)
+})
+
+test.each([
+  ['from published id', 'agot', 'agot'],
+  ['from draft id', 'drafts.agot', 'agot'],
+  ['from version id', 'versions.summer-drop.agot', 'agot'],
+])('getPublishedId(): %s', (_, documentId, shouldEqual) => {
+  expect(getPublishedId(documentId)).toEqual(shouldEqual)
 })

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -115,8 +115,8 @@ export function getVersionId(id: string, bundle: string): string {
 /** @internal */
 export function getPublishedId(id: string): PublishedId {
   if (isVersionId(id)) {
-    // always return the last segment of the id
-    return id.split('.').pop() as PublishedId
+    // make sure to only remove the versions prefix and the bundle name
+    return id.split(PATH_SEPARATOR).slice(2).join(PATH_SEPARATOR) as PublishedId as PublishedId
   }
 
   if (isDraftId(id)) {

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -113,8 +113,8 @@ export function getVersionId(id: string, bundle: string): string {
 /** @internal */
 export function getPublishedId(id: string): PublishedId {
   if (isVersionId(id)) {
-    const [version, bundle, ...publishedId] = id.split('.')
-    return publishedId.join('.') as PublishedId
+    // always return the last segment of the id
+    return id.split('.').pop() as PublishedId
   }
 
   if (isDraftId(id)) {

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -174,7 +174,6 @@ export function collate<
   T extends {
     _id: string
     _type: string
-    _version?: Record<string, never>
   },
 >(documents: T[], {bundlePerspective}: CollateOptions = {}): CollatedHit<T>[] {
   const byId = documents.reduce((res, doc) => {

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -1,5 +1,6 @@
 import {type SanityDocument, type SanityDocumentLike} from '@sanity/types'
 
+import {getBundleSlug} from '../bundles/util/util'
 import {isNonNullable} from './isNonNullable'
 
 /** @internal */
@@ -179,7 +180,7 @@ export function collate<
   const byId = documents.reduce((res, doc) => {
     const publishedId = getPublishedId(doc._id)
     const isVersion = isVersionId(doc._id)
-    const bundle = isVersion ? doc._id.split('.').at(0) : undefined
+    const bundle = isVersion ? getBundleSlug(doc._id) : undefined
 
     let entry = res.get(publishedId)
     if (!entry) {

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -181,7 +181,7 @@ export function collate<
   const byId = documents.reduce((res, doc) => {
     const publishedId = getPublishedId(doc._id)
     const isVersion = isVersionId(doc._id)
-    const bundle = isVersion ? getBundleSlug(doc._id) : undefined
+    const bundle = getBundleSlug(doc._id)
 
     let entry = res.get(publishedId)
     if (!entry) {

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -15,6 +15,7 @@ export type PublishedId = Opaque<string, 'publishedId'>
 
 /** @internal */
 export const DRAFTS_FOLDER = 'drafts'
+/** @internal */
 export const VERSION_FOLDER = 'versions'
 const PATH_SEPARATOR = '.'
 const DRAFTS_PREFIX = `${DRAFTS_FOLDER}${PATH_SEPARATOR}`
@@ -59,7 +60,7 @@ export function isDraftId(id: string): id is DraftId {
   return id.startsWith(DRAFTS_PREFIX)
 }
 
-/* @interal */
+/** @internal */
 export function isVersionId(id: string): boolean {
   return id.startsWith(VERSION_PREFIX)
 }

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -81,7 +81,7 @@ export function getIdPair(
     draftId: getDraftId(id),
     ...(version
       ? {
-          versionId: id.startsWith(`${version}.`) ? id : [version, getPublishedId(id)].join('.'),
+          versionId: isVersionId(id) ? id : getVersionId(id, version),
         }
       : {}),
   }
@@ -112,7 +112,7 @@ export function getVersionId(id: string, bundle: string): string {
 
 /** @internal */
 export function getPublishedId(id: string): PublishedId {
-  if (isVersionId(id)) {
+  if (isVersionId(id) || id.includes(PATH_SEPARATOR)) {
     // always return the last segment of the id
     return id.split('.').pop() as PublishedId
   }

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -112,7 +112,7 @@ export function getVersionId(id: string, bundle: string): string {
 
 /** @internal */
 export function getPublishedId(id: string): PublishedId {
-  if (isVersionId(id) || id.includes(PATH_SEPARATOR)) {
+  if (isVersionId(id)) {
     // always return the last segment of the id
     return id.split('.').pop() as PublishedId
   }

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -14,8 +14,10 @@ export type PublishedId = Opaque<string, 'publishedId'>
 
 /** @internal */
 export const DRAFTS_FOLDER = 'drafts'
+export const VERSION_FOLDER = 'versions'
 const PATH_SEPARATOR = '.'
 const DRAFTS_PREFIX = `${DRAFTS_FOLDER}${PATH_SEPARATOR}`
+const VERSION_PREFIX = `${VERSION_FOLDER}${PATH_SEPARATOR}`
 
 /**
  *
@@ -56,6 +58,11 @@ export function isDraftId(id: string): id is DraftId {
   return id.startsWith(DRAFTS_PREFIX)
 }
 
+/* @interal */
+export function isVersionId(id: string): boolean {
+  return id.startsWith(VERSION_PREFIX)
+}
+
 /**
  * TODO: Improve return type based on presence of `version` option.
  *
@@ -82,7 +89,7 @@ export function getIdPair(
 
 /** @internal */
 export function isPublishedId(id: string): id is PublishedId {
-  return !isDraftId(id)
+  return !isDraftId(id) && !isVersionId(id)
 }
 
 /** @internal */
@@ -90,10 +97,24 @@ export function getDraftId(id: string): DraftId {
   return isDraftId(id) ? id : ((DRAFTS_PREFIX + id) as DraftId)
 }
 
+/* @internal */
+export function getVersionId(id: string, bundle: string): string {
+  if (isVersionId(id)) {
+    const [version, bundleName, ...publishedId] = id.split('.')
+    if (bundleName === bundle) return id
+    return `${VERSION_PREFIX}${bundle}${PATH_SEPARATOR}${publishedId}`
+  }
+
+  const publishedId = getPublishedId(id)
+
+  return `${VERSION_PREFIX}${bundle}${PATH_SEPARATOR}${publishedId}`
+}
+
 /** @internal */
-export function getPublishedId(id: string, isVersion?: boolean): PublishedId {
-  if (isVersion) {
-    return id.split(PATH_SEPARATOR).slice(1).join(PATH_SEPARATOR) as PublishedId
+export function getPublishedId(id: string): PublishedId {
+  if (isVersionId(id)) {
+    const [version, bundle, ...publishedId] = id.split('.')
+    return publishedId.join('.') as PublishedId
   }
 
   if (isDraftId(id)) {
@@ -157,8 +178,8 @@ export function collate<
   },
 >(documents: T[], {bundlePerspective}: CollateOptions = {}): CollatedHit<T>[] {
   const byId = documents.reduce((res, doc) => {
-    const isVersion = Boolean(doc._version)
-    const publishedId = getPublishedId(doc._id, isVersion)
+    const publishedId = getPublishedId(doc._id)
+    const isVersion = isVersionId(doc._id)
     const bundle = isVersion ? doc._id.split('.').at(0) : undefined
 
     let entry = res.get(publishedId)

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -99,7 +99,7 @@ export function getDraftId(id: string): DraftId {
   return isDraftId(id) ? id : ((DRAFTS_PREFIX + id) as DraftId)
 }
 
-/* @internal */
+/**  @internal */
 export function getVersionId(id: string, bundle: string): string {
   if (isVersionId(id)) {
     const [version, bundleName, ...publishedId] = id.split('.')

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -19,6 +19,7 @@ import {
   getDraftId,
   getExpandOperations,
   getPublishedId,
+  isVersionId,
   type OnPathFocusPayload,
   type PatchEvent,
   setAtPath,
@@ -517,10 +518,8 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   })
 
   const isNonExistent = !value?._id
-  const isNonExistentInBundle =
-    typeof bundlePerspective !== 'undefined' && !value._id.startsWith(`${bundlePerspective}.`)
-  const existsInBundle =
-    typeof bundlePerspective !== 'undefined' && value._id.startsWith(`${bundlePerspective}.`)
+  const isNonExistentInBundle = typeof bundlePerspective !== 'undefined' && !isVersionId(value._id)
+  const existsInBundle = typeof bundlePerspective !== 'undefined' && isVersionId(value._id)
 
   const readOnly = useMemo(() => {
     const hasNoPermission = !isPermissionsLoading && !permissions?.granted

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx
@@ -113,7 +113,7 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
 
   const renderItem = useCallback<CommandListRenderItemCallback<SanityDocument>>(
     (item, {activeIndex}) => {
-      const publishedId = getPublishedId(item._id, Boolean(item._version))
+      const publishedId = getPublishedId(item._id)
       const isSelected = childItemId === publishedId
       const pressed = !isActive && isSelected
       const selected = isActive && isSelected

--- a/packages/sanity/src/structure/panes/documentList/helpers.ts
+++ b/packages/sanity/src/structure/panes/documentList/helpers.ts
@@ -10,7 +10,7 @@ import {
 } from '@sanity/types'
 import * as PathUtils from '@sanity/util/paths'
 import {type ExprNode, parse} from 'groq-js'
-import {collate, getPublishedId} from 'sanity'
+import {collate, getPublishedId, isVersionId} from 'sanity'
 
 import {type DocumentListPaneItem, type SortOrder} from './types'
 
@@ -22,9 +22,9 @@ export function removePublishedWithDrafts(
   documents: SanityDocumentLike[],
   {bundlePerspective}: {bundlePerspective?: string} = {},
 ): DocumentListPaneItem[] {
-  return collate(documents, {bundlePerspective}).map((entry) => {
+  return collate(documents).map((entry) => {
     const doc = entry.version || entry.draft || entry.published
-    const isVersion = Boolean(doc?._version)
+    const isVersion = isVersionId(doc?._id || '')
     const hasDraft = Boolean(entry.draft)
 
     return {

--- a/packages/sanity/src/structure/panes/documentList/helpers.ts
+++ b/packages/sanity/src/structure/panes/documentList/helpers.ts
@@ -22,7 +22,7 @@ export function removePublishedWithDrafts(
   documents: SanityDocumentLike[],
   {bundlePerspective}: {bundlePerspective?: string} = {},
 ): DocumentListPaneItem[] {
-  return collate(documents).map((entry) => {
+  return collate(documents, {bundlePerspective}).map((entry) => {
     const doc = entry.version || entry.draft || entry.published
     const isVersion = isVersionId(doc?._id || '')
     const hasDraft = Boolean(entry.draft)

--- a/packages/sanity/src/structure/panes/documentList/helpers.ts
+++ b/packages/sanity/src/structure/panes/documentList/helpers.ts
@@ -24,7 +24,7 @@ export function removePublishedWithDrafts(
 ): DocumentListPaneItem[] {
   return collate(documents, {bundlePerspective}).map((entry) => {
     const doc = entry.version || entry.draft || entry.published
-    const isVersion = isVersionId(doc?._id || '')
+    const isVersion = doc?.id && isVersionId(doc._id)
     const hasDraft = Boolean(entry.draft)
 
     return {


### PR DESCRIPTION
### Description

- Change `newVersion` to use `versions.[bundle].[id]` vs `[bundle].[id]`
- Change `newVersion` to remove `_version`
- Update `getPublishedId`
- Update places where `_version` was being used
- Add `getVersionId` and `isVersionId`
- Remove `isVersion` parameter from `getPublishedId` (and update each location where it was used)
- Update areas where `getVersionId` / `isVersionId` makes sense to be used
- Update tests

❗ 
- Using an alternative groq to `versionsOf` since that changes hasn't landed in CL yet

#### Dependencies
- waiting for `versionsOf` to work with version.(bundle).(id)
- has _version removal landed?
 
### What to review

- Did I miss anything? 
- Does the structure tool work as you'd expect?
- Does the linking documents in the release tool work as expected?
- Can you edit / see the right documents on the structure tool list?
- Can you add new documents to versions and have those have the right ids?
- Any use cases that are breaking and that weren't caught by the tests / manual test?

### How to test
In the preview you can check the release `New release with a punch` which should have already 2 documents with the new id structure. Feel to create new docs and add them to releases.

❗ **old documents will not appear on lists / will appear disabled / won't be part of the number of the bundles metada**

