### PR TITLE
feat(codegen): function resolving

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -63,6 +63,21 @@ describe('findQueries with the groq template', () => {
       expect(queryResult?.result).toEqual('*[_type == "author"]')
     })
 
+    test('with function with literal parameters', () => {
+      const source = `
+      import { groq } from "groq";
+      const getType = (type, x = '2') => () =>  \`\${type}\${x}\`;
+      const query = groq\`*[_type == "\${getType("author")()}"]\`
+      const res = sanity.fetch(query);
+    `
+
+      const queries = findQueriesInSource(source, 'test.ts')
+
+      const queryResult = queries[0]
+
+      expect(queryResult?.result).toEqual('*[_type == "author2"]')
+    })
+
     test('with block comment', () => {
       const source = `
         import { groq } from "groq";

--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -124,6 +124,18 @@ describe('findQueries with the groq template', () => {
     expect(queries[0].result).toBe('*[_type == "foo bar"]')
   })
 
+  test('can import from export *', () => {
+    const source = `
+      import { groq } from "groq";
+      import {foo}  from "./fixtures/exportStar";
+      const postQuery = groq\`*[_type == "\${foo}"]\`
+      const res = sanity.fetch(postQueryResult);
+    `
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(1)
+    expect(queries[0].result).toBe('*[_type == "foo"]')
+  })
+
   test('will ignore declarations with ignore tag', () => {
     const source = `
       import { groq } from "groq";

--- a/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
+++ b/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import {type TransformOptions} from '@babel/core'
-import traverse, {type Scope} from '@babel/traverse'
+import traverse, {Scope} from '@babel/traverse'
 import * as babelTypes from '@babel/types'
 import createDebug from 'debug'
 
@@ -125,12 +125,13 @@ export function resolveExpression({
   }
 
   if (babelTypes.isVariableDeclarator(node)) {
-    if (!node.init) {
+    const init = node.init ?? (babelTypes.isAssignmentPattern(node.id) && node.id.right)
+    if (!init) {
       throw new Error(`Unsupported variable declarator`)
     }
 
     return resolveExpression({
-      node: node.init,
+      node: init,
       fnArguments,
       scope,
       filename,
@@ -174,11 +175,20 @@ export function resolveExpression({
     babelTypes.isFunctionDeclaration(node) ||
     babelTypes.isFunctionExpression(node)
   ) {
+    const newScope = new Scope(scope.path, scope)
+
+    params.forEach((param, i) => {
+      newScope.push({
+        id: param as babelTypes.LVal,
+        init: fnArguments[i] as babelTypes.Expression | undefined,
+      })
+    })
+
     return resolveExpression({
       node: node.body,
       params: node.params,
       fnArguments,
-      scope,
+      scope: newScope,
       filename,
       file,
       babelConfig,
@@ -198,7 +208,7 @@ export function resolveExpression({
   }
 
   if (babelTypes.isImportDefaultSpecifier(node) || babelTypes.isImportSpecifier(node)) {
-    return resolveImportSpecifier({node, file, scope, filename, resolver, babelConfig})
+    return resolveImportSpecifier({node, file, scope, filename, fnArguments, resolver, babelConfig})
   }
 
   if (babelTypes.isAssignmentPattern(node)) {
@@ -245,7 +255,10 @@ function resolveIdentifier({
         babelTypes.isIdentifier(param.left) &&
         node.name === param.left.name),
   )
-  const argument = fnArguments[paramIndex]
+  let argument = fnArguments[paramIndex]
+  if (!argument && paramIndex >= 0 && babelTypes.isAssignmentPattern(params[paramIndex])) {
+    argument = params[paramIndex].right
+  }
   if (argument && babelTypes.isLiteral(argument)) {
     return resolveExpression({
       node: argument,
@@ -320,6 +333,7 @@ function resolveImportSpecifier({
   node,
   file,
   filename,
+  fnArguments,
   resolver,
   babelConfig,
 }: {
@@ -327,6 +341,7 @@ function resolveImportSpecifier({
   file: babelTypes.File
   scope: Scope
   filename: string
+  fnArguments: babelTypes.Node[]
   resolver: NodeJS.RequireResolve
   babelConfig: TransformOptions
 }): resolveExpressionReturnType {
@@ -382,6 +397,7 @@ function resolveImportSpecifier({
       node: binding.path.node,
       file: tree,
       scope: newScope,
+      fnArguments,
       babelConfig,
       filename: resolvedFile,
       resolver,
@@ -413,6 +429,7 @@ function resolveImportSpecifier({
       node: namedExport,
       importName: newImportName,
       filename: resolvedFile,
+      fnArguments,
       resolver,
       babelConfig,
     })
@@ -446,12 +463,14 @@ function resolveExportSpecifier({
   node,
   importName,
   filename,
+  fnArguments,
   babelConfig,
   resolver,
 }: {
   node: babelTypes.ExportNamedDeclaration | babelTypes.ExportAllDeclaration
   importName: string
   filename: string
+  fnArguments: babelTypes.Node[]
   babelConfig: TransformOptions
   resolver: NodeJS.RequireResolve
 }): resolveExpressionReturnType {
@@ -484,6 +503,7 @@ function resolveExportSpecifier({
       filename: importFileName,
       babelConfig,
       resolver,
+      fnArguments,
     })
   }
 


### PR DESCRIPTION
### Description

Adds support to Typegen for:
* Export all (`export * from "source.ts"`)
* Nested functions with parameters (#7748)
* Function parameters with default values

### What to review

Only worker code for the Typescript parser was changed. Examples of code that wasn't but is now successfully parsed is in the new tests.

### Testing

Tests were added for the newly supported features.

### Notes for release

Typegen now supports slightly more advanced types of interpolation, e.g. 
```ts
const query = groq`*[_type="asdf"] { 
    "linkA": ${linkQuery('linkA')},
}`;
```
Client code can also import through an export all without confusing Typegen.
