### PR TITLE
fix(core): avoid attempting to render media preview images when no value is set

### DIFF
--- a/packages/sanity/src/core/preview/components/SanityDefaultPreview.tsx
+++ b/packages/sanity/src/core/preview/components/SanityDefaultPreview.tsx
@@ -83,16 +83,18 @@ export function SanityDefaultPreview(props: SanityDefaultPreviewProps): ReactEle
       return false
     }
 
-    if (isValidElementType(mediaProp)) {
-      return mediaProp
-    }
+    if (mediaProp) {
+      if (isValidElementType(mediaProp)) {
+        return mediaProp
+      }
 
-    if (isValidElement(mediaProp)) {
-      return mediaProp
-    }
+      if (isValidElement(mediaProp)) {
+        return mediaProp
+      }
 
-    if (isImageSource(mediaProp)) {
-      return renderMedia
+      if (isImageSource(mediaProp)) {
+        return renderMedia
+      }
     }
 
     // Handle image urls


### PR DESCRIPTION
The current code attempts to construct an image URL for `undefined`. This results in a thrown (caught) exception which we can avoid by checking this value before attempting to render.

### Description
Help reduce the amount of work done per pane item in lists, as these would keep attempting to render a media image preview for undefined values. This situation is caught, but this is processing we do not need to do.

### What to review
That there are no side-effects to avoiding this attempted render

### Testing
Manual testing to verify that media preview images are rendering as expected.

### Notes for release
Not required