### PR TITLE
feat(core): add versions to references and status icons

### DIFF
--- a/packages/@sanity/types/src/schema/preview.ts
+++ b/packages/@sanity/types/src/schema/preview.ts
@@ -10,6 +10,9 @@ export interface PrepareViewOptions {
 
 /** @public */
 export interface PreviewValue {
+  _id?: string
+  _createdAt?: string
+  _updatedAt?: string
   title?: string
   subtitle?: string
   description?: string

--- a/packages/sanity/src/core/components/documentStatusIndicator/DocumentStatusIndicator.tsx
+++ b/packages/sanity/src/core/components/documentStatusIndicator/DocumentStatusIndicator.tsx
@@ -1,62 +1,92 @@
 import {DotIcon} from '@sanity/icons'
 import {type PreviewValue, type SanityDocument} from '@sanity/types'
-import {Text} from '@sanity/ui'
-import {useMemo} from 'react'
+import {Flex, Text} from '@sanity/ui'
+import {type ComponentType, useMemo} from 'react'
 import {styled} from 'styled-components'
 
 import {type VersionsRecord} from '../../preview/utils/getPreviewStateObservable'
+import {useReleases} from '../../store/release/useReleases'
 
 interface DocumentStatusProps {
   draft?: PreviewValue | Partial<SanityDocument> | null
   published?: PreviewValue | Partial<SanityDocument> | null
-  version?: PreviewValue | Partial<SanityDocument> | null
-  // eslint-disable-next-line
-  versions?: VersionsRecord
+  versions: VersionsRecord | undefined
 }
 
 const Root = styled(Text)`
-  &[data-status='edited'] {
-    --card-icon-color: var(--card-badge-caution-dot-color);
-  }
-  &[data-status='unpublished'] {
+  &[data-status='not-published'] {
     --card-icon-color: var(--card-badge-default-dot-color);
     opacity: 0.5 !important;
   }
+  &[data-status='draft'] {
+    --card-icon-color: var(--card-badge-caution-dot-color);
+  }
+  &[data-status='asap'] {
+    --card-icon-color: var(--card-badge-critical-dot-color);
+  }
+  &[data-status='undecided'] {
+    --card-icon-color: var(--card-badge-explore-dot-color);
+  }
+  &[data-status='scheduled'] {
+    --card-icon-color: var(--card-badge-primary-dot-color);
+  }
 `
+
+type Status = 'not-published' | 'draft' | 'asap' | 'scheduled' | 'undecided'
 
 /**
  * Renders a dot indicating the current document status.
  *
- * - Yellow (caution) for published documents with edits
- * - Gray (default) for unpublished documents (with or without edits)
- *
- * No dot will be displayed for published documents without edits or for version documents.
- *
  * @internal
  */
-export function DocumentStatusIndicator({draft, published, version}: DocumentStatusProps) {
-  const $draft = Boolean(draft)
-  const $published = Boolean(published)
-  const $version = Boolean(version)
+export function DocumentStatusIndicator({draft, published, versions}: DocumentStatusProps) {
+  const {data: releases} = useReleases()
+  const versionsList = useMemo(
+    () =>
+      versions
+        ? Object.keys(versions).map((versionName) => {
+            const release = releases?.find((r) => r.name === versionName)
+            return release?.metadata.releaseType
+          })
+        : [],
+    [releases, versions],
+  )
 
-  const status = useMemo(() => {
-    if ($version) return undefined
-    if ($draft && !$published) return 'unpublished'
-    return 'edited'
-  }, [$draft, $published, $version])
+  const indicators: {
+    status: Status
+    show: boolean
+  }[] = [
+    {
+      status: draft && !published ? 'not-published' : 'draft',
+      show: Boolean(draft),
+    },
+    {
+      status: 'asap',
+      show: versionsList.includes('asap'),
+    },
+    {
+      status: 'scheduled',
+      show: versionsList.includes('scheduled'),
+    },
+    {
+      status: 'undecided',
+      show: versionsList.includes('undecided'),
+    },
+  ]
 
-  // Return null if the document is:
-  // - Published without edits
-  // - Neither published or without edits (this shouldn't be possible)
-  // - A version
-  if ((!$draft && !$published) || (!$draft && $published) || $version) {
-    return null
-  }
-
-  // TODO: Remove debug `status[0]` output.
   return (
-    <Root data-status={status} size={1}>
-      <DotIcon />
-    </Root>
+    <Flex>
+      {indicators
+        .filter(({show}) => show)
+        .map(({status}) => (
+          <Dot key={status} status={status} />
+        ))}
+    </Flex>
   )
 }
+
+const Dot: ComponentType<{status: Status}> = ({status}) => (
+  <Root data-status={status} size={1}>
+    <DotIcon />
+  </Root>
+)

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferencePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferencePreview.tsx
@@ -45,8 +45,6 @@ export function ReferencePreview(props: {
     [previewId, refType.name],
   )
 
-  const {draft, published, version} = preview
-
   const previewProps = useMemo(
     () => ({
       children: (
@@ -61,28 +59,31 @@ export function ReferencePreview(props: {
             <DocumentStatusIndicator
               draft={preview.draft}
               published={preview.published}
-              version={preview.version}
+              versions={preview.versions}
             />
           </Inline>
         </Box>
       ),
       layout,
       schemaType: refType,
-      tooltip: <DocumentStatus draft={draft} published={published} version={version} />,
+      tooltip: (
+        <DocumentStatus
+          draft={preview.draft}
+          published={preview.published}
+          versions={preview.versions}
+        />
+      ),
       value: previewStub,
     }),
     [
       documentPresence,
-      draft,
       layout,
       preview.draft,
       preview.published,
-      preview.version,
+      preview.versions,
       previewStub,
-      published,
       refType,
       showTypeLabel,
-      version,
     ],
   )
 

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/types.ts
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/types.ts
@@ -9,6 +9,7 @@ import {type ComponentType, type ReactNode} from 'react'
 import {type Observable} from 'rxjs'
 
 import {type DocumentAvailability} from '../../../preview'
+import {type VersionsRecord} from '../../../preview/utils/getPreviewStateObservable'
 import {type ObjectInputProps} from '../../types'
 
 export type PreviewDocumentValue = PreviewValue & {
@@ -25,6 +26,7 @@ export interface ReferenceInfo {
     draft: PreviewDocumentValue | undefined
     published: PreviewDocumentValue | undefined
     version: PreviewDocumentValue | undefined
+    versions: VersionsRecord
   }
 }
 

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/useReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/useReferenceInput.tsx
@@ -8,10 +8,11 @@ import {
   useMemo,
   useRef,
 } from 'react'
+import {usePerspective} from 'sanity'
 
 import {type FIXME} from '../../../FIXME'
 import {useSchema} from '../../../hooks'
-import {useDocumentPreviewStore} from '../../../store'
+import {useDocumentPreviewStore, useReleases} from '../../../store'
 import {isNonNullable} from '../../../util'
 import {useFormValue} from '../../contexts/FormValue'
 import {useReferenceInputOptions} from '../../studio'
@@ -34,6 +35,8 @@ interface Options {
 export function useReferenceInput(options: Options) {
   const {path, schemaType, version} = options
   const schema = useSchema()
+  const perspective = usePerspective()
+  const releases = useReleases()
   const documentPreviewStore = useDocumentPreviewStore()
   const {EditReferenceLinkComponent, onEditReference, activePath, initialValueTemplateItems} =
     useReferenceInputOptions()
@@ -114,8 +117,24 @@ export function useReferenceInput(options: Options) {
   }, [disableNew, initialValueTemplateItems, schemaType.to])
 
   const getReferenceInfo = useCallback(
-    (id: string) => adapter.getReferenceInfo(documentPreviewStore, id, schemaType, {version}),
-    [documentPreviewStore, schemaType, version],
+    (id: string) =>
+      adapter.getReferenceInfo(
+        documentPreviewStore,
+        id,
+        schemaType,
+        {version},
+        {
+          bundleIds: releases.releasesIds,
+          bundleStack: perspective.bundlesPerspective,
+        },
+      ),
+    [
+      documentPreviewStore,
+      schemaType,
+      version,
+      releases.releasesIds,
+      perspective.bundlesPerspective,
+    ],
   )
 
   return {

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -357,6 +357,11 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Title for the default ordering/SortOrder if no orderings are provided and the title field is found */
   'default-orderings.title': 'Sort by Title',
 
+  /** Label to show in the document footer indicating the creation date of the document */
+  'document-status.created': 'Created {{date}}',
+
+  /** Label to show in the document status indicating the date of the status */
+  'document-status.date': '{{date}}',
   /** Label to show in the document footer indicating the last edited date of the document */
   'document-status.edited': 'Edited {{date}}',
   /** Label to show in the document footer indicating the document is not published*/

--- a/packages/sanity/src/core/preview/components/SanityDefaultPreview.tsx
+++ b/packages/sanity/src/core/preview/components/SanityDefaultPreview.tsx
@@ -132,8 +132,8 @@ export function SanityDefaultPreview(props: SanityDefaultPreviewProps): ReactEle
       <Tooltip
         content={tooltip}
         disabled={!tooltip}
-        fallbackPlacements={['top-end']}
-        placement="bottom-end"
+        fallbackPlacements={['top-end', 'bottom-end']}
+        placement="right"
       >
         {/* Currently tooltips won't trigger without a wrapping element */}
         <div>{children}</div>

--- a/packages/sanity/src/core/preview/types.ts
+++ b/packages/sanity/src/core/preview/types.ts
@@ -96,6 +96,7 @@ export interface DraftsModelDocumentAvailability {
    * document readability for the version document
    */
   version?: DocumentAvailability
+  // TODO:  validate versions availability?
 }
 
 /**

--- a/packages/sanity/src/core/preview/utils/getPreviewStateObservable.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewStateObservable.ts
@@ -13,7 +13,7 @@ import {type DocumentPreviewStore} from '../documentPreviewStore'
  */
 export type VersionsRecord = Record<string, PreparedSnapshot>
 
-type VersionTuple = [bundleId: string, snapshot: PreparedSnapshot]
+export type VersionTuple = [bundleId: string, snapshot: PreparedSnapshot]
 
 export interface PreviewState {
   isLoading?: boolean

--- a/packages/sanity/src/core/scheduledPublishing/components/scheduleItem/PreviewWrapper.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/components/scheduleItem/PreviewWrapper.tsx
@@ -154,6 +154,7 @@ const PreviewWrapper = (props: Props) => {
                     <DocumentStatusIndicator
                       draft={previewState?.draft}
                       published={previewState?.published}
+                      versions={previewState?.versions}
                     />
                   ) : (
                     <StatusDotPlaceholder />

--- a/packages/sanity/src/core/scheduledPublishing/utils/paneItemHelpers.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/utils/paneItemHelpers.tsx
@@ -7,6 +7,7 @@ import {combineLatest, type Observable, of} from 'rxjs'
 import {map, startWith} from 'rxjs/operators'
 
 import {type DocumentPreviewStore} from '../../preview'
+import {type VersionsRecord} from '../../preview/utils/getPreviewStateObservable'
 import {getDraftId, getPublishedId} from '../../util/draftUtils'
 import {type Schedule} from '../types'
 
@@ -14,6 +15,7 @@ export interface PaneItemPreviewState {
   isLoading?: boolean
   draft?: SanityDocument | null
   published?: SanityDocument | null
+  versions?: VersionsRecord
 }
 
 export interface PreviewValue {

--- a/packages/sanity/src/core/store/release/useReleases.ts
+++ b/packages/sanity/src/core/store/release/useReleases.ts
@@ -1,5 +1,6 @@
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
+import {getBundleIdFromReleaseId} from 'sanity'
 
 import {sortReleases} from '../../releases/hooks/utils'
 import {useReleasesStore} from '../_legacy/datastores'
@@ -11,6 +12,10 @@ interface ReleasesState {
    * Sorted array of releases, excluding archived releases
    */
   data: ReleaseDocument[]
+  /**
+   * Sorted array of release IDs, excluding archived releases
+   */
+  releasesIds: string[]
   /**
    * Array of archived releases
    */
@@ -37,8 +42,13 @@ export function useReleases(): ReleasesState {
     () => Array.from(state.releases.values()).filter((release) => release.state === 'archived'),
     [state.releases],
   )
+  const releasesIds = useMemo(
+    () => releasesAsArray.map((release) => getBundleIdFromReleaseId(release._id)),
+    [releasesAsArray],
+  )
   return {
     data: releasesAsArray,
+    releasesIds: releasesIds,
     archivedReleases,
     dispatch,
     error: state.error,

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
@@ -3,7 +3,7 @@ import {type SchemaType} from '@sanity/types'
 import {Badge, Box, Flex} from '@sanity/ui'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
-import {getBundleIdFromReleaseId, getPublishedId} from 'sanity'
+import {getPublishedId} from 'sanity'
 import {styled} from 'styled-components'
 
 import {type GeneralPreviewLayoutKey} from '../../../../../../../components'
@@ -61,10 +61,10 @@ export function SearchResultItemPreview({
   const observable = useMemo(
     () =>
       getPreviewStateObservable(documentPreviewStore, schemaType, getPublishedId(documentId), '', {
-        bundleIds: (releases.data ?? []).map((release) => getBundleIdFromReleaseId(release._id)),
+        bundleIds: releases.releasesIds,
         bundleStack: bundlesPerspective,
       }),
-    [releases.data, bundlesPerspective, documentId, documentPreviewStore, schemaType],
+    [documentPreviewStore, schemaType, documentId, releases.releasesIds, bundlesPerspective],
   )
 
   const {
@@ -96,19 +96,12 @@ export function SearchResultItemPreview({
       <Flex align="center" gap={3}>
         {presence && presence.length > 0 && <DocumentPreviewPresence presence={presence} />}
         {showBadge && <Badge>{schemaType.title}</Badge>}
-        <DocumentStatusIndicator
-          draft={draft}
-          published={published}
-          version={version}
-          versions={versions}
-        />
+        <DocumentStatusIndicator draft={draft} published={published} versions={versions} />
       </Flex>
     )
-  }, [draft, isLoading, presence, published, schemaType.title, showBadge, version, versions])
+  }, [draft, isLoading, presence, published, schemaType.title, showBadge, versions])
 
-  const tooltip = (
-    <DocumentStatus draft={draft} published={published} version={version} versions={versions} />
-  )
+  const tooltip = <DocumentStatus draft={draft} published={published} versions={versions} />
 
   return (
     <SearchResultItemPreviewBox>

--- a/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
@@ -10,7 +10,6 @@ import {
   DocumentStatus,
   DocumentStatusIndicator,
   type GeneralPreviewLayoutKey,
-  getBundleIdFromReleaseId,
   getPreviewStateObservable,
   getPreviewValueWithFallback,
   isRecord,
@@ -52,10 +51,17 @@ export function PaneItemPreview(props: PaneItemPreviewProps) {
   const previewStateObservable = useMemo(
     () =>
       getPreviewStateObservable(props.documentPreviewStore, schemaType, value._id, title, {
-        bundleIds: (releases.data ?? []).map((release) => getBundleIdFromReleaseId(release._id)),
+        bundleIds: releases.releasesIds,
         bundleStack: bundlesPerspective,
       }),
-    [props.documentPreviewStore, schemaType, value._id, title, releases.data, bundlesPerspective],
+    [
+      props.documentPreviewStore,
+      schemaType,
+      value._id,
+      title,
+      releases.releasesIds,
+      bundlesPerspective,
+    ],
   )
 
   const {
@@ -79,19 +85,12 @@ export function PaneItemPreview(props: PaneItemPreviewProps) {
     <TooltipDelayGroupProvider>
       <Flex align="center" gap={3}>
         {presence && presence.length > 0 && <DocumentPreviewPresence presence={presence} />}
-        <DocumentStatusIndicator
-          draft={draft}
-          published={published}
-          version={version}
-          versions={versions}
-        />
+        <DocumentStatusIndicator draft={draft} published={published} versions={versions} />
       </Flex>
     </TooltipDelayGroupProvider>
   )
 
-  const tooltip = (
-    <DocumentStatus draft={draft} published={published} version={version} versions={versions} />
-  )
+  const tooltip = <DocumentStatus draft={draft} published={published} versions={versions} />
 
   return (
     <SanityDefaultPreview

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
@@ -76,11 +76,7 @@ export function DocumentStatusBar(props: DocumentStatusBarProps) {
           >
             <Flex align="center" flex={1} gap={collapsed ? 2 : 3} wrap="wrap" paddingRight={3}>
               <Flex align="center">
-                {showingRevision ? (
-                  <RevisionStatusLine />
-                ) : (
-                  <DocumentStatusLine singleLine={!collapsed} />
-                )}
+                {showingRevision ? <RevisionStatusLine /> : <DocumentStatusLine />}
                 <SpacerButton size="large" />
               </Flex>
               <DocumentBadges />

--- a/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetColumns.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetColumns.tsx
@@ -50,7 +50,7 @@ const PreviewCell = (props: {
   const displayValue = (draft?.title ?? published?.title ?? 'Untitled') as string
   return (
     <Flex align="center" gap={3}>
-      <DocumentStatusIndicator draft={draft} published={published} />
+      <DocumentStatusIndicator draft={draft} published={published} versions={undefined} />
       <Text size={1}>{displayValue}</Text>
     </Flex>
   )


### PR DESCRIPTION
### Description

This PR adds changes to the preview and document status components.
It nows shows the versions of the document.

The preview value correctly reflects the stack of releases when previewing a release.
So if a document is part of the releases `asap1, asap2, scheduled1, undecided1` and user is seeing the release `scheduled2` the preview value will reflect the value of the document in release `scheduled1` which is scheduled to be released before scheduled 2

<img width="679" alt="Screenshot 2024-10-29 at 08 51 06" src="https://github.com/user-attachments/assets/feaf355b-af8b-4fa5-b3e4-7f0a89c3fbd4">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
