### PR TITLE
refactor(preview): extract global listener, refactor preview APIs and improve typings

### DIFF
--- a/packages/sanity/src/core/preview/availability.ts
+++ b/packages/sanity/src/core/preview/availability.ts
@@ -67,34 +67,10 @@ function mutConcat<T>(array: T[], chunks: T[]) {
   return array
 }
 
-export function create_preview_availability(
+export function createPreviewAvailabilityObserver(
   versionedClient: SanityClient,
   observePaths: ObservePathsFn,
-): {
-  observeDocumentPairAvailability(id: string): Observable<DraftsModelDocumentAvailability>
-} {
-  /**
-   * Returns an observable of metadata for a given drafts model document
-   */
-  function observeDocumentPairAvailability(
-    id: string,
-  ): Observable<DraftsModelDocumentAvailability> {
-    const draftId = getDraftId(id)
-    const publishedId = getPublishedId(id)
-    return combineLatest([
-      observeDocumentAvailability(draftId),
-      observeDocumentAvailability(publishedId),
-    ]).pipe(
-      distinctUntilChanged(shallowEquals),
-      map(([draftReadability, publishedReadability]) => {
-        return {
-          draft: draftReadability,
-          published: publishedReadability,
-        }
-      }),
-    )
-  }
-
+): (id: string) => Observable<DraftsModelDocumentAvailability> {
   /**
    * Observable of metadata for the document with the given id
    * If we can't read a document it is either because it's not readable or because it doesn't exist
@@ -158,5 +134,25 @@ export function create_preview_availability(
     })
   }
 
-  return {observeDocumentPairAvailability}
+  /**
+   * Returns an observable of metadata for a given drafts model document
+   */
+  return function observeDocumentPairAvailability(
+    id: string,
+  ): Observable<DraftsModelDocumentAvailability> {
+    const draftId = getDraftId(id)
+    const publishedId = getPublishedId(id)
+    return combineLatest([
+      observeDocumentAvailability(draftId),
+      observeDocumentAvailability(publishedId),
+    ]).pipe(
+      distinctUntilChanged(shallowEquals),
+      map(([draftReadability, publishedReadability]) => {
+        return {
+          draft: draftReadability,
+          published: publishedReadability,
+        }
+      }),
+    )
+  }
 }

--- a/packages/sanity/src/core/preview/constants.tsx
+++ b/packages/sanity/src/core/preview/constants.tsx
@@ -8,7 +8,7 @@ export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
  * How long to wait after the last subscriber has unsubscribed before resetting the observable and disconnecting the listener
  * We want to keep the listener alive for a short while after the last subscriber has unsubscribed to avoid unnecessary reconnects
  */
-export const LISTENER_RESET_DELAY = 2000
+export const LISTENER_RESET_DELAY = 10_000
 
 export const AVAILABILITY_READABLE = {
   available: true,

--- a/packages/sanity/src/core/preview/constants.tsx
+++ b/packages/sanity/src/core/preview/constants.tsx
@@ -4,6 +4,12 @@ import {type PreviewValue} from '@sanity/types'
 export const INCLUDE_FIELDS_QUERY = ['_id', '_rev', '_type']
 export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
 
+/**
+ * How long to wait after the last subscriber has unsubscribed before resetting the observable and disconnecting the listener
+ * We want to keep the listener alive for a short while after the last subscriber has unsubscribed to avoid unnecessary reconnects
+ */
+export const LISTENER_RESET_DELAY = 2000
+
 export const AVAILABILITY_READABLE = {
   available: true,
   reason: 'READABLE',

--- a/packages/sanity/src/core/preview/createGlobalListener.ts
+++ b/packages/sanity/src/core/preview/createGlobalListener.ts
@@ -1,0 +1,31 @@
+import {type SanityClient} from '@sanity/client'
+import {timer} from 'rxjs'
+
+import {LISTENER_RESET_DELAY} from './constants'
+import {shareReplayLatest} from './utils/shareReplayLatest'
+
+/**
+ * @internal
+ * Creates a listener that will emit 'welcome' for all new subscribers immediately, and thereafter emit at every mutation event
+ */
+export function createGlobalListener(client: SanityClient) {
+  return client
+    .listen(
+      '*[!(_id in path("_.**"))]',
+      {},
+      {
+        events: ['welcome', 'mutation', 'reconnect'],
+        includeResult: false,
+        includePreviousRevision: false,
+        includeMutations: false,
+        visibility: 'query',
+        tag: 'preview.global',
+      },
+    )
+    .pipe(
+      shareReplayLatest({
+        predicate: (event) => event.type === 'welcome' || event.type === 'reconnect',
+        resetOnRefCountZero: () => timer(LISTENER_RESET_DELAY),
+      }),
+    )
+}

--- a/packages/sanity/src/core/preview/createPathObserver.ts
+++ b/packages/sanity/src/core/preview/createPathObserver.ts
@@ -122,8 +122,9 @@ function normalizePaths(path: (FieldName | PreviewPath)[]): PreviewPath[] {
 /**
  * Creates a function that allows observing nested paths on a document.
  * If the path includes a reference, the reference will be "followed", allowing for selecting paths within the referenced document.
- * @param options - Options - Requires a function that can observe fields on a document
- * */
+ * @param options - Requires a function that can observe fields on a document
+ * @internal
+ */
 export function createPathObserver(options: {observeFields: ObserveFieldsFn}) {
   const {observeFields} = options
 

--- a/packages/sanity/src/core/preview/createPathObserver.ts
+++ b/packages/sanity/src/core/preview/createPathObserver.ts
@@ -119,16 +119,19 @@ function normalizePaths(path: (FieldName | PreviewPath)[]): PreviewPath[] {
   )
 }
 
-export function createPathObserver(context: {observeFields: ObserveFieldsFn}) {
-  const {observeFields} = context
+/**
+ * Creates a function that allows observing nested paths on a document.
+ * If the path includes a reference, the reference will be "followed", allowing for selecting paths within the referenced document.
+ * @param options - Options - Requires a function that can observe fields on a document
+ * */
+export function createPathObserver(options: {observeFields: ObserveFieldsFn}) {
+  const {observeFields} = options
 
-  return {
-    observePaths(
-      value: Previewable,
-      paths: (FieldName | PreviewPath)[],
-      apiConfig?: ApiConfig,
-    ): Observable<Record<string, unknown> | null> {
-      return observePaths(value, normalizePaths(paths), observeFields, apiConfig)
-    },
+  return (
+    value: Previewable,
+    paths: (FieldName | PreviewPath)[],
+    apiConfig?: ApiConfig,
+  ): Observable<Record<string, unknown> | null> => {
+    return observePaths(value, normalizePaths(paths), observeFields, apiConfig)
   }
 }

--- a/packages/sanity/src/core/preview/createPreviewObserver.ts
+++ b/packages/sanity/src/core/preview/createPreviewObserver.ts
@@ -5,15 +5,17 @@ import {
   type PrepareViewOptions,
 } from '@sanity/types'
 import {isPlainObject} from 'lodash'
-import {type Observable, of as observableOf} from 'rxjs'
+import {type Observable, of} from 'rxjs'
 import {map, switchMap} from 'rxjs/operators'
 
+import {type ObserveForPreviewFn} from './documentPreviewStore'
 import {
   type ApiConfig,
+  type ObserveDocumentTypeFromIdFn,
+  type ObservePathsFn,
   type PreparedSnapshot,
   type Previewable,
   type PreviewableType,
-  type PreviewPath,
 } from './types'
 import {getPreviewPaths} from './utils/getPreviewPaths'
 import {invokePrepare, prepareForPreview} from './utils/prepareForPreview'
@@ -28,27 +30,25 @@ function isReference(value: unknown): value is {_ref: string} {
 
 // Takes a value and its type and prepares a snapshot for it that can be passed to a preview component
 export function createPreviewObserver(context: {
-  observeDocumentTypeFromId: (id: string, apiConfig?: ApiConfig) => Observable<string | undefined>
-  observePaths: (value: Previewable, paths: PreviewPath[], apiConfig?: ApiConfig) => any
-}): (
-  value: Previewable,
-  type: PreviewableType,
-  viewOptions?: PrepareViewOptions,
-  apiConfig?: ApiConfig,
-) => Observable<PreparedSnapshot> {
+  observeDocumentTypeFromId: ObserveDocumentTypeFromIdFn
+  observePaths: ObservePathsFn
+}): ObserveForPreviewFn {
   const {observeDocumentTypeFromId, observePaths} = context
 
   return function observeForPreview(
     value: Previewable,
     type: PreviewableType,
-    viewOptions?: PrepareViewOptions,
-    apiConfig?: ApiConfig,
+    options: {
+      viewOptions?: PrepareViewOptions
+      apiConfig?: ApiConfig
+    } = {},
   ): Observable<PreparedSnapshot> {
+    const {viewOptions = {}, apiConfig} = options
     if (isCrossDatasetReferenceSchemaType(type)) {
       // if the value is of type crossDatasetReference, but has no _ref property, we cannot prepare any value for the preview
       // and the most appropriate thing to do is to return `undefined` for snapshot
       if (!isCrossDatasetReference(value)) {
-        return observableOf({snapshot: undefined})
+        return of({snapshot: undefined})
       }
 
       const refApiConfig = {projectId: value._projectId, dataset: value._dataset}
@@ -57,9 +57,11 @@ export function createPreviewObserver(context: {
         switchMap((typeName) => {
           if (typeName) {
             const refType = type.to.find((toType) => toType.type === typeName)
-            return observeForPreview(value, refType as any, {}, refApiConfig)
+            if (refType) {
+              return observeForPreview(value, refType, {apiConfig: refApiConfig, viewOptions})
+            }
           }
-          return observableOf({snapshot: undefined})
+          return of({snapshot: undefined})
         }),
       )
     }
@@ -67,22 +69,24 @@ export function createPreviewObserver(context: {
       // if the value is of type reference, but has no _ref property, we cannot prepare any value for the preview
       // and the most appropriate thing to do is to return `undefined` for snapshot
       if (!isReference(value)) {
-        return observableOf({snapshot: undefined})
+        return of({snapshot: undefined})
       }
       // Previewing references actually means getting the referenced value,
       // and preview using the preview config of its type
-      // todo: We need a way of knowing the type of the referenced value by looking at the reference record alone
+      // We do this since there's no way of knowing the type of the referenced value by looking at the reference value alone
       return observeDocumentTypeFromId(value._ref).pipe(
         switchMap((typeName) => {
           if (typeName) {
             const refType = type.to.find((toType) => toType.name === typeName)
-            return observeForPreview(value, refType as any)
+            if (refType) {
+              return observeForPreview(value, refType)
+            }
           }
           // todo: in case we can't read the document type, we can figure out the reason why e.g. whether it's because
           //  the document doesn't exist or it's not readable due to lack of permission.
           //  We can use the "observeDocumentAvailability" function
           //  for this, but currently not sure if needed
-          return observableOf({snapshot: undefined})
+          return of({snapshot: undefined})
         }),
       )
     }
@@ -91,7 +95,7 @@ export function createPreviewObserver(context: {
       return observePaths(value, paths, apiConfig).pipe(
         map((snapshot) => ({
           type: type,
-          snapshot: snapshot && prepareForPreview(snapshot, type as any, viewOptions),
+          snapshot: snapshot ? prepareForPreview(snapshot, type, viewOptions) : null,
         })),
       )
     }
@@ -100,7 +104,7 @@ export function createPreviewObserver(context: {
     // the SchemaType doesn't have a `select` field. The schema compiler
     // provides a default `preview` implementation for `object`s, `image`s,
     // `file`s, and `document`s
-    return observableOf({
+    return of({
       type,
       snapshot:
         value && isRecord(value) ? invokePrepare(type, value, viewOptions).returnValue : null,

--- a/packages/sanity/src/core/preview/createPreviewObserver.ts
+++ b/packages/sanity/src/core/preview/createPreviewObserver.ts
@@ -28,7 +28,10 @@ function isReference(value: unknown): value is {_ref: string} {
   return isPlainObject(value)
 }
 
-// Takes a value and its type and prepares a snapshot for it that can be passed to a preview component
+/**
+ * Takes a value and its type and prepares a snapshot for it that can be passed to a preview component
+ * @internal
+ */
 export function createPreviewObserver(context: {
   observeDocumentTypeFromId: ObserveDocumentTypeFromIdFn
   observePaths: ObservePathsFn

--- a/packages/sanity/src/core/preview/documentPair.ts
+++ b/packages/sanity/src/core/preview/documentPair.ts
@@ -1,31 +1,27 @@
-import {type SanityClient} from '@sanity/client'
 import {type SanityDocument} from '@sanity/types'
 import {combineLatest, type Observable, of} from 'rxjs'
 import {map, switchMap} from 'rxjs/operators'
 
 import {getIdPair, isRecord} from '../util'
-import {create_preview_availability} from './availability'
-import {type DraftsModelDocument, type ObservePathsFn, type PreviewPath} from './types'
+import {
+  type DraftsModelDocument,
+  type ObserveDocumentAvailabilityFn,
+  type ObservePathsFn,
+  type PreviewPath,
+} from './types'
 
-export function create_preview_documentPair(
-  versionedClient: SanityClient,
-  observePaths: ObservePathsFn,
-): {
-  observePathsDocumentPair: <T extends SanityDocument = SanityDocument>(
-    id: string,
-    paths: PreviewPath[],
-  ) => Observable<DraftsModelDocument<T>>
-} {
-  const {observeDocumentPairAvailability} = create_preview_availability(
-    versionedClient,
-    observePaths,
-  )
+export function createObservePathsDocumentPair(options: {
+  observeDocumentPairAvailability: ObserveDocumentAvailabilityFn
+  observePaths: ObservePathsFn
+}): <T extends SanityDocument = SanityDocument>(
+  id: string,
+  paths: PreviewPath[],
+) => Observable<DraftsModelDocument<T>> {
+  const {observeDocumentPairAvailability, observePaths} = options
 
   const ALWAYS_INCLUDED_SNAPSHOT_PATHS: PreviewPath[] = [['_updatedAt'], ['_createdAt'], ['_type']]
 
-  return {observePathsDocumentPair}
-
-  function observePathsDocumentPair<T extends SanityDocument = SanityDocument>(
+  return function observePathsDocumentPair<T extends SanityDocument = SanityDocument>(
     id: string,
     paths: PreviewPath[],
   ): Observable<DraftsModelDocument<T>> {

--- a/packages/sanity/src/core/preview/documentPreviewStore.ts
+++ b/packages/sanity/src/core/preview/documentPreviewStore.ts
@@ -1,14 +1,15 @@
-import {type SanityClient} from '@sanity/client'
+import {type MutationEvent, type SanityClient, type WelcomeEvent} from '@sanity/client'
 import {type PrepareViewOptions, type SanityDocument} from '@sanity/types'
 import {type Observable} from 'rxjs'
-import {distinctUntilChanged, map} from 'rxjs/operators'
+import {distinctUntilChanged, filter, map} from 'rxjs/operators'
 
 import {isRecord} from '../util'
-import {create_preview_availability} from './availability'
+import {createPreviewAvailabilityObserver} from './availability'
+import {createGlobalListener} from './createGlobalListener'
 import {createPathObserver} from './createPathObserver'
 import {createPreviewObserver} from './createPreviewObserver'
-import {create_preview_documentPair} from './documentPair'
-import {create_preview_observeFields} from './observeFields'
+import {createObservePathsDocumentPair} from './documentPair'
+import {createObserveFields} from './observeFields'
 import {
   type ApiConfig,
   type DraftsModelDocument,
@@ -26,11 +27,15 @@ import {
 export type ObserveForPreviewFn = (
   value: Previewable,
   type: PreviewableType,
-  viewOptions?: PrepareViewOptions,
-  apiConfig?: ApiConfig,
+  options?: {viewOptions?: PrepareViewOptions; apiConfig?: ApiConfig},
 ) => Observable<PreparedSnapshot>
 
 /**
+ * The document preview store supports subscribing to content for previewing purposes.
+ * Documents observed by this store will be kept in sync and receive real-time updates from all collaborators,
+ * but has no support for optimistic updates, so any local edits will require a server round-trip before becoming visible,
+ * which means this store is less suitable for real-time editing scenarios.
+ *
  * @hidden
  * @beta */
 export interface DocumentPreviewStore {
@@ -63,20 +68,19 @@ export function createDocumentPreviewStore({
   client,
 }: DocumentPreviewStoreOptions): DocumentPreviewStore {
   const versionedClient = client.withConfig({apiVersion: '1'})
+  const globalListener = createGlobalListener(versionedClient).pipe(
+    filter(
+      (event): event is MutationEvent | WelcomeEvent =>
+        // ignore reconnect events for now until we've verified that downstream consumers can handle them
+        event.type === 'mutation' || event.type === 'welcome',
+    ),
+  )
+  const invalidationChannel = globalListener.pipe(
+    map((event) => (event.type === 'welcome' ? {type: 'connected' as const} : event)),
+  )
 
-  // NOTE: this is workaroudn for circumventing a circular dependency between `observePaths` and
-  // `observeFields`.
-  // eslint-disable-next-line camelcase
-  const __proxy_observePaths: ObservePathsFn = (value, paths, apiConfig) => {
-    return observePaths(value, paths, apiConfig)
-  }
-
-  const {observeFields} = create_preview_observeFields({
-    observePaths: __proxy_observePaths,
-    versionedClient,
-  })
-
-  const {observePaths} = createPathObserver({observeFields})
+  const observeFields = createObserveFields({client: versionedClient, invalidationChannel})
+  const observePaths = createPathObserver({observeFields})
 
   function observeDocumentTypeFromId(
     id: string,
@@ -88,21 +92,24 @@ export function createDocumentPreviewStore({
     )
   }
 
-  // const {createPreviewObserver} = create_preview_createPreviewObserver(observeDocumentTypeFromId)
   const observeForPreview = createPreviewObserver({observeDocumentTypeFromId, observePaths})
-  const {observeDocumentPairAvailability} = create_preview_availability(
+  const observeDocumentPairAvailability = createPreviewAvailabilityObserver(
     versionedClient,
     observePaths,
   )
-  const {observePathsDocumentPair} = create_preview_documentPair(versionedClient, observePaths)
+
+  const observePathsDocumentPair = createObservePathsDocumentPair({
+    observeDocumentPairAvailability,
+    observePaths,
+  })
 
   // @todo: explain why the API is like this now, and that it should not be like this in the future!
+
   return {
     observePaths,
     observeForPreview,
     observeDocumentTypeFromId,
 
-    // eslint-disable-next-line camelcase
     unstable_observeDocumentPairAvailability: observeDocumentPairAvailability,
     unstable_observePathsDocumentPair: observePathsDocumentPair,
   }

--- a/packages/sanity/src/core/preview/observeFields.ts
+++ b/packages/sanity/src/core/preview/observeFields.ts
@@ -50,6 +50,7 @@ type Cache = {
  * Creates a function that allows observing individual fields on a document.
  * It will automatically debounce and batch requests, and maintain an in-memory cache of the latest field values
  * @param options - Options to use when creating the observer
+ * @internal
  */
 export function createObserveFields(options: {
   client: SanityClient

--- a/packages/sanity/src/core/preview/observeFields.ts
+++ b/packages/sanity/src/core/preview/observeFields.ts
@@ -5,7 +5,6 @@ import {
   concat,
   defer,
   EMPTY,
-  from,
   fromEvent,
   merge,
   type Observable,
@@ -29,8 +28,7 @@ import {
   type ApiConfig,
   type FieldName,
   type Id,
-  type ObservePathsFn,
-  type PreviewPath,
+  type InvalidationChannelEvent,
   type Selection,
 } from './types'
 import {debounceCollect} from './utils/debounceCollect'
@@ -48,58 +46,19 @@ type Cache = {
   [id: string]: CachedFieldObserver[]
 }
 
-export function create_preview_observeFields(context: {
-  observePaths: ObservePathsFn
-  versionedClient: SanityClient
+/**
+ * Creates a function that allows observing individual fields on a document.
+ * It will automatically debounce and batch requests, and maintain an in-memory cache of the latest field values
+ * @param options - Options to use when creating the observer
+ */
+export function createObserveFields(options: {
+  client: SanityClient
+  invalidationChannel: Observable<InvalidationChannelEvent>
 }) {
-  const {observePaths, versionedClient} = context
-
-  let _globalListener: any
-
-  const getGlobalEvents = () => {
-    if (!_globalListener) {
-      const allEvents$ = from(
-        versionedClient.listen(
-          '*[!(_id in path("_.**"))]',
-          {},
-          {
-            events: ['welcome', 'mutation'],
-            includeResult: false,
-            visibility: 'query',
-            tag: 'preview.global',
-          },
-        ),
-      ).pipe(share())
-
-      // This is a stream of welcome events from the server, each telling us that we have established listener connection
-      // We map these to snapshot fetch/sync. It is good to wait for the first welcome event before fetching any snapshots as, we may miss
-      // events that happens in the time period after initial fetch and before the listener is established.
-      const welcome$ = allEvents$.pipe(
-        filter((event: any) => event.type === 'welcome'),
-        shareReplay({refCount: true, bufferSize: 1}),
-      )
-
-      // This will keep the listener active forever and in turn reduce the number of initial fetches
-      // as less 'welcome' events will be emitted.
-      // @todo: see if we can delay unsubscribing or connect with some globally defined shared listener
-      welcome$.subscribe()
-
-      const mutations$ = allEvents$.pipe(filter((event: any) => event.type === 'mutation'))
-
-      _globalListener = {
-        welcome$,
-        mutations$,
-      }
-    }
-
-    return _globalListener
-  }
-
+  const {client: currentDatasetClient, invalidationChannel} = options
   function listen(id: Id) {
-    const globalEvents = getGlobalEvents()
-    return merge(
-      globalEvents.welcome$,
-      globalEvents.mutations$.pipe(filter((event: any) => event.documentId === id)),
+    return invalidationChannel.pipe(
+      filter((event) => event.type === 'connected' || event.documentId === id),
     )
   }
 
@@ -112,13 +71,20 @@ export function create_preview_observeFields(context: {
     }
   }
 
-  const fetchDocumentPathsFast = debounceCollect(fetchAllDocumentPathsWith(versionedClient), 100)
-  const fetchDocumentPathsSlow = debounceCollect(fetchAllDocumentPathsWith(versionedClient), 1000)
+  const fetchDocumentPathsFast = debounceCollect(
+    fetchAllDocumentPathsWith(currentDatasetClient),
+    100,
+  )
 
-  function currentDatasetListenFields(id: Id, fields: PreviewPath[]) {
+  const fetchDocumentPathsSlow = debounceCollect(
+    fetchAllDocumentPathsWith(currentDatasetClient),
+    1000,
+  )
+
+  function currentDatasetListenFields(id: Id, fields: FieldName[]) {
     return listen(id).pipe(
-      switchMap((event: any) => {
-        if (event.type === 'welcome' || event.visibility === 'query') {
+      switchMap((event) => {
+        if (event.type === 'connected' || event.visibility === 'query') {
           return fetchDocumentPathsFast(id, fields as any).pipe(
             mergeMap((result) => {
               return concat(
@@ -137,17 +103,11 @@ export function create_preview_observeFields(context: {
     )
   }
 
-  // keep for debugging purposes for now
-  // function fetchDocumentPaths(id, selection) {
-  //   return client.observable.fetch(`*[_id==$id]{_id,_type,${selection.join(',')}}`, {id})
-  //     .map(result => result[0])
-  // }
-
   const CACHE: Cache = {} // todo: use a LRU cache instead (e.g. hashlru or quick-lru)
 
   const getBatchFetcherForDataset = memoize(
     function getBatchFetcherForDataset(apiConfig: ApiConfig) {
-      const client = versionedClient.withConfig(apiConfig)
+      const client = currentDatasetClient.withConfig(apiConfig)
       const fetchAll = fetchAllDocumentPathsWith(client)
       return debounceCollect(fetchAll, 10)
     },
@@ -165,19 +125,19 @@ export function create_preview_observeFields(context: {
     share(),
   )
 
-  function crossDatasetListenFields(id: Id, fields: PreviewPath[], apiConfig: ApiConfig) {
+  function crossDatasetListenFields(id: Id, fields: FieldName[], apiConfig: ApiConfig) {
     return visiblePoll$.pipe(startWith(0)).pipe(
       switchMap(() => {
         const batchFetcher = getBatchFetcherForDataset(apiConfig)
-        return batchFetcher(id, fields as any)
+        return batchFetcher(id, fields)
       }),
     )
   }
 
   function createCachedFieldObserver<T>(
-    id: any,
-    fields: any,
-    apiConfig: ApiConfig,
+    id: string,
+    fields: FieldName[],
+    apiConfig?: ApiConfig,
   ): CachedFieldObserver {
     let latest: T | null = null
     const changes$ = merge(
@@ -209,7 +169,7 @@ export function create_preview_observeFields(context: {
     )
 
     if (missingFields.length > 0) {
-      existingObservers.push(createCachedFieldObserver(id, fields, apiConfig as any))
+      existingObservers.push(createCachedFieldObserver(id, fields, apiConfig))
     }
 
     const cachedFieldObservers = existingObservers
@@ -226,8 +186,7 @@ export function create_preview_observeFields(context: {
     )
   }
 
-  // API
-  return {observeFields: cachedObserveFields}
+  return cachedObserveFields
 
   function pickFrom(objects: Record<string, any>[], fields: string[]) {
     return [...INCLUDE_FIELDS, ...fields].reduce((result, fieldName) => {

--- a/packages/sanity/src/core/preview/types.ts
+++ b/packages/sanity/src/core/preview/types.ts
@@ -1,5 +1,5 @@
 import {
-  type PreviewConfig,
+  type CrossDatasetType,
   type PreviewValue,
   type Reference,
   type SanityDocumentLike,
@@ -55,10 +55,7 @@ export type AvailabilityReason = 'READABLE' | 'PERMISSION_DENIED' | 'NOT_FOUND'
 /**
  * @hidden
  * @beta */
-export interface PreviewableType {
-  fields?: {name: string; type: SchemaType}[]
-  preview?: PreviewConfig
-}
+export type PreviewableType = SchemaType | CrossDatasetType
 
 /**
  * @hidden
@@ -113,6 +110,17 @@ export interface DraftsModelDocument<T extends SanityDocumentLike = SanityDocume
 }
 
 /**
+ * Event emitted to notify preview subscribers when they need to refetch a document being previewed
+ * - 'connected' will happen when the store is connected to the invalidation channel, both initially and after a reconnect after a connection loss
+ * - 'mutation' will happen when a document has been mutated and the store needs to refetch a document
+ * @hidden
+ * @beta
+ */
+export type InvalidationChannelEvent =
+  | {type: 'connected'}
+  | {type: 'mutation'; documentId: string; visibility: string}
+
+/**
  * @hidden
  * @beta */
 export interface PreparedSnapshot {
@@ -121,7 +129,10 @@ export interface PreparedSnapshot {
 }
 
 /** @internal */
-export type ObserveDocumentTypeFromIdFn = (id: string) => Observable<string | undefined>
+export type ObserveDocumentTypeFromIdFn = (
+  id: string,
+  apiConfig?: ApiConfig,
+) => Observable<string | undefined>
 
 /**
  * @hidden
@@ -132,4 +143,11 @@ export interface ObservePathsFn {
     paths: (string | PreviewPath)[],
     apiConfig?: ApiConfig,
   ): Observable<PreviewValue | SanityDocumentLike | Reference | string | null>
+}
+
+/**
+ * @hidden
+ * @beta */
+export interface ObserveDocumentAvailabilityFn {
+  (id: string): Observable<{draft: DocumentAvailability; published: DocumentAvailability}>
 }

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -1,7 +1,7 @@
 import {type PreviewValue, type SchemaType, type SortOrdering} from '@sanity/types'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
-import {of} from 'rxjs'
+import {type Observable, of} from 'rxjs'
 import {catchError, map} from 'rxjs/operators'
 
 import {useDocumentPreviewStore} from '../store'
@@ -32,13 +32,16 @@ function useDocumentPreview(props: {
 }): State {
   const {enabled = true, ordering, schemaType, value: previewValue} = props || {}
   const {observeForPreview} = useDocumentPreviewStore()
-  const observable = useMemo(() => {
+  const observable = useMemo<Observable<State>>(() => {
     if (!enabled || !previewValue || !schemaType) return of(PENDING_STATE)
 
-    return observeForPreview(previewValue as Previewable, schemaType, {ordering}).pipe(
+    return observeForPreview(previewValue as Previewable, schemaType, {
+      viewOptions: {ordering: ordering},
+    }).pipe(
       map((event) => ({isLoading: false, value: event.snapshot || undefined})),
       catchError((error) => of({isLoading: false, error})),
     )
-  }, [enabled, observeForPreview, ordering, previewValue, schemaType])
+  }, [enabled, previewValue, schemaType, observeForPreview, ordering])
+
   return useObservable(observable, INITIAL_STATE)
 }

--- a/packages/sanity/src/core/preview/utils/getPreviewPaths.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewPaths.ts
@@ -1,11 +1,9 @@
-import {type SchemaType} from '@sanity/types'
-
-import {type PreviewPath} from '../types'
+import {type PreviewableType, type PreviewPath} from '../types'
 
 const DEFAULT_PREVIEW_PATHS: PreviewPath[] = [['_createdAt'], ['_updatedAt']]
 
 /** @internal */
-export function getPreviewPaths(preview: SchemaType['preview']): PreviewPath[] | undefined {
+export function getPreviewPaths(preview: PreviewableType['preview']): PreviewPath[] | undefined {
   const selection = preview?.select
 
   if (!selection) return undefined

--- a/packages/sanity/src/core/preview/utils/getPreviewStateObservable.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewStateObservable.ts
@@ -27,13 +27,10 @@ export function getPreviewStateObservable(
 ): Observable<PreviewState> {
   const draft$ = isLiveEditEnabled(schemaType)
     ? of({snapshot: null})
-    : documentPreviewStore.observeForPreview(
-        {_type: 'reference', _ref: getDraftId(documentId)},
-        schemaType,
-      )
+    : documentPreviewStore.observeForPreview({_id: getDraftId(documentId)}, schemaType)
 
   const published$ = documentPreviewStore.observeForPreview(
-    {_type: 'reference', _ref: getPublishedId(documentId)},
+    {_id: getPublishedId(documentId)},
     schemaType,
   )
 

--- a/packages/sanity/src/core/preview/utils/shareReplayLatest.test.ts
+++ b/packages/sanity/src/core/preview/utils/shareReplayLatest.test.ts
@@ -1,0 +1,37 @@
+import {expect, test} from '@jest/globals'
+import {concat, from, lastValueFrom, of, share, timer} from 'rxjs'
+import {concatMap, delay, mergeMap, take, toArray} from 'rxjs/operators'
+
+import {shareReplayLatest} from './shareReplayLatest'
+
+test('replayLatest() replays matching value to new subscribers', async () => {
+  const observable = from(['foo', 'bar', 'baz']).pipe(
+    concatMap((value) => of(value).pipe(delay(100))),
+    share(),
+    shareReplayLatest((v) => v === 'foo'),
+  )
+
+  const result = observable.pipe(
+    mergeMap((value) =>
+      value === 'bar' ? concat(of(value), observable.pipe(take(1))) : of(value),
+    ),
+    toArray(),
+  )
+  expect(await lastValueFrom(result)).toEqual(['foo', 'bar', 'foo', 'baz'])
+})
+
+test('replayLatest() doesnt keep the replay value after resets', async () => {
+  const observable = timer(0, 10).pipe(
+    shareReplayLatest({
+      resetOnRefCountZero: true,
+      resetOnComplete: true,
+      predicate: (v) => v < 2,
+    }),
+  )
+
+  const result = observable.pipe(take(5), toArray())
+  expect(await lastValueFrom(result)).toEqual([0, 1, 2, 3, 4])
+
+  const resultAfter = observable.pipe(take(5), toArray())
+  expect(await lastValueFrom(resultAfter)).toEqual([0, 1, 2, 3, 4])
+})

--- a/packages/sanity/src/core/preview/utils/shareReplayLatest.ts
+++ b/packages/sanity/src/core/preview/utils/shareReplayLatest.ts
@@ -1,0 +1,70 @@
+import {
+  finalize,
+  merge,
+  type MonoTypeOperatorFunction,
+  Observable,
+  share,
+  type ShareConfig,
+  tap,
+} from 'rxjs'
+
+export type ShareReplayLatestConfig<T> = ShareConfig<T> & {predicate: (value: T) => boolean}
+
+/**
+ * A variant of share that takes a predicate function to determine which value to replay to new subscribers
+ * @param predicate - Predicate function to determine which value to replay
+ */
+export function shareReplayLatest<T>(predicate: (value: T) => boolean): MonoTypeOperatorFunction<T>
+
+/**
+ * A variant of share that takes a predicate function to determine which value to replay to new subscribers
+ * @param config - ShareConfig with additional predicate function
+ */
+export function shareReplayLatest<T>(
+  config: ShareReplayLatestConfig<T>,
+): MonoTypeOperatorFunction<T>
+
+/**
+ * A variant of share that takes a predicate function to determine which value to replay to new subscribers
+ * @param configOrPredicate - Predicate function to determine which value to replay
+ * @param config - Optional ShareConfig
+ */
+export function shareReplayLatest<T>(
+  configOrPredicate: ShareReplayLatestConfig<T> | ShareReplayLatestConfig<T>['predicate'],
+  config?: ShareConfig<T>,
+) {
+  return _shareReplayLatest(
+    typeof configOrPredicate === 'function'
+      ? {predicate: configOrPredicate, ...config}
+      : configOrPredicate,
+  )
+}
+function _shareReplayLatest<T>(config: ShareReplayLatestConfig<T>): MonoTypeOperatorFunction<T> {
+  return (source: Observable<T>) => {
+    let latest: T | undefined
+    let emitted = false
+
+    const {predicate, ...shareConfig} = config
+
+    const wrapped = source.pipe(
+      tap((value) => {
+        if (config.predicate(value)) {
+          emitted = true
+          latest = value
+        }
+      }),
+      finalize(() => {
+        emitted = false
+        latest = undefined
+      }),
+      share(shareConfig),
+    )
+    const emitLatest = new Observable<T>((subscriber) => {
+      if (emitted) {
+        subscriber.next(latest)
+      }
+      subscriber.complete()
+    })
+    return merge(wrapped, emitLatest)
+  }
+}


### PR DESCRIPTION
### Description

Note: This originally happened as part of work in a feature branch, but the changes here are generic and standalone improvements that makes sense to merge to main already.

This extracts the global listener used by the preview system, improves consistency and readability and typings of of the core/preview code. These changes should not affect the behavior of previews in any significant way or cause any visible differences in how previews work currently.

This also includes a small improvement to the global preview listener: Currently this listener is subscribed once, and the subscription is kept active forever. This means that if the user navigates to a part of the Studio that does need to preview anything, the listener connection is still kept active. With the changes proposed here, the global preview listener is now refcount'ed, and shuts down when no longer needed. To avoid excessive unsubscribe+resubscribes, the listener teardown is delayed to two seconds after the last subscriber unsubscribes. Demo here:

https://github.com/user-attachments/assets/1e822027-901e-4ef6-b231-7c5a4d388c19



### What to review
Does the changes make sense?

### Testing
Existing tests should be enough. Also improves TypeScript coverage, which helps.

### Notes for release
n/a - not user facing
