### PR TITLE
fix(core): emit local settings value immediately upon subscription

### DIFF
--- a/packages/sanity/src/core/store/key-value/localStorageSWR.ts
+++ b/packages/sanity/src/core/store/key-value/localStorageSWR.ts
@@ -1,27 +1,16 @@
 import {isEqual} from 'lodash'
-import {fromEvent, merge, NEVER} from 'rxjs'
-import {distinctUntilChanged, filter, map, tap} from 'rxjs/operators'
+import {merge, of} from 'rxjs'
+import {distinctUntilChanged, tap} from 'rxjs/operators'
 
 import {localStoreStorage} from './storage/localStoreStorage'
 import {type KeyValueStore, type KeyValueStoreValue} from './types'
-
-// Whether or not to enable instant user sync between tabs
-// if set to true, the setting will update instantly across all tabs
-const ENABLE_CROSS_TAB_SYNC = false
 
 /**
  * Wraps a KeyValueStore and adds Stale-While-Revalidate (SWR) behavior to it
  */
 export function withLocalStorageSWR(wrappedStore: KeyValueStore): KeyValueStore {
-  const storageEvent = ENABLE_CROSS_TAB_SYNC ? fromEvent<StorageEvent>(window, 'storage') : NEVER
-
   function getKey(key: string) {
-    const lsUpdates = storageEvent.pipe(
-      filter((event) => event.key === key),
-      map(() => localStoreStorage.getKey(key)),
-    )
-
-    return merge(lsUpdates, wrappedStore.getKey(key)).pipe(
+    return merge(of(localStoreStorage.getKey(key)), wrappedStore.getKey(key)).pipe(
       distinctUntilChanged(isEqual),
       tap((value) => {
         localStoreStorage.setKey(key, value)


### PR DESCRIPTION
### Description
Fixes an oversight in #7554. This reads and emits the current local settings value upon subscription (syncronously), which was the intention with #7554, but I forgot to actually read it initially 🙈 

### What to review

I also removed the (currently disabled) sync between tabs. We can revisit this in the future, but if we want this it should probably be on a "per-setting" basis.

### Notes for release

n/a internal
