### PR TITLE
fix(typegen): dont treat all document type refs as references

### DIFF
--- a/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
+++ b/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
@@ -1,5 +1,225 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Extract schema test Can extract inline documents 1`] = `
+Array [
+  Object {
+    "attributes": Object {
+      "_createdAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_id": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_rev": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_type": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+          "value": "validDocument",
+        },
+      },
+      "_updatedAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "inlineAuthor": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "attributes": Object {
+            "_type": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+                "value": "author",
+              },
+            },
+            "name": Object {
+              "optional": true,
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+              },
+            },
+          },
+          "type": "object",
+        },
+      },
+      "inlineAuthors": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "of": Object {
+            "attributes": Object {
+              "_type": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                  "value": "author",
+                },
+              },
+              "name": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "rest": Object {
+              "attributes": Object {
+                "_key": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                  },
+                },
+              },
+              "type": "object",
+            },
+            "type": "object",
+          },
+          "type": "array",
+        },
+      },
+      "referenceAuthor": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "attributes": Object {
+            "_ref": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+              },
+            },
+            "_type": Object {
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "string",
+                "value": "reference",
+              },
+            },
+            "_weak": Object {
+              "optional": true,
+              "type": "objectAttribute",
+              "value": Object {
+                "type": "boolean",
+              },
+            },
+          },
+          "dereferencesTo": "author",
+          "type": "object",
+        },
+      },
+      "referenceAuthors": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "of": Object {
+            "attributes": Object {
+              "_ref": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                },
+              },
+              "_type": Object {
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "string",
+                  "value": "reference",
+                },
+              },
+              "_weak": Object {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": Object {
+                  "type": "boolean",
+                },
+              },
+            },
+            "dereferencesTo": "author",
+            "rest": Object {
+              "attributes": Object {
+                "_key": Object {
+                  "type": "objectAttribute",
+                  "value": Object {
+                    "type": "string",
+                  },
+                },
+              },
+              "type": "object",
+            },
+            "type": "object",
+          },
+          "type": "array",
+        },
+      },
+    },
+    "name": "validDocument",
+    "type": "document",
+  },
+  Object {
+    "attributes": Object {
+      "_createdAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_id": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_rev": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "_type": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+          "value": "author",
+        },
+      },
+      "_updatedAt": Object {
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "name": Object {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": Object {
+          "type": "string",
+        },
+      },
+    },
+    "name": "author",
+    "type": "document",
+  },
+]
+`;
+
 exports[`Extract schema test Extracts  schema general 1`] = `
 Array [
   Object {
@@ -972,28 +1192,97 @@ Array [
               "of": Array [
                 Object {
                   "attributes": Object {
-                    "_ref": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                      },
-                    },
                     "_type": Object {
                       "type": "objectAttribute",
                       "value": Object {
                         "type": "string",
-                        "value": "reference",
+                        "value": "author",
                       },
                     },
-                    "_weak": Object {
+                    "name": Object {
                       "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
-                        "type": "boolean",
+                        "type": "string",
+                      },
+                    },
+                    "profilePicture": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "attributes": Object {
+                          "_type": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                              "value": "image",
+                            },
+                          },
+                          "asset": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "attributes": Object {
+                                "_ref": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "_type": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                    "value": "reference",
+                                  },
+                                },
+                                "_weak": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "boolean",
+                                  },
+                                },
+                              },
+                              "dereferencesTo": "sanity.imageAsset",
+                              "type": "object",
+                            },
+                          },
+                          "attribution": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                          "caption": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                          "crop": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "name": "sanity.imageCrop",
+                              "type": "inline",
+                            },
+                          },
+                          "hotspot": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "name": "sanity.imageHotspot",
+                              "type": "inline",
+                            },
+                          },
+                        },
+                        "type": "object",
                       },
                     },
                   },
