### PR TITLE
fix(releases): blocking UI elements that allow for adding documents to inactive releases

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1104,6 +1104,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
    * when there are templates/types available for creation
    */
   'new-document.create-new-document-label': 'New document…',
+  /** Tooltip message for add document button when the selected perspective is for published or inactive release */
+  'new-document.disabled-release.tooltip': 'You cannot add documents to this release',
   /** Placeholder for the "filter" input within the new document menu */
   'new-document.filter-placeholder': 'Search document types',
   /** Loading indicator text within the new document menu */

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -36,6 +36,7 @@ export {
   LATEST,
   type ReleaseDocument,
   useDocumentVersions,
+  useIsReleaseActive,
   usePerspective,
   useReleases,
   useVersionOperations,

--- a/packages/sanity/src/core/releases/hooks/index.ts
+++ b/packages/sanity/src/core/releases/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useDocumentVersions'
+export * from './useIsReleaseActive'
 export * from './usePerspective'
 export * from './useVersionOperations'

--- a/packages/sanity/src/core/releases/hooks/useIsReleaseActive.ts
+++ b/packages/sanity/src/core/releases/hooks/useIsReleaseActive.ts
@@ -1,6 +1,7 @@
 import {isDraftPerspective, isPublishedPerspective} from '../util/util'
 import {usePerspective} from './usePerspective'
 
+/** @internal */
 export const useIsReleaseActive = () => {
   const {selectedPerspective} = usePerspective()
 

--- a/packages/sanity/src/core/releases/hooks/useIsReleaseActive.ts
+++ b/packages/sanity/src/core/releases/hooks/useIsReleaseActive.ts
@@ -1,0 +1,11 @@
+import {isDraftPerspective, isPublishedPerspective} from '../util/util'
+import {usePerspective} from './usePerspective'
+
+export const useIsReleaseActive = () => {
+  const {selectedPerspective} = usePerspective()
+
+  return (
+    !isPublishedPerspective(selectedPerspective) &&
+    (isDraftPerspective(selectedPerspective) || selectedPerspective.state === 'active')
+  )
+}

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
@@ -11,13 +11,12 @@ import {
 } from '@sanity/ui'
 import {type ChangeEvent, type KeyboardEvent, useCallback, useMemo, useRef, useState} from 'react'
 import ReactFocusLock from 'react-focus-lock'
-import {usePerspective} from 'sanity'
 
 import {Button, type ButtonProps, Tooltip, type TooltipProps} from '../../../../../ui-components'
 import {InsufficientPermissionsMessage} from '../../../../components'
 import {useSchema} from '../../../../hooks'
 import {useGetI18nText, useTranslation} from '../../../../i18n'
-import {isDraftPerspective, isPublishedPerspective} from '../../../../releases'
+import {useIsReleaseActive} from '../../../../releases/hooks/useIsReleaseActive'
 import {useCurrentUser} from '../../../../store'
 import {useColorSchemeValue} from '../../../colorScheme'
 import {filterOptions} from './filter'
@@ -48,7 +47,7 @@ interface NewDocumentButtonProps {
 export function NewDocumentButton(props: NewDocumentButtonProps) {
   const {canCreateDocument, modal = 'popover', loading, options} = props
 
-  const {currentGlobalBundle} = usePerspective()
+  const isReleaseActive = useIsReleaseActive()
   const [open, setOpen] = useState<boolean>(false)
   const [searchQuery, setSearchQuery] = useState<string>('')
   const popoverRef = useRef<HTMLDivElement | null>(null)
@@ -61,10 +60,6 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
   const scheme = useColorSchemeValue()
   const currentUser = useCurrentUser()
   const schema = useSchema()
-
-  const isReleaseActive =
-    !isPublishedPerspective(currentGlobalBundle) &&
-    (isDraftPerspective(currentGlobalBundle) || currentGlobalBundle.state === 'active')
 
   const hasNewDocumentOptions = options.length > 0
   const disabled = !canCreateDocument || !hasNewDocumentOptions || !isReleaseActive

--- a/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -3,20 +3,19 @@ import {Menu} from '@sanity/ui'
 import {type ComponentProps, type ForwardedRef, forwardRef, useMemo} from 'react'
 import {
   type InitialValueTemplateItem,
-  isDraftPerspective,
   isPublishedPerspective,
   LATEST,
   type Template,
   type TemplatePermissionsResult,
   useGetI18nText,
   usePerspective,
-  useSchema,
   useTemplatePermissions,
   useTemplates,
   useTranslation,
 } from 'sanity'
 import {IntentLink} from 'sanity/router'
 
+import {useIsReleaseActive} from '../../../core/releases/hooks/useIsReleaseActive'
 import {Button, MenuButton, MenuItem, type PopoverProps} from '../../../ui-components'
 import {structureLocaleNamespace} from '../../i18n'
 import {IntentButton} from '../IntentButton'
@@ -58,13 +57,9 @@ interface PaneHeaderCreateButtonProps {
 }
 
 export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonProps) {
-  const schema = useSchema()
   const templates = useTemplates()
-  const {selectedReleaseId, selectedPerspective} = usePerspective()
-
-  const isReleaseActive =
-    !isPublishedPerspective(selectedPerspective) &&
-    (isDraftPerspective(selectedPerspective) || selectedPerspective.state === 'active')
+  const {selectedReleaseId} = usePerspective()
+  const isReleaseActive = useIsReleaseActive()
 
   const {t} = useTranslation(structureLocaleNamespace)
   const {t: tCore} = useTranslation()

--- a/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -8,6 +8,7 @@ import {
   type Template,
   type TemplatePermissionsResult,
   useGetI18nText,
+  useIsReleaseActive,
   usePerspective,
   useTemplatePermissions,
   useTemplates,
@@ -15,7 +16,6 @@ import {
 } from 'sanity'
 import {IntentLink} from 'sanity/router'
 
-import {useIsReleaseActive} from '../../../core/releases/hooks/useIsReleaseActive'
 import {Button, MenuButton, MenuItem, type PopoverProps} from '../../../ui-components'
 import {structureLocaleNamespace} from '../../i18n'
 import {IntentButton} from '../IntentButton'


### PR DESCRIPTION
### Description
![blockAddDocsToScheduled](https://github.com/user-attachments/assets/06cf8a99-8f65-4882-ba8c-2cf3155ea5b9)
Currently if you are in published perspective or a scheduled release perspective, trying to add a new release in studio will show a new draft has been created but will be read only. The global perspective will remain as published or scheduled release even though the document form is showing a draft.

This change disables the UI elements that allow for creating documents in these scenarios.

NOTE: currently the tooltip clarification is the same for published as it is for a scheduled release. This should probably be made clearer to avoid confusion by separating these 2 scenarios, but I'd rather get this initial change in, and can then follow up once the copy has been confirmed later.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
There aren't currently any tests for these components or for their parents, so adding testing coverage here is a larger task
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
