### PR TITLE
feat(cli): use auto-updates flag in init

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/bootstrapTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapTemplate.ts
@@ -127,6 +127,7 @@ export async function bootstrapTemplate(
   const cliConfig = await createCliConfig({
     projectId: variables.projectId,
     dataset: variables.dataset,
+    autoUpdates: variables.autoUpdates,
   })
 
   // Write non-template files to disc

--- a/packages/@sanity/cli/src/actions/init-project/createCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init-project/createCliConfig.ts
@@ -14,33 +14,55 @@ export default defineCliConfig({
    * Enable auto-updates for studios.
    * Learn more at https://www.sanity.io/docs/cli#auto-updates
    */
-  autoUpdates: true,
+  autoUpdates: __BOOL__autoUpdates__,
 })
 `
 
 export interface GenerateCliConfigOptions {
   projectId: string
   dataset: string
+  autoUpdates: boolean
 }
 
 export function createCliConfig(options: GenerateCliConfigOptions): string {
   const variables = options
   const template = defaultTemplate.trimStart()
   const ast = parse(template, {parser})
+
   traverse(ast, {
     StringLiteral: {
       enter({node}) {
         const value = node.value
-        if (!value.startsWith('%') || !value.endsWith('%')) {
-          return
+        if (value.startsWith('%') && value.endsWith('%')) {
+          const variableName = value.slice(1, -1) as keyof GenerateCliConfigOptions
+          if (!(variableName in variables)) {
+            throw new Error(`Template variable '${value}' not defined`)
+          }
+          const newValue = variables[variableName]
+          /*
+           * although there are valid non-strings in our config,
+           * they're not in StringLiteral nodes, so assume undefined
+           */
+          node.value = typeof newValue === 'string' ? newValue : ''
         }
-
-        const variableName = value.slice(1, -1) as keyof GenerateCliConfigOptions
-        if (!(variableName in variables)) {
-          throw new Error(`Template variable '${value}' not defined`)
+      },
+    },
+    Identifier: {
+      enter({node}) {
+        if (node.name.startsWith('__BOOL__')) {
+          const variableName = node.name.replace(
+            /^__BOOL__(.+?)__$/,
+            '$1',
+          ) as keyof GenerateCliConfigOptions
+          if (!(variableName in variables)) {
+            throw new Error(`Template variable '${variableName}' not defined`)
+          }
+          const value = variables[variableName]
+          if (typeof value !== 'boolean') {
+            throw new Error(`Expected boolean value for '${variableName}'`)
+          }
+          node.name = value.toString()
         }
-
-        node.value = variables[variableName] || ''
       },
     },
   })

--- a/packages/@sanity/cli/src/actions/init-project/createCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init-project/createCliConfig.ts
@@ -33,36 +33,38 @@ export function createCliConfig(options: GenerateCliConfigOptions): string {
     StringLiteral: {
       enter({node}) {
         const value = node.value
-        if (value.startsWith('%') && value.endsWith('%')) {
-          const variableName = value.slice(1, -1) as keyof GenerateCliConfigOptions
-          if (!(variableName in variables)) {
-            throw new Error(`Template variable '${value}' not defined`)
-          }
-          const newValue = variables[variableName]
-          /*
-           * although there are valid non-strings in our config,
-           * they're not in StringLiteral nodes, so assume undefined
-           */
-          node.value = typeof newValue === 'string' ? newValue : ''
+        if (!value.startsWith('%') || !value.endsWith('%')) {
+          return
         }
+        const variableName = value.slice(1, -1) as keyof GenerateCliConfigOptions
+        if (!(variableName in variables)) {
+          throw new Error(`Template variable '${value}' not defined`)
+        }
+        const newValue = variables[variableName]
+        /*
+         * although there are valid non-strings in our config,
+         * they're not in StringLiteral nodes, so assume undefined
+         */
+        node.value = typeof newValue === 'string' ? newValue : ''
       },
     },
     Identifier: {
       enter({node}) {
-        if (node.name.startsWith('__BOOL__')) {
-          const variableName = node.name.replace(
-            /^__BOOL__(.+?)__$/,
-            '$1',
-          ) as keyof GenerateCliConfigOptions
-          if (!(variableName in variables)) {
-            throw new Error(`Template variable '${variableName}' not defined`)
-          }
-          const value = variables[variableName]
-          if (typeof value !== 'boolean') {
-            throw new Error(`Expected boolean value for '${variableName}'`)
-          }
-          node.name = value.toString()
+        if (!node.name.startsWith('__BOOL__')) {
+          return
         }
+        const variableName = node.name.replace(
+          /^__BOOL__(.+?)__$/,
+          '$1',
+        ) as keyof GenerateCliConfigOptions
+        if (!(variableName in variables)) {
+          throw new Error(`Template variable '${variableName}' not defined`)
+        }
+        const value = variables[variableName]
+        if (typeof value !== 'boolean') {
+          throw new Error(`Expected boolean value for '${variableName}'`)
+        }
+        node.name = value.toString()
       },
     },
   })

--- a/packages/@sanity/cli/src/actions/init-project/createCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init-project/createCliConfig.ts
@@ -49,11 +49,11 @@ export function createCliConfig(options: GenerateCliConfigOptions): string {
       },
     },
     Identifier: {
-      enter({node}) {
-        if (!node.name.startsWith('__BOOL__')) {
+      enter(path) {
+        if (!path.node.name.startsWith('__BOOL__')) {
           return
         }
-        const variableName = node.name.replace(
+        const variableName = path.node.name.replace(
           /^__BOOL__(.+?)__$/,
           '$1',
         ) as keyof GenerateCliConfigOptions
@@ -64,7 +64,7 @@ export function createCliConfig(options: GenerateCliConfigOptions): string {
         if (typeof value !== 'boolean') {
           throw new Error(`Expected boolean value for '${variableName}'`)
         }
-        node.name = value.toString()
+        path.replaceWith({type: 'BooleanLiteral', value})
       },
     },
   })

--- a/packages/@sanity/cli/src/actions/init-project/createCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init-project/createCliConfig.ts
@@ -9,7 +9,12 @@ export default defineCliConfig({
   api: {
     projectId: '%projectId%',
     dataset: '%dataset%'
-  }
+  },
+  /**
+   * Enable auto-updates for studios.
+   * Learn more at https://www.sanity.io/docs/cli#auto-updates
+   */
+  autoUpdates: true,
 })
 `
 

--- a/packages/@sanity/cli/src/actions/init-project/createStudioConfig.ts
+++ b/packages/@sanity/cli/src/actions/init-project/createStudioConfig.ts
@@ -34,6 +34,7 @@ export interface GenerateConfigOptions {
   variables: {
     projectId: string
     dataset: string
+    autoUpdates: boolean
     projectName?: string
     sourceName?: string
     sourceTitle?: string
@@ -60,8 +61,12 @@ export function createStudioConfig(options: GenerateConfigOptions): string {
         if (!(variableName in variables)) {
           throw new Error(`Template variable '${value}' not defined`)
         }
-
-        node.value = variables[variableName] || ''
+        const newValue = variables[variableName]
+        /*
+         * although there are valid non-strings in our config,
+         * they're not in this template, so assume undefined
+         */
+        node.value = typeof newValue === 'string' ? newValue : ''
       },
     },
   })

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -567,6 +567,12 @@ export default async function initSanity(
     trace.log({step: 'useTypeScript', selectedOption: useTypeScript ? 'yes' : 'no'})
   }
 
