### PR TITLE
fix(core): update how bundleSlug is obtained from the version ids

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
@@ -3,6 +3,7 @@ import {type SanityDocument, type Schema} from '@sanity/types'
 import {combineLatest, type Observable} from 'rxjs'
 import {map, publishReplay, refCount, startWith, switchMap} from 'rxjs/operators'
 
+import {getVersionFromId} from '../../../../util'
 import {type IdPair, type PendingMutationsEvent} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {memoizeKeyGen} from './memoizeKeyGen'
@@ -79,7 +80,7 @@ export const editState = memoize(
         liveEditSchemaType,
         ready: true,
         transactionSyncLock,
-        bundleSlug: idPair.versionId?.split('.').at(0),
+        bundleSlug: idPair.versionId ? getVersionFromId(idPair.versionId) : undefined,
       })),
       startWith({
         id: idPair.publishedId,
@@ -91,7 +92,7 @@ export const editState = memoize(
         liveEditSchemaType,
         ready: false,
         transactionSyncLock: null,
-        bundleSlug: idPair.versionId?.split('.').at(0),
+        bundleSlug: idPair.versionId ? getVersionFromId(idPair.versionId) : undefined,
       }),
       publishReplay(1),
       refCount(),


### PR DESCRIPTION
### Description

When the new versions id was introduced `versions.release-slug.foo` the update to the way we calculate the `bundleSlug` was not added. 
This adds that change, using the new `getVersionFromId` function which gives us safety in how the bundleSlug is obtained from the id. 

Previously, version ids were `release-slug.foo` that's why we were accessing it using the `.at(0)`

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
