### PR TITLE
refactor(sanity): fix date formating, add locked chips and locked document on scheduled releases

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1172,7 +1172,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.chip.tooltip.created-date': 'Created {{date}}',
   /** Label for tooltip in chip with the lasted edited date */
   'release.chip.tooltip.edited-date': 'Edited {{date}}',
-  /** Label for tooltip in chip when document is intended for a future release */
+  /** Label for tooltip in chip when document is intended for a future release that hasn't been scheduled */
   'release.chip.tooltip.intended-for-date': 'Intended for {{date}}',
   /** Label for tooltip in chip when there is no recent draft edits */
   'release.chip.tooltip.no-edits': 'No edits',
@@ -1180,8 +1180,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.chip.tooltip.not-published': 'Not published',
   /** Label for tooltip in chip with the published date */
   'release.chip.tooltip.published-date': 'Published {{date}}',
-  /** Label for tooltip in scheduled chip without a known date */
-  'release.chip.tooltip.unknown-date': 'Unknown date',
+  /** Label for tooltip in chip when document is in a release that has been scheduled */
+  'release.chip.tooltip.scheduled-for-date': 'Scheduled for {{date}}',
   /** Label for tooltip on deleted release */
   'release.deleted-tooltip': 'This release has been deleted',
   /** Title for creating releases dialog */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1182,6 +1182,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.chip.tooltip.published-date': 'Published {{date}}',
   /** Label for tooltip in chip when document is in a release that has been scheduled */
   'release.chip.tooltip.scheduled-for-date': 'Scheduled for {{date}}',
