### PR TITLE
fix(core): version document's history was returning error

### DIFF
--- a/packages/sanity/src/core/store/_legacy/history/createHistoryStore.ts
+++ b/packages/sanity/src/core/store/_legacy/history/createHistoryStore.ts
@@ -112,7 +112,7 @@ const getTimelineController = ({
 }): TimelineController => {
   const timeline = new Timeline({
     enableTrace: isDev,
-    publishedId: documentId,
+    documentId,
   })
   return new TimelineController({
     client,

--- a/packages/sanity/src/core/store/_legacy/history/history/Aligner.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/Aligner.ts
@@ -90,8 +90,8 @@ export class Aligner {
   constructor(timeline: Timeline) {
     this.timeline = timeline
     this._states = {
-      draft: emptyVersionState(timeline.draftId),
-      published: emptyVersionState(timeline.documentId),
+      draft: emptyVersionState(timeline.versionId),
+      published: emptyVersionState(timeline.publishedId),
     }
   }
 

--- a/packages/sanity/src/core/store/_legacy/history/history/Aligner.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/Aligner.ts
@@ -91,7 +91,7 @@ export class Aligner {
     this.timeline = timeline
     this._states = {
       draft: emptyVersionState(timeline.draftId),
-      published: emptyVersionState(timeline.publishedId),
+      published: emptyVersionState(timeline.documentId),
     }
   }
 

--- a/packages/sanity/src/core/store/_legacy/history/history/Timeline.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/Timeline.ts
@@ -124,7 +124,7 @@ export class Timeline {
         }
 
     if (entry.version === 'draft') {
-      transaction.draftEffect = entry.effects as any
+      transaction.versionEffect = entry.effects as any
     } else {
       transaction.publishedEffect = entry.effects as any
     }
@@ -149,7 +149,7 @@ export class Timeline {
       id: event.id,
       author: event.author,
       timestamp: event.timestamp,
-      draftEffect: event.effects[this.versionId],
+      versionEffect: event.effects[this.versionId],
       publishedEffect: event.effects[this.publishedId],
     })
   }
@@ -332,8 +332,8 @@ export class Timeline {
     for (let idx = lastIdx; idx >= firstIdx; idx--) {
       const transaction = this._transactions.get(idx)
 
-      if (transaction.draftEffect) {
-        draft = applyPatch(draft, transaction.draftEffect.revert)
+      if (transaction.versionEffect) {
+        draft = applyPatch(draft, transaction.versionEffect.revert)
       }
 
       if (transaction.publishedEffect) {
@@ -377,8 +377,8 @@ export class Timeline {
         const preDraftValue = draftValue
         const prePublishedValue = publishedValue
 
-        if (transaction.draftEffect) {
-          draftValue = incremental.applyPatch(draftValue, transaction.draftEffect.apply, meta)
+        if (transaction.versionEffect) {
+          draftValue = incremental.applyPatch(draftValue, transaction.versionEffect.apply, meta)
         }
 
         if (transaction.publishedEffect) {

--- a/packages/sanity/src/core/store/_legacy/history/history/Timeline.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/Timeline.ts
@@ -1,6 +1,7 @@
 import {type Diff} from '@sanity/diff'
 import {type TransactionLogEventWithEffects} from '@sanity/types'
 import {applyPatch, incremental} from 'mendoza'
+import {isVersionId} from 'sanity'
 
 import {type Annotation, type Chunk} from '../../../../field'
 import {chunkFromTransaction, mergeChunk} from './chunker'
@@ -60,7 +61,7 @@ export class Timeline {
 
   constructor(opts: TimelineOptions) {
     this.publishedId = opts.publishedId
-    this.draftId = `drafts.${opts.publishedId}`
+    this.draftId = isVersionId(opts.publishedId) ? opts.publishedId : `drafts.${opts.publishedId}`
 
     if (opts.enableTrace) {
       this._trace = []

--- a/packages/sanity/src/core/store/_legacy/history/history/Timeline.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/Timeline.ts
@@ -24,7 +24,7 @@ export type ParsedTimeRef = Chunk | 'loading' | 'invalid'
  * @hidden
  * @beta */
 export interface TimelineOptions {
-  publishedId: string
+  documentId: string
   enableTrace?: boolean
 }
 
@@ -43,7 +43,7 @@ export interface TimelineOptions {
 export class Timeline {
   reachedEarliestEntry = false
 
-  publishedId: string
+  documentId: string
   draftId: string
   private _transactions = new TwoEndedArray<Transaction>()
   private _chunks = new TwoEndedArray<Chunk>()
@@ -60,14 +60,15 @@ export class Timeline {
   private _trace?: TraceEvent[]
 
   constructor(opts: TimelineOptions) {
-    this.publishedId = opts.publishedId
-    this.draftId = isVersionId(opts.publishedId) ? opts.publishedId : `drafts.${opts.publishedId}`
+    const {documentId} = opts
+    this.documentId = documentId
+    this.draftId = isVersionId(documentId) ? documentId : `drafts.${documentId}`
 
     if (opts.enableTrace) {
       this._trace = []
       this._trace.push({
         type: 'initial',
-        publishedId: opts.publishedId,
+        publishedId: documentId,
       })
       ;(window as any).__sanityTimelineTrace = this._trace
     }
@@ -149,7 +150,7 @@ export class Timeline {
       author: event.author,
       timestamp: event.timestamp,
       draftEffect: event.effects[this.draftId],
-      publishedEffect: event.effects[this.publishedId],
+      publishedEffect: event.effects[this.documentId],
     })
   }
 

--- a/packages/sanity/src/core/store/_legacy/history/history/Timeline.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/Timeline.ts
@@ -43,8 +43,8 @@ export interface TimelineOptions {
 export class Timeline {
   reachedEarliestEntry = false
 
-  documentId: string
-  draftId: string
+  publishedId: string
+  versionId: string
   private _transactions = new TwoEndedArray<Transaction>()
   private _chunks = new TwoEndedArray<Chunk>()
 
@@ -61,8 +61,8 @@ export class Timeline {
 
   constructor(opts: TimelineOptions) {
     const {documentId} = opts
-    this.documentId = documentId
-    this.draftId = isVersionId(documentId) ? documentId : `drafts.${documentId}`
+    this.publishedId = documentId
+    this.versionId = isVersionId(documentId) ? documentId : `drafts.${documentId}`
 
     if (opts.enableTrace) {
       this._trace = []
@@ -149,8 +149,8 @@ export class Timeline {
       id: event.id,
       author: event.author,
       timestamp: event.timestamp,
-      draftEffect: event.effects[this.draftId],
-      publishedEffect: event.effects[this.documentId],
+      draftEffect: event.effects[this.versionId],
+      publishedEffect: event.effects[this.publishedId],
     })
   }
 

--- a/packages/sanity/src/core/store/_legacy/history/history/Timeline.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/Timeline.ts
@@ -60,7 +60,7 @@ export class Timeline {
   private _trace?: TraceEvent[]
 
   constructor(opts: TimelineOptions) {
-    const {documentId} = opts
+    const {documentId}: TimelineOptions = opts
     this.publishedId = documentId
     this.versionId = isVersionId(documentId) ? documentId : `drafts.${documentId}`
 

--- a/packages/sanity/src/core/store/_legacy/history/history/Timeline.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/Timeline.ts
@@ -59,12 +59,11 @@ export class Timeline {
   private _recreateTransactionsFrom?: number
   private _trace?: TraceEvent[]
 
-  constructor(opts: TimelineOptions) {
-    const {documentId}: TimelineOptions = opts
+  constructor({documentId, enableTrace}: TimelineOptions) {
     this.publishedId = documentId
     this.versionId = isVersionId(documentId) ? documentId : `drafts.${documentId}`
 
-    if (opts.enableTrace) {
+    if (enableTrace) {
       this._trace = []
       this._trace.push({
         type: 'initial',

--- a/packages/sanity/src/core/store/_legacy/history/history/TimelineController.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/TimelineController.ts
@@ -273,8 +273,8 @@ export class TimelineController {
   }
 
   private async fetchMoreTransactions() {
-    const publishedId = this.timeline.documentId
-    const draftId = this.timeline.draftId
+    const publishedId = this.timeline.publishedId
+    const versionId = this.timeline.versionId
     const clientConfig = this.client.config()
     const limit = TRANSLOG_ENTRY_LIMIT
 
@@ -285,7 +285,7 @@ export class TimelineController {
     }
 
     const transactionsUrl = this.client.getUrl(
-      `/data/history/${clientConfig.dataset}/transactions/${publishedId},${draftId}?${queryParams}`,
+      `/data/history/${clientConfig.dataset}/transactions/${publishedId},${versionId}?${queryParams}`,
     )
     const stream = await getJsonStream(transactionsUrl, clientConfig.token)
     const reader = stream.getReader()

--- a/packages/sanity/src/core/store/_legacy/history/history/TimelineController.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/TimelineController.ts
@@ -273,7 +273,7 @@ export class TimelineController {
   }
 
   private async fetchMoreTransactions() {
-    const publishedId = this.timeline.publishedId
+    const publishedId = this.timeline.documentId
     const draftId = this.timeline.draftId
     const clientConfig = this.client.config()
     const limit = TRANSLOG_ENTRY_LIMIT

--- a/packages/sanity/src/core/store/_legacy/history/history/chunker.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/chunker.ts
@@ -90,7 +90,7 @@ function getChunkState(effect?: MendozaEffectPair): ChunkState {
  * | published upsert   | liveEdit       | publish       | liveEdit     |
  */
 function getChunkType(transaction: Transaction): ChunkType {
-  const draftState = getChunkState(transaction.draftEffect)
+  const draftState = getChunkState(transaction.versionEffect)
   const publishedState = getChunkState(transaction.publishedEffect)
 
   if (publishedState === 'unedited') {
@@ -125,10 +125,10 @@ function getChunkType(transaction: Transaction): ChunkType {
 }
 
 export function chunkFromTransaction(transaction: Transaction): Chunk {
-  const modifiedDraft = Boolean(transaction.draftEffect)
+  const modifiedDraft = Boolean(transaction.versionEffect)
   const modifiedPublished = Boolean(transaction.publishedEffect)
 
-  const draftDeleted = transaction.draftEffect && isDeletePatch(transaction.draftEffect.apply)
+  const draftDeleted = transaction.versionEffect && isDeletePatch(transaction.versionEffect.apply)
   const publishedDeleted =
     transaction.publishedEffect && isDeletePatch(transaction.publishedEffect.apply)
 

--- a/packages/sanity/src/core/store/_legacy/history/history/replay.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/replay.ts
@@ -18,7 +18,7 @@ export function replay(events: TraceEvent[]): Timeline {
   if (fst?.type !== 'initial') throw new Error('no initial event')
 
   const timeline = new Timeline({
-    publishedId: fst.publishedId,
+    documentId: fst.publishedId,
   })
 
   /* eslint-disable no-console */

--- a/packages/sanity/src/core/store/_legacy/history/history/types.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/types.ts
@@ -26,6 +26,6 @@ export interface Transaction {
   id: string
   author: string
   timestamp: string
-  draftEffect?: MendozaEffectPair
+  versionEffect?: MendozaEffectPair
   publishedEffect?: MendozaEffectPair
 }

--- a/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
+++ b/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
@@ -18,7 +18,6 @@ import {
   type Chunk,
   DRAFTS_FOLDER,
   getVersionId,
-  isVersionId,
   remoteSnapshots,
   type RemoteSnapshotVersionEvent,
   type SelectionState,
@@ -119,8 +118,7 @@ export function useTimelineStore({
     () =>
       historyStore.getTimelineController({
         client,
-        documentId:
-          isVersionId(documentId) && version ? getVersionId(documentId, version) : documentId,
+        documentId: version ? getVersionId(documentId, version) : documentId,
         documentType,
       }),
     [client, documentId, documentType, historyStore, version],


### PR DESCRIPTION
### Description
https://www.loom.com/share/b1e04c690f7b45dcb40d153cf055c97b?sid=6a600c40-cf41-4bc3-ad0c-d0b90bba4414
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
1. The first commit includes the fix for this issue - https://github.com/sanity-io/sanity/commit/5cff65b34ac04d4c1c038b5e624c53b3e8f2862a
2. The second is a refactor. The intention behind this renaming of `publishedId` to `documentId`, is to give affordance that in cases where the document is a version, then publishedId is a misnomer. It was really this line:  `this.draftId = isVersionId(documentId) ? documentId : `drafts.${documentId}`` where it felt incorrect to refer to `publishedId`
3. A further refactor in `Timeline` to use `versionId` to reference a version Id and a canonical draft
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
N/A
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
