### PR TITLE
feat(releases): suffix to bundle slug

### DIFF
--- a/packages/sanity/src/core/bundles/components/dialog/BundleDetailsDialog.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/BundleDetailsDialog.tsx
@@ -63,7 +63,6 @@ export function BundleDetailsDialog(props: BundleDetailsDialogProps): JSX.Elemen
 
           const submitValue = {...value, title: value.title?.trim()}
           await bundleOperation(submitValue)
-          setValue(submitValue)
           if (formAction === 'create') {
             setPerspective(value.slug)
           }

--- a/packages/sanity/src/core/bundles/components/dialog/BundleDetailsDialog.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/BundleDetailsDialog.tsx
@@ -60,8 +60,10 @@ export function BundleDetailsDialog(props: BundleDetailsDialogProps): JSX.Elemen
         try {
           event.preventDefault()
           setIsSubmitting(true)
-          await bundleOperation(value)
-          setValue(value)
+
+          const submitValue = {...value, title: value.title?.trim()}
+          await bundleOperation(submitValue)
+          setValue(submitValue)
           if (formAction === 'create') {
             setPerspective(value.slug)
           }
@@ -103,7 +105,7 @@ export function BundleDetailsDialog(props: BundleDetailsDialogProps): JSX.Elemen
         </Box>
         <Flex justify="flex-end" padding={3}>
           <Button
-            disabled={!value.title || isSubmitting}
+            disabled={!value.title?.trim() || isSubmitting}
             iconRight={ArrowRightIcon}
             type="submit"
             text={dialogTitle}

--- a/packages/sanity/src/core/bundles/components/dialog/BundleDetailsDialog.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/BundleDetailsDialog.tsx
@@ -6,7 +6,7 @@ import {useTranslation} from 'sanity'
 import {type BundleDocument} from '../../../store/bundles/types'
 import {useBundleOperations} from '../../../store/bundles/useBundleOperations'
 import {usePerspective} from '../../hooks/usePerspective'
-import {BundleForm} from './BundleForm'
+import {BundleForm, DEFAULT_BUNDLE} from './BundleForm'
 
 interface BundleDetailsDialogProps {
   onCancel: () => void
@@ -18,7 +18,6 @@ export function BundleDetailsDialog(props: BundleDetailsDialogProps): JSX.Elemen
   const {onCancel, onSubmit, bundle} = props
   const toast = useToast()
   const {createBundle, updateBundle} = useBundleOperations()
-  const [hasErrors, setHasErrors] = useState(false)
   const formAction = bundle ? 'edit' : 'create'
   const {t} = useTranslation()
 
@@ -33,13 +32,7 @@ export function BundleDetailsDialog(props: BundleDetailsDialogProps): JSX.Elemen
       }
     }
 
-    return {
-      slug: '',
-      title: '',
-      hue: 'gray',
-      icon: 'cube',
-      //publishAt: undefined,
-    }
+    return DEFAULT_BUNDLE
   })
   const [isSubmitting, setIsSubmitting] = useState(false)
 
@@ -92,10 +85,6 @@ export function BundleDetailsDialog(props: BundleDetailsDialogProps): JSX.Elemen
     setValue(changedValue)
   }, [])
 
-  const handleOnError = useCallback((errorsExist: boolean) => {
-    setHasErrors(errorsExist)
-  }, [])
-
   const dialogTitle =
     formAction === 'edit' ? t('bundle.dialog.edit.title') : t('bundle.dialog.create.title')
 
@@ -110,14 +99,13 @@ export function BundleDetailsDialog(props: BundleDetailsDialogProps): JSX.Elemen
     >
       <form onSubmit={handleOnSubmit}>
         <Box padding={6}>
-          <BundleForm onChange={handleOnChange} onError={handleOnError} value={value} />
+          <BundleForm onChange={handleOnChange} value={value} />
         </Box>
         <Flex justify="flex-end" padding={3}>
           <Button
