### PR TITLE
fix: prevent excessive requests to access endpoint 

### DIFF
--- a/packages/sanity/src/core/store/_legacy/grants/documentPairPermissions.ts
+++ b/packages/sanity/src/core/store/_legacy/grants/documentPairPermissions.ts
@@ -42,7 +42,7 @@ function getPairPermissions({
   draft,
   published,
   liveEdit,
-}: PairPermissionsOptions): Array<[string, Observable<PermissionCheckResult>] | null> {
+}: PairPermissionsOptions): Array<[string, Observable<PermissionCheckResult>]> {
   // this was introduced because we ran into a bug where a user with publish
   // access was marked as not allowed to duplicate a document unless it had a
   // draft variant. this would happen in non-live edit cases where the document
@@ -220,9 +220,9 @@ export function getDocumentPairPermissions({
         draft,
         published,
         liveEdit,
-      }).map(([label, observable]: any) =>
-        observable.pipe(
-          map(({granted, reason}: any) => ({
+      }).map(([label, permissionCheck$]) =>
+        permissionCheck$.pipe(
+          map(({granted, reason}) => ({
             granted,
             reason: granted ? '' : `not allowed to ${label}: ${reason}`,
             label,
@@ -234,7 +234,7 @@ export function getDocumentPairPermissions({
       if (!pairPermissions.length) return of({granted: true, reason: ''})
 
       return combineLatest(pairPermissions).pipe(
-        map((permissionResults: any[]) => {
+        map((permissionResults) => {
           const granted = permissionResults.every((permissionResult) => permissionResult.granted)
           const reason = granted
             ? ''

--- a/packages/sanity/src/core/store/_legacy/grants/types.ts
+++ b/packages/sanity/src/core/store/_legacy/grants/types.ts
@@ -27,7 +27,7 @@ export interface GrantsStore {
   /**
    * Returns an observable of `PermissionCheckResult`
    *
-   * This API is returns an observable (vs a promise) so the consumer can reac
+   * This API is returns an observable (vs a promise) so the consumer can react
    * to incoming changes to the user permissions (e.g. for changing _debug_
    * roles).
    *

--- a/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
@@ -80,6 +80,7 @@ export function RequestAccessScreen() {
     client
       .request<AccessRequest[] | null>({
         url: `/access/requests/me`,
+        tag: 'request-access',
       })
       .then((requests) => {
         if (requests && requests?.length) {

--- a/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
@@ -83,35 +83,35 @@ export function RequestAccessScreen() {
         tag: 'request-access',
       })
       .then((requests) => {
-        if (requests && requests?.length) {
-          const projectRequests = requests.filter((request) => request.resourceId === projectId)
-          const declinedRequest = projectRequests.find((request) => request.status === 'declined')
-          if (
-            declinedRequest &&
-            isAfter(addWeeks(new Date(declinedRequest.createdAt), 2), new Date())
-          ) {
-            setHasBeenDenied(true)
-            return
-          }
-          const pendingRequest = projectRequests.find(
-            (request) =>
-              request.status === 'pending' &&
-              // Access request is less than 2 weeks old
-              isAfter(addWeeks(new Date(request.createdAt), 2), new Date()),
-          )
-          if (pendingRequest) {
-            setHasPendingRequest(true)
-            return
-          }
-          const oldPendingRequest = projectRequests.find(
-            (request) =>
-              request.status === 'pending' &&
-              // Access request is more than 2 weeks old
-              isBefore(addWeeks(new Date(request.createdAt), 2), new Date()),
-          )
-          if (oldPendingRequest) {
-            setExpiredHasPendingRequest(true)
-          }
+        if (!requests || !requests.length) return
+
+        const projectRequests = requests.filter((request) => request.resourceId === projectId)
+        const declinedRequest = projectRequests.find((request) => request.status === 'declined')
+        if (
+          declinedRequest &&
+          isAfter(addWeeks(new Date(declinedRequest.createdAt), 2), new Date())
+        ) {
+          setHasBeenDenied(true)
+          return
+        }
+        const pendingRequest = projectRequests.find(
+          (request) =>
+            request.status === 'pending' &&
+            // Access request is less than 2 weeks old
+            isAfter(addWeeks(new Date(request.createdAt), 2), new Date()),
+        )
+        if (pendingRequest) {
+          setHasPendingRequest(true)
+          return
+        }
+        const oldPendingRequest = projectRequests.find(
+          (request) =>
+            request.status === 'pending' &&
+            // Access request is more than 2 weeks old
+            isBefore(addWeeks(new Date(request.createdAt), 2), new Date()),
+        )
+        if (oldPendingRequest) {
+          setExpiredHasPendingRequest(true)
         }
       })
       .catch((err) => {

--- a/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
@@ -33,6 +33,7 @@ export const useRoleRequestsStatus = () => {
     return from(
       client.request<AccessRequest[] | null>({
         url: `/access/requests/me`,
+        tag: 'use-role-requests-status',
       }),
     ).pipe(
       map((requests) => {

--- a/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
@@ -37,39 +37,41 @@ export const useRoleRequestsStatus = () => {
       }),
     ).pipe(
       map((requests) => {
-        if (requests && requests.length) {
-          // Filter requests for the specific project and where type is 'role'
-          const projectRequests = requests.filter(
-            (request) => request.resourceId === projectId && request.type === 'role',
-          )
-
-          const declinedRequest = projectRequests.find((request) => request.status === 'declined')
-          if (
-            declinedRequest &&
-            isAfter(addWeeks(new Date(declinedRequest.createdAt), 2), new Date())
-          ) {
-            return {loading: false, error: false, status: 'declined'}
-          }
-
-          const pendingRequest = projectRequests.find(
-            (request) =>
-              request.status === 'pending' &&
-              isAfter(addWeeks(new Date(request.createdAt), 2), new Date()),
-          )
-          if (pendingRequest) {
-            return {loading: false, error: false, status: 'pending'}
-          }
-
-          const oldPendingRequest = projectRequests.find(
-            (request) =>
-              request.status === 'pending' &&
-              isBefore(addWeeks(new Date(request.createdAt), 2), new Date()),
-          )
-          if (oldPendingRequest) {
-            return {loading: false, error: false, status: 'expired'}
-          }
+        if (!requests || requests.length === 0) {
+          return {loading: false, error: false, status: 'none'}
         }
-        return {loading: false, error: false, status: 'none'}
+
+        // Filter requests for the specific project and where type is 'role'
+        const projectRequests = requests.filter(
+          (request) => request.resourceId === projectId && request.type === 'role',
+        )
+
+        const declinedRequest = projectRequests.find((request) => request.status === 'declined')
+        if (
+          declinedRequest &&
+          isAfter(addWeeks(new Date(declinedRequest.createdAt), 2), new Date())
+        ) {
+          return {loading: false, error: false, status: 'declined'}
+        }
+
+        const pendingRequest = projectRequests.find(
+          (request) =>
+            request.status === 'pending' &&
+            isAfter(addWeeks(new Date(request.createdAt), 2), new Date()),
+        )
+        if (pendingRequest) {
+          return {loading: false, error: false, status: 'pending'}
+        }
+
+        const oldPendingRequest = projectRequests.find(
+          (request) =>
+            request.status === 'pending' &&
+            isBefore(addWeeks(new Date(request.createdAt), 2), new Date()),
+        )
+
+        return oldPendingRequest
+          ? {loading: false, error: false, status: 'expired'}
+          : {loading: false, error: false, status: 'none'}
       }),
       catchError((err) => {
         console.error('Failed to fetch access requests', err)

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -12,7 +12,7 @@ import {useDocumentPane} from '../useDocumentPane'
 import {
   DeletedDocumentBanner,
   DeprecatedDocumentTypeBanner,
-  PermissionCheckBanner,
+  InsufficientPermissionBanner,
   ReferenceChangedBanner,
 } from './banners'
 import {DraftLiveEditBanner} from './banners/DraftLiveEditBanner'
@@ -51,7 +51,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     activeViewId,
     displayed,
     documentId,
-    documentType,
     editState,
     inspector,
     value,
@@ -63,7 +62,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     isDeleting,
     isDeleted,
     timelineStore,
-    onChange,
   } = useDocumentPane()
   const {collapsed: layoutCollapsed} = usePaneLayout()
   const {collapsed} = usePane()
@@ -164,10 +162,9 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
 
                   {activeView.type === 'form' && !isPermissionsLoading && ready && (
                     <>
-                      <PermissionCheckBanner
-                        granted={Boolean(permissions?.granted)}
-                        requiredPermission={requiredPermission}
-                      />
+                      {!permissions?.granted && (
+                        <InsufficientPermissionBanner requiredPermission={requiredPermission} />
+                      )}
                       {!isDeleting && isDeleted && (
                         <DeletedDocumentBanner revisionId={lastNonDeletedRevId} />
                       )}

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/InsufficientPermissionBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/InsufficientPermissionBanner.tsx
@@ -12,12 +12,13 @@ import {AskToEditDialogOpened} from '../../../../components/requestPermissionDia
 import {structureLocaleNamespace} from '../../../../i18n'
 import {Banner} from './Banner'
 
-interface PermissionCheckBannerProps {
-  granted: boolean
+interface InsufficientPermissionBannerProps {
   requiredPermission: 'update' | 'create'
 }
 
-export function PermissionCheckBanner({granted, requiredPermission}: PermissionCheckBannerProps) {
+export function InsufficientPermissionBanner({
+  requiredPermission,
+}: InsufficientPermissionBannerProps) {
   const currentUser = useCurrentUser()
 
   const {
@@ -37,8 +38,6 @@ export function PermissionCheckBanner({granted, requiredPermission}: PermissionC
   const listFormat = useListFormat({style: 'short'})
   const {t} = useTranslation(structureLocaleNamespace)
   const telemetry = useTelemetry()
-
-  if (granted) return null
 
   const roleTitles = currentUserRoles.map((role) => role.title)
   const roles = listFormat

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/index.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/index.ts
@@ -1,4 +1,4 @@
 export * from './DeletedDocumentBanner'
 export * from './DeprecatedDocumentTypeBanner'
-export * from './PermissionCheckBanner'
+export * from './InsufficientPermissionBanner'
 export * from './ReferenceChangedBanner'


### PR DESCRIPTION
### Description

This one needs a proper read-through, I am not super confident with these changes - especially the last commit. There might be a lot easier ways to solve the problem outlined in the title here, but let me explain:

When researching why there were constant requests being fired to the `/access` API, I saw that it was due to a hook being run inside of the `<PermissionCheckBanner />`. Upon further inspection, I saw that this component remounts (unmounts and mounts) constantly while edits are going on, due to the continuous evaluation of permissions as the document changes. When this happens, the `isPermissionsLoading` state gets set to `true`, which triggers the banner to unmount. Once it's calculated if it should be allowed/disallowed, it re-mounts. My hunch is that this is not only causing the additional requests that we want to get rid of, but potentially also affects performance negatively.

While reading the code of the `useDocumentValuePermissions` and the underlying `createHookFromObservableFactory` and friends, it seems like the intention _is_ to [keep the old state while recalculating](https://github.com/sanity-io/sanity/blob/92de3d9606957a3ce8b6c1c93444dab76536da46/packages/sanity/src/core/util/createHookFromObservableFactory.ts#L59) - but because the `document` being passed as an argument is recreated on any edit, the observable factory gets called again and the state resets. In my mind it would be better (for the permission check in particular) to assume that the grants don't change _that_ quickly, and keep the old cached value around. I refactored the code to do this, but the code is a lot simpler/more naive than `createHookFromObservableFactory` + `useObservable`, so I'd be happy to have some more eyes on this and see if there are edge cases it wouldn't account for.

> [!NOTE]
> While writing this, I realized that we should probably throw away that cached value on document ID change.

[Running the new eFPS suite](https://github.com/sanity-io/sanity/actions/runs/11188606113/job/31107661697), the eFPS looks about the same, while blocking time seems lower - lets see what another run says once I open the PR.

Aside from the above, I also refactored some code a bit - using observable requests for cancellation, minimizing state updates with predefined constants and preferring to "return early" from functions for less indentation (easier to read in my book).

### What to review

I'd do commit-by-commit - most of the changes should be fairly straightforward, except the last two. In particular, the last change needs a very thorough read-through. 

### Testing

I want to add some tests for `useDocumentValuePermissions`, but figured I would open this up for an early look since it needs a proper read-through.

### Notes for release

- Fixed an issue where unnecessary requests to the API would be triggered while editing a document
