### PR TITLE
refactor(cli): updates projects list command to link to manage

### DIFF
--- a/packages/@sanity/cli/src/commands/projects/listProjectsCommand.ts
+++ b/packages/@sanity/cli/src/commands/projects/listProjectsCommand.ts
@@ -37,9 +37,9 @@ const listProjectsCommand: CliCommandDefinition = {
 
     const projects = await client.projects.list()
     const ordered = sortBy(
-      projects.map(({displayName, id, members = [], studioHost = '', createdAt}) => {
-        const studio = studioHost ? `https://${studioHost}.sanity.studio` : 'Not deployed'
-        return [id, members.length, displayName, studio, createdAt].map(String)
+      projects.map(({displayName, id, members = [], createdAt}) => {
+        const manage = `https://www.sanity.io/manage/project/${id}`
+        return [id, members.length, displayName, manage, createdAt].map(String)
       }),
       [headings.indexOf(flags.sort)],
     )

--- a/packages/@sanity/cli/test/basics.test.ts
+++ b/packages/@sanity/cli/test/basics.test.ts
@@ -38,7 +38,7 @@ describeCliTest('CLI: basic commands', () => {
 
     testConcurrent('projects list', async () => {
       const result = await runSanityCmdCommand(version, ['projects', 'list'])
-      expect(result.stdout).toContain('.sanity.studio')
+      expect(result.stdout).toContain('https://www.sanity.io/manage/project/')
       expect(result.code).toBe(0)
     })
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Previously `sanity projects list` command listed a URL to the deployed studio but since a project can have multiple studios it does not make sense to show the URL anymore. A decision was made to instead link to manage and in future we can have a command to list deployments for a project.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Changes makes sense

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

1. Run `pnpm build` at the root
2. cd `dev/test-studio` 
3. run `npx sanity projects list` 

Confirm the link to manage works

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

Updates project list command to link to manage instead of single deployed studio 

(Might not be needed, please confirm before adding) 
