### PR TITLE
fix(structure): add support to edit live documents in published perspective

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -97,8 +97,12 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'banners.deprecated-document-type-banner.text': 'This document type has been deprecated.',
   /** The text for publish action for discarding the version */
   'banners.live-edit-draft-banner.discard.tooltip': 'Discard draft',
+  /** The text content for the live edit document when viewed from the draft perspective */
+  'banners.live-edit-draft-banner.draft-perspective':
+    'The type <strong>{{schemaType}}</strong> has <code>liveEdit</code> enabled, select the published document to edit it.',
   /** The text for publish action for the draft banner */
   'banners.live-edit-draft-banner.publish.tooltip': 'Publish to continue editing',
+
   /** The text content for the live edit document when it's a draft */
   'banners.live-edit-draft-banner.text':
     'The type <strong>{{schemaType}}</strong> has <code>liveEdit</code> enabled, but a draft version of this document exists. Publish or discard the draft in order to continue live editing it.',

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -597,8 +597,11 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     const isLocked = editState.transactionSyncLock?.enabled
     // in cases where the document has drafts but the schema is live edit,
     // there is a risk of data loss, so we disable editing in this case
-    const isLiveEditAndDraft = Boolean(liveEdit && editState.draft)
-    const isSystemPerspectiveApplied = perspective && typeof bundlePerspective === 'undefined'
+    const isLiveEditAndDraftPerspective = liveEdit && !perspective
+    const isLiveEditAndPublishedPerspective = liveEdit && perspective === 'published'
+
+    const isSystemPerspectiveApplied =
+      isLiveEditAndPublishedPerspective || (perspective ? perspective && bundlePerspective : true)
 
     const isReleaseLocked =
       typeof currentGlobalBundle === 'object' && 'state' in currentGlobalBundle
@@ -607,7 +610,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
     return (
       (bundlePerspective && !existsInBundle) ||
-      isSystemPerspectiveApplied ||
+      !isSystemPerspectiveApplied ||
       !ready ||
       revTime !== null ||
       hasNoPermission ||
@@ -617,7 +620,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       isLocked ||
       isDeleting ||
       isDeleted ||
-      isLiveEditAndDraft ||
+      isLiveEditAndDraftPerspective ||
       isCreateLinked ||
       isReleaseLocked
     )
@@ -628,7 +631,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     isNonExistent,
     connectionState,
     editState.transactionSyncLock?.enabled,
-    editState.draft,
     liveEdit,
     perspective,
     bundlePerspective,

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
@@ -8,6 +8,7 @@ import {
   type ObjectSchemaType,
   Translate,
   useDocumentOperation,
+  usePerspective,
   useTranslation,
 } from 'sanity'
 
@@ -30,6 +31,8 @@ export function DraftLiveEditBanner({
   const {t} = useTranslation(structureLocaleNamespace)
   const [isPublishing, setPublishing] = useState(false)
   const [isDiscarding, setDiscarding] = useState(false)
+  const {perspective} = usePerspective()
+
   const telemetry = useTelemetry()
 
   const {publish, discardChanges} = useDocumentOperation(documentId, displayed?._type || '')
@@ -53,10 +56,10 @@ export function DraftLiveEditBanner({
     }
   })
 
-  if (displayed && displayed._id && !isDraftId(displayed._id)) {
+  const hasDraft = displayed && displayed._id && isDraftId(displayed._id)
+  if (perspective && !hasDraft) {
     return null
   }
-
   return (
     <Banner
       content={
@@ -64,23 +67,31 @@ export function DraftLiveEditBanner({
           <Text size={1} weight="medium">
             <Translate
               t={t}
-              i18nKey={'banners.live-edit-draft-banner.text'}
+              i18nKey={
+                hasDraft
+                  ? 'banners.live-edit-draft-banner.text'
+                  : 'banners.live-edit-draft-banner.draft-perspective'
+              }
               values={{schemaType: schemaType.title}}
             />
           </Text>
-          <Button
-            onClick={handlePublish}
-            text={t('action.publish.live-edit.label')}
-            tooltipProps={{content: t('banners.live-edit-draft-banner.publish.tooltip')}}
-            loading={isPublishing}
-          />
+          {hasDraft && (
+            <>
+              <Button
+                onClick={handlePublish}
+                text={t('action.publish.live-edit.label')}
+                tooltipProps={{content: t('banners.live-edit-draft-banner.publish.tooltip')}}
+                loading={isPublishing}
+              />
 
-          <Button
-            onClick={handleDiscard}
-            text={t('banners.live-edit-draft-banner.discard.tooltip')}
-            tooltipProps={{content: t('banners.live-edit-draft-banner.discard.tooltip')}}
-            loading={isDiscarding}
-          />
+              <Button
+                onClick={handleDiscard}
+                text={t('banners.live-edit-draft-banner.discard.tooltip')}
+                tooltipProps={{content: t('banners.live-edit-draft-banner.discard.tooltip')}}
+                loading={isDiscarding}
+              />
+            </>
+          )}
         </Flex>
       }
       data-testid="live-edit-type-banner"

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -114,7 +114,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
             )}
           </Text>
         }
-        disabled={!editState?.published}
+        disabled={editState?.liveEdit ? false : !editState?.published}
         onClick={handleBundleChange('published')}
         selected={
           /** the publish is selected when:

--- a/test/e2e/tests/document-actions/liveEdit.spec.ts
+++ b/test/e2e/tests/document-actions/liveEdit.spec.ts
@@ -8,6 +8,9 @@ test(`liveEdited document can be created, edited, and deleted`, async ({
   const name = 'Test Name'
 
   await createDraftDocument('/test/content/playlist')
+  await page.getByText('select the publish document to edit it')
+  // Navigate to the published perspective
+  await page.getByRole('button', {name: 'Published'}).click()
   await page.getByTestId('field-name').getByTestId('string-input').fill(name)
 
   await page.getByTestId('action-menu-button').click()


### PR DESCRIPTION
### Description

This PR changes how the `readOnly` state in the document pane provider works to support editing `live edit` document from the published view, and it disables editing them in the draft view.

| draft mode | Publish mode |
|--------|--------|
|<img width="840" alt="Screenshot 2024-11-28 at 14 22 49" src="https://github.com/user-attachments/assets/983bcff2-0d4a-46c2-a701-649c94098e9d">|<img width="839" alt="Screenshot 2024-11-28 at 14 22 57" src="https://github.com/user-attachments/assets/a4da4530-38c5-4cd5-bcfc-f51c4f62e102">|

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
