### PR TITLE
chore(core): single addon dataset context

### DIFF
--- a/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
+++ b/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
@@ -1,5 +1,5 @@
 import {type SanityClient} from '@sanity/client'
-import {useCallback, useEffect, useMemo, useState} from 'react'
+import {useCallback, useContext, useEffect, useMemo, useState} from 'react'
 import {AddonDatasetContext} from 'sanity/_singletons'
 
 import {useClient} from '../../hooks'
@@ -13,13 +13,7 @@ interface AddonDatasetSetupProviderProps {
   children: React.ReactNode
 }
 
-/**
- * This provider sets the addon dataset client, currently called `comments` dataset.
- * It also exposes a `createAddonDataset` function that can be used to create the addon dataset if it does not exist.
- * @beta
- * @hidden
- */
-export function AddonDatasetProvider(props: AddonDatasetSetupProviderProps) {
+function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
   const {children} = props
   const {dataset, projectId} = useWorkspace()
   const originalClient = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
@@ -133,4 +127,17 @@ export function AddonDatasetProvider(props: AddonDatasetSetupProviderProps) {
   )
 
   return <AddonDatasetContext.Provider value={ctxValue}>{children}</AddonDatasetContext.Provider>
+}
+
+/**
+ * This provider sets the addon dataset client, currently called `comments` dataset.
+ * It also exposes a `createAddonDataset` function that can be used to create the addon dataset if it does not exist.
+ * @beta
+ * @hidden
+ */
+export function AddonDatasetProvider(props: AddonDatasetSetupProviderProps) {
+  const context = useContext(AddonDatasetContext)
+  // Avoid mounting the provider if it's already provided by a parent
+  if (context) return props.children
+  return <AddonDatasetProviderInner {...props} />
 }


### PR DESCRIPTION
### Description
The addon dataset context will only be wrapped if it does not already exist. This is inkeeping with how many newer contexts are being defined, to avoid multiple separate contexts being nested
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
N/A
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
