### PR TITLE
fix: support react compiler for auto updating studios

### DIFF
--- a/packages/@repo/package.bundle/src/package.bundle.ts
+++ b/packages/@repo/package.bundle/src/package.bundle.ts
@@ -12,7 +12,12 @@ export const defaultConfig: UserConfig = {
     'process.env.NODE_ENV': '"production"',
     'process.env': {},
   },
-  plugins: [react(), tsconfigPaths()],
+  plugins: [
+    react({
+      babel: {plugins: [['babel-plugin-react-compiler', {target: '18'}]]},
+    }),
+    tsconfigPaths(),
+  ],
   build: {
     emptyOutDir: true,
     sourcemap: true,


### PR DESCRIPTION
### Description

[When using both `autoUpdates: true` and `reactCompiler: {target: '18' | '19'}`](https://github.com/sanity-io/community-studio/blob/52042ca23eecd0d853439a2f79e2d248abf612fe/sanity.cli.ts#L8-L10) then only userland custom studio code is compiled, while the `sanity` and `@sanity/vision` modules are not.
I thought we were pulling these packages off of npm, I wasn't aware they had their own vite pipeline 😅 
It turns out that if `autoUpdates: true` is in use, then the `sanity` and `@sanity/vision` code isn't pre-compiled by React Compiler.

### What to review

I'm not super familiar with how this pipeline is setup, so I hope it's the right place 😮‍💨 

### Testing

I don't know how we can test this e2e without publishing. I've verified that other libraries that are pushed out, like `@sanity/ui`, as well as custom studio code, works just fine with `autoUpdates: true`, [as seen in the community studio for example](https://community.sanity.tools/structure/help). I see no reason it should fail for `sanity` and `@sanity/vision`.

### Notes for release

When using `autoUpdates: true` the `sanity` and `@sanity/vision` were no longer using pre-compiled code auto-memoized by the React Compiler. Leading to slower perf. It doesn't make sense to be forced to choose between fastest possible studio vs lowest effort maintenance. You can, and should, have your cake and eat it too 🍰 