### PR TITLE
fix(core): fix copy related issues

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
@@ -17,6 +17,7 @@ import {MenuButton, MenuItem, TooltipDelayGroupProvider} from '../../../../ui-co
 import {ContextMenuButton} from '../../../components/contextMenuButton'
 import {type DocumentFieldActionNode} from '../../../config'
 import {useTranslation} from '../../../i18n'
+import {EMPTY_ARRAY} from '../../../util/empty'
 import {FormField} from '../../components'
 import {usePublishedId} from '../../contexts/DocumentIdProvider'
 import {FieldActionsProvider, FieldActionsResolver} from '../../field'
@@ -223,10 +224,13 @@ export function ReferenceField(props: ReferenceFieldProps) {
     [handleClear, handleReplace, inputId, OpenLink, readOnly, t, value?._ref],
   )
 
-  const handleFocus = useCallback(() => inputProps.onPathFocus([]), [inputProps])
-  const handleBlur = useCallback(
-    (event: FocusEvent) => inputProps.elementProps.onBlur(event),
-    [inputProps.elementProps],
+  const handleFocus = useCallback(
+    (event: FocusEvent) => {
+      if (event.target === elementRef.current) {
+        inputProps.onPathFocus(EMPTY_ARRAY)
+      }
+    },
+    [inputProps],
   )
 
   return (
@@ -279,7 +283,6 @@ export function ReferenceField(props: ReferenceFieldProps) {
                       selected={selected}
                       tone="inherit"
                       onFocus={handleFocus}
-                      onBlur={handleBlur}
                     >
                       <PreviewReferenceValue
                         value={value}

--- a/packages/sanity/src/core/studio/copyPaste/utils.ts
+++ b/packages/sanity/src/core/studio/copyPaste/utils.ts
@@ -168,13 +168,7 @@ export function isEmptyValue(value: unknown): boolean {
 
 export function isNativeEditableElement(el: EventTarget): boolean {
   if (el instanceof HTMLElement && el.isContentEditable) return true
-  if (el instanceof HTMLInputElement) {
-    // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types
-    if (/|text|email|number|password|search|tel|url/.test(el.type || '')) {
-      return !(el.disabled || el.readOnly)
-    }
-  }
-  if (el instanceof HTMLTextAreaElement) return !(el.disabled || el.readOnly)
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) return true
   return false
 }
 


### PR DESCRIPTION
### Description

This fixes a few issues related to copy paste:

Referenced could not open when you had a reference field inside a field group and was not on the All fields tab. The fix here was to remove the `onBlur` handler. I'm not entirely sure why this breaks inside a group, since I could only reproduce in a newly installed studio and not inside the monorepo.  Having a blur handler here is a footgun, and doesn't make sense given that we don't want to change the focused path until you click another field.

Fixes #7265

It was also not possible to copy selected text in a textarea, since the Copy action was triggered and copied the full field content to the clipboard. Text areas should now be ignored.

### What to review

- That copying selected text in a textarea works
- That a reference can open inside a group

### Notes for release

- Fixes an issue where references would not open if clicked on inside a Field Group
- Fixes an issue where it wasn't possible to copy a text selection inside a text area field