### PR TITLE
fix: restore support for defaultOrdering.

### DIFF
--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -411,6 +411,17 @@ export const structure: StructureResolver = (S, {schema, documentStore, i18n}) =
 
       S.divider(),
 
+      S.listItem()
+        .title('Default ordering test')
+        .id('default-ordering')
+        .child(() =>
+          S.documentTypeList('species')
+            .defaultOrdering([{field: 'species', direction: 'asc'}])
+            .title('Species')
+            .id('default-ordering-list')
+            .filter('_type == $type'),
+        ),
+
       ...S.documentTypeListItems()
         .filter((listItem) => {
           const id = listItem.getId()

--- a/packages/sanity/src/core/store/key-value/localStorageSWR.ts
+++ b/packages/sanity/src/core/store/key-value/localStorageSWR.ts
@@ -10,12 +10,14 @@ import {type KeyValueStore, type KeyValueStoreValue} from './types'
  */
 export function withLocalStorageSWR(wrappedStore: KeyValueStore): KeyValueStore {
   function getKey(key: string) {
-    return merge(of(localStoreStorage.getKey(key)), wrappedStore.getKey(key)).pipe(
-      distinctUntilChanged(isEqual),
-      tap((value) => {
-        localStoreStorage.setKey(key, value)
-      }),
-    )
+    return merge(
+      of(localStoreStorage.getKey(key)),
+      wrappedStore.getKey(key).pipe(
+        tap((wrappedStoreValue) => {
+          localStoreStorage.setKey(key, wrappedStoreValue)
+        }),
+      ),
+    ).pipe(distinctUntilChanged(isEqual))
   }
   function setKey(key: string, nextValue: KeyValueStoreValue) {
     localStoreStorage.setKey(key, nextValue)

--- a/packages/sanity/src/structure/useStructureToolSetting.ts
+++ b/packages/sanity/src/structure/useStructureToolSetting.ts
@@ -1,5 +1,6 @@
 import {useCallback, useMemo} from 'react'
 import {useObservable} from 'react-rx'
+import {map} from 'rxjs/operators'
 import {useKeyValueStore} from 'sanity'
 
 const STRUCTURE_TOOL_NAMESPACE = 'studio.structure-tool'
@@ -17,8 +18,10 @@ export function useStructureToolSetting<ValueType>(
   const keyValueStoreKey = [STRUCTURE_TOOL_NAMESPACE, namespace, key].filter(Boolean).join('.')
 
   const value$ = useMemo(() => {
-    return keyValueStore.getKey(keyValueStoreKey)
-  }, [keyValueStore, keyValueStoreKey])
+    return keyValueStore
+      .getKey(keyValueStoreKey)
+      .pipe(map((value) => (value === null ? defaultValue : value)))
+  }, [defaultValue, keyValueStore, keyValueStoreKey])
 
   const value = useObservable(value$, defaultValue) as ValueType
   const set = useCallback(


### PR DESCRIPTION
fixes #7586

### Description
#7554 broke default sorting because `useStructureToolSetting` always returned `null` from localStorage synchronously, therefore overriding the passed defaultValue. This fixes the issue by always falling back to the defaultValue whenever the settings store emits `null`.

### What to review
Does it make sense?

### Testing

Ideally `useStructureToolSetting` should have unit tests, but I'm not able to prioritize spending time on that right now.

I've manually tested and verified that the behavior is as intended.

### Notes for release

- Fixes a bug causing default sorting for document lists to not be applied