### PR TITLE
chore(ci): use environment variables, not secrets, for non-sensitive vars

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -8,8 +8,6 @@ on:
       TURBO_TOKEN:
       SANITY_E2E_SESSION_TOKEN_NEW:
         required: true
-      SANITY_E2E_PROJECT_ID:
-        required: true
 
 jobs:
   prepare:
@@ -152,8 +150,8 @@ jobs:
       #     # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
       #     # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
       #     SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
-      #     SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
-      #     SANITY_E2E_DATASET: ${{ secrets.SANITY_E2E_DATASET }}
+      #     SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID }}
+      #     SANITY_E2E_DATASET: ${{ vars.SANITY_E2E_DATASET }}
       #   run: pnpm e2e:setup && pnpm e2e:build
 
       - name: Build E2E test studio on PR
@@ -164,7 +162,7 @@ jobs:
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
-          SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
+          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID }}
           SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
         run: pnpm e2e:setup && pnpm e2e:build
 

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -73,8 +73,8 @@ jobs:
 
       - name: Run eFPS tests
         env:
-          VITE_PERF_EFPS_PROJECT_ID: ${{ secrets.PERF_EFPS_PROJECT_ID }}
-          VITE_PERF_EFPS_DATASET: ${{ secrets.PERF_EFPS_DATASET }}
+          VITE_PERF_EFPS_PROJECT_ID: ${{ vars.PERF_EFPS_PROJECT_ID }}
+          VITE_PERF_EFPS_DATASET: ${{ vars.PERF_EFPS_DATASET }}
           PERF_EFPS_SANITY_TOKEN: ${{ secrets.PERF_EFPS_SANITY_TOKEN }}
           REFERENCE_TAG: ${{ github.event.inputs.reference_tag || 'latest' }}
           ENABLE_PROFILER: ${{ github.event.inputs.enable_profiler || false }}

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Extract API docs
         env:
-          EXTRACT_SANITY_PROJECT_ID: "${{((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/current') && secrets.EXTRACT_SANITY_PROJECT_ID || secrets.DEV_EXTRACT_SANITY_PROJECT_ID}}"
-          EXTRACT_SANITY_DATASET: "${{((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/current') && secrets.EXTRACT_SANITY_DATASET || secrets.DEV_EXTRACT_SANITY_DATASET}}"
+          EXTRACT_SANITY_PROJECT_ID: "${{((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/current') && vars.EXTRACT_SANITY_PROJECT_ID || vars.DEV_EXTRACT_SANITY_PROJECT_ID}}"
+          EXTRACT_SANITY_DATASET: "${{((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/current') && vars.EXTRACT_SANITY_DATASET || vars.DEV_EXTRACT_SANITY_DATASET}}"
           EXTRACT_SANITY_API_TOKEN: "${{((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/current') && secrets.EXTRACT_SANITY_API_TOKEN || secrets.DEV_EXTRACT_SANITY_API_TOKEN}}"
         run: pnpm etl sanity


### PR DESCRIPTION
 ### Description

I don't think there's any reason to hide variables such as dataset and project IDs. It makes it harder to debug issues and read logs, as any value in these secrets will be scrubbed from logs as `****`. In particular, we use `test` as a dataset name 😅


### What to review

- CI configs still looks right
- [Environment variables](https://github.com/sanity-io/sanity/settings/variables/actions) are in place to take the place of the secrets

### Testing

Letting the CI workflows run should be enough

### Notes for release

None
