### PR TITLE
fix(core): when publishing a release unpin it

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/ReleasePublishAllButton/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleasePublishAllButton/ReleasePublishAllButton.tsx
@@ -8,6 +8,7 @@ import {Button, Dialog} from '../../../../../ui-components'
 import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
 import {Translate, useTranslation} from '../../../../i18n'
 import {PublishedRelease} from '../../../__telemetry__/releases.telemetry'
+import {usePerspective} from '../../../hooks/usePerspective'
 import {releasesLocaleNamespace} from '../../../i18n'
 import {type ReleaseDocument} from '../../../index'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
@@ -28,6 +29,7 @@ export const ReleasePublishAllButton = ({
   const router = useRouter()
   const {publishRelease} = useReleaseOperations()
   const {t} = useTranslation(releasesLocaleNamespace)
+  const perspective = usePerspective()
   const telemetry = useTelemetry()
   const [publishBundleStatus, setPublishBundleStatus] = useState<'idle' | 'confirm' | 'publishing'>(
     'idle',
@@ -60,6 +62,12 @@ export const ReleasePublishAllButton = ({
       })
       // TODO: handle a published release on the document list
       router.navigate({})
+      if (
+        perspective.currentGlobalBundle !== 'published' &&
+        perspective.currentGlobalBundle?._id === release._id
+      ) {
+        perspective.setPerspective('drafts')
+      }
     } catch (publishingError) {
       toast.push({
         status: 'error',
@@ -77,7 +85,7 @@ export const ReleasePublishAllButton = ({
     } finally {
       setPublishBundleStatus('idle')
     }
-  }, [release, publishRelease, telemetry, toast, t, router])
+  }, [release, publishRelease, telemetry, toast, t, router, perspective])
 
   const confirmPublishDialog = useMemo(() => {
     if (publishBundleStatus === 'idle') return null


### PR DESCRIPTION
### Description
This restores the changes introduced in https://github.com/sanity-io/sanity/pull/7862 which seems to be lost from the `corel` branch.
Once a released is published (archived), it should be unpinned if it was pinned, to avoid bugs in the rest of the system.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
