### PR TITLE
fix: add --legacy-peer-deps to next-sanity pacakge install

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -524,7 +524,7 @@ export default async function initSanity(
     }
 
     if (chosen === 'npm') {
-      await execa('npm', ['install', 'next-sanity@9'], execOptions)
+      await execa('npm', ['install', '--legacy-peer-deps', 'next-sanity@9'], execOptions)
     } else if (chosen === 'yarn') {
       await execa('npx', ['install-peerdeps', '--yarn', 'next-sanity@9'], execOptions)
     } else if (chosen === 'pnpm') {


### PR DESCRIPTION
### Description

When running `npx sanity@latest init` inside a Next.js 15 project the install errors because of React 19 incompatability.

### What to review

That the `yarn` and `pnpm` install commands don't also need editing.

### Notes for release

* Added `--legacy-peer-deps` flag to the automatic install of `next-sanity` inside Next.js projects