### PR TITLE
fix(core): update eslintrc config to show no-restricted-imports rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -174,7 +174,12 @@ const config = {
 
     // Prefer local components vs certain @sanity/ui imports (in sanity package)
     {
-      files: ['packages/sanity/**'],
+      files: ['packages/sanity/src/**'],
+      excludedFiles: [
+        '**/__workshop__/**',
+        'packages/sanity/src/_singletons/**',
+        'packages/sanity/src/_createContext/**',
+      ],
       rules: {
         'no-restricted-imports': [
           'error',
@@ -212,33 +217,9 @@ const config = {
               },
               {
                 name: 'react',
-                importNames: ['default'],
+                importNames: ['default', 'createContext'],
                 message:
-                  'Please use named imports, e.g. `import {useEffect, useMemo, type ComponentType} from "react"` instead.',
-              },
-            ],
-          },
-        ],
-      },
-    },
-
-    // Prefer createContext in _singletons
-    {
-      files: ['packages/sanity/src/**'],
-      excludedFiles: [
-        '**/__workshop__/**',
-        'packages/sanity/src/_singletons/**',
-        'packages/sanity/src/_createContext/**',
-      ],
-      rules: {
-        'no-restricted-imports': [
-          'error',
-          {
-            paths: [
-              {
-                name: 'react',
-                importNames: ['createContext'],
-                message: 'Please place context in _singletons',
+                  'Please use named imports, e.g. `import {useEffect, useMemo, type ComponentType} from "react"` instead.\nPlease place "context" in _singletons',
               },
             ],
           },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -174,7 +174,7 @@ const config = {
 
     // Prefer local components vs certain @sanity/ui imports (in sanity package)
     {
-      files: ['packages/sanity/src/**'],
+      files: ['packages/sanity/**'],
       excludedFiles: [
         '**/__workshop__/**',
         'packages/sanity/src/_singletons/**',

--- a/packages/sanity/src/core/form/studio/tree-editing/components/TreeEditingDialog.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/components/TreeEditingDialog.tsx
@@ -1,4 +1,9 @@
-import {Button, Card, Dialog, Flex} from '@sanity/ui'
+import {
+  Card,
+  // eslint-disable-next-line no-restricted-imports
+  Dialog, // Custom dialog needed
+  Flex,
+} from '@sanity/ui'
 // eslint-disable-next-line camelcase
 import {getTheme_v2, type Theme} from '@sanity/ui/theme'
 import {toString} from '@sanity/util/paths'
@@ -16,6 +21,7 @@ import {
 } from 'sanity'
 import {css, styled} from 'styled-components'
 
+import {Button} from '../../../../../ui-components'
 import {
   buildTreeEditingState,
   type BuildTreeEditingStateProps,
@@ -219,6 +225,7 @@ export function TreeEditingDialog(props: TreeEditingDialogProps): JSX.Element | 
           <Card borderTop>
             <Flex align="center" justify="flex-end" paddingX={3} paddingY={2} sizing="border">
               <Button
+                size="large"
                 data-testid="tree-editing-done"
                 text={t('tree-editing-dialog.sidebar.action.done')}
                 onClick={onClose}

--- a/packages/sanity/src/core/form/studio/tree-editing/components/breadcrumbs/TreeEditingBreadcrumbs.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/components/breadcrumbs/TreeEditingBreadcrumbs.tsx
@@ -1,5 +1,12 @@
 import {ChevronDownIcon} from '@sanity/icons'
-import {Box, Button, Flex, Text, useElementSize} from '@sanity/ui'
+import {
+  Box,
+  // eslint-disable-next-line no-restricted-imports
+  Button, // Custom button needed, special padding support required
+  Flex,
+  Text,
+  useElementSize,
+} from '@sanity/ui'
 // eslint-disable-next-line camelcase
 import {getTheme_v2, type Theme} from '@sanity/ui/theme'
 import {isEqual} from 'lodash'

--- a/packages/sanity/src/core/form/studio/tree-editing/components/breadcrumbs/TreeEditingBreadcrumbsMenu.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/components/breadcrumbs/TreeEditingBreadcrumbsMenu.tsx
@@ -1,5 +1,11 @@
 import {CheckmarkIcon} from '@sanity/icons'
-import {Button, Flex, Stack, Text} from '@sanity/ui'
+import {
+  // eslint-disable-next-line no-restricted-imports
+  Button, // Custom button needed, support for children
+  Flex,
+  Stack,
+  Text,
+} from '@sanity/ui'
 import {isEqual} from 'lodash'
 import {useCallback} from 'react'
 import {

--- a/packages/sanity/src/core/form/studio/tree-editing/components/breadcrumbs/TreeEditingBreadcrumbsMenuButton.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/components/breadcrumbs/TreeEditingBreadcrumbsMenuButton.tsx
@@ -1,4 +1,4 @@
-import {Box, Card, Flex, Popover, type PopoverProps, Text, useClickOutsideEvent} from '@sanity/ui'
+import {Box, Card, Flex, Text, useClickOutsideEvent} from '@sanity/ui'
 // eslint-disable-next-line camelcase
 import {
   cloneElement,
@@ -12,6 +12,7 @@ import ReactFocusLock from 'react-focus-lock'
 import {type Path} from 'sanity'
 import {css, styled} from 'styled-components'
 
+import {Popover, type PopoverProps} from '../../../../../../ui-components'
 import {type TreeEditingBreadcrumb} from '../../types'
 import {ITEM_HEIGHT, MAX_DISPLAYED_ITEMS} from './constants'
 import {TreeEditingBreadcrumbsMenu} from './TreeEditingBreadcrumbsMenu'
@@ -158,7 +159,6 @@ export function TreeEditingBreadcrumbsMenuButton(
 
   return (
     <StyledPopover
-      animate
       constrainSize
       content={content}
       data-testid="tree-editing-breadcrumbs-menu-popover"

--- a/packages/sanity/src/core/form/studio/tree-editing/components/search/TreeEditingSearch.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/components/search/TreeEditingSearch.tsx
@@ -1,9 +1,10 @@
 import {SearchIcon} from '@sanity/icons'
-import {Card, Flex, Popover, type PopoverProps, Stack, Text, TextInput} from '@sanity/ui'
+import {Card, Flex, Stack, Text, TextInput} from '@sanity/ui'
 import {type ChangeEvent, type KeyboardEvent, useCallback, useMemo, useState} from 'react'
 import {type Path, useTranslation} from 'sanity'
 import {css, styled} from 'styled-components'
 
+import {Popover, type PopoverProps} from '../../../../../../ui-components'
 import {useSearchableList} from '../../hooks'
 import {type TreeEditingMenuItem} from '../../types'
 import {ITEM_HEIGHT, MAX_DISPLAYED_ITEMS} from './constants'
@@ -138,7 +139,6 @@ export function TreeEditingSearch(props: TreeEditingSearchProps): JSX.Element {
 
   return (
     <StyledPopover
-      animate
       constrainSize
       content={content}
       fallbackPlacements={POPOVER_FALLBACK_PLACEMENTS}

--- a/packages/sanity/src/core/form/studio/tree-editing/components/search/TreeEditingSearchMenu.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/components/search/TreeEditingSearchMenu.tsx
@@ -1,4 +1,10 @@
-import {Box, Button, Stack, Text} from '@sanity/ui'
+import {
+  Box,
+  // eslint-disable-next-line no-restricted-imports
+  Button, // Custom button needed, special children support required
+  Stack,
+  Text,
+} from '@sanity/ui'
 import {isEqual} from 'lodash'
 import {useCallback} from 'react'
 import {

--- a/packages/sanity/src/core/form/studio/tree-editing/components/tree-menu/TreeEditingMenuItem.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/components/tree-menu/TreeEditingMenuItem.tsx
@@ -1,6 +1,13 @@
 import {hues} from '@sanity/color'
 import {ChevronRightIcon, StackCompactIcon} from '@sanity/icons'
-import {Button, Card, Flex, Stack, Text} from '@sanity/ui'
+import {
+  // eslint-disable-next-line no-restricted-imports
+  Button, // Custom button needed, special children support required
+  Card,
+  Flex,
+  Stack,
+  Text,
+} from '@sanity/ui'
 // eslint-disable-next-line camelcase
 import {getTheme_v2} from '@sanity/ui/theme'
 import {toString} from '@sanity/util/paths'

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -1,8 +1,9 @@
-import {Box, Button, Stack, useToast} from '@sanity/ui'
+import {Box, Stack, useToast} from '@sanity/ui'
 import {type ReactNode, useCallback, useEffect, useRef} from 'react'
 import {SANITY_VERSION} from 'sanity'
 import semver from 'semver'
 
+import {Button} from '../../../ui-components'
 import {hasSanityPackageInImportMap} from '../../environment/hasSanityPackageInImportMap'
 import {useTranslation} from '../../i18n'
 import {checkForLatestVersions} from './checkForLatestVersions'
@@ -34,6 +35,7 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
         <Stack space={2} paddingBottom={2}>
           <Box>
             <Button
+              size="large"
               aria-label={t('package-version.new-package-available.reload-button')}
               onClick={onClick}
               text={t('package-version.new-package-available.reload-button')}

--- a/packages/sanity/src/structure/panes/documentList/sheetList/ColumnsControl.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/ColumnsControl.tsx
@@ -1,8 +1,9 @@
-import {Box, Button, Checkbox, Flex, Menu, MenuButton, Stack, Text} from '@sanity/ui'
+import {Box, Checkbox, Flex, Menu, Stack, Text} from '@sanity/ui'
 import {type Column, type Table} from '@tanstack/react-table'
 import {useCallback} from 'react'
 import {type SanityDocument, useTranslation} from 'sanity'
 
+import {Button, MenuButton} from '../../../../ui-components'
 import {VISIBLE_COLUMN_LIMIT} from './useDocumentSheetColumns'
 
 type ColumnsControlProps = {
@@ -32,7 +33,7 @@ export function ColumnsControl({table}: ColumnsControlProps) {
 
   return (
     <MenuButton
-      button={<Button mode="bleed" text={t('sheet-list.edit-columns')} size={1} />}
+      button={<Button mode="bleed" text={t('sheet-list.edit-columns')} />}
       id="columns-control"
       menu={
         <Menu padding={3} paddingTop={4} style={{width: 240}}>
@@ -68,7 +69,6 @@ export function ColumnsControl({table}: ColumnsControlProps) {
             <Button
               width="fill"
               mode="ghost"
-              size={1}
               text={t('sheet-list.reset-columns')}
               onClick={setInitialColumns}
             />

--- a/packages/sanity/src/structure/panes/documentList/sheetList/DocumentSheetListHeader.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/DocumentSheetListHeader.tsx
@@ -1,11 +1,11 @@
 import {CloseIcon, EllipsisHorizontalIcon} from '@sanity/icons'
 import {type SanityDocument} from '@sanity/types'
-import {Box, Flex, Menu, MenuButton, Text} from '@sanity/ui'
+import {Box, Flex, Menu, Text} from '@sanity/ui'
 import {flexRender, type Header as HeaderType, type HeaderGroup} from '@tanstack/react-table'
 import {useTranslation} from 'sanity'
 import {styled} from 'styled-components'
 
-import {Button, MenuItem, Tooltip} from '../../../../ui-components'
+import {Button, MenuButton, MenuItem, Tooltip} from '../../../../ui-components'
 
 const Header = styled.th<{width: number}>`
   margin: 16px;

--- a/packages/sanity/src/ui-components/tooltip/Tooltip.tsx
+++ b/packages/sanity/src/ui-components/tooltip/Tooltip.tsx
@@ -3,7 +3,9 @@ import {
   Flex,
   type HotkeysProps,
   Text,
+  // eslint-disable-next-line no-restricted-imports
   Tooltip as UITooltip,
+  // eslint-disable-next-line no-restricted-imports
   type TooltipProps as UITooltipProps,
 } from '@sanity/ui'
 import {type ForwardedRef, forwardRef} from 'react'


### PR DESCRIPTION
### Description
The existing eslint config is overriding the original `no-restricted-imports` rule.
When this rule was added:
```
'no-restricted-imports': [
          'error',
          {
            paths: [
              {
                name: 'react',
                importNames: ['createContext'],
                message: 'Please place context in _singletons',
              },
            ],
          },
```

The previous rules stopped working.

- This PR introduces changes to make all the `no-restricted-imports` rules work at the same time.
- This PR also fixes the failing checks, by either importing the corresponding files or opting out where needed.



With the changes introduced, now we are seeing all the expected errors.
<img width="942" alt="Screenshot 2024-08-14 at 09 55 18" src="https://github.com/user-attachments/assets/36cbdb17-13b8-467d-9716-665d8c981f47">


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->



### What to review

- Are this changes ok? 
- Is there any way to configure the eslint file to expose different error messages for React default import error and context error ?
- **Small caveat:** The error for "Please place context in _singletons" is not standalone anymore, it's shared with the React default error. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Create a .tsx file inside `packages/sanity/*` and add the following code, the errors should show in the file and when running the lint check action.
```
import {Button} from '@sanity/ui'
import React, {createContext} from 'react'
import styled from 'styled-components'

const StyledButton = styled(Button)`
  padding: 10px;
`
const context = createContext(null)

export function Test() {
  const [count, setCount] = React.useState(0)
  return <StyledButton onClick={() => setCount(count + 1)} text={`count: ${count}`} />
}
```
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
