### PR TITLE
feat(sanity): add document comparison tool

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -261,6 +261,7 @@
     "rxjs-exhaustmap-with-trailing": "^2.1.1",
     "rxjs-mergemap-array": "^0.1.0",
     "scroll-into-view-if-needed": "^3.0.3",
+    "scrollmirror": "^1.2.0",
     "semver": "^7.3.5",
     "shallow-equals": "^1.0.0",
     "speakingurl": "^14.0.1",

--- a/packages/sanity/src/_singletons/context/ConnectorContext.ts
+++ b/packages/sanity/src/_singletons/context/ConnectorContext.ts
@@ -9,5 +9,6 @@ export const ConnectorContext = createContext<ConnectorContextValue>(
     isReviewChangesOpen: false,
     onOpenReviewChanges: () => undefined,
     onSetFocus: () => undefined,
+    isInteractive: true,
   } as ConnectorContextValue,
 )

--- a/packages/sanity/src/core/changeIndicators/ChangeIndicator.tsx
+++ b/packages/sanity/src/core/changeIndicators/ChangeIndicator.tsx
@@ -7,10 +7,12 @@ import {
   memo,
   type MouseEvent,
   useCallback,
+  useContext,
   useMemo,
   useState,
 } from 'react'
 import deepCompare from 'react-fast-compare'
+import {ConnectorContext} from 'sanity/_singletons'
 
 import {EMPTY_ARRAY} from '../util'
 import {ElementWithChangeBar} from './ElementWithChangeBar'
