### PR TITLE
fix(sanity): support future UI tones

### DIFF
--- a/packages/sanity/src/core/components/StatusButton.tsx
+++ b/packages/sanity/src/core/components/StatusButton.tsx
@@ -1,4 +1,3 @@
-import {useTheme} from '@sanity/ui'
 import {type ForwardedRef, forwardRef, type HTMLProps, type ReactNode, useMemo} from 'react'
 import {styled} from 'styled-components'
 
@@ -46,9 +45,8 @@ export const StatusButton = forwardRef(function StatusButton(
     tone,
     ...restProps
   } = props
-  const theme = useTheme()
-  const toneColor = tone && theme.sanity.color.solid[tone]
-  const dotStyle = useMemo(() => ({backgroundColor: toneColor?.enabled.bg}), [toneColor])
+
+  const dotStyle = useMemo(() => ({backgroundColor: `var(--card-badge-${tone}-dot-color)`}), [tone])
   const disabled = Boolean(disabledProp)
 
   return (

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.styled.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.styled.tsx
@@ -1,6 +1,5 @@
-import {Card, type CardTone, Flex, rgba, studioTheme} from '@sanity/ui'
-import {useColorSchemeValue} from 'sanity'
-import {css, styled} from 'styled-components'
+import {Card, Flex} from '@sanity/ui'
+import {styled} from 'styled-components'
 
 export const RatioBox = styled(Card)`
   position: relative;
@@ -18,24 +17,17 @@ export const RatioBox = styled(Card)`
   }
 `
 
-export const Overlay = styled(Flex)<{
-  $tone: Exclude<CardTone, 'inherit'>
-}>(({$tone}) => {
-  const colorScheme = useColorSchemeValue()
-  const textColor = studioTheme.color[colorScheme][$tone].card.enabled.fg
-  const backgroundColor = rgba(studioTheme.color[colorScheme][$tone].card.enabled.bg, 0.8)
-
-  return css`
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    backdrop-filter: blur(10px);
-    color: ${$tone ? textColor : ''};
-    background-color: ${backgroundColor};
-  `
-})
+export const Overlay = styled(Card)`
+  display: flex;
+  justify-content: flex-end;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  backdrop-filter: blur(10px);
+  background-color: color-mix(in srgb, transparent, var(--card-bg-color) 80%);
+`
 
 export const FlexOverlay = styled(Flex)`
   position: absolute;

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.tsx
@@ -94,7 +94,7 @@ function OverlayComponent({
   content: ReactNode
 }) {
   return (
-    <Overlay justify="flex-end" padding={3} $tone={cardTone}>
+    <Overlay padding={3} tone={cardTone}>
       <FlexOverlay direction="column" align="center" justify="center">
         {content}
       </FlexOverlay>


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

In order to support new tones introduced in Sanity UI, we need to do some minor refactoring to internal studio components.

The reason why this is necessary, is that in 2 places we rely on Sanity UI v1’s theming object in a way which is not future compatible.

The most elegant solution to this is to remove dependency on the theme object, and use CSS variables and primitive components instead.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

- The internal `StatusButton` component has a little dot which can be colored. This PR changes how this dot is colored to using a CSS variable instead of accessing the theme object. Please review that the color application works as intended.
- The internal `Overlay` component within the `ImagePreview` component – which shows when dragging a file from the OS on top of an image field – can be toned according to its status. This PR changes how this overlay is colored to using the `Card` primitive instead of accessing the theme object.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

This change has been tested by running and building the Test Studio locally.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

- Internal changes only.

