### PR TITLE
feat(form): add support for disabling array input capabilities

### DIFF
--- a/dev/test-studio/schema/debug/arrayCapabilities.ts
+++ b/dev/test-studio/schema/debug/arrayCapabilities.ts
@@ -1,0 +1,77 @@
+import {defineType} from '@sanity/types'
+
+const DISABLED_ACTIONS = ['add', 'addBefore', 'addAfter', 'duplicate', 'remove', 'copy'] as const
+
+export const arrayCapabilities = defineType({
+  name: 'arrayCapabilitiesExample',
+  type: 'document',
+  title: 'Array Capabilities test',
+  // icon,
+  fields: [
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+    },
+    {
+      name: 'objectArray',
+      options: {
+        collapsible: true,
+        collapsed: true,
+        disableActions: DISABLED_ACTIONS,
+      },
+      title: 'Object array',
+      description: `With disabledActions: ${DISABLED_ACTIONS.join(', ')}`,
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          name: 'something',
+          title: 'Something',
+          fields: [{name: 'first', type: 'string', title: 'First string'}],
+        },
+      ],
+    },
+    {
+      name: 'objectArrayAsGrid',
+      options: {
+        layout: 'grid',
+        collapsible: true,
+        collapsed: true,
+        disableActions: DISABLED_ACTIONS,
+      },
+      title: 'Object array with grid layout',
+      description: `With disabledActions: ${DISABLED_ACTIONS.join(', ')}`,
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          name: 'something',
+          title: 'Something',
+          fields: [{name: 'first', type: 'string', title: 'First string'}],
+        },
+      ],
+    },
+    {
+      name: 'primitiveArray',
+      options: {
+        collapsible: true,
+        collapsed: true,
+        disableActions: DISABLED_ACTIONS,
+      },
+      title: 'Primitive array',
+      description: `With disabledActions: ${DISABLED_ACTIONS.join(', ')}`,
+      type: 'array',
+      of: [
+        {
+          type: 'string',
+          title: 'A string',
+        },
+        {
+          type: 'number',
+          title: 'A number',
+        },
+      ],
+    },
+  ],
+})

