### PR TITLE
chore(tests): collapsing ct test report comment

### DIFF
--- a/packages/sanity/playwright-ct/scripts/utils.ts
+++ b/packages/sanity/playwright-ct/scripts/utils.ts
@@ -137,13 +137,13 @@ function generateMarkdownTable(rows: SummaryRow[]) {
 }
 
 function generateTestingSummary(rows: SummaryRow[]) {
-  const hasFailedTests = rows.some((row) => row.totalFailed > 0)
+  const failedTestCount = sumBy(rows, 'totalFailed')
 
-  return `${hasFailedTests ? '❌ Failed Tests' : '✅ All Tests Passed'} -- open for details`
+  return `${failedTestCount > 0 ? `❌ Failed Tests (${failedTestCount})` : '✅ All Tests Passed'} -- expand for details`
 }
 
 function formatAsCollapsable(summary: string, detail: string) {
-  return `<details><summary>${summary}</summary>${detail}</details>`
+  return `<details>\n<summary>${summary}</summary>\n\n${detail}\n</details>`
 }
 
 /**


### PR DESCRIPTION
### Description
Minor update to collapse the component testing table comment in a PR. This will avoid a wall of comments on a newly opened PR an _should_ make it a little quicker to spot when component tests are failing.

When all tests are passing:
<img width="927" alt="Screenshot 2024-08-19 at 11 38 52" src="https://github.com/user-attachments/assets/38b88e26-4fc8-4d64-ac46-a3df0b1f28a4">

When tests are failing:
<img width="924" alt="Screenshot 2024-08-19 at 11 19 11" src="https://github.com/user-attachments/assets/72e15106-7e4d-45a7-bd37-53a7f318a16d">


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
N/A
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
