### PR TITLE
feat(cli): add support for remote templates with `--template` 

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -72,7 +72,8 @@
     "prettier": "^3.3.0",
     "semver": "^7.3.5",
     "silver-fleece": "1.1.0",
-    "validate-npm-package-name": "^3.0.0"
+    "validate-npm-package-name": "^3.0.0",
+    "yaml": "^2.6.1"
   },
   "devDependencies": {
     "@repo/package.config": "workspace:*",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -73,7 +73,8 @@
     "semver": "^7.3.5",
     "silver-fleece": "1.1.0",
     "validate-npm-package-name": "^3.0.0",
-    "yaml": "^2.6.1"
+    "yaml": "^2.6.1",
+    "yarn": "^1.22.22"
   },
   "devDependencies": {
     "@repo/package.config": "workspace:*",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -73,8 +73,7 @@
     "semver": "^7.3.5",
     "silver-fleece": "1.1.0",
     "validate-npm-package-name": "^3.0.0",
-    "yaml": "^2.6.1",
-    "yarn": "^1.22.22"
+    "yaml": "^2.6.1"
   },
   "devDependencies": {
     "@repo/package.config": "workspace:*",

--- a/packages/@sanity/cli/src/actions/init-project/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapLocalTemplate.ts
@@ -14,8 +14,9 @@ import {createPackageManifest} from './createPackageManifest'
 import {createStudioConfig, type GenerateConfigOptions} from './createStudioConfig'
 import {type ProjectTemplate} from './initProject'
 import templates from './templates'
+import {updateInitialTemplateMetadata} from './updateInitialTemplateMetadata'
 
-export interface BootstrapOptions {
+export interface BootstrapLocalOptions {
   packageName: string
   templateName: string
   /**
@@ -28,8 +29,8 @@ export interface BootstrapOptions {
   variables: GenerateConfigOptions['variables']
 }
 
-export async function bootstrapTemplate(
-  opts: BootstrapOptions,
+export async function bootstrapLocalTemplate(
+  opts: BootstrapLocalOptions,
   context: CliCommandContext,
 ): Promise<ProjectTemplate> {
   const {apiClient, cliRoot, output} = context
@@ -142,22 +143,8 @@ export async function bootstrapTemplate(
     ),
   ])
 
-  // Store template name metadata on project
-  try {
-    await apiClient({api: {projectId}}).request({
-      method: 'PATCH',
-      uri: `/projects/${projectId}`,
-      body: {metadata: {initialTemplate: `cli-${templateName}`}},
-    })
-  } catch (err: unknown) {
-    // Non-critical that we update this metadata, and user does not need to be aware
-    let message = typeof err === 'string' ? err : '<unknown error>'
-    if (err instanceof Error) {
-      message = err.message
-    }
-
-    debug('Failed to update initial template metadata for project: %s', message)
-  }
+  debug('Updating initial template metadata')
+  await updateInitialTemplateMetadata(apiClient, variables.projectId, `cli-${templateName}`)
 
   // Finish up by providing init process with template-specific info
   spinner.succeed()

--- a/packages/@sanity/cli/src/actions/init-project/bootstrapRemoteTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapRemoteTemplate.ts
@@ -1,0 +1,69 @@
+import {mkdir} from 'node:fs/promises'
+import {join} from 'node:path'
+
+import {debug} from '../../debug'
+import {type CliCommandContext} from '../../types'
+import {
+  applyEnvVariables,
+  downloadAndExtractRepo,
+  generateSanityApiReadToken,
+  getMonoRepo,
+  isNextJsTemplate,
+  type RepoInfo,
+  tryApplyPackageName,
+  validateRemoteTemplate,
+} from '../../util/remoteTemplate'
+import {type GenerateConfigOptions} from './createStudioConfig'
+import {tryGitInit} from './git'
+import {updateInitialTemplateMetadata} from './updateInitialTemplateMetadata'
+
+export interface BootstrapRemoteOptions {
+  outputPath: string
+  repoInfo: RepoInfo
+  bearerToken?: string
+  packageName: string
+  variables: GenerateConfigOptions['variables']
+}
+
+const INITIAL_COMMIT_MESSAGE = 'Initial commit from Sanity CLI'
+
+export async function bootstrapRemoteTemplate(
+  opts: BootstrapRemoteOptions,
+  context: CliCommandContext,
+): Promise<void> {
+  const {outputPath, repoInfo, bearerToken, variables, packageName} = opts
+  const {output, apiClient} = context
+  const name = [repoInfo.username, repoInfo.name, repoInfo.filePath].filter(Boolean).join('/')
+  const spinner = output.spinner(`Bootstrapping files from template "${name}"`).start()
+
+  debug('Validating remote template')
+  const packages = await getMonoRepo(repoInfo, bearerToken)
+  await validateRemoteTemplate(repoInfo, packages, bearerToken)
+
+  debug('Create new directory "%s"', outputPath)
+  await mkdir(outputPath, {recursive: true})
+
+  debug('Downloading and extracting repo to %s', outputPath)
+  await downloadAndExtractRepo(outputPath, repoInfo, bearerToken)
+
+  debug('Applying environment variables')
+  const readToken = await generateSanityApiReadToken(variables.projectId, apiClient)
+  const isNext = await isNextJsTemplate(outputPath)
+  const envName = isNext ? '.env.local' : '.env'
+
+  for (const folder of packages ?? ['']) {
+    const path = join(outputPath, folder)
+    await applyEnvVariables(path, {...variables, readToken}, envName)
+  }
+
+  debug('Setting package name to %s', packageName)
+  await tryApplyPackageName(outputPath, packageName)
+
+  debug('Initializing git repository')
+  tryGitInit(outputPath, INITIAL_COMMIT_MESSAGE)
+
+  debug('Updating initial template metadata')
+  await updateInitialTemplateMetadata(apiClient, variables.projectId, `external-${name}`)
+
+  spinner.succeed()
+}

--- a/packages/@sanity/cli/src/actions/init-project/updateInitialTemplateMetadata.ts
+++ b/packages/@sanity/cli/src/actions/init-project/updateInitialTemplateMetadata.ts
@@ -1,0 +1,24 @@
+import {debug} from '../../debug'
+import {type CliApiClient} from '../../types'
+
+export async function updateInitialTemplateMetadata(
+  apiClient: CliApiClient,
+  projectId: string,
+  templateName: string,
+): Promise<void> {
+  try {
+    await apiClient({api: {projectId}}).request({
+      method: 'PATCH',
+      uri: `/projects/${projectId}`,
+      body: {metadata: {initialTemplate: templateName}},
+    })
+  } catch (err: unknown) {
+    // Non-critical that we update this metadata, and user does not need to be aware
+    let message = typeof err === 'string' ? err : '<unknown error>'
+    if (err instanceof Error) {
+      message = err.message
+    }
+
+    debug('Failed to update initial template metadata for project: %s', message)
+  }
+}

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -58,6 +58,11 @@ export interface InitFlags {
   'project'?: string
   'dataset'?: string
   'template'?: string
+  /**
+   * Used for accessing private GitHub repo templates
+   * @beta
+   */
+  'template-token'?: string
 
   'visibility'?: string
   'typescript'?: boolean

--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -349,3 +349,12 @@ export interface CliConfig {
 export type UserViteConfig =
   | InlineConfig
   | ((config: InlineConfig, env: ConfigEnv) => InlineConfig | Promise<InlineConfig>)
+
+export type SanityUser = {
+  id: string
+  name: string
+  email: string
+  profileImage?: string
+  tosAcceptedAt?: string
+  provider: 'google' | 'github' | 'sanity' | `saml-${string}`
+}

--- a/packages/@sanity/cli/src/util/getProviderName.ts
+++ b/packages/@sanity/cli/src/util/getProviderName.ts
@@ -1,0 +1,9 @@
+import {type SanityUser} from '../types'
+
+export function getProviderName(provider: SanityUser['provider']) {
+  if (provider === 'google') return 'Google'
+  if (provider === 'github') return 'GitHub'
+  if (provider === 'sanity') return 'Email'
+  if (provider.startsWith('saml-')) return 'SAML'
+  return provider
+}

--- a/packages/@sanity/cli/src/util/journeyConfig.ts
+++ b/packages/@sanity/cli/src/util/journeyConfig.ts
@@ -183,7 +183,6 @@ async function fetchJourneySchema(schemaUrl: string): Promise<DocumentOrObject[]
  */
 async function assembleJourneySchemaTypeFileContent(schemaType: DocumentOrObject): Promise<string> {
   const serialised = wrapSchemaTypeInHelpers(schemaType)
-  console.log('serialised', serialised)
   const imports = getImports(serialised)
   const prettifiedSchemaType = await format(serialised, {
     parser: 'typescript',

--- a/packages/@sanity/cli/src/util/journeyConfig.ts
+++ b/packages/@sanity/cli/src/util/journeyConfig.ts
@@ -183,6 +183,7 @@ async function fetchJourneySchema(schemaUrl: string): Promise<DocumentOrObject[]
  */
 async function assembleJourneySchemaTypeFileContent(schemaType: DocumentOrObject): Promise<string> {
   const serialised = wrapSchemaTypeInHelpers(schemaType)
+  console.log('serialised', serialised)
   const imports = getImports(serialised)
   const prettifiedSchemaType = await format(serialised, {
     parser: 'typescript',

--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -50,7 +50,8 @@ function isGithubRepoShorthand(value: string): boolean {
   // sanity-io/sanity
   // sanity-io/sanity/templates/next-js
   // sanity-io/templates/live-content-api
-  return /^[\w-]+\/[\w-.]+(\/[\w-.]+)*$/.test(value)
+  // sanity-io/sanity/packages/@sanity/cli/test/test-template
+  return /^[\w-]+\/[\w-.]+(\/[@\w-.]+)*$/.test(value)
 }
 
 function isGithubRepoUrl(value: string | URL): value is URL | GithubUrlString {

--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -1,0 +1,507 @@
+import {access, readFile, writeFile} from 'node:fs/promises'
+import {join, posix, sep} from 'node:path'
+import {Readable} from 'node:stream'
+import {pipeline} from 'node:stream/promises'
+import {type ReadableStream} from 'node:stream/web'
+
+import {x} from 'tar'
+import {parse as parseYaml} from 'yaml'
+
+import {type CliApiClient, type PackageJson} from '../types'
+
+const ENV_VAR = {
+  PROJECT_ID: /SANITY(?:_STUDIO)?_PROJECT_ID/, // Matches SANITY_PROJECT_ID and SANITY_STUDIO_PROJECT_ID
+  DATASET: /SANITY(?:_STUDIO)?_DATASET/, // Matches SANITY_DATASET and SANITY_STUDIO_DATASET
+  READ_TOKEN: 'SANITY_API_READ_TOKEN',
+  API_VERSION: /SANITY(?:_STUDIO)?_API_VERSION/, // Matches SANITY_API_VERSION and SANITY_STUDIO_API_VERSION
+} as const
+
+const ENV_FILE = {
+  TEMPLATE: '.env.template',
+  EXAMPLE: '.env.example',
+  LOCAL_EXAMPLE: '.env.local.example',
+} as const
+
+const ENV_TEMPLATE_FILES = [ENV_FILE.TEMPLATE, ENV_FILE.EXAMPLE, ENV_FILE.LOCAL_EXAMPLE] as const
+
+type EnvData = {
+  projectId: string
+  dataset: string
+  readToken?: string
+  apiVersion?: string
+}
+
+type GithubUrlString =
+  | `https://github.com/${string}/${string}`
+  | `https://www.github.com/${string}/${string}`
+
+export type RepoInfo = {
+  username: string
+  name: string
+  branch: string
+  filePath: string
+}
+
+function isGithubRepoShorthand(value: string): boolean {
+  if (URL.canParse(value)) {
+    return false
+  }
+  // This supports :owner/:repo and :owner/:repo/nested/path, e.g.
+  // sanity-io/sanity
+  // sanity-io/sanity/templates/next-js
+  // sanity-io/templates/live-content-api
+  return /^[\w-]+\/[\w-.]+(\/[\w-.]+)*$/.test(value)
+}
+
+function isGithubRepoUrl(value: string | URL): value is URL | GithubUrlString {
+  if (URL.canParse(value) === false) {
+    return false
+  }
+  const url = new URL(value)
+  const pathSegments = url.pathname.slice(1).split('/')
+
+  return (
+    url.protocol === 'https:' &&
+    url.hostname === 'github.com' &&
+    // The pathname must have at least 2 segments. If it has more than 2, the
+    // third must be "tree" and it must have at least 4 segments.
+    // https://github.com/:owner/:repo
+    // https://github.com/:owner/:repo/tree/:ref
+    pathSegments.length >= 2 &&
+    (pathSegments.length > 2 ? pathSegments[2] === 'tree' && pathSegments.length >= 4 : true)
+  )
+}
+
+async function downloadTarStream(url: string, bearerToken?: string): Promise<Readable> {
+  const headers: Record<string, string> = {}
+  if (bearerToken) {
+    headers.Authorization = `Bearer ${bearerToken}`
+  }
+
+  const res = await fetch(url, {headers})
+
+  if (!res.body) {
+    throw new Error(`Failed to download: ${url}`)
+  }
+
+  return Readable.fromWeb(res.body as ReadableStream)
+}
+
+export function checkIsRemoteTemplate(templateName?: string): boolean {
+  return templateName?.includes('/') ?? false
+}
+
+export async function getGitHubRepoInfo(value: string, bearerToken?: string): Promise<RepoInfo> {
+  let username = ''
+  let name = ''
+  let branch = ''
+  let filePath = ''
+
+  if (isGithubRepoShorthand(value)) {
+    const parts = value.split('/')
+    username = parts[0]
+    name = parts[1]
+    // If there are more segments after owner/repo, they form the file path
+    if (parts.length > 2) {
+      filePath = parts.slice(2).join('/')
+    }
+  }
+
+  if (isGithubRepoUrl(value)) {
+    const url = new URL(value)
+    const pathSegments = url.pathname.slice(1).split('/')
+    username = pathSegments[0]
+    name = pathSegments[1]
+
+    // If we have a "tree" segment, everything after branch is the file path
+    if (pathSegments[2] === 'tree') {
+      branch = pathSegments[3]
+      if (pathSegments.length > 4) {
+        filePath = pathSegments.slice(4).join('/')
+      }
+    }
+  }
+
+  if (!username || !name) {
+    throw new Error('Invalid GitHub repository format')
+  }
+
+  try {
+    const headers: Record<string, string> = {}
+    if (bearerToken) {
+      headers.Authorization = `Bearer ${bearerToken}`
+    }
+
+    const infoResponse = await fetch(`https://api.github.com/repos/${username}/${name}`, {
+      headers,
+    })
+
+    if (infoResponse.status !== 200) {
+      if (infoResponse.status === 404) {
+        throw new Error(
+          'GitHub repository not found. For private repositories, use --template-token to provide an access token',
+        )
+      }
+      throw new Error('GitHub repository not found')
+    }
+
+    const info = await infoResponse.json()
+
+    return {
+      username,
+      name,
+      branch: branch || info.default_branch,
+      filePath,
+    }
+  } catch {
+    throw new Error(
+      'GitHub repository not found. For private repositories, use --template-token to provide an access token',
+    )
+  }
+}
+
+export async function downloadAndExtractRepo(
+  root: string,
+  {username, name, branch, filePath}: RepoInfo,
+  bearerToken?: string,
+) {
+  let rootPath: string | null = null
+  await pipeline(
+    await downloadTarStream(
+      `https://codeload.github.com/${username}/${name}/tar.gz/${branch}`,
+      bearerToken,
+    ),
+    x({
+      cwd: root,
+      strip: filePath ? filePath.split('/').length + 1 : 1,
+      filter: (p: string) => {
+        const posixPath = p.split(sep).join(posix.sep)
+        if (rootPath === null) {
+          const pathSegments = posixPath.split(posix.sep)
+          rootPath = pathSegments.length ? pathSegments[0] : null
+        }
+        return posixPath.startsWith(`${rootPath}${filePath ? `/${filePath}/` : '/'}`)
+      },
+    }),
+  )
+}
+
+/**
+ * Checks if a GitHub repository is a monorepo by examining common monorepo configuration files.
+ * Supports pnpm workspaces, Lerna, Rush, and npm workspaces (package.json).
+ * @returns Promise that resolves to an array of package paths/names if monorepo is detected, undefined otherwise
+ */
+export async function getMonoRepo(
+  repoInfo: RepoInfo,
+  bearerToken?: string,
+): Promise<string[] | undefined> {
+  const {username, name, branch, filePath} = repoInfo
+  const baseUrl = `https://raw.githubusercontent.com/${username}/${name}/${branch}/${filePath}`
+
+  const headers: Record<string, string> = {}
+  if (bearerToken) {
+    headers.Authorization = `Bearer ${bearerToken}`
+  }
+
+  type MonorepoHandler = {
+    check: (content: string) => string[] | undefined
+  }
+
+  const handlers: Record<string, MonorepoHandler> = {
+    'package.json': {
+      check: (content) => {
+        try {
+          const pkg = JSON.parse(content)
+          if (!pkg.workspaces) return undefined
+          return Array.isArray(pkg.workspaces) ? pkg.workspaces : pkg.workspaces.packages
+        } catch {
+          return undefined
+        }
+      },
+    },
+    'pnpm-workspace.yaml': {
+      check: (content) => {
+        try {
+          const config = parseYaml(content)
+          return config.packages
+        } catch {
+          return undefined
+        }
+      },
+    },
+    'lerna.json': {
+      check: (content) => {
+        try {
+          const config = JSON.parse(content)
+          return config.packages
+        } catch {
+          return undefined
+        }
+      },
+    },
+    'rush.json': {
+      check: (content) => {
+        try {
+          const config = JSON.parse(content)
+          return config.projects?.map((p: {packageName: string}) => p.packageName)
+        } catch {
+          return undefined
+        }
+      },
+    },
+  }
+
+  const fileChecks = await Promise.all(
+    Object.keys(handlers).map(async (file) => {
+      const response = await fetch(`${baseUrl}/${file}`, {headers})
+      return {file, exists: response.status === 200, content: await response.text()}
+    }),
+  )
+
+  for (const check of fileChecks) {
+    if (!check.exists) continue
+    const result = handlers[check.file].check(check.content)
+    if (result) return result
+  }
+
+  return undefined
+}
+
+/**
+ * Validates a single package within a repository against required criteria.
+ */
+async function validatePackage(
+  baseUrl: string,
+  packagePath: string,
+  headers: Record<string, string>,
+  isRoot: boolean,
+): Promise<{
+  hasSanityConfig: boolean
+  hasSanityCli: boolean
+  hasEnvFile: boolean
+  hasSanityDep: boolean
+}> {
+  const packageUrl = packagePath ? `${baseUrl}/${packagePath}` : baseUrl
+
+  const requiredFiles = [
+    'package.json',
+    'sanity.config.ts',
+    'sanity.config.js',
+    'sanity.cli.ts',
+    'sanity.cli.js',
+    ...ENV_TEMPLATE_FILES,
+  ]
+
+  const fileChecks = await Promise.all(
+    requiredFiles.map(async (file) => {
+      const response = await fetch(`${packageUrl}/${file}`, {headers})
+      return {file, exists: response.status === 200, content: await response.text()}
+    }),
+  )
+
+  const packageJson = fileChecks.find((f) => f.file === 'package.json')
+  if (!packageJson?.exists) {
+    throw new Error(`Package at ${packagePath || 'root'} must include a package.json file`)
+  }
+
+  let hasSanityDep = false
+  try {
+    const pkg: PackageJson = JSON.parse(packageJson.content)
+    hasSanityDep = !!(pkg.dependencies?.sanity || pkg.devDependencies?.sanity)
+  } catch (err) {
+    throw new Error(`Invalid package.json file in ${packagePath || 'root'}`)
+  }
+
+  const hasSanityConfig = fileChecks.some(
+    (f) => f.exists && (f.file === 'sanity.config.ts' || f.file === 'sanity.config.js'),
+  )
+
+  const hasSanityCli = fileChecks.some(
+    (f) => f.exists && (f.file === 'sanity.cli.ts' || f.file === 'sanity.cli.js'),
+  )
+
+  const envFile = fileChecks.find(
+    (f) => f.exists && ENV_TEMPLATE_FILES.includes(f.file as (typeof ENV_TEMPLATE_FILES)[number]),
+  )
+  if (envFile) {
+    const envContent = envFile.content
+    const hasProjectId = envContent.match(ENV_VAR.PROJECT_ID)
+    const hasDataset = envContent.match(ENV_VAR.DATASET)
+
+    if (!hasProjectId || !hasDataset) {
+      const missing = []
+      if (!hasProjectId) missing.push('SANITY_PROJECT_ID or SANITY_STUDIO_PROJECT_ID')
+      if (!hasDataset) missing.push('SANITY_DATASET or SANITY_STUDIO_DATASET')
+      throw new Error(
+        `Environment template in ${
+          packagePath || 'repo'
+        } must include the following variables: ${missing.join(', ')}`,
+      )
+    }
+  }
+
+  return {
+    hasSanityConfig,
+    hasSanityCli,
+    hasEnvFile: Boolean(envFile),
+    hasSanityDep,
+  }
+}
+
+/**
+ * Validates a GitHub repository template against required criteria.
+ * Supports both monorepo and single-package repositories.
+ *
+ * For monorepos:
+ * - Each package must have a valid package.json
+ * - At least one package must include 'sanity' in dependencies or devDependencies
+ * - At least one package must have sanity.config.js/ts and sanity.cli.js/ts
+ * - Each package must have a .env.template, .env.example, or .env.local.example
+ *
+ * For single-package repositories:
+ * - Must have a valid package.json with 'sanity' dependency
+ * - Must have sanity.config.js/ts and sanity.cli.js/ts
+ * - Must have .env.template, .env.example, or .env.local.example
+ *
+ * Environment files must include:
+ * - SANITY_PROJECT_ID or SANITY_STUDIO_PROJECT_ID variable
+ * - SANITY_DATASET or SANITY_STUDIO_DATASET variable
+ *
+ * @throws Error if validation fails with specific reason
+ */
+export async function validateRemoteTemplate(
+  repoInfo: RepoInfo,
+  packages: string[] = [''],
+  bearerToken?: string,
+): Promise<void> {
+  const {username, name, branch, filePath} = repoInfo
+  const baseUrl = `https://raw.githubusercontent.com/${username}/${name}/${branch}/${filePath}`
+
+  const headers: Record<string, string> = {}
+  if (bearerToken) {
+    headers.Authorization = `Bearer ${bearerToken}`
+  }
+
+  const validations = await Promise.all(
+    packages.map((pkg) => validatePackage(baseUrl, pkg, headers, pkg === '')),
+  )
+
+  const hasSanityDep = validations.some((v) => v.hasSanityDep)
+  if (!hasSanityDep) {
+    throw new Error('At least one package must include "sanity" as a dependency in package.json')
+  }
+
+  const hasSanityConfig = validations.some((v) => v.hasSanityConfig)
+  if (!hasSanityConfig) {
+    throw new Error('At least one package must include a sanity.config.js or sanity.config.ts file')
+  }
+
+  const hasSanityCli = validations.some((v) => v.hasSanityCli)
+  if (!hasSanityCli) {
+    throw new Error('At least one package must include a sanity.cli.js or sanity.cli.ts file')
+  }
+
+  const missingEnvPackages = packages.filter((pkg, i) => !validations[i].hasEnvFile)
+  if (missingEnvPackages.length > 0) {
+    throw new Error(
+      `The following packages are missing .env.template, .env.example, or .env.local.example files: ${missingEnvPackages.join(
+        ', ',
+      )}`,
+    )
+  }
+}
+
+export async function isNextJsTemplate(root: string): Promise<boolean> {
+  try {
+    const packageJson = await readFile(join(root, 'package.json'), 'utf8')
+    const pkg = JSON.parse(packageJson)
+    return !!(pkg.dependencies?.next || pkg.devDependencies?.next)
+  } catch {
+    return false
+  }
+}
+
+export async function applyEnvVariables(
+  root: string,
+  envData: EnvData,
+  targetName = '.env',
+): Promise<void> {
+  const templatePath = await Promise.any(
+    ENV_TEMPLATE_FILES.map(async (file) => {
+      await access(join(root, file))
+      return file
+    }),
+  ).catch(() => {
+    throw new Error('Could not find .env.template, .env.example or .env.local.example file')
+  })
+
+  try {
+    const templateContent = await readFile(join(root, templatePath), 'utf8')
+    const {projectId, dataset, readToken = '', apiVersion = 'vX'} = envData
+
+    const findAndReplaceVariable = (
+      content: string,
+      varRegex: RegExp | string,
+      value: string,
+      useQuotes: boolean,
+    ) => {
+      const pattern = varRegex instanceof RegExp ? varRegex : new RegExp(`${varRegex}=.*$`, 'm')
+      const match = content.match(pattern)
+      if (!match) return content
+
+      const varName = match[0].split('=')[0]
+      return content.replace(
+        new RegExp(`${varName}=.*$`, 'm'),
+        `${varName}=${useQuotes ? `"${value}"` : value}`,
+      )
+    }
+
+    let envContent = templateContent
+    const vars = [
+      {pattern: ENV_VAR.PROJECT_ID, value: projectId},
+      {pattern: ENV_VAR.DATASET, value: dataset},
+      {pattern: ENV_VAR.READ_TOKEN, value: readToken},
+      {pattern: ENV_VAR.API_VERSION, value: apiVersion},
+    ]
+    const useQuotes = templateContent.includes('="')
+
+    for (const {pattern, value} of vars) {
+      envContent = findAndReplaceVariable(envContent, pattern, value, useQuotes)
+    }
+
+    await writeFile(join(root, targetName), envContent)
+  } catch (err) {
+    throw new Error(
+      'Failed to set environment variables. This could be due to file permissions or the .env file format. See https://www.sanity.io/docs/environment-variables for details on environment variable setup.',
+    )
+  }
+}
+
+export async function tryApplyPackageName(root: string, name: string): Promise<void> {
+  try {
+    const packageJson = await readFile(join(root, 'package.json'), 'utf8')
+    const pkg: PackageJson = JSON.parse(packageJson)
+    pkg.name = name
+
+    await writeFile(join(root, 'package.json'), JSON.stringify(pkg, null, 2))
+  } catch (err) {
+    // noop
+  }
+}
+
+export async function generateSanityApiReadToken(
+  projectId: string,
+  apiClient: CliApiClient,
+): Promise<string> {
+  const response = await apiClient({requireProject: false, requireUser: true})
+    .config({apiVersion: 'v2021-06-07'})
+    .request<{key: string}>({
+      uri: `/projects/${projectId}/tokens`,
+      method: 'POST',
+      body: {
+        label: `API Read Token (${Date.now()})`,
+        roleName: 'viewer',
+      },
+    })
+  return response.key
+}

--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -127,6 +127,11 @@ export async function getGitHubRepoInfo(value: string, bearerToken?: string): Pr
     throw new Error('Invalid GitHub repository format')
   }
 
+  const tokenMessage =
+    'GitHub repository not found. For private repositories, use --template-token to provide an access token.\n\n' +
+    'You can generate a new token at https://github.com/settings/personal-access-tokens/new\n' +
+    'Set the token to "read-only" with repository access and a short expiry (e.g. 7 days) for security.'
+
   try {
     const headers: Record<string, string> = {}
     if (bearerToken) {
@@ -139,11 +144,7 @@ export async function getGitHubRepoInfo(value: string, bearerToken?: string): Pr
 
     if (infoResponse.status !== 200) {
       if (infoResponse.status === 404) {
-        throw new Error(
-          'GitHub repository not found. For private repositories, use --template-token to provide an access token.\n\n' +
-            'You can generate a new token at https://github.com/settings/personal-access-tokens/new\n' +
-            'Set the token to "read-only" with repository access and a short expiry (e.g. 7 days) for security.',
-        )
+        throw new Error(tokenMessage)
       }
       throw new Error('GitHub repository not found')
     }
@@ -157,9 +158,7 @@ export async function getGitHubRepoInfo(value: string, bearerToken?: string): Pr
       filePath,
     }
   } catch {
-    throw new Error(
-      'GitHub repository not found. For private repositories, use --template-token to provide an access token',
-    )
+    throw new Error(tokenMessage)
   }
 }
 
@@ -167,7 +166,7 @@ export async function downloadAndExtractRepo(
   root: string,
   {username, name, branch, filePath}: RepoInfo,
   bearerToken?: string,
-) {
+): Promise<void> {
   let rootPath: string | null = null
   await pipeline(
     await downloadTarStream(

--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -13,7 +13,6 @@ const ENV_VAR = {
   PROJECT_ID: /SANITY(?:_STUDIO)?_PROJECT_ID/, // Matches SANITY_PROJECT_ID and SANITY_STUDIO_PROJECT_ID
   DATASET: /SANITY(?:_STUDIO)?_DATASET/, // Matches SANITY_DATASET and SANITY_STUDIO_DATASET
   READ_TOKEN: 'SANITY_API_READ_TOKEN',
-  API_VERSION: /SANITY(?:_STUDIO)?_API_VERSION/, // Matches SANITY_API_VERSION and SANITY_STUDIO_API_VERSION
 } as const
 
 const ENV_FILE = {
@@ -28,7 +27,6 @@ type EnvData = {
   projectId: string
   dataset: string
   readToken?: string
-  apiVersion?: string
 }
 
 type GithubUrlString =
@@ -438,7 +436,7 @@ export async function applyEnvVariables(
 
   try {
     const templateContent = await readFile(join(root, templatePath), 'utf8')
-    const {projectId, dataset, readToken = '', apiVersion = 'vX'} = envData
+    const {projectId, dataset, readToken = ''} = envData
 
     const findAndReplaceVariable = (
       content: string,
@@ -462,7 +460,6 @@ export async function applyEnvVariables(
       {pattern: ENV_VAR.PROJECT_ID, value: projectId},
       {pattern: ENV_VAR.DATASET, value: dataset},
       {pattern: ENV_VAR.READ_TOKEN, value: readToken},
-      {pattern: ENV_VAR.API_VERSION, value: apiVersion},
     ]
     const useQuotes = templateContent.includes('="')
 

--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -140,7 +140,9 @@ export async function getGitHubRepoInfo(value: string, bearerToken?: string): Pr
     if (infoResponse.status !== 200) {
       if (infoResponse.status === 404) {
         throw new Error(
-          'GitHub repository not found. For private repositories, use --template-token to provide an access token',
+          'GitHub repository not found. For private repositories, use --template-token to provide an access token.\n\n' +
+            'You can generate a new token at https://github.com/settings/personal-access-tokens/new\n' +
+            'Set the token to "read-only" with repository access and a short expiry (e.g. 7 days) for security.',
         )
       }
       throw new Error('GitHub repository not found')

--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -277,7 +277,6 @@ async function validatePackage(
   baseUrl: string,
   packagePath: string,
   headers: Record<string, string>,
-  isRoot: boolean,
 ): Promise<{
   hasSanityConfig: boolean
   hasSanityCli: boolean
@@ -386,7 +385,7 @@ export async function validateRemoteTemplate(
   }
 
   const validations = await Promise.all(
-    packages.map((pkg) => validatePackage(baseUrl, pkg, headers, pkg === '')),
+    packages.map((pkg) => validatePackage(baseUrl, pkg, headers)),
   )
 
   const hasSanityDep = validations.some((v) => v.hasSanityDep)

--- a/packages/@sanity/cli/test/init.test.ts
+++ b/packages/@sanity/cli/test/init.test.ts
@@ -123,7 +123,7 @@ describeCliTest('CLI: `sanity init v3`', () => {
         .then(() => true)
         .catch(() => false)
       const hasEnvFile = await fs
-        .access(path.join(baseTestPath, outpath, '.env'))
+        .access(path.join(baseTestPath, outpath, '.env.local'))
         .then(() => true)
         .catch(() => false)
 
@@ -161,7 +161,7 @@ describeCliTest('CLI: `sanity init v3`', () => {
         .then(() => true)
         .catch(() => false)
       const hasEnvFile = await fs
-        .access(path.join(baseTestPath, outpath, '.env'))
+        .access(path.join(baseTestPath, outpath, '.env.local'))
         .then(() => true)
         .catch(() => false)
 
@@ -190,7 +190,7 @@ describeCliTest('CLI: `sanity init v3`', () => {
         'manual',
       ])
 
-      const envContent = await fs.readFile(path.join(baseTestPath, outpath, '.env'), 'utf-8')
+      const envContent = await fs.readFile(path.join(baseTestPath, outpath, '.env.local'), 'utf-8')
 
       expect(envContent).toContain(`SANITY_PROJECT_ID=${cliProjectId}`)
       expect(envContent).toContain(`SANITY_DATASET=${testRunArgs.dataset}`)

--- a/packages/@sanity/cli/test/init.test.ts
+++ b/packages/@sanity/cli/test/init.test.ts
@@ -91,4 +91,157 @@ describeCliTest('CLI: `sanity init v3`', () => {
     expect(cliConfig).toContain(`dataset: '${testRunArgs.dataset}'`)
     expect(cliConfig).toContain(`autoUpdates: false`)
   })
+
+  describe('remote templates', () => {
+    testConcurrent('initializes a project from a GitHub repository shorthand', async () => {
+      const version = 'v3'
+      const testRunArgs = getTestRunArgs(version)
+      const outpath = 'test-remote-template-shorthand'
+
+      await runSanityCmdCommand(version, [
+        'init',
+        '--y',
+        '--project',
+        cliProjectId,
+        '--dataset',
+        testRunArgs.dataset,
+        '--template',
+        'sanity-io/sanity/packages/@sanity/cli/test/test-template',
+        '--output-path',
+        `${baseTestPath}/${outpath}`,
+        '--package-manager',
+        'manual',
+      ])
+
+      // Check if essential files exist
+      const hasPackageJson = await fs
+        .access(path.join(baseTestPath, outpath, 'package.json'))
+        .then(() => true)
+        .catch(() => false)
+      const hasSanityConfig = await fs
+        .access(path.join(baseTestPath, outpath, 'sanity.config.ts'))
+        .then(() => true)
+        .catch(() => false)
+      const hasEnvFile = await fs
+        .access(path.join(baseTestPath, outpath, '.env'))
+        .then(() => true)
+        .catch(() => false)
+
+      expect(hasPackageJson).toBe(true)
+      expect(hasSanityConfig).toBe(true)
+      expect(hasEnvFile).toBe(true)
+    })
+
+    testConcurrent('initializes a project from a GitHub URL', async () => {
+      const version = 'v3'
+      const testRunArgs = getTestRunArgs(version)
+      const outpath = 'test-remote-template-url'
+
+      await runSanityCmdCommand(version, [
+        'init',
+        '--y',
+        '--project',
+        cliProjectId,
+        '--dataset',
+        testRunArgs.dataset,
+        '--template',
+        'https://github.com/sanity-io/sanity/tree/next/packages/@sanity/cli/test/test-template',
+        '--output-path',
+        `${baseTestPath}/${outpath}`,
+        '--package-manager',
+        'manual',
+      ])
+
+      const hasPackageJson = await fs
+        .access(path.join(baseTestPath, outpath, 'package.json'))
+        .then(() => true)
+        .catch(() => false)
+      const hasSanityConfig = await fs
+        .access(path.join(baseTestPath, outpath, 'sanity.config.ts'))
+        .then(() => true)
+        .catch(() => false)
+      const hasEnvFile = await fs
+        .access(path.join(baseTestPath, outpath, '.env'))
+        .then(() => true)
+        .catch(() => false)
+
+      expect(hasPackageJson).toBe(true)
+      expect(hasSanityConfig).toBe(true)
+      expect(hasEnvFile).toBe(true)
+    })
+
+    testConcurrent('correctly applies environment variables', async () => {
+      const version = 'v3'
+      const testRunArgs = getTestRunArgs(version)
+      const outpath = 'test-remote-template-env'
+
+      await runSanityCmdCommand(version, [
+        'init',
+        '--y',
+        '--project',
+        cliProjectId,
+        '--dataset',
+        testRunArgs.dataset,
+        '--template',
+        'SimeonGriggs/sanity-remix-template',
+        '--output-path',
+        `${baseTestPath}/${outpath}`,
+        '--package-manager',
+        'manual',
+      ])
+
+      const envContent = await fs.readFile(path.join(baseTestPath, outpath, '.env'), 'utf-8')
+
+      expect(envContent).toContain(`SANITY_PROJECT_ID=${cliProjectId}`)
+      expect(envContent).toContain(`SANITY_DATASET=${testRunArgs.dataset}`)
+    })
+
+    testConcurrent('fails with invalid repository format', async () => {
+      const version = 'v3'
+      const testRunArgs = getTestRunArgs(version)
+      const outpath = 'test-remote-template-invalid'
+
+      await expect(
+        runSanityCmdCommand(version, [
+          'init',
+          '--y',
+          '--project',
+          cliProjectId,
+          '--dataset',
+          testRunArgs.dataset,
+          '--template',
+          'invalid-repo-format',
+          '--output-path',
+          `${baseTestPath}/${outpath}`,
+          '--package-manager',
+          'manual',
+        ]),
+      ).rejects.toThrow()
+    })
+
+    testConcurrent('fails with non-existent repository', async () => {
+      const version = 'v3'
+      const testRunArgs = getTestRunArgs(version)
+      const outpath = 'test-remote-template-nonexistent'
+
+      await expect(
+        runSanityCmdCommand(version, [
+          'init',
+          '--y',
+          '--project',
+          cliProjectId,
+          '--dataset',
+          testRunArgs.dataset,
+          '--template',
+          'sanity-io/non-existent-template',
+          '--output-path',
+          `${baseTestPath}/${outpath}`,
+          '--package-manager',
+          'manual',
+        ]),
+      ).rejects.toThrow(
+        'GitHub repository not found. For private repositories, use --template-token to provide an access token',
+      )
+    })
+  })
 })

--- a/packages/@sanity/cli/test/init.test.ts
+++ b/packages/@sanity/cli/test/init.test.ts
@@ -183,7 +183,7 @@ describeCliTest('CLI: `sanity init v3`', () => {
         '--dataset',
         testRunArgs.dataset,
         '--template',
-        'SimeonGriggs/sanity-remix-template',
+        'sanity-io/sanity/packages/@sanity/cli/test/test-template',
         '--output-path',
         `${baseTestPath}/${outpath}`,
         '--package-manager',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
         version: 0.0.1-alpha.1
       '@sanity/tsdoc':
         specifier: 1.0.142
-        version: 1.0.142(@types/babel__core@7.20.5)(@types/node@22.10.0)(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react-is@19.0.0-rc-b01722d5-20241114)(react@19.0.0-rc-f994737d14-20240522)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522))(terser@5.32.0)(yaml@2.5.0)
+        version: 1.0.142(@types/babel__core@7.20.5)(@types/node@22.10.0)(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react-is@19.0.0-rc-b01722d5-20241114)(react@19.0.0-rc-f994737d14-20240522)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522))(terser@5.32.0)(yaml@2.6.1)
       '@sanity/ui':
         specifier: ^2.9.0
         version: 2.9.0(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react-is@19.0.0-rc-b01722d5-20241114)(react@19.0.0-rc-f994737d14-20240522)(styled-components@6.1.13(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522))
@@ -512,13 +512,13 @@ importers:
         version: link:../../packages/@sanity/migrate
       '@sanity/preview-url-secret':
         specifier: ^2.0.0
-        version: 2.0.5(@sanity/client@6.23.0(debug@4.3.7))
+        version: 2.0.5(@sanity/client@6.23.0)
       '@sanity/react-loader':
         specifier: ^1.8.3
         version: 1.10.24(@sanity/client@6.23.0)(react@18.3.1)
       '@sanity/tsdoc':
         specifier: 1.0.142
-        version: 1.0.142(@types/babel__core@7.20.5)(@types/node@22.10.0)(babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124)(react-dom@18.3.1(react@18.3.1))(react-is@19.0.0-rc-b01722d5-20241114)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.32.0)(yaml@2.5.0)
+        version: 1.0.142(@types/babel__core@7.20.5)(@types/node@22.10.0)(babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124)(react-dom@18.3.1(react@18.3.1))(react-is@19.0.0-rc-b01722d5-20241114)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.32.0)(yaml@2.6.1)
       '@sanity/types':
         specifier: workspace:*
         version: link:../../packages/@sanity/types
@@ -787,7 +787,7 @@ importers:
     dependencies:
       '@babel/traverse':
         specifier: ^7.23.5
-        version: 7.25.9
+        version: 7.25.9(supports-color@5.5.0)
       '@sanity/client':
         specifier: ^6.23.0
         version: 6.23.0(debug@4.3.7)
@@ -805,7 +805,7 @@ importers:
         version: 4.1.2
       debug:
         specifier: ^4.3.4
-        version: 4.3.7(supports-color@9.4.0)
+        version: 4.3.7(supports-color@5.5.0)
       decompress:
         specifier: ^4.2.0
         version: 4.2.1
@@ -836,6 +836,12 @@ importers:
       validate-npm-package-name:
         specifier: ^3.0.0
         version: 3.0.0
+      yaml:
+        specifier: ^2.6.1
+        version: 2.6.1
+      yarn:
+        specifier: ^1.22.22
+        version: 1.22.22
     devDependencies:
       '@repo/package.config':
         specifier: workspace:*
@@ -1025,13 +1031,13 @@ importers:
         version: 7.25.9(@babel/core@7.26.0)
       '@babel/traverse':
         specifier: ^7.23.5
-        version: 7.25.9
+        version: 7.25.9(supports-color@5.5.0)
       '@babel/types':
         specifier: ^7.23.9
         version: 7.26.0
       debug:
         specifier: ^4.3.4
-        version: 4.3.7(supports-color@9.4.0)
+        version: 4.3.7(supports-color@5.5.0)
       globby:
         specifier: ^10.0.0
         version: 10.0.2
@@ -1111,7 +1117,7 @@ importers:
         version: 2.0.1
       debug:
         specifier: ^4.3.4
-        version: 4.3.7(supports-color@9.4.0)
+        version: 4.3.7(supports-color@5.5.0)
       fast-fifo:
         specifier: ^1.3.2
         version: 1.3.2
@@ -1154,7 +1160,7 @@ importers:
         version: 3.0.2
       debug:
         specifier: ^4.3.4
-        version: 4.3.7(supports-color@9.4.0)
+        version: 4.3.7(supports-color@5.5.0)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1253,7 +1259,7 @@ importers:
         version: 1.0.15(@sanity/types@packages+@sanity+types)(react-dom@19.0.0-rc-f994737d14-20240522(react@18.3.1))(react-is@19.0.0-rc-b01722d5-20241114)(react@18.3.1)(styled-components@6.1.13(react-dom@19.0.0-rc-f994737d14-20240522(react@18.3.1))(react@18.3.1))
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.5.0))
+        version: 4.3.4(vite@6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.6.1))
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1591,7 +1597,7 @@ importers:
         version: 2.30.0
       debug:
         specifier: ^4.3.4
-        version: 4.3.7(supports-color@9.4.0)
+        version: 4.3.7(supports-color@5.5.0)
       esbuild:
         specifier: 0.21.5
         version: 0.21.5
@@ -1805,7 +1811,7 @@ importers:
         version: 6.11.14(@types/babel__core@7.20.5)(@types/node@22.10.0)(babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124)(debug@4.3.7)(typescript@5.7.2)
       '@sanity/tsdoc':
         specifier: 1.0.142
-        version: 1.0.142(@types/babel__core@7.20.5)(@types/node@22.10.0)(babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124)(debug@4.3.7)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.32.0)(yaml@2.5.0)
+        version: 1.0.142(@types/babel__core@7.20.5)(@types/node@22.10.0)(babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124)(debug@4.3.7)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.32.0)(yaml@2.6.1)
       '@sanity/ui-workshop':
         specifier: ^1.2.11
         version: 1.2.11(@sanity/icons@3.5.0(react@18.3.1))(@sanity/ui@2.9.0(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/node@22.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.32.0)
@@ -4423,6 +4429,10 @@ packages:
 
   '@sanity/browserslist-config@1.0.3':
     resolution: {integrity: sha512-UkJuiTyROgPcxbvpHYyXwr+T88Np4eLzu3h05gMgeZ2hv3EM7g/4VMyng5HuA1JdPQPEdq8bmmfQDR+u4KC+TA==}
+
+  '@sanity/client@6.22.5-beta.1':
+    resolution: {integrity: sha512-t7K1mQkCluLg2nzEQBpBqZgdfL2vKUoqpAja87ff2K/UkrCOUyrz6+VG5gVhLb0Zo5xCfrTAn6I9PzTfdgS60Q==}
+    engines: {node: '>=14.18'}
 
   '@sanity/client@6.23.0':
     resolution: {integrity: sha512-83dwqW0HZxKSFaII2lAhuPzNbZVWv+HIUiWQhef4gytisqPo1WXt3s5B63nu3U9Y2TO1gHf96gIWGSBrmWV0sw==}
@@ -7047,9 +7057,17 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.0:
+    resolution: {integrity: sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==}
+    engines: {node: '>=18.0.0'}
+
   eventsource@2.0.2:
     resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
     engines: {node: '>=12.0.0'}
+
+  eventsource@3.0.0-beta.0:
+    resolution: {integrity: sha512-VL1epPiVzE1oAt4lZzMR5HBoTpNrAyNXPfRQukjnEK7TwuQgTXYoUgsb2RW+v1lMoMqsLBkjtTbLYCL71VT4JA==}
+    engines: {node: '>=18.0.0'}
 
   execa@2.1.0:
     resolution: {integrity: sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==}
@@ -11700,8 +11718,8 @@ packages:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
 
-  yaml@2.5.0:
-    resolution: {integrity: sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==}
+  yaml@2.6.1:
+    resolution: {integrity: sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==}
     engines: {node: '>= 14'}
     hasBin: true
 
@@ -11724,6 +11742,11 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yarn@1.22.22:
+    resolution: {integrity: sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -11792,10 +11815,10 @@ snapshots:
       '@babel/helpers': 7.26.0
       '@babel/parser': 7.26.2
       '@babel/template': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       '@babel/types': 7.26.0
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -11832,7 +11855,7 @@ snapshots:
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.25.9':
     dependencies:
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
@@ -11853,7 +11876,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.25.9
       '@babel/helper-replace-supers': 7.25.9(@babel/core@7.26.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -11870,7 +11893,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -11878,14 +11901,7 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.25.9':
     dependencies:
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-imports@7.25.9':
-    dependencies:
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
@@ -11900,9 +11916,9 @@ snapshots:
   '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
       '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11917,7 +11933,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-wrap-function': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11926,20 +11942,20 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-member-expression-to-functions': 7.25.9
       '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-simple-access@7.25.9':
     dependencies:
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
     dependencies:
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
@@ -11953,7 +11969,7 @@ snapshots:
   '@babel/helper-wrap-function@7.25.9':
     dependencies:
       '@babel/template': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
@@ -11971,7 +11987,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11998,7 +12014,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12042,14 +12058,14 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.26.0)
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-async-to-generator@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.26.0)
     transitivePeerDependencies:
@@ -12088,7 +12104,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-replace-supers': 7.25.9(@babel/core@7.26.0)
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -12152,7 +12168,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12199,7 +12215,7 @@ snapshots:
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12313,7 +12329,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.0)
       '@babel/types': 7.26.0
@@ -12529,18 +12545,6 @@ snapshots:
       '@babel/parser': 7.26.2
       '@babel/types': 7.26.0
 
-  '@babel/traverse@7.25.9':
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.2
-      '@babel/parser': 7.26.2
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.0
-      debug: 4.3.7(supports-color@9.4.0)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/traverse@7.25.9(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -12739,7 +12743,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.12.0':
     dependencies:
-      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
       '@babel/runtime': 7.26.0
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -13112,7 +13116,7 @@ snapshots:
   '@eslint/config-array@0.18.0':
     dependencies:
       '@eslint/object-schema': 2.1.4
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -13120,7 +13124,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -13134,7 +13138,7 @@ snapshots:
   '@eslint/eslintrc@3.2.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -13223,7 +13227,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -14034,7 +14038,7 @@ snapshots:
       '@sanity/schema': link:packages/@sanity/schema
       '@sanity/types': link:packages/@sanity/types
       '@xstate/react': 5.0.0(@types/react@18.3.12)(react@18.3.1)(xstate@5.19.0)
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       get-random-values-esm: 1.0.2
       lodash: 4.17.21
       lodash.startcase: 4.4.0
@@ -14111,7 +14115,7 @@ snapshots:
   '@rollup/plugin-babel@6.0.4(@babel/core@7.26.0)(@types/babel__core@7.20.5)(rollup@4.28.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
       '@rollup/pluginutils': 5.1.0(rollup@4.28.0)
     optionalDependencies:
       '@types/babel__core': 7.20.5
@@ -14299,6 +14303,14 @@ snapshots:
 
   '@sanity/browserslist-config@1.0.3': {}
 
+  '@sanity/client@6.22.5-beta.1(debug@4.3.7)':
+    dependencies:
+      eventsource: 3.0.0-beta.0
+      get-it: 8.6.5(debug@4.3.7)
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - debug
+
   '@sanity/client@6.23.0(debug@4.3.7)':
     dependencies:
       '@sanity/eventsource': 5.0.2
@@ -14417,7 +14429,7 @@ snapshots:
       '@sanity/client': 6.23.0(debug@4.3.7)
       '@sanity/util': 3.37.2(debug@4.3.7)
       archiver: 7.0.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       get-it: 8.6.5(debug@4.3.7)
       lodash: 4.17.21
       mississippi: 4.0.0
@@ -14425,7 +14437,7 @@ snapshots:
       rimraf: 3.0.2
       split2: 4.2.0
       tar: 7.4.3
-      yaml: 2.5.0
+      yaml: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -14468,7 +14480,7 @@ snapshots:
       '@sanity/generate-help-url': 3.0.0
       '@sanity/mutator': 3.37.2
       '@sanity/uuid': 3.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       file-url: 2.0.2
       get-it: 8.6.5(debug@4.3.7)
       get-uri: 2.0.4
@@ -14546,7 +14558,7 @@ snapshots:
 
   '@sanity/mutate@0.10.2(debug@4.3.7)':
     dependencies:
-      '@sanity/client': 6.23.0(debug@4.3.7)
+      '@sanity/client': 6.22.5-beta.1(debug@4.3.7)
       '@sanity/diff-match-patch': 3.1.1
       hotscript: 1.0.13
       lodash: 4.17.21
@@ -14573,7 +14585,7 @@ snapshots:
     dependencies:
       '@sanity/diff-match-patch': 3.1.1
       '@sanity/uuid': 3.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -14688,7 +14700,7 @@ snapshots:
       '@sanity/comlink': 2.0.0
       '@sanity/icons': 3.5.0(react@18.3.1)
       '@sanity/logos': 2.1.13(@sanity/color@3.0.6)(react@18.3.1)
-      '@sanity/preview-url-secret': 2.0.5(@sanity/client@6.23.0(debug@4.3.7))
+      '@sanity/preview-url-secret': 2.0.5(@sanity/client@6.23.0)
       '@sanity/ui': 2.9.0(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/uuid': 3.0.2
       '@types/lodash.isequal': 4.5.8
@@ -14715,7 +14727,7 @@ snapshots:
       prettier: 3.4.1
       prettier-plugin-packagejson: 2.5.3(prettier@3.4.1)
 
-  '@sanity/preview-url-secret@2.0.5(@sanity/client@6.23.0(debug@4.3.7))':
+  '@sanity/preview-url-secret@2.0.5(@sanity/client@6.23.0)':
     dependencies:
       '@sanity/client': 6.23.0(debug@4.3.7)
       '@sanity/uuid': 3.0.2
@@ -14749,7 +14761,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/tsdoc@1.0.142(@types/babel__core@7.20.5)(@types/node@22.10.0)(babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124)(debug@4.3.7)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.32.0)(yaml@2.5.0)':
+  '@sanity/tsdoc@1.0.142(@types/babel__core@7.20.5)(@types/node@22.10.0)(babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124)(debug@4.3.7)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.32.0)(yaml@2.6.1)':
     dependencies:
       '@microsoft/api-extractor': 7.48.0(@types/node@22.10.0)
       '@microsoft/api-extractor-model': 7.30.0(@types/node@22.10.0)
@@ -14763,7 +14775,7 @@ snapshots:
       '@sanity/pkg-utils': 6.11.14(@types/babel__core@7.20.5)(@types/node@22.10.0)(babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124)(debug@4.3.7)(typescript@5.7.2)
       '@sanity/ui': 2.9.0(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@types/cpx': 1.5.5
-      '@vitejs/plugin-react': 4.3.4(vite@6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.5.0))
+      '@vitejs/plugin-react': 4.3.4(vite@6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.6.1))
       cac: 6.7.14
       chalk: 4.1.2
       chokidar: 4.0.1
@@ -14787,7 +14799,7 @@ snapshots:
       styled-components: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tmp: 0.2.3
       typescript: 5.7.2
-      vite: 6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.5.0)
+      vite: 6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@types/babel__core'
       - '@types/node'
@@ -14806,7 +14818,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@sanity/tsdoc@1.0.142(@types/babel__core@7.20.5)(@types/node@22.10.0)(babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124)(react-dom@18.3.1(react@18.3.1))(react-is@19.0.0-rc-b01722d5-20241114)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.32.0)(yaml@2.5.0)':
+  '@sanity/tsdoc@1.0.142(@types/babel__core@7.20.5)(@types/node@22.10.0)(babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124)(react-dom@18.3.1(react@18.3.1))(react-is@19.0.0-rc-b01722d5-20241114)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.32.0)(yaml@2.6.1)':
     dependencies:
       '@microsoft/api-extractor': 7.48.0(@types/node@22.10.0)
       '@microsoft/api-extractor-model': 7.30.0(@types/node@22.10.0)
@@ -14820,7 +14832,7 @@ snapshots:
       '@sanity/pkg-utils': 6.11.14(@types/babel__core@7.20.5)(@types/node@22.10.0)(babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124)(typescript@5.7.2)
       '@sanity/ui': 2.9.0(react-dom@18.3.1(react@18.3.1))(react-is@19.0.0-rc-b01722d5-20241114)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@types/cpx': 1.5.5
-      '@vitejs/plugin-react': 4.3.4(vite@6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.5.0))
+      '@vitejs/plugin-react': 4.3.4(vite@6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.6.1))
       cac: 6.7.14
       chalk: 4.1.2
       chokidar: 4.0.1
@@ -14844,7 +14856,7 @@ snapshots:
       styled-components: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tmp: 0.2.3
       typescript: 5.7.2
-      vite: 6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.5.0)
+      vite: 6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@types/babel__core'
       - '@types/node'
@@ -14863,7 +14875,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@sanity/tsdoc@1.0.142(@types/babel__core@7.20.5)(@types/node@22.10.0)(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react-is@19.0.0-rc-b01722d5-20241114)(react@19.0.0-rc-f994737d14-20240522)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522))(terser@5.32.0)(yaml@2.5.0)':
+  '@sanity/tsdoc@1.0.142(@types/babel__core@7.20.5)(@types/node@22.10.0)(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react-is@19.0.0-rc-b01722d5-20241114)(react@19.0.0-rc-f994737d14-20240522)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522))(terser@5.32.0)(yaml@2.6.1)':
     dependencies:
       '@microsoft/api-extractor': 7.48.0(@types/node@22.10.0)
       '@microsoft/api-extractor-model': 7.30.0(@types/node@22.10.0)
@@ -14877,7 +14889,7 @@ snapshots:
       '@sanity/pkg-utils': 6.11.14(@types/babel__core@7.20.5)(@types/node@22.10.0)(babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124)(typescript@5.7.2)
       '@sanity/ui': 2.9.0(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react-is@19.0.0-rc-b01722d5-20241114)(react@19.0.0-rc-f994737d14-20240522)(styled-components@6.1.13(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522))
       '@types/cpx': 1.5.5
-      '@vitejs/plugin-react': 4.3.4(vite@6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.5.0))
+      '@vitejs/plugin-react': 4.3.4(vite@6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.6.1))
       cac: 6.7.14
       chalk: 4.1.2
       chokidar: 4.0.1
@@ -14901,7 +14913,7 @@ snapshots:
       styled-components: 6.1.13(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522)
       tmp: 0.2.3
       typescript: 5.7.2
-      vite: 6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.5.0)
+      vite: 6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@types/babel__core'
       - '@types/node'
@@ -15068,7 +15080,7 @@ snapshots:
     dependencies:
       '@sanity/comlink': 2.0.0
       '@sanity/mutate': 0.11.0-canary.3(xstate@5.19.0)
-      '@sanity/preview-url-secret': 2.0.5(@sanity/client@6.23.0(debug@4.3.7))
+      '@sanity/preview-url-secret': 2.0.5(@sanity/client@6.23.0)
       '@vercel/stega': 0.1.2
       get-random-values-esm: 1.0.2
       react: 18.3.1
@@ -15186,7 +15198,7 @@ snapshots:
       '@swc-node/sourcemap-support': 0.5.1
       '@swc/core': 1.7.14(@swc/helpers@0.5.13)
       colorette: 2.0.20
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       oxc-resolver: 1.10.2
       pirates: 4.0.6
       tslib: 2.8.1
@@ -15674,7 +15686,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.2)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.7.2
@@ -15687,7 +15699,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.2)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 9.10.0
     optionalDependencies:
       typescript: 5.7.2