@@ -23,6 +25,7 @@ const ChangeBarWrapper = memo(function ChangeBarWrapper(
     hasFocus: boolean
     isChanged?: boolean
     withHoverEffect?: boolean
+    isInteractive?: boolean
   },
 ) {
   const {
@@ -34,6 +37,7 @@ const ChangeBarWrapper = memo(function ChangeBarWrapper(
     onMouseLeave: onMouseLeaveProp,
     path = EMPTY_ARRAY,
     withHoverEffect,
+    isInteractive,
     ...restProps
   } = props
   const layer = useLayer()
@@ -82,6 +86,7 @@ const ChangeBarWrapper = memo(function ChangeBarWrapper(
         isChanged={isChanged}
         disabled={disabled}
         withHoverEffect={withHoverEffect}
+        isInteractive={isInteractive}
       >
         {children}
       </ElementWithChangeBar>
@@ -102,6 +107,7 @@ export function ChangeIndicator(
   props: ChangeIndicatorProps & Omit<HTMLProps<HTMLDivElement>, 'as'>,
 ) {
   const {children, hasFocus, isChanged, path, withHoverEffect, ...restProps} = props
+  const {isInteractive} = useContext(ConnectorContext)
 
   return (
     <ChangeBarWrapper
@@ -110,6 +116,7 @@ export function ChangeIndicator(
       hasFocus={hasFocus}
       isChanged={isChanged}
       withHoverEffect={withHoverEffect}
+      isInteractive={isInteractive}
     >
       {children}
     </ChangeBarWrapper>

--- a/packages/sanity/src/core/changeIndicators/ConnectorContext.ts
+++ b/packages/sanity/src/core/changeIndicators/ConnectorContext.ts
@@ -5,4 +5,5 @@ export interface ConnectorContextValue {
   isReviewChangesOpen: boolean
   onOpenReviewChanges: () => void | undefined
   onSetFocus: (nextPath: Path) => void | undefined
+  isInteractive?: boolean
 }

--- a/packages/sanity/src/core/changeIndicators/ElementWithChangeBar.styled.tsx
+++ b/packages/sanity/src/core/changeIndicators/ElementWithChangeBar.styled.tsx
@@ -110,8 +110,11 @@ export const ChangeBarMarker = styled.div((props) => {
   `
 })
 
-export const ChangeBarButton = styled.button<{$withHoverEffect?: boolean}>((props) => {
-  const {$withHoverEffect} = props
+export const ChangeBarButton = styled.button<{
+  $withHoverEffect?: boolean
+  $isInteractive?: boolean
+}>((props) => {
+  const {$withHoverEffect, $isInteractive} = props
 
   return css`
     appearance: none;
@@ -123,8 +126,13 @@ export const ChangeBarButton = styled.button<{$withHoverEffect?: boolean}>((prop
     opacity: 0;
     position: absolute;
     height: 100%;
-    cursor: pointer;
-    pointer-events: all;
+
+    ${$isInteractive &&
+    css`
+      cursor: pointer;
+      pointer-events: all;
+    `}
+
     left: calc(-0.25rem + var(--change-bar-offset));
     width: calc(1rem - 1px);
     transition: opacity ${animationSpeed}ms;

--- a/packages/sanity/src/core/changeIndicators/ElementWithChangeBar.tsx
+++ b/packages/sanity/src/core/changeIndicators/ElementWithChangeBar.tsx
@@ -18,8 +18,16 @@ export function ElementWithChangeBar(props: {
   hasFocus?: boolean
   isChanged?: boolean
   withHoverEffect?: boolean
+  isInteractive?: boolean
 }) {
-  const {children, disabled, hasFocus, isChanged, withHoverEffect = true} = props
+  const {
+    children,
+    disabled,
+    hasFocus,
+    isChanged,
+    withHoverEffect = true,
+    isInteractive = true,
+  } = props
 
   const {onOpenReviewChanges, isReviewChangesOpen} = useContext(ConnectorContext)
   const {zIndex} = useLayer()
@@ -30,7 +38,7 @@ export function ElementWithChangeBar(props: {
       disabled || !isChanged ? null : (
         <ChangeBar data-testid="change-bar" $zIndex={zIndex}>
           <ChangeBarMarker data-testid="change-bar__marker" />
-          <Tooltip content={t('changes.change-bar.aria-label')} portal>
+          <Tooltip content={t('changes.change-bar.aria-label')} portal disabled={!isInteractive}>
             <ChangeBarButton
               aria-label={t('changes.change-bar.aria-label')}
               data-testid="change-bar__button"
@@ -38,11 +46,21 @@ export function ElementWithChangeBar(props: {
               tabIndex={-1}
               type="button"
               $withHoverEffect={withHoverEffect}
+              $isInteractive={isInteractive}
             />
           </Tooltip>
         </ChangeBar>
       ),
-    [disabled, isChanged, isReviewChangesOpen, onOpenReviewChanges, t, withHoverEffect, zIndex],
+    [
+      disabled,
+      isChanged,
+      isInteractive,
+      isReviewChangesOpen,
+      onOpenReviewChanges,
+      t,
+      withHoverEffect,
+      zIndex,
+    ],
   )
 
   return (

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/useReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/useReferenceInput.tsx
@@ -40,8 +40,13 @@ export function useReferenceInput(options: Options) {
   const schema = useSchema()
   const perspective = usePerspective()
   const documentPreviewStore = useDocumentPreviewStore()
-  const {EditReferenceLinkComponent, onEditReference, activePath, initialValueTemplateItems} =
-    useReferenceInputOptions()
+  const {
+    EditReferenceLinkComponent,
+    onEditReference,
+    activePath,
+    initialValueTemplateItems,
+    ...inheritedOptions
+  } = useReferenceInputOptions()
 
   const documentValue = useFormValue([]) as FIXME
   const documentRef = useValueRef(documentValue)
@@ -52,7 +57,7 @@ export function useReferenceInput(options: Options) {
     return schema.get(documentTypeName)?.liveEdit
   }, [documentTypeName, schema])
 
-  const disableNew = schemaType.options?.disableNew === true
+  const disableNew = inheritedOptions.disableNew ?? schemaType.options?.disableNew === true
 
   const template = options.value?._strengthenOnPublish?.template
   const EditReferenceLink = useMemo(

--- a/packages/sanity/src/core/form/studio/contexts/ReferenceInputOptions.tsx
+++ b/packages/sanity/src/core/form/studio/contexts/ReferenceInputOptions.tsx
@@ -54,6 +54,11 @@ export interface ReferenceInputOptions {
    * Similar to `EditReferenceChildLink` expect without the wrapping component
    */
   onEditReference?: (options: EditReferenceOptions) => void
+
+  /**
+   * Prevent creation of documents from reference fields.
+   */
+  disableNew?: boolean
 }
 
 /**
@@ -75,6 +80,7 @@ export function ReferenceInputOptionsProvider(
     EditReferenceLinkComponent,
     onEditReference,
     initialValueTemplateItems,
+    disableNew,
   } = props
 
   const contextValue = useMemo(
@@ -83,8 +89,15 @@ export function ReferenceInputOptionsProvider(
       EditReferenceLinkComponent,
       onEditReference,
       initialValueTemplateItems,
+      disableNew,
     }),
-    [activePath, EditReferenceLinkComponent, onEditReference, initialValueTemplateItems],
+    [
+      activePath,
+      EditReferenceLinkComponent,
+      onEditReference,
+      initialValueTemplateItems,
+      disableNew,
+    ],
   )
 
   return (

--- a/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
@@ -68,8 +68,13 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
   const documentPreviewStore = useDocumentPreviewStore()
   const {selectedReleaseId} = usePerspective()
   const {path, schemaType} = props
-  const {EditReferenceLinkComponent, onEditReference, activePath, initialValueTemplateItems} =
-    useReferenceInputOptions()
+  const {
+    EditReferenceLinkComponent,
+    onEditReference,
+    activePath,
+    initialValueTemplateItems,
+    ...inheritedOptions
+  } = useReferenceInputOptions()
   const {strategy: searchStrategy} = source.search
 
   const documentValue = useFormValue([]) as FIXME
@@ -79,7 +84,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
 
   const isDocumentLiveEdit = useMemo(() => refType?.liveEdit, [refType])
 
-  const disableNew = schemaType.options?.disableNew === true
+  const disableNew = inheritedOptions.disableNew ?? schemaType.options?.disableNew === true
   const getClient = source.getClient
 
   const handleSearch = useCallback(

--- a/packages/sanity/src/core/hooks/useEditState.ts
+++ b/packages/sanity/src/core/hooks/useEditState.ts
@@ -12,7 +12,7 @@ export function useEditState(
   version?: string | undefined,
 ): EditStateFor {
   if (version === 'published' || version === 'draft') {
-    throw new Error('Version cannot be published or daft')
+    throw new Error('Version cannot be published or draft')
   }
   const documentStore = useDocumentStore()
 

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -35,6 +35,7 @@ export {
   isReleasePerspective,
   isReleaseScheduledOrScheduling,
   LATEST,
+  ReleaseAvatar,
   type ReleaseDocument,
   RELEASES_INTENT,
   RELEASES_STUDIO_CLIENT_OPTIONS,

--- a/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
+++ b/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
@@ -3,6 +3,7 @@ import {PerspectiveContext} from 'sanity/_singletons'
 
 import {getReleasesPerspectiveStack} from '../releases/hooks/utils'
 import {useActiveReleases} from '../releases/store/useActiveReleases'
+import {isSystemBundleName} from '../util/draftUtils'
 import {EMPTY_ARRAY} from '../util/empty'
 import {getSelectedPerspective} from './getSelectedPerspective'
 import {type PerspectiveContextValue, type ReleaseId, type SelectedPerspective} from './types'
@@ -40,8 +41,9 @@ export function PerspectiveProvider({
     () => ({
       selectedPerspective,
       selectedPerspectiveName,
-      selectedReleaseId:
-        selectedPerspectiveName === 'published' ? undefined : selectedPerspectiveName,
+      selectedReleaseId: isSystemBundleName(selectedPerspectiveName)
+        ? undefined
+        : selectedPerspectiveName,
       perspectiveStack,
       excludedPerspectives,
     }),

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -12,8 +12,6 @@ const releasesLocaleStrings = {
   'action.archive.tooltip': 'Unschedule this release to archive it',
   /** Action text for showing the archived releases */
   'action.archived': 'Archived',
-  /** Action text for comparing document versions */
-  'action.compare-versions': 'Compare versions',
   /** Action text for reverting a release by creating a new release */
   'action.create-revert-release': 'Stage in new release',
   /** Action text for deleting a release */

--- a/packages/sanity/src/core/releases/plugin/documentActions/index.ts
+++ b/packages/sanity/src/core/releases/plugin/documentActions/index.ts
@@ -11,7 +11,9 @@ export default function resolveDocumentActions(
 ): Action[] {
   const duplicateAction = existingActions.filter(({name}) => name === 'DuplicateAction')
 
-  return context.versionType === 'version'
-    ? duplicateAction.concat(DiscardVersionAction).concat(UnpublishVersionAction)
-    : existingActions
+  if (context.versionType === 'version') {
+    return duplicateAction.concat(DiscardVersionAction, UnpublishVersionAction)
+  }
+
+  return existingActions
 }

--- a/packages/sanity/src/core/releases/tool/components/Chip.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Chip.tsx
@@ -1,7 +1,13 @@
 import {Box, Card, Flex, Text} from '@sanity/ui'
-import {type ReactNode} from 'react'
+import {type ComponentType, type ReactNode} from 'react'
 
-export function Chip(props: {avatar?: ReactNode; text: ReactNode; icon?: ReactNode}) {
+interface Props {
+  avatar?: ReactNode
+  text: ReactNode
+  icon?: ReactNode
+}
+
+export const Chip: ComponentType<Props> = (props) => {
   const {avatar, text, icon} = props
 
   return (

--- a/packages/sanity/src/core/releases/tool/components/Chip.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Chip.tsx
@@ -1,17 +1,17 @@
-import {Box, Card, Flex, Text} from '@sanity/ui'
+import {Box, Card, type CardProps, Flex, Text} from '@sanity/ui'
 import {type ComponentType, type ReactNode} from 'react'
 
-interface Props {
+type Props = {
   avatar?: ReactNode
   text: ReactNode
   icon?: ReactNode
-}
+} & Pick<CardProps, 'tone'>
 
-export const Chip: ComponentType<Props> = (props) => {
+export const Chip: ComponentType<Props> = ({tone, ...props}) => {
   const {avatar, text, icon} = props
 
   return (
-    <Card muted radius="full">
+    <Card muted radius="full" tone={tone}>
       <Flex align={'center'}>
         {icon && (
           <Box padding={1} marginLeft={1}>

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -106,9 +106,38 @@ export function getDraftId(id: string): DraftId {
   return isDraftId(id) ? id : ((DRAFTS_PREFIX + id) as DraftId)
 }
 
+/** @internal */
+export const systemBundles = ['drafts', 'published'] as const
+
+/** @internal */
+export type SystemBundle = (typeof systemBundles)[number]
+
+/** @internal */
+export function isSystemBundle(maybeSystemBundle: unknown): maybeSystemBundle is SystemBundle {
+  return systemBundles.includes(maybeSystemBundle as SystemBundle)
+}
+
+/** @internal */
+const systemBundleNames = ['draft', 'published'] as const
+
+/** @internal */
+type SystemBundleName = (typeof systemBundleNames)[number]
+
+/**
+ * `isSystemBundle` should be preferred, but some parts of the codebase currently use the singular
+ * "draft" name instead of the plural "drafts".
+ *
+ * @internal
+ */
+export function isSystemBundleName(
+  maybeSystemBundleName: unknown,
+): maybeSystemBundleName is SystemBundleName {
+  return systemBundleNames.includes(maybeSystemBundleName as SystemBundleName)
+}
+
 /**  @internal */
 export function getVersionId(id: string, version: string): string {
-  if (version === 'drafts' || version === 'published') {
+  if (isSystemBundle(version)) {
     throw new Error('Version can not be "published" or "drafts"')
   }
 

--- a/packages/sanity/src/structure/diffView/components/DialogLayout.ts
+++ b/packages/sanity/src/structure/diffView/components/DialogLayout.ts
@@ -1,0 +1,14 @@
+import {styled} from 'styled-components'
+
+export const DialogLayout = styled.div`
+  --offset-block: 40px;
+  display: grid;
+  height: calc(100vh - var(--offset-block));
+  min-height: 0;
+  overflow: hidden;
+  grid-template-areas:
+    'header header'
+    'previous-document next-document';
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: min-content minmax(0, 1fr);
+`

--- a/packages/sanity/src/structure/diffView/components/DiffView.tsx
+++ b/packages/sanity/src/structure/diffView/components/DiffView.tsx
@@ -1,0 +1,72 @@
+import {type ComponentType, useContext, useMemo, useState} from 'react'
+import {type DocumentLayoutProps} from 'sanity'
+import {ReferenceInputOptionsContext} from 'sanity/_singletons'
+
+import {Dialog} from '../../../ui-components/dialog/Dialog'
+import {useCreatePathSyncChannel} from '../hooks/useCreatePathSyncChannel'
+import {useDiffViewRouter} from '../hooks/useDiffViewRouter'
+import {useDiffViewState} from '../hooks/useDiffViewState'
+import {useScrollMirror} from '../hooks/useScrollMirror'
+import {VersionModeHeader} from '../versionMode/components/VersionModeHeader'
+import {DialogLayout} from './DialogLayout'
+import {DiffViewPane} from './DiffViewPane'
+import {EditReferenceLinkComponent} from './EditReferenceLinkComponent'
+
+export const DiffView: ComponentType<Pick<DocumentLayoutProps, 'documentId'>> = ({documentId}) => {
+  const {documents, state, mode} = useDiffViewState()
+  const {exitDiffView} = useDiffViewRouter()
+  const syncChannel = useCreatePathSyncChannel()
+  const [previousPaneElement, setPreviousPaneElement] = useState<HTMLElement | null>(null)
+  const [nextPaneElement, setNextPaneElement] = useState<HTMLElement | null>(null)
+  const referenceInputOptionsContext = useContext(ReferenceInputOptionsContext)
+
+  const diffViewReferenceInputOptionsContext = useMemo(
+    () => ({
+      ...referenceInputOptionsContext,
+      disableNew: true,
+      EditReferenceLinkComponent,
+    }),
+    [referenceInputOptionsContext],
+  )
+
+  useScrollMirror([previousPaneElement, nextPaneElement])
+
+  return (
+    <ReferenceInputOptionsContext.Provider value={diffViewReferenceInputOptionsContext}>
+      <Dialog
+        id="diffView"
+        width="auto"
+        onClose={exitDiffView}
+        padding={false}
+        __unstable_hideCloseButton
+      >
+        <DialogLayout>
+          {mode === 'version' && <VersionModeHeader documentId={documentId} state={state} />}
+          {state === 'ready' && (
+            <>
+              <DiffViewPane
+                documentType={documents.previous.type}
+                documentId={documents.previous.id}
+                role="previous"
+                ref={setPreviousPaneElement}
+                scrollElement={previousPaneElement}
+                syncChannel={syncChannel}
+                compareDocument={documents.previous}
+              />
+              <DiffViewPane
+                documentType={documents.next.type}
+                documentId={documents.next.id}
+                role="next"
+                ref={setNextPaneElement}
+                scrollElement={nextPaneElement}
+                syncChannel={syncChannel}
+                // The previous document's edit state is used to calculate the diff inroduced by the next document.
+                compareDocument={documents.previous}
+              />
+            </>
+          )}
+        </DialogLayout>
+      </Dialog>
+    </ReferenceInputOptionsContext.Provider>
+  )
+}

--- a/packages/sanity/src/structure/diffView/components/DiffViewPane.tsx
+++ b/packages/sanity/src/structure/diffView/components/DiffViewPane.tsx
@@ -1,0 +1,238 @@
+import {type Path, type SanityDocument} from '@sanity/types'
+import {
+  BoundaryElementProvider,
+  Card,
+  Container as UiContainer,
+  DialogProvider,
+  PortalProvider,
+} from '@sanity/ui'
+import {noop} from 'lodash'
+import {
+  type CSSProperties,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import {
+  ChangeIndicatorsTracker,
+  createPatchChannel,
+  FormBuilder,
+  getPublishedId,
+  getVersionFromId,
+  isDraftId,
+  isPublishedId,
+  isVersionId,
+  LoadingBlock,
+  useDocumentForm,
+  useEditState,
+  VirtualizerScrollInstanceProvider,
+} from 'sanity'
+import {ConnectorContext} from 'sanity/_singletons'
+import {styled} from 'styled-components'
+
+import {usePathSyncChannel} from '../hooks/usePathSyncChannel'
+import {type PathSyncChannel} from '../types/pathSyncChannel'
+import {Scroller} from './Scroller'
+
+const DiffViewPaneLayout = styled(Card)`
+  position: relative;
+  grid-area: var(--grid-area);
+`
+
+const Container = styled(UiContainer)`
+  width: auto;
+`
+
+interface DiffViewPaneProps {
+  documentType: string
+  documentId: string
+  role: 'previous' | 'next'
+  scrollElement: HTMLElement | null
+  syncChannel: PathSyncChannel
+  compareDocument: {
+    type: string
+    id: string
+  }
+}
+
+export const DiffViewPane = forwardRef<HTMLDivElement, DiffViewPaneProps>(function DiffViewPane(
+  {role, documentType, documentId, scrollElement, syncChannel, compareDocument},
+  ref,
+) {
+  const containerElement = useRef<HTMLDivElement | null>(null)
+  const [portalElement, setPortalElement] = useState<HTMLDivElement | null>(null)
+  const [boundaryElement, setBoundaryElement] = useState<HTMLDivElement | null>(null)
+  const compareValue = useCompareValue({compareDocument})
+  const [patchChannel] = useState(() => createPatchChannel())
+
+  const {
+    formState,
+    onChange,
+    onFocus,
+    onBlur,
+    onSetActiveFieldGroup,
+    onSetCollapsedFieldSet,
+    onSetCollapsedPath,
+    collapsedFieldSets,
+    ready,
+    collapsedPaths,
+    schemaType,
+    value,
+    onProgrammaticFocus,
+    ...documentForm
+  } = useDocumentForm({
+    documentId: getPublishedId(documentId),
+    documentType,
+    selectedPerspectiveName: perspectiveName(documentId),
+    releaseId: getVersionFromId(documentId),
+    comparisonValue: compareValue,
+  })
+
+  const isLoading = formState === null || !ready
+
+  const pathSyncChannel = usePathSyncChannel({
+    id: role,
+    syncChannel,
+  })
+
+  const onPathOpen = useCallback(
+    (path: Path) => {
+      documentForm.onPathOpen(path)
+      pathSyncChannel.push({source: role, path})
+    },
+    [documentForm, pathSyncChannel, role],
+  )
+
+  useEffect(() => {
+    const subscription = pathSyncChannel.path.subscribe((path) => onProgrammaticFocus(path))
+    return () => subscription.unsubscribe()
+  }, [onProgrammaticFocus, pathSyncChannel.path])
+
+  return (
+    <ConnectorContext.Provider
+      value={{
+        // Render the change indicators inertly, because the diff view modal does not currently
+        // provide a way to display document inspectors.
+        isInteractive: false,
+        onOpenReviewChanges: noop,
+        onSetFocus: noop,
+        isReviewChangesOpen: false,
+      }}
+    >
+      <ChangeIndicatorsTracker>
+        <VirtualizerScrollInstanceProvider
+          scrollElement={scrollElement}
+          containerElement={containerElement}
+        >
+          <BoundaryElementProvider element={boundaryElement}>
+            <DiffViewPaneLayout
+              ref={setBoundaryElement}
+              style={
+                {
+                  '--grid-area': `${role}-document`,
+                } as CSSProperties
+              }
+              borderLeft={role === 'next'}
+            >
+              <Scroller
+                ref={ref}
+                style={
+                  {
+                    // The scroll position is synchronised between panes. This style hides the
+                    // scrollbar for all panes except the one displaying the next document.
+                    '--scrollbar-width': role !== 'next' && 'none',
+                  } as CSSProperties
+                }
+              >
+                <PortalProvider element={portalElement}>
+                  <DialogProvider position="absolute">
+                    {isLoading ? (
+                      <LoadingBlock showText />
+                    ) : (
+                      <Container ref={containerElement} padding={4} width={1}>
+                        <FormBuilder
+                          // eslint-disable-next-line camelcase
+                          __internal_patchChannel={patchChannel}
+                          id={`diffView-pane-${role}`}
+                          onChange={onChange}
+                          onPathFocus={onFocus}
+                          onPathOpen={onPathOpen}
+                          onPathBlur={onBlur}
+                          onFieldGroupSelect={onSetActiveFieldGroup}
+                          onSetFieldSetCollapsed={onSetCollapsedFieldSet}
+                          onSetPathCollapsed={onSetCollapsedPath}
+                          collapsedPaths={collapsedPaths}
+                          collapsedFieldSets={collapsedFieldSets}
+                          focusPath={formState.focusPath}
+                          changed={formState.changed}
+                          focused={formState.focused}
+                          groups={formState.groups}
+                          validation={formState.validation}
+                          members={formState.members}
+                          presence={formState.presence}
+                          schemaType={schemaType}
+                          value={value}
+                        />
+                      </Container>
+                    )}
+                  </DialogProvider>
+                </PortalProvider>
+              </Scroller>
+              <div data-testid="diffView-document-panel-portal" ref={setPortalElement} />
+            </DiffViewPaneLayout>
+          </BoundaryElementProvider>
+        </VirtualizerScrollInstanceProvider>
+      </ChangeIndicatorsTracker>
+    </ConnectorContext.Provider>
+  )
+})
+
+function perspectiveName(documentId: string): string | undefined {
+  if (isVersionId(documentId)) {
+    return getVersionFromId(documentId)
+  }
+
+  if (isPublishedId(documentId)) {
+    return 'published'
+  }
+
+  return undefined
+}
+
+type UseCompareValueOptions = Pick<DiffViewPaneProps, 'compareDocument'>
+
+/**
+ * Fetch the contents of `compareDocument` for comparison with another version of the document.
+ */
+function useCompareValue({compareDocument}: UseCompareValueOptions): SanityDocument | undefined {
+  const compareDocumentEditState = useEditState(
+    getPublishedId(compareDocument.id),
+    compareDocument.type,
+    'low',
+    getVersionFromId(compareDocument.id),
+  )
+
+  return useMemo(() => {
+    if (isVersionId(compareDocument.id)) {
+      return compareDocumentEditState.version ?? undefined
+    }
+
+    if (isDraftId(compareDocument.id)) {
+      return compareDocumentEditState.draft ?? undefined
+    }
+
+    if (isPublishedId(compareDocument.id)) {
+      return compareDocumentEditState.published ?? undefined
+    }
+
+    return undefined
+  }, [
+    compareDocument.id,
+    compareDocumentEditState.draft,
+    compareDocumentEditState.published,
+    compareDocumentEditState.version,
+  ])
+}

--- a/packages/sanity/src/structure/diffView/components/EditReferenceLinkComponent.tsx
+++ b/packages/sanity/src/structure/diffView/components/EditReferenceLinkComponent.tsx
@@ -1,0 +1,29 @@
+import {type ReferenceInputOptions} from 'sanity'
+import {useIntentLink} from 'sanity/router'
+import {styled} from 'styled-components'
+
+const Link = styled.a`
+  flex: 1;
+  text-decoration: none;
+  color: inherit;
+`
+
+export const EditReferenceLinkComponent: ReferenceInputOptions['EditReferenceLinkComponent'] = ({
+  children,
+  documentId: _documentId,
+  documentType,
+}) => {
+  const {href} = useIntentLink({
+    intent: 'edit',
+    params: {
+      id: _documentId,
+      type: documentType,
+    },
+  })
+
+  return (
+    <Link href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </Link>
+  )
+}

--- a/packages/sanity/src/structure/diffView/components/PathSyncChannelSubscriber.ts
+++ b/packages/sanity/src/structure/diffView/components/PathSyncChannelSubscriber.ts
@@ -1,0 +1,9 @@
+import {type ComponentType} from 'react'
+
+import {usePathSyncChannel} from '../hooks/usePathSyncChannel'
+import {type PathSyncChannelProps} from '../types/pathSyncChannel'
+
+export const PathSyncChannelSubscriber: ComponentType<PathSyncChannelProps> = (props) => {
+  usePathSyncChannel(props)
+  return undefined
+}

--- a/packages/sanity/src/structure/diffView/components/Scroller.ts
+++ b/packages/sanity/src/structure/diffView/components/Scroller.ts
@@ -1,0 +1,11 @@
+import {styled} from 'styled-components'
+
+export const Scroller = styled.div`
+  position: relative;
+  height: 100%;
+  overflow: auto;
+  scroll-behavior: smooth;
+  scrollbar-width: var(--scrollbar-width);
+  overscroll-behavior: contain;
+  will-change: scroll-position;
+`

--- a/packages/sanity/src/structure/diffView/constants.ts
+++ b/packages/sanity/src/structure/diffView/constants.ts
@@ -1,0 +1,19 @@
+/**
+ * @internal
+ */
+export const DIFF_VIEW_SEARCH_PARAMETER = 'diffView'
+
+/**
+ * @internal
+ */
+export const DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER = 'previousDocument'
+
+/**
+ * @internal
+ */
+export const DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER = 'nextDocument'
+
+/**
+ * @internal
+ */
+export const DIFF_SEARCH_PARAM_DELIMITER = ','

--- a/packages/sanity/src/structure/diffView/hooks/useCreatePathSyncChannel.ts
+++ b/packages/sanity/src/structure/diffView/hooks/useCreatePathSyncChannel.ts
@@ -1,0 +1,11 @@
+import {useMemo} from 'react'
+import {Subject} from 'rxjs'
+
+import {type PathSyncChannel, type PathSyncState} from '../types/pathSyncChannel'
+
+/**
+ * @internal
+ */
+export function useCreatePathSyncChannel(): PathSyncChannel {
+  return useMemo(() => new Subject<PathSyncState>(), [])
+}

--- a/packages/sanity/src/structure/diffView/hooks/useDiffViewRouter.ts
+++ b/packages/sanity/src/structure/diffView/hooks/useDiffViewRouter.ts
@@ -1,0 +1,90 @@
+import {fromPairs, toPairs} from 'lodash'
+import {useCallback} from 'react'
+import {useRouter} from 'sanity/router'
+
+import {
+  DIFF_SEARCH_PARAM_DELIMITER,
+  DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_SEARCH_PARAMETER,
+} from '../constants'
+import {type DiffViewMode} from '../types/diffViewMode'
+
+type NavigateDiffView = (
+  options: {
+    mode?: DiffViewMode
+  } & Partial<
+    Record<
+      'previousDocument' | 'nextDocument',
+      {
+        type: string
+        id: string
+      }
+    >
+  >,
+) => void
+
+export interface DiffViewRouter {
+  navigateDiffView: NavigateDiffView
+  exitDiffView: () => void
+}
+
+/**
+ * @internal
+ */
+export function useDiffViewRouter(): DiffViewRouter {
+  const {navigate, state: routerState} = useRouter()
+
+  const navigateDiffView = useCallback<NavigateDiffView>(
+    ({mode, previousDocument, nextDocument}) => {
+      const next = {
+        ...fromPairs(routerState._searchParams),
+        ...(mode
+          ? {
+              [DIFF_VIEW_SEARCH_PARAMETER]: mode,
+            }
+          : {}),
+        ...(previousDocument
+          ? {
+              [DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER]: [
+                previousDocument.type,
+                previousDocument.id,
+              ].join(DIFF_SEARCH_PARAM_DELIMITER),
+            }
+          : {}),
+        ...(nextDocument
+          ? {
+              [DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER]: [nextDocument.type, nextDocument.id].join(
+                DIFF_SEARCH_PARAM_DELIMITER,
+              ),
+            }
+          : {}),
+      }
+
+      navigate({
+        ...routerState,
+        _searchParams: toPairs(next),
+      })
+    },
+    [navigate, routerState],
+  )
+
+  const exitDiffView = useCallback(() => {
+    navigate({
+      ...routerState,
+      _searchParams: (routerState._searchParams ?? []).filter(
+        ([key]) =>
+          ![
+            DIFF_VIEW_SEARCH_PARAMETER,
+            DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
+            DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER,
+          ].includes(key),
+      ),
+    })
+  }, [navigate, routerState])
+
+  return {
+    navigateDiffView,
+    exitDiffView,
+  }
+}

--- a/packages/sanity/src/structure/diffView/hooks/useDiffViewState.ts
+++ b/packages/sanity/src/structure/diffView/hooks/useDiffViewState.ts
@@ -1,0 +1,154 @@
+import {useEffect, useMemo} from 'react'
+import {useRouter} from 'sanity/router'
+
+import {
+  DIFF_SEARCH_PARAM_DELIMITER,
+  DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_SEARCH_PARAMETER,
+} from '../constants'
+import {type DiffViewMode, diffViewModes} from '../types/diffViewMode'
+
+function isDiffViewMode(maybeDiffViewMode: unknown): maybeDiffViewMode is DiffViewMode {
+  return diffViewModes.includes(maybeDiffViewMode as DiffViewMode)
+}
+
+type DiffViewState =
+  | {
+      isActive: true
+      state: 'ready'
+      mode: DiffViewMode
+      documents: Record<
+        'previous' | 'next',
+        {
+          type: string
+          id: string
+        }
+      >
+    }
+  | {
+      isActive: true
+      state: 'error'
+      mode: DiffViewMode
+      documents?: never
+    }
+  | {
+      isActive: false
+      state?: never
+      mode?: never
+      documents?: never
+    }
+
+export function useDiffViewState({
+  onParamsError,
+}: {
+  onParamsError?: (errors: DiffViewStateErrorWithInput[]) => void
+} = {}): DiffViewState {
+  const {state: routerState} = useRouter()
+  const searchParams = new URLSearchParams(routerState._searchParams)
+  const previousDocument = searchParams.get(DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER)
+  const nextDocument = searchParams.get(DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER)
+  const mode = searchParams.get(DIFF_VIEW_SEARCH_PARAMETER)
+  const anyParamSet = [previousDocument, nextDocument, mode].some((param) => param !== null)
+
+  const params = useMemo(
+    () =>
+      parseParams({
+        previousDocument: previousDocument ?? '',
+        nextDocument: nextDocument ?? '',
+        mode: mode ?? '',
+      }),
+    [mode, nextDocument, previousDocument],
+  )
+
+  useEffect(() => {
+    if (params.result === 'error' && anyParamSet) {
+      onParamsError?.(params.errors)
+    }
+  }, [anyParamSet, onParamsError, params])
+
+  if (params.result === 'error') {
+    return {
+      isActive: false,
+    }
+  }
+
+  return {
+    state: 'ready',
+    isActive: true,
+    ...params.params,
+  }
+}
+
+type DiffViewStateError =
+  | 'invalidModeParam'
+  | 'invalidPreviousDocumentParam'
+  | 'invalidNextDocumentParam'
+
+type DiffViewStateErrorWithInput = [error: DiffViewStateError, input: unknown]
+
+interface ParamsSuccess {
+  result: 'success'
+  params: Pick<DiffViewState & {state: 'ready'}, 'mode' | 'documents'>
+}
+
+interface ParamsError {
+  result: 'error'
+  errors: DiffViewStateErrorWithInput[]
+}
+
+function parseParams({
+  previousDocument,
+  nextDocument,
+  mode,
+}: {
+  previousDocument: string
+  nextDocument: string
+  mode: string
+}): ParamsSuccess | ParamsError {
+  const errors: DiffViewStateErrorWithInput[] = []
+
+  const [previousDocumentType, previousDocumentId] = previousDocument
+    .split(DIFF_SEARCH_PARAM_DELIMITER)
+    .filter(Boolean)
+
+  const [nextDocumentType, nextDocumentId] = nextDocument
+    .split(DIFF_SEARCH_PARAM_DELIMITER)
+    .filter(Boolean)
+
+  if (!isDiffViewMode(mode)) {
+    errors.push(['invalidModeParam', mode])
+  }
+
+  if (typeof previousDocumentType === 'undefined' || typeof previousDocumentId === 'undefined') {
+    errors.push(['invalidPreviousDocumentParam', previousDocument])
+  }
+
+  if (typeof nextDocumentType === 'undefined' || typeof nextDocumentId === 'undefined') {
+    errors.push(['invalidNextDocumentParam', nextDocument])
+  }
+
+  if (errors.length !== 0) {
+    return {
+      result: 'error',
+      errors,
+    }
+  }
+
+  return {
+    result: 'success',
+    params: {
+      mode,
+      documents: {
+        previous: {
+          type: previousDocumentType,
+          id: previousDocumentId,
+        },
+        next: {
+          type: nextDocumentType,
+          id: nextDocumentId,
+        },
+      },
+    },
+  } as ParamsSuccess
+}

--- a/packages/sanity/src/structure/diffView/hooks/usePathSyncChannel.ts
+++ b/packages/sanity/src/structure/diffView/hooks/usePathSyncChannel.ts
@@ -1,0 +1,40 @@
+import {type Path} from '@sanity/types'
+import {useCallback, useMemo} from 'react'
+import deepEquals from 'react-fast-compare'
+import {distinctUntilChanged, filter, map, type Observable} from 'rxjs'
+
+import {type PathSyncChannelProps, type PathSyncState} from '../types/pathSyncChannel'
+
+type Push = (state: PathSyncState) => void
+
+/**
+ * Synchronise the open path between multiple document panes.
+ *
+ * @internal
+ */
+export function usePathSyncChannel({syncChannel, id}: PathSyncChannelProps): {
+  push: Push
+  path: Observable<Path>
+} {
+  const push = useCallback<Push>(
+    (state) => syncChannel.next({...state, source: id}),
+    [id, syncChannel],
+  )
+
+  const path = useMemo(
+    () =>
+      syncChannel.pipe(
+        distinctUntilChanged<PathSyncState>((previous, next) =>
+          deepEquals(previous.path, next.path),
+        ),
+        filter(({source}) => source !== id),
+        map((state) => state.path),
+      ),
+    [id, syncChannel],
+  )
+
+  return {
+    path,
+    push,
+  }
+}

--- a/packages/sanity/src/structure/diffView/hooks/useScrollMirror.tsx
+++ b/packages/sanity/src/structure/diffView/hooks/useScrollMirror.tsx
@@ -1,0 +1,20 @@
+import {useEffect} from 'react'
+import ScrollMirror from 'scrollmirror'
+
+/**
+ * Use the ScrollMirror library to synchronise the scroll position for an array of elements.
+ *
+ * @internal
+ */
+export function useScrollMirror(elements: (HTMLElement | null)[]): void {
+  useEffect(() => {
+    const existentElements = elements.filter((element) => element !== null)
+
+    if (existentElements.length === 0) {
+      return undefined
+    }
+
+    const scrollMirror = new ScrollMirror(existentElements)
+    return () => scrollMirror.destroy()
+  }, [elements])
+}

--- a/packages/sanity/src/structure/diffView/index.ts
+++ b/packages/sanity/src/structure/diffView/index.ts
@@ -1,0 +1,1 @@
+export * from './hooks/useDiffViewRouter'

--- a/packages/sanity/src/structure/diffView/plugin/DiffViewDocumentLayout.tsx
+++ b/packages/sanity/src/structure/diffView/plugin/DiffViewDocumentLayout.tsx
@@ -1,0 +1,41 @@
+import {useToast} from '@sanity/ui'
+import {type ComponentType, type PropsWithChildren} from 'react'
+import {type DocumentLayoutProps, useTranslation} from 'sanity'
+
+import {structureLocaleNamespace} from '../../i18n'
+import {DiffView} from '../components/DiffView'
+import {useDiffViewState} from '../hooks/useDiffViewState'
+
+export const DiffViewDocumentLayout: ComponentType<
+  PropsWithChildren<Pick<DocumentLayoutProps, 'documentId' | 'documentType'>>
+> = ({children, documentId}) => {
+  const toast = useToast()
+  const {t} = useTranslation(structureLocaleNamespace)
+  const {isActive} = useDiffViewState({
+    onParamsError: (errors) => {
+      toast.push({
+        id: 'diffViewParamsParsingError',
+        status: 'error',
+        title: t('compare-version.error.invalidParams.title'),
+        description: (
+          <ul>
+            {errors.map(([error, input]) => (
+              <li key={error}>
+                {t(`compare-version.error.${error}`, {
+                  input,
+                })}
+              </li>
+            ))}
+          </ul>
+        ),
+      })
+    },
+  })
+
+  return (
+    <>
+      {children}
+      {isActive && <DiffView documentId={documentId} />}
+    </>
+  )
+}

--- a/packages/sanity/src/structure/diffView/types/diffViewMode.ts
+++ b/packages/sanity/src/structure/diffView/types/diffViewMode.ts
@@ -1,0 +1,9 @@
+/**
+ * @internal
+ */
+export const diffViewModes = ['version'] as const
+
+/**
+ * @internal
+ */
+export type DiffViewMode = (typeof diffViewModes)[number]

--- a/packages/sanity/src/structure/diffView/types/pathSyncChannel.ts
+++ b/packages/sanity/src/structure/diffView/types/pathSyncChannel.ts
@@ -1,0 +1,23 @@
+import {type Path} from '@sanity/types'
+import {type Subject} from 'rxjs'
+
+/**
+ * @internal
+ */
+export interface PathSyncState {
+  path: Path
+  source?: string
+}
+
+/**
+ * @internal
+ */
+export type PathSyncChannel = Subject<PathSyncState>
+
+/**
+ * @internal
+ */
+export interface PathSyncChannelProps {
+  syncChannel: PathSyncChannel
+  id: string
+}

--- a/packages/sanity/src/structure/diffView/versionMode/components/VersionModeHeader.tsx
+++ b/packages/sanity/src/structure/diffView/versionMode/components/VersionModeHeader.tsx
@@ -1,0 +1,376 @@
+import {CloseIcon, LockIcon, TransferIcon} from '@sanity/icons'
+import {
+  Box,
+  // eslint-disable-next-line no-restricted-imports -- we need more control over how the `Button` component is rendered
+  Button,
+  type ButtonTone,
+  Flex,
+  Menu,
+  // eslint-disable-next-line no-restricted-imports -- the `VersionModeHeader` component needs more control over how the `MenuItem` component is rendered
+  MenuItem,
+  Stack,
+  Text,
+} from '@sanity/ui'
+import {type TFunction} from 'i18next'
+import {type ComponentProps, type ComponentType, useCallback, useMemo} from 'react'
+import {
+  type DocumentLayoutProps,
+  formatRelativeLocalePublishDate,
+  getDraftId,
+  getPublishedId,
+  getReleaseIdFromReleaseDocumentId,
+  getReleaseTone,
+  getVersionFromId,
+  getVersionId,
+  isDraftId,
+  isPublishedId,
+  isReleaseDocument,
+  isReleaseScheduledOrScheduling,
+  ReleaseAvatar,
+  type ReleaseDocument,
+  useActiveReleases,
+  useDocumentVersions,
+  useEditState,
+  useTranslation,
+} from 'sanity'
+import {styled} from 'styled-components'
+
+import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'
+import {structureLocaleNamespace} from '../../../i18n'
+import {useDiffViewRouter} from '../../hooks/useDiffViewRouter'
+import {useDiffViewState} from '../../hooks/useDiffViewState'
+
+const VersionModeHeaderLayout = styled.header`
+  display: grid;
+  grid-area: header;
+  grid-template-columns: 1fr min-content 1fr;
+  border-block-end: 1px solid var(--card-border-color);
+`
+
+const VersionModeHeaderLayoutSection = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`
+
+/**
+ * The header component that is rendered when diff view is being used to compare versions of a
+ * document.
+ *
+ * @internal
+ */
+export const VersionModeHeader: ComponentType<
+  {state: 'pending' | 'ready' | 'error'} & Pick<DocumentLayoutProps, 'documentId'>
+> = ({documentId, state}) => {
+  const {t} = useTranslation(structureLocaleNamespace)
+  const {data: documentVersions} = useDocumentVersions({documentId})
+  const {exitDiffView, navigateDiffView} = useDiffViewRouter()
+  const {documents} = useDiffViewState()
+  const activeReleases = useActiveReleases()
+  const releasesIds = documentVersions.flatMap((id) => getVersionFromId(id) ?? [])
+
+  const releases = useMemo(() => {
+    return activeReleases.data.filter((release) => {
+      const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
+      return typeof releaseId !== 'undefined' && releasesIds.includes(releaseId)
+    })
+  }, [activeReleases.data, releasesIds])
+
+  const onSelectPreviousRelease = useCallback(
+    (selectedDocumentId: string): void => {
+      if (typeof documents?.previous !== 'undefined') {
+        navigateDiffView({
+          previousDocument: {
+            ...documents.previous,
+            id: selectedDocumentId,
+          },
+        })
+      }
+    },
+    [documents?.previous, navigateDiffView],
+  )
+
+  const onSelectNextRelease = useCallback(
+    (selectedDocumentId: string): void => {
+      if (typeof documents?.next !== 'undefined') {
+        navigateDiffView({
+          nextDocument: {
+            ...documents.next,
+            id: selectedDocumentId,
+          },
+        })
+      }
+    },
+    [documents?.next, navigateDiffView],
+  )
+
+  return (
+    <VersionModeHeaderLayout>
+      <VersionModeHeaderLayoutSection>
+        <Box padding={4}>
+          <Text as="h1" size={1} muted>
+            {t('compare-versions.title')}
+          </Text>
+        </Box>
+        {typeof documents?.previous !== 'undefined' && (
+          <VersionMenu
+            releases={releases}
+            onSelectRelease={onSelectPreviousRelease}
+            role="previous"
+            documentId={documentId}
+            state={state}
+            document={documents.previous}
+          />
+        )}
+      </VersionModeHeaderLayoutSection>
+      <Flex align="center" paddingX={3}>
+        <Text size={1}>
+          <TransferIcon />
+        </Text>
+      </Flex>
+      <VersionModeHeaderLayoutSection>
+        {typeof documents?.next !== 'undefined' && (
+          <VersionMenu
+            releases={releases}
+            onSelectRelease={onSelectNextRelease}
+            role="next"
+            documentId={documentId}
+            state={state}
+            document={documents.next}
+          />
+        )}
+        <Box
+          padding={3}
+          style={{
+            justifySelf: 'end',
+          }}
+        >
+          <Button icon={CloseIcon} mode="bleed" onClick={exitDiffView} padding={2} />
+        </Box>
+      </VersionModeHeaderLayoutSection>
+    </VersionModeHeaderLayout>
+  )
+}
+
+interface VersionMenuProps {
+  state: 'pending' | 'ready' | 'error'
+  releases: ReleaseDocument[]
+  role: 'previous' | 'next'
+  onSelectRelease: (releaseId: string) => void
+  documentId: string
+  document: {
+    type: string
+    id: string
+  }
+}
+
+const VersionMenu: ComponentType<VersionMenuProps> = ({
+  releases = [],
+  onSelectRelease,
+  role,
+  documentId,
+  document,
+}) => {
+  const {published, draft} = useEditState(getPublishedId(document.id), document.type)
+  const selected = useMemo(() => findRelease(document.id, releases), [document.id, releases])
+  const {t: tStructure} = useTranslation(structureLocaleNamespace)
+  const {t: tCore} = useTranslation()
+
+  return (
+    <MenuButton
+      id={role}
+      button={
+        <Button
+          type="button"
+          mode="bleed"
+          padding={2}
+          paddingRight={3}
+          radius="full"
+          selected
+          {...getMenuButtonProps({selected, tCore, tStructure})}
+        />
+      }
+      menu={
+        <Menu>
+          {published && (
+            <VersionMenuItem
+              type="published"
+              onSelect={onSelectRelease}
+              isSelected={selected === 'published'}
+              documentId={documentId}
+            />
+          )}
+          {draft && (
+            <VersionMenuItem
+              type="draft"
+              onSelect={onSelectRelease}
+              isSelected={selected === 'draft'}
+              documentId={documentId}
+            />
+          )}
+          {releases.map((release) => (
+            <VersionMenuItem
+              key={release._id}
+              release={release}
+              onSelect={onSelectRelease}
+              isSelected={typeof selected !== 'string' && selected?._id === release._id}
+              documentId={documentId}
+            />
+          ))}
+        </Menu>
+      }
+    />
+  )
+}
+
+type VersionMenuItemProps = {
+  onSelect: (releaseId: string) => void
+  isSelected?: boolean
+  documentId: string
+} & (
+  | {
+      release: ReleaseDocument
+      type?: never
+    }
+  | {
+      type: 'published' | 'draft'
+      release?: never
+    }
+)
+
+const VersionMenuItem: ComponentType<VersionMenuItemProps> = ({
+  type,
+  release,
+  onSelect,
+  isSelected,
+  documentId,
+}) => {
+  const {t: tCore} = useTranslation()
+  const {t: tStructure} = useTranslation(structureLocaleNamespace)
+
+  const onClick = useCallback(() => {
+    if (type === 'draft') {
+      onSelect(getDraftId(documentId))
+      return
+    }
+
+    if (type === 'published') {
+      onSelect(getPublishedId(documentId))
+      return
+    }
+
+    if (typeof release?._id !== 'undefined') {
+      onSelect(getVersionId(documentId, getReleaseIdFromReleaseDocumentId(release._id)))
+    }
+  }, [type, onSelect, documentId, release?._id])
+
+  if (type) {
+    const tone: ButtonTone = type === 'published' ? 'positive' : 'caution'
+
+    return (
+      <MenuItem padding={1} paddingRight={3} onClick={onClick} pressed={isSelected}>
+        <Flex gap={1}>
+          <ReleaseAvatar padding={2} tone={tone} />
+          <Box paddingY={2}>
+            <Text size={1} weight="medium">
+              {tStructure(['compare-versions.status', type].join('.'))}
+            </Text>
+          </Box>
+        </Flex>
+      </MenuItem>
+    )
+  }
+
+  const tone: ButtonTone = release ? getReleaseTone(release) : 'neutral'
+
+  return (
+    <MenuItem padding={1} paddingRight={3} onClick={onClick} pressed={isSelected}>
+      <Flex gap={1}>
+        <ReleaseAvatar padding={2} tone={tone} />
+        <Stack flex={1} paddingY={2} paddingRight={2} space={2}>
+          <Text size={1} weight="medium">
+            {release.metadata.title}
+          </Text>
+          {['asap', 'undecided'].includes(release.metadata.releaseType) && (
+            <Text muted size={1}>
+              {tCore(`release.type.${release.metadata.releaseType}`)}
+            </Text>
+          )}
+          {release.metadata.releaseType === 'scheduled' && (
+            <Text muted size={1}>
+              {formatRelativeLocalePublishDate(release)}
+            </Text>
+          )}
+        </Stack>
+        <Flex flex="none">
+          {isReleaseScheduledOrScheduling(release) && (
+            <Box padding={2}>
+              <Text size={1}>
+                <LockIcon />
+              </Text>
+            </Box>
+          )}
+        </Flex>
+      </Flex>
+    </MenuItem>
+  )
+}
+
+function getMenuButtonProps({
+  selected,
+  tCore,
+  tStructure,
+}: {
+  selected?: ReleaseDocument | 'published' | 'draft'
+  tCore: TFunction
+  tStructure: TFunction
+}): Pick<ComponentProps<typeof Button>, 'text' | 'tone' | 'icon' | 'iconRight' | 'disabled'> {
+  if (typeof selected === 'undefined') {
+    return {
+      text: tCore('common.loading'),
+      tone: 'neutral',
+      disabled: true,
+    }
+  }
+
+  if (isReleaseDocument(selected)) {
+    const tone: ButtonTone = selected ? getReleaseTone(selected) : 'neutral'
+
+    return {
+      text: selected?.metadata.title,
+      icon: <ReleaseAvatar padding={1} tone={tone} />,
+      iconRight: selected && isReleaseScheduledOrScheduling(selected) ? <LockIcon /> : undefined,
+      tone,
+    }
+  }
+
+  const tone: ButtonTone = selected === 'published' ? 'positive' : 'caution'
+
+  return {
+    text: tStructure(['compare-versions.status', selected].join('.')),
+    icon: <ReleaseAvatar padding={1} tone={tone} />,
+    tone,
+  }
+}
+
+/**
+ * If the provided document id represents a version, find and return the corresponding release
+ * document. Otherwise, return a string literal signifying whether the document id represents a
+ * published or draft document.
+ */
+function findRelease(
+  documentId: string,
+  releases: ReleaseDocument[],
+): ReleaseDocument | 'published' | 'draft' | undefined {
+  if (isPublishedId(documentId)) {
+    return 'published'
+  }
+
+  if (isDraftId(documentId)) {
+    return 'draft'
+  }
+
+  return releases.find(
+    ({_id}) => getReleaseIdFromReleaseDocumentId(_id) === getVersionFromId(documentId),
+  )
+}

--- a/packages/sanity/src/structure/hooks/useDocumentIdStack.ts
+++ b/packages/sanity/src/structure/hooks/useDocumentIdStack.ts
@@ -1,0 +1,65 @@
+import {useMemo} from 'react'
+import {getReleaseIdFromReleaseDocumentId, getVersionId} from 'sanity'
+
+import {type DocumentPaneContextValue} from '../panes/document/DocumentPaneContext'
+import {useFilteredReleases} from './useFilteredReleases'
+
+/**
+ * @internal
+ */
+export interface DocumentIdStack {
+  /**
+   * The position of the displayed document within the stack.
+   */
+  position: number
+  /**
+   * The id of the previous document in the stack.
+   */
+  previousId?: string
+  /**
+   * The id of the next document in the stack.
+   */
+  nextId?: string
+  /**
+   * An array of document ids comprising the stack the displayed document is a member of, ordered per
+   * release layering.
+   */
+  stack: string[]
+}
+
+/**
+ * Get a stack of document ids representing existing versions of the provided document with release
+ * layering applied.
+ *
+ * @internal
+ */
+export function useDocumentIdStack({
+  displayed,
+  documentId,
+  editState,
+}: Pick<DocumentPaneContextValue, 'displayed' | 'documentId' | 'editState'>): DocumentIdStack {
+  const filteredReleases = useFilteredReleases({displayed, documentId})
+  const systemStack = [editState?.published?._id, editState?.draft?._id]
+
+  const releaseStack = filteredReleases.currentReleases.map(
+    (release) =>
+      editState?.id && getVersionId(editState.id, getReleaseIdFromReleaseDocumentId(release._id)),
+  )
+
+  const stack = systemStack.concat(releaseStack).filter((id) => typeof id === 'string')
+
+  const position = useMemo(
+    () => stack.findIndex((id) => id === displayed?._id),
+    [displayed?._id, stack],
+  )
+
+  const previousId = useMemo(() => stack[position - 1] ?? undefined, [position, stack])
+  const nextId = useMemo(() => stack[position + 1] ?? undefined, [position, stack])
+
+  return {
+    position,
+    previousId,
+    nextId,
+    stack,
+  }
+}

--- a/packages/sanity/src/structure/hooks/useFilteredReleases.ts
+++ b/packages/sanity/src/structure/hooks/useFilteredReleases.ts
@@ -1,0 +1,84 @@
+import {useMemo} from 'react'
+import {
+  getReleaseIdFromReleaseDocumentId,
+  getVersionFromId,
+  type ReleaseDocument,
+  useActiveReleases,
+  useArchivedReleases,
+  useDocumentVersions,
+  usePerspective,
+} from 'sanity'
+
+import {usePaneRouter} from '../components/paneRouter/usePaneRouter'
+import {type DocumentPaneContextValue} from '../panes/document/DocumentPaneContext'
+
+type FilterReleases = {
+  notCurrentReleases: ReleaseDocument[]
+  currentReleases: ReleaseDocument[]
+  inCreation: ReleaseDocument | null
+}
+
+/**
+ * @internal
+ */
+export function useFilteredReleases({
+  displayed,
+  documentId,
+}: Pick<DocumentPaneContextValue, 'displayed' | 'documentId'>): FilterReleases {
+  const {selectedReleaseId} = usePerspective()
+  const {data: releases} = useActiveReleases()
+  const {data: archivedReleases} = useArchivedReleases()
+  const {data: documentVersions} = useDocumentVersions({documentId})
+  const isCreatingDocument = displayed && !displayed._createdAt
+  const {params} = usePaneRouter()
+
+  return useMemo(() => {
+    if (!documentVersions) return {notCurrentReleases: [], currentReleases: [], inCreation: null}
+    // Gets the releases ids from the document versions, it means, the releases that the document belongs to
+    const releasesIds = documentVersions.map((id) => getVersionFromId(id))
+    const activeReleases = releases.reduce(
+      (acc: FilterReleases, release) => {
+        const versionDocExists = releasesIds.includes(
+          getReleaseIdFromReleaseDocumentId(release._id),
+        )
+        const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
+        const isCreatingThisVersion =
+          isCreatingDocument &&
+          releaseId === getVersionFromId(displayed._id || '') &&
+          releaseId === selectedReleaseId
+
+        if (isCreatingThisVersion) {
+          acc.inCreation = release
+        } else if (versionDocExists) {
+          acc.currentReleases.push(release)
+        } else {
+          acc.notCurrentReleases.push(release)
+        }
+        return acc
+      },
+      {notCurrentReleases: [], currentReleases: [], inCreation: null},
+    )
+
+    // without historyVersion, version is not in an archived release
+    if (!params?.historyVersion) return activeReleases
+
+    const archivedRelease = archivedReleases.find(
+      (r) => getReleaseIdFromReleaseDocumentId(r._id) === params?.historyVersion,
+    )
+
+    // only for explicitly archived releases; published releases use published perspective
+    if (archivedRelease?.state === 'archived') {
+      activeReleases.currentReleases.push(archivedRelease)
+    }
+
+    return activeReleases
+  }, [
+    archivedReleases,
+    isCreatingDocument,
+    displayed?._id,
+    documentVersions,
+    params?.historyVersion,
+    releases,
+    selectedReleaseId,
+  ])
+}

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -161,6 +161,7 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'buttons.split-pane-close-button.title': 'Close split pane',
   /** The title for the close group button on the split pane on the document panel header */
   'buttons.split-pane-close-group-button.title': 'Close pane group',
+
   /** The label used in the changes inspector for the from selector */
   'changes.from.label': 'From',
   /* The label for the history tab in the changes inspector*/
@@ -169,6 +170,26 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'changes.tab.review-changes': 'Review changes',
   /** The label used in the changes inspector for the to selector */
   'changes.to.label': 'To',
+
+  /** The error message shown when the specified document comparison mode is not supported */
+  'compare-version.error.invalidModeParam':
+    '"{{input}}" is not a supported document comparison mode.',
+  /** The error message shown when the next document for comparison could not be extracted from the URL */
+  'compare-version.error.invalidNextDocumentParam': 'The next document parameter is invalid.',
+  /** The error message shown when the document comparison URL could not be parsed */
+  'compare-version.error.invalidParams.title': 'Unable to compare documents',
+  /** The error message shown when the previous document for comparison could not be extracted from the URL */
+  'compare-version.error.invalidPreviousDocumentParam':
+    'The previous document parameter is invalid.',
+  /** The text for the "Compare versions" action for a document */
+  'compare-versions.menu-item.title': 'Compare versions',
+  /** The string used to label draft documents */
+  'compare-versions.status.draft': 'Draft',
+  /** The string used to label published documents */
+  'compare-versions.status.published': 'Published',
+  /** The title used when comparing versions of a document */
+  'compare-versions.title': 'Compare versions',
+
   /** The text in the "Cancel" button in the confirm delete dialog that cancels the action and closes the dialog */
   'confirm-delete-dialog.cancel-button.text': 'Cancel',
   /** Used in `confirm-delete-dialog.cdr-summary.title` */

--- a/packages/sanity/src/structure/panes/document/DocumentPane.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPane.tsx
@@ -16,6 +16,7 @@ import {
 } from 'sanity'
 
 import {usePaneRouter} from '../../components'
+import {DiffViewDocumentLayout} from '../../diffView/plugin/DiffViewDocumentLayout'
 import {structureLocaleNamespace} from '../../i18n'
 import {type DocumentPaneNode} from '../../types'
 import {ErrorPane} from '../error'
@@ -145,9 +146,11 @@ function DocumentPaneInner(props: DocumentPaneProviderProps) {
         initialValueTemplateItems={templatePermissions}
         activePath={activePath}
       >
-        <CommentsWrapper documentId={options.id} documentType={options.type}>
-          <DocumentLayout documentId={options.id} documentType={options.type} />
-        </CommentsWrapper>
+        <DiffViewDocumentLayout documentId={options.id} documentType={options.type}>
+          <CommentsWrapper documentId={options.id} documentType={options.type}>
+            <DocumentLayout documentId={options.id} documentType={options.type} />
+          </CommentsWrapper>
+        </DiffViewDocumentLayout>
       </ReferenceInputOptionsProvider>
     </DocumentPaneProviderWrapper>
   )

--- a/packages/sanity/src/structure/panes/document/document-layout/DocumentLayout.tsx
+++ b/packages/sanity/src/structure/panes/document/document-layout/DocumentLayout.tsx
@@ -27,6 +27,7 @@ import {styled} from 'styled-components'
 import {TooltipDelayGroupProvider} from '../../../../ui-components'
 import {Pane, PaneFooter, usePane, usePaneLayout, usePaneRouter} from '../../../components'
 import {DOCUMENT_PANEL_PORTAL_ELEMENT} from '../../../constants'
+import {useDocumentIdStack} from '../../../hooks/useDocumentIdStack'
 import {structureLocaleNamespace} from '../../../i18n'
 import {useStructureTool} from '../../../useStructureTool'
 import {
@@ -66,8 +67,10 @@ const StyledChangeConnectorRoot = styled(ChangeConnectorRoot)`
 export function DocumentLayout() {
   const {
     changesOpen,
+    displayed,
     documentId,
     documentType,
+    editState,
     fieldActions,
     focusPath,
     inspectOpen,
@@ -128,6 +131,8 @@ export function DocumentLayout() {
     [inspectors, inspector?.name],
   )
 
+  const documentIdStack = useDocumentIdStack({displayed, documentId, editState})
+
   const hasValue = Boolean(value)
 
   const menuItems = useMemo(
@@ -139,9 +144,19 @@ export function DocumentLayout() {
         inspectorMenuItems,
         inspectors,
         previewUrl,
+        documentIdStack,
         t,
       }),
-    [currentInspector, features, hasValue, inspectorMenuItems, inspectors, previewUrl, t],
+    [
+      currentInspector,
+      documentIdStack,
+      features,
+      hasValue,
+      inspectorMenuItems,
+      inspectors,
+      previewUrl,
+      t,
+    ],
   )
 
   const handleKeyUp = useCallback(

--- a/packages/sanity/src/structure/panes/document/menuItems.ts
+++ b/packages/sanity/src/structure/panes/document/menuItems.ts
@@ -1,6 +1,7 @@
-import {EarthAmericasIcon, JsonIcon, LinkIcon} from '@sanity/icons'
+import {EarthAmericasIcon, JsonIcon, LinkIcon, TransferIcon} from '@sanity/icons'
 import {type DocumentInspector, type DocumentInspectorMenuItem, type TFunction} from 'sanity'
 
+import {type DocumentIdStack} from '../../hooks/useDocumentIdStack'
 import {type PaneMenuItem, type StructureToolFeatures} from '../../types'
 import {INSPECT_ACTION_PREFIX} from './constants'
 
@@ -10,6 +11,7 @@ interface GetMenuItemsParams {
   hasValue: boolean
   inspectors: DocumentInspector[]
   previewUrl?: string | null
+  documentIdStack?: DocumentIdStack
   inspectorMenuItems: DocumentInspectorMenuItem[]
   t: TFunction
 }
@@ -52,6 +54,25 @@ function getInspectItem({hasValue, t}: GetMenuItemsParams): PaneMenuItem {
   }
 }
 
+function getCompareVersionsItem({documentIdStack, t}: GetMenuItemsParams): PaneMenuItem | null {
+  const isDisabled = typeof documentIdStack?.previousId === 'undefined'
+
+  // TODO: It would be preferable to display the option in an inert state, but the `isDisabled`
+  // property does not appear to have any impact. Instead, we simply exclude the option when
+  // there is no version to compare.
+  if (isDisabled) {
+    return null
+  }
+
+  return {
+    action: 'compareVersions',
+    group: 'inspectors',
+    title: t('compare-versions.menu-item.title'),
+    icon: TransferIcon,
+    isDisabled,
+  }
+}
+
 export function getProductionPreviewItem({previewUrl, t}: GetMenuItemsParams): PaneMenuItem | null {
   if (!previewUrl) return null
 
@@ -69,6 +90,7 @@ export function getMenuItems(params: GetMenuItemsParams): PaneMenuItem[] {
   const items = [
     // Get production preview item
     getProductionPreviewItem(params),
+    getCompareVersionsItem(params),
   ].filter(Boolean) as PaneMenuItem[]
 
   return [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1213,7 +1213,7 @@ importers:
         version: 6.2.3
       '@codemirror/language':
         specifier: ^6.2.1
-        version: 6.10.8
+        version: 6.10.7
       '@codemirror/search':
         specifier: ^6.0.1
         version: 6.5.10
@@ -1246,7 +1246,7 @@ importers:
         version: 2.15.0(@emotion/is-prop-valid@1.3.1)(react-dom@19.0.0(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.15(react-dom@19.0.0(react@18.3.1))(react@18.3.1))
       '@uiw/react-codemirror':
         specifier: ^4.11.4
-        version: 4.23.8(@babel/runtime@7.26.9)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.4)(codemirror@6.0.1)(react-dom@19.0.0(react@18.3.1))(react@18.3.1)
+        version: 4.23.8(@babel/runtime@7.26.9)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.7)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.4)(codemirror@6.0.1)(react-dom@19.0.0(react@18.3.1))(react@18.3.1)
       is-hotkey-esm:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1665,6 +1665,9 @@ importers:
       scroll-into-view-if-needed:
         specifier: ^3.0.3
         version: 3.1.0
+      scrollmirror:
+        specifier: ^1.2.0
+        version: 1.2.0
       semver:
         specifier: ^7.3.5
         version: 7.7.1
@@ -2666,8 +2669,8 @@ packages:
   '@codemirror/lang-sql@6.8.0':
     resolution: {integrity: sha512-aGLmY4OwGqN3TdSx3h6QeA1NrvaYtF7kkoWR/+W7/JzB0gQtJ+VJxewlnE3+VImhA4WVlhmkJr109PefOOhjLg==}
 
-  '@codemirror/language@6.10.8':
-    resolution: {integrity: sha512-wcP8XPPhDH2vTqf181U8MbZnW+tDyPYy0UzVOa+oHORjyT+mhhom9vBd7dApJwoDz9Nb/a8kHjJIsuA/t8vNFw==}
+  '@codemirror/language@6.10.7':
+    resolution: {integrity: sha512-aOswhVOLYhMNeqykt4P7+ukQSpGL0ynZYaEyFDVHE7fl2xgluU3yuE9MdgYNfw6EmaNidoFMIQ2iTh1ADrnT6A==}
 
   '@codemirror/legacy-modes@6.4.3':
     resolution: {integrity: sha512-s1g+q4bil8Cs4O+ueIiKIhz9MQOGcRyxJglma8BYIWc/oEJLo13S3LYSWKaqhKwXGgt1GgZ66hCploHZD9Sstw==}
@@ -10566,6 +10569,9 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
+  scrollmirror@1.2.0:
+    resolution: {integrity: sha512-81kLoolfRECsobTkCECpEDacpHXf2pDABtyZfj0wuEZXFBgODM+/NVuiFSB+gvoiWxjf//G+kt3tRkISvbNEGw==}
+
   seek-bzip@1.0.6:
     resolution: {integrity: sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==}
     hasBin: true
@@ -12882,14 +12888,14 @@ snapshots:
 
   '@codemirror/autocomplete@6.18.6':
     dependencies:
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
       '@lezer/common': 1.2.3
 
   '@codemirror/commands@6.8.0':
     dependencies:
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
       '@lezer/common': 1.2.3
@@ -12897,7 +12903,7 @@ snapshots:
   '@codemirror/lang-css@6.3.1':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@codemirror/state': 6.5.2
       '@lezer/common': 1.2.3
       '@lezer/css': 1.1.10
@@ -12907,7 +12913,7 @@ snapshots:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/lang-css': 6.3.1
       '@codemirror/lang-javascript': 6.2.3
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
       '@lezer/common': 1.2.3
@@ -12916,13 +12922,13 @@ snapshots:
 
   '@codemirror/lang-java@6.0.1':
     dependencies:
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@lezer/java': 1.1.3
 
   '@codemirror/lang-javascript@6.2.3':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@codemirror/lint': 6.8.4
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
@@ -12931,14 +12937,14 @@ snapshots:
 
   '@codemirror/lang-json@6.0.1':
     dependencies:
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@lezer/json': 1.0.3
 
   '@codemirror/lang-markdown@6.3.2':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/lang-html': 6.4.9
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
       '@lezer/common': 1.2.3
@@ -12947,7 +12953,7 @@ snapshots:
   '@codemirror/lang-php@6.0.1':
     dependencies:
       '@codemirror/lang-html': 6.4.9
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@codemirror/state': 6.5.2
       '@lezer/common': 1.2.3
       '@lezer/php': 1.0.2
@@ -12955,13 +12961,13 @@ snapshots:
   '@codemirror/lang-sql@6.8.0':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@codemirror/state': 6.5.2
       '@lezer/common': 1.2.3
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
 
-  '@codemirror/language@6.10.8':
+  '@codemirror/language@6.10.7':
     dependencies:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
@@ -12972,7 +12978,7 @@ snapshots:
 
   '@codemirror/legacy-modes@6.4.3':
     dependencies:
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
 
   '@codemirror/lint@6.8.4':
     dependencies:
@@ -12992,7 +12998,7 @@ snapshots:
 
   '@codemirror/theme-one-dark@6.1.2':
     dependencies:
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
       '@lezer/highlight': 1.2.1
@@ -14762,7 +14768,7 @@ snapshots:
       '@codemirror/lang-markdown': 6.3.2
       '@codemirror/lang-php': 6.0.1
       '@codemirror/lang-sql': 6.8.0
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@codemirror/legacy-modes': 6.4.3
       '@codemirror/search': 6.5.10
       '@codemirror/state': 6.5.2
@@ -14772,8 +14778,8 @@ snapshots:
       '@sanity/icons': 3.7.0(react@18.3.1)
       '@sanity/incompatible-plugin': 1.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sanity/ui': 2.15.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@uiw/codemirror-themes': 4.23.8(@codemirror/language@6.10.8)(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
-      '@uiw/react-codemirror': 4.23.8(@babel/runtime@7.26.9)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.8)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.4)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@uiw/codemirror-themes': 4.23.8(@codemirror/language@6.10.7)(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
+      '@uiw/react-codemirror': 4.23.8(@babel/runtime@7.26.9)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.7)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.4)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       sanity: link:packages/sanity
@@ -16113,30 +16119,30 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
 
-  '@uiw/codemirror-extensions-basic-setup@4.23.8(@codemirror/autocomplete@6.18.6)(@codemirror/commands@6.8.0)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)':
+  '@uiw/codemirror-extensions-basic-setup@4.23.8(@codemirror/autocomplete@6.18.6)(@codemirror/commands@6.8.0)(@codemirror/language@6.10.7)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/commands': 6.8.0
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@codemirror/lint': 6.8.4
       '@codemirror/search': 6.5.10
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
 
-  '@uiw/codemirror-themes@4.23.8(@codemirror/language@6.10.8)(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)':
+  '@uiw/codemirror-themes@4.23.8(@codemirror/language@6.10.7)(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)':
     dependencies:
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
 
-  '@uiw/react-codemirror@4.23.8(@babel/runtime@7.26.9)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.4)(codemirror@6.0.1)(react-dom@19.0.0(react@18.3.1))(react@18.3.1)':
+  '@uiw/react-codemirror@4.23.8(@babel/runtime@7.26.9)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.7)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.4)(codemirror@6.0.1)(react-dom@19.0.0(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.9
       '@codemirror/commands': 6.8.0
       '@codemirror/state': 6.5.2
       '@codemirror/theme-one-dark': 6.1.2
       '@codemirror/view': 6.36.4
-      '@uiw/codemirror-extensions-basic-setup': 4.23.8(@codemirror/autocomplete@6.18.6)(@codemirror/commands@6.8.0)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
+      '@uiw/codemirror-extensions-basic-setup': 4.23.8(@codemirror/autocomplete@6.18.6)(@codemirror/commands@6.8.0)(@codemirror/language@6.10.7)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
       codemirror: 6.0.1
       react: 18.3.1
       react-dom: 19.0.0(react@18.3.1)
@@ -16146,14 +16152,14 @@ snapshots:
       - '@codemirror/lint'
       - '@codemirror/search'
 
-  '@uiw/react-codemirror@4.23.8(@babel/runtime@7.26.9)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.8)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.4)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@uiw/react-codemirror@4.23.8(@babel/runtime@7.26.9)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.7)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.4)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.9
       '@codemirror/commands': 6.8.0
       '@codemirror/state': 6.5.2
       '@codemirror/theme-one-dark': 6.1.2
       '@codemirror/view': 6.36.4
-      '@uiw/codemirror-extensions-basic-setup': 4.23.8(@codemirror/autocomplete@6.18.6)(@codemirror/commands@6.8.0)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
+      '@uiw/codemirror-extensions-basic-setup': 4.23.8(@codemirror/autocomplete@6.18.6)(@codemirror/commands@6.8.0)(@codemirror/language@6.10.7)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
       codemirror: 6.0.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -17105,7 +17111,7 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/commands': 6.8.0
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.10.7
       '@codemirror/lint': 6.8.4
       '@codemirror/search': 6.5.10
       '@codemirror/state': 6.5.2
@@ -22342,6 +22348,8 @@ snapshots:
   scroll-into-view-if-needed@3.1.0:
     dependencies:
       compute-scroll-into-view: 3.1.1
+
+  scrollmirror@1.2.0: {}
 
   seek-bzip@1.0.6:
     dependencies:


### PR DESCRIPTION
### Description

This branch adds a diff view for comparing documents. Primarily, this is for use with versions, but it has been designed to support comparing any two documents.

Most of the commits are supporting work (this should probably be a stack). The main feature addition occurs in  4f030aa23991dabdda009283e9d648f18dd0baab.
#### Navigating to diff view

Users can navigate to the diff view by setting the following URL search parameters:

```
| Name               | Type                  | Required | Description                                                                                              |
|--------------------|-----------------------|----------|----------------------------------------------------------------------------------------------------------|
| `diffView`         | `'version'`           | Required | Enable *version comparison* mode UI.                                                                     |
| `previousDocument` | `${string},${string}` | Required | The document type and id identifying the *previous* document for comparison, delimited by `,` character. |
| `nextDocument`     | `${string},${string}` | Required | The document type and id identifying the *next* document for comparison, delimited by `,` character.     |
```

##### Example: specifying both `previousDocument` and `nextDocument`

```
/test/structure/author;8701af36-f4e2-4f32-b13e-fc522ddb381f?perspective=r64awNgUC&structure[diffView]=version&structure[nextDocument]=author%2Cversions.r64awNgUC.8701af36-f4e2-4f32-b13e-fc522ddb381f&structure[previousDocument]=author%2Cversions.rO2NP9B76.8701af36-f4e2-4f32-b13e-fc522ddb381f
```

### New dependency: [ScrollMirror](https://www.npmjs.com/package/scrollmirror)

I've added [ScrollMirror](https://www.npmjs.com/package/scrollmirror) to handle scroll position syncing between two panes that may have different heights. This is achieved by syncing the percentage scroll position of each pane. We could implement this directly in the Studio codebase if we wish.

### What to review

- General implementation.
- Introduction of `ScrollMirror` dependency.

### Testing

There are no tests just yet, as I've spent more time than I expected making the code render in a test environment. First, I [needed to move the diff view code](https://github.com/sanity-io/sanity/commit/2cc93c797f028cc172e11499de8fa9a0725495dc) that was originally organised as a plugin to be part of `sanity/structure`. Then I encountered many issues with existing imports in `sanity/structure` resolving to `undefined` when running in a test environment.

- Navigate to a diff view. Ensure the UI works as expected.
- Navigate to a diff view using the "Compare versions" document action. Ensure the diff view is opened as expected.

I will follow up with tests as soon as these problems are resolved.

### Notes for release

The new document comparison tool provides a side-by-side view of two different document by versions, highlighting the fields that have changed between the _previous_ and _next_ versions. Select "Compare versions" from the document actions menu when viewing any draft or version document in Studio to open the tool.

By default, the first pane displays the _previous_ version, and the second pane shows _next_ version (the version that introduces changes). Use the menu at the top of each pane to switch the versions displayed.