### PR TITLE
fix(sanity): reset search cursor state when any parameter changes

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.test.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.test.ts
@@ -240,6 +240,113 @@ describe('searchReducer', () => {
       ]
     `)
   })
+
+  it.each<SearchAction>([
+    {
+      type: 'SEARCH_CLEAR',
+    },
+    {
+      type: 'TERMS_QUERY_SET',
+      query: 'test query b',
+    },
+    {
+      type: 'TERMS_SET',
+      terms: {
+        query: 'test',
+        types: [],
+      },
+    },
+    {
+      type: 'ORDERING_SET',
+      ordering: {
+        titleKey: 'search.ordering.test-label',
+        sort: {
+          field: '_createdAt',
+          direction: 'desc',
+        },
+      },
+    },
+    {
+      type: 'ORDERING_RESET',
+    },
+    {
+      type: 'TERMS_FILTERS_ADD',
+      filter: {
+        filterName: 'test',
+        operatorType: 'test',
+      },
+    },
+    {
+      type: 'TERMS_FILTERS_REMOVE',
+      filterKey: 'test',
+    },
+    {
+      type: 'TERMS_FILTERS_SET_OPERATOR',
+      filterKey: 'test',
+      operatorType: 'test',
+    },
+    {
+      type: 'TERMS_FILTERS_SET_VALUE',
+      filterKey: 'test',
+    },
+    {
+      type: 'TERMS_FILTERS_CLEAR',
+    },
+    {
+      type: 'TERMS_TYPE_ADD',
+      schemaType: mockSearchableType,
+    },
+    {
+      type: 'TERMS_TYPE_REMOVE',
+      schemaType: mockSearchableType,
+    },
+    {
+      type: 'TERMS_TYPES_CLEAR',
+    },
+  ])('should reset cursor state when any parameter changes ($type)', async (action) => {
+    const {result} = renderHook(() => useReducer(searchReducer, initialState))
+    const [, dispatch] = result.current
+
+    act(() =>
+      dispatch({
+        type: 'TERMS_QUERY_SET',
+        query: 'test query a',
+      }),
+    )
+
+    act(() =>
+      dispatch({
+        type: 'SEARCH_REQUEST_COMPLETE',
+        nextCursor: 'cursorA',
+        hits: [],
+      }),
+    )
+
+    act(() =>
+      dispatch({
+        type: 'PAGE_INCREMENT',
+      }),
+    )
+
+    act(() =>
+      dispatch({
+        type: 'SEARCH_REQUEST_COMPLETE',
+        nextCursor: 'cursorB',
+        hits: [],
+      }),
+    )
+
+    const [stateA] = result.current
+
+    expect(stateA.cursor).toBe('cursorA')
+    expect(stateA.nextCursor).toBe('cursorB')
+    act(() => dispatch(action))
+
+    const [stateB] = result.current
+
+    expect(stateB.cursor).toBeNull()
+    expect(stateB.nextCursor).toBeNull()
+  })
 })
 
 it.each<SearchAction>([

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.ts
@@ -179,6 +179,8 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
         ...state,
         ordering: getOrderings({searchStrategy: state.strategy}).relevance,
         terms: stripRecent(state.terms),
+        cursor: null,
+        nextCursor: null,
         result: {
           ...state.result,
           hasLocal: false,
@@ -189,6 +191,8 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
         ...state,
         ordering: action.ordering,
         terms: stripRecent(state.terms),
+        cursor: null,
+        nextCursor: null,
         result: {
           ...state.result,
           hasLocal: false,
@@ -262,6 +266,8 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
         }),
         filters,
         lastAddedFilter: newFilter,
+        cursor: null,
+        nextCursor: null,
         terms: {
           ...state.terms,
           filter: generateFilterQuery({
@@ -288,6 +294,8 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
           types: state.terms.types,
         }),
         filters,
+        cursor: null,
+        nextCursor: null,
         terms: {
           ...state.terms,
           filter: generateFilterQuery({
@@ -319,6 +327,8 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
           types: state.terms.types,
         }),
         filters,
+        cursor: null,
+        nextCursor: null,
         terms: {
           ...state.terms,
           filter: generateFilterQuery({
@@ -362,6 +372,8 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
       return {
         ...state,
         filters,
+        cursor: null,
+        nextCursor: null,
         terms: {
           ...state.terms,
           filter: generateFilterQuery({
@@ -391,6 +403,8 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
       return {
         ...state,
         filters,
+        cursor: null,
+        nextCursor: null,
         terms: {
           ...state.terms,
           filter: generateFilterQuery({


### PR DESCRIPTION
### Description

This branch fixes global search pagination bugs caused by the cursor state not correctly being reset when some input parameters change. For example, when removing a filter, the cursor was not being reset. This could cause the next result set to be fetched using a cursor for the previously active set of filters.

This isn't currently a problem, because global search results aren't paginated. However, we will begin using pagination when we soon introduce the new GROQ search strategy.

### What to review

- Global search input parameters and predicated builder (e.g. filters).

### Testing

- Added unit tests to the reducer to ensure cursor state is reset when input parameters change.