+  /** Label for tooltip in scheduled chip without a known date */
+  'release.chip.tooltip.unknown-date': 'Unknown date',
   /** Label for tooltip on deleted release */
   'release.deleted-tooltip': 'This release has been deleted',
   /** Title for creating releases dialog */

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -31,6 +31,7 @@ export {
   isDraftPerspective,
   isPublishedPerspective,
   isReleaseDocument,
+  isReleaseLocked,
   LATEST,
   type ReleaseDocument,
   useDocumentVersions,

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -31,7 +31,7 @@ export {
   isDraftPerspective,
   isPublishedPerspective,
   isReleaseDocument,
-  isReleaseLocked,
+  isReleaseScheduledOrScheduling,
   LATEST,
   type ReleaseDocument,
   useDocumentVersions,

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -1,3 +1,4 @@
+import {LockIcon} from '@sanity/icons'
 import {type BadgeTone, useClickOutsideEvent, useGlobalKeyDown} from '@sanity/ui'
 import {
   memo,
@@ -47,6 +48,7 @@ export const VersionChip = memo(function VersionChip(props: {
   onClick: () => void
   text: string
   tone: BadgeTone
+  locked?: boolean
   contextValues: {
     documentId: string
     releases: ReleaseDocument[]
@@ -65,6 +67,7 @@ export const VersionChip = memo(function VersionChip(props: {
     onClick,
     text,
     tone,
+    locked = false,
     contextValues: {
       documentId,
       releases,
@@ -174,6 +177,7 @@ export const VersionChip = memo(function VersionChip(props: {
           text={text}
           tone={tone}
           icon={<ReleaseAvatar padding={1} tone={tone} />}
+          iconRight={locked && LockIcon}
           onContextMenu={handleContextMenu}
         />
       </Tooltip>
@@ -190,6 +194,7 @@ export const VersionChip = memo(function VersionChip(props: {
             onCreateRelease={openCreateReleaseDialog}
             disabled={contextMenuDisabled}
             onCreateVersion={handleAddVersion}
+            locked={locked}
           />
         }
         fallbackPlacements={[]}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
@@ -9,6 +9,7 @@ import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {isPublishedId} from '../../../../util/draftUtils'
 import {type ReleaseDocument} from '../../../store/types'
+import {isReleaseScheduledOrScheduling} from '../../../util/util'
 import {VersionContextMenuItem} from './VersionContextMenuItem'
 
 const ReleasesList = styled(Stack)`
@@ -72,8 +73,7 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: {
         >
           <ReleasesList key={fromRelease} space={1}>
             {optionsReleaseList.map((option) => {
-              const isReleaseScheduled =
-                option.value.state === 'scheduled' || option.value.state === 'scheduling'
+              const isReleaseScheduled = isReleaseScheduledOrScheduling(option.value)
               return (
                 <MenuItem
                   as="a"

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
@@ -27,6 +27,7 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: {
   onCreateRelease: () => void
   onCreateVersion: (targetId: string) => void
   disabled?: boolean
+  locked?: boolean
 }) {
   const {
     documentId,
@@ -38,6 +39,7 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: {
     onCreateRelease,
     onCreateVersion,
     disabled,
+    locked,
   } = props
   const {t} = useTranslation()
   const isPublished = isPublishedId(documentId) && !isVersion
@@ -98,7 +100,7 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: {
               icon={TrashIcon}
               onClick={onDiscard}
               text={t('release.action.discard-version')}
-              disabled={disabled}
+              disabled={disabled || locked}
             />
           </>
         )}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuItem.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuItem.tsx
@@ -1,11 +1,12 @@
 import {LockIcon} from '@sanity/icons'
 import {Flex, Stack, Text} from '@sanity/ui'
+import {formatRelative} from 'date-fns'
 import {memo} from 'react'
 
-import {useDateTimeFormat} from '../../../../hooks/useDateTimeFormat'
 import {useTranslation} from '../../../../i18n'
 import {type ReleaseDocument} from '../../../store/types'
 import {getReleaseTone} from '../../../util/getReleaseTone'
+import {getPublishDateFromRelease} from '../../../util/util'
 import {ReleaseAvatar} from '../../ReleaseAvatar'
 
 export const VersionContextMenuItem = memo(function VersionContextMenuItem(props: {
@@ -13,10 +14,6 @@ export const VersionContextMenuItem = memo(function VersionContextMenuItem(props
 }) {
   const {release} = props
   const {t} = useTranslation()
-  const dateTimeFormat = useDateTimeFormat({
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  })
   const isScheduled = release.state === 'scheduled' || release.state === 'scheduling'
 
   return (
@@ -30,9 +27,9 @@ export const VersionContextMenuItem = memo(function VersionContextMenuItem(props
           {release.metadata.releaseType === 'asap' && <>{t('release.type.asap')}</>}
           {release.metadata.releaseType === 'scheduled' &&
             (release.metadata.intendedPublishAt ? (
-              <>{dateTimeFormat.format(new Date(release.metadata.intendedPublishAt))}</>
+              <>{formatRelative(getPublishDateFromRelease(release), new Date())}</>
             ) : (
-              /** @todo add date when it's scheduled and not just with a date */
+              /** should not be allowed to do, but a fall back in case if somehow no date is added */
               <>{t('release.chip.tooltip.unknown-date')}</>
             ))}
           {release.metadata.releaseType === 'undecided' && <>{t('release.type.undecided')}</>}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuItem.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuItem.tsx
@@ -6,7 +6,7 @@ import {memo} from 'react'
 import {useTranslation} from '../../../../i18n'
 import {type ReleaseDocument} from '../../../store/types'
 import {getReleaseTone} from '../../../util/getReleaseTone'
-import {getPublishDateFromRelease} from '../../../util/util'
+import {getPublishDateFromRelease, isReleaseScheduledOrScheduling} from '../../../util/util'
 import {ReleaseAvatar} from '../../ReleaseAvatar'
 
 export const VersionContextMenuItem = memo(function VersionContextMenuItem(props: {
@@ -14,7 +14,7 @@ export const VersionContextMenuItem = memo(function VersionContextMenuItem(props
 }) {
   const {release} = props
   const {t} = useTranslation()
-  const isScheduled = release.state === 'scheduled' || release.state === 'scheduling'
+  const isScheduled = isReleaseScheduledOrScheduling(release)
 
   return (
     <Flex gap={3} justify="center" align="center">

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenuItem.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenuItem.test.tsx
@@ -36,7 +36,7 @@ describe('VersionContextMenuItem', () => {
     const scheduledRelease = {...mockRelease, releaseType: 'scheduled' as ReleaseType}
 
     render(<VersionContextMenuItem release={scheduledRelease} />, {wrapper})
-    expect(screen.getByText('Oct 1, 2023, 3:00 AM')).toBeInTheDocument()
+    expect(screen.getByText('10/01/2023')).toBeInTheDocument()
   })
 
   it('renders release type as ASAP', async () => {

--- a/packages/sanity/src/core/releases/tool/components/ReleasePublishAllButton/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleasePublishAllButton/ReleaseScheduleButton.tsx
@@ -13,7 +13,7 @@ import {getCalendarLabels} from '../../../../form/inputs/DateInputs/utils'
 import {Translate, useTranslation} from '../../../../i18n'
 import {ScheduledRelease} from '../../../__telemetry__/releases.telemetry'
 import {releasesLocaleNamespace} from '../../../i18n'
-import {type ReleaseDocument} from '../../../index'
+import {isReleaseScheduledOrScheduling, type ReleaseDocument} from '../../../index'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
 import {type DocumentInRelease} from '../../detail/useBundleDocuments'
 
@@ -178,11 +178,11 @@ export const ReleaseScheduleButton = ({
       return t('schedule-button-tooltip.validation.error')
     }
 
-    if (release.state === 'scheduled' || release.state === 'scheduling') {
+    if (isReleaseScheduledOrScheduling(release)) {
       return t('schedule-button-tooltip.already-scheduled')
     }
     return null
-  }, [hasDocumentValidationErrors, isValidatingDocuments, release.state, t])
+  }, [hasDocumentValidationErrors, isValidatingDocuments, release, t])
 
   // TODO: this is a duplicate of logic in ReleasePublishAllButton
   const scheduleTooltipContent = useMemo(() => {

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardFooter.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardFooter.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-nested-ternary */
 import {Card, Flex} from '@sanity/ui'
 
-import {type ReleaseDocument} from '../../index'
+import {isReleaseScheduledOrScheduling, type ReleaseDocument} from '../../index'
 import {ReleaseMenuButton} from '../components/ReleaseMenuButton/ReleaseMenuButton'
 import {ReleasePublishAllButton} from '../components/ReleasePublishAllButton/ReleasePublishAllButton'
 import {ReleaseScheduleButton} from '../components/ReleasePublishAllButton/ReleaseScheduleButton'
@@ -26,7 +26,7 @@ export function ReleaseDashboardFooter(props: {
 
         <Flex flex="none" gap={1}>
           {release.metadata.releaseType === 'scheduled' ? (
-            release.state === 'scheduled' || release.state === 'scheduling' ? (
+            isReleaseScheduledOrScheduling(release) ? (
               <ReleaseUnscheduleButton
                 release={release}
                 documents={documents}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseTypePicker.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseTypePicker.tsx
@@ -2,7 +2,7 @@ import {LockIcon} from '@sanity/icons'
 import {Flex, Spinner, Stack, TabList, Text, useClickOutsideEvent} from '@sanity/ui'
 import {format, isBefore, isValid, parse} from 'date-fns'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
-import {type ReleaseDocument, useTranslation} from 'sanity'
+import {isReleaseScheduledOrScheduling, type ReleaseDocument, useTranslation} from 'sanity'
 
 import {Button, Popover, Tab} from '../../../../ui-components'
 import {MONTH_PICKER_VARIANT} from '../../../../ui-components/inputs/DateInputs/calendar/Calendar'
@@ -63,7 +63,7 @@ export function ReleaseTypePicker(props: {release: ReleaseDocument}): JSX.Elemen
   }, [open])
 
   const isPublishDateInPast = !!publishDate && isBefore(new Date(publishDate), new Date())
-  const isReleaseScheduled = release.state === 'scheduling' || release.state === 'scheduled'
+  const isReleaseScheduled = isReleaseScheduledOrScheduling(release)
 
   const publishDateLabel = useMemo(() => {
     if (releaseType === 'asap') return t('release.type.asap')

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -13,7 +13,7 @@ import {usePerspective} from '../../hooks/usePerspective'
 import {releasesLocaleNamespace} from '../../i18n'
 import {getBundleIdFromReleaseDocumentId} from '../../util/getBundleIdFromReleaseDocumentId'
 import {getReleaseTone} from '../../util/getReleaseTone'
-import {getReleasePublishDate} from '../../util/util'
+import {getReleasePublishDate, isReleaseScheduledOrScheduling} from '../../util/util'
 import {type TableRowProps} from '../components/Table/Table'
 import {Headers} from '../components/Table/TableHeader'
 import {type Column} from '../components/Table/types'
@@ -160,7 +160,7 @@ export const releasesOverviewColumnDefs: (
       cell: ({cellProps, datum: release}) => (
         <Flex {...cellProps} align="center" paddingX={2} paddingY={3} gap={2} sizing="border">
           <ReleaseTime release={release} />
-          {(release.state === 'scheduled' || release.state === 'scheduling') && (
+          {isReleaseScheduledOrScheduling(release) && (
             <Text size={1}>
               <LockIcon />
             </Text>

--- a/packages/sanity/src/core/releases/util/util.ts
+++ b/packages/sanity/src/core/releases/util/util.ts
@@ -97,6 +97,6 @@ export function isDraftPerspective(bundle: CurrentPerspective | string): bundle 
 }
 
 /** @internal */
-export function isReleaseLocked(release: ReleaseDocument): boolean {
+export function isReleaseScheduledOrScheduling(release: ReleaseDocument): boolean {
   return release.state === 'scheduled' || release.state === 'scheduling'
 }

--- a/packages/sanity/src/core/releases/util/util.ts
+++ b/packages/sanity/src/core/releases/util/util.ts
@@ -95,3 +95,8 @@ export function isPublishedPerspective(bundle: CurrentPerspective | string): bun
 export function isDraftPerspective(bundle: CurrentPerspective | string): bundle is typeof LATEST {
   return bundle === LATEST
 }
+
+/** @internal */
+export function isReleaseLocked(release: ReleaseDocument): boolean {
+  return release.state === 'scheduled' || release.state === 'scheduling'
+}

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -102,7 +102,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const documentId = getPublishedId(documentIdRaw)
   const documentType = options.type
   const params = useUnique(paneRouter.params) || EMPTY_PARAMS
-  const {perspective} = usePerspective()
+  const {perspective, currentGlobalBundle} = usePerspective()
 
   const bundlePerspective = resolveBundlePerspective(perspective)
 
@@ -599,6 +599,11 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     const isLiveEditAndDraft = Boolean(liveEdit && editState.draft)
     const isSystemPerspectiveApplied = perspective && typeof bundlePerspective === 'undefined'
 
+    const isReleaseLocked =
+      typeof currentGlobalBundle === 'object' && 'state' in currentGlobalBundle
+        ? currentGlobalBundle.state === 'scheduled' || currentGlobalBundle.state === 'scheduling'
+        : false
+
     return (
       (bundlePerspective && !existsInBundle) ||
       isSystemPerspectiveApplied ||
@@ -612,7 +617,8 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       isDeleting ||
       isDeleted ||
       isLiveEditAndDraft ||
-      isCreateLinked
+      isCreateLinked ||
+      isReleaseLocked
     )
   }, [
     isPermissionsLoading,
@@ -625,6 +631,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     liveEdit,
     perspective,
     bundlePerspective,
+    currentGlobalBundle,
     existsInBundle,
     ready,
     revTime,

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -22,6 +22,7 @@ import {
   getExpandOperations,
   getPublishedId,
   getVersionFromId,
+  isReleaseScheduledOrScheduling,
   isSanityCreateLinkedDocument,
   isVersionId,
   type OnPathFocusPayload,
@@ -601,7 +602,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
     const isReleaseLocked =
       typeof currentGlobalBundle === 'object' && 'state' in currentGlobalBundle
-        ? currentGlobalBundle.state === 'scheduled' || currentGlobalBundle.state === 'scheduling'
+        ? isReleaseScheduledOrScheduling(currentGlobalBundle)
         : false
 
     return (

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -3,6 +3,7 @@ import {createElement, useEffect, useMemo, useRef, useState} from 'react'
 import {
   isDraftPerspective,
   isPublishedPerspective,
+  isReleaseScheduledOrScheduling,
   type ReleaseDocument,
   ScrollContainer,
   usePerspective,
@@ -143,13 +144,13 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
 
   const currentPerspectiveIsRelease =
     !isPublishedPerspective(currentGlobalBundle) && !isDraftPerspective(currentGlobalBundle)
-  const isReleaseLocked =
+  const isScheduledRelease =
     typeof currentGlobalBundle === 'object' && 'state' in currentGlobalBundle
-      ? currentGlobalBundle.state === 'scheduled' || currentGlobalBundle.state === 'scheduling'
+      ? isReleaseScheduledOrScheduling(currentGlobalBundle)
       : false
 
   const banners = useMemo(() => {
-    if ((!existsInBundle && currentPerspectiveIsRelease) || isReleaseLocked) {
+    if ((!existsInBundle && currentPerspectiveIsRelease) || isScheduledRelease) {
       return (
         <AddToReleaseBanner
           documentId={value._id}
@@ -190,7 +191,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     existsInBundle,
     isLiveEdit,
     isPermissionsLoading,
-    isReleaseLocked,
+    isScheduledRelease,
     permissions?.granted,
     ready,
     requiredPermission,

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -3,6 +3,7 @@ import {createElement, useEffect, useMemo, useRef, useState} from 'react'
 import {
   isDraftPerspective,
   isPublishedPerspective,
+  type ReleaseDocument,
   ScrollContainer,
   usePerspective,
   VirtualizerScrollInstanceProvider,
@@ -142,10 +143,19 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
 
   const currentPerspectiveIsRelease =
     !isPublishedPerspective(currentGlobalBundle) && !isDraftPerspective(currentGlobalBundle)
+  const isReleaseLocked =
+    typeof currentGlobalBundle === 'object' && 'state' in currentGlobalBundle
+      ? currentGlobalBundle.state === 'scheduled' || currentGlobalBundle.state === 'scheduling'
+      : false
 
   const banners = useMemo(() => {
-    if (!existsInBundle && currentPerspectiveIsRelease) {
-      return <AddToReleaseBanner documentId={value._id} currentRelease={currentGlobalBundle} />
+    if ((!existsInBundle && currentPerspectiveIsRelease) || isReleaseLocked) {
+      return (
+        <AddToReleaseBanner
+          documentId={value._id}
+          currentRelease={currentGlobalBundle as ReleaseDocument}
+        />
+      )
     }
 
     if (activeView.type === 'form' && isLiveEdit && ready) {
@@ -180,6 +190,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     existsInBundle,
     isLiveEdit,
     isPermissionsLoading,
+    isReleaseLocked,
     permissions?.granted,
     ready,
     requiredPermission,

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
@@ -6,6 +6,7 @@ import {
   getBundleIdFromReleaseDocumentId,
   getPublishDateFromRelease,
   getReleaseTone,
+  isReleaseScheduledOrScheduling,
   LATEST,
   type ReleaseDocument,
   Translate,
@@ -31,7 +32,7 @@ export function AddToReleaseBanner({
   const {createVersion} = useVersionOperations()
 
   const isScheduled =
-    (currentRelease?.state === 'scheduled' || currentRelease?.state === 'scheduling') &&
+    isReleaseScheduledOrScheduling(currentRelease) &&
     currentRelease.metadata.releaseType === 'scheduled'
 
   const handleAddToRelease = useCallback(async () => {

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -202,6 +202,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
             onClick={handleBundleChange(release.name)}
             text={release.metadata.title || t('release.placeholder-untitled-release')}
             tone={getReleaseTone(release)}
+            locked={release.state === 'scheduled' || release.state === 'scheduling'}
             contextValues={{
               documentId: displayed?._id || '',
               menuReleaseId: release._id,

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -5,6 +5,7 @@ import {
   getPublishDateFromRelease,
   getReleaseTone,
   getVersionFromId,
+  isReleaseScheduledOrScheduling,
   type ReleaseDocument,
   Translate,
   useDateTimeFormat,
@@ -202,7 +203,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
             onClick={handleBundleChange(release.name)}
             text={release.metadata.title || t('release.placeholder-untitled-release')}
             tone={getReleaseTone(release)}
-            locked={release.state === 'scheduled' || release.state === 'scheduling'}
+            locked={isReleaseScheduledOrScheduling(release)}
             contextValues={{
               documentId: displayed?._id || '',
               menuReleaseId: release._id,

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -1,6 +1,8 @@
 import {Text} from '@sanity/ui'
+import {formatRelative} from 'date-fns'
 import {memo, useCallback, useMemo} from 'react'
 import {
+  getPublishDateFromRelease,
   getReleaseTone,
   getVersionFromId,
   type ReleaseDocument,
@@ -22,31 +24,38 @@ type FilterReleases = {
 
 const TooltipContent = ({release}: {release: ReleaseDocument}) => {
   const {t} = useTranslation()
-  const dateTimeFormat = useDateTimeFormat({
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  })
 
   if (release.metadata.releaseType === 'asap') {
     return <Text size={1}>{t('release.type.asap')}</Text>
   }
   if (release.metadata.releaseType === 'scheduled') {
+    const isActive = release.state === 'active'
+
     return (
-      <Text size={1}>
-        {release.metadata.intendedPublishAt ? (
-          <Translate
-            t={t}
-            i18nKey="release.chip.tooltip.intended-for-date"
-            values={{
-              date: dateTimeFormat.format(new Date(release.metadata.intendedPublishAt)),
-            }}
-          />
-        ) : (
-          t('release.chip.tooltip.unknown-date')
-        )}
-      </Text>
+      release.metadata.intendedPublishAt && (
+        <Text size={1}>
+          {isActive ? (
+            <Translate
+              t={t}
+              i18nKey="release.chip.tooltip.intended-for-date"
+              values={{
+                date: formatRelative(getPublishDateFromRelease(release), new Date()),
+              }}
+            />
+          ) : (
+            <Translate
+              t={t}
+              i18nKey="release.chip.tooltip.scheduled-for-date"
+              values={{
+                date: formatRelative(getPublishDateFromRelease(release), new Date()),
+              }}
+            />
+          )}
+        </Text>
+      )
     )
   }
+
   if (release.metadata.releaseType === 'undecided') {
     return <Text size={1}>{t('release.type.undecided')}</Text>
   }


### PR DESCRIPTION
### Description

updated tooltip contents
update formatting for document header
add locked icon to chips on the document header 
add banner when the release is scheduled / locked
make document readOnly when release is locked

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
