### PR TITLE
fix: explicitly list allowed image types for upload

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -108,10 +108,8 @@ function BaseImageInputComponent(props: BaseImageInputProps): JSX.Element {
   }, [path])
 
   const clearUploadStatus = useCallback(() => {
-    if (value?._upload) {
-      onChange(unset(['_upload']))
-    }
-  }, [onChange, value?._upload])
+    onChange(unset(['_upload']))
+  }, [onChange])
   const cancelUpload = useCallback(() => {
     if (uploadSubscription.current) {
       uploadSubscription.current.unsubscribe()

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
@@ -9,6 +9,7 @@ import {type Observable} from 'rxjs'
 import {MenuItem} from '../../../../../ui-components'
 import {useTranslation} from '../../../../i18n'
 import {ActionsMenu} from '../common/ActionsMenu'
+import {SUPPORTED_IMAGE_UPLOAD_TYPES} from '../constants'
 import {ImageActionsMenu, ImageActionsMenuWaitPlaceholder} from './ImageActionsMenu'
 import {type BaseImageInputProps} from './types'
 
@@ -54,7 +55,10 @@ function ImageInputAssetMenuComponent(
   } = props
   const {t} = useTranslation()
 
-  const accept = useMemo(() => get(schemaType, 'options.accept', 'image/*'), [schemaType])
+  const accept = useMemo(
+    () => get(schemaType, 'options.accept', SUPPORTED_IMAGE_UPLOAD_TYPES.join(',')),
+    [schemaType],
+  )
   const asset = value?.asset
 
   const showAdvancedEditButton = value && asset && isImageToolEnabled

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetSource.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetSource.tsx
@@ -3,6 +3,7 @@ import {get} from 'lodash'
 import {memo, useMemo} from 'react'
 
 import {WithReferencedAsset} from '../../../utils/WithReferencedAsset'
+import {SUPPORTED_IMAGE_UPLOAD_TYPES} from '../constants'
 import {type BaseImageInputProps} from './types'
 
 function ImageInputAssetSourceComponent(
@@ -20,7 +21,10 @@ function ImageInputAssetSourceComponent(
     selectedAssetSource,
     value,
   } = props
-  const accept = useMemo(() => get(schemaType, 'options.accept', 'image/*'), [schemaType])
+  const accept = useMemo(
+    () => get(schemaType, 'options.accept', SUPPORTED_IMAGE_UPLOAD_TYPES.join(',')),
+    [schemaType],
+  )
 
   if (!selectedAssetSource) {
     return null

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputUploadPlaceholder.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputUploadPlaceholder.tsx
@@ -3,6 +3,7 @@ import {get} from 'lodash'
 import {memo, useMemo} from 'react'
 
 import {UploadPlaceholder} from '../common/UploadPlaceholder'
+import {SUPPORTED_IMAGE_UPLOAD_TYPES} from '../constants'
 import {type BaseImageInputProps, type FileInfo} from './types'
 
 function ImageInputUploadPlaceholderComponent(props: {
@@ -28,7 +29,10 @@ function ImageInputUploadPlaceholderComponent(props: {
     () => hoveringFiles.filter((file) => resolveUploader(schemaType, file)),
     [hoveringFiles, resolveUploader, schemaType],
   )
-  const accept = useMemo(() => get(schemaType, 'options.accept', 'image/*'), [schemaType])
+  const accept = useMemo(
+    () => get(schemaType, 'options.accept', SUPPORTED_IMAGE_UPLOAD_TYPES.join(',')),
+    [schemaType],
+  )
 
   const rejectedFilesCount = hoveringFiles.length - acceptedFiles.length
 

--- a/packages/sanity/src/core/form/inputs/files/__workshop__/UploadPlaceholderStory.tsx
+++ b/packages/sanity/src/core/form/inputs/files/__workshop__/UploadPlaceholderStory.tsx
@@ -2,6 +2,7 @@ import {Card, Container, Flex} from '@sanity/ui'
 
 import {Button} from '../../../../../ui-components'
 import {UploadPlaceholder} from '../common/UploadPlaceholder'
+import {SUPPORTED_IMAGE_UPLOAD_TYPES} from '../constants'
 
 export default function UploadPlaceholderStory() {
   return (
@@ -9,7 +10,7 @@ export default function UploadPlaceholderStory() {
       <Container width={1}>
         <Card>
           <UploadPlaceholder
-            accept="image/*"
+            accept={SUPPORTED_IMAGE_UPLOAD_TYPES.join(',')}
             acceptedFiles={[{name: 'foo.jpg', type: 'image/jpeg'}]}
             browse={<Button text="Browse btn" mode="ghost" />}
             directUploads

--- a/packages/sanity/src/core/form/inputs/files/constants.ts
+++ b/packages/sanity/src/core/form/inputs/files/constants.ts
@@ -4,3 +4,19 @@
  * the upload will be marked as stale/interrupted.
  */
 export const STALE_UPLOAD_MS = 1000 * 60 * 2
+
+/**
+ * The mime types of image formats we support uploading
+ *
+ * @internal
+ */
+export const SUPPORTED_IMAGE_UPLOAD_TYPES = [
+  'image/bmp',
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/svg',
+  'image/tiff',
+  'image/webp',
+  '.psd', // Many different mime types for PSD files, so we just use the extension
+]

--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/assets.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/assets.ts
@@ -73,10 +73,13 @@ export const uploadImageAsset = (
   client: SanityClient,
   file: File | Blob,
   options?: UploadOptions,
-) => uploadAsset(client, 'image', file, options)
+): Observable<UploadEvent> => uploadAsset(client, 'image', file, options)
 
-export const uploadFileAsset = (client: SanityClient, file: File | Blob, options?: UploadOptions) =>
-  uploadAsset(client, 'file', file, options)
+export const uploadFileAsset = (
+  client: SanityClient,
+  file: File | Blob,
+  options?: UploadOptions,
+): Observable<UploadEvent> => uploadAsset(client, 'file', file, options)
 
 /**
  *
@@ -123,11 +126,17 @@ function observeAssetDoc(documentPreviewStore: DocumentPreviewStore, id: string)
     )
 }
 
-export function observeImageAsset(documentPreviewStore: DocumentPreviewStore, id: string) {
+export function observeImageAsset(
+  documentPreviewStore: DocumentPreviewStore,
+  id: string,
+): Observable<ImageAsset> {
   return observeAssetDoc(documentPreviewStore, id) as Observable<ImageAsset>
 }
 
-export function observeFileAsset(documentPreviewStore: DocumentPreviewStore, id: string) {
+export function observeFileAsset(
+  documentPreviewStore: DocumentPreviewStore,
+  id: string,
+): Observable<FileAsset> {
   return observeAssetDoc(documentPreviewStore, id) as Observable<FileAsset>
 }
 

--- a/packages/sanity/src/core/form/studio/uploads/uploadImage.ts
+++ b/packages/sanity/src/core/form/studio/uploads/uploadImage.ts
@@ -21,12 +21,11 @@ export function uploadImage(
   options?: UploadOptions,
 ): Observable<UploadProgressEvent> {
   const upload$ = uploadImageAsset(client, file, options).pipe(
-    filter((event: any) => event.stage !== 'download'),
+    filter((event) => !('stage' in event) || event.stage !== 'download'),
     map((event) => ({
       ...event,
-      progress: 2 + (event.percent / 100) * 98,
+      progress: event.type === 'complete' ? 100 : 2 + (event.percent / 100) * 98,
     })),
-
     map((event) => {
       if (event.type === 'complete') {
         return createUploadEvent([

--- a/packages/sanity/src/core/form/studio/uploads/uploaders.ts
+++ b/packages/sanity/src/core/form/studio/uploads/uploaders.ts
@@ -2,6 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {type SchemaType} from '@sanity/types'
 import {map} from 'rxjs/operators'
 
+import {SUPPORTED_IMAGE_UPLOAD_TYPES} from '../../inputs/files/constants'
 import {set} from '../../patch'
 import {type Uploader, type UploaderDef, type UploadOptions} from './types'
 import {uploadFile} from './uploadFile'
@@ -9,7 +10,7 @@ import {uploadImage} from './uploadImage'
 
 const UPLOAD_IMAGE: UploaderDef = {
   type: 'image',
-  accepts: 'image/*',
+  accepts: SUPPORTED_IMAGE_UPLOAD_TYPES.join(','),
   upload: (client: SanityClient, file: File, type?: SchemaType, options?: UploadOptions) =>
     uploadImage(client, file, options),
 }

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/asset/Asset.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/asset/Asset.tsx
@@ -7,6 +7,7 @@ import {styled} from 'styled-components'
 
 import {Button, MenuButton, MenuItem} from '../../../../../../../../../../ui-components'
 import {type Source} from '../../../../../../../../../config'
+import {SUPPORTED_IMAGE_UPLOAD_TYPES} from '../../../../../../../../../form/inputs/files/constants'
 import {FileSource, ImageSource} from '../../../../../../../../../form/studio/assetSource'
 import {useClient} from '../../../../../../../../../hooks'
 import {useTranslation} from '../../../../../../../../../i18n'
@@ -102,13 +103,15 @@ export function SearchFilterAssetInput(type?: AssetType) {
 
     const AssetSourceComponent = selectedAssetSource?.component
 
-    const fontSize = fullscreen ? 2 : 1
-
     const buttonText = t(value ? 'search.filter-asset-change' : 'search.filter-asset-select', {
       context: type,
     })
 
-    const accept = get(type, 'options.accept', type === 'image' ? 'image/*' : '')
+    const accept = get(
+      type,
+      'options.accept',
+      type === 'image' ? SUPPORTED_IMAGE_UPLOAD_TYPES.join(',') : '',
+    )
 
     return (
       <ContainerBox>


### PR DESCRIPTION
### Description

We're currently allowing `image/*` in the image input, but only a certain types are allowed by our backend. In particular, we recently added support for AVIF images to be _output_, but we don't yet support them to be uploaded. Instead of letting users upload the entire image  before they get a message saying they are not supported, we should flag our support in the image selection dialog.

Also fixed a race condition issue with the `clearUploadStatus` callback - when the image fails to be uploaded, eg rejected because of an unsupported format, the value doesn't seem to have a value - and thus does not get unset. Instead it is stuck in the pending state (100% done) until someone resets it. I don't quite see the need to check before unsetting - but let me know if I am overlooking something.

Did some minor typing/lint cleanups along the way.

### What to review

- Do image uploads still work as expected?
- Are there dragons to be aware of?
- There are so many layers I had to add these types to - are some of these meant to be "backend agnostic" and thus I should only apply it to the ones that deals with the Sanity CDN specifically?

### Testing

Ideally there should be a test to ensure that you can't select eg an AVIF, but I couldn't find a good way of doing so at the moment :/

### Notes for release

- Fixed an issue where unsupported image types would be uploaded but then rejected by the server. Only accepted image file types are now 
