### PR TITLE
refactor(structure): add timeout to reconnecting message

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -748,14 +748,18 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   )
 
   useEffect(() => {
+    let timeout: NodeJS.Timeout
     if (connectionState === 'reconnecting') {
-      setTimeout(() => {
+      timeout = setTimeout(() => {
         pushToast({
           id: 'sanity/structure/reconnecting',
           status: 'warning',
           title: t('panes.document-pane-provider.reconnecting.title'),
         })
       }, 2000) // 2 seconds, we can iterate on the value
+    }
+    return () => {
+      if (timeout) clearTimeout(timeout)
     }
   }, [connectionState, pushToast, t])
 

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -755,7 +755,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
           status: 'warning',
           title: t('panes.document-pane-provider.reconnecting.title'),
         })
-      }, 2000)
+      }, 2000) // 2 seconds, we can iterate on the value
     }
   }, [connectionState, pushToast, t])
 

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -749,11 +749,13 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
   useEffect(() => {
     if (connectionState === 'reconnecting') {
-      pushToast({
-        id: 'sanity/structure/reconnecting',
-        status: 'warning',
-        title: t('panes.document-pane-provider.reconnecting.title'),
-      })
+      setTimeout(() => {
+        pushToast({
+          id: 'sanity/structure/reconnecting',
+          status: 'warning',
+          title: t('panes.document-pane-provider.reconnecting.title'),
+        })
+      }, 2000)
     }
   }, [connectionState, pushToast, t])
 

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -748,7 +748,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   )
 
   useEffect(() => {
-    let timeout: NodeJS.Timeout
+    let timeout: ReturnType<typeof setTimeout>
     if (connectionState === 'reconnecting') {
       timeout = setTimeout(() => {
         pushToast({


### PR DESCRIPTION
### Description

Add a timeout to the toast message so that it doesn't trigger immediately.

### Testing

In any doc you can use `window.stop()` in the dev console which will set the studio state to trigger the reconnecting state

### Notes for release

Add timeout to reconnecting message
