### PR TITLE
chore(cli): remove reliance on node-machine-id

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -68,7 +68,6 @@
     "esbuild-register": "^3.5.0",
     "get-it": "^8.6.5",
     "groq-js": "^1.13.0",
-    "node-machine-id": "^1.1.12",
     "pkg-dir": "^5.0.0",
     "prettier": "^3.3.0",
     "semver": "^7.3.5",

--- a/packages/@sanity/cli/src/cli.ts
+++ b/packages/@sanity/cli/src/cli.ts
@@ -5,7 +5,6 @@ import path from 'node:path'
 
 import chalk from 'chalk'
 import dotenv from 'dotenv'
-import {machineId} from 'node-machine-id'
 import resolveFrom from 'resolve-from'
 
 import {CliCommand} from './__telemetry__/cli.telemetry'
@@ -85,7 +84,6 @@ export async function runCli(cliRoot: string, {cliVersion}: {cliVersion: string}
   )
 
   telemetry.updateUserProperties({
-    deviceId: await machineId(),
     runtimeVersion: process.version,
     runtime: detectRuntime(),
     cliVersion: pkg.version,

--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -94,7 +94,6 @@ export interface CliBaseCommandContext {
 }
 
 export interface TelemetryUserProperties {
-  deviceId: string
   runtime: string
   runtimeVersion: string
   cliVersion: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -800,9 +800,6 @@ importers:
       groq-js:
         specifier: ^1.13.0
         version: 1.13.0
-      node-machine-id:
-        specifier: ^1.1.12
-        version: 1.1.12
       pkg-dir:
         specifier: ^5.0.0
         version: 5.0.0


### PR DESCRIPTION
### Description
This removes our usage of- and dependency on- the (seemingly abandoned) `node-machine-id` package

Closes: #7538 
Fixes: #7542

### What to review
Does the change make sense?

### Testing
The existing test coverage on telemetry should be sufficient. I ran an additional manual check to verifiy that telemetry events are still submitted from the CLI, and I did not observe any errors.

### Notes for release

- Fixes an issue that could cause CLI to crash  in certain environments.