### PR TITLE
refactor(sanity): remove commented publishat input

### DIFF
--- a/packages/sanity/src/core/bundles/components/dialog/BundleForm.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/BundleForm.tsx
@@ -1,18 +1,20 @@
 //import {CalendarIcon} from '@sanity/icons'
 import {type ColorHueKey} from '@sanity/color'
-import {type IconSymbol} from '@sanity/icons'
-import {Flex, Stack, Text, TextArea, TextInput} from '@sanity/ui'
+import {CalendarIcon, type IconSymbol} from '@sanity/icons'
+import {Box, Flex, Stack, Text, TextArea, TextInput} from '@sanity/ui'
 import {useCallback, useMemo, useRef, useState} from 'react'
 import {
   FormFieldHeaderText,
   type FormNodeValidation,
+  useDateTimeFormat,
   useTranslation,
-  //useDateTimeFormat,
-  //useTranslation,
 } from 'sanity'
 
-//import {type CalendarLabels} from '../../../form/inputs/DateInputs/base/calendar/types'
-//import {getCalendarLabels} from '../../../form/inputs/DateInputs/utils'
+import {Button, Popover} from '../../../../ui-components'
+import {type CalendarLabels} from '../../../../ui-components/inputs/DateInputs/calendar/types'
+import {DatePicker} from '../../../../ui-components/inputs/DateInputs/DatePicker'
+import {LazyTextInput} from '../../../../ui-components/inputs/DateInputs/LazyTextInput'
+import {getCalendarLabels} from '../../../form/inputs/DateInputs/utils'
 import {type BundleDocument} from '../../../store/bundles/types'
 import {BundleIconEditorPicker, type BundleIconEditorPickerValue} from './BundleIconEditorPicker'
 import {useGetBundleSlug} from './useGetBundleSlug'
