### PR TITLE
feat(cli): add `--max-fetch-concurrency` to prevent stalled validators

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/validation/validateAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/validateAction.ts
@@ -18,6 +18,7 @@ interface ValidateFlags {
   'file'?: string
   'level'?: 'error' | 'warning' | 'info'
   'max-custom-validation-concurrency'?: number
+  'max-fetch-concurrency'?: number
   'yes'?: boolean
   'y'?: boolean
 }
@@ -103,6 +104,15 @@ export default async function validateAction(
     throw new Error(`'--max-custom-validation-concurrency' must be an integer.`)
   }
 
+  const maxFetchConcurrency = flags['max-fetch-concurrency']
+  if (
+    maxFetchConcurrency &&
+    typeof maxFetchConcurrency !== 'number' &&
+    !Number.isInteger(maxFetchConcurrency)
+  ) {
+    throw new Error(`'--max-fetch-concurrency' must be an integer.`)
+  }
+
   const clientConfig: Partial<ClientConfig> = {
     ...apiClient({
       requireUser: true,
@@ -140,6 +150,7 @@ export default async function validateAction(
     workDir,
     level,
     maxCustomValidationConcurrency,
+    maxFetchConcurrency,
     ndjsonFilePath,
     reporter: (worker) => {
       const reporter =

--- a/packages/sanity/src/_internal/cli/actions/validation/validateDocuments.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/validateDocuments.ts
@@ -11,8 +11,6 @@ import {
 } from '../../threads/validateDocuments'
 import {createReceiver, type WorkerChannelReceiver} from '../../util/workerChannels'
 
-const DEFAULT_MAX_CUSTOM_VALIDATION_CONCURRENCY = 5
-
 export interface ValidateDocumentsOptions<TReturn = unknown> {
   level?: 'error' | 'warning' | 'info'
   workspace?: string
@@ -23,6 +21,7 @@ export interface ValidateDocumentsOptions<TReturn = unknown> {
   dataset?: string // override
   ndjsonFilePath?: string
   maxCustomValidationConcurrency?: number
+  maxFetchConcurrency?: number
   reporter?: (worker: WorkerChannelReceiver<ValidationWorkerChannel>) => TReturn
 }
 
@@ -72,6 +71,7 @@ export function validateDocuments(options: ValidateDocumentsOptions): unknown {
     reporter = defaultReporter,
     level,
     maxCustomValidationConcurrency,
+    maxFetchConcurrency,
     ndjsonFilePath,
   } = options
 
@@ -100,8 +100,8 @@ export function validateDocuments(options: ValidateDocumentsOptions): unknown {
       projectId,
       level,
       ndjsonFilePath,
-      maxCustomValidationConcurrency:
-        maxCustomValidationConcurrency ?? DEFAULT_MAX_CUSTOM_VALIDATION_CONCURRENCY,
+      maxCustomValidationConcurrency,
+      maxFetchConcurrency,
     } satisfies ValidateDocumentsWorkerData,
     // eslint-disable-next-line no-process-env
     env: process.env,

--- a/packages/sanity/src/_internal/cli/commands/documents/validateDocumentsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/documents/validateDocumentsCommand.ts
@@ -11,6 +11,7 @@ Options
   --format <pretty|ndjson|json> The output format used to print the found validation markers and report progress.
   --level <error|warning|info> The minimum level reported out. Defaults to warning.
   --max-custom-validation-concurrency <number> Specify how many custom validators can run concurrently. Defaults to 5.
+  --max-fetch-concurrency <number> Specify how many \`client.fetch\` requests are allow concurrency at once. Defaults to 25.
 
 Examples
   # Validates all documents in a Sanity project with more than one workspace
@@ -20,7 +21,7 @@ Examples
   sanity documents validate --workspace default --dataset staging
 
   # Save the results of the report into a file
-  sanity documents validate > report.txt
+  sanity documents validate --yes > report.txt
 
   # Report out info level validation markers too
   sanity documents validate --level info

--- a/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
+++ b/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
@@ -43,6 +43,7 @@ export interface ValidateDocumentsWorkerData {
   ndjsonFilePath?: string
   level?: ValidationMarker['level']
   maxCustomValidationConcurrency?: number
+  maxFetchConcurrency?: number
 }
 
 /** @internal */
@@ -79,6 +80,7 @@ const {
   projectId,
   level,
   maxCustomValidationConcurrency,
+  maxFetchConcurrency,
 } = _workerData as ValidateDocumentsWorkerData
 
 if (isMainThread || !parentPort) {
@@ -359,6 +361,7 @@ async function validateDocuments() {
             getDocumentExists,
             environment: 'cli',
             maxCustomValidationConcurrency,
+            maxFetchConcurrency,
           }),
           new Promise<typeof timeout>((resolve) =>
             setTimeout(() => resolve(timeout), DOCUMENT_VALIDATION_TIMEOUT),


### PR DESCRIPTION

### Description

This PR addresses an issue where the `sanity documents validate` CLI command times out for complex validation rules. The problem occurs when a set of documents with custom validators requires more concurrent `client.fetch` requests than the current hard-coded limit allows, potentially causing the validation process to block indefinitely.

Changes introduced:
1. Increased the default maximum fetch concurrency from 10 to 25.
2. Made the maximum fetch concurrency configurable via a new CLI flag `--max-fetch-concurrency`.
3. Made the default maximum custom validation concurrency explicit and configurable.

These changes aim to prevent situations where the validation process exhausts the available concurrent requests, leading to timeouts.

Related issue: SDX-1617

### What to review

1. Review the changes in `validateAction.ts`, `validateDocuments.ts`, and `validateDocument.ts` to ensure the new `maxFetchConcurrency` option is correctly implemented and passed through the validation process.
2. Check the updated `validateDocumentsCommand.ts` to confirm the new `--max-fetch-concurrency` CLI flag is properly documented.
3. Verify that the default values for both `maxCustomValidationConcurrency` and `maxFetchConcurrency` are set correctly (5 and 25, respectively).
4. Ensure that the concurrency limiter is created with the new configurable maximum fetch concurrency.

### Testing

To test these changes:
1. Run the `sanity documents validate` command on a dataset with complex validation rules that previously timed out.
2. Try different values for `--max-fetch-concurrency` to ensure it affects the validation process as expected.
3. Verify that setting a lower `--max-custom-validation-concurrency` value doesn't cause timeouts when combined with the increased fetch concurrency.

I manually tested these changes by running a reproduction locally using the dataset and repo provided by Ken Jones (see slack thread attached to the ticket). With the increased fetch concurrency limit of 25, the validation process completed successfully without timeouts, confirming that the changes resolve the issue in this specific case.

Additional automated tests should be added to verify the behavior of the new concurrency settings.

### Notes for release

This update addresses an issue where the `sanity documents validate` CLI command could time out when validating documents with complex custom validation rules. The changes include:

1. Increased default maximum fetch concurrency from 10 to 25, which should resolve most timeout issues.
2. Added a new CLI flag `--max-fetch-concurrency` to allow users to adjust the maximum number of concurrent `client.fetch` requests during validation.
3. Made the default maximum custom validation concurrency explicit and configurable.

Usage:
```
sanity documents validate --max-fetch-concurrency <number>
```

These changes should improve the performance and reliability of document validation for projects with complex custom validation rules. Users experiencing timeouts during validation should try increasing the `--max-fetch-concurrency` value if issues persist with the new default.