### PR TITLE
chore: fix wrong version format in generate documents script

### DIFF
--- a/scripts/generate-documents/run.ts
+++ b/scripts/generate-documents/run.ts
@@ -43,8 +43,7 @@ export function run(_args: ProgramArgs) {
       const bundleDocument = bundle
         ? {
             ...template({...templateOptions, title: `${title} - Published`}),
-            _id: `${bundle}.${id}`,
-            _version: {},
+            _id: `versions.${bundle}.${id}`,
             title: `${title} - Bundle: ${bundle}`,
           }
         : undefined


### PR DESCRIPTION
### Description
Small follow up from #7387 - the way a document was added to a bundle was based on the old way, this fixes it by prepending `versions.` to the id instead of writing to the `_version` property

### Testing
n/a

### Notes for release
n/a – internal