### PR TITLE
feat(sanity): add always present document action to copy url to clipboard

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -7,6 +7,8 @@ import {defineLocalesResources} from 'sanity'
  * @internal
  */
 const structureLocaleStrings = defineLocalesResources('structure', {
+  /** Label for the "Copy Document URL" document action */
+  'action.copy-document-url.label': 'Copy Document URL',
   /** Tooltip when action button is disabled because the operation is not ready   */
   'action.delete.disabled.not-ready': 'Operation not ready',
   /** Tooltip when action button is disabled because the document does not exist */
@@ -349,6 +351,8 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text when a generic operation succeeded (fallback, generally not shown)  */
   'panes.document-operation-results.operation-success':
     'Successfully performed {{context}} on document',
+  /** The text when copy URL operation succeeded  */
+  'panes.document-operation-results.operation-success_copy-url': 'Document URL copied to clipboard',
   /** The text when a delete operation succeeded  */
   'panes.document-operation-results.operation-success_delete':
     'The document was successfully deleted',

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -43,7 +43,6 @@ import {
   useValidationStatus,
 } from 'sanity'
 import {DocumentPaneContext} from 'sanity/_singletons'
-import {useRouter} from 'sanity/router'
 
 import {usePaneRouter} from '../../components'
 import {structureLocaleNamespace} from '../../i18n'
@@ -404,7 +403,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   )
 
   const telemetry = useTelemetry()
-  const {resolveIntentLink} = useRouter()
 
   const handleMenuAction = useCallback(
     (item: PaneMenuItem) => {
@@ -415,8 +413,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
       if (item.action === 'copy-document-url' && navigator) {
         telemetry.log(DocumentURLCopied)
-        const documentIntentLink = resolveIntentLink('edit', {id: documentId})
-        navigator.clipboard.writeText(window.location.origin + documentIntentLink)
+        navigator.clipboard.writeText(window.location.toString())
         pushToast({
           id: 'copy-document-url',
           status: 'info',
@@ -462,8 +459,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       toggleLegacyInspect,
       pushToast,
       telemetry,
-      resolveIntentLink,
-      documentId,
     ],
   )
 

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -43,6 +43,7 @@ import {
   useValidationStatus,
 } from 'sanity'
 import {DocumentPaneContext} from 'sanity/_singletons'
+import {useIntentLink} from 'sanity/router'
 
 import {usePaneRouter} from '../../components'
 import {structureLocaleNamespace} from '../../i18n'
@@ -403,6 +404,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   )
 
   const telemetry = useTelemetry()
+  const {href: documentEditIntentLink} = useIntentLink({intent: 'edit', params: {id: documentId}})
 
   const handleMenuAction = useCallback(
     (item: PaneMenuItem) => {
@@ -413,7 +415,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
       if (item.action === 'copy-document-url' && navigator) {
         telemetry.log(DocumentURLCopied)
-        navigator.clipboard.writeText(window.location.toString())
+        navigator.clipboard.writeText(window.location.origin + documentEditIntentLink)
         pushToast({
           id: 'copy-document-url',
           status: 'info',
@@ -459,6 +461,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       toggleLegacyInspect,
       pushToast,
       telemetry,
+      documentEditIntentLink,
     ],
   )
 

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import {isActionEnabled} from '@sanity/schema/_internal'
+import {useTelemetry} from '@sanity/telemetry/react'
 import {
   type ObjectSchemaType,
   type Path,
@@ -47,6 +48,7 @@ import {usePaneRouter} from '../../components'
 import {structureLocaleNamespace} from '../../i18n'
 import {type PaneMenuItem} from '../../types'
 import {useStructureTool} from '../../useStructureTool'
+import {DocumentURLCopied} from './__telemetry__'
 import {
   DEFAULT_MENU_ITEM_GROUPS,
   EMPTY_PARAMS,
@@ -400,6 +402,8 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     [inspectOpen, params, setPaneParams],
   )
 
+  const telemetry = useTelemetry()
+
   const handleMenuAction = useCallback(
     (item: PaneMenuItem) => {
       if (item.action === 'production-preview' && previewUrl) {
@@ -408,6 +412,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       }
 
       if (item.action === 'copy-document-url' && navigator) {
+        telemetry.log(DocumentURLCopied)
         navigator.clipboard.writeText(window.location.toString())
         pushToast({
           id: 'copy-document-url',
@@ -453,6 +458,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       previewUrl,
       toggleLegacyInspect,
       pushToast,
+      telemetry,
     ],
   )
 

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -43,7 +43,7 @@ import {
   useValidationStatus,
 } from 'sanity'
 import {DocumentPaneContext} from 'sanity/_singletons'
-import {useIntentLink} from 'sanity/router'
+import {useRouter} from 'sanity/router'
 
 import {usePaneRouter} from '../../components'
 import {structureLocaleNamespace} from '../../i18n'
@@ -404,7 +404,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   )
 
   const telemetry = useTelemetry()
-  const {href: documentEditIntentLink} = useIntentLink({intent: 'edit', params: {id: documentId}})
+  const {resolveIntentLink} = useRouter()
 
   const handleMenuAction = useCallback(
     (item: PaneMenuItem) => {
@@ -415,7 +415,8 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
       if (item.action === 'copy-document-url' && navigator) {
         telemetry.log(DocumentURLCopied)
-        navigator.clipboard.writeText(window.location.origin + documentEditIntentLink)
+        const documentIntentLink = resolveIntentLink('edit', {id: documentId})
+        navigator.clipboard.writeText(window.location.origin + documentIntentLink)
         pushToast({
           id: 'copy-document-url',
           status: 'info',
@@ -461,7 +462,8 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       toggleLegacyInspect,
       pushToast,
       telemetry,
-      documentEditIntentLink,
+      resolveIntentLink,
+      documentId,
     ],
   )
 

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -413,6 +413,10 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
       if (item.action === 'copy-document-url' && navigator) {
         telemetry.log(DocumentURLCopied)
+        // Chose to copy the user's current URL instead of
+        // the document's edit intent link because
+        // of bugs when resolving a document that has
+        // multiple access paths within Structure
         navigator.clipboard.writeText(window.location.toString())
         pushToast({
           id: 'copy-document-url',

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -407,6 +407,16 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
         return true
       }
 
+      if (item.action === 'copy-document-url') {
+        navigator.clipboard.writeText(window.location.toString())
+        pushToast({
+          id: 'copy-document-url',
+          status: 'info',
+          title: t('panes.document-operation-results.operation-success_copy-url'),
+        })
+        return true
+      }
+
       if (item.action === 'inspect') {
         toggleLegacyInspect(true)
         return true
@@ -434,6 +444,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       return false
     },
     [
+      t,
       closeInspector,
       handleHistoryOpen,
       inspectorName,
@@ -441,6 +452,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       openInspector,
       previewUrl,
       toggleLegacyInspect,
+      pushToast,
     ],
   )
 

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -407,7 +407,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
         return true
       }
 
-      if (item.action === 'copy-document-url') {
+      if (item.action === 'copy-document-url' && navigator) {
         navigator.clipboard.writeText(window.location.toString())
         pushToast({
           id: 'copy-document-url',

--- a/packages/sanity/src/structure/panes/document/__telemetry__/documentPanes.telemetry.ts
+++ b/packages/sanity/src/structure/panes/document/__telemetry__/documentPanes.telemetry.ts
@@ -1,0 +1,10 @@
+import {defineEvent} from '@sanity/telemetry'
+
+/**
+ * @internal
+ */
+export const DocumentURLCopied = defineEvent({
+  name: 'DocumentURLCopied',
+  version: 1,
+  description: 'User copied document URL to clipboard',
+})

--- a/packages/sanity/src/structure/panes/document/__telemetry__/index.ts
+++ b/packages/sanity/src/structure/panes/document/__telemetry__/index.ts
@@ -1,0 +1,1 @@
+export * from './documentPanes.telemetry'

--- a/packages/sanity/src/structure/panes/document/menuItems.ts
+++ b/packages/sanity/src/structure/panes/document/menuItems.ts
@@ -1,4 +1,4 @@
-import {EarthAmericasIcon, JsonIcon} from '@sanity/icons'
+import {EarthAmericasIcon, JsonIcon, LinkIcon} from '@sanity/icons'
 import {type DocumentInspector, type DocumentInspectorMenuItem, type TFunction} from 'sanity'
 
 import {type PaneMenuItem, type StructureToolFeatures} from '../../types'
@@ -72,6 +72,12 @@ export function getMenuItems(params: GetMenuItemsParams): PaneMenuItem[] {
   ].filter(Boolean) as PaneMenuItem[]
 
   return [
+    {
+      action: 'copy-document-url',
+      showAsAction: true,
+      title: params.t('action.copy-document-url.label'),
+      icon: LinkIcon,
+    },
     ...inspectorItems,
 
     // TODO: convert to inspector or document view?

--- a/packages/sanity/src/structure/panes/document/menuItems.ts
+++ b/packages/sanity/src/structure/panes/document/menuItems.ts
@@ -72,6 +72,7 @@ export function getMenuItems(params: GetMenuItemsParams): PaneMenuItem[] {
   ].filter(Boolean) as PaneMenuItem[]
 
   return [
+    // Always present document menu item to copy current url to clipboard
     {
       action: 'copy-document-url',
       showAsAction: true,


### PR DESCRIPTION
### Description

This PR adds a document pane menu item that enables user's to easily copy the current 
document's URL to their clipboard and share it with colleagues and collaborators.

[Linear issue](https://linear.app/sanity/issue/GRO-2405/add-share-button-to-studio)

https://github.com/user-attachments/assets/ba52e457-8d5a-44ed-ac0c-e37a5a034603

### What to review

The code add for this feature is relatively straightforward. However, I'm unsure if the logic's location and the placement of the internalization strings is acceptable. Feedback on this would be greatly appreciated.

### Testing

To test, navigate to a document and click on the added menu item. The current URL should be successfully copied to the clipboard.
