### PR TITLE
chore: telemetry definition files are owned by @data-eng

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,7 +48,7 @@ packages/sanity/src/structure/panes/documentList/sheetList @sanity-io/studio-ex
 /packages/@sanity/cli/templates/shopify* @thebiggianthead
 
 # Telemetry definitions
-*.telemetry.ts @sanity-io/growth
+*.telemetry.ts @sanity-io/data-eng
 
 # -- Plugins --
 


### PR DESCRIPTION
No notes for release, merely updating CODEOWNERS to @sanity-io/data-eng from @sanity-io/growth  for who gets pinged for these files
