### PR TITLE
test(e2e): add unpublish e2e test

### DIFF
--- a/test/e2e/tests/document-actions/unpublish.spec.ts
+++ b/test/e2e/tests/document-actions/unpublish.spec.ts
@@ -1,0 +1,38 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+test(`should be able to unpublish a published document`, async ({page, createDraftDocument}) => {
+  /** publish initial action */
+  const titleA = 'Title A'
+
+  const documentStatus = page.getByTestId('pane-footer-document-status')
+  const publishButton = page.getByTestId('action-Publish')
+  const contextFooterMenu = page.getByTestId('action-menu-button')
+  const unpublishButton = page.getByTestId('action-Unpublish')
+  const titleInput = page.getByTestId('field-title').getByTestId('string-input')
+
+  const unpublishModal = page
+    .getByTestId('document-panel-portal')
+    .locator('div')
+    .filter({hasText: 'Unpublish document?Are you'})
+    .nth(1)
+
+  await createDraftDocument('/test/content/book')
+  await titleInput.fill(titleA)
+
+  // Wait for the document to be published.
+  await page.waitForTimeout(1_000)
+  await publishButton.click()
+  await expect(documentStatus).toContainText('Published just now')
+
+  await contextFooterMenu.click()
+  await expect(unpublishButton).toBeVisible()
+  await unpublishButton.click()
+
+  await page.waitForTimeout(1_000)
+
+  await expect(unpublishModal).toBeVisible()
+  await page.getByTestId('confirm-button').click()
+
+  await expect(documentStatus).toContainText('Not published')
+})


### PR DESCRIPTION
### Description

- As part of making sure we have more e2e tests for actions. The unpublish one was specifically pointed out.

### What to review

Overall health of test

### Testing

This PR is just a e2e test

### Notes for release

N/A
