### PR TITLE
fix(base): support restoring cross dataset references

### DIFF
--- a/packages/@sanity/base/src/datastores/history/createHistoryStore.ts
+++ b/packages/@sanity/base/src/datastores/history/createHistoryStore.ts
@@ -120,7 +120,12 @@ const getAllRefIds = (doc) =>
   jsonReduce(
     doc,
     (acc, node) =>
-      node && typeof node === 'object' && '_ref' in node && !acc.includes(node._ref)
+      node &&
+      typeof node === 'object' &&
+      '_ref' in node &&
+      // exclude cross dataset refs
+      !('_dataset' in node) &&
+      !acc.includes(node._ref)
         ? [...acc, node._ref]
         : acc,
     []
@@ -149,7 +154,13 @@ function jsonMap(value, mapFn) {
 
 const mapRefNodes = (doc, mapFn) =>
   jsonMap(doc, (node) => {
-    return node && typeof node === 'object' && typeof node._ref === 'string' ? mapFn(node) : node
+    return node &&
+      typeof node === 'object' &&
+      typeof node._ref === 'string' &&
+      // exclude cross dataset refs
+      !('_dataset' in node)
+      ? mapFn(node)
+      : node
   })
 
 export const removeMissingReferences = (doc, existingIds) =>


### PR DESCRIPTION
### Description
Fixes an issue that cleared cross dataset references when restoring a document from history

### Notes for release
n/a - fixes an issue in v2 which is EOL