### PR TITLE
fix(core): update useReleaseHistory to fetch with the version documents

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
@@ -45,7 +45,7 @@ export const ReleaseDetail = () => {
   const {loading: documentsLoading, results} = useBundleDocuments(parsedBundleId)
 
   const documentIds = results.map((result) => result.document?._id)
-  const history = useReleaseHistory(documentIds)
+  const history = useReleaseHistory(documentIds, parsedBundleId)
 
   const bundle = data?.find((storeBundle) => storeBundle._id === parsedBundleId)
   const bundleHasDocuments = !!results.length

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/useReleaseHistory.ts
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/useReleaseHistory.ts
@@ -24,13 +24,13 @@ export function useReleaseHistory(
   const {dataset, token} = client.config()
   const [history, setHistory] = useState<TransactionLogEventWithEffects[]>([])
   const queryParams = `tag=sanity.studio.tasks.history&effectFormat=mendoza&excludeContent=true&includeIdentifiedDocumentsOnly=true`
-  const publishedIds = bundleDocumentsIds.map((id) => getVersionId(id, releaseId)).join(',')
+  const versionIds = bundleDocumentsIds.map((id) => getVersionId(id, releaseId)).join(',')
   const transactionsUrl = client.getUrl(
-    `/data/history/${dataset}/transactions/${publishedIds}?${queryParams}`,
+    `/data/history/${dataset}/transactions/${versionIds}?${queryParams}`,
   )
 
   const fetchAndParseAll = useCallback(async () => {
-    if (!publishedIds) return
+    if (!versionIds) return
     if (!releaseId) return
     const transactions: TransactionLogEventWithEffects[] = []
     const stream = await getJsonStream(transactionsUrl, token)
@@ -47,7 +47,7 @@ export function useReleaseHistory(
       transactions.push(result.value)
     }
     setHistory(transactions)
-  }, [publishedIds, transactionsUrl, token, releaseId])
+  }, [versionIds, transactionsUrl, token, releaseId])
 
   useEffect(() => {
     fetchAndParseAll()


### PR DESCRIPTION
### Description

The `useReleaseHistory` hook was incorrectly constructing the ID of the documents it needs to fetch and construct the history.

<img width="600" alt="Screenshot 2024-09-04 at 09 54 27" src="https://github.com/user-attachments/assets/1de8826a-1e74-4a15-8787-9889f80a9d80">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
