### PR TITLE
feat: preserve visited documents in `documents-store` [WIP]

### DIFF
--- a/packages/sanity/src/core/preview/createGlobalListener.ts
+++ b/packages/sanity/src/core/preview/createGlobalListener.ts
@@ -19,6 +19,7 @@ export function createGlobalListener(client: SanityClient) {
         includePreviousRevision: false,
         includeMutations: false,
         visibility: 'query',
+        effectFormat: 'mendoza',
         tag: 'preview.global',
       },
     )

--- a/packages/sanity/src/core/preview/createObserveDocument.ts
+++ b/packages/sanity/src/core/preview/createObserveDocument.ts
@@ -1,0 +1,87 @@
+import {type MutationEvent, type SanityClient, type WelcomeEvent} from '@sanity/client'
+import {type SanityDocument} from '@sanity/types'
+import {memoize, uniq} from 'lodash'
+import {EMPTY, finalize, type Observable, of} from 'rxjs'
+import {concatMap, map, scan, shareReplay} from 'rxjs/operators'
+
+import {type ApiConfig} from './types'
+import {applyMendozaPatch} from './utils/applyMendozaPatch'
+import {debounceCollect} from './utils/debounceCollect'
+
+export function createObserveDocument({
+  mutationChannel,
+  client,
+}: {
+  client: SanityClient
+  mutationChannel: Observable<WelcomeEvent | MutationEvent>
+}) {
+  const getBatchFetcher = memoize(
+    function getBatchFetcher(apiConfig: {dataset: string; projectId: string}) {
+      const _client = client.withConfig(apiConfig)
+
+      function batchFetchDocuments(ids: [string][]) {
+        return _client.observable
+          .fetch(`*[_id in $ids]`, {ids: uniq(ids.flat())}, {tag: 'preview.observe-document'})
+          .pipe(
+            // eslint-disable-next-line max-nested-callbacks
+            map((result) => ids.map(([id]) => result.find((r: {_id: string}) => r._id === id))),
+          )
+      }
+      return debounceCollect(batchFetchDocuments, 100)
+    },
+    (apiConfig) => apiConfig.dataset + apiConfig.projectId,
+  )
+
+  const MEMO: Record<string, Observable<SanityDocument | undefined>> = {}
+
+  function observeDocument(id: string, apiConfig?: ApiConfig) {
+    const _apiConfig = apiConfig || {
+      dataset: client.config().dataset!,
+      projectId: client.config().projectId!,
+    }
+    const fetchDocument = getBatchFetcher(_apiConfig)
+    return mutationChannel.pipe(
+      concatMap((event) => {
+        if (event.type === 'welcome') {
+          return fetchDocument(id).pipe(map((document) => ({type: 'sync' as const, document})))
+        }
+        return event.documentId === id ? of(event) : EMPTY
+      }),
+      scan((current: SanityDocument | undefined, event) => {
+        if (event.type === 'sync') {
+          return event.document
+        }
+        if (event.type === 'mutation') {
+          return applyMutationEvent(current, event)
+        }
+        //@ts-expect-error - this should never happen
+        throw new Error(`Unexpected event type: "${event.type}"`)
+      }, undefined),
+    )
+  }
+  return function memoizedObserveDocument(id: string, apiConfig?: ApiConfig) {
+    const key = apiConfig ? `${id}-${JSON.stringify(apiConfig)}` : id
+    if (!(key in MEMO)) {
+      MEMO[key] = observeDocument(id, apiConfig).pipe(
+        finalize(() => delete MEMO[key]),
+        shareReplay({bufferSize: 1, refCount: true}),
+      )
+    }
+    return MEMO[key]
+  }
+}
+
+function applyMutationEvent(current: SanityDocument | undefined, event: MutationEvent) {
+  if (event.previousRev !== current?._rev) {
+    console.warn('Document out of sync, skipping mutation')
+    return current
+  }
+  if (!event.effects) {
+    throw new Error(
+      'Mutation event is missing effects. Is the listener set up with effectFormat=mendoza?',
+    )
+  }
+  const next = applyMendozaPatch(current, event.effects.apply)
+  // next will be undefined in case of deletion
+  return next ? {...next, _rev: event.resultRev} : undefined
+}

