### PR TITLE
fix: opt-out `@tanstack/react-virtual` from React Compiler

### DIFF
--- a/packages/sanity/src/core/components/commandList/CommandList.tsx
+++ b/packages/sanity/src/core/components/commandList/CommandList.tsx
@@ -1,3 +1,6 @@
+'use no memo'
+// The `use no memo` directive is due to a known issue with react-virtual and react compiler: https://github.com/TanStack/virtual/issues/736
+
 import {Box, rem, Stack} from '@sanity/ui'
 import {type ScrollToOptions, useVirtualizer, type Virtualizer} from '@tanstack/react-virtual'
 import {throttle} from 'lodash'

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
@@ -1,3 +1,6 @@
+'use no memo'
+// The `use no memo` directive is due to a known issue with react-virtual and react compiler: https://github.com/TanStack/virtual/issues/736
+
 import {type DragStartEvent} from '@dnd-kit/core'
 import {isKeySegment} from '@sanity/types'
 import {Card, Stack, Text, useTheme} from '@sanity/ui'

--- a/packages/sanity/src/core/scheduledPublishing/tool/schedules/VirtualList.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/schedules/VirtualList.tsx
@@ -1,3 +1,6 @@
+'use no memo'
+// The `use no memo` directive is due to a known issue with react-virtual and react compiler: https://github.com/TanStack/virtual/issues/736
+
 import {CheckmarkCircleIcon} from '@sanity/icons'
 import {Box, Flex} from '@sanity/ui'
 import {useVirtualizer} from '@tanstack/react-virtual'

--- a/packages/sanity/src/core/scheduledPublishing/tool/schedules/VirtualListItem.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/schedules/VirtualListItem.tsx
@@ -1,3 +1,6 @@
+'use no memo'
+// The `use no memo` directive is due to a known issue with react-virtual and react compiler: https://github.com/TanStack/virtual/issues/736
+
 import {Box, Card, Flex, Label} from '@sanity/ui'
 import {type VirtualItem, type Virtualizer} from '@tanstack/react-virtual'
 import {type CSSProperties, useEffect, useMemo, useState} from 'react'


### PR DESCRIPTION
### Description

Adding React Compiler caused a regression in paths that uses `import {useVirtualizer} from '@tanstack/react-virtual'`. [It's a known issue](https://github.com/TanStack/virtual/issues/736), and I've subscribed to the issue so I get notified when we can come back and remove the `'use no memo'` directives 👍 

### What to review

This should fix SAPP-1945, repro: https://test-studio.sanity.dev/test/structure/input-standard;arraysTest;18db9a51-b3fe-4843-94a6-c5a2ba6ac039

### Testing

Didn't have time to add an E2E test that covers this case, but it might be worth doing in a follow-up 🙌  Manually tested by checking http://localhost:3333/test/structure/input-standard;arraysTest;18db9a51-b3fe-4843-94a6-c5a2ba6ac039 and scrolling, verifying that array reference items render without focusing/clicking first.

### Notes for release

Fixes a regression introduced in `v3.65.0` where array list references rendered far too lazily, and required focus or clicking, when initially "below the fold" of the browser window. They now correctly render on scroll ✨ 
