### PR TITLE
chore(structure): add DocumentListBuilder.filter JSdoc details

### DIFF
--- a/packages/sanity/src/structure/structureBuilder/DocumentList.ts
+++ b/packages/sanity/src/structure/structureBuilder/DocumentList.ts
@@ -142,7 +142,7 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Set Document list filter
-   * @param filter - filter
+   * @param filter - GROQ-filter used to determine which documents to display. Do not support joins, since they operate on individual documents, and will ignore order-clauses and projections. See https://www.sanity.io/docs/realtime-updates
    * @returns document list builder based on the options and filter provided. See {@link DocumentListBuilder}
    */
   filter(filter: string): DocumentListBuilder {

--- a/packages/sanity/src/structure/structureBuilder/DocumentList.ts
+++ b/packages/sanity/src/structure/structureBuilder/DocumentList.ts
@@ -142,7 +142,7 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Set Document list filter
-   * @param filter - GROQ-filter used to determine which documents to display. Do not support joins, since they operate on individual documents, and will ignore order-clauses and projections. See https://www.sanity.io/docs/realtime-updates
+   * @param filter - GROQ-filter used to determine which documents to display. Do not support joins, since they operate on individual documents, and will ignore order-clauses and projections. See {@link https://www.sanity.io/docs/realtime-updates}
    * @returns document list builder based on the options and filter provided. See {@link DocumentListBuilder}
    */
   filter(filter: string): DocumentListBuilder {


### PR DESCRIPTION
### Description
The JSdoc details for the `DocumentListBuilder.filter` don't provide enough information of how the filter works and what it supports.
This adds extra information and the reference to the realtime-updates docs

Once this is merged, will also update the docs in https://www.sanity.io/docs/structure-builder-reference#filter-c0dc69f8c387 to: 
<img width="705" alt="Screenshot 2024-08-21 at 10 29 16" src="https://github.com/user-attachments/assets/c5fb4bc9-0990-4185-be6d-c8d43a9da9e3">

Solves: https://github.com/sanity-io/sanity/issues/7399 


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
n/a
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

n/a
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
