### PR TITLE
fix(core): export BetaFeatures and ScheduledPublishing types

### DIFF
--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -903,9 +903,10 @@ export type DefaultPluginsWorkspaceOptions = {
 }
 
 /**
- * Configuration for studio features.
+ * @internal
+ * Configuration for studio beta features.
  * */
-interface BetaFeatures {
+export interface BetaFeatures {
   /**
    * @beta
    * @hidden

--- a/packages/sanity/src/core/scheduledPublishing/index.ts
+++ b/packages/sanity/src/core/scheduledPublishing/index.ts
@@ -1,3 +1,4 @@
 export * from './components/editScheduleForm/EditScheduleForm'
 export * from './plugin/documentActions/schedule/ScheduleAction'
 export * from './plugin/documentBadges/scheduled/ScheduledBadge'
+export {type ScheduledPublishingPluginOptions} from './types'


### PR DESCRIPTION
### Description

Export types `BetaFeatures` and `ScheduledPublishing` from `sanity` 

External libraries, like [sanity-typed ](https://github.com/saiichihashimoto/sanity-typed) need the types used in `defineConfig` to be exported.

fixes: https://github.com/sanity-io/sanity/issues/7637


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Any side effect to consider? 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
No new functionality added, no tests added.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a 
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
