### PR TITLE
feat(sanity): Update presence menu button for inviting new collaborators

### DIFF
--- a/dev/design-studio/package.json
+++ b/dev/design-studio/package.json
@@ -31,7 +31,7 @@
     "start": "../.bin/sanity start --port 4000"
   },
   "dependencies": {
-    "@sanity/icons": "^3.3.1",
+    "@sanity/icons": "^3.4.0",
     "@sanity/ui": "^2.8.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/dev/studio-e2e-testing/package.json
+++ b/dev/studio-e2e-testing/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@sanity/google-maps-input": "^4.0.0",
-    "@sanity/icons": "^3.3.1",
+    "@sanity/icons": "^3.4.0",
     "@sanity/ui": "^2.8.8",
     "@sanity/vision": "3.55.0",
     "react": "^18.3.1",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -23,7 +23,7 @@
     "@sanity/client": "^6.21.2",
     "@sanity/color": "^3.0.0",
     "@sanity/google-maps-input": "^4.0.0",
-    "@sanity/icons": "^3.3.1",
+    "@sanity/icons": "^3.4.0",
     "@sanity/image-url": "^1.0.2",
     "@sanity/locale-ko-kr": "^1.0.1",
     "@sanity/locale-nb-no": "^1.0.1",

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1100,7 +1100,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Title of the alert for studio users when packages in their studio are out-of-date */
   'package-version.new-package-available.title': 'Sanity Studio is ready to update!',
   /** Label for action to manage members of the current studio project */
-  'presence.action.manage-members': 'Manage members',
+  'presence.action.manage-members': 'Invite collaborators',
   /** Accessibility label for presence menu button */
   'presence.aria-label': 'Global presence',
   /** Message description for when no one else is currently present */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1100,7 +1100,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Title of the alert for studio users when packages in their studio are out-of-date */
   'package-version.new-package-available.title': 'Sanity Studio is ready to update!',
   /** Label for action to invite members to the current studio project */
-  'presence.action.manage-members': 'Invite collaborators',
+  'presence.action.manage-members': 'Invite members',
   /** Accessibility label for presence menu button */
   'presence.aria-label': 'Global presence',
   /** Message description for when no one else is currently present */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1099,7 +1099,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'package-version.new-package-available.reload-button': 'Push to reload',
   /** Title of the alert for studio users when packages in their studio are out-of-date */
   'package-version.new-package-available.title': 'Sanity Studio is ready to update!',
-  /** Label for action to manage members of the current studio project */
+  /** Label for action to invite members to the current studio project */
   'presence.action.manage-members': 'Invite collaborators',
   /** Accessibility label for presence menu button */
   'presence.aria-label': 'Global presence',

--- a/packages/sanity/src/core/studio/components/navbar/navDrawer/ManageMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/navDrawer/ManageMenu.tsx
@@ -1,4 +1,4 @@
-import {CogIcon, UsersIcon} from '@sanity/icons'
+import {AddUserIcon, CogIcon} from '@sanity/icons'
 import {Card, Stack} from '@sanity/ui'
 
 import {Button} from '../../../../../ui-components'
@@ -39,8 +39,8 @@ export function ManageMenu() {
             <Button
               aria-label={t('user-menu.action.invite-members-aria-label')}
               as="a"
-              href={`https://sanity.io/manage/project/${projectId}/members`}
-              icon={UsersIcon}
+              href={`https://www.sanity.io/manage/project/${projectId}/members`}
+              icon={AddUserIcon}
               justify="flex-start"
               mode="bleed"
               size="large"

--- a/packages/sanity/src/core/studio/components/navbar/navDrawer/ManageMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/navDrawer/ManageMenu.tsx
@@ -39,7 +39,7 @@ export function ManageMenu() {
             <Button
               aria-label={t('user-menu.action.invite-members-aria-label')}
               as="a"
-              href={`https://www.sanity.io/manage/project/${projectId}/members`}
+              href={`https://www.sanity.io/manage/project/${projectId}/members?invite=true`}
               icon={AddUserIcon}
               justify="flex-start"
               mode="bleed"

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
@@ -107,8 +107,8 @@ export function PresenceMenu() {
 
             <MenuItem
               as="a"
-              href={`https://sanity.io/manage/project/${projectId}/members?invite=true`}
-              iconRight={AddUserIcon}
+              href={`https://www.sanity.io/manage/project/${projectId}/members?invite=true`}
+              icon={AddUserIcon}
               onFocus={handleClearFocusedItem}
               rel="noopener noreferrer"
               target="_blank"

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
@@ -1,4 +1,4 @@
-import {AddIcon, UsersIcon} from '@sanity/icons'
+import {AddUserIcon, UsersIcon} from '@sanity/icons'
 import {Box, Menu, MenuDivider, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo, useState} from 'react'
 import {styled} from 'styled-components'
@@ -108,7 +108,7 @@ export function PresenceMenu() {
             <MenuItem
               as="a"
               href={`https://sanity.io/manage/project/${projectId}/members?invite=true`}
-              iconRight={AddIcon}
+              iconRight={AddUserIcon}
               onFocus={handleClearFocusedItem}
               rel="noopener noreferrer"
               target="_blank"

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
@@ -1,4 +1,4 @@
-import {CogIcon, UsersIcon} from '@sanity/icons'
+import {AddIcon, UsersIcon} from '@sanity/icons'
 import {Box, Menu, MenuDivider, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo, useState} from 'react'
 import {styled} from 'styled-components'
@@ -107,8 +107,8 @@ export function PresenceMenu() {
 
             <MenuItem
               as="a"
-              href={`https://sanity.io/manage/project/${projectId}`}
-              iconRight={CogIcon}
+              href={`https://sanity.io/manage/project/${projectId}/members`}
+              iconRight={AddIcon}
               onFocus={handleClearFocusedItem}
               rel="noopener noreferrer"
               target="_blank"

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
@@ -107,7 +107,7 @@ export function PresenceMenu() {
 
             <MenuItem
               as="a"
-              href={`https://sanity.io/manage/project/${projectId}/members`}
+              href={`https://sanity.io/manage/project/${projectId}/members?invite=true`}
               iconRight={AddIcon}
               onFocus={handleClearFocusedItem}
               rel="noopener noreferrer"

--- a/packages/sanity/src/core/studio/components/navbar/userMenu/ManageMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/userMenu/ManageMenu.tsx
@@ -1,4 +1,4 @@
-import {CogIcon, UsersIcon} from '@sanity/icons'
+import {AddUserIcon, CogIcon} from '@sanity/icons'
 import {MenuDivider} from '@sanity/ui'
 
 import {MenuItem} from '../../../../../ui-components'
@@ -27,10 +27,10 @@ export function ManageMenu() {
         <MenuItem
           as="a"
           aria-label={t('user-menu.action.invite-members-aria-label')}
-          href={`https://sanity.io/manage/project/${projectId}/members`}
+          href={`https://www.sanity.io/manage/project/${projectId}/members`}
           target="_blank"
           text={t('user-menu.action.invite-members')}
-          icon={UsersIcon}
+          icon={AddUserIcon}
         />
       )}
     </>

--- a/packages/sanity/src/core/studio/components/navbar/userMenu/ManageMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/userMenu/ManageMenu.tsx
@@ -27,7 +27,7 @@ export function ManageMenu() {
         <MenuItem
           as="a"
           aria-label={t('user-menu.action.invite-members-aria-label')}
-          href={`https://www.sanity.io/manage/project/${projectId}/members`}
+          href={`https://www.sanity.io/manage/project/${projectId}/members?invite=true`}
           target="_blank"
           text={t('user-menu.action.invite-members')}
           icon={AddUserIcon}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,7 +243,7 @@ importers:
   dev/design-studio:
     dependencies:
       '@sanity/icons':
-        specifier: ^3.3.1
+        specifier: ^3.4.0
         version: 3.4.0(react@18.3.1)
       '@sanity/ui':
         specifier: ^2.8.8
@@ -370,7 +370,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1(react-dom@18.3.1(react@18.3.1))(react-is@19.0.0-rc-a7d1240c-20240731)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/icons':
-        specifier: ^3.3.1
+        specifier: ^3.4.0
         version: 3.4.0(react@18.3.1)
       '@sanity/ui':
         specifier: ^2.8.8
@@ -457,7 +457,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1(react-dom@18.3.1(react@18.3.1))(react-is@19.0.0-rc-a7d1240c-20240731)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/icons':
-        specifier: ^3.3.1
+        specifier: ^3.4.0
         version: 3.4.0(react@18.3.1)
       '@sanity/image-url':
         specifier: ^1.0.2


### PR DESCRIPTION
### Description

This PR makes some updates to the presence dropdown menu action button to encourage seat expansion.

![SCR-20240826-oisj](https://github.com/user-attachments/assets/c6f375c4-1c0e-48b1-80d5-57c8a2f3df49)

- Button text has been changed to "Invite collaborators"
- `@sanity/icons` has been updated to version 3.4.0
- Icon has been changed to new AddUserIcon
- Link has been updated to take the user directly to the project members tab

[Linear issues](https://linear.app/sanity/issue/GRO-2406/studio-update-manage-members-dropdown-menu-item)

### What to review

Review the text and link changes.

### Testing

Change does not affect or require new automated tests. To test the change, navigate to a studio document with someone else present and open the presence menu by clicking on the user avatars.

### Notes for release

No notes for release
