### PR TITLE
fix: protect against falsy `selectedGroup`

### DIFF
--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -79,7 +79,7 @@ type PrepareFieldMember = <T>(props: {
   field: ObjectField
   parent: FormStateOptions<ObjectSchemaType, T> & {
     groups: FormFieldGroup[]
-    selectedGroup: FormFieldGroup
+    selectedGroup?: FormFieldGroup
   }
   index: number
 }) => ObjectMember | HiddenField | null
@@ -117,8 +117,12 @@ function isFieldEnabledByGroupFilter(
   // the groups config for the "enclosing object" type
   groupsConfig: FormFieldGroup[],
   fieldGroup: string | string[] | undefined,
-  selectedGroup: FormFieldGroup,
+  selectedGroup: FormFieldGroup | undefined,
 ) {
+  if (!selectedGroup) {
+    return false
+  }
+
   if (selectedGroup.name === ALL_FIELDS_GROUP.name) {
     return true
   }
@@ -827,7 +831,7 @@ export function createPrepareFormState({
       },
     )
 
-    const selectedGroup = groups.find((group) => group.selected)!
+    const selectedGroup = groups.find((group) => group.selected)
 
     // note: this is needed because not all object types gets a ´fieldsets´ property during schema parsing.
     // ideally members should be normalized as part of the schema parsing and not here


### PR DESCRIPTION
### Description

This fixes a bug that caused the document editor to crash in certain cases where there is no selected group. This occurs when the default field group is not found. Allow this value to be `undefined` and checking for it fixes the issue.

### What to review

Does this correct protect against all cases where the selectedGroup is undefined? Are all the types updated correctly?

### Testing

This was tested manually in the admin studio. I built sanity package, packed it, and install it in the admin studio and the issue was resolved.

### Notes for release

Fixes a bug that caused the document editor to crash when the default field group is not found.