--- a/packages/sanity/src/core/preview/documentPreviewStore.ts
+++ b/packages/sanity/src/core/preview/documentPreviewStore.ts
@@ -1,11 +1,12 @@
 import {type MutationEvent, type SanityClient, type WelcomeEvent} from '@sanity/client'
 import {type PrepareViewOptions, type SanityDocument} from '@sanity/types'
-import {type Observable} from 'rxjs'
+import {combineLatest, type Observable} from 'rxjs'
 import {distinctUntilChanged, filter, map} from 'rxjs/operators'
 
 import {isRecord} from '../util'
 import {createPreviewAvailabilityObserver} from './availability'
 import {createGlobalListener} from './createGlobalListener'
+import {createObserveDocument} from './createObserveDocument'
 import {createPathObserver} from './createPathObserver'
 import {createPreviewObserver} from './createPreviewObserver'
 import {createObservePathsDocumentPair} from './documentPair'
@@ -56,6 +57,18 @@ export interface DocumentPreviewStore {
     id: string,
     paths: PreviewPath[],
   ) => Observable<DraftsModelDocument<T>>
+  /**
+   * Observe a complete document with the given ID
+   * @hidden
+   * @beta
+   */
+  unstable_observeDocument: (id: string) => Observable<SanityDocument | undefined>
+  /**
+   * Observe a list of complete documents with the given IDs
+   * @hidden
+   * @beta
+   */
+  unstable_observeDocuments: (ids: string[]) => Observable<(SanityDocument | undefined)[]>
 }
 
 /** @internal */