@@ -15703,7 +15715,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.2)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.7.2)
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.7.2)
     optionalDependencies:
@@ -15715,7 +15727,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.2)
       '@typescript-eslint/utils': 7.18.0(eslint@9.10.0)(typescript@5.7.2)
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 9.10.0
       ts-api-utils: 1.3.0(typescript@5.7.2)
     optionalDependencies:
@@ -15729,7 +15741,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -15867,14 +15879,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.3.4(vite@6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.5.0))':
+  '@vitejs/plugin-react@4.3.4(vite@6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.6.1))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.5.0)
+      vite: 6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15882,7 +15894,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
@@ -16029,13 +16041,13 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17241,12 +17253,12 @@ snapshots:
   depcheck@1.4.7:
     dependencies:
       '@babel/parser': 7.26.2
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       '@vue/compiler-sfc': 3.4.37
       callsite: 1.0.0
       camelcase: 6.3.0
       cosmiconfig: 7.1.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       deps-regex: 0.2.0
       findup-sync: 5.0.0
       ignore: 5.3.2
@@ -17548,21 +17560,21 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.19.12):
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       esbuild: 0.19.12
     transitivePeerDependencies:
       - supports-color
 
   esbuild-register@3.6.0(esbuild@0.21.5):
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       esbuild: 0.21.5
     transitivePeerDependencies:
       - supports-color
 
   esbuild-register@3.6.0(esbuild@0.24.0):
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       esbuild: 0.24.0
     transitivePeerDependencies:
       - supports-color
