### PR TITLE
fix: move cliInitializedAt call higher in init flow

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -594,26 +594,31 @@ export default async function initSanity(
 
   trace.log({step: 'importTemplateDataset', selectedOption: shouldImport ? 'yes' : 'no'})
 
-  // record that template files attempted to be created locally
-  await apiClient({api: {projectId: projectId}})
-    .request<SanityProject>({uri: `/projects/${projectId}`})
-    .then((project: SanityProject) => {
-      if (!project?.metadata?.cliInitializedAt) {
-        return apiClient({api: {projectId}}).request({
-          method: 'PATCH',
-          uri: `/projects/${projectId}`,
-          body: {metadata: {cliInitializedAt: new Date().toISOString()}},
-        })
-      }
-      return Promise.resolve()
-    })
-    .catch(() => {
-      // Non-critical update
-      debug('Failed to update cliInitializedAt metadata')
-    })
+  const [_, bootstrapPromise] = await Promise.allSettled([
+    // record template files attempted to be created locally
+    apiClient({api: {projectId: projectId}})
+      .request<SanityProject>({uri: `/projects/${projectId}`})
+      .then((project: SanityProject) => {
+        if (!project?.metadata?.cliInitializedAt) {
+          return apiClient({api: {projectId}}).request({
+            method: 'PATCH',
+            uri: `/projects/${projectId}`,
+            body: {metadata: {cliInitializedAt: new Date().toISOString()}},
+          })
+        }
+        return Promise.resolve()
+      })
+      .catch(() => {
+        // Non-critical update
+        debug('Failed to update cliInitializedAt metadata')
+      }),
+    // Bootstrap Sanity, creating required project files, manifests etc
+    bootstrapTemplate(templateOptions, context),
+  ])
 
-  // Bootstrap Sanity, creating required project files, manifests etc
-  await bootstrapTemplate(templateOptions, context)
+  if (bootstrapPromise.status === 'rejected' && bootstrapPromise.reason instanceof Error) {
+    throw bootstrapPromise.reason
+  }
 
   let pkgManager: PackageManager
 

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -594,11 +594,8 @@ export default async function initSanity(
 
   trace.log({step: 'importTemplateDataset', selectedOption: shouldImport ? 'yes' : 'no'})
 
-  // Bootstrap Sanity, creating required project files, manifests etc
-  await bootstrapTemplate(templateOptions, context)
-
-  // update that files were initialized locally; do not halt flow for request
-  apiClient({api: {projectId: projectId}})
+  // record that template files attempted to be created locally
+  await apiClient({api: {projectId: projectId}})
     .request<SanityProject>({uri: `/projects/${projectId}`})
     .then((project: SanityProject) => {
       if (!project?.metadata?.cliInitializedAt) {
@@ -614,6 +611,9 @@ export default async function initSanity(
       // Non-critical update
       debug('Failed to update cliInitializedAt metadata')
     })
+
+  // Bootstrap Sanity, creating required project files, manifests etc
+  await bootstrapTemplate(templateOptions, context)
 
   let pkgManager: PackageManager
 


### PR DESCRIPTION
### Description

The call to patch the `cliInitializedAt` needs to be moved above the bootstrapping of the template as it is is necessary for indicating failure cases from that function.

### Testing
Should not break anything in project init flow. (all errors from the call will continue to be caught and debug logged only)

### Notes for release
not required
