### PR TITLE
fix(structure): memoize search query results

### DIFF
--- a/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx
@@ -20,8 +20,10 @@ import {structureLocaleNamespace} from '../../i18n'
 import {FULL_LIST_LIMIT} from './constants'
 import {type DocumentListPaneItem, type LoadingVariant} from './types'
 
-const RootBox = styled(Box)`
+const RootBox = styled(Box)<{$opacity?: number}>`
   position: relative;
+  opacity: ${(props) => props.$opacity || 1};
+  transition: opacity 0.4s;
 `
 
 const CommandListBox = styled(Box)`
@@ -44,7 +46,7 @@ interface DocumentListPaneContentProps {
   items: DocumentListPaneItem[]
   layout?: GeneralPreviewLayoutKey
   loadingVariant?: LoadingVariant
-  onListChange: () => void
+  onEndReached: () => void
   onRetry?: () => void
   paneTitle: string
   searchInputElement: HTMLInputElement | null
@@ -78,7 +80,7 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
     items,
     layout,
     loadingVariant,
-    onListChange,
+    onEndReached,
     onRetry,
     paneTitle,
     searchInputElement,
@@ -89,14 +91,14 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
 
   const {collapsed: layoutCollapsed} = usePaneLayout()
   const {collapsed, index} = usePane()
-  const [shouldRender, setShouldRender] = useState(false)
+  const [shouldRender, setShouldRender] = useState(!collapsed)
   const {t} = useTranslation(structureLocaleNamespace)
 
   const handleEndReached = useCallback(() => {
-    if (isLoading || isLazyLoading || !shouldRender) return
-
-    onListChange()
-  }, [isLazyLoading, isLoading, onListChange, shouldRender])
+    if (shouldRender) {
+      onEndReached()
+    }
+  }, [onEndReached, shouldRender])
 
   useEffect(() => {
     if (collapsed) return undefined
@@ -224,7 +226,7 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
     const key = `${index}-${collapsed}`
 
     return (
-      <RootBox overflow="hidden" height="fill">
+      <RootBox overflow="hidden" height="fill" $opacity={loadingVariant === 'subtle' ? 0.8 : 1}>
         <CommandListBox>
           <CommandList
             activeItemDataAttr="data-hovered"

--- a/packages/sanity/src/structure/panes/documentList/constants.ts
+++ b/packages/sanity/src/structure/panes/documentList/constants.ts
@@ -4,3 +4,5 @@ export const PARTIAL_PAGE_LIMIT = 100
 export const FULL_LIST_LIMIT = 2000
 export const DEFAULT_ORDERING: SortOrder = {by: [{field: '_updatedAt', direction: 'desc'}]}
 export const EMPTY_RECORD: Record<string, unknown> = {}
+
+export const ENABLE_LRU_MEMO = true

--- a/packages/sanity/src/structure/panes/documentList/types.ts
+++ b/packages/sanity/src/structure/panes/documentList/types.ts
@@ -11,10 +11,4 @@ export type SortOrder = {
   extendedProjection?: string
 }
 
-export interface QueryResult {
-  error: {message: string} | null
-  onRetry?: () => void
-  result: {documents: SanityDocumentLike[]} | null
-}
-
-export type LoadingVariant = 'spinner' | 'initial'
+export type LoadingVariant = 'spinner' | 'initial' | 'subtle'

--- a/packages/sanity/src/structure/panes/documentList/useDocumentList.ts
+++ b/packages/sanity/src/structure/panes/documentList/useDocumentList.ts
@@ -1,6 +1,19 @@
-import {useCallback, useEffect, useMemo, useState} from 'react'
-import {concat, fromEvent, merge, of, Subject, throwError} from 'rxjs'
-import {catchError, map, mergeMap, scan, startWith, take} from 'rxjs/operators'
+import {observableCallback} from 'observable-callback'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {concat, fromEvent, merge, of} from 'rxjs'
+import {
+  catchError,
+  filter,
+  map,
+  mergeMap,
+  scan,
+  share,
+  shareReplay,
+  take,
+  takeUntil,
+  withLatestFrom,
+} from 'rxjs/operators'
 import {
   DEFAULT_STUDIO_CLIENT_OPTIONS,
   useClient,
@@ -12,15 +25,7 @@ import {
 import {DEFAULT_ORDERING, FULL_LIST_LIMIT, PARTIAL_PAGE_LIMIT} from './constants'
 import {findStaticTypesInFilter, removePublishedWithDrafts} from './helpers'
 import {listenSearchQuery} from './listenSearchQuery'
-import {type DocumentListPaneItem, type QueryResult, type SortOrder} from './types'
-
-const EMPTY_ARRAY: [] = []
-
-const INITIAL_STATE: QueryResult = {
-  error: null,
-  onRetry: undefined,
-  result: null,
-}
+import {type DocumentListPaneItem, type SortOrder} from './types'
 
 interface UseDocumentListOpts {
   apiVersion?: string
@@ -32,25 +37,30 @@ interface UseDocumentListOpts {
 
 interface DocumentListState {
   error: {message: string} | null
-  hasMaxItems?: boolean
-  isLazyLoading: boolean
+  isLoadingFullList: boolean
   isLoading: boolean
-  isSearchReady: boolean
+  fromCache?: boolean
   items: DocumentListPaneItem[]
-  onListChange: () => void
-  onRetry?: () => void
 }
 
-const INITIAL_QUERY_RESULTS: QueryResult = {
-  result: null,
+const INITIAL_QUERY_STATE: DocumentListState = {
   error: null,
+  isLoading: true,
+  isLoadingFullList: false,
+  fromCache: false,
+  items: [],
+}
+
+interface UseDocumentListHookValue extends DocumentListState {
+  onRetry: () => void
+  onLoadFullList: () => void
 }
 
 /**
  * @internal
  */
-export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
-  const {filter, params: paramsProp, sortOrder, searchQuery, apiVersion} = opts
+export function useDocumentList(opts: UseDocumentListOpts): UseDocumentListHookValue {
+  const {filter: searchFilter, params: paramsProp, sortOrder, searchQuery, apiVersion} = opts
   const client = useClient({
     ...DEFAULT_STUDIO_CLIENT_OPTIONS,
     apiVersion: apiVersion || DEFAULT_STUDIO_CLIENT_OPTIONS.apiVersion,
@@ -59,172 +69,139 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
   const schema = useSchema()
   const maxFieldDepth = useSearchMaxFieldDepth()
 
-  const [resultState, setResult] = useState<QueryResult>(INITIAL_STATE)
-  const {onRetry, error, result} = resultState
-
-  const documents = result?.documents
-
-  // Filter out published documents that have drafts to avoid duplicates in the list.
-  const items = useMemo(
-    () => (documents ? removePublishedWithDrafts(documents) : EMPTY_ARRAY),
-    [documents],
-  )
-
-  // A state variable to keep track of whether we are currently lazy loading the list.
-  // This is used to determine whether we should show the loading spinner at the bottom of the list.
-  const [isLazyLoading, setIsLazyLoading] = useState<boolean>(false)
-
-  // A state to keep track of whether we have fetched the full list of documents.
-  const [hasFullList, setHasFullList] = useState<boolean>(false)
-
-  // A state to keep track of whether we should fetch the full list of documents.
-  const [shouldFetchFullList, setShouldFetchFullList] = useState<boolean>(false)
-
   // Get the type name from the filter, if it is a simple type filter.
   const typeNameFromFilter = useMemo(
-    () => findStaticTypesInFilter(filter, paramsProp),
-    [filter, paramsProp],
+    () => findStaticTypesInFilter(searchFilter, paramsProp),
+    [searchFilter, paramsProp],
   )
 
-  // We can't have the loading state as part of the result state, since the loading
-  // state would be updated whenever a mutation is performed in a document in the list.
-  // Instead, we determine if the list is loading by checking if the result is null.
-  // The result is null when:
-  // 1. We are making the initial request
-  // 2. The user has performed a search or changed the sort order
-  const isLoading = result === null && !error
-
-  // A flag to indicate whether we have reached the maximum number of documents.
-  const hasMaxItems = documents?.length === FULL_LIST_LIMIT
-
-  // This function is triggered when the user has scrolled to the bottom of the list
-  // and we need to fetch more items.
-  const onListChange = useCallback(() => {
-    if (isLoading || hasFullList || shouldFetchFullList) return
-
-    setShouldFetchFullList(true)
-  }, [isLoading, hasFullList, shouldFetchFullList])
-
-  const handleSetResult = useCallback(
-    (res: QueryResult) => {
-      if (res.error) {
-        setResult(res)
-        return
-      }
-
-      const documentsLength = res.result?.documents?.length || 0
-      const isLoadingMoreItems = !res.error && res?.result === null && shouldFetchFullList
-
-      // 1. When the result is null and shouldFetchFullList is true, we are loading _more_ items.
-      // In this case, we want to wait for the next result and set the isLazyLoading state to true.
-      if (isLoadingMoreItems) {
-        setIsLazyLoading(true)
-        return
-      }
-
-      // 2. If the result is not null, and less than the partial page limit, we know that
-      // we have fetched the full list of documents. In this case, we want to set the
-      // hasFullList state to true to prevent further requests.
-      if (documentsLength < PARTIAL_PAGE_LIMIT && documentsLength !== 0 && !shouldFetchFullList) {
-        setHasFullList(true)
-      }
-
-      // 3. If the result is null, we are loading items. In this case, we want to
-      // wait for the next result.
-      if (res?.result === null) {
-        setResult((prev) => ({...(prev.error ? res : prev)}))
-        return
-      }
-
-      // 4. Finally, set the result
-      setIsLazyLoading(false)
-      setResult(res)
-    },
-    [shouldFetchFullList],
-  )
+  const [onRetry$, onRetry] = useMemo(() => observableCallback(), [])
+  const [onFetchFullList$, onLoadFullList] = useMemo(() => observableCallback(), [])
 
   const queryResults$ = useMemo(() => {
-    const onRetry$ = new Subject<void>()
-    const _onRetry = () => onRetry$.next()
-
-    const limit = shouldFetchFullList ? FULL_LIST_LIMIT : PARTIAL_PAGE_LIMIT
-    const sort = sortOrder || DEFAULT_ORDERING
-
-    return listenSearchQuery({
+    const listenSearchQueryArgs = {
       client,
-      filter,
-      limit,
+      filter: searchFilter,
+      limit: PARTIAL_PAGE_LIMIT,
       params: paramsProp,
       schema,
       searchQuery: searchQuery || '',
-      sort,
+      sort: sortOrder || DEFAULT_ORDERING,
       staticTypeNames: typeNameFromFilter,
       maxFieldDepth,
       enableLegacySearch,
-    }).pipe(
-      map((results) => ({
-        result: {documents: results},
-        error: null,
-      })),
-      startWith(INITIAL_QUERY_RESULTS),
-      catchError((err) => {
-        if (err instanceof ProgressEvent) {
-          // todo: hack to work around issue with get-it (used by sanity/client) that propagates connection errors as ProgressEvent instances. This if-block can be removed once @sanity/client is par with a version of get-it that includes this fix: https://github.com/sanity-io/get-it/pull/127
-          return throwError(() => new Error(`Request error`))
-        }
-        return throwError(() => err)
-      }),
-      catchError((err, caught$) => {
+    }
+
+    const partialList$ = listenSearchQuery(listenSearchQueryArgs).pipe(
+      shareReplay({refCount: true, bufferSize: 1}),
+    )
+
+    // we want to fetch the full list if the last result of the partial list is at the limit
+    const fullList$ = onFetchFullList$.pipe(
+      withLatestFrom(partialList$),
+      filter(([, result]) => result?.documents.length === PARTIAL_PAGE_LIMIT),
+      // we want to set up the full list listener only once
+      take(1),
+      mergeMap(() =>
+        concat(
+          of({type: 'loadFullList' as const}),
+          listenSearchQuery({...listenSearchQueryArgs, limit: FULL_LIST_LIMIT}).pipe(
+            map((result) => ({type: 'result' as const, result})),
+          ),
+        ),
+      ),
+      share(),
+    )
+
+    // The combined search results from both partial page and full list
+    return merge(
+      partialList$.pipe(
+        map((result) => ({
+          type: 'result' as const,
+          result,
+        })),
+        // when the full list listener kicks off, we want to stop the partial list listener
+        takeUntil(fullList$),
+      ),
+      fullList$,
+    ).pipe(
+      catchError((err: unknown, caught$) => {
         return concat(
-          of({result: null, error: err}),
+          of({type: 'error' as const, error: safeError(err)}),
           merge(fromEvent(window, 'online'), onRetry$).pipe(
             take(1),
             mergeMap(() => caught$),
           ),
         )
       }),
-      scan((prev, next) => ({...prev, ...next, onRetry: _onRetry})),
+      scan((prev, event) => {
+        if (event.type === 'error') {
+          return {
+            ...prev,
+            error: event.error,
+          }
+        }
+        if (event.type === 'result') {
+          return {
+            ...prev,
+            error: null,
+            fromCache: event.result.fromCache,
+            isLoading: false,
+            items: removePublishedWithDrafts(event.result.documents),
+            isLoadingFullList: false,
+          }
+        }
+        if (event.type === 'loadFullList') {
+          return {
+            ...prev,
+            error: null,
+            isLoadingFullList: true,
+          }
+        }
+        throw new Error('Unexpected')
+      }, INITIAL_QUERY_STATE),
     )
   }, [
-    shouldFetchFullList,
-    sortOrder,
     client,
-    filter,
+    searchFilter,
     paramsProp,
     schema,
     searchQuery,
+    sortOrder,
     typeNameFromFilter,
     maxFieldDepth,
     enableLegacySearch,
+    onFetchFullList$,
+    onRetry$,
   ])
 
-  useEffect(() => {
-    const sub = queryResults$.subscribe(handleSetResult)
-
-    return () => {
-      sub.unsubscribe()
-    }
-  }, [handleSetResult, queryResults$])
-
-  const reset = useCallback(() => {
-    setHasFullList(false)
-    setIsLazyLoading(false)
-    setResult(INITIAL_STATE)
-    setShouldFetchFullList(false)
-  }, [])
-
-  useEffect(() => {
-    reset()
-  }, [reset, filter, paramsProp, sortOrder, searchQuery])
+  const {error, items, isLoading, fromCache, isLoadingFullList} = useObservable(
+    queryResults$,
+    INITIAL_QUERY_STATE,
+  )
 
   return {
     error,
-    hasMaxItems,
-    isLazyLoading,
-    isLoading,
-    isSearchReady: !error,
-    items,
-    onListChange,
     onRetry,
+    isLoading,
+    items,
+    fromCache,
+    onLoadFullList,
+    isLoadingFullList,
   }
+}
+
+// todo: candidate for re-use
+const nonErrorThrownWarning = `[WARNING: This was thrown as a non-error. Only Error instances should be thrown]`
+function safeError(thrown: unknown): Error {
+  if (thrown instanceof Error) {
+    return thrown
+  }
+  if (typeof thrown === 'object' && thrown !== null) {
+    if ('message' in thrown && typeof thrown.message === 'string') {
+      return new Error(`${thrown.message} ${nonErrorThrownWarning}`)
+    }
+    return new Error(`${String(thrown)} ${nonErrorThrownWarning}`)
+  }
+  return new Error(`${String(thrown)} ${nonErrorThrownWarning}`)
 }


### PR DESCRIPTION
### Description
This adds Stale-While-Revalidate behavior to document lists in the Studio. This means that when coming back to a previous list, we'll immediately show the last known contents, and then fetch the new version in the background. In many cases this means that going back and forth between document lists feels instant.

### What to review

The actual SWR logic is implemented with an LRU cache in [packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts](https://github.com/sanity-io/sanity/compare/simplify-key-value-store...fix-memoize-list-results?expand=1#diff-351b61b4553a9471d3d02094781702e9da5aeb21780233022f8543efc2590813) and it uses a memo key based on various input parameters for the search query request.

I took the liberty of refactoring some of the logic and renaming a few variables etc based on my (ever evolving) understanding of the existing code. Please let me know if I missed the mark on something.

### Testing
I couldn't think of a good way to robustly test the SWR behavior introduced here. Let me know if you have any suggestions!

I've manually verified the following:
- Document lists updates in real-time
- Searching in lists works as before
- If navigating back to a list triggers a background refresh, so if a document has been added or removed it's reflected after a short while.
- Sorting lists works as before
- Scrolling to the end of a list fetches the "full" list (show a loading spinner at the bottom and retains scroll position)
- Loading variants works as they used to (I also added a new "subtle" one that appears if revalidating takes longer than a few hundred milliseconds)
- Error handling and retrying works as before

@hermanwikner and @robinpyon tagging you as reviewers here as well since you did the original work on doument list search including `listenSearchQuery` and `useDocumentList`.

### Notes for release
- Navigating between previously visited document lists in the studio is now instant
