### PR TITLE
fix(core): document store cache memo not working

### DIFF
--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -159,7 +159,7 @@ export function useDocumentStore(): DocumentStore {
 
     resourceCache.set({
       namespace: 'documentStore',
-      dependencies: [getClient, documentPreviewStore, historyStore, schema, i18n],
+      dependencies: [getClient, documentPreviewStore, historyStore, schema, i18n, workspace],
       value: documentStore,
     })
 


### PR DESCRIPTION
### Description

The document store cache was never found so each time we try to access it is creating a new store. 
This is because the dependencies used in the cache were not the same in the set and get.

This PR fixes that.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is there any possible side effect of utilizing the  memoized store?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Existing tests should cover this .
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

