### PR TITLE
refactor(sanity): add changes to allow for comments in version documents

### DIFF
--- a/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
@@ -268,6 +268,9 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
     ? getBundleSlug(props.parentComment.target.document._ref)
     : undefined
 
+  /* TODO - once we understand how to set up with "finished" releases
+  we need to add a condition to the readOnly prop in this component */
+
   const renderedReplies = useMemo(
     () =>
       splicedReplies.map((reply) => (

--- a/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
@@ -11,7 +11,6 @@ import {
   useRef,
   useState,
 } from 'react'
-import {getBundleSlug, isVersionId} from 'sanity'
 import {css, styled} from 'styled-components'
 
 import {Button} from '../../../../ui-components'
@@ -264,10 +263,6 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
     }
   }, [replies])
 
-  const label = isVersionId(props.parentComment.target.document._ref)
-    ? getBundleSlug(props.parentComment.target.document._ref)
-    : undefined
-
   /* TODO - once we understand how to set up with "finished" releases
   we need to add a condition to the readOnly prop in this component */
 
@@ -294,26 +289,24 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
             onReactionSelect={onReactionSelect}
             readOnly={readOnly}
             withAvatar={avatarConfig.threadCommentsAvatar}
-            version={label}
           />
         </Stack>
       )),
     [
-      splicedReplies,
-      avatarConfig.avatarSize,
       avatarConfig.threadCommentsAvatar,
+      avatarConfig.avatarSize,
       currentUser,
-      parentComment,
+      handleInputKeyDown,
       mentionOptions,
-      mode,
       onCopyLink,
       onCreateRetry,
       onDelete,
       onEdit,
-      handleInputKeyDown,
       onReactionSelect,
+      parentComment,
       readOnly,
-      label,
+      splicedReplies,
+      mode,
     ],
   )
 
@@ -363,7 +356,6 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
             onStatusChange={onStatusChange}
             readOnly={readOnly}
             withAvatar={avatarConfig.parentCommentAvatar}
-            version={label}
           />
         </Stack>
 

--- a/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
@@ -266,7 +266,7 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
 
   const label = isVersionId(props.parentComment.target.document._ref)
     ? getBundleSlug(props.parentComment.target.document._ref)
-    : 'published'
+    : undefined
 
   const renderedReplies = useMemo(
     () =>
@@ -291,24 +291,26 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
             onReactionSelect={onReactionSelect}
             readOnly={readOnly}
             withAvatar={avatarConfig.threadCommentsAvatar}
+            version={label}
           />
         </Stack>
       )),
     [
-      avatarConfig.threadCommentsAvatar,
+      splicedReplies,
       avatarConfig.avatarSize,
+      avatarConfig.threadCommentsAvatar,
       currentUser,
-      handleInputKeyDown,
+      parentComment,
       mentionOptions,
+      mode,
       onCopyLink,
       onCreateRetry,
       onDelete,
       onEdit,
+      handleInputKeyDown,
       onReactionSelect,
-      parentComment,
       readOnly,
-      splicedReplies,
-      mode,
+      label,
     ],
   )
 
@@ -336,7 +338,6 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
         space={4}
       >
         <Stack as="li" {...applyCommentIdAttr(parentComment._id)}>
-          <div>{label}</div>
           <CommentsListItemLayout
             avatarSize={avatarConfig.avatarSize}
             canDelete={parentComment.authorId === currentUser.id}
@@ -359,6 +360,7 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
             onStatusChange={onStatusChange}
             readOnly={readOnly}
             withAvatar={avatarConfig.parentCommentAvatar}
+            version={label}
           />
         </Stack>
 

--- a/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
@@ -11,6 +11,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import {getBundleSlug, isVersionId} from 'sanity'
 import {css, styled} from 'styled-components'
 
 import {Button} from '../../../../ui-components'
@@ -263,6 +264,10 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
     }
   }, [replies])
 
+  const label = isVersionId(props.parentComment.target.document._ref)
+    ? getBundleSlug(props.parentComment.target.document._ref)
+    : 'published'
+
   const renderedReplies = useMemo(
     () =>
       splicedReplies.map((reply) => (
@@ -331,6 +336,7 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
         space={4}
       >
         <Stack as="li" {...applyCommentIdAttr(parentComment._id)}>
+          <div>{label}</div>
           <CommentsListItemLayout
             avatarSize={avatarConfig.avatarSize}
             canDelete={parentComment.authorId === currentUser.id}

--- a/packages/sanity/src/core/comments/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsListItemLayout.tsx
@@ -166,6 +166,7 @@ interface CommentsListItemLayoutProps {
   onStatusChange?: (id: string, status: CommentStatus) => void
   readOnly?: boolean
   withAvatar?: boolean
+  version?: string
 }
 
 const RELATIVE_TIME_OPTIONS: RelativeTimeOptions = {useTemporalPhrase: true}
@@ -193,6 +194,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
     onStatusChange,
     readOnly,
     withAvatar = true,
+    version,
   } = props
   const {_createdAt, authorId, message, _id, lastEditedAt} = comment
   const [user] = useUser(authorId)
@@ -336,6 +338,9 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
     <TextSkeleton size={1} style={SKELETON_INLINE_STYLE} />
   )
 
+  // TODO - it's still unclear if we want to show that the comments belong to a specific version
+  // we can do that by displaying the version somewhere in the UI
+
   return (
     <RootStack
       data-menu-open={menuOpen ? 'true' : 'false'}
@@ -398,7 +403,6 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
               </Box>
             )}
           </Flex>
