### PR TITLE
perf(core): memoize `prepareFormState`

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/utils/TestForm.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/utils/TestForm.tsx
@@ -157,7 +157,8 @@ export function TestForm(props: TestFormProps) {
     validateStaticDocument(document, workspace, (result) => setValidation(result))
   }, [document, workspace])
 
-  const formState = useFormState(schemaType, {
+  const formState = useFormState({
+    schemaType,
     focusPath,
     collapsedPaths,
     collapsedFieldSets,
@@ -166,7 +167,7 @@ export function TestForm(props: TestFormProps) {
     openPath,
     presence: presenceFromProps,
     validation,
-    value: document,
+    documentValue: document,
   })
 
   const formStateRef = useRef(formState)

--- a/packages/sanity/src/core/form/store/__tests__/collapsible.test.ts
+++ b/packages/sanity/src/core/form/store/__tests__/collapsible.test.ts
@@ -99,7 +99,7 @@ test("doesn't make primitive fields collapsed even if they are configured to be"
   const result = prepareFormState({
     ...DEFAULT_PROPS,
     schemaType: bookType,
-    value: {_id: 'foo', _type: 'book'},
+    documentValue: {_id: 'foo', _type: 'book'},
   })
 
   expect(result).not.toBe(null)
@@ -127,7 +127,7 @@ describe('collapsible object fields', () => {
     const result = prepareFormState({
       ...DEFAULT_PROPS,
       schemaType: bookType,
-      value: {_id: 'foo', _type: 'book'},
+      documentValue: {_id: 'foo', _type: 'book'},
     })
 
     expect(result).not.toBe(null)
@@ -147,7 +147,7 @@ describe('collapsible object fields', () => {
     const result = prepareFormState({
       ...DEFAULT_PROPS,
       schemaType: bookType,
-      value: {_id: 'foo', _type: 'book'},
+      documentValue: {_id: 'foo', _type: 'book'},
     })
 
     expect(result).not.toBe(null)
@@ -190,7 +190,7 @@ describe('collapsible object fields', () => {
     const result = prepareFormState({
       ...DEFAULT_PROPS,
       schemaType: bookType,
-      value: {_id: 'foo', _type: 'book'},
+      documentValue: {_id: 'foo', _type: 'book'},
     })
 
     expect(result).not.toBe(null)

--- a/packages/sanity/src/core/form/store/__tests__/collapsible.test.ts
+++ b/packages/sanity/src/core/form/store/__tests__/collapsible.test.ts
@@ -1,9 +1,9 @@
-import {describe, expect, it, test} from '@jest/globals'
+import {beforeEach, describe, expect, it, test} from '@jest/globals'
 import {Schema} from '@sanity/schema'
 import {type ObjectSchemaType, type Path} from '@sanity/types'
 
 import {pathToString} from '../../../field'
-import {prepareFormState} from '../formState'
+import {createPrepareFormState, type PrepareFormState} from '../formState'
 import {type FieldMember, type ObjectFormNode} from '../types'
 import {isObjectFormNode} from '../types/asserters'
 import {DEFAULT_PROPS} from './shared'
@@ -81,6 +81,12 @@ function getBookType(fieldOptions: {
   }).get('book')
 }
 
+let prepareFormState!: PrepareFormState
+
+beforeEach(() => {
+  prepareFormState = createPrepareFormState()
+})
+
 test("doesn't make primitive fields collapsed even if they are configured to be", () => {
   // Note: the schema validation should possibly enforce this
   // Note2: We might want to support making all kinds of fields collapsible, even primitive fields
@@ -93,7 +99,7 @@ test("doesn't make primitive fields collapsed even if they are configured to be"
   const result = prepareFormState({
     ...DEFAULT_PROPS,
     schemaType: bookType,
-    document: {_id: 'foo', _type: 'book'},
+    value: {_id: 'foo', _type: 'book'},
   })
 
   expect(result).not.toBe(null)
@@ -121,7 +127,7 @@ describe('collapsible object fields', () => {
     const result = prepareFormState({
       ...DEFAULT_PROPS,
       schemaType: bookType,
-      document: {_id: 'foo', _type: 'book'},
+      value: {_id: 'foo', _type: 'book'},
     })
 
     expect(result).not.toBe(null)
@@ -141,7 +147,7 @@ describe('collapsible object fields', () => {
     const result = prepareFormState({
       ...DEFAULT_PROPS,
       schemaType: bookType,
-      document: {_id: 'foo', _type: 'book'},
+      value: {_id: 'foo', _type: 'book'},
     })
 
     expect(result).not.toBe(null)
@@ -160,7 +166,7 @@ describe('collapsible object fields', () => {
     const result = prepareFormState({
       ...DEFAULT_PROPS,
       schemaType: bookType,
-      document: {_id: 'foo', _type: 'book'},
+      value: {_id: 'foo', _type: 'book'},
     })
 
     expect(result).not.toBe(null)
@@ -184,7 +190,7 @@ describe('collapsible object fields', () => {
     const result = prepareFormState({
       ...DEFAULT_PROPS,
       schemaType: bookType,
-      document: {_id: 'foo', _type: 'book'},
+      value: {_id: 'foo', _type: 'book'},
     })
 
     expect(result).not.toBe(null)

--- a/packages/sanity/src/core/form/store/__tests__/equality.test.ts
+++ b/packages/sanity/src/core/form/store/__tests__/equality.test.ts
@@ -1,8 +1,8 @@
-import {expect, test} from '@jest/globals'
+import {beforeEach, expect, test} from '@jest/globals'
 import {Schema} from '@sanity/schema'
 import {type ConditionalProperty} from '@sanity/types'
 
-import {prepareFormState} from '../formState'
+import {createPrepareFormState, type PrepareFormState} from '../formState'
 import {DEFAULT_PROPS} from './shared'
 
 function getBookType(properties: {
@@ -73,20 +73,26 @@ function getBookType(properties: {
   }).get('book')
 }
 
+let prepareFormState!: PrepareFormState
+
+beforeEach(() => {
+  prepareFormState = createPrepareFormState()
+})
+
 test('it doesnt return new object equalities given the same input', () => {
-  const document = {_id: 'test', _type: 'foo'}
+  const value = {_id: 'test', _type: 'foo'}
   const bookType = getBookType({})
 
   const state1 = prepareFormState({
     ...DEFAULT_PROPS,
     schemaType: bookType,
-    document,
+    value,
   })
 
   const state2 = prepareFormState({
     ...DEFAULT_PROPS,
     schemaType: bookType,
-    document,
+    value,
   })
   expect(state1).not.toBe(null)
   expect(state2).not.toBe(null)

--- a/packages/sanity/src/core/form/store/__tests__/equality.test.ts
+++ b/packages/sanity/src/core/form/store/__tests__/equality.test.ts
@@ -80,19 +80,19 @@ beforeEach(() => {
 })
 
 test('it doesnt return new object equalities given the same input', () => {
-  const value = {_id: 'test', _type: 'foo'}
+  const documentValue = {_id: 'test', _type: 'foo'}
   const bookType = getBookType({})
 
   const state1 = prepareFormState({
     ...DEFAULT_PROPS,
     schemaType: bookType,
-    value,
+    documentValue,
   })
 
   const state2 = prepareFormState({
     ...DEFAULT_PROPS,
     schemaType: bookType,
-    value,
+    documentValue,
   })
   expect(state1).not.toBe(null)
   expect(state2).not.toBe(null)

--- a/packages/sanity/src/core/form/store/__tests__/formState.test.ts
+++ b/packages/sanity/src/core/form/store/__tests__/formState.test.ts
@@ -12,10 +12,6 @@ import {startsWith, toString} from '@sanity/util/paths'
 
 import {createSchema} from '../../../schema/createSchema'
 import {
-  createCallbackResolver,
-  type RootCallbackResolver,
-} from '../conditional-property/createCallbackResolver'
-import {
   createPrepareFormState,
   type PrepareFormState,
   type RootFormStateOptions,
@@ -35,8 +31,8 @@ import {
 import {type StateTree} from '../types/state'
 
 let prepareFormState!: PrepareFormState
-let prepareHiddenState!: RootCallbackResolver<'hidden'>
-let prepareReadOnlyState!: RootCallbackResolver<'readOnly'>
+
+type RemoveFirstChar<S extends string> = S extends `${infer _}${infer R}` ? R : S
 
 beforeEach(() => {
   prepareFormState = createPrepareFormState({
@@ -50,8 +46,6 @@ beforeEach(() => {
       preparePrimitiveInputState: jest.fn,
     },
   })
-  prepareHiddenState = createCallbackResolver({property: 'hidden'})
-  prepareReadOnlyState = createCallbackResolver({property: 'readOnly'})
 })
 const schema = createSchema({
   name: 'default',
@@ -334,7 +328,10 @@ const rootFormNodeOptions: Partial<{
   },
 }
 
-const paths: {path: Path; expectedCalls: {[K in keyof PrepareFormState]: number}}[] = [
+const paths: {
+  path: Path
+  expectedCalls: {[K in RemoveFirstChar<keyof PrepareFormState>]: number}
+}[] = [
   {
     path: ['title'],
     expectedCalls: {
@@ -467,32 +464,35 @@ describe.each(
       expect(startsWith(differentNode.path, path)).toBe(true)
     }
 
-    expect(prepareFormState.prepareArrayOfObjectsInputState).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareArrayOfObjectsInputState).toHaveBeenCalledTimes(
       expectedCalls.prepareArrayOfObjectsInputState,
     )
-    expect(prepareFormState.prepareArrayOfObjectsMember).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareArrayOfObjectsMember).toHaveBeenCalledTimes(
       expectedCalls.prepareArrayOfObjectsMember,
     )
-    expect(prepareFormState.prepareArrayOfPrimitivesInputState).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareArrayOfPrimitivesInputState).toHaveBeenCalledTimes(
       expectedCalls.prepareArrayOfPrimitivesInputState,
     )
-    expect(prepareFormState.prepareArrayOfPrimitivesMember).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareArrayOfPrimitivesMember).toHaveBeenCalledTimes(
       expectedCalls.prepareArrayOfPrimitivesMember,
     )
-    expect(prepareFormState.prepareFieldMember).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareFieldMember).toHaveBeenCalledTimes(
       expectedCalls.prepareFieldMember,
     )
-    expect(prepareFormState.prepareObjectInputState).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareObjectInputState).toHaveBeenCalledTimes(
       expectedCalls.prepareObjectInputState,
     )
-    expect(prepareFormState.preparePrimitiveInputState).toHaveBeenCalledTimes(
+    expect(prepareFormState._preparePrimitiveInputState).toHaveBeenCalledTimes(
       expectedCalls.preparePrimitiveInputState,
     )
   })
 })
 
 describe('hidden', () => {
-  const pathsToTest: {path: Path; expectedCalls: {[K in keyof PrepareFormState]: number}}[] = [
+  const pathsToTest: {
+    path: Path
+    expectedCalls: {[K in RemoveFirstChar<keyof PrepareFormState>]: number}
+  }[] = [
     {
       path: ['title'],
       expectedCalls: {
@@ -565,32 +565,35 @@ describe('hidden', () => {
     }
 
     // Verify memoization: functions should be called only for affected nodes
-    expect(prepareFormState.prepareArrayOfObjectsInputState).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareArrayOfObjectsInputState).toHaveBeenCalledTimes(
       expectedCalls.prepareArrayOfObjectsInputState,
     )
-    expect(prepareFormState.prepareArrayOfObjectsMember).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareArrayOfObjectsMember).toHaveBeenCalledTimes(
       expectedCalls.prepareArrayOfObjectsMember,
     )
-    expect(prepareFormState.prepareArrayOfPrimitivesInputState).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareArrayOfPrimitivesInputState).toHaveBeenCalledTimes(
       expectedCalls.prepareArrayOfPrimitivesInputState,
     )
-    expect(prepareFormState.prepareArrayOfPrimitivesMember).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareArrayOfPrimitivesMember).toHaveBeenCalledTimes(
       expectedCalls.prepareArrayOfPrimitivesMember,
     )
-    expect(prepareFormState.prepareFieldMember).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareFieldMember).toHaveBeenCalledTimes(
       expectedCalls.prepareFieldMember,
     )
-    expect(prepareFormState.prepareObjectInputState).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareObjectInputState).toHaveBeenCalledTimes(
       expectedCalls.prepareObjectInputState,
     )
-    expect(prepareFormState.preparePrimitiveInputState).toHaveBeenCalledTimes(
+    expect(prepareFormState._preparePrimitiveInputState).toHaveBeenCalledTimes(
       expectedCalls.preparePrimitiveInputState,
     )
   })
 })
 
 describe('collapsedPaths', () => {
-  const pathsToTest: {path: Path; expectedCalls: {[K in keyof PrepareFormState]: number}}[] = [
+  const pathsToTest: {
+    path: Path
+    expectedCalls: {[K in RemoveFirstChar<keyof PrepareFormState>]: number}
+  }[] = [
     {
       path: ['simpleObject'],
       expectedCalls: {
@@ -657,25 +660,25 @@ describe('collapsedPaths', () => {
     expect(member && 'collapsed' in member && member.collapsed).toBe(true)
 
     // Verify memoization: functions should be called only for affected nodes
-    expect(prepareFormState.prepareArrayOfObjectsInputState).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareArrayOfObjectsInputState).toHaveBeenCalledTimes(
       expectedCalls.prepareArrayOfObjectsInputState,
     )
-    expect(prepareFormState.prepareArrayOfObjectsMember).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareArrayOfObjectsMember).toHaveBeenCalledTimes(
       expectedCalls.prepareArrayOfObjectsMember,
     )
-    expect(prepareFormState.prepareArrayOfPrimitivesInputState).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareArrayOfPrimitivesInputState).toHaveBeenCalledTimes(
       expectedCalls.prepareArrayOfPrimitivesInputState,
     )
-    expect(prepareFormState.prepareArrayOfPrimitivesMember).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareArrayOfPrimitivesMember).toHaveBeenCalledTimes(
       expectedCalls.prepareArrayOfPrimitivesMember,
     )
-    expect(prepareFormState.prepareFieldMember).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareFieldMember).toHaveBeenCalledTimes(
       expectedCalls.prepareFieldMember,
     )
-    expect(prepareFormState.prepareObjectInputState).toHaveBeenCalledTimes(
+    expect(prepareFormState._prepareObjectInputState).toHaveBeenCalledTimes(
       expectedCalls.prepareObjectInputState,
     )
-    expect(prepareFormState.preparePrimitiveInputState).toHaveBeenCalledTimes(
+    expect(prepareFormState._preparePrimitiveInputState).toHaveBeenCalledTimes(
       expectedCalls.preparePrimitiveInputState,
     )
   })
@@ -711,13 +714,13 @@ describe('collapsedFieldSets', () => {
     expect(fieldset?.collapsed).toBe(true)
 
     // Verify memoization: functions should be called only for affected nodes
-    expect(prepareFormState.prepareArrayOfObjectsInputState).toHaveBeenCalledTimes(0)
-    expect(prepareFormState.prepareArrayOfObjectsMember).toHaveBeenCalledTimes(0)
-    expect(prepareFormState.prepareArrayOfPrimitivesInputState).toHaveBeenCalledTimes(0)
-    expect(prepareFormState.prepareArrayOfPrimitivesMember).toHaveBeenCalledTimes(0)
-    expect(prepareFormState.prepareFieldMember).toHaveBeenCalledTimes(8)
-    expect(prepareFormState.prepareObjectInputState).toHaveBeenCalledTimes(1)
-    expect(prepareFormState.preparePrimitiveInputState).toHaveBeenCalledTimes(0)
+    expect(prepareFormState._prepareArrayOfObjectsInputState).toHaveBeenCalledTimes(0)
+    expect(prepareFormState._prepareArrayOfObjectsMember).toHaveBeenCalledTimes(0)
+    expect(prepareFormState._prepareArrayOfPrimitivesInputState).toHaveBeenCalledTimes(0)
+    expect(prepareFormState._prepareArrayOfPrimitivesMember).toHaveBeenCalledTimes(0)
+    expect(prepareFormState._prepareFieldMember).toHaveBeenCalledTimes(8)
+    expect(prepareFormState._prepareObjectInputState).toHaveBeenCalledTimes(1)
+    expect(prepareFormState._preparePrimitiveInputState).toHaveBeenCalledTimes(0)
   })
 })
 
@@ -747,12 +750,12 @@ describe('fieldGroupState', () => {
     ])
 
     // Verify memoization: functions should be called only for affected nodes
-    expect(prepareFormState.prepareArrayOfObjectsInputState).toHaveBeenCalledTimes(1)
-    expect(prepareFormState.prepareArrayOfObjectsMember).toHaveBeenCalledTimes(0)
-    expect(prepareFormState.prepareArrayOfPrimitivesInputState).toHaveBeenCalledTimes(1)
-    expect(prepareFormState.prepareArrayOfPrimitivesMember).toHaveBeenCalledTimes(0)
-    expect(prepareFormState.prepareFieldMember).toHaveBeenCalledTimes(8)
-    expect(prepareFormState.prepareObjectInputState).toHaveBeenCalledTimes(3)
-    expect(prepareFormState.preparePrimitiveInputState).toHaveBeenCalledTimes(4)
+    expect(prepareFormState._prepareArrayOfObjectsInputState).toHaveBeenCalledTimes(1)
+    expect(prepareFormState._prepareArrayOfObjectsMember).toHaveBeenCalledTimes(0)
+    expect(prepareFormState._prepareArrayOfPrimitivesInputState).toHaveBeenCalledTimes(1)
+    expect(prepareFormState._prepareArrayOfPrimitivesMember).toHaveBeenCalledTimes(0)
+    expect(prepareFormState._prepareFieldMember).toHaveBeenCalledTimes(8)
+    expect(prepareFormState._prepareObjectInputState).toHaveBeenCalledTimes(3)
+    expect(prepareFormState._preparePrimitiveInputState).toHaveBeenCalledTimes(4)
   })
 })

--- a/packages/sanity/src/core/form/store/__tests__/formState.test.ts
+++ b/packages/sanity/src/core/form/store/__tests__/formState.test.ts
@@ -1,0 +1,268 @@
+import {beforeEach, expect, it, jest} from '@jest/globals'
+import {type CurrentUser, defineField, defineType, type ObjectSchemaType} from '@sanity/types'
+
+import {createSchema} from '../../../schema/createSchema'
+import {
+  createCallbackResolver,
+  type RootCallbackResolver,
+} from '../conditional-property/createCallbackResolver'
+import {createPrepareFormState, type PrepareFormState} from '../formState'
+
+let prepareFormState!: PrepareFormState
+let prepareHiddenState!: RootCallbackResolver<'hidden'>
+let prepareReadOnlyState!: RootCallbackResolver<'readOnly'>
+
+beforeEach(() => {
+  prepareFormState = createPrepareFormState({
+    decorators: {
+      prepareArrayOfObjectsInputState: jest.fn,
+      prepareArrayOfObjectsMember: jest.fn,
+      prepareArrayOfPrimitivesInputState: jest.fn,
+      prepareArrayOfPrimitivesMember: jest.fn,
+      prepareFieldMember: jest.fn,
+      prepareObjectInputState: jest.fn,
+      preparePrimitiveInputState: jest.fn,
+    },
+  })
+  prepareHiddenState = createCallbackResolver({property: 'hidden'})
+  prepareReadOnlyState = createCallbackResolver({property: 'readOnly'})
+})
+
+const schema = createSchema({
+  name: 'default',
+  types: [
+    defineType({
+      name: 'testDocument',
+      type: 'document',
+      title: 'Test Document',
+      fields: [
+        defineField({
+          name: 'title',
+          type: 'string',
+          title: 'Title',
+          validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+          name: 'simpleObject',
+          type: 'object',
+          title: 'Simple ',
+          fields: [
+            {name: 'field1', type: 'string', title: 'Field 1'},
+            {name: 'field2', type: 'number', title: 'Field 2'},
+          ],
+        }),
+        defineField({
+          name: 'arrayOfPrimitives',
+          type: 'array',
+          title: ' of Primitives',
+          of: [{type: 'string'}],
+        }),
+        defineField({
+          name: 'arrayOfObjects',
+          type: 'array',
+          title: ' of Objects',
+          of: [
+            {
+              type: 'object',
+              name: 'arrayObject',
+              fields: [
+                defineField({name: 'objectTitle', type: 'string', title: ' Title'}),
+                defineField({name: 'objectValue', type: 'number', title: ' Value'}),
+              ],
+            },
+          ],
+        }),
+        defineField({
+          name: 'nestedObject',
+          type: 'object',
+          title: 'Nested ',
+          fields: [
+            defineField({name: 'nestedField1', type: 'string', title: 'Nested Field 1'}),
+            defineField({
+              name: 'nestedObject',
+              type: 'object',
+              title: 'Nested ',
+              fields: [
+                defineField({
+                  name: 'deeplyNestedField',
+                  type: 'string',
+                  title: 'Deeply Nested Field',
+                }),
+              ],
+            }),
+            defineField({
+              name: 'nestedArray',
+              type: 'array',
+              title: 'Nested ',
+              of: [{type: 'string'}],
+            }),
+          ],
+        }),
+        defineField({
+          name: 'conditionalField',
+          type: 'string',
+          title: 'Conditional Field',
+          hidden: ({document}) => !document?.title,
+        }),
+        defineField({
+          name: 'fieldWithValidation',
+          type: 'string',
+          title: 'Field with Validation',
+          validation: (Rule) => Rule.min(5).max(10),
+        }),
+        defineField({
+          name: 'fieldsetField1',
+          type: 'string',
+          title: 'Fieldset Field 1',
+          fieldset: 'testFieldset',
+        }),
+        defineField({
+          name: 'fieldsetField2',
+          type: 'number',
+          title: 'Fieldset Field 2',
+          fieldset: 'testFieldset',
+        }),
+      ],
+      fieldsets: [
+        {
+          name: 'testFieldset',
+          title: 'Test Fieldset',
+          options: {collapsible: true, collapsed: false},
+        },
+      ],
+    }),
+  ],
+})
+
+const schemaType = schema.get('testDocument') as ObjectSchemaType
+
+const currentUser: Omit<CurrentUser, 'role'> = {
+  email: 'rico@sanity.io',
+  id: 'exampleId',
+  name: 'Rico Kahler',
+  roles: [],
+}
+
+const value = {
+  _type: 'testDocument',
+  title: 'Example Test Document',
+  simpleObject: {
+    field1: 'Simple  String',
+    field2: 42,
+  },
+  arrayOfPrimitives: ['First string', 'Second string', 'Third string'],
+  arrayOfObjects: [
+    {
+      _type: 'arrayObject',
+      _key: 'object0',
+      objectTitle: 'First ',
+      objectValue: 10,
+    },
+    {
+      _type: 'arrayObject',
+      _key: 'object1',
+      objectTitle: 'Second ',
+      objectValue: 20,
+    },
+  ],
+  nestedObject: {
+    nestedField1: 'Nested Field Value',
+    nestedObject: {
+      deeplyNestedField: 'Deeply Nested Value',
+    },
+    nestedArray: ['Nested  Item 1', 'Nested  Item 2'],
+  },
+  conditionalField: 'This field is visible',
+  fieldWithValidation: 'Valid',
+  fieldsetField1: 'Fieldset String Value',
+  fieldsetField2: 99,
+}
+
+it('creates the root form node', () => {
+  const result = prepareFormState({
+    currentUser,
+    focusPath: [],
+    level: 0,
+    openPath: [],
+    path: [],
+    presence: [],
+    schemaType,
+    validation: [],
+    changed: false,
+    changesOpen: false,
+    collapsedFieldSets: {},
+    collapsedPaths: {},
+    value,
+    comparisonValue: null,
+    fieldGroupState: {},
+    hidden: prepareHiddenState({
+      currentUser,
+      document: value,
+      schemaType,
+    }),
+    readOnly: prepareReadOnlyState({
+      currentUser,
+      document: value,
+      schemaType,
+    }),
+  })
+
+  expect(prepareFormState.prepareArrayOfObjectsInputState).toHaveBeenCalledTimes(1)
+  expect(prepareFormState.prepareArrayOfObjectsMember).toHaveBeenCalledTimes(2)
+  expect(prepareFormState.prepareArrayOfPrimitivesInputState).toHaveBeenCalledTimes(2)
+  expect(prepareFormState.prepareArrayOfPrimitivesMember).toHaveBeenCalledTimes(5)
+  expect(prepareFormState.prepareFieldMember).toHaveBeenCalledTimes(19)
+  expect(prepareFormState.prepareObjectInputState).toHaveBeenCalledTimes(6)
+  expect(prepareFormState.preparePrimitiveInputState).toHaveBeenCalledTimes(18)
+
+  expect(result).toMatchObject({
+    changed: true,
+    focusPath: [],
+    focused: true,
+    groups: [],
+    id: '',
+    level: 0,
+    members: [
+      {
+        key: 'field-title',
+        kind: 'field',
+      },
+      {
+        key: 'field-simpleObject',
+        kind: 'field',
+      },
+      {
+        key: 'field-arrayOfPrimitives',
+        kind: 'field',
+      },
+      {
+        key: 'field-arrayOfObjects',
+        kind: 'field',
+      },
+      {
+        key: 'field-nestedObject',
+        kind: 'field',
+      },
+      {
+        key: 'field-conditionalField',
+        kind: 'field',
+      },
+      {
+        key: 'field-fieldWithValidation',
+        kind: 'field',
+      },
+      {
+        key: 'fieldset-testFieldset',
+        kind: 'fieldSet',
+      },
+    ],
+    path: [],
+    presence: [],
+    readOnly: undefined,
+    validation: [],
+    schemaType,
+    value,
+  })
+})
+
+it.todo('does not recompute nodes that have not changed')

--- a/packages/sanity/src/core/form/store/__tests__/members.hidden.test.ts
+++ b/packages/sanity/src/core/form/store/__tests__/members.hidden.test.ts
@@ -90,12 +90,13 @@ test('it omits the hidden member field from the members array', () => {
     subtitle: {hidden: () => true},
   })
 
-  const document = {_id: 'foo', _type: 'book'}
+  const documentValue = {_id: 'foo', _type: 'book'}
   const result = prepareFormState({
     ...DEFAULT_PROPS,
-    hidden: prepareHiddenState({currentUser: MOCK_USER, document, schemaType}),
+    hidden: prepareHiddenState({currentUser: MOCK_USER, documentValue, schemaType}),
     schemaType,
-    value: document,
+    documentValue,
+    comparisonValue: documentValue,
   })
 
   expect(result).not.toBe(null)
@@ -110,12 +111,12 @@ test('it omits nested hidden members from the members array', () => {
   const schemaType = getBookType({
     author: {hidden: () => true},
   })
-  const document = {_id: 'foo', _type: 'book'}
+  const documentValue = {_id: 'foo', _type: 'book'}
   const result = prepareFormState({
     ...DEFAULT_PROPS,
     schemaType: schemaType,
-    hidden: prepareHiddenState({currentUser: MOCK_USER, document, schemaType}),
-    value: document,
+    hidden: prepareHiddenState({currentUser: MOCK_USER, documentValue: documentValue, schemaType}),
+    documentValue,
   })
 
   expect(result).not.toBe(null)
@@ -137,7 +138,7 @@ test('it "upward propagates" hidden fields', () => {
     ...DEFAULT_PROPS,
     schemaType,
     value: document,
-    hidden: prepareHiddenState({currentUser: MOCK_USER, document, schemaType}),
+    hidden: prepareHiddenState({currentUser: MOCK_USER, documentValue: document, schemaType}),
   })
   expect(result).not.toBe(null)
   if (result === null) {

--- a/packages/sanity/src/core/form/store/__tests__/members.hidden.test.ts
+++ b/packages/sanity/src/core/form/store/__tests__/members.hidden.test.ts
@@ -1,12 +1,13 @@
-import {expect, test} from '@jest/globals'
+import {beforeEach, expect, test} from '@jest/globals'
 import {Schema} from '@sanity/schema'
 import {type ConditionalProperty, type ObjectSchemaType} from '@sanity/types'
 
-import {prepareFormState} from '../formState'
-import {DEFAULT_PROPS} from './shared'
-
-// eslint-disable-next-line no-empty-function,@typescript-eslint/no-empty-function
-const noop = () => {}
+import {
+  createCallbackResolver,
+  type RootCallbackResolver,
+} from '../conditional-property/createCallbackResolver'
+import {createPrepareFormState, type PrepareFormState} from '../formState'
+import {DEFAULT_PROPS, MOCK_USER} from './shared'
 
 function getBookType(properties: {
   root?: {hidden?: ConditionalProperty; readOnly?: ConditionalProperty}
@@ -76,14 +77,25 @@ function getBookType(properties: {
   }).get('book')
 }
 
+let prepareFormState!: PrepareFormState
+let prepareHiddenState!: RootCallbackResolver<'hidden'>
+
+beforeEach(() => {
+  prepareFormState = createPrepareFormState()
+  prepareHiddenState = createCallbackResolver({property: 'hidden'})
+})
+
 test('it omits the hidden member field from the members array', () => {
-  const bookType: ObjectSchemaType = getBookType({
+  const schemaType: ObjectSchemaType = getBookType({
     subtitle: {hidden: () => true},
   })
+
+  const document = {_id: 'foo', _type: 'book'}
   const result = prepareFormState({
     ...DEFAULT_PROPS,
-    schemaType: bookType,
-    document: {_id: 'foo', _type: 'book'},
+    hidden: prepareHiddenState({currentUser: MOCK_USER, document, schemaType}),
+    schemaType,
+    value: document,
   })
 
   expect(result).not.toBe(null)
@@ -95,13 +107,15 @@ test('it omits the hidden member field from the members array', () => {
 })
 
 test('it omits nested hidden members from the members array', () => {
-  const bookType = getBookType({
+  const schemaType = getBookType({
     author: {hidden: () => true},
   })
+  const document = {_id: 'foo', _type: 'book'}
   const result = prepareFormState({
     ...DEFAULT_PROPS,
-    schemaType: bookType,
-    document: {_id: 'foo', _type: 'book'},
+    schemaType: schemaType,
+    hidden: prepareHiddenState({currentUser: MOCK_USER, document, schemaType}),
+    value: document,
   })
 
   expect(result).not.toBe(null)
@@ -114,14 +128,16 @@ test('it omits nested hidden members from the members array', () => {
 
 test('it "upward propagates" hidden fields', () => {
   // If the hidden callback for every field of an object type returns true, the whole object should be hidden
-  const bookType = getBookType({
+  const schemaType = getBookType({
     authorFirstName: {hidden: () => true},
     authorLastName: {hidden: () => true},
   })
+  const document = {_id: 'foo', _type: 'book'}
   const result = prepareFormState({
-    schemaType: bookType,
-    document: {_id: 'foo', _type: 'book'},
     ...DEFAULT_PROPS,
+    schemaType,
+    value: document,
+    hidden: prepareHiddenState({currentUser: MOCK_USER, document, schemaType}),
   })
   expect(result).not.toBe(null)
   if (result === null) {

--- a/packages/sanity/src/core/form/store/__tests__/shared.ts
+++ b/packages/sanity/src/core/form/store/__tests__/shared.ts
@@ -7,8 +7,6 @@ export const DEFAULT_PROPS = {
   presence: [],
   focusPath: [],
   path: [],
-  hidden: false,
-  readOnly: false,
   currentUser: MOCK_USER,
   openPath: [],
   onSetCollapsedField: noop,

--- a/packages/sanity/src/core/form/store/__tests__/shared.ts
+++ b/packages/sanity/src/core/form/store/__tests__/shared.ts
@@ -1,19 +1,14 @@
-// eslint-disable-next-line no-empty-function,@typescript-eslint/no-empty-function
-const noop = () => {}
-
 export const MOCK_USER = {id: 'bjoerge', email: 'bjoerge@gmail.com', name: 'Bjørge', roles: []}
 export const DEFAULT_PROPS = {
   validation: [],
   presence: [],
   focusPath: [],
-  path: [],
   currentUser: MOCK_USER,
   openPath: [],
-  onSetCollapsedField: noop,
-  onSetCollapsedFieldSet: noop,
-  onSetActiveFieldGroupAtPath: noop,
-  onChange: noop,
-  onBlur: noop,
-  onFocus: noop,
-  level: 0,
+  comparisonValue: undefined,
+  hidden: undefined,
+  readOnly: undefined,
+  fieldGroupState: undefined,
+  collapsedPaths: undefined,
+  collapsedFieldSets: undefined,
 }

--- a/packages/sanity/src/core/form/store/conditional-property/createCallbackResolver.ts
+++ b/packages/sanity/src/core/form/store/conditional-property/createCallbackResolver.ts
@@ -151,12 +151,12 @@ export function createCallbackResolver<TProperty extends 'hidden' | 'readOnly'>(
   const stableTrue = {value: true}
   let last: {serializedHash: string; result: StateTree<boolean> | undefined} | null = null
 
-  return ({
+  function callbackResult({
     currentUser,
     documentValue,
     schemaType,
     ...options
-  }: ResolveRootCallbackStateOptions<TProperty>) => {
+  }: ResolveRootCallbackStateOptions<TProperty>) {
     const hash = {
       currentUser: getId(currentUser),
       schemaType: getId(schemaType),
@@ -192,4 +192,6 @@ export function createCallbackResolver<TProperty extends 'hidden' | 'readOnly'>(
 
     return result
   }
+
+  return callbackResult
 }

--- a/packages/sanity/src/core/form/store/conditional-property/createCallbackResolver.ts
+++ b/packages/sanity/src/core/form/store/conditional-property/createCallbackResolver.ts
@@ -136,7 +136,7 @@ export interface CreateCallbackResolverOptions<TProperty extends 'hidden' | 'rea
 }
 
 export type ResolveRootCallbackStateOptions<TProperty extends 'hidden' | 'readOnly'> = {
-  document: unknown
+  documentValue: unknown
   currentUser: Omit<CurrentUser, 'role'> | null
   schemaType: SchemaType
 } & {[K in TProperty]?: boolean}
@@ -151,23 +151,17 @@ export function createCallbackResolver<TProperty extends 'hidden' | 'readOnly'>(
   const stableTrue = {value: true}
   let last: {serializedHash: string; result: StateTree<boolean> | undefined} | null = null
 
-  const getHash = ({
-    currentUser,
-    document,
-    schemaType,
-  }: ResolveRootCallbackStateOptions<TProperty>) => ({
-    currentUser: getId(currentUser),
-    schemaType: getId(schemaType),
-    document: getId(document),
-  })
-
   return ({
     currentUser,
-    document,
+    documentValue,
     schemaType,
     ...options
   }: ResolveRootCallbackStateOptions<TProperty>) => {
-    const hash = getHash({currentUser, schemaType, document, ...options})
+    const hash = {
+      currentUser: getId(currentUser),
+      schemaType: getId(schemaType),
+      document: getId(documentValue),
+    }
     const serializedHash = JSON.stringify(hash)
 
     if (property in options) {
@@ -182,11 +176,11 @@ export function createCallbackResolver<TProperty extends 'hidden' | 'readOnly'>(
       last?.result ?? null,
       resolveCallbackState({
         currentUser,
-        document,
+        document: documentValue,
         level: 0,
         parent: null,
         schemaType,
-        value: document,
+        value: documentValue,
         property,
       }),
     )

--- a/packages/sanity/src/core/form/store/conditional-property/createCallbackResolver.ts
+++ b/packages/sanity/src/core/form/store/conditional-property/createCallbackResolver.ts
@@ -1,0 +1,201 @@
+import {type CurrentUser, isKeyedObject, type SchemaType} from '@sanity/types'
+
+import {EMPTY_ARRAY} from '../../../util/empty'
+import {MAX_FIELD_DEPTH} from '../constants'
+import {type StateTree} from '../types/state'
+import {getId} from '../utils/getId'
+import {getItemType} from '../utils/getItemType'
+import {immutableReconcile} from '../utils/immutableReconcile'
+import {
+  type ConditionalPropertyCallbackContext,
+  resolveConditionalProperty,
+} from './resolveConditionalProperty'
+
+interface ResolveCallbackStateOptions {
+  property: 'readOnly' | 'hidden'
+  value: unknown
+  parent: unknown
+  document: unknown
+  currentUser: Omit<CurrentUser, 'role'> | null
+  schemaType: SchemaType
+  level: number
+}
+
+function resolveCallbackState({
+  value,
+  parent,
+  document,
+  currentUser,
+  schemaType,
+  level,
+  property,
+}: ResolveCallbackStateOptions): StateTree<boolean> | undefined {
+  const context: ConditionalPropertyCallbackContext = {
+    value,
+    parent,
+    document: document as ConditionalPropertyCallbackContext['document'],
+    currentUser,
+  }
+  const selfValue = resolveConditionalProperty(schemaType[property], context)
+
+  // we don't have to calculate the children if the current value is true
+  // because readOnly and hidden inherit. If the parent is readOnly or hidden
+  // then its children are assumed to also be readOnly or hidden respectively.
+  if (selfValue || level === MAX_FIELD_DEPTH) {
+    return {value: selfValue}
+  }
+
+  const children: Record<string, StateTree<boolean>> = {}
+
+  if (schemaType.jsonType === 'object') {
+    // note: this is needed because not all object types gets a ´fieldsets´ property during schema parsing.
+    // ideally members should be normalized as part of the schema parsing and not here
+    const normalizedSchemaMembers: typeof schemaType.fieldsets = schemaType.fieldsets
+      ? schemaType.fieldsets
+      : schemaType.fields.map((field) => ({single: true, field}))
+
+    for (const fieldset of normalizedSchemaMembers) {
+      if (fieldset.single) {
+        const childResult = resolveCallbackState({
+          currentUser,
+          document,
+          parent: value,
+          value: (value as any)?.[fieldset.field.name],
+          schemaType: fieldset.field.type,
+          level: level + 1,
+          property,
+        })
+        if (!childResult) continue
+
+        children[fieldset.field.name] = childResult
+        continue
+      }
+
+      const fieldsetValue = resolveConditionalProperty(fieldset.hidden, context)
+      if (fieldsetValue) {
+        children[`fieldset:${fieldset.name}`] = {
+          value: fieldsetValue,
+        }
+      }
+
+      for (const field of fieldset.fields) {
+        const childResult = resolveCallbackState({
+          currentUser,
+          document,
+          parent: value,
+          value: (value as any)?.[field.name],
+          schemaType: field.type,
+          level: level + 1,
+          property,
+        })
+        if (!childResult) continue
+
+        children[field.name] = childResult
+      }
+    }
+
+    for (const group of schemaType.groups ?? EMPTY_ARRAY) {
+      // should only be true for `'hidden'`
+      if (property in group) {
+        const groupResult = resolveConditionalProperty(group[property as 'hidden'], context)
+        if (!groupResult) continue
+
+        children[`group:${group.name}`] = {value: groupResult}
+      }
+    }
+  }
+
+  if (schemaType.jsonType === 'array' && Array.isArray(value)) {
+    if (value.every(isKeyedObject)) {
+      for (const item of value) {
+        const itemType = getItemType(schemaType, item)
+        if (!itemType) continue
+
+        const childResult = resolveCallbackState({
+          currentUser,
+          document,
+          level: level + 1,
+          value: item,
+          parent: value,
+          schemaType: itemType,
+          property,
+        })
+        if (!childResult) continue
+
+        children[item._key] = childResult
+      }
+    }
+  }
+
+  if (Object.keys(children).length) return {children}
+  return undefined
+}
+
+export interface CreateCallbackResolverOptions<TProperty extends 'hidden' | 'readOnly'> {
+  property: TProperty
+}
+
+export type ResolveRootCallbackStateOptions<TProperty extends 'hidden' | 'readOnly'> = {
+  document: unknown
+  currentUser: Omit<CurrentUser, 'role'> | null
+  schemaType: SchemaType
+} & {[K in TProperty]?: boolean}
+
+export type RootCallbackResolver<TProperty extends 'hidden' | 'readOnly'> = (
+  options: ResolveRootCallbackStateOptions<TProperty>,
+) => StateTree<boolean> | undefined
+
+export function createCallbackResolver<TProperty extends 'hidden' | 'readOnly'>({
+  property,
+}: CreateCallbackResolverOptions<TProperty>): RootCallbackResolver<TProperty> {
+  const stableTrue = {value: true}
+  let last: {serializedHash: string; result: StateTree<boolean> | undefined} | null = null
+
+  const getHash = ({
+    currentUser,
+    document,
+    schemaType,
+  }: ResolveRootCallbackStateOptions<TProperty>) => ({
+    currentUser: getId(currentUser),
+    schemaType: getId(schemaType),
+    document: getId(document),
+  })
+
+  return ({
+    currentUser,
+    document,
+    schemaType,
+    ...options
+  }: ResolveRootCallbackStateOptions<TProperty>) => {
+    const hash = getHash({currentUser, schemaType, document, ...options})
+    const serializedHash = JSON.stringify(hash)
+
+    if (property in options) {
+      if (options[property] === true) {
+        return stableTrue
+      }
+    }
+
+    if (last?.serializedHash === serializedHash) return last.result
+
+    const result = immutableReconcile(
+      last?.result ?? null,
+      resolveCallbackState({
+        currentUser,
+        document,
+        level: 0,
+        parent: null,
+        schemaType,
+        value: document,
+        property,
+      }),
+    )
+
+    last = {
+      result,
+      serializedHash,
+    }
+
+    return result
+  }
+}

--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -250,7 +250,7 @@ export function createPrepareFormState({
         collapsedFieldSets: getId(parent.collapsedFieldSets?.children?.[field.name]),
         collapsedPaths: getId(parent.collapsedPaths?.children?.[field.name]),
         currentUser: getId(parent.currentUser),
-        fieldGroupState: getId(parent.fieldGroupState?.children?.[field.name]),
+        fieldGroupState: getId(parent.fieldGroupState),
         hidden:
           parent.hidden === true ||
           parent.hidden?.value ||

--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -22,7 +22,7 @@ import {castArray, isEqual as _isEqual} from 'lodash'
 
 import {type FIXME} from '../../FIXME'
 import {type FormNodePresence} from '../../presence'
-import {EMPTY_ARRAY, isRecord} from '../../util'
+import {EMPTY_ARRAY, EMPTY_OBJECT, isRecord} from '../../util'
 import {getFieldLevel} from '../studio/inputResolver/helpers'
 import {ALL_FIELDS_GROUP, MAX_FIELD_DEPTH} from './constants'
 import {
@@ -222,8 +222,25 @@ export interface CreatePrepareFormStateOptions {
   }
 }
 
+export interface RootFormStateOptions {
+  schemaType: ObjectSchemaType
+  documentValue: unknown
+  comparisonValue: unknown
+  currentUser: Omit<CurrentUser, 'role'> | null
+  hidden: boolean | StateTree<boolean> | undefined
+  readOnly: boolean | StateTree<boolean> | undefined
+  openPath: Path
+  focusPath: Path
+  presence: FormNodePresence[]
+  validation: ValidationMarker[]
+  fieldGroupState: StateTree<string> | undefined
+  collapsedPaths: StateTree<boolean> | undefined
+  collapsedFieldSets: StateTree<boolean> | undefined
+  changesOpen?: boolean
+}
+
 export interface PrepareFormState {
-  (props: FormStateOptions<ObjectSchemaType, unknown>): ObjectFormNode | null
+  (options: RootFormStateOptions): ObjectFormNode | null
   prepareFieldMember: PrepareFieldMember
   prepareObjectInputState: PrepareObjectInputState
   prepareArrayOfPrimitivesInputState: PrepareArrayOfPrimitivesInputState
@@ -1095,10 +1112,40 @@ export function createPrepareFormState({
   )
 
   return Object.assign(
-    function prepareFormState(
-      props: FormStateOptions<ObjectSchemaType, unknown>,
-    ): ObjectFormNode | null {
-      return prepareObjectInputState(props)
+    function prepareFormState({
+      collapsedFieldSets,
+      collapsedPaths,
+      comparisonValue,
+      currentUser,
+      documentValue,
+      fieldGroupState,
+      focusPath,
+      hidden,
+      openPath,
+      presence,
+      readOnly,
+      schemaType,
+      validation,
+      changesOpen,
+    }: RootFormStateOptions): ObjectFormNode | null {
+      return prepareObjectInputState({
+        collapsedFieldSets,
+        collapsedPaths,
+        comparisonValue,
+        currentUser,
+        value: documentValue,
+        fieldGroupState,
+        focusPath,
+        hidden: hidden === false ? EMPTY_OBJECT : hidden,
+        openPath,
+        presence,
+        readOnly: readOnly === false ? EMPTY_OBJECT : readOnly,
+        schemaType,
+        validation,
+        changesOpen,
+        level: 0,
+        path: [],
+      })
     },
     {
       prepareFieldMember,

--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-nested-callbacks */
 /* eslint-disable max-statements */
 /* eslint-disable camelcase, no-else-return */
 
@@ -17,13 +18,12 @@ import {
 } from '@sanity/types'
 import {resolveTypeName} from '@sanity/util/content'
 import {isEqual, pathFor, startsWith, toString, trimChildPath} from '@sanity/util/paths'
-import {castArray, isEqual as _isEqual, pick} from 'lodash'
+import {castArray, isEqual as _isEqual} from 'lodash'
 
 import {type FIXME} from '../../FIXME'
 import {type FormNodePresence} from '../../presence'
 import {EMPTY_ARRAY, isRecord} from '../../util'
 import {getFieldLevel} from '../studio/inputResolver/helpers'
-import {resolveConditionalProperty} from './conditional-property'
 import {ALL_FIELDS_GROUP, MAX_FIELD_DEPTH} from './constants'
 import {
   type FieldSetMember,
@@ -45,10 +45,92 @@ import {
   type ArrayOfPrimitivesFormNode,
   type ObjectFormNode,
 } from './types/nodes'
+import {createMemoizer, type FunctionDecorator} from './utils/createMemoizer'
 import {getCollapsedWithDefaults} from './utils/getCollapsibleOptions'
+import {getId} from './utils/getId'
 import {getItemType, getPrimitiveItemType} from './utils/getItemType'
 
 type PrimitiveSchemaType = BooleanSchemaType | NumberSchemaType | StringSchemaType
+
+interface FormStateOptions<TSchemaType, T> {
+  schemaType: TSchemaType
+  path: Path
+  value?: T
+  comparisonValue?: T | null
+  changed?: boolean
+  currentUser: Omit<CurrentUser, 'role'> | null
+  hidden?: StateTree<boolean> | undefined
+  readOnly?: StateTree<boolean> | undefined
+  openPath: Path
+  focusPath: Path
+  presence: FormNodePresence[]
+  validation: ValidationMarker[]
+  fieldGroupState?: StateTree<string>
+  collapsedPaths?: StateTree<boolean>
+  collapsedFieldSets?: StateTree<boolean>
+  // nesting level
+  level: number
+  changesOpen?: boolean
+}
+
+type PrepareFieldMember = <T>(props: {
+  field: ObjectField
+  parent: FormStateOptions<ObjectSchemaType, T> & {
+    groups: FormFieldGroup[]
+    selectedGroup: FormFieldGroup
+  }
+  index: number
+}) => ObjectMember | HiddenField | null
+
+type PrepareObjectInputState = <T>(
+  props: FormStateOptions<ObjectSchemaType, T>,
+  enableHiddenCheck?: boolean,
+) => ObjectFormNode | null
+
+type PrepareArrayOfPrimitivesInputState = <T extends (boolean | string | number)[]>(
+  props: FormStateOptions<ArraySchemaType, T>,
+) => ArrayOfPrimitivesFormNode | null
+
+type PrepareArrayOfObjectsInputState = <T extends {_key: string}[]>(
+  props: FormStateOptions<ArraySchemaType, T>,
+) => ArrayOfObjectsFormNode | null
+
+type PrepareArrayOfObjectsMember = (props: {
+  arrayItem: {_key: string}
+  parent: FormStateOptions<ArraySchemaType, unknown>
+  index: number
+}) => ArrayOfObjectsMember
+
+type PrepareArrayOfPrimitivesMember = (props: {
+  arrayItem: unknown
+  parent: FormStateOptions<ArraySchemaType, unknown>
+  index: number
+}) => ArrayOfPrimitivesMember
+
+type PreparePrimitiveInputState = <TSchemaType extends PrimitiveSchemaType>(
+  props: FormStateOptions<TSchemaType, unknown>,
+) => PrimitiveFormNode
+
+function serializeState({path, state}: {path: Path; state: FormStateOptions<unknown, unknown>}) {
+  return {
+    path,
+    level: state.level,
+    changesOpen: state.changesOpen,
+    presence: state.presence.filter((p) => startsWith(path, p.path)),
+    validation: state.validation.filter((v) => startsWith(path, v.path)),
+    focusPath: startsWith(path, state.focusPath) ? state.focusPath.slice(path.length) : EMPTY_ARRAY,
+    openPath: startsWith(path, state.openPath) ? state.openPath.slice(path.length) : EMPTY_ARRAY,
+    value: getId(state.value),
+    comparisonValue: getId(state.comparisonValue),
+    collapsedFieldSets: getId(state.collapsedFieldSets),
+    collapsedPaths: state.collapsedPaths,
+    currentUser: getId(state.currentUser),
+    fieldGroupState: getId(state.fieldGroupState),
+    hidden: getId(state.hidden),
+    readOnly: getId(state.readOnly),
+    schemaType: getId(state.schemaType),
+  }
+}
 
 function isFieldEnabledByGroupFilter(
   // the groups config for the "enclosing object" type
@@ -128,937 +210,904 @@ function isChangedValue(value: any, comparisonValue: any) {
   return !_isEqual(value, comparisonValue)
 }
 
-/*
- * Takes a field in context of a parent object and returns prepared props for it
- */
-function prepareFieldMember(props: {
-  field: ObjectField
-  parent: RawState<ObjectSchemaType, unknown> & {
-    groups: FormFieldGroup[]
-    selectedGroup: FormFieldGroup
-  }
-  index: number
-}): ObjectMember | HiddenField | null {
-  const {parent, field, index} = props
-  const fieldPath = pathFor([...parent.path, field.name])
-  const fieldLevel = getFieldLevel(field.type, parent.level + 1)
-
-  const parentValue = parent.value
-  const parentComparisonValue = parent.comparisonValue
-  if (!isAcceptedObjectValue(parentValue)) {
-    // Note: we validate each field, before passing it recursively to this function so getting this error means that the
-    // ´prepareFormState´ function itself has been called with a non-object value
-    throw new Error('Unexpected non-object value')
-  }
-
-  const normalizedFieldGroupNames = field.group ? castArray(field.group) : []
-  const inSelectedGroup = isFieldEnabledByGroupFilter(
-    parent.groups,
-    field.group,
-    parent.selectedGroup,
-  )
-
-  if (isObjectSchemaType(field.type)) {
-    const fieldValue = parentValue?.[field.name]
-    const fieldComparisonValue = isRecord(parentComparisonValue)
-      ? parentComparisonValue?.[field.name]
-      : undefined
-
-    if (!isAcceptedObjectValue(fieldValue)) {
-      return {
-        kind: 'error',
-        key: field.name,
-        fieldName: field.name,
-        error: {
-          type: 'INCOMPATIBLE_TYPE',
-          expectedSchemaType: field.type,
-          resolvedValueType: resolveTypeName(fieldValue),
-          value: fieldValue,
-        },
-      }
-    }
-
-    const conditionalPropertyContext = {
-      value: fieldValue,
-      parent: parent.value,
-      document: parent.document,
-      currentUser: parent.currentUser,
-    }
-    const hidden = resolveConditionalProperty(field.type.hidden, conditionalPropertyContext)
-
-    if (hidden) {
-      return {
-        kind: 'hidden',
-        key: `field-${field.name}`,
-        name: field.name,
-        index: index,
-      }
-    }
-
-    // readonly is inherited
-    const readOnly =
-      parent.readOnly || resolveConditionalProperty(field.type.readOnly, conditionalPropertyContext)
-
-    // todo: consider requiring a _type annotation for object values on fields as well
-    // if (resolvedValueType !== field.type.name) {
-    //   return {
-    //     kind: 'error',
-    //     key: field.name,
-    //     error: {
-    //       type: 'TYPE_ANNOTATION_MISMATCH',
-    //       expectedSchemaType: field.type,
-    //       resolvedValueType,
-    //     },
-    //   }
-    // }
-
-    const fieldGroupState = parent.fieldGroupState?.children?.[field.name]
-    const scopedCollapsedPaths = parent.collapsedPaths?.children?.[field.name]
-    const scopedCollapsedFieldsets = parent.collapsedFieldSets?.children?.[field.name]
-
-    const inputState = prepareObjectInputState({
-      schemaType: field.type,
-      currentUser: parent.currentUser,
-      parent: parent.value,
-      document: parent.document,
-      value: fieldValue,
-      changed: isChangedValue(fieldValue, fieldComparisonValue),
-      comparisonValue: fieldComparisonValue,
-      presence: parent.presence,
-      validation: parent.validation,
-      fieldGroupState,
-      path: fieldPath,
-      level: fieldLevel,
-      focusPath: parent.focusPath,
-      openPath: parent.openPath,
-      collapsedPaths: scopedCollapsedPaths,
-      collapsedFieldSets: scopedCollapsedFieldsets,
-      readOnly,
-      changesOpen: parent.changesOpen,
-    })
-
-    if (inputState === null) {
-      // if inputState is null is either because we reached max field depth or if it has no visible members
-      return null
-    }
-
-    const defaultCollapsedState = getCollapsedWithDefaults(field.type.options as FIXME, fieldLevel)
-    const collapsed = scopedCollapsedPaths
-      ? scopedCollapsedPaths.value
-      : defaultCollapsedState.collapsed
-
-    return {
-      kind: 'field',
-      key: `field-${field.name}`,
-      name: field.name,
-      index: index,
-
-      inSelectedGroup,
-      groups: normalizedFieldGroupNames,
-
-      open: startsWith(fieldPath, parent.openPath),
-      field: inputState,
-      collapsed,
-      collapsible: defaultCollapsedState.collapsible,
-    }
-  } else if (isArraySchemaType(field.type)) {
-    const fieldValue = parentValue?.[field.name] as unknown[] | undefined
-    const fieldComparisonValue = isRecord(parentComparisonValue)
-      ? parentComparisonValue?.[field.name]
-      : undefined
-    if (isArrayOfObjectsSchemaType(field.type)) {
-      const hasValue = typeof fieldValue !== 'undefined'
-      if (hasValue && !isValidArrayOfObjectsValue(fieldValue)) {
-        const resolvedValueType = resolveTypeName(fieldValue)
-
-        return {
-          kind: 'error',
-          key: field.name,
-          fieldName: field.name,
-          error: {
-            type: 'INCOMPATIBLE_TYPE',
-            expectedSchemaType: field.type,
-            resolvedValueType,
-            value: fieldValue,
-          },
-        }
-      }
-
-      if (hasValue && !everyItemIsObject(fieldValue)) {
-        return {
-          kind: 'error',
-          key: field.name,
-          fieldName: field.name,
-          error: {
-            type: 'MIXED_ARRAY',
-            schemaType: field.type,
-            value: fieldValue,
-          },
-        }
-      }
-
-      if (hasValue && !everyItemHasKey(fieldValue)) {
-        return {
-          kind: 'error',
-          key: field.name,
-          fieldName: field.name,
-          error: {
-            type: 'MISSING_KEYS',
-            value: fieldValue,
-            schemaType: field.type,
-          },
-        }
-      }
-
-      const duplicateKeyEntries = hasValue ? findDuplicateKeyEntries(fieldValue) : []
-      if (duplicateKeyEntries.length > 0) {
-        return {
-          kind: 'error',
-          key: field.name,
-          fieldName: field.name,
-          error: {
-            type: 'DUPLICATE_KEYS',
-            duplicates: duplicateKeyEntries,
-            schemaType: field.type,
-          },
-        }
-      }
-
-      const fieldGroupState = parent.fieldGroupState?.children?.[field.name]
-      const scopedCollapsedPaths = parent.collapsedPaths?.children?.[field.name]
-      const scopedCollapsedFieldSets = parent.collapsedFieldSets?.children?.[field.name]
-
-      const readOnly =
-        parent.readOnly ||
-        resolveConditionalProperty(field.type.readOnly, {
-          value: fieldValue,
-          parent: parent.value,
-          document: parent.document,
-          currentUser: parent.currentUser,
-        })
-
-      const fieldState = prepareArrayOfObjectsInputState({
-        schemaType: field.type,
-        parent: parent.value,
-        currentUser: parent.currentUser,
-        document: parent.document,
-        value: fieldValue,
-        changed: isChangedValue(fieldValue, fieldComparisonValue),
-        comparisonValue: fieldComparisonValue as FIXME,
-        fieldGroupState,
-        focusPath: parent.focusPath,
-        openPath: parent.openPath,
-        presence: parent.presence,
-        validation: parent.validation,
-        collapsedPaths: scopedCollapsedPaths,
-        collapsedFieldSets: scopedCollapsedFieldSets,
-        level: fieldLevel,
-        path: fieldPath,
-        readOnly,
-      })
-
-      if (fieldState === null) {
-        return null
-      }
-
-      return {
-        kind: 'field',
-        key: `field-${field.name}`,
-        name: field.name,
-        index: index,
-
-        open: startsWith(fieldPath, parent.openPath),
-
-        inSelectedGroup,
-        groups: normalizedFieldGroupNames,
-
-        collapsible: false,
-        collapsed: false,
-        // note: this is what we actually end up passing down as to the next input component
-        field: fieldState,
-      }
-    } else {
-      // array of primitives
-      if (!isValidArrayOfPrimitivesValue(fieldValue)) {
-        const resolvedValueType = resolveTypeName(fieldValue)
-
-        return {
-          kind: 'error',
-          key: field.name,
-          fieldName: field.name,
-          error: {
-            type: 'INCOMPATIBLE_TYPE',
-            expectedSchemaType: field.type,
-            resolvedValueType,
-            value: fieldValue,
-          },
-        }
-      }
-
-      const fieldGroupState = parent.fieldGroupState?.children?.[field.name]
-      const scopedCollapsedPaths = parent.collapsedPaths?.children?.[field.name]
-      const scopedCollapsedFieldSets = parent.collapsedFieldSets?.children?.[field.name]
-
-      const readOnly =
-        parent.readOnly ||
-        resolveConditionalProperty(field.type.readOnly, {
-          value: fieldValue,
-          parent: parent.value,
-          document: parent.document,
-          currentUser: parent.currentUser,
-        })
-
-      const fieldState = prepareArrayOfPrimitivesInputState({
-        changed: isChangedValue(fieldValue, fieldComparisonValue),
-        comparisonValue: fieldComparisonValue as FIXME,
-        schemaType: field.type,
-        parent: parent.value,
-        currentUser: parent.currentUser,
-        document: parent.document,
-        value: fieldValue,
-        fieldGroupState,
-        focusPath: parent.focusPath,
-        openPath: parent.openPath,
-        presence: parent.presence,
-        validation: parent.validation,
-        collapsedPaths: scopedCollapsedPaths,
-        collapsedFieldSets: scopedCollapsedFieldSets,
-        level: fieldLevel,
-        path: fieldPath,
-        readOnly,
-      })
-
-      if (fieldState === null) {
-        return null
-      }
-
-      return {
-        kind: 'field',
-        key: `field-${field.name}`,
-        name: field.name,
-        index: index,
-
-        inSelectedGroup,
-        groups: normalizedFieldGroupNames,
-
-        open: startsWith(fieldPath, parent.openPath),
-
-        // todo: consider support for collapsible arrays
-        collapsible: false,
-        collapsed: false,
-        // note: this is what we actually end up passing down as to the next input component
-        field: fieldState,
-      }
-    }
-  } else {
-    // primitive fields
-
-    const fieldValue = parentValue?.[field.name] as undefined | boolean | string | number
-    const fieldComparisonValue = isRecord(parentComparisonValue)
-      ? parentComparisonValue?.[field.name]
-      : undefined
-
-    const conditionalPropertyContext = {
-      value: fieldValue,
-      parent: parent.value,
-      document: parent.document,
-      currentUser: parent.currentUser,
-    }
-
-    // note: we *only* want to call the conditional props here, as it's handled by the prepare<Object|Array>InputProps otherwise
-    const hidden = resolveConditionalProperty(field.type.hidden, conditionalPropertyContext)
-
-    if (hidden) {
-      return null
-    }
-
-    const readOnly =
-      parent.readOnly || resolveConditionalProperty(field.type.readOnly, conditionalPropertyContext)
-
-    const fieldState = preparePrimitiveInputState({
-      ...parent,
-      comparisonValue: fieldComparisonValue,
-      value: fieldValue as boolean | string | number | undefined,
-      schemaType: field.type as PrimitiveSchemaType,
-      path: fieldPath,
-      readOnly,
-    })
-
-    return {
-      kind: 'field',
-      key: `field-${field.name}`,
-      name: field.name,
-      index: index,
-      open: startsWith(fieldPath, parent.openPath),
-
-      inSelectedGroup,
-      groups: normalizedFieldGroupNames,
-
-      // todo: consider support for collapsible primitive fields
-      collapsible: false,
-      collapsed: false,
-      field: fieldState,
-    }
+export interface CreatePrepareFormStateOptions {
+  decorators?: {
+    prepareFieldMember?: FunctionDecorator<PrepareFieldMember>
+    prepareObjectInputState?: FunctionDecorator<PrepareObjectInputState>
+    prepareArrayOfPrimitivesInputState?: FunctionDecorator<PrepareArrayOfPrimitivesInputState>
+    prepareArrayOfObjectsInputState?: FunctionDecorator<PrepareArrayOfObjectsInputState>
+    prepareArrayOfObjectsMember?: FunctionDecorator<PrepareArrayOfObjectsMember>
+    prepareArrayOfPrimitivesMember?: FunctionDecorator<PrepareArrayOfPrimitivesMember>
+    preparePrimitiveInputState?: FunctionDecorator<PreparePrimitiveInputState>
   }
 }
 
-interface RawState<SchemaType, T> {
-  schemaType: SchemaType
-  value?: T
-  comparisonValue?: T | null
-  changed?: boolean
-  document: FIXME_SanityDocument
-  currentUser: Omit<CurrentUser, 'role'> | null
-  parent?: unknown
-  hidden?: boolean
-  readOnly?: boolean
-  path: Path
-  openPath: Path
-  focusPath: Path
-  presence: FormNodePresence[]
-  validation: ValidationMarker[]
-  fieldGroupState?: StateTree<string>
-  collapsedPaths?: StateTree<boolean>
-  collapsedFieldSets?: StateTree<boolean>
-  // nesting level
-  level: number
-  changesOpen?: boolean
+export interface PrepareFormState {
+  (props: FormStateOptions<ObjectSchemaType, unknown>): ObjectFormNode | null
+  prepareFieldMember: PrepareFieldMember
+  prepareObjectInputState: PrepareObjectInputState
+  prepareArrayOfPrimitivesInputState: PrepareArrayOfPrimitivesInputState
+  prepareArrayOfObjectsInputState: PrepareArrayOfObjectsInputState
+  prepareArrayOfObjectsMember: PrepareArrayOfObjectsMember
+  prepareArrayOfPrimitivesMember: PrepareArrayOfPrimitivesMember
+  preparePrimitiveInputState: PreparePrimitiveInputState
 }
 
-function prepareObjectInputState<T>(
-  props: RawState<ObjectSchemaType, T>,
-  enableHiddenCheck?: false,
-): ObjectFormNode
-function prepareObjectInputState<T>(
-  props: RawState<ObjectSchemaType, T>,
-  enableHiddenCheck?: true,
-): ObjectFormNode | null
-function prepareObjectInputState<T>(
-  props: RawState<ObjectSchemaType, T>,
-  enableHiddenCheck = true,
-): ObjectFormNode | null {
-  if (props.level === MAX_FIELD_DEPTH) {
-    return null
-  }
-
-  const conditionalPropertyContext = {
-    value: props.value,
-    parent: props.parent,
-    document: props.document,
-    currentUser: props.currentUser,
-  }
-
-  // readonly is inherited
-  const readOnly =
-    props.readOnly ||
-    resolveConditionalProperty(props.schemaType.readOnly, conditionalPropertyContext)
-
-  const schemaTypeGroupConfig = props.schemaType.groups || []
-  const defaultGroupName = (schemaTypeGroupConfig.find((g) => g.default) || ALL_FIELDS_GROUP)?.name
-
-  const groups = [ALL_FIELDS_GROUP, ...schemaTypeGroupConfig].flatMap((group): FormFieldGroup[] => {
-    const groupHidden = resolveConditionalProperty(group.hidden, conditionalPropertyContext)
-    const isSelected = group.name === (props.fieldGroupState?.value || defaultGroupName)
-
-    // Set the "all-fields" group as selected when review changes is open to enable review of all
-    // fields and changes together. When review changes is closed - switch back to the selected tab.
-    const selected = props.changesOpen ? group.name === ALL_FIELDS_GROUP.name : isSelected
-    // Also disable non-selected groups when review changes is open
-    const disabled = props.changesOpen ? !selected : false
-
-    return groupHidden
-      ? []
-      : [
-          {
-            disabled,
-            icon: group?.icon,
-            name: group.name,
-            selected,
-            title: group.title,
-            i18n: group.i18n,
-          },
-        ]
+export function createPrepareFormState({
+  decorators = {},
+}: CreatePrepareFormStateOptions = {}): PrepareFormState {
+  const memoizePrepareFieldMember = createMemoizer<PrepareFieldMember>({
+    decorator: decorators.prepareFieldMember,
+    getPath: ({parent, field}) => [...parent.path, field.name],
+    hashInput: ({parent, field, index}) => {
+      return {
+        ...serializeState({
+          path: [...parent.path, field.name],
+          state: parent,
+        }),
+        index,
+        value: getId((parent.value as any)?.[field.name]),
+      }
+    },
   })
 
-  const selectedGroup = groups.find((group) => group.selected)!
-
-  // note: this is needed because not all object types gets a ´fieldsets´ property during schema parsing.
-  // ideally members should be normalized as part of the schema parsing and not here
-  const normalizedSchemaMembers: typeof props.schemaType.fieldsets = props.schemaType.fieldsets
-    ? props.schemaType.fieldsets
-    : props.schemaType.fields.map((field) => ({single: true, field}))
-
-  // create a members array for the object
-  const members = normalizedSchemaMembers.flatMap(
-    (fieldSet, index): (ObjectMember | HiddenField)[] => {
-      // "single" means not part of a fieldset
-      if (fieldSet.single) {
-        const field = fieldSet.field
-
-        const fieldMember = prepareFieldMember({
-          field: field,
-          parent: {...props, readOnly, groups, selectedGroup},
-          index,
-        })
-
-        return fieldMember ? [fieldMember] : []
-      }
-
-      // it's an actual fieldset
-      const fieldsetFieldNames = fieldSet.fields.map((f) => f.name)
-      const fieldsetHidden = resolveConditionalProperty(fieldSet.hidden, {
-        currentUser: props.currentUser,
-        document: props.document,
-        parent: props.value,
-        value: pick(props.value, fieldsetFieldNames),
-      })
-
-      const fieldsetReadOnly = resolveConditionalProperty(fieldSet.readOnly, {
-        currentUser: props.currentUser,
-        document: props.document,
-        parent: props.value,
-        value: pick(props.value, fieldsetFieldNames),
-      })
-
-      const fieldsetMembers = fieldSet.fields.flatMap(
-        (field): (FieldMember | FieldError | HiddenField)[] => {
-          if (fieldsetHidden) {
-            return [
-              {
-                kind: 'hidden',
-                key: `field-${field.name}`,
-                name: field.name,
-                index: index,
-              },
-            ]
-          }
-          const fieldMember = prepareFieldMember({
-            field: field,
-            parent: {...props, readOnly: readOnly || fieldsetReadOnly, groups, selectedGroup},
-            index,
-          }) as FieldMember | FieldError | HiddenField
-
-          return fieldMember ? [fieldMember] : []
-        },
-      )
-
-      const defaultCollapsedState = getCollapsedWithDefaults(fieldSet.options, props.level)
-
-      const collapsed =
-        (props.collapsedFieldSets?.children || {})[fieldSet.name]?.value ??
-        defaultCollapsedState.collapsed
-
-      return [
-        {
-          kind: 'fieldSet',
-          key: `fieldset-${fieldSet.name}`,
-          _inSelectedGroup: isFieldEnabledByGroupFilter(groups, fieldSet.group, selectedGroup),
-          groups: fieldSet.group ? castArray(fieldSet.group) : [],
-          fieldSet: {
-            path: pathFor(props.path.concat(fieldSet.name)),
-            name: fieldSet.name,
-            title: fieldSet.title,
-            description: fieldSet.description,
-            hidden: false,
-            level: props.level + 1,
-            members: fieldsetMembers.filter(
-              (member): member is FieldMember => member.kind !== 'hidden',
-            ),
-            collapsible: defaultCollapsedState?.collapsible,
-            collapsed,
-            columns: fieldSet?.options?.columns,
-          },
-        },
-      ]
-    },
-  )
-
-  const hasFieldGroups = schemaTypeGroupConfig.length > 0
-
-  const filteredPresence = props.presence.filter((item) => isEqual(item.path, props.path))
-  const presence = filteredPresence.length ? filteredPresence : EMPTY_ARRAY
-
-  const validation = props.validation
-    .filter((item) => isEqual(item.path, props.path))
-    .map((v) => ({level: v.level, message: v.message, path: v.path}))
-
-  const visibleMembers = members.filter(
-    (member): member is ObjectMember => member.kind !== 'hidden',
-  )
-
-  // Return null here only when enableHiddenCheck, or we end up with array members that have 'item: null' when they
-  // really should not be. One example is when a block object inside the PT-input have a type with one single hidden field.
-  // Then it should still be possible to see the member item, even though all of it's fields are null.
-  if (visibleMembers.length === 0 && enableHiddenCheck) {
-    return null
-  }
-
-  const visibleGroups = hasFieldGroups
-    ? groups.flatMap((group) => {
-        // The "all fields" group is always visible
-        if (group.name === ALL_FIELDS_GROUP.name) {
-          return group
-        }
-        const hasVisibleMembers = visibleMembers.some((member) => {
-          if (member.kind === 'error') {
-            return false
-          }
-          if (member.kind === 'field') {
-            return member.groups.includes(group.name)
-          }
-
-          return (
-            member.groups.includes(group.name) ||
-            member.fieldSet.members.some(
-              (fieldsetMember) =>
-                fieldsetMember.kind !== 'error' && fieldsetMember.groups.includes(group.name),
-            )
-          )
-        })
-        return hasVisibleMembers ? group : []
-      })
-    : []
-
-  const filtereredMembers = visibleMembers.flatMap(
-    (member): (FieldError | FieldMember | FieldSetMember)[] => {
-      if (member.kind === 'error') {
-        return [member]
-      }
-      if (member.kind === 'field') {
-        return member.inSelectedGroup ? [member] : []
-      }
-
-      const filteredFieldsetMembers: ObjectMember[] = member.fieldSet.members.filter(
-        (fieldsetMember) => fieldsetMember.kind !== 'field' || fieldsetMember.inSelectedGroup,
-      )
-      return filteredFieldsetMembers.length > 0
-        ? [
-            {
-              ...member,
-              fieldSet: {...member.fieldSet, members: filteredFieldsetMembers},
-            } as FieldSetMember,
-          ]
-        : []
-    },
-  )
-
-  const node = {
-    value: props.value as Record<string, unknown> | undefined,
-    changed: isChangedValue(props.value, props.comparisonValue),
-    schemaType: props.schemaType,
-    readOnly,
-    path: props.path,
-    id: toString(props.path),
-    level: props.level,
-    focused: isEqual(props.path, props.focusPath),
-    focusPath: trimChildPath(props.path, props.focusPath),
-    presence,
-    validation,
-    // this is currently needed by getExpandOperations which needs to know about hidden members
-    // (e.g. members not matching current group filter) in order to determine what to expand
-    members: filtereredMembers,
-    groups: visibleGroups,
-  }
-  Object.defineProperty(node, '_allMembers', {
-    value: members,
-    enumerable: false,
+  const memoizePrepareObjectInputState = createMemoizer<PrepareObjectInputState>({
+    decorator: decorators.prepareObjectInputState,
+    getPath: ({path}) => path,
+    hashInput: (state) => serializeState({path: state.path, state}),
   })
-  return node
-}
 
-function prepareArrayOfPrimitivesInputState<T extends (boolean | string | number)[]>(
-  props: RawState<ArraySchemaType, T>,
-): ArrayOfPrimitivesFormNode | null {
-  if (props.level === MAX_FIELD_DEPTH) {
-    return null
-  }
+  const memoizePrepareArrayOfPrimitivesInputState =
+    createMemoizer<PrepareArrayOfPrimitivesInputState>({
+      decorator: decorators.prepareArrayOfPrimitivesInputState,
+      getPath: ({path}) => path,
+      hashInput: (state) => serializeState({path: state.path, state}),
+    })
 
-  const conditionalPropertyContext = {
-    comparisonValue: props.comparisonValue,
-    value: props.value,
-    parent: props.parent,
-    document: props.document,
-    currentUser: props.currentUser,
-  }
+  const memoizePrepareArrayOfObjectsInputState = createMemoizer<PrepareArrayOfObjectsInputState>({
+    decorator: decorators.prepareArrayOfObjectsInputState,
+    getPath: ({path}) => path,
+    hashInput: (state) => serializeState({path: state.path, state}),
+  })
 
-  const hidden = resolveConditionalProperty(props.schemaType.hidden, conditionalPropertyContext)
-
-  if (hidden) {
-    return null
-  }
-
-  const readOnly =
-    props.readOnly ||
-    resolveConditionalProperty(props.schemaType.readOnly, conditionalPropertyContext)
-
-  // Todo: improve error handling at the parent level so that the value here is either undefined or an array
-  const items = Array.isArray(props.value) ? props.value : []
-
-  const filteredPresence = props.presence.filter((item) => isEqual(item.path, props.path))
-  const presence = filteredPresence.length ? filteredPresence : EMPTY_ARRAY
-  const validation = props.validation
-    .filter((item) => isEqual(item.path, props.path))
-    .map((v) => ({level: v.level, message: v.message, path: v.path}))
-  const members = items.flatMap((item, index) =>
-    prepareArrayOfPrimitivesMember({arrayItem: item, parent: props, index}),
-  )
-  return {
-    // checks for changes not only on the array itself, but also on any of its items
-    changed: props.changed || members.some((m) => m.kind === 'item' && m.item.changed),
-    value: props.value as T,
-    readOnly,
-    schemaType: props.schemaType,
-    focused: isEqual(props.path, props.focusPath),
-    focusPath: trimChildPath(props.path, props.focusPath),
-    path: props.path,
-    id: toString(props.path),
-    level: props.level,
-    validation,
-    presence,
-    members,
-  }
-}
-
-function prepareArrayOfObjectsInputState<T extends {_key: string}[]>(
-  props: RawState<ArraySchemaType, T>,
-): ArrayOfObjectsFormNode | null {
-  if (props.level === MAX_FIELD_DEPTH) {
-    return null
-  }
-
-  const conditionalPropertyContext = {
-    value: props.value,
-    parent: props.parent,
-    document: props.document,
-    currentUser: props.currentUser,
-  }
-  const hidden = resolveConditionalProperty(props.schemaType.hidden, conditionalPropertyContext)
-
-  if (hidden) {
-    return null
-  }
-
-  const readOnly =
-    props.readOnly ||
-    resolveConditionalProperty(props.schemaType.readOnly, conditionalPropertyContext)
-
-  // Todo: improve error handling at the parent level so that the value here is either undefined or an array
-  const items = Array.isArray(props.value) ? props.value : []
-
-  const filteredPresence = props.presence.filter((item) => isEqual(item.path, props.path))
-  const presence = filteredPresence.length ? filteredPresence : EMPTY_ARRAY
-  const validation = props.validation
-    .filter((item) => isEqual(item.path, props.path))
-    .map((v) => ({level: v.level, message: v.message, path: v.path}))
-
-  const members = items.flatMap((item, index) =>
-    prepareArrayOfObjectsMember({
-      arrayItem: item,
-      parent: props,
+  const memoizePrepareArrayOfObjectsMember = createMemoizer<PrepareArrayOfObjectsMember>({
+    decorator: decorators.prepareArrayOfObjectsMember,
+    getPath: ({parent, arrayItem}) => [...parent.path, {_key: arrayItem._key}],
+    hashInput: ({parent, arrayItem, index}) => ({
+      ...serializeState({path: [...parent.path, {_key: arrayItem._key}], state: parent}),
+      // note that this overrides the `parent.value` on purpose. we don't want
+      // to bust the cache for the parent if the item is the same
+      value: getId(arrayItem),
+      hidden: getId(parent.hidden?.children?.[arrayItem._key]),
       index,
     }),
-  )
-
-  return {
-    // checks for changes not only on the array itself, but also on any of its items
-    changed: props.changed || members.some((m) => m.kind === 'item' && m.item.changed),
-    value: props.value as T,
-    readOnly,
-    schemaType: props.schemaType,
-    focused: isEqual(props.path, props.focusPath),
-    focusPath: trimChildPath(props.path, props.focusPath),
-    path: props.path,
-    id: toString(props.path),
-    level: props.level,
-    validation,
-    presence,
-    members,
-  }
-}
-
-/*
- * Takes a field in context of a parent object and returns prepared props for it
- */
-function prepareArrayOfObjectsMember(props: {
-  arrayItem: {_key: string}
-  parent: RawState<ArraySchemaType, unknown>
-  index: number
-}): ArrayOfObjectsMember {
-  const {arrayItem, parent, index} = props
-
-  const itemType = getItemType(parent.schemaType, arrayItem) as ObjectSchemaType
-
-  const key = arrayItem._key
-
-  if (!itemType) {
-    const itemTypeName = resolveTypeName(arrayItem)
-    return {
-      kind: 'error',
-      key,
-      index,
-      error: {
-        type: 'INVALID_ITEM_TYPE',
-        resolvedValueType: itemTypeName,
-        value: arrayItem,
-        validTypes: parent.schemaType.of,
-      },
-    }
-  }
-
-  const itemPath = pathFor([...parent.path, {_key: key}])
-  const itemLevel = parent.level + 1
-
-  const conditionalPropertyContext = {
-    value: parent.value,
-    parent: props.parent,
-    document: parent.document,
-    currentUser: parent.currentUser,
-  }
-  const readOnly =
-    parent.readOnly ||
-    resolveConditionalProperty(parent.schemaType.readOnly, conditionalPropertyContext)
-
-  const fieldGroupState = parent.fieldGroupState?.children?.[key]
-  const scopedCollapsedPaths = parent.collapsedPaths?.children?.[key]
-  const scopedCollapsedFieldsets = parent.collapsedFieldSets?.children?.[key]
-  const comparisonValue =
-    (Array.isArray(parent.comparisonValue) &&
-      parent.comparisonValue.find((i) => i._key === arrayItem._key)) ||
-    undefined
-
-  const itemState = prepareObjectInputState(
-    {
-      schemaType: itemType,
-      level: itemLevel,
-      document: parent.document,
-      value: arrayItem,
-      comparisonValue,
-      changed: isChangedValue(arrayItem, comparisonValue),
-      path: itemPath,
-      focusPath: parent.focusPath,
-      openPath: parent.openPath,
-      currentUser: parent.currentUser,
-      collapsedPaths: scopedCollapsedPaths,
-      collapsedFieldSets: scopedCollapsedFieldsets,
-      presence: parent.presence,
-      validation: parent.validation,
-      fieldGroupState,
-      readOnly,
-    },
-    false,
-  ) as ObjectArrayFormNode
-
-  const defaultCollapsedState = getCollapsedWithDefaults(itemType.options, itemLevel)
-  const collapsed = scopedCollapsedPaths?.value ?? defaultCollapsedState.collapsed
-  return {
-    kind: 'item',
-    key,
-    index,
-    open: startsWith(itemPath, parent.openPath),
-    collapsed: collapsed,
-    collapsible: true,
-    parentSchemaType: parent.schemaType,
-    item: itemState,
-  }
-}
-
-/*
- * Takes a field in contet of a parent object and returns prepared props for it
- */
-function prepareArrayOfPrimitivesMember(props: {
-  arrayItem: unknown
-  parent: RawState<ArraySchemaType, unknown>
-  index: number
-}): ArrayOfPrimitivesMember {
-  const {arrayItem, parent, index} = props
-  const itemType = getPrimitiveItemType(parent.schemaType, arrayItem)
-
-  const itemPath = pathFor([...parent.path, index])
-  const itemValue = (parent.value as unknown[] | undefined)?.[index] as string | boolean | number
-  const itemComparisonValue = (parent.comparisonValue as unknown[] | undefined)?.[index] as
-    | string
-    | boolean
-    | number
-  const itemLevel = parent.level + 1
-
-  // Best effort attempt to make a stable key for each item in the array
-  // Since items may be reordered and change at any time, there's no way to reliably address each item uniquely
-  // This is a "best effort"-attempt at making sure we don't re-use internal state for item inputs
-  // when items are added to or removed from the array
-  const key = `${itemType?.name || 'invalid-type'}-${String(index)}`
-
-  if (!itemType) {
-    return {
-      kind: 'error',
-      key,
-      index,
-      error: {
-        type: 'INVALID_ITEM_TYPE',
-        validTypes: parent.schemaType.of,
-        resolvedValueType: resolveTypeName(itemType),
-        value: itemValue,
-      },
-    }
-  }
-
-  const readOnly =
-    parent.readOnly ||
-    resolveConditionalProperty(itemType.readOnly, {
-      value: itemValue,
-      parent: parent.value,
-      document: parent.document,
-      currentUser: parent.currentUser,
-    })
-
-  const item = preparePrimitiveInputState({
-    ...parent,
-    path: itemPath,
-    schemaType: itemType as PrimitiveSchemaType,
-    level: itemLevel,
-    value: itemValue,
-    comparisonValue: itemComparisonValue,
-    readOnly,
   })
 
-  return {
-    kind: 'item',
-    key,
-    index,
-    parentSchemaType: parent.schemaType,
-    open: isEqual(itemPath, parent.openPath),
-    item,
-  }
-}
+  const memoizePrepareArrayOfPrimitivesMember = createMemoizer<PrepareArrayOfPrimitivesMember>({
+    decorator: decorators.prepareArrayOfPrimitivesMember,
+    getPath: ({parent, index}) => [...parent.path, index],
+    hashInput: ({parent, index, arrayItem}) => ({
+      ...serializeState({path: [...parent.path, index], state: parent}),
+      // overrides `parent.value` on purpose. we don't want
+      // to bust the cache for the parent if the item is the same
+      value: `${arrayItem}`,
+      index,
+    }),
+  })
 
-function preparePrimitiveInputState<SchemaType extends PrimitiveSchemaType>(
-  props: RawState<SchemaType, unknown>,
-): PrimitiveFormNode {
-  const filteredPresence = props.presence.filter((item) => isEqual(item.path, props.path))
-  const presence = filteredPresence.length ? filteredPresence : EMPTY_ARRAY
+  const memoizePreparePrimitiveInputState = createMemoizer<PreparePrimitiveInputState>({
+    decorator: decorators.preparePrimitiveInputState,
+    getPath: ({path}) => path,
+    hashInput: (state) => serializeState({path: state.path, state}),
+  })
 
-  const validation = props.validation
-    .filter((item) => isEqual(item.path, props.path))
-    .map((v) => ({level: v.level, message: v.message, path: v.path}))
-  return {
-    schemaType: props.schemaType,
-    changed: isChangedValue(props.value, props.comparisonValue),
-    value: props.value,
-    level: props.level,
-    id: toString(props.path),
-    readOnly: props.readOnly,
-    focused: isEqual(props.path, props.focusPath),
-    path: props.path,
-    presence,
-    validation,
-  } as PrimitiveFormNode
-}
+  /*
+   * Takes a field in context of a parent object and returns prepared props for it
+   */
+  const prepareFieldMember = memoizePrepareFieldMember(function _prepareFieldMember(props) {
+    const {field, index, parent} = props
+    const fieldPath = pathFor([...parent.path, field.name])
+    const fieldLevel = getFieldLevel(field.type, parent.level + 1)
 
-/** @internal */
-export type FIXME_SanityDocument = Record<string, unknown>
+    const parentValue = parent.value
+    const parentComparisonValue = parent.comparisonValue
+    if (!isAcceptedObjectValue(parentValue)) {
+      // Note: we validate each field, before passing it recursively to this function so getting this error means that the
+      // ´prepareFormState´ function itself has been called with a non-object value
+      throw new Error('Unexpected non-object value')
+    }
 
-/** @internal */
-export function prepareFormState<T extends FIXME_SanityDocument>(
-  props: RawState<ObjectSchemaType, T>,
-): ObjectFormNode | null {
-  return prepareObjectInputState(props)
+    const normalizedFieldGroupNames = field.group ? castArray(field.group) : []
+    const inSelectedGroup = isFieldEnabledByGroupFilter(
+      parent.groups,
+      field.group,
+      parent.selectedGroup,
+    )
+
+    if (isObjectSchemaType(field.type)) {
+      const fieldValue = parentValue?.[field.name]
+      const fieldComparisonValue = isRecord(parentComparisonValue)
+        ? parentComparisonValue?.[field.name]
+        : undefined
+
+      if (!isAcceptedObjectValue(fieldValue)) {
+        return {
+          kind: 'error',
+          key: field.name,
+          fieldName: field.name,
+          error: {
+            type: 'INCOMPATIBLE_TYPE',
+            expectedSchemaType: field.type,
+            resolvedValueType: resolveTypeName(fieldValue),
+            value: fieldValue,
+          },
+        }
+      }
+
+      const hidden = parent?.hidden?.value || parent.hidden?.children?.[field.name]?.value
+
+      if (hidden) {
+        return {
+          kind: 'hidden',
+          key: `field-${field.name}`,
+          name: field.name,
+          index: index,
+        }
+      }
+
+      // todo: consider requiring a _type annotation for object values on fields as well
+      // if (resolvedValueType !== field.type.name) {
+      //   return {
+      //     kind: 'error',
+      //     key: field.name,
+      //     error: {
+      //       type: 'TYPE_ANNOTATION_MISMATCH',
+      //       expectedSchemaType: field.type,
+      //       resolvedValueType,
+      //     },
+      //   }
+      // }
+
+      const fieldGroupState = parent.fieldGroupState?.children?.[field.name]
+      const scopedCollapsedPaths = parent.collapsedPaths?.children?.[field.name]
+      const scopedCollapsedFieldsets = parent.collapsedFieldSets?.children?.[field.name]
+      const scopedHidden = parent.hidden?.children?.[field.name]
+      const scopedReadOnly = parent.readOnly?.children?.[field.name]
+
+      const inputState = prepareObjectInputState({
+        schemaType: field.type,
+        currentUser: parent.currentUser,
+        value: fieldValue,
+        changed: isChangedValue(fieldValue, fieldComparisonValue),
+        comparisonValue: fieldComparisonValue,
+        presence: parent.presence,
+        validation: parent.validation,
+        fieldGroupState,
+        path: fieldPath,
+        level: fieldLevel,
+        focusPath: parent.focusPath,
+        openPath: parent.openPath,
+        collapsedPaths: scopedCollapsedPaths,
+        collapsedFieldSets: scopedCollapsedFieldsets,
+        hidden: scopedHidden,
+        readOnly: scopedReadOnly,
+        changesOpen: parent.changesOpen,
+      })
+
+      if (inputState === null) {
+        // if inputState is null is either because we reached max field depth or if it has no visible members
+        return null
+      }
+
+      const defaultCollapsedState = getCollapsedWithDefaults(field.type.options, fieldLevel)
+      const collapsed = scopedCollapsedPaths
+        ? scopedCollapsedPaths.value
+        : defaultCollapsedState.collapsed
+
+      return {
+        kind: 'field',
+        key: `field-${field.name}`,
+        name: field.name,
+        index: index,
+
+        inSelectedGroup,
+        groups: normalizedFieldGroupNames,
+
+        open: startsWith(fieldPath, parent.openPath),
+        field: inputState,
+        collapsed,
+        collapsible: defaultCollapsedState.collapsible,
+      }
+    } else if (isArraySchemaType(field.type)) {
+      const fieldValue = parentValue?.[field.name] as unknown[] | undefined
+      const fieldComparisonValue = isRecord(parentComparisonValue)
+        ? parentComparisonValue?.[field.name]
+        : undefined
+      if (isArrayOfObjectsSchemaType(field.type)) {
+        const hasValue = typeof fieldValue !== 'undefined'
+        if (hasValue && !isValidArrayOfObjectsValue(fieldValue)) {
+          const resolvedValueType = resolveTypeName(fieldValue)
+
+          return {
+            kind: 'error',
+            key: field.name,
+            fieldName: field.name,
+            error: {
+              type: 'INCOMPATIBLE_TYPE',
+              expectedSchemaType: field.type,
+              resolvedValueType,
+              value: fieldValue,
+            },
+          }
+        }
+
+        if (hasValue && !everyItemIsObject(fieldValue)) {
+          return {
+            kind: 'error',
+            key: field.name,
+            fieldName: field.name,
+            error: {
+              type: 'MIXED_ARRAY',
+              schemaType: field.type,
+              value: fieldValue,
+            },
+          }
+        }
+
+        if (hasValue && !everyItemHasKey(fieldValue)) {
+          return {
+            kind: 'error',
+            key: field.name,
+            fieldName: field.name,
+            error: {
+              type: 'MISSING_KEYS',
+              value: fieldValue,
+              schemaType: field.type,
+            },
+          }
+        }
+
+        const duplicateKeyEntries = hasValue ? findDuplicateKeyEntries(fieldValue) : []
+        if (duplicateKeyEntries.length > 0) {
+          return {
+            kind: 'error',
+            key: field.name,
+            fieldName: field.name,
+            error: {
+              type: 'DUPLICATE_KEYS',
+              duplicates: duplicateKeyEntries,
+              schemaType: field.type,
+            },
+          }
+        }
+
+        const fieldGroupState = parent.fieldGroupState?.children?.[field.name]
+        const scopedCollapsedPaths = parent.collapsedPaths?.children?.[field.name]
+        const scopedCollapsedFieldSets = parent.collapsedFieldSets?.children?.[field.name]
+        const scopedReadOnly = parent.readOnly?.children?.[field.name]
+        const scopedHidden = parent.hidden?.children?.[field.name]
+
+        const fieldState = prepareArrayOfObjectsInputState({
+          schemaType: field.type,
+          currentUser: parent.currentUser,
+          value: fieldValue,
+          changed: isChangedValue(fieldValue, fieldComparisonValue),
+          comparisonValue: fieldComparisonValue as FIXME,
+          fieldGroupState,
+          focusPath: parent.focusPath,
+          openPath: parent.openPath,
+          presence: parent.presence,
+          validation: parent.validation,
+          collapsedPaths: scopedCollapsedPaths,
+          collapsedFieldSets: scopedCollapsedFieldSets,
+          level: fieldLevel,
+          path: fieldPath,
+          readOnly: scopedReadOnly,
+          hidden: scopedHidden,
+          changesOpen: parent.changesOpen,
+        })
+
+        if (fieldState === null) {
+          return null
+        }
+
+        return {
+          kind: 'field',
+          key: `field-${field.name}`,
+          name: field.name,
+          index: index,
+
+          open: startsWith(fieldPath, parent.openPath),
+
+          inSelectedGroup,
+          groups: normalizedFieldGroupNames,
+
+          collapsible: false,
+          collapsed: false,
+          // note: this is what we actually end up passing down as to the next input component
+          field: fieldState,
+        }
+      } else {
+        // array of primitives
+        if (!isValidArrayOfPrimitivesValue(fieldValue)) {
+          const resolvedValueType = resolveTypeName(fieldValue)
+
+          return {
+            kind: 'error',
+            key: field.name,
+            fieldName: field.name,
+            error: {
+              type: 'INCOMPATIBLE_TYPE',
+              expectedSchemaType: field.type,
+              resolvedValueType,
+              value: fieldValue,
+            },
+          }
+        }
+
+        const fieldGroupState = parent.fieldGroupState?.children?.[field.name]
+        const scopedCollapsedPaths = parent.collapsedPaths?.children?.[field.name]
+        const scopedCollapsedFieldSets = parent.collapsedFieldSets?.children?.[field.name]
+        const scopedReadOnly = parent.readOnly?.children?.[field.name]
+        const scopedHidden = parent.hidden?.children?.[field.name]
+
+        const fieldState = prepareArrayOfPrimitivesInputState({
+          changed: isChangedValue(fieldValue, fieldComparisonValue),
+          comparisonValue: fieldComparisonValue as FIXME,
+          schemaType: field.type,
+          currentUser: parent.currentUser,
+          value: fieldValue,
+          fieldGroupState,
+          focusPath: parent.focusPath,
+          openPath: parent.openPath,
+          presence: parent.presence,
+          validation: parent.validation,
+          collapsedPaths: scopedCollapsedPaths,
+          collapsedFieldSets: scopedCollapsedFieldSets,
+          level: fieldLevel,
+          path: fieldPath,
+          readOnly: scopedReadOnly,
+          hidden: scopedHidden,
+          changesOpen: parent.changesOpen,
+        })
+
+        if (fieldState === null) {
+          return null
+        }
+
+        return {
+          kind: 'field',
+          key: `field-${field.name}`,
+          name: field.name,
+          index: index,
+
+          inSelectedGroup,
+          groups: normalizedFieldGroupNames,
+
+          open: startsWith(fieldPath, parent.openPath),
+
+          // todo: consider support for collapsible arrays
+          collapsible: false,
+          collapsed: false,
+          // note: this is what we actually end up passing down as to the next input component
+          field: fieldState,
+        }
+      }
+    } else {
+      // primitive fields
+
+      const fieldValue = parentValue?.[field.name] as undefined | boolean | string | number
+      const fieldComparisonValue = isRecord(parentComparisonValue)
+        ? parentComparisonValue?.[field.name]
+        : undefined
+
+      // note: we *only* want to call the conditional props here, as it's handled by the prepare<Object|Array>InputProps otherwise
+      const hidden = parent.hidden?.value || parent.hidden?.children?.[field.name]?.value
+
+      if (hidden) {
+        return null
+      }
+
+      const scopedReadOnly = parent.readOnly?.children?.[field.name]
+      const scopedHidden = parent.hidden?.children?.[field.name]
+
+      const fieldState = preparePrimitiveInputState({
+        ...parent,
+        comparisonValue: fieldComparisonValue,
+        value: fieldValue as boolean | string | number | undefined,
+        schemaType: field.type as PrimitiveSchemaType,
+        path: fieldPath,
+        readOnly: scopedReadOnly,
+        hidden: scopedHidden,
+      })
+
+      return {
+        kind: 'field',
+        key: `field-${field.name}`,
+        name: field.name,
+        index: index,
+        open: startsWith(fieldPath, parent.openPath),
+
+        inSelectedGroup,
+        groups: normalizedFieldGroupNames,
+
+        // todo: consider support for collapsible primitive fields
+        collapsible: false,
+        collapsed: false,
+        field: fieldState,
+      }
+    }
+  })
+
+  const prepareObjectInputState = memoizePrepareObjectInputState(function _prepareObjectInputState(
+    props,
+    enableHiddenCheck = true,
+  ) {
+    if (props.level === MAX_FIELD_DEPTH) {
+      return null
+    }
+
+    const readOnly = props.readOnly?.value
+
+    const schemaTypeGroupConfig = props.schemaType.groups || []
+    const defaultGroupName = (schemaTypeGroupConfig.find((g) => g.default) || ALL_FIELDS_GROUP)
+      ?.name
+
+    const groups = [ALL_FIELDS_GROUP, ...schemaTypeGroupConfig].flatMap(
+      (group): FormFieldGroup[] => {
+        const groupHidden = props.hidden?.children?.[`group:${group.name}`]?.value
+        const isSelected = group.name === (props.fieldGroupState?.value || defaultGroupName)
+
+        // Set the "all-fields" group as selected when review changes is open to enable review of all
+        // fields and changes together. When review changes is closed - switch back to the selected tab.
+        const selected = props.changesOpen ? group.name === ALL_FIELDS_GROUP.name : isSelected
+        // Also disable non-selected groups when review changes is open
+        const disabled = props.changesOpen ? !selected : false
+
+        return groupHidden
+          ? []
+          : [
+              {
+                disabled,
+                icon: group?.icon,
+                name: group.name,
+                selected,
+                title: group.title,
+                i18n: group.i18n,
+              },
+            ]
+      },
+    )
+
+    const selectedGroup = groups.find((group) => group.selected)!
+
+    // note: this is needed because not all object types gets a ´fieldsets´ property during schema parsing.
+    // ideally members should be normalized as part of the schema parsing and not here
+    const normalizedSchemaMembers: typeof props.schemaType.fieldsets = props.schemaType.fieldsets
+      ? props.schemaType.fieldsets
+      : props.schemaType.fields.map((field) => ({single: true, field}))
+
+    // create a members array for the object
+    const members = normalizedSchemaMembers.flatMap(
+      (fieldSet, index): (ObjectMember | HiddenField)[] => {
+        // "single" means not part of a fieldset
+        if (fieldSet.single) {
+          const field = fieldSet.field
+
+          const fieldMember = prepareFieldMember({
+            field: field,
+            parent: {...props, groups, selectedGroup},
+            index,
+          })
+
+          return fieldMember ? [fieldMember] : []
+        }
+
+        // it's an actual fieldset
+        const fieldsetHidden = props.hidden?.children?.[`fieldset:${fieldSet.name}`]?.value
+
+        const fieldsetMembers = fieldSet.fields.flatMap(
+          (field): (FieldMember | FieldError | HiddenField)[] => {
+            if (fieldsetHidden) {
+              return [
+                {
+                  kind: 'hidden',
+                  key: `field-${field.name}`,
+                  name: field.name,
+                  index: index,
+                },
+              ]
+            }
+            const fieldMember = prepareFieldMember({
+              field: field,
+              parent: {...props, groups, selectedGroup},
+              index,
+            }) as FieldMember | FieldError | HiddenField
+
+            return fieldMember ? [fieldMember] : []
+          },
+        )
+
+        const defaultCollapsedState = getCollapsedWithDefaults(fieldSet.options, props.level)
+
+        const collapsed =
+          (props.collapsedFieldSets?.children || {})[fieldSet.name]?.value ??
+          defaultCollapsedState.collapsed
+
+        return [
+          {
+            kind: 'fieldSet',
+            key: `fieldset-${fieldSet.name}`,
+            _inSelectedGroup: isFieldEnabledByGroupFilter(groups, fieldSet.group, selectedGroup),
+            groups: fieldSet.group ? castArray(fieldSet.group) : [],
+            fieldSet: {
+              path: pathFor(props.path.concat(fieldSet.name)),
+              name: fieldSet.name,
+              title: fieldSet.title,
+              description: fieldSet.description,
+              hidden: false,
+              level: props.level + 1,
+              members: fieldsetMembers.filter(
+                (member): member is FieldMember => member.kind !== 'hidden',
+              ),
+              collapsible: defaultCollapsedState?.collapsible,
+              collapsed,
+              columns: fieldSet?.options?.columns,
+            },
+          },
+        ]
+      },
+    )
+
+    const hasFieldGroups = schemaTypeGroupConfig.length > 0
+
+    const filteredPresence = props.presence.filter((item) => isEqual(item.path, props.path))
+    const presence = filteredPresence.length ? filteredPresence : EMPTY_ARRAY
+
+    const validation = props.validation
+      .filter((item) => isEqual(item.path, props.path))
+      .map((v) => ({level: v.level, message: v.message, path: v.path}))
+
+    const visibleMembers = members.filter(
+      (member): member is ObjectMember => member.kind !== 'hidden',
+    )
+
+    // Return null here only when enableHiddenCheck, or we end up with array members that have 'item: null' when they
+    // really should not be. One example is when a block object inside the PT-input have a type with one single hidden field.
+    // Then it should still be possible to see the member item, even though all of it's fields are null.
+    if (visibleMembers.length === 0 && enableHiddenCheck) {
+      return null
+    }
+
+    const visibleGroups = hasFieldGroups
+      ? groups.flatMap((group) => {
+          // The "all fields" group is always visible
+          if (group.name === ALL_FIELDS_GROUP.name) {
+            return group
+          }
+          const hasVisibleMembers = visibleMembers.some((member) => {
+            if (member.kind === 'error') {
+              return false
+            }
+            if (member.kind === 'field') {
+              return member.groups.includes(group.name)
+            }
+
+            return (
+              member.groups.includes(group.name) ||
+              member.fieldSet.members.some(
+                (fieldsetMember) =>
+                  fieldsetMember.kind !== 'error' && fieldsetMember.groups.includes(group.name),
+              )
+            )
+          })
+          return hasVisibleMembers ? group : []
+        })
+      : []
+
+    const filtereredMembers = visibleMembers.flatMap(
+      (member): (FieldError | FieldMember | FieldSetMember)[] => {
+        if (member.kind === 'error') {
+          return [member]
+        }
+        if (member.kind === 'field') {
+          return member.inSelectedGroup ? [member] : []
+        }
+
+        const filteredFieldsetMembers: ObjectMember[] = member.fieldSet.members.filter(
+          (fieldsetMember) => fieldsetMember.kind !== 'field' || fieldsetMember.inSelectedGroup,
+        )
+        return filteredFieldsetMembers.length > 0
+          ? [
+              {
+                ...member,
+                fieldSet: {...member.fieldSet, members: filteredFieldsetMembers},
+              } as FieldSetMember,
+            ]
+          : []
+      },
+    )
+
+    const node = {
+      value: props.value as Record<string, unknown> | undefined,
+      changed: isChangedValue(props.value, props.comparisonValue),
+      schemaType: props.schemaType,
+      readOnly,
+      path: props.path,
+      id: toString(props.path),
+      level: props.level,
+      focused: isEqual(props.path, props.focusPath),
+      focusPath: trimChildPath(props.path, props.focusPath),
+      presence,
+      validation,
+      // this is currently needed by getExpandOperations which needs to know about hidden members
+      // (e.g. members not matching current group filter) in order to determine what to expand
+      members: filtereredMembers,
+      groups: visibleGroups,
+    }
+    Object.defineProperty(node, '_allMembers', {
+      value: members,
+      enumerable: false,
+    })
+    return node
+  })
+
+  const prepareArrayOfPrimitivesInputState = memoizePrepareArrayOfPrimitivesInputState(
+    function _prepareArrayOfPrimitivesInputState(props) {
+      if (props.level === MAX_FIELD_DEPTH) {
+        return null
+      }
+
+      if (props.hidden?.value) {
+        return null
+      }
+
+      // Todo: improve error handling at the parent level so that the value here is either undefined or an array
+      const items = Array.isArray(props.value) ? props.value : []
+
+      const filteredPresence = props.presence.filter((item) => isEqual(item.path, props.path))
+      const presence = filteredPresence.length ? filteredPresence : EMPTY_ARRAY
+      const validation = props.validation
+        .filter((item) => isEqual(item.path, props.path))
+        .map((v) => ({level: v.level, message: v.message, path: v.path}))
+      const members = items.flatMap((item, index) =>
+        prepareArrayOfPrimitivesMember({arrayItem: item, parent: props, index}),
+      )
+      return {
+        // checks for changes not only on the array itself, but also on any of its items
+        changed: props.changed || members.some((m) => m.kind === 'item' && m.item.changed),
+        value: props.value,
+        readOnly: props.readOnly?.value,
+        schemaType: props.schemaType,
+        focused: isEqual(props.path, props.focusPath),
+        focusPath: trimChildPath(props.path, props.focusPath),
+        path: props.path,
+        id: toString(props.path),
+        level: props.level,
+        validation,
+        presence,
+        members,
+      }
+    },
+  )
+
+  const prepareArrayOfObjectsInputState = memoizePrepareArrayOfObjectsInputState(
+    function _prepareArrayOfObjectsInputState(props) {
+      if (props.level === MAX_FIELD_DEPTH) {
+        return null
+      }
+
+      if (props.hidden?.value) {
+        return null
+      }
+
+      // Todo: improve error handling at the parent level so that the value here is either undefined or an array
+      const items = Array.isArray(props.value) ? props.value : []
+
+      const filteredPresence = props.presence.filter((item) => isEqual(item.path, props.path))
+      const presence = filteredPresence.length ? filteredPresence : EMPTY_ARRAY
+      const validation = props.validation
+        .filter((item) => isEqual(item.path, props.path))
+        .map((v) => ({level: v.level, message: v.message, path: v.path}))
+
+      const members = items.flatMap((item, index) =>
+        prepareArrayOfObjectsMember({
+          arrayItem: item,
+          parent: props,
+          index,
+        }),
+      )
+
+      return {
+        // checks for changes not only on the array itself, but also on any of its items
+        changed: props.changed || members.some((m) => m.kind === 'item' && m.item.changed),
+        value: props.value,
+        readOnly: props.readOnly?.value,
+        schemaType: props.schemaType,
+        focused: isEqual(props.path, props.focusPath),
+        focusPath: trimChildPath(props.path, props.focusPath),
+        path: props.path,
+        id: toString(props.path),
+        level: props.level,
+        validation,
+        presence,
+        members,
+      }
+    },
+  )
+
+  /*
+   * Takes a field in context of a parent object and returns prepared props for it
+   */
+  const prepareArrayOfObjectsMember = memoizePrepareArrayOfObjectsMember(
+    function _prepareArrayOfObjectsMember(props) {
+      const {arrayItem, parent, index} = props
+
+      const itemType = getItemType(parent.schemaType, arrayItem) as ObjectSchemaType
+
+      const key = arrayItem._key
+
+      if (!itemType) {
+        const itemTypeName = resolveTypeName(arrayItem)
+        return {
+          kind: 'error',
+          key,
+          index,
+          error: {
+            type: 'INVALID_ITEM_TYPE',
+            resolvedValueType: itemTypeName,
+            value: arrayItem,
+            validTypes: parent.schemaType.of,
+          },
+        }
+      }
+
+      const itemPath = pathFor([...parent.path, {_key: key}])
+      const itemLevel = parent.level + 1
+
+      const fieldGroupState = parent.fieldGroupState?.children?.[key]
+      const scopedCollapsedPaths = parent.collapsedPaths?.children?.[key]
+      const scopedCollapsedFieldsets = parent.collapsedFieldSets?.children?.[key]
+      const scopedReadOnly = parent?.readOnly?.children?.[key]
+      const scopedHidden = parent?.hidden?.children?.[key]
+      const comparisonValue =
+        (Array.isArray(parent.comparisonValue) &&
+          parent.comparisonValue.find((i) => i._key === arrayItem._key)) ||
+        undefined
+
+      const itemState = prepareObjectInputState(
+        {
+          schemaType: itemType,
+          level: itemLevel,
+          value: arrayItem,
+          comparisonValue,
+          changed: isChangedValue(arrayItem, comparisonValue),
+          path: itemPath,
+          focusPath: parent.focusPath,
+          openPath: parent.openPath,
+          currentUser: parent.currentUser,
+          collapsedPaths: scopedCollapsedPaths,
+          collapsedFieldSets: scopedCollapsedFieldsets,
+          presence: parent.presence,
+          validation: parent.validation,
+          fieldGroupState,
+          readOnly: scopedReadOnly,
+          hidden: scopedHidden,
+        },
+        false,
+      ) as ObjectArrayFormNode
+
+      const defaultCollapsedState = getCollapsedWithDefaults(itemType.options, itemLevel)
+      const collapsed = scopedCollapsedPaths?.value ?? defaultCollapsedState.collapsed
+      return {
+        kind: 'item',
+        key,
+        index,
+        open: startsWith(itemPath, parent.openPath),
+        collapsed: collapsed,
+        collapsible: true,
+        parentSchemaType: parent.schemaType,
+        item: itemState,
+      }
+    },
+  )
+
+  /*
+   * Takes a field in contet of a parent object and returns prepared props for it
+   */
+  const prepareArrayOfPrimitivesMember = memoizePrepareArrayOfPrimitivesMember(
+    function _prepareArrayOfPrimitivesMember(props) {
+      const {arrayItem, parent, index} = props
+      const itemType = getPrimitiveItemType(parent.schemaType, arrayItem)
+
+      const itemPath = pathFor([...parent.path, index])
+      const itemValue = (parent.value as unknown[] | undefined)?.[index] as
+        | string
+        | boolean
+        | number
+      const itemComparisonValue = (parent.comparisonValue as unknown[] | undefined)?.[index] as
+        | string
+        | boolean
+        | number
+      const itemLevel = parent.level + 1
+
+      // Best effort attempt to make a stable key for each item in the array
+      // Since items may be reordered and change at any time, there's no way to reliably address each item uniquely
+      // This is a "best effort"-attempt at making sure we don't re-use internal state for item inputs
+      // when items are added to or removed from the array
+      const key = `${itemType?.name || 'invalid-type'}-${String(index)}`
+
+      if (!itemType) {
+        return {
+          kind: 'error',
+          key,
+          index,
+          error: {
+            type: 'INVALID_ITEM_TYPE',
+            validTypes: parent.schemaType.of,
+            resolvedValueType: resolveTypeName(itemType),
+            value: itemValue,
+          },
+        }
+      }
+
+      const item = preparePrimitiveInputState({
+        ...parent,
+        path: itemPath,
+        schemaType: itemType as PrimitiveSchemaType,
+        level: itemLevel,
+        value: itemValue,
+        comparisonValue: itemComparisonValue,
+      })
+
+      return {
+        kind: 'item',
+        key,
+        index,
+        parentSchemaType: parent.schemaType,
+        open: isEqual(itemPath, parent.openPath),
+        item,
+      }
+    },
+  )
+
+  const preparePrimitiveInputState = memoizePreparePrimitiveInputState(
+    function _preparePrimitiveInputState(props) {
+      const filteredPresence = props.presence.filter((item) => isEqual(item.path, props.path))
+      const presence = filteredPresence.length ? filteredPresence : EMPTY_ARRAY
+
+      const validation = props.validation
+        .filter((item) => isEqual(item.path, props.path))
+        .map((v) => ({level: v.level, message: v.message, path: v.path}))
+      return {
+        schemaType: props.schemaType,
+        changed: isChangedValue(props.value, props.comparisonValue),
+        value: props.value,
+        level: props.level,
+        id: toString(props.path),
+        readOnly: props.readOnly?.value,
+        focused: isEqual(props.path, props.focusPath),
+        path: props.path,
+        presence,
+        validation,
+      } as PrimitiveFormNode
+    },
+  )
+
+  return Object.assign(
+    function prepareFormState(
+      props: FormStateOptions<ObjectSchemaType, unknown>,
+    ): ObjectFormNode | null {
+      return prepareObjectInputState(props)
+    },
+    {
+      prepareFieldMember,
+      prepareObjectInputState,
+      prepareArrayOfPrimitivesInputState,
+      prepareArrayOfObjectsInputState,
+      prepareArrayOfObjectsMember,
+      prepareArrayOfPrimitivesMember,
+      preparePrimitiveInputState,
+    },
+  )
 }

--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -222,13 +222,21 @@ export interface RootFormStateOptions {
 
 export interface PrepareFormState {
   (options: RootFormStateOptions): ObjectFormNode | null
-  prepareFieldMember: PrepareFieldMember
-  prepareObjectInputState: PrepareObjectInputState
-  prepareArrayOfPrimitivesInputState: PrepareArrayOfPrimitivesInputState
-  prepareArrayOfObjectsInputState: PrepareArrayOfObjectsInputState
-  prepareArrayOfObjectsMember: PrepareArrayOfObjectsMember
-  prepareArrayOfPrimitivesMember: PrepareArrayOfPrimitivesMember
-  preparePrimitiveInputState: PreparePrimitiveInputState
+
+  /** @internal */
+  _prepareFieldMember: PrepareFieldMember
+  /** @internal */
+  _prepareObjectInputState: PrepareObjectInputState
+  /** @internal */
+  _prepareArrayOfPrimitivesInputState: PrepareArrayOfPrimitivesInputState
+  /** @internal */
+  _prepareArrayOfObjectsInputState: PrepareArrayOfObjectsInputState
+  /** @internal */
+  _prepareArrayOfObjectsMember: PrepareArrayOfObjectsMember
+  /** @internal */
+  _prepareArrayOfPrimitivesMember: PrepareArrayOfPrimitivesMember
+  /** @internal */
+  _preparePrimitiveInputState: PreparePrimitiveInputState
 }
 
 export function createPrepareFormState({
@@ -1247,50 +1255,50 @@ export function createPrepareFormState({
     },
   )
 
-  return Object.assign(
-    function prepareFormState({
+  function prepareFormState({
+    collapsedFieldSets,
+    collapsedPaths,
+    comparisonValue,
+    currentUser,
+    documentValue,
+    fieldGroupState,
+    focusPath,
+    hidden,
+    openPath,
+    presence,
+    readOnly,
+    schemaType,
+    validation,
+    changesOpen,
+  }: RootFormStateOptions): ObjectFormNode | null {
+    return prepareObjectInputState({
       collapsedFieldSets,
       collapsedPaths,
       comparisonValue,
       currentUser,
-      documentValue,
+      value: documentValue,
       fieldGroupState,
       focusPath,
-      hidden,
+      hidden: hidden === false ? EMPTY_OBJECT : hidden,
       openPath,
       presence,
-      readOnly,
+      readOnly: readOnly === false ? EMPTY_OBJECT : readOnly,
       schemaType,
       validation,
       changesOpen,
-    }: RootFormStateOptions): ObjectFormNode | null {
-      return prepareObjectInputState({
-        collapsedFieldSets,
-        collapsedPaths,
-        comparisonValue,
-        currentUser,
-        value: documentValue,
-        fieldGroupState,
-        focusPath,
-        hidden: hidden === false ? EMPTY_OBJECT : hidden,
-        openPath,
-        presence,
-        readOnly: readOnly === false ? EMPTY_OBJECT : readOnly,
-        schemaType,
-        validation,
-        changesOpen,
-        level: 0,
-        path: [],
-      })
-    },
-    {
-      prepareFieldMember,
-      prepareObjectInputState,
-      prepareArrayOfPrimitivesInputState,
-      prepareArrayOfObjectsInputState,
-      prepareArrayOfObjectsMember,
-      prepareArrayOfPrimitivesMember,
-      preparePrimitiveInputState,
-    },
-  )
+      level: 0,
+      path: [],
+    })
+  }
+
+  prepareFormState._prepareFieldMember = prepareFieldMember
+  prepareFormState._prepareFieldMember = prepareFieldMember
+  prepareFormState._prepareObjectInputState = prepareObjectInputState
+  prepareFormState._prepareArrayOfPrimitivesInputState = prepareArrayOfPrimitivesInputState
+  prepareFormState._prepareArrayOfObjectsInputState = prepareArrayOfObjectsInputState
+  prepareFormState._prepareArrayOfObjectsMember = prepareArrayOfObjectsMember
+  prepareFormState._prepareArrayOfPrimitivesMember = prepareArrayOfPrimitivesMember
+  prepareFormState._preparePrimitiveInputState = preparePrimitiveInputState
+
+  return prepareFormState
 }

--- a/packages/sanity/src/core/form/store/index.ts
+++ b/packages/sanity/src/core/form/store/index.ts
@@ -1,5 +1,4 @@
 export {resolveConditionalProperty} from './conditional-property'
-export type {FIXME_SanityDocument} from './formState' // eslint-disable-line camelcase
 export * from './stateTreeHelper'
 export * from './types'
 export * from './useFormState'

--- a/packages/sanity/src/core/form/store/types/state.ts
+++ b/packages/sanity/src/core/form/store/types/state.ts
@@ -2,7 +2,7 @@
  * @hidden
  * @beta */
 export interface StateTree<T> {
-  value: T | undefined
+  value?: T | undefined
   children?: {
     [key: string]: StateTree<T>
   }

--- a/packages/sanity/src/core/form/store/useFormState.ts
+++ b/packages/sanity/src/core/form/store/useFormState.ts
@@ -1,7 +1,6 @@
 /* eslint-disable camelcase */
 
 import {type ObjectSchemaType, type Path, type ValidationMarker} from '@sanity/types'
-import {pathFor} from '@sanity/util/paths'
 import {useMemo} from 'react'
 
 import {type FormNodePresence} from '../../presence'
@@ -18,37 +17,39 @@ export type FormState<
 > = ObjectFormNode<T, S>
 
 /** @internal */
+export interface UseFormStateOptions {
+  schemaType: ObjectSchemaType
+  documentValue: unknown
+  comparisonValue: unknown
+  openPath: Path
+  focusPath: Path
+  presence: FormNodePresence[]
+  validation: ValidationMarker[]
+  fieldGroupState?: StateTree<string> | undefined
+  collapsedFieldSets?: StateTree<boolean> | undefined
+  collapsedPaths?: StateTree<boolean> | undefined
+  readOnly?: boolean
+  changesOpen?: boolean
+}
+
+/** @internal */
 export function useFormState<
   T extends {[key in string]: unknown} = {[key in string]: unknown},
   S extends ObjectSchemaType = ObjectSchemaType,
->(
-  schemaType: ObjectSchemaType,
-  {
-    comparisonValue,
-    value,
-    fieldGroupState,
-    collapsedFieldSets,
-    collapsedPaths,
-    focusPath,
-    openPath,
-    presence,
-    validation,
-    readOnly: inputReadOnly,
-    changesOpen,
-  }: {
-    fieldGroupState?: StateTree<string> | undefined
-    collapsedFieldSets?: StateTree<boolean> | undefined
-    collapsedPaths?: StateTree<boolean> | undefined
-    value: unknown
-    comparisonValue: unknown
-    openPath: Path
-    focusPath: Path
-    presence: FormNodePresence[]
-    validation: ValidationMarker[]
-    changesOpen?: boolean
-    readOnly?: boolean
-  },
-): FormState<T, S> | null {
+>({
+  comparisonValue,
+  documentValue,
+  fieldGroupState,
+  collapsedFieldSets,
+  collapsedPaths,
+  focusPath,
+  openPath,
+  presence,
+  validation,
+  readOnly: inputReadOnly,
+  changesOpen,
+  schemaType,
+}: UseFormStateOptions): FormState<T, S> | null {
   // note: feel free to move these state pieces out of this hook
   const currentUser = useCurrentUser()
 
@@ -99,17 +100,24 @@ export function useFormState<
     return {
       hidden: prepareHiddenState({
         currentUser,
-        document: value,
+        documentValue: documentValue,
         schemaType,
       }),
       readOnly: prepareReadOnlyState({
         currentUser,
-        document: value,
+        documentValue: documentValue,
         schemaType,
         readOnly: inputReadOnly,
       }),
     }
-  }, [prepareHiddenState, currentUser, value, schemaType, prepareReadOnlyState, inputReadOnly])
+  }, [
+    prepareHiddenState,
+    currentUser,
+    documentValue,
+    schemaType,
+    prepareReadOnlyState,
+    inputReadOnly,
+  ])
 
   return useMemo(() => {
     return prepareFormState({
@@ -117,14 +125,12 @@ export function useFormState<
       fieldGroupState: reconciledFieldGroupState,
       collapsedFieldSets: reconciledCollapsedFieldsets,
       collapsedPaths: reconciledCollapsedPaths,
-      value,
+      documentValue,
       comparisonValue,
       focusPath,
       openPath,
       readOnly,
       hidden,
-      path: pathFor([]),
-      level: 0,
       currentUser,
       presence,
       validation,
@@ -136,7 +142,7 @@ export function useFormState<
     reconciledFieldGroupState,
     reconciledCollapsedFieldsets,
     reconciledCollapsedPaths,
-    value,
+    documentValue,
     comparisonValue,
     focusPath,
     openPath,

--- a/packages/sanity/src/core/form/store/utils/__tests__/immutableReconcile.test.ts
+++ b/packages/sanity/src/core/form/store/utils/__tests__/immutableReconcile.test.ts
@@ -1,104 +1,47 @@
-import {expect, test} from '@jest/globals'
+import {beforeEach, expect, jest, test} from '@jest/globals'
+import {defineField, defineType} from '@sanity/types'
 
-import {immutableReconcile} from '../immutableReconcile'
+import {createSchema} from '../../../../schema/createSchema'
+import {createImmutableReconcile} from '../immutableReconcile'
+
+const immutableReconcile = createImmutableReconcile({decorator: jest.fn})
+
+beforeEach(() => {
+  ;(immutableReconcile as jest.Mock).mockClear()
+})
 
 test('it preserves previous value if shallow equal', () => {
   const prev = {test: 'hi'}
   const next = {test: 'hi'}
-  expect(immutableReconcile(prev, next)).toBe(prev)
+  const reconciled = immutableReconcile(prev, next)
+  expect(reconciled).toBe(prev)
+  expect(immutableReconcile).toHaveBeenCalledTimes(2)
 })
 
 test('it preserves previous value if deep equal', () => {
   const prev = {arr: [{foo: 'bar'}]}
   const next = {arr: [{foo: 'bar'}]}
-  expect(immutableReconcile(prev, next)).toBe(prev)
+  const reconciled = immutableReconcile(prev, next)
+  expect(reconciled).toBe(prev)
+  expect(immutableReconcile).toHaveBeenCalledTimes(4)
 })
 
 test('it preserves previous nodes that are deep equal', () => {
   const prev = {arr: [{foo: 'bar'}], x: 1}
   const next = {arr: [{foo: 'bar'}]}
-  expect(immutableReconcile(prev, next).arr).toBe(prev.arr)
+  const reconciled = immutableReconcile(prev, next)
+  expect(reconciled.arr).toBe(prev.arr)
 })
 
 test('it keeps equal objects in arrays', () => {
   const prev = {arr: ['foo', {greet: 'hello'}, {other: []}], x: 1}
   const next = {arr: ['bar', {greet: 'hello'}, {other: []}]}
-  expect(immutableReconcile(prev, next).arr).not.toBe(prev.arr)
-  expect(immutableReconcile(prev, next).arr[1]).toBe(prev.arr[1])
-  expect(immutableReconcile(prev, next).arr[2]).toBe(prev.arr[2])
-})
-
-test('it handles changing cyclic structures', () => {
-  const createObject = (differentiator: string) => {
-    // will be different if differentiator is different
-    const root: Record<string, any> = {id: 'root'}
-
-    // will be different if differentiator is different
-    root.a = {id: 'a'}
-
-    // will be different if differentiator is different
-    root.a.b = {id: 'b', diff: differentiator}
-
-    // cycle
-    root.a.b.a = root.a
-    // will never be different
-    root.a.b.c = {id: 'c'}
-
-    return root
-  }
-
-  const prev = createObject('previous')
-  const next = createObject('next')
-
   const reconciled = immutableReconcile(prev, next)
 
-  expect(prev).not.toBe(reconciled)
-  expect(next).not.toBe(reconciled)
-
-  // A sub object of root has changed, creating new object
-  expect(next.a).not.toBe(reconciled.a)
-
-  // A sub-object of root.a has changed, creating new object
-  expect(next.a.b).not.toBe(reconciled.a.b)
-
-  // root.a.b.c is has not changed, therefore reuse.
-  expect(next.a.b.c).not.toBe(reconciled.a.b.c)
-
-  expect(prev.a.b.c).toBe(reconciled.a.b.c)
-
-  // The new reconcile will retain reconcilable objects also within loops.
-  expect(prev.a.b.a.b.c).toBe(reconciled.a.b.a.b.c)
-
-  // This is because it retains the loop.
-  expect(reconciled.a).toBe(reconciled.a.b.a)
-  expect(prev.a.b.c).toBe(reconciled.a.b.a.b.c)
-})
-
-test('it handles non-changing cyclic structures', () => {
-  const cyclic: Record<string, unknown> = {test: 'foo'}
-  cyclic.self = cyclic
-
-  const prev = {
-    cyclic,
-    arr: [
-      {cyclic, value: 'old'},
-      {cyclic, value: 'unchanged'},
-    ],
-    other: {cyclic, value: 'unchanged'},
-  }
-  const next = {
-    cyclic,
-    arr: [
-      {cyclic, value: 'new'},
-      {cyclic, value: 'unchanged'},
-    ],
-    other: {cyclic, value: 'unchanged'},
-  }
-
-  const reconciled = immutableReconcile(prev, next)
   expect(reconciled.arr).not.toBe(prev.arr)
   expect(reconciled.arr[1]).toBe(prev.arr[1])
-  expect(reconciled.other).toBe(prev.other)
+  expect(reconciled.arr[2]).toBe(prev.arr[2])
+  expect(immutableReconcile).toHaveBeenCalledTimes(7)
 })
 
 test('keeps the previous values where they deep equal to the next', () => {
@@ -120,13 +63,44 @@ test('keeps the previous values where they deep equal to the next', () => {
     new: ['foo', 'bar'],
   }
 
-  const result = immutableReconcile(prev, next)
+  const reconciled = immutableReconcile(prev, next)
 
-  expect(result).not.toBe(prev)
-  expect(result).not.toBe(next)
+  expect(reconciled).not.toBe(prev)
+  expect(reconciled).not.toBe(next)
 
-  expect(result.array).toBe(prev.array)
-  expect(result.object.keep).toBe(prev.object.keep)
+  expect(reconciled.array).toBe(prev.array)
+  expect(reconciled.object.keep).toBe(prev.object.keep)
+  expect(immutableReconcile).toHaveBeenCalledTimes(11)
+})
+
+test('skips reconciling if the previous sub-values are already referentially equal', () => {
+  const keep = {foo: 'bar'}
+  const prev = {
+    test: 'hi',
+    array: ['aloha', keep],
+    object: {
+      x: {y: 'CHANGE'},
+      keep,
+    },
+  }
+  const next = {
+    test: 'hi',
+    array: ['aloha', keep],
+    object: {
+      x: {y: 'CHANGED'},
+      keep,
+    },
+    new: ['foo', 'bar'],
+  }
+
+  const reconciled = immutableReconcile(prev, next)
+
+  expect(reconciled).not.toBe(prev)
+  expect(reconciled).not.toBe(next)
+
+  expect(reconciled.array).toBe(prev.array)
+  expect(reconciled.object.keep).toBe(prev.object.keep)
+  expect(immutableReconcile).toHaveBeenCalledTimes(9)
 })
 
 test('does not mutate any of its input', () => {
@@ -170,6 +144,33 @@ test('returns new array when previous and next has different length', () => {
   expect(immutableReconcile(moreItems, lessItems)).not.toBe(moreItems)
 
   expect(immutableReconcile(lessItems, moreItems)).not.toBe(lessItems)
+})
+
+test('does not reconcile schema type values', () => {
+  const schema = createSchema({
+    name: 'default',
+    types: [
+      defineType({
+        name: 'myType',
+        type: 'document',
+        fields: [defineField({name: 'myString', type: 'string'})],
+      }),
+      defineType({
+        name: 'myOtherType',
+        type: 'document',
+        fields: [defineField({name: 'myString2', type: 'string'})],
+      }),
+    ],
+  })
+  const schemaType = schema.get('myType')!
+  const otherSchemaType = schema.get('myOtherType')!
+
+  const prev = {schemaType}
+  const next = {schemaType: otherSchemaType}
+
+  const reconciled = immutableReconcile(prev, next)
+  expect(reconciled.schemaType).toBe(otherSchemaType)
+  expect(immutableReconcile).toHaveBeenCalledTimes(2)
 })
 
 test('returns latest non-enumerable value', () => {

--- a/packages/sanity/src/core/form/store/utils/createMemoizer.ts
+++ b/packages/sanity/src/core/form/store/utils/createMemoizer.ts
@@ -22,30 +22,21 @@ export function createMemoizer<TFunction extends (...args: never[]) => unknown>(
 }: MemoizerOptions<TFunction>): FunctionDecorator<TFunction> {
   const cache = new Map<string, {serializedHash: string; result: ReturnType<TFunction>}>()
 
-  return (fn) => {
-    const memoizedFn = ((...args: Parameters<TFunction>) => {
+  function memoizer(fn: TFunction): TFunction {
+    function memoizedFn(...args: Parameters<TFunction>) {
       const path = toString(getPath(...args))
       const hashed = hashInput(...args)
       const serializedHash = JSON.stringify(hashed)
       const cached = cache.get(path)
       if (serializedHash === cached?.serializedHash) return cached.result
 
-      // if (cached) {
-      //   console.log({
-      //     name: fn.name,
-      //     path,
-      //     // reason: objectDiff(JSON.parse(cached.serializedHash), hashed).join(', '),
-      //     prev: JSON.parse(cached.serializedHash),
-      //     next: hashed,
-      //   })
-      // }
-
       const result = fn(...args) as ReturnType<TFunction>
       cache.set(path, {serializedHash, result})
-
       return result
-    }) as TFunction
+    }
 
-    return decorator(memoizedFn)
+    return decorator(memoizedFn as TFunction)
   }
+
+  return memoizer
 }

--- a/packages/sanity/src/core/form/store/utils/createMemoizer.ts
+++ b/packages/sanity/src/core/form/store/utils/createMemoizer.ts
@@ -1,0 +1,51 @@
+import {type Path} from '@sanity/types'
+import {toString} from '@sanity/util/paths'
+
+export type FunctionDecorator<TFunction extends (...args: never[]) => unknown> = (
+  fn: TFunction,
+) => TFunction
+
+export interface MemoizerOptions<TFunction extends (...args: never[]) => unknown> {
+  getPath: (...args: Parameters<TFunction>) => Path
+  hashInput: (...args: Parameters<TFunction>) => unknown
+  decorator: ((fn: TFunction) => TFunction) | undefined
+}
+
+function identity<T>(t: T) {
+  return t
+}
+
+export function createMemoizer<TFunction extends (...args: never[]) => unknown>({
+  getPath,
+  hashInput,
+  decorator = identity,
+}: MemoizerOptions<TFunction>): FunctionDecorator<TFunction> {
+  const cache = new Map<string, {serializedHash: string; result: ReturnType<TFunction>}>()
+
+  return (fn) => {
+    const memoizedFn = ((...args: Parameters<TFunction>) => {
+      const path = toString(getPath(...args))
+      const hashed = hashInput(...args)
+      const serializedHash = JSON.stringify(hashed)
+      const cached = cache.get(path)
+      if (serializedHash === cached?.serializedHash) return cached.result
+
+      // if (cached) {
+      //   console.log({
+      //     name: fn.name,
+      //     path,
+      //     // reason: objectDiff(JSON.parse(cached.serializedHash), hashed).join(', '),
+      //     prev: JSON.parse(cached.serializedHash),
+      //     next: hashed,
+      //   })
+      // }
+
+      const result = fn(...args) as ReturnType<TFunction>
+      cache.set(path, {serializedHash, result})
+
+      return result
+    }) as TFunction
+
+    return decorator(memoizedFn)
+  }
+}

--- a/packages/sanity/src/core/form/store/utils/getId.ts
+++ b/packages/sanity/src/core/form/store/utils/getId.ts
@@ -4,6 +4,19 @@ const idCache = new WeakMap<object, string>()
 const undefinedKey = Symbol('GetIdUndefined')
 const nullKey = Symbol('GetIdNull')
 
+/**
+ * Generates a stable ID for various types of values, including `undefined`, `null`, objects, functions, and symbols.
+ *
+ * - **Primitives (string, number, boolean):** The value itself is used as the ID.
+ * - **Undefined and null:** Special symbols (`undefinedKey` and `nullKey`) are used to generate unique IDs.
+ * - **Objects and functions:** An ID is generated using the `nanoid` library and cached in a `WeakMap` for stable future retrieval.
+ *
+ * This function is used to reconcile inputs in `prepareFormState` immutably, allowing IDs to be generated and cached based
+ * on the reference of the object. This ensures that memoization functions can use these IDs for consistent hashing without
+ * recalculating on each call, as the inputs themselves are immutably edited.
+ *
+ * @internal
+ */
 export function getId(value: unknown): string {
   switch (typeof value) {
     case 'undefined': {

--- a/packages/sanity/src/core/form/store/utils/getId.ts
+++ b/packages/sanity/src/core/form/store/utils/getId.ts
@@ -1,0 +1,28 @@
+import {nanoid} from 'nanoid'
+
+const idCache = new WeakMap<object, string>()
+const undefinedKey = Symbol('GetIdUndefined')
+const nullKey = Symbol('GetIdNull')
+
+export function getId(value: unknown): string {
+  switch (typeof value) {
+    case 'undefined': {
+      return getId(undefinedKey)
+    }
+    case 'function':
+    case 'object':
+    case 'symbol': {
+      if (value === null) return getId(nullKey)
+
+      const cached = idCache.get(value as object)
+      if (cached) return cached
+
+      const id = nanoid()
+      idCache.set(value as object, id)
+      return id
+    }
+    default: {
+      return `${value}`
+    }
+  }
+}

--- a/packages/sanity/src/core/form/store/utils/getId.ts
+++ b/packages/sanity/src/core/form/store/utils/getId.ts
@@ -1,8 +1,8 @@
 import {nanoid} from 'nanoid'
 
 const idCache = new WeakMap<object, string>()
-const undefinedKey = Symbol('GetIdUndefined')
-const nullKey = Symbol('GetIdNull')
+const undefinedKey = {key: 'GetIdUndefined'}
+const nullKey = {key: 'GetIdNull'}
 
 /**
  * Generates a stable ID for various types of values, including `undefined`, `null`, objects, functions, and symbols.

--- a/packages/sanity/src/core/form/store/utils/immutableReconcile.ts
+++ b/packages/sanity/src/core/form/store/utils/immutableReconcile.ts
@@ -1,76 +1,97 @@
-/**
- * Reconciles two versions of a state tree by iterating over the next and deep comparing against the next towards the previous.
- * Wherever identical values are found, the previous value is kept, preserving object identities for arrays and objects where possible
- * @param previous - the previous value
- * @param next - the next/current value
- */
-export function immutableReconcile<T>(previous: unknown, next: T): T {
-  return _immutableReconcile(previous, next, new WeakMap())
+import {type SchemaType} from '@sanity/types'
+
+function isPlainObject(obj: unknown): boolean {
+  return obj !== null && typeof obj === 'object' && obj.constructor === Object
 }
 
-function _immutableReconcile<T>(
-  previous: unknown,
-  next: T,
-  /**
-   * Keep track of visited nodes to prevent infinite recursion in case of circular structures
-   */
-  parents: WeakMap<any, any>,
-): T {
-  if (previous === next) return previous as T
-
-  if (parents.has(next)) {
-    return parents.get(next)
-  }
-
-  // eslint-disable-next-line no-eq-null
-  if (previous == null || next == null) return next
-
-  const prevType = typeof previous
-  const nextType = typeof next
-
-  // Different types
-  if (prevType !== nextType) return next
-
-  if (Array.isArray(next)) {
-    assertType<unknown[]>(previous)
-    assertType<unknown[]>(next)
-
-    let allEqual = previous.length === next.length
-    const result: unknown[] = []
-    parents.set(next, result)
-    for (let index = 0; index < next.length; index++) {
-      const nextItem = _immutableReconcile(previous[index], next[index], parents)
-
-      if (nextItem !== previous[index]) {
-        allEqual = false
-      }
-      result[index] = nextItem
-    }
-    parents.set(next, allEqual ? previous : result)
-    return (allEqual ? previous : result) as any
-  }
-
-  if (typeof next === 'object') {
-    assertType<Record<string, unknown>>(previous)
-    assertType<Record<string, unknown>>(next)
-
-    const nextKeys = Object.getOwnPropertyNames(next)
-    let allEqual = Object.getOwnPropertyNames(previous).length === nextKeys.length
-    const result: Record<string, unknown> = {}
-    parents.set(next, result)
-    for (const key of nextKeys) {
-      const nextValue = _immutableReconcile(previous[key], next[key]!, parents)
-      if (nextValue !== previous[key]) {
-        allEqual = false
-      }
-      result[key] = nextValue
-    }
-    parents.set(next, allEqual ? previous : result)
-    return (allEqual ? previous : result) as T
-  }
-  return next
+function isSchemaType(obj: unknown): obj is SchemaType {
+  if (typeof obj !== 'object') return false
+  if (!obj) return false
+  if (!('jsonType' in obj) || typeof obj.jsonType !== 'string') return false
+  if (!('name' in obj) || typeof obj.name !== 'string') return false
+  return true
 }
 
-// just some typescript trickery get type assertion
-// eslint-disable-next-line @typescript-eslint/no-empty-function, no-empty-function
-function assertType<T>(value: unknown): asserts value is T {}
+interface ImmutableReconcile<T> {
+  (prev: T | null, curr: T): T
+}
+
+export interface CreateImmutableReconcileOptions {
+  decorator?: <T>(fn: ImmutableReconcile<T>) => ImmutableReconcile<T>
+}
+
+function identity<T>(t: T) {
+  return t
+}
+
+export function createImmutableReconcile({
+  decorator = identity,
+}: CreateImmutableReconcileOptions = {}): <T>(prev: T | null, curr: T) => T {
+  const immutableReconcile = decorator(function _immutableReconcile<T>(prev: T | null, curr: T): T {
+    if (prev === curr) return curr
+    if (prev === null) return curr
+    if (typeof prev !== 'object' || typeof curr !== 'object') return curr
+
+    if (Array.isArray(prev) && Array.isArray(curr)) {
+      if (prev.length !== curr.length) return curr
+
+      const reconciled = curr.map((item, index) => immutableReconcile(prev[index], item))
+      if (reconciled.every((item, index) => item === prev[index])) return prev
+      return reconciled as T
+    }
+
+    // skip these, they're recursive structures and will cause stack overflows
+    // they're stable anyway
+    if (isSchemaType(prev) || isSchemaType(curr)) return curr
+
+    // skip these as well
+    if (!isPlainObject(prev) || !isPlainObject(curr)) return curr
+
+    const prevObj = prev as Record<string, unknown>
+    const currObj = curr as Record<string, unknown>
+
+    const reconciled: Record<string, unknown> = {}
+    let changed = false
+
+    const enumerableKeys = new Set(Object.keys(currObj))
+
+    for (const key of Object.getOwnPropertyNames(currObj)) {
+      if (key in prevObj) {
+        const reconciledValue = immutableReconcile(prevObj[key], currObj[key])
+        if (enumerableKeys.has(key)) {
+          reconciled[key] = reconciledValue
+        } else {
+          Object.defineProperty(reconciled, key, {
+            value: reconciledValue,
+            enumerable: false,
+          })
+        }
+        changed = changed || reconciledValue !== prevObj[key]
+      } else {
+        if (enumerableKeys.has(key)) {
+          reconciled[key] = currObj[key]
+        } else {
+          Object.defineProperty(reconciled, key, {
+            value: currObj[key],
+            enumerable: false,
+          })
+        }
+        changed = true
+      }
+    }
+
+    // Check if any keys were removed
+    for (const key of Object.getOwnPropertyNames(prevObj)) {
+      if (!(key in currObj)) {
+        changed = true
+        break
+      }
+    }
+
+    return changed ? (reconciled as T) : prev
+  })
+
+  return immutableReconcile
+}
+
+export const immutableReconcile = createImmutableReconcile()

--- a/packages/sanity/src/core/form/studio/FormBuilder.test.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilder.test.tsx
@@ -54,7 +54,7 @@ describe('FormBuilder', () => {
 
     const focusPath: Path = []
     const openPath: Path = []
-    const value = {_id: 'test', _type: 'test'}
+    const documentValue = {_id: 'test', _type: 'test'}
 
     const onChange = jest.fn()
     const onFieldGroupSelect = jest.fn()
@@ -79,9 +79,10 @@ describe('FormBuilder', () => {
 
       const patchChannel = useMemo(() => createPatchChannel(), [])
 
-      const formState = useFormState(schemaType, {
-        value,
-        comparisonValue: value,
+      const formState = useFormState({
+        schemaType,
+        documentValue,
+        comparisonValue: documentValue,
         focusPath,
         collapsedPaths: undefined,
         collapsedFieldSets: undefined,
@@ -150,7 +151,7 @@ describe('FormBuilder', () => {
 
     const focusPath: Path = []
     const openPath: Path = []
-    const value = {_id: 'test', _type: 'test'}
+    const documentValue = {_id: 'test', _type: 'test'}
 
     const onChange = jest.fn()
     const onFieldGroupSelect = jest.fn()
@@ -175,9 +176,10 @@ describe('FormBuilder', () => {
 
       const patchChannel = useMemo(() => createPatchChannel(), [])
 
-      const formState = useFormState(schemaType, {
-        value,
-        comparisonValue: value,
+      const formState = useFormState({
+        schemaType,
+        documentValue,
+        comparisonValue: documentValue,
         focusPath,
         collapsedPaths: undefined,
         collapsedFieldSets: undefined,

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/useTasksFormBuilder.ts
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/useTasksFormBuilder.ts
@@ -93,11 +93,12 @@ export function useTasksFormBuilder(options: TasksFormBuilderOptions): TasksForm
   const connectionState = useConnectionState(documentId, documentType)
   const editState = useEditState(documentId, documentType)
 
-  const value = editState?.draft || editState?.published || initialValue
+  const documentValue = editState?.draft || editState?.published || initialValue
 
-  const formState = useFormState(tasksSchemaType, {
-    value: value,
-    comparisonValue: value,
+  const formState = useFormState({
+    schemaType: tasksSchemaType,
+    documentValue,
+    comparisonValue: documentValue,
     readOnly: false,
     changesOpen: false,
     presence,

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -542,8 +542,9 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     schemaType,
   ])
 
-  const formState = useFormState(schemaType!, {
-    value: displayed,
+  const formState = useFormState({
+    schemaType: schemaType!,
+    documentValue: displayed,
     readOnly,
     comparisonValue: compareValue,
     focusPath,

--- a/packages/sanity/test/form/renderInput.tsx
+++ b/packages/sanity/test/form/renderInput.tsx
@@ -125,9 +125,10 @@ export async function renderInput<ElementProps>(props: {
 
     if (!docType) throw new Error(`no document type: test`)
 
-    const formState = useFormState(docType, {
-      comparisonValue: documentValue as any,
-      value: documentValue as any,
+    const formState = useFormState({
+      schemaType: docType,
+      comparisonValue: documentValue,
+      documentValue,
       focusPath,
       collapsedPaths: undefined,
       collapsedFieldSets: undefined,


### PR DESCRIPTION
### Description

This PR introduces memoization to the `prepareFormState` function to significantly improve performance, especially for complex documents with multiple large objects in arrays.

Key changes:
- Implemented memoization for `prepareFormState` and its sub-functions for improved performance for complex documents, with up to 10x improvements in some cases
- Removed computation of `hidden` and `readOnly`. Their `StateTree`s are calculated outside of `prepareFormState` to remove the dependency of the `document` to the inputs of `prepareFormState`.

This addresses performance issues with form state computation, particularly for large and complex documents.

Note: Dependes on #7407 

### What to review

- Review the memoization implementation in `prepareFormState`
- Check the implementation of conditionally hidden and readOnly states
- Verify performance improvements, especially for complex documents and documents with large Portable Text fields

### Testing

Automated tests are not yet complete. Manual testing has been performed:

- Compared performance between memoized version and non-memoized version (see attached screenshots)
- Tested with complex documents, including the synthetic fixture
- Verified improvements in eFPS for various document types

Before:

![CleanShot 2024-09-11 at 22 34 58@2x](https://github.com/user-attachments/assets/876c9ece-59a5-4b48-a1b1-158459ab847e)

After:

![CleanShot 2024-09-11 at 22 35 14@2x](https://github.com/user-attachments/assets/9e630882-6511-4032-b49f-8e2203f75c53)


TODO: Complete automated tests

### Notes for release

This change introduces significant performance improvements for form state computation in Sanity, especially for complex documents:

- Up to 10x performance improvement for documents with multiple large objects in arrays
- Noticeable improvements for documents with large Portable Text fields
- Implemented memoization for form state computation

Limitations:
- Computing conditionally `hidden` and `readOnly` states still adds significant computation time, especially for very large documents
- React rendering remains a bottleneck for documents with large Portable Text fields

Note: This is a significant performance enhancement that will benefit most users, especially those working with complex document structures.