### PR TITLE
fix(core): disable scheduledPublishing and tasks if `/features` returns error

### DIFF
--- a/packages/sanity/src/core/scheduledPublishing/tool/Tool.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/Tool.tsx
@@ -81,8 +81,8 @@ export default function Tool() {
       <Container width={1} paddingTop={4}>
         <Box paddingTop={4} paddingX={4}>
           <ErrorCallout
-            description="You do not have permission to edit schedules."
-            title="Insufficient permissions"
+            description="Something went wrong loading permissions, please try again."
+            title="Permissions check failed"
           />
         </Box>
       </Container>

--- a/packages/sanity/src/core/scheduledPublishing/tool/Tool.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/Tool.tsx
@@ -1,4 +1,4 @@
-import {Box, Flex, Text, useTheme} from '@sanity/ui'
+import {Box, Container, Flex, Text, useTheme} from '@sanity/ui'
 import {parse} from 'date-fns'
 import {useEffect, useMemo, useRef} from 'react'
 import {type RouterContextValue, useRouter} from 'sanity/router'
@@ -11,6 +11,7 @@ import {SCHEDULE_FILTERS, TOOL_HEADER_HEIGHT} from '../constants'
 import usePollSchedules from '../hooks/usePollSchedules'
 import useTimeZone from '../hooks/useTimeZone'
 import {type Schedule, type ScheduleState} from '../types'
+import {useScheduledPublishingEnabled} from './contexts/ScheduledPublishingEnabledProvider'
 import {SchedulesProvider} from './contexts/schedules'
 import {ScheduleFilters} from './scheduleFilters'
 import {Schedules} from './schedules'
@@ -32,6 +33,7 @@ export default function Tool() {
 
   const {sanity: theme} = useTheme()
   const {error, isInitialLoading, schedules = NO_SCHEDULE} = usePollSchedules()
+  const {enabled} = useScheduledPublishingEnabled()
 
   const lastScheduleState = useRef<ScheduleState | undefined>()
 
@@ -72,6 +74,19 @@ export default function Tool() {
     } else {
       router.navigate({state: lastScheduleState?.current || SCHEDULE_FILTERS[0]})
     }
+  }
+
+  if (!enabled) {
+    return (
+      <Container width={1} paddingTop={4}>
+        <Box paddingTop={4} paddingX={4}>
+          <ErrorCallout
+            description="You do not have permission to edit schedules."
+            title="Insufficient permissions"
+          />
+        </Box>
+      </Container>
+    )
   }
 
   return (

--- a/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.test.tsx
@@ -85,6 +85,21 @@ describe('ScheduledPublishingEnabledProvider', () => {
     expect(value.result.current).toEqual({enabled: false, mode: null})
   })
 
+  it('should not show the plugin if useFeatureEnabled has an error', () => {
+    require('../../../hooks').useFeatureEnabled.mockReturnValue({
+      enabled: false,
+      isLoading: true,
+      error: new Error('Something went wrong'),
+    })
+    require('../../../studio').useWorkspace.mockReturnValue({scheduledPublishing: {enabled: true}})
+
+    const value = renderHook(useScheduledPublishingEnabled, {
+      wrapper: ScheduledPublishingEnabledProvider,
+    })
+
+    expect(value.result.current).toEqual({enabled: false, mode: null})
+  })
+
   it('should call "useFeatureEnabled" with "scheduledPublishing"', () => {
     useWorkspaceMock.mockReturnValue({scheduledPublishing: {enabled: false}})
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: false})

--- a/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.test.tsx
@@ -86,12 +86,12 @@ describe('ScheduledPublishingEnabledProvider', () => {
   })
 
   it('should not show the plugin if useFeatureEnabled has an error', () => {
-    require('../../../hooks').useFeatureEnabled.mockReturnValue({
+    useFeatureEnabledMock.mockReturnValue({
       enabled: false,
       isLoading: true,
       error: new Error('Something went wrong'),
     })
-    require('../../../studio').useWorkspace.mockReturnValue({scheduledPublishing: {enabled: true}})
+    useWorkspaceMock.mockReturnValue({scheduledPublishing: {enabled: true}})
 
     const value = renderHook(useScheduledPublishingEnabled, {
       wrapper: ScheduledPublishingEnabledProvider,

--- a/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx
@@ -26,13 +26,13 @@ interface TaksEnabledProviderProps {
  */
 
 export function ScheduledPublishingEnabledProvider({children}: TaksEnabledProviderProps) {
-  const {enabled, isLoading} = useFeatureEnabled('scheduledPublishing')
+  const {enabled, isLoading, error} = useFeatureEnabled('scheduledPublishing')
   const {scheduledPublishing} = useWorkspace()
 
   const isWorkspaceEnabled = scheduledPublishing.enabled
 
   const value: ScheduledPublishingEnabledContextValue = useMemo(() => {
-    if (!isWorkspaceEnabled || isLoading) {
+    if (!isWorkspaceEnabled || isLoading || error) {
       return {
         enabled: false,
         mode: null,
@@ -42,7 +42,7 @@ export function ScheduledPublishingEnabledProvider({children}: TaksEnabledProvid
       enabled: true,
       mode: enabled ? 'default' : 'upsell',
     }
-  }, [enabled, isLoading, isWorkspaceEnabled])
+  }, [enabled, isLoading, isWorkspaceEnabled, error])
 
   return (
     <ScheduledPublishingEnabledContext.Provider value={value}>

--- a/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.test.tsx
@@ -68,12 +68,12 @@ describe('TasksEnabledProvider', () => {
   })
 
   it('should not show the plugin if useFeatureEnabled has an error', () => {
-    require('../../../hooks').useFeatureEnabled.mockReturnValue({
+    useFeatureEnabledMock.mockReturnValue({
       enabled: false,
       isLoading: true,
       error: new Error('Something went wrong'),
     })
-    require('../../../studio').useWorkspace.mockReturnValue({tasks: {enabled: true}})
+    useWorkspaceMock.mockReturnValue({tasks: {enabled: true}})
 
     const value = renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
 

--- a/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.test.tsx
@@ -67,6 +67,19 @@ describe('TasksEnabledProvider', () => {
     expect(value.result.current).toEqual({enabled: false, mode: null})
   })
 
+  it('should not show the plugin if useFeatureEnabled has an error', () => {
+    require('../../../hooks').useFeatureEnabled.mockReturnValue({
+      enabled: false,
+      isLoading: true,
+      error: new Error('Something went wrong'),
+    })
+    require('../../../studio').useWorkspace.mockReturnValue({tasks: {enabled: true}})
+
+    const value = renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
+
+    expect(value.result.current).toEqual({enabled: false, mode: null})
+  })
+
   it('should call "useFeatureEnabled" with "sanityTasks"', () => {
     useWorkspaceMock.mockReturnValue({tasks: {enabled: false}})
 

--- a/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.tsx
+++ b/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.tsx
@@ -13,12 +13,12 @@ interface TaksEnabledProviderProps {
  * @internal
  */
 export function TasksEnabledProvider({children}: TaksEnabledProviderProps) {
-  const {enabled, isLoading} = useFeatureEnabled('sanityTasks')
+  const {enabled, isLoading, error} = useFeatureEnabled('sanityTasks')
 
   const isWorkspaceEnabled = useWorkspace().tasks?.enabled
 
   const value: TasksEnabledContextValue = useMemo(() => {
-    if (!isWorkspaceEnabled || isLoading) {
+    if (!isWorkspaceEnabled || isLoading || error) {
       return {
         enabled: false,
         mode: null,
@@ -28,7 +28,7 @@ export function TasksEnabledProvider({children}: TaksEnabledProviderProps) {
       enabled: true,
       mode: enabled ? 'default' : 'upsell',
     }
-  }, [enabled, isLoading, isWorkspaceEnabled])
+  }, [enabled, isLoading, isWorkspaceEnabled, error])
 
   return <TasksEnabledContext.Provider value={value}>{children}</TasksEnabledContext.Provider>
 }


### PR DESCRIPTION
### Description

Some users have reported that they see the upsell ui even though the feature is enabled for the project.
That is due to the `features` api returning an error if the user doesn't have the right permissions to query it.

This PR adds the same check for `scheduledPublishing` and `tasks` plugins.
In `comments` we are currently doing that check here https://github.com/sanity-io/sanity/blob/edx-1599/packages/sanity/src/core/comments/hooks/useResolveCommentsEnabled.ts#L42-L43



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Are this changes ok?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
New tests have been introduced to guard this behavior.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
Disable schedule publishing and tasks plugin if user doesn't have the right access. 
