### PR TITLE
fix(core): fix reference preview flickering and improve loading

### DIFF
--- a/dev/test-studio/schema/debug/simpleReferences.js
+++ b/dev/test-studio/schema/debug/simpleReferences.js
@@ -9,42 +9,16 @@ export const simpleReferences = {
       type: 'string',
     },
     {
+      name: 'image',
+      title: 'Title',
+      type: 'image',
+    },
+    {
       name: 'referenceField',
       title: 'Reference field',
       description: 'A simple reference field',
       type: 'reference',
-      to: [{type: 'author'}],
-    },
-    {
-      name: 'arrayWithObjects',
-      options: {collapsible: true, collapsed: true},
-      title: 'Array with named objects',
-      description: 'This array contains objects of type as defined inline',
-      type: 'array',
-      of: [
-        {
-          type: 'object',
-          name: 'something',
-          title: 'Something',
-          // options: {modal: 'inline'},
-          fields: [
-            {name: 'first', type: 'string', title: 'First string'},
-            {name: 'second', type: 'string', title: 'Second string'},
-          ],
-        },
-        {
-          type: 'object',
-          name: 'otherThing',
-          title: 'OtherThing',
-          options: {modal: 'inline'},
-          fields: [{name: 'value', type: 'string', title: 'First string'}],
-        },
-        {
-          type: 'reference',
-          title: 'A reference to an author or a book',
-          to: [{type: 'author'}, {type: 'book'}],
-        },
-      ],
+      to: [{type: 'simpleReferences'}],
     },
   ],
 }

