### PR TITLE
chore(deps): upgrade moment, drop `@types` module

### DIFF
--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -124,13 +124,12 @@
     "@sanity/client": "^6.21.3",
     "@sanity/types": "3.58.0",
     "get-random-values-esm": "1.0.2",
-    "moment": "^2.29.4",
+    "moment": "^2.30.1",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@repo/package.config": "workspace:*",
     "@repo/test-config": "workspace:*",
-    "@types/moment": "^2.13.0",
     "rimraf": "^3.0.2",
     "vitest": "^2.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1258,7 +1258,7 @@ importers:
         specifier: 1.0.2
         version: 1.0.2
       moment:
-        specifier: ^2.29.4
+        specifier: ^2.30.1
         version: 2.30.1
       rxjs:
         specifier: ^7.8.1
@@ -1270,9 +1270,6 @@ importers:
       '@repo/test-config':
         specifier: workspace:*
         version: link:../../@repo/test-config
-      '@types/moment':
-        specifier: ^2.13.0
-        version: 2.13.0
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -5105,10 +5102,6 @@ packages:
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
-
-  '@types/moment@2.13.0':
-    resolution: {integrity: sha512-DyuyYGpV6r+4Z1bUznLi/Y7HpGn4iQ4IVcGn8zrr1P4KotKLdH0sbK1TFR6RGyX6B+G8u83wCzL+bpawKU/hdQ==}
-    deprecated: This is a stub types definition for Moment (https://github.com/moment/moment). Moment provides its own type definitions, so you don't need @types/moment installed!
 
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
@@ -15952,10 +15945,6 @@ snapshots:
   '@types/minimatch@5.1.2': {}
 
   '@types/minimist@1.2.5': {}
-
-  '@types/moment@2.13.0':
-    dependencies:
-      moment: 2.30.1
 
   '@types/ms@0.7.34': {}
 


### PR DESCRIPTION
### Description

We are implicitly already depending on the new version (through the version range), so this is mostly to get rid of a deprecation notice on the types module.

### What to review

Stuff still works. The only place we still use this is in a deprecated old date format that we can hopefully get rid of in Sanity v4.

### Testing

No new tests needed.

### Notes for release

None.