### PR TITLE
fix(sanity): allow global search "contains" filter to match inside words

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/stringOperators.test.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/stringOperators.test.ts
@@ -23,7 +23,12 @@ describe('stringOperators', () => {
 
   it('should create a valid filter for stringMatches', () => {
     const filter = stringOperators.stringMatches.groqFilter({fieldPath, value})
-    expect(filter).toEqual(`${fieldPath} match "${value}"`)
+    expect(filter).toEqual(`${fieldPath} match "*${value}*"`)
+  })
+
+  it('should create a valid filter for stringNotMatches', () => {
+    const filter = stringOperators.stringNotMatches.groqFilter({fieldPath, value})
+    expect(filter).toEqual(`!(${fieldPath} match "*${value}*")`)
   })
 
   it('should create a valid filter for stringNotEqual', () => {

--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/stringOperators.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/stringOperators.ts
@@ -37,7 +37,7 @@ export const stringOperators = {
     nameKey: 'search.operator.string-contains.name',
     descriptionKey: 'search.operator.string-contains.description',
     groqFilter: ({fieldPath, value}) =>
-      value && fieldPath ? `${fieldPath} match ${toJSON(value)}` : null,
+      value && fieldPath ? `${fieldPath} match "*${value}*"` : null,
     initialValue: null,
     inputComponent: SearchFilterStringInput as SearchOperatorInput<string | number>,
     type: 'stringMatches',
@@ -55,7 +55,7 @@ export const stringOperators = {
     nameKey: 'search.operator.string-not-contains.name',
     descriptionKey: 'search.operator.string-not-contains.description',
     groqFilter: ({fieldPath, value}) =>
-      value && fieldPath ? `!(${fieldPath} match ${toJSON(value)})` : null,
+      value && fieldPath ? `!(${fieldPath} match "*${value}*")` : null,
     initialValue: null,
     inputComponent: SearchFilterStringInput as SearchOperatorInput<string | number>,
     type: 'stringNotMatches',


### PR DESCRIPTION
### Description

This branch adjusts the global search "contains" filter to allow matches inside words. Although this filter is named `stringMatches` internally, it is publicly named "contains", which suggests it should match *inside* words.

The match expression is wrapped in wildcard `*` operators to achieve this. 

#### Example: searching for documents by title containing "blo"

| Before | After |
| --- | --- |
| <img width="837" alt="Screenshot 2024-10-02 at 10 24 17" src="https://github.com/user-attachments/assets/908107a4-df00-4702-8a74-6a4322f43f4c"> | <img width="837" alt="Screenshot 2024-10-02 at 10 25 11" src="https://github.com/user-attachments/assets/df83340f-7249-4576-af36-f0293d0f264a"> |

### What to review

- Does this change make sense?
- Do global searches using the "contains" filter still produce relevant results?

### Testing

- Updated unit tests in `packages/sanity/src/core/studio/components/navbar/search/definitions/operators/stringOperators.test.ts`.

### Notes for release

- The global search "contains" filter now matches inside words.
