### PR TITLE
fix: Start in Create type exclusion now recursively checks for sanityCreate.exclude options

### DIFF
--- a/dev/test-create-integration-studio/schema.ts
+++ b/dev/test-create-integration-studio/schema.ts
@@ -11,6 +11,20 @@ export const seoGroup: FieldGroupDefinition = {
 
 export const schemaTypes = [
   defineType({
+    type: 'document',
+    name: 'sanity-create-excluded',
+    fields: [
+      defineField({
+        name: 'title',
+        title: 'New documents of this type should not have a Start in Create button',
+        type: 'string',
+      }),
+    ],
+    options: {
+      sanityCreate: {exclude: true},
+    },
+  }),
+  defineType({
     title: 'Documentation Article',
     name: 'create-test-article',
     type: 'document',

--- a/packages/sanity/src/core/create/__tests__/createUtils.test.ts
+++ b/packages/sanity/src/core/create/__tests__/createUtils.test.ts
@@ -1,0 +1,76 @@
+import {defineType, type ObjectSchemaType} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+
+import {createSchema} from '../../schema'
+import {isSanityCreateExcludedType} from '../createUtils'
+
+const basicDoc = defineType({
+  type: 'document',
+  name: 'test',
+  fields: [{type: 'string', name: 'title'}],
+})
+
+describe('createUtils', () => {
+  describe('isSanityCreateExcludedType', () => {
+    it(`should include type without options`, async () => {
+      const documentType = getDocumentType([basicDoc], basicDoc.name)
+      expect(isSanityCreateExcludedType(documentType)).toEqual(false)
+    })
+
+    it(`should exclude type via direct options`, async () => {
+      const documentType = getDocumentType(
+        [
+          defineType({
+            ...basicDoc,
+            options: {sanityCreate: {exclude: true}},
+          }),
+        ],
+        basicDoc.name,
+      )
+      expect(isSanityCreateExcludedType(documentType)).toEqual(true)
+    })
+
+    it(`should exclude type via parent options`, async () => {
+      const documentType = getDocumentType(
+        [
+          {
+            type: 'document',
+            name: 'parentDoc',
+            fields: [{type: 'string', name: 'title'}],
+            options: {sanityCreate: {exclude: true}},
+          },
+          {
+            type: 'parentDoc',
+            name: 'test',
+          },
+        ],
+        basicDoc.name,
+      )
+      expect(isSanityCreateExcludedType(documentType)).toEqual(true)
+    })
+
+    it(`should include type when child type overrides parent options`, async () => {
+      const documentType = getDocumentType(
+        [
+          {
+            type: 'document',
+            name: 'parentDoc',
+            fields: [{type: 'string', name: 'title'}],
+            options: {sanityCreate: {exclude: true}},
+          },
+          {
+            type: 'parentDoc',
+            name: 'test',
+            options: {sanityCreate: {exclude: false}},
+          },
+        ],
+        basicDoc.name,
+      )
+      expect(isSanityCreateExcludedType(documentType)).toEqual(false)
+    })
+  })
+})
+
+function getDocumentType(docDefs: ReturnType<typeof defineType>[], docName: string) {
+  return createSchema({name: 'test', types: docDefs}).get(docName) as ObjectSchemaType
+}

--- a/packages/sanity/src/core/create/createUtils.ts
+++ b/packages/sanity/src/core/create/createUtils.ts
@@ -29,5 +29,12 @@ export function isSanityCreateLinkedDocument(doc: SanityDocumentLike | undefined
  * @internal
  */
 export function isSanityCreateExcludedType(schemaType: SchemaType): boolean {
-  return !!(schemaType?.type?.options as BaseSchemaTypeOptions | undefined)?.sanityCreate?.exclude
+  const options = schemaType.options as BaseSchemaTypeOptions | undefined
+  if (typeof options?.sanityCreate?.exclude === 'boolean') {
+    return options?.sanityCreate?.exclude
+  }
+  if (schemaType?.type) {
+    return isSanityCreateExcludedType(schemaType?.type)
+  }
+  return false
 }


### PR DESCRIPTION
### Description

Turns out that "Start in Create" button did not correctly check for `options.sanityCreate.exclude: true`, and it was essentially not possible to opt-out per document type.

This new implementation checks options recursively (and more importantly maybe; it checks the base type 🤦 ). Recursion stops at the first boolean `sanityCreate.exclude`. This allows alias types to override parent options.

### What to review

Read the unit-tests and 👍 👎 

### Testing

I deployed a new version of the test studio for this:

https://create-integration-test.sanity.studio/

Check that:
* New "Documentation Article" documents has a "Start in Sanity Create" button.
* New "Sanity Create Excluded" documents does does NOT have a "Start in Sanity Create" button.

### Notes for release

Fixes an issue where the `options.sanityCreate.exclude: true` was not respected when determining if the "Start in Sanity Create" button should be shown for studios with `beta.create.startInCreateEnabled: true` set in sanity.config.

Setting `options.sanityCreate.exclude: true` on a document type will now correctly hide "Start in Sanity Create" for new documents of that type.
