### PR TITLE
Next.js specific defaults for new projects

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -240,7 +240,11 @@ export default async function initSanity(
     throw new Error('`--reconfigure` is deprecated - manual configuration is now required')
   }
 
-  const envFilename = typeof env === 'string' ? env : '.env'
+  let envFilenameDefault = '.env'
+  if (detectedFramework && detectedFramework.slug === 'nextjs') {
+    envFilenameDefault = '.env.local'
+  }
+  const envFilename = typeof env === 'string' ? env : envFilenameDefault
   if (!envFilename.startsWith('.env')) {
     throw new Error(`Env filename must start with .env`)
   }
@@ -433,10 +437,39 @@ export default async function initSanity(
     const appendEnv = unattended ? true : await promptForAppendEnv(prompt, envFilename)
 
     if (appendEnv) {
-      await createOrAppendEnvVars(envFilename, detectedFramework, {
-        log: true,
-      })
+      await createOrAppendEnvVars(envFilename, detectedFramework, {log: true})
     }
+
+    if (embeddedStudio) {
+      const nextjsLocalDevOrigin = 'http://localhost:3000'
+      const existingCorsOrigins = await apiClient({api: {projectId}}).request({
+        method: 'GET',
+        uri: '/cors',
+      })
+      const hasExistingCorsOrigin = existingCorsOrigins.some(
+        (item: {origin: string}) => item.origin === nextjsLocalDevOrigin,
+      )
+      if (!hasExistingCorsOrigin) {
+        await apiClient({api: {projectId}})
+          .request({
+            method: 'POST',
+            url: '/cors',
+            body: {origin: nextjsLocalDevOrigin, allowCredentials: true},
+            maxRedirects: 0,
+          })
+          .then((res) => {
+            print(
+              res.id
+                ? `Added ${nextjsLocalDevOrigin} to CORS origins`
+                : `Failed to add ${nextjsLocalDevOrigin} to CORS origins`,
+            )
+          })
+          .catch((error) => {
+            print(`Failed to add ${nextjsLocalDevOrigin} to CORS origins`, error)
+          })
+      }
+    }
+
     const {chosen} = await getPackageManagerChoice(workDir, {interactive: false})
     trace.log({step: 'selectPackageManager', selectedOption: chosen})
     const packages = ['@sanity/vision@3', 'sanity@3', '@sanity/image-url@1', 'styled-components@6']


### PR DESCRIPTION
### Description

When running `sanity init` inside a Next.js project, this will:

* Default the name of the `.env` file (if created) to `.env.local` as this is what Next.js `.gitignore` targets
* Create a new CORS origin for Next.js default `http://localhost:3000` so that the user isn't prompted to do so the first time they open the Studio

### What to review

I would've thought there'd be somewhere else in the codebase where this check-first-then-add-CORS logic would already exist, but couldn't find it, so recreated it.

### Testing

Create a new Next.js project
```
npx create-next-app@latest --tailwind --ts --app --src-dir --eslint --import-alias "@/*"
```

Within it, run the below (but obviously targeting your local build)
```
npx sanity init
```

### Notes for release

* When `sanity init` is run inside a Next.js project, an appropriate CORS origin is added to the project
* When `sanity init` is run inside a Next.js project, environment variables are written to an `.env.local` file