### PR TITLE
fix(structure): passing from operation context to label for success toast

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -349,8 +349,7 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'panes.document-operation-results.operation-error_unpublish':
     'An error occurred while attempting to unpublish this document. This usually means that there are other documents that refers to it.',
   /** The text when a generic operation succeeded (fallback, generally not shown)  */
-  'panes.document-operation-results.operation-success':
-    'Successfully performed {{context}} on document',
+  'panes.document-operation-results.operation-success': 'Successfully performed {{op}} on document',
   /** The text when copy URL operation succeeded  */
   'panes.document-operation-results.operation-success_copy-url': 'Document URL copied to clipboard',
   /** The text when a delete operation succeeded  */

--- a/packages/sanity/src/structure/panes/document/DocumentOperationResults.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentOperationResults.tsx
@@ -53,6 +53,7 @@ export const DocumentOperationResults = memo(function DocumentOperationResults()
             i18nKey="panes.document-operation-results.operation-success"
             t={t}
             values={{
+              op: event.op,
               title: documentTitle,
             }}
             components={{


### PR DESCRIPTION
### Description
When an operation is completed, and there is not a specific label that exists for the operation, then a general toast should appear and interpolate the name of the operation. However, this was trying to read from `{{context}}` which didn't exist in the scope. As such the toast description was incorrect.

This PR just passes through the operation name to the i18n scope, so that it can be interpolated correctly
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
