### PR TITLE
feat(sanity): add config for onUncaughtError

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -192,6 +192,7 @@ const config = {
                   'ButtonProps',
                   'Dialog',
                   'DialogProps',
+                  'ErrorBoundary',
                   'MenuButton',
                   'MenuButtonProps',
                   'MenuGroup',

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -154,7 +154,7 @@ const defaultWorkspace = {
   dataset: 'test',
   plugins: [sharedSettings()],
 
-  onStudioError: (error, errorInfo) => {
+  onUncaughtError: (error, errorInfo) => {
     // eslint-disable-next-line no-console
     console.log(error)
     // eslint-disable-next-line no-console
@@ -253,7 +253,7 @@ export default defineConfig([
     dataset: 'test',
     plugins: [sharedSettings(), studioComponentsPlugin(), formComponentsPlugin()],
     basePath: '/custom-components',
-    onStudioError: (error, errorInfo) => {
+    onUncaughtError: (error, errorInfo) => {
       // eslint-disable-next-line no-console
       console.log(error)
       // eslint-disable-next-line no-console

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -77,13 +77,6 @@ const sharedSettings = definePlugin({
     },
   },
 
-  onStudioError: (error, errorInfo) => {
-    // eslint-disable-next-line no-console
-    console.log(error)
-    // eslint-disable-next-line no-console
-    console.log(errorInfo)
-  },
-
   document: {
     actions: documentActions,
     inspectors: (prev, ctx) => {
@@ -160,6 +153,13 @@ const defaultWorkspace = {
   projectId: 'ppsg7ml5',
   dataset: 'test',
   plugins: [sharedSettings()],
+
+  onStudioError: (error, errorInfo) => {
+    // eslint-disable-next-line no-console
+    console.log(error)
+    // eslint-disable-next-line no-console
+    console.log(errorInfo)
+  },
   basePath: '/test',
   icon: SanityMonogram,
   // eslint-disable-next-line camelcase

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -77,6 +77,13 @@ const sharedSettings = definePlugin({
     },
   },
 
+  onStudioError: (error, errorMessage) => {
+    // eslint-disable-next-line no-console
+    console.log(error)
+    // eslint-disable-next-line no-console
+    console.log(errorMessage)
+  },
+
   document: {
     actions: documentActions,
     inspectors: (prev, ctx) => {

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -77,11 +77,11 @@ const sharedSettings = definePlugin({
     },
   },
 
-  onStudioError: (error, errorMessage) => {
+  onStudioError: (error, errorInfo) => {
     // eslint-disable-next-line no-console
     console.log(error)
     // eslint-disable-next-line no-console
-    console.log(errorMessage)
+    console.log(errorInfo)
   },
 
   document: {
@@ -253,6 +253,12 @@ export default defineConfig([
     dataset: 'test',
     plugins: [sharedSettings(), studioComponentsPlugin(), formComponentsPlugin()],
     basePath: '/custom-components',
+    onStudioError: (error, errorInfo) => {
+      // eslint-disable-next-line no-console
+      console.log(error)
+      // eslint-disable-next-line no-console
+      console.log(errorInfo)
+    },
     form: {
       components: {
         input: Input,

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -310,7 +310,7 @@ export const documentCommentsEnabledReducer = (opts: {
   return result
 }
 
-export const onStudioErrorResolver = (opts: {
+export const onUncaughtErrorResolver = (opts: {
   config: PluginOptions
   context: {error: Error; errorInfo: ErrorInfo}
 }) => {
@@ -320,13 +320,13 @@ export const onStudioErrorResolver = (opts: {
     // There is no concept of 'previous value' in this API. We only care about the final value.
     // That is, if a plugin returns true, but the next plugin returns false, the result will be false.
     // The last plugin 'wins'.
-    const resolver = pluginConfig.onStudioError
+    const resolver = pluginConfig.onUncaughtError
 
     if (typeof resolver === 'function') return resolver(context.error, context.errorInfo)
     if (!resolver) return undefined
 
     throw new Error(
-      `Expected \`document.onStudioError\` to be a a function, but received ${getPrintableType(
+      `Expected \`document.onUncaughtError\` to be a a function, but received ${getPrintableType(
         resolver,
       )}`,
     )

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -1,5 +1,5 @@
 import {type AssetSource, type SchemaTypeDefinition} from '@sanity/types'
-import {type ReactNode} from 'react'
+import {type ErrorInfo, type ReactNode} from 'react'
 
 import {type LocaleConfigContext, type LocaleDefinition, type LocaleResourceBundle} from '../i18n'
 import {type Template, type TemplateItem} from '../templates'
@@ -308,6 +308,26 @@ export const documentCommentsEnabledReducer = (opts: {
   }, initialValue)
 
   return result
+}
+
+export const onStudioErrorResolver = (opts: {
+  config: PluginOptions
+  context: {error: Error; errorInfo: ErrorInfo}
+}) => {
+  const {config, context} = opts
+
+  // There is no concept of 'previous value' in this API. We only care about the final value.
+  // That is, if a plugin returns true, but the next plugin returns false, the result will be false.
+  // The last plugin 'wins'.
+  const resolver = config.onStudioError
+
+  if (typeof resolver === 'function') return resolver(context.error, context.errorInfo)
+
+  throw new Error(
+    `Expected \`document.onStudioERror\` to be a a function, but received ${getPrintableType(
+      resolver,
+    )}`,
+  )
 }
 
 export const internalTasksReducer = (opts: {

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -322,6 +322,7 @@ export const onStudioErrorResolver = (opts: {
   const resolver = config.onStudioError
 
   if (typeof resolver === 'function') return resolver(context.error, context.errorInfo)
+  if (!resolver) return undefined
 
   throw new Error(
     `Expected \`document.onStudioError\` to be a a function, but received ${getPrintableType(

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -324,7 +324,7 @@ export const onStudioErrorResolver = (opts: {
   if (typeof resolver === 'function') return resolver(context.error, context.errorInfo)
 
   throw new Error(
-    `Expected \`document.onStudioERror\` to be a a function, but received ${getPrintableType(
+    `Expected \`document.onStudioError\` to be a a function, but received ${getPrintableType(
       resolver,
     )}`,
   )

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -38,7 +38,7 @@ import {
   internalTasksReducer,
   legacySearchEnabledReducer,
   newDocumentOptionsResolver,
-  onStudioErrorResolver,
+  onUncaughtErrorResolver,
   partialIndexingEnabledReducer,
   resolveProductionUrlReducer,
   schemaTemplatesReducer,
@@ -633,8 +633,8 @@ function resolveSource({
       staticInitialValueTemplateItems,
       options: config,
     },
-    onStudioError: (error: Error, errorInfo: ErrorInfo) => {
-      return onStudioErrorResolver({
+    onUncaughtError: (error: Error, errorInfo: ErrorInfo) => {
+      return onUncaughtErrorResolver({
         config,
         context: {
           error: error,

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -4,7 +4,13 @@ import {type CurrentUser, type Schema, type SchemaValidationProblem} from '@sani
 import {studioTheme} from '@sanity/ui'
 import {type i18n} from 'i18next'
 import {startCase} from 'lodash'
-import {type ComponentType, createElement, type ElementType, isValidElement} from 'react'
+import {
+  type ComponentType,
+  createElement,
+  type ElementType,
+  type ErrorInfo,
+  isValidElement,
+} from 'react'
 import {isValidElementType} from 'react-is'
 import {map, shareReplay} from 'rxjs/operators'
 
@@ -32,6 +38,7 @@ import {
   internalTasksReducer,
   legacySearchEnabledReducer,
   newDocumentOptionsResolver,
+  onStudioErrorResolver,
   partialIndexingEnabledReducer,
   resolveProductionUrlReducer,
   schemaTemplatesReducer,
@@ -626,6 +633,16 @@ function resolveSource({
       staticInitialValueTemplateItems,
       options: config,
     },
+    onStudioError: (error: Error, errorInfo: ErrorInfo) => {
+      return onStudioErrorResolver({
+        config,
+        context: {
+          error: error,
+          errorInfo: errorInfo,
+        },
+      })
+    },
+
     beta: {
       treeArrayEditing: {
         // This beta feature is no longer available.

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -10,7 +10,7 @@ import {
   type SchemaTypeDefinition,
 } from '@sanity/types'
 import {type i18n} from 'i18next'
-import {type ComponentType, type ReactNode} from 'react'
+import {type ComponentType, type ErrorInfo, type ReactNode} from 'react'
 import {type Observable} from 'rxjs'
 import {type Router, type RouterState} from 'sanity/router'
 
@@ -392,6 +392,10 @@ export interface PluginOptions {
    * @internal
    */
   beta?: BetaFeatures
+  /** Configuration for error handling.
+   * @internal
+   */
+  onStudioError?: (error: Error, errorInfo: ErrorInfo) => void
 }
 
 /** @internal */
@@ -781,6 +785,10 @@ export interface Source {
    * @internal
    */
   beta?: BetaFeatures
+  /** Configuration for error handling.
+   * @internal
+   */
+  onStudioError?: (error: Error, errorInfo: ErrorInfo) => void
 }
 
 /** @internal */

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -393,9 +393,9 @@ export interface PluginOptions {
    */
   beta?: BetaFeatures
   /** Configuration for error handling.
-   * @internal
+   * @beta
    */
-  onStudioError?: (error: Error, errorInfo: ErrorInfo) => void
+  onUncaughtError?: (error: Error, errorInfo: ErrorInfo) => void
 }
 
 /** @internal */
@@ -788,7 +788,7 @@ export interface Source {
   /** Configuration for error handling.
    * @internal
    */
-  onStudioError?: (error: Error, errorInfo: ErrorInfo) => void
+  onUncaughtError?: (error: Error, errorInfo: ErrorInfo) => void
 }
 
 /** @internal */

--- a/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.test.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.test.tsx
@@ -25,8 +25,8 @@ describe('FormBuilderInputErrorBoundary', () => {
     expect(screen.getByTestId('child')).toBeInTheDocument()
   })
 
-  it('calls onStudioError when an error is caught', async () => {
-    const onStudioError = jest.fn()
+  it('calls onUncaughtError when an error is caught', async () => {
+    const onUncaughtError = jest.fn()
 
     const ThrowErrorComponent = () => {
       throw new Error('An EXPECTED, testing error occurred!')
@@ -40,7 +40,7 @@ describe('FormBuilderInputErrorBoundary', () => {
         name: 'default',
         projectId: 'test',
         dataset: 'test',
-        onStudioError,
+        onUncaughtError,
       },
     })
 
@@ -52,6 +52,6 @@ describe('FormBuilderInputErrorBoundary', () => {
       </TestProvider>,
     )
 
-    expect(onStudioError).toHaveBeenCalledTimes(1)
+    expect(onUncaughtError).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.test.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.test.tsx
@@ -1,0 +1,69 @@
+import {beforeAll, describe, expect, it, jest} from '@jest/globals'
+import {studioTheme, ThemeProvider} from '@sanity/ui'
+import {render, screen} from '@testing-library/react'
+
+import {LocaleProviderBase} from '../../i18n/components/LocaleProvider'
+import {prepareI18n} from '../../i18n/i18nConfig'
+import {usEnglishLocale} from '../../i18n/locales'
+import {useSource} from '../../studio/source'
+import {FormBuilderInputErrorBoundary} from './FormBuilderInputErrorBoundary'
+
+// Mock dependencies
+jest.mock('../../studio/source', () => ({
+  useSource: jest.fn(),
+}))
+
+jest.mock('use-hot-module-reload', () => ({
+  useHotModuleReload: jest.fn(),
+}))
+
+const useSourceMock = useSource as jest.Mock
+
+describe('FormBuilderInputErrorBoundary', () => {
+  beforeAll(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders children when there is no error', async () => {
+    render(
+      <FormBuilderInputErrorBoundary>
+        <div data-testid="child">Child Component</div>
+      </FormBuilderInputErrorBoundary>,
+    )
+
+    expect(screen.getByTestId('child')).toBeInTheDocument()
+  })
+
+  it('calls onStudioError when an error is caught', async () => {
+    const onStudioError = jest.fn()
+    useSourceMock.mockReturnValue({onStudioError})
+
+    const ThrowErrorComponent = () => {
+      throw new Error('An EXPECTED, testing error occurred!')
+    }
+
+    const locales = [usEnglishLocale]
+    const {i18next} = prepareI18n({
+      projectId: 'test',
+      dataset: 'test',
+      name: 'test',
+    })
+
+    render(
+      <ThemeProvider theme={studioTheme}>
+        <LocaleProviderBase
+          projectId={'test'}
+          sourceId={'test'}
+          locales={locales}
+          i18next={i18next}
+        >
+          <FormBuilderInputErrorBoundary>
+            <ThrowErrorComponent />
+          </FormBuilderInputErrorBoundary>
+        </LocaleProviderBase>
+      </ThemeProvider>,
+    )
+
+    expect(onStudioError).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.tsx
@@ -1,12 +1,12 @@
-import {Box, Card, Code, ErrorBoundary, Stack, Text} from '@sanity/ui'
+import {Box, Card, Code, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo, useState} from 'react'
 import {useHotModuleReload} from 'use-hot-module-reload'
 
+import {ErrorBoundary} from '../../../ui-components/errorBoundary'
 import {SchemaError} from '../../config'
 import {isDev} from '../../environment'
 import {useTranslation} from '../../i18n'
 import {CorsOriginError} from '../../store'
-import {useSource} from '../../studio/source'
 import {isRecord} from '../../util'
 import {Alert} from '../components/Alert'
 
@@ -28,22 +28,10 @@ export function FormBuilderInputErrorBoundary(
     error: null,
     info: {},
   })
-  const source = useSource()
   const handleRetry = useCallback(() => setError({error: null, info: {}}), [])
-  const handleCatch = useCallback(
-    ({error: caughtError, info: caughtInfo}: {error: Error; info: React.ErrorInfo}) => {
-      setError({error: caughtError, info: caughtInfo})
-
-      if (source?.onStudioError) {
-        const {onStudioError} = source
-        onStudioError(caughtError, caughtInfo)
-      }
-    },
-    [source],
-  )
 
   if (!error) {
-    return <ErrorBoundary onCatch={handleCatch}>{children}</ErrorBoundary>
+    return <ErrorBoundary onCatch={setError}>{children}</ErrorBoundary>
   }
 
   return <ErrorCard error={error} info={info} onRetry={handleRetry} />

--- a/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.tsx
@@ -1,12 +1,12 @@
 import {Box, Card, Code, ErrorBoundary, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo, useState} from 'react'
-import {useSource} from 'sanity'
 import {useHotModuleReload} from 'use-hot-module-reload'
 
 import {SchemaError} from '../../config'
 import {isDev} from '../../environment'
 import {useTranslation} from '../../i18n'
 import {CorsOriginError} from '../../store'
+import {useSource} from '../../studio/source'
 import {isRecord} from '../../util'
 import {Alert} from '../components/Alert'
 

--- a/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.tsx
@@ -28,17 +28,18 @@ export function FormBuilderInputErrorBoundary(
     error: null,
     info: {},
   })
-  const {onStudioError} = useSource()
+  const source = useSource()
   const handleRetry = useCallback(() => setError({error: null, info: {}}), [])
   const handleCatch = useCallback(
     ({error: caughtError, info: caughtInfo}: {error: Error; info: React.ErrorInfo}) => {
       setError({error: caughtError, info: caughtInfo})
 
-      if (onStudioError) {
+      if (source?.onStudioError) {
+        const {onStudioError} = source
         onStudioError(caughtError, caughtInfo)
       }
     },
-    [onStudioError],
+    [source],
   )
 
   if (!error) {

--- a/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import {Box, Card, Code, ErrorBoundary, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo, useState} from 'react'
+import {useSource} from 'sanity'
 import {useHotModuleReload} from 'use-hot-module-reload'
 
 import {SchemaError} from '../../config'
@@ -27,10 +28,21 @@ export function FormBuilderInputErrorBoundary(
     error: null,
     info: {},
   })
+  const {onStudioError} = useSource()
   const handleRetry = useCallback(() => setError({error: null, info: {}}), [])
+  const handleCatch = useCallback(
+    ({error: caughtError, info: caughtInfo}: {error: Error; info: React.ErrorInfo}) => {
+      setError({error: caughtError, info: caughtInfo})
+
+      if (onStudioError) {
+        onStudioError(caughtError, caughtInfo)
+      }
+    },
+    [onStudioError],
+  )
 
   if (!error) {
-    return <ErrorBoundary onCatch={setError}>{children}</ErrorBoundary>
+    return <ErrorBoundary onCatch={handleCatch}>{children}</ErrorBoundary>
   }
 
   return <ErrorCard error={error} info={info} onRetry={handleRetry} />

--- a/packages/sanity/src/core/studio/StudioErrorBoundary.tsx
+++ b/packages/sanity/src/core/studio/StudioErrorBoundary.tsx
@@ -1,16 +1,6 @@
 /* eslint-disable i18next/no-literal-string */
 /* eslint-disable @sanity/i18n/no-attribute-string-literals */
-import {
-  Box,
-  Card,
-  Code,
-  Container,
-  ErrorBoundary,
-  type ErrorBoundaryProps,
-  Heading,
-  Stack,
-  Text,
-} from '@sanity/ui'
+import {Box, Card, Code, Container, type ErrorBoundaryProps, Heading, Stack, Text} from '@sanity/ui'
 import {
   type ComponentType,
   type ErrorInfo,
@@ -23,6 +13,7 @@ import {ErrorActions, isDev, isProd} from 'sanity'
 import {styled} from 'styled-components'
 import {useHotModuleReload} from 'use-hot-module-reload'
 
+import {ErrorBoundary} from '../../ui-components'
 import {SchemaError} from '../config'
 import {errorReporter} from '../error/errorReporter'
 import {CorsOriginError} from '../store'

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/FilterForm.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/FilterForm.tsx
@@ -64,6 +64,7 @@ export function FilterForm({filter}: FilterFormProps) {
   }
 
   // Flex order is reversed to ensure form inputs are focusable first
+  // Context for onStudioError config property: This ErrorBoundary will bubble to the ErrorBoundary in WorkspaceRouterProvider
   return (
     <ErrorBoundary onCatch={handleCatchError}>
       <FocusLock autoFocus={!supportsTouch} returnFocus>

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/FilterForm.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/FilterForm.tsx
@@ -1,9 +1,9 @@
 import {TrashIcon} from '@sanity/icons'
-import {Box, Card, ErrorBoundary, Flex, Stack, Text} from '@sanity/ui'
+import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
 import {type ErrorInfo, useCallback, useState} from 'react'
 import FocusLock from 'react-focus-lock'
 
-import {Button} from '../../../../../../../../ui-components'
+import {Button, ErrorBoundary} from '../../../../../../../../ui-components'
 import {supportsTouch} from '../../../../../../../util'
 import {useSearchState} from '../../../contexts/search/useSearchState'
 import {getFilterDefinition} from '../../../definitions/filters'
@@ -64,7 +64,6 @@ export function FilterForm({filter}: FilterFormProps) {
   }
 
   // Flex order is reversed to ensure form inputs are focusable first
-  // Context for onStudioError config property: This ErrorBoundary will bubble to the ErrorBoundary in WorkspaceRouterProvider
   return (
     <ErrorBoundary onCatch={handleCatchError}>
       <FocusLock autoFocus={!supportsTouch} returnFocus>

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceLoader.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceLoader.tsx
@@ -1,8 +1,8 @@
-import {ErrorBoundary} from '@sanity/ui'
 import {type ComponentType, type ReactNode, useEffect, useState} from 'react'
 import {combineLatest, of} from 'rxjs'
 import {catchError, map} from 'rxjs/operators'
 
+import {ErrorBoundary} from '../../../ui-components'
 import {
   ConfigResolutionError,
   type Source,

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.test.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.test.tsx
@@ -69,8 +69,8 @@ describe('WorkspaceRouterProvider', () => {
     expect(screen.getByText('Children')).toBeInTheDocument()
   })
 
-  it('calls onStudioError when an error is caught', async () => {
-    const onStudioError = jest.fn()
+  it('calls onUncaughtError when an error is caught', async () => {
+    const onUncaughtError = jest.fn()
 
     const ThrowErrorComponent = () => {
       throw new Error('An EXPECTED, testing error occurred!')
@@ -84,7 +84,7 @@ describe('WorkspaceRouterProvider', () => {
         name: 'default',
         projectId: 'test',
         dataset: 'test',
-        onStudioError,
+        onUncaughtError,
       },
     })
 
@@ -98,7 +98,7 @@ describe('WorkspaceRouterProvider', () => {
         </TestProvider>,
       )
     } catch {
-      expect(onStudioError).toHaveBeenCalledTimes(1)
+      expect(onUncaughtError).toHaveBeenCalledTimes(1)
     }
   })
 })

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.test.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.test.tsx
@@ -1,0 +1,114 @@
+import {describe, expect, it, jest} from '@jest/globals'
+import {ErrorBoundary, studioTheme, ThemeProvider} from '@sanity/ui'
+import {render, screen} from '@testing-library/react'
+
+import {LocaleProviderBase, usEnglishLocale} from '../../i18n'
+import {prepareI18n} from '../../i18n/i18nConfig'
+import {useSource} from '../source'
+import {WorkspaceRouterProvider} from './WorkspaceRouterProvider'
+
+jest.mock('../router/RouterHistoryContext', () => ({
+  useRouterHistory: () => ({
+    location: {pathname: '/'},
+    listen: jest.fn(),
+  }),
+}))
+
+jest.mock('../source', () => ({
+  useSource: jest.fn(),
+}))
+
+jest.mock('../router', () => ({
+  createRouter: () => ({
+    getBasePath: jest.fn(),
+    decode: jest.fn(),
+    isNotFound: jest.fn(),
+  }),
+}))
+
+jest.mock('sanity/router', () => ({
+  RouterProvider: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+  IntentLink: () => <div>IntentLink</div>,
+}))
+
+jest.mock('./WorkspaceRouterProvider', () => ({
+  ...(jest.requireActual('./WorkspaceRouterProvider') as object),
+  useRouterFromWorkspaceHistory: jest.fn(),
+}))
+
+const useSourceMock = useSource as jest.Mock
+
+describe('WorkspaceRouterProvider', () => {
+  const LoadingComponent = () => <div>Loading...</div>
+  const children = <div>Children</div>
+  const workspace = {
+    basePath: '',
+    tools: [],
+    icon: null,
+    unstable_sources: [],
+    scheduledPublishing: false,
+    document: {},
+    form: {},
+    search: {},
+    title: 'Default Workspace',
+    name: 'default',
+    projectId: 'test',
+    dataset: 'test',
+    schema: {},
+    templates: {},
+    currentUser: {},
+    authenticated: true,
+    auth: {},
+    getClient: jest.fn(),
+    i18n: {},
+    __internal: {},
+    type: 'workspace',
+    // Add other required properties with appropriate default values
+  } as unknown as Workspace
+
+  it('renders children when state is not null', () => {
+    render(
+      <WorkspaceRouterProvider LoadingComponent={LoadingComponent} workspace={workspace}>
+        {children}
+      </WorkspaceRouterProvider>,
+    )
+
+    expect(screen.getByText('Children')).toBeInTheDocument()
+  })
+
+  it('calls onStudioError when an error is caught', () => {
+    const onStudioError = jest.fn()
+    useSourceMock.mockReturnValue({onStudioError})
+
+    const ThrowErrorComponent = () => {
+      throw new Error('An EXPECTED, testing error occurred!')
+    }
+
+    const locales = [usEnglishLocale]
+    const {i18next} = prepareI18n({
+      projectId: 'test',
+      dataset: 'test',
+      name: 'test',
+    })
+
+    render(
+      <ThemeProvider theme={studioTheme}>
+        <LocaleProviderBase
+          projectId={'test'}
+          sourceId={'test'}
+          locales={locales}
+          i18next={i18next}
+        >
+          {/* prevents thrown error from breaking the test */}
+          <ErrorBoundary onCatch={({error, info}) => <></>}>
+            <WorkspaceRouterProvider LoadingComponent={LoadingComponent} workspace={workspace}>
+              <ThrowErrorComponent />
+            </WorkspaceRouterProvider>
+          </ErrorBoundary>
+        </LocaleProviderBase>
+      </ThemeProvider>,
+    )
+
+    expect(onStudioError).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.test.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.test.tsx
@@ -1,7 +1,6 @@
 import {describe, expect, it, jest} from '@jest/globals'
-import {ErrorBoundary} from '@sanity/ui'
 import {render, screen} from '@testing-library/react'
-import {type SanityClient} from 'sanity'
+import {type SanityClient, type Workspace} from 'sanity'
 
 import {createMockSanityClient} from '../../../../test/mocks/mockSanityClient'
 import {createTestProvider} from '../../../../test/testUtils/TestProvider'
@@ -89,17 +88,17 @@ describe('WorkspaceRouterProvider', () => {
       },
     })
 
-    render(
-      <TestProvider>
-        {/* prevents thrown error from breaking the test */}
-        <ErrorBoundary onCatch={({error, info}) => <></>}>
+    try {
+      render(
+        <TestProvider>
+          {/* prevents thrown error from breaking the test */}
           <WorkspaceRouterProvider LoadingComponent={LoadingComponent} workspace={workspace}>
             <ThrowErrorComponent />
           </WorkspaceRouterProvider>
-        </ErrorBoundary>
-      </TestProvider>,
-    )
-
-    expect(onStudioError).toHaveBeenCalledTimes(1)
+        </TestProvider>,
+      )
+    } catch {
+      expect(onStudioError).toHaveBeenCalledTimes(1)
+    }
   })
 })

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
@@ -35,7 +35,7 @@ export function WorkspaceRouterProvider({
 
   const handleCatchError = useCallback(({error}: {error: Error}) => {
     /** catches errors in studio that bubble up, throwing the error */
-    throw new Error(error.message)
+throw error
   }, [])
 
   // `state` is only null if the Studio is somehow rendering in SSR or using hydrateRoot in combination with `unstable_noAuthBoundary`.

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
@@ -1,4 +1,3 @@
-import {ErrorBoundary} from '@sanity/ui'
 import {escapeRegExp, isEqual} from 'lodash'
 import {
   type ComponentType,
@@ -12,11 +11,11 @@ import {
 import {type Router, RouterProvider, type RouterState} from 'sanity/router'
 import {useSyncExternalStoreWithSelector} from 'use-sync-external-store/with-selector.js'
 
+import {ErrorBoundary} from '../../../ui-components/errorBoundary'
 import {type Tool, type Workspace} from '../../config'
 import {createRouter, type RouterHistory, type RouterStateEvent} from '../router'
 import {decodeUrlState, resolveDefaultState, resolveIntentState} from '../router/helpers'
 import {useRouterHistory} from '../router/RouterHistoryContext'
-import {useSource} from '../source'
 
 interface WorkspaceRouterProviderProps {
   children: ReactNode
@@ -33,20 +32,11 @@ export function WorkspaceRouterProvider({
   const history = useRouterHistory()
   const router = useMemo(() => createRouter({basePath, tools}), [basePath, tools])
   const [state, onNavigate] = useRouterFromWorkspaceHistory(history, router, tools)
-  const source = useSource()
 
-  const handleCatchError = useCallback(
-    ({error, info}: {error: Error; info: React.ErrorInfo}) => {
-      /** catches errors in studio to be able to be caught in the config */
-      if (source?.onStudioError) {
-        const {onStudioError} = source
-        onStudioError(error, info)
-      }
-
-      throw new Error(error.message)
-    },
-    [source],
-  )
+  const handleCatchError = useCallback(({error}: {error: Error}) => {
+    /** catches errors in studio that bubble up, throwing the error */
+    throw new Error(error.message)
+  }, [])
 
   // `state` is only null if the Studio is somehow rendering in SSR or using hydrateRoot in combination with `unstable_noAuthBoundary`.
   // Which makes this loading condition extremely rare, most of the time it'll render `RouteProvider` right away.

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
@@ -35,7 +35,7 @@ export function WorkspaceRouterProvider({
 
   const handleCatchError = useCallback(({error}: {error: Error}) => {
     /** catches errors in studio that bubble up, throwing the error */
-throw error
+    throw error
   }, [])
 
   // `state` is only null if the Studio is somehow rendering in SSR or using hydrateRoot in combination with `unstable_noAuthBoundary`.

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
@@ -9,7 +9,6 @@ import {
   useMemo,
   useRef,
 } from 'react'
-import {useSource} from 'sanity'
 import {type Router, RouterProvider, type RouterState} from 'sanity/router'
 import {useSyncExternalStoreWithSelector} from 'use-sync-external-store/with-selector.js'
 
@@ -17,6 +16,7 @@ import {type Tool, type Workspace} from '../../config'
 import {createRouter, type RouterHistory, type RouterStateEvent} from '../router'
 import {decodeUrlState, resolveDefaultState, resolveIntentState} from '../router/helpers'
 import {useRouterHistory} from '../router/RouterHistoryContext'
+import {useSource} from '../source'
 
 interface WorkspaceRouterProviderProps {
   children: ReactNode

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
@@ -11,7 +11,7 @@ import {
 import {type Router, RouterProvider, type RouterState} from 'sanity/router'
 import {useSyncExternalStoreWithSelector} from 'use-sync-external-store/with-selector.js'
 
-import {ErrorBoundary} from '../../../ui-components/errorBoundary'
+import {ErrorBoundary} from '../../../ui-components'
 import {type Tool, type Workspace} from '../../config'
 import {createRouter, type RouterHistory, type RouterStateEvent} from '../router'
 import {decodeUrlState, resolveDefaultState, resolveIntentState} from '../router/helpers'

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
@@ -56,7 +56,7 @@ type HandleNavigate = (opts: {path: string; replace?: boolean}) => void
 /**
  * @internal
  */
-export function useRouterFromWorkspaceHistory(
+function useRouterFromWorkspaceHistory(
   history: RouterHistory,
   router: Router,
   tools: Tool[],

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
@@ -33,18 +33,19 @@ export function WorkspaceRouterProvider({
   const history = useRouterHistory()
   const router = useMemo(() => createRouter({basePath, tools}), [basePath, tools])
   const [state, onNavigate] = useRouterFromWorkspaceHistory(history, router, tools)
-  const {onStudioError} = useSource()
+  const source = useSource()
 
   const handleCatchError = useCallback(
     ({error, info}: {error: Error; info: React.ErrorInfo}) => {
       /** catches errors in studio to be able to be caught in the config */
-      if (onStudioError) {
+      if (source?.onStudioError) {
+        const {onStudioError} = source
         onStudioError(error, info)
       }
 
       throw new Error(error.message)
     },
-    [onStudioError],
+    [source],
   )
 
   // `state` is only null if the Studio is somehow rendering in SSR or using hydrateRoot in combination with `unstable_noAuthBoundary`.
@@ -65,7 +66,7 @@ type HandleNavigate = (opts: {path: string; replace?: boolean}) => void
 /**
  * @internal
  */
-function useRouterFromWorkspaceHistory(
+export function useRouterFromWorkspaceHistory(
   history: RouterHistory,
   router: Router,
   tools: Tool[],

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/index.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/index.tsx
@@ -1,8 +1,8 @@
-import {Box, ErrorBoundary, Text} from '@sanity/ui'
+import {Box, Text} from '@sanity/ui'
 import {type ComponentProps, useCallback, useId, useState} from 'react'
 import {useTranslation} from 'sanity'
 
-import {Dialog} from '../../../ui-components'
+import {Dialog, ErrorBoundary} from '../../../ui-components'
 import {structureLocaleNamespace} from '../../i18n'
 import {ConfirmDeleteDialog, type ConfirmDeleteDialogProps} from './ConfirmDeleteDialog'
 
@@ -18,7 +18,6 @@ function ConfirmDeleteDialogContainer(props: ConfirmDeleteDialogProps) {
   const [error, setError] = useState<ErrorInfo | null>(null)
   const handleRetry = useCallback(() => setError(null), [])
 
-  // Context for onStudioError config property: This ErrorBoundary will bubble to the ErrorBoundary in WorkspaceRouterProvider
   return error ? (
     <Dialog
       id={`dialog-error-${id}`}

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/index.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/index.tsx
@@ -18,6 +18,7 @@ function ConfirmDeleteDialogContainer(props: ConfirmDeleteDialogProps) {
   const [error, setError] = useState<ErrorInfo | null>(null)
   const handleRetry = useCallback(() => setError(null), [])
 
+  // Context for onStudioError config property: This ErrorBoundary will bubble to the ErrorBoundary in WorkspaceRouterProvider
   return error ? (
     <Dialog
       id={`dialog-error-${id}`}

--- a/packages/sanity/src/structure/components/structureTool/StructureTitle.tsx
+++ b/packages/sanity/src/structure/components/structureTool/StructureTitle.tsx
@@ -46,6 +46,7 @@ const DocumentTitle = (props: {documentId: string; documentType: string}) => {
     document.title = newTitle
   }, [documentTitle, settled, newTitle])
 
+  throw new Error('This is an error from the structure tool')
   return null
 }
 

--- a/packages/sanity/src/structure/components/structureTool/StructureTitle.tsx
+++ b/packages/sanity/src/structure/components/structureTool/StructureTitle.tsx
@@ -46,7 +46,6 @@ const DocumentTitle = (props: {documentId: string; documentType: string}) => {
     document.title = newTitle
   }, [documentTitle, settled, newTitle])
 
-  throw new Error('This is an error from the structure tool')
   return null
 }
 

--- a/packages/sanity/src/structure/components/structureTool/StructureToolBoundary.tsx
+++ b/packages/sanity/src/structure/components/structureTool/StructureToolBoundary.tsx
@@ -1,5 +1,5 @@
 import {ErrorBoundary} from '@sanity/ui'
-import {useEffect, useState} from 'react'
+import {useCallback, useEffect, useState} from 'react'
 import {SourceProvider, type Tool, useWorkspace} from 'sanity'
 
 import {setActivePanes} from '../../getIntentState'
@@ -25,11 +25,24 @@ export function StructureToolBoundary({tool: {options}}: StructureToolBoundaryPr
   }, [])
 
   const [{error}, setError] = useState<{error: unknown}>({error: null})
+
+  const handleCatchError = useCallback(
+    ({error: caughtError, info: caughtInfo}: {error: Error; info: React.ErrorInfo}) => {
+      setError({error: caughtError})
+      const {onStudioError} = firstSource
+
+      if (onStudioError) {
+        onStudioError(caughtError, caughtInfo)
+      }
+    },
+    [firstSource],
+  )
+
   // this re-throws if the error it catches is not a PaneResolutionError
   if (error) return <StructureError error={error} />
 
   return (
-    <ErrorBoundary onCatch={setError}>
+    <ErrorBoundary onCatch={handleCatchError}>
       <SourceProvider name={source || firstSource.name}>
         <StructureToolProvider defaultDocumentNode={defaultDocumentNode} structure={structure}>
           <StructureTool onPaneChange={setActivePanes} />

--- a/packages/sanity/src/structure/components/structureTool/StructureToolBoundary.tsx
+++ b/packages/sanity/src/structure/components/structureTool/StructureToolBoundary.tsx
@@ -1,7 +1,7 @@
-import {ErrorBoundary} from '@sanity/ui'
-import {useCallback, useEffect, useState} from 'react'
+import {useEffect, useState} from 'react'
 import {SourceProvider, type Tool, useWorkspace} from 'sanity'
 
+import {ErrorBoundary} from '../../../ui-components/errorBoundary'
 import {setActivePanes} from '../../getIntentState'
 import {StructureToolProvider} from '../../StructureToolProvider'
 import {type StructureToolOptions} from '../../types'
@@ -26,23 +26,11 @@ export function StructureToolBoundary({tool: {options}}: StructureToolBoundaryPr
 
   const [{error}, setError] = useState<{error: unknown}>({error: null})
 
-  const handleCatchError = useCallback(
-    ({error: caughtError, info: caughtInfo}: {error: Error; info: React.ErrorInfo}) => {
-      setError({error: caughtError})
-      const {onStudioError} = firstSource
-
-      if (onStudioError) {
-        onStudioError(caughtError, caughtInfo)
-      }
-    },
-    [firstSource],
-  )
-
   // this re-throws if the error it catches is not a PaneResolutionError
   if (error) return <StructureError error={error} />
 
   return (
-    <ErrorBoundary onCatch={handleCatchError}>
+    <ErrorBoundary onCatch={setError}>
       <SourceProvider name={source || firstSource.name}>
         <StructureToolProvider defaultDocumentNode={defaultDocumentNode} structure={structure}>
           <StructureTool onPaneChange={setActivePanes} />

--- a/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
@@ -13,7 +13,7 @@ import {
 } from '@sanity/types'
 import {Box, Card, type CardTone, ErrorBoundary, Flex, Stack, Text} from '@sanity/ui'
 import {createElement, type ErrorInfo, Fragment, useCallback, useMemo, useState} from 'react'
-import {type DocumentInspectorProps, useSource, useTranslation} from 'sanity'
+import {type DocumentInspectorProps, useTranslation} from 'sanity'
 
 import {DocumentInspectorHeader} from '../../documentInspector'
 import {useDocumentPane} from '../../useDocumentPane'
@@ -44,7 +44,6 @@ export function ValidationInspector(props: DocumentInspectorProps) {
     [onFocus, onPathOpen],
   )
 
-  throw new Error('This is an error from the validation inspector')
   return (
     <Flex direction="column" height="fill" overflow="hidden">
       <DocumentInspectorHeader

--- a/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
@@ -92,6 +92,7 @@ function ValidationCard(props: {
   const handleOpen = useCallback(() => onOpen(marker.path), [marker, onOpen])
   const [errorInfo, setErrorInfo] = useState<{error: Error; info: ErrorInfo} | null>(null)
 
+  // Context for onStudioError config property: This ErrorBoundary will bubble to the ErrorBoundary in WorkspaceRouterProvider
   return (
     <ErrorBoundary onCatch={setErrorInfo}>
       {errorInfo && (

--- a/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
@@ -11,10 +11,11 @@ import {
   type SchemaType,
   type ValidationMarker,
 } from '@sanity/types'
-import {Box, Card, type CardTone, ErrorBoundary, Flex, Stack, Text} from '@sanity/ui'
+import {Box, Card, type CardTone, Flex, Stack, Text} from '@sanity/ui'
 import {createElement, type ErrorInfo, Fragment, useCallback, useMemo, useState} from 'react'
 import {type DocumentInspectorProps, useTranslation} from 'sanity'
 
+import {ErrorBoundary} from '../../../../../ui-components'
 import {DocumentInspectorHeader} from '../../documentInspector'
 import {useDocumentPane} from '../../useDocumentPane'
 import {getPathTitles} from './getPathTitles'
@@ -92,7 +93,6 @@ function ValidationCard(props: {
   const handleOpen = useCallback(() => onOpen(marker.path), [marker, onOpen])
   const [errorInfo, setErrorInfo] = useState<{error: Error; info: ErrorInfo} | null>(null)
 
-  // Context for onStudioError config property: This ErrorBoundary will bubble to the ErrorBoundary in WorkspaceRouterProvider
   return (
     <ErrorBoundary onCatch={setErrorInfo}>
       {errorInfo && (

--- a/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
@@ -13,7 +13,7 @@ import {
 } from '@sanity/types'
 import {Box, Card, type CardTone, ErrorBoundary, Flex, Stack, Text} from '@sanity/ui'
 import {createElement, type ErrorInfo, Fragment, useCallback, useMemo, useState} from 'react'
-import {type DocumentInspectorProps, useTranslation} from 'sanity'
+import {type DocumentInspectorProps, useSource, useTranslation} from 'sanity'
 
 import {DocumentInspectorHeader} from '../../documentInspector'
 import {useDocumentPane} from '../../useDocumentPane'
@@ -44,6 +44,7 @@ export function ValidationInspector(props: DocumentInspectorProps) {
     [onFocus, onPathOpen],
   )
 
+  throw new Error('This is an error from the validation inspector')
   return (
     <Flex direction="column" height="fill" overflow="hidden">
       <DocumentInspectorHeader

--- a/packages/sanity/src/ui-components/errorBoundary/ErrorBoundary.tsx
+++ b/packages/sanity/src/ui-components/errorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import {
+  // eslint-disable-next-line no-restricted-imports
   ErrorBoundary as UIErrorBoundary,
   type ErrorBoundaryProps as UIErrorBoundaryProps,
 } from '@sanity/ui'

--- a/packages/sanity/src/ui-components/errorBoundary/ErrorBoundary.tsx
+++ b/packages/sanity/src/ui-components/errorBoundary/ErrorBoundary.tsx
@@ -2,9 +2,9 @@ import {
   ErrorBoundary as UIErrorBoundary,
   type ErrorBoundaryProps as UIErrorBoundaryProps,
 } from '@sanity/ui'
-import {useCallback} from 'react'
+import {useCallback, useContext} from 'react'
 
-import {useSource} from '../../core/studio/source'
+import {SourceContext} from '../../_singletons'
 
 export type ErrorBoundaryProps = UIErrorBoundaryProps
 
@@ -14,7 +14,7 @@ export type ErrorBoundaryProps = UIErrorBoundaryProps
  */
 export function ErrorBoundary({onCatch, ...rest}: ErrorBoundaryProps): JSX.Element {
   // Use context, because source could be undefined and we don't want to throw in that case
-  const source = useSource()
+  const source = useContext(SourceContext)
 
   const handleCatch = useCallback(
     ({error: caughtError, info: caughtInfo}: {error: Error; info: React.ErrorInfo}) => {

--- a/packages/sanity/src/ui-components/errorBoundary/ErrorBoundary.tsx
+++ b/packages/sanity/src/ui-components/errorBoundary/ErrorBoundary.tsx
@@ -10,7 +10,7 @@ import {SourceContext} from '../../_singletons'
 export type ErrorBoundaryProps = UIErrorBoundaryProps
 
 /**
- * ErrorBoundary component that catches errors and uses onStudioError config property
+ * ErrorBoundary component that catches errors and uses onUncaughtError config property
  * It also calls the onCatch prop if it exists.
  */
 export function ErrorBoundary({onCatch, ...rest}: ErrorBoundaryProps): JSX.Element {
@@ -19,8 +19,8 @@ export function ErrorBoundary({onCatch, ...rest}: ErrorBoundaryProps): JSX.Eleme
 
   const handleCatch = useCallback(
     ({error: caughtError, info: caughtInfo}: {error: Error; info: React.ErrorInfo}) => {
-      // Send the error to the source if it has an onStudioError method
-      source?.onStudioError?.(caughtError, caughtInfo)
+      // Send the error to the source if it has an onUncaughtError method
+      source?.onUncaughtError?.(caughtError, caughtInfo)
 
       // Call the onCatch prop if it exists
       onCatch?.({error: caughtError, info: caughtInfo})

--- a/packages/sanity/src/ui-components/errorBoundary/ErrorBoundary.tsx
+++ b/packages/sanity/src/ui-components/errorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,31 @@
+import {
+  ErrorBoundary as UIErrorBoundary,
+  type ErrorBoundaryProps as UIErrorBoundaryProps,
+} from '@sanity/ui'
+import {useCallback} from 'react'
+
+import {useSource} from '../../core/studio/source'
+
+export type ErrorBoundaryProps = UIErrorBoundaryProps
+
+/**
+ * ErrorBoundary component that catches errors and uses onStudioError config property
+ * It also calls the onCatch prop if it exists.
+ */
+export function ErrorBoundary({onCatch, ...rest}: ErrorBoundaryProps): JSX.Element {
+  // Use context, because source could be undefined and we don't want to throw in that case
+  const source = useSource()
+
+  const handleCatch = useCallback(
+    ({error: caughtError, info: caughtInfo}: {error: Error; info: React.ErrorInfo}) => {
+      // Send the error to the source if it has an onStudioError method
+      source?.onStudioError?.(caughtError, caughtInfo)
+
+      // Call the onCatch prop if it exists
+      onCatch?.({error: caughtError, info: caughtInfo})
+    },
+    [source, onCatch],
+  )
+
+  return <UIErrorBoundary {...rest} onCatch={handleCatch} />
+}

--- a/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
+++ b/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
@@ -14,28 +14,6 @@ describe('ErrorBoundary', () => {
     jest.clearAllMocks()
   })
 
-  const Wrapper = ({children}: {children: React.ReactNode}) => {
-    const locales = [usEnglishLocale]
-    const {i18next} = prepareI18n({
-      projectId: 'test',
-      dataset: 'test',
-      name: 'test',
-    })
-
-    return (
-      <ThemeProvider theme={studioTheme}>
-        <LocaleProviderBase
-          projectId={'test'}
-          sourceId={'test'}
-          locales={locales}
-          i18next={i18next}
-        >
-          {children}
-        </LocaleProviderBase>
-      </ThemeProvider>
-    )
-  }
-
   it('calls onStudioError when an error is caught', async () => {
     const onStudioError = jest.fn()
     const onCatch = jest.fn()

--- a/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
+++ b/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
@@ -1,0 +1,82 @@
+import {beforeAll, describe, expect, it, jest} from '@jest/globals'
+import {studioTheme, ThemeProvider} from '@sanity/ui'
+import {render} from '@testing-library/react'
+
+import {LocaleProviderBase, usEnglishLocale} from '../../../core/i18n'
+import {prepareI18n} from '../../../core/i18n/i18nConfig'
+import {useSource} from '../../../core/studio/source'
+import {ErrorBoundary} from '../ErrorBoundary'
+
+// Mock dependencies
+jest.mock('../../../core/studio/source', () => ({
+  useSource: jest.fn(),
+}))
+
+const useSourceMock = useSource as jest.Mock
+
+describe('ErrorBoundary', () => {
+  beforeAll(() => {
+    jest.clearAllMocks()
+  })
+
+  const Wrapper = ({children}: {children: React.ReactNode}) => {
+    const locales = [usEnglishLocale]
+    const {i18next} = prepareI18n({
+      projectId: 'test',
+      dataset: 'test',
+      name: 'test',
+    })
+
+    return (
+      <ThemeProvider theme={studioTheme}>
+        <LocaleProviderBase
+          projectId={'test'}
+          sourceId={'test'}
+          locales={locales}
+          i18next={i18next}
+        >
+          {children}
+        </LocaleProviderBase>
+      </ThemeProvider>
+    )
+  }
+
+  it('calls onStudioError when an error is caught', () => {
+    const onStudioError = jest.fn()
+    const onCatch = jest.fn()
+
+    useSourceMock.mockReturnValue({onStudioError})
+
+    const ThrowErrorComponent = () => {
+      throw new Error('An EXPECTED, testing error occurred!')
+    }
+
+    render(
+      <Wrapper>
+        <ErrorBoundary onCatch={onCatch}>
+          <ThrowErrorComponent />
+        </ErrorBoundary>
+      </Wrapper>,
+    )
+
+    expect(onStudioError).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCatch prop when an error is caught when no onStudioError exists', () => {
+    const onCatch = jest.fn()
+
+    const ThrowErrorComponent = () => {
+      throw new Error('An EXPECTED, testing error occurred!')
+    }
+
+    render(
+      <Wrapper>
+        <ErrorBoundary onCatch={onCatch}>
+          <ThrowErrorComponent />
+        </ErrorBoundary>
+      </Wrapper>,
+    )
+
+    expect(onCatch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
+++ b/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
@@ -1,7 +1,10 @@
 import {beforeAll, describe, expect, it, jest} from '@jest/globals'
 import {studioTheme, ThemeProvider} from '@sanity/ui'
 import {render} from '@testing-library/react'
+import {type SanityClient} from 'sanity'
 
+import {createMockSanityClient} from '../../../../test/mocks/mockSanityClient'
+import {createTestProvider} from '../../../../test/testUtils/TestProvider'
 import {LocaleProviderBase, usEnglishLocale} from '../../../core/i18n'
 import {prepareI18n} from '../../../core/i18n/i18nConfig'
 import {ErrorBoundary} from '../ErrorBoundary'
@@ -33,7 +36,7 @@ describe('ErrorBoundary', () => {
     )
   }
 
-  it('calls onStudioError when an error is caught', () => {
+  it('calls onStudioError when an error is caught', async () => {
     const onStudioError = jest.fn()
     const onCatch = jest.fn()
 
@@ -41,12 +44,24 @@ describe('ErrorBoundary', () => {
       throw new Error('An EXPECTED, testing error occurred!')
     }
 
+    const client = createMockSanityClient() as unknown as SanityClient
+
+    const TestProvider = await createTestProvider({
+      client,
+      config: {
+        name: 'default',
+        projectId: 'test',
+        dataset: 'test',
+        onStudioError,
+      },
+    })
+
     render(
-      <Wrapper>
+      <TestProvider>
         <ErrorBoundary onCatch={onCatch}>
           <ThrowErrorComponent />
         </ErrorBoundary>
-      </Wrapper>,
+      </TestProvider>,
     )
 
     expect(onStudioError).toHaveBeenCalledTimes(1)

--- a/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
+++ b/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
@@ -4,15 +4,7 @@ import {render} from '@testing-library/react'
 
 import {LocaleProviderBase, usEnglishLocale} from '../../../core/i18n'
 import {prepareI18n} from '../../../core/i18n/i18nConfig'
-import {useSource} from '../../../core/studio/source'
 import {ErrorBoundary} from '../ErrorBoundary'
-
-// Mock dependencies
-jest.mock('../../../core/studio/source', () => ({
-  useSource: jest.fn(),
-}))
-
-const useSourceMock = useSource as jest.Mock
 
 describe('ErrorBoundary', () => {
   beforeAll(() => {
@@ -45,8 +37,6 @@ describe('ErrorBoundary', () => {
     const onStudioError = jest.fn()
     const onCatch = jest.fn()
 
-    useSourceMock.mockReturnValue({onStudioError})
-
     const ThrowErrorComponent = () => {
       throw new Error('An EXPECTED, testing error occurred!')
     }
@@ -65,16 +55,38 @@ describe('ErrorBoundary', () => {
   it('calls onCatch prop when an error is caught when no onStudioError exists', () => {
     const onCatch = jest.fn()
 
+    const WrapperWithoutError = ({children}: {children: React.ReactNode}) => {
+      const locales = [usEnglishLocale]
+      const {i18next} = prepareI18n({
+        projectId: 'test',
+        dataset: 'test',
+        name: 'test',
+      })
+
+      return (
+        <ThemeProvider theme={studioTheme}>
+          <LocaleProviderBase
+            projectId={'test'}
+            sourceId={'test'}
+            locales={locales}
+            i18next={i18next}
+          >
+            {children}
+          </LocaleProviderBase>
+        </ThemeProvider>
+      )
+    }
+
     const ThrowErrorComponent = () => {
       throw new Error('An EXPECTED, testing error occurred!')
     }
 
     render(
-      <Wrapper>
+      <WrapperWithoutError>
         <ErrorBoundary onCatch={onCatch}>
           <ThrowErrorComponent />
         </ErrorBoundary>
-      </Wrapper>,
+      </WrapperWithoutError>,
     )
 
     expect(onCatch).toHaveBeenCalledTimes(1)

--- a/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
+++ b/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
@@ -14,8 +14,8 @@ describe('ErrorBoundary', () => {
     jest.clearAllMocks()
   })
 
-  it('calls onStudioError when an error is caught', async () => {
-    const onStudioError = jest.fn()
+  it('calls onUncaughtError when an error is caught', async () => {
+    const onUncaughtError = jest.fn()
     const onCatch = jest.fn()
 
     const ThrowErrorComponent = () => {
@@ -30,7 +30,7 @@ describe('ErrorBoundary', () => {
         name: 'default',
         projectId: 'test',
         dataset: 'test',
-        onStudioError,
+        onUncaughtError,
       },
     })
 
@@ -42,10 +42,10 @@ describe('ErrorBoundary', () => {
       </TestProvider>,
     )
 
-    expect(onStudioError).toHaveBeenCalledTimes(1)
+    expect(onUncaughtError).toHaveBeenCalledTimes(1)
   })
 
-  it('calls onCatch prop when an error is caught when no onStudioError exists', () => {
+  it('calls onCatch prop when an error is caught when no onUncaughtError exists', () => {
     const onCatch = jest.fn()
 
     const WrapperWithoutError = ({children}: {children: React.ReactNode}) => {

--- a/packages/sanity/src/ui-components/errorBoundary/index.ts
+++ b/packages/sanity/src/ui-components/errorBoundary/index.ts
@@ -1,0 +1,1 @@
+export * from './ErrorBoundary'

--- a/packages/sanity/src/ui-components/index.ts
+++ b/packages/sanity/src/ui-components/index.ts
@@ -1,6 +1,7 @@
 export * from './button'
 export * from './conditionalWrapper'
 export * from './dialog'
+export * from './errorBoundary'
 export * from './menuButton'
 export * from './menuGroup'
 export * from './menuItem'


### PR DESCRIPTION
### Description

Adds ability to callback when an error happens and allows developers to add custom error telemetry (for example)

I will drop the throw errors before merging, those are for testing purposes

### What to review

- Does the code make sense? 
- Does the naming of the callback make sense?
- I tried in other places, however, while discussing it with others in the team after not finding a place that would have context for the `useSource`, the current place where it exists seems to be the better option. If you all have any other suggestions I'd love to hear it!

### Testing

Automated tests are in place.
You can also manually trigger it by adding `throw new error("oh no new error)` within the `imageInput` or the `studioComponents` and then going to the `custom-components/structure` workspace and seeing the console logs work

### Notes for release

Adds ability to callback when an error happens and allows developers to use errors thrown by the studio
