### PR TITLE
chore(test-studio): fix custom markers PTE example

### DIFF
--- a/dev/test-studio/schema/standard/portableText/customMarkers/schemaTypes.tsx
+++ b/dev/test-studio/schema/standard/portableText/customMarkers/schemaTypes.tsx
@@ -1,5 +1,5 @@
 import {LinkIcon, RocketIcon} from '@sanity/icons'
-import {defineType} from 'sanity'
+import {type BlockAnnotationProps, defineType} from 'sanity'
 
 import {CustomContentInput} from './CustomContentInput'
 
@@ -9,7 +9,9 @@ const boostRender = (props: any) => (
 
 const normalRender = (props: any) => <span style={{fontFamily: 'monospace'}}>{props.children}</span>
 
-const hyperLinkRender = (props: any) => <span style={{color: 'blue'}}>{props.children}</span>
+const hyperLinkRender = (props: BlockAnnotationProps) => (
+  <span style={{color: 'blue'}}>{props.textElement}</span>
+)
 
 export const ptCustomMarkersTestType = defineType({
   type: 'document',


### PR DESCRIPTION
Before this change, annotations would not be properly rendered in the editor. Instead of rendering the text element, the form for editing the annotation was rendered in the editor. This is clearly not intended and causes Slate to blow up when you try to focus the rendered form.

---

Can be tested here: 

Annotated text before:
![Screenshot 2024-08-12 at 13 51 37](https://github.com/user-attachments/assets/153e1048-6783-4241-99a9-a17b3ae2a9c4)

Annotated text now:
![Screenshot 2024-08-12 at 13 51 11](https://github.com/user-attachments/assets/569b9ce2-3f1d-4f89-91d4-d2bd0d1da53a)
