### PR TITLE
feat: propagate `PairListenerOptions`; add telemetry for `OutOfSyncError`

### DIFF
--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -15,7 +15,7 @@ import {
   createConnectionStatusStore,
 } from './connection-status/connection-status-store'
 import {createDocumentStore, type DocumentStore} from './document'
-import {DocumentOutOfSync} from './document/__telemetry__/documentOutOfSyncEvents.telemetry'
+import {DocumentDesynced} from './document/__telemetry__/documentOutOfSyncEvents.telemetry'
 import {fetchFeatureToggle} from './document/document-pair/utils/fetchFeatureToggle'
 import {type OutOfSyncError} from './document/utils/sequentializeListenerEvents'
 import {createGrantsStore, type GrantsStore} from './grants'
@@ -148,7 +148,7 @@ export function useDocumentStore(): DocumentStore {
 
   const handleSyncErrorRecovery = useCallback(
     (error: OutOfSyncError) => {
-      telemetry.log(DocumentOutOfSync, {errorName: error.name})
+      telemetry.log(DocumentDesynced, {errorName: error.name})
     },
     [telemetry],
   )

--- a/packages/sanity/src/core/store/_legacy/document/__telemetry__/documentOutOfSyncEvents.telemetry.ts
+++ b/packages/sanity/src/core/store/_legacy/document/__telemetry__/documentOutOfSyncEvents.telemetry.ts
@@ -1,0 +1,7 @@
+import {defineEvent} from '@sanity/telemetry'
+
+export const DocumentOutOfSync = defineEvent<{errorName: string}>({
+  name: 'Document out of sync',
+  version: 1,
+  description: 'Occurs when a "hole" in events from the document pair listener is detected.',
+})

--- a/packages/sanity/src/core/store/_legacy/document/__telemetry__/documentOutOfSyncEvents.telemetry.ts
+++ b/packages/sanity/src/core/store/_legacy/document/__telemetry__/documentOutOfSyncEvents.telemetry.ts
@@ -1,7 +1,7 @@
 import {defineEvent} from '@sanity/telemetry'
 
 export const DocumentOutOfSync = defineEvent<{errorName: string}>({
-  name: 'Document out of sync',
+  name: 'Document Desynced',
   version: 1,
   description: 'Occurs when a "hole" in events from the document pair listener is detected.',
 })

--- a/packages/sanity/src/core/store/_legacy/document/__telemetry__/documentOutOfSyncEvents.telemetry.ts
+++ b/packages/sanity/src/core/store/_legacy/document/__telemetry__/documentOutOfSyncEvents.telemetry.ts
@@ -1,7 +1,8 @@
 import {defineEvent} from '@sanity/telemetry'
 
-export const DocumentOutOfSync = defineEvent<{errorName: string}>({
+export const DocumentDesynced = defineEvent<{errorName: string}>({
   name: 'Document Desynced',
   version: 1,
-  description: 'Occurs when a "hole" in events from the document pair listener is detected.',
+  description:
+    'Occurs when a "hole" in events from the document pair listener is detected and recovered from.',
 })

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -12,7 +12,7 @@ import {
   type MutationPayload,
   type RemoteSnapshotEvent,
 } from '../buffered-doc'
-import {getPairListener, type ListenerEvent} from '../getPairListener'
+import {getPairListener, type ListenerEvent, type PairListenerOptions} from '../getPairListener'
 import {type IdPair, type PendingMutationsEvent, type ReconnectEvent} from '../types'
 import {actionsApiClient} from './utils/actionsApiClient'
 
@@ -200,11 +200,12 @@ export function checkoutPair(
   client: SanityClient,
   idPair: IdPair,
   serverActionsEnabled: Observable<boolean>,
+  pairListenerOptions?: PairListenerOptions,
 ): Pair {
   const {publishedId, draftId} = idPair
 
   const listenerEventsConnector = new Subject<ListenerEvent>()
-  const listenerEvents$ = getPairListener(client, idPair).pipe(
+  const listenerEvents$ = getPairListener(client, idPair, pairListenerOptions).pipe(
     share({connector: () => listenerEventsConnector}),
   )
 

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/consistencyStatus.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/consistencyStatus.ts
@@ -2,6 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {combineLatest, type Observable} from 'rxjs'
 import {distinctUntilChanged, map, publishReplay, refCount, switchMap} from 'rxjs/operators'
 
+import {type PairListenerOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {memoizedPair} from './memoizedPair'
@@ -14,14 +15,16 @@ export const consistencyStatus: (
   idPair: IdPair,
   typeName: string,
   serverActionsEnabled: Observable<boolean>,
+  pairListenerOptions?: PairListenerOptions,
 ) => Observable<boolean> = memoize(
   (
     client: SanityClient,
     idPair: IdPair,
     typeName: string,
     serverActionsEnabled: Observable<boolean>,
+    pairListenerOptions?: PairListenerOptions,
   ) => {
-    return memoizedPair(client, idPair, typeName, serverActionsEnabled).pipe(
+    return memoizedPair(client, idPair, typeName, serverActionsEnabled, pairListenerOptions).pipe(
       switchMap(({draft, published}) =>
         combineLatest([draft.consistency$, published.consistency$]),
       ),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/documentEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/documentEvents.ts
@@ -2,6 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {merge, type Observable} from 'rxjs'
 import {switchMap} from 'rxjs/operators'
 
+import {type PairListenerOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {type DocumentVersionEvent} from './checkoutPair'
@@ -16,8 +17,9 @@ export const documentEvents = memoize(
     idPair: IdPair,
     typeName: string,
     serverActionsEnabled: Observable<boolean>,
+    pairListenerOptions?: PairListenerOptions,
   ): Observable<DocumentVersionEvent> => {
-    return memoizedPair(client, idPair, typeName, serverActionsEnabled).pipe(
+    return memoizedPair(client, idPair, typeName, serverActionsEnabled, pairListenerOptions).pipe(
       switchMap(({draft, published}) => merge(draft.events, published.events)),
     )
   },

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editOperations.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editOperations.ts
@@ -4,6 +4,7 @@ import {concat, EMPTY, merge, type Observable, of} from 'rxjs'
 import {map, mergeMap, shareReplay} from 'rxjs/operators'
 
 import {type HistoryStore} from '../../history'
+import {type PairListenerOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {memoizeKeyGen} from './memoizeKeyGen'
@@ -19,6 +20,7 @@ export const editOperations = memoize(
       historyStore: HistoryStore
       schema: Schema
       serverActionsEnabled: Observable<boolean>
+      pairListenerOptions?: PairListenerOptions
     },
     idPair: IdPair,
     typeName: string,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
@@ -3,6 +3,7 @@ import {type SanityDocument, type Schema} from '@sanity/types'
 import {combineLatest, type Observable} from 'rxjs'
 import {map, publishReplay, refCount, startWith, switchMap} from 'rxjs/operators'
 
+import {type PairListenerOptions} from '../getPairListener'
 import {type IdPair, type PendingMutationsEvent} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {memoizeKeyGen} from './memoizeKeyGen'
@@ -35,12 +36,19 @@ export const editState = memoize(
       client: SanityClient
       schema: Schema
       serverActionsEnabled: Observable<boolean>
+      pairListenerOptions?: PairListenerOptions
     },
     idPair: IdPair,
     typeName: string,
   ): Observable<EditStateFor> => {
     const liveEdit = isLiveEditEnabled(ctx.schema, typeName)
-    return snapshotPair(ctx.client, idPair, typeName, ctx.serverActionsEnabled).pipe(
+    return snapshotPair(
+      ctx.client,
+      idPair,
+      typeName,
+      ctx.serverActionsEnabled,
+      ctx.pairListenerOptions,
+    ).pipe(
       switchMap((versions) =>
         combineLatest([
           versions.draft.snapshots$,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
@@ -2,6 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {Observable} from 'rxjs'
 import {publishReplay, refCount} from 'rxjs/operators'
 
+import {type PairListenerOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {checkoutPair, type Pair} from './checkoutPair'
@@ -12,15 +13,17 @@ export const memoizedPair: (
   idPair: IdPair,
   typeName: string,
   serverActionsEnabled: Observable<boolean>,
+  pairListenerOptions?: PairListenerOptions,
 ) => Observable<Pair> = memoize(
   (
     client: SanityClient,
     idPair: IdPair,
     _typeName: string,
     serverActionsEnabled: Observable<boolean>,
+    pairListenerOptions?: PairListenerOptions,
   ): Observable<Pair> => {
     return new Observable<Pair>((subscriber) => {
-      const pair = checkoutPair(client, idPair, serverActionsEnabled)
+      const pair = checkoutPair(client, idPair, serverActionsEnabled, pairListenerOptions)
       subscriber.next(pair)
 
       return pair.complete

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
@@ -7,6 +7,7 @@ import {combineLatest, type Observable} from 'rxjs'
 import {map, publishReplay, refCount, switchMap} from 'rxjs/operators'
 
 import {type HistoryStore} from '../../history'
+import {type PairListenerOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {memoizeKeyGen} from './memoizeKeyGen'
@@ -20,11 +21,18 @@ export const operationArgs = memoize(
       historyStore: HistoryStore
       schema: Schema
       serverActionsEnabled: Observable<boolean>
+      pairListenerOptions?: PairListenerOptions
     },
     idPair: IdPair,
     typeName: string,
   ): Observable<OperationArgs> => {
-    return snapshotPair(ctx.client, idPair, typeName, ctx.serverActionsEnabled).pipe(
+    return snapshotPair(
+      ctx.client,
+      idPair,
+      typeName,
+      ctx.serverActionsEnabled,
+      ctx.pairListenerOptions,
+    ).pipe(
       switchMap((versions) =>
         combineLatest([
           versions.draft.snapshots$,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -19,6 +19,7 @@ import {
 } from 'rxjs/operators'
 
 import {type HistoryStore} from '../../history'
+import {type PairListenerOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {consistencyStatus} from './consistencyStatus'
@@ -143,6 +144,7 @@ export const operationEvents = memoize(
     historyStore: HistoryStore
     schema: Schema
     serverActionsEnabled: Observable<boolean>
+    pairListenerOptions?: PairListenerOptions
   }) => {
     const result$: Observable<IntermediarySuccess | IntermediaryError> = operationCalls$.pipe(
       groupBy((op) => op.idPair.publishedId),
@@ -165,6 +167,7 @@ export const operationEvents = memoize(
                   args.idPair,
                   args.typeName,
                   ctx.serverActionsEnabled,
+                  ctx.pairListenerOptions,
                 ).pipe(filter(Boolean))
                 const ready$ = requiresConsistency ? isConsistent$.pipe(take(1)) : of(true)
                 return ready$.pipe(

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/remoteSnapshots.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/remoteSnapshots.ts
@@ -2,6 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {merge, type Observable} from 'rxjs'
 import {switchMap} from 'rxjs/operators'
 
+import {type PairListenerOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {type RemoteSnapshotVersionEvent} from './checkoutPair'
@@ -15,8 +16,9 @@ export const remoteSnapshots = memoize(
     idPair: IdPair,
     typeName: string,
     serverActionsEnabled: Observable<boolean>,
+    pairListenerOptions?: PairListenerOptions,
   ): Observable<RemoteSnapshotVersionEvent> => {
-    return memoizedPair(client, idPair, typeName, serverActionsEnabled).pipe(
+    return memoizedPair(client, idPair, typeName, serverActionsEnabled, pairListenerOptions).pipe(
       switchMap(({published, draft}) => merge(published.remoteSnapshot$, draft.remoteSnapshot$)),
     )
   },

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/snapshotPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/snapshotPair.ts
@@ -4,6 +4,7 @@ import {type Observable} from 'rxjs'
 import {filter, map, publishReplay, refCount} from 'rxjs/operators'
 
 import {type BufferedDocumentEvent, type MutationPayload, type SnapshotEvent} from '../buffered-doc'
+import {type PairListenerOptions} from '../getPairListener'
 import {type IdPair, type PendingMutationsEvent, type ReconnectEvent} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {type DocumentVersion} from './checkoutPair'
@@ -66,8 +67,9 @@ export const snapshotPair = memoize(
     idPair: IdPair,
     typeName: string,
     serverActionsEnabled: Observable<boolean>,
+    pairListenerOptions?: PairListenerOptions,
   ): Observable<SnapshotPair> => {
-    return memoizedPair(client, idPair, typeName, serverActionsEnabled).pipe(
+    return memoizedPair(client, idPair, typeName, serverActionsEnabled, pairListenerOptions).pipe(
       map(({published, draft, transactionsPendingEvents$}): SnapshotPair => {
         return {
           transactionsPendingEvents$,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
@@ -9,6 +9,7 @@ import {type SourceClientOptions} from '../../../../config'
 import {type LocaleSource} from '../../../../i18n'
 import {type DraftsModelDocumentAvailability} from '../../../../preview'
 import {validateDocumentWithReferences, type ValidationStatus} from '../../../../validation'
+import {type PairListenerOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {editState} from './editState'
@@ -31,6 +32,7 @@ export const validation = memoize(
       schema: Schema
       i18n: LocaleSource
       serverActionsEnabled: Observable<boolean>
+      pairListenerOptions?: PairListenerOptions
     },
     {draftId, publishedId}: IdPair,
     typeName: string,

--- a/packages/sanity/src/core/store/_legacy/document/document-store.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-store.ts
@@ -23,6 +23,7 @@ import {
 } from './document-pair/operationEvents'
 import {type OperationsAPI} from './document-pair/operations'
 import {validation} from './document-pair/validation'
+import {type PairListenerOptions} from './getPairListener'
 import {getInitialValueStream, type InitialValueMsg, type InitialValueOptions} from './initialValue'
 import {listenQuery, type ListenQueryOptions} from './listenQuery'
 import {resolveTypeForDocument} from './resolveTypeForDocument'
@@ -85,6 +86,7 @@ export interface DocumentStoreOptions {
   initialValueTemplates: Template[]
   i18n: LocaleSource
   serverActionsEnabled: Observable<boolean>
+  pairListenerOptions?: PairListenerOptions
 }
 
 /** @internal */
@@ -96,6 +98,7 @@ export function createDocumentStore({
   schema,
   i18n,
   serverActionsEnabled,
+  pairListenerOptions,
 }: DocumentStoreOptions): DocumentStore {
   const observeDocumentPairAvailability =
     documentPreviewStore.unstable_observeDocumentPairAvailability
@@ -113,12 +116,13 @@ export function createDocumentStore({
     schema,
     i18n,
     serverActionsEnabled,
+    pairListenerOptions,
   }
 
   return {
     // Public API
     checkoutPair(idPair) {
-      return checkoutPair(client, idPair, serverActionsEnabled)
+      return checkoutPair(client, idPair, serverActionsEnabled, pairListenerOptions)
     },
     initialValue(opts, context) {
       return getInitialValueStream(
@@ -129,8 +133,8 @@ export function createDocumentStore({
         context,
       )
     },
-    listenQuery(query, params, options) {
-      return listenQuery(client, query, params, options)
+    listenQuery(query, params, listenQueryOptions) {
+      return listenQuery(client, query, params, listenQueryOptions)
     },
     resolveTypeForDocument(id, specifiedType) {
       return resolveTypeForDocument(client, id, specifiedType)
@@ -142,6 +146,7 @@ export function createDocumentStore({
           getIdPairFromPublished(publishedId),
           type,
           serverActionsEnabled,
+          pairListenerOptions,
         )
       },
       documentEvents(publishedId, type) {
@@ -150,6 +155,7 @@ export function createDocumentStore({
           getIdPairFromPublished(publishedId),
           type,
           serverActionsEnabled,
+          pairListenerOptions,
         )
       },
       editOperations(publishedId, type) {
@@ -164,6 +170,7 @@ export function createDocumentStore({
           historyStore,
           schema,
           serverActionsEnabled,
+          pairListenerOptions,
         }).pipe(
           filter(
             (result) =>

--- a/packages/sanity/src/core/store/_legacy/document/utils/createMemoizer.ts
+++ b/packages/sanity/src/core/store/_legacy/document/utils/createMemoizer.ts
@@ -1,34 +1,17 @@
 import {type Observable} from 'rxjs'
 
-export function memoize<T, Arg1>(
-  fn: (arg1: Arg1) => Observable<T>,
-  keyGen: (arg1: Arg1) => string,
-): (arg1: Arg1) => Observable<T>
-export function memoize<T, Arg1, Arg2>(
-  fn: (arg1: Arg1, arg2: Arg2) => Observable<T>,
-  keyGen: (arg1: Arg1, arg2: Arg2) => string,
-): (arg1: Arg1, arg2: Arg2) => Observable<T>
-
-export function memoize<T, Arg1, Arg2, Arg3>(
-  fn: (arg1: Arg1, arg2: Arg2, arg3: Arg3) => Observable<T>,
-  keyGen: (arg1: Arg1, arg2: Arg2, arg3: Arg3) => string,
-): (arg1: Arg1, arg2: Arg2, arg3: Arg3) => Observable<T>
-
-export function memoize<T, Arg1, Arg2, Arg3, Arg4>(
-  fn: (arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) => Observable<T>,
-  keyGen: (arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) => string,
-): (arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) => Observable<T>
-
-export function memoize<T, Args>(
-  fn: (...args: Args[]) => Observable<T>,
-  keyGen: (...args: Args[]) => string,
-) {
-  const MEMO: {[key: string]: Observable<T>} = Object.create(null)
-  return (...args: any[]) => {
+export function memoize<TFunction extends (...args: any[]) => Observable<any>>(
+  fn: TFunction,
+  keyGen: (...args: Parameters<TFunction>) => string,
+): TFunction {
+  const MEMO: {[key: string]: Observable<unknown>} = Object.create(null)
+  const memoizedFn = (...args: Parameters<TFunction>): Observable<unknown> => {
     const key = keyGen(...args)
     if (!(key in MEMO)) {
       MEMO[key] = fn(...args)
     }
     return MEMO[key]
   }
+
+  return memoizedFn as TFunction
 }

--- a/packages/sanity/src/core/store/_legacy/grants/documentPairPermissions.ts
+++ b/packages/sanity/src/core/store/_legacy/grants/documentPairPermissions.ts
@@ -14,7 +14,7 @@ import {
   type PartialExcept,
 } from '../../../util'
 import {useGrantsStore} from '../datastores'
-import {snapshotPair} from '../document'
+import {type PairListenerOptions, snapshotPair} from '../document'
 import {fetchFeatureToggle} from '../document/document-pair/utils/fetchFeatureToggle'
 import {type GrantsStore, type PermissionCheckResult} from './types'
 
@@ -170,6 +170,7 @@ export interface DocumentPairPermissionsOptions {
   type: string
   permission: DocumentPermission
   serverActionsEnabled: Observable<boolean>
+  pairListenerOptions?: PairListenerOptions
 }
 
 /**
@@ -187,6 +188,7 @@ export function getDocumentPairPermissions({
   permission,
   type,
   serverActionsEnabled,
+  pairListenerOptions,
 }: DocumentPairPermissionsOptions): Observable<PermissionCheckResult> {
   // this case was added to fix a crash that would occur if the `schemaType` was
   // omitted from `S.documentList()`
@@ -204,6 +206,7 @@ export function getDocumentPairPermissions({
     {draftId: getDraftId(id), publishedId: getPublishedId(id)},
     type,
     serverActionsEnabled,
+    pairListenerOptions,
   ).pipe(
     switchMap((pair) =>
       combineLatest([pair.draft.snapshots$, pair.published.snapshots$]).pipe(
@@ -283,6 +286,7 @@ export function useDocumentPairPermissions({
   client: overrideClient,
   schema: overrideSchema,
   grantsStore: overrideGrantsStore,
+  pairListenerOptions,
 }: PartialExcept<DocumentPairPermissionsOptions, 'id' | 'type' | 'permission'>): ReturnType<
   typeof useDocumentPairPermissionsFromHookFactory
 > {
@@ -306,8 +310,26 @@ export function useDocumentPairPermissions({
 
   return useDocumentPairPermissionsFromHookFactory(
     useMemo(
-      () => ({client, schema, grantsStore, id, permission, type, serverActionsEnabled}),
-      [client, grantsStore, id, permission, schema, type, serverActionsEnabled],
+      () => ({
+        client,
+        schema,
+        grantsStore,
+        id,
+        permission,
+        type,
+        serverActionsEnabled,
+        pairListenerOptions,
+      }),
+      [
+        client,
+        schema,
+        grantsStore,
+        id,
+        permission,
+        type,
+        serverActionsEnabled,
+        pairListenerOptions,
+      ],
     ),
   )
 }


### PR DESCRIPTION
### Description

The following builds off of #7576. This PR:

- Propagates the `PairListenerOptions` through the document-store
- Adds telemetry for when the `onSyncErrorRecovery` fires.

### What to review

- Did I cover all APIs that need to propagate this? Seemed best to add it to the `document-store` options instead of each individual method
- Am I logging the telemetry event correctly?

### Testing

- There were no existing tests for the document-store so I just manually tested that this fired
- I also went through all the types and ensured that the option was propagated correctly

### Notes for release

N/A - this one builds off of #7576 but is mostly internal changes