### PR TITLE
chore(core): update announcements card close icon

### DIFF
--- a/packages/sanity/src/core/studio/studioAnnouncements/StudioAnnouncementsCard.tsx
+++ b/packages/sanity/src/core/studio/studioAnnouncements/StudioAnnouncementsCard.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import {RemoveIcon} from '@sanity/icons'
+import {CloseIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Box, Card, Stack, Text} from '@sanity/ui'
 // eslint-disable-next-line camelcase
@@ -72,7 +72,7 @@ const Root = styled.div((props) => {
 const ButtonRoot = styled.div`
   z-index: 1;
   position: absolute;
-  top: 4px;
+  top: 0px;
   right: 6px;
 `
 
@@ -152,7 +152,7 @@ export function StudioAnnouncementsCard({
               id="close-floating-button"
               mode="bleed"
               onClick={onCardDismiss}
-              icon={RemoveIcon}
+              icon={CloseIcon}
               tone="default"
               aria-label={t('announcement.floating-button.dismiss-label')}
               tooltipProps={{


### PR DESCRIPTION
### Description
Updates icon used in the close button for the studio announcements card.
From  `-` to `x`

![image](https://github.com/user-attachments/assets/e9890521-3859-43af-bd8c-3e9bcc75b268)


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
