### PR TITLE
fix: issue with the US formatting used by formatRelative when no locale defined

### DIFF
--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuItem.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuItem.tsx
@@ -1,9 +1,9 @@
 import {LockIcon} from '@sanity/icons'
 import {Flex, Stack, Text} from '@sanity/ui'
-import {formatRelative} from 'date-fns'
 import {memo} from 'react'
 
 import {useTranslation} from '../../../../i18n'
+import {formatRelativeLocale} from '../../../../util/formatRelativeLocale'
 import {type ReleaseDocument} from '../../../store/types'
 import {getReleaseTone} from '../../../util/getReleaseTone'
 import {getPublishDateFromRelease, isReleaseScheduledOrScheduling} from '../../../util/util'
@@ -27,7 +27,7 @@ export const VersionContextMenuItem = memo(function VersionContextMenuItem(props
           {release.metadata.releaseType === 'asap' && <>{t('release.type.asap')}</>}
           {release.metadata.releaseType === 'scheduled' &&
             (release.metadata.intendedPublishAt ? (
-              <>{formatRelative(getPublishDateFromRelease(release), new Date())}</>
+              <>{formatRelativeLocale(getPublishDateFromRelease(release), new Date())}</>
             ) : (
               /** should not be allowed to do, but a fall back in case if somehow no date is added */
               <>{t('release.chip.tooltip.unknown-date')}</>

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenuItem.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenuItem.test.tsx
@@ -20,6 +20,10 @@ const mockRelease: ReleaseDocument = {
   },
 }
 
+vi.mock('../../../../../util/formatRelativeLocale', () => ({
+  formatRelativeLocale: () => 'formatted date',
+}))
+
 describe('VersionContextMenuItem', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -36,7 +40,7 @@ describe('VersionContextMenuItem', () => {
     const scheduledRelease = {...mockRelease, releaseType: 'scheduled' as ReleaseType}
 
     render(<VersionContextMenuItem release={scheduledRelease} />, {wrapper})
-    expect(screen.getByText('10/01/2023')).toBeInTheDocument()
+    expect(screen.getByText('formatted date')).toBeInTheDocument()
   })
 
   it('renders release type as ASAP', async () => {

--- a/packages/sanity/src/core/releases/navbar/GlobalPerspectiveMenuItem.tsx
+++ b/packages/sanity/src/core/releases/navbar/GlobalPerspectiveMenuItem.tsx
@@ -1,18 +1,22 @@
-import {DotIcon, EyeClosedIcon, EyeOpenIcon} from '@sanity/icons'
+import {DotIcon, EyeClosedIcon, EyeOpenIcon, LockIcon} from '@sanity/icons'
 // eslint-disable-next-line no-restricted-imports -- custom use for MenuItem & Button not supported by ui-components
 import {Box, Button, Flex, MenuItem, Stack, Text} from '@sanity/ui'
-import {formatRelative} from 'date-fns'
 import {type CSSProperties, forwardRef, type MouseEvent, useCallback, useMemo} from 'react'
 import {css, styled} from 'styled-components'
 
 import {Tooltip} from '../../../ui-components/tooltip'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
+import {formatRelativeLocale} from '../../util/formatRelativeLocale'
 import {ReleaseAvatar} from '../components/ReleaseAvatar'
 import {usePerspective} from '../hooks/usePerspective'
 import {type ReleaseDocument} from '../store/types'
 import {getBundleIdFromReleaseDocumentId} from '../util/getBundleIdFromReleaseDocumentId'
 import {getReleaseTone} from '../util/getReleaseTone'
-import {getPublishDateFromRelease, isPublishedPerspective} from '../util/util'
+import {
+  getPublishDateFromRelease,
+  isPublishedPerspective,
+  isReleaseScheduledOrScheduling,
+} from '../util/util'
 import {GlobalPerspectiveMenuItemIndicator} from './PerspectiveLayerIndicator'
 
 export interface LayerRange {
@@ -128,7 +132,8 @@ export const GlobalPerspectiveMenuItem = forwardRef<
     [releaseId, isReleasePublishedPerspective, setPerspective, setPerspectiveFromReleaseDocumentId],
   )
 
-  const canReleaseBeExcluded = !isPublishedPerspective(release) && inRange && !last
+  const canReleaseBeExcluded =
+    !isPublishedPerspective(release) && !isReleaseScheduledOrScheduling(release) && inRange && !last
 
   return (
     <GlobalPerspectiveMenuItemIndicator
@@ -169,10 +174,10 @@ export const GlobalPerspectiveMenuItem = forwardRef<
               {displayTitle}
             </Text>
             {!isPublishedPerspective(release) &&
-              release.metadata.releaseType !== 'undecided' &&
+              release.metadata.releaseType === 'scheduled' &&
               (release.publishAt || release.metadata.intendedPublishAt) && (
                 <Text muted size={1}>
-                  {formatRelative(getPublishDateFromRelease(release), new Date())}
+                  {formatRelativeLocale(getPublishDateFromRelease(release), new Date())}
                 </Text>
               )}
           </Stack>
@@ -188,6 +193,13 @@ export const GlobalPerspectiveMenuItem = forwardRef<
                   padding={2}
                 />
               </Tooltip>
+            )}
+            {!isPublishedPerspective(release) && isReleaseScheduledOrScheduling(release) && (
+              <Box padding={2}>
+                <Text size={1}>
+                  <LockIcon />
+                </Text>
+              </Box>
             )}
           </Box>
         </Flex>

--- a/packages/sanity/src/core/util/__tests__/formatRelativeLocale.test.ts
+++ b/packages/sanity/src/core/util/__tests__/formatRelativeLocale.test.ts
@@ -1,0 +1,31 @@
+import {formatRelative} from 'date-fns'
+import {describe, expect, it} from 'vitest'
+
+import {formatRelativeLocale} from '../formatRelativeLocale'
+
+const currentDate = new Date('2023-10-01')
+
+describe('formatRelativeLocale', () => {
+  it('should return relative format for dates within a week', () => {
+    const dateWithinWeek = new Date(currentDate.getTime() + 2 * 24 * 60 * 60 * 1000) // 2 days later
+
+    const result = formatRelativeLocale(dateWithinWeek, currentDate)
+    expect(result).toBe(formatRelative(dateWithinWeek, currentDate)) // Should match formatRelative directly
+  })
+
+  it('should return a locale date string for dates more than a week away', () => {
+    const dateMoreThanAWeek = new Date(currentDate.getTime() + 10 * 24 * 60 * 60 * 1000) // 10 days later
+
+    const result = formatRelativeLocale(dateMoreThanAWeek, currentDate)
+    // expect locale string (MM/dd/yyyy format)
+    expect(result).toBe(dateMoreThanAWeek.toLocaleDateString())
+  })
+
+  it('should return locale date string for past dates more than a week ago', () => {
+    const dateMoreThanAWeekAgo = new Date(currentDate.getTime() - 10 * 24 * 60 * 60 * 1000) // 10 days ago
+
+    const result = formatRelativeLocale(dateMoreThanAWeekAgo, currentDate)
+    // Expected to be in locale format
+    expect(result).toBe(dateMoreThanAWeekAgo.toLocaleDateString())
+  })
+})

--- a/packages/sanity/src/core/util/formatRelativeLocale.ts
+++ b/packages/sanity/src/core/util/formatRelativeLocale.ts
@@ -1,0 +1,18 @@
+import {formatRelative, isValid, parse} from 'date-fns'
+
+/**
+ * date-fns `formatRelative` defaults to formatting as `mm/dd/yyyy` if the date is more/less than
+ * a week away. `formatRelativeLocale` will adjust formatting in these cases to match the correct
+ * locale format.
+ * @internal
+ */
+export const formatRelativeLocale = (...args: Parameters<typeof formatRelative>) => {
+  const dateFnsRelative = formatRelative(...args)
+
+  // if date is of format mm/dd/yyyy, format as a locale string instead
+  if (isValid(parse(dateFnsRelative, 'MM/dd/yyyy', new Date()))) {
+    const [dateTime] = args
+    return new Date(dateTime).toLocaleDateString()
+  }
+  return dateFnsRelative
+}

--- a/packages/sanity/src/core/util/index.ts
+++ b/packages/sanity/src/core/util/index.ts
@@ -1,6 +1,7 @@
 export * from './createHookFromObservableFactory'
 export * from './draftUtils'
 export * from './empty'
+export * from './formatRelativeLocale'
 export * from './globalScope'
 export * from './isArray'
 export * from './isNonNullable'

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
@@ -2,6 +2,7 @@ import {LockIcon} from '@sanity/icons'
 import {Flex, Text} from '@sanity/ui'
 import {type CSSProperties, useCallback} from 'react'
 import {
+  formatRelativeLocale,
   getBundleIdFromReleaseDocumentId,
   getPublishDateFromRelease,
   getReleaseTone,
@@ -14,7 +15,6 @@ import {
 } from 'sanity'
 import {structureLocaleNamespace} from 'sanity/structure'
 
-import {formatRelativeLocale} from '../../../../../core/util/formatRelativeLocale'
 import {Button} from '../../../../../ui-components'
 import {Banner} from './Banner'
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
@@ -1,6 +1,5 @@
 import {LockIcon} from '@sanity/icons'
 import {Flex, Text} from '@sanity/ui'
-import {formatRelative} from 'date-fns'
 import {type CSSProperties, useCallback} from 'react'
 import {
   getBundleIdFromReleaseDocumentId,
@@ -15,6 +14,7 @@ import {
 } from 'sanity'
 import {structureLocaleNamespace} from 'sanity/structure'
 
+import {formatRelativeLocale} from '../../../../../core/util/formatRelativeLocale'
 import {Button} from '../../../../../ui-components'
 import {Banner} from './Banner'
 
@@ -55,7 +55,10 @@ export function AddToReleaseBanner({
                   t={tCore}
                   i18nKey="release.banner.scheduled-for-publishing-on"
                   values={{
-                    date: formatRelative(getPublishDateFromRelease(currentRelease), new Date()),
+                    date: formatRelativeLocale(
+                      getPublishDateFromRelease(currentRelease),
+                      new Date(),
+                    ),
                   }}
                 />
               </Flex>

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -1,5 +1,4 @@
 import {Text} from '@sanity/ui'
-import {formatRelative} from 'date-fns'
 import {memo, useCallback, useMemo} from 'react'
 import {
   getPublishDateFromRelease,
@@ -16,6 +15,7 @@ import {
   versionDocumentExists,
 } from 'sanity'
 
+import {formatRelativeLocale} from '../../../../../../core/util/formatRelativeLocale'
 import {useDocumentPane} from '../../../useDocumentPane'
 
 type FilterReleases = {
@@ -40,7 +40,7 @@ const TooltipContent = ({release}: {release: ReleaseDocument}) => {
               t={t}
               i18nKey="release.chip.tooltip.intended-for-date"
               values={{
-                date: formatRelative(getPublishDateFromRelease(release), new Date()),
+                date: formatRelativeLocale(getPublishDateFromRelease(release), new Date()),
               }}
             />
           ) : (
@@ -48,7 +48,7 @@ const TooltipContent = ({release}: {release: ReleaseDocument}) => {
               t={t}
               i18nKey="release.chip.tooltip.scheduled-for-date"
               values={{
-                date: formatRelative(getPublishDateFromRelease(release), new Date()),
+                date: formatRelativeLocale(getPublishDateFromRelease(release), new Date()),
               }}
             />
           )}

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -1,6 +1,7 @@
 import {Text} from '@sanity/ui'
 import {memo, useCallback, useMemo} from 'react'
 import {
+  formatRelativeLocale,
   getPublishDateFromRelease,
   getReleaseTone,
   getVersionFromId,
@@ -15,7 +16,6 @@ import {
   versionDocumentExists,
 } from 'sanity'
 
-import {formatRelativeLocale} from '../../../../../../core/util/formatRelativeLocale'
 import {useDocumentPane} from '../../../useDocumentPane'
 
 type FilterReleases = {


### PR DESCRIPTION
### Description
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
Currently:
For dates more than a week in the past/future, these would be formatted as 'MM/dd/yyyy':
<img width="373" alt="Screenshot 2024-11-12 at 13 19 53" src="https://github.com/user-attachments/assets/f7076cc6-3dd4-4a53-bc71-6264d8294fbc">

Now:
These dates are formatted correctly according to the locale formatting of the client, eg in my case 'dd/MM/yyyy':
<img width="369" alt="Screenshot 2024-11-12 at 13 26 06" src="https://github.com/user-attachments/assets/3173fb1d-b3c8-4a2a-acf0-0382a6da09cc">

Ideally we would pass through the client locale to `date-fns` however given the way that `date-fns` requires the locale to be imported, and that the mappings of `navigator.language` to the `date-fns` are rather specific, taking the approach in this PR felt most extensible to all locales.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Added tests for the wrapper util `formatRelativeLocale`
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

N/A
