### PR TITLE
fix(core): update cache dependencies for useBundlesStore

### DIFF
--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -281,22 +281,28 @@ export function useBundlesStore(): BundlesStore {
   const resourceCache = useResourceCache()
   const workspace = useWorkspace()
   const currentUser = useCurrentUser()
-  const {client: addonClient, ready} = useAddonDataset()
+  const addonDataset = useAddonDataset()
   const studioClient = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
 
   return useMemo(() => {
     const bundlesStore =
       resourceCache.get<BundlesStore>({
-        dependencies: [workspace, addonClient, {addonClientReady: ready}],
+        dependencies: [workspace, addonDataset, currentUser],
         namespace: 'BundlesStore',
-      }) || createBundlesStore({addonClient, studioClient, addonClientReady: ready, currentUser})
+      }) ||
+      createBundlesStore({
+        addonClient: addonDataset.client,
+        addonClientReady: addonDataset.ready,
+        studioClient,
+        currentUser,
+      })
 
     resourceCache.set({
-      dependencies: [workspace, addonClient, {addonClientReady: ready}],
+      dependencies: [workspace, addonDataset, currentUser],
       namespace: 'BundlesStore',
       value: bundlesStore,
     })
 
     return bundlesStore
-  }, [addonClient, resourceCache, studioClient, workspace, ready, currentUser])
+  }, [resourceCache, workspace, addonDataset, studioClient, currentUser])
 }


### PR DESCRIPTION
### Description

The bundles store was added to the resource cache with a key that was not possible to recreate, given it was using an object created in place which gets a new identity every time a component invoque `useBundlesStore`.

```
dependencies: [workspace, addonClient, {addonClientReady: ready}]

// {addonClientReady: ready} is incorrect, the object is created in place so it has a new identity each time it is created
```

Generating in some cases hundreds of requests with the query `*[_type == "bundle"]`

<img width="500" alt="Screenshot 2024-08-14 at 11 20 46" src="https://github.com/user-attachments/assets/7ef4f3d7-6bb7-4846-a956-828dbb73ce72">



By updating the dependencies to use **stable objects** this issue is fixed, and the store is created only once and the request is only triggered once.




<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
