### PR TITLE
feat(tasks): link tasks to the version document

### DIFF
--- a/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
+++ b/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
@@ -4,6 +4,7 @@ import {type ReactNode, useCallback, useState} from 'react'
 import {filter, firstValueFrom} from 'rxjs'
 import {
   getPublishedId,
+  getVersionFromId,
   getVersionId,
   useDocumentOperation,
   useDocumentStore,
@@ -12,7 +13,6 @@ import {
 
 import {Button} from '../../../../ui-components'
 import {type BundleDocument} from '../../../store/bundles/types'
-import {getBundleSlug} from '../../util/util'
 
 interface BundleActionsProps {
   currentGlobalBundle: BundleDocument
@@ -35,7 +35,9 @@ export function BundleActions(props: BundleActionsProps): ReactNode {
   const {slug, title, archivedAt} = currentGlobalBundle
   const documentStore = useDocumentStore()
   const [creatingVersion, setCreatingVersion] = useState<boolean>(false)
-  const [isInVersion, setIsInVersion] = useState<boolean>(() => getBundleSlug(documentId) === slug)
+  const [isInVersion, setIsInVersion] = useState<boolean>(
+    () => getVersionFromId(documentId) === slug,
+  )
 
   const toast = useToast()
   const {newVersion} = useDocumentOperation(publishedId, documentType, bundleSlug)
@@ -50,7 +52,7 @@ export function BundleActions(props: BundleActionsProps): ReactNode {
       return
     }
     // only add to version if there isn't already a version in that bundle of this doc
-    if (getBundleSlug(documentId) === slug) {
+    if (getVersionFromId(documentId) === slug) {
       toast.push({
         status: 'error',
         title: `There's already a version of this document in the bundle ${title}`,

--- a/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/bundles/hooks/useDocumentVersions.tsx
@@ -4,8 +4,8 @@ import {map, of} from 'rxjs'
 import {catchError, scan} from 'rxjs/operators'
 import {
   type BundleDocument,
-  getBundleSlug,
   getPublishedId,
+  getVersionFromId,
   useBundles,
   useDocumentPreviewStore,
 } from 'sanity'
@@ -48,7 +48,7 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
         map(({documentIds}) => {
           return documentIds.flatMap((id) => {
             // eslint-disable-next-line max-nested-callbacks
-            const matchingBundle = bundles?.find((bundle) => getBundleSlug(id) === bundle.slug)
+            const matchingBundle = bundles?.find((bundle) => getVersionFromId(id) === bundle.slug)
             return matchingBundle || []
           })
         }),

--- a/packages/sanity/src/core/bundles/util/util.test.ts
+++ b/packages/sanity/src/core/bundles/util/util.test.ts
@@ -1,20 +1,6 @@
 import {describe, expect, it} from '@jest/globals'
 
-import {getBundleSlug, getDocumentIsInPerspective} from './util'
-
-describe('getBundleSlug', () => {
-  it('should return the bundle slug', () => {
-    expect(getBundleSlug('versions.summer.my-document-id')).toBe('summer')
-  })
-
-  it('should return the undefined if no bundle slug is found and document is a draft', () => {
-    expect(getBundleSlug('drafts.my-document-id')).toBe(undefined)
-  })
-
-  it('should return the undefined if no bundle slug is found and document is published', () => {
-    expect(getBundleSlug('my-document-id')).toBe(undefined)
-  })
-})
+import {getDocumentIsInPerspective} from './util'
 
 // * - document: `summer.my-document-id`, perspective: `bundle.summer` : **true**
 // * - document: `my-document-id`, perspective: `bundle.summer` : **false**

--- a/packages/sanity/src/core/bundles/util/util.ts
+++ b/packages/sanity/src/core/bundles/util/util.ts
@@ -1,22 +1,7 @@
 import speakingurl from 'speakingurl'
 
 import {type BundleDocument} from '../../store/bundles/types'
-import {isVersionId} from '../../util'
-
-/**
- * @internal
- * @hidden
- */
-export function getBundleSlug(documentId: string): string | undefined {
-  if (documentId.indexOf('.') === -1) return undefined
-
-  if (isVersionId(documentId)) {
-    const [, bundleSlug] = documentId.split('.')
-    return bundleSlug
-  }
-
-  return undefined
-}
+import {getVersionFromId, isVersionId} from '../../util'
 
 /**
  * @beta
@@ -35,7 +20,7 @@ export function getDocumentIsInPerspective(
   documentId: string,
   perspective: string | undefined,
 ): boolean {
-  const bundleSlug = getBundleSlug(documentId)
+  const bundleSlug = getVersionFromId(documentId)
 
   if (!perspective) return !isVersionId(documentId)
 

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -2,7 +2,6 @@ export {
   BundleActions,
   BundleBadge,
   BundlesMenu,
-  getBundleSlug,
   getDocumentIsInPerspective,
   LATEST,
   useDocumentVersions,

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
@@ -3,6 +3,7 @@ import {type SchemaType} from '@sanity/types'
 import {Badge, Box, Flex} from '@sanity/ui'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
+import {getPublishedId, getVersionFromId, isVersionId} from 'sanity'
 import {styled} from 'styled-components'
 
 import {type GeneralPreviewLayoutKey} from '../../../../../../../components'
@@ -49,10 +50,18 @@ export function SearchResultItemPreview({
   const documentPreviewStore = useDocumentPreviewStore()
 
   const observable = useMemo(
-    () => getPreviewStateObservable(documentPreviewStore, schemaType, documentId, ''),
+    () =>
+      getPreviewStateObservable(
+        documentPreviewStore,
+        schemaType,
+        getPublishedId(documentId),
+        '',
+        getVersionFromId(documentId),
+      ),
     [documentId, documentPreviewStore, schemaType],
   )
-  const {draft, published, isLoading} = useObservable(observable, {
+
+  const {draft, published, isLoading, version} = useObservable(observable, {
     draft: null,
     isLoading: true,
     published: null,
@@ -84,7 +93,11 @@ export function SearchResultItemPreview({
         {...getPreviewValueWithFallback({
           draft,
           published,
+          version,
           value: sanityDocument,
+          perspective: isVersionId(documentId)
+            ? `bundle.${getVersionFromId(documentId)}`
+            : undefined,
         })}
         isPlaceholder={isLoading ?? true}
         layout={layout || 'default'}

--- a/packages/sanity/src/core/tasks/components/form/fields/TargetField.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/TargetField.tsx
@@ -17,6 +17,7 @@ import {
   SearchResultItemPreview,
   useWorkspace,
 } from '../../../../studio'
+import {getPublishedId, getVersionFromId} from '../../../../util/draftUtils'
 import {tasksLocaleNamespace} from '../../../i18n'
 import {type FormMode, type TaskTarget} from '../../../types'
 import {CurrentWorkspaceProvider} from '../CurrentWorkspaceProvider'
@@ -98,12 +99,15 @@ function Preview(props: {value: TaskTarget; handleRemove: () => void}) {
   const CardLink = useMemo(
     () =>
       forwardRef(function LinkComponent(linkProps, ref: ForwardedRef<HTMLAnchorElement>) {
+        const versionId = getVersionFromId(documentId)
+
         return (
           <StyledIntentLink
             {...linkProps}
             intent="edit"
-            params={{id: documentId, type: documentType}}
+            params={{id: getPublishedId(documentId), type: documentType}}
             ref={ref}
+            searchParams={versionId ? [['perspective', `bundle.${versionId}`]] : undefined}
           />
         )
       }),

--- a/packages/sanity/src/core/tasks/components/form/utils.ts
+++ b/packages/sanity/src/core/tasks/components/form/utils.ts
@@ -1,6 +1,6 @@
 import {isPortableTextTextBlock} from '@sanity/types'
 
-import {getPublishedId} from '../../../util'
+import {getPublishedId, isVersionId} from '../../../util'
 import {type TaskDocument, type TaskTarget} from '../../types'
 
 interface GetTargetValueOptions {
@@ -18,7 +18,8 @@ export function getTargetValue({
   return {
     documentType: documentType,
     document: {
-      _ref: getPublishedId(documentId),
+      // Version documents should be referenced by their version id.
+      _ref: isVersionId(documentId) ? documentId : getPublishedId(documentId),
       _type: 'crossDatasetReference',
       _dataset: dataset,
       _projectId: projectId,

--- a/packages/sanity/src/core/tasks/plugin/structure/SetActiveDocument.tsx
+++ b/packages/sanity/src/core/tasks/plugin/structure/SetActiveDocument.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react'
 
-import {getPublishedId} from '../../../util'
+import {getPublishedId, isVersionId} from '../../../util'
 import {type ActiveDocument, useIsLastPane, useTasks, useTasksEnabled} from '../../context'
 
 function SetActiveDocumentInner(document: ActiveDocument) {
@@ -11,7 +11,8 @@ function SetActiveDocumentInner(document: ActiveDocument) {
   useEffect(() => {
     if (documentId && isLast && documentType) {
       setActiveDocument?.({
-        documentId: getPublishedId(documentId),
+        // Use the version id if it's a version document.
+        documentId: isVersionId(documentId) ? documentId : getPublishedId(documentId),
         documentType,
       })
     }

--- a/packages/sanity/src/core/util/draftUtils.test.ts
+++ b/packages/sanity/src/core/util/draftUtils.test.ts
@@ -1,7 +1,14 @@
-import {expect, test} from '@jest/globals'
+import {describe, expect, it, test} from '@jest/globals'
 import {type SanityDocument} from '@sanity/types'
 
-import {collate, documentIdEquals, getPublishedId, getVersionId, removeDupes} from './draftUtils'
+import {
+  collate,
+  documentIdEquals,
+  getPublishedId,
+  getVersionFromId,
+  getVersionId,
+  removeDupes,
+} from './draftUtils'
 
 test('collate()', () => {
   const foo = {_type: 'foo', _id: 'foo'}
@@ -60,4 +67,18 @@ test.each([
   ['from complex id with version', 'versions.summer-drop.foo.agot', 'foo.agot'],
 ])('getPublishedId(): %s', (_, documentId, shouldEqual) => {
   expect(getPublishedId(documentId)).toEqual(shouldEqual)
+})
+
+describe('getVersionFromId', () => {
+  it('should return the bundle slug', () => {
+    expect(getVersionFromId('versions.summer.my-document-id')).toBe('summer')
+  })
+
+  it('should return the undefined if no bundle slug is found and document is a draft', () => {
+    expect(getVersionFromId('drafts.my-document-id')).toBe(undefined)
+  })
+
+  it('should return the undefined if no bundle slug is found and document is published', () => {
+    expect(getVersionFromId('my-document-id')).toBe(undefined)
+  })
 })

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.test.tsx
@@ -37,7 +37,6 @@ jest.mock('sanity', () => {
   return {
     ...actual,
     unstable_useValuePreview: jest.fn(),
-    getBundleSlug: jest.fn(() => ''),
     useDocumentVersions: jest.fn(),
   }
 })


### PR DESCRIPTION
### Description

When tasks are created for a version document , link the task with the version document instead of the live document, so tasks for a version are only visible in a version. And the version won't show tasks from the published document.
https://www.loom.com/share/487a5c732b7d4367a7d737720f24351a?sid=99a7112b-00a0-4730-a0e2-da5bd78a1091

#### Other changes: 
- This PR renames and move `getBundleSlug` to `getVersionFromId`, given the id is not specifically related to the bundles, it's related to the `version` 

#### TODO: 
- Once the search allows looking for version documents the tasks document search should be updated to allow users to link tasks to version documents from there. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
