### PR TITLE
refactor(sanity): re-add sanity::versionOf

### DIFF
--- a/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
@@ -42,27 +42,24 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
   const documentPreviewStore = useDocumentPreviewStore()
 
   const observable = useMemo(() => {
-    return (
-      documentPreviewStore
-        // TODO - re-add versionOf once CL has it ready
-        .unstable_observeDocumentIdSet(`_id in path("versions.**") && _id match '*.${publishedId}'`)
-        .pipe(
-          map(({documentIds}) => {
-            return documentIds.flatMap((id) => {
-              // eslint-disable-next-line max-nested-callbacks
-              const matchingBundle = bundles?.find((bundle) => getBundleSlug(id) === bundle.slug)
-              return matchingBundle || []
-            })
-          }),
-          map((data) => ({data})),
-          catchError((error) => {
-            return of({error})
-          }),
-          scan((state, result) => {
-            return {...state, ...result}
-          }, INITIAL_STATE),
-        )
-    )
+    return documentPreviewStore
+      .unstable_observeDocumentIdSet(`sanity::versionOf("${publishedId}")`)
+      .pipe(
+        map(({documentIds}) => {
+          return documentIds.flatMap((id) => {
+            // eslint-disable-next-line max-nested-callbacks
+            const matchingBundle = bundles?.find((bundle) => getBundleSlug(id) === bundle.slug)
+            return matchingBundle || []
+          })
+        }),
+        map((data) => ({data})),
+        catchError((error) => {
+          return of({error})
+        }),
+        scan((state, result) => {
+          return {...state, ...result}
+        }, INITIAL_STATE),
+      )
   }, [bundles, documentPreviewStore, publishedId])
 
   return useObservable(observable, INITIAL_STATE)


### PR DESCRIPTION
### Description

Work in CL has finalised, so I'm re-adding the right query

❗ the query is not optimised for all datasets (including the one we are using by default in the studio), but this should not bea concern for this PR
