### PR TITLE
fix: use absolute urls for published sourcemap urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "npm-run-all2": "^6.2.3",
     "ora": "^8.0.1",
     "prettier": "^3.3.3",
+    "read-package-up": "^11.0.0",
     "rimraf": "^3.0.2",
     "rxjs": "^7.8.1",
     "sanity": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
+      read-package-up:
+        specifier: ^11.0.0
+        version: 11.0.0
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -7369,6 +7372,10 @@ packages:
   find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
+  find-up-simple@1.0.0:
+    resolution: {integrity: sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==}
+    engines: {node: '>=18'}
+
   find-up@2.1.0:
     resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
     engines: {node: '>=4'}
@@ -7980,6 +7987,10 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  index-to-position@0.1.2:
+    resolution: {integrity: sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==}
+    engines: {node: '>=18'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -9662,6 +9673,10 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse-json@8.1.0:
+    resolution: {integrity: sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==}
+    engines: {node: '>=18'}
+
   parse-ms@2.1.0:
     resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
     engines: {node: '>=6'}
@@ -10238,6 +10253,10 @@ packages:
     resolution: {integrity: sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  read-package-up@11.0.0:
+    resolution: {integrity: sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==}
+    engines: {node: '>=18'}
+
   read-pkg-up@3.0.0:
     resolution: {integrity: sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==}
     engines: {node: '>=4'}
@@ -10253,6 +10272,10 @@ packages:
   read-pkg@5.2.0:
     resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
     engines: {node: '>=8'}
+
+  read-pkg@9.0.1:
+    resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
+    engines: {node: '>=18'}
 
   read@3.0.1:
     resolution: {integrity: sha512-SLBrDU/Srs/9EoWhU5GdbAoxG1GzpQHo/6qiGItaoLJ1thmYpcNIM1qISEUvyHBzfGlWIyd6p2DNi1oV1VmAuw==}
@@ -11508,6 +11531,10 @@ packages:
   unicode-property-aliases-ecmascript@2.1.0:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
+
+  unicorn-magic@0.1.0:
+    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
+    engines: {node: '>=18'}
 
   union-value@1.0.1:
     resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==}
@@ -18966,6 +18993,8 @@ snapshots:
 
   find-root@1.1.0: {}
 
+  find-up-simple@1.0.0: {}
+
   find-up@2.1.0:
     dependencies:
       locate-path: 2.0.0
@@ -19678,6 +19707,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  index-to-position@0.1.2: {}
 
   inflight@1.0.6:
     dependencies:
@@ -21870,6 +21901,12 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse-json@8.1.0:
+    dependencies:
+      '@babel/code-frame': 7.24.7
+      index-to-position: 0.1.2
+      type-fest: 4.24.0
+
   parse-ms@2.1.0: {}
 
   parse-passwd@1.0.0: {}
@@ -22400,6 +22437,12 @@ snapshots:
       json-parse-even-better-errors: 3.0.2
       npm-normalize-package-bin: 3.0.1
 
+  read-package-up@11.0.0:
+    dependencies:
+      find-up-simple: 1.0.0
+      read-pkg: 9.0.1
+      type-fest: 4.24.0
+
   read-pkg-up@3.0.0:
     dependencies:
       find-up: 2.1.0
@@ -22423,6 +22466,14 @@ snapshots:
       normalize-package-data: 2.5.0
       parse-json: 5.2.0
       type-fest: 0.6.0
+
+  read-pkg@9.0.1:
+    dependencies:
+      '@types/normalize-package-data': 2.4.4
+      normalize-package-data: 6.0.2
+      parse-json: 8.1.0
+      type-fest: 4.24.0
+      unicorn-magic: 0.1.0
 
   read@3.0.1:
     dependencies:
@@ -23913,6 +23964,8 @@ snapshots:
   unicode-match-property-value-ecmascript@2.1.0: {}
 
   unicode-property-aliases-ecmascript@2.1.0: {}
+
+  unicorn-magic@0.1.0: {}
 
   union-value@1.0.1:
     dependencies:

--- a/scripts/uploadBundles.ts
+++ b/scripts/uploadBundles.ts
@@ -1,10 +1,16 @@
+import {type Dirent, readdirSync, readFileSync} from 'node:fs'
 import {readdir, readFile, stat, writeFile} from 'node:fs/promises'
+import {type SourceMapPayload} from 'node:module'
 import path from 'node:path'
 
-// eslint-disable-next-line import/no-extraneous-dependencies
+/* eslint-disable import/no-extraneous-dependencies */
 import {Storage, type UploadOptions} from '@google-cloud/storage'
+import {type NormalizedReadResult, readPackageUp} from 'read-package-up'
 
+/* eslint-enable import/no-extraneous-dependencies */
 import {readEnv} from './utils/envVars'
+
+const BASE_PATH = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
 
 type KnownEnvVar = 'GOOGLE_PROJECT_ID' | 'GCLOUD_SERVICE_KEY' | 'GCLOUD_BUCKET'
 
@@ -14,6 +20,8 @@ const storage = new Storage({
 })
 
 const bucket = storage.bucket(readEnv<KnownEnvVar>('GCLOUD_BUCKET'))
+
+const monoRepoPackageVersions: Record<string, string> = getMonorepoPackageVersions()
 
 const corePkgs = ['sanity', '@sanity/vision'] as const
 
@@ -59,7 +67,7 @@ async function copyPackages() {
   for (const pkg of corePkgs) {
     console.log(`Copying files from ${pkg}`)
 
-    const packageJson = JSON.parse(await readFile(`packages/${pkg}/package.json`, 'utf8'))
+    const {packageJson} = await readPackageJson(`packages/${pkg}/package.json`)
 
     const {version} = packageJson
     packageVersions.set(pkg, version)
@@ -160,7 +168,111 @@ async function updateManifest(newVersions: Map<string, string>) {
   }
 }
 
+async function cleanupSourceMaps() {
+  const packageVersions = new Map<string, string>()
+
+  // First we iterate through each core package located in `packages/`
+  for (const pkg of corePkgs) {
+    const {packageJson} = await readPackageJson(`packages/${pkg}/package.json`)
+
+    const {version} = packageJson
+    packageVersions.set(pkg, version)
+
+    for await (const filePath of getFiles(`packages/${pkg}/dist`)) {
+      if (path.extname(filePath) !== '.map') {
+        continue
+      }
+
+      try {
+        const sourceMap = await readSourceMap(filePath)
+        const newSources = await Promise.all(
+          sourceMap.sources.map((source) => rewriteSource(source, filePath)),
+        )
+        sourceMap.sources = newSources
+        await writeFile(filePath, JSON.stringify(sourceMap), 'utf-8')
+      } catch (error) {
+        throw new Error(`Failed to rewrite source map from ${pkg}`, {cause: error})
+      }
+    }
+
+    console.log(`Completed source map rewriting for directory ${pkg}`)
+  }
+}
+
+/**
+ * Rewrite source paths to absolute URLs for CDN-published bundles.
+ *
+ * Technically speaking this is "incorrect", as we don't use the URLs given for actually building,
+ * however it is useful for debugging purposes, and leaving the original paths do not make sense
+ * as we are not hosting the source files on the CDN anyway.
+ *
+ * The `sourcesContent` property does contain the actual contents we need for most debugging,
+ * so this is mostly a way for us to jump to a file we can peek at, as well as telling us which
+ * version of the file we are looking at. This is more helpful than, say,
+ * `../../node_modules/someModule/index.js`.
+ *
+ * The URLs we rewrite to are as follows:
+ * - For absolute URLs, leave them as-is.
+ * - For dependencies (eg anything inside of `node_modules`), we use jsdelivr.net.
+ * - For Sanity monorepo packages, we use GitHub URLs. Note that these link to the HTML interface,
+ *     _NOT_ the raw file - so any tools that tries to actually fetch the file might fail. If this
+ *     proves to be an issue, we could switch to `raw.githubusercontent.com` instead, but it is
+ *     less user-friendly for us developers.
+ *
+ * @param source - The source path to rewrite
+ * @param sourceMapPath - The path to the source map file that contained this source path
+ * @returns The rewritten source path (URL)
+ * @internal
+ */
+async function rewriteSource(source: string, sourceMapPath: string): Promise<string> {
+  if (/^https?:\/\//.test(source)) {
+    return source
+  }
+
+  const sourceMapDir = path.dirname(sourceMapPath)
+  const sourcePath = path.resolve(sourceMapDir, source)
+  if (sourcePath.includes('node_modules')) {
+    const {
+      packageJson: {name, version},
+      packagePath,
+    } = await readPackageJson(sourcePath)
+
+    if (name === 'sanity-root') {
+      throw new Error(`Found sanity-root instead of a package for ${sourcePath}`)
+    }
+    const pathFromPackage = path.relative(packagePath, sourcePath)
+    // eg `../../../node_modules/.pnpm/@sanity+client@6.22.0_debug@4.3.7/node_modules/@sanity/client/dist/index.browser.js`
+    // => `https://cdn.jsdelivr.net/npm/@sanity/client@6.22.1/dist/index.browser.js`
+    return `https://cdn.jsdelivr.net/npm/${name}@${version}/${pathFromPackage}`
+  }
+
+  // eg `../src/core/schema/createSchema.ts` =>
+  // => `https://github.com/sanity-io/sanity/blob/v3.59.1/packages/sanity/src/core/schema/createSchema.ts`
+  const relativePath = path.posix.relative(BASE_PATH, sourcePath)
+  const pathParts = relativePath.split('/')
+
+  if (pathParts.shift() !== 'packages') {
+    console.warn('Failed to rewrite source path, unknown path type', {source, sourceMapPath})
+    return source
+  }
+
+  const pkgName = pathParts[0].startsWith('@') ? `${pathParts[0]}/${pathParts[1]}` : pathParts[0]
+  const pkgVersion = monoRepoPackageVersions[pkgName]
+  if (!pkgVersion) {
+    console.warn(`Failed to rewrite source path, could not find version for ${pkgName}`)
+    return source
+  }
+
+  // Encode for GitHub URLs, eg `@sanity/vision` -> `%40sanity/vision`
+  const cleanDir = encodeURIComponent(relativePath).replace(/%2F/g, '/')
+  return `https://github.com/sanity-io/sanity/blob/v${pkgVersion}/${cleanDir}`
+}
+
 async function uploadBundles() {
+  // Clean up source maps
+  await cleanupSourceMaps()
+  console.log('**Completed cleaning up source maps** ✅')
+
   // Copy all the bundles
   const pkgVersions = await copyPackages()
   console.log('**Completed copying all files** ✅')
@@ -168,6 +280,58 @@ async function uploadBundles() {
   // Update the manifest json file
   await updateManifest(pkgVersions)
   console.log('**Completed updating manifest** ✅')
+}
+
+async function readSourceMap(
+  filePath: string,
+): Promise<Omit<SourceMapPayload, 'sourceRoot'> & {sourceRoot?: string}> {
+  const sourceMap = JSON.parse(await readFile(filePath, 'utf8'))
+  if (typeof sourceMap !== 'object' || sourceMap === null || Array.isArray(sourceMap)) {
+    throw new Error(`Invalid source map at ${filePath}`)
+  }
+
+  if (!('sources' in sourceMap)) {
+    throw new Error(`Missing 'sources' in source map at ${filePath}`)
+  }
+
+  return sourceMap
+}
+
+async function readPackageJson(
+  fromFilePath: string,
+): Promise<NormalizedReadResult & {packagePath: string}> {
+  const depPkg = await readPackageUp({cwd: fromFilePath})
+  if (!depPkg || !depPkg.packageJson) {
+    throw new Error(`No package.json found for ${fromFilePath}`)
+  }
+
+  return {...depPkg, packagePath: path.dirname(depPkg.path)}
+}
+
+function getMonorepoPackageVersions(): Record<string, string> {
+  const isDir = (dirent: Dirent) => dirent.isDirectory() && !dirent.name.startsWith('.')
+  const getFullPath = (dirent: Dirent) => path.join(dirent.parentPath, dirent.name)
+  const listOpts = {withFileTypes: true} as const
+
+  const scoped = readdirSync(path.join(BASE_PATH, 'packages', '@sanity'), listOpts)
+    .filter(isDir)
+    .map(getFullPath)
+
+  const unscoped = readdirSync(path.join(BASE_PATH, 'packages'), listOpts)
+    .filter((dirent) => isDir(dirent) && !dirent.name.startsWith('@'))
+    .map(getFullPath)
+
+  const versions: Record<string, string> = {}
+  ;[...scoped, ...unscoped].forEach((pkgPath) => {
+    try {
+      const {name, version} = JSON.parse(readFileSync(path.join(pkgPath, 'package.json'), 'utf-8'))
+      versions[name] = version
+    } catch (err) {
+      console.warn(`Failed to read package.json for ${pkgPath}`, err)
+    }
+  })
+
+  return versions
 }
 
 uploadBundles().catch((err) => {


### PR DESCRIPTION
### Description

The source maps we upload to our module CDN now contains source maps, which helps in debugging. Sources are inlined, but the original source _locations_ are also left intact. This isn't a _problem_ per se, but it does lead to tooling trying to link to them and failing. For instance, a source map could be referencing `../../../node_modules/.pnpm/@sanity+client@6.22.0_debug@4.3.7/node_modules/@sanity/client/dist/index.browser.js`, which would be resolved to `https://modules.sanity-cdn.com/modules/v1/node_modules/.pnpm/@sanity+client@6.22.0_debug@4.3.7/node_modules/@sanity/client/dist/index.browser.js`, which we obviously do not host.

It is helpful to have _some_ source location, as from the example above I can see that the source pointed to `@sanity/client`. To make this even more helpful, this PR takes the approach of rewriting these sources to point to absolute URLs.

Technically speaking this is "incorrect", as we don't use the URLs given for actually building the bundles, however it is useful for debugging purposes, and leaving the original paths do not make sense as we are not hosting the source files on the CDN anyway.
 
The URLs we rewrite to are as follows:
- For absolute URLs, leave them as-is.
- For dependencies (eg anything inside of `node_modules`), we use `jsdelivr.net`.
- For Sanity monorepo packages, we use GitHub URLs. Note that these link to the HTML interface, _NOT_ the raw file - so any tools that tries to actually fetch the file might fail. If this proves to be an issue, we could switch to `raw.githubusercontent.com` instead, but it is less user-friendly for us developers.

### What to review

- Do these changes make sense? Are they going to cause issues?
- See any issues in the code?

### Testing

I've built the bundles locally and ran a modified uploading script (disabling the actual upload logic) and verified that the sources gets correctly rewritten.

### Notes for release

None