@@ -17712,7 +17724,7 @@ snapshots:
   eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.7.2))(eslint-plugin-import@2.30.0)(eslint@8.57.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
       eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
@@ -17988,7 +18000,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -18032,7 +18044,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.2.0
       eslint-visitor-keys: 4.2.0
@@ -18105,7 +18117,13 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.0: {}
+
   eventsource@2.0.2: {}
+
+  eventsource@3.0.0-beta.0:
+    dependencies:
+      eventsource-parser: 3.0.0
 
   execa@2.1.0:
     dependencies:
@@ -18420,7 +18438,7 @@ snapshots:
 
   follow-redirects@1.15.6(debug@4.3.7):
     optionalDependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
 
   for-each@0.3.3:
     dependencies:
@@ -18852,7 +18870,7 @@ snapshots:
 
   groq-js@1.14.1:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -19000,28 +19018,28 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.5:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -19442,7 +19460,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -21704,7 +21722,7 @@ snapshots:
   rollup-plugin-esbuild@6.1.1(esbuild@0.24.0)(rollup@4.28.0):
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.28.0)
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       es-module-lexer: 1.5.4
       esbuild: 0.24.0
       get-tsconfig: 4.8.0
@@ -22154,7 +22172,7 @@ snapshots:
   socks-proxy-agent@8.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -22785,7 +22803,7 @@ snapshots:
   tuf-js@2.2.1:
     dependencies:
       '@tufjs/models': 2.0.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       make-fetch-happen: 13.0.1
     transitivePeerDependencies:
       - supports-color