-            disabled={!value.title || isSubmitting || hasErrors}
+            disabled={!value.title || isSubmitting}
             iconRight={ArrowRightIcon}
             type="submit"
-            // localize Text
             text={dialogTitle}
             loading={isSubmitting}
             data-testid="submit-release-button"

--- a/packages/sanity/src/core/bundles/components/dialog/BundleForm.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/BundleForm.tsx
@@ -15,7 +15,7 @@ import {
 //import {getCalendarLabels} from '../../../form/inputs/DateInputs/utils'
 import {type BundleDocument} from '../../../store/bundles/types'
 import {BundleIconEditorPicker, type BundleIconEditorPickerValue} from './BundleIconEditorPicker'
-import {useGetBundleSlug} from './getBundleSlug'
+import {useGetBundleSlug} from './useGetBundleSlug'
 
 interface BaseBundleDocument extends Partial<BundleDocument> {
   hue: ColorHueKey

--- a/packages/sanity/src/core/bundles/components/dialog/BundleForm.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/BundleForm.tsx
@@ -1,28 +1,40 @@
 //import {CalendarIcon} from '@sanity/icons'
+import {type ColorHueKey} from '@sanity/color'
+import {type IconSymbol} from '@sanity/icons'
 import {Flex, Stack, Text, TextArea, TextInput} from '@sanity/ui'
 import {useCallback, useMemo, useRef, useState} from 'react'
 import {
   FormFieldHeaderText,
   type FormNodeValidation,
-  useBundles,
   useTranslation,
   //useDateTimeFormat,
   //useTranslation,
 } from 'sanity'
-import speakingurl from 'speakingurl'
 
 //import {type CalendarLabels} from '../../../form/inputs/DateInputs/base/calendar/types'
 //import {getCalendarLabels} from '../../../form/inputs/DateInputs/utils'
 import {type BundleDocument} from '../../../store/bundles/types'
-import {isDraftOrPublished} from '../../util/util'
 import {BundleIconEditorPicker, type BundleIconEditorPickerValue} from './BundleIconEditorPicker'
+import {useGetBundleSlug} from './getBundleSlug'
+
+interface BaseBundleDocument extends Partial<BundleDocument> {
+  hue: ColorHueKey
+  icon: IconSymbol
+}
+
+export const DEFAULT_BUNDLE: BaseBundleDocument = {
+  slug: '',
+  title: '',
+  description: '',
+  hue: 'gray',
+  icon: 'cube',
+}
 
 export function BundleForm(props: {
   onChange: (params: Partial<BundleDocument>) => void
-  onError: (errorsExist: boolean) => void
   value: Partial<BundleDocument>
 }): JSX.Element {
-  const {onChange, onError, value} = props
+  const {onChange, value} = props
   const {title, description, icon, hue /*, publishAt*/} = value
   // derive the action from whether the initial value prop has a slug
   // only editing existing bundles will provide a value.slug
@@ -35,7 +47,6 @@ export function BundleForm(props: {
   const [showDatePicker, setShowDatePicker] = useState(false)
 
   const [isInitialRender, setIsInitialRender] = useState(true)
-  const {data} = useBundles()
 
   const [titleErrors, setTitleErrors] = useState<FormNodeValidation[]>([])
   /*const [dateErrors, setDateErrors] = useState<FormNodeValidation[]>([])
@@ -51,69 +62,37 @@ export function BundleForm(props: {
 
   const iconValue: BundleIconEditorPickerValue = useMemo(
     () => ({
-      icon: icon ?? 'cube',
-      hue: hue ?? 'gray',
+      icon: icon ?? DEFAULT_BUNDLE.icon,
+      hue: hue ?? DEFAULT_BUNDLE.hue,
     }),
     [icon, hue],
   )
 
-  const generateSlugFromTitle = useCallback(
-    (pickedTitle: string) => {
-      if (isEditing && value.slug) {
-        const slug = value.slug
-        return {slug, slugExists: false}
-      }
-      const newSlug = speakingurl(pickedTitle)
-      const slugExists = Boolean(data && data.find((bundle) => bundle.slug === newSlug))
-
-      return {slug: newSlug, slugExists}
-    },
-    [isEditing, value, data],
-  )
+  const generateSlugFromTitle = useGetBundleSlug()
 
   const handleBundleTitleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const pickedTitle = event.target.value
-      const {slug: newSlug, slugExists} = generateSlugFromTitle(pickedTitle)
-      const isEmptyTitle = pickedTitle.trim() === '' && !isInitialRender
+      const {slug: existingSlug} = value
 
-      if (isDraftOrPublished(pickedTitle) || slugExists || (isEmptyTitle && !isInitialRender)) {
-        if (isEmptyTitle && !isInitialRender) {
-          // if the title is empty and it's not the first opening of the dialog, show an error
-          // TODO localize text
+      const nextSlug = (isEditing && existingSlug) || generateSlugFromTitle(pickedTitle)
 
-          setTitleErrors([{level: 'error', message: 'Bundle needs a name', path: []}])
-        }
-        if (isDraftOrPublished(pickedTitle)) {
-          // if the title is 'drafts' or 'published', show an error
-          // TODO localize text
-          setTitleErrors([
-            {level: 'error', message: "Title cannot be 'drafts' or 'published'", path: []},
-          ])
-        }
-        if (slugExists) {
-          // if the bundle already exists, show an error
-          // TODO localize text
-          setTitleErrors([{level: 'error', message: 'Bundle already exists', path: []}])
-        }
-
-        onError(true)
-      } else {
-        setTitleErrors([])
-        onError(false)
-      }
-
-      setIsInitialRender(false)
-      onChange({...value, title: pickedTitle, slug: newSlug})
+      onChange({
+        ...value,
+        title: pickedTitle,
+        slug: nextSlug,
+      })
     },
-    [generateSlugFromTitle, isInitialRender, onChange, onError, value],
+    [generateSlugFromTitle, isEditing, onChange, value],
   )
 
   const handleBundleDescriptionChange = useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const v = event.target.value
+      const {value: descriptionValue} = event.target
 
-      onChange({...value, description: v || undefined})
+      if (typeof descriptionValue !== 'undefined') {
+        onChange({...value, description: descriptionValue})
+      }
     },
     [onChange, value],
   )

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleDetailsDialog.test.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleDetailsDialog.test.tsx
@@ -48,6 +48,8 @@ describe('BundleDetailsDialog', () => {
         data: [],
         loading: true,
         dispatch: jest.fn(),
+        error: undefined,
+        deletedBundles: {},
       })
 
       //mockUseDateTimeFormat.mockReturnValue({format: jest.fn().mockReturnValue('Mocked date')})
@@ -72,6 +74,7 @@ describe('BundleDetailsDialog', () => {
         title: 'Bundle 1',
         hue: 'gray',
         icon: 'cube',
+        description: '',
         //publishAt: undefined,
       }
 
@@ -113,6 +116,8 @@ describe('BundleDetailsDialog', () => {
         data: [],
         loading: true,
         dispatch: jest.fn(),
+        error: undefined,
+        deletedBundles: {},
       })
 
       //mockUseDateTimeFormat.mockReturnValue({format: jest.fn().mockReturnValue('Mocked date')})

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleDetailsDialog.test.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleDetailsDialog.test.tsx
@@ -143,10 +143,15 @@ describe('BundleDetailsDialog', () => {
       fireEvent.change(screen.getByTestId('bundle-form-title'), {target: {value: ''}})
 
       expect(screen.getByTestId('submit-release-button')).toBeDisabled()
+
+      // whitespace should be trimmed
+      fireEvent.change(screen.getByTestId('bundle-form-title'), {target: {value: '   '}})
+
+      expect(screen.getByTestId('submit-release-button')).toBeDisabled()
     })
 
     it('should patch the bundle document when submitted', () => {
-      fireEvent.change(screen.getByTestId('bundle-form-title'), {target: {value: 'New title'}})
+      fireEvent.change(screen.getByTestId('bundle-form-title'), {target: {value: 'New title  '}})
       fireEvent.change(screen.getByTestId('bundle-form-description'), {
         target: {value: 'New description'},
       })

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleForm.test.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/BundleForm.test.tsx
@@ -50,7 +50,13 @@ describe('BundleForm', () => {
         },
         // Add more mock data if needed
       ]
-      mockUseBundleStore.mockReturnValue({data: mockData, loading: false, dispatch: jest.fn()})
+      mockUseBundleStore.mockReturnValue({
+        data: mockData,
+        loading: false,
+        dispatch: jest.fn(),
+        error: undefined,
+        deletedBundles: {},
+      })
 
       mockUseDateTimeFormat.mockReturnValue({format: jest.fn().mockReturnValue('Mocked date')})
 
@@ -94,34 +100,23 @@ describe('BundleForm', () => {
     expect(onChangeMock).toHaveBeenCalledWith({...valueMock, publishAt: ''})
   })*/
 
-    it('should show an error when the title is "drafts"', () => {
+    it('should allow for a "drafts" title bundle to be created', () => {
       const titleInput = screen.getByTestId('bundle-form-title')
 
       fireEvent.change(titleInput, {target: {value: 'drafts'}})
 
-      expect(screen.getByTestId('input-validation-icon-error')).toBeInTheDocument()
+      expect(onChangeMock).toHaveBeenCalledWith({...valueMock, title: 'drafts', slug: 'drafts-1'})
     })
 
-    it('should show an error when the title is "published"', () => {
+    it('should allow for a "published" title bundle to be created', () => {
       const titleInput = screen.getByTestId('bundle-form-title')
       fireEvent.change(titleInput, {target: {value: 'published'}})
 
-      expect(screen.getByTestId('input-validation-icon-error')).toBeInTheDocument()
-    })
-
-    it('should show an error when the bundle already exists', () => {
-      const titleInput = screen.getByTestId('bundle-form-title')
-      fireEvent.change(titleInput, {target: {value: 'Spring Drop'}})
-
-      expect(screen.getByTestId('input-validation-icon-error')).toBeInTheDocument()
-    })
-
-    it('should show an error when the title is empty', () => {
-      const titleInput = screen.getByTestId('bundle-form-title')
-      fireEvent.change(titleInput, {target: {value: 'test'}}) // Set a valid title first
-      fireEvent.change(titleInput, {target: {value: ' '}}) // remove the title
-
-      expect(screen.getByTestId('input-validation-icon-error')).toBeInTheDocument()
+      expect(onChangeMock).toHaveBeenCalledWith({
+        ...valueMock,
+        title: 'published',
+        slug: 'published-1',
+      })
     })
 
     /*it('should show an error when the publishAt input value is invalid', () => {

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/useGetBundleSlug.test.ts
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/useGetBundleSlug.test.ts
@@ -1,0 +1,88 @@
+import {describe, expect, it, jest} from '@jest/globals'
+import {renderHook} from '@testing-library/react'
+
+import {type BundleDocument, useBundles} from '../../../../store/bundles'
+import {useGetBundleSlug} from '../useGetBundleSlug'
+
+jest.mock('../../../../store/bundles', () => ({
+  useBundles: jest.fn(),
+}))
+
+const mockUseBundles = useBundles as jest.Mock<typeof useBundles>
+
+const generateMockUseBundles = (bundles: {slug: string}[] | null) => {
+  mockUseBundles.mockReturnValue({
+    data: bundles as BundleDocument[],
+    loading: false,
+    error: undefined,
+    dispatch: jest.fn(),
+    deletedBundles: {},
+  })
+}
+
+describe('useGetBundleSlug', () => {
+  it('should generate a new slug when there are no existing bundles', () => {
+    generateMockUseBundles([])
+
+    const {
+      result: {current},
+    } = renderHook(() => useGetBundleSlug())
+
+    expect(current('New Bundle')).toBe('new-bundle')
+  })
+
+  it("should generate a new slug when the slug doesn' already exist", () => {
+    generateMockUseBundles([{slug: 'test-bundle-1'}])
+
+    const {
+      result: {current},
+    } = renderHook(() => useGetBundleSlug())
+
+    expect(current('New Bundle')).toBe('new-bundle')
+  })
+
+  it('should generate a new slug with the correct suffix when similar slugs exist', () => {
+    generateMockUseBundles([
+      {slug: 'test-bundle'},
+      {slug: 'test-bundle-1'},
+      {slug: 'test-bundle-2'},
+    ])
+
+    const {
+      result: {current},
+    } = renderHook(() => useGetBundleSlug())
+
+    expect(current('Test Bundle')).toBe('test-bundle-3')
+  })
+
+  it('should generate a new slug when a suffix count is already provided', () => {
+    generateMockUseBundles([{slug: 'test-bundle-1'}])
+
+    const {
+      result: {current},
+    } = renderHook(() => useGetBundleSlug())
+
+    expect(current('Test Bundle 1')).toBe('test-bundle-1-1')
+  })
+
+  it('should handle protected slugs', () => {
+    generateMockUseBundles([])
+
+    const {
+      result: {current},
+    } = renderHook(() => useGetBundleSlug())
+
+    expect(current('Drafts')).toBe('drafts-1')
+    expect(current('published')).toBe('published-1')
+  })
+
+  it('should handle no bundles', () => {
+    generateMockUseBundles(null)
+
+    const {
+      result: {current},
+    } = renderHook(() => useGetBundleSlug())
+
+    expect(current('New Bundle')).toBe('new-bundle')
+  })
+})

--- a/packages/sanity/src/core/bundles/components/dialog/__tests__/useGetBundleSlug.test.ts
+++ b/packages/sanity/src/core/bundles/components/dialog/__tests__/useGetBundleSlug.test.ts
@@ -26,43 +26,56 @@ describe('useGetBundleSlug', () => {
 
     const {
       result: {current},
-    } = renderHook(() => useGetBundleSlug())
+    } = renderHook(useGetBundleSlug)
 
-    expect(current('New Bundle')).toBe('new-bundle')
+    expect(current('New Bundle')).toEqual('new-bundle')
   })
 
-  it("should generate a new slug when the slug doesn' already exist", () => {
+  it("should generate a new slug when the slug doesn't already exist", () => {
     generateMockUseBundles([{slug: 'test-bundle-1'}])
 
     const {
       result: {current},
-    } = renderHook(() => useGetBundleSlug())
+    } = renderHook(useGetBundleSlug)
 
-    expect(current('New Bundle')).toBe('new-bundle')
+    expect(current('New Bundle')).toEqual('new-bundle')
   })
 
-  it('should generate a new slug with the correct suffix when similar slugs exist', () => {
-    generateMockUseBundles([
-      {slug: 'test-bundle'},
-      {slug: 'test-bundle-1'},
-      {slug: 'test-bundle-2'},
-    ])
+  it.each([
+    [[{slug: 'test-bundle'}], 'Test Bundle', 'test-bundle-1'],
+    [[{slug: 'test-bundle'}], 'Test Bundle 3', 'test-bundle-3'],
+    [
+      [{slug: 'test-bundle'}, {slug: 'test-bundle-1'}, {slug: 'test-bundle-2'}],
+      'Test Bundle',
+      'test-bundle-3',
+    ],
+    [
+      [{slug: 'test-bundle'}, {slug: 'test-bundle-3'}, {slug: 'test-bundle-2'}],
+      'Test Bundle',
+      'test-bundle-1',
+    ],
+    [[{slug: 'test-bundle-3'}, {slug: 'test-bundle-2'}], 'Test Bundle', 'test-bundle'],
+  ])(
+    'should generate the next lowest suffix when the slug already exists',
+    (existingBundleSlugs, requestBundleTitle, resultSlug) => {
+      generateMockUseBundles(existingBundleSlugs)
 
-    const {
-      result: {current},
-    } = renderHook(() => useGetBundleSlug())
+      const {
+        result: {current},
+      } = renderHook(useGetBundleSlug)
 
-    expect(current('Test Bundle')).toBe('test-bundle-3')
-  })
+      expect(current(requestBundleTitle)).toEqual(resultSlug)
+    },
+  )
 
   it('should generate a new slug when a suffix count is already provided', () => {
-    generateMockUseBundles([{slug: 'test-bundle-1'}])
+    generateMockUseBundles([{slug: 'test-bundle-1-2'}])
 
     const {
       result: {current},
-    } = renderHook(() => useGetBundleSlug())
+    } = renderHook(useGetBundleSlug)
 
-    expect(current('Test Bundle 1')).toBe('test-bundle-1-1')
+    expect(current('Test Bundle 1 2')).toEqual('test-bundle-1-2-1')
   })
 
   it('should handle protected slugs', () => {
@@ -70,10 +83,10 @@ describe('useGetBundleSlug', () => {
 
     const {
       result: {current},
-    } = renderHook(() => useGetBundleSlug())
+    } = renderHook(useGetBundleSlug)
 
-    expect(current('Drafts')).toBe('drafts-1')
-    expect(current('published')).toBe('published-1')
+    expect(current('Drafts')).toEqual('drafts-1')
+    expect(current('published')).toEqual('published-1')
   })
 
   it('should handle no bundles', () => {
@@ -81,8 +94,8 @@ describe('useGetBundleSlug', () => {
 
     const {
       result: {current},
-    } = renderHook(() => useGetBundleSlug())
+    } = renderHook(useGetBundleSlug)
 
-    expect(current('New Bundle')).toBe('new-bundle')
+    expect(current('New Bundle')).toEqual('new-bundle')
   })
 })

--- a/packages/sanity/src/core/bundles/components/dialog/getBundleSlug.ts
+++ b/packages/sanity/src/core/bundles/components/dialog/getBundleSlug.ts
@@ -1,0 +1,42 @@
+import {useCallback} from 'react'
+import speakingurl from 'speakingurl'
+
+import {useBundles} from '../../../store/bundles'
+
+export function useGetBundleSlug() {
+  const {data: bundles} = useBundles()
+
+  // From existing bundles:
+  // if slug doesn't exist, return -1
+  // if slug does exist, return the highest suffix number (or 0 if no suffix)
+  const getMaxSuffixForSlug = useCallback(
+    (baseSlug: string): number => {
+      if (!bundles) return -1
+
+      const suffixRegex = new RegExp(`^${baseSlug}(?:-(\\d+))?$`)
+      return bundles.reduce((maxSlugSuffix, {slug}) => {
+        const isBaseSlugMatch = slug.match(suffixRegex)
+        if (!isBaseSlugMatch) return maxSlugSuffix
+
+        const suffixNumber = parseInt(isBaseSlugMatch[1] || '0', 10)
+        return Math.max(maxSlugSuffix, suffixNumber)
+      }, -1)
+    },
+    [bundles],
+  )
+
+  const generateSlugFromTitle = useCallback(
+    (pickedTitle: string) => {
+      const newSlug = speakingurl(pickedTitle)
+      const existingSlugMaxSuffix = getMaxSuffixForSlug(newSlug)
+
+      // newSlug doesn't exist yet
+      if (existingSlugMaxSuffix === -1) return newSlug
+
+      return `${newSlug}-${existingSlugMaxSuffix + 1}`
+    },
+    [getMaxSuffixForSlug],
+  )
+
+  return generateSlugFromTitle
+}

--- a/packages/sanity/src/core/bundles/components/dialog/useGetBundleSlug.ts
+++ b/packages/sanity/src/core/bundles/components/dialog/useGetBundleSlug.ts
@@ -3,6 +3,8 @@ import speakingurl from 'speakingurl'
 
 import {useBundles} from '../../../store/bundles'
 
+const PROTECTED_SLUGS = ['drafts', 'published']
+
 export function useGetBundleSlug() {
   const {data: bundles} = useBundles()
 
@@ -14,13 +16,16 @@ export function useGetBundleSlug() {
       if (!bundles) return -1
 
       const suffixRegex = new RegExp(`^${baseSlug}(?:-(\\d+))?$`)
-      return bundles.reduce((maxSlugSuffix, {slug}) => {
-        const isBaseSlugMatch = slug.match(suffixRegex)
-        if (!isBaseSlugMatch) return maxSlugSuffix
+      return [...bundles, ...PROTECTED_SLUGS.map((slug) => ({slug}))].reduce(
+        (maxSlugSuffix, {slug}) => {
+          const isBaseSlugMatch = slug.match(suffixRegex)
+          if (!isBaseSlugMatch) return maxSlugSuffix
 
-        const suffixNumber = parseInt(isBaseSlugMatch[1] || '0', 10)
-        return Math.max(maxSlugSuffix, suffixNumber)
-      }, -1)
+          const suffixNumber = parseInt(isBaseSlugMatch[1] || '0', 10)
+          return Math.max(maxSlugSuffix, suffixNumber)
+        },
+        -1,
+      )
     },
     [bundles],
   )

--- a/packages/sanity/src/core/bundles/components/dialog/useGetBundleSlug.ts
+++ b/packages/sanity/src/core/bundles/components/dialog/useGetBundleSlug.ts
@@ -5,6 +5,8 @@ import {useBundles} from '../../../store/bundles'
 
 const PROTECTED_SLUGS = ['drafts', 'published']
 
+const NO_EXISTING_SLUG: number = -1
+
 export function useGetBundleSlug() {
   const {data: bundles} = useBundles()
 
@@ -13,7 +15,7 @@ export function useGetBundleSlug() {
   // if slug does exist, return the highest suffix number (or 0 if no suffix)
   const getMaxSuffixForSlug = useCallback(
     (baseSlug: string): number => {
-      if (!bundles) return -1
+      if (!bundles) return NO_EXISTING_SLUG
 
       const suffixRegex = new RegExp(`^${baseSlug}(?:-(\\d+))?$`)
       return [...bundles, ...PROTECTED_SLUGS.map((slug) => ({slug}))].reduce(
@@ -24,7 +26,7 @@ export function useGetBundleSlug() {
           const suffixNumber = parseInt(isBaseSlugMatch[1] || '0', 10)
           return Math.max(maxSlugSuffix, suffixNumber)
         },
-        -1,
+        NO_EXISTING_SLUG,
       )
     },
     [bundles],
@@ -36,7 +38,7 @@ export function useGetBundleSlug() {
       const existingSlugMaxSuffix = getMaxSuffixForSlug(newSlug)
 
       // newSlug doesn't exist yet
-      if (existingSlugMaxSuffix === -1) return newSlug
+      if (existingSlugMaxSuffix === NO_EXISTING_SLUG) return newSlug
 
       return `${newSlug}-${existingSlugMaxSuffix + 1}`
     },

--- a/packages/sanity/src/core/bundles/components/dialog/useGetBundleSlug.ts
+++ b/packages/sanity/src/core/bundles/components/dialog/useGetBundleSlug.ts
@@ -5,29 +5,43 @@ import {useBundles} from '../../../store/bundles'
 
 const PROTECTED_SLUGS = ['drafts', 'published']
 
-const NO_EXISTING_SLUG: number = -1
+const NO_EXISTING_SLUG: number = 0
 
 export function useGetBundleSlug() {
   const {data: bundles} = useBundles()
 
   // From existing bundles:
-  // if slug doesn't exist, return -1
-  // if slug does exist, return the highest suffix number (or 0 if no suffix)
-  const getMaxSuffixForSlug = useCallback(
+  // if slug doesn't exist, return NO_EXISTING_SLUG
+  // if slug does exist, returns lowest suffix number available
+  const getMinimumAvailableSuffixForSlug = useCallback(
     (baseSlug: string): number => {
       if (!bundles) return NO_EXISTING_SLUG
 
       const suffixRegex = new RegExp(`^${baseSlug}(?:-(\\d+))?$`)
-      return [...bundles, ...PROTECTED_SLUGS.map((slug) => ({slug}))].reduce(
-        (maxSlugSuffix, {slug}) => {
-          const isBaseSlugMatch = slug.match(suffixRegex)
-          if (!isBaseSlugMatch) return maxSlugSuffix
+      const descExistingSlugSuffixes = [...bundles, ...PROTECTED_SLUGS.map((slug) => ({slug}))]
+        .reduce<number[]>((existingSuffixes, {slug: existingBundleSlug}) => {
+          const isBaseSlugMatch = existingBundleSlug.match(suffixRegex)
+          if (!isBaseSlugMatch) return existingSuffixes
 
-          const suffixNumber = parseInt(isBaseSlugMatch[1] || '0', 10)
-          return Math.max(maxSlugSuffix, suffixNumber)
-        },
-        NO_EXISTING_SLUG,
-      )
+          const suffixNumber = parseInt(isBaseSlugMatch[1] ?? String(NO_EXISTING_SLUG), 10)
+          existingSuffixes.push(suffixNumber)
+
+          return existingSuffixes
+        }, [])
+        .sort((aSuffix, bSuffix) => bSuffix - aSuffix)
+
+      if (!descExistingSlugSuffixes.length) return NO_EXISTING_SLUG
+      const [maxSuffix] = descExistingSlugSuffixes
+      const maxNextSuffix =
+        maxSuffix + (descExistingSlugSuffixes.includes(NO_EXISTING_SLUG) ? 1 : 0)
+
+      const lowestAvailableSuffix =
+        Array.from({length: maxNextSuffix}, (_, index) => index).find(
+          (index) => !descExistingSlugSuffixes.includes(index),
+        ) ?? undefined
+      if (lowestAvailableSuffix === undefined) return maxSuffix + 1
+
+      return lowestAvailableSuffix
     },
     [bundles],
   )
@@ -35,14 +49,14 @@ export function useGetBundleSlug() {
   const generateSlugFromTitle = useCallback(
     (pickedTitle: string) => {
       const newSlug = speakingurl(pickedTitle)
-      const existingSlugMaxSuffix = getMaxSuffixForSlug(newSlug)
+      const nextAvailableSuffixForSlug = getMinimumAvailableSuffixForSlug(newSlug)
 
       // newSlug doesn't exist yet
-      if (existingSlugMaxSuffix === NO_EXISTING_SLUG) return newSlug
+      if (nextAvailableSuffixForSlug === NO_EXISTING_SLUG) return newSlug
 
-      return `${newSlug}-${existingSlugMaxSuffix + 1}`
+      return `${newSlug}-${nextAvailableSuffixForSlug}`
     },
-    [getMaxSuffixForSlug],
+    [getMinimumAvailableSuffixForSlug],
   )
 
   return generateSlugFromTitle


### PR DESCRIPTION
### Description
There are now no error states in the bundle form. If a protected title is entered, then a unique slug will still be generated (eg title of Published, will create slug of `published-1`). If a slug already exists, the the closest unique one will be used. This allows for bundles with identical titles to be generated
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* new `useGetBundleSlug` hook that does the generation of slug from title
* Testing for `useGetBundleSlug`
* Updated tests for `BundleForm` and `BundleDetailsDialog`
* Trimming bundle title

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Relevant tests added and updated. Tests related to asserting on showing form errors have been removed
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
