### PR TITLE
feat(sanity): add telemetry when creating a draft

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -48,7 +48,7 @@ import {usePaneRouter} from '../../components'
 import {structureLocaleNamespace} from '../../i18n'
 import {type PaneMenuItem} from '../../types'
 import {useStructureTool} from '../../useStructureTool'
-import {DocumentURLCopied} from './__telemetry__'
+import {CreatedDraft, DocumentURLCopied} from './__telemetry__'
 import {
   DEFAULT_MENU_ITEM_GROUPS,
   EMPTY_PARAMS,
@@ -294,6 +294,10 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   })
 
   patchRef.current = (event: PatchEvent) => {
+    // when creating a new draft
+    if (!editState.draft && !editState.published) {
+      telemetry.log(CreatedDraft)
+    }
     patch.execute(toMutationPatches(event.patches), initialValue.value)
   }
 

--- a/packages/sanity/src/structure/panes/document/__telemetry__/documentPanes.telemetry.ts
+++ b/packages/sanity/src/structure/panes/document/__telemetry__/documentPanes.telemetry.ts
@@ -8,3 +8,13 @@ export const DocumentURLCopied = defineEvent({
   version: 1,
   description: 'User copied document URL to clipboard',
 })
+
+/**
+ * When a draft is successfully created
+ * @internal
+ */
+export const CreatedDraft = defineEvent({
+  name: 'Create a new draft',
+  version: 1,
+  description: 'User created a new draft',
+})


### PR DESCRIPTION
### Description

Add telemetry for when creating a new draft

### What to review

Should the condition be different, is there a better way of checking that? Did I place it in the right place? Should I reword the comment? 

### Testing

No behaviour was changed apart from adding telemetry

### Notes for release

Add telemetry when creating a draft