### PR TITLE
fix: significantly speed up styled-components in dev mode

### DIFF
--- a/dev/starter-next-studio/next.config.js
+++ b/dev/starter-next-studio/next.config.js
@@ -1,4 +1,8 @@
 module.exports = {
+  env: {
+    // Matches the behavior of `sanity dev` which sets styled-components to use the fastest way of inserting CSS rules in both dev and production. It's default behavior is to disable it in dev mode.
+    SC_DISABLE_SPEEDY: 'false',
+  },
   async redirects() {
     return [
       {

--- a/dev/test-next-studio/next.config.mjs
+++ b/dev/test-next-studio/next.config.mjs
@@ -21,6 +21,8 @@ const config = {
   env: {
     // Support the ability to debug log the studio, for example `DEBUG="sanity:pte:* pnpm dev:next-studio"`
     DEBUG: process.env.DEBUG,
+    // Matches the behavior of `sanity dev` which sets styled-components to use the fastest way of inserting CSS rules in both dev and production. It's default behavior is to disable it in dev mode.
+    SC_DISABLE_SPEEDY: 'false',
   },
   transpilePackages: [
     '@sanity/block-tools',

--- a/packages/sanity/src/_internal/cli/server/getViteConfig.ts
+++ b/packages/sanity/src/_internal/cli/server/getViteConfig.ts
@@ -120,6 +120,16 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
       // eslint-disable-next-line no-process-env
       '__SANITY_STAGING__': process.env.SANITY_INTERNAL_ENV === 'staging',
       'process.env.MODE': JSON.stringify(mode),
+      /**
+       * Yes, double negatives are confusing.
+       * The default value of `SC_DISABLE_SPEEDY` is `process.env.NODE_ENV === 'production'`: https://github.com/styled-components/styled-components/blob/99c02f52d69e8e509c0bf012cadee7f8e819a6dd/packages/styled-components/src/constants.ts#L34
+       * Which means that in production, use the much faster way of inserting CSS rules, based on the CSSStyleSheet API (https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule)
+       * while in dev mode, use the slower way of inserting CSS rules, which appends text nodes to the `<style>` tag: https://github.com/styled-components/styled-components/blob/99c02f52d69e8e509c0bf012cadee7f8e819a6dd/packages/styled-components/src/sheet/Tag.ts#L74-L76
+       * There are historical reasons for this, primarily that browsers initially did not support editing CSS rules in the DevTools inspector if `CSSStyleSheet.insetRule` were used.
+       * However, that's no longer the case (since Chrome 81 back in April 2020: https://developer.chrome.com/docs/css-ui/css-in-js), the latest version of FireFox also supports it,
+       * and there is no longer any reason to use the much slower method in dev mode.
+       */
+      'process.env.SC_DISABLE_SPEEDY': JSON.stringify('false'),
       ...getStudioEnvironmentVariables({prefix: 'process.env.', jsonEncode: true}),
     },
   }


### PR DESCRIPTION
# TL;DR – 1 LOC makes `sanity dev` render **_10 times faster_** 🤯 

### Description

This PR enables `styled-components` "speedy mode" in `sanity dev` by explicitly setting the `‎SC_DISABLE_SPEEDY` flag to `false`. By default, `styled-components` have different modes for inserting CSS rules, choosing which mode to use based on whether `process.env.NODE_ENV` is set to `production` or not. When `NODE_ENV` is `production`, it uses the "speedy mode," which significantly boosts performance. Otherwise, it falls back to a slower mode.

I discovered this performance difference while working on an unrelated benchmark in the [`concurrent-styled-components`](https://github.com/sanity-io/concurrent-styled-components#readme) repository. I noticed that `styled-components` had drastically different performance results depending on whether I ran `next dev` or `next build && next start`. After adding `‎SC_DISABLE_SPEEDY: 'false'` in my [`next.config.ts`](https://github.com/sanity-io/concurrent-styled-components/blob/7a61339c437634184bc1688d30112513c6c2b52d/next.config.ts#L7-L9), the performance in development mode dramatically improved, almost matching production levels (it does match if `reactStrictMode` is `false`).

#### How are CSS rules inserted when `NODE_ENV` is `development`?

`styled-components` is a mature library that has been around for a long time. Initially, CSS-in-JS libraries inserted styles by [adding text nodes to a `<style>` tag](https://github.com/styled-components/styled-components/blob/99c02f52d69e8e509c0bf012cadee7f8e819a6dd/packages/styled-components/src/sheet/Tag.ts#L74-L76):

```js
document
  .querySelector('style[data-styled="active"]')
  .appendChild(
    document.createTextNode(
      'body { transform: scale(0.5) }',
    ),
  )
```

When using this method, you can open the `<style>` tag in DevTools and inspect the text nodes:

![Pasted Graphic](https://github.com/user-attachments/assets/dafa6129-d34e-4ac9-946f-092411f72f05)


To confirm this, run the following snippet to see a bunch of text:

```js
document.querySelector('style[data-styled="active"]')
  .innerText
```

The downside is that every time a text node is added to the `<style>`, the browser has to parse the entire `innerText`. In large applications like Sanity Studio, this can start off at almost half a megabyte, and as more CSS is loaded, it only grows larger, taking even longer to parse.

#### What is "speedy mode"?

"Speedy mode" was introduced in [v3.1.0](https://github.com/styled-components/styled-components/blob/v5.3.11/CHANGELOG.md#v310---2018-01-29). It uses the [CSSOM API `CSSStyleSheet.insertRule` instead of text nodes](https://github.com/styled-components/styled-components/blob/99c02f52d69e8e509c0bf012cadee7f8e819a6dd/packages/styled-components/src/sheet/Tag.ts#L35):

```js
document
  .querySelector('style[data-styled="active"]')
  .sheet.insertRule('body { transform: scale(0.5) }')
```

With "speedy mode" enabled, the `<style>` tag appears empty in DevTools:

![Pasted Graphic 1](https://github.com/user-attachments/assets/824b1180-3125-4415-9fec-6332cbfdee81)


To verify "speedy mode," inspect the `cssRules`:

```js
document.querySelector('style[data-styled="active"]').sheet
  .cssRules
```

However, `cssRules` alone isn't a sufficient indicator of "speedy mode" because it's also available when using text nodes. You need to check that `innerText` is empty while `cssRules` has entries:

```js
const node = document.querySelector(
  'style[data-styled="active"]',
)
const isSpeedySc =
  node.innerText.length === 0 &&
  node.sheet.cssRules.length > 0
```

#### Why isn't "speedy mode" always enabled?

- "Speedy mode" was introduced in v3.1.0 and set to be enabled only when `NODE_ENV` is not `development` because, while browser support for `CSSStyleSheet.insertRule` was good (available since v1 versions of Safari, Chrome, Firefox, and IE v9), it was poorly supported in testing environments like jsdom, such as in Jest. For example, `jest-styled-components` broke in v3.1.0 and was patched in [v3.1.3](https://github.com/styled-components/styled-components/blob/v5.3.11/CHANGELOG.md#v313---2018-01-29).

- Poor DevTools support was another reason it wasn't enabled by default in development. Chrome added support for editing rules in "speedy mode" in [version 81, released in April 2020](https://developer.chrome.com/docs/css-ui/css-in-js), and Firefox also supports it now. With Speedy disabled, developers could edit rules directly from generated CSS-in-JS in DevTools:
  ![editable safari](https://github.com/user-attachments/assets/d9a809a7-f1c5-4580-aaae-586086a38e64)


- Safari, however, still does not allow editing rules with `CSSStyleSheet.insertRule` in DevTools. It only allows inspecting them:
  ![not editable safari](https://github.com/user-attachments/assets/ecb29bb4-f9a5-4af4-af3b-30bbc04296f3)
  Given Safari already lacks a React DevTools extension, the argument against enabling "speedy mode" in development for Safari users becomes weaker. Developers who need to edit styles can use Chrome or Firefox, which they typically already use as their main development browsers.

#### What's the purpose of the `SC_DISABLE_SPEEDY` flag?

In [v4.1.0](https://github.com/styled-components/styled-components/blob/v5.3.11/CHANGELOG.md#v410---2018-11-12), the `SC_DISABLE_SPEEDY` flag was added to disable "speedy mode" in production environments due to issues such as the [Yandex crawler not supporting CSSOM styles](https://github.com/styled-components/styled-components/issues/2038). The idea was that in production, you typically want "speedy mode" enabled for better performance, but in certain edge cases, you can disable it.

Over time, more flags were added to support popular bundler setups, as shown in the [constants file](https://github.com/styled-components/styled-components/blob/99c02f52d69e8e509c0bf012cadee7f8e819a6dd/packages/styled-components/src/constants.ts#L17-L34):

- `process.env.REACT_APP_SC_DISABLE_SPEEDY`
- `process.env.SC_DISABLE_SPEEDY`

It is counterintuitive because while the flag’s name suggests disabling "speedy mode," we use it to force-enable "speedy mode" in development where it is off by default. This double-negative logic can be confusing, but it provides a way to achieve consistent behavior between development and production.

Despite recent improvements in browser DevTools, not all environments support editing dynamically generated and injected CSS rules. Chrome and Firefox have full editing capabilities, while Safari remains read-only for such rules. This limitation is one of the reasons `styled-components` maintainers originally chose to disable "speedy mode" by default in development while enabling it in production, where such editing capabilities are less critical. However, given the current landscape of browser support, enabling "speedy mode" in development aligns with modern expectations and usage.

### What to review

- Run `sanity dev` and verify that "speedy mode" is enabled:

  ```js
  const node = document.querySelector('style[data-styled="active"]')
  console.log(node.innerText.length === 0 && node.sheet.cssRules.length > 0 ? 'Speedy is enabled 🎉' : 'Speedy is disabled 😞')
  ```

- When clicking around in the Studio, cold start performance should be significantly and noticeably improved. Clicking on a tool that lazy-loads, like Vision, should reach first render faster. Opening popovers, dialogs, new screens, and UI should all be faster. Re-render performance on components that respond to input and render changed CSS (e.g., hovering inputs that change border color, hovering a tooltip, typing in an input that changes to invalid status, typing into a search field) should also be much faster.

### Testing

The performance profiling on Vision Tool shows that before applying the `‎SC_DISABLE_SPEEDY` flag, the VisionGui component's render was significantly faster than 30 other components. After applying the flag, VisionGui's render time remained the same (2.9ms), but all other styled components in that render pass became significantly faster, making VisionGui the slowest component. This change results in a substantial performance boost, especially for views with many styled components, as seen in the attached profiles.

- **Before:**  
  ![Pasted Graphic 4](https://github.com/user-attachments/assets/ca76008c-d645-4e32-ac70-fee9bfd39d05)


- **After:**
  ![Pasted Graphic 5](https://github.com/user-attachments/assets/301b0cec-53e0-4b56-b1ae-09eb26ddfd54)


You can load the profiling JSON files into React DevTools using the "Load profile" button for further analysis:
- [vision before.json](https://github.com/user-attachments/files/16802959/vision.before.json)
- [vision after.json](https://github.com/user-attachments/files/16802960/vision.after.json)

They were produced by running `pnpm dev` and clicking "Reload and start profiling" on http://localhost:3333/test/vision

### Notes for release

This change enables `styled-components` "speedy mode" in `sanity dev`, improving developer mode performance. This change impacts only development builds (`sanity dev`), and production builds (`sanity build` or `sanity start`) remain unaffected since "speedy mode" has always been enabled in production.

Developers embedding Sanity Studio in other frameworks like Next.js or Remix need to adjust their own build tooling to declare the `SC_DISABLE_SPEEDY` flag to achieve the same performance benefits. For example, Next.js users can add this snippet to their `next.config.{js,mjs,ts}` file:

```js
export default {
  env: {
    SC_DISABLE_SPEEDY: 'false' // makes styled-components as fast in dev mode as it is in production mode
  }
}
```

For Safari users, while they will still be able to inspect and see CSS rules coming from `styled-components`, these will now be read-only in the DevTools inspector. The performance benefits from enabling "speedy mode" in development mode are significant for Safari users and outweigh the convenience of being able to edit these rules directly in the inspector. With Hot Module Reload, developers can still quickly make changes to their source code, and the new styles will apply immediately.

Enabling "speedy mode" offers a faster development experience across the board. Developers using Safari for testing purposes can still verify the functionality of the studio, and for more detailed CSS editing, they can switch to Chrome, Firefox, or other Chromium-based browsers like Arc or Brave.

It's still possible to restore the old behaviour of disabling speedy in dev mode in userland with a custom `sanity.cli.ts` override:
```ts
import {defineCliConfig} from 'sanity/cli'
import {type UserConfig} from 'vite'

export default defineCliConfig({
  vite(viteConfig: UserConfig): UserConfig {
    return {
      ...viteConfig,
      define: {
        ...viteConfig.define,
        // `sanity dev` enables speedy in both development and production, this line restores the default `styled-components` behaviour of only enabling it in production
        'process.env.SC_DISABLE_SPEEDY': JSON.stringify(process.env.NODE_ENV !== 'production'),
      },
    }
  },
})
```