-                  "dereferencesTo": "author",
                   "rest": Object {
                     "attributes": Object {
                       "_key": Object {
@@ -1107,28 +1396,97 @@ Array [
                                   "value": Object {
                                     "of": Object {
                                       "attributes": Object {
-                                        "_ref": Object {
-                                          "type": "objectAttribute",
-                                          "value": Object {
-                                            "type": "string",
-                                          },
-                                        },
                                         "_type": Object {
                                           "type": "objectAttribute",
                                           "value": Object {
                                             "type": "string",
-                                            "value": "reference",
+                                            "value": "author",
                                           },
                                         },
-                                        "_weak": Object {
+                                        "name": Object {
                                           "optional": true,
                                           "type": "objectAttribute",
                                           "value": Object {
-                                            "type": "boolean",
+                                            "type": "string",
+                                          },
+                                        },
+                                        "profilePicture": Object {
+                                          "optional": true,
+                                          "type": "objectAttribute",
+                                          "value": Object {
+                                            "attributes": Object {
+                                              "_type": Object {
+                                                "type": "objectAttribute",
+                                                "value": Object {
+                                                  "type": "string",
+                                                  "value": "image",
+                                                },
+                                              },
+                                              "asset": Object {
+                                                "optional": true,
+                                                "type": "objectAttribute",
+                                                "value": Object {
+                                                  "attributes": Object {
+                                                    "_ref": Object {
+                                                      "type": "objectAttribute",
+                                                      "value": Object {
+                                                        "type": "string",
+                                                      },
+                                                    },
+                                                    "_type": Object {
+                                                      "type": "objectAttribute",
+                                                      "value": Object {
+                                                        "type": "string",
+                                                        "value": "reference",
+                                                      },
+                                                    },
+                                                    "_weak": Object {
+                                                      "optional": true,
+                                                      "type": "objectAttribute",
+                                                      "value": Object {
+                                                        "type": "boolean",
+                                                      },
+                                                    },
+                                                  },
+                                                  "dereferencesTo": "sanity.imageAsset",
+                                                  "type": "object",
+                                                },
+                                              },
+                                              "attribution": Object {
+                                                "optional": true,
+                                                "type": "objectAttribute",
+                                                "value": Object {
+                                                  "type": "string",
+                                                },
+                                              },
+                                              "caption": Object {
+                                                "optional": true,
+                                                "type": "objectAttribute",
+                                                "value": Object {
+                                                  "type": "string",
+                                                },
+                                              },
+                                              "crop": Object {
+                                                "optional": true,
+                                                "type": "objectAttribute",
+                                                "value": Object {
+                                                  "name": "sanity.imageCrop",
+                                                  "type": "inline",
+                                                },
+                                              },
+                                              "hotspot": Object {
+                                                "optional": true,
+                                                "type": "objectAttribute",
+                                                "value": Object {
+                                                  "name": "sanity.imageHotspot",
+                                                  "type": "inline",
+                                                },
+                                              },
+                                            },
+                                            "type": "object",
                                           },
                                         },
                                       },
-                                      "dereferencesTo": "author",
                                       "rest": Object {
                                         "attributes": Object {
                                           "_key": Object {
@@ -1418,28 +1776,97 @@ Array [
                       },
                       Object {
                         "attributes": Object {
-                          "_ref": Object {
-                            "type": "objectAttribute",
-                            "value": Object {
-                              "type": "string",
-                            },
-                          },
                           "_type": Object {
                             "type": "objectAttribute",
                             "value": Object {
                               "type": "string",
-                              "value": "reference",
+                              "value": "author",
                             },
                           },
-                          "_weak": Object {
+                          "name": Object {
                             "optional": true,
                             "type": "objectAttribute",
                             "value": Object {
-                              "type": "boolean",
+                              "type": "string",
+                            },
+                          },
+                          "profilePicture": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "attributes": Object {
+                                "_type": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                    "value": "image",
+                                  },
+                                },
+                                "asset": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "attributes": Object {
+                                      "_ref": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
+                                        },
+                                      },
+                                      "_type": Object {
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "string",
+                                          "value": "reference",
+                                        },
+                                      },
+                                      "_weak": Object {
+                                        "optional": true,
+                                        "type": "objectAttribute",
+                                        "value": Object {
+                                          "type": "boolean",
+                                        },
+                                      },
+                                    },
+                                    "dereferencesTo": "sanity.imageAsset",
+                                    "type": "object",
+                                  },
+                                },
+                                "attribution": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "caption": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "crop": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "name": "sanity.imageCrop",
+                                    "type": "inline",
+                                  },
+                                },
+                                "hotspot": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "name": "sanity.imageHotspot",
+                                    "type": "inline",
+                                  },
+                                },
+                              },
+                              "type": "object",
                             },
                           },
                         },