@@ -78,6 +91,8 @@ export function createDocumentPreviewStore({
   const invalidationChannel = globalListener.pipe(
     map((event) => (event.type === 'welcome' ? {type: 'connected' as const} : event)),
   )
+
+  const observeDocument = createObserveDocument({client, mutationChannel: globalListener})
 
   const observeFields = createObserveFields({client: versionedClient, invalidationChannel})
   const observePaths = createPathObserver({observeFields})
@@ -110,6 +125,9 @@ export function createDocumentPreviewStore({
     observeForPreview,
     observeDocumentTypeFromId,
 
+    unstable_observeDocument: observeDocument,
+    unstable_observeDocuments: (ids: string[]) =>
+      combineLatest(ids.map((id) => observeDocument(id))),
     unstable_observeDocumentPairAvailability: observeDocumentPairAvailability,
     unstable_observePathsDocumentPair: observePathsDocumentPair,
   }

--- a/packages/sanity/src/core/preview/utils/applyMendozaPatch.ts
+++ b/packages/sanity/src/core/preview/utils/applyMendozaPatch.ts
@@ -1,0 +1,18 @@
+import {type SanityDocument} from '@sanity/types'
+import {applyPatch, type RawPatch} from 'mendoza'
+
+function omitRev(document: SanityDocument | undefined) {
+  if (document === undefined) {
+    return undefined
+  }
+  const {_rev, ...doc} = document
+  return doc
+}
+
+export function applyMendozaPatch(
+  document: SanityDocument | undefined,
+  patch: RawPatch,
+): SanityDocument | undefined {
+  const next = applyPatch(omitRev(document), patch)
+  return next === null ? undefined : next
+}

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
@@ -1,7 +1,7 @@
 import {type SanityClient} from '@sanity/client'
 import {type SanityDocument, type Schema} from '@sanity/types'
 import {combineLatest, type Observable} from 'rxjs'
-import {map, publishReplay, refCount, startWith, switchMap} from 'rxjs/operators'
+import {map, publishReplay, refCount, startWith, switchMap, take} from 'rxjs/operators'
 
 import {type IdPair, type PendingMutationsEvent} from '../types'
 import {memoize} from '../utils/createMemoizer'
@@ -38,36 +38,49 @@ export const editState = memoize(
     },
     idPair: IdPair,
     typeName: string,
+    visited$: Observable<(SanityDocument | undefined)[]>,
   ): Observable<EditStateFor> => {
     const liveEdit = isLiveEditEnabled(ctx.schema, typeName)
-    return snapshotPair(ctx.client, idPair, typeName, ctx.serverActionsEnabled).pipe(
-      switchMap((versions) =>
-        combineLatest([
-          versions.draft.snapshots$,
-          versions.published.snapshots$,
-          versions.transactionsPendingEvents$.pipe(
-            map((ev: PendingMutationsEvent) => (ev.phase === 'begin' ? LOCKED : NOT_LOCKED)),
-            startWith(NOT_LOCKED),
+    return visited$.pipe(
+      take(1),
+      map((visited) => {
+        return {
+          draft: visited.find((doc) => doc?._id === idPair.draftId) || null,
+          published: visited.find((doc) => doc?._id === idPair.publishedId) || null,
+        }
+      }),
+      switchMap((visitedPair) => {
+        return snapshotPair(ctx.client, idPair, typeName, ctx.serverActionsEnabled).pipe(
+          switchMap((versions) =>
+            combineLatest([
+              versions.draft.snapshots$,
+              versions.published.snapshots$,
+              versions.transactionsPendingEvents$.pipe(
+                // eslint-disable-next-line max-nested-callbacks
+                map((ev: PendingMutationsEvent) => (ev.phase === 'begin' ? LOCKED : NOT_LOCKED)),
+                startWith(NOT_LOCKED),
+              ),
+            ]),
           ),
-        ]),
-      ),
-      map(([draftSnapshot, publishedSnapshot, transactionSyncLock]) => ({
-        id: idPair.publishedId,
-        type: typeName,
-        draft: draftSnapshot,
-        published: publishedSnapshot,
-        liveEdit,
-        ready: true,
-        transactionSyncLock,
-      })),
-      startWith({
-        id: idPair.publishedId,
-        type: typeName,
-        draft: null,
-        published: null,
-        liveEdit,
-        ready: false,
-        transactionSyncLock: null,
+          map(([draftSnapshot, publishedSnapshot, transactionSyncLock]) => ({
+            id: idPair.publishedId,
+            type: typeName,
+            draft: draftSnapshot,
+            published: publishedSnapshot,
+            liveEdit,
+            ready: true,
+            transactionSyncLock,
+          })),
+          startWith({
+            id: idPair.publishedId,
+            type: typeName,
+            draft: visitedPair.draft,
+            published: visitedPair.published,
+            liveEdit,
+            ready: false,
+            transactionSyncLock: null,
+          }),
+        )
       }),
       publishReplay(1),
       refCount(),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
@@ -1,5 +1,5 @@
 import {type SanityClient} from '@sanity/client'
-import {type Schema} from '@sanity/types'
+import {type SanityDocument, type Schema} from '@sanity/types'
 import {omit} from 'lodash'
 import {asyncScheduler, type Observable} from 'rxjs'
 import {distinctUntilChanged, map, shareReplay, throttleTime} from 'rxjs/operators'
@@ -34,8 +34,9 @@ export const validation = memoize(
     },
     {draftId, publishedId}: IdPair,
     typeName: string,
+    visited$: Observable<(SanityDocument | undefined)[]>,
   ): Observable<ValidationStatus> => {
-    const document$ = editState(ctx, {draftId, publishedId}, typeName).pipe(
+    const document$ = editState(ctx, {draftId, publishedId}, typeName, visited$).pipe(
       map(({draft, published}) => draft || published),
       throttleTime(DOC_UPDATE_DELAY, asyncScheduler, {trailing: true}),
       distinctUntilChanged((prev, next) => {

--- a/packages/sanity/src/core/store/_legacy/document/getVisitedDocuments.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/getVisitedDocuments.test.ts
@@ -1,0 +1,211 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {type SanityDocument} from '@sanity/types'
+import {of} from 'rxjs'
+
+import {getVisitedDocuments} from './getVisitedDocuments'
+
+const mockObserveDocuments = jest.fn((ids: string[]) => {
+  // Return an observable that emits an array of documents corresponding to the IDs
+  return of(
+    ids.map(
+      (id) =>
+        ({
+          _id: id,
+          _type: 'foo',
+        }) as unknown as SanityDocument,
+    ),
+  )
+})
+
+type Emissions = (SanityDocument | undefined)[][]
+
+describe('getVisitedDocuments', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should start with an empty array', () => {
+    const {visited$} = getVisitedDocuments({observeDocuments: mockObserveDocuments})
+
+    const emissions: Emissions = []
+
+    visited$.subscribe((docs) => {
+      emissions.push(docs)
+    })
+
+    expect(emissions).toHaveLength(1)
+    expect(emissions[0]).toEqual([])
+  })
+
+  it('should emit documents when an ID is added', () => {
+    const {visited$, add} = getVisitedDocuments({observeDocuments: mockObserveDocuments})
+
+    const emissions: Emissions = []
+
+    visited$.subscribe((docs) => {
+      emissions.push(docs)
+    })
+
+    add('doc1')
+
+    expect(emissions).toHaveLength(2)
+
+    const expectedDocs = [
+      {_id: 'doc1', _type: 'foo'},
+      {_id: 'drafts.doc1', _type: 'foo'},
+    ]
+
+    expect(emissions[1]).toEqual(expectedDocs)
+  })
+
+  it('should emit documents when multiple IDs are added', () => {
+    const {visited$, add} = getVisitedDocuments({observeDocuments: mockObserveDocuments})
+
+    const emissions: Emissions = []
+
+    visited$.subscribe((docs) => {
+      emissions.push(docs)
+    })
+
+    add('doc1')
+    add('doc2')
+
+    expect(emissions).toHaveLength(3)
+
+    const expectedDocs = [
+      {_id: 'doc1', _type: 'foo'},
+      {_id: 'drafts.doc1', _type: 'foo'},
+      {_id: 'doc2', _type: 'foo'},
+      {_id: 'drafts.doc2', _type: 'foo'},
+    ]
+
+    expect(emissions[2]).toEqual(expectedDocs)
+  })
+
+  it('should move an existing ID to the end when re-added', () => {
+    const {visited$, add} = getVisitedDocuments({observeDocuments: mockObserveDocuments})
+
+    const emissions: Emissions = []
+
+    visited$.subscribe((docs) => {
+      emissions.push(docs)
+    })
+
+    add('doc1')
+    add('doc2')
+    add('doc3')
+    add('doc2') // Re-add 'doc2'
+
+    // Expected IDs after re-adding 'doc2': ['doc1', 'doc3', 'doc2']
+    const expectedDocs = [
+      {_id: 'doc1', _type: 'foo'},
+      {_id: 'drafts.doc1', _type: 'foo'},
+      {_id: 'doc3', _type: 'foo'},
+      {_id: 'drafts.doc3', _type: 'foo'},
+      {_id: 'doc2', _type: 'foo'},
+      {_id: 'drafts.doc2', _type: 'foo'},
+    ]
+
+    expect(emissions[emissions.length - 1]).toEqual(expectedDocs)
+  })
+
+  it('should not duplicate documents when the same ID is added multiple times', () => {
+    const {visited$, add} = getVisitedDocuments({observeDocuments: mockObserveDocuments})
+
+    const emissions: Emissions = []
+
+    visited$.subscribe((docs) => {
+      emissions.push(docs)
+    })
+
+    add('doc1')
+    add('doc1')
+    add('doc1')
+
+    expect(emissions).toHaveLength(4)
+
+    const expectedDocs = [
+      {_id: 'doc1', _type: 'foo'},
+      {_id: 'drafts.doc1', _type: 'foo'},
+    ]
+
+    expect(emissions[emissions.length - 1]).toEqual(expectedDocs)
+  })
+
+  it('should maintain up to MAX_OBSERVED_DOCUMENTS IDs', () => {
+    const {visited$, add} = getVisitedDocuments({observeDocuments: mockObserveDocuments})
+
+    const emissions: Emissions = []
+    const docIds = ['doc1', 'doc2', 'doc3', 'doc4', 'doc5', 'doc6']
+
+    visited$.subscribe((docs) => {
+      emissions.push(docs)
+    })
+
+    docIds.forEach((id) => add(id))
+
+    expect(mockObserveDocuments).toHaveBeenLastCalledWith([
+      'doc2',
+      'drafts.doc2',
+      'doc3',
+      'drafts.doc3',
+      'doc4',
+      'drafts.doc4',
+      'doc5',
+      'drafts.doc5',
+      'doc6',
+      'drafts.doc6',
+    ])
+
+    // The last emission should only contain the last 5 documents (doc2 to doc6) in the correct order, removes the oldest doc (doc1)
+    const expectedDocs = [
+      {_id: 'doc2', _type: 'foo'},
+      {_id: 'drafts.doc2', _type: 'foo'},
+      {_id: 'doc3', _type: 'foo'},
+      {_id: 'drafts.doc3', _type: 'foo'},
+      {_id: 'doc4', _type: 'foo'},
+      {_id: 'drafts.doc4', _type: 'foo'},
+      {_id: 'doc5', _type: 'foo'},
+      {_id: 'drafts.doc5', _type: 'foo'},
+      {_id: 'doc6', _type: 'foo'},
+      {_id: 'drafts.doc6', _type: 'foo'},
+    ]
+
+    expect(emissions[emissions.length - 1]).toEqual(expectedDocs)
+  })
+
+  it('should keep the observer alive even when no one is subscribed', () => {
+    const {visited$, add} = getVisitedDocuments({observeDocuments: mockObserveDocuments})
+
+    const emissionsFirstSub: Emissions = []
+    const emissionsSecondSub: Emissions = []
+
+    const subscription = visited$.subscribe((docs) => {
+      emissionsFirstSub.push(docs)
+    })
+
+    add('doc1')
+    add('doc2')
+
+    expect(emissionsFirstSub).toHaveLength(3)
+
+    const expectedDocs = [
+      {_id: 'doc1', _type: 'foo'},
+      {_id: 'drafts.doc1', _type: 'foo'},
+      {_id: 'doc2', _type: 'foo'},
+      {_id: 'drafts.doc2', _type: 'foo'},
+    ]
+
+    expect(emissionsFirstSub[emissionsFirstSub.length - 1]).toEqual(expectedDocs)
+
+    // unsubscribe
+    subscription.unsubscribe()
+
+    visited$.subscribe((docs) => {
+      emissionsSecondSub.push(docs)
+    })
+    // Should have the last emitted documents
+    expect(emissionsSecondSub).toHaveLength(1)
+    expect(emissionsSecondSub[emissionsSecondSub.length - 1]).toEqual(expectedDocs)
+  })
+})

--- a/packages/sanity/src/core/store/_legacy/document/getVisitedDocuments.ts
+++ b/packages/sanity/src/core/store/_legacy/document/getVisitedDocuments.ts
@@ -1,0 +1,60 @@
+import {type SanityDocument} from '@sanity/types'
+import {type Observable, ReplaySubject, Subject} from 'rxjs'
+import {map, scan, share, startWith, switchMap} from 'rxjs/operators'
+
+import {type DocumentPreviewStore} from '../../../preview'
+import {getDraftId, getPublishedId} from '../../../util'
+
+const MAX_OBSERVED_DOCUMENTS = 5
+
+/**
+ * Keeps a listener of the documents the user visited through the form.
+ * Allowing us to provide a quick way to navigate back to the last visited documents.
+ */
+export function getVisitedDocuments({
+  observeDocuments,
+}: {
+  observeDocuments: DocumentPreviewStore['unstable_observeDocuments']
+}): {
+  add: (id: string) => void
+  visited$: Observable<(SanityDocument | undefined)[]>
+} {
+  const observedDocumentsSubject = new Subject<string>()
+
+  const visited$ = observedDocumentsSubject.pipe(
+    scan((prev: string[], nextDoc: string) => {
+      const nextDocs = [...prev]
+      if (nextDocs.includes(nextDoc)) {
+        // Doc is already observed, remove it from the current position and push it to the end
+        nextDocs.splice(nextDocs.indexOf(nextDoc), 1)
+        nextDocs.push(nextDoc)
+      } else {
+        // Doc is not observed, push it to the end
+        nextDocs.push(nextDoc)
+      }
+      // Remove the oldest doc if we're observing more than the max allowed
+      if (nextDocs.length > MAX_OBSERVED_DOCUMENTS) {
+        nextDocs.shift()
+      }
+      return nextDocs
+    }, []),
+    map((ids) => ids.flatMap((id) => [getPublishedId(id), getDraftId(id)])),
+    switchMap((ids) => {
+      return observeDocuments(ids)
+    }),
+    startWith([]),
+    share({
+      connector: () => new ReplaySubject(1),
+      resetOnError: false,
+      resetOnComplete: false,
+      resetOnRefCountZero: false,
+    }),
+  )
+
+  return {
+    add: (id: string) => {
+      observedDocumentsSubject.next(id)
+    },
+    visited$,
+  }
+}

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -166,7 +166,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     >
       <PresenceOverlay margins={margins}>
         <Box as="form" onSubmit={preventDefault} ref={setRef}>
-          {connectionState === 'connecting' || !ready ? (
+          {connectionState === 'connecting' && !editState?.draft && !editState?.published ? (
             <Delay ms={300}>
               {/* TODO: replace with loading block */}
               <Flex align="center" direction="column" height="fill" justify="center">
@@ -205,7 +205,9 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
                 onSetPathCollapsed={onSetCollapsedPath}
                 openPath={openPath}
                 presence={presence}
-                readOnly={connectionState === 'reconnecting' || formState.readOnly}
+                readOnly={
+                  connectionState === 'reconnecting' || formState.readOnly || !editState?.ready
+                }
                 schemaType={formState.schemaType}
                 validation={validation}
                 value={

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTabs.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTabs.tsx
@@ -35,7 +35,7 @@ function DocumentHeaderTab(props: {
   viewId: string | null
 }) {
   const {icon, id, isActive, label, tabPanelId, viewId, ...rest} = props
-  const {ready} = useDocumentPane()
+  const {ready, editState} = useDocumentPane()
   const {setView} = usePaneRouter()
   const handleClick = useCallback(() => setView(viewId), [setView, viewId])
 
@@ -43,7 +43,7 @@ function DocumentHeaderTab(props: {
     <Tab
       {...rest} // required to enable <TabList> keyboard navigation
       aria-controls={tabPanelId}
-      disabled={!ready}
+      disabled={!ready && !editState?.draft && !editState?.published}
       icon={icon}
       id={id}
       label={label}

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.test.tsx
@@ -39,7 +39,7 @@ describe('DocumentHeaderTitle', () => {
   const defaultProps = {
     connectionState: 'connected',
     schemaType: {title: 'Test Schema', name: 'testSchema'},
-    value: {title: 'Test Value'},
+    editState: {draft: {title: 'Test Value'}},
   }
 
   const defaultValue = {
@@ -63,14 +63,31 @@ describe('DocumentHeaderTitle', () => {
     await waitFor(() => expect(getByText('Untitled')).toBeInTheDocument())
   })
 
-  it('should return an empty fragment when connectionState is not "connected"', async () => {
+  it('should return an empty fragment when connectionState is not "connected" and editState is empty', async () => {
+    mockUseDocumentPane.mockReturnValue({
+      ...defaultProps,
+      connectionState: 'connecting',
+      editState: null,
+    } as unknown as DocumentPaneContextValue)
+
+    const {container} = render(<DocumentHeaderTitle />)
+    await waitFor(() => expect(container.firstChild).toBeNull())
+  })
+
+  it('should render the header title when connectionState is not "connected" and editState has values', async () => {
     mockUseDocumentPane.mockReturnValue({
       ...defaultProps,
       connectionState: 'connecting',
     } as unknown as DocumentPaneContextValue)
 
-    const {container} = render(<DocumentHeaderTitle />)
-    await waitFor(() => expect(container.firstChild).toBeNull())
+    mockUseValuePreview.mockReturnValue({
+      ...defaultValue,
+      error: undefined,
+      value: {title: 'Test Value'},
+    })
+
+    const {getByText} = render(<DocumentHeaderTitle />)
+    await waitFor(() => expect(getByText('Test Value')).toBeInTheDocument())
   })
 
   it('should return the title if it is provided', async () => {
@@ -89,7 +106,7 @@ describe('DocumentHeaderTitle', () => {
   it('should return "New {schemaType?.title || schemaType?.name}" if documentValue is not provided', async () => {
     mockUseDocumentPane.mockReturnValue({
       ...defaultProps,
-      value: null,
+      editState: null,
     } as unknown as DocumentPaneContextValue)
 
     const client = createMockSanityClient()
@@ -146,7 +163,7 @@ describe('DocumentHeaderTitle', () => {
       expect(mockUseValuePreview).toHaveBeenCalledWith({
         enabled: true,
         schemaType: defaultProps.schemaType,
-        value: defaultProps.value,
+        value: defaultProps.editState.draft,
       }),
     )
   })

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
@@ -5,8 +5,9 @@ import {structureLocaleNamespace} from '../../../../i18n'
 import {useDocumentPane} from '../../useDocumentPane'
 
 export function DocumentHeaderTitle(): ReactElement {
-  const {connectionState, schemaType, title, value: documentValue} = useDocumentPane()
-  const subscribed = Boolean(documentValue) && connectionState !== 'connecting'
+  const {connectionState, schemaType, title, editState} = useDocumentPane()
+  const documentValue = editState?.draft || editState?.published
+  const subscribed = Boolean(documentValue)
 
   const {error, value} = useValuePreview({
     enabled: subscribed,
@@ -15,7 +16,7 @@ export function DocumentHeaderTitle(): ReactElement {
   })
   const {t} = useTranslation(structureLocaleNamespace)
 
-  if (connectionState === 'connecting') {
+  if (connectionState === 'connecting' && !subscribed) {
     return <></>
   }
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -137,7 +137,7 @@ export const DocumentPanelHeader = memo(
         <PaneHeader
           border
           ref={ref}
-          loading={connectionState === 'connecting'}
+          loading={connectionState === 'connecting' && !editState?.draft && !editState?.published}
           title={<DocumentHeaderTitle />}
           tabs={showTabs && <DocumentHeaderTabs />}
           tabIndex={tabIndex}

--- a/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
+++ b/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
@@ -22,8 +22,9 @@ interface UseDocumentTitle {
  * @returns The document title or error. See {@link UseDocumentTitle}
  */
 export function useDocumentTitle(): UseDocumentTitle {
-  const {connectionState, schemaType, title, value: documentValue} = useDocumentPane()
-  const subscribed = Boolean(documentValue) && connectionState !== 'connecting'
+  const {connectionState, schemaType, title, editState} = useDocumentPane()
+  const documentValue = editState?.draft || editState?.published
+  const subscribed = Boolean(documentValue)
 
   const {error, value} = useValuePreview({
     enabled: subscribed,
@@ -31,7 +32,7 @@ export function useDocumentTitle(): UseDocumentTitle {
     value: documentValue,
   })
 
-  if (connectionState === 'connecting') {
+  if (connectionState === 'connecting' && !subscribed) {
     return {error: undefined, title: undefined}
   }
 


### PR DESCRIPTION
### Description

This PR adds the ability to listen to the last N visited documents, allowing us to render them immediately when you open the form instead of having to wait for it to be fully loaded again.
It works for the following case:
- User navigates to document **foo** (Shows loading state)
- User navigates to document **bar** (Shows loading state)
- User navigates back to document **foo**  (Shows document immediately, as it has been visited before)

⚠️  It partially copies necessary changes from `corel` https://github.com/sanity-io/sanity/pull/7176
⚠️  It modifies the preview store to use mendoza patches.

https://github.com/user-attachments/assets/0694f058-ddd0-4856-9b42-f9ab04ff9a69


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

It modifies the preview store to use mendoza patches, does this requires any other update?
Is something else from `corel` needed to be moved to this branch for the preview store to work?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
New tests added for the new observable.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Improvements to documents loading, preserving the last 5(confirm number) visited documents so users can see the document before the listener connection is established.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
