### PR TITLE
(feat) Listen for authorization expiry message

### DIFF
--- a/packages/sanity/src/core/store/_legacy/presence/message-transports/transport.ts
+++ b/packages/sanity/src/core/store/_legacy/presence/message-transports/transport.ts
@@ -48,5 +48,6 @@ export type TransportEvent = StateEvent | RollCallEvent | DisconnectEvent
 // This is the interface a transport must implement
 export type Transport = [
   Observable<TransportEvent>,
+  Observable<TransportEvent>,
   (message: TransportMessage) => Observable<void>,
 ]

--- a/packages/sanity/src/core/store/_legacy/presence/presence-store.ts
+++ b/packages/sanity/src/core/store/_legacy/presence/presence-store.ts
@@ -121,7 +121,10 @@ export function __tmp_wrap_presenceStore(context: {
 }): PresenceStore {
   const {bifur, connectionStatusStore, userStore} = context
 
-  const [presenceEvents$, sendMessage] = createBifurTransport(bifur, SESSION_ID)
+  const [presenceEvents$, authorizationEvents$, sendMessage] = createBifurTransport(
+    bifur,
+    SESSION_ID,
+  )
 
   const currentLocation$ = new BehaviorSubject<PresenceLocation[]>([])
   const locationChange$ = currentLocation$.pipe(distinctUntilChanged())
@@ -142,6 +145,12 @@ export function __tmp_wrap_presenceStore(context: {
     // do not respond to my own rollcall requests
     filter((event: RollCallEvent) => event.sessionId !== SESSION_ID),
   )
+
+  // const authExpireNotifications$ = authorizationEvents$.pipe(
+  //   filter((event: TransportEvent): event is RollCallEvent => event === 'rollCall'),
+  //   // do not respond to my own rollcall requests
+  //   filter((event: RollCallEvent) => event.sessionId !== SESSION_ID),
+  // )
 
   const REPORT_MIN_INTERVAL = 30000
 


### PR DESCRIPTION
### Description
Add a listener for the new authorization subscription message https://github.com/sanity-io/bifur-client/pull/8

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
