### PR TITLE
fix: add padding above the "Push to reload" button instead of below

### DIFF
--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -32,7 +32,7 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
       id: 'new-package-available',
       title: t('package-version.new-package-available.title'),
       description: (
-        <Stack space={2} paddingBottom={2}>
+        <Stack space={2} paddingTop={2}>
           <Box>
             <Button
               size="large"

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -1,4 +1,4 @@
-import {Box, Stack, useToast} from '@sanity/ui'
+import {Box, useToast} from '@sanity/ui'
 import {type ReactNode, useCallback, useEffect, useRef} from 'react'
 import {SANITY_VERSION} from 'sanity'
 import semver from 'semver'
@@ -10,7 +10,7 @@ import {checkForLatestVersions} from './checkForLatestVersions'
 
 // How often to to check last timestamp. at 30 min, should fetch new version
 const REFRESH_INTERVAL = 1000 * 30 // every 30 seconds
-const SHOW_TOAST_FREQUENCY = 1000 * 60 * 30 //half hour
+const SHOW_TOAST_FREQUENCY = 1000 * 60 * 30 // half hour
 
 const currentPackageVersions: Record<string, string> = {
   sanity: SANITY_VERSION,
@@ -32,17 +32,15 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
       id: 'new-package-available',
       title: t('package-version.new-package-available.title'),
       description: (
-        <Stack space={2} paddingTop={2}>
-          <Box>
-            <Button
-              size="large"
-              aria-label={t('package-version.new-package-available.reload-button')}
-              onClick={onClick}
-              text={t('package-version.new-package-available.reload-button')}
-              tone={'primary'}
-            />
-          </Box>
-        </Stack>
+        <Box paddingTop={2}>
+          <Button
+            size="large"
+            aria-label={t('package-version.new-package-available.reload-button')}
+            onClick={onClick}
+            text={t('package-version.new-package-available.reload-button')}
+            tone={'primary'}
+          />
+        </Box>
       ),
       closable: true,
       status: 'info',


### PR DESCRIPTION
### Description

Fixes this padding issue by moving it above the button instead of below. This screenshot shows the current state:

![Screenshot 2024-09-04 at 09 59 21](https://github.com/user-attachments/assets/6f34de4f-e63a-46b4-8fde-e5c4acb8bd65)

### Notes for release

Adjusts vertical padding around "Push to reload" button