### PR TITLE
fix(sanity): add prop for constraintSize

### DIFF
--- a/packages/sanity/src/ui-components/inputs/DateInputs/DateTimeInput.tsx
+++ b/packages/sanity/src/ui-components/inputs/DateInputs/DateTimeInput.tsx
@@ -30,6 +30,7 @@ export interface DateTimeInputProps {
   timeStep?: number
   value?: Date
   calendarLabels: CalendarLabels
+  constrainSize?: boolean
 }
 
 export const DateTimeInput = forwardRef(function DateTimeInput(
@@ -44,6 +45,7 @@ export const DateTimeInput = forwardRef(function DateTimeInput(
     selectTime,
     timeStep,
     calendarLabels,
+    constrainSize = true,
     ...rest
   } = props
   const popoverRef = useRef<HTMLDivElement | null>(null)
@@ -103,7 +105,7 @@ export const DateTimeInput = forwardRef(function DateTimeInput(
           // see https://github.com/sanity-io/design/issues/519
           <LayerProvider zOffset={1000}>
             <Popover
-              constrainSize
+              constrainSize={constrainSize}
               data-testid="date-input-dialog"
               portal
               content={


### PR DESCRIPTION
### Description

Add a prop to the dateTImeInput in ui-components because you might not want it always (example: from within a modal)

![image](https://github.com/user-attachments/assets/4f8d085e-9181-4250-8aa7-9b86437cd2f6)

### What to review
- Addition makes sense, is there anything missing?

### Notes for release

Add ability to constraint the size of the date picker popover in the DateTimeInput in ui-components
