### PR TITLE
feat(sanity): rename `newVersion` operation to `createVersion`

### DIFF
--- a/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
+++ b/packages/sanity/src/core/bundles/components/panes/BundleActions.tsx
@@ -43,7 +43,7 @@ export function BundleActions(props: BundleActionsProps): ReactNode {
   )
 
   const toast = useToast()
-  const {newVersion} = useDocumentOperation(publishedId, documentType, bundleId)
+  const {createVersion} = useDocumentOperation(publishedId, documentType, bundleId)
   const {t} = useTranslation()
   const telemetry = useTelemetry()
 
@@ -72,10 +72,10 @@ export function BundleActions(props: BundleActionsProps): ReactNode {
     const createVersionSuccess = firstValueFrom(
       documentStore.pair
         .operationEvents(getPublishedId(documentId), documentType)
-        .pipe(filter((e) => e.op === 'newVersion' && e.type === 'success')),
+        .pipe(filter((e) => e.op === 'createVersion' && e.type === 'success')),
     )
 
-    newVersion.execute(versionId)
+    createVersion.execute(versionId)
 
     // only change if the version was created successfully
     await createVersionSuccess
@@ -90,7 +90,7 @@ export function BundleActions(props: BundleActionsProps): ReactNode {
     globalBundleId,
     documentStore.pair,
     documentType,
-    newVersion,
+    createVersion,
     telemetry,
     toast,
     title,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -25,10 +25,10 @@ import {consistencyStatus} from './consistencyStatus'
 import {operationArgs} from './operationArgs'
 import {type OperationArgs, type OperationsAPI} from './operations'
 import {commit} from './operations/commit'
+import {createVersion} from './operations/createVersion'
 import {del} from './operations/delete'
 import {discardChanges} from './operations/discardChanges'
 import {duplicate} from './operations/duplicate'
-import {newVersion} from './operations/newVersion'
 import {patch} from './operations/patch'
 import {publish} from './operations/publish'
 import {restore} from './operations/restore'
@@ -61,7 +61,7 @@ const operationImpls = {
   unpublish,
   duplicate,
   restore,
-  newVersion,
+  createVersion,
 } as const
 
 //as we add server operations one by one, we can add them here

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/createVersion.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/createVersion.ts
@@ -4,7 +4,7 @@ import {type OperationImpl} from './types'
 
 const omitProps = ['_createdAt', '_updatedAt']
 
-export const newVersion: OperationImpl<[baseDocumentId: string], 'NO_NEW_VERSION'> = {
+export const createVersion: OperationImpl<[baseDocumentId: string], 'NO_NEW_VERSION'> = {
   disabled: ({snapshots}) => {
     return snapshots.published || snapshots.draft ? false : 'NO_NEW_VERSION'
   },
@@ -24,7 +24,7 @@ export const newVersion: OperationImpl<[baseDocumentId: string], 'NO_NEW_VERSION
         _type: source._type,
       },
       {
-        tag: 'document.newVersion',
+        tag: 'document.createVersion',
       },
     )
   },

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/helpers.ts
@@ -8,10 +8,10 @@ import {publish as serverPublish} from '../serverOperations/publish'
 import {restore as serverRestore} from '../serverOperations/restore'
 import {unpublish as serverUnpublish} from '../serverOperations/unpublish'
 import {commit} from './commit'
+import {createVersion} from './createVersion'
 import {del} from './delete'
 import {discardChanges} from './discardChanges'
 import {duplicate} from './duplicate'
-import {newVersion} from './newVersion'
 import {patch} from './patch'
 import {restore} from './restore'
 import {type Operation, type OperationArgs, type OperationImpl, type OperationsAPI} from './types'
@@ -39,7 +39,7 @@ export const GUARDED: OperationsAPI = {
   unpublish: createOperationGuard('unpublish'),
   duplicate: createOperationGuard('duplicate'),
   restore: createOperationGuard('restore'),
-  newVersion: createOperationGuard('newVersion'),
+  createVersion: createOperationGuard('createVersion'),
 }
 const createEmitter =
   (operationName: keyof OperationsAPI, idPair: IdPair, typeName: string) =>
@@ -69,7 +69,10 @@ export function createOperationsAPI(args: OperationArgs): OperationsAPI {
     unpublish: wrap('unpublish', unpublish, args),
     duplicate: wrap('duplicate', duplicate, args),
     restore: wrap('restore', restore, args),
-    newVersion: wrap('newVersion', newVersion, args) as Operation<[string], 'NO_NEW_VERSION'>,
+    createVersion: wrap('createVersion', createVersion, args) as Operation<
+      [string],
+      'NO_NEW_VERSION'
+    >,
   }
 
   //as we add server operations one by one, we can add them here

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/types.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/types.ts
@@ -37,7 +37,7 @@ export interface OperationsAPI {
   unpublish: Operation<[], 'LIVE_EDIT_ENABLED' | 'NOT_PUBLISHED'> | GuardedOperation
   duplicate: Operation<[documentId: string], 'NOTHING_TO_DUPLICATE'> | GuardedOperation
   restore: Operation<[revision: string]> | GuardedOperation
-  newVersion: GuardedOperation | Operation<[documentId: string], 'NO_NEW_VERSION'>
+  createVersion: GuardedOperation | Operation<[documentId: string], 'NO_NEW_VERSION'>
 }
 
 /** @internal */

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -352,6 +352,9 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'panes.document-operation-results.operation-success': 'Successfully performed {{op}} on document',
   /** The text when copy URL operation succeeded  */
   'panes.document-operation-results.operation-success_copy-url': 'Document URL copied to clipboard',
+  /**  */
+  'panes.document-operation-results.operation-success_createVersion':
+    '<Strong>{{title}}</Strong> was added to the release',
   /** The text when a delete operation succeeded  */
   'panes.document-operation-results.operation-success_delete':
     'The document was successfully deleted',
@@ -361,9 +364,6 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text when a duplicate operation succeeded  */
   'panes.document-operation-results.operation-success_duplicate':
     'The document was successfully duplicated',
-  /**  */
-  'panes.document-operation-results.operation-success_newVersion':
-    '<Strong>{{title}}</Strong> was added to the release',
   /** The text when a publish operation succeeded  */
   'panes.document-operation-results.operation-success_publish':
     '<Strong>{{title}}</Strong> was published',


### PR DESCRIPTION
### Description

This branch renames the `newVersion` operation to `createVersion`. This makes it consistent with the other operation names, which are all based on verbs.