### PR TITLE
chore(test-studio): add asset types to structure navigation

### DIFF
--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -1,4 +1,5 @@
 import {
+  BinaryDocumentIcon,
   CodeIcon,
   CogIcon,
   EarthGlobeIcon,
@@ -231,7 +232,7 @@ export const structure: StructureResolver = (S, {schema, documentStore, i18n}) =
                     options: {
                       filter: '_type == "author" || _type == "book"',
                     },
-                  }),
+                  }).apiVersion('2023-07-28'),
                 ),
 
               // A singleton not using `documentListItem`, eg no built-in preview
@@ -456,6 +457,9 @@ export const structure: StructureResolver = (S, {schema, documentStore, i18n}) =
             ]),
           )
         }),
+      S.divider(),
+      S.documentTypeListItem('sanity.imageAsset').icon(ImagesIcon),
+      S.documentTypeListItem('sanity.fileAsset').icon(BinaryDocumentIcon),
     ])
 }
 


### PR DESCRIPTION
### Description

It is useful to  see the image and file assets at times - this PR adds some structure entries for them to the test studio structure. Also removes an annoying warning about not specifying API version for one of the document lists.

### What to review

Structure items shows up, works.

### Testing

None

### Notes for release

None
