### PR TITLE
feat(sanity): update document footer for versions

### DIFF
--- a/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
+++ b/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
@@ -104,6 +104,7 @@ export function BundleActions(props: BundleActionsProps): ReactNode {
   const handleDiscardVersion = useCallback(async () => {
     setIsDiscarding(true)
     try {
+      // TODO: should we use the document operations for this?
       await client.delete(documentId)
 
       toast.push({

--- a/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
+++ b/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
@@ -133,17 +133,24 @@ export function BundleActions(props: BundleActionsProps): ReactNode {
 
   if (archivedAt) return null
 
+  const bundleActionButtonProps = isInVersion
+    ? {
+        text: t('bundle.action.discard-version', {title}),
+        icon: TrashIcon,
+        tone: 'caution' as const,
+        onClick: handleDiscardVersion,
+      }
+    : {
+        text: t('bundle.action.add-to-release', {title}),
+        icon: AddIcon,
+        tone: 'primary' as const,
+        onClick: handleAddVersion,
+      }
+
   return (
     <Button
+      {...bundleActionButtonProps}
       data-testid={`action-add-to-${globalBundleId}`}
-      text={
-        isInVersion
-          ? t('bundle.action.discard-version', {title})
-          : t('bundle.action.add-to-release', {title})
-      }
-      icon={isInVersion ? TrashIcon : AddIcon}
-      tone={isInVersion ? 'caution' : 'primary'}
-      onClick={isInVersion ? handleDiscardVersion : handleAddVersion}
       loading={creatingVersion || isDiscarding}
     />
   )

--- a/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
@@ -1,9 +1,12 @@
 import {type PreviewValue, type SanityDocument} from '@sanity/types'
 import {Flex, Text} from '@sanity/ui'
+import {useMemo} from 'react'
 import {styled} from 'styled-components'
 
 import {useDateTimeFormat, useRelativeTime} from '../../hooks'
 import {useTranslation} from '../../i18n'
+import {type BundleDocument} from '../../store/bundles'
+import {PerspectiveBadge} from '../perspective/PerspectiveBadge'
 
 interface DocumentStatusProps {
   absoluteDate?: boolean
@@ -11,6 +14,7 @@ interface DocumentStatusProps {
   published?: PreviewValue | Partial<SanityDocument> | null
   version?: PreviewValue | Partial<SanityDocument> | null
   singleLine?: boolean
+  currentGlobalBundle?: Partial<BundleDocument>
 }
 
 const StyledText = styled(Text)`
@@ -33,6 +37,7 @@ export function DocumentStatus({
   published,
   version,
   singleLine,
+  currentGlobalBundle,
 }: DocumentStatusProps) {
   const {t} = useTranslation()
   const draftUpdatedAt = draft && '_updatedAt' in draft ? draft._updatedAt : ''
@@ -67,6 +72,18 @@ export function DocumentStatus({
     ? versionDateAbsolute || draftDateAbsolute
     : versionUpdatedTimeAgo || draftUpdatedTimeAgo
 
+  const {title} = currentGlobalBundle || {}
+
+  const documentStatus = useMemo(() => {
+    if (published && '_id' in published) {
+      return 'published'
+    } else if (version && '_id' in version) {
+      return 'version'
+    }
+
+    return 'draft'
+  }, [published, version])
+
   return (
     <Flex
       align={singleLine ? 'center' : 'flex-start'}
@@ -75,6 +92,10 @@ export function DocumentStatus({
       gap={2}
       wrap="nowrap"
     >
+      {version && currentGlobalBundle && (
+        <PerspectiveBadge releaseTitle={title} documentStatus={documentStatus} />
+      )}
+
       {!version && !publishedDate && (
         <StyledText size={1} weight="medium">
           {t('document-status.not-published')}

--- a/packages/sanity/src/core/components/perspective/PerspectiveBadge.tsx
+++ b/packages/sanity/src/core/components/perspective/PerspectiveBadge.tsx
@@ -1,0 +1,40 @@
+import {Box, Text} from '@sanity/ui'
+import {type CSSProperties, useMemo} from 'react'
+
+export function PerspectiveBadge(props: {
+  releaseTitle?: string
+  // TODO: prep work for potentially reusing this on document headers
+  documentStatus: 'draft' | 'published' | 'version'
+}): JSX.Element | null {
+  const {releaseTitle = 'draft', documentStatus} = props
+  const isPublished = documentStatus === 'published'
+  const isDraft = documentStatus === 'draft'
+
+  const displayTitle = useMemo(() => {
+    if (isPublished) {
+      return 'published'
+    }
+
+    if (isDraft) {
+      return 'edited'
+    }
+
+    return releaseTitle
+  }, [isDraft, isPublished, releaseTitle])
+
+  return (
+    <Box
+      padding={1}
+      style={
+        {
+          color: `var(--card-badge-caution-fg-color)`,
+          backgroundColor: `var(--card-badge-caution-bg-color)`,
+          borderRadius: 3,
+          textDecoration: 'none',
+        } as CSSProperties
+      }
+    >
+      <Text size={1}>{displayTitle}</Text>
+    </Box>
+  )
+}

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -120,10 +120,16 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
     "The '<strong>{{title}}</strong>' release has been deleted.",
   /** Action message to add document to release */
   'bundle.action.add-to-release': 'Add to {{title}}',
-  /** Action message for when document is already in release  */
-  'bundle.action.already-in-release': 'Already in release {{title}}',
   /** Action message for creating releases */
   'bundle.action.create': 'Create release',
+  /** Action message for when document is already in release  */
+  'bundle.action.discard-version': 'Discard version',
+  /** Description for toast when version discarding failed */
+  'bundle.action.discard-version.failure': 'Failed to discard version',
+  /** Description for toast when version deletion is successfully discarded */
+  'bundle.action.discard-version.success':
+    '<strong>{{title}}</strong> version was successfully discarded',
+
   /** Label for tooltip on deleted release */
   'bundle.deleted-tooltip': 'This release has been deleted',
   /** Title for creating releases dialog */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -376,7 +376,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Label to show in the document footer indicating the published date of the document */
   'document-status.published': 'Published {{date}}',
   /** Label to show in the document footer indicating the revision from date of the document */
-  'document-status.revision-from': 'Revision from {{date}}',
+  'document-status.revision-from': 'Revision from <em>{{date}}</em>',
 
   /** The value of the <code>_key</code> property must be a unique string. */
   'form.error.duplicate-keys-alert.details.additional-description':

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -375,6 +375,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'document-status.not-published': 'Not published',
   /** Label to show in the document footer indicating the published date of the document */
   'document-status.published': 'Published {{date}}',
+  /** Label to show in the document footer indicating the revision from date of the document */
+  'document-status.revision-from': 'Revision from {{date}}',
 
   /** The value of the <code>_key</code> property must be a unique string. */
   'form.error.duplicate-keys-alert.details.additional-description':

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -14,12 +14,6 @@ const releasesLocaleStrings = {
   'action.delete.failure': 'Failed to delete release',
   /** Description for toast when release is successfully deleted */
   'action.delete.success': '<strong>{{title}}</strong> release was successfully deleted',
-  /** Action text for discarding a document version */
-  'action.discard-version': 'Discard version',
-  /** Description for toast when version discarding failed */
-  'action.discard-version.failure': 'Failed to discard version',
-  /** Description for toast when version deletion is successfully discarded */
-  'action.discard-version.success': '<strong>{{title}}</strong> version was successfully discarded',
   /** Action text for editing a release */
   'action.edit': 'Edit',
   /** Action text for opening a release */

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -7,6 +7,7 @@ import {Dialog, MenuButton, MenuItem} from '../../../../../ui-components'
 import {ContextMenuButton} from '../../../../components/contextMenuButton'
 import {useClient} from '../../../../hooks/useClient'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../../studioClient'
+import {releasesLocaleNamespace} from '../../../i18n'
 import {type BundleDocumentRow} from '../ReleaseSummary'
 
 export const DocumentActions = memo(
@@ -21,7 +22,8 @@ export const DocumentActions = memo(
     const [discardStatus, setDiscardStatus] = useState<'idle' | 'discarding' | 'error'>('idle')
     const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
     const toast = useToast()
-    const {t} = useTranslation()
+    const {t: coreT} = useTranslation()
+    const {t} = useTranslation(releasesLocaleNamespace)
 
     const handleDiscardVersion = async () => {
       try {
@@ -35,7 +37,7 @@ export const DocumentActions = memo(
           status: 'success',
           description: (
             <Translate
-              t={t}
+              t={coreT}
               i18nKey={'bundle.action.discard-version.success'}
               values={{title: document.document.title as string}}
             />
@@ -47,7 +49,7 @@ export const DocumentActions = memo(
         toast.push({
           closable: true,
           status: 'error',
-          title: t('bundle.action.discard-version.failure'),
+          title: coreT('bundle.action.discard-version.failure'),
         })
       } finally {
         setShowDiscardDialog(false)
@@ -63,7 +65,7 @@ export const DocumentActions = memo(
             menu={
               <Menu>
                 <MenuItem
-                  text={t('bundle.action.discard-version')}
+                  text={coreT('bundle.action.discard-version')}
                   icon={CloseIcon}
                   onClick={() => setShowDiscardDialog(true)}
                 />

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -26,6 +26,8 @@ export const DocumentActions = memo(
     const handleDiscardVersion = async () => {
       try {
         setDiscardStatus('discarding')
+
+        // TODO: should we use the document operations for this?
         await client.delete(document.document._id)
 
         toast.push({

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -7,7 +7,6 @@ import {Dialog, MenuButton, MenuItem} from '../../../../../ui-components'
 import {ContextMenuButton} from '../../../../components/contextMenuButton'
 import {useClient} from '../../../../hooks/useClient'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../../studioClient'
-import {releasesLocaleNamespace} from '../../../i18n'
 import {type BundleDocumentRow} from '../ReleaseSummary'
 
 export const DocumentActions = memo(
@@ -22,7 +21,7 @@ export const DocumentActions = memo(
     const [discardStatus, setDiscardStatus] = useState<'idle' | 'discarding' | 'error'>('idle')
     const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
     const toast = useToast()
-    const {t} = useTranslation(releasesLocaleNamespace)
+    const {t} = useTranslation()
 
     const handleDiscardVersion = async () => {
       try {
@@ -35,7 +34,7 @@ export const DocumentActions = memo(
           description: (
             <Translate
               t={t}
-              i18nKey={'action.discard-version.success'}
+              i18nKey={'bundle.action.discard-version.success'}
               values={{title: document.document.title as string}}
             />
           ),
@@ -46,7 +45,7 @@ export const DocumentActions = memo(
         toast.push({
           closable: true,
           status: 'error',
-          title: t('action.discard-version.failure'),
+          title: t('bundle.action.discard-version.failure'),
         })
       } finally {
         setShowDiscardDialog(false)
@@ -62,7 +61,7 @@ export const DocumentActions = memo(
             menu={
               <Menu>
                 <MenuItem
-                  text={t('action.discard-version')}
+                  text={t('bundle.action.discard-version')}
                   icon={CloseIcon}
                   onClick={() => setShowDiscardDialog(true)}
                 />

--- a/packages/sanity/src/structure/documentActions/HistoryRestoreAction.tsx
+++ b/packages/sanity/src/structure/documentActions/HistoryRestoreAction.tsx
@@ -1,4 +1,4 @@
-import {RestoreIcon} from '@sanity/icons'
+import {RevertIcon} from '@sanity/icons'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {
   type DocumentActionComponent,
@@ -72,14 +72,14 @@ export const HistoryRestoreAction: DocumentActionComponent = ({
 
     return {
       label: t('action.restore.label'),
-      color: 'primary',
+      tone: 'caution',
       onHandle: handle,
       title: t(
         isRevisionInitial
           ? 'action.restore.disabled.cannot-restore-initial'
           : 'action.restore.tooltip',
       ),
-      icon: RestoreIcon,
+      icon: RevertIcon,
       dialog,
       disabled: isRevisionInitial,
     }

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -77,7 +77,7 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** Label for the "Restore" document action */
   'action.restore.label': 'Revert to revision',
   /** Default tooltip for the action */
-  'action.restore.tooltip': 'Restore to this version',
+  'action.restore.tooltip': 'Restore to this revision',
 
   /** Tooltip when action is disabled because the document is not already published */
   'action.unpublish.disabled.not-published': 'This document is not published',

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -75,7 +75,7 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'action.restore.disabled.cannot-restore-initial': "You can't restore to the initial version",
 
   /** Label for the "Restore" document action */
-  'action.restore.label': 'Restore',
+  'action.restore.label': 'Revert to revision',
   /** Default tooltip for the action */
   'action.restore.tooltip': 'Restore to this version',
 

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
@@ -7,6 +7,7 @@ import {useDocumentPane} from '../useDocumentPane'
 import {DocumentBadges} from './DocumentBadges'
 import {DocumentStatusBarActions, HistoryStatusBarActions} from './DocumentStatusBarActions'
 import {DocumentStatusLine} from './DocumentStatusLine'
+import {RevisionStatusLine} from './RevisionStatusLine'
 import {useResizeObserver} from './useResizeObserver'
 
 export interface DocumentStatusBarProps {
@@ -47,7 +48,11 @@ export function DocumentStatusBar(props: DocumentStatusBarProps) {
           >
             <Flex align="center" flex={1} gap={collapsed ? 2 : 3} wrap="wrap" paddingRight={3}>
               <Flex align="center">
-                <DocumentStatusLine singleLine={!collapsed} />
+                {showingRevision ? (
+                  <RevisionStatusLine />
+                ) : (
+                  <DocumentStatusLine singleLine={!collapsed} />
+                )}
                 <SpacerButton size="large" />
               </Flex>
               <DocumentBadges />

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
@@ -1,4 +1,4 @@
-import {Flex} from '@sanity/ui'
+import {Card, Flex} from '@sanity/ui'
 import {type Ref, useCallback, useState} from 'react'
 import {useTimelineSelector} from 'sanity'
 
@@ -34,35 +34,37 @@ export function DocumentStatusBar(props: DocumentStatusBarProps) {
   const shouldRender = editState?.ready && typeof collapsed === 'boolean'
 
   return (
-    <Flex direction="column" ref={setRootElement} sizing="border">
-      {shouldRender && (
-        <Flex
-          align="stretch"
-          gap={1}
-          justify="space-between"
-          paddingY={2}
-          paddingLeft={4}
-          paddingRight={3}
-        >
-          <Flex align="center" flex={1} gap={collapsed ? 2 : 3} wrap="wrap" paddingRight={3}>
-            <Flex align="center">
-              <DocumentStatusLine singleLine={!collapsed} />
-              <SpacerButton size="large" />
-            </Flex>
-            <DocumentBadges />
-          </Flex>
-
+    <Card tone={showingRevision ? 'caution' : undefined}>
+      <Flex direction="column" ref={setRootElement} sizing="border">
+        {shouldRender && (
           <Flex
-            align="flex-start"
-            justify="flex-end"
-            ref={actionsBoxRef}
-            style={{flexShrink: 0, marginLeft: 'auto'}}
+            align="stretch"
+            gap={1}
+            justify="space-between"
+            paddingY={2}
+            paddingLeft={4}
+            paddingRight={3}
           >
-            <SpacerButton size="large" />
-            {showingRevision ? <HistoryStatusBarActions /> : <DocumentStatusBarActions />}
+            <Flex align="center" flex={1} gap={collapsed ? 2 : 3} wrap="wrap" paddingRight={3}>
+              <Flex align="center">
+                <DocumentStatusLine singleLine={!collapsed} />
+                <SpacerButton size="large" />
+              </Flex>
+              <DocumentBadges />
+            </Flex>
+
+            <Flex
+              align="flex-start"
+              justify="flex-end"
+              ref={actionsBoxRef}
+              style={{flexShrink: 0, marginLeft: 'auto'}}
+            >
+              <SpacerButton size="large" />
+              {showingRevision ? <HistoryStatusBarActions /> : <DocumentStatusBarActions />}
+            </Flex>
           </Flex>
-        </Flex>
-      )}
-    </Flex>
+        )}
+      </Flex>
+    </Card>
   )
 }

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
@@ -22,6 +22,7 @@ export function DocumentStatusBar(props: DocumentStatusBarProps) {
 
   // Subscribe to external timeline state changes
   const showingRevision = useTimelineSelector(timelineStore, (state) => state.onOlderRevision)
+  const showingVersion = editState?.version !== null
 
   const [collapsed, setCollapsed] = useState<boolean | null>(null)
   const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null)
@@ -35,7 +36,7 @@ export function DocumentStatusBar(props: DocumentStatusBarProps) {
   const shouldRender = editState?.ready && typeof collapsed === 'boolean'
 
   return (
-    <Card tone={showingRevision ? 'caution' : undefined}>
+    <Card tone={showingRevision || showingVersion ? 'caution' : undefined}>
       <Flex direction="column" ref={setRootElement} sizing="border">
         {shouldRender && (
           <Flex

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -103,23 +103,20 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
                 />
               ) : (
                 <>
-                  {
-                    /** TODO DO WE STILL NEED THIS OR CAN WE MOVE THIS TO THE PLUGIN? */
-                    isBundleDocument(currentGlobalBundle) && formState?.value?._id ? (
-                      <BundleActions
-                        currentGlobalBundle={currentGlobalBundle}
-                        documentId={formState.value._id as string}
-                        documentType={documentType}
-                        {...actionProps}
-                        key={formState.value._id as string}
-                      />
-                    ) : (
-                      <div>
-                        {/* eslint-disable-next-line i18next/no-literal-string */}
-                        <Text>Not a bundle</Text>
-                      </div>
-                    )
-                  }
+                  {isBundleDocument(currentGlobalBundle) && formState?.value?._id ? (
+                    <BundleActions
+                      currentGlobalBundle={currentGlobalBundle}
+                      documentId={formState.value._id as string}
+                      documentType={documentType}
+                      {...actionProps}
+                      key={formState.value._id as string}
+                    />
+                  ) : (
+                    <div>
+                      {/* eslint-disable-next-line i18next/no-literal-string */}
+                      <Text>Not a bundle</Text>
+                    </div>
+                  )}
                 </>
               )}
             </Stack>

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
@@ -1,8 +1,9 @@
 import {Flex} from '@sanity/ui'
 import {useEffect, useLayoutEffect, useState} from 'react'
-import {DocumentStatus, DocumentStatusIndicator, useSyncState} from 'sanity'
+import {DocumentStatus, DocumentStatusIndicator, usePerspective, useSyncState} from 'sanity'
 
 import {Tooltip} from '../../../../ui-components'
+import {usePaneRouter} from '../../../components/paneRouter'
 import {useDocumentPane} from '../useDocumentPane'
 import {DocumentStatusPulse} from './DocumentStatusPulse'
 
@@ -19,6 +20,8 @@ export function DocumentStatusLine({singleLine}: DocumentStatusLineProps) {
   const [status, setStatus] = useState<'saved' | 'syncing' | null>(null)
 
   const syncState = useSyncState(documentId, documentType, {version: editState?.bundleId})
+  const paneRouter = usePaneRouter()
+  const {currentGlobalBundle} = usePerspective(paneRouter.perspective)
 
   const lastUpdated = value?._updatedAt
 
@@ -76,6 +79,7 @@ export function DocumentStatusLine({singleLine}: DocumentStatusLineProps) {
           published={editState?.published}
           version={editState?.version}
           singleLine={singleLine}
+          currentGlobalBundle={currentGlobalBundle}
         />
       </Flex>
     </Tooltip>

--- a/packages/sanity/src/structure/panes/document/statusBar/RevisionStatusLine.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/RevisionStatusLine.tsx
@@ -1,0 +1,56 @@
+import {RestoreIcon} from '@sanity/icons'
+import {Box, Flex, Text} from '@sanity/ui'
+import {format} from 'date-fns'
+import {createElement} from 'react'
+import {Translate, useTranslation} from 'sanity'
+import {styled} from 'styled-components'
+
+import {useDocumentPane} from '../useDocumentPane'
+
+export const StatusText = styled(Text)`
+  color: var(--card-muted-fg-color);
+
+  em {
+    color: var(--card-fg-color);
+    font-weight: 500;
+    font-style: normal;
+  }
+`
+
+export function RevisionStatusLine(): JSX.Element {
+  const {displayed} = useDocumentPane()
+  const {t} = useTranslation()
+
+  const message = {
+    name: 'revision',
+    icon: RestoreIcon,
+    text: (
+      <Translate
+        t={t}
+        i18nKey="document-status.revision-from"
+        values={{
+          date: format(
+            new Date(displayed?._updatedAt || displayed?._createdAt || 0),
+            `MMM d, yyyy '@' pp`,
+          ),
+        }}
+      />
+    ),
+    tone: 'caution',
+  }
+
+  return (
+    <>
+      <Flex flex={1} gap={3} padding={2}>
+        <Box flex="none">
+          <Text size={1}>{createElement(message.icon)}</Text>
+        </Box>
+        <Box flex={1}>
+          <StatusText size={1} textOverflow="ellipsis">
+            {message.text}
+          </StatusText>
+        </Box>
+      </Flex>
+    </>
+  )
+}


### PR DESCRIPTION
### Description

- [x] Add discard action on version
- [x] Add version badge (with name) to document footer
- [x] Moved translations from releases plugins to core translations (needed them on the footer)  

Part of the code uses changes that exist in [this PR](https://github.com/sanity-io/sanity/pull/7448) from [history-updates](https://github.com/sanity-io/sanity/tree/history-updates) which are required and useful for this PR

<img width="766" alt="image" src="https://github.com/user-attachments/assets/ded113f3-244f-461f-8f9e-3f67dd69f1f9">

____

❗ 

I didn't add the "version" text after because If found it strange. I want to bring it up with Marius that it feels _strange_, the badge should be enough. We don't add specifics about drafts or published text wise. In any case, if anyone or if Marius has a strong opinion I can of course add it

<img width="766" alt="Screenshot 2024-09-04 at 14 28 51" src="https://github.com/user-attachments/assets/62334308-d4d5-4c52-8651-17f8812a045f">


### What to review

Do the changes make sense? Is there a better way of doing it?
