### PR TITLE
fix: invalid locale namespace specified for create

### DIFF
--- a/packages/sanity/src/core/create/i18n/resources.ts
+++ b/packages/sanity/src/core/create/i18n/resources.ts
@@ -5,7 +5,7 @@ import {defineLocalesResources} from '../../i18n'
  *
  * @internal
  */
-const createLocaleStrings = defineLocalesResources('comments', {
+const createLocaleStrings = defineLocalesResources('create', {
   /** "Start in Sanity Create" action button text */
   'start-in-create-action.label': 'Start in Sanity Create',
 


### PR DESCRIPTION
### Description

The namespace was incorrectly specified for the new `create` strings, which causes issues for the locales repository, as it clobbers the `comments` namespace.

### What to review

Should be pretty obvious ;)

### Testing

Shouldn't be needed.

### Notes for release

None.
