### PR TITLE
feat(typegen): allow injecting groq parameter type with comments

### DIFF
--- a/packages/@sanity/codegen/src/safeParseQuery.ts
+++ b/packages/@sanity/codegen/src/safeParseQuery.ts
@@ -1,16 +1,28 @@
 import {parse} from 'groq-js'
 
+import {type QueryParameter} from './typescript/expressionResolvers'
+
 /**
  * safeParseQuery parses a GROQ query string, but first attempts to extract any parameters used in slices. This method is _only_
  * intended for use in type generation where we don't actually execute the parsed AST on a dataset, and should not be used elsewhere.
  * @internal
  */
-export function safeParseQuery(query: string) {
+export function safeParseQuery(
+  query: string,
+  parameters: QueryParameter[] = [],
+): ReturnType<typeof parse> {
   const params: Record<string, unknown> = {}
 
   for (const param of extractSliceParams(query)) {
     params[param] = 0 // we don't care about the value, just the type
   }
+  for (const param of parameters) {
+    if (param.typeNode.type === 'unknown') {
+      continue
+    }
+    params[param.name] = param.typeNode.value
+  }
+
   return parse(query, {params})
 }
 

--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -116,6 +116,35 @@ describe('findQueries with the groq template', () => {
     expect(queries[0].result).toBe('*[_type == "foo bar"]')
   })
 
+  test('can infer parameters from comment', () => {
+    const source = `
+      import { groq } from "groq";
+
+      // @groq-parameter {string} $type - The type of the document
+      // @groq-parameter {string} $language - The wanted language
+      // @groq-parameter {string} $missing
+      const postQuery = groq\`*[_type == "foo"]{ "lang": languages[$language] } \`
+    `
+
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(1)
+    expect(queries[0].parameters.type).toStrictEqual({
+      name: 'type',
+      typeNode: {type: 'string', value: ''},
+      description: 'The type of the document',
+    })
+    expect(queries[0].parameters.language).toStrictEqual({
+      name: 'language',
+      typeNode: {type: 'string', value: ''},
+      description: 'The wanted language',
+    })
+    expect(queries[0].parameters.missing).toStrictEqual({
+      name: 'missing',
+      typeNode: {type: 'string', value: ''},
+      description: undefined,
+    })
+  })
+
   test('will ignore declarations with ignore tag', () => {
     const source = `
       import { groq } from "groq";

--- a/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
+++ b/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
@@ -5,12 +5,19 @@ import {type TransformOptions} from '@babel/core'
 import traverse, {type Scope} from '@babel/traverse'
 import * as babelTypes from '@babel/types'
 import createDebug from 'debug'
+import {type PrimitiveTypeNode, type UnknownTypeNode} from 'groq-js'
 
 import {parseSourceFile} from './parseSource'
 
 const debug = createDebug('sanity:codegen:findQueries:debug')
 
 type resolveExpressionReturnType = string
+
+export type QueryParameter = {
+  name: string
+  description?: string
+  typeNode: PrimitiveTypeNode | UnknownTypeNode
+}
 
 /**
  * NamedQueryResult is a result of a named query
@@ -20,6 +27,8 @@ export interface NamedQueryResult {
   name: string
   /** result is a groq query */
   result: resolveExpressionReturnType
+  /** list of parameter to infer types or values */
+  parameters: Record<string, QueryParameter>
 
   /** location is the location of the query in the source */
   location: {


### PR DESCRIPTION
### Description

[Filter, ElementAccess and AttributeAccess are syntactically ambiguous, and the following algorithm is used to disambiguate between them.](https://spec.groq.dev/draft/#sec-Disambiguating-square-bracket-traversal) 

This is a work in progress PR to allow users to inject their parameter types so that we can parse queries that contains `languages[$lang]`

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