@@ -35,30 +37,30 @@ export function BundleForm(props: {
   value: Partial<BundleDocument>
 }): JSX.Element {
   const {onChange, value} = props
-  const {title, description, icon, hue /*, publishAt*/} = value
+  const {title, description, icon, hue, publishedAt} = value
   // derive the action from whether the initial value prop has a slug
   // only editing existing bundles will provide a value.slug
   const {current: action} = useRef(value.slug ? 'edit' : 'create')
   const isEditing = action === 'edit'
   const {t} = useTranslation()
 
-  //const dateFormatter = useDateTimeFormat()
+  const dateFormatter = useDateTimeFormat()
 
   const [showDatePicker, setShowDatePicker] = useState(false)
 
   const [isInitialRender, setIsInitialRender] = useState(true)
 
   const [titleErrors, setTitleErrors] = useState<FormNodeValidation[]>([])
-  /*const [dateErrors, setDateErrors] = useState<FormNodeValidation[]>([])
+  const [dateErrors, setDateErrors] = useState<FormNodeValidation[]>([])
 
-  /*const publishAtDisplayValue = useMemo(() => {
-    if (!publishAt) return ''
-    return dateFormatter.format(new Date(publishAt as Date))
-  }, [dateFormatter, publishAt])
+  const publishAtDisplayValue = useMemo(() => {
+    if (!publishedAt) return ''
+    return dateFormatter.format(new Date(publishedAt))
+  }, [dateFormatter, publishedAt])
 
   const [displayDate, setDisplayDate] = useState(publishAtDisplayValue)
   const {t: coreT} = useTranslation()
-  const calendarLabels: CalendarLabels = useMemo(() => getCalendarLabels(coreT), [coreT])*/
+  const calendarLabels: CalendarLabels = useMemo(() => getCalendarLabels(coreT), [coreT])
 
   const iconValue: BundleIconEditorPickerValue = useMemo(
     () => ({
@@ -101,10 +103,10 @@ export function BundleForm(props: {
     setShowDatePicker(!showDatePicker)
   }, [showDatePicker])
 
-  /*const handleBundlePublishAtChange = useCallback(
+  const handleBundlePublishAtChange = useCallback(
     (nextDate: Date | undefined) => {
-      onChange({...value, publishAt: nextDate})
-      setDisplayDate(dateFormatter.format(new Date(nextDate as Date)))
+      onChange({...value, publishedAt: nextDate?.toString()})
+      setDisplayDate(dateFormatter.format(new Date(nextDate as unknown as Date)))
 
       setShowDatePicker(false)
     },
@@ -128,16 +130,14 @@ export function BundleForm(props: {
           },
         ])
         setDisplayDate(dateValue)
-        onError(true)
       } else {
         setDateErrors([])
         setDisplayDate(dateValue)
-        onChange({...value, publishAt: dateValue})
-        onError(false)
+        onChange({...value, publishedAt: dateValue})
       }
     },
-    [onChange, value, onError],
-  )*/
+    [onChange, value],
+  )
 
   const handleIconValueChange = useCallback(
     (pickedIcon: BundleIconEditorPickerValue) => {
@@ -172,10 +172,10 @@ export function BundleForm(props: {
         />
       </Stack>
 
-      {/*<Stack space={3}>
+      <Stack space={3}>
         <FormFieldHeaderText title="Schedule for publishing at" validation={dateErrors} />
 
-        <TextInput
+        <LazyTextInput
           suffix={
             <Popover
               constrainSize
@@ -184,7 +184,7 @@ export function BundleForm(props: {
                   <DatePicker
                     onChange={handleBundlePublishAtChange}
                     calendarLabels={calendarLabels}
-                    value={publishAt as Date}
+                    value={publishedAt as unknown as Date}
                     selectTime
                   />
                 </Box>
@@ -197,8 +197,8 @@ export function BundleForm(props: {
                 <Button
                   icon={CalendarIcon}
                   mode="bleed"
-                  padding={2}
                   onClick={handleOpenDatePicker}
+                  tooltipProps={null}
                 />
               </Box>
             </Popover>
@@ -208,7 +208,7 @@ export function BundleForm(props: {
           data-testid="bundle-form-publish-at"
           customValidity={dateErrors.length > 0 ? 'error' : undefined}
         />
-      </Stack>*/}
+      </Stack>
     </Stack>
   )
 }

--- a/packages/sanity/src/core/bundles/components/dialog/BundleForm.tsx
+++ b/packages/sanity/src/core/bundles/components/dialog/BundleForm.tsx
@@ -1,7 +1,6 @@
-//import {CalendarIcon} from '@sanity/icons'
 import {type ColorHueKey} from '@sanity/color'
-import {CalendarIcon, type IconSymbol} from '@sanity/icons'
-import {Box, Flex, Stack, Text, TextArea, TextInput} from '@sanity/ui'
+import {type IconSymbol} from '@sanity/icons'
+import {Flex, Stack, Text, TextArea, TextInput} from '@sanity/ui'
 import {useCallback, useMemo, useRef, useState} from 'react'
 import {
   FormFieldHeaderText,
@@ -10,10 +9,8 @@ import {
   useTranslation,
 } from 'sanity'
 
-import {Button, Popover} from '../../../../ui-components'
 import {type CalendarLabels} from '../../../../ui-components/inputs/DateInputs/calendar/types'
-import {DatePicker} from '../../../../ui-components/inputs/DateInputs/DatePicker'
-import {LazyTextInput} from '../../../../ui-components/inputs/DateInputs/LazyTextInput'
+import {DateTimeInput} from '../../../../ui-components/inputs/DateInputs/DateTimeInput'
 import {getCalendarLabels} from '../../../form/inputs/DateInputs/utils'
 import {type BundleDocument} from '../../../store/bundles/types'
 import {BundleIconEditorPicker, type BundleIconEditorPickerValue} from './BundleIconEditorPicker'
@@ -49,6 +46,7 @@ export function BundleForm(props: {
   const [showDatePicker, setShowDatePicker] = useState(false)
 
   const [isInitialRender, setIsInitialRender] = useState(true)
+  const [inputValue, setInputValue] = useState<string | undefined>(undefined)
 
   const [titleErrors, setTitleErrors] = useState<FormNodeValidation[]>([])
   const [dateErrors, setDateErrors] = useState<FormNodeValidation[]>([])
@@ -99,44 +97,12 @@ export function BundleForm(props: {
     [onChange, value],
   )
 
-  const handleOpenDatePicker = useCallback(() => {
-    setShowDatePicker(!showDatePicker)
-  }, [showDatePicker])
-
   const handleBundlePublishAtChange = useCallback(
-    (nextDate: Date | undefined) => {
-      onChange({...value, publishedAt: nextDate?.toString()})
-      setDisplayDate(dateFormatter.format(new Date(nextDate as unknown as Date)))
-
-      setShowDatePicker(false)
+    (date: Date | null) => {
+      setInputValue(date ? dateFormatter.format(date) : undefined)
+      onChange({...value, publishedAt: date?.toDateString()})
     },
     [dateFormatter, onChange, value],
-  )
-
-  const handlePublishAtInputChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const dateValue = event.target.value.trim()
-
-      // there's likely a better way of doing this
-      // needs to check that the date is not invalid & not empty
-      // in which case it can update the input value but not the actual bundle value
-      if (new Date(event.target.value).toString() === 'Invalid Date' && dateValue !== '') {
-        // if the date is invalid, show an error
-        setDateErrors([
-          {
-            level: 'error',
-            message: 'Should be an empty or valid date',
-            path: [],
-          },
-        ])
-        setDisplayDate(dateValue)
-      } else {
-        setDateErrors([])
-        setDisplayDate(dateValue)
-        onChange({...value, publishedAt: dateValue})
-      }
-    },
-    [onChange, value],
   )
 
   const handleIconValueChange = useCallback(
@@ -175,38 +141,12 @@ export function BundleForm(props: {
       <Stack space={3}>
         <FormFieldHeaderText title="Schedule for publishing at" validation={dateErrors} />
 
-        <LazyTextInput
-          suffix={
-            <Popover
-              constrainSize
-              content={
-                <Box overflow="auto">
-                  <DatePicker
-                    onChange={handleBundlePublishAtChange}
-                    calendarLabels={calendarLabels}
-                    value={publishedAt as unknown as Date}
-                    selectTime
-                  />
-                </Box>
-              }
-              open={showDatePicker}
-              placement="bottom-end"
-              radius={2}
-            >
-              <Box padding={1} style={{border: '1px solid transparent'}}>
-                <Button
-                  icon={CalendarIcon}
-                  mode="bleed"
-                  onClick={handleOpenDatePicker}
-                  tooltipProps={null}
-                />
-              </Box>
-            </Popover>
-          }
-          value={displayDate}
-          onChange={handlePublishAtInputChange}
-          data-testid="bundle-form-publish-at"
-          customValidity={dateErrors.length > 0 ? 'error' : undefined}
+        <DateTimeInput
+          selectTime
+          onChange={handleBundlePublishAtChange}
+          calendarLabels={calendarLabels}
+          value={value.publishedAt ? new Date(value.publishedAt) : undefined}
+          inputValue={inputValue || ''}
         />
       </Stack>
     </Stack>


### PR DESCRIPTION
### Description

Made the input use the generic date inputs.
This is temporary since the design for the dialog will likely change this is useful for being able to create releases with published dates

### What to review

Code changes

### Testing

Can you create a release with a publishAt date (in the future)?
Does it appear properly?