-
           {!isEditing && !displayError && (
             <ContextMenuBox data-root-menu={isParent ? 'true' : 'false'} onClick={stopPropagation}>
               <CommentsListItemContextMenu

--- a/packages/sanity/src/core/comments/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsListItemLayout.tsx
@@ -338,8 +338,8 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
     <TextSkeleton size={1} style={SKELETON_INLINE_STYLE} />
   )
 
-  // TODO - it's still unclear if we want to show that the comments belong to a specific version
-  // we can do that by displaying the version somewhere in the UI
+  /* TODO - it's still unclear if we want to show that the comments belong to a specific version 
+  we can do that by displaying the version somewhere in the UI */
 
   return (
     <RootStack

--- a/packages/sanity/src/core/comments/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsListItemLayout.tsx
@@ -166,7 +166,6 @@ interface CommentsListItemLayoutProps {
   onStatusChange?: (id: string, status: CommentStatus) => void
   readOnly?: boolean
   withAvatar?: boolean
-  version?: string
 }
 
 const RELATIVE_TIME_OPTIONS: RelativeTimeOptions = {useTemporalPhrase: true}
@@ -194,7 +193,6 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
     onStatusChange,
     readOnly,
     withAvatar = true,
-    version,
   } = props
   const {_createdAt, authorId, message, _id, lastEditedAt} = comment
   const [user] = useUser(authorId)
@@ -338,9 +336,6 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
     <TextSkeleton size={1} style={SKELETON_INLINE_STYLE} />
   )
 
-  /* TODO - it's still unclear if we want to show that the comments belong to a specific version 
-  we can do that by displaying the version somewhere in the UI */
-
   return (
     <RootStack
       data-menu-open={menuOpen ? 'true' : 'false'}
@@ -403,6 +398,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
               </Box>
             )}
           </Flex>
