### PR TITLE
fix: add svg hotspot+crop gotcha to image tool dialog

### DIFF
--- a/packages/sanity/src/core/form/components/Details.tsx
+++ b/packages/sanity/src/core/form/components/Details.tsx
@@ -1,5 +1,5 @@
 import {ToggleArrowRightIcon} from '@sanity/icons'
-import {Box, Flex, Inline, Text} from '@sanity/ui'
+import {Box, Flex, Text} from '@sanity/ui'
 import {type ReactNode, useCallback, useEffect, useState} from 'react'
 import {styled} from 'styled-components'
 
@@ -37,9 +37,10 @@ const ToggleArrow = styled(ToggleArrowRightIcon)<{open: boolean}>`
 
 const Header = styled(Flex)`
   cursor: default;
+  line-height: 0;
 `
 
-const IconBox = styled(Box)`
+const IconBox = styled(Flex)`
   & > div > svg {
     transform: rotate(0);
     transition: transform 100ms;
@@ -61,8 +62,8 @@ export function Details(props: DetailsProps) {
   return (
     <Box {...restProps}>
       <HeaderButton type="button" onClick={handleToggle}>
-        <Header align="center">
-          <Inline>
+        <Header>
+          <Flex align="center">
             <IconBox data-open={open ? '' : undefined}>
               <Text size={1}>
                 <ToggleArrow open={open} />
@@ -70,11 +71,11 @@ export function Details(props: DetailsProps) {
             </IconBox>
             {icon && <Box marginLeft={1}>{icon}</Box>}
             <Box flex={1} marginLeft={1}>
-              <Text size={1} weight="medium">
+              <Text textOverflow="ellipsis" size={1} weight="medium">
                 {title}
               </Text>
             </Box>
-          </Inline>
+          </Flex>
         </Header>
       </HeaderButton>
 

--- a/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
@@ -1,12 +1,13 @@
 import {type Image, type ImageSchemaType} from '@sanity/types'
 import {Box, Card, Flex, Grid, Heading, Text} from '@sanity/ui'
-import {type ReactNode, useCallback, useEffect, useState} from 'react'
+import {type ReactNode, useCallback, useEffect, useMemo, useState} from 'react'
 import {styled} from 'styled-components'
 
 import {ChangeIndicator} from '../../../../changeIndicators'
 import {LoadingBlock} from '../../../../components/loadingBlock'
-import {useTranslation} from '../../../../i18n'
+import {Translate, useTranslation} from '../../../../i18n'
 import {EMPTY_ARRAY} from '../../../../util'
+import {AlertStrip} from '../../../components/AlertStrip'
 import {FormField} from '../../../components/formField'
 import {useDidUpdate} from '../../../hooks/useDidUpdate'
 import {set} from '../../../patch'
@@ -111,6 +112,8 @@ export function ImageToolInput(props: ImageToolInputProps) {
     [onChange, readOnly, schemaType.fields],
   )
 
+  const isSvg = useMemo(() => value?.asset?._ref?.split('-').at(-1) === 'svg', [value?.asset?._ref])
+
   const {t} = useTranslation()
   return (
     <FormField
@@ -120,6 +123,32 @@ export function ImageToolInput(props: ImageToolInputProps) {
       deprecated={schemaType.deprecated}
       __unstable_presence={presence}
     >
+      {isSvg ? (
+        <AlertStrip
+          status="info"
+          padding={2}
+          marginY={2}
+          title={t('inputs.imagetool.svg-gotcha.title')}
+        >
+          <Text size={1}>
+            <Translate
+              t={t}
+              i18nKey="inputs.imagetool.svg-gotcha.description"
+              components={{
+                ImageUrlDocumentationLink: ({children}) => (
+                  <a href="https://www.sanity.io/docs/image-urls#fm-048ba39d9e88">{children}</a>
+                ),
+                ImageUrlPackageDocumentationLink: ({children}) => (
+                  <a href="https://www.sanity.io/docs/image-urls#fm-048ba39d9e88">
+                    <code>{children}</code>
+                  </a>
+                ),
+              }}
+            />
+          </Text>
+        </AlertStrip>
+      ) : null}
+
       <div>
         <Card
           __unstable_checkered

--- a/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
@@ -1,5 +1,5 @@
 import {type Image, type ImageSchemaType} from '@sanity/types'
-import {Box, Card, Flex, Grid, Heading, Text} from '@sanity/ui'
+import {Box, Card, Flex, Grid, Heading, Stack, Text} from '@sanity/ui'
 import {type ReactNode, useCallback, useEffect, useMemo, useState} from 'react'
 import {styled} from 'styled-components'
 
@@ -7,7 +7,7 @@ import {ChangeIndicator} from '../../../../changeIndicators'
 import {LoadingBlock} from '../../../../components/loadingBlock'
 import {Translate, useTranslation} from '../../../../i18n'
 import {EMPTY_ARRAY} from '../../../../util'
-import {AlertStrip} from '../../../components/AlertStrip'
+import {Details} from '../../../components/Details'
 import {FormField} from '../../../components/formField'
 import {useDidUpdate} from '../../../hooks/useDidUpdate'
 import {set} from '../../../patch'
@@ -124,29 +124,33 @@ export function ImageToolInput(props: ImageToolInputProps) {
       __unstable_presence={presence}
     >
       {isSvg ? (
-        <AlertStrip
-          status="info"
-          padding={2}
-          marginY={2}
-          title={t('inputs.imagetool.svg-gotcha.title')}
-        >
-          <Text size={1}>
-            <Translate
-              t={t}
-              i18nKey="inputs.imagetool.svg-gotcha.description"
-              components={{
-                ImageUrlDocumentationLink: ({children}) => (
-                  <a href="https://www.sanity.io/docs/image-urls#fm-048ba39d9e88">{children}</a>
-                ),
-                ImageUrlPackageDocumentationLink: ({children}) => (
-                  <a href="https://www.sanity.io/docs/image-urls#fm-048ba39d9e88">
-                    <code>{children}</code>
-                  </a>
-                ),
-              }}
-            />
-          </Text>
-        </AlertStrip>
+        <>
+          <Card padding={3} marginY={3} tone="caution" radius={2}>
+            <Stack space={4}>
+              <Text size={1}>{t('inputs.imagetool.svg-warning.title')}</Text>
+              <Details title={t('inputs.imagetool.svg-warning.expand-developer-info')}>
+                <Text size={1}>
+                  <Translate
+                    t={t}
+                    i18nKey="inputs.imagetool.svg-warning.developer-info"
+                    components={{
+                      ImageUrlDocumentationLink: ({children}) => (
+                        <a href="https://www.sanity.io/docs/image-urls#fm-048ba39d9e88">
+                          {children}
+                        </a>
+                      ),
+                      ImageUrlPackageDocumentationLink: ({children}) => (
+                        <a href="https://www.sanity.io/docs/image-urls#fm-048ba39d9e88">
+                          <code>{children}</code>
+                        </a>
+                      ),
+                    }}
+                  />
+                </Text>
+              </Details>
+            </Stack>
+          </Card>
+        </>
       ) : null}
 
       <div>

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -654,10 +654,12 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Error: `{{errorMessage}}` */
   'inputs.imagetool.load-error': 'Error: {{errorMessage}}',
   /** SVG images are not adjusted for hotspot and crop when served from the Sanity image. If you want the below hotspot and crop settings to apply, make sure to append `fp=jpg` to the image url, or call `format('jpg')` if using `@sanity/image-url` */
-  'inputs.imagetool.svg-gotcha.description': `SVG images are not adjusted for hotspot and crop when served from the Sanity image. If you want the below hotspot and crop settings to apply, make sure to append  <code>fp=jpg</code> to the <ImageUrlDocumentationLink>image url</ImageUrlDocumentationLink>, or call <code>format('jpg')</code> if using <ImageUrlPackageDocumentationLink>@sanity/image-url</ImageUrlPackageDocumentationLink>`,
+  'inputs.imagetool.svg-warning.developer-info': `SVG images are not adjusted for hotspot and crop when served from the Sanity image API. If you want the below hotspot and crop settings to apply, make sure to append  <code>fp=jpg</code> to the <ImageUrlDocumentationLink>image url</ImageUrlDocumentationLink>, or call <code>format('jpg')</code> if using <ImageUrlPackageDocumentationLink>@sanity/image-url</ImageUrlPackageDocumentationLink>`,
+  /** See developer info */
+  'inputs.imagetool.svg-warning.expand-developer-info': 'See developer info',
   /** Gotcha: Serving SVGs with hotspot and crop from the Sanity Image API */
-  'inputs.imagetool.svg-gotcha.title':
-    'Gotcha: Serving SVGs with hotspot and crop from the Sanity Image API',
+  'inputs.imagetool.svg-warning.title':
+    "Warning: Hotspot and crop might not be applied to this image where it's presented.",
   /** Hotspot & Crop */
   'inputs.imagetool.title': 'Hotspot & Crop',
   /** Convert to `{{targetType}}` */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -653,6 +653,11 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
     'Adjust the rectangle to crop image. Adjust the circle to specify the area that should always be visible.',
   /** Error: `{{errorMessage}}` */
   'inputs.imagetool.load-error': 'Error: {{errorMessage}}',
+  /** SVG images are not adjusted for hotspot and crop when served from the Sanity image. If you want the below hotspot and crop settings to apply, make sure to append `fp=jpg` to the image url, or call `format('jpg')` if using `@sanity/image-url` */
+  'inputs.imagetool.svg-gotcha.description': `SVG images are not adjusted for hotspot and crop when served from the Sanity image. If you want the below hotspot and crop settings to apply, make sure to append  <code>fp=jpg</code> to the <ImageUrlDocumentationLink>image url</ImageUrlDocumentationLink>, or call <code>format('jpg')</code> if using <ImageUrlPackageDocumentationLink>@sanity/image-url</ImageUrlPackageDocumentationLink>`,
+  /** Gotcha: Serving SVGs with hotspot and crop from the Sanity Image API */
+  'inputs.imagetool.svg-gotcha.title':
+    'Gotcha: Serving SVGs with hotspot and crop from the Sanity Image API',
   /** Hotspot & Crop */
   'inputs.imagetool.title': 'Hotspot & Crop',
   /** Convert to `{{targetType}}` */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -654,7 +654,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Error: `{{errorMessage}}` */
   'inputs.imagetool.load-error': 'Error: {{errorMessage}}',
   /** SVG images are not adjusted for hotspot and crop when served from the Sanity image. If you want the below hotspot and crop settings to apply, make sure to append `fp=jpg` to the image url, or call `format('jpg')` if using `@sanity/image-url` */
-  'inputs.imagetool.svg-warning.developer-info': `SVG images are not adjusted for hotspot and crop when served from the Sanity image API. If you want the below hotspot and crop settings to apply, make sure to append  <code>fp=jpg</code> to the <ImageUrlDocumentationLink>image url</ImageUrlDocumentationLink>, or call <code>format('jpg')</code> if using <ImageUrlPackageDocumentationLink>@sanity/image-url</ImageUrlPackageDocumentationLink>`,
+  'inputs.imagetool.svg-warning.developer-info': `The Asset Pipeline does not support hotspot and crop for SVG as an output image format. To enable hotspot & crop, output this image to any of the supported bitmap formats. For example: <code>fm=jpg</code> to the <ImageUrlDocumentationLink>Image URL</ImageUrlDocumentationLink> or call <code>.format('png')</code> with <ImageUrlPackageDocumentationLink>@sanity/image-url</ImageUrlPackageDocumentationLink>.`,
   /** See developer info */
   'inputs.imagetool.svg-warning.expand-developer-info': 'See developer info',
   /** Gotcha: Serving SVGs with hotspot and crop from the Sanity Image API */


### PR DESCRIPTION
### Description
The fact that hotspot and crop won't be applied to SVG images is [unexpected](https://github.com/sanity-io/sanity/issues/2966) and can easily become a time sink to debug because it fails silently, and we don't offer much docs around it either (at least to my knowledge). This PR adds a gotcha to the hotspot/crop UI in case you're setting it on an SVG.

Note: I believe we still want to alow setting hotspot/crop for SVGs because it works fine when appending `fmt=jpg` to the image url.

![image](https://github.com/user-attachments/assets/21bb6e7a-e505-47a8-9836-11fa254a572b)

### What to review
- Is the phrasing clear/sensible? Note: this message might appear a bit confusing to non-devs. I don't think we have an easy way to tell whether the current user is a developer or not, and I think it's an OK tradeoff showing it to everyone. I did consider only showing it during DEV, but I think that would make it less likely to be noticed as it requires the developer to actually upload an SVG when running locally. We could consider making it dismissable if we think it's too confusing.

### Testing
- Upload an SVG to an image field (for example [this](https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg)) and try to modify hotspot/crop

### Notes for release
- Adds a warning about limited hotspot/crop support for SVGs in the hotspot/crop dialog for image fields