### PR TITLE
chore: enable source maps for package bundles

### DIFF
--- a/packages/@repo/package.bundle/src/package.bundle.ts
+++ b/packages/@repo/package.bundle/src/package.bundle.ts
@@ -15,6 +15,7 @@ export const defaultConfig: UserConfig = {
   plugins: [react(), tsconfigPaths()],
   build: {
     emptyOutDir: true,
+    sourcemap: true,
     lib: {
       entry: {},
       formats: ['es'],


### PR DESCRIPTION
### Description

Enables source maps for the package bundles, and uploads them to the bucket as well. This also adds a check for the files found in the traversed directories - if they're not `.mjs` or `.map`, we will throw. I think this is actually a feature in disguise, as we don't necessarily want to start uploading other stuff that might be emitted/part of the folder structure.

I originally used the mime-types npm module, but felt the extra dependency was unnecessary for two different file types - so sticking with just a simple map for now.

### What to review

- Bundling outputs sourcemap and references it in the javascript file
- Upload script logic appears correct

### Testing

Ran this locally, but without uploading to a bucket.

### Notes for release

None
