### PR TITLE
feat(sanity): omit search weights when possible

### DIFF
--- a/packages/sanity/src/core/search/weighted/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/weighted/createSearchQuery.ts
@@ -138,11 +138,16 @@ export function createSearchQuery(
     '!(_id in path("versions.**"))',
   ].filter(Boolean)
 
-  const selections = specs.map((spec) => {
-    const constraint = `_type == "${spec.typeName}" => `
-    const selection = `{ ${spec.paths.map((cfg, i) => `"w${i}": ${pathWithMapper(cfg)}`)} }`
-    return `${constraint}${selection}`
-  })
+  const selections = searchOpts.skipSortByScore
+    ? []
+    : specs.map((spec) => {
+        const constraint = `_type == "${spec.typeName}" => `
+        if (searchOpts.skipSortByScore) {
+          return undefined
+        }
+        const selection = `{ ${spec.paths.map((cfg, i) => `"w${i}": ${pathWithMapper(cfg)}`)} }`
+        return `${constraint}${selection}`
+      })
 
   // Default to `_id asc` (GROQ default) if no search sort is provided
   const sortOrder = toOrderClause(searchOpts?.sort || [{field: '_id', direction: 'asc'}])


### PR DESCRIPTION
### Description

When conducting a search, consumers may skip sorting via the `skipSortByScore` option. In this scenario, it's not necessary to query for weights.

Examples of this include:

- Document list filtering.
- Global search when sorting by properties other than relevace, such as updated at or created at.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
