### PR TITLE
fix(core): discard announcements dialog onClickOutside

### DIFF
--- a/packages/sanity/src/core/studio/studioAnnouncements/StudioAnnouncementsDialog.tsx
+++ b/packages/sanity/src/core/studio/studioAnnouncements/StudioAnnouncementsDialog.tsx
@@ -173,6 +173,7 @@ export function StudioAnnouncementsDialog({
     <Dialog
       id="in-app-communication-dialog"
       onClose={onClose}
+      onClickOutside={onClose}
       width={1}
       bodyHeight="fill"
       padding={false}


### PR DESCRIPTION
### Description

Adds **onClickOutside** handler to the announcements dialog.
When clicking outside of the dialog we want it to close.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
fix: close the announcements dialog when clicking outside
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
