### PR TITLE
fix(structure): improve and clean up form ready state

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -252,7 +252,9 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
    * a timeline revision in this instance will display an error localized to the popover itself.
    */
   const ready =
-    connectionState === 'connected' && editState.ready && (timelineReady || !!timelineError)
+    connectionState === 'connected' &&
+    editState.ready &&
+    (!params.rev || timelineReady || !!timelineError)
 
   const displayed: Partial<SanityDocument> | undefined = useMemo(
     () => (onOlderRevision ? timelineDisplayed || {_id: value._id, _type: value._type} : value),


### PR DESCRIPTION
### Description

Currently, we defer marking the document as "ready" until we have loaded the timeline. This was originally done to avoid the confusion from first loading the current revision of the document and then replacing it when the selected revision is loaded from the timeline.

In a certain cases, loading the timeline can be quite slow, so the changes in this PR only waits if there's actually a selected revision (represented by `params.rev` being set)


### What to review
Does it make sense? Any case I'm not thinking about?

### Testing
Unfortunately non-trivial to add automated tests for, but I've verfied that the current behavior is preserved if params.rev is set.

### Notes for release
- fixed an issue that could in certain rare cases make loading of a document to take a long time.
