### PR TITLE
docs(sanity): update label onUncaughtError from internal to beta

### DIFF
--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -786,7 +786,7 @@ export interface Source {
    */
   beta?: BetaFeatures
   /** Configuration for error handling.
-   * @internal
+   * @beta
    */
   onUncaughtError?: (error: Error, errorInfo: ErrorInfo) => void
 }


### PR DESCRIPTION
### Description

Mistakenly a property in Source was tagged as internal when it should have been beta.
This impacts the docs 
