### PR TITLE
fix: create integration copy + layout updates

### DIFF
--- a/packages/sanity/src/core/create/components/CreateLinkedDocumentBannerContent.tsx
+++ b/packages/sanity/src/core/create/components/CreateLinkedDocumentBannerContent.tsx
@@ -13,7 +13,7 @@ import {
 import {useCallback, useRef, useState} from 'react'
 
 import {Button, Popover} from '../../../ui-components'
-import {Translate, useTranslation} from '../../i18n'
+import {useTranslation} from '../../i18n'
 import {createLocaleNamespace} from '../i18n'
 import {type CreateLinkedDocumentBannerContentProps} from '../types'
 import {CreateLearnMoreButton} from './CreateLearnMoreButton'
@@ -61,9 +61,7 @@ export function CreateLinkedDocumentBannerContent(props: CreateLinkedDocumentBan
         </Flex>
         <Stack space={4}>
           <Heading size={2}>{t('create-link-info-popover.header')}</Heading>
-          <Text size={1}>
-            <Translate t={t} i18nKey={'create-link-info-popover.text'} />
-          </Text>
+          <Text size={1}>{t('create-link-info-popover.text')}</Text>
           <Flex flex={1} justify="flex-end">
             <CreateLearnMoreButton />
           </Flex>
@@ -73,15 +71,17 @@ export function CreateLinkedDocumentBannerContent(props: CreateLinkedDocumentBan
   )
 
   return (
-    <Flex gap={2} align="center">
-      <Text size={0} weight="medium">
-        <ReadOnlyIcon />
-      </Text>
-      <Box>
-        <Text size={1} weight="medium">
-          {t('studio-create-link-banner.text')}
+    <Flex gap={1} align="center">
+      <Flex gap={2} align="center">
+        <Text size={0} weight="medium">
+          <ReadOnlyIcon />
         </Text>
-      </Box>
+        <Box>
+          <Text size={1} weight="medium">
+            {t('studio-create-link-banner.text')}
+          </Text>
+        </Box>
+      </Flex>
       <Popover
         content={popoverContent}
         open={infoOpen}
@@ -96,7 +96,8 @@ export function CreateLinkedDocumentBannerContent(props: CreateLinkedDocumentBan
           icon={InfoOutlineIcon}
           mode="bleed"
           onClick={toggleOpen}
-          style={{marginBottom: '-1em', marginTop: '-1em'}}
+          // Negative margins added to prevent the button from blowing out banner height
+          style={{marginBottom: '-0.5em', marginTop: '-0.5em'}}
           tooltipProps={{content: t('create-link-info.tooltip')}}
         />
       </Popover>

--- a/packages/sanity/src/core/create/components/CreateUnlinkConfirmDialog.tsx
+++ b/packages/sanity/src/core/create/components/CreateUnlinkConfirmDialog.tsx
@@ -1,7 +1,7 @@
-import {Flex, Stack, Text} from '@sanity/ui'
+import {Stack, Text} from '@sanity/ui'
 import {useCallback, useId, useState} from 'react'
 
-import {Button, Dialog} from '../../../ui-components'
+import {Dialog} from '../../../ui-components'
 import {PatchEvent, unset} from '../../form'
 import {Translate, useTranslation} from '../../i18n'
 import {createLocaleNamespace} from '../i18n'
@@ -30,8 +30,24 @@ export function CreateUnlinkConfirmDialog(props: CreateUnlinkConfirmDialogProps)
   }, [onDocumentChange, telemetry])
 
   return (
-    <Dialog id={id} header={t('unlink-from-create-dialog.header')} onClose={onClose}>
-      <Stack space={5}>
+    <Dialog
+      footer={{
+        cancelButton: {
+          onClick: onClose,
+          text: t('unlink-from-create-dialog.cancel.text'),
+        },
+        confirmButton: {
+          disabled: unlinking,
+          onClick: unlink,
+          text: t('unlink-from-create-dialog.unlink.text'),
+          tone: 'primary',
+        },
+      }}
+      id={id}
+      header={t('unlink-from-create-dialog.header')}
+      onClose={onClose}
+    >
+      <Stack space={4}>
         <Text size={1}>
           <Translate
             t={t}
@@ -41,20 +57,6 @@ export function CreateUnlinkConfirmDialog(props: CreateUnlinkConfirmDialogProps)
         </Text>
 
         <Text size={1}>{t('unlink-from-create-dialog.second-paragraph')}</Text>
-
-        <Flex flex={1} justify="flex-end" gap={2}>
-          <Button
-            mode="bleed"
-            text={t('unlink-from-create-dialog.cancel.text')}
-            onClick={onClose}
-          />
-          <Button
-            tone="primary"
-            text={t('unlink-from-create-dialog.unlink.text')}
-            onClick={unlink}
-            disabled={unlinking}
-          />
-        </Flex>
       </Stack>
     </Dialog>
   )

--- a/packages/sanity/src/core/create/i18n/resources.ts
+++ b/packages/sanity/src/core/create/i18n/resources.ts
@@ -10,13 +10,13 @@ const createLocaleStrings = defineLocalesResources('create', {
   'start-in-create-action.label': 'Start in Sanity Create',
 
   /** Header of the "Start writing in Create" dialog */
-  'start-in-create-dialog.header': 'Start authoring with Sanity Create',
+  'start-in-create-dialog.header': 'Start authoring in Sanity Create',
   /** The lede text in the "Start writing in Create" dialog */
   'start-in-create-dialog.lede':
-    'Map your free-form ideas back to the studio as structured content whilst you write.',
+    'Author in a free-form editor and have it mapped back to the Studio as structured content, as you type.',
   /** The details on what "Start writing in Create" implies */
   'start-in-create-dialog.details':
-    'This will open Sanity Create in a new window and automatically link this document.',
+    'This will open Sanity Create in a new window and automatically link it to this document.',
   /** CTA in "Start writing in Create" dialog: Continue to create */
   'start-in-create-dialog.cta.continue': 'Continue',
   /** CTA in "Start writing in Create" dialog: Learn more */
@@ -29,29 +29,30 @@ const createLocaleStrings = defineLocalesResources('create', {
   /** Header of the "Linking in progress" dialog */
   'linking-in-progress-dialog.header': 'Linking in progress',
   /** Lede text for the "Linking in progress" dialog */
-  'linking-in-progress-dialog.lede': 'Please continue in the newly opened Sanity Create window.',
+  'linking-in-progress-dialog.lede':
+    'Please return to Sanity Create. Linking the document should only take a few seconds.',
   /** Details for the "Linking in progress" dialog */
   'linking-in-progress-dialog.details':
-    'On completion, this dialog will automatically close and changes from Sanity Create will appear in this document in real-time.',
+    'When complete, this dialog will close and edits made in Sanity Create will start appearing here as they happen.',
   /** "Linking in progress" troubleshooting button title */
-  'linking-in-progress-dialog.troubleshooting.button.title': 'Link failed?',
+  'linking-in-progress-dialog.troubleshooting.button.title': 'Linking taking a while?',
   /** "Linking in progress" troubleshooting content */
   'linking-in-progress-dialog.troubleshooting.content':
-    "If you're unable to link to Sanity Create, please confirm that your deployed studio is up to date and you are logged in to both Sanity Studio and Create with the same user account.",
+    'Did you close the Sanity Create window? Does the process appear to be stuck? Please reload this page and try again.',
   /** Text for the document pane banner informing users that the document is linked to Sanity Create */
   'studio-create-link-banner.text': 'This document is linked to Sanity Create',
 
   /** Tooltip for Create Link button */
-  'create-link-info.tooltip': 'Sanity Create information',
+  'create-link-info.tooltip': 'Learn more',
   /** Text above header in Create Link info popover */
   'create-link-info-popover.eyebrow-title': 'Sanity Create',
   /** Text in badge above header in Create Link info popover */
   'create-link-info-popover.eyebrow-badge': 'Beta',
   /** Header in Create Link info popover */
-  'create-link-info-popover.header': 'Gather. Contextualize. Realize.',
+  'create-link-info-popover.header': 'Idea first authoring',
   /** Informational text in Create Link info popover */
   'create-link-info-popover.text':
-    'Map your free-form ideas back to the studio as <em>structured content</em> whilst you write.',
+    'Sanity Create lets you author in a free-form editor that automatically maps back to the Studio as structured content - as you type.',
 
   /** Edit in Create button text */
   'edit-in-create-button.text': 'Edit in Sanity Create',

--- a/packages/sanity/src/core/create/start-in-create/StartInCreateAction.tsx
+++ b/packages/sanity/src/core/create/start-in-create/StartInCreateAction.tsx
@@ -16,7 +16,8 @@ import {useStudioAppIdStore} from '../studio-app/useStudioAppIdStore'
 import {type CreateLinkedSanityDocument} from '../types'
 import {useSanityCreateTelemetry} from '../useSanityCreateTelemetry'
 import {CreateLinkingDialog} from './CreateLinkingDialog'
-import {StartInCreateDialog} from './StartInCreateDialog'
+import {StartInCreateActionContent} from './StartInCreateActionContent'
+import {StartInCreateActionFooter} from './StartInCreateActionFooter'
 
 export function createStartInCreateAction(appIdCache: AppIdCache): DocumentActionComponent {
   const StartInCreateActionWrapper: DocumentActionComponent = function StartInCreateActionWrapper(
@@ -69,10 +70,9 @@ export function StartInCreateAction(
       : isDialogOpen && {
           type: 'dialog',
           onClose: closeDialog,
-          header: t('start-in-create-dialog.header'),
-          width: 'small',
-          content: (
-            <StartInCreateDialog
+          content: <StartInCreateActionContent />,
+          footer: (
+            <StartInCreateActionFooter
               onLinkingStarted={linkingStarted}
               createLinkId={createLinkId}
               appId={appId}
@@ -80,6 +80,8 @@ export function StartInCreateAction(
               autoConfirm={autoConfirm}
             />
           ),
+          header: t('start-in-create-dialog.header'),
+          width: 'small',
         },
     onHandle: () => {
       if (!isDialogOpen) {

--- a/packages/sanity/src/core/create/start-in-create/StartInCreateActionContent.tsx
+++ b/packages/sanity/src/core/create/start-in-create/StartInCreateActionContent.tsx
@@ -1,0 +1,21 @@
+import {Stack, Text} from '@sanity/ui'
+
+import {useTranslation} from '../../i18n'
+import {CreateSvg} from '../components/media/CreateSvg'
+import {createLocaleNamespace} from '../i18n'
+
+export function StartInCreateActionContent() {
+  const {t} = useTranslation(createLocaleNamespace)
+
+  return (
+    <Stack space={4}>
+      <CreateSvg />
+      <Text size={1} weight="semibold">
+        {t('start-in-create-dialog.lede')}
+      </Text>
+      <Text muted size={1}>
+        {t('start-in-create-dialog.details')}
+      </Text>
+    </Stack>
+  )
+}

--- a/packages/sanity/src/core/create/start-in-create/StartInCreateActionFooter.tsx
+++ b/packages/sanity/src/core/create/start-in-create/StartInCreateActionFooter.tsx
@@ -1,17 +1,16 @@
 import {LaunchIcon} from '@sanity/icons'
 import {Checkbox, Flex, Stack, Text, useToast} from '@sanity/ui'
 import {useCallback, useEffect, useId, useState} from 'react'
+import {useTranslation} from 'react-i18next'
 
 import {Button} from '../../../ui-components'
-import {useTranslation} from '../../i18n'
 import {useWorkspace} from '../../studio'
 import {CreateLearnMoreButton} from '../components/CreateLearnMoreButton'
-import {CreateSvg} from '../components/media/CreateSvg'
 import {getCreateLinkUrl} from '../createDocumentUrls'
 import {createLocaleNamespace} from '../i18n'
 import {useSanityCreateTelemetry} from '../useSanityCreateTelemetry'
 
-export interface StartInCreateDialogProps {
+interface StartInCreateActionFooterProps {
   createLinkId: string
   appId: string
   type: string
@@ -19,7 +18,7 @@ export interface StartInCreateDialogProps {
   autoConfirm: boolean
 }
 
-export function StartInCreateDialog(props: StartInCreateDialogProps) {
+export function StartInCreateActionFooter(props: StartInCreateActionFooterProps) {
   const {createLinkId, appId, type, onLinkingStarted, autoConfirm} = props
   const {t} = useTranslation(createLocaleNamespace)
   const checkboxId = useId()
@@ -61,13 +60,6 @@ export function StartInCreateDialog(props: StartInCreateDialogProps) {
 
   return (
     <Stack space={4}>
-      <CreateSvg />
-      <Text size={1} weight="semibold">
-        {t('start-in-create-dialog.lede')}
-      </Text>
-      <Text muted size={1}>
-        {t('start-in-create-dialog.details')}
-      </Text>
       <Flex gap={2} align="center">
         <Checkbox id={checkboxId} checked={dontShowAgain} onChange={toggleDontShowAgain} />
         <Text as="label" htmlFor={checkboxId} muted size={1}>

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -280,16 +280,8 @@ export function BlockObject(props: BlockObjectProps) {
         ref={memberItem?.elementRef as RefObject<HTMLDivElement> | undefined}
         contentEditable={false}
       >
-        <Flex
-          data-object-block="" // used by create
-          paddingBottom={1}
-          marginY={3}
-          style={debugRender()}
-        >
-          <PreviewContainer
-            data-object-block-inner="" // used by create
-            {...innerPaddingProps}
-          >
+        <Flex paddingBottom={1} marginY={3} style={debugRender()}>
+          <PreviewContainer {...innerPaddingProps}>
             <Box flex={1}>
               <Tooltip
                 placement="top"

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
@@ -266,16 +266,11 @@ export function TextBlock(props: TextBlockProps) {
       <Box
         {...outerPaddingProps}
         data-testid="text-block"
-        data-text-block="" // used by create
         ref={memberItem?.elementRef as RefObject<HTMLDivElement>}
         style={debugRender()}
       >
         <TextBlockFlexWrapper data-testid="text-block__wrapper">
-          <Flex
-            data-text-block-inner="" // used by create
-            flex={1}
-            {...innerPaddingProps}
-          >
+          <Flex flex={1} {...innerPaddingProps}>
             <Box flex={1}>
               <Tooltip
                 content={toolTipContent}


### PR DESCRIPTION
### Description

This PR introduces some very minor copy and layout updates to the existing Studio → Create integration. All changes are purely cosmetic.

### What to review

- All copy changes should read naturally (these have been pre-vetted)
- All dialog buttons (the "Start in Sanity Create" document action and "Unlink" button) should now look more 'native', as they're now correctly passed to the dialog-specific `footer` prop (as opposed to rendering these within the dialog body)

### Testing

N/A – copy and minor layout tweaks only

### Notes for release

Not required