### PR TITLE
refactor(core): remove unneeded PTE event handling

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -238,10 +238,6 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
           onBlur(change.event)
           setHasFocusWithin(false)
           break
-        case 'undo':
-        case 'redo':
-          onChange(toFormPatches(change.patches))
-          break
         case 'invalidValue':
           setInvalidValue(change)
           break


### PR DESCRIPTION
PTE does not emit the `undo` and `redo` events, and I don't think it ever has, at least not for a long time. Whenever an undo or redo happens, the end result is still patches and the `mutation` event is enough to listen for that.

---

You can test this by verifying that undo/redo still works.