### PR TITLE
ci(efps): allow recording video in efps suite

### DIFF
--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -12,6 +12,11 @@ on:
         required: true
         type: boolean
         default: false
+      record_video:
+        description: "Record video"
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   efps:
@@ -78,6 +83,7 @@ jobs:
           PERF_EFPS_SANITY_TOKEN: ${{ secrets.PERF_EFPS_SANITY_TOKEN }}
           REFERENCE_TAG: ${{ github.event.inputs.reference_tag || 'latest' }}
           ENABLE_PROFILER: ${{ github.event.inputs.enable_profiler || false }}
+          RECORD_VIDEO: ${{ github.event.inputs.record_video || false }}
         run: pnpm efps:test
 
       - name: PR comment with report

--- a/perf/efps/index.ts
+++ b/perf/efps/index.ts
@@ -28,6 +28,8 @@ const HEADLESS = true
 const ENABLE_PROFILER = process.env.ENABLE_PROFILER === 'true'
 // eslint-disable-next-line turbo/no-undeclared-env-vars
 const REFERENCE_TAG = process.env.REFERENCE_TAG || 'latest'
+// eslint-disable-next-line turbo/no-undeclared-env-vars
+const RECORD_VIDEO = process.env.RECORD_VIDEO === 'true'
 const TESTS = [article, recipe, synthetic]
 
 const projectId = process.env.VITE_PERF_EFPS_PROJECT_ID!
@@ -169,6 +171,7 @@ async function runAbTest(test: EfpsTest) {
         resultsDir,
         client,
         headless: HEADLESS,
+        recordVideo: RECORD_VIDEO,
         enableProfiler: ENABLE_PROFILER,
         projectId,
         sanityPkgPath: referenceSanityPkgPath,
@@ -189,6 +192,7 @@ async function runAbTest(test: EfpsTest) {
         resultsDir,
         client,
         headless: HEADLESS,
+        recordVideo: RECORD_VIDEO,
         enableProfiler: ENABLE_PROFILER,
         projectId,
         sanityPkgPath: experimentSanityPkgPath,

--- a/perf/efps/runTest.ts
+++ b/perf/efps/runTest.ts
@@ -16,27 +16,29 @@ import {type EfpsResult, type EfpsTest, type EfpsTestRunnerContext} from './type
 const workspaceDir = path.dirname(fileURLToPath(import.meta.url))
 
 interface RunTestOptions {
-  test: EfpsTest
-  resultsDir: string
-  projectId: string
-  headless: boolean
   client: SanityClient
-  sanityPkgPath: string
-  key: string
   enableProfiler: boolean
+  headless: boolean
+  key: string
   log: (text: string) => void
+  projectId: string
+  recordVideo: boolean
+  resultsDir: string
+  sanityPkgPath: string
+  test: EfpsTest
 }
 
 export async function runTest({
-  test,
-  resultsDir,
-  projectId,
-  headless,
   client,
-  sanityPkgPath,
-  key,
   enableProfiler,
+  headless,
+  key,
   log,
+  projectId,
+  recordVideo,
+  resultsDir,
+  sanityPkgPath,
+  test,
 }: RunTestOptions): Promise<EfpsResult[]> {
   const outDir = path.join(workspaceDir, 'builds', test.name, key)
   const testResultsDir = path.join(resultsDir, test.name, key)
@@ -75,6 +77,7 @@ export async function runTest({
     log('Launching browser…')
     browser = await chromium.launch({headless})
     context = await browser.newContext({
+      recordVideo: recordVideo ? {dir: testResultsDir} : undefined,
       storageState: {
         cookies: [],
         origins: [


### PR DESCRIPTION
### Description

Sometimes it can be really helpful to see what is going on in the eFPS test suite. This PR adds an option to record videos for runs. It is off by default, cause I don't think we necessarily need the videos for every run - but we may consider changing it if we see it being really useful.

### Notes for release

None
