### PR TITLE
fix(core): update intent link for releases tool

### DIFF
--- a/packages/sanity/src/core/releases/components/BundleMenuButton/BundleMenuButton.tsx
+++ b/packages/sanity/src/core/releases/components/BundleMenuButton/BundleMenuButton.tsx
@@ -57,9 +57,9 @@ export const BundleMenuButton = ({disabled, bundle, documentCount}: BundleMenuBu
         ),
       })
       setDiscardStatus('idle')
-      if (router.state.bundleId) {
+      if (router.state.releaseId) {
         // navigate back to bundle overview
-        router.navigate({bundleId: undefined})
+        router.navigate({releaseId: undefined})
       }
     } catch (e) {
       setDiscardStatus('error')

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -80,7 +80,7 @@ const releasesLocaleStrings = {
   /** Text for when no releases are found */
   'no-releases': 'No Releases',
   /** Text for when a release is not found */
-  'not-found': 'Release not found: {{bundleId}}',
+  'not-found': 'Release not found: {{releaseId}}',
 
   /** Description for the release tool */
   'overview.description':

--- a/packages/sanity/src/core/releases/plugin/index.ts
+++ b/packages/sanity/src/core/releases/plugin/index.ts
@@ -25,14 +25,14 @@ export const releases = definePlugin({
       name: 'releases',
       title: 'Releases',
       component: ReleasesTool,
-      router: route.create('/', [route.create('/:bundleId')]),
+      router: route.create('/', [route.create('/:releaseId')]),
       canHandleIntent: (intent) => {
         // If intent is release, open the releases tool.
         return Boolean(intent === 'release')
       },
       getIntentState(intent, params) {
         if (intent === 'release') {
-          return {bundleId: params.id}
+          return {releaseId: params.id}
         }
         return null
       },

--- a/packages/sanity/src/core/releases/plugin/index.ts
+++ b/packages/sanity/src/core/releases/plugin/index.ts
@@ -26,12 +26,13 @@ export const releases = definePlugin({
       title: 'Releases',
       component: ReleasesTool,
       router: route.create('/', [route.create('/:bundleId')]),
-      canHandleIntent: (intent, params) => {
-        return Boolean(intent === 'release' && params.slug)
+      canHandleIntent: (intent) => {
+        // If intent is release, open the releases tool.
+        return Boolean(intent === 'release')
       },
       getIntentState(intent, params) {
         if (intent === 'release') {
-          return {bundleId: params.slug}
+          return {bundleId: params.id}
         }
         return null
       },

--- a/packages/sanity/src/core/releases/tool/ReleasesTool.tsx
+++ b/packages/sanity/src/core/releases/tool/ReleasesTool.tsx
@@ -6,8 +6,8 @@ import {ReleasesOverview} from './overview/ReleasesOverview'
 export function ReleasesTool() {
   const router = useRouter()
 
-  const {bundleId} = router.state
-  if (bundleId) return <ReleaseDetail />
+  const {releaseId} = router.state
+  if (releaseId) return <ReleaseDetail />
 
   return <ReleasesOverview />
 }

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
@@ -36,18 +36,18 @@ export const ReleaseDetail = () => {
 
   const activeScreen = getActiveScreen(router)
 
-  const {bundleId}: ReleasesRouterState = router.state
+  const {releaseId: releaseIdRaw}: ReleasesRouterState = router.state
 
-  const parsedBundleId = decodeURIComponent(bundleId || '')
+  const releaseId = decodeURIComponent(releaseIdRaw || '')
   const {data, loading, deletedBundles} = useBundles()
-  const deletedBundle = deletedBundles[parsedBundleId]
+  const deletedBundle = deletedBundles[releaseId]
 
-  const {loading: documentsLoading, results} = useBundleDocuments(parsedBundleId)
+  const {loading: documentsLoading, results} = useBundleDocuments(releaseId)
 
   const documentIds = results.map((result) => result.document?._id)
-  const history = useReleaseHistory(documentIds, parsedBundleId)
+  const history = useReleaseHistory(documentIds, releaseId)
 
-  const bundle = data?.find((storeBundle) => storeBundle._id === parsedBundleId)
+  const bundle = data?.find((storeBundle) => storeBundle._id === releaseId)
   const bundleHasDocuments = !!results.length
   const showPublishButton = loading || !bundle?.publishedAt
   const isPublishButtonDisabled = loading || !bundle || !bundleHasDocuments
@@ -222,7 +222,7 @@ export const ReleaseDetail = () => {
       <Card flex={1} tone="critical">
         <Container width={0}>
           <Stack paddingX={4} paddingY={6} space={1}>
-            <Heading>{t('not-found', {bundleId})}</Heading>
+            <Heading>{t('not-found', {releaseId})}</Heading>
           </Stack>
         </Container>
       </Card>

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
@@ -59,10 +59,10 @@ const renderTest = async () => {
   return render(
     <RouterProvider
       state={{
-        bundleId: 'test-bundle-id',
+        releaseId: 'test-bundle-id',
       }}
       onNavigate={mockRouterNavigate}
-      router={route.create('/', [route.create('/:bundleId')])}
+      router={route.create('/', [route.create('/:releaseId')])}
     >
       <ReleaseDetail />
     </RouterProvider>,

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseReview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseReview.test.tsx
@@ -126,7 +126,7 @@ jest.mock('sanity/router', () => ({
   ...(jest.requireActual('sanity/router') || {}),
   IntentLink: jest.fn().mockImplementation((props: any) => <a> {props.children}</a>),
   useRouter: jest.fn().mockReturnValue({
-    state: {bundleId: 'differences'},
+    state: {releaseId: 'differences'},
     navigate: jest.fn(),
   }),
 }))

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -20,7 +20,7 @@ const ReleaseNameCell: Column<TableBundle>['cell'] = ({cellProps, datum: bundle}
     : {
         as: 'a',
         // navigate to bundle detail
-        onClick: () => router.navigate({bundleId: bundle._id}),
+        onClick: () => router.navigate({releaseId: bundle._id}),
       }
 
   return (

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -284,7 +284,7 @@ describe('ReleasesOverview', () => {
       const bundleRow = screen.getAllByTestId('table-row')[1]
       fireEvent.click(within(bundleRow).getByText('Bundle 1'))
 
-      expect(useRouter().navigate).toHaveBeenCalledWith({bundleId: 'b1abcdefg'})
+      expect(useRouter().navigate).toHaveBeenCalledWith({releaseId: 'b1abcdefg'})
     })
   })
 })

--- a/packages/sanity/src/core/releases/types/router.ts
+++ b/packages/sanity/src/core/releases/types/router.ts
@@ -1,5 +1,5 @@
 import {type RouterState} from 'sanity/router'
 
 export interface ReleasesRouterState extends RouterState {
-  bundleId?: string
+  releaseId?: string
 }

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
@@ -62,7 +62,7 @@ export const DocumentHeaderTitle = memo(function DocumentHeaderTitle(): ReactEle
           </span>
         )}
       </TitleContainer>
-      <Flex flex="none" gap={1}>
+      <Flex flex="none" align="center" gap={1}>
         <DocumentPerspectiveMenu />
       </Flex>
     </Flex>

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveMenu.tsx
@@ -1,18 +1,54 @@
 import {ChevronDownIcon} from '@sanity/icons'
 // eslint-disable-next-line no-restricted-imports -- Bundle Button requires more fine-grained styling than studio button
 import {Box, Button} from '@sanity/ui'
-import {memo, useCallback, useMemo} from 'react'
-import {BundleBadge, BundlesMenu, usePerspective, useTranslation} from 'sanity'
-import {useRouter} from 'sanity/router'
-import {styled} from 'styled-components'
+// eslint-disable-next-line camelcase
+import {getTheme_v2} from '@sanity/ui/theme'
+import {memo, useMemo} from 'react'
+import {BundleBadge, type BundleDocument, BundlesMenu, usePerspective, useTranslation} from 'sanity'
+import {IntentLink} from 'sanity/router'
+import {css, styled} from 'styled-components'
 
 import {Button as StudioButton} from '../../../../../../ui-components'
 import {usePaneRouter} from '../../../../../components'
 import {useDocumentPane} from '../../../useDocumentPane'
 
-const BadgeButton = styled(Button)({
-  cursor: 'pointer',
+const BadgeButton = styled(Button)((props) => {
+  const theme = getTheme_v2(props.theme)
+  const mode = props.mode || 'default'
+  const tone = props.tone || 'default'
+  const color = theme.color.button[mode][tone]
+
+  return css`
+    cursor: pointer;
+    border-radius: 999px !important;
+    @media (hover: hover) {
+      &:hover {
+        text-decoration: none !important;
+        background-color: ${color.hovered.bg};
+      }
+    }
+  `
 })
+
+const ReleaseLink = ({release}: {release: Partial<BundleDocument>}) => {
+  const {hue, title, icon, _id: releaseId} = release
+
+  return (
+    <BadgeButton
+      mode="bleed"
+      padding={0}
+      radius="full"
+      data-testid="button-document-release"
+      intent="release"
+      params={{id: releaseId}}
+      target="_blank"
+      rel="noopener noreferrer"
+      as={IntentLink}
+    >
+      <BundleBadge hue={hue} title={title} icon={icon} padding={2} />
+    </BadgeButton>
+  )
+}
 
 export const DocumentPerspectiveMenu = memo(function DocumentPerspectiveMenu() {
   const paneRouter = usePaneRouter()
@@ -20,13 +56,6 @@ export const DocumentPerspectiveMenu = memo(function DocumentPerspectiveMenu() {
   const {currentGlobalBundle} = usePerspective(paneRouter.perspective)
 
   const {documentVersions, existsInBundle} = useDocumentPane()
-  const {title, hue, icon, _id: bundleId} = currentGlobalBundle
-
-  const router = useRouter()
-
-  const handleBundleClick = useCallback(() => {
-    router.navigateIntent('release', {id: bundleId})
-  }, [router, bundleId])
 
   const bundlesMenuButton = useMemo(
     () => (
@@ -41,17 +70,7 @@ export const DocumentPerspectiveMenu = memo(function DocumentPerspectiveMenu() {
 
   return (
     <>
-      {currentGlobalBundle && existsInBundle && (
-        <BadgeButton
-          onClick={handleBundleClick}
-          mode="bleed"
-          padding={0}
-          radius="full"
-          data-testid="button-document-release"
-        >
-          <BundleBadge hue={hue} title={title} icon={icon} padding={2} />
-        </BadgeButton>
-      )}
+      {currentGlobalBundle && existsInBundle && <ReleaseLink release={currentGlobalBundle} />}
 
       {/** TODO IS THIS STILL NEEDED? VS THE PICKER IN STUDIO NAVBAR? */}
 


### PR DESCRIPTION
### Description

Fixes an issue with intent link in which the intent was not resolved correctly.
It also replaces the <Button> for a <Link> component, which will allow users to cmd + click to open in new tab. 

Updates the `bundleId` param in the releases tool router for `releaseId`

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Are the changes correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Existing tests have been updated to reflect the change.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
