### PR TITLE
chore(cli): temporarily disable telemetry tests

### DIFF
--- a/packages/@sanity/cli/test/telemetry.test.ts
+++ b/packages/@sanity/cli/test/telemetry.test.ts
@@ -1,11 +1,10 @@
-import {expect, test} from 'vitest'
+import {describe, expect, test} from 'vitest'
 
-import {describeCliTest} from './shared/describe'
 import {runSanityCmdCommand} from './shared/environment'
 
 const testTimeout = 60000 // 60 seconds
 
-describeCliTest('CLI: `sanity telemetry status`', () => {
+describe.skip('CLI: `sanity telemetry status`', () => {
   test(
     'sanity telemetry status: granted',
     async () => {
@@ -13,6 +12,8 @@ describeCliTest('CLI: `sanity telemetry status`', () => {
         env: {
           DEBUG: 'sanity:*',
           CI: 'false',
+          // Mock current state (prior to enabling)
+          SANITY_CLI_MOCK_TELEMETRY_CONSENT_STATUS: 'unset',
         },
       })
 
@@ -97,7 +98,7 @@ https://www.sanity.io/telemetry
   )
 })
 
-describeCliTest('CLI: `sanity telemetry enable`', () => {
+describe.skip('CLI: `sanity telemetry enable`', () => {
   test(
     'sanity telemetry enable: success',
     async () => {
@@ -153,7 +154,7 @@ https://www.sanity.io/telemetry
   )
 })
 
-describeCliTest('CLI: `sanity telemetry disable`', () => {
+describe.skip('CLI: `sanity telemetry disable`', () => {
   test(
     'sanity telemetry disable: success',
     async () => {


### PR DESCRIPTION
### Description

The CLI telemetry tests are very flakey and doesn't hold up well when there are multiple runs going on at the same time, since they reuse the same user for setting/enabling status and then checking the result.

This temporarily disables them, until we can find a better way to mock the network calls or similar.

### What to review

- Tests are disabled

### Testing

We're dropping some tests here - we could consider refactoring them to at least check that we get _some_ output from the commands, but seems less than useful right now.

### Notes for release

None