@@ -23079,7 +23097,7 @@ snapshots:
   vite-node@2.1.1(@types/node@18.19.44)(terser@5.32.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       pathe: 1.1.2
       vite: 5.4.11(@types/node@18.19.44)(terser@5.32.0)
     transitivePeerDependencies:
@@ -23096,7 +23114,7 @@ snapshots:
   vite-node@2.1.1(@types/node@22.10.0)(terser@5.32.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       pathe: 1.1.2
       vite: 5.4.11(@types/node@22.10.0)(terser@5.32.0)
     transitivePeerDependencies:
@@ -23112,7 +23130,7 @@ snapshots:
 
   vite-tsconfig-paths@4.3.2(typescript@5.7.2)(vite@4.5.5(@types/node@22.10.0)(terser@5.32.0)):
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.1.1(typescript@5.7.2)
     optionalDependencies:
@@ -23151,7 +23169,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.32.0
 
-  vite@6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.5.0):
+  vite@6.0.2(@types/node@22.10.0)(terser@5.32.0)(yaml@2.6.1):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.49
@@ -23160,7 +23178,7 @@ snapshots:
       '@types/node': 22.10.0
       fsevents: 2.3.3
       terser: 5.32.0
-      yaml: 2.5.0
+      yaml: 2.6.1
 
   vitest@2.1.1(@types/node@18.19.44)(jsdom@23.2.0)(terser@5.32.0):
     dependencies:
@@ -23172,7 +23190,7 @@ snapshots:
       '@vitest/spy': 2.1.1
       '@vitest/utils': 2.1.1
       chai: 5.1.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       magic-string: 0.30.11
       pathe: 1.1.2
       std-env: 3.7.0
@@ -23207,7 +23225,7 @@ snapshots:
       '@vitest/spy': 2.1.1
       '@vitest/utils': 2.1.1
       chai: 5.1.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       magic-string: 0.30.11
       pathe: 1.1.2
       std-env: 3.7.0
@@ -23422,7 +23440,7 @@ snapshots:
 
   yaml@1.10.2: {}
 
-  yaml@2.5.0: {}
+  yaml@2.6.1: {}
 
   yargs-parser@20.2.9: {}
 
@@ -23457,6 +23475,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yarn@1.22.22: {}
 
   yauzl@2.10.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -839,9 +839,6 @@ importers:
       yaml:
         specifier: ^2.6.1
         version: 2.6.1
-      yarn:
-        specifier: ^1.22.22
-        version: 1.22.22
     devDependencies:
       '@repo/package.config':
         specifier: workspace:*
@@ -11742,11 +11739,6 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
-
-  yarn@1.22.22:
-    resolution: {integrity: sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==}
-    engines: {node: '>=4.0.0'}
-    hasBin: true
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -23475,8 +23467,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yarn@1.22.22: {}
 
   yauzl@2.10.0:
     dependencies:


### PR DESCRIPTION
## Introducing Support for Remote Templates in `--template` Flag

### What is a remote template?

A remote template is really any GitHub repo that passes a given set of requirements.
The requirements are:

#### **Monorepo Repositories**

1. **package.json**  
   - Each package must have a valid `package.json`.  
   - At least one package must include `sanity` in its `dependencies` or `devDependencies`.

2. **Sanity Configuration Files**  
   - At least one package must include both `sanity.config.js/ts` and `sanity.cli.js/ts`.

3. **Environment Template Files**  
   - Each package must have at least one of the following:
     - `.env.template`
     - `.env.example`
     - `.env.local.example`

#### **Single-Package Repositories**

1. **package.json**  
   - The repository must have a valid `package.json` with `sanity` listed in `dependencies` or `devDependencies`.

2. **Sanity Configuration Files**  
   - The repository must include both `sanity.config.js/ts` and `sanity.cli.js/ts`.

3. **Environment Template File**  
   - The repository must have one of the following:
     - `.env.template`
     - `.env.example`
     - `.env.local.example`

#### **Environment Variables**
For both monorepos and single-package repositories, the environment file must include in all packages:
- `SANITY_PROJECT_ID` or `SANITY_STUDIO_PROJECT_ID`
- `SANITY_DATASET` or `SANITY_STUDIO_DATASET`

If any of these criteria are not met, the validation will fail with a detailed error message.

### What to review

- Make sure running `--template` flag works for both built in schema type templates and remote templates
- Are there any other template validations that should be added?
- Is the testing sufficient?
- Implementation in general

### Testing

**Shorthand Example**
   ```shell
   npm create@latest sanity --template SimeonGriggs/sanity-remix-template
   ```

**GitHub URL**
   ```shell
   npm create@latest sanity --template https://github.com/SimeonGriggs/sanity-remix-template
   ```

**Nested Directory in a Repository**
   ```shell
   npm create@latest sanity --template sanity-io/sanity/templates/next-js
   ```

### Notes for release

No notes afaik for now