### PR TITLE
fix(ci): avoid literal as const package exports due to etl error

### DIFF
--- a/packages/sanity/src/core/releases/i18n/index.ts
+++ b/packages/sanity/src/core/releases/i18n/index.ts
@@ -5,7 +5,9 @@ import {type LocaleResourceBundle} from '../../i18n'
  *
  * @public
  */
-export const releasesLocaleNamespace = 'releases' as const
+// api extractor take issues with 'as const' for literals
+// eslint-disable-next-line @typescript-eslint/prefer-as-const
+export const releasesLocaleNamespace: 'releases' = 'releases'
 
 /**
  * The default locale release for the releases tool, which is US English.

--- a/packages/sanity/src/core/releases/store/constants.ts
+++ b/packages/sanity/src/core/releases/store/constants.ts
@@ -1,5 +1,9 @@
-export const RELEASE_DOCUMENT_TYPE = 'system.release' as const
+// api extractor take issues with 'as const' for literals
+// eslint-disable-next-line @typescript-eslint/prefer-as-const
+export const RELEASE_DOCUMENT_TYPE: 'system.release' = 'system.release'
 export const RELEASE_DOCUMENTS_PATH = '_.releases'
 
-export const RELEASE_METADATA_TMP_DOC_TYPE = 'system-tmp.release' as const
+// api extractor take issues with 'as const' for literals
+// eslint-disable-next-line @typescript-eslint/prefer-as-const
+export const RELEASE_METADATA_TMP_DOC_TYPE: 'system-tmp.release' = 'system-tmp.release'
 export const RELEASE_METADATA_TMP_DOC_PATH = 'system-tmp-releases'


### PR DESCRIPTION
Should fix the `pnpm etl sanity` task that's currently failing in the base branch
