### PR TITLE
fix(core): add missing `listenerName` property on welcome event

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/types.ts
+++ b/packages/sanity/src/core/store/_legacy/document/types.ts
@@ -3,6 +3,7 @@ import {type MutationPayload} from './buffered-doc/types'
 /** @internal */
 export interface WelcomeEvent {
   type: 'welcome'
+  listenerName: string
 }
 
 /** @internal */


### PR DESCRIPTION
### Description

The `listenerName` property is handy to debug certain listener related issues, but was not part of the typings.

### What to review

That there's no… typo, I guess?

### Testing

Shouldn't need any changes.

### Notes for release

None.