### PR TITLE
fix(preview): allow `null` as valid cache/memo value for preview fields

### DIFF
--- a/packages/sanity/src/core/preview/__test__/observeFields.test.ts
+++ b/packages/sanity/src/core/preview/__test__/observeFields.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it} from '@jest/globals'
+import {firstValueFrom, of, Subject} from 'rxjs'
+import {take, tap} from 'rxjs/operators'
+
+import {type ClientLike, createObserveFields} from '../observeFields'
+import {type InvalidationChannelEvent} from '../types'
+
+describe('observeFields', () => {
+  it('should cache the last known value and emit sync', async () => {
+    const client: ClientLike = {
+      observable: {
+        fetch: (query) => {
+          expect(query).toEqual('[*[_id in ["foo"]][0...1]{_id,_rev,_type,bar}][0...1]')
+          return of([
+            [
+              // no result
+            ],
+          ])
+        },
+      },
+      withConfig: () => client,
+    }
+
+    const invalidationChannel = new Subject<InvalidationChannelEvent>()
+    const observeFields = createObserveFields({
+      invalidationChannel,
+      client,
+    })
+    const first = firstValueFrom(observeFields('foo', ['bar']).pipe(take(1)))
+    invalidationChannel.next({type: 'connected'})
+
+    expect(await first).toMatchInlineSnapshot(`null`)
+
+    // After we got first value from server and it turned out to be `null`, we should have `null` as the memoized sync value
+    let syncValue = undefined
+    observeFields('foo', ['bar'])
+      .pipe(
+        tap((value) => {
+          syncValue = value
+        }),
+        take(1),
+      )
+      .subscribe()
+      .unsubscribe()
+    expect(syncValue).toBe(null)
+  })
+})

--- a/packages/sanity/src/core/preview/observeFields.ts
+++ b/packages/sanity/src/core/preview/observeFields.ts
@@ -154,9 +154,10 @@ export function createObserveFields(options: {
     fields: FieldName[],
     apiConfig?: ApiConfig,
   ): CachedFieldObserver {
-    let latest: T | null = null
+    // Note: `undefined` means the memo has not been set, while `null` means the memo is explicitly set to null (e.g. we did fetch, but got null back)
+    let latest: T | undefined | null = undefined
     const changes$ = merge(
-      defer(() => (latest === null ? EMPTY : observableOf(latest))),
+      defer(() => (latest === undefined ? EMPTY : observableOf(latest))),
       (apiConfig
         ? (crossDatasetListenFields(id, fields, apiConfig) as any)
         : currentDatasetListenFields(id, fields)) as Observable<T>,

--- a/packages/sanity/src/core/preview/observeFields.ts
+++ b/packages/sanity/src/core/preview/observeFields.ts
@@ -1,4 +1,3 @@
-import {type SanityClient} from '@sanity/client'
 import {difference, flatten, memoize} from 'lodash'
 import {
   combineLatest,
@@ -47,13 +46,28 @@ type Cache = {
 }
 
 /**
+ * Note: this should be the minimal interface createObserveFields needs to function
+ * It should be kept compatible with the Sanity Client
+ */
+export interface ClientLike {
+  withConfig(config: ApiConfig): ClientLike
+  observable: {
+    fetch: (
+      query: string,
+      params: Record<string, string>,
+      options: {tag: string},
+    ) => Observable<unknown>
+  }
+}
+
+/**
  * Creates a function that allows observing individual fields on a document.
  * It will automatically debounce and batch requests, and maintain an in-memory cache of the latest field values
  * @param options - Options to use when creating the observer
  * @internal
  */
 export function createObserveFields(options: {
-  client: SanityClient
+  client: ClientLike
   invalidationChannel: Observable<InvalidationChannelEvent>
 }) {
   const {client: currentDatasetClient, invalidationChannel} = options
@@ -63,11 +77,11 @@ export function createObserveFields(options: {
     )
   }
 
-  function fetchAllDocumentPathsWith(client: SanityClient) {
+  function fetchAllDocumentPathsWith(client: ClientLike) {
     return function fetchAllDocumentPath(selections: Selection[]) {
       const combinedSelections = combineSelections(selections)
       return client.observable
-        .fetch(toQuery(combinedSelections), {}, {tag: 'preview.document-paths'} as any)
+        .fetch(toQuery(combinedSelections), {}, {tag: 'preview.document-paths'})
         .pipe(map((result: any) => reassemble(result, combinedSelections)))
     }
   }


### PR DESCRIPTION
### Description
When previewing a document field, we keep a memo of the latest value so that when resubscribing to the same document later starts by emitting the latest known value (before we fetch from the server).

However, there was a flaw in the current implementation causing unneccessary loading states to appear in the studio:

In short: We assumed the memo being `null` meant that it hadn't been set, but in many cases it’s being explicitly set to `null` because we get `null` back from fetching the fields from the server.

This PR fixes the issue by instead treating `undefined` as "memo not being set".


### What to review
See code changes + added tests

### Testing
Added a unit test covering this particular case.


### Notes for release

- Fixes a few cases of unnecessary loading states appearing in the Studio