### PR TITLE
fix: do not show latest version if auto-updating

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
@@ -2,6 +2,7 @@ import {Box, MenuDivider, Text} from '@sanity/ui'
 
 import {MenuItem} from '../../../../../ui-components'
 import {LoadingBlock} from '../../../../components/loadingBlock'
+import {hasSanityPackageInImportMap} from '../../../../environment/hasSanityPackageInImportMap'
 import {useTranslation} from '../../../../i18n'
 import {SANITY_VERSION} from '../../../../version'
 import {type ResourcesResponse, type Section} from './helper-functions/types'
@@ -15,6 +16,7 @@ interface ResourcesMenuItemProps {
 export function ResourcesMenuItems({error, isLoading, value}: ResourcesMenuItemProps) {
   const sections = value?.resources?.sectionArray
   const latestStudioVersion = value?.latestVersion
+  const isAutoUpdating = hasSanityPackageInImportMap()
   const {t} = useTranslation()
 
   if (isLoading) {
@@ -61,7 +63,7 @@ export function ResourcesMenuItems({error, isLoading, value}: ResourcesMenuItemP
         <Text size={1} muted weight="medium" textOverflow="ellipsis">
           {t('help-resources.studio-version', {studioVersion: SANITY_VERSION})}
         </Text>
-        {!error && latestStudioVersion && (
+        {!error && latestStudioVersion && !isAutoUpdating && (
           <Box paddingTop={2}>
             <Text size={1} muted textOverflow="ellipsis">
               {t('help-resources.latest-sanity-version', {


### PR DESCRIPTION
### Description
We do not want to show the latest version label to those on auto-updating studios. There are a couple of scenarios in which the current text could be confusing:
1. If we are doing a gradual rollout -- the users may be in a bucket that does not allow them to upgrade to the "latest" version. 
2. If developers have pinned the studio version to a past version and again, the user does not have the power to update.

### What to review
Any edge cases in which this may not be helpful.

### Testing
I would like to test this! I am trying to reduce flakiness in our test suite so we can [run the entire suite against auto-updating studios](https://github.com/sanity-io/sanity/pull/7002). Once that is done, I will write a test for this as well!
