### PR TITLE
output path when extracting schema

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/schema/extractAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/schema/extractAction.ts
@@ -88,8 +88,8 @@ export default async function extractAction(
 
     spinner.succeed(
       enforceRequiredFields
-        ? 'Extracted schema, with enforced required fields'
-        : 'Extracted schema',
+        ? `Extracted schema to ${path} with enforced required fields`
+        : `Extracted schema to ${path}`,
     )
   } catch (err) {
     trace.error(err)


### PR DESCRIPTION
### Description

When running `schema extract` there's no feedback about what has happened, only that it succeeded or failed. I'd like it to be more descriptive and obvious, especially useful when modifying the output path.

### What to review

I've only modified the `.succeed` call, but I see also these lines:

```ts
spinner.text = `Writing schema to ${path}`
```
```ts
    .start(
      enforceRequiredFields
        ? 'Extracting schema, with enforced required fields'
        : 'Extracting schema',
    )
```

But I've not seen them when I run `schema extract`, I only get the succeed call.

### Testing

Does this need testing?

### Notes for release

* Output path to file when extracting schema