### PR TITLE
fix(sanity): prevent layout shifts in image input

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAsset.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAsset.tsx
@@ -1,36 +1,36 @@
 import {type UploadState} from '@sanity/types'
 import {Box, type CardTone} from '@sanity/ui'
-import {type FocusEvent, forwardRef, memo, useMemo} from 'react'
+import {type FocusEvent, memo, useMemo} from 'react'
 
 import {ChangeIndicator} from '../../../../changeIndicators'
 import {type InputProps} from '../../../types'
 import {FileTarget} from '../common/styles'
 import {UploadWarning} from '../common/UploadWarning'
+import {type ImageUrlBuilder} from '../types'
 import {type BaseImageInputProps, type BaseImageInputValue, type FileInfo} from './types'
+import {usePreviewImageSource} from './usePreviewImageSource'
 
 const ASSET_FIELD_PATH = ['asset'] as const
 
-function ImageInputAssetComponent(
-  props: {
-    elementProps: BaseImageInputProps['elementProps']
-    handleClearUploadState: () => void
-    handleFilesOut: () => void
-    handleFilesOver: (hoveringFiles: FileInfo[]) => void
-    handleFileTargetFocus: (event: FocusEvent<Element, Element>) => void
-    handleSelectFiles: (files: File[]) => void
-    hoveringFiles: FileInfo[]
-    inputProps: Omit<InputProps, 'renderDefault'>
-    isStale: boolean
-    readOnly: boolean | undefined
-    renderAssetMenu(): JSX.Element | null
-    renderPreview: () => JSX.Element
-    renderUploadPlaceholder(): JSX.Element
-    renderUploadState(uploadState: UploadState): JSX.Element
-    tone: CardTone
-    value: BaseImageInputValue | undefined
-  },
-  forwardedRef: React.ForwardedRef<HTMLDivElement>,
-) {
+function ImageInputAssetComponent(props: {
+  elementProps: BaseImageInputProps['elementProps']
+  handleClearUploadState: () => void
+  handleFilesOut: () => void
+  handleFilesOver: (hoveringFiles: FileInfo[]) => void
+  handleFileTargetFocus: (event: FocusEvent<Element, Element>) => void
+  handleSelectFiles: (files: File[]) => void
+  hoveringFiles: FileInfo[]
+  imageUrlBuilder: ImageUrlBuilder
+  inputProps: Omit<InputProps, 'renderDefault'>
+  isStale: boolean
+  readOnly: boolean | undefined
+  renderAssetMenu(): JSX.Element | null
+  renderPreview: () => JSX.Element
+  renderUploadPlaceholder(): JSX.Element
+  renderUploadState(uploadState: UploadState): JSX.Element
+  tone: CardTone
+  value: BaseImageInputValue | undefined
+}) {
   const {
     elementProps,
     handleClearUploadState,
@@ -48,13 +48,15 @@ function ImageInputAssetComponent(
     renderUploadState,
     tone,
     value,
+    imageUrlBuilder,
   } = props
 
   const hasValueOrUpload = Boolean(value?._upload || value?.asset)
   const path = useMemo(() => inputProps.path.concat(ASSET_FIELD_PATH), [inputProps.path])
+  const {customProperties} = usePreviewImageSource({value, imageUrlBuilder})
 
   return (
-    <>
+    <div style={customProperties}>
       {isStale && (
         <Box marginBottom={2}>
           <UploadWarning onClearStale={handleClearUploadState} />
@@ -79,7 +81,7 @@ function ImageInputAssetComponent(
           >
             {!value?.asset && renderUploadPlaceholder()}
             {!value?._upload && value?.asset && (
-              <div style={{position: 'relative'}} ref={forwardedRef}>
+              <div style={{position: 'relative'}}>
                 {renderPreview()}
                 {renderAssetMenu()}
               </div>
@@ -87,7 +89,7 @@ function ImageInputAssetComponent(
           </FileTarget>
         )}
       </ChangeIndicator>
-    </>
+    </div>
   )
 }
-export const ImageInputAsset = memo(forwardRef(ImageInputAssetComponent))
+export const ImageInputAsset = memo(ImageInputAssetComponent)

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputPreview.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputPreview.tsx
@@ -1,41 +1,33 @@
-import {isImageSource} from '@sanity/asset-utils'
 import {type ImageSchemaType} from '@sanity/types'
 import {memo, useMemo} from 'react'
-import {useDevicePixelRatio} from 'use-device-pixel-ratio'
 
 import {useTranslation} from '../../../../i18n'
 import {type UploaderResolver} from '../../../studio/uploads/types'
 import {type ImageUrlBuilder} from '../types'
 import {ImagePreview} from './ImagePreview'
 import {type BaseImageInputValue, type FileInfo} from './types'
+import {usePreviewImageSource} from './usePreviewImageSource'
 
 export const ImageInputPreview = memo(function ImageInputPreviewComponent(props: {
   directUploads: boolean | undefined
   handleOpenDialog: () => void
   hoveringFiles: FileInfo[]
   imageUrlBuilder: ImageUrlBuilder
-  initialHeight: number | undefined
   readOnly: boolean | undefined
   resolveUploader: UploaderResolver
   schemaType: ImageSchemaType
-  value: BaseImageInputValue | undefined
+  value: BaseImageInputValue
 }) {
   const {
     directUploads,
     handleOpenDialog,
     hoveringFiles,
     imageUrlBuilder,
-    initialHeight,
     readOnly,
     resolveUploader,
     schemaType,
     value,
   } = props
-
-  const isValueImageSource = useMemo(() => isImageSource(value), [value])
-  if (!value || !isValueImageSource) {
-    return null
-  }
 
   return (
     <RenderImageInputPreview
@@ -43,7 +35,6 @@ export const ImageInputPreview = memo(function ImageInputPreviewComponent(props:
       handleOpenDialog={handleOpenDialog}
       hoveringFiles={hoveringFiles}
       imageUrlBuilder={imageUrlBuilder}
-      initialHeight={initialHeight}
       readOnly={readOnly}
       resolveUploader={resolveUploader}
       schemaType={schemaType}
@@ -57,7 +48,6 @@ function RenderImageInputPreview(props: {
   handleOpenDialog: () => void
   hoveringFiles: FileInfo[]
   imageUrlBuilder: ImageUrlBuilder
-  initialHeight: number | undefined
   readOnly: boolean | undefined
   resolveUploader: UploaderResolver
   schemaType: ImageSchemaType
@@ -68,7 +58,6 @@ function RenderImageInputPreview(props: {
     handleOpenDialog,
     hoveringFiles,
     imageUrlBuilder,
-    initialHeight,
     readOnly,
     resolveUploader,
     schemaType,
@@ -84,20 +73,17 @@ function RenderImageInputPreview(props: {
     () => hoveringFiles.length - acceptedFiles.length,
     [acceptedFiles, hoveringFiles],
   )
-  const dpr = useDevicePixelRatio()
-  const imageUrl = useMemo(
-    () => imageUrlBuilder.width(2000).fit('max').image(value).dpr(dpr).auto('format').url(),
-    [dpr, imageUrlBuilder, value],
-  )
+
+  const {url} = usePreviewImageSource({value, imageUrlBuilder})
+
   return (
     <ImagePreview
       alt={t('inputs.image.preview-uploaded-image')}
       drag={!value?._upload && hoveringFiles.length > 0}
-      initialHeight={initialHeight}
       isRejected={rejectedFilesCount > 0 || !directUploads}
       onDoubleClick={handleOpenDialog}
       readOnly={readOnly}
-      src={imageUrl}
+      src={url}
     />
   )
 }

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.styled.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.styled.tsx
@@ -1,29 +1,19 @@
 import {Card, type CardTone, Flex, rgba, studioTheme} from '@sanity/ui'
 import {css, styled} from 'styled-components'
 
-export const MAX_DEFAULT_HEIGHT = 30
-
 export const RatioBox = styled(Card)`
   position: relative;
   width: 100%;
-  overflow: hidden;
-  overflow: clip;
   min-height: 3.75rem;
-  max-height: 20rem;
-
-  & > div[data-container] {
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: flex !important;
-    align-items: center;
-    justify-content: center;
-  }
+  max-height: min(calc(var(--image-height) * 1px), 20rem);
+  aspect-ratio: var(--image-width) / var(--image-height);
 
   & img {
-    max-width: 100%;
-    max-height: 100%;
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: scale-down;
+    object-position: center;
   }
 `
 

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.styled.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.styled.tsx
@@ -1,4 +1,5 @@
 import {Card, type CardTone, Flex, rgba, studioTheme} from '@sanity/ui'
+import {useColorSchemeValue} from 'sanity'
 import {css, styled} from 'styled-components'
 
 export const RatioBox = styled(Card)`
@@ -20,8 +21,9 @@ export const RatioBox = styled(Card)`
 export const Overlay = styled(Flex)<{
   $tone: Exclude<CardTone, 'inherit'>
 }>(({$tone}) => {
-  const textColor = studioTheme.color.light[$tone].card.enabled.fg
-  const backgroundColor = rgba(studioTheme.color.light[$tone].card.enabled.bg, 0.8)
+  const colorScheme = useColorSchemeValue()
+  const textColor = studioTheme.color[colorScheme][$tone].card.enabled.fg
+  const backgroundColor = rgba(studioTheme.color[colorScheme][$tone].card.enabled.bg, 0.8)
 
   return css`
     position: absolute;

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.styled.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.styled.tsx
@@ -18,9 +18,8 @@ export const RatioBox = styled(Card)`
 `
 
 export const Overlay = styled(Flex)<{
-  $drag: boolean
   $tone: Exclude<CardTone, 'inherit'>
-}>(({$drag, $tone}) => {
+}>(({$tone}) => {
   const textColor = studioTheme.color.light[$tone].card.enabled.fg
   const backgroundColor = rgba(studioTheme.color.light[$tone].card.enabled.bg, 0.8)
 
@@ -30,9 +29,9 @@ export const Overlay = styled(Flex)<{
     left: 0;
     right: 0;
     bottom: 0;
-    backdrop-filter: ${$drag ? 'blur(10px)' : ''};
+    backdrop-filter: blur(10px);
     color: ${$tone ? textColor : ''};
-    background-color: ${$drag ? backgroundColor : 'transparent'};
+    background-color: ${backgroundColor};
   `
 })
 

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.styled.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.styled.tsx
@@ -5,7 +5,7 @@ export const RatioBox = styled(Card)`
   position: relative;
   width: 100%;
   min-height: 3.75rem;
-  max-height: min(calc(var(--image-height) * 1px), 20rem);
+  max-height: min(calc(var(--image-height) * 1px), 30vh);
   aspect-ratio: var(--image-width) / var(--image-height);
 
   & img {

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.tsx
@@ -1,58 +1,24 @@
 import {AccessDeniedIcon, ImageIcon, ReadOnlyIcon} from '@sanity/icons'
-import {Box, Card, type CardTone, Heading, Text, useElementRect} from '@sanity/ui'
+import {Box, type Card, type CardTone, Heading, Text} from '@sanity/ui'
 import {type ComponentProps, type ReactNode, useCallback, useEffect, useState} from 'react'
 
 import {LoadingBlock} from '../../../../components/loadingBlock'
 import {useTranslation} from '../../../../i18n'
-import {FlexOverlay, MAX_DEFAULT_HEIGHT, Overlay, RatioBox} from './ImagePreview.styled'
+import {FlexOverlay, Overlay, RatioBox} from './ImagePreview.styled'
 
 interface Props {
   alt: string
   drag: boolean
-  initialHeight: number | undefined
   isRejected: boolean
   readOnly?: boolean | null
   src: string
 }
 
-/*
-  Used for setting the initial image height - specifically for images
-  that are small and so can take less space in the document
-*/
-const getImageSize = (src: string): number[] => {
-  const imageUrlParams = new URLSearchParams(src.split('?')[1])
-  const rect = imageUrlParams.get('rect')
-
-  if (rect) {
-    return [rect.split(',')[2], rect.split(',')[3]].map(Number)
-  }
-
-  return src.split('-')[1].split('.')[0].split('x').map(Number)
-}
-
 export function ImagePreview(props: ComponentProps<typeof Card> & Props) {
-  const {drag, readOnly, isRejected, src, initialHeight, ...rest} = props
+  const {drag, readOnly, isRejected, src, ...rest} = props
   const [isLoaded, setLoaded] = useState(false)
-  const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null)
-  const rootRect = useElementRect(rootElement)
-  const rootWidth = rootRect?.width || 0
   const acceptTone = isRejected || readOnly ? 'critical' : 'primary'
   const tone = drag ? acceptTone : 'default'
-
-  const maxHeightToPx = (MAX_DEFAULT_HEIGHT * document.documentElement.clientHeight) / 100 // convert from vh to px, max height of the input
-
-  const [imageWidth, imageHeight] = getImageSize(src)
-
-  const imageRatio = imageWidth / imageHeight
-
-  // is the image wider than root? if so calculate the resized height
-  const renderedImageHeight = imageWidth > rootWidth ? rootWidth / imageRatio : imageHeight
-
-  /*
-    if the rendered image is smaller than the max height then it doesn't require a height set
-    otherwise, set the max height (to prevent a large image in the document)
-  */
-  const rootHeight = renderedImageHeight < maxHeightToPx ? null : `${MAX_DEFAULT_HEIGHT}vh`
 
   useEffect(() => {
     /* set for when the src is being switched when the image input already had a image src
@@ -65,26 +31,19 @@ export function ImagePreview(props: ComponentProps<typeof Card> & Props) {
   }, [])
 
   const {t} = useTranslation()
-  return (
-    <RatioBox
-      {...rest}
-      ref={setRootElement}
-      style={{height: initialHeight && !isLoaded ? initialHeight : rootHeight}}
-      tone="transparent"
-    >
-      <Card data-container tone="inherit">
-        {!isLoaded && (
-          <OverlayComponent cardTone="transparent" drag content={<LoadingBlock showText />} />
-        )}
-        <img
-          src={src}
-          data-testid="hotspot-image-input"
-          alt={props.alt}
-          onLoad={onLoadChange}
-          referrerPolicy="strict-origin-when-cross-origin"
-        />
-      </Card>
 
+  return (
+    <RatioBox {...rest} tone="transparent">
+      {!isLoaded && (
+        <OverlayComponent cardTone="transparent" drag content={<LoadingBlock showText />} />
+      )}
+      <img
+        src={src}
+        data-testid="hotspot-image-input"
+        alt={props.alt}
+        onLoad={onLoadChange}
+        referrerPolicy="strict-origin-when-cross-origin"
+      />
       {drag && (
         <OverlayComponent
           cardTone={tone}

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.tsx
@@ -34,9 +34,7 @@ export function ImagePreview(props: ComponentProps<typeof Card> & Props) {
 
   return (
     <RatioBox {...rest} tone="transparent">
-      {!isLoaded && (
-        <OverlayComponent cardTone="transparent" drag content={<LoadingBlock showText />} />
-      )}
+      {!isLoaded && <OverlayComponent cardTone="transparent" content={<LoadingBlock showText />} />}
       <img
         src={src}
         data-testid="hotspot-image-input"
@@ -47,7 +45,6 @@ export function ImagePreview(props: ComponentProps<typeof Card> & Props) {
       {drag && (
         <OverlayComponent
           cardTone={tone}
-          drag={drag}
           content={
             <>
               <Box marginBottom={3}>
@@ -91,15 +88,13 @@ function getHoverTextTranslationKey({
 
 function OverlayComponent({
   cardTone,
-  drag,
   content,
 }: {
   cardTone: Exclude<CardTone, 'inherit'>
-  drag: boolean
   content: ReactNode
 }) {
   return (
-    <Overlay justify="flex-end" padding={3} $drag={drag} $tone={cardTone}>
+    <Overlay justify="flex-end" padding={3} $tone={cardTone}>
       <FlexOverlay direction="column" align="center" justify="center">
         {content}
       </FlexOverlay>

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/usePreviewImageSource.ts
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/usePreviewImageSource.ts
@@ -1,0 +1,55 @@
+import {getImageDimensions, isImageSource, type SanityImageDimensions} from '@sanity/asset-utils'
+import {type CSSProperties, useMemo} from 'react'
+import {useDevicePixelRatio} from 'use-device-pixel-ratio'
+
+import {type ImageUrlBuilder} from '../types'
+import {type BaseImageInputValue} from './types'
+
+export function usePreviewImageSource<Value extends BaseImageInputValue | undefined>({
+  value,
+  imageUrlBuilder,
+}: {
+  value: Value
+  imageUrlBuilder: ImageUrlBuilder
+}): {
+  url: Value extends undefined ? undefined : string
+  dimensions: SanityImageDimensions
+  customProperties: CSSProperties
+} {
+  const dpr = useDevicePixelRatio()
+
+  const url = useMemo(
+    () =>
+      value && isImageSource(value)
+        ? imageUrlBuilder.width(2000).fit('max').image(value).dpr(dpr).auto('format').url()
+        : undefined,
+    [dpr, imageUrlBuilder, value],
+  ) as Value extends undefined ? undefined : string
+
+  const dimensions = useMemo<SanityImageDimensions>(
+    () =>
+      url
+        ? getImageDimensions(url)
+        : {
+            width: 0,
+            height: 0,
+            aspectRatio: 0,
+          },
+    [url],
+  )
+
+  const customProperties = useMemo(
+    () =>
+      ({
+        '--image-width': dimensions.width,
+        '--image-height': dimensions.height,
+      }) as CSSProperties,
+    [dimensions.width, dimensions.height],
+  )
+
+  return {
+    url,
+    dimensions,
+    customProperties,
+  }
+}

--- a/packages/sanity/src/core/form/inputs/files/common/UploadProgress.styled.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/UploadProgress.styled.tsx
@@ -1,12 +1,14 @@
-import {Card, Code, Flex, Stack} from '@sanity/ui'
+import {Code, Flex, Stack} from '@sanity/ui'
 import {styled} from 'styled-components'
 
-export const CardWrapper = styled(Card)`
-  min-height: 82px;
+import {RatioBox} from '../ImageInput/ImagePreview.styled'
+
+export const CardWrapper = styled(RatioBox)`
   box-sizing: border-box;
 `
 
 export const FlexWrapper = styled(Flex)`
+  box-sizing: border-box;
   text-overflow: ellipsis;
   overflow: hidden;
   overflow: clip;

--- a/packages/sanity/src/core/form/inputs/files/common/UploadProgress.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/UploadProgress.tsx
@@ -12,11 +12,10 @@ type Props = {
   uploadState: UploadState
   onCancel?: () => void
   onStale?: () => void
-  height?: number
 }
 const elapsedMs = (date: string): number => new Date().getTime() - new Date(date).getTime()
 
-export function UploadProgress({uploadState, onCancel, onStale, height}: Props) {
+export function UploadProgress({uploadState, onCancel, onStale}: Props) {
   const filename = uploadState.file.name
 
   useEffect(() => {
@@ -27,13 +26,15 @@ export function UploadProgress({uploadState, onCancel, onStale, height}: Props) 
 
   const {t} = useTranslation()
   return (
-    <CardWrapper
-      tone="primary"
-      padding={4}
-      border
-      style={{height: height ? `${height}px` : undefined}}
-    >
-      <FlexWrapper align="center" justify="space-between" height="fill" direction="row" gap={2}>
+    <CardWrapper tone="primary" border>
+      <FlexWrapper
+        padding={4}
+        align="center"
+        justify="space-between"
+        height="fill"
+        direction="row"
+        gap={2}
+      >
         <LeftSection>
           <Flex justify="center" gap={[3, 3, 2, 2]} direction={['column', 'column', 'row']}>
             <Text size={1}>


### PR DESCRIPTION
### Description

This branch introduces refinements to the image input preview, primarily to address the layout shift reported in #7337.

There are two scenarios in which layout shift can occur:

1. When the image is loading.
2. When the selected image state transitions to the uploading state, and the uploading state subsequently transitions to the new image. There has been a previous attempt to fix this (#6930), but I believe this may be causing the layout shift when the image loads.

This branch removes the ref added in #6930. Instead of attempting to preserve the last known height of the image preview DOM node using a ref, the known image dimensions are set as CSS custom properties on the outer container of the image input. Both the image preview and upload state UI use CSS to match the aspect ratio of the selected image, eliminating both layout shifts noted above.

Importantly, the value of the image field reflects the previously selected image while the next image is uploading. This means the upload state UI can match the dimensions of the previously selected image, addressing layout shift when uploading a new image in a simpler manner than before.

This branch also introduces a couple of other refinements to the image input:

1. Fixes incorrect use of light colour scheme in overlay components, regardless of whether the user has light mode active. In dark mode, this caused a flash of a light placeholder block, which looks janky.
2. Allows the image preview's block size to extend to `30vh`. I believe there was previously [an attempt to achieve this](https://github.com/sanity-io/sanity/blob/7c814a88e4d0629650b57d4705892ade2b7d1220/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.tsx#L55), but the block size was ultimately [limited to a `rem` value in CSS](https://github.com/sanity-io/sanity/blob/7c814a88e4d0629650b57d4705892ade2b7d1220/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.styled.tsx#L12). Moving the calculations to CSS makes it simpler to allow the block size to extend to a `vh` value, while collapsing to the intrinsic height of the image if it's less than `30vh`.

#### Demo

| Before (video) | After (video) | 
| --- | --- | 
| https://github.com/user-attachments/assets/f79bb9f8-cf62-4f51-a1d0-8bd2b3e9cdf7  | https://github.com/user-attachments/assets/8df6455a-17b4-4d08-a049-521576fca43d |
| Noticeable layout jitter when loading the image, and a flash of the light colour mode when dark mode is active make images quite janky. | After these changes, images are much more stable. | 

#### Images now have a maximum height of `30vh`.

| Before | After | 
| --- | --- | 
| <img width="1205" alt="before-max-height" src="https://github.com/user-attachments/assets/00c9251e-b970-49eb-817e-650528bdc05c"> | <img width="1205" alt="after-max-height" src="https://github.com/user-attachments/assets/7b9f4946-4ffa-46ba-a3fb-550d8dee7d2d"> |

#### We still preserve the aspect ratio of the current image to prevent layout shifts when uploading a new one, which was first addressed by Cody in #6930. Now we achieve it in a simpler way.

https://github.com/user-attachments/assets/d24a10fc-5440-4a26-b89e-478b473d61a6

### What to review

Does the approach make sense?

### Testing

- Tested various image sizes and aspect ratios.
- Tested various image states (image present, image uploading, image upload failed).
- Tested various viewport sizes.
- Tested in Safari, Chrome, and Firefox.

### Notes for release

- Eliminated layout shifts in image fields.
- Fixed incorrect usage of light mode in image field overlays when dark mode is active.