+
           {!isEditing && !displayError && (
             <ContextMenuBox data-root-menu={isParent ? 'true' : 'false'} onClick={stopPropagation}>
               <CommentsListItemContextMenu

--- a/packages/sanity/src/core/comments/context/comments/CommentsProvider.tsx
+++ b/packages/sanity/src/core/comments/context/comments/CommentsProvider.tsx
@@ -6,6 +6,7 @@ import {CommentsContext} from 'sanity/_singletons'
 import {useEditState, useSchema, useUserListWithPermissions} from '../../../hooks'
 import {useCurrentUser} from '../../../store'
 import {useAddonDataset, useWorkspace} from '../../../studio'
+import {getPublishedId} from '../../../util'
 import {
   type CommentOperationsHookOptions,
   useCommentOperations,
@@ -67,7 +68,7 @@ type TransactionId = string
 export const CommentsProvider = memo(function CommentsProvider(props: CommentsProviderProps) {
   const {
     children,
-    documentId,
+    documentId: versionOrPublishedId,
     documentType,
     isCommentsOpen,
     onCommentsOpen,
@@ -83,13 +84,17 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
   const commentsEnabled = useCommentsEnabled()
   const [status, setStatus] = useState<CommentStatus>('open')
   const {client, createAddonDataset, isCreatingDataset} = useAddonDataset()
-  const publishedId = documentId
 
   const bundlePerspective = perspective?.startsWith('bundle.')
     ? perspective.split('bundle.').at(1)
     : undefined
 
-  const editState = useEditState(publishedId, documentType, 'default', bundlePerspective)
+  const editState = useEditState(
+    getPublishedId(versionOrPublishedId),
+    documentType,
+    'default',
+    bundlePerspective,
+  )
   const schemaType = useSchema().get(documentType)
   const currentUser = useCurrentUser()
 
@@ -118,7 +123,7 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
     error,
     loading,
   } = useCommentsStore({
-    documentId: publishedId,
+    documentId: versionOrPublishedId,
     client,
     transactionsIdMap,
     onLatestTransactionIdReceived: handleOnLatestTransactionIdReceived,
@@ -235,7 +240,7 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
         client,
         currentUser,
         dataset,
-        documentId: publishedId,
+        documentId: versionOrPublishedId,
         documentRevisionId,
         documentType,
         getComment,
@@ -263,7 +268,7 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
         client,
         currentUser,
         dataset,
-        publishedId,
+        versionOrPublishedId,
         documentRevisionId,
         documentType,
         getComment,
@@ -283,7 +288,7 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
 
   const ctxValue = useMemo(
     (): CommentsContextValue => ({
-      documentId,
+      documentId: versionOrPublishedId,
       documentType,
 
       isCreatingDataset,
@@ -316,7 +321,7 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
       mentionOptions,
     }),
     [
-      documentId,
+      versionOrPublishedId,
       documentType,
       isCreatingDataset,
       status,

--- a/packages/sanity/src/core/comments/context/comments/CommentsProvider.tsx
+++ b/packages/sanity/src/core/comments/context/comments/CommentsProvider.tsx
@@ -6,7 +6,6 @@ import {CommentsContext} from 'sanity/_singletons'
 import {useEditState, useSchema, useUserListWithPermissions} from '../../../hooks'
 import {useCurrentUser} from '../../../store'
 import {useAddonDataset, useWorkspace} from '../../../studio'
-import {getPublishedId} from '../../../util'
 import {
   type CommentOperationsHookOptions,
   useCommentOperations,
@@ -84,7 +83,7 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
   const commentsEnabled = useCommentsEnabled()
   const [status, setStatus] = useState<CommentStatus>('open')
   const {client, createAddonDataset, isCreatingDataset} = useAddonDataset()
-  const publishedId = getPublishedId(documentId)
+  const publishedId = documentId
 
   const bundlePerspective = perspective?.startsWith('bundle.')
     ? perspective.split('bundle.').at(1)

--- a/packages/sanity/src/core/comments/context/comments/CommentsProvider.tsx
+++ b/packages/sanity/src/core/comments/context/comments/CommentsProvider.tsx
@@ -89,7 +89,6 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
     ? perspective.split('bundle.').at(1)
     : undefined
 
-  // TODO: Allow versions to have separate comments.
   const editState = useEditState(publishedId, documentType, 'default', bundlePerspective)
   const schemaType = useSchema().get(documentType)
   const currentUser = useCurrentUser()

--- a/packages/sanity/src/core/comments/store/useCommentsStore.ts
+++ b/packages/sanity/src/core/comments/store/useCommentsStore.ts
@@ -2,7 +2,6 @@ import {type ListenEvent, type ListenOptions, type SanityClient} from '@sanity/c
 import {useCallback, useEffect, useMemo, useReducer, useRef, useState} from 'react'
 import {catchError, of} from 'rxjs'
 
-import {getPublishedId} from '../../util'
 import {type CommentDocument, type Loadable} from '../types'
 import {commentsReducer, type CommentsReducerAction, type CommentsReducerState} from './reducer'
 
@@ -64,7 +63,7 @@ export function useCommentsStore(opts: CommentsStoreOptions): CommentsStoreRetur
 
   const didInitialFetch = useRef<boolean>(false)
 
-  const params = useMemo(() => ({documentId: getPublishedId(documentId)}), [documentId])
+  const params = useMemo(() => ({documentId: documentId}), [documentId])
 
   const initialFetch = useCallback(async () => {
     if (!client) {
@@ -84,7 +83,7 @@ export function useCommentsStore(opts: CommentsStoreOptions): CommentsStoreRetur
   const handleListenerEvent = useCallback(
     async (event: ListenEvent<Record<string, CommentDocument>>) => {
       // Fetch all comments on initial connection
-      if (event.type === 'welcome' && !didInitialFetch.current) {
+      if (event.type === 'welcome') {
         setLoading(true)
         await initialFetch()
         setLoading(false)

--- a/packages/sanity/src/core/comments/store/useCommentsStore.ts
+++ b/packages/sanity/src/core/comments/store/useCommentsStore.ts
@@ -2,6 +2,7 @@ import {type ListenEvent, type ListenOptions, type SanityClient} from '@sanity/c
 import {useCallback, useEffect, useMemo, useReducer, useRef, useState} from 'react'
 import {catchError, of} from 'rxjs'
 
+import {getPublishedId, isVersionId} from '../../util'
 import {type CommentDocument, type Loadable} from '../types'
 import {commentsReducer, type CommentsReducerAction, type CommentsReducerState} from './reducer'
 
@@ -63,7 +64,10 @@ export function useCommentsStore(opts: CommentsStoreOptions): CommentsStoreRetur
 
   const didInitialFetch = useRef<boolean>(false)
 
-  const params = useMemo(() => ({documentId: documentId}), [documentId])
+  const params = useMemo(
+    () => ({documentId: isVersionId(documentId) ? documentId : getPublishedId(documentId)}),
+    [documentId],
+  )
 
   const initialFetch = useCallback(async () => {
     if (!client) {

--- a/packages/sanity/src/core/comments/store/useCommentsStore.ts
+++ b/packages/sanity/src/core/comments/store/useCommentsStore.ts
@@ -87,7 +87,7 @@ export function useCommentsStore(opts: CommentsStoreOptions): CommentsStoreRetur
   const handleListenerEvent = useCallback(
     async (event: ListenEvent<Record<string, CommentDocument>>) => {
       // Fetch all comments on initial connection
-      if (event.type === 'welcome') {
+      if (event.type === 'welcome' && !didInitialFetch.current) {
         setLoading(true)
         await initialFetch()
         setLoading(false)

--- a/packages/sanity/src/structure/panes/document/DocumentPane.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPane.tsx
@@ -130,7 +130,7 @@ function DocumentPaneInner(props: DocumentPaneProviderProps) {
     <DocumentPaneProvider
       // this needs to be here to avoid formState from being re-used across (incompatible) document types
       // see https://github.com/sanity-io/sanity/discussions/3794 for a description of the problem
-      key={`${documentType}-${options.id}`}
+      key={`${documentType}-${options.id}-${paneRouter.perspective || ''}`}
       {...providerProps}
     >
       {/* NOTE: this is a temporary location for this provider until we */}

--- a/packages/sanity/src/structure/panes/document/comments/CommentsWrapper.tsx
+++ b/packages/sanity/src/structure/panes/document/comments/CommentsWrapper.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useLayoutEffect, useRef} from 'react'
+import {useCallback, useLayoutEffect, useMemo, useRef} from 'react'
 import {
   COMMENTS_INSPECTOR_NAME,
   CommentsEnabledProvider,
@@ -42,7 +42,10 @@ function CommentsProviderWrapper(props: CommentsWrapperProps) {
   const router = useRouter()
   const {params, setParams, createPathWithParams, ...paneRouter} = usePaneRouter()
   const perspective = paneRouter.perspective ?? router.stickyParams.perspective
-  const docId = version ? getVersionId(documentId, version) : documentId
+  const versionOrPublishedId = useMemo(
+    () => (version ? getVersionId(documentId, version) : documentId),
+    [documentId, version],
+  )
 
   const selectedCommentId = params?.comment
   const paramsRef = useRef(params)
@@ -84,7 +87,7 @@ function CommentsProviderWrapper(props: CommentsWrapperProps) {
 
   return (
     <CommentsProvider
-      documentId={docId}
+      documentId={versionOrPublishedId}
       documentType={documentType}
       getCommentLink={getCommentLink}
       isCommentsOpen={inspector?.name === COMMENTS_INSPECTOR_NAME}

--- a/packages/sanity/src/structure/panes/document/comments/CommentsWrapper.tsx
+++ b/packages/sanity/src/structure/panes/document/comments/CommentsWrapper.tsx
@@ -3,6 +3,7 @@ import {
   COMMENTS_INSPECTOR_NAME,
   CommentsEnabledProvider,
   CommentsProvider,
+  getVersionId,
   useCommentsEnabled,
 } from 'sanity'
 import {useRouter} from 'sanity/router'
@@ -37,10 +38,11 @@ function CommentsProviderWrapper(props: CommentsWrapperProps) {
   const {children, documentId, documentType} = props
 
   const {enabled} = useCommentsEnabled()
-  const {connectionState, onPathOpen, inspector, openInspector} = useDocumentPane()
+  const {connectionState, onPathOpen, inspector, openInspector, version} = useDocumentPane()
   const router = useRouter()
   const {params, setParams, createPathWithParams, ...paneRouter} = usePaneRouter()
   const perspective = paneRouter.perspective ?? router.stickyParams.perspective
+  const docId = version ? getVersionId(documentId, version) : documentId
 
   const selectedCommentId = params?.comment
   const paramsRef = useRef(params)
@@ -82,7 +84,7 @@ function CommentsProviderWrapper(props: CommentsWrapperProps) {
 
   return (
     <CommentsProvider
-      documentId={documentId}
+      documentId={docId}
       documentType={documentType}
       getCommentLink={getCommentLink}
       isCommentsOpen={inspector?.name === COMMENTS_INSPECTOR_NAME}


### PR DESCRIPTION
### Description

Added changes to the comments to allow for version comments to show up when the version is switched to.


https://github.com/user-attachments/assets/42de80ed-38b5-467c-b343-4d4022b53f7d

Added a todo for when the release is "complete", tested out the readOnly and it looks to do what we want. The rest will depend on design
