### PR TITLE
fix: warnings on React 19

### DIFF
--- a/dev/test-next-studio/next-env.d.ts
+++ b/dev/test-next-studio/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/packages/sanity/src/core/components/commandList/CommandList.tsx
+++ b/packages/sanity/src/core/components/commandList/CommandList.tsx
@@ -4,6 +4,8 @@ import {throttle} from 'lodash'
 import {
   cloneElement,
   forwardRef,
+  Fragment,
+  isValidElement,
   type ReactElement,
   useCallback,
   useEffect,
@@ -612,9 +614,14 @@ export const CommandList = forwardRef<CommandListHandle, CommandListProps>(funct
               virtualIndex,
             }) as ReactElement
 
-            const clonedItem = cloneElement(itemToRender, {
-              tabIndex: -1,
-            })
+            const clonedItem = cloneElement(
+              itemToRender,
+              isValidElement(itemToRender) && itemToRender.type == Fragment
+                ? {}
+                : {
+                    tabIndex: -1,
+                  },
+            )
 
             const activeAriaAttributes =
               typeof activeIndex === 'number' && !disabled
@@ -655,3 +662,4 @@ export const CommandList = forwardRef<CommandListHandle, CommandListProps>(funct
     </VirtualListBox>
   )
 })
+CommandList.displayName = 'ForwardRef(CommandList)'

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
@@ -99,7 +99,7 @@ function SubSection({subSection}: {subSection: Section}) {
           case 'internalAction': // TODO: Add support for internal actions (MVI-2)
             if (!item.type) return null
             if (item.type === 'studio-announcements-modal')
-              return <StudioAnnouncementsMenuItem text={item.title} />
+              return <StudioAnnouncementsMenuItem key={item._key} text={item.title} />
             return (
               item.type === 'show-welcome-modal' && <MenuItem key={item._key} text={item.title} />
             )


### PR DESCRIPTION
### Description

On React 19, on Next 15 in `next dev` in particular, we got warnings that show up as errors, and that aren't actionable in userland as the problem is in our code.
One half of it [was fixed](https://github.com/sanity-io/ui/pull/1430) in `@sanity/ui` #7653
The rest is in this PR.

The errors seen in userland are:

<img width="1251" alt="image" src="https://github.com/user-attachments/assets/3f55344b-413a-4af7-b7bb-f19f2f3897bb">

<img width="1248" alt="image" src="https://github.com/user-attachments/assets/eaf951a1-279a-4bdc-b321-fdb3a3a4edeb">

As well as this console warning:
<img width="908" alt="Screenshot 2024-10-22 at 15 29 10" src="https://github.com/user-attachments/assets/0c89f178-e09a-4e27-84f8-6a243137f878">

### What to review

These are minor changes but have a glance to see if we're avoiding any regressions.

### Testing

You can test the before/after by running `pnpm dev:next-studio` on `next`, then on this branch.
Opening http://localhost:3333/test/structure/author, and the help menu:
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/21405fd9-6467-46d6-bb94-430b177ad6ec">
Should be enough to both trigger the dialog, and the `console.warn` instances.

### Notes for release

Fixed warnings on React 19:
- Accessing element.ref was removed in React 19.
- Invalid prop `tabIndex` was supplied to `React.Fragment`.
