### PR TITLE
fix(core): filter own state events in presence store

### DIFF
--- a/packages/sanity/src/core/store/_legacy/presence/presence-store.ts
+++ b/packages/sanity/src/core/store/_legacy/presence/presence-store.ts
@@ -211,6 +211,8 @@ export function __tmp_wrap_presenceStore(context: {
   }
 
   const states$: Observable<{[sessionId: string]: Session}> = merge(syncEvent$, useMock$).pipe(
+    // do not respond to my own state events
+    filter((event) => event.sessionId !== SESSION_ID),
     scan(
       (keyed, event: StateEvent | DisconnectEvent): {[sessionId: string]: Session} =>
         event.type === 'disconnect'


### PR DESCRIPTION
### Description

When the user takes actions that trigger presence announcements such as focusing a field, these come back on the websocket as events, just like any other user. This would trigger re-renders in components that subscribe to presence state. This does not seem required for your own presence announcements, so I have filtered these events out.

I confirmed that this stopped re-rendering due to global presence hook update when focusing fields.

### What to review

That is makes sense to filter out these events and that they are not required for other logic elsewhere.

### Testing

Relying on test suite and review

### Notes for release

Optimize handling of certain live collaboration events
