### PR TITLE
feat(cli): respect `--no-auto-updates flag` in CLI config

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -16,6 +16,7 @@ import {BuildTrace} from './build.telemetry'
 import {buildVendorDependencies} from '../../server/buildVendorDependencies'
 import {compareStudioDependencyVersions} from '../../util/compareStudioDependencyVersions'
 import {getAutoUpdateImportMap} from '../../util/getAutoUpdatesImportMap'
+import {shouldAutoUpdate} from '../../util/shouldAutoUpdate'
 
 const rimraf = promisify(rimrafCallback)
 
@@ -58,9 +59,7 @@ export default async function buildSanityStudio(
     return {didCompile: false}
   }
 
-  const autoUpdatesEnabled =
-    flags['auto-updates'] ||
-    (cliConfig && 'autoUpdates' in cliConfig && cliConfig.autoUpdates === true)
+  const autoUpdatesEnabled = shouldAutoUpdate({flags, cliConfig})
 
   // Get the version without any tags if any
   const coercedSanityVersion = semver.coerce(installedSanityVersion)?.version

--- a/packages/sanity/src/_internal/cli/actions/deploy/deployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/deploy/deployAction.ts
@@ -5,6 +5,7 @@ import zlib from 'node:zlib'
 import {type CliCommandArguments, type CliCommandContext} from '@sanity/cli'
 import tar from 'tar-fs'
 
+import {shouldAutoUpdate} from '../../util/shouldAutoUpdate'
 import buildSanityStudio, {type BuildSanityStudioCommandFlags} from '../build/buildAction'
 import {
   checkDir,
@@ -29,10 +30,8 @@ export default async function deployStudioAction(
   const flags = {build: true, ...args.extOptions}
   const customSourceDir = args.argsWithoutOptions[0]
   const sourceDir = path.resolve(process.cwd(), customSourceDir || path.join(workDir, 'dist'))
-  const isAutoUpdating =
-    flags['auto-updates'] ||
-    (cliConfig && 'autoUpdates' in cliConfig && cliConfig.autoUpdates === true) ||
-    false
+  const isAutoUpdating = shouldAutoUpdate({flags, cliConfig})
+
   const installedSanityVersion = await getInstalledSanityVersion()
   const configStudioHost = cliConfig && 'studioHost' in cliConfig && cliConfig.studioHost
 

--- a/packages/sanity/src/_internal/cli/util/__tests__/shouldAutoUpdate.test.ts
+++ b/packages/sanity/src/_internal/cli/util/__tests__/shouldAutoUpdate.test.ts
@@ -1,0 +1,40 @@
+import {describe, expect, it} from '@jest/globals'
+import {type CliConfig} from '@sanity/cli'
+
+import {type BuildSanityStudioCommandFlags} from '../../actions/build/buildAction'
+import {shouldAutoUpdate} from '../shouldAutoUpdate'
+
+describe('shouldAutoUpdate', () => {
+  it('should return true when flags["auto-updates"] is true', () => {
+    const flags: BuildSanityStudioCommandFlags = {'auto-updates': true}
+    expect(shouldAutoUpdate({flags})).toBe(true)
+  })
+
+  it('should return false when flags["auto-updates"] is false', () => {
+    const flags: BuildSanityStudioCommandFlags = {'auto-updates': false}
+    expect(shouldAutoUpdate({flags})).toBe(false)
+  })
+
+  it('should return true when cliConfig.autoUpdates is true and flags["auto-updates"] is not set', () => {
+    const flags: BuildSanityStudioCommandFlags = {}
+    const cliConfig: CliConfig = {autoUpdates: true}
+    expect(shouldAutoUpdate({flags, cliConfig})).toBe(true)
+  })
+
+  it('should return false when cliConfig.autoUpdates is false and flags["auto-updates"] is not set', () => {
+    const flags: BuildSanityStudioCommandFlags = {}
+    const cliConfig: CliConfig = {autoUpdates: false}
+    expect(shouldAutoUpdate({flags, cliConfig})).toBe(false)
+  })
+
+  it('should return false when both flags["auto-updates"] and cliConfig.autoUpdates are not set', () => {
+    const flags: BuildSanityStudioCommandFlags = {}
+    expect(shouldAutoUpdate({flags})).toBe(false)
+  })
+
+  it('should prioritize flags over cliConfig when both are set', () => {
+    const flags: BuildSanityStudioCommandFlags = {'auto-updates': false}
+    const cliConfig: CliConfig = {autoUpdates: true}
+    expect(shouldAutoUpdate({flags, cliConfig})).toBe(false)
+  })
+})

--- a/packages/sanity/src/_internal/cli/util/shouldAutoUpdate.ts
+++ b/packages/sanity/src/_internal/cli/util/shouldAutoUpdate.ts
@@ -1,0 +1,27 @@
+import {type CliConfig} from '@sanity/cli'
+
+import {type BuildSanityStudioCommandFlags} from '../actions/build/buildAction'
+
+interface AutoUpdateSources {
+  flags: BuildSanityStudioCommandFlags
+  cliConfig?: CliConfig
+}
+
+/**
+ * Compares parameters from various sources to determine whether or not to auto-update
+ * @param sources - The sources of the auto-update parameter, including CLI flags and the CLI config
+ * @returns boolean
+ * @internal
+ */
+export function shouldAutoUpdate({flags, cliConfig}: AutoUpdateSources): boolean {
+  // cli flags (for example, '--no-auto-updates') should take precedence
+  if ('auto-updates' in flags) {
+    return Boolean(flags['auto-updates'])
+  }
+
+  if (cliConfig && 'autoUpdates' in cliConfig) {
+    return Boolean(cliConfig.autoUpdates)
+  }
+
+  return false
+}


### PR DESCRIPTION
### Description
As auto-updates become the new "default" way to build and deploy studios, we should ensure we're offering ways to easily override default behavior. This PR adds a helper function used in the build and deploy functions that prioritizes CLI flags first, then `sanity.cli.{ts|js}` parameters, and then finally a default (which we can easily change).

### What to review
The new file -- does it belong in utils (it was a bit hard to place since it was shared by two different actions)?
Ways to test I may have missed? (see below)

### Testing
This function is quite simple and goes through several layers of abstraction -- I'm not sure if it's particularly useful to test on its own. It would be ideal to test the `--no-auto-updates` command line input, but I'm not sure it's possible. An integration test with the flags and a cliConfig context is also not particularly useful, because we have to mock the build action in our current tests.

In lieu of that, please find a recording of the various options and configuration.


https://github.com/user-attachments/assets/588acd10-6206-4096-91e6-e5681d498cd5

