### PR TITLE
chore(structure): remove perspective from paneRouter

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/__tests__/ReleaseDetailsDialog.test.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/__tests__/ReleaseDetailsDialog.test.tsx
@@ -90,7 +90,7 @@ describe('ReleaseDetailsDialog', () => {
 
       expect(useReleaseOperations().createRelease).toHaveBeenCalledWith(
         expect.objectContaining({
-          _id: expect.stringMatching(/_\.releases\.r\w{8}$/),
+          _id: expect.stringMatching(/r\w{8}$/),
           ...value,
         }),
       )
@@ -98,9 +98,8 @@ describe('ReleaseDetailsDialog', () => {
 
       expect(usePerspective().setPerspective).toHaveBeenCalledOnce()
 
-      expect(usePerspective().setPerspective).toHaveBeenCalledWith(
-        expect.stringMatching(/_\.releases\.r\w{8}$/),
-      )
+      expect(usePerspective().setPerspective).toHaveBeenCalledWith(expect.stringMatching(/r\w{8}$/))
+
       expect(onSubmitMock).toHaveBeenCalled()
     })
   })

--- a/packages/sanity/src/structure/components/paneRouter/PaneRouterProvider.tsx
+++ b/packages/sanity/src/structure/components/paneRouter/PaneRouterProvider.tsx
@@ -24,8 +24,6 @@ export function PaneRouterProvider(props: {
   params: Record<string, string | undefined>
   payload: unknown
   siblingIndex: number
-  // TODO: Remove this paneRouter perspective - releases are only global
-  perspective?: string
 }) {
   const {children, flatIndex, index, params, payload, siblingIndex} = props
   const {navigate, navigateIntent, resolvePathFromState} = useRouter()
@@ -221,9 +219,6 @@ export function PaneRouterProvider(props: {
 
       // Proxied navigation to a given intent. Consider just exposing `router` instead?
       navigateIntent,
-
-      // Perspective of the current pane
-      perspective: props.perspective,
     }),
     [
       flatIndex,
@@ -237,7 +232,6 @@ export function PaneRouterProvider(props: {
       setPayload,
       createPathWithParams,
       navigateIntent,
-      props.perspective,
       modifyCurrentGroup,
       lastPane,
       navigate,

--- a/packages/sanity/src/structure/components/paneRouter/types.ts
+++ b/packages/sanity/src/structure/components/paneRouter/types.ts
@@ -168,10 +168,4 @@ export interface PaneRouterContextValue {
     params: Record<string, string>,
     options?: {replace?: boolean},
   ) => void
-
-  /**
-   * TODO: Remove this paneRouter perspective - releases are only global
-   * Perspective of the current pane
-   */
-  perspective?: string
 }

--- a/packages/sanity/src/structure/components/structureTool/StructureTitle.tsx
+++ b/packages/sanity/src/structure/components/structureTool/StructureTitle.tsx
@@ -4,17 +4,16 @@ import {
   resolveBundlePerspective,
   unstable_useValuePreview as useValuePreview,
   useEditState,
+  usePerspective,
   useSchema,
   useTranslation,
 } from 'sanity'
-import {useRouter} from 'sanity/router'
 
 import {LOADING_PANE} from '../../constants'
 import {structureLocaleNamespace} from '../../i18n'
 import {type Panes} from '../../structureResolvers'
 import {type DocumentPaneNode} from '../../types'
 import {useStructureTool} from '../../useStructureTool'
-import {usePaneRouter} from '../paneRouter'
 
 interface StructureTitleProps {
   resolvedPanes: Panes['resolvedPanes']
@@ -23,9 +22,7 @@ interface StructureTitleProps {
 // TODO: Fix state jank when editing different versions inside panes.
 const DocumentTitle = (props: {documentId: string; documentType: string}) => {
   const {documentId, documentType} = props
-  const router = useRouter()
-  const paneRouter = usePaneRouter()
-  const perspective = paneRouter.perspective ?? router.stickyParams.perspective
+  const {perspective} = usePerspective()
 
   const editState = useEditState(
     documentId,

--- a/packages/sanity/src/structure/panes/StructureToolPane.tsx
+++ b/packages/sanity/src/structure/panes/StructureToolPane.tsx
@@ -1,9 +1,7 @@
 import {isEqual} from 'lodash'
 import {lazy, memo, Suspense} from 'react'
-import {useRouter} from 'sanity/router'
 
 import {PaneRouterProvider} from '../components/paneRouter'
-import {useResolvedPanes} from '../structureResolvers'
 import {type PaneNode} from '../types'
 import {LoadingPane} from './loading'
 import {UnknownPane} from './unknown'
@@ -54,8 +52,6 @@ export const StructureToolPane = memo(
     } = props
 
     const PaneComponent = paneMap[pane.type] || UnknownPane
-    const {stickyParams} = useRouter()
-    const {resolvedPanes} = useResolvedPanes()
 
     return (
       <PaneRouterProvider
@@ -64,7 +60,6 @@ export const StructureToolPane = memo(
         params={params}
         payload={payload}
         siblingIndex={siblingIndex}
-        perspective={params.perspective ?? stickyParams.perspective}
       >
         <Suspense fallback={<LoadingPane paneKey={paneKey} path={path} selected={selected} />}>
           <PaneComponent

--- a/packages/sanity/src/structure/panes/document/DocumentPane.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPane.tsx
@@ -8,6 +8,7 @@ import {
   SourceProvider,
   Translate,
   useDocumentType,
+  usePerspective,
   useSource,
   useTemplatePermissions,
   useTemplates,
@@ -44,6 +45,7 @@ export const DocumentPane = memo(function DocumentPane(props: DocumentPaneProvid
 function DocumentPaneInner(props: DocumentPaneProviderProps) {
   const {pane, paneKey} = props
   const {resolveNewDocumentOptions} = useSource().document
+  const {perspective} = usePerspective()
   const paneRouter = usePaneRouter()
   const options = usePaneOptions(pane.options, paneRouter.params)
   const {documentType, isLoaded: isDocumentLoaded} = useDocumentType(options.id, options.type)
@@ -130,7 +132,7 @@ function DocumentPaneInner(props: DocumentPaneProviderProps) {
     <DocumentPaneProvider
       // this needs to be here to avoid formState from being re-used across (incompatible) document types
       // see https://github.com/sanity-io/sanity/discussions/3794 for a description of the problem
-      key={`${documentType}-${options.id}-${paneRouter.perspective || ''}`}
+      key={`${documentType}-${options.id}-${perspective || ''}`}
       {...providerProps}
     >
       {/* NOTE: this is a temporary location for this provider until we */}

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -21,6 +21,7 @@ import {
   getDraftId,
   getExpandOperations,
   getPublishedId,
+  getVersionFromId,
   isSanityCreateLinkedDocument,
   isVersionId,
   type OnPathFocusPayload,
@@ -37,6 +38,7 @@ import {
   useEditState,
   useFormState,
   useInitialValue,
+  usePerspective,
   usePresenceStore,
   useSchema,
   useSource,
@@ -100,7 +102,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const documentId = getPublishedId(documentIdRaw)
   const documentType = options.type
   const params = useUnique(paneRouter.params) || EMPTY_PARAMS
-  const {perspective} = paneRouter
+  const {perspective} = usePerspective()
 
   const bundlePerspective = resolveBundlePerspective(perspective)
 
@@ -584,8 +586,10 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
   const isCreateLinked = isSanityCreateLinkedDocument(value)
   const isNonExistent = !value?._id
-  const isNonExistentInBundle = typeof bundlePerspective !== 'undefined' && !isVersionId(value._id)
-  const existsInBundle = typeof bundlePerspective !== 'undefined' && isVersionId(value._id)
+  const isNonExistentInBundle =
+    typeof bundlePerspective !== 'undefined' && getVersionFromId(value._id) !== bundlePerspective
+  const existsInBundle =
+    typeof bundlePerspective !== 'undefined' && getVersionFromId(value._id) === bundlePerspective
 
   const readOnly = useMemo(() => {
     const hasNoPermission = !isPermissionsLoading && !permissions?.granted

--- a/packages/sanity/src/structure/panes/document/comments/CommentsWrapper.tsx
+++ b/packages/sanity/src/structure/panes/document/comments/CommentsWrapper.tsx
@@ -5,8 +5,8 @@ import {
   CommentsProvider,
   getVersionId,
   useCommentsEnabled,
+  usePerspective,
 } from 'sanity'
-import {useRouter} from 'sanity/router'
 
 import {usePaneRouter} from '../../../components'
 import {useDocumentPane} from '../useDocumentPane'
@@ -39,9 +39,8 @@ function CommentsProviderWrapper(props: CommentsWrapperProps) {
 
   const {enabled} = useCommentsEnabled()
   const {connectionState, onPathOpen, inspector, openInspector, version} = useDocumentPane()
-  const router = useRouter()
-  const {params, setParams, createPathWithParams, ...paneRouter} = usePaneRouter()
-  const perspective = paneRouter.perspective ?? router.stickyParams.perspective
+  const {params, setParams, createPathWithParams} = usePaneRouter()
+  const {perspective} = usePerspective()
   const versionOrPublishedId = useMemo(
     () => (version ? getVersionId(documentId, version) : documentId),
     [documentId, version],

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx
@@ -11,6 +11,7 @@ import {
   getPublishedId,
   resolveBundlePerspective,
   useDocumentPreviewStore,
+  usePerspective,
   useTranslation,
 } from 'sanity'
 
@@ -33,8 +34,8 @@ interface ParentReferenceInfo {
 
 export const ReferenceChangedBanner = memo(() => {
   const documentPreviewStore = useDocumentPreviewStore()
-  const {params, groupIndex, routerPanesState, replaceCurrent, BackLink, perspective} =
-    usePaneRouter()
+  const {perspective} = usePerspective()
+  const {params, groupIndex, routerPanesState, replaceCurrent, BackLink} = usePaneRouter()
   const routerReferenceId = routerPanesState[groupIndex]?.[0].id
   const parentGroup = routerPanesState[groupIndex - 1] as RouterPaneGroup | undefined
   const parentSibling = parentGroup?.[0]

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -12,8 +12,8 @@ import {
   useTranslation,
   versionDocumentExists,
 } from 'sanity'
-import {useDocumentPane, usePaneRouter} from 'sanity/structure'
 
+import {useDocumentPane} from '../../../useDocumentPane'
 import {VersionChip} from './VersionChip'
 
 type FilterReleases = {
@@ -55,7 +55,7 @@ const TooltipContent = ({release}: {release: ReleaseDocument}) => {
 }
 
 export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
-  const {perspective} = usePaneRouter()
+  const {perspective} = usePerspective()
   const {t} = useTranslation()
   const {setPerspective} = usePerspective()
   const dateTimeFormat = useDateTimeFormat({

--- a/packages/sanity/src/structure/panes/document/inspectors/validation/index.ts
+++ b/packages/sanity/src/structure/panes/document/inspectors/validation/index.ts
@@ -8,10 +8,10 @@ import {
   isValidationError,
   isValidationWarning,
   resolveBundlePerspective,
+  usePerspective,
   useTranslation,
   useValidationStatus,
 } from 'sanity'
-import {usePaneRouter} from 'sanity/structure'
 
 import {VALIDATION_INSPECTOR_NAME} from '../../constants'
 import {ValidationInspector} from './ValidationInspector'
@@ -19,12 +19,11 @@ import {ValidationInspector} from './ValidationInspector'
 function useMenuItem(props: DocumentInspectorUseMenuItemProps): DocumentInspectorMenuItem {
   const {documentId, documentType} = props
   const {t} = useTranslation('validation')
-  const paneRouter = usePaneRouter()
-
+  const {perspective} = usePerspective()
   const {validation: validationMarkers} = useValidationStatus(
     documentId,
     documentType,
-    resolveBundlePerspective(paneRouter.perspective),
+    resolveBundlePerspective(perspective),
   )
 
   const validation: FormNodeValidation[] = useMemo(


### PR DESCRIPTION
### Description

Perspective is only a global concept, initially we allowed changing the perspective in each pane, but that is not supported anymore.
Removing this simplifies things for consumers and allows presentation to render the releases form in the correct way.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
