### PR TITLE
fix(core): explicitly pass `randomKey(12)` as the PTE `keyGenerator`

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -13,6 +13,7 @@ import {
 import {useTelemetry} from '@sanity/telemetry/react'
 import {isKeySegment, type PortableTextBlock} from '@sanity/types'
 import {Box, Flex, Text, useToast} from '@sanity/ui'
+import {randomKey} from '@sanity/util/content'
 import {sortBy} from 'lodash'
 import {
   type MutableRefObject,
@@ -53,6 +54,10 @@ import {usePatches} from './usePatches'
 interface UploadTask {
   file: File
   uploaderCandidates: ResolvedUploader[]
+}
+
+function keyGenerator() {
+  return randomKey(12)
 }
 
 /** @internal */
@@ -384,6 +389,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
           <PortableTextMemberItemsProvider memberItems={portableTextMemberItems}>
             <PortableTextEditor
               patches$={patches$}
+              keyGenerator={keyGenerator}
               onChange={handleEditorChange}
               maxBlocks={undefined} // TODO: from schema?
               ref={editorRef}


### PR DESCRIPTION
In an effort to make `@portabletext/editor` become more stand-alone, I'm looking into removing the few `@sanity/*` dependencies that it has. Here, `@sanity/util` is a low-hanging fruit.

If the `keyGenerator` prop isn't passed, the `PortableTextEditor` will use `randomKey(12)` from `@sanity/util`. However, passing this key generator explictly from the `PortableTextInput` removes this implicit dependency. Now, the Studio keeps getting the same type of random keys and `@portabletext/editor` is free to remove the `@sanity/util` dependency and just copy/paste the source code of `randomKey` or use another default key generator.