### PR TITLE
fix(sanity): prevent empty patches being created

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
@@ -44,7 +44,11 @@ export const patch: OperationImpl<[patches: any[], initialDocument?: Record<stri
       return
     }
     const ensureDraft = snapshots.draft
-      ? []
+      ? draft.patch([
+          {
+            unset: ['_empty_action_guard_pseudo_field_'],
+          },
+        ])
       : [
           draft.create({
             ...initialDocument,


### PR DESCRIPTION
### Description

This branch prevents the `patch` Actions API operation resulting in an empty array of mutations being executed, regardless of whether the operation is a noop.

This caused Studio to get stuck in a syncing state when all of the following conditions were true:

1. Attempting to publish a draft that has no corresponding published document.
2. A custom publish action sets a document value prior to publication.
3. The value the custom publish action tries to set is already the value set in the draft.

### What to review

Does this solution make sense?

### Testing

This can be tested in Test Studio by:

1. Navigating to [a document with custom document actions](http://localhost:3333/test/structure/input-debug;documentActionsTest).
2. Creating a new document.
3. Setting the "Some Boolean" field to `true` in the UI.
4. Executing the "Custom publish that sets someBoolean to true" document action.

Prior to this fix, Studio would become stuck in a "saving" state, and the document would never be published.