+  // we enable auto-updates by default, but allow users to specify otherwise
+  let autoUpdates = true
+  if (typeof cliFlags['auto-updates'] === 'boolean') {
+    autoUpdates = cliFlags['auto-updates']
+  }
+
   // Build a full set of resolved options
   const templateOptions: BootstrapOptions = {
     outputPath,
@@ -575,6 +581,7 @@ export default async function initSanity(
     schemaUrl,
     useTypeScript,
     variables: {
+      autoUpdates,
       dataset: datasetName,
       projectId,
       projectName: displayName || answers.projectName,

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -27,6 +27,7 @@ Options
   --coupon <name> Optionally select a coupon for a new project (cannot be used with --project-plan)
   --no-typescript Do not use TypeScript for template files
   --package-manager <name> Specify which package manager to use [allowed: ${allowedPackageManagersString}]
+  --no-auto-updates Disable import maps that keep your studio up-to-date with the latest Sanity versions
 
 Examples
   # Initialize a new project, prompt for required information along the way
@@ -60,6 +61,7 @@ export interface InitFlags {
 
   'visibility'?: string
   'typescript'?: boolean
+  'auto-updates'?: boolean
   /**
    * Used for initializing a project from a server schema that is saved in the Journey API
    * Overrides `project` option.

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -27,7 +27,7 @@ Options
   --coupon <name> Optionally select a coupon for a new project (cannot be used with --project-plan)
   --no-typescript Do not use TypeScript for template files
   --package-manager <name> Specify which package manager to use [allowed: ${allowedPackageManagersString}]
-  --no-auto-updates Disable import maps that keep your studio up-to-date with the latest Sanity versions
+  --no-auto-updates Disable auto updates of studio versions
 
 Examples
   # Initialize a new project, prompt for required information along the way

--- a/packages/@sanity/cli/test/init.test.ts
+++ b/packages/@sanity/cli/test/init.test.ts
@@ -40,7 +40,7 @@ describeCliTest('CLI: `sanity init v3`', () => {
     })
   })
 
-  testConcurrent('adds autoUpdate: true to cli config for javascript projects', async () => {
+  testConcurrent('adds autoUpdates: true to cli config for javascript projects', async () => {
     const version = 'v3'
     const testRunArgs = getTestRunArgs(version)
     const outpath = `test-template-${version}`
@@ -64,5 +64,31 @@ describeCliTest('CLI: `sanity init v3`', () => {
     expect(cliConfig).toContain(`projectId: '${cliProjectId}'`)
     expect(cliConfig).toContain(`dataset: '${testRunArgs.dataset}'`)
     expect(cliConfig).toContain(`autoUpdates: true`)
+  })
+
+  testConcurrent('adds autoUpdates: false to cli config if flag provided', async () => {
+    const version = 'v3'
+    const testRunArgs = getTestRunArgs(version)
+    const outpath = `test-template-${version}`
+
+    await runSanityCmdCommand(version, [
+      'init',
+      '--y',
+      '--project',
+      cliProjectId,
+      '--dataset',
+      testRunArgs.dataset,
+      '--output-path',
+      `${baseTestPath}/${outpath}`,
+      '--package-manager',
+      'manual',
+      '--no-auto-updates',
+    ])
+
+    const cliConfig = await fs.readFile(path.join(baseTestPath, outpath, 'sanity.cli.ts'), 'utf-8')
+
+    expect(cliConfig).toContain(`projectId: '${cliProjectId}'`)
+    expect(cliConfig).toContain(`dataset: '${testRunArgs.dataset}'`)
+    expect(cliConfig).toContain(`autoUpdates: false`)
   })
 })

--- a/packages/@sanity/cli/test/init.test.ts
+++ b/packages/@sanity/cli/test/init.test.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import {describe, expect} from '@jest/globals'
+
+import templates from '../src/actions/init-project/templates'
+import {describeCliTest, testConcurrent} from './shared/describe'
+import {baseTestPath, cliProjectId, getTestRunArgs, runSanityCmdCommand} from './shared/environment'
+
+describeCliTest('CLI: `sanity init v3`', () => {
+  describe.each(Object.keys(templates))('for template %s', (template) => {
+    testConcurrent('adds autoUpdates: true to cli config', async () => {
+      const version = 'v3'
+      const testRunArgs = getTestRunArgs(version)
+      const outpath = `test-template-${template}-${version}`
+
+      await runSanityCmdCommand(version, [
+        'init',
+        '--y',
+        '--project',
+        cliProjectId,
+        '--dataset',
+        testRunArgs.dataset,
+        '--template',
+        template,
+        '--output-path',
+        `${baseTestPath}/${outpath}`,
+        '--package-manager',
+        'manual',
+      ])
+
+      const cliConfig = await fs.readFile(
+        path.join(baseTestPath, outpath, 'sanity.cli.ts'),
+        'utf-8',
+      )
+
+      expect(cliConfig).toContain(`projectId: '${cliProjectId}'`)
+      expect(cliConfig).toContain(`dataset: '${testRunArgs.dataset}'`)
+      expect(cliConfig).toContain(`autoUpdates: true`)
+    })
+  })
+
+  testConcurrent('adds autoUpdate: true to cli config for javascript projects', async () => {
+    const version = 'v3'
+    const testRunArgs = getTestRunArgs(version)
+    const outpath = `test-template-${version}`
+
+    await runSanityCmdCommand(version, [
+      'init',
+      '--y',
+      '--project',
+      cliProjectId,
+      '--dataset',
+      testRunArgs.dataset,
+      '--output-path',
+      `${baseTestPath}/${outpath}`,
+      '--package-manager',
+      'manual',
+      '--no-typescript',
+    ])
+
+    const cliConfig = await fs.readFile(path.join(baseTestPath, outpath, 'sanity.cli.js'), 'utf-8')
+
+    expect(cliConfig).toContain(`projectId: '${cliProjectId}'`)
+    expect(cliConfig).toContain(`dataset: '${testRunArgs.dataset}'`)
+    expect(cliConfig).toContain(`autoUpdates: true`)
+  })
+})

--- a/packages/sanity/src/_internal/cli/commands/build/buildCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/build/buildCommand.ts
@@ -4,7 +4,7 @@ import {BuildSanityStudioCommandFlags} from '../../actions/build/buildAction'
 const helpText = `
 Options
   --source-maps Enable source maps for built bundles (increases size of bundle)
-  --auto-updates Enable auto updates of studio versions
+  --auto-updates / --no-auto-updates Enable/disable auto updates of studio versions
   --no-minify Skip minifying built JavaScript (speeds up build, increases size of bundle)
   -y, --yes Unattended mode, answers "yes" to any "yes/no" prompt and otherwise uses defaults
 

--- a/packages/sanity/src/_internal/cli/commands/deploy/deployCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/deploy/deployCommand.ts
@@ -9,7 +9,7 @@ import {type DeployStudioActionFlags} from '../../actions/deploy/deployAction'
 const helpText = `
 Options
   --source-maps Enable source maps for built bundles (increases size of bundle)
-  --auto-updates Enable auto updates of studio versions
+  --auto-updates / --no-auto-updates Enable/disable auto updates of studio versions
   --no-minify Skip minifying built JavaScript (speeds up build, increases size of bundle)
   --no-build Don't build the studio prior to deploy, instead deploying the version currently in \`dist/\`
 


### PR DESCRIPTION
### Description
As we move to make auto-updates the default way of updating studios, we want to ensure that we give developers the option to maintain legacy behavior and keep to specific versions if they prefer.

This PR updates the `sanity init` command to allow a `--no-auto-updates` flag that will then be injected into the CLI configuration as `autoUpdates: true` or `autoUpdates: false`

This required a bit of refactoring of our template logic, since we previously only dealt with string variables. I've added another way of identifying the variables we're injecting, but happy to refactor if this is not ideal.

### What to review
Are there any ways in which auto-updates might be undefined? Any gotchas in the AST parser?

### Testing
I've added a test for this against Typescript -- if needed, I can repeat those tests for the other cases (Javascript, templates) but assume all will be consistent. 

(No release notes because this feature is still in beta)
