### PR TITLE
fix(structure): live edit on draft documents

### DIFF
--- a/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
+++ b/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
@@ -31,6 +31,7 @@ const myStringType = defineArrayMember({
 })
 
 export default defineType({
+  liveEdit: true,
   name: 'simpleBlock',
   title: 'Simple block',
   type: 'document',

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -95,6 +95,12 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'banners.deleted-document-banner.text': 'This document has been deleted.',
   /** The text content for the deprecated document type banner */
   'banners.deprecated-document-type-banner.text': 'This document type has been deprecated.',
+  /** The text content for the live edit document when it's a draft on how to solve it */
+  'banners.live-edit-draft-banner.explanation':
+    'Disable "live edit" in the schema to publish the draft. Once published, "live edit" can be reactivated.',
+  /** The text content for the live edit document when it's a draft */
+  'banners.live-edit-draft-banner.text':
+    'This "live" document cannot be edited while a draft version of it exists.',
   /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
   'banners.permission-check-banner.missing-permission_create_one':
     'Your role <Roles/> does not have permissions to create this document.',

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -95,12 +95,11 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'banners.deleted-document-banner.text': 'This document has been deleted.',
   /** The text content for the deprecated document type banner */
   'banners.deprecated-document-type-banner.text': 'This document type has been deprecated.',
-  /** The text content for the live edit document when it's a draft on how to solve it */
-  'banners.live-edit-draft-banner.explanation':
-    'Disable "live edit" in the schema to publish the draft. Once published, "live edit" can be reactivated.',
   /** The text content for the live edit document when it's a draft */
   'banners.live-edit-draft-banner.text':
-    'This "live" document cannot be edited while a draft version of it exists.',
+    'This live document cannot be edited while a draft version of it exists. Publish the draft in order to continue live editing it.',
+  /** The text for publish action for the draft banner */
+  'banners.live-edit-draft-banner.tooltip': 'Publish to continue editing',
   /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
   'banners.permission-check-banner.missing-permission_create_one':
     'Your role <Roles/> does not have permissions to create this document.',

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -101,7 +101,7 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'banners.live-edit-draft-banner.publish.tooltip': 'Publish to continue editing',
   /** The text content for the live edit document when it's a draft */
   'banners.live-edit-draft-banner.text':
-    'This live document cannot be edited while a draft version of it exists. Publish or discard the draft in order to continue live editing it.',
+    'The type <strong>{{schemaType}}</strong> has <code>liveEdit</code> enabled, but a draft version of this document exists. Publish or discard the draft in order to continue live editing it.',
   /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
   'banners.permission-check-banner.missing-permission_create_one':
     'Your role <Roles/> does not have permissions to create this document.',

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -95,11 +95,13 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'banners.deleted-document-banner.text': 'This document has been deleted.',
   /** The text content for the deprecated document type banner */
   'banners.deprecated-document-type-banner.text': 'This document type has been deprecated.',
+  /** The text for publish action for discarding the version */
+  'banners.live-edit-draft-banner.discard.tooltip': 'Discard draft',
+  /** The text for publish action for the draft banner */
+  'banners.live-edit-draft-banner.publish.tooltip': 'Publish to continue editing',
   /** The text content for the live edit document when it's a draft */
   'banners.live-edit-draft-banner.text':
-    'This live document cannot be edited while a draft version of it exists. Publish the draft in order to continue live editing it.',
-  /** The text for publish action for the draft banner */
-  'banners.live-edit-draft-banner.tooltip': 'Publish to continue editing',
+    'This live document cannot be edited while a draft version of it exists. Publish or discard the draft in order to continue live editing it.',
   /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
   'banners.permission-check-banner.missing-permission_create_one':
     'Your role <Roles/> does not have permissions to create this document.',

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -517,6 +517,9 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     const createActionDisabled = isNonExistent && !isActionEnabled(schemaType!, 'create')
     const reconnecting = connectionState === 'reconnecting'
     const isLocked = editState.transactionSyncLock?.enabled
+    // in cases where the document has drafts but the schema is live edit,
+    // there is a risk of data loss, so we disable editing in this case
+    const isLiveEditAndDraft = Boolean(liveEdit && editState.draft)
 
     return (
       !ready ||
@@ -527,19 +530,22 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       reconnecting ||
       isLocked ||
       isDeleting ||
-      isDeleted
+      isDeleted ||
+      isLiveEditAndDraft
     )
   }, [
-    connectionState,
-    editState.transactionSyncLock,
-    isNonExistent,
-    isDeleted,
-    isDeleting,
     isPermissionsLoading,
     permissions?.granted,
+    schemaType,
+    isNonExistent,
+    connectionState,
+    editState.transactionSyncLock?.enabled,
+    editState.draft,
+    liveEdit,
     ready,
     revTime,
-    schemaType,
+    isDeleting,
+    isDeleted,
   ])
 
   const formState = useFormState({

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -4,6 +4,7 @@ import {ScrollContainer, useTimelineSelector, VirtualizerScrollInstanceProvider}
 import {css, styled} from 'styled-components'
 
 import {PaneContent, usePane, usePaneLayout} from '../../../components'
+import {isLiveEditEnabled} from '../../../components/paneItem/helpers'
 import {useStructureTool} from '../../../useStructureTool'
 import {DocumentInspectorPanel} from '../documentInspector'
 import {InspectDialog} from '../inspectDialog'
@@ -14,6 +15,7 @@ import {
   PermissionCheckBanner,
   ReferenceChangedBanner,
 } from './banners'
+import {DraftLiveEditBanner} from './banners/DraftLiveEditBanner'
 import {FormView} from './documentViews'
 
 interface DocumentPanelProps {
@@ -117,6 +119,8 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     (state) => state.lastNonDeletedRevId,
   )
 
+  const isLiveEdit = isLiveEditEnabled(schemaType)
+
   // Scroll to top as `documentId` changes
   useEffect(() => {
     if (!documentScrollElement?.scrollTo) return
@@ -150,6 +154,8 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
                   scrollElement={documentScrollElement}
                   containerElement={formContainerElement}
                 >
+                  {activeView.type === 'form' && isLiveEdit && ready && <DraftLiveEditBanner />}
+
                   {activeView.type === 'form' && !isPermissionsLoading && ready && (
                     <>
                       <PermissionCheckBanner

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -154,7 +154,13 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
                   scrollElement={documentScrollElement}
                   containerElement={formContainerElement}
                 >
-                  {activeView.type === 'form' && isLiveEdit && ready && <DraftLiveEditBanner />}
+                  {activeView.type === 'form' && isLiveEdit && ready && (
+                    <DraftLiveEditBanner
+                      displayed={displayed}
+                      documentId={documentId}
+                      schemaType={schemaType}
+                    />
+                  )}
 
                   {activeView.type === 'form' && !isPermissionsLoading && ready && (
                     <>

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
@@ -2,7 +2,7 @@ import {ErrorOutlineIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Flex, Text} from '@sanity/ui'
 import {useCallback, useEffect, useState} from 'react'
-import {isDraftId, useDocumentOperation, useTranslation} from 'sanity'
+import {isDraftId, Translate, useDocumentOperation, useTranslation} from 'sanity'
 
 import {Button} from '../../../../../ui-components'
 import {structureLocaleNamespace} from '../../../../i18n'
@@ -14,7 +14,7 @@ import {
 import {Banner} from './Banner'
 
 export function DraftLiveEditBanner(): JSX.Element | null {
-  const {displayed, documentId} = useDocumentPane()
+  const {displayed, documentId, schemaType} = useDocumentPane()
   const {t} = useTranslation(structureLocaleNamespace)
   const [isPublishing, setPublishing] = useState(false)
   const [isDiscarding, setDiscarding] = useState(false)
@@ -50,7 +50,11 @@ export function DraftLiveEditBanner(): JSX.Element | null {
       content={
         <Flex align="center" justify="space-between" gap={1}>
           <Text size={1} weight="medium">
-            {t('banners.live-edit-draft-banner.text')}
+            <Translate
+              t={t}
+              i18nKey={'banners.live-edit-draft-banner.text'}
+              values={{schemaType: schemaType.title}}
+            />
           </Text>
           <Button
             onClick={handlePublish}

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
@@ -1,6 +1,6 @@
 import {ErrorOutlineIcon} from '@sanity/icons'
-import {Flex, Stack, Text} from '@sanity/ui'
-import {useCallback, useState} from 'react'
+import {Flex, Text} from '@sanity/ui'
+import {useCallback, useEffect, useState} from 'react'
 import {isDraftId, useDocumentOperation, useTranslation} from 'sanity'
 
 import {Button} from '../../../../../ui-components'
@@ -12,13 +12,26 @@ export function DraftLiveEditBanner(): JSX.Element | null {
   const {displayed, documentId} = useDocumentPane()
   const {t} = useTranslation(structureLocaleNamespace)
   const [isPublishing, setPublishing] = useState(false)
+  const [isDiscarding, setDiscarding] = useState(false)
 
-  const {publish} = useDocumentOperation(documentId, displayed?._type || '')
+  const {publish, discardChanges} = useDocumentOperation(documentId, displayed?._type || '')
 
   const handlePublish = useCallback(() => {
     publish.execute()
     setPublishing(true)
   }, [publish])
+
+  const handleDiscard = useCallback(() => {
+    discardChanges.execute()
+    setDiscarding(true)
+  }, [discardChanges])
+
+  useEffect(() => {
+    return () => {
+      setPublishing(false)
+      setDiscarding(false)
+    }
+  })
 
   if (displayed && displayed._id && !isDraftId(displayed._id)) {
     return null
@@ -27,17 +40,22 @@ export function DraftLiveEditBanner(): JSX.Element | null {
   return (
     <Banner
       content={
-        <Flex align="center" justify="space-between">
-          <Stack space={2}>
-            <Text size={1} weight="medium">
-              {t('banners.live-edit-draft-banner.text')}
-            </Text>
-          </Stack>
+        <Flex align="center" justify="space-between" gap={1}>
+          <Text size={1} weight="medium">
+            {t('banners.live-edit-draft-banner.text')}
+          </Text>
           <Button
             onClick={handlePublish}
             text={t('action.publish.live-edit.label')}
-            tooltipProps={{content: t('banners.live-edit-draft-banner.tooltip')}}
+            tooltipProps={{content: t('banners.live-edit-draft-banner.publish.tooltip')}}
             loading={isPublishing}
+          />
+
+          <Button
+            onClick={handleDiscard}
+            text={t('banners.live-edit-draft-banner.discard.tooltip')}
+            tooltipProps={{content: t('banners.live-edit-draft-banner.discard.tooltip')}}
+            loading={isDiscarding}
           />
         </Flex>
       }

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
@@ -13,10 +13,7 @@ import {
 
 import {Button} from '../../../../../ui-components'
 import {structureLocaleNamespace} from '../../../../i18n'
-import {
-  DiscardedLiveEditDraft,
-  PublishedLiveEditDraft,
-} from './__telemetry__/DraftLiveEditBanner.telemetry'
+import {ResolvedLiveEdit} from './__telemetry__/DraftLiveEditBanner.telemetry'
 import {Banner} from './Banner'
 
 interface DraftLiveEditBannerProps {
@@ -40,13 +37,13 @@ export function DraftLiveEditBanner({
   const handlePublish = useCallback(() => {
     publish.execute()
     setPublishing(true)
-    telemetry.log(PublishedLiveEditDraft)
+    telemetry.log(ResolvedLiveEdit, {liveEditResolveType: 'publish'})
   }, [publish, telemetry])
 
   const handleDiscard = useCallback(() => {
     discardChanges.execute()
     setDiscarding(true)
-    telemetry.log(DiscardedLiveEditDraft)
+    telemetry.log(ResolvedLiveEdit, {liveEditResolveType: 'discard'})
   }, [discardChanges, telemetry])
 
   useEffect(() => {

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
@@ -1,0 +1,33 @@
+import {ErrorOutlineIcon} from '@sanity/icons'
+import {Stack, Text} from '@sanity/ui'
+import {isDraftId, useTranslation} from 'sanity'
+
+import {structureLocaleNamespace} from '../../../../i18n'
+import {useDocumentPane} from '../../useDocumentPane'
+import {Banner} from './Banner'
+
+export function DraftLiveEditBanner(): JSX.Element | null {
+  const {displayed} = useDocumentPane()
+  const {t} = useTranslation(structureLocaleNamespace)
+
+  if (displayed && displayed._id && !isDraftId(displayed._id)) {
+    return null
+  }
+
+  return (
+    <Banner
+      content={
+        <Stack space={2}>
+          <Text size={1} weight="medium">
+            {t('banners.live-edit-draft-banner.text')}
+          </Text>
+          <Text size={1} weight="medium">
+            {t('banners.live-edit-draft-banner.explanation')}
+          </Text>
+        </Stack>
+      }
+      data-testid="live-edit-type-banner"
+      icon={ErrorOutlineIcon}
+    />
+  )
+}

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
@@ -1,14 +1,24 @@
 import {ErrorOutlineIcon} from '@sanity/icons'
-import {Stack, Text} from '@sanity/ui'
-import {isDraftId, useTranslation} from 'sanity'
+import {Flex, Stack, Text} from '@sanity/ui'
+import {useCallback, useState} from 'react'
+import {isDraftId, useDocumentOperation, useTranslation} from 'sanity'
 
+import {Button} from '../../../../../ui-components'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {useDocumentPane} from '../../useDocumentPane'
 import {Banner} from './Banner'
 
 export function DraftLiveEditBanner(): JSX.Element | null {
-  const {displayed} = useDocumentPane()
+  const {displayed, documentId} = useDocumentPane()
   const {t} = useTranslation(structureLocaleNamespace)
+  const [isPublishing, setPublishing] = useState(false)
+
+  const {publish} = useDocumentOperation(documentId, displayed?._type || '')
+
+  const handlePublish = useCallback(() => {
+    publish.execute()
+    setPublishing(true)
+  }, [publish])
 
   if (displayed && displayed._id && !isDraftId(displayed._id)) {
     return null
@@ -17,14 +27,19 @@ export function DraftLiveEditBanner(): JSX.Element | null {
   return (
     <Banner
       content={
-        <Stack space={2}>
-          <Text size={1} weight="medium">
-            {t('banners.live-edit-draft-banner.text')}
-          </Text>
-          <Text size={1} weight="medium">
-            {t('banners.live-edit-draft-banner.explanation')}
-          </Text>
-        </Stack>
+        <Flex align="center" justify="space-between">
+          <Stack space={2}>
+            <Text size={1} weight="medium">
+              {t('banners.live-edit-draft-banner.text')}
+            </Text>
+          </Stack>
+          <Button
+            onClick={handlePublish}
+            text={t('action.publish.live-edit.label')}
+            tooltipProps={{content: t('banners.live-edit-draft-banner.tooltip')}}
+            loading={isPublishing}
+          />
+        </Flex>
       }
       data-testid="live-edit-type-banner"
       icon={ErrorOutlineIcon}

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
@@ -1,20 +1,35 @@
+import {type SanityDocument} from '@sanity/client'
 import {ErrorOutlineIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Flex, Text} from '@sanity/ui'
 import {useCallback, useEffect, useState} from 'react'
-import {isDraftId, Translate, useDocumentOperation, useTranslation} from 'sanity'
+import {
+  isDraftId,
+  type ObjectSchemaType,
+  Translate,
+  useDocumentOperation,
+  useTranslation,
+} from 'sanity'
 
 import {Button} from '../../../../../ui-components'
 import {structureLocaleNamespace} from '../../../../i18n'
-import {useDocumentPane} from '../../useDocumentPane'
 import {
   DiscardedLiveEditDraft,
   PublishedLiveEditDraft,
 } from './__telemetry__/DraftLiveEditBanner.telemetry'
 import {Banner} from './Banner'
 
-export function DraftLiveEditBanner(): JSX.Element | null {
-  const {displayed, documentId, schemaType} = useDocumentPane()
+interface DraftLiveEditBannerProps {
+  displayed: Partial<SanityDocument> | null
+  documentId: string
+  schemaType: ObjectSchemaType
+}
+
+export function DraftLiveEditBanner({
+  displayed,
+  documentId,
+  schemaType,
+}: DraftLiveEditBannerProps): JSX.Element | null {
   const {t} = useTranslation(structureLocaleNamespace)
   const [isPublishing, setPublishing] = useState(false)
   const [isDiscarding, setDiscarding] = useState(false)

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
@@ -1,4 +1,5 @@
 import {ErrorOutlineIcon} from '@sanity/icons'
+import {useTelemetry} from '@sanity/telemetry/react'
 import {Flex, Text} from '@sanity/ui'
 import {useCallback, useEffect, useState} from 'react'
 import {isDraftId, useDocumentOperation, useTranslation} from 'sanity'
@@ -6,6 +7,10 @@ import {isDraftId, useDocumentOperation, useTranslation} from 'sanity'
 import {Button} from '../../../../../ui-components'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {useDocumentPane} from '../../useDocumentPane'
+import {
+  DiscardedLiveEditDraft,
+  PublishedLiveEditDraft,
+} from './__telemetry__/DraftLiveEditBanner.telemetry'
 import {Banner} from './Banner'
 
 export function DraftLiveEditBanner(): JSX.Element | null {
@@ -13,18 +18,21 @@ export function DraftLiveEditBanner(): JSX.Element | null {
   const {t} = useTranslation(structureLocaleNamespace)
   const [isPublishing, setPublishing] = useState(false)
   const [isDiscarding, setDiscarding] = useState(false)
+  const telemetry = useTelemetry()
 
   const {publish, discardChanges} = useDocumentOperation(documentId, displayed?._type || '')
 
   const handlePublish = useCallback(() => {
     publish.execute()
     setPublishing(true)
-  }, [publish])
+    telemetry.log(PublishedLiveEditDraft)
+  }, [publish, telemetry])
 
   const handleDiscard = useCallback(() => {
     discardChanges.execute()
     setDiscarding(true)
-  }, [discardChanges])
+    telemetry.log(DiscardedLiveEditDraft)
+  }, [discardChanges, telemetry])
 
   useEffect(() => {
     return () => {

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/__telemetry__/DraftLiveEditBanner.telemetry.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/__telemetry__/DraftLiveEditBanner.telemetry.ts
@@ -5,7 +5,7 @@ import {defineEvent} from '@sanity/telemetry'
  * @internal
  */
 export const PublishedLiveEditDraft = defineEvent({
-  name: 'Publish a draft (live edit)',
+  name: 'Resolve liveEdit by publishing draft',
   version: 1,
   description: 'User published a draft when a draft of a live edit document to continue editing',
 })
@@ -15,7 +15,7 @@ export const PublishedLiveEditDraft = defineEvent({
  * @internal
  */
 export const DiscardedLiveEditDraft = defineEvent({
-  name: 'Create a new draft',
+  name: 'Resolve liveEdit by discarding draftt',
   version: 1,
   description: 'User discarded a draft when a draft of a live edit document to continue editing',
 })

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/__telemetry__/DraftLiveEditBanner.telemetry.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/__telemetry__/DraftLiveEditBanner.telemetry.ts
@@ -1,0 +1,21 @@
+import {defineEvent} from '@sanity/telemetry'
+
+/**
+ * When a draft in a live edit document is published
+ * @internal
+ */
+export const PublishedLiveEditDraft = defineEvent({
+  name: 'Publish a draft (live edit)',
+  version: 1,
+  description: 'User published a draft when a draft of a live edit document to continue editing',
+})
+
+/*
+ * When a draft in a live edit document is discarded
+ * @internal
+ */
+export const DiscardedLiveEditDraft = defineEvent({
+  name: 'Create a new draft',
+  version: 1,
+  description: 'User discarded a draft when a draft of a live edit document to continue editing',
+})

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/__telemetry__/DraftLiveEditBanner.telemetry.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/__telemetry__/DraftLiveEditBanner.telemetry.ts
@@ -1,21 +1,15 @@
 import {defineEvent} from '@sanity/telemetry'
 
+interface TypeInfo {
+  liveEditResolveType: 'publish' | 'discard'
+}
+
 /**
  * When a draft in a live edit document is published
  * @internal
  */
-export const PublishedLiveEditDraft = defineEvent({
-  name: 'Resolve liveEdit by publishing draft',
+export const ResolvedLiveEdit = defineEvent<TypeInfo>({
+  name: 'Resolved LiveEdit Draft',
   version: 1,
-  description: 'User published a draft when a draft of a live edit document to continue editing',
-})
-
-/*
- * When a draft in a live edit document is discarded
- * @internal
- */
-export const DiscardedLiveEditDraft = defineEvent({
-  name: 'Resolve liveEdit by discarding draftt',
-  version: 1,
-  description: 'User discarded a draft when a draft of a live edit document to continue editing',
+  description: 'User resolved a draft of a live edit document to continue editing',
 })

--- a/test/e2e/tests/desk/liveEditDraft.spec.ts
+++ b/test/e2e/tests/desk/liveEditDraft.spec.ts
@@ -1,0 +1,31 @@
+/* eslint-disable max-nested-callbacks */
+import {expect, test} from '@playwright/test'
+
+import {createUniqueDocument, withDefaultClient} from '../../helpers'
+
+withDefaultClient((context) => {
+  test.describe('sanity/structure: document pane', () => {
+    test('on live edit document with a draft, a banner should appear', async ({page}) => {
+      // create published document
+      const uniqueDoc = await createUniqueDocument(context.client, {_type: 'playlist'})
+      const id = uniqueDoc._id!
+
+      // create draft document
+      await createUniqueDocument(context.client, {
+        _type: 'playlist',
+        _id: `drafts.${id}`,
+        name: 'Edited by e2e test runner',
+      })
+
+      await page.goto(`/test/content/playlist;${id}`)
+
+      await expect(page.getByTestId('document-panel-scroller')).toBeAttached()
+      await expect(page.getByTestId('string-input')).toBeAttached()
+
+      // checks that inputs are set to read only
+      await expect(await page.getByTestId('string-input')).toHaveAttribute('readonly', '')
+      // checks that the banner is visible
+      await expect(page.getByTestId('live-edit-type-banner')).toBeVisible()
+    })
+  })
+})


### PR DESCRIPTION
### Description

When editing a live document that had a draft version of it, the users were being unable to edit the document.
Worst, when using the PTE they would be able to edit and add text, the would get a notification that the document was saved but when refreshing the data would be lost.

The current fix makes the document readOnly when the document is liveEdit AND a draft is being displayed.
The solution is for the user to publish the draft (that shouldn't exist).

It also allows to publish or discard the open draft

Before

https://github.com/user-attachments/assets/b33b7d6c-b3b5-45b9-8aa3-786b125e954b

After

https://github.com/user-attachments/assets/3c8ae367-87d1-4340-8951-76530078cf24


### What to review

The code and if the UI makes sense. I considered adding a drop down menu like we have for the extended actions in the footer but decided that it doesn't make sense to obscure the choices in this case

### Testing

You can manually test it by going to some older documents of the type SImpleBlock (which will be dropped before merging)
There is also an e2e test set up

### Notes for release

Fixes issue with drafts on live edit schema 