### PR TITLE
refactor(sanity): fix type issues with collate, update tests and readQueryResult

### DIFF
--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
@@ -243,7 +243,7 @@ export function referenceSearch(
   })
   return search(textTerm, {includeDrafts: true}).pipe(
     map(({hits}) => hits.map(({hit}) => hit)),
-    map((docs) => collate(docs)),
+    map((docs) => collate({documents: docs})),
     // pick the 100 best matches
     map((collated) => collated.slice(0, 100)),
     mergeMap((collated) => {

--- a/packages/sanity/src/core/form/studio/inputs/crossDatasetReference/datastores/search.ts
+++ b/packages/sanity/src/core/form/studio/inputs/crossDatasetReference/datastores/search.ts
@@ -31,7 +31,7 @@ export function search(
     isCrossDataset: true,
   }).pipe(
     map(({hits}) => hits.map(({hit}) => hit)),
-    map((docs) => collate(docs)),
+    map((docs) => collate({documents: docs})),
     map((collated) =>
       collated.map((entry) => ({
         id: entry.id,

--- a/packages/sanity/src/core/util/draftUtils.test.ts
+++ b/packages/sanity/src/core/util/draftUtils.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it, test} from '@jest/globals'
-import {type SanityDocument} from '@sanity/types'
+import {type SanityDocument, type SanityDocumentLike} from '@sanity/types'
 
 import {
   collate,
@@ -11,12 +11,12 @@ import {
 } from './draftUtils'
 
 test('collate()', () => {
-  const foo = {_type: 'foo', _id: 'foo'}
-  const fooDraft = {_type: 'foo', _id: 'drafts.foo'}
-  const barDraft = {_type: 'foo', _id: 'drafts.bar'}
-  const baz = {_type: 'foo', _id: 'baz'}
+  const foo = {_type: 'foo', _id: 'foo'} as SanityDocumentLike
+  const fooDraft = {_type: 'foo', _id: 'drafts.foo'} as SanityDocumentLike
+  const barDraft = {_type: 'foo', _id: 'drafts.bar'} as SanityDocumentLike
+  const baz = {_type: 'foo', _id: 'baz'} as SanityDocumentLike
 
-  expect(collate([foo, fooDraft, barDraft, baz])).toEqual([
+  expect(collate({documents: [foo, fooDraft, barDraft, baz]})).toEqual([
     {type: 'foo', id: 'foo', draft: fooDraft, published: foo},
     {type: 'foo', id: 'bar', draft: barDraft},
     {type: 'foo', id: 'baz', published: baz},

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -180,8 +180,10 @@ export interface CollatedHit<T extends {_id: string} = {_id: string}> {
 }
 
 /** @internal */
-export function collate<T extends {_id: string; _type: string}>(documents: T[]): CollatedHit<T>[] {
-  const byId = documents.reduce((res, doc) => {
+export function collate<T extends {_id: string; _type: string}>(documents: {
+  documents: SanityDocumentLike[]
+}): CollatedHit<T>[] {
+  const byId = documents.documents?.reduce((res, doc) => {
     const publishedId = getPublishedId(doc._id)
     let entry = res.get(publishedId)
     if (!entry) {
@@ -199,7 +201,7 @@ export function collate<T extends {_id: string; _type: string}>(documents: T[]):
 /** @internal */
 // Removes published documents that also has a draft
 export function removeDupes(documents: SanityDocumentLike[]): SanityDocumentLike[] {
-  return collate(documents)
+  return collate({documents})
     .map((entry) => entry.draft || entry.published)
     .filter(isNonNullable)
 }

--- a/packages/sanity/src/structure/panes/documentList/helpers.ts
+++ b/packages/sanity/src/structure/panes/documentList/helpers.ts
@@ -19,9 +19,9 @@ export function getDocumentKey(value: DocumentListPaneItem, index: number): stri
 }
 
 export function removePublishedWithDrafts(documents: SanityDocumentLike[]): DocumentListPaneItem[] {
-  return collate(documents).map((entry) => {
+  return collate({documents}).map((entry) => {
     const doc = entry.draft || entry.published
-    const isVersion = doc?.id && isVersionId(doc._id)
+    const isVersion = doc?._id && isVersionId(doc._id)
     const hasDraft = Boolean(entry.draft)
 
     return {

--- a/packages/sanity/src/structure/panes/documentList/types.ts
+++ b/packages/sanity/src/structure/panes/documentList/types.ts
@@ -1,6 +1,12 @@
 import {type SanityDocumentLike} from '@sanity/types'
 import {type SearchSort} from 'sanity'
 
+export interface QueryResult {
+  error: {message: string} | null
+  onRetry?: () => void
+  result: {documents: SanityDocumentLike[]} | null
+}
+
 export interface DocumentListPaneItem extends SanityDocumentLike {
   hasPublished: boolean
   hasDraft: boolean


### PR DESCRIPTION
### Description

- Re-adds `QueryResult` interface
- Changing the type in the collate to not explode when versions are present.

When rebasing against `next` something went wrong specifically around this [PR](https://github.com/sanity-io/sanity/pull/7555/files). I wasn't able to fix it by using rebasing however this unblocks us and allows us to continue work.

I imagine that the fix will likely be more around making sure that the collate prop type stayed the same (making the changes in the ENABLE_LRU_MEMO changes however I don't know the larger impact of making that change, so, for now I've set this up.

Folks that are more knowledgeable around this should weight in before I merge since this is more like a temporary bandaid than a fix 🥲 

Ash set up a branch `corel-pre-rebase-20241003` in case if you want to give the rebase another stab to avoid some of these issues. Keep in mind that you'll need to cherry pick [StickParams](https://github.com/sanity-io/sanity/pull/7429) commits as well