### PR TITLE
test(e2e): restore last e2e tests

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Decorators.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Decorators.spec.tsx
@@ -40,6 +40,9 @@ const DEFAULT_DECORATORS = [
 test.describe('Portable Text Input', () => {
   test.describe('Decorators', () => {
     test('Render default decorators with keyboard shortcuts', async ({mount, page}) => {
+      // avoid flakiness to make sure the test has the best chance despite being slow
+      test.slow()
+
       const {
         getModifierKey,
         getFocusedPortableTextEditor,

--- a/packages/sanity/src/structure/components/pane/PaneMenuButtonItem.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneMenuButtonItem.tsx
@@ -108,6 +108,7 @@ function PaneContextMenuItem(props: {disabled?: boolean; node: _PaneMenuItem}) {
         pressed={node.selected}
         text={title}
         tone={node.tone}
+        data-testid={`action-${node.title?.toLocaleLowerCase().replace(' ', '')}`}
       />
     </TooltipOfDisabled>
   )

--- a/packages/sanity/src/structure/components/pane/PaneMenuButtonItem.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneMenuButtonItem.tsx
@@ -6,6 +6,7 @@ import {useIntentLink} from 'sanity/router'
 
 import {MenuGroup, MenuItem, type PopoverProps} from '../../../ui-components'
 import {type Intent} from '../../structureBuilder'
+import {toLowerCaseNoSpaces} from '../../util/toLowerCaseNoSpaces'
 import {type _PaneMenuItem, type _PaneMenuNode} from './types'
 
 const MENU_GROUP_POPOVER_PROPS: PopoverProps = {
@@ -108,7 +109,7 @@ function PaneContextMenuItem(props: {disabled?: boolean; node: _PaneMenuItem}) {
         pressed={node.selected}
         text={title}
         tone={node.tone}
-        data-testid={`action-${node.title?.toLocaleLowerCase().replace(' ', '')}`}
+        data-testid={`action-${toLowerCaseNoSpaces(node.title)}`}
       />
     </TooltipOfDisabled>
   )

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -56,7 +56,8 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
   } = useDocumentPane()
   const documentStore = useDocumentStore()
   const presence = useDocumentPresence(documentId)
-  const {title} = useDocumentTitle()
+  const currentTitle = useDocumentTitle()
+  const {title} = value ?? currentTitle
 
   // The `patchChannel` is an INTERNAL publish/subscribe channel that we use to notify form-builder
   // nodes about both remote and local patches.
@@ -184,7 +185,11 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
             </Box>
           ) : (
             <>
-              <FormHeader documentId={documentId} schemaType={formState.schemaType} title={title} />
+              <FormHeader
+                documentId={documentId}
+                schemaType={formState.schemaType}
+                title={title as string}
+              />
               <FormBuilder
                 __internal_fieldActions={fieldActions}
                 __internal_patchChannel={patchChannel}

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -56,9 +56,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
   } = useDocumentPane()
   const documentStore = useDocumentStore()
   const presence = useDocumentPresence(documentId)
-  const currentTitle = useDocumentTitle()
-  const {title} = value ?? currentTitle
-
+  const {title} = useDocumentTitle()
   // The `patchChannel` is an INTERNAL publish/subscribe channel that we use to notify form-builder
   // nodes about both remote and local patches.
   // - Used by the Portable Text input to modify selections.
@@ -185,11 +183,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
             </Box>
           ) : (
             <>
-              <FormHeader
-                documentId={documentId}
-                schemaType={formState.schemaType}
-                title={title as string}
-              />
+              <FormHeader documentId={documentId} schemaType={formState.schemaType} title={title} />
               <FormBuilder
                 __internal_fieldActions={fieldActions}
                 __internal_patchChannel={patchChannel}

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -58,7 +58,7 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
           <Tooltip disabled={!tooltipContent} content={tooltipContent} placement="top">
             <Stack>
               <Button
-                data-testid={`action-${firstActionState.label}`}
+                data-testid={`action-${firstActionState.label.toLocaleLowerCase().replaceAll(' ', '')}`}
                 disabled={disabled || Boolean(firstActionState.disabled)}
                 icon={firstActionState.icon}
                 // eslint-disable-next-line react/jsx-handler-names

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -11,6 +11,7 @@ import {
 import {Button, Tooltip} from '../../../../ui-components'
 import {RenderActionCollectionState} from '../../../components'
 import {HistoryRestoreAction} from '../../../documentActions'
+import {toLowerCaseNoSpaces} from '../../../util/toLowerCaseNoSpaces'
 import {useDocumentPane} from '../useDocumentPane'
 import {ActionMenuButton} from './ActionMenuButton'
 import {ActionStateDialog} from './ActionStateDialog'
@@ -58,7 +59,7 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
           <Tooltip disabled={!tooltipContent} content={tooltipContent} placement="top">
             <Stack>
               <Button
-                data-testid={`action-${firstActionState.label.toLocaleLowerCase().replaceAll(' ', '')}`}
+                data-testid={`action-${toLowerCaseNoSpaces(firstActionState.label)}`}
                 disabled={disabled || Boolean(firstActionState.disabled)}
                 icon={firstActionState.icon}
                 // eslint-disable-next-line react/jsx-handler-names

--- a/packages/sanity/src/structure/util/toLowerCaseNoSpaces.tsx
+++ b/packages/sanity/src/structure/util/toLowerCaseNoSpaces.tsx
@@ -1,0 +1,10 @@
+/**
+ * Remove the spaces and lower case the string
+ *
+ * @param str - string to remove the spaces and lower case
+ * @returns str with no spaces and lower case
+ */
+export function toLowerCaseNoSpaces(str: string | undefined): string {
+  if (!str) return ''
+  return str.toLocaleLowerCase().replaceAll(' ', '')
+}

--- a/test/e2e/tests/document-actions/delete.spec.ts
+++ b/test/e2e/tests/document-actions/delete.spec.ts
@@ -24,7 +24,7 @@ test(`published documents can be deleted`, async ({page, createDraftDocument}) =
   await page.waitForTimeout(1000)
 
   // Wait for the document to be published.
-  await page.getByTestId('action-Publish').click()
+  await page.getByTestId('action-publish').click()
   expect(await paneFooter.textContent()).toMatch(/published/i)
 
   await page.getByTestId('action-menu-button').click()

--- a/test/e2e/tests/document-actions/discardChanges.spec.ts
+++ b/test/e2e/tests/document-actions/discardChanges.spec.ts
@@ -27,7 +27,7 @@ test(`is possible to discard changes if a changed document has a published versi
 
   const titleInput = page.getByTestId('field-title').getByTestId('string-input')
   const paneFooter = page.getByTestId('pane-footer')
-  const publishButton = page.getByTestId('action-Publish')
+  const publishButton = page.getByTestId('action-publish')
   const actionMenuButton = page.getByTestId('action-menu-button')
   const discardChangesButton = page.getByTestId('action-Discardchanges')
 
@@ -50,7 +50,7 @@ test(`displays the published document state after discarding changes`, async ({
 
   const titleInput = page.getByTestId('field-title').getByTestId('string-input')
   const paneFooter = page.getByTestId('pane-footer')
-  const publishButton = page.getByTestId('action-Publish')
+  const publishButton = page.getByTestId('action-publish')
   const actionMenuButton = page.getByTestId('action-menu-button')
   const discardChangesButton = page.getByTestId('action-Discardchanges')
   const confirmButton = page.getByTestId('confirm-dialog-confirm-button')

--- a/test/e2e/tests/document-actions/discardChanges.spec.ts
+++ b/test/e2e/tests/document-actions/discardChanges.spec.ts
@@ -19,11 +19,7 @@ test(`isn't possible to discard changes if a changed document has no published v
   await expect(discardChangesButton).toBeHidden()
 })
 
-/* 
-  Test skipped due to on going developments around server actions that make them flaky 
-  Re-enable this test when the server actions are stable 
-  */
-test.skip(`is possible to discard changes if a changed document has a published version`, async ({
+test(`is possible to discard changes if a changed document has a published version`, async ({
   page,
   createDraftDocument,
 }) => {
@@ -46,11 +42,7 @@ test.skip(`is possible to discard changes if a changed document has a published 
   await expect(discardChangesButton).toBeEnabled()
 })
 
-/* 
-  Test skipped due to on going developments around server actions that make them flaky 
-  Re-enable this test when the server actions are stable 
-  */
-test.skip(`displays the published document state after discarding changes`, async ({
+test(`displays the published document state after discarding changes`, async ({
   page,
   createDraftDocument,
 }) => {

--- a/test/e2e/tests/document-actions/discardChanges.spec.ts
+++ b/test/e2e/tests/document-actions/discardChanges.spec.ts
@@ -33,8 +33,10 @@ test(`is possible to discard changes if a changed document has a published versi
 
   await titleInput.fill('This is a book')
 
-  publishButton.click()
-  await expect(paneFooter).toContainText('Published just now', {timeout: 50000})
+  // Wait for the document to be published.
+  await page.waitForTimeout(1_000)
+  await publishButton.click()
+  await expect(page.getByTestId('pane-footer-document-status')).toContainText('Published just now')
 
   await titleInput.fill('This is not a book')
 
@@ -57,8 +59,10 @@ test(`displays the published document state after discarding changes`, async ({
 
   await titleInput.fill('This is a book')
 
-  publishButton.click()
-  await expect(paneFooter).toContainText('Published just now', {timeout: 50000})
+  // Wait for the document to be published.
+  await page.waitForTimeout(1_000)
+  await publishButton.click()
+  await expect(page.getByTestId('pane-footer-document-status')).toContainText('Published just now')
 
   // Change the title.
   await titleInput.fill('This is not a book')

--- a/test/e2e/tests/document-actions/discardChanges.spec.ts
+++ b/test/e2e/tests/document-actions/discardChanges.spec.ts
@@ -26,7 +26,6 @@ test(`is possible to discard changes if a changed document has a published versi
   await createDraftDocument('/test/content/book')
 
   const titleInput = page.getByTestId('field-title').getByTestId('string-input')
-  const paneFooter = page.getByTestId('pane-footer')
   const publishButton = page.getByTestId('action-publish')
   const actionMenuButton = page.getByTestId('action-menu-button')
   const discardChangesButton = page.getByTestId('action-Discardchanges')
@@ -51,7 +50,6 @@ test(`displays the published document state after discarding changes`, async ({
   await createDraftDocument('/test/content/book')
 
   const titleInput = page.getByTestId('field-title').getByTestId('string-input')
-  const paneFooter = page.getByTestId('pane-footer')
   const publishButton = page.getByTestId('action-publish')
   const actionMenuButton = page.getByTestId('action-menu-button')
   const discardChangesButton = page.getByTestId('action-Discardchanges')

--- a/test/e2e/tests/document-actions/publish.spec.ts
+++ b/test/e2e/tests/document-actions/publish.spec.ts
@@ -14,7 +14,7 @@ test(`document panel displays correct title for published document`, async ({
   await expect(page.getByTestId('document-panel-document-title')).toHaveText(title)
 
   // Focus the publish button to trigger the tooltip showing the keyboard shortcut
-  page.getByTestId('action-Publish').focus()
+  page.getByTestId('action-publish').focus()
 
   // There is a delay before the tooltip opens, let's explicitly wait for it
   await page.waitForTimeout(300)
@@ -28,7 +28,7 @@ test(`document panel displays correct title for published document`, async ({
   expect(hotkeys).toHaveText(isMac ? 'CtrlOptionP' : 'CtrlAltP')
 
   // Wait for the document to be published.
-  page.getByTestId('action-Publish').click()
+  page.getByTestId('action-publish').click()
   await expect(page.getByText('Published just now')).toBeVisible()
 
   // Ensure the correct title is displayed after publishing.

--- a/test/e2e/tests/document-actions/restore.spec.ts
+++ b/test/e2e/tests/document-actions/restore.spec.ts
@@ -59,7 +59,7 @@ test(`respects overridden restore action`, async ({page, createDraftDocument}) =
 
   const publishKeypress = () => page.locator('body').press('Control+Alt+p')
   const documentStatus = page.getByTestId('pane-footer-document-status')
-  const restoreButton = page.getByTestId('action-Restore')
+  const restoreButton = page.getByTestId('action-reverttorevision')
   const customRestoreButton = page.getByRole('button').getByText('Custom restore')
   const confirmButton = page.getByTestId('confirm-dialog-confirm-button')
   const contextMenuButton = page
@@ -135,7 +135,7 @@ test(`respects removed restore action`, async ({page, createDraftDocument}) => {
 
   const documentStatus = page.getByTestId('pane-footer-document-status')
   const publishButton = page.getByTestId('action-publish')
-  const restoreButton = page.getByTestId('action-restore')
+  const restoreButton = page.getByTestId('action-reverttorevision')
   const contextMenuButton = page
     .getByTestId('document-pane')
     .getByTestId('pane-context-menu-button')

--- a/test/e2e/tests/document-actions/restore.spec.ts
+++ b/test/e2e/tests/document-actions/restore.spec.ts
@@ -1,24 +1,22 @@
 import {expect} from '@playwright/test'
 import {test} from '@sanity/test'
 
-/* 
-  Test skipped due to on going developments around server actions that make them flaky 
-  Re-enable this test when the server actions are stable 
-  */
-test.skip(`documents can be restored to an earlier revision`, async ({
-  page,
-  createDraftDocument,
-}) => {
+test(`documents can be restored to an earlier revision`, async ({page, createDraftDocument}) => {
   const titleA = 'Title A'
   const titleB = 'Title B'
 
   const documentStatus = page.getByTestId('pane-footer-document-status')
-  const publishButton = page.getByTestId('action-Publish')
-  const restoreButton = page.getByTestId('action-Restore')
+  const publishButton = page.getByTestId('action-publish')
+  const restoreButton = page.getByTestId('action-reverttorevision')
   const confirmButton = page.getByTestId('confirm-dialog-confirm-button')
-  const timelineMenuOpenButton = page.getByTestId('timeline-menu-open-button')
+  const contextMenuButton = page
+    .getByTestId('document-pane')
+    .getByTestId('pane-context-menu-button')
+  const historyMenuButton = page.getByTestId('action-history')
+  const historyPane = page.getByLabel('History').getByTestId('scroll-container')
+
   const timelineItemButton = page.getByTestId('timeline-item-button')
-  const previousRevisionButton = timelineItemButton.nth(2)
+  const previousRevisionButton = timelineItemButton.nth(1)
   const title = page.getByTestId('document-panel-document-title')
   const titleInput = page.getByTestId('field-title').getByTestId('string-input')
 
@@ -40,8 +38,11 @@ test.skip(`documents can be restored to an earlier revision`, async ({
   await expect(documentStatus).toContainText('Published just now')
 
   // Pick the previous revision from the revision timeline.
-  await timelineMenuOpenButton.click()
-  await expect(previousRevisionButton).toBeVisible()
+  await contextMenuButton.click()
+  await expect(contextMenuButton).toBeVisible()
+  await historyMenuButton.click()
+  await expect(historyPane).toBeVisible()
+
   await previousRevisionButton.click({force: true})
 
   await expect(titleInput).toHaveValue(titleA)
@@ -52,11 +53,7 @@ test.skip(`documents can be restored to an earlier revision`, async ({
   await expect(title).toHaveText(titleA)
 })
 
-/* 
-  Test skipped due to on going developments around server actions that make them flaky 
-  Re-enable this test when the server actions are stable 
-  */
-test.skip(`respects overridden restore action`, async ({page, createDraftDocument}) => {
+test(`respects overridden restore action`, async ({page, createDraftDocument}) => {
   const titleA = 'Title A'
   const titleB = 'Title B'
 
@@ -65,9 +62,14 @@ test.skip(`respects overridden restore action`, async ({page, createDraftDocumen
   const restoreButton = page.getByTestId('action-Restore')
   const customRestoreButton = page.getByRole('button').getByText('Custom restore')
   const confirmButton = page.getByTestId('confirm-dialog-confirm-button')
-  const timelineMenuOpenButton = page.getByTestId('timeline-menu-open-button')
+  const contextMenuButton = page
+    .getByTestId('document-pane')
+    .getByTestId('pane-context-menu-button')
+  const historyMenuButton = page.getByTestId('action-history')
+  const historyPane = page.getByLabel('History').getByTestId('scroll-container')
+
   const timelineItemButton = page.getByTestId('timeline-item-button')
-  const previousRevisionButton = timelineItemButton.nth(2)
+  const previousRevisionButton = timelineItemButton.nth(1)
   const titleInput = page.getByTestId('field-title').getByTestId('string-input')
 
   await createDraftDocument('/test/content/input-debug;documentActionsTest')
@@ -99,8 +101,10 @@ test.skip(`respects overridden restore action`, async ({page, createDraftDocumen
   await expect(documentStatus).toContainText('Published just now')
 
   // Pick the previous revision from the revision timeline.
-  await timelineMenuOpenButton.click()
-  await expect(previousRevisionButton).toBeVisible()
+  await contextMenuButton.click()
+  await expect(contextMenuButton).toBeVisible()
+  await historyMenuButton.click()
+  await expect(historyPane).toBeVisible()
   await previousRevisionButton.click({force: true})
 
   await expect(titleInput).toHaveValue(titleA)
@@ -125,20 +129,21 @@ test.skip(`respects overridden restore action`, async ({page, createDraftDocumen
   await expect(title).toHaveText(titleA)
 })
 
-/* 
-  Test skipped due to on going developments around server actions that make them flaky 
-  Re-enable this test when the server actions are stable 
-  */
-test.skip(`respects removed restore action`, async ({page, createDraftDocument}) => {
+test(`respects removed restore action`, async ({page, createDraftDocument}) => {
   const titleA = 'Title A'
   const titleB = 'Title B'
 
   const documentStatus = page.getByTestId('pane-footer-document-status')
-  const publishButton = page.getByTestId('action-Publish')
-  const restoreButton = page.getByTestId('action-Restore')
-  const timelineMenuOpenButton = page.getByTestId('timeline-menu-open-button')
+  const publishButton = page.getByTestId('action-publish')
+  const restoreButton = page.getByTestId('action-restore')
+  const contextMenuButton = page
+    .getByTestId('document-pane')
+    .getByTestId('pane-context-menu-button')
+  const historyMenuButton = page.getByTestId('action-history')
+  const historyPane = page.getByLabel('History').getByTestId('scroll-container')
+
   const timelineItemButton = page.getByTestId('timeline-item-button')
-  const previousRevisionButton = timelineItemButton.nth(2)
+  const previousRevisionButton = timelineItemButton.nth(1)
   const title = page.getByTestId('document-panel-document-title')
   const titleInput = page.getByTestId('field-title').getByTestId('string-input')
 
@@ -160,8 +165,10 @@ test.skip(`respects removed restore action`, async ({page, createDraftDocument})
   await expect(documentStatus).toContainText('Published just now')
 
   // Pick the previous revision from the revision timeline.
-  await timelineMenuOpenButton.click()
-  await expect(previousRevisionButton).toBeVisible()
+  await contextMenuButton.click()
+  await expect(contextMenuButton).toBeVisible()
+  await historyMenuButton.click()
+  await expect(historyPane).toBeVisible()
   await previousRevisionButton.click({force: true})
 
   await expect(titleInput).toHaveValue(titleA)
@@ -170,11 +177,7 @@ test.skip(`respects removed restore action`, async ({page, createDraftDocument})
   await expect(restoreButton).not.toBeVisible()
 })
 
-/* 
-  Test skipped due to on going developments around server actions that make them flaky 
-  Re-enable this test when the server actions are stable 
-  */
-test.skip(`user defined restore actions should not appear in any other document action group UI`, async ({
+test(`user defined restore actions should not appear in any other document action group UI`, async ({
   page,
   createDraftDocument,
 }) => {

--- a/test/e2e/tests/document-actions/restore.spec.ts
+++ b/test/e2e/tests/document-actions/restore.spec.ts
@@ -17,7 +17,6 @@ test(`documents can be restored to an earlier revision`, async ({page, createDra
 
   const timelineItemButton = page.getByTestId('timeline-item-button')
   const previousRevisionButton = timelineItemButton.nth(1)
-  const title = page.getByTestId('document-panel-document-title')
   const titleInput = page.getByTestId('field-title').getByTestId('string-input')
 
   await createDraftDocument('/test/content/book')
@@ -30,7 +29,7 @@ test(`documents can be restored to an earlier revision`, async ({page, createDra
 
   // Change the title.
   await titleInput.fill(titleB)
-  await expect(title).toHaveText(titleB)
+  await expect(titleInput).toHaveValue(titleB)
 
   // Wait for the document to be published.
   await page.waitForTimeout(1_000)
@@ -50,10 +49,12 @@ test(`documents can be restored to an earlier revision`, async ({page, createDra
   // Wait for the revision to be restored.
   await restoreButton.click()
   await confirmButton.click()
-  await expect(title).toHaveText(titleA)
+  await expect(titleInput).toHaveValue(titleA)
 })
 
 test(`respects overridden restore action`, async ({page, createDraftDocument}) => {
+  // trying to avoid flaky test based on shorter timeout
+  test.slow()
   const titleA = 'Title A'
   const titleB = 'Title B'
 
@@ -79,7 +80,6 @@ test(`respects overridden restore action`, async ({page, createDraftDocument}) =
     state: 'visible',
   })
 
-  const title = page.getByTestId('document-panel-document-title')
   await titleInput.fill(titleA)
 
   // Wait for the document to be published.
@@ -93,7 +93,7 @@ test(`respects overridden restore action`, async ({page, createDraftDocument}) =
 
   // Change the title.
   await titleInput.fill(titleB)
-  await expect(title).toHaveText(titleB)
+  await expect(titleInput).toHaveValue(titleB)
 
   // Wait for the document to be published.
   await page.waitForTimeout(1_000)
@@ -126,7 +126,7 @@ test(`respects overridden restore action`, async ({page, createDraftDocument}) =
     {selector: '[data-testid="document-panel-document-title"]', testTitle: titleB},
   )
 
-  await expect(title).toHaveText(titleA)
+  await expect(titleInput).toHaveValue(titleA)
 })
 
 test(`respects removed restore action`, async ({page, createDraftDocument}) => {
@@ -144,7 +144,6 @@ test(`respects removed restore action`, async ({page, createDraftDocument}) => {
 
   const timelineItemButton = page.getByTestId('timeline-item-button')
   const previousRevisionButton = timelineItemButton.nth(1)
-  const title = page.getByTestId('document-panel-document-title')
   const titleInput = page.getByTestId('field-title').getByTestId('string-input')
 
   await createDraftDocument('/test/content/input-debug;removeRestoreActionTest')
@@ -157,7 +156,7 @@ test(`respects removed restore action`, async ({page, createDraftDocument}) => {
 
   // Change the title.
   await titleInput.fill(titleB)
-  await expect(title).toHaveText(titleB)
+  await expect(titleInput).toHaveValue(titleB)
 
   // Wait for the document to be published.
   await page.waitForTimeout(1_000)

--- a/test/e2e/tests/document-actions/unpublish.spec.ts
+++ b/test/e2e/tests/document-actions/unpublish.spec.ts
@@ -6,7 +6,7 @@ test(`should be able to unpublish a published document`, async ({page, createDra
   const titleA = 'Title A'
 
   const documentStatus = page.getByTestId('pane-footer-document-status')
-  const publishButton = page.getByTestId('action-Publish')
+  const publishButton = page.getByTestId('action-publish')
   const contextFooterMenu = page.getByTestId('action-menu-button')
   const unpublishButton = page.getByTestId('action-Unpublish')
   const titleInput = page.getByTestId('field-title').getByTestId('string-input')

--- a/test/e2e/tests/inputs/date.spec.ts
+++ b/test/e2e/tests/inputs/date.spec.ts
@@ -19,7 +19,7 @@ test(`date input shows validation on selecting date from datepicker`, async ({
     page.getByTestId('field-requiredDate').getByTestId('input-validation-icon-error'),
   ).toBeVisible()
 
-  await expect(page.getByTestId('action-Publish')).toBeDisabled()
+  await expect(page.getByTestId('action-publish')).toBeDisabled()
 })
 
 test.skip(`date input shows validation on entering date in the text field`, async ({
@@ -36,7 +36,7 @@ test.skip(`date input shows validation on entering date in the text field`, asyn
     page.getByTestId('field-requiredDate').getByTestId('input-validation-icon-error'),
   ).toBeVisible()
 
-  await expect(page.getByTestId('action-Publish')).toBeDisabled()
+  await expect(page.getByTestId('action-publish')).toBeDisabled()
 })
 
 test(`publish button is disabled when invalid date is entered in the field`, async ({
@@ -51,7 +51,7 @@ test(`publish button is disabled when invalid date is entered in the field`, asy
   // TODO: Remove this after fixing the blur test
   await page.getByTestId('field-requiredDate').getByTestId('date-input').blur()
 
-  await expect(page.getByTestId('action-Publish')).toBeDisabled()
+  await expect(page.getByTestId('action-publish')).toBeDisabled()
 })
 
 test(`date input shows validation on entering date in the textfield and onBlur`, async ({
@@ -69,5 +69,5 @@ test(`date input shows validation on entering date in the textfield and onBlur`,
     page.getByTestId('field-requiredDate').getByTestId('input-validation-icon-error'),
   ).toBeVisible()
 
-  await expect(page.getByTestId('action-Publish')).toBeDisabled()
+  await expect(page.getByTestId('action-publish')).toBeDisabled()
 })

--- a/test/e2e/tests/inputs/datetime.spec.ts
+++ b/test/e2e/tests/inputs/datetime.spec.ts
@@ -51,7 +51,7 @@ test(`publish button is disabled when invalid date is entered in the field`, asy
   // TODO: Remove this after fixing the blur test
   await page.getByTestId('field-requiredDatetime').getByTestId('date-input').blur()
 
-  await expect(page.getByTestId('action-Publish')).toBeDisabled()
+  await expect(page.getByTestId('action-publish')).toBeDisabled()
 })
 
 test(`datetime inputs shows validation on entering date in the textfield and onBlur`, async ({

--- a/test/e2e/tests/inputs/reference.spec.ts
+++ b/test/e2e/tests/inputs/reference.spec.ts
@@ -32,7 +32,7 @@ withDefaultClient((context) => {
     // at the moment e.g. `page.getByTestId('field-author')`.
     const referenceInput = page.getByTestId('reference-input')
     const paneFooter = page.getByTestId('pane-footer')
-    const publishButton = page.getByTestId('action-Publish')
+    const publishButton = page.getByTestId('action-publish')
     const authorListbox = page.locator('#author-listbox')
 
     // Open the Author reference input.

--- a/test/e2e/tests/inputs/text.spec.ts
+++ b/test/e2e/tests/inputs/text.spec.ts
@@ -79,7 +79,7 @@ test.describe('inputs: text', () => {
 
     const titleInput = page.getByTestId('field-title').getByTestId('string-input')
     const paneFooter = page.getByTestId('pane-footer-document-status')
-    const publishButton = page.getByTestId('action-Publish')
+    const publishButton = page.getByTestId('action-publish')
 
     // wait for form to be attached
     await expect(page.getByTestId('document-panel-scroller')).toBeAttached()

--- a/test/e2e/tests/tree-editing/TreeEditingBasicInteraction.spec.ts
+++ b/test/e2e/tests/tree-editing/TreeEditingBasicInteraction.spec.ts
@@ -55,7 +55,7 @@ test.skip('basic - main document action', () => {
   })
 
   test(`actions - blocked main document action when modal is open`, async ({page}) => {
-    await expect(page.getByTestId('action-Publish')).toBeDisabled()
+    await expect(page.getByTestId('action-publish')).toBeDisabled()
   })
 
   test(`actions - main document action when modal is closed will be enabled`, async ({
@@ -68,6 +68,6 @@ test.skip('basic - main document action', () => {
     await page.getByTestId('tree-editing-done').click()
 
     await expect(page.getByTestId('tree-editing-dialog')).not.toBeVisible()
-    await expect(page.getByTestId('action-Publish')).not.toBeDisabled()
+    await expect(page.getByTestId('action-publish')).not.toBeDisabled()
   })
 })


### PR DESCRIPTION
### Description

- We had some e2e tests that were disabled due to being unreliable while work with the Actions was on going. As things seem more stable, this PR brings back those tests.
- Some updates had to be done to data-test ids since a lot of them were breaking (not correctly formatted, hence why the large number of files)

### What to review

Review tests and make sure they make sense, I have tried reducing the flakiness but they are e2e tests so 🫠 any pointers would be appreciated.

### Testing

This PR is just tests 

### Notes for release

N/A