### PR TITLE
feat(releases): timezone selection updates filtering and dateTime display on release overview

### DIFF
--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -13,6 +13,7 @@ import {
   type CalendarProps,
 } from '../../../../ui-components/inputs/DateFilters/calendar/CalendarFilter'
 import {useTranslation} from '../../../i18n'
+import useDialogTimeZone from '../../../scheduledPublishing/hooks/useDialogTimeZone'
 import useTimeZone from '../../../scheduledPublishing/hooks/useTimeZone'
 import {CreateReleaseDialog} from '../../components/dialog/CreateReleaseDialog'
 import {usePerspective} from '../../hooks/usePerspective'
@@ -137,6 +138,7 @@ export function ReleasesOverview() {
   const {t: tCore} = useTranslation()
   const {timeZone} = useTimeZone()
   const {currentGlobalBundleId} = usePerspective()
+  const {DialogTimeZone, dialogProps, dialogTimeZoneShow} = useDialogTimeZone()
 
   const getRowProps = useCallback(
     (datum: TableRelease): Partial<TableRowProps> =>
@@ -347,7 +349,9 @@ export function ReleasesOverview() {
                   mode="bleed"
                   padding={2}
                   text={`${timeZone.abbreviation} (${timeZone.namePretty})`}
+                  onClick={dialogTimeZoneShow}
                 />
+                {DialogTimeZone && <DialogTimeZone {...dialogProps} />}
                 {loadingOrHasReleases && createReleaseButton}
               </Flex>
             </Flex>

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -139,7 +139,7 @@ export function ReleasesOverview() {
   const loadingTableData = loading || (!releasesMetadata && Boolean(releaseIds.length))
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: tCore} = useTranslation()
-  const {timeZone} = useTimeZone()
+  const {timeZone, utcToCurrentZoneDate} = useTimeZone()
   const {currentGlobalBundleId} = usePerspective()
   const {DialogTimeZone, dialogProps, dialogTimeZoneShow} = useDialogTimeZone()
   const getTimezoneAdjustedDateTimeRange = useTimezoneAdjustedDateTimeRange()
@@ -185,11 +185,19 @@ export function ReleasesOverview() {
     [],
   )
 
-  const handleSelectFilterDate = useCallback((date?: Date) => {
-    setReleaseFilterDate((prevFilterDate) =>
-      prevFilterDate && date && isSameDay(prevFilterDate, date) ? undefined : date,
-    )
-  }, [])
+  const handleSelectFilterDate = useCallback(
+    (date?: Date) =>
+      setReleaseFilterDate((prevFilterDate) => {
+        if (!date) return undefined
+
+        const timeZoneAdjustedDate = utcToCurrentZoneDate(date)
+
+        return prevFilterDate && isSameDay(prevFilterDate, timeZoneAdjustedDate)
+          ? undefined
+          : timeZoneAdjustedDate
+      }),
+    [utcToCurrentZoneDate],
+  )
 
   const clearFilterDate = useCallback(() => {
     setReleaseFilterDate(undefined)

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -23,7 +23,7 @@ import {type TableRelease} from './ReleasesOverview'
 
 const ReleaseTime = ({release}: {release: TableRelease}) => {
   const {t} = useTranslation()
-  const {timeZone} = useTimeZone()
+  const {timeZone, utcToCurrentZoneDate} = useTimeZone()
   const {abbreviation: localeTimeZoneAbbreviation} = getLocalTimeZone()
 
   const {metadata} = release
@@ -45,9 +45,9 @@ const ReleaseTime = ({release}: {release: TableRelease}) => {
     const publishDate = getPublishDateFromRelease(release)
 
     return publishDate
-      ? `${format(new Date(publishDate), 'PPpp')} ${getTimezoneAbbreviation()}`
+      ? `${format(utcToCurrentZoneDate(publishDate), 'PPpp')} ${getTimezoneAbbreviation()}`
       : null
-  }, [metadata.releaseType, release, t, getTimezoneAbbreviation])
+  }, [metadata.releaseType, release, utcToCurrentZoneDate, getTimezoneAbbreviation, t])
 
   return (
     <Text muted size={1}>

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -2,12 +2,13 @@ import {LockIcon, PinFilledIcon, PinIcon} from '@sanity/icons'
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
 import {format} from 'date-fns'
 import {type TFunction} from 'i18next'
-import {useCallback} from 'react'
+import {useCallback, useMemo} from 'react'
 import {useRouter} from 'sanity/router'
 
 import {Button, Tooltip} from '../../../../ui-components'
 import {RelativeTime} from '../../../components'
 import {Translate, useTranslation} from '../../../i18n'
+import useTimeZone, {getLocalTimeZone} from '../../../scheduledPublishing/hooks/useTimeZone'
 import {ReleaseAvatar} from '../../components/ReleaseAvatar'
 import {usePerspective} from '../../hooks/usePerspective'
 import {releasesLocaleNamespace} from '../../i18n'
@@ -22,9 +23,18 @@ import {type TableRelease} from './ReleasesOverview'
 
 const ReleaseTime = ({release}: {release: TableRelease}) => {
   const {t} = useTranslation()
+  const {timeZone} = useTimeZone()
+  const {abbreviation: localeTimeZoneAbbreviation} = getLocalTimeZone()
+
   const {metadata} = release
 
-  const getTimeString = () => {
+  const getTimezoneAbbreviation = useCallback(() => {
+    if (timeZone.abbreviation === localeTimeZoneAbbreviation) return ''
+
+    return `(${timeZone.abbreviation})`
+  }, [localeTimeZoneAbbreviation, timeZone.abbreviation])
+
+  const timeString = useMemo(() => {
     if (metadata.releaseType === 'asap') {
       return t('release.type.asap')
     }
@@ -34,12 +44,14 @@ const ReleaseTime = ({release}: {release: TableRelease}) => {
 
     const publishDate = getPublishDateFromRelease(release)
 
-    return publishDate ? format(new Date(publishDate), 'PPpp') : null
-  }
+    return publishDate
+      ? `${format(new Date(publishDate), 'PPpp')} ${getTimezoneAbbreviation()}`
+      : null
+  }, [metadata.releaseType, release, t, getTimezoneAbbreviation])
 
   return (
     <Text muted size={1}>
-      {getTimeString()}
+      {timeString}
     </Text>
   )
 }

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -1,9 +1,11 @@
 import {act, fireEvent, render, screen, waitFor, within} from '@testing-library/react'
+import {format, set} from 'date-fns'
 import {useRouter} from 'sanity/router'
-import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {getByDataUi, queryByDataUi} from '../../../../../../test/setup/customQueries'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import useTimeZone, {getLocalTimeZone} from '../../../../scheduledPublishing/hooks/useTimeZone'
 import {
   activeASAPRelease,
   activeScheduledRelease,
@@ -30,7 +32,12 @@ import {type ReleasesMetadata} from '../../../store/useReleasesMetadata'
 import {useBundleDocumentsMockReturn} from '../../detail/__tests__/__mocks__/useBundleDocuments.mock'
 import {ReleasesOverview} from '../ReleasesOverview'
 
-const TODAY = new Date()
+const TODAY = set(new Date(), {
+  hours: 22,
+  minutes: 0,
+  seconds: 0,
+  milliseconds: 0,
+})
 
 vi.mock('sanity', () => ({
   SANITY_VERSION: '0.0.0',
@@ -58,6 +65,27 @@ vi.mock('sanity/router', async (importOriginal) => ({
 vi.mock('../../../hooks/usePerspective', () => ({
   usePerspective: vi.fn(() => usePerspectiveMockReturn),
 }))
+
+vi.mock('../../../../scheduledPublishing/hooks/useTimeZone', async (importOriginal) => ({
+  ...(await importOriginal()),
+  getLocalTimeZone: vi.fn().mockReturnValue({
+    abbreviation: 'SCT',
+  }),
+  default: vi.fn(() => ({
+    timeZone: {
+      abbreviation: 'SCT', // Sanity Central Time :)
+      namePretty: 'Sanity/Oslo',
+      offset: '+00:00',
+      name: 'SCT',
+    },
+    utcToCurrentZoneDate: vi.fn((date: Date) => date),
+    getCurrentZoneDate: vi.fn(),
+    zoneDateToUtc: vi.fn((date) => date),
+  })),
+}))
+
+const mockGetLocaleTimeZone = getLocalTimeZone as Mock<typeof getLocalTimeZone>
+const mockUseTimeZone = useTimeZone as Mock<typeof useTimeZone>
 
 describe('ReleasesOverview', () => {
   beforeEach(() => {
@@ -132,7 +160,10 @@ describe('ReleasesOverview', () => {
     const releases: ReleaseDocument[] = [
       {
         ...activeScheduledRelease,
-        metadata: {...activeScheduledRelease.metadata, intendedPublishAt: TODAY.toISOString()},
+        metadata: {
+          ...activeScheduledRelease.metadata,
+          intendedPublishAt: TODAY.toISOString(),
+        },
       },
       activeASAPRelease,
       activeUndecidedRelease,
@@ -189,6 +220,13 @@ describe('ReleasesOverview', () => {
       const asapReleaseRow = screen.getAllByTestId('table-row')[3]
 
       within(asapReleaseRow).getByText('Undecided')
+    })
+
+    it('shows time for scheduled releases', () => {
+      const scheduledReleaseRow = screen.getAllByTestId('table-row')[2]
+
+      const date = format(TODAY, 'MMM d, yyyy')
+      within(scheduledReleaseRow).getByText(`${date}, 10:00:00 PM`)
     })
 
     it('has release menu actions for each release', () => {
@@ -279,6 +317,77 @@ describe('ReleasesOverview', () => {
           await waitFor(() => {
             expect(screen.getAllByTestId('table-row')).toHaveLength(4)
           })
+        })
+      })
+    })
+
+    describe('timezone selection', () => {
+      it('shows the selected timezone', () => {
+        screen.getByText('SCT (Sanity/Oslo)')
+      })
+
+      it('opens the timezone selector', () => {
+        fireEvent.click(screen.getByText('SCT (Sanity/Oslo)'))
+
+        within(getByDataUi(document.body, 'DialogCard')).getByText('Select time zone')
+      })
+
+      it('shows dates with timezone abbreviation when it is not the locale', () => {
+        mockGetLocaleTimeZone.mockReturnValue({
+          abbreviation: 'NST', // Not Sanity Time
+          namePretty: 'Not Sanity Time',
+          offset: '+00:00',
+          name: 'NST',
+          alternativeName: 'Not Sanity Time',
+          mainCities: 'Not Sanity City',
+          value: 'Not Sanity Time',
+        })
+
+        activeRender.rerender(<ReleasesOverview />)
+
+        const scheduledReleaseRow = screen.getAllByTestId('table-row')[2]
+
+        const date = format(TODAY, 'MMM d, yyyy')
+        within(scheduledReleaseRow).getByText(`${date}, 10:00:00 PM (SCT)`)
+      })
+
+      describe('when a different timezone is selected', () => {
+        beforeEach(() => {
+          mockUseTimeZone.mockReturnValue({
+            // spoof a timezone that is 8 hours ahead of UTC
+            zoneDateToUtc: vi.fn((date) => set(date, {hours: new Date(date).getHours() - 8})),
+            utcToCurrentZoneDate: vi.fn((date) => date),
+            getCurrentZoneDate: vi.fn(() => TODAY),
+            timeZone: {
+              abbreviation: 'SCT',
+              namePretty: 'Sanity/Oslo',
+              offset: '+00:00',
+              name: 'SCT',
+              alternativeName: 'Sanity/Oslo',
+              mainCities: 'Sanity City',
+              value: 'Sanity/Oslo',
+            },
+            setTimeZone: vi.fn(),
+            formatDateTz: vi.fn(),
+          })
+
+          activeRender.rerender(<ReleasesOverview />)
+        })
+
+        it('shows today as having no releases', () => {
+          const todayTile = within(getByDataUi(document.body, 'Calendar')).getByText(
+            TODAY.getDate(),
+          )
+          expect(todayTile.parentNode).not.toHaveStyle('font-weight: 700')
+        })
+
+        it('shows no releases when filtered by today', () => {
+          const todayTile = within(getByDataUi(document.body, 'Calendar')).getByText(
+            TODAY.getDate(),
+          )
+          fireEvent.click(todayTile)
+
+          expect(screen.queryAllByTestId('table-row')).toHaveLength(0)
         })
       })
     })

--- a/packages/sanity/src/core/scheduledPublishing/hooks/__tests__/__mocks__/useTimeZone.mock.ts
+++ b/packages/sanity/src/core/scheduledPublishing/hooks/__tests__/__mocks__/useTimeZone.mock.ts
@@ -1,0 +1,31 @@
+import {type Mock, type Mocked, vi} from 'vitest'
+
+import {type NormalizedTimeZone} from '../../../types'
+import useTimeZone, {getLocalTimeZone} from '../../useTimeZone'
+
+const mockTimeZone: NormalizedTimeZone = {
+  abbreviation: 'SCT', // Sanity Central Time :)
+  namePretty: 'Sanity/Oslo',
+  offset: '+00:00',
+  name: 'SCT',
+  alternativeName: 'Sanity/Oslo',
+  mainCities: 'Oslo',
+  value: 'SCT',
+}
+
+// default export
+export const useTimeZoneMockReturn: Mocked<ReturnType<typeof useTimeZone>> = {
+  zoneDateToUtc: vi.fn((date) => date),
+  utcToCurrentZoneDate: vi.fn((date) => date),
+  getCurrentZoneDate: vi.fn(() => new Date()),
+  timeZone: mockTimeZone,
+  setTimeZone: vi.fn(),
+  formatDateTz: vi.fn(),
+}
+
+export const getLocalTimeZoneMockReturn: Mocked<ReturnType<typeof getLocalTimeZone>> = mockTimeZone
+
+// default export
+export const mockUseTimeZone = useTimeZone as Mock<typeof useTimeZone>
+
+export const mockGetLocaleTimeZone = getLocalTimeZone as Mock<typeof getLocalTimeZone>


### PR DESCRIPTION
### Description
![calendarlocalePR](https://github.com/user-attachments/assets/cf3b7d79-7ef5-495c-83ba-3ef03c15370e)
Above demonstrates that:
* Selecting a timezone will highlight the correct date as being today in the calendar
* Will present the dates of releases according to the selected timezone
* Will filter by date according to those releases within the timezone date
* Can change the timezone
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Note that `useTimeZone` and a few other helpers were introduced in `ScheduledPublishing` and still exist nested in that directory.

As part of a quick follow PR (coming shortly), I'll move these parts that are now shared across content releases and scheduled publishing to a more generic place.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Updated tests for `ReleasesOverview`
Added mocks for `useTimeZone`
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
