### PR TITLE
chore(cli): update help copy for deploy command

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/deploy/deployCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/deploy/deployCommand.ts
@@ -12,6 +12,7 @@ Options
   --auto-updates / --no-auto-updates Enable/disable auto updates of studio versions
   --no-minify Skip minifying built JavaScript (speeds up build, increases size of bundle)
   --no-build Don't build the studio prior to deploy, instead deploying the version currently in \`dist/\`
+  -y, --yes Unattended mode, answers "yes" to any "yes/no" prompt and otherwise uses defaults
 
 Examples
   sanity deploy


### PR DESCRIPTION
### Description

Updates the help text for `sanity deploy` to include the `-y, --yes` flag (unattended mode), which deploy inherits from build.

### What to review

Is this indeed an intended flag for deploy and if so does the description, taken from build, adequately describe the flag.

### Testing

I ran a manual test with the flag set to confirm it works as described

### Notes for release

Not required
