### PR TITLE
fix(deps): update and pin `react-i18next` to 14.0.2

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -240,7 +240,7 @@
     "react-copy-to-clipboard": "^5.0.4",
     "react-fast-compare": "^3.2.0",
     "react-focus-lock": "^2.8.1",
-    "react-i18next": "^13.0.1",
+    "react-i18next": "14.0.2",
     "react-is": "^18.2.0",
     "react-refractor": "^2.1.6",
     "react-rx": "^4.0.0",

--- a/packages/sanity/src/core/i18n/i18nConfig.ts
+++ b/packages/sanity/src/core/i18n/i18nConfig.ts
@@ -86,7 +86,6 @@ function createI18nApi({
     },
 
     /** @internal */
-    // @ts-expect-error types are missing
     i18next: i18nInstance,
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1624,8 +1624,8 @@ importers:
         specifier: ^2.8.1
         version: 2.12.1(@types/react@18.3.3)(react@18.3.1)
       react-i18next:
-        specifier: ^13.0.1
-        version: 13.5.0(i18next@23.11.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 14.0.2
+        version: 14.0.2(i18next@23.11.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-is:
         specifier: ^18.2.0
         version: 18.3.1
@@ -9601,8 +9601,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
-  react-i18next@13.5.0:
-    resolution: {integrity: sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA==}
+  react-i18next@14.0.2:
+    resolution: {integrity: sha512-YOB/H1IgXveEWeTsCHez18QjDXImzVZOcF9/JroSbjYoN1LOfCoARFJUQQ8VNow0TnGOtHq9SwTmismm78CTTA==}
     peerDependencies:
       i18next: '>= 23.2.3'
       react: '>= 16.8.0'
@@ -20937,7 +20937,7 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  react-i18next@13.5.0(i18next@23.11.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-i18next@14.0.2(i18next@23.11.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.25.0
       html-parse-stringify: 3.0.1


### PR DESCRIPTION
### Description

Our dependency for translations, `react-i18next` has an open performance regression caused by multiple re-renders from `useTranslation`

https://github.com/i18next/react-i18next/issues/1756

As one maintainer mentiones, this issue was fixed in version `14.0.2` of that library, a fix they later rolled back because it broke changing of languages at runtime:
https://github.com/i18next/react-i18next/issues/1756#issuecomment-2282227940

Since we currently do not support changing languages, I suggest we pin to `14.0.2` until the library is fixed properly in more current versions.

### What to review

That the version we upgraded to is still compatible with the way we use their API. They seem to bump major versions for fixes and type changes.

https://github.com/i18next/react-i18next/blob/master/CHANGELOG.md

### Testing

I manually profiled the application and found that random re-renders due to `useTranslation` hook were not present in the same way they were before this version change.

### Notes for release

Pin `react-i18next` to version `14.0.2` to address potential performance regression in that library