--- a/packages/sanity/src/core/components/previews/general/DefaultPreview.tsx
+++ b/packages/sanity/src/core/components/previews/general/DefaultPreview.tsx
@@ -48,7 +48,7 @@ const SubtitleSkeleton = styled(TextSkeleton).attrs({animated: true, radius: 1, 
   max-width: ${rem(120)};
   width: 60%;
 `
-
+const SKELETON_DELAY = 300
 /**
  * @hidden
  * @beta */
@@ -75,13 +75,18 @@ export function DefaultPreview(props: DefaultPreviewProps) {
         <Flex align="center" flex={1} gap={2}>
           {media && (
             <Box flex="none">
-              <Skeleton animated radius={1} style={PREVIEW_SIZES.default.media} />
+              <Skeleton
+                animated
+                delay={SKELETON_DELAY}
+                radius={1}
+                style={PREVIEW_SIZES.default.media}
+              />
             </Box>
           )}
 
           <Stack data-testid="default-preview__heading" flex={1} space={2}>
-            <TitleSkeleton />
-            <SubtitleSkeleton />
+            <TitleSkeleton delay={SKELETON_DELAY} />
+            <SubtitleSkeleton delay={SKELETON_DELAY} />
           </Stack>
 
           <Box flex="none" padding={1}>

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/AutocompleteContainer.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/AutocompleteContainer.tsx
@@ -35,7 +35,7 @@ export const AutocompleteContainer = forwardRef(function AutocompleteContainer(
   const inputWrapperRect = useElementRect(rootElement)
 
   return (
-    <Root ref={handleNewRef} gap={1} $narrow={(inputWrapperRect?.width || 0) < 480}>
+    <Root ref={handleNewRef} gap={1} $narrow={(inputWrapperRect?.width || 480) < 480}>
       {props.children}
     </Root>
   )

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
@@ -30,7 +30,8 @@ import {ReferenceFinalizeAlertStrip} from './ReferenceFinalizeAlertStrip'
 import {ReferenceLinkCard} from './ReferenceLinkCard'
 import {ReferenceMetadataLoadErrorAlertStrip} from './ReferenceMetadataLoadFailure'
 import {ReferenceStrengthMismatchAlertStrip} from './ReferenceStrengthMismatchAlertStrip'
-import {useReferenceInfo} from './useReferenceInfo'
+import {type ReferenceInfo} from './types'
+import {type Loadable, useReferenceInfo} from './useReferenceInfo'
 import {useReferenceInput} from './useReferenceInput'
 
 interface ReferenceFieldProps extends Omit<ObjectFieldProps, 'renderDefault'> {
@@ -88,7 +89,10 @@ export function ReferenceField(props: ReferenceFieldProps) {
   const hasErrors = props.validation.some((v) => v.level === 'error')
   const hasWarnings = props.validation.some((v) => v.level === 'warning')
 
-  const loadableReferenceInfo = useReferenceInfo(value?._ref, getReferenceInfo)
+  const loadableReferenceInfo: Loadable<ReferenceInfo> = useReferenceInfo(
+    value?._ref,
+    getReferenceInfo,
+  )
 
   const refTypeName = loadableReferenceInfo.result?.type || value?._strengthenOnPublish?.type
 

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/types.ts
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/types.ts
@@ -11,13 +11,19 @@ import {type Observable} from 'rxjs'
 import {type DocumentAvailability} from '../../../preview'
 import {type ObjectInputProps} from '../../types'
 
+export type PreviewDocumentValue = PreviewValue & {
+  _id: string
+  _createdAt?: string
+  _updatedAt?: string
+}
+
 export interface ReferenceInfo {
   id: string
   type: string | undefined
   availability: DocumentAvailability
   preview: {
-    draft: (PreviewValue & {_id: string; _createdAt?: string; _updatedAt?: string}) | undefined
-    published: (PreviewValue & {_id: string; _createdAt?: string; _updatedAt?: string}) | undefined
+    draft: PreviewDocumentValue | undefined
+    published: PreviewDocumentValue | undefined
   }
 }
 

--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
@@ -2,7 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {DEFAULT_MAX_FIELD_DEPTH} from '@sanity/schema/_internal'
 import {type ReferenceFilterSearchOptions, type ReferenceSchemaType} from '@sanity/types'
 import {combineLatest, type Observable, of} from 'rxjs'
-import {map, mergeMap, startWith, switchMap} from 'rxjs/operators'
+import {map, mergeMap, switchMap} from 'rxjs/operators'
 
 import {type DocumentPreviewStore, getPreviewPaths, prepareForPreview} from '../../../../preview'
 import {createSearch} from '../../../../search'
@@ -113,7 +113,6 @@ export function getReferenceInfo(
                   }
                 : undefined,
             ),
-            startWith(undefined),
           )
 
           const publishedPreview$ = documentPreviewStore
@@ -127,7 +126,6 @@ export function getReferenceInfo(
                     }
                   : undefined,
               ),
-              startWith(undefined),
             )
 
           const value$ = combineLatest([draftPreview$, publishedPreview$]).pipe(

--- a/packages/sanity/src/core/preview/availability.ts
+++ b/packages/sanity/src/core/preview/availability.ts
@@ -6,7 +6,7 @@ import {combineLatest, defer, from, type Observable, of} from 'rxjs'
 import {distinctUntilChanged, map, mergeMap, reduce, switchMap} from 'rxjs/operators'
 import shallowEquals from 'shallow-equals'
 
-import {getDraftId, getPublishedId, isRecord} from '../util'
+import {createSWR, getDraftId, getPublishedId, isRecord} from '../util'
 import {
   AVAILABILITY_NOT_FOUND,
   AVAILABILITY_PERMISSION_DENIED,
@@ -21,6 +21,11 @@ import {
 import {debounceCollect} from './utils/debounceCollect'
 
 const MAX_DOCUMENT_ID_CHUNK_SIZE = 11164
+
+/**
+ * Create an SWR operator for document availability
+ */
+const swr = createSWR<DocumentAvailability>({maxSize: 1000})
 
 /**
  * Takes an array of document IDs and puts them into individual chunks.
@@ -89,6 +94,8 @@ export function createPreviewAvailabilityObserver(
           : // we can't read the _rev field for two possible reasons: 1) the document isn't readable or 2) the document doesn't exist
             fetchDocumentReadability(id)
       }),
+      swr(id),
+      map((ev) => ev.value),
     )
   }
 

--- a/packages/sanity/src/core/preview/components/PreviewLoader.tsx
+++ b/packages/sanity/src/core/preview/components/PreviewLoader.tsx
@@ -42,10 +42,12 @@ export function PreviewLoader(
   const [element, setElement] = useState<HTMLDivElement | null>(null)
 
   // Subscribe to visibility
-  const isVisible = useVisibility({
-    element: skipVisibilityCheck ? null : element,
-    hideDelay: _HIDE_DELAY,
-  })
+  const isVisible =
+    useVisibility({
+      disabled: skipVisibilityCheck,
+      element: element,
+      hideDelay: _HIDE_DELAY,
+    }) || skipVisibilityCheck
 
   // Subscribe document preview value
   const preview = useValuePreview({

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -17,8 +17,13 @@ interface State {
 const INITIAL_STATE: State = {
   isLoading: true,
 }
-const PENDING_STATE: State = {
+
+const IDLE_STATE: State = {
   isLoading: false,
+  value: {
+    title: undefined,
+    description: undefined,
+  },
 }
 /**
  * @internal
@@ -33,7 +38,8 @@ function useDocumentPreview(props: {
   const {enabled = true, ordering, schemaType, value: previewValue} = props || {}
   const {observeForPreview} = useDocumentPreviewStore()
   const observable = useMemo<Observable<State>>(() => {
-    if (!enabled || !previewValue || !schemaType) return of(PENDING_STATE)
+    // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
+    if (!enabled || !previewValue || !schemaType) return of(IDLE_STATE)
 
     return observeForPreview(previewValue as Previewable, schemaType, {
       viewOptions: {ordering: ordering},

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -183,7 +183,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
                   >
                     <FormView
                       hidden={formViewHidden}
-                      key={documentId + (ready ? '_ready' : '_pending')}
                       margins={margins}
                       ref={formContainerElement}
                     />


### PR DESCRIPTION
### Description

This PR fixes various loading and rendering issues with reference previews. It should significantly reduce the number of re-renderings and layout shifts happening as we load what's needed to preview references in the Studio. These issues are particularily visible behind slower networks.

Here's before/after with network throttling set to 3g
**Before**
https://github.com/user-attachments/assets/1b87897e-0abf-49db-8a2e-edb3669e2353

**After**
https://github.com/user-attachments/assets/a37704a0-4b52-4f94-8f76-3a2101cc0f2e

Included some additional improvments here as well:
- useVisibility now use [`Element.checkVisibility()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility) if available
- Waiting 300ms before showing "loading skeletons". This aligns with how it's done for [document lists](https://github.com/sanity-io/sanity/blob/7fcf22a948a1806c7c7409355df5d0b8617c576e/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx#L213)

### What to review

- Modifications to the ReferenceInput and related components
- Improvements in the useReferenceInfo hook and getReferenceInfo function
- Updates to the PreviewLoader and useValuePreview hook
- Changes to the useVisibility hook and its implementation

### Testing
Should be covered by existing tests

### Notes for release
- Improved loading state of reference previews