### PR TITLE
fix(core): correctly reset PTE list counts after non-numbered lists and in sublists

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
@@ -101,15 +101,16 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $readOnly?:
       margin-top: ${({theme}) => theme.sanity.space[2]}px;
     }
 
+    /* Reset the list count if the element is not a numbered list item */
+    & > :not(.pt-list-item-number) {
+      counter-set: ${TEXT_LEVELS.map((l) => createListName(l)).join(' ')};
+    }
+
     /* Reset the list count all the sub-list items */
     & > .pt-list-item-number.pt-list-item-level-${TEXT_LEVELS[0]} {
       counter-set: ${TEXT_LEVELS.slice(1)
         .map((l) => createListName(l))
         .join(' ')};
-    }
-
-    & > :not(.pt-list-item-number) {
-      counter-set: ${TEXT_LEVELS.map((l) => createListName(l)).join(' ')};
     }
 
     & > .pt-list-item + :not(.pt-list-item) {

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
@@ -95,25 +95,22 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $readOnly?:
     & > .pt-list-item-bullet + .pt-list-item-number,
     & > .pt-list-item-number + .pt-list-item-bullet {
       margin-top: ${({theme}) => theme.sanity.space[3]}px;
-      counter-reset: ${TEXT_LEVELS.map((l) => createListName(l)).join(' ')};
     }
 
     & > :not(.pt-list-item) + .pt-list-item {
       margin-top: ${({theme}) => theme.sanity.space[2]}px;
     }
 
-    /* Reset the list count if the element is not a numbered list item */
+    /* Reset the list count all the sub-list items */
+    & > .pt-list-item-number.pt-list-item-level-${TEXT_LEVELS[0]} {
+      counter-set: ${TEXT_LEVELS.slice(1)
+        .map((l) => createListName(l))
+        .join(' ')};
+    }
+
     & > :not(.pt-list-item-number) {
       counter-set: ${TEXT_LEVELS.map((l) => createListName(l)).join(' ')};
     }
-
-    ${TEXT_LEVELS.slice(1).map((l) => {
-      return css`
-        & > .pt-list-item-level-${l} + .pt-list-item-level-${l - 1} {
-          counter-reset: ${createListName(l)};
-        }
-      `
-    })}
 
     & > .pt-list-item + :not(.pt-list-item) {
       margin-top: ${({theme}) => theme.sanity.space[3]}px;


### PR DESCRIPTION
### Description
I find that the numbered list is incorrectly indexed in two places.

####  Case 1: On Sub-list items
The indices of list items starting at `level 2` to `level 9` do not start over even though they are separate lists. Instead, they continue on the counter from the previous list. This is already mentioned at #6879.

##### Before
```
1. L1
  a. L2
    i. L3
2. L1
  b. L2 // This is supposed to be 'a.'
    ii.L3 // This is supposed to be 'i.'
```
##### After
```
1. L1
  a. L2
    i. L3
2. L1
  a. L2
    i.L3
```


#### Case 2: Created right after a bullet list
If a numbered list is created right after a bullet list, the indices continue from the previous list counter. It is caused by using the `counter-reset` instead of `counter-set`, making the reset step ineffective.

##### Before
```
1. L1
2. L1
Some random text
● Bullet list item 1
● Bullet list item 2
3. L1 // This is supposed to reset to '1'
4. L1 // This is supposed to '2'
```
##### After
```
1. L1
2. L1
Some random text
● Bullet list item 1
● Bullet list item 2
1. L1
2. L1
```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Overall, the counter is initialized under the `.pt-editable` element and will be reset to `0` at every element that is not a numbered list item. In addition, the counter increases by `1` at each numbered list item until the list ends. On the other hand, it resets the counter for elements not part of the numbered list.

In order to fix __Case 1__, I removed the code on `line:98` and let the rule set for non-numbered list items take effect on bullet list items as well. 

In order to fix __Case 2__, I decided to target the `level 1` list item and reset the counter all levels between `2 - 9`.


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
I test it manually by creating various lists which have multi-level nested items. In addition, I intend to add more different block elements between the lists to ensure the counter is correct.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
