### PR TITLE
fix(core): Fix Title in "Untitled was published" toast

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentOperationResults.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentOperationResults.tsx
@@ -1,5 +1,5 @@
 import {useToast} from '@sanity/ui'
-import {memo, useEffect, useRef} from 'react'
+import {memo, useEffect, useMemo, useRef} from 'react'
 import {Translate, useDocumentOperationEvent, useTranslation} from 'sanity'
 
 import {usePaneRouter} from '../../components'
@@ -13,23 +13,25 @@ export const DocumentOperationResults = memo(function DocumentOperationResults()
   const {push: pushToast} = useToast()
   const {documentId, documentType, value: documentPaneValue} = useDocumentPane()
   const documentTitleInfo = useDocumentTitle()
-  let title = documentTitleInfo.title
   const titleError = documentTitleInfo.error
   const event: any = useDocumentOperationEvent(documentId, documentType)
   const prevEvent = useRef(event)
   const paneRouter = usePaneRouter()
   const {t} = useTranslation(structureLocaleNamespace)
 
-  if (
-    !title &&
-    !titleError &&
-    !IGNORE_OPS.includes(event?.op) &&
-    typeof documentPaneValue.title === 'string' &&
-    event?.type === 'success'
-  ) {
-    // If title isn't be set from document preview, use the title from the document pane value
-    title = documentPaneValue.title
-  }
+  const title = useMemo(() => {
+    // If title isn't set from document preview, use the title from the document pane value
+    if (
+      !documentTitleInfo.title &&
+      !titleError &&
+      !IGNORE_OPS.includes(event?.op) &&
+      typeof documentPaneValue.title === 'string' &&
+      event?.type === 'success'
+    ) {
+      return documentPaneValue.title
+    }
+    return documentTitleInfo.title
+  }, [documentTitleInfo.title, titleError, event, documentPaneValue.title])
   //Truncate the document title and add "..." if it is over 25 characters
   const documentTitleBase = title || t('panes.document-operation-results.operation-undefined-title')
   const documentTitle =

--- a/packages/sanity/src/structure/panes/document/DocumentOperationResults.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentOperationResults.tsx
@@ -11,13 +11,25 @@ const IGNORE_OPS = ['patch', 'commit']
 
 export const DocumentOperationResults = memo(function DocumentOperationResults() {
   const {push: pushToast} = useToast()
-  const {documentId, documentType} = useDocumentPane()
-  const {title} = useDocumentTitle()
+  const {documentId, documentType, value: documentPaneValue} = useDocumentPane()
+  const documentTitleInfo = useDocumentTitle()
+  let title = documentTitleInfo.title
+  const titleError = documentTitleInfo.error
   const event: any = useDocumentOperationEvent(documentId, documentType)
   const prevEvent = useRef(event)
   const paneRouter = usePaneRouter()
   const {t} = useTranslation(structureLocaleNamespace)
 
+  if (
+    !title &&
+    !titleError &&
+    !IGNORE_OPS.includes(event?.op) &&
+    typeof documentPaneValue.title === 'string' &&
+    event?.type === 'success'
+  ) {
+    // If title isn't be set from document preview, use the title from the document pane value
+    title = documentPaneValue.title
+  }
   //Truncate the document title and add "..." if it is over 25 characters
   const documentTitleBase = title || t('panes.document-operation-results.operation-undefined-title')
   const documentTitle =


### PR DESCRIPTION
### Description
This PR fixes a bug where a success message shows "Untitled was published" when publishing (and unpublishing) a document with a title. This is especially prevalent on documents with an `image` field. 

It adds an additional check for a title in the current document title when the title is not available on the document preview title.

### What to review
Ensure that the using the document pane value directly as a last resort for a title is a safe approach.

### Testing
* Create a new document with an image field
* Add a `title` and then publish the document
* Ensure that the success toast includes the title that you typed and not "Untitled was published" 
* Unpublish the document
* Ensure that the success toast includes the title that you typed and not "Untitled was unpublished" 

### Notes for release
* Fixes the "Untitled was published" success toast issue
