### PR TITLE
fix: forward onItemPrepend/onItemAppend to ArrayFunctions

### DIFF
--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
@@ -24,7 +24,8 @@ export function GridArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
     elementProps,
     members,
     onChange,
-    onInsert,
+    onItemPrepend,
+    onItemAppend,
     onItemMove,
     onUpload,
     readOnly,
@@ -39,20 +40,6 @@ export function GridArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
     value = EMPTY,
   } = props
   const {t} = useTranslation()
-
-  const handlePrepend = useCallback(
-    (item: Item) => {
-      onInsert({items: [item], position: 'before', referenceItem: 0})
-    },
-    [onInsert],
-  )
-
-  const handleAppend = useCallback(
-    (item: Item) => {
-      onInsert({items: [item], position: 'after', referenceItem: -1})
-    },
-    [onInsert],
-  )
 
   const sortable = schemaType.options?.sortable !== false
 
@@ -118,8 +105,8 @@ export function GridArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
 
       <ArrayFunctions
         onChange={onChange}
-        onItemAppend={handleAppend}
-        onItemPrepend={handlePrepend}
+        onItemAppend={onItemAppend}
+        onItemPrepend={onItemPrepend}
         onValueCreate={createProtoArrayValue}
         readOnly={readOnly}
         schemaType={schemaType}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
@@ -35,6 +35,8 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
     onUpload,
     focusPath,
     readOnly,
+    onItemAppend,
+    onItemPrepend,
     renderAnnotation,
     renderBlock,
     renderField,
@@ -51,20 +53,6 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
   // Stores the index of the item being dragged
   const [activeDragItemIndex, setActiveDragItemIndex] = useState<number | null>(null)
   const {space} = useTheme().sanity
-
-  const handlePrepend = useCallback(
-    (item: Item) => {
-      onInsert({items: [item], position: 'before', referenceItem: 0})
-    },
-    [onInsert],
-  )
-
-  const handleAppend = useCallback(
-    (item: Item) => {
-      onInsert({items: [item], position: 'after', referenceItem: -1})
-    },
-    [onInsert],
-  )
 
   const memberKeys = useMemoCompare(
     useMemo(() => members.map((member) => member.key), [members]),
@@ -277,8 +265,8 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
       </UploadTargetCard>
       <ArrayFunctions
         onChange={onChange}
-        onItemAppend={handleAppend}
-        onItemPrepend={handlePrepend}
+        onItemAppend={onItemAppend}
+        onItemPrepend={onItemPrepend}
         onValueCreate={createProtoArrayValue}
         readOnly={readOnly}
         schemaType={schemaType}

--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
@@ -262,17 +262,26 @@ export function ArrayOfObjectsField(props: {
     [handleChange, member.field.value],
   )
 
-  const handlePrependItem = useCallback(
-    (item: any) => {
-      handleChange([setIfMissing([]), insert([ensureKey(item)], 'before', [0])])
+  const handleItemPrepend = useCallback(
+    (item: ObjectItem) => {
+      handleInsert({
+        items: [item],
+        position: 'before',
+        referenceItem: 0,
+      })
     },
-    [handleChange],
+    [handleInsert],
   )
-  const handleAppendItem = useCallback(
-    (item: any) => {
-      handleChange([setIfMissing([]), insert([ensureKey(item)], 'after', [-1])])
+
+  const handleItemAppend = useCallback(
+    (item: ObjectItem) => {
+      handleInsert({
+        items: [item],
+        position: 'after',
+        referenceItem: -1,
+      })
     },
-    [handleChange],
+    [handleInsert],
   )
 
   const handleRemoveItem = useCallback(
@@ -379,8 +388,8 @@ export function ArrayOfObjectsField(props: {
       onInsert: handleInsert,
       onItemMove: handleMoveItem,
       onItemRemove: handleRemoveItem,
-      onItemAppend: handleAppendItem,
-      onItemPrepend: handlePrependItem,
+      onItemAppend: handleItemAppend,
+      onItemPrepend: handleItemPrepend,
       onPathFocus: handleFocusChildPath,
       resolveInitialValue,
       onUpload: handleUpload,
@@ -417,8 +426,8 @@ export function ArrayOfObjectsField(props: {
     handleInsert,
     handleMoveItem,
     handleRemoveItem,
-    handleAppendItem,
-    handlePrependItem,
+    handleItemAppend,
+    handleItemPrepend,
     handleFocusChildPath,
     resolveInitialValue,
     handleUpload,


### PR DESCRIPTION
### Description
All array inputs are passed `onItemPrepend` and `onItemAppend` that they  can call to append and prepend items. Still, the default array input(s) defines their own internal handlers for these two events and passes them on to the ArrayFunctions component. This is both unneccesary, and also makes it harder to customize the behavior by passing in a different onItemAppend function to the array input. This PR removes the redundant handleItemPrepend/handleItemAppend handlers in the standard array inputs.

### What to review

Does the changes make sense?
I also additionally refactored the internal append/prepend handlers so they build upon the default insertion handler and aligned some naming with current convention (e.g. changed from `handleAppendItem` to `handleItemAppend`)

### Testing
There should not be any significant differences to how this works today, and existing tests should catch any regressions.

### Notes for release

- Array input now forwards the received onItemPrepend and onItemAppend to the insert button/Array Functions component