-                        "dereferencesTo": "author",
                         "rest": Object {
                           "attributes": Object {
                             "_key": Object {
@@ -1874,28 +2301,97 @@ Array [
                 },
                 Object {
                   "attributes": Object {
-                    "_ref": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                      },
-                    },
                     "_type": Object {
                       "type": "objectAttribute",
                       "value": Object {
                         "type": "string",
-                        "value": "reference",
+                        "value": "author",
                       },
                     },
-                    "_weak": Object {
+                    "name": Object {
                       "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
-                        "type": "boolean",
+                        "type": "string",
+                      },
+                    },
+                    "profilePicture": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "attributes": Object {
+                          "_type": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                              "value": "image",
+                            },
+                          },
+                          "asset": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "attributes": Object {
+                                "_ref": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "_type": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                    "value": "reference",
+                                  },
+                                },
+                                "_weak": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "boolean",
+                                  },
+                                },
+                              },
+                              "dereferencesTo": "sanity.imageAsset",
+                              "type": "object",
+                            },
+                          },
+                          "attribution": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                          "caption": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                          "crop": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "name": "sanity.imageCrop",
+                              "type": "inline",
+                            },
+                          },
+                          "hotspot": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "name": "sanity.imageHotspot",
+                              "type": "inline",
+                            },
+                          },
+                        },
+                        "type": "object",
                       },
                     },
                   },
-                  "dereferencesTo": "author",
                   "rest": Object {
                     "attributes": Object {
                       "_key": Object {
@@ -2439,28 +2935,97 @@ Array [
                 },
                 Object {
                   "attributes": Object {
-                    "_ref": Object {
-                      "type": "objectAttribute",
-                      "value": Object {
-                        "type": "string",
-                      },
-                    },
                     "_type": Object {
                       "type": "objectAttribute",
                       "value": Object {
                         "type": "string",
-                        "value": "reference",
+                        "value": "author",
                       },
                     },
-                    "_weak": Object {
+                    "name": Object {
                       "optional": true,
                       "type": "objectAttribute",
                       "value": Object {
-                        "type": "boolean",
+                        "type": "string",
+                      },
+                    },
+                    "profilePicture": Object {
+                      "optional": true,
+                      "type": "objectAttribute",
+                      "value": Object {
+                        "attributes": Object {
+                          "_type": Object {
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                              "value": "image",
+                            },
+                          },
+                          "asset": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "attributes": Object {
+                                "_ref": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "_type": Object {
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "string",
+                                    "value": "reference",
+                                  },
+                                },
+                                "_weak": Object {
+                                  "optional": true,
+                                  "type": "objectAttribute",
+                                  "value": Object {
+                                    "type": "boolean",
+                                  },
+                                },
+                              },
+                              "dereferencesTo": "sanity.imageAsset",
+                              "type": "object",
+                            },
+                          },
+                          "attribution": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                          "caption": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "type": "string",
+                            },
+                          },
+                          "crop": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "name": "sanity.imageCrop",
+                              "type": "inline",
+                            },
+                          },
+                          "hotspot": Object {
+                            "optional": true,
+                            "type": "objectAttribute",
+                            "value": Object {
+                              "name": "sanity.imageHotspot",
+                              "type": "inline",
+                            },
+                          },
+                        },
+                        "type": "object",
                       },
                     },
                   },
-                  "dereferencesTo": "author",
                   "rest": Object {
                     "attributes": Object {
                       "_key": Object {


### PR DESCRIPTION
### Description

It's possible to reference a document the same way as an object is referenced. However, they will not get the builtin attributes that are available on a document stored in Content Lake. The Studio treats it as a "normal" object. Since we are making some assumption around document we are inlining the whole object whenever this happens, it's an edge case and not a recommended pattern as it is mixing concerns.


### What to review

Correctness. This change also changed a snapshot in the existing test. This is because the referenced block type from the fixture is using "author" as a inline type reference, but also using author as a reference.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Updated the current snapshots and added a specific test for inlined documents

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

TypeGen: Fixes an edge case where referencing documents with a normal "type"-reference, and not a "reference-type" reference extracted an incorrect representation of the schema.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

Fixes #6913 