### PR TITLE
fix(cli): do not throw during migrate if project ID is passed through flag

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -164,8 +164,14 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
 
     const projectConfig = apiClient({
       requireUser: true,
-      requireProject: true,
+      requireProject: false,
     }).config()
+
+    if (!project && projectConfig.projectId) {
+      throw new Error(
+        'sanity.cli.js does not contain a project identifier ("api.projectId") and no --project option was provided.',
+      )
+    }
 
     const apiConfig = {
       dataset: dataset ?? projectConfig.dataset!,

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -167,7 +167,7 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
       requireProject: false,
     }).config()
 
-    if (!project && projectConfig.projectId) {
+    if (!project && !projectConfig.projectId) {
       throw new Error(
         'sanity.cli.js does not contain a project identifier ("api.projectId") and no --project option was provided.',
       )


### PR DESCRIPTION
### Description

This PR sets the `apiClient`'s  `requireProject` to `false` and instead only throws an error if both the cli config and the `--project` option are missing

### What to review

Verify that the change is as expected and that the wording of the error is correct.

### Testing
* create a simple migration script with sanity, `sanity migration create` and follow the prompt
make sure there is no `sanity.cli.js` in your codebase

Next steps:
* Open /code/migrations/migration_id/index.ts in your code editor and write the code for your migration.
* Dry run the migration with:
`sanity migration run migration_id --project= --dataset`
* Run the migration against a dataset with:
`sanity migration run migration_id --project= --dataset --no-dry-run`

* edit the script and run it as:
`sanity migration run migration_id --project=real_project_id --dataset real_dataset`

you should NOT get an error. 

Test again without specifying  a `--project`  project ID, you should see an error.

### Notes for release
None
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
