### PR TITLE
feat(cli): add warning and docs for react-19 and Next.Js combined

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -305,7 +305,8 @@ export default async function initSanity(
   }
 
   let initNext = false
-  if (detectedFramework?.slug === 'nextjs') {
+  const isNextJs = detectedFramework?.slug === 'nextjs'
+  if (isNextJs) {
     initNext = await prompt.single({
       type: 'confirm',
       message:
@@ -334,21 +335,25 @@ export default async function initSanity(
   // Ensure we are using the output path provided by user
   outputPath = answers.outputPath
 
-  const packageJson = readPackageJson(`${outputPath}/package.json`)
-  const reactVersion = packageJson.dependencies?.react
-  const isUsingReact19 = semver.coerce(reactVersion)?.major === 19
-  const isUsingNextJs15 =
-    detectedFramework?.slug === 'nextjs' &&
-    semver.coerce(detectedFramework?.detectedVersion)?.major === 15
+  if (isNextJs) {
+    const packageJson = readPackageJson(`${outputPath}/package.json`)
+    const reactVersion = packageJson?.dependencies?.react
 
-  if (isUsingNextJs15 && isUsingReact19) {
-    warn('╭────────────────────────────────────────────────────────────╮')
-    warn('│                                                            │')
-    warn('│ It looks like you are using Next.js 15 and React 19        │')
-    warn('│ Please read our compatibility guide.                       │')
-    warn('│ https://www.sanity.io/help/react-19                        │')
-    warn('│                                                            │')
-    warn('╰────────────────────────────────────────────────────────────╯')
+    if (reactVersion) {
+      const isUsingReact19 = semver.coerce(reactVersion)?.major === 19
+      const isUsingNextJs15 =
+        isNextJs && semver.coerce(detectedFramework?.detectedVersion)?.major === 15
+
+      if (isUsingNextJs15 && isUsingReact19) {
+        warn('╭────────────────────────────────────────────────────────────╮')
+        warn('│                                                            │')
+        warn('│ It looks like you are using Next.js 15 and React 19        │')
+        warn('│ Please read our compatibility guide.                       │')
+        warn('│ https://www.sanity.io/help/react-19                        │')
+        warn('│                                                            │')
+        warn('╰────────────────────────────────────────────────────────────╯')
+      }
+    }
   }
 
   if (initNext) {

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -337,11 +337,11 @@ export default async function initSanity(
   const packageJson = readPackageJson(`${outputPath}/package.json`)
   const reactVersion = packageJson.dependencies?.react
   const isUsingReact19 = semver.coerce(reactVersion)?.major === 19
-  if (
+  const isUsingNextJs15 =
     detectedFramework?.slug === 'nextjs' &&
-    detectedFramework?.detectedVersion?.startsWith('15') &&
-    isUsingReact19
-  ) {
+    semver.coerce(detectedFramework?.detectedVersion)?.major === 15
+
+  if (isUsingNextJs15 && isUsingReact19) {
     warn('╭────────────────────────────────────────────────────────────╮')
     warn('│                                                            │')
     warn('│ It looks like you are using Next.js 15 and React 19        │')

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 
 import {type DatasetAclMode, type SanityProject} from '@sanity/client'
 import {type Framework} from '@vercel/frameworks'
+import {type detectFrameworkRecord} from '@vercel/fs-detectors'
 import dotenv from 'dotenv'
 import execa, {type CommonOptions} from 'execa'
 import {deburr, noop} from 'lodash'
@@ -112,7 +113,9 @@ export interface ProjectOrganization {
 // eslint-disable-next-line max-statements, complexity
 export default async function initSanity(
   args: CliCommandArguments<InitFlags>,
-  context: CliCommandContext & {detectedFramework: Framework | null},
+  context: CliCommandContext & {
+    detectedFramework: Awaited<ReturnType<typeof detectFrameworkRecord>>
+  },
 ): Promise<void> {
   const {
     output,
@@ -336,7 +339,6 @@ export default async function initSanity(
   const isUsingReact19 = semver.coerce(reactVersion)?.major === 19
   if (
     detectedFramework?.slug === 'nextjs' &&
-    // @ts-expect-error - Detected version is not typed into Framework interface
     detectedFramework?.detectedVersion?.startsWith('15') &&
     isUsingReact19
   ) {

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -341,8 +341,7 @@ export default async function initSanity(
 
     if (reactVersion) {
       const isUsingReact19 = semver.coerce(reactVersion)?.major === 19
-      const isUsingNextJs15 =
-        isNextJs && semver.coerce(detectedFramework?.detectedVersion)?.major === 15
+      const isUsingNextJs15 = semver.coerce(detectedFramework?.detectedVersion)?.major === 15
 
       if (isUsingNextJs15 && isUsingReact19) {
         warn('╭────────────────────────────────────────────────────────────╮')

--- a/packages/@sanity/cli/src/actions/init-project/readPackageJson.ts
+++ b/packages/@sanity/cli/src/actions/init-project/readPackageJson.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs'
+
+import {type PackageJson} from '@sanity/cli'
+
+/**
+ * Read the `package.json` file at the given path
+ *
+ * @param filePath - Path to package.json to read
+ * @returns The parsed package.json
+ */
+export function readPackageJson(filePath: string): PackageJson {
+  try {
+    // eslint-disable-next-line no-sync
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+  } catch (err) {
+    throw new Error(`Failed to read "${filePath}": ${err.message}`)
+  }
+}

--- a/packages/@sanity/cli/src/actions/init-project/readPackageJson.ts
+++ b/packages/@sanity/cli/src/actions/init-project/readPackageJson.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 
-import {type PackageJson} from '@sanity/cli'
+import {type PackageJson} from '../../types'
 
 /**
  * Read the `package.json` file at the given path

--- a/packages/@sanity/cli/src/actions/init-project/readPackageJson.ts
+++ b/packages/@sanity/cli/src/actions/init-project/readPackageJson.ts
@@ -8,11 +8,11 @@ import {type PackageJson} from '../../types'
  * @param filePath - Path to package.json to read
  * @returns The parsed package.json
  */
-export function readPackageJson(filePath: string): PackageJson {
+export function readPackageJson(filePath: string): PackageJson | undefined {
   try {
     // eslint-disable-next-line no-sync
     return JSON.parse(fs.readFileSync(filePath, 'utf8'))
   } catch (err) {
-    throw new Error(`Failed to read "${filePath}": ${err.message}`)
+    return undefined
   }
 }


### PR DESCRIPTION
### Description
Using React 19 in an embebed studio inside NextJs is not supported. 
We want to show documentation to users on how to fix the issue in the cli when starting the project.

This adds warning and documentation for users https://www.sanity.io/help/react-19

https://github.com/user-attachments/assets/39e61c72-91f6-4d2a-aa33-abecb2eeb2db



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Are we missing something?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Add warning and documentation for users using React 19 and NextJs 15, visit https://www.sanity.io/help/react-19
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
