### PR TITLE
refactor(core): remove PTE connection event handling

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -133,7 +133,6 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   const [invalidValue, setInvalidValue] = useState<InvalidValue | null>(null)
   const [isFullscreen, setIsFullscreen] = useState(initialFullscreen ?? false)
   const [isActive, setIsActive] = useState(initialActive ?? false)
-  const [isOffline, setIsOffline] = useState(false)
   const [hasFocusWithin, setHasFocusWithin] = useState(false)
   const telemetry = useTelemetry()
 
@@ -220,13 +219,6 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
         case 'mutation':
           onChange(toFormPatches(change.patches))
           break
-        case 'connection':
-          if (change.value === 'offline') {
-            setIsOffline(true)
-          } else if (change.value === 'online') {
-            setIsOffline(false)
-          }
-          break
         case 'selection':
           setFocusPathFromEditorSelection(change.selection)
           break
@@ -276,13 +268,13 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
             onChange={handleEditorChange}
             onIgnore={handleIgnoreInvalidValue}
             resolution={invalidValue.resolution}
-            readOnly={isOffline || readOnly}
+            readOnly={readOnly}
           />
         </Box>
       )
     }
     return null
-  }, [handleEditorChange, handleIgnoreInvalidValue, invalidValue, isOffline, readOnly])
+  }, [handleEditorChange, handleIgnoreInvalidValue, invalidValue, readOnly])
 
   const handleActivate = useCallback((): void => {
     if (!isActive) {
@@ -393,7 +385,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
               onChange={handleEditorChange}
               maxBlocks={undefined} // TODO: from schema?
               ref={editorRef}
-              readOnly={isOffline || readOnly}
+              readOnly={readOnly}
               schemaType={schemaType}
               value={value}
             >


### PR DESCRIPTION
Currently, PTE emits a connection event whenever it goes offline and online.
However, I don't believe this logic belongs inside PTE:
https://github.com/portabletext/editor/blob/main/packages/editor/src/editor/editor-machine.ts#L41-L60

At the same time, Studio already does an even better job at making sure to mark
fields as `readOnly` when it detects that it's offline.