### PR TITLE
fix(core):  `VersionOriginType` to `DocumentVariantType`

### DIFF
--- a/packages/sanity/src/core/releases/__telemetry__/releases.telemetry.ts
+++ b/packages/sanity/src/core/releases/__telemetry__/releases.telemetry.ts
@@ -1,6 +1,6 @@
 import {defineEvent} from '@sanity/telemetry'
 
-import {type VersionOriginTypes} from '../index'
+import {type DocumentVariantType} from '../../util/draftUtils'
 
 interface VersionInfo {
   /**
@@ -10,7 +10,7 @@ interface VersionInfo {
   /**
    * the origin of the version created (from a draft or from a version)
    */
-  documentOrigin: VersionOriginTypes
+  documentOrigin: DocumentVariantType
 }
 
 export interface OriginInfo {

--- a/packages/sanity/src/core/releases/__telemetry__/releases.telemetry.ts
+++ b/packages/sanity/src/core/releases/__telemetry__/releases.telemetry.ts
@@ -1,6 +1,6 @@
 import {defineEvent} from '@sanity/telemetry'
 
-import {type DocumentVariantType} from '../../util/draftUtils'
+import {type DocumentVariantType} from '../../util/getDocumentVariantType'
 
 interface VersionInfo {
   /**

--- a/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
+++ b/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
@@ -2,7 +2,7 @@ import {useTelemetry} from '@sanity/telemetry/react'
 import {useToast} from '@sanity/ui'
 
 import {Translate, useTranslation} from '../../i18n'
-import {getDocumentVariantType} from '../../util/draftUtils'
+import {getDocumentVariantType} from '../../util/getDocumentVariantType'
 import {AddedVersion} from '../__telemetry__/releases.telemetry'
 import {useReleaseOperations} from '../store/useReleaseOperations'
 import {usePerspective} from './usePerspective'

--- a/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
+++ b/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
@@ -2,9 +2,9 @@ import {useTelemetry} from '@sanity/telemetry/react'
 import {useToast} from '@sanity/ui'
 
 import {Translate, useTranslation} from '../../i18n'
+import {getDocumentVariantType} from '../../util/draftUtils'
 import {AddedVersion} from '../__telemetry__/releases.telemetry'
 import {useReleaseOperations} from '../store/useReleaseOperations'
-import {getCreateVersionOrigin} from '../util/util'
 import {usePerspective} from './usePerspective'
 
 export interface VersionOperationsValue {
@@ -30,7 +30,7 @@ export function useVersionOperations(): VersionOperationsValue {
     documentId: string,
     initialValue?: Record<string, unknown>,
   ) => {
-    const origin = getCreateVersionOrigin(documentId)
+    const origin = getDocumentVariantType(documentId)
     try {
       await createVersion(releaseId, documentId, initialValue)
       setPerspectiveFromReleaseId(releaseId)

--- a/packages/sanity/src/core/releases/tool/detail/AddDocumentSearch.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/AddDocumentSearch.tsx
@@ -6,7 +6,7 @@ import {AddedVersion} from 'sanity'
 
 import {SearchPopover} from '../../../studio/components/navbar/search/components/SearchPopover'
 import {SearchProvider} from '../../../studio/components/navbar/search/contexts/search/SearchProvider'
-import {getDocumentVariantType} from '../../../util/draftUtils'
+import {getDocumentVariantType} from '../../../util/getDocumentVariantType'
 import {useReleaseOperations} from '../../store/useReleaseOperations'
 import {getBundleIdFromReleaseDocumentId} from '../../util/getBundleIdFromReleaseDocumentId'
 import {useBundleDocuments} from './useBundleDocuments'

--- a/packages/sanity/src/core/releases/tool/detail/AddDocumentSearch.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/AddDocumentSearch.tsx
@@ -6,9 +6,9 @@ import {AddedVersion} from 'sanity'
 
 import {SearchPopover} from '../../../studio/components/navbar/search/components/SearchPopover'
 import {SearchProvider} from '../../../studio/components/navbar/search/contexts/search/SearchProvider'
+import {getDocumentVariantType} from '../../../util/draftUtils'
 import {useReleaseOperations} from '../../store/useReleaseOperations'
 import {getBundleIdFromReleaseDocumentId} from '../../util/getBundleIdFromReleaseDocumentId'
-import {getCreateVersionOrigin} from '../../util/util'
 import {useBundleDocuments} from './useBundleDocuments'
 
 export function AddDocumentSearch({
@@ -38,7 +38,7 @@ export function AddDocumentSearch({
           title: 'Document added to release',
         })
 
-        const origin = getCreateVersionOrigin(item._id)
+        const origin = getDocumentVariantType(item._id)
 
         telemetry.log(AddedVersion, {
           documentOrigin: origin,

--- a/packages/sanity/src/core/releases/util/util.ts
+++ b/packages/sanity/src/core/releases/util/util.ts
@@ -1,13 +1,10 @@
 import {
   formatRelativeLocale,
   getVersionFromId,
-  isDraftId,
-  isPublishedId,
   isVersionId,
   resolveBundlePerspective,
 } from '../../util'
 import {type CurrentPerspective} from '../hooks/usePerspective'
-import {type VersionOriginTypes} from '../index'
 import {type ReleaseDocument} from '../store/types'
 import {LATEST} from './const'
 
@@ -51,17 +48,6 @@ export function versionDocumentExists(
 
 export function isDraftOrPublished(versionName: string): boolean {
   return versionName === 'drafts' || versionName === 'published'
-}
-
-/**
- * @beta
- * @param documentId - The document id, e.g. `my-document-id` or `drafts.my-document-id` or `summer.my-document-id`
- * @returns VersionOriginTypes - the origin from which this version is being created from
- */
-export function getCreateVersionOrigin(documentId: string): VersionOriginTypes {
-  if (isDraftId(documentId)) return 'draft'
-  if (isPublishedId(documentId)) return 'published'
-  return 'version'
 }
 
 /** @internal */

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -5,6 +5,7 @@ import {omit} from 'lodash'
 import {EMPTY, from, merge, type Observable, Subject} from 'rxjs'
 import {filter, map, mergeMap, share, take, tap} from 'rxjs/operators'
 
+import {type DocumentVariantType} from '../../../../util/draftUtils'
 import {
   type BufferedDocumentEvent,
   type CommitRequest,
@@ -14,7 +15,6 @@ import {
 } from '../buffered-doc'
 import {getPairListener, type ListenerEvent, type PairListenerOptions} from '../getPairListener'
 import {type IdPair, type PendingMutationsEvent, type ReconnectEvent} from '../types'
-import {type VersionOriginTypes} from './operations'
 import {actionsApiClient} from './utils/actionsApiClient'
 
 const isMutationEventForDocId =
@@ -28,7 +28,7 @@ const isMutationEventForDocId =
 /**
  * @hidden
  * @beta */
-export type WithVersion<T> = T & {version: VersionOriginTypes}
+export type WithVersion<T> = T & {version: DocumentVariantType}
 
 /**
  * @hidden

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -5,7 +5,7 @@ import {omit} from 'lodash'
 import {EMPTY, from, merge, type Observable, Subject} from 'rxjs'
 import {filter, map, mergeMap, share, take, tap} from 'rxjs/operators'
 
-import {type DocumentVariantType} from '../../../../util/draftUtils'
+import {type DocumentVariantType} from '../../../../util/getDocumentVariantType'
 import {
   type BufferedDocumentEvent,
   type CommitRequest,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/types.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/types.ts
@@ -23,9 +23,6 @@ export interface Operation<ExtraArgs extends any[] = [], ErrorStrings extends st
 type GuardedOperation = Operation<any[], 'NOT_READY'>
 type Patch = any
 
-/** @beta */
-export type VersionOriginTypes = 'published' | 'draft' | 'version'
-
 /** @internal */
 // Note: Changing this interface in a backwards incompatible manner will be a breaking change
 export interface OperationsAPI {

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -210,3 +210,16 @@ export function removeDupes(documents: SanityDocumentLike[]): SanityDocumentLike
     .map((entry) => entry.draft || entry.published)
     .filter(isNonNullable)
 }
+
+/**
+ * @beta
+ * Given a document id, it indicates whether it is a draft, version or published document.
+ */
+export type DocumentVariantType = 'draft' | 'version' | 'published'
+
+/** @beta */
+export function getDocumentVariantType(documentId: string): 'draft' | 'version' | 'published' {
+  if (isDraftId(documentId)) return 'draft'
+  if (isVersionId(documentId)) return 'version'
+  return 'published'
+}

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -210,16 +210,3 @@ export function removeDupes(documents: SanityDocumentLike[]): SanityDocumentLike
     .map((entry) => entry.draft || entry.published)
     .filter(isNonNullable)
 }
-
-/**
- * @beta
- * Given a document id, it indicates whether it is a draft, version or published document.
- */
-export type DocumentVariantType = 'draft' | 'version' | 'published'
-
-/** @beta */
-export function getDocumentVariantType(documentId: string): 'draft' | 'version' | 'published' {
-  if (isDraftId(documentId)) return 'draft'
-  if (isVersionId(documentId)) return 'version'
-  return 'published'
-}

--- a/packages/sanity/src/core/util/getDocumentVariantType.ts
+++ b/packages/sanity/src/core/util/getDocumentVariantType.ts
@@ -1,0 +1,23 @@
+import {isDraftId, isVersionId} from './draftUtils'
+
+/**
+ * Indicates the type of document variant, either `draft`, `version` or `published`.
+ * Draft documents are prefixed with `drafts.`.
+ * Version documents are prefixed with `versions.<versionName>`
+ * The rest are considered published documents.
+ * @beta
+ */
+export type DocumentVariantType = 'draft' | 'version' | 'published'
+
+/**
+ * Takes a document id and returns the variant type for that document
+ * If it's a document that starts with `version.` it's a `version` document.
+ * If it's a document that starts with `drafts.` it's a `draft` document.
+ * Otherwise, it's a `published` document.
+ * @beta
+ * */
+export function getDocumentVariantType(documentId: string): DocumentVariantType {
+  if (isDraftId(documentId)) return 'draft'
+  if (isVersionId(documentId)) return 'version'
+  return 'published'
+}

--- a/test/e2e/tests/navbar/appearanceMenu.spec.ts
+++ b/test/e2e/tests/navbar/appearanceMenu.spec.ts
@@ -15,7 +15,7 @@ test('color scheme changes and persists', async ({page, baseURL}) => {
   await page.goto(baseURL ?? '/test/content')
 
   await page.locator(`[id='user-menu']`).click()
-  await expect(await page.getByTestId('user-menu')).toBeVisible()
+  await expect(await page.getByTestId('user-menu')).toBeVisible({timeout: 4000})
   await expect(await page.getByTestId('color-scheme-dark')).toBeVisible()
   await page.getByTestId('color-scheme-dark').click()
 


### PR DESCRIPTION
### Description
Renames `VersionOriginType` to `DocumentVariantType`, given this type is useful in more contexts not only the creation of a document.
This type will indicate the type of document we are working with according to the id.
If it's a document that starts with `version` it's a version document.
If it's a document that starts with `drafts` it's a draft document.
Otherwise, it's a published document.

It's quite obvious when you see the id, but exposing a function that we can use to get this information in a type safe way is necessary when we need the ui, or other internal functions, to react different according to the type of document we are using. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
