### PR TITLE
Remove references to implicit globals `document` and `Text`

### DIFF
--- a/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/word.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/word.ts
@@ -70,16 +70,16 @@ export default (html: string, doc: Document): Document => {
   for (let i = mappedElements.snapshotLength - 1; i >= 0; i--) {
     const mappedElm = mappedElements.snapshotItem(i) as HTMLElement
     const tags = elementMap[mappedElm.className]
-    const text = new Text(mappedElm.textContent || '')
+    const text = doc.createTextNode(mappedElm.textContent || '')
     if (!tags) {
       continue
     }
 
-    const parentElement = document.createElement(tags[0])
+    const parentElement = doc.createElement(tags[0])
     let parent = parentElement
     let child = parentElement
     tags.slice(1).forEach((tag) => {
-      child = document.createElement(tag)
+      child = doc.createElement(tag)
       parent.appendChild(child)
       parent = child
     })


### PR DESCRIPTION
### Description

I replaced references to the global `document` with the `doc` parameter and `new Text` with `doc.createTextNode`. I only found this in the MS Word-generated html preprocessor. This should fix the errors that I hit while running the portable text conversion on certain html in jsdom.

### What to review

Double-check that this is a fix of a mistake.

### Testing

I have not tested this outside of edits to the package in the `node_modules` of my project

### Notes for release

* Fixed an edge-case bug in the `@sanity/block-tools` package's html to portable text preprocessing of word-generated html which broke outside of browsers