### PR TITLE
feat: Start in Create button is now enabled by default

### DIFF
--- a/dev/test-create-integration-studio/sanity.config.ts
+++ b/dev/test-create-integration-studio/sanity.config.ts
@@ -15,7 +15,8 @@ export default defineConfig({
 
   beta: {
     create: {
-      startInCreateEnabled: true,
+      // defaults to true
+      //startInCreateEnabled: true,
       fallbackStudioOrigin: 'create-integration-test.sanity.studio',
     },
   },

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -660,7 +660,7 @@ function resolveSource({
         enabled: false,
       },
       create: {
-        startInCreateEnabled: startInCreateEnabledReducer({config, initialValue: false}),
+        startInCreateEnabled: startInCreateEnabledReducer({config, initialValue: true}),
         fallbackStudioOrigin: createFallbackOriginReducer(config),
       },
     },


### PR DESCRIPTION
### Description

This PR makes "Start in Create" button enabled by default for pristine, new documents. 

For more context, see the original feature PR: https://github.com/sanity-io/sanity/pull/7635

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->




### Testing

Feel free to run `test-create-integration-studio` locally and check that it has a `Start in Create` button for new documents.

### Notes for release

For new documents you will now find a "Start in Create" button in place of "Publish"

![image](https://github.com/user-attachments/assets/d3c9ed61-7b94-4ad2-baec-73fc003158b6)

This allows you to start authoring the document in [Sanity Create](https://www.sanity.io/create), by linking a new Create document to the Studio document.

By default any Studio deployed with `sanity deploy` (on this version or later) will have the button show up in the deployed studio. 
For studios hosted with other means, please confer [Configuring Content Mapping](https://www.sanity.io/docs/configure-content-mapping) documentation.

## Configure for localhost
To enable "Start in Create" on localhost, you will have to configure `beta.create.fallbackStudioOrigin`.
This value must exactly match the name shown for a studio deployment in the [Sanity project management console](https://sanity.io/manage), and the studio must have `create-manifest.json` available.

```ts
import { defineConfig } from 'sanity';

export default defineConfig({
  // ...rest of config
  beta: {
    create: {
      startInCreateEnabled: true,
      fallbackStudioOrigin: 'my-cool-project.sanity.studio'
    }
  }
})
```

## Opting out 
You can hide the "Start in Create" button by setting `beta.create.startInCreateEnabled: false`:
```ts
import { defineConfig } from 'sanity';

export default defineConfig({
  // ...rest of config
  beta: {
    create: {
      startInCreateEnabled: false,
    }
  }
})
```

## More on Content Mapping
For more details, see our [Configuring Content Mapping](https://www.sanity.io/docs/configure-content-mapping) documentation.