### PR TITLE
fix(sanity): update the title to be ellipsed when the text is too long 

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
@@ -2,10 +2,16 @@ import {DocumentIcon} from '@sanity/icons'
 import {Flex, Text} from '@sanity/ui'
 import {createElement, memo, type ReactElement} from 'react'
 import {unstable_useValuePreview as useValuePreview, useTranslation} from 'sanity'
+import {styled} from 'styled-components'
 
 import {structureLocaleNamespace} from '../../../../i18n'
 import {useDocumentPane} from '../../useDocumentPane'
 import {DocumentPerspectiveMenu} from './perspective/DocumentPerspectiveMenu'
+
+const TitleContainer = styled(Text)`
+  max-width: 100%;
+  min-width: 0;
+`
 
 export const DocumentHeaderTitle = memo(function DocumentHeaderTitle(): ReactElement {
   const {connectionState, schemaType, title, value: documentValue} = useDocumentPane()
@@ -41,14 +47,13 @@ export const DocumentHeaderTitle = memo(function DocumentHeaderTitle(): ReactEle
   }
 
   return (
-    <Flex flex="none" gap={3} paddingX={2} style={{flex: 1, alignItems: 'center'}}>
+    <Flex flex={1} align="center" gap={3} paddingX={2}>
       <Text size={1}>{createElement(schemaType?.options?.icon || DocumentIcon)}</Text>
-      <Text
+      <TitleContainer
         muted={!value?.title}
         size={1}
         textOverflow="ellipsis"
         weight={value?.title ? 'semibold' : undefined}
-        style={{maxWidth: '100%', minWidth: '0'}}
         title={value?.title}
       >
         {value?.title || (
@@ -56,7 +61,7 @@ export const DocumentHeaderTitle = memo(function DocumentHeaderTitle(): ReactEle
             {t('panes.document-header-title.untitled.text')}
           </span>
         )}
-      </Text>
+      </TitleContainer>
       <Flex flex="none" gap={1}>
         <DocumentPerspectiveMenu />
       </Flex>

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
@@ -41,23 +41,21 @@ export const DocumentHeaderTitle = memo(function DocumentHeaderTitle(): ReactEle
   }
 
   return (
-    <Flex flex={1} gap={0}>
-      <Flex flex="none" gap={3} padding={2}>
-        <Text size={1}>{createElement(schemaType?.options?.icon || DocumentIcon)}</Text>
-        <Text
-          muted={!value?.title}
-          size={1}
-          textOverflow="ellipsis"
-          weight={value?.title ? 'semibold' : undefined}
-        >
-          {value?.title || (
-            <span style={{color: 'var(--card-muted-fg-color)'}}>
-              {t('panes.document-header-title.untitled.text')}
-            </span>
-          )}
-        </Text>
-      </Flex>
-
+    <Flex flex="none" gap={3} paddingX={2} style={{flex: 1, alignItems: 'center'}}>
+      <Text size={1}>{createElement(schemaType?.options?.icon || DocumentIcon)}</Text>
+      <Text
+        muted={!value?.title}
+        size={1}
+        textOverflow="ellipsis"
+        weight={value?.title ? 'semibold' : undefined}
+        style={{maxWidth: '100%', minWidth: '0'}}
+      >
+        {value?.title || (
+          <span style={{color: 'var(--card-muted-fg-color)'}}>
+            {t('panes.document-header-title.untitled.text')}
+          </span>
+        )}
+      </Text>
       <Flex flex="none" gap={1}>
         <DocumentPerspectiveMenu />
       </Flex>

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
@@ -49,6 +49,7 @@ export const DocumentHeaderTitle = memo(function DocumentHeaderTitle(): ReactEle
         textOverflow="ellipsis"
         weight={value?.title ? 'semibold' : undefined}
         style={{maxWidth: '100%', minWidth: '0'}}
+        title={value?.title}
       >
         {value?.title || (
           <span style={{color: 'var(--card-muted-fg-color)'}}>


### PR DESCRIPTION
### Description

Before  
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/06c36265-1cd3-4d90-b892-3dfee642d813">  

After (hovering over the title text)
<img width="1033" alt="image" src="https://github.com/user-attachments/assets/e3cb0320-977f-4f17-bc1d-6227e6d64aab">

### What to review

- Double check the css makes sense

### Testing
Manual testing
- When no global bundle: the drop arrow should be next to the title, the title should behave as normal (if it's short or long)
- With a global bundle but no version document: the drop down arrow should be next to the title 
- With a global bundle and document version selected: the drop down arrow and badge next to it, the title should behave as normal (ellipsing if it's too long). The whole content should be in the title
