### PR TITLE
test: compare local benchmark to `latest` and exit 1

### DIFF
--- a/perf/efps/index.ts
+++ b/perf/efps/index.ts
@@ -118,27 +118,20 @@ const formatPercentagePlain = (value: number): string => {
   return `${sign}${rounded}%`
 }
 
-function getStatus(
-  p50Diff: number,
-  p75Diff: number,
-  p90Diff: number,
-): 'error' | 'warning' | 'passed' {
+function getStatus(p50Diff: number, p75Diff: number, p90Diff: number): 'error' | 'passed' {
   if (p50Diff < -50 || p75Diff < -50 || p90Diff < -50) {
     return 'error'
-  } else if (p50Diff < -20 || p75Diff < -20 || p90Diff < -20) {
-    return 'warning'
   }
   return 'passed'
 }
 
-function getStatusEmoji(status: 'error' | 'warning' | 'passed'): string {
+function getStatusEmoji(status: 'error' | 'passed'): string {
   if (status === 'error') return '🔴'
-  if (status === 'warning') return '⚠️'
   return '✅'
 }
 
 // Initialize the overall status
-let overallStatus: 'error' | 'warning' | 'passed' = 'passed'
+let overallStatus: 'error' | 'passed' = 'passed'
 
 interface TestResult {
   testName: string
@@ -215,8 +208,6 @@ for (const test of tests) {
         // Update overall status
         if (testStatus === 'error') {
           overallStatus = 'error'
-        } else if (testStatus === 'warning' && overallStatus === 'passed') {
-          overallStatus = 'warning'
         }
 
         const rowLabel = [chalk.bold(test.name), label ? `(${label})` : ''].join(' ')
@@ -257,9 +248,7 @@ console.log(`
 `)
 
 // Map overallStatus to status text
-const statusText =
-  // eslint-disable-next-line no-nested-ternary
-  overallStatus === 'error' ? 'Error' : overallStatus === 'warning' ? 'Warning' : 'Passed'
+const statusText = overallStatus === 'error' ? 'Error' : 'Passed'
 const statusEmoji = getStatusEmoji(overallStatus)
 
 // Build the markdown content
@@ -280,8 +269,8 @@ const markdownContent = [
   '',
 ].join('\n')
 
-// Write markdown file
-const markdownOutputPath = path.join(resultsDir, 'benchmark-results.md')
+// Write markdown file to root of results
+const markdownOutputPath = path.join(workspaceDir, 'results', 'benchmark-results.md')
 await fs.promises.writeFile(markdownOutputPath, markdownContent)
 
 // Exit with code 1 if regression detected


### PR DESCRIPTION
### Description

This PR refactors the benchmark suite to compare the performance between the local version of the `sanity` package and the latest published version from npm. The key changes introduced are:

- **Downloading and Using Latest `sanity` Package**: The benchmark suite now automatically downloads the latest version of the `sanity` package as a tarball, extracts it, and aliases it in the Vite build process. This allows us to run benchmarks against both the local and the latest versions.

- **Running Benchmarks for Both Versions**: For each test in the suite, benchmarks are executed twice—once using the local `sanity` package and once using the latest version. This provides a direct comparison of performance metrics between the two versions.

- **Comparing and Displaying Results**: The results from both runs are collected and percentage differences are calculated. These differences are displayed in a table format, showing improvements or regressions in performance.

- **Exiting on Significant Regression**: If the benchmark detects a performance regression exceeding 50% (i.e., the local version performs worse than the latest version by more than 50%), the script exits with an exit code of `1`. This helps in automated environments to catch significant performance issues early.

**Why are these changes introduced?**

These changes are introduced to:

- Enable developers to easily compare the performance of their current branch against the main branch or the latest published version.
- Detect significant performance regressions early in the development process.
- Integrate performance benchmarking more tightly into the development and CI/CD workflow.

**What issue(s) does this solve?**

- Streamlines performance comparisons between different versions of the `sanity` package.
- Automates detection of significant performance regressions.
- Enhances the reliability of the benchmark suite by providing consistent and comparable results.

### What to review

**Steps for Reviewers:**

1. **Code Changes**:
   - Review the changes in `index.ts` and `runTest.ts`.
   - Ensure that the logic for downloading and aliasing the latest `sanity` package is sound and doesn't introduce side effects.
   - Check the modifications in the Vite build configuration to confirm that the correct version of `sanity` is used in each benchmark run.

2. **Benchmark Execution**:
   - Verify that the benchmarks are running twice for each test—once with the local version and once with the latest version.
   - Ensure that the percentage differences are calculated accurately and displayed correctly in the output table.

3. **Exit Conditions**:
   - Test scenarios where performance regressions exceed the 50% threshold to confirm that the script exits with code `1`.
   - Check that normal execution (without significant regressions) completes successfully without unintended exits.

**Affected Areas:**

- **Benchmark Suite Scripts**: Specifically `index.ts` and `runTest.ts`.
- **Build and Execution Flow**: The way the benchmarks are built and executed has been modified to accommodate dual runs and comparisons.
- **CI/CD Integration**: The exit code behavior may affect CI pipelines that rely on the benchmark suite.

### Testing

**Testing Performed:**

- **Manual Testing**:
  - Ran the benchmark suite locally to ensure that it correctly downloads the latest `sanity` package and aliases it in the build.
  - Verified that benchmarks are executed for both versions and that results are collected without errors.
  - Checked the calculation of percentage differences by comparing known performance metrics.
  - Tested the exit behavior by artificially introducing performance regressions exceeding 50% and confirming that the script exits with code `1`.

**Automated Testing:**

- No automated tests were added for this change due to the nature of the benchmark suite and the difficulty in simulating performance regressions in a controlled automated environment.
- The changes rely heavily on external dependencies and runtime performance, which are challenging to test automatically without introducing flakiness.

**Reasoning:**

- Given the complexity and runtime dependencies, manual testing was deemed sufficient to validate the functionality.
- The focus was on ensuring that the benchmark suite behaves correctly in practical use cases.

### Notes for release

**What Changed:**

- The benchmark suite now compares performance between the local development version and the latest published version of the `sanity` package.
- It automatically downloads the latest `sanity` package and includes it in the benchmark runs.
- The suite calculates and displays percentage differences in performance metrics between the two versions.
- If a performance regression exceeding 50% is detected, the suite exits with an exit code of `1`.

**How to Use It:**

- Run the benchmark suite as usual using the `npm start` or `npm test` commands.
- The suite will handle downloading the latest `sanity` package and running the benchmarks for both versions automatically.
- Upon completion, the results will be displayed in the console, showing performance metrics and percentage differences.

**Example Output:**

![CleanShot 2024-09-19 at 14 30 32@2x](https://github.com/user-attachments/assets/27319d9c-ff91-43b7-8ec4-8024e9929cc4)

**Are there limitations?**

- **Environment Dependency**: The performance metrics can vary depending on the machine and environment where the benchmarks are run.
- **Exit Behavior**: The script will exit with code `1` if a performance regression exceeding 50% is detected. This may affect CI/CD pipelines and should be handled appropriately.
- **Benchmark Scope**: The comparisons are limited to the tests included in the suite. Additional tests may be needed to cover all use cases.

**Not Required for Release Notes:**

- This change enhances internal tooling and does not affect end-users directly.
- No changes to public APIs or user-facing features.