### PR TITLE
fix(typegen): find queries imported with defineQuery from next-sanity

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -363,4 +363,29 @@ describe('findQueries with defineQuery', () => {
     const queries = findQueriesInSource(source, __filename, undefined)
     expect(queries.length).toBe(0)
   })
+
+  test('can import from next-sanity', () => {
+    const source = `
+    import { defineQuery } from "next-sanity";
+    const postQuery = defineQuery("*[_type == 'author']");
+    const res = sanity.fetch(postQuery);
+  `
+
+    const queries = findQueriesInSource(source, 'test.ts')
+    expect(queries.length).toBe(1)
+    const queryResult = queries[0]
+
+    expect(queryResult?.result).toEqual("*[_type == 'author']")
+  })
+
+  test('wont import from other package names', () => {
+    const source = `
+    import { defineQuery } from "other";
+    const postQuery = defineQuery("*[_type == 'author']");
+    const res = sanity.fetch(postQuery);
+  `
+
+    const queries = findQueriesInSource(source, 'test.ts')
+    expect(queries.length).toBe(0)
+  })
 })

--- a/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
+++ b/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
@@ -13,6 +13,7 @@ const require = createRequire(__filename)
 const groqTagName = 'groq'
 const defineQueryFunctionName = 'defineQuery'
 const groqModuleName = 'groq'
+const nextSanityModuleName = 'next-sanity'
 
 const ignoreValue = '@sanity-typegen-ignore'
 
@@ -52,7 +53,8 @@ export function findQueriesInSource(
       // Look for strings wrapped in a defineQuery function call
       const isDefineQueryCall =
         babelTypes.isCallExpression(init) &&
-        isImportFrom(groqModuleName, defineQueryFunctionName, scope, init.callee)
+        (isImportFrom(groqModuleName, defineQueryFunctionName, scope, init.callee) ||
+          isImportFrom(nextSanityModuleName, defineQueryFunctionName, scope, init.callee))
 
       if (babelTypes.isIdentifier(node.id) && (isGroqTemplateTag || isDefineQueryCall)) {
         // If we find a comment leading the decleration which macthes with ignoreValue we don't add


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Find queries imported with defineQuery from next-sanity

### What to review

Any other packages we should detect?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Added 👍 

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

TypeGen: generate types defined by defineQuery from the next-sanity package

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
