### PR TITLE
feat: Request Edit Access flow

### DIFF
--- a/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
@@ -150,7 +150,7 @@ export function RequestAccessScreen() {
         } else {
           toast.push({
             title: 'There was a problem submitting your request.',
-            status: errMessage,
+            status: 'error',
           })
         }
       })

--- a/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
@@ -13,7 +13,7 @@ import {
 import {Button, Dialog} from '../../../ui-components'
 import {NotAuthenticatedScreen} from './NotAuthenticatedScreen'
 
-interface AccessRequest {
+export interface AccessRequest {
   id: string
   status: 'pending' | 'accepted' | 'declined'
   resourceId: string
@@ -22,6 +22,8 @@ interface AccessRequest {
   updatedAt: string
   updatedByUserId: string
   requestedByUserId: string
+  requestedRole: string
+  type: 'access' | 'role'
   note: string
 }
 
@@ -127,7 +129,7 @@ export function RequestAccessScreen() {
       .request<AccessRequest | null>({
         url: `/access/project/${projectId}/requests`,
         method: 'post',
-        body: {note, requestUrl: window?.location.href},
+        body: {note, requestUrl: window?.location.href, type: 'access'},
       })
       .then((request) => {
         if (request) setHasPendingRequest(true)

--- a/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
@@ -13,6 +13,7 @@ import {
 import {Button, Dialog} from '../../../ui-components'
 import {NotAuthenticatedScreen} from './NotAuthenticatedScreen'
 
+/** @internal */
 export interface AccessRequest {
   id: string
   status: 'pending' | 'accepted' | 'declined'

--- a/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
@@ -84,7 +84,10 @@ export function RequestAccessScreen() {
         if (requests && requests?.length) {
           const projectRequests = requests.filter((request) => request.resourceId === projectId)
           const declinedRequest = projectRequests.find((request) => request.status === 'declined')
-          if (declinedRequest) {
+          if (
+            declinedRequest &&
+            isAfter(addWeeks(new Date(declinedRequest.createdAt), 2), new Date())
+          ) {
             setHasBeenDenied(true)
             return
           }

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -1,6 +1,6 @@
-import {Box, Card, Flex, Stack, Text, TextInput, useToast} from '@sanity/ui'
+import {Box, Card, DialogProvider, Flex, Stack, Text, TextInput, useToast} from '@sanity/ui'
 import {useEffect, useId, useMemo, useState} from 'react'
-import {type Role, useClient, useProjectId, useTranslation} from 'sanity'
+import {type Role, useClient, useProjectId, useTranslation, useZIndex} from 'sanity'
 import {styled} from 'styled-components'
 
 import {Dialog} from '../../../ui-components'
@@ -58,6 +58,7 @@ export function RequestPermissionDialog({
   const projectId = useProjectId()
   const client = useClient({apiVersion: '2024-09-26'})
   const toast = useToast()
+  const zOffset = useZIndex()
 
   const [isSubmitting, setIsSubmitting] = useState(false)
 
@@ -126,61 +127,63 @@ export function RequestPermissionDialog({
   }
 
   return (
-    <Dialog
-      width={1}
-      id={dialogId}
-      header={t('request-permission-dialog.header.text')}
-      footer={{
-        cancelButton: {
-          onClick: onClose,
-          text: t('confirm-dialog.cancel-button.fallback-text'),
-        },
-        confirmButton: {
-          loading: isSubmitting,
-          disabled: hasTooManyRequests || hasBeenDenied,
-          text: t('request-permission-dialog.confirm-button.text'),
-          tone: 'primary',
-          onClick: onConfirm,
-        },
-      }}
-      onClose={onClose}
-      onClickOutside={onClose}
-    >
-      <DialogBody>
-        <Stack space={4}>
-          <Text>{t('request-permission-dialog.description.text')}</Text>
-          {hasTooManyRequests || hasBeenDenied ? (
-            <Card tone={'caution'} padding={3} radius={2} shadow={1}>
-              <Text size={1}>
-                {hasTooManyRequests && (
-                  <>{msgError ?? t('request-permission-dialog.warning.limit-reached.text')}</>
-                )}
-                {hasBeenDenied && (
-                  <>{msgError ?? t('request-permission-dialog.warning.denied.text')}</>
-                )}
-              </Text>
-            </Card>
-          ) : (
-            <Stack space={3} paddingBottom={0}>
-              <TextInput
-                placeholder={t('request-permission-dialog.note-input.placeholder.text')}
-                disabled={isSubmitting}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') onConfirm()
-                }}
-                maxLength={MAX_NOTE_LENGTH}
-                value={note}
-                onChange={(e) => {
-                  setNote(e.currentTarget.value)
-                  setNoteLength(e.currentTarget.value.length)
-                }}
-              />
+    <DialogProvider position={'fixed'} zOffset={zOffset.fullscreen}>
+      <Dialog
+        width={1}
+        id={dialogId}
+        header={t('request-permission-dialog.header.text')}
+        footer={{
+          cancelButton: {
+            onClick: onClose,
+            text: t('confirm-dialog.cancel-button.fallback-text'),
+          },
+          confirmButton: {
+            loading: isSubmitting,
+            disabled: hasTooManyRequests || hasBeenDenied,
+            text: t('request-permission-dialog.confirm-button.text'),
+            tone: 'primary',
+            onClick: onConfirm,
+          },
+        }}
+        onClose={onClose}
+        onClickOutside={onClose}
+      >
+        <DialogBody>
+          <Stack space={4}>
+            <Text>{t('request-permission-dialog.description.text')}</Text>
+            {hasTooManyRequests || hasBeenDenied ? (
+              <Card tone={'caution'} padding={3} radius={2} shadow={1}>
+                <Text size={1}>
+                  {hasTooManyRequests && (
+                    <>{msgError ?? t('request-permission-dialog.warning.limit-reached.text')}</>
+                  )}
+                  {hasBeenDenied && (
+                    <>{msgError ?? t('request-permission-dialog.warning.denied.text')}</>
+                  )}
+                </Text>
+              </Card>
+            ) : (
+              <Stack space={3} paddingBottom={0}>
+                <TextInput
+                  placeholder={t('request-permission-dialog.note-input.placeholder.text')}
+                  disabled={isSubmitting}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') onConfirm()
+                  }}
+                  maxLength={MAX_NOTE_LENGTH}
+                  value={note}
+                  onChange={(e) => {
+                    setNote(e.currentTarget.value)
+                    setNoteLength(e.currentTarget.value.length)
+                  }}
+                />
 
-              <Text align="right" muted size={1}>{`${noteLength}/${MAX_NOTE_LENGTH}`}</Text>
-            </Stack>
-          )}
-        </Stack>
-      </DialogBody>
-    </Dialog>
+                <Text align="right" muted size={1}>{`${noteLength}/${MAX_NOTE_LENGTH}`}</Text>
+              </Stack>
+            )}
+          </Stack>
+        </DialogBody>
+      </Dialog>
+    </DialogProvider>
   )
 }

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -39,7 +39,7 @@ export const LoadingContainer = styled(Flex).attrs({
 /** @internal */
 export interface RequestPermissionDialogProps {
   onClose?: () => void
-  onRequstSubmitted?: () => void
+  onRequestSubmitted?: () => void
 }
 
 /**
@@ -51,7 +51,7 @@ export interface RequestPermissionDialogProps {
  */
 export function RequestPermissionDialog({
   onClose,
-  onRequstSubmitted,
+  onRequestSubmitted,
 }: RequestPermissionDialogProps) {
   const {t} = useTranslation(structureLocaleNamespace)
   const dialogId = `request-permissions-${useId()}`
@@ -98,7 +98,7 @@ export function RequestPermissionDialog({
       })
       .then((request) => {
         if (request) {
-          if (onRequstSubmitted) onRequstSubmitted()
+          if (onRequestSubmitted) onRequestSubmitted()
           toast.push({title: 'Edit access requested'})
         }
       })

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -67,7 +67,7 @@ export function RequestPermissionDialog({
   const [noteLength, setNoteLength] = useState<number>(0)
 
   const [msgError, setMsgError] = useState<string | undefined>()
-  const [hasTooManyRequests, setHasTooManyRequests] = useState<boolean>(true)
+  const [hasTooManyRequests, setHasTooManyRequests] = useState<boolean>(false)
   const [hasBeenDenied, setHasBeenDenied] = useState<boolean>(false)
 
   useEffect(() => {

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -3,22 +3,9 @@ import {useEffect, useId, useMemo, useState} from 'react'
 import {type Role, useClient, useProjectId, useTranslation, useZIndex} from 'sanity'
 import {styled} from 'styled-components'
 
+import {type AccessRequest} from '../../../core/studio/screens'
 import {Dialog} from '../../../ui-components'
 import {structureLocaleNamespace} from '../../i18n'
-
-interface AccessRequest {
-  id: string
-  status: 'pending' | 'accepted' | 'declined'
-  resourceId: string
-  resourceType: 'project'
-  createdAt: string
-  updatedAt: string
-  updatedByUserId: string
-  requestedByUserId: string
-  requestedRole: string
-  requestType: string
-  note: string
-}
 
 const MAX_NOTE_LENGTH = 150
 

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -1,3 +1,4 @@
+import {useTelemetry} from '@sanity/telemetry/react'
 import {Box, Card, DialogProvider, Flex, Stack, Text, TextInput, useToast} from '@sanity/ui'
 import {useId, useMemo, useState} from 'react'
 import {useObservable} from 'react-rx'
@@ -8,6 +9,7 @@ import {styled} from 'styled-components'
 import {type AccessRequest} from '../../../core/studio/screens'
 import {Dialog} from '../../../ui-components'
 import {structureLocaleNamespace} from '../../i18n'
+import {AskToEditRequestSent} from './__telemetry__/RequestPermissionDialog.telemetry'
 
 const MAX_NOTE_LENGTH = 150
 
@@ -43,6 +45,7 @@ export function RequestPermissionDialog({
   onRequestSubmitted,
 }: RequestPermissionDialogProps) {
   const {t} = useTranslation(structureLocaleNamespace)
+  const telemtry = useTelemetry()
   const dialogId = `request-permissions-${useId()}`
   const projectId = useProjectId()
   const client = useClient({apiVersion: '2024-09-26'})
@@ -84,6 +87,7 @@ export function RequestPermissionDialog({
       .then((request) => {
         if (request) {
           if (onRequestSubmitted) onRequestSubmitted()
+          telemtry.log(AskToEditRequestSent)
           toast.push({title: 'Edit access requested'})
         }
       })

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -58,13 +58,13 @@ export function RequestPermissionDialog({
   const [hasTooManyRequests, setHasTooManyRequests] = useState<boolean>(false)
   const [hasBeenDenied, setHasBeenDenied] = useState<boolean>(false)
 
-  const requestedRole$: Observable<'Administrator' | 'Editor'> = useMemo(() => {
-    const adminRole = 'Administrator' as const
+  const requestedRole$: Observable<'administrator' | 'editor'> = useMemo(() => {
+    const adminRole = 'administrator' as const
     if (!projectId || !client) return of(adminRole)
     return client.observable.request<Role[]>({url: `/projects/${projectId}/roles`}).pipe(
       map((roles) => {
         const hasEditor = roles.find((role) => role.name === 'editor')
-        return hasEditor ? 'Editor' : adminRole
+        return hasEditor ? 'editor' : adminRole
       }),
       startWith(adminRole),
       catchError(() => of(adminRole)),
@@ -73,7 +73,7 @@ export function RequestPermissionDialog({
 
   const requestedRole = useObservable(requestedRole$)
 
-  const onConfirm = () => {
+  const onSubmit = () => {
     setIsSubmitting(true)
     client
       .request<AccessRequest | null>({
@@ -128,7 +128,7 @@ export function RequestPermissionDialog({
             disabled: hasTooManyRequests || hasBeenDenied,
             text: t('request-permission-dialog.confirm-button.text'),
             tone: 'primary',
-            onClick: onConfirm,
+            type: 'submit',
           },
         }}
         onClose={onClose}
@@ -154,7 +154,7 @@ export function RequestPermissionDialog({
                   placeholder={t('request-permission-dialog.note-input.placeholder.text')}
                   disabled={isSubmitting}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter') onConfirm()
+                    if (e.key === 'Enter') onSubmit()
                   }}
                   maxLength={MAX_NOTE_LENGTH}
                   value={note}

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -38,7 +38,7 @@ export const LoadingContainer = styled(Flex).attrs({
 
 /** @internal */
 export interface RequestPermissionDialogProps {
-  onCancel?: () => void
+  onClose?: () => void
   onRequstSubmitted?: () => void
 }
 
@@ -50,7 +50,7 @@ export interface RequestPermissionDialogProps {
  * @internal
  */
 export function RequestPermissionDialog({
-  onCancel,
+  onClose,
   onRequstSubmitted,
 }: RequestPermissionDialogProps) {
   const {t} = useTranslation(structureLocaleNamespace)
@@ -132,7 +132,7 @@ export function RequestPermissionDialog({
       header={t('request-permission-dialog.header.text')}
       footer={{
         cancelButton: {
-          onClick: onCancel,
+          onClick: onClose,
           text: t('confirm-dialog.cancel-button.fallback-text'),
         },
         confirmButton: {
@@ -143,8 +143,8 @@ export function RequestPermissionDialog({
           onClick: onConfirm,
         },
       }}
-      onClose={onCancel}
-      onClickOutside={onCancel}
+      onClose={onClose}
+      onClickOutside={onClose}
     >
       <DialogBody>
         <Stack space={4}>

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -124,6 +124,7 @@ export function RequestPermissionDialog({
             text: t('confirm-dialog.cancel-button.fallback-text'),
           },
           confirmButton: {
+            onClick: onSubmit,
             loading: isSubmitting,
             disabled: hasTooManyRequests || hasBeenDenied,
             text: t('request-permission-dialog.confirm-button.text'),

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -71,6 +71,7 @@ export function RequestPermissionDialog({
   const [hasTooManyRequests, setHasTooManyRequests] = useState<boolean>(false)
   const [hasBeenDenied, setHasBeenDenied] = useState<boolean>(false)
 
+  //   Get the available roles for the project
   useEffect(() => {
     if (!projectId || !client) return
     client
@@ -81,6 +82,7 @@ export function RequestPermissionDialog({
       .then((data) => setRoles(data))
   }, [projectId, client])
 
+  //   Set a default requestedRole based on the available roles
   const requestedRole = useMemo(() => {
     const hasEditor = roles?.find((role) => role.name === 'editor')
     return hasEditor ? 'Editor' : 'Administrator'
@@ -92,7 +94,7 @@ export function RequestPermissionDialog({
       .request<AccessRequest | null>({
         url: `/access/project/${projectId}/requests`,
         method: 'post',
-        body: {note, requestUrl: window?.location.href, requestedRole, requestType: 'role'},
+        body: {note, requestUrl: window?.location.href, requestedRole, type: 'role'},
       })
       .then((request) => {
         if (request) {

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -70,7 +70,7 @@ export function RequestPermissionDialog({
   }, [projectId, client])
 
   //   Set a default requestedRole based on the available roles
-  const roleName = useMemo(() => {
+  const requestedRole = useMemo(() => {
     const hasEditor = roles?.find((role) => role.name === 'editor')
     return hasEditor ? 'Editor' : 'Administrator'
   }, [roles])
@@ -81,7 +81,7 @@ export function RequestPermissionDialog({
       .request<AccessRequest | null>({
         url: `/access/project/${projectId}/requests`,
         method: 'post',
-        body: {note, requestUrl: window?.location.href, roleName, type: 'role'},
+        body: {note, requestUrl: window?.location.href, requestedRole, type: 'role'},
       })
       .then((request) => {
         if (request) {

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -56,7 +56,7 @@ export function RequestPermissionDialog({
   const {t} = useTranslation(structureLocaleNamespace)
   const dialogId = `request-permissions-${useId()}`
   const projectId = useProjectId()
-  const client = useClient()
+  const client = useClient({apiVersion: '2024-09-26'})
   const toast = useToast()
 
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -149,7 +149,6 @@ export function RequestPermissionDialog({
       <DialogBody>
         <Stack space={4}>
           <Text>{t('request-permission-dialog.description.text')}</Text>
-          <Text>{t('request-permission-dialog.note-input.description.text')}</Text>
           {hasTooManyRequests || hasBeenDenied ? (
             <Card tone={'caution'} padding={3} radius={2} shadow={1}>
               <Text size={1}>

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable i18next/no-literal-string */
-
 import {Box, Card, Flex, Stack, Text, TextInput, useToast} from '@sanity/ui'
 import {useEffect, useId, useMemo, useState} from 'react'
 import {type Role, useClient, useProjectId, useTranslation} from 'sanity'
@@ -131,16 +129,16 @@ export function RequestPermissionDialog({
     <Dialog
       width={1}
       id={dialogId}
-      header={'Ask to edit'}
+      header={t('request-permission-dialog.header.text')}
       footer={{
         cancelButton: {
           onClick: onCancel,
-          text: t('confirm-delete-dialog.cancel-button.text'),
+          text: t('confirm-dialog.cancel-button.fallback-text'),
         },
         confirmButton: {
           loading: isSubmitting,
           disabled: hasTooManyRequests || hasBeenDenied,
-          text: 'Send request',
+          text: t('request-permission-dialog.confirm-button.text'),
           tone: 'primary',
           onClick: onConfirm,
         },
@@ -150,30 +148,23 @@ export function RequestPermissionDialog({
     >
       <DialogBody>
         <Stack space={4}>
-          <Text>
-            A request will be made to administrators asking to grant you increased permission to
-            this project.
-          </Text>
-          <Text>If you'd like, you can add a note</Text>
+          <Text>{t('request-permission-dialog.description.text')}</Text>
+          <Text>{t('request-permission-dialog.note-input.description.text')}</Text>
           {hasTooManyRequests || hasBeenDenied ? (
             <Card tone={'caution'} padding={3} radius={2} shadow={1}>
               <Text size={1}>
                 {hasTooManyRequests && (
-                  <>
-                    {msgError ??
-                      `You've reached the limit for role requests across all projects. Please wait
-                      before submitting more requests or contact an admin for assistance.`}
-                  </>
+                  <>{msgError ?? t('request-permission-dialog.warning.limit-reached.text')}</>
                 )}
                 {hasBeenDenied && (
-                  <>{msgError ?? `Your request to access this project has been declined.`}</>
+                  <>{msgError ?? t('request-permission-dialog.warning.denied.text')}</>
                 )}
               </Text>
             </Card>
           ) : (
             <Stack space={3} paddingBottom={0}>
               <TextInput
-                placeholder="Add note..."
+                placeholder={t('request-permission-dialog.note-input.placeholder.text')}
                 disabled={isSubmitting}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') onConfirm()

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -1,0 +1,196 @@
+/* eslint-disable i18next/no-literal-string */
+
+import {Box, Card, Flex, Stack, Text, TextInput, useToast} from '@sanity/ui'
+import {useEffect, useId, useMemo, useState} from 'react'
+import {type Role, useClient, useProjectId, useTranslation} from 'sanity'
+import {styled} from 'styled-components'
+
+import {Dialog} from '../../../ui-components'
+import {structureLocaleNamespace} from '../../i18n'
+
+interface AccessRequest {
+  id: string
+  status: 'pending' | 'accepted' | 'declined'
+  resourceId: string
+  resourceType: 'project'
+  createdAt: string
+  updatedAt: string
+  updatedByUserId: string
+  requestedByUserId: string
+  requestedRole: string
+  requestType: string
+  note: string
+}
+
+const MAX_NOTE_LENGTH = 150
+
+/** @internal */
+export const DialogBody = styled(Box)`
+  box-sizing: border-box;
+`
+
+/** @internal */
+export const LoadingContainer = styled(Flex).attrs({
+  align: 'center',
+  direction: 'column',
+  justify: 'center',
+})`
+  height: 110px;
+`
+
+/** @internal */
+export interface RequestPermissionDialogProps {
+  onCancel?: () => void
+  onRequstSubmitted?: () => void
+}
+
+/**
+ * A confirmation dialog used to prevent unwanted document deletes. Loads all
+ * the referencing internal and cross-data references prior to showing the
+ * delete button.
+ *
+ * @internal
+ */
+export function RequestPermissionDialog({
+  onCancel,
+  onRequstSubmitted,
+}: RequestPermissionDialogProps) {
+  const {t} = useTranslation(structureLocaleNamespace)
+  const dialogId = `request-permissions-${useId()}`
+  const projectId = useProjectId()
+  const client = useClient()
+  const toast = useToast()
+
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const [roles, setRoles] = useState<Role[]>()
+
+  const [note, setNote] = useState('')
+  const [noteLength, setNoteLength] = useState<number>(0)
+
+  const [msgError, setMsgError] = useState<string | undefined>()
+  const [hasTooManyRequests, setHasTooManyRequests] = useState<boolean>(true)
+  const [hasBeenDenied, setHasBeenDenied] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (!projectId || !client) return
+    client
+      .request({
+        url: `/projects/${projectId}/roles`,
+        method: 'get',
+      })
+      .then((data) => setRoles(data))
+  }, [projectId, client])
+
+  const requestedRole = useMemo(() => {
+    const hasEditor = roles?.find((role) => role.name === 'editor')
+    return hasEditor ? 'Editor' : 'Administrator'
+  }, [roles])
+
+  const onConfirm = () => {
+    setIsSubmitting(true)
+    client
+      .request<AccessRequest | null>({
+        url: `/access/project/${projectId}/requests`,
+        method: 'post',
+        body: {note, requestUrl: window?.location.href, requestedRole, requestType: 'role'},
+      })
+      .then((request) => {
+        if (request) {
+          if (onRequstSubmitted) onRequstSubmitted()
+          toast.push({title: 'Edit access requested'})
+        }
+      })
+      .catch((err) => {
+        const statusCode = err?.response?.statusCode
+        const errMessage = err?.response?.body?.message
+        if (statusCode === 429) {
+          // User is over their cross-project request limit
+          setHasTooManyRequests(true)
+          setMsgError(errMessage)
+        }
+        if (statusCode === 409) {
+          // If we get a 409, user has been denied on this project or has a valid pending request
+          // valid pending request should be handled by GET request above
+          setHasBeenDenied(true)
+          setMsgError(errMessage)
+        } else {
+          toast.push({
+            title: 'There was a problem submitting your request.',
+            status: errMessage,
+          })
+        }
+      })
+      .finally(() => {
+        setIsSubmitting(false)
+      })
+    setIsSubmitting(false)
+  }
+
+  return (
+    <Dialog
+      width={1}
+      id={dialogId}
+      header={'Ask to edit'}
+      footer={{
+        cancelButton: {
+          onClick: onCancel,
+          text: t('confirm-delete-dialog.cancel-button.text'),
+        },
+        confirmButton: {
+          loading: isSubmitting,
+          disabled: hasTooManyRequests || hasBeenDenied,
+          text: 'Send request',
+          tone: 'primary',
+          onClick: onConfirm,
+        },
+      }}
+      onClose={onCancel}
+      onClickOutside={onCancel}
+    >
+      <DialogBody>
+        <Stack space={4}>
+          <Text>
+            A request will be made to administrators asking to grant you increased permission to
+            this project.
+          </Text>
+          <Text>If you'd like, you can add a note</Text>
+          {hasTooManyRequests || hasBeenDenied ? (
+            <Card tone={'caution'} padding={3} radius={2} shadow={1}>
+              <Text size={1}>
+                {hasTooManyRequests && (
+                  <>
+                    {msgError ??
+                      `You've reached the limit for role requests across all projects. Please wait
+                      before submitting more requests or contact an admin for assistance.`}
+                  </>
+                )}
+                {hasBeenDenied && (
+                  <>{msgError ?? `Your request to access this project has been declined.`}</>
+                )}
+              </Text>
+            </Card>
+          ) : (
+            <Stack space={3} paddingBottom={0}>
+              <TextInput
+                placeholder="Add note..."
+                disabled={isSubmitting}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') onConfirm()
+                }}
+                maxLength={MAX_NOTE_LENGTH}
+                value={note}
+                onChange={(e) => {
+                  setNote(e.currentTarget.value)
+                  setNoteLength(e.currentTarget.value.length)
+                }}
+              />
+
+              <Text align="right" muted size={1}>{`${noteLength}/${MAX_NOTE_LENGTH}`}</Text>
+            </Stack>
+          )}
+        </Stack>
+      </DialogBody>
+    </Dialog>
+  )
+}

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -6,10 +6,10 @@ import {catchError, map, type Observable, of, startWith} from 'rxjs'
 import {type Role, useClient, useProjectId, useTranslation, useZIndex} from 'sanity'
 import {styled} from 'styled-components'
 
-import {type AccessRequest} from '../../../core/studio/screens'
 import {Dialog} from '../../../ui-components'
 import {structureLocaleNamespace} from '../../i18n'
 import {AskToEditRequestSent} from './__telemetry__/RequestPermissionDialog.telemetry'
+import {type AccessRequest} from './useRoleRequestsStatus'
 
 const MAX_NOTE_LENGTH = 150
 

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -70,7 +70,7 @@ export function RequestPermissionDialog({
   }, [projectId, client])
 
   //   Set a default requestedRole based on the available roles
-  const requestedRole = useMemo(() => {
+  const roleName = useMemo(() => {
     const hasEditor = roles?.find((role) => role.name === 'editor')
     return hasEditor ? 'Editor' : 'Administrator'
   }, [roles])
@@ -81,7 +81,7 @@ export function RequestPermissionDialog({
       .request<AccessRequest | null>({
         url: `/access/project/${projectId}/requests`,
         method: 'post',
-        body: {note, requestUrl: window?.location.href, requestedRole, type: 'role'},
+        body: {note, requestUrl: window?.location.href, roleName, type: 'role'},
       })
       .then((request) => {
         if (request) {

--- a/packages/sanity/src/structure/components/requestPermissionDialog/__telemetry__/RequestPermissionDialog.telemetry.ts
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/__telemetry__/RequestPermissionDialog.telemetry.ts
@@ -1,0 +1,17 @@
+import {defineEvent} from '@sanity/telemetry'
+
+/**
+ * When a draft in a live edit document is published
+ * @internal
+ */
+export const AskToEditDialogOpened = defineEvent({
+  name: 'Ask To Edit Dialog Opened',
+  version: 1,
+  description: 'User clicked the "Ask to edit" button in the document permissions banner',
+})
+
+export const AskToEditRequestSent = defineEvent({
+  name: 'Ask To Edit Request Sent',
+  version: 1,
+  description: 'User sent a role change request from the dialog',
+})

--- a/packages/sanity/src/structure/components/requestPermissionDialog/__telemetry__/RequestPermissionDialog.telemetry.ts
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/__telemetry__/RequestPermissionDialog.telemetry.ts
@@ -10,6 +10,7 @@ export const AskToEditDialogOpened = defineEvent({
   description: 'User clicked the "Ask to edit" button in the document permissions banner',
 })
 
+/** @internal */
 export const AskToEditRequestSent = defineEvent({
   name: 'Ask To Edit Request Sent',
   version: 1,

--- a/packages/sanity/src/structure/components/requestPermissionDialog/index.ts
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/index.ts
@@ -1,0 +1,2 @@
+export * from './RequestPermissionDialog'
+export * from './useRoleRequestsStatus'

--- a/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
@@ -55,7 +55,7 @@ export const useRoleRequestsStatus = () => {
               return 'expired'
             }
           }
-          return 'none' // No relevant requests found
+          return 'none' // No pending requests found
         }),
         catchError((err) => {
           console.error(err)
@@ -76,7 +76,7 @@ export const useRoleRequestsStatus = () => {
     })
 
     return () => {
-      subscription.unsubscribe() // Cleanup on component unmount
+      subscription.unsubscribe()
     }
   }, [client, projectId])
 

--- a/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
@@ -5,7 +5,19 @@ import {from, of} from 'rxjs'
 import {catchError, map, startWith} from 'rxjs/operators'
 import {useClient, useProjectId} from 'sanity'
 
-import {type AccessRequest} from '../../../core/studio/screens'
+export interface AccessRequest {
+  id: string
+  status: 'pending' | 'accepted' | 'declined'
+  resourceId: string
+  resourceType: 'project'
+  createdAt: string
+  updatedAt: string
+  updatedByUserId: string
+  requestedByUserId: string
+  requestedRole: string
+  type: 'access' | 'role'
+  note: string
+}
 
 export const useRoleRequestsStatus = () => {
   const client = useClient({apiVersion: '2024-07-01'})

--- a/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
@@ -1,7 +1,8 @@
 import {addWeeks, isAfter, isBefore} from 'date-fns'
-import {useEffect, useState} from 'react'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
 import {from, of} from 'rxjs'
-import {catchError, map} from 'rxjs/operators'
+import {catchError, map, startWith} from 'rxjs/operators'
 import {useClient, useProjectId} from 'sanity'
 
 import {type AccessRequest} from '../../../core/studio/screens'
@@ -9,76 +10,63 @@ import {type AccessRequest} from '../../../core/studio/screens'
 export const useRoleRequestsStatus = () => {
   const client = useClient({apiVersion: '2024-07-01'})
   const projectId = useProjectId()
-  const [status, setStatus] = useState<string>()
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState(false)
 
-  useEffect(() => {
-    const checkRoleRequests$ = () => {
-      setLoading(true)
-      if (!client || !projectId) {
-        return of()
-      }
+  const checkRoleRequests = useMemo(() => {
+    if (!client || !projectId) {
+      return of({loading: false, error: false, status: 'none'})
+    }
 
-      return from(
-        client.request<AccessRequest[] | null>({
-          url: `/access/requests/me`,
-        }),
-      ).pipe(
-        map((requests) => {
-          if (requests && requests.length) {
-            // Filter requests for the specific project and where type is 'role'
-            const projectRequests = requests.filter(
-              (request) => request.resourceId === projectId && request.type === 'role',
-            )
+    return from(
+      client.request<AccessRequest[] | null>({
+        url: `/access/requests/me`,
+      }),
+    ).pipe(
+      map((requests) => {
+        if (requests && requests.length) {
+          // Filter requests for the specific project and where type is 'role'
+          const projectRequests = requests.filter(
+            (request) => request.resourceId === projectId && request.type === 'role',
+          )
 
-            const declinedRequest = projectRequests.find((request) => request.status === 'declined')
-            if (declinedRequest) {
-              return 'denied'
-            }
-
-            const pendingRequest = projectRequests.find(
-              (request) =>
-                request.status === 'pending' &&
-                isAfter(addWeeks(new Date(request.createdAt), 2), new Date()),
-            )
-            if (pendingRequest) {
-              return 'pending'
-            }
-
-            const oldPendingRequest = projectRequests.find(
-              (request) =>
-                request.status === 'pending' &&
-                isBefore(addWeeks(new Date(request.createdAt), 2), new Date()),
-            )
-            if (oldPendingRequest) {
-              return 'expired'
-            }
+          const declinedRequest = projectRequests.find((request) => request.status === 'declined')
+          if (declinedRequest) {
+            return {loading: false, error: false, status: 'denied'}
           }
-          return 'none' // No pending requests found
-        }),
-        catchError((err) => {
-          console.error(err)
-          return of()
-        }),
-      )
-    }
 
-    const subscription = checkRoleRequests$().subscribe({
-      next: (value) => {
-        setLoading(false)
-        setStatus(value)
-      },
-      error: (err) => {
+          const pendingRequest = projectRequests.find(
+            (request) =>
+              request.status === 'pending' &&
+              isAfter(addWeeks(new Date(request.createdAt), 2), new Date()),
+          )
+          if (pendingRequest) {
+            return {loading: false, error: false, status: 'pending'}
+          }
+
+          const oldPendingRequest = projectRequests.find(
+            (request) =>
+              request.status === 'pending' &&
+              isBefore(addWeeks(new Date(request.createdAt), 2), new Date()),
+          )
+          if (oldPendingRequest) {
+            return {loading: false, error: false, status: 'expired'}
+          }
+        }
+        return {loading: false, error: false, status: 'none'}
+      }),
+      catchError((err) => {
         console.error(err)
-        setError(err)
-      },
-    })
-
-    return () => {
-      subscription.unsubscribe()
-    }
+        return of({loading: false, error: true, status: undefined})
+      }),
+      startWith({loading: true, error: false, status: undefined}), // Start with loading state
+    )
   }, [client, projectId])
+
+  // Use useObservable to subscribe to the checkRoleRequests observable
+  const {loading, error, status} = useObservable(checkRoleRequests, {
+    loading: true,
+    error: false,
+    status: undefined,
+  })
 
   return {data: status, loading, error}
 }

--- a/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
@@ -29,8 +29,11 @@ export const useRoleRequestsStatus = () => {
           )
 
           const declinedRequest = projectRequests.find((request) => request.status === 'declined')
-          if (declinedRequest) {
-            return {loading: false, error: false, status: 'denied'}
+          if (
+            declinedRequest &&
+            isAfter(addWeeks(new Date(declinedRequest.createdAt), 2), new Date())
+          ) {
+            return {loading: false, error: false, status: 'declined'}
           }
 
           const pendingRequest = projectRequests.find(

--- a/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
@@ -5,6 +5,7 @@ import {from, of} from 'rxjs'
 import {catchError, map, startWith} from 'rxjs/operators'
 import {useClient, useProjectId} from 'sanity'
 
+/** @internal */
 export interface AccessRequest {
   id: string
   status: 'pending' | 'accepted' | 'declined'
@@ -19,6 +20,7 @@ export interface AccessRequest {
   note: string
 }
 
+/** @internal */
 export const useRoleRequestsStatus = () => {
   const client = useClient({apiVersion: '2024-07-01'})
   const projectId = useProjectId()
@@ -69,7 +71,7 @@ export const useRoleRequestsStatus = () => {
         return {loading: false, error: false, status: 'none'}
       }),
       catchError((err) => {
-        console.error(err)
+        console.error('Failed to fetch access requests', err)
         return of({loading: false, error: true, status: undefined})
       }),
       startWith({loading: true, error: false, status: undefined}), // Start with loading state

--- a/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
@@ -7,7 +7,7 @@ import {useClient, useProjectId} from 'sanity'
 import {type AccessRequest} from '../../../core/studio/screens'
 
 export const useRoleRequestsStatus = () => {
-  const client = useClient()
+  const client = useClient({apiVersion: '2024-07-01'})
   const projectId = useProjectId()
   const [status, setStatus] = useState<string>()
   const [loading, setLoading] = useState(false)

--- a/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
@@ -10,9 +10,12 @@ export const useRoleRequestsStatus = () => {
   const client = useClient()
   const projectId = useProjectId()
   const [status, setStatus] = useState<string>()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(false)
 
   useEffect(() => {
     const checkRoleRequests$ = () => {
+      setLoading(true)
       if (!client || !projectId) {
         return of()
       }
@@ -54,16 +57,22 @@ export const useRoleRequestsStatus = () => {
           }
           return 'none' // No relevant requests found
         }),
-        catchError((error) => {
-          console.error(error)
-          return of('error') // Return 'error' status on request failure
+        catchError((err) => {
+          console.error(err)
+          return of()
         }),
       )
     }
 
     const subscription = checkRoleRequests$().subscribe({
-      next: (value) => setStatus(value),
-      error: (err) => console.error(err),
+      next: (value) => {
+        setLoading(false)
+        setStatus(value)
+      },
+      error: (err) => {
+        console.error(err)
+        setError(err)
+      },
     })
 
     return () => {
@@ -71,5 +80,5 @@ export const useRoleRequestsStatus = () => {
     }
   }, [client, projectId])
 
-  return status
+  return {data: status, loading, error}
 }

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -104,16 +104,16 @@ const structureLocaleStrings = defineLocalesResources('structure', {
     'The type <strong>{{schemaType}}</strong> has <code>liveEdit</code> enabled, but a draft version of this document exists. Publish or discard the draft in order to continue live editing it.',
   /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
   'banners.permission-check-banner.missing-permission_create_one':
-    'Your role <Roles/> does not have permissions to create this document.',
+    'Your role <Roles/> does not have permissions to publish this document.',
   /** The text for the permission check banner if the user only has multiple roles, but they do not allow updating this document */
   'banners.permission-check-banner.missing-permission_create_other':
-    'Your roles <Roles/> do not have permissions to create this document.',
+    'Your roles <Roles/> do not have permissions to publish this document.',
   /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
   'banners.permission-check-banner.missing-permission_update_one':
-    'Your role <Roles/> does not have permissions to update this document.',
+    'Your role <Roles/> does not have permissions to edit this document.',
   /** The text for the permission check banner if the user only has multiple roles, but they do not allow updating this document */
   'banners.permission-check-banner.missing-permission_update_other':
-    'Your roles <Roles/> do not have permissions to update this document.',
+    'Your roles <Roles/> do not have permissions to edit this document.',
   /** The text for the request permission button that appears for viewer roles */
   'banners.permission-check-banner.request-permission-button.text': 'Ask to edit',
   /** The text for the reload button */

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -417,9 +417,9 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'request-permission-dialog.confirm-button.text': 'Send request',
   /** The description text for the request permission dialog used in the permissions banner */
   'request-permission-dialog.description.text':
-    'A request will be made to administrators asking to grant you increased permission to this project.',
+    "Your request will be sent to the project administrator(s). If you'd like, you can also include a note",
   /** The header/title for the request permission dialog used in the permissions banner */
-  'request-permission-dialog.header.text': 'Ask to edit',
+  'request-permission-dialog.header.text': 'Ask for edit access',
   /** The text describing the note input for the request permission dialog used in the permissions banner */
   'request-permission-dialog.note-input.description.text': "If you'd like, you can add a note",
   /** The placeholder for the note input in the request permission dialog used in the permissions banner */

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -104,16 +104,16 @@ const structureLocaleStrings = defineLocalesResources('structure', {
     'The type <strong>{{schemaType}}</strong> has <code>liveEdit</code> enabled, but a draft version of this document exists. Publish or discard the draft in order to continue live editing it.',
   /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
   'banners.permission-check-banner.missing-permission_create_one':
-    'Your role <Roles/> does not have permissions to publish this document.',
+    "You don't have permission to publish this document.",
   /** The text for the permission check banner if the user only has multiple roles, but they do not allow updating this document */
   'banners.permission-check-banner.missing-permission_create_other':
-    'Your roles <Roles/> do not have permissions to publish this document.',
+    "You don't have permission to publish this document.",
   /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
   'banners.permission-check-banner.missing-permission_update_one':
-    'Your role <Roles/> does not have permissions to edit this document.',
+    "You don't have permission to edit this document.",
   /** The text for the permission check banner if the user only has multiple roles, but they do not allow updating this document */
   'banners.permission-check-banner.missing-permission_update_other':
-    'Your roles <Roles/> do not have permissions to edit this document.',
+    "You don't have permission to edit this document.",
   /** The text for the request permission button that appears for viewer roles */
   'banners.permission-check-banner.request-permission-button.text': 'Ask to edit',
   /** The text for the reload button */

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -114,6 +114,8 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text for the permission check banner if the user only has multiple roles, but they do not allow updating this document */
   'banners.permission-check-banner.missing-permission_update_other':
     'Your roles <Roles/> do not have permissions to update this document.',
+  /** The text for the request permission button that appears for viewer roles */
+  'banners.permission-check-banner.request-permission-button.text': 'Ask to edit',
   /** The text for the reload button */
   'banners.reference-changed-banner.reason-changed.reload-button.text': 'Reload reference',
   /** The text for the reference change banner if the reason is that the reference has been changed */

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -411,6 +411,24 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text for the "Open preview" action for a document */
   'production-preview.menu-item.title': 'Open preview',
 
+  /** The text for the confirm button in the request permission dialog used in the permissions banner */
+  'request-permission-dialog.confirm-button.text': 'Send request',
+  /** The description text for the request permission dialog used in the permissions banner */
+  'request-permission-dialog.description.text':
+    'A request will be made to administrators asking to grant you increased permission to this project.',
+  /** The header/title for the request permission dialog used in the permissions banner */
+  'request-permission-dialog.header.text': 'Ask to edit',
+  /** The text describing the note input for the request permission dialog used in the permissions banner */
+  'request-permission-dialog.note-input.description.text': "If you'd like, you can add a note",
+  /** The placeholder for the note input in the request permission dialog used in the permissions banner */
+  'request-permission-dialog.note-input.placeholder.text': 'Add note...',
+  /** The error/warning text in the request permission dialog when the user's request has been declined */
+  'request-permission-dialog.warning.denied.text':
+    'Your request to access this project has been declined.',
+  /** The error/warning text in the request permission dialog when the user's request has been denied due to too many outstanding requests */
+  'request-permission-dialog.warning.limit-reached.text':
+    "You've reached the limit for role requests across all projects. Please wait before submitting more requests or contact an admin for assistance.",
+
   /** Label for button when status is saved */
   'status-bar.document-status-pulse.status.saved.text': 'Saved',
   /** Label for button when status is syncing */

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -102,18 +102,18 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text content for the live edit document when it's a draft */
   'banners.live-edit-draft-banner.text':
     'The type <strong>{{schemaType}}</strong> has <code>liveEdit</code> enabled, but a draft version of this document exists. Publish or discard the draft in order to continue live editing it.',
-  /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
+  /** The text for the permission check banner if the user only has one role, and it does not allow publishing this document */
   'banners.permission-check-banner.missing-permission_create_one':
-    'Your role <Roles/> does not have permissions to publish this document.',
-  /** The text for the permission check banner if the user only has multiple roles, but they do not allow updating this document */
+    'Your role <Roles/> does not have permission to publish this document.',
+  /** The text for the permission check banner if the user only has multiple roles, but they do not allow publishing this document */
   'banners.permission-check-banner.missing-permission_create_other':
-    'Your roles <Roles/> do not have permissions to publish this document.',
-  /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
+    'Your roles <Roles/> do not have permission to publish this document.',
+  /** The text for the permission check banner if the user only has one role, and it does not allow editing this document */
   'banners.permission-check-banner.missing-permission_update_one':
-    'Your role <Roles/> does not have permissions to edit this document.',
-  /** The text for the permission check banner if the user only has multiple roles, but they do not allow updating this document */
+    'Your role <Roles/> does not have permission to edit this document.',
+  /** The text for the permission check banner if the user only has multiple roles, but they do not allow editing this document */
   'banners.permission-check-banner.missing-permission_update_other':
-    'Your roles <Roles/> do not have permissions to edit this document.',
+    'Your roles <Roles/> do not have permission to edit this document.',
   /** The pending text for the request permission button that appears for viewer roles */
   'banners.permission-check-banner.request-permission-button.sent': 'Editor request sent',
   /** The text for the request permission button that appears for viewer roles */
@@ -431,7 +431,7 @@ const structureLocaleStrings = defineLocalesResources('structure', {
     'Your request to access this project has been declined.',
   /** The error/warning text in the request permission dialog when the user's request has been denied due to too many outstanding requests */
   'request-permission-dialog.warning.limit-reached.text':
-    "You've reached the limit for role requests across all projects. Please wait before submitting more requests or contact an admin for assistance.",
+    "You've reached the limit for role requests across all projects. Please wait before submitting more requests or contact an administrator for assistance.",
 
   /** Label for button when status is saved */
   'status-bar.document-status-pulse.status.saved.text': 'Saved',

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -104,16 +104,16 @@ const structureLocaleStrings = defineLocalesResources('structure', {
     'The type <strong>{{schemaType}}</strong> has <code>liveEdit</code> enabled, but a draft version of this document exists. Publish or discard the draft in order to continue live editing it.',
   /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
   'banners.permission-check-banner.missing-permission_create_one':
-    "You don't have permission to publish this document.",
+    'Your role <Roles/> does not have permissions to publish this document.',
   /** The text for the permission check banner if the user only has multiple roles, but they do not allow updating this document */
   'banners.permission-check-banner.missing-permission_create_other':
-    "You don't have permission to publish this document.",
+    'Your roles <Roles/> do not have permissions to publish this document.',
   /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
   'banners.permission-check-banner.missing-permission_update_one':
-    "You don't have permission to edit this document.",
+    'Your role <Roles/> does not have permissions to edit this document.',
   /** The text for the permission check banner if the user only has multiple roles, but they do not allow updating this document */
   'banners.permission-check-banner.missing-permission_update_other':
-    "You don't have permission to edit this document.",
+    'Your roles <Roles/> do not have permissions to publish this document.',
   /** The text for the request permission button that appears for viewer roles */
   'banners.permission-check-banner.request-permission-button.text': 'Ask to edit',
   /** The text for the reload button */

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -113,7 +113,7 @@ const structureLocaleStrings = defineLocalesResources('structure', {
     'Your role <Roles/> does not have permissions to edit this document.',
   /** The text for the permission check banner if the user only has multiple roles, but they do not allow updating this document */
   'banners.permission-check-banner.missing-permission_update_other':
-    'Your roles <Roles/> do not have permissions to publish this document.',
+    'Your roles <Roles/> do not have permissions to edit this document.',
   /** The text for the request permission button that appears for viewer roles */
   'banners.permission-check-banner.request-permission-button.text': 'Ask to edit',
   /** The text for the reload button */

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -115,7 +115,7 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'banners.permission-check-banner.missing-permission_update_other':
     'Your roles <Roles/> do not have permissions to edit this document.',
   /** The pending text for the request permission button that appears for viewer roles */
-  'banners.permission-check-banner.request-permission-button.sent': 'Request sent',
+  'banners.permission-check-banner.request-permission-button.sent': 'Editor request sent',
   /** The text for the request permission button that appears for viewer roles */
   'banners.permission-check-banner.request-permission-button.text': 'Ask to edit',
   /** The text for the reload button */

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -114,6 +114,8 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text for the permission check banner if the user only has multiple roles, but they do not allow updating this document */
   'banners.permission-check-banner.missing-permission_update_other':
     'Your roles <Roles/> do not have permissions to edit this document.',
+  /** The pending text for the request permission button that appears for viewer roles */
+  'banners.permission-check-banner.request-permission-button.sent': 'Request sent',
   /** The text for the request permission button that appears for viewer roles */
   'banners.permission-check-banner.request-permission-button.text': 'Ask to edit',
   /** The text for the reload button */

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/Banner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/Banner.tsx
@@ -1,4 +1,4 @@
-import {type ButtonTone, Card, type CardTone, Flex, Text} from '@sanity/ui'
+import {type ButtonMode, type ButtonTone, Card, type CardTone, Flex, Text} from '@sanity/ui'
 import {type ComponentType, type ElementType, type JSX, type ReactNode} from 'react'
 
 import {Button} from '../../../../../ui-components'
@@ -11,6 +11,7 @@ interface BannerProps {
     text: string
     tone?: ButtonTone
     disabled?: boolean
+    mode?: ButtonMode
   }
   content: ReactNode
   icon?: ComponentType
@@ -34,7 +35,9 @@ export function Banner(props: BannerProps) {
           {content}
         </Flex>
 
-        {action && <Button {...action} mode={'ghost'} tone={action.tone || 'default'} />}
+        {action && (
+          <Button {...action} mode={action.mode || 'ghost'} tone={action.tone || 'default'} />
+        )}
       </Flex>
     </Card>
   )

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/Banner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/Banner.tsx
@@ -10,6 +10,7 @@ interface BannerProps {
     onClick?: () => void
     text: string
     tone?: ButtonTone
+    disabled?: boolean
   }
   content: ReactNode
   icon?: ComponentType

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/Banner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/Banner.tsx
@@ -1,7 +1,7 @@
-import {type ButtonMode, type ButtonTone, Card, type CardTone, Flex, Text} from '@sanity/ui'
+import {Card, type CardTone, Flex, Text} from '@sanity/ui'
 import {type ComponentType, type ElementType, type JSX, type ReactNode} from 'react'
 
-import {Button} from '../../../../../ui-components'
+import {Button, type ButtonProps} from '../../../../../ui-components'
 
 interface BannerProps {
   action?: {
@@ -9,9 +9,7 @@ interface BannerProps {
     icon?: ComponentType
     onClick?: () => void
     text: string
-    tone?: ButtonTone
-    mode?: ButtonMode
-  }
+  } & ButtonProps
   content: ReactNode
   icon?: ComponentType
   tone?: CardTone
@@ -35,13 +33,7 @@ export function Banner(props: BannerProps) {
         </Flex>
 
         {action && (
-          <Button
-            as={action?.as}
-            mode={action.mode || 'ghost'}
-            onClick={action?.onClick}
-            text={action.text}
-            tone={action.tone || 'default'}
-          />
+          <Button {...action} mode={action.mode || 'ghost'} tone={action.tone || 'default'} />
         )}
       </Flex>
     </Card>

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/Banner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/Banner.tsx
@@ -1,8 +1,7 @@
-import {type ButtonTone, Card, type CardTone, Flex, Text} from '@sanity/ui'
+import {type ButtonMode, type ButtonTone, Card, type CardTone, Flex, Text} from '@sanity/ui'
 import {type ComponentType, type ElementType, type JSX, type ReactNode} from 'react'
 
 import {Button} from '../../../../../ui-components'
-import {SpacerButton} from '../../../../components/spacerButton'
 
 interface BannerProps {
   action?: {
@@ -11,34 +10,34 @@ interface BannerProps {
     onClick?: () => void
     text: string
     tone?: ButtonTone
+    mode?: ButtonMode
   }
   content: ReactNode
   icon?: ComponentType
   tone?: CardTone
+  center?: boolean
 }
 
 export function Banner(props: BannerProps) {
-  const {action, content, icon: Icon, tone = 'transparent', ...rest} = props
+  const {action, center, content, icon: Icon, tone = 'transparent', ...rest} = props
 
   return (
     <Card borderBottom paddingX={4} paddingY={2} tone={tone} {...rest}>
-      <Flex align="center" gap={3}>
+      <Flex align="center" justify={center ? 'center' : undefined} gap={3}>
         {Icon && (
           <Text size={0}>
             <Icon />
           </Text>
         )}
 
-        <Flex align="center" flex={1} gap={2} paddingY={3}>
+        <Flex align="center" flex={center ? undefined : 1} gap={2} paddingY={3}>
           {content}
         </Flex>
-
-        <SpacerButton />
 
         {action && (
           <Button
             as={action?.as}
-            mode="ghost"
+            mode={action.mode || 'ghost'}
             onClick={action?.onClick}
             text={action.text}
             tone={action.tone || 'default'}

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/Banner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/Banner.tsx
@@ -16,22 +16,21 @@ interface BannerProps {
   content: ReactNode
   icon?: ComponentType
   tone?: CardTone
-  center?: boolean
 }
 
 export function Banner(props: BannerProps) {
-  const {action, center, content, icon: Icon, tone = 'transparent', ...rest} = props
+  const {action, content, icon: Icon, tone = 'transparent', ...rest} = props
 
   return (
     <Card borderBottom paddingX={4} paddingY={2} tone={tone} {...rest}>
-      <Flex align="center" justify={center ? 'center' : undefined} gap={3}>
+      <Flex align="center" gap={3}>
         {Icon && (
           <Text size={0}>
             <Icon />
           </Text>
         )}
 
-        <Flex align="center" flex={center ? undefined : 1} gap={2} paddingY={3}>
+        <Flex align="center" flex={1} gap={2} paddingY={3}>
           {content}
         </Flex>
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/Banner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/Banner.tsx
@@ -1,7 +1,7 @@
-import {Card, type CardTone, Flex, Text} from '@sanity/ui'
+import {type ButtonTone, Card, type CardTone, Flex, Text} from '@sanity/ui'
 import {type ComponentType, type ElementType, type JSX, type ReactNode} from 'react'
 
-import {Button, type ButtonProps} from '../../../../../ui-components'
+import {Button} from '../../../../../ui-components'
 
 interface BannerProps {
   action?: {
@@ -9,7 +9,8 @@ interface BannerProps {
     icon?: ComponentType
     onClick?: () => void
     text: string
-  } & ButtonProps
+    tone?: ButtonTone
+  }
   content: ReactNode
   icon?: ComponentType
   tone?: CardTone
@@ -32,9 +33,7 @@ export function Banner(props: BannerProps) {
           {content}
         </Flex>
 
-        {action && (
-          <Button {...action} mode={action.mode || 'ghost'} tone={action.tone || 'default'} />
-        )}
+        {action && <Button {...action} mode={'ghost'} tone={action.tone || 'default'} />}
       </Flex>
     </Card>
   )

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
@@ -67,7 +67,7 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
                     : t('banners.permission-check-banner.request-permission-button.text'),
                 tone: roleRequestStatus === 'pending' ? 'default' : 'primary',
                 disabled: roleRequestStatus === 'pending',
-                // mode: 'bleed',
+                mode: roleRequestStatus === 'pending' ? 'bleed' : undefined,
               }
             : undefined
         }

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
@@ -36,7 +36,7 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
 
   const listFormat = useListFormat({style: 'short'})
   const {t} = useTranslation(structureLocaleNamespace)
-  const telemtry = useTelemetry()
+  const telemetry = useTelemetry()
 
   if (granted) return null
 
@@ -68,7 +68,7 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
                   ? undefined
                   : () => {
                       setShowRequestPermissionDialog(true)
-                      telemtry.log(AskToEditDialogOpened)
+                      telemetry.log(AskToEditDialogOpened)
                     },
                 text: requestPending
                   ? t('banners.permission-check-banner.request-permission-button.sent')

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
@@ -58,7 +58,6 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
             />
           </Text>
         }
-        center
         action={
           isOnlyViewer && roleRequestStatus && !requestStatusError && !requestStatusLoading
             ? {

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
@@ -3,7 +3,10 @@ import {Text} from '@sanity/ui'
 import {useState} from 'react'
 import {Translate, useCurrentUser, useListFormat, useTranslation} from 'sanity'
 
-import {RequestPermissionDialog} from '../../../../components/requestPermissionDialog/RequestPermissionDialog'
+import {
+  RequestPermissionDialog,
+  useRoleRequestsStatus,
+} from '../../../../components/requestPermissionDialog'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {Banner} from './Banner'
 
@@ -15,6 +18,7 @@ interface PermissionCheckBannerProps {
 export function PermissionCheckBanner({granted, requiredPermission}: PermissionCheckBannerProps) {
   const currentUser = useCurrentUser()
 
+  const roleRequestStatus = useRoleRequestsStatus()
   const currentUserRoles = currentUser?.roles || []
   const isOnlyViewer = currentUserRoles.length === 1 && currentUserRoles[0].name === 'viewer'
   const [showRequestPermissionDialog, setShowRequestPermissionDialog] = useState(false)
@@ -47,11 +51,18 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
         }
         center
         action={
-          isOnlyViewer
+          isOnlyViewer && roleRequestStatus
             ? {
-                onClick: () => setShowRequestPermissionDialog(true),
-                text: t('banners.permission-check-banner.request-permission-button.text'),
-                tone: 'primary',
+                onClick:
+                  roleRequestStatus === 'none'
+                    ? () => setShowRequestPermissionDialog(true)
+                    : undefined,
+                text:
+                  roleRequestStatus === 'none'
+                    ? t('banners.permission-check-banner.request-permission-button.text')
+                    : t('banners.permission-check-banner.request-permission-button.sent'),
+                tone: roleRequestStatus === 'none' ? 'primary' : 'default',
+                disabled: roleRequestStatus !== 'none',
                 // mode: 'bleed',
               }
             : undefined

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
@@ -17,7 +17,7 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
 
   const currentUserRoles = currentUser?.roles || []
   const isOnlyViewer = currentUserRoles.length === 1 && currentUserRoles[0].name === 'viewer'
-  const [showRequestPermissionDialog, setShowDialog] = useState(false)
+  const [showRequestPermissionDialog, setShowRequestPermissionDialog] = useState(false)
 
   const listFormat = useListFormat({style: 'short'})
   const {t} = useTranslation(structureLocaleNamespace)
@@ -49,7 +49,7 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
         action={
           isOnlyViewer
             ? {
-                onClick: () => setShowDialog(true),
+                onClick: () => setShowRequestPermissionDialog(true),
                 text: t('banners.permission-check-banner.request-permission-button.text'),
                 tone: 'primary',
                 // mode: 'bleed',
@@ -61,8 +61,8 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
       />
       {showRequestPermissionDialog && (
         <RequestPermissionDialog
-          onClose={() => setShowDialog(false)}
-          onRequestSubmitted={() => setShowDialog(false)}
+          onClose={() => setShowRequestPermissionDialog(false)}
+          onRequestSubmitted={() => setShowRequestPermissionDialog(false)}
         />
       )}
     </>

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
@@ -45,12 +45,14 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
             />
           </Text>
         }
+        center
         action={
           isOnlyViewer
             ? {
                 onClick: () => setShowDialog(true),
                 text: t('banners.permission-check-banner.request-permission-button.text'),
                 tone: 'primary',
+                // mode: 'bleed',
               }
             : undefined
         }

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
@@ -1,7 +1,9 @@
 import {ReadOnlyIcon} from '@sanity/icons'
 import {Text} from '@sanity/ui'
+import {useState} from 'react'
 import {Translate, useCurrentUser, useListFormat, useTranslation} from 'sanity'
 
+import {RequestPermissionDialog} from '../../../../components/requestPermissionDialog/RequestPermissionDialog'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {Banner} from './Banner'
 
@@ -12,12 +14,17 @@ interface PermissionCheckBannerProps {
 
 export function PermissionCheckBanner({granted, requiredPermission}: PermissionCheckBannerProps) {
   const currentUser = useCurrentUser()
+
+  const currentUserRoles = currentUser?.roles || []
+  const isOnlyViewer = currentUserRoles.length === 1 && currentUserRoles[0].name === 'viewer'
+  const [showRequestPermissionDialog, setShowDialog] = useState(false)
+
   const listFormat = useListFormat({style: 'short'})
   const {t} = useTranslation(structureLocaleNamespace)
 
   if (granted) return null
 
-  const roleTitles = (currentUser?.roles || []).map((role) => role.title)
+  const roleTitles = currentUserRoles.map((role) => role.title)
   const roles = listFormat
     .formatToParts(roleTitles)
     .map((part) =>
@@ -25,20 +32,33 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
     )
 
   return (
-    <Banner
-      content={
-        <Text size={1} weight="medium">
-          <Translate
-            t={t}
-            i18nKey="banners.permission-check-banner.missing-permission"
-            components={{Roles: () => <>{roles}</>}}
-            values={{count: roles.length, roles: roleTitles}}
-            context={requiredPermission}
-          />
-        </Text>
-      }
-      data-testid="permission-check-banner"
-      icon={ReadOnlyIcon}
-    />
+    <>
+      <Banner
+        content={
+          <Text size={1} weight="medium">
+            <Translate
+              t={t}
+              i18nKey="banners.permission-check-banner.missing-permission"
+              components={{Roles: () => <>{roles}</>}}
+              values={{count: roles.length, roles: roleTitles}}
+              context={requiredPermission}
+            />
+          </Text>
+        }
+        action={
+          isOnlyViewer
+            ? {
+                onClick: () => setShowDialog(true),
+                text: t('banners.permission-check-banner.request-permission-button.text'),
+              }
+            : undefined
+        }
+        data-testid="permission-check-banner"
+        icon={ReadOnlyIcon}
+      />
+      {showRequestPermissionDialog && (
+        <RequestPermissionDialog onClose={() => setShowDialog(false)} />
+      )}
+    </>
   )
 }

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
@@ -18,7 +18,11 @@ interface PermissionCheckBannerProps {
 export function PermissionCheckBanner({granted, requiredPermission}: PermissionCheckBannerProps) {
   const currentUser = useCurrentUser()
 
-  const roleRequestStatus = useRoleRequestsStatus()
+  const {
+    data: roleRequestStatus,
+    loading: requestStatusLoading,
+    error: requestStatusError,
+  } = useRoleRequestsStatus()
   const currentUserRoles = currentUser?.roles || []
   const isOnlyViewer = currentUserRoles.length === 1 && currentUserRoles[0].name === 'viewer'
   const [showRequestPermissionDialog, setShowRequestPermissionDialog] = useState(false)
@@ -51,18 +55,18 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
         }
         center
         action={
-          isOnlyViewer && roleRequestStatus
+          isOnlyViewer && roleRequestStatus && !requestStatusError && !requestStatusLoading
             ? {
                 onClick:
-                  roleRequestStatus === 'none'
-                    ? () => setShowRequestPermissionDialog(true)
-                    : undefined,
+                  roleRequestStatus === 'pending'
+                    ? undefined
+                    : () => setShowRequestPermissionDialog(true),
                 text:
-                  roleRequestStatus === 'none'
-                    ? t('banners.permission-check-banner.request-permission-button.text')
-                    : t('banners.permission-check-banner.request-permission-button.sent'),
-                tone: roleRequestStatus === 'none' ? 'primary' : 'default',
-                disabled: roleRequestStatus !== 'none',
+                  roleRequestStatus === 'pending'
+                    ? t('banners.permission-check-banner.request-permission-button.sent')
+                    : t('banners.permission-check-banner.request-permission-button.text'),
+                tone: roleRequestStatus === 'pending' ? 'default' : 'primary',
+                disabled: roleRequestStatus === 'pending',
                 // mode: 'bleed',
               }
             : undefined

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
@@ -27,7 +27,7 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
   } = useRoleRequestsStatus()
   const [requestSent, setRequestSent] = useState(false)
   const requestPending = useMemo(
-    () => roleRequestStatus === 'pending' || requestSent,
+    () => roleRequestStatus === 'pending' || roleRequestStatus === 'declined' || requestSent,
     [roleRequestStatus, requestSent],
   )
   const currentUserRoles = currentUser?.roles || []

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
@@ -58,7 +58,10 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
         icon={ReadOnlyIcon}
       />
       {showRequestPermissionDialog && (
-        <RequestPermissionDialog onClose={() => setShowDialog(false)} />
+        <RequestPermissionDialog
+          onClose={() => setShowDialog(false)}
+          onRequestSubmitted={() => setShowDialog(false)}
+        />
       )}
     </>
   )

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
@@ -1,4 +1,5 @@
 import {ReadOnlyIcon} from '@sanity/icons'
+import {useTelemetry} from '@sanity/telemetry/react'
 import {Text} from '@sanity/ui'
 import {useMemo, useState} from 'react'
 import {Translate, useCurrentUser, useListFormat, useTranslation} from 'sanity'
@@ -7,6 +8,7 @@ import {
   RequestPermissionDialog,
   useRoleRequestsStatus,
 } from '../../../../components/requestPermissionDialog'
+import {AskToEditDialogOpened} from '../../../../components/requestPermissionDialog/__telemetry__/RequestPermissionDialog.telemetry'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {Banner} from './Banner'
 
@@ -34,6 +36,7 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
 
   const listFormat = useListFormat({style: 'short'})
   const {t} = useTranslation(structureLocaleNamespace)
+  const telemtry = useTelemetry()
 
   if (granted) return null
 
@@ -61,7 +64,12 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
         action={
           isOnlyViewer && roleRequestStatus && !requestStatusError && !requestStatusLoading
             ? {
-                onClick: requestPending ? undefined : () => setShowRequestPermissionDialog(true),
+                onClick: requestPending
+                  ? undefined
+                  : () => {
+                      setShowRequestPermissionDialog(true)
+                      telemtry.log(AskToEditDialogOpened)
+                    },
                 text: requestPending
                   ? t('banners.permission-check-banner.request-permission-button.sent')
                   : t('banners.permission-check-banner.request-permission-button.text'),

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/PermissionCheckBanner.tsx
@@ -50,6 +50,7 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
             ? {
                 onClick: () => setShowDialog(true),
                 text: t('banners.permission-check-banner.request-permission-button.text'),
+                tone: 'primary',
               }
             : undefined
         }


### PR DESCRIPTION
### Description

This PR introduces a new "Request Edit Access" feature into the studio that allows users to make a request for a role change from Viewer to Editor/Administrator (depending on the project's available roles).

### What to review

There are 2 main areas of the Studio that are touched/introduced with this PR:
1. The `PermissionCheckBanner` and..
2. The new `RequestPermissionDialog`

#### `PermissionCheckBanner`

This banner has been updated to show an "Ask to edit" button in the action area if the user is ONLY a Viewer.

![image](https://github.com/user-attachments/assets/cd2ca28c-1148-494d-8945-fd3356da0268)


#### `RequestPermissionDialog`

This is where most of the code is introduced. This new Dialog works very similarly to the `RequestAccessScreen` with some changes to the request logic, error handling, and POST params.

![SCR-20240926-kqsu](https://github.com/user-attachments/assets/19616c4d-c877-4ffe-8dec-3334addc8383)

### Testing

This PR introduces no new automated tests.

### Notes for release

This new "Request Edit Access" feature will be available to all users - with administrators being able to Approve/Deny requests in the Requests tab in Manage.
