### PR TITLE
test(sanity): skip toolbar test

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Toolbar.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Toolbar.spec.tsx
@@ -105,7 +105,8 @@ test.describe('Portable Text Input', () => {
       })
     })
 
-    test.describe('Opening block style', () => {
+    // TODO - needs rewrite to avoid flakiness
+    test.skip('Opening block style', () => {
       test('on a simple editor', async ({mount, page}) => {
         const {getFocusedPortableTextInput} = testHelpers({page})
         await mount(<ToolbarStory />)


### PR DESCRIPTION
### Description

Skip toolbar test (spoken on slack) to prepare for eventual rewrite (linear story has been created)

### Notes for release

N/A