### PR TITLE
fix(core): add opt out option to studioAnnouncements 

### DIFF
--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -99,4 +99,7 @@ export default defineConfig({
       enabled: true,
     },
   },
+  announcements: {
+    enabled: false,
+  },
 })

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -497,3 +497,26 @@ export const createFallbackOriginReducer = (config: PluginOptions): string | und
 
   return result
 }
+
+export const announcementsEnabledReducer = (opts: {
+  config: PluginOptions
+  initialValue: boolean
+}): boolean => {
+  const {config, initialValue} = opts
+  const flattenedConfig = flattenConfig(config, [])
+
+  const result = flattenedConfig.reduce((acc, {config: innerConfig}) => {
+    const resolver = innerConfig.announcements?.enabled
+
+    if (!resolver && typeof resolver !== 'boolean') return acc
+    if (typeof resolver === 'boolean') return resolver
+
+    throw new Error(
+      `Expected \`announcements.enabled\` to be a boolean, but received ${getPrintableType(
+        resolver,
+      )}`,
+    )
+  }, initialValue)
+
+  return result
+}

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -25,6 +25,7 @@ import {operatorDefinitions} from '../studio/components/navbar/search/definition
 import {type InitialValueTemplateItem, type Template, type TemplateItem} from '../templates'
 import {EMPTY_ARRAY, isNonNullable} from '../util'
 import {
+  announcementsEnabledReducer,
   createFallbackOriginReducer,
   documentActionsReducer,
   documentBadgesReducer,
@@ -662,6 +663,10 @@ function resolveSource({
         startInCreateEnabled: startInCreateEnabledReducer({config, initialValue: false}),
         fallbackStudioOrigin: createFallbackOriginReducer(config),
       },
+    },
+
+    announcements: {
+      enabled: announcementsEnabledReducer({config, initialValue: true}),
     },
   }
 

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -416,6 +416,13 @@ export interface PluginOptions {
    * @beta
    */
   onUncaughtError?: (error: Error, errorInfo: ErrorInfo) => void
+  /**
+   * @hidden
+   * @internal
+   */
+  announcements?: {
+    enabled: boolean
+  }
 }
 
 /** @internal */
@@ -810,6 +817,13 @@ export interface Source {
    * @beta
    */
   onUncaughtError?: (error: Error, errorInfo: ErrorInfo) => void
+  /**
+   * @hidden
+   * @internal
+   */
+  announcements?: {
+    enabled: boolean
+  }
 }
 
 /** @internal */

--- a/packages/sanity/src/core/studio/studioAnnouncements/StudioAnnouncementsProvider.tsx
+++ b/packages/sanity/src/core/studio/studioAnnouncements/StudioAnnouncementsProvider.tsx
@@ -6,6 +6,7 @@ import {catchError, combineLatest, map, type Observable, startWith} from 'rxjs'
 import {StudioAnnouncementContext} from 'sanity/_singletons'
 
 import {useClient} from '../../hooks/useClient'
+import {useSource} from '../../studio/source'
 import {useWorkspace} from '../../studio/workspace'
 import {SANITY_VERSION} from '../../version'
 import {
@@ -28,11 +29,7 @@ interface StudioAnnouncementsProviderProps {
 }
 const CLIENT_OPTIONS = {apiVersion: 'v2024-09-19'}
 
-/**
- * @internal
- * @hidden
- */
-export function StudioAnnouncementsProvider({children}: StudioAnnouncementsProviderProps) {
+function StudioAnnouncementsProviderInner({children}: StudioAnnouncementsProviderProps) {
   const telemetry = useTelemetry()
   const [dialogMode, setDialogMode] = useState<DialogMode | null>(null)
   const [isCardDismissed, setIsCardDismissed] = useState(false)
@@ -158,4 +155,17 @@ export function StudioAnnouncementsProvider({children}: StudioAnnouncementsProvi
       )}
     </StudioAnnouncementContext.Provider>
   )
+}
+
+/**
+ * @internal
+ * @hidden
+ */
+export function StudioAnnouncementsProvider(props: StudioAnnouncementsProviderProps) {
+  const source = useSource()
+
+  if (source.announcements?.enabled) {
+    return <StudioAnnouncementsProviderInner {...props} />
+  }
+  return props.children
 }

--- a/packages/sanity/src/core/studio/studioAnnouncements/useStudioAnnouncements.tsx
+++ b/packages/sanity/src/core/studio/studioAnnouncements/useStudioAnnouncements.tsx
@@ -5,8 +5,13 @@ import {type StudioAnnouncementsContextValue} from './types'
 
 export function useStudioAnnouncements(): StudioAnnouncementsContextValue {
   const context = useContext(StudioAnnouncementContext)
+
   if (!context) {
-    throw new Error('useStudioAnnouncements: missing context value')
+    return {
+      studioAnnouncements: [],
+      unseenAnnouncements: [],
+      onDialogOpen: () => {},
+    }
   }
 
   return context


### PR DESCRIPTION
### Description
Adds a new config flag that can be used to opt out from announcements.
It also opts out in e2e tests, given tests are failing when the announcement renders

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is the config name accurate?
Announcements should work as always in the test studio, you can test it by appending the `?reset-announcements` to the test studio url.
https://test-studio-git-announcements-opt-out.sanity.dev/test/structure?reset-announcements=true

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

New tests for the opt out flag has been added
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
