### PR TITLE
fix: vertically center pane header when no tabs

### DIFF
--- a/packages/sanity/src/structure/components/pane/PaneHeader.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneHeader.tsx
@@ -67,7 +67,7 @@ export const PaneHeader = forwardRef(function PaneHeader(
               gap={1}
               onClick={handleLayoutClick}
               padding={3}
-              paddingBottom={collapsed ? 3 : 2}
+              paddingBottom={collapsed || !showTabsOrSubActions ? 3 : 2}
               sizing="border"
               style={layoutStyle}
             >


### PR DESCRIPTION
### Description

Previously the difference in height on the document pane header weren't very noticeable as it was perceived as a toolbar with two rows, while presentation tool and tasks were single row.

<img width="1436" alt="This is n a release nowa draft" src="https://github.com/user-attachments/assets/a671b560-38b7-4e16-b089-c283810c0468">

Annotated with guides
<img width="1423" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/2af2a96e-61e1-4316-8324-c150689bd022">


This changed with #7462, which moved the revision dropdown into the top row, making the toolbar single row as well unless custom tabs are defined in structure builder:

<img width="1434" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/c203ea52-b870-4876-b17b-45c14625661f">

With guides:
<img width="1435" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/378f8eaf-a795-4a0d-97f3-a43c350645e0">

For neurodivergents like me this tiny misalignment becomes a constant distraction and frustrating. It's like an airhorn, and there is no noise cancelling headphones. So I had no choice but to make this PR 😅

Now it's perfectly balanced, like everything should be:
<img width="1436" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/a07edf78-35ca-4148-8276-7234c3b6850b">

<img width="1433" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/a6c0fce3-6a77-4e96-b384-e4a3af6019a5">


Without regressing the custom tabs layout
<img width="1432" alt="Gandalf on a draft jkj as as as as" src="https://github.com/user-attachments/assets/b3ded2c4-7ba0-4b7d-a65f-b362b56abfe0">



### What to review

Test the document tabs, I hope I haven't missed a spot 🙌 

### Testing

Existing tests should be sufficient.

### Notes for release

Fixed a regression in v3.65.0 that caused the document editor panel header to look slightly misaligned with presentation tool's URL bar, and the Tasks panel header.
