### PR TITLE
fix: support creating version with initial value

### DIFF
--- a/packages/sanity/src/core/releases/hooks/__tests__/useVersionOperations.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useVersionOperations.test.tsx
@@ -30,6 +30,7 @@ describe('useVersionOperations', () => {
     expect(useReleaseOperationsMockReturn.createVersion).toHaveBeenCalledWith(
       'releaseId',
       'documentId',
+      undefined,
     )
     expect(usePerspectiveMockReturn.setPerspectiveFromReleaseId).toHaveBeenCalledWith('releaseId')
   })
@@ -45,6 +46,7 @@ describe('useVersionOperations', () => {
     expect(useReleaseOperationsMockReturn.discardVersion).toHaveBeenCalledWith(
       'releaseId',
       'documentId',
+      undefined,
     )
   })
 })

--- a/packages/sanity/src/core/releases/hooks/__tests__/useVersionOperations.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useVersionOperations.test.tsx
@@ -46,7 +46,6 @@ describe('useVersionOperations', () => {
     expect(useReleaseOperationsMockReturn.discardVersion).toHaveBeenCalledWith(
       'releaseId',
       'documentId',
-      undefined,
     )
   })
 })

--- a/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
+++ b/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
@@ -8,7 +8,11 @@ import {getCreateVersionOrigin} from '../util/util'
 import {usePerspective} from './usePerspective'
 
 export interface VersionOperationsValue {
-  createVersion: (releaseId: string, documentId: string) => Promise<void>
+  createVersion: (
+    releaseId: string,
+    documentId: string,
+    initialValue?: Record<string, unknown>,
+  ) => Promise<void>
   discardVersion: (releaseId: string, documentId: string) => Promise<void>
 }
 
@@ -21,10 +25,14 @@ export function useVersionOperations(): VersionOperationsValue {
   const toast = useToast()
   const {t} = useTranslation()
 
-  const handleCreateVersion = async (releaseId: string, documentId: string) => {
+  const handleCreateVersion = async (
+    releaseId: string,
+    documentId: string,
+    initialValue?: Record<string, unknown>,
+  ) => {
     const origin = getCreateVersionOrigin(documentId)
     try {
-      await createVersion(releaseId, documentId)
+      await createVersion(releaseId, documentId, initialValue)
       setPerspectiveFromReleaseId(releaseId)
       telemetry.log(AddedVersion, {
         documentOrigin: origin,

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -155,6 +155,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
         <AddToReleaseBanner
           documentId={value._id}
           currentRelease={currentGlobalBundle as ReleaseDocument}
+          value={displayed || undefined}
         />
       )
     }

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
@@ -21,9 +21,11 @@ import {Banner} from './Banner'
 export function AddToReleaseBanner({
   documentId,
   currentRelease,
+  value,
 }: {
   documentId: string
   currentRelease: ReleaseDocument
+  value?: Record<string, unknown>
 }): JSX.Element {
   const tone = getReleaseTone(currentRelease ?? LATEST)
   const {t} = useTranslation(structureLocaleNamespace)
@@ -37,9 +39,9 @@ export function AddToReleaseBanner({
 
   const handleAddToRelease = useCallback(async () => {
     if (currentRelease._id) {
-      await createVersion(getBundleIdFromReleaseDocumentId(currentRelease._id), documentId)
+      await createVersion(getBundleIdFromReleaseDocumentId(currentRelease._id), documentId, value)
     }
-  }, [createVersion, currentRelease._id, documentId])
+  }, [createVersion, currentRelease._id, documentId, value])
 
   return (
     <Banner


### PR DESCRIPTION
### Description
Fixes an issue that made it impossible to create a new document in a release. Ideally you should be able to just start typing, but this fix at least makes it _possible_.

Also adds low-level API support for providing an initial/fallback value to use when adding a version to a document.
