### PR TITLE
fix(core): remove timeout and retry from releases store

### DIFF
--- a/packages/sanity/src/core/releases/store/createReleaseStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseStore.ts
@@ -10,13 +10,11 @@ import {
   merge,
   type Observable,
   of,
-  retry,
   scan,
   shareReplay,
   Subject,
   switchMap,
   tap,
-  timeout,
 } from 'rxjs'
 import {map, mergeMap, startWith, toArray} from 'rxjs/operators'
 
@@ -129,12 +127,6 @@ export function createReleaseStore(context: {
     tap(() => fetchPending$.next(true)),
     concatWith(
       listenQuery(client, QUERY, {}, {tag: 'releases.listen'}).pipe(
-        timeout(10_000), // 10s timeout
-        retry({
-          count: 2,
-          delay: 1_000,
-          resetOnSuccess: true,
-        }),
         tap(() => fetchPending$.next(false)),
         map((releases) =>
           releases.map(


### PR DESCRIPTION
### Description
Removes the timeout and retry function from the observable, given they are not needed and was causing issues by creating new listeners every 10 seconds.

Retry is not needed here given is already included in the listener.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
