### PR TITLE
fix(cli): use studioHost from CLI config for intent link

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/validation/validateAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/validateAction.ts
@@ -1,7 +1,12 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import {type CliCommandArguments, type CliCommandContext, type CliOutputter} from '@sanity/cli'
+import {
+  type CliCommandArguments,
+  type CliCommandContext,
+  type CliConfig,
+  type CliOutputter,
+} from '@sanity/cli'
 import {type ClientConfig} from '@sanity/client'
 import chalk from 'chalk'
 import logSymbols from 'log-symbols'
@@ -31,7 +36,7 @@ export type BuiltInValidationReporter = (options: {
 
 export default async function validateAction(
   args: CliCommandArguments<ValidateFlags>,
-  {apiClient, workDir, output, prompt}: CliCommandContext,
+  {apiClient, workDir, output, cliConfig, prompt}: CliCommandContext,
 ): Promise<void> {
   const flags = args.extOptions
   const unattendedMode = Boolean(flags.yes || flags.y)
@@ -160,6 +165,7 @@ export default async function validateAction(
 
       return reporter({output, worker, flags})
     },
+    studioHost: (cliConfig as CliConfig)?.studioHost,
   })
 
   process.exitCode = overallLevel === 'error' ? 1 : 0

--- a/packages/sanity/src/_internal/cli/actions/validation/validateDocuments.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/validateDocuments.ts
@@ -23,6 +23,7 @@ export interface ValidateDocumentsOptions<TReturn = unknown> {
   maxCustomValidationConcurrency?: number
   maxFetchConcurrency?: number
   reporter?: (worker: WorkerChannelReceiver<ValidationWorkerChannel>) => TReturn
+  studioHost?: string
 }
 
 export interface DocumentValidationResult {
@@ -102,6 +103,7 @@ export function validateDocuments(options: ValidateDocumentsOptions): unknown {
       ndjsonFilePath,
       maxCustomValidationConcurrency,
       maxFetchConcurrency,
+      studioHost: options.studioHost,
     } satisfies ValidateDocumentsWorkerData,
     // eslint-disable-next-line no-process-env
     env: process.env,

--- a/packages/sanity/src/_internal/cli/threads/__tests__/validateDocuments.test.ts
+++ b/packages/sanity/src/_internal/cli/threads/__tests__/validateDocuments.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import {Worker} from 'node:worker_threads'
 
 import {afterAll, beforeAll, describe, expect, it, jest} from '@jest/globals'
-import {type SanityDocument, type SanityProject} from '@sanity/client'
+import {type SanityDocument} from '@sanity/client'
 import {evaluate, parse} from 'groq-js'
 
 import {getMonorepoAliases} from '../../server/sanityMonorepo'
@@ -125,14 +125,6 @@ describe('validateDocuments', () => {
       }
 
       switch (resource) {
-        case 'projects': {
-          json({
-            studioHost: 'https://example.sanity.studio',
-            metadata: {externalStudioHost: localhost},
-          } satisfies Partial<SanityProject>)
-          return
-        }
-
         case 'data': {
           const [method] = rest
           switch (method) {
@@ -195,6 +187,7 @@ describe('validateDocuments', () => {
         useCdn: true,
         useProjectHostname: false,
       },
+      studioHost: localhost,
     }
 
     const filepath = require.resolve('../validateDocuments')


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Updates the validate command to use studioHost configured in the CLI config instead of relying on the projects endpoint studioHost for this information.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Changes makes sense

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Tests Updates

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

N/A (does not seem it is important to mention in release notes)
