### PR TITLE
perf(core): memoize resolveInitialValueForType

### DIFF
--- a/packages/sanity/src/core/store/_legacy/grants/__tests__/templatePermissions.test.ts
+++ b/packages/sanity/src/core/store/_legacy/grants/__tests__/templatePermissions.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import {type SanityClient} from '@sanity/client'
-import {type InitialValueResolverContext} from '@sanity/types'
+import {type InitialValueResolverContext, type Schema} from '@sanity/types'
 import {firstValueFrom} from 'rxjs'
 import {describe, expect, it} from 'vitest'
 
@@ -51,6 +51,14 @@ describe('getTemplatePermissions', () => {
       userId: null,
     })
 
+    const context: InitialValueResolverContext = {
+      projectId: 'test-project',
+      dataset: 'test-dataset',
+      schema: schema as Schema,
+      currentUser: null,
+      getClient: () => client as unknown as SanityClient,
+    }
+
     const permissions = firstValueFrom(
       getTemplatePermissions({
         grantsStore,
@@ -62,15 +70,17 @@ describe('getTemplatePermissions', () => {
             templateId: 'author-developer-locked',
             type: 'initialValueTemplateItem',
             schemaType: 'author',
+            parameters: {},
           },
           {
             id: 'author-developer-unlocked',
             templateId: 'author-developer-unlocked',
             type: 'initialValueTemplateItem',
             schemaType: 'author',
+            parameters: {},
           },
         ],
-        context: {} as InitialValueResolverContext,
+        context,
       }),
     )
 
@@ -79,6 +89,7 @@ describe('getTemplatePermissions', () => {
         description: undefined,
         granted: false,
         icon: undefined,
+        i18n: undefined,
         schemaType: 'author',
         id: 'author-developer-locked',
         reason: 'No matching grants found',
@@ -93,11 +104,13 @@ describe('getTemplatePermissions', () => {
         templateId: 'author-developer-locked',
         title: 'Developer',
         type: 'initialValueTemplateItem',
+        parameters: {},
       },
       {
         description: undefined,
         granted: true,
         icon: undefined,
+        i18n: undefined,
         schemaType: 'author',
         id: 'author-developer-unlocked',
         reason: 'Matching grant',
@@ -112,6 +125,7 @@ describe('getTemplatePermissions', () => {
         templateId: 'author-developer-unlocked',
         title: 'Developer',
         type: 'initialValueTemplateItem',
+        parameters: {},
       },
     ])
   })


### PR DESCRIPTION
### Description

This PR refactors the template permissions resolution to handle templates sequentially instead of in parallel. The key changes are:

- Replaces `combineLatest` with `from().pipe(concatMap())` to process templates one at a time
- Improves caching of initial value resolution to reduce duplicate computations
- Fixes test timeouts by properly mocking async operations and providing complete contexts

These changes were introduced to improve performance and reliability when resolving template permissions, particularly for large numbers of templates. The sequential processing helps prevent potential race conditions and resource contention.

### What to review

Key areas to review:
1. The shift from parallel to sequential processing in `templatePermissions.ts`
2. The new caching implementation in `resolve.ts` including:
   - Cache key generation with `stableStringify`
   - Handling of context properties in cache keys
   - WeakMap usage for type-level caching
3. Updated tests that verify both the sequential processing and caching behavior
4. Mock implementations ensuring proper Observable completion

### Testing

The changes are thoroughly tested through:
- Updated unit tests for `templatePermissions.ts` that verify sequential processing
- Expanded test suite for `resolve.ts` covering various caching scenarios:
  - Object property order independence
  - Array handling
  - Null/undefined values
  - Context property changes
  - Cache invalidation cases
- Edge cases for template resolution like missing templates or schema types

### Notes for release

Performance improvements for template permissions:
- Template permissions are now resolved sequentially instead of in parallel, improving reliability for large numbers of templates
- Added smarter caching for initial value resolution, reducing duplicate computations
- No API changes or breaking changes - this is an internal optimization

These changes should result in more predictable performance and reduced resource usage when working with templates, particularly in larger projects with many templates.