### PR TITLE
feat(sanity): preserve current sticky parameters when resolving intent links

### DIFF
--- a/packages/sanity/src/router/IntentLink.test.tsx
+++ b/packages/sanity/src/router/IntentLink.test.tsx
@@ -1,5 +1,6 @@
 import {describe, expect, it} from '@jest/globals'
 import {render} from '@testing-library/react'
+import {noop} from 'lodash'
 
 import {IntentLink} from './IntentLink'
 import {route} from './route'
@@ -28,6 +29,70 @@ describe('IntentLink', () => {
     // Component should render the query param in the href
     expect(component.container.querySelector('a')?.href).toContain(
       '/test/intent/edit/id=document-id-123;type=document-type/?perspective=bundle.summer-drop',
+    )
+  })
+
+  it('should preserve sticky parameters when resolving intent link', () => {
+    const router = route.create('/test', [route.intents('/intent')])
+    const component = render(
+      <IntentLink
+        intent="edit"
+        params={{
+          id: 'document-id-123',
+          type: 'document-type',
+        }}
+      />,
+      {
+        wrapper: ({children}) => (
+          <RouterProvider
+            onNavigate={noop}
+            router={router}
+            state={{
+              _searchParams: [['perspective', 'bundle.summer-drop']],
+            }}
+          >
+            {children}
+          </RouterProvider>
+        ),
+      },
+    )
+    // Component should render the query param in the href
+    expect(component.container.querySelector('a')?.href).toContain(
+      '/test/intent/edit/id=document-id-123;type=document-type/?perspective=bundle.summer-drop',
+    )
+  })
+
+  it('should allow sticky parameters to be overridden when resolving intent link', () => {
+    const router = route.create('/test', [route.intents('/intent')])
+    const component = render(
+      <IntentLink
+        intent="edit"
+        params={{
+          id: 'document-id-123',
+          type: 'document-type',
+        }}
+        searchParams={[['perspective', `bundle.autumn-drop`]]}
+      />,
+      {
+        wrapper: ({children}) => (
+          <RouterProvider
+            onNavigate={noop}
+            router={router}
+            state={{
+              _searchParams: [['perspective', 'bundle.summer-drop']],
+            }}
+          >
+            {children}
+          </RouterProvider>
+        ),
+      },
+    )
+    // Component should render the query param in the href
+    expect(component.container.querySelector('a')?.href).toContain(
+      '/test/intent/edit/id=document-id-123;type=document-type/?perspective=bundle.autumn-drop',
+    )
+    expect(component.container.querySelector('a')?.href).not.toContain(
+      'perspective=bundle.summer-drop',
     )
   })
 })

--- a/packages/sanity/src/router/IntentLink.test.tsx
+++ b/packages/sanity/src/router/IntentLink.test.tsx
@@ -20,7 +20,7 @@ describe('IntentLink', () => {
       />,
       {
         wrapper: ({children}) => (
-          <RouterProvider onNavigate={() => null} router={router} state={{}}>
+          <RouterProvider onNavigate={noop} router={router} state={{}}>
             {children}
           </RouterProvider>
         ),

--- a/packages/sanity/src/router/RouterProvider.tsx
+++ b/packages/sanity/src/router/RouterProvider.tsx
@@ -1,4 +1,4 @@
-import {partition} from 'lodash'
+import {fromPairs, partition, toPairs} from 'lodash'
 import {type ReactElement, type ReactNode, useCallback, useMemo} from 'react'
 import {RouterContext} from 'sanity/_singletons'
 
@@ -88,10 +88,13 @@ export function RouterProvider(props: RouterProviderProps): ReactElement {
         intent: intentName,
         params,
         payload,
-        _searchParams,
+        _searchParams: toPairs({
+          ...fromPairs((state._searchParams ?? []).filter(([key]) => STICKY.includes(key))),
+          ...fromPairs(_searchParams ?? []),
+        }),
       })
     },
-    [routerProp],
+    [routerProp, state._searchParams],
   )
 
   const resolvePathFromState = useCallback(


### PR DESCRIPTION
### Description

This branch introduces preservation of current sticky parameters when resolving intent links. In practice, this means the `perspective` parameter is preserved when resolving an intent.

Search parameters provided when resolving an intent link take precedence over any sticky parameters currently applied, allowing developers to replace sticky parameters when resolving an intent link.

### What to review

Sticky parameters are preserved when resolving intent links. For example; when navigating to a document via a global search result.

### Testing

Added new unit tests in `packages/sanity/src/router/IntentLink.test.tsx`.