### PR TITLE
chore(deps): upgrade `@sanity/asset-utils` to v2

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -156,7 +156,7 @@
     "@portabletext/editor": "^1.1.2",
     "@portabletext/react": "^3.0.0",
     "@rexxars/react-json-inspector": "^8.0.1",
-    "@sanity/asset-utils": "^1.2.5",
+    "@sanity/asset-utils": "^2.0.6",
     "@sanity/bifur-client": "^0.4.1",
     "@sanity/block-tools": "3.59.0",
     "@sanity/cli": "3.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1428,8 +1428,8 @@ importers:
         specifier: ^8.0.1
         version: 8.0.1(react@18.3.1)
       '@sanity/asset-utils':
-        specifier: ^1.2.5
-        version: 1.3.0
+        specifier: ^2.0.6
+        version: 2.0.6
       '@sanity/bifur-client':
         specifier: ^0.4.1
         version: 0.4.1
@@ -4472,6 +4472,10 @@ packages:
   '@sanity/asset-utils@1.3.0':
     resolution: {integrity: sha512-uyIOtGA4Duf+68I3BSbYHY5P+WGftn3QtNJD2Pn7h9WPGYsSrWViIPebE9yRN8N0NHhYj+hDQXaMpVdjG7r+zA==}
     engines: {node: '>=10'}
+
+  '@sanity/asset-utils@2.0.6':
+    resolution: {integrity: sha512-rjJG09JRdmIHQcHJjD1nd4wUbjQAsQUpjV51SOqabDPdRMzAx82I2cosnctNzBY+YXGhYYtlkVXjELW51B8ZZw==}
+    engines: {node: '>=18'}
 
   '@sanity/assist@3.0.6':
     resolution: {integrity: sha512-CFbpY+eI5CCEuYq61tFtKql1SAbxkT0KHECcWjRWthwBaGuePwrZt/9T/kPr0T4YWIPyH/NJc4b/bIM0dhYa6A==}
@@ -14791,6 +14795,8 @@ snapshots:
       - '@types/node'
 
   '@sanity/asset-utils@1.3.0': {}
+
+  '@sanity/asset-utils@2.0.6': {}
 
   '@sanity/assist@3.0.6(@sanity/mutator@packages+@sanity+mutator)(react-dom@18.3.1(react@18.3.1))(react-is@19.0.0-rc-a7d1240c-20240731)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:


### PR DESCRIPTION
### Description

Just a dependency update. v2 of this module uses ESM by default, aside from that there shouldn't be any meaningful changes.

### What to review

Stuff still works. In particular, image and file fields + copy/paste of these fields.

### Testing

Existing tests should hopefully be enough.
Have done some manual testing as well.

### Notes for release

None
