### PR TITLE
fix(vision): add a warning about unsupported perspective when pasting

### DIFF
--- a/packages/@sanity/vision/src/SUPPORTED_PERSPECTIVES.ts
+++ b/packages/@sanity/vision/src/SUPPORTED_PERSPECTIVES.ts
@@ -1,0 +1,15 @@
+import {type ClientPerspective} from '@sanity/client'
+
+export type SupportedPerspective = 'raw' | 'previewDrafts' | 'published' | 'drafts'
+
+export const SUPPORTED_PERSPECTIVES = [
+  'raw',
+  'previewDrafts',
+  'published',
+  'drafts',
+] satisfies ClientPerspective[]
+export const DEFAULT_PERSPECTIVE = SUPPORTED_PERSPECTIVES[0]
+
+export function isSupportedPerspective(p: string): p is SupportedPerspective {
+  return SUPPORTED_PERSPECTIVES.includes(p as SupportedPerspective)
+}

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -1,11 +1,6 @@
 /* eslint-disable complexity */
 import SplitPane from '@rexxars/react-split-pane'
-import {
-  type ClientPerspective,
-  type ListenEvent,
-  type MutationEvent,
-  type SanityClient,
-} from '@sanity/client'
+import {type ListenEvent, type MutationEvent, type SanityClient} from '@sanity/client'
 import {CopyIcon, ErrorOutlineIcon, PlayIcon, StopIcon} from '@sanity/icons'
 import {
   Box,
@@ -28,7 +23,12 @@ import {type TFunction, Translate} from 'sanity'
 
 import {API_VERSIONS, DEFAULT_API_VERSION} from '../apiVersions'
 import {VisionCodeMirror} from '../codemirror/VisionCodeMirror'
-import {DEFAULT_PERSPECTIVE, isPerspective, PERSPECTIVES} from '../perspectives'
+import {
+  DEFAULT_PERSPECTIVE,
+  isSupportedPerspective,
+  SUPPORTED_PERSPECTIVES,
+  type SupportedPerspective,
+} from '../SUPPORTED_PERSPECTIVES'
 import {type VisionProps} from '../types'
 import {encodeQueryString} from '../util/encodeQueryString'
 import {getCsvBlobUrl, getJsonBlobUrl} from '../util/getBlobUrl'
@@ -116,7 +116,7 @@ interface VisionGuiState {
   dataset: string
   apiVersion: string
   customApiVersion: string | false
-  perspective: ClientPerspective
+  perspective: SupportedPerspective
 
   // Selected options validation state
   isValidApiVersion: boolean
@@ -187,7 +187,7 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
       apiVersion = DEFAULT_API_VERSION
     }
 
-    if (!PERSPECTIVES.includes(perspective)) {
+    if (!SUPPORTED_PERSPECTIVES.includes(perspective)) {
       perspective = DEFAULT_PERSPECTIVE
     }
 
@@ -336,9 +336,18 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
       }
     }
 
-    const perspective = PERSPECTIVES.includes(parts.options.perspective as ClientPerspective)
-      ? (parts.options.perspective as ClientPerspective)
+    const perspective = isSupportedPerspective(parts.options.perspective)
+      ? parts.options.perspective
       : undefined
+
+    if (!isSupportedPerspective(parts.options.perspective)) {
+      this.props.toast.push({
+        closable: true,
+        id: 'vision-paste-unsupported-perspective',
+        status: 'warning',
+        title: 'Perspective in pasted url is currently not supported. Falling back to "raw"',
+      })
+    }
 
     evt.preventDefault()
     this.setState(
@@ -447,7 +456,7 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
 
   handleChangePerspective(evt: ChangeEvent<HTMLSelectElement>) {
     const perspective = evt.target.value
-    if (!isPerspective(perspective)) {
+    if (!isSupportedPerspective(perspective)) {
       return
     }
 
@@ -759,7 +768,7 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
                 </Card>
 
                 <Select value={perspective} onChange={this.handleChangePerspective}>
-                  {PERSPECTIVES.map((p) => (
+                  {SUPPORTED_PERSPECTIVES.map((p) => (
                     <option key={p}>{p}</option>
                   ))}
                 </Select>

--- a/packages/@sanity/vision/src/perspectives.ts
+++ b/packages/@sanity/vision/src/perspectives.ts
@@ -1,8 +1,0 @@
-import {type ClientPerspective} from '@sanity/client'
-
-export const PERSPECTIVES = ['raw', 'previewDrafts', 'published'] satisfies ClientPerspective[]
-export const DEFAULT_PERSPECTIVE = PERSPECTIVES[0]
-
-export function isPerspective(p: string): p is ClientPerspective {
-  return PERSPECTIVES.includes(p as ClientPerspective)
-}


### PR DESCRIPTION
### Description

https://github.com/sanity-io/sanity/pull/7935 broke (internal) vision types because of the changes introduced in https://github.com/sanity-io/client/pull/934

This is a quickfix that shows a warning if you try to paste an url with a perspective param not included in the allowlist defined here. This should fix the issue at hand, and be good enough for now until we land support for releases/perspective layering in vision

### What to review
Does the change look ok?

### Testing

The tests should be sufficient here.

### Notes for release
n/a - this warning would likey not appear to anyone for a while