### PR TITLE
feat(core): move bundlesPerspective to usePerspective hook, sort releases

### DIFF
--- a/packages/sanity/src/core/releases/components/ReleasesMenu.tsx
+++ b/packages/sanity/src/core/releases/components/ReleasesMenu.tsx
@@ -25,15 +25,14 @@ interface BundleListProps {
   releases: ReleaseDocument[] | null
   loading: boolean
   actions?: ReactElement
-  perspective?: string
 }
 
 /**
  * @internal
  */
 export const ReleasesMenu = memo(function ReleasesMenu(props: BundleListProps): ReactElement {
-  const {releases, loading, actions, button, perspective} = props
-  const {currentGlobalBundle, setPerspectiveFromRelease} = usePerspective(perspective)
+  const {releases, loading, actions, button} = props
+  const {currentGlobalBundle, setPerspectiveFromRelease} = usePerspective()
   const {t} = useTranslation()
 
   const sortedBundlesToDisplay = useMemo(() => {

--- a/packages/sanity/src/core/releases/hooks/__tests__/utils.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/utils.test.ts
@@ -1,0 +1,230 @@
+import {createReleaseId, getBundleIdFromReleaseId, type ReleaseDocument} from 'sanity'
+import {describe, expect, it} from 'vitest'
+
+import {RELEASE_DOCUMENT_TYPE} from '../../../store/release/constants'
+import {getReleasesPerspective, sortReleases} from '../utils'
+
+function createReleaseMock(
+  value: Partial<
+    Omit<ReleaseDocument, 'metadata'> & {
+      metadata: Partial<ReleaseDocument['metadata']>
+    }
+  >,
+): ReleaseDocument {
+  const id = value._id || createReleaseId()
+  const name = getBundleIdFromReleaseId(id)
+  return {
+    _id: id,
+    _type: RELEASE_DOCUMENT_TYPE,
+    _createdAt: new Date().toISOString(),
+    _updatedAt: new Date().toISOString(),
+    name: getBundleIdFromReleaseId(id),
+    createdBy: 'snty1',
+    state: 'active',
+    ...value,
+    metadata: {
+      title: `Release ${name}`,
+      releaseType: 'asap',
+      ...value.metadata,
+    },
+  }
+}
+describe('sortReleases()', () => {
+  it('should return the asap releases ordered by createdAt', () => {
+    const releases: ReleaseDocument[] = [
+      createReleaseMock({
+        _id: 'system-tmp-releases.asap1',
+        _createdAt: '2024-10-24T00:00:00Z',
+        metadata: {
+          releaseType: 'asap',
+        },
+      }),
+      createReleaseMock({
+        _id: 'system-tmp-releases.asap2',
+        _createdAt: '2024-10-25T00:00:00Z',
+        metadata: {
+          releaseType: 'asap',
+        },
+      }),
+    ]
+    const sorted = sortReleases(releases)
+    const expectedOrder = ['asap2', 'asap1']
+    expectedOrder.forEach((expectedName, idx) => {
+      expect(sorted[idx].name).toBe(expectedName)
+    })
+  })
+  it('should return the scheduled releases ordered by intendedPublishAt or publishAt', () => {
+    const releases: ReleaseDocument[] = [
+      createReleaseMock({
+        _id: 'system-tmp-releases.future2',
+        metadata: {
+          releaseType: 'scheduled',
+          intendedPublishAt: '2024-11-25T00:00:00Z',
+        },
+      }),
+      createReleaseMock({
+        _id: 'system-tmp-releases.future1',
+        metadata: {
+          releaseType: 'scheduled',
+          intendedPublishAt: '2024-11-23T00:00:00Z',
+        },
+      }),
+      createReleaseMock({
+        _id: 'system-tmp-releases.future4',
+        state: 'scheduled',
+        publishAt: '2024-11-31T00:00:00Z',
+        metadata: {
+          releaseType: 'scheduled',
+          intendedPublishAt: '2024-10-20T00:00:00Z',
+        },
+      }),
+      createReleaseMock({
+        _id: 'system-tmp-releases.future3',
+        state: 'scheduled',
+        publishAt: '2024-11-26T00:00:00Z',
+        metadata: {
+          releaseType: 'scheduled',
+          intendedPublishAt: '2024-11-22T00:00:00Z',
+        },
+      }),
+    ]
+    const sorted = sortReleases(releases)
+    const expectedOrder = ['future4', 'future3', 'future2', 'future1']
+    expectedOrder.forEach((expectedName, idx) => {
+      expect(sorted[idx].name).toBe(expectedName)
+    })
+  })
+  it('should return the undecided releases ordered by createdAt', () => {
+    const releases: ReleaseDocument[] = [
+      createReleaseMock({
+        _id: 'system-tmp-releases.undecided1',
+        _createdAt: '2024-10-25T00:00:00Z',
+        metadata: {
+          releaseType: 'undecided',
+        },
+      }),
+      createReleaseMock({
+        _id: 'system-tmp-releases.undecided2',
+        _createdAt: '2024-10-26T00:00:00Z',
+        metadata: {
+          releaseType: 'undecided',
+        },
+      }),
+    ]
+    const sorted = sortReleases(releases)
+    const expectedOrder = ['undecided2', 'undecided1']
+    expectedOrder.forEach((expectedName, idx) => {
+      expect(sorted[idx].name).toBe(expectedName)
+    })
+  })
+  it("should gracefully combine all release types, and sort them by 'undecided', 'scheduled', 'asap'", () => {
+    const releases = [
+      createReleaseMock({
+        _id: 'system-tmp-releases.asap2',
+        _createdAt: '2024-10-25T00:00:00Z',
+        metadata: {
+          releaseType: 'asap',
+        },
+      }),
+      createReleaseMock({
+        _id: 'system-tmp-releases.asap1',
+        _createdAt: '2024-10-24T00:00:00Z',
+        metadata: {
+          releaseType: 'asap',
+        },
+      }),
+      createReleaseMock({
+        _id: 'system-tmp-releases.undecided2',
+        _createdAt: '2024-10-26T00:00:00Z',
+        metadata: {
+          releaseType: 'undecided',
+        },
+      }),
+      createReleaseMock({
+        _id: 'system-tmp-releases.future4',
+        state: 'scheduled',
+        publishAt: '2024-11-31T00:00:00Z',
+        metadata: {
+          releaseType: 'scheduled',
+          intendedPublishAt: '2024-10-20T00:00:00Z',
+        },
+      }),
+      createReleaseMock({
+        _id: 'system-tmp-releases.future1',
+        metadata: {
+          releaseType: 'scheduled',
+          intendedPublishAt: '2024-11-23T00:00:00Z',
+        },
+      }),
+    ]
+    const sorted = sortReleases(releases)
+    const expectedOrder = ['undecided2', 'future4', 'future1', 'asap2', 'asap1']
+    expectedOrder.forEach((expectedName, idx) => {
+      expect(sorted[idx].name).toBe(expectedName)
+    })
+  })
+})
+
+describe('getReleasesPerspective()', () => {
+  const releases = [
+    createReleaseMock({
+      _id: 'system-tmp-releases.asap2',
+      _createdAt: '2024-10-25T00:00:00Z',
+      metadata: {
+        releaseType: 'asap',
+      },
+    }),
+    createReleaseMock({
+      _id: 'system-tmp-releases.asap1',
+      _createdAt: '2024-10-24T00:00:00Z',
+      metadata: {
+        releaseType: 'asap',
+      },
+    }),
+    createReleaseMock({
+      _id: 'system-tmp-releases.undecided2',
+      _createdAt: '2024-10-26T00:00:00Z',
+      metadata: {
+        releaseType: 'undecided',
+      },
+    }),
+    createReleaseMock({
+      _id: 'system-tmp-releases.future4',
+      state: 'scheduled',
+      publishAt: '2024-11-31T00:00:00Z',
+      metadata: {
+        releaseType: 'scheduled',
+        intendedPublishAt: '2024-10-20T00:00:00Z',
+      },
+    }),
+    createReleaseMock({
+      _id: 'system-tmp-releases.future1',
+      metadata: {
+        releaseType: 'scheduled',
+        intendedPublishAt: '2024-11-23T00:00:00Z',
+      },
+    }),
+  ]
+  // Define your test cases with the expected outcomes
+  const testCases = [
+    {perspective: 'bundle.asap1', excluded: [], expected: ['asap1', 'drafts']},
+    {perspective: 'bundle.asap2', excluded: [], expected: ['asap2', 'asap1', 'drafts']},
+    {
+      perspective: 'bundle.undecided2',
+      excluded: [],
+      expected: ['undecided2', 'future4', 'future1', 'asap2', 'asap1', 'drafts'],
+    },
+    {
+      perspective: 'bundle.undecided2',
+      excluded: ['future1', 'drafts'],
+      expected: ['undecided2', 'future4', 'asap2', 'asap1'],
+    },
+  ]
+  it.each(testCases)(
+    'should return the correct release stack for %s',
+    ({perspective, excluded, expected}) => {
+      const result = getReleasesPerspective({releases, perspective, excluded})
+      expect(result).toEqual(expected)
+    },
+  )
+})

--- a/packages/sanity/src/core/releases/hooks/__tests__/utils.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/utils.test.ts
@@ -1,7 +1,9 @@
-import {createReleaseId, getBundleIdFromReleaseId, type ReleaseDocument} from 'sanity'
 import {describe, expect, it} from 'vitest'
 
 import {RELEASE_DOCUMENT_TYPE} from '../../../store/release/constants'
+import {type ReleaseDocument} from '../../../store/release/types'
+import {createReleaseId} from '../../util/createReleaseId'
+import {getBundleIdFromReleaseId} from '../../util/getBundleIdFromReleaseId'
 import {getReleasesPerspective, sortReleases} from '../utils'
 
 function createReleaseMock(

--- a/packages/sanity/src/core/releases/hooks/__tests__/utils.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/utils.test.ts
@@ -35,14 +35,14 @@ describe('sortReleases()', () => {
   it('should return the asap releases ordered by createdAt', () => {
     const releases: ReleaseDocument[] = [
       createReleaseMock({
-        _id: 'system-tmp-releases.asap1',
+        _id: '_.releases.asap1',
         _createdAt: '2024-10-24T00:00:00Z',
         metadata: {
           releaseType: 'asap',
         },
       }),
       createReleaseMock({
-        _id: 'system-tmp-releases.asap2',
+        _id: '_.releases.asap2',
         _createdAt: '2024-10-25T00:00:00Z',
         metadata: {
           releaseType: 'asap',
@@ -58,21 +58,21 @@ describe('sortReleases()', () => {
   it('should return the scheduled releases ordered by intendedPublishAt or publishAt', () => {
     const releases: ReleaseDocument[] = [
       createReleaseMock({
-        _id: 'system-tmp-releases.future2',
+        _id: '_.releases.future2',
         metadata: {
           releaseType: 'scheduled',
           intendedPublishAt: '2024-11-25T00:00:00Z',
         },
       }),
       createReleaseMock({
-        _id: 'system-tmp-releases.future1',
+        _id: '_.releases.future1',
         metadata: {
           releaseType: 'scheduled',
           intendedPublishAt: '2024-11-23T00:00:00Z',
         },
       }),
       createReleaseMock({
-        _id: 'system-tmp-releases.future4',
+        _id: '_.releases.future4',
         state: 'scheduled',
         publishAt: '2024-11-31T00:00:00Z',
         metadata: {
@@ -81,7 +81,7 @@ describe('sortReleases()', () => {
         },
       }),
       createReleaseMock({
-        _id: 'system-tmp-releases.future3',
+        _id: '_.releases.future3',
         state: 'scheduled',
         publishAt: '2024-11-26T00:00:00Z',
         metadata: {
@@ -99,14 +99,14 @@ describe('sortReleases()', () => {
   it('should return the undecided releases ordered by createdAt', () => {
     const releases: ReleaseDocument[] = [
       createReleaseMock({
-        _id: 'system-tmp-releases.undecided1',
+        _id: '_.releases.undecided1',
         _createdAt: '2024-10-25T00:00:00Z',
         metadata: {
           releaseType: 'undecided',
         },
       }),
       createReleaseMock({
-        _id: 'system-tmp-releases.undecided2',
+        _id: '_.releases.undecided2',
         _createdAt: '2024-10-26T00:00:00Z',
         metadata: {
           releaseType: 'undecided',
@@ -122,28 +122,28 @@ describe('sortReleases()', () => {
   it("should gracefully combine all release types, and sort them by 'undecided', 'scheduled', 'asap'", () => {
     const releases = [
       createReleaseMock({
-        _id: 'system-tmp-releases.asap2',
+        _id: '_.releases.asap2',
         _createdAt: '2024-10-25T00:00:00Z',
         metadata: {
           releaseType: 'asap',
         },
       }),
       createReleaseMock({
-        _id: 'system-tmp-releases.asap1',
+        _id: '_.releases.asap1',
         _createdAt: '2024-10-24T00:00:00Z',
         metadata: {
           releaseType: 'asap',
         },
       }),
       createReleaseMock({
-        _id: 'system-tmp-releases.undecided2',
+        _id: '_.releases.undecided2',
         _createdAt: '2024-10-26T00:00:00Z',
         metadata: {
           releaseType: 'undecided',
         },
       }),
       createReleaseMock({
-        _id: 'system-tmp-releases.future4',
+        _id: '_.releases.future4',
         state: 'scheduled',
         publishAt: '2024-11-31T00:00:00Z',
         metadata: {
@@ -152,7 +152,7 @@ describe('sortReleases()', () => {
         },
       }),
       createReleaseMock({
-        _id: 'system-tmp-releases.future1',
+        _id: '_.releases.future1',
         metadata: {
           releaseType: 'scheduled',
           intendedPublishAt: '2024-11-23T00:00:00Z',
@@ -170,28 +170,28 @@ describe('sortReleases()', () => {
 describe('getReleasesPerspective()', () => {
   const releases = [
     createReleaseMock({
-      _id: 'system-tmp-releases.asap2',
+      _id: '_.releases.asap2',
       _createdAt: '2024-10-25T00:00:00Z',
       metadata: {
         releaseType: 'asap',
       },
     }),
     createReleaseMock({
-      _id: 'system-tmp-releases.asap1',
+      _id: '_.releases.asap1',
       _createdAt: '2024-10-24T00:00:00Z',
       metadata: {
         releaseType: 'asap',
       },
     }),
     createReleaseMock({
-      _id: 'system-tmp-releases.undecided2',
+      _id: '_.releases.undecided2',
       _createdAt: '2024-10-26T00:00:00Z',
       metadata: {
         releaseType: 'undecided',
       },
     }),
     createReleaseMock({
-      _id: 'system-tmp-releases.future4',
+      _id: '_.releases.future4',
       state: 'scheduled',
       publishAt: '2024-11-31T00:00:00Z',
       metadata: {
@@ -200,7 +200,7 @@ describe('getReleasesPerspective()', () => {
       },
     }),
     createReleaseMock({
-      _id: 'system-tmp-releases.future1',
+      _id: '_.releases.future1',
       metadata: {
         releaseType: 'scheduled',
         intendedPublishAt: '2024-11-23T00:00:00Z',

--- a/packages/sanity/src/core/releases/hooks/utils.ts
+++ b/packages/sanity/src/core/releases/hooks/utils.ts
@@ -1,10 +1,9 @@
-import {getBundleIdFromReleaseId} from 'sanity'
-
 import {type ReleaseDocument} from '../../store/release/types'
 import {DRAFTS_FOLDER} from '../../util/draftUtils'
 import {resolveBundlePerspective} from '../../util/resolvePerspective'
+import {getBundleIdFromReleaseId} from '../util/getBundleIdFromReleaseId'
 
-export function sortReleases(releases: ReleaseDocument[]): ReleaseDocument[] {
+export function sortReleases(releases: ReleaseDocument[] = []): ReleaseDocument[] {
   // The order should always be:
   // [undecided (sortByCreatedAt), scheduled(sortBy publishAt || metadata.intendedPublishAt), asap(sortByCreatedAt)]
   return releases.toSorted((a, b) => {

--- a/packages/sanity/src/core/releases/hooks/utils.ts
+++ b/packages/sanity/src/core/releases/hooks/utils.ts
@@ -1,0 +1,78 @@
+import {getBundleIdFromReleaseId} from 'sanity'
+
+import {type ReleaseDocument} from '../../store/release/types'
+import {DRAFTS_FOLDER} from '../../util/draftUtils'
+import {resolveBundlePerspective} from '../../util/resolvePerspective'
+
+export function sortReleases(releases: ReleaseDocument[]): ReleaseDocument[] {
+  // The order should always be:
+  // [undecided (sortByCreatedAt), scheduled(sortBy publishAt || metadata.intendedPublishAt), asap(sortByCreatedAt)]
+  return releases.toSorted((a, b) => {
+    // undecided are always first, then by createdAt descending
+    if (a.metadata.releaseType === 'undecided' && b.metadata.releaseType !== 'undecided') {
+      return -1
+    }
+    if (a.metadata.releaseType !== 'undecided' && b.metadata.releaseType === 'undecided') {
+      return 1
+    }
+    if (a.metadata.releaseType === 'undecided' && b.metadata.releaseType === 'undecided') {
+      // Sort by createdAt
+      return new Date(b._createdAt).getTime() - new Date(a._createdAt).getTime()
+    }
+
+    // Scheduled are always at the middle, then by publishAt descending
+    if (a.metadata.releaseType === 'scheduled' && b.metadata.releaseType === 'scheduled') {
+      const aPublishAt = a.publishAt || a.metadata.intendedPublishAt
+      if (!aPublishAt) {
+        return 1
+      }
+      const bPublishAt = b.publishAt || b.metadata.intendedPublishAt
+      if (!bPublishAt) {
+        return -1
+      }
+      return new Date(bPublishAt).getTime() - new Date(aPublishAt).getTime()
+    }
+
+    // ASAP are always last, then by createdAt descending
+    if (a.metadata.releaseType === 'asap' && b.metadata.releaseType !== 'asap') {
+      return 1
+    }
+    if (a.metadata.releaseType !== 'asap' && b.metadata.releaseType === 'asap') {
+      return -1
+    }
+    if (a.metadata.releaseType === 'asap' && b.metadata.releaseType === 'asap') {
+      // Sort by createdAt
+      return new Date(b._createdAt).getTime() - new Date(a._createdAt).getTime()
+    }
+
+    return 0
+  })
+}
+
+export function getReleasesPerspective({
+  releases,
+  perspective,
+  excluded,
+}: {
+  releases: ReleaseDocument[]
+  perspective: string | undefined // Includes the bundle.<releaseName> or 'published'
+  excluded: string[]
+}): string[] {
+  if (!perspective?.startsWith('bundle.')) {
+    return []
+  }
+  const perspectiveId = resolveBundlePerspective(perspective)
+  if (!perspectiveId) {
+    return []
+  }
+
+  const sorted = sortReleases(releases).map((release) => getBundleIdFromReleaseId(release._id))
+  const selectedIndex = sorted.indexOf(perspectiveId)
+  if (selectedIndex === -1) {
+    return []
+  }
+  return sorted
+    .slice(selectedIndex)
+    .concat(DRAFTS_FOLDER)
+    .filter((name) => !excluded.includes(name))
+}

--- a/packages/sanity/src/core/releases/hooks/utils.ts
+++ b/packages/sanity/src/core/releases/hooks/utils.ts
@@ -6,7 +6,7 @@ import {getBundleIdFromReleaseId} from '../util/getBundleIdFromReleaseId'
 export function sortReleases(releases: ReleaseDocument[] = []): ReleaseDocument[] {
   // The order should always be:
   // [undecided (sortByCreatedAt), scheduled(sortBy publishAt || metadata.intendedPublishAt), asap(sortByCreatedAt)]
-  return releases.toSorted((a, b) => {
+  return [...releases].sort((a, b) => {
     // undecided are always first, then by createdAt descending
     if (a.metadata.releaseType === 'undecided' && b.metadata.releaseType !== 'undecided') {
       return -1

--- a/packages/sanity/src/core/releases/tool/detail/AddDocumentSearch.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/AddDocumentSearch.tsx
@@ -1,10 +1,11 @@
+import {type SanityDocumentLike} from '@sanity/types'
 import {LayerProvider, PortalProvider, useToast} from '@sanity/ui'
 import {useCallback} from 'react'
-import {getBundleIdFromReleaseId, useReleaseOperations} from 'sanity'
 
-import {type SanityDocumentLike} from '../../../../../../@sanity/types/src/documents/types'
+import {useReleaseOperations} from '../../../store/release/useReleaseOperations'
 import {SearchPopover} from '../../../studio/components/navbar/search/components/SearchPopover'
 import {SearchProvider} from '../../../studio/components/navbar/search/contexts/search/SearchProvider'
+import {getBundleIdFromReleaseId} from '../../util/getBundleIdFromReleaseId'
 
 export function AddDocumentSearch({
   open,

--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -1,9 +1,8 @@
 /* eslint-disable camelcase */
 
 import {useTelemetry} from '@sanity/telemetry/react'
-import {useCallback, useMemo, useRef} from 'react'
+import {useCallback, useMemo} from 'react'
 import {of} from 'rxjs'
-import {useRouter} from 'sanity/router'
 
 import {useClient, useSchema, useTemplates} from '../../hooks'
 import {createDocumentPreviewStore, type DocumentPreviewStore} from '../../preview'
@@ -297,32 +296,26 @@ export function useKeyValueStore(): KeyValueStore {
 export function useReleasesStore(): ReleaseStore {
   const resourceCache = useResourceCache()
   const workspace = useWorkspace()
-  const currentUser = useCurrentUser()
   const previewStore = useDocumentPreviewStore()
   const studioClient = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
-  const router = useRouter()
-  const perspectiveRef = useRef(router.perspectiveState.perspective)
 
-  // TODO: Include hidden layers state.
   return useMemo(() => {
     const releaseStore =
       resourceCache.get<ReleaseStore>({
-        dependencies: [workspace, currentUser, previewStore],
+        dependencies: [workspace, previewStore],
         namespace: 'ReleasesStore',
       }) ||
       createReleaseStore({
         client: studioClient,
-        currentUser,
-        perspective: perspectiveRef.current,
         previewStore,
       })
 
     resourceCache.set({
-      dependencies: [workspace, currentUser, previewStore],
+      dependencies: [workspace, previewStore],
       namespace: 'ReleasesStore',
       value: releaseStore,
     })
 
     return releaseStore
-  }, [resourceCache, workspace, studioClient, currentUser, previewStore])
+  }, [resourceCache, workspace, studioClient, previewStore])
 }

--- a/packages/sanity/src/core/store/release/createReleaseStore.ts
+++ b/packages/sanity/src/core/store/release/createReleaseStore.ts
@@ -1,5 +1,4 @@
 import {type ListenEvent, type ListenOptions, type SanityClient} from '@sanity/client'
-import {type User} from '@sanity/types'
 import {
   BehaviorSubject,
   catchError,
@@ -70,10 +69,8 @@ const INITIAL_STATE: ReleasesReducerState = {
 export function createReleaseStore(context: {
   previewStore: DocumentPreviewStore
   client: SanityClient
-  currentUser: User | null
-  perspective?: string
 }): ReleaseStore {
-  const {client, currentUser, previewStore} = context
+  const {client, previewStore} = context
 
   const dispatch$ = new Subject<ReleasesReducerAction>()
   const fetchPending$ = new BehaviorSubject<boolean>(false)
@@ -159,7 +156,7 @@ export function createReleaseStore(context: {
 
   const state$ = merge(listFetch$, dispatch$).pipe(
     filter((action): action is ReleasesReducerAction => typeof action !== 'undefined'),
-    scan((state, action) => releasesReducer(state, action, context.perspective), INITIAL_STATE),
+    scan((state, action) => releasesReducer(state, action), INITIAL_STATE),
     startWith(INITIAL_STATE),
     shareReplay(1),
   )

--- a/packages/sanity/src/core/store/release/types.ts
+++ b/packages/sanity/src/core/store/release/types.ts
@@ -46,10 +46,16 @@ export interface ReleaseDocument {
   _type: typeof RELEASE_DOCUMENT_TYPE
   _createdAt: string
   _updatedAt: string
+  /**
+   * The same as the last path segment of the _id, added by the backend.
+   */
   name: string
   createdBy: string
   state: ReleaseState
   finalDocumentStates?: ReleaseFinalDocumentState[]
+  /**
+   * If defined, it takes precedence over the intendedPublishAt, the state should be 'scheduled'
+   */
   publishAt?: string
   metadata: {
     title: string

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
@@ -3,7 +3,7 @@ import {type SchemaType} from '@sanity/types'
 import {Badge, Box, Flex} from '@sanity/ui'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
-import {getBundleIdFromReleaseId, getPublishedId} from 'sanity'
+import {getBundleIdFromReleaseId, getPublishedId, usePerspective} from 'sanity'
 import {styled} from 'styled-components'
 
 import {type GeneralPreviewLayoutKey} from '../../../../../../../components'
@@ -55,14 +55,15 @@ export function SearchResultItemPreview({
 }: SearchResultItemPreviewProps) {
   const documentPreviewStore = useDocumentPreviewStore()
   const releases = useReleases()
+  const {bundlesPerspective} = usePerspective()
 
   const observable = useMemo(
     () =>
       getPreviewStateObservable(documentPreviewStore, schemaType, getPublishedId(documentId), '', {
         bundleIds: (releases.data ?? []).map((release) => getBundleIdFromReleaseId(release._id)),
-        bundleStack: releases.stack,
+        bundleStack: bundlesPerspective,
       }),
-    [releases.data, releases.stack, documentId, documentPreviewStore, schemaType],
+    [releases.data, bundlesPerspective, documentId, documentPreviewStore, schemaType],
   )
 
   const {

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
@@ -3,7 +3,7 @@ import {type SchemaType} from '@sanity/types'
 import {Badge, Box, Flex} from '@sanity/ui'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
-import {getBundleIdFromReleaseId, getPublishedId, usePerspective} from 'sanity'
+import {getBundleIdFromReleaseId, getPublishedId} from 'sanity'
 import {styled} from 'styled-components'
 
 import {type GeneralPreviewLayoutKey} from '../../../../../../../components'
@@ -15,6 +15,7 @@ import {
   getPreviewValueWithFallback,
   SanityDefaultPreview,
 } from '../../../../../../../preview'
+import {usePerspective} from '../../../../../../../releases/hooks/usePerspective'
 import {
   type DocumentPresence,
   useDocumentPreviewStore,

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
@@ -1,11 +1,12 @@
 import {isEqual} from 'lodash'
 import {type ReactNode, useEffect, useMemo, useReducer, useRef, useState} from 'react'
+import {usePerspective} from 'sanity'
 import {SearchContext} from 'sanity/_singletons'
 
 import {type CommandListHandle} from '../../../../../../components'
 import {useSchema} from '../../../../../../hooks'
 import {type SearchTerms} from '../../../../../../search'
-import {useCurrentUser, useReleases} from '../../../../../../store'
+import {useCurrentUser} from '../../../../../../store'
 import {resolvePerspectiveOptions} from '../../../../../../util/resolvePerspective'
 import {useSource} from '../../../../../source'
 import {SEARCH_LIMIT} from '../../constants'
@@ -31,7 +32,7 @@ interface SearchProviderProps {
 export function SearchProvider({children, fullscreen}: SearchProviderProps) {
   const [onClose, setOnClose] = useState<(() => void) | null>(null)
   const [searchCommandList, setSearchCommandList] = useState<CommandListHandle | null>(null)
-  const releases = useReleases()
+  const {bundlesPerspective} = usePerspective()
   const schema = useSchema()
   const currentUser = useCurrentUser()
   const {
@@ -141,7 +142,7 @@ export function SearchProvider({children, fullscreen}: SearchProviderProps) {
           skipSortByScore: ordering.ignoreScore,
           ...(ordering.sort ? {sort: [ordering.sort]} : {}),
           cursor: cursor || undefined,
-          ...resolvePerspectiveOptions(releases.stack),
+          ...resolvePerspectiveOptions(bundlesPerspective),
         },
         terms: {
           ...terms,
@@ -167,7 +168,7 @@ export function SearchProvider({children, fullscreen}: SearchProviderProps) {
     searchState.terms,
     terms,
     cursor,
-    releases.stack,
+    bundlesPerspective,
   ])
 
   /**

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
@@ -1,10 +1,10 @@
 import {isEqual} from 'lodash'
 import {type ReactNode, useEffect, useMemo, useReducer, useRef, useState} from 'react'
-import {usePerspective} from 'sanity'
 import {SearchContext} from 'sanity/_singletons'
 
 import {type CommandListHandle} from '../../../../../../components'
 import {useSchema} from '../../../../../../hooks'
+import {usePerspective} from '../../../../../../releases/hooks/usePerspective'
 import {type SearchTerms} from '../../../../../../search'
 import {useCurrentUser} from '../../../../../../store'
 import {resolvePerspectiveOptions} from '../../../../../../util/resolvePerspective'

--- a/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
@@ -15,6 +15,7 @@ import {
   getPreviewValueWithFallback,
   isRecord,
   SanityDefaultPreview,
+  usePerspective,
   useReleases,
 } from 'sanity'
 
@@ -47,14 +48,14 @@ export function PaneItemPreview(props: PaneItemPreviewProps) {
       : null
 
   const releases = useReleases()
-
+  const {bundlesPerspective} = usePerspective()
   const previewStateObservable = useMemo(
     () =>
       getPreviewStateObservable(props.documentPreviewStore, schemaType, value._id, title, {
         bundleIds: (releases.data ?? []).map((release) => getBundleIdFromReleaseId(release._id)),
-        bundleStack: releases.stack,
+        bundleStack: bundlesPerspective,
       }),
-    [props.documentPreviewStore, schemaType, value._id, title, releases.data, releases.stack],
+    [props.documentPreviewStore, schemaType, value._id, title, releases.data, bundlesPerspective],
   )
 
   const {

--- a/packages/sanity/src/structure/components/paneRouter/PaneRouterProvider.tsx
+++ b/packages/sanity/src/structure/components/paneRouter/PaneRouterProvider.tsx
@@ -24,6 +24,7 @@ export function PaneRouterProvider(props: {
   params: Record<string, string | undefined>
   payload: unknown
   siblingIndex: number
+  // TODO: Remove this paneRouter perspective - releases are only global
   perspective?: string
 }) {
   const {children, flatIndex, index, params, payload, siblingIndex} = props

--- a/packages/sanity/src/structure/components/paneRouter/types.ts
+++ b/packages/sanity/src/structure/components/paneRouter/types.ts
@@ -170,6 +170,7 @@ export interface PaneRouterContextValue {
   ) => void
 
   /**
+   * TODO: Remove this paneRouter perspective - releases are only global
    * Perspective of the current pane
    */
   perspective?: string

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -19,7 +19,7 @@ import {VersionChip} from './VersionChip'
 export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
   const {perspective} = usePaneRouter()
   const {t} = useTranslation()
-  const {setPerspective} = usePerspective(perspective)
+  const {setPerspective} = usePerspective()
   const dateTimeFormat = useDateTimeFormat({
     dateStyle: 'medium',
     timeStyle: 'short',
@@ -41,10 +41,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
   // remove the archived releases
   const filteredReleases =
     (documentVersions &&
-      releases?.filter(
-        (release) =>
-          !versionDocumentExists(documentVersions, release._id) && release.state !== 'archived',
-      )) ||
+      releases?.filter((release) => !versionDocumentExists(documentVersions, release._id))) ||
     []
 
   const asapReleases = documentVersions?.filter(

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
@@ -3,7 +3,6 @@ import {useEffect, useLayoutEffect, useState} from 'react'
 import {DocumentStatus, DocumentStatusIndicator, usePerspective, useSyncState} from 'sanity'
 
 import {Tooltip} from '../../../../ui-components'
-import {usePaneRouter} from '../../../components/paneRouter'
 import {useDocumentPane} from '../useDocumentPane'
 import {DocumentStatusPulse} from './DocumentStatusPulse'
 
@@ -20,8 +19,7 @@ export function DocumentStatusLine({singleLine}: DocumentStatusLineProps) {
   const [status, setStatus] = useState<'saved' | 'syncing' | null>(null)
 
   const syncState = useSyncState(documentId, documentType, {version: editState?.bundleId})
-  const paneRouter = usePaneRouter()
-  const {currentGlobalBundle} = usePerspective(paneRouter.perspective)
+  const {currentGlobalBundle} = usePerspective()
 
   const lastUpdated = value?._updatedAt
 

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -6,6 +6,7 @@ import {debounce, map, type Observable, of, tap, timer} from 'rxjs'
 import {
   type GeneralPreviewLayoutKey,
   useI18nText,
+  usePerspective,
   useReleases,
   useSchema,
   useTranslation,
@@ -75,6 +76,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   const {childItemId, isActive, pane, paneKey, sortOrder: sortOrderRaw, layout} = props
   const schema = useSchema()
   const releases = useReleases()
+  const {bundlesPerspective} = usePerspective()
   const {displayOptions, options} = pane
   const {apiVersion, filter} = options
   const params = useShallowUnique(options.params || EMPTY_RECORD)
@@ -111,7 +113,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   } = useDocumentList({
     apiVersion,
     filter,
-    perspective: releases.stack,
+    perspective: bundlesPerspective,
     params,
     searchQuery: searchQuery?.trim(),
     sortOrder,


### PR DESCRIPTION
### Description

This Pr moves the `releases.stack` to the `usePerspective` hook into the `bundlesPerspective` property, this relates to the client query parameter.

This also includes changes to sort the releases and exports the releases from the store now sorted.

The sorting is as it follows:
- undecided sorted by created at
- scheduled sorted by publishAt || intended publish date
- asap sorted by created at

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Tests for sorting and bundles perspective have been added.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
