### PR TITLE
chore(ci): use `efps` for job name, use node 20, clarify tag description

### DIFF
--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       reference_tag:
-        description: "Reference tag for comparison"
+        description: "npm reference tag for comparison"
         required: true
         default: "latest"
       enable_profiler:
@@ -14,7 +14,7 @@ on:
         default: false
 
 jobs:
-  install:
+  efps:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm


### PR DESCRIPTION
### Description

Minor; it took me 15 seconds to figure out that reference tag meant npm tag, not git tag.
Also, "install" seems a bit wide for the job name since it does the whole run.
…and we might as well use Node 20, I'd say?

### What to review

Changes make sense

### Testing

Don't think this should affect anything

### Notes for release

None