--- a/dev/test-studio/schema/debug/simpleArrayOfObjects.js
+++ b/dev/test-studio/schema/debug/simpleArrayOfObjects.js
@@ -13,7 +13,11 @@ export const simpleArrayOfObjects = {
     },
     {
       name: 'arrayWithObjects',
-      options: {collapsible: true, collapsed: true},
+      options: {
+        collapsible: true,
+        collapsed: true,
+        disableActions: ['add'],
+      },
       title: 'Array with named objects',
       description: 'This array contains objects of type as defined inline',
       type: 'array',

--- a/dev/test-studio/schema/debug/simpleArrayOfObjects.js
+++ b/dev/test-studio/schema/debug/simpleArrayOfObjects.js
@@ -13,11 +13,7 @@ export const simpleArrayOfObjects = {
     },
     {
       name: 'arrayWithObjects',
-      options: {
-        collapsible: true,
-        collapsed: true,
-        disableActions: ['add'],
-      },
+      options: {collapsible: true, collapsed: true},
       title: 'Array with named objects',
       description: 'This array contains objects of type as defined inline',
       type: 'array',

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -6,6 +6,7 @@ import conditionalFieldset from './ci/conditionalFieldset'
 import validationTest from './ci/validationCI'
 import actions from './debug/actions'
 import {allNativeInputComponents} from './debug/allNativeInputComponents'
+import {arrayCapabilities} from './debug/arrayCapabilities'
 import button from './debug/button'
 import {circularCrossDatasetReferenceTest} from './debug/circularCrossDatasetReference'
 import {collapsibleObjects} from './debug/collapsibleObjects'
@@ -241,6 +242,7 @@ export const schemaTypes = [
   recursivePopover,
   patchOnMountDebug,
   simpleArrayOfObjects,
+  arrayCapabilities,
   simpleReferences,
   reservedFieldNames,
   review,

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -81,6 +81,7 @@ export const DEBUG_INPUT_TYPES = [
   'scrollBug',
   'select',
   'simpleArrayOfObjects',
+  'arrayCapabilities',
   'simpleReferences',
   'thesis',
   'typeWithNoToplevelStrings',

--- a/packages/@sanity/types/src/schema/definition/type/array.ts
+++ b/packages/@sanity/types/src/schema/definition/type/array.ts
@@ -17,6 +17,38 @@ import {
 
 export type {InsertMenuOptions}
 
+/**
+ * Types of array actions that can be performed
+ * @beta
+ */
+export type ArrayActionName =
+  /**
+   * Add any item to the array at any position
+   */
+  | 'add'
+  /**
+   * Add item after an existing item
+   */
+  | 'addBefore'
+
+  /**
+   * Add item after an existing item
+   */
+  | 'addAfter'
+  /**
+   * Remove any item
+   */
+  | 'remove'
+  /**
+   * Duplicate item
+   */
+  | 'duplicate'
+
+  /**
+   * Copy item
+   */
+  | 'copy'
+
 /** @public */
 export interface ArrayOptions<V = unknown> extends SearchConfiguration, BaseSchemaTypeOptions {
   list?: TitledListValue<V>[] | V[]
@@ -35,6 +67,13 @@ export interface ArrayOptions<V = unknown> extends SearchConfiguration, BaseSche
    * @deprecated tree editing beta feature has been disabled
    */
   treeEditing?: boolean
+
+  /**
+   * A list of array actions to disable
+   * Possible options are defined by {@link ArrayActionName}
+   * @beta
+   */
+  disableActions?: ArrayActionName[]
 }
 
 /** @public */

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions.tsx
@@ -65,6 +65,10 @@ export function ArrayOfObjectsFunctions<
     },
   })
 
+  if (schemaType.options?.disableActions?.includes('add')) {
+    return null
+  }
+
   if (readOnly) {
     return (
       <Tooltip portal content={t('inputs.array.read-only-label')}>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
@@ -213,6 +213,7 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
             }}
             button={
               <ContextMenuButton
+                data-testid="array-item-menu-button"
                 selected={insertBefore.state.open || insertAfter.state.open ? true : undefined}
               />
             }

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
@@ -62,7 +62,7 @@ function getTone({
   return hasWarnings ? 'caution' : 'default'
 }
 const MENU_POPOVER_PROPS = {portal: true, tone: 'default'} as const
-
+const EMPTY_ARRAY: never[] = []
 export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemProps<Item>) {
   const {
     schemaType,
@@ -162,9 +162,48 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
     referenceElement: contextMenuButtonElement,
   })
 
+  const disableActions = parentSchemaType.options?.disableActions || EMPTY_ARRAY
+
+  const menuItems = useMemo(() => {
+    return [
+      !disableActions.includes('remove') && (
+        <MenuItem
+          text={t('inputs.array.action.remove')}
+          tone="critical"
+          icon={TrashIcon}
+          onClick={onRemove}
+        />
+      ),
+      !disableActions.includes('copy') && (
+        <MenuItem text={t('inputs.array.action.copy')} icon={CopyIcon} onClick={handleCopy} />
+      ),
+      !disableActions.includes('duplicate') && (
+        <MenuItem
+          text={t('inputs.array.action.duplicate')}
+          icon={AddDocumentIcon}
+          onClick={handleDuplicate}
+        />
+      ),
+      !disableActions.includes('add') &&
+        !disableActions.includes('addBefore') &&
+        insertBefore.menuItem,
+      !disableActions.includes('add') &&
+        !disableActions.includes('addAfter') &&
+        insertAfter.menuItem,
+    ].filter(Boolean)
+  }, [
+    disableActions,
+    handleCopy,
+    handleDuplicate,
+    insertAfter.menuItem,
+    insertBefore.menuItem,
+    onRemove,
+    t,
+  ])
+
   const menu = useMemo(
     () =>
-      readOnly ? null : (
+      readOnly || menuItems.length === 0 ? null : (
         <>
           <MenuButton
             ref={setContextMenuButtonElement}
@@ -178,35 +217,14 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
               />
             }
             id={`${props.inputId}-menuButton`}
-            menu={
-              <Menu>
-                <MenuItem
-                  text={t('inputs.array.action.remove')}
-                  tone="critical"
-                  icon={TrashIcon}
-                  onClick={onRemove}
-                />
-                <MenuItem
-                  text={t('inputs.array.action.copy')}
-                  icon={CopyIcon}
-                  onClick={handleCopy}
-                />
-                <MenuItem
-                  text={t('inputs.array.action.duplicate')}
-                  icon={AddDocumentIcon}
-                  onClick={handleDuplicate}
-                />
-                {insertBefore.menuItem}
-                {insertAfter.menuItem}
-              </Menu>
-            }
+            menu={<Menu>{menuItems}</Menu>}
             popover={MENU_POPOVER_PROPS}
           />
           {insertBefore.popover}
           {insertAfter.popover}
         </>
       ),
-    [insertBefore, insertAfter, handleCopy, handleDuplicate, onRemove, props.inputId, readOnly, t],
+    [readOnly, insertBefore, insertAfter, props.inputId, menuItems],
   )
 
   const tone = getTone({readOnly, hasErrors, hasWarnings})

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/InsertMenuGroups.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/InsertMenuGroups.tsx
@@ -41,7 +41,7 @@ export const InsertMenuGroups = memo(function InsertMenuGroups(props: Props) {
   )
 })
 
-function InsertMenuGroup(
+export function InsertMenuGroup(
   props: Props & {
     pos: 'before' | 'after'
     text: ComponentProps<typeof MenuItem>['text']

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/InsertMenuMenuItems.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/InsertMenuMenuItems.tsx
@@ -78,6 +78,7 @@ export function useInsertMenuMenuItems(props: InsertMenuItemsProps) {
     () =>
       types ? (
         <MenuItem
+          key="insertBefore"
           text={
             types.length === 1
               ? t('inputs.array.action.add-before')
@@ -93,6 +94,7 @@ export function useInsertMenuMenuItems(props: InsertMenuItemsProps) {
     () =>
       types ? (
         <MenuItem
+          key="insertAfter"
           text={
             types.length === 1
               ? t('inputs.array.action.add-after')

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -46,7 +46,7 @@ function getTone({
 const MENU_POPOVER_PROPS = {portal: true, tone: 'default'} as const
 
 const BUTTON_CARD_STYLE = {position: 'relative'} as const
-
+const EMPTY_ARRAY: never[] = []
 export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: PreviewItemProps<Item>) {
   const {
     schemaType,
@@ -150,9 +150,55 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
     referenceElement: contextMenuButtonElement,
   })
 
+  const disableActions = parentSchemaType.options?.disableActions || EMPTY_ARRAY
+
+  const menuItems = useMemo(() => {
+    return [
+      !disableActions.includes('remove') && (
+        <MenuItem
+          key="remove"
+          text={t('inputs.array.action.remove')}
+          tone="critical"
+          icon={TrashIcon}
+          onClick={onRemove}
+        />
+      ),
+      !disableActions.includes('copy') && (
+        <MenuItem
+          key="copy"
+          text={t('inputs.array.action.copy')}
+          icon={CopyIcon}
+          onClick={handleCopy}
+        />
+      ),
+      !disableActions.includes('duplicate') && (
+        <MenuItem
+          key="duplicate"
+          text={t('inputs.array.action.duplicate')}
+          icon={AddDocumentIcon}
+          onClick={handleDuplicate}
+        />
+      ),
+      !disableActions.includes('add') &&
+        !disableActions.includes('addBefore') &&
+        insertBefore.menuItem,
+      !disableActions.includes('add') &&
+        !disableActions.includes('addAfter') &&
+        insertAfter.menuItem,
+    ].filter(Boolean)
+  }, [
+    disableActions,
+    handleCopy,
+    handleDuplicate,
+    insertAfter.menuItem,
+    insertBefore.menuItem,
+    onRemove,
+    t,
+  ])
+
   const menu = useMemo(
     () =>
-      readOnly ? null : (
+      readOnly || menuItems.length === 0 ? null : (
         <>
           <MenuButton
             ref={setContextMenuButtonElement}
@@ -166,35 +212,14 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
               />
             }
             id={`${props.inputId}-menuButton`}
-            menu={
-              <Menu>
-                <MenuItem
-                  text={t('inputs.array.action.remove')}
-                  tone="critical"
-                  icon={TrashIcon}
-                  onClick={onRemove}
-                />
-                <MenuItem
-                  text={t('inputs.array.action.copy')}
-                  icon={CopyIcon}
-                  onClick={handleCopy}
-                />
-                <MenuItem
-                  text={t('inputs.array.action.duplicate')}
-                  icon={AddDocumentIcon}
-                  onClick={handleDuplicate}
-                />
-                {insertBefore.menuItem}
-                {insertAfter.menuItem}
-              </Menu>
-            }
+            menu={<Menu>{menuItems}</Menu>}
             popover={MENU_POPOVER_PROPS}
           />
           {insertBefore.popover}
           {insertAfter.popover}
         </>
       ),
-    [readOnly, insertBefore, insertAfter, props.inputId, t, onRemove, handleCopy, handleDuplicate],
+    [menuItems, readOnly, insertBefore, insertAfter, props.inputId],
   )
 
   const tone = getTone({readOnly, hasErrors, hasWarnings})

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -208,6 +208,7 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
             }}
             button={
               <ContextMenuButton
+                data-testid="array-item-menu-button"
                 selected={insertBefore.state.open || insertAfter.state.open ? true : undefined}
               />
             }

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions.tsx
@@ -39,6 +39,10 @@ export function ArrayOfPrimitivesFunctions<
       ? 'inputs.array.action.add-item-select-type'
       : 'inputs.array.action.add-item'
 
+  if (schemaType.options?.disableActions?.includes('add')) {
+    return null
+  }
+
   if (readOnly) {
     return (
       <Tooltip portal content={t('inputs.array.read-only-label')}>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions.tsx
@@ -47,7 +47,14 @@ export function ArrayOfPrimitivesFunctions<
     return (
       <Tooltip portal content={t('inputs.array.read-only-label')}>
         <Grid>
-          <Button icon={AddIcon} mode="ghost" disabled size="large" text={t(addItemI18nKey)} />
+          <Button
+            data-testid="add-single-primitive-button"
+            icon={AddIcon}
+            mode="ghost"
+            disabled
+            size="large"
+            text={t(addItemI18nKey)}
+          />
         </Grid>
       </Tooltip>
     )
@@ -57,6 +64,7 @@ export function ArrayOfPrimitivesFunctions<
     <Grid gap={1} style={{gridTemplateColumns: 'repeat(auto-fit, minmax(100px, 1fr))'}}>
       {schemaType.of.length === 1 ? (
         <Button
+          data-testid="add-multiple--primitive-button"
           icon={AddIcon}
           mode="ghost"
           onClick={handleAddBtnClick}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
@@ -1,4 +1,4 @@
-import {AddDocumentIcon, CopyIcon, TrashIcon} from '@sanity/icons'
+import {AddDocumentIcon, CopyIcon, InsertAboveIcon, InsertBelowIcon, TrashIcon} from '@sanity/icons'
 import {type SchemaType} from '@sanity/types'
 import {Box, Flex, Menu} from '@sanity/ui'
 import {type ForwardedRef, forwardRef, useCallback, useMemo} from 'react'
@@ -9,7 +9,7 @@ import {useTranslation} from '../../../../i18n'
 import {FieldPresence} from '../../../../presence'
 import {FormFieldValidationStatus} from '../../../components/formField'
 import {type PrimitiveItemProps} from '../../../types/itemProps'
-import {InsertMenuGroups} from '../ArrayOfObjectsInput/InsertMenuGroups'
+import {InsertMenuGroup} from '../ArrayOfObjectsInput/InsertMenuGroups'
 import {RowLayout} from '../layouts/RowLayout'
 import {getEmptyValue} from './getEmptyValue'
 
@@ -33,6 +33,7 @@ export const ItemRow = forwardRef(function ItemRow(
     onRemove,
     readOnly,
     inputId,
+    parentSchemaType,
     validation,
     children,
     presence,
@@ -72,28 +73,61 @@ export const ItemRow = forwardRef(function ItemRow(
 
   const {t} = useTranslation()
 
+  const disableActions = parentSchemaType.options?.disableActions || []
+
+  const menuItems = [
+    !disableActions.includes('remove') && (
+      <MenuItem
+        key="remove"
+        text={t('inputs.array.action.remove')}
+        tone="critical"
+        icon={TrashIcon}
+        onClick={onRemove}
+      />
+    ),
+    !disableActions.includes('copy') && (
+      <MenuItem
+        key="copy"
+        text={t('inputs.array.action.copy')}
+        icon={CopyIcon}
+        onClick={handleCopy}
+      />
+    ),
+    !disableActions.includes('duplicate') && (
+      <MenuItem
+        key="duplicate"
+        text={t('inputs.array.action.duplicate')}
+        icon={AddDocumentIcon}
+        onClick={handleDuplicate}
+      />
+    ),
+    !(disableActions.includes('add') || disableActions.includes('addBefore')) && (
+      <InsertMenuGroup
+        pos="before"
+        types={insertableTypes}
+        onInsert={handleInsert}
+        text={t('inputs.array.action.add-before')}
+        icon={InsertAboveIcon}
+      />
+    ),
+    !disableActions.includes('add') &&
+      !(disableActions.includes('addAfter') && disableActions.includes('addBefore')) && (
+        <InsertMenuGroup
+          pos="after"
+          types={insertableTypes}
+          onInsert={handleInsert}
+          text={t('inputs.array.action.add-after')}
+          icon={InsertBelowIcon}
+        />
+      ),
+  ]
+
   const menu = (
     <MenuButton
       button={<ContextMenuButton />}
       id={`${inputId}-menuButton`}
       popover={MENU_BUTTON_POPOVER_PROPS}
-      menu={
-        <Menu>
-          <MenuItem
-            text={t('inputs.array.action.remove')}
-            tone="critical"
-            icon={TrashIcon}
-            onClick={onRemove}
-          />
-          <MenuItem text={t('inputs.array.action.copy')} icon={CopyIcon} onClick={handleCopy} />
-          <MenuItem
-            text={t('inputs.array.action.duplicate')}
-            icon={AddDocumentIcon}
-            onClick={handleDuplicate}
-          />
-          <InsertMenuGroups types={insertableTypes} onInsert={handleInsert} />
-        </Menu>
-      }
+      menu={<Menu>{menuItems}</Menu>}
     />
   )
 

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
@@ -19,6 +19,7 @@ export type DefaultItemProps = Omit<PrimitiveItemProps, 'renderDefault'> & {
 }
 
 const MENU_BUTTON_POPOVER_PROPS = {portal: true, tone: 'default'} as const
+const EMPTY_ARRAY: never[] = []
 
 export const ItemRow = forwardRef(function ItemRow(
   props: DefaultItemProps,
@@ -73,69 +74,76 @@ export const ItemRow = forwardRef(function ItemRow(
 
   const {t} = useTranslation()
 
-  const disableActions = parentSchemaType.options?.disableActions || []
+  const disableActions = parentSchemaType.options?.disableActions || EMPTY_ARRAY
 
-  const menuItems = [
-    !disableActions.includes('remove') && (
-      <MenuItem
-        key="remove"
-        text={t('inputs.array.action.remove')}
-        tone="critical"
-        icon={TrashIcon}
-        onClick={onRemove}
-      />
-    ),
-    !disableActions.includes('copy') && (
-      <MenuItem
-        key="copy"
-        text={t('inputs.array.action.copy')}
-        icon={CopyIcon}
-        onClick={handleCopy}
-      />
-    ),
-    !disableActions.includes('duplicate') && (
-      <MenuItem
-        key="duplicate"
-        text={t('inputs.array.action.duplicate')}
-        icon={AddDocumentIcon}
-        onClick={handleDuplicate}
-      />
-    ),
-    !(disableActions.includes('add') || disableActions.includes('addBefore')) && (
-      <InsertMenuGroup
-        pos="before"
-        types={insertableTypes}
-        onInsert={handleInsert}
-        text={t('inputs.array.action.add-before')}
-        icon={InsertAboveIcon}
-      />
-    ),
-    !disableActions.includes('add') &&
-      !(disableActions.includes('addAfter') && disableActions.includes('addBefore')) && (
-        <InsertMenuGroup
-          pos="after"
-          types={insertableTypes}
-          onInsert={handleInsert}
-          text={t('inputs.array.action.add-after')}
-          icon={InsertBelowIcon}
-        />
-      ),
-  ]
-
-  const menu = (
-    <MenuButton
-      button={<ContextMenuButton />}
-      id={`${inputId}-menuButton`}
-      popover={MENU_BUTTON_POPOVER_PROPS}
-      menu={<Menu>{menuItems}</Menu>}
-    />
+  const menuItems = useMemo(
+    () =>
+      [
+        !disableActions.includes('remove') && (
+          <MenuItem
+            key="remove"
+            text={t('inputs.array.action.remove')}
+            tone="critical"
+            icon={TrashIcon}
+            onClick={onRemove}
+          />
+        ),
+        !disableActions.includes('copy') && (
+          <MenuItem
+            key="copy"
+            text={t('inputs.array.action.copy')}
+            icon={CopyIcon}
+            onClick={handleCopy}
+          />
+        ),
+        !disableActions.includes('duplicate') && (
+          <MenuItem
+            key="duplicate"
+            text={t('inputs.array.action.duplicate')}
+            icon={AddDocumentIcon}
+            onClick={handleDuplicate}
+          />
+        ),
+        !(disableActions.includes('add') || disableActions.includes('addBefore')) && (
+          <InsertMenuGroup
+            pos="before"
+            types={insertableTypes}
+            onInsert={handleInsert}
+            text={t('inputs.array.action.add-before')}
+            icon={InsertAboveIcon}
+          />
+        ),
+        !disableActions.includes('add') &&
+          !(disableActions.includes('addAfter') && disableActions.includes('addBefore')) && (
+            <InsertMenuGroup
+              pos="after"
+              types={insertableTypes}
+              onInsert={handleInsert}
+              text={t('inputs.array.action.add-after')}
+              icon={InsertBelowIcon}
+            />
+          ),
+      ].filter(Boolean),
+    [disableActions, handleCopy, handleDuplicate, handleInsert, insertableTypes, onRemove, t],
   )
 
+  const menu = useMemo(
+    () =>
+      readOnly || menuItems.length === 0 ? null : (
+        <MenuButton
+          button={<ContextMenuButton />}
+          id={`${inputId}-menuButton`}
+          popover={MENU_BUTTON_POPOVER_PROPS}
+          menu={<Menu>{menuItems}</Menu>}
+        />
+      ),
+    [inputId, menuItems, readOnly],
+  )
   return (
     <RowLayout
       tone={tone}
       readOnly={!!readOnly}
-      menu={!readOnly && menu}
+      menu={menu}
       dragHandle={sortable}
       presence={presence.length === 0 ? null : <FieldPresence presence={presence} maxAvatars={1} />}
       validation={

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
@@ -113,16 +113,15 @@ export const ItemRow = forwardRef(function ItemRow(
             icon={InsertAboveIcon}
           />
         ),
-        !disableActions.includes('add') &&
-          !(disableActions.includes('addAfter') && disableActions.includes('addBefore')) && (
-            <InsertMenuGroup
-              pos="after"
-              types={insertableTypes}
-              onInsert={handleInsert}
-              text={t('inputs.array.action.add-after')}
-              icon={InsertBelowIcon}
-            />
-          ),
+        !disableActions.includes('add') && !disableActions.includes('addAfter') && (
+          <InsertMenuGroup
+            pos="after"
+            types={insertableTypes}
+            onInsert={handleInsert}
+            text={t('inputs.array.action.add-after')}
+            icon={InsertBelowIcon}
+          />
+        ),
       ].filter(Boolean),
     [disableActions, handleCopy, handleDuplicate, handleInsert, insertableTypes, onRemove, t],
   )

--- a/packages/sanity/src/core/form/studio/inputResolver/fieldResolver.tsx
+++ b/packages/sanity/src/core/form/studio/inputResolver/fieldResolver.tsx
@@ -5,7 +5,7 @@ import {
   isReferenceSchemaType,
   type SchemaType,
 } from '@sanity/types'
-import {type ComponentType, useState} from 'react'
+import {type ComponentType, useMemo, useState} from 'react'
 
 import {ChangeIndicator} from '../../../changeIndicators'
 import {type DocumentFieldActionNode} from '../../../config'
@@ -81,11 +81,24 @@ function ObjectOrArrayField(field: ObjectFieldProps | ArrayFieldProps) {
   const documentId = usePublishedId()
   const focused = Boolean(field.inputProps.focused)
 
+  const disableActions = field.schemaType.options?.disableActions || EMPTY_ARRAY
+
+  const actions = useMemo(() => {
+    return field.actions?.filter((a) => {
+      if (a.name === 'pasteField') {
+        return !disableActions.includes('add')
+      }
+      if (a.name === 'copyField') {
+        return !disableActions.includes('copy')
+      }
+      return true
+    })
+  }, [disableActions, field.actions])
   return (
     <>
       {documentId && field.actions && field.actions.length > 0 && (
         <FieldActionsResolver
-          actions={field.actions}
+          actions={actions || EMPTY_ARRAY}
           documentId={documentId}
           documentType={field.schemaType.name}
           onActions={setFieldActionNodes}

--- a/test/e2e/tests/inputs/array-capabilities.spec.ts
+++ b/test/e2e/tests/inputs/array-capabilities.spec.ts
@@ -1,0 +1,46 @@
+import {expect} from '@playwright/test'
+import {type SanityDocument} from '@sanity/client'
+import {test as base} from '@sanity/test'
+
+const test = base.extend<{testDoc: SanityDocument}>({
+  testDoc: async ({page, sanityClient}, use) => {
+    const testDoc = await sanityClient.create({
+      _type: 'arrayCapabilitiesExample',
+      title: 'e2e fixture',
+      objectArray: [
+        {_type: 'something', _key: '5b75c4005e47', first: 'First'},
+        {_type: 'something', _key: 'd2aa1b6c4ca7', first: 'Second'},
+      ],
+      objectArrayAsGrid: [
+        {_type: 'something', _key: '6ec7989ea20a', first: 'First'},
+        {_type: 'something', _key: '630ae68957fb', first: 'Second'},
+      ],
+      primitiveArray: ['First', 2],
+    })
+    await use(testDoc)
+    await sanityClient.delete(testDoc._id)
+  },
+})
+
+test(`Scenario: Disabling all array capabilities`, async ({page, testDoc}) => {
+  await page.goto(`/test/content/arrayCapabilitiesExample;${testDoc._id}`)
+  await expect(page.getByTestId('document-panel-scroller')).toBeAttached({
+    timeout: 40000,
+  })
+
+  const [objectArrayField, gridObjectArrayField, primitiveArrayField] = [
+    page.getByTestId('field-objectArray'),
+    page.getByTestId('field-objectArrayAsGrid'),
+    page.getByTestId('field-primitiveArray'),
+  ] as const
+
+  for (const field of [objectArrayField, gridObjectArrayField]) {
+    await expect(field).toBeAttached()
+    await expect(field.getByTestId('array-item-menu-button')).not.toBeAttached()
+    await expect(field.getByTestId('add-single-object-button')).not.toBeAttached()
+    await expect(field.getByTestId('add-multiple-object-button')).not.toBeAttached()
+  }
+  await expect(primitiveArrayField).toBeAttached()
+  await expect(primitiveArrayField.getByTestId('add-single-primitive-button')).not.toBeAttached()
+  await expect(primitiveArrayField.getByTestId('add-multiple-primitive-button')).not.toBeAttached()
+})


### PR DESCRIPTION
### Description

This adds support for the `disableActions` option on array fields for disabling various array input capabilities like:
  - `add` – Removes the ability to add new items to the array
  - `addBefore` – Removes the "Add item before"-menu item from the array item menu
  - `addAfter` – Removes the "Add item after"-menu item from the array item menu
  - `remove` – Removes the ability to remove items from the array
  - `duplicate` – Removes the ability to duplicate array items
  - `copy` – Removes the ability to copy items from the array

Usage example:
```ts
{
      name: 'someArrayField',
      options: {
        disableActions: ['add', 'duplicate'],
      },
      title: "Array you can't add elements to",
      type: 'array',
      of: [
        {
          type: 'object',
          name: 'something',
          title: 'Something',
          fields: [{name: 'first', type: 'string', title: 'First string'}],
        },
      ],
    }
```

Things to note:
- These changes are only about UI affordances, and doesn't imply any form of write protection for the actual data. Items can still be added or removed to an array by sending mutations to the API.
- This only applies to arrays of objects and arrays of primitive values. Not to portable text arrays.
- Disabling `add` will also implicitly disable `addBefore` and `addAfter`, thus disable inserting new items to the array entirely (although items can still be inserted via `duplicate`).
- There might not be a compelling use case for disabling the ability to `copy` here(?), but including it for completeness. If all known actions are disabled, the menu items and "add"-affordances will be removed from the UI.
- If we later decide to introduce a new default action, this will appear after upgrading the Studio, and will have to be explicitly disabled.
- Disabling `copy` will also disable the `copy` _field action_ (for the entire array). In the same vein, disabling `add` will remove the "paste" field action. However, any other field actions that may have been added by plugins etc. may still be able to manipulate the array in ways disallowed by `disableActions`

### What to review
Does it make sense?

### Testing
- Disable each of the capabilities and check that it works as expected. Toggle individual capabilities in [dev/test-studio/schema/debug/arrayCapabilities.ts](https://github.com/sanity-io/sanity/blob/sdx-1641/dev/test-studio/schema/debug/arrayCapabilities.ts#L3)
I've also added a basic e2e test that asserts that menu items and add button doesn't appear when all capabilities are disabled

### Notes for release

- Adds support for the `disableActions` option on array fields for disabling various array input capabilities 
