### PR TITLE
fix(core): skip updating focusPath state if unchanged

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -8,7 +8,7 @@ import {
   type SanityDocumentLike,
 } from '@sanity/types'
 import {useToast} from '@sanity/ui'
-import {fromString as pathFromString, resolveKeyedPath} from '@sanity/util/paths'
+import {fromString as pathFromString, pathFor, resolveKeyedPath} from '@sanity/util/paths'
 import {omit, throttle} from 'lodash'
 import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import deepEquals from 'react-fast-compare'
@@ -609,10 +609,11 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   )
 
   const handleFocus = useCallback(
-    (nextFocusPath: Path, payload?: OnPathFocusPayload) => {
-      setFocusPath(nextFocusPath)
-      if (!deepEquals(focusPathRef.current, nextFocusPath)) {
-        setOpenPath(nextFocusPath.slice(0, -1))
+    (_nextFocusPath: Path, payload?: OnPathFocusPayload) => {
+      const nextFocusPath = pathFor(_nextFocusPath)
+      if (nextFocusPath !== focusPathRef.current) {
+        setFocusPath(pathFor(nextFocusPath))
+        setOpenPath(pathFor(nextFocusPath.slice(0, -1)))
         focusPathRef.current = nextFocusPath
         onFocusPath?.(nextFocusPath)
       }


### PR DESCRIPTION
### Description

As seen in the chart below, the commit that merged [#6370](https://github.com/sanity-io/sanity/pull/6370) had severe impact on editor FPS.

![image](https://github.com/user-attachments/assets/534cca7d-a539-4111-b458-d096042f37f1)

The reason for this is that [#6370](https://github.com/sanity-io/sanity/pull/6370) reverted an earlier [PR](https://github.com/sanity-io/sanity/pull/6129) that, among other things, [skipped](https://github.com/sanity-io/sanity/pull/6370/commits/21846c07de1e3a23cb9608d8290efe68ac698db7#diff-7d4931380ae88cfbe9b089e1b3ff44dd33c5a1ce0d737817076e3ef6be17a494L534) updating focusPath state in DocumentPaneProvider if the emitted focusPath was (deeply) equal to the current focus path. This, in combination with the portable text input emitting onFocus on selection change, which is emitted from the portable text editor on every keystroke, triggered excessive re-renders even in cases where the focus path did not really change.

This fixes the issue by skipping the state update if focus-path hasn't changed. Instead of taking the handed focusPath as-is, it gets it from the [pool](https://en.wikipedia.org/wiki/Object_pool_pattern) of existing focus paths, which returns a stable instance for equal paths.

### Relevant benchmarks.
Note: `body` is the Portable Text array here. Higher is better

#### Before
<img width="515" alt="image" src="https://github.com/user-attachments/assets/cc9f023b-e0f6-4616-8d2b-dd54a705051b">

#### After (higher is better)
<img width="513" alt="image" src="https://github.com/user-attachments/assets/e068a129-7cf2-4cae-9679-b7888898bb70">


### What to review
Does the change make sense?

### Testing
Should be covered by existing tests.

### Notes for release

- Improved Portable Text editor performance