### PR TITLE
refactor(sanity): update translations to use releases namespace

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1151,13 +1151,6 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.action.copy-to': 'Copy version to',
   /** Action message for creating new releases */
   'release.action.create-new': 'New release',
-  /** Action message for when document is already in release  */
-  'release.action.discard-version': 'Discard version',
-  /** Description for toast when version discarding failed */
-  'release.action.discard-version.failure': 'Failed to discard version',
-  /** Description for toast when version deletion is successfully discarded */
-  'release.action.discard-version.success':
-    '<strong>{{title}}</strong> version was successfully discarded',
   /** Action message for when a new release is created off an existing version, draft or published document */
   'release.action.new-release': 'New Release',
   /** Action message for when the view release is pressed */

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
@@ -8,6 +8,7 @@ import {MenuGroup} from '../../../../../ui-components/menuGroup/MenuGroup'
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {isPublishedId} from '../../../../util/draftUtils'
+import {releasesLocaleNamespace} from '../../../i18n'
 import {type ReleaseDocument} from '../../../store/types'
 import {isReleaseScheduledOrScheduling} from '../../../util/util'
 import {VersionContextMenuItem} from './VersionContextMenuItem'
@@ -42,7 +43,7 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: {
     disabled,
     locked,
   } = props
-  const {t} = useTranslation()
+  const {t} = useTranslation(releasesLocaleNamespace)
   const isPublished = isPublishedId(documentId) && !isVersion
   const optionsReleaseList = releases.map((release) => ({
     value: release,
@@ -99,7 +100,7 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: {
             <MenuItem
               icon={TrashIcon}
               onClick={onDiscard}
-              text={t('release.action.discard-version')}
+              text={t('action.discard-version')}
               disabled={disabled || locked}
             />
           </>

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -3,6 +3,7 @@ import * as sanity from 'sanity'
 import {describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {releasesUsEnglishLocaleBundle} from '../../../../i18n'
 import {VersionContextMenu} from '../VersionContextMenu'
 
 vi.mock('sanity/router', () => ({
@@ -55,7 +56,9 @@ describe('VersionContextMenu', () => {
   }
 
   it('renders the menu items correctly', async () => {
-    const wrapper = await createTestProvider()
+    const wrapper = await createTestProvider({
+      resources: [releasesUsEnglishLocaleBundle],
+    })
 
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
 
@@ -69,7 +72,9 @@ describe('VersionContextMenu', () => {
   })
 
   it('calls onCreateRelease when "New release" is clicked', async () => {
-    const wrapper = await createTestProvider()
+    const wrapper = await createTestProvider({
+      resources: [releasesUsEnglishLocaleBundle],
+    })
 
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
 
@@ -81,7 +86,9 @@ describe('VersionContextMenu', () => {
   })
 
   it('hides discard version on published chip', async () => {
-    const wrapper = await createTestProvider()
+    const wrapper = await createTestProvider({
+      resources: [releasesUsEnglishLocaleBundle],
+    })
     const publishedProps = {
       ...defaultProps,
       documentId: 'testid',
@@ -97,7 +104,9 @@ describe('VersionContextMenu', () => {
   })
 
   it('calls onDiscard when "Discard version" is clicked', async () => {
-    const wrapper = await createTestProvider()
+    const wrapper = await createTestProvider({
+      resources: [releasesUsEnglishLocaleBundle],
+    })
 
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
 
@@ -108,7 +117,9 @@ describe('VersionContextMenu', () => {
   })
 
   it('calls onCreateRelease when a "new release" is clicked', async () => {
-    const wrapper = await createTestProvider()
+    const wrapper = await createTestProvider({
+      resources: [releasesUsEnglishLocaleBundle],
+    })
 
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
 
@@ -120,7 +131,9 @@ describe('VersionContextMenu', () => {
   })
 
   it('calls onCreateVersion when a release is clicked and sets the perspective to the release', async () => {
-    const wrapper = await createTestProvider()
+    const wrapper = await createTestProvider({
+      resources: [releasesUsEnglishLocaleBundle],
+    })
 
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
 

--- a/packages/sanity/src/core/releases/hooks/__tests__/useVersionOperations.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useVersionOperations.test.tsx
@@ -2,6 +2,7 @@ import {act, renderHook} from '@testing-library/react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {releasesUsEnglishLocaleBundle} from '../../i18n'
 import {useReleaseOperationsMockReturn} from '../../store/__tests__/__mocks/useReleaseOperations.mock'
 import {useVersionOperations} from '../useVersionOperations'
 import {usePerspectiveMockReturn} from './__mocks__/usePerspective.mock'
@@ -20,7 +21,9 @@ describe('useVersionOperations', () => {
   })
 
   it('should create a version successfully', async () => {
-    const wrapper = await createTestProvider()
+    const wrapper = await createTestProvider({
+      resources: [releasesUsEnglishLocaleBundle],
+    })
     const {result} = renderHook(() => useVersionOperations(), {wrapper})
 
     await act(async () => {
@@ -36,7 +39,9 @@ describe('useVersionOperations', () => {
   })
 
   it('should discard a version successfully', async () => {
-    const wrapper = await createTestProvider()
+    const wrapper = await createTestProvider({
+      resources: [releasesUsEnglishLocaleBundle],
+    })
     const {result} = renderHook(() => useVersionOperations(), {wrapper})
 
     await act(async () => {

--- a/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
+++ b/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
@@ -4,6 +4,7 @@ import {useToast} from '@sanity/ui'
 import {Translate, useTranslation} from '../../i18n'
 import {getDocumentVariantType} from '../../util/getDocumentVariantType'
 import {AddedVersion} from '../__telemetry__/releases.telemetry'
+import {releasesLocaleNamespace} from '../i18n'
 import {useReleaseOperations} from '../store/useReleaseOperations'
 import {usePerspective} from './usePerspective'
 
@@ -23,7 +24,7 @@ export function useVersionOperations(): VersionOperationsValue {
 
   const {setPerspectiveFromReleaseId} = usePerspective()
   const toast = useToast()
-  const {t} = useTranslation()
+  const {t} = useTranslation(releasesLocaleNamespace)
 
   const handleCreateVersion = async (
     releaseId: string,
@@ -57,7 +58,7 @@ export function useVersionOperations(): VersionOperationsValue {
         description: (
           <Translate
             t={t}
-            i18nKey={'release.action.discard-version.success'}
+            i18nKey={'action.discard-version.success'}
             values={{title: document.title as string}}
           />
         ),
@@ -66,7 +67,7 @@ export function useVersionOperations(): VersionOperationsValue {
       toast.push({
         closable: true,
         status: 'error',
-        title: t('release.action.discard-version.failure'),
+        title: t('action.discard-version.failure'),
         description: err.message,
       })
     }

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -20,6 +20,12 @@ const releasesLocaleStrings = {
   'action.delete.failure': 'Failed to delete release',
   /** Description for toast when release is successfully deleted */
   'action.delete.success': '<strong>{{title}}</strong> release was successfully deleted',
+  /** Action message for when document is already in release  */
+  'action.discard-version': 'Discard version',
+  /** Description for toast when version discarding failed */
+  'action.discard-version.failure': 'Failed to discard version',
+  /** Description for toast when version deletion is successfully discarded */
+  'action.discard-version.success': '<strong>{{title}}</strong> version was successfully discarded',
   /** Action text for editing a release */
   'action.edit': 'Edit release',
   /** Action text for opening a release */

--- a/packages/sanity/src/core/releases/tool/components/ReleasePublishAllButton/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleasePublishAllButton/ReleasePublishAllButton.tsx
@@ -8,6 +8,7 @@ import {Button, Dialog} from '../../../../../ui-components'
 import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
 import {Translate, useTranslation} from '../../../../i18n'
 import {PublishedRelease} from '../../../__telemetry__/releases.telemetry'
+import {usePerspective} from '../../../hooks/usePerspective'
 import {releasesLocaleNamespace} from '../../../i18n'
 import {type ReleaseDocument} from '../../../index'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
@@ -28,6 +29,7 @@ export const ReleasePublishAllButton = ({
   const router = useRouter()
   const {publishRelease} = useReleaseOperations()
   const {t} = useTranslation(releasesLocaleNamespace)
+  const perspective = usePerspective()
   const telemetry = useTelemetry()
   const [publishBundleStatus, setPublishBundleStatus] = useState<'idle' | 'confirm' | 'publishing'>(
     'idle',
@@ -60,6 +62,12 @@ export const ReleasePublishAllButton = ({
       })
       // TODO: handle a published release on the document list
       router.navigate({})
+      if (
+        perspective.currentGlobalBundle !== 'published' &&
+        perspective.currentGlobalBundle?._id === release._id
+      ) {
+        perspective.setPerspective('drafts')
+      }
     } catch (publishingError) {
       toast.push({
         status: 'error',
@@ -77,7 +85,7 @@ export const ReleasePublishAllButton = ({
     } finally {
       setPublishBundleStatus('idle')
     }
-  }, [release, publishRelease, telemetry, toast, t, router])
+  }, [release, publishRelease, telemetry, toast, t, router, perspective])
 
   const confirmPublishDialog = useMemo(() => {
     if (publishBundleStatus === 'idle') return null

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -43,14 +43,11 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
   )
 
   const renderRowActions: ({datum}: {datum: BundleDocumentRow | unknown}) => JSX.Element =
-    useCallback(
-      ({datum}) => {
-        const document = datum as BundleDocumentRow
+    useCallback(({datum}) => {
+      const document = datum as BundleDocumentRow
 
-        return <DocumentActions document={document} releaseTitle={release.metadata.title} />
-      },
-      [release.metadata.title],
-    )
+      return <DocumentActions document={document} />
+    }, [])
 
   const documentTableColumnDefs = useMemo(
     () => getDocumentTableColumnDefs(release._id, t),

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -6,18 +6,13 @@ import {MenuButton, MenuItem} from '../../../../../ui-components'
 import {ContextMenuButton} from '../../../../components/contextMenuButton'
 import {useTranslation} from '../../../../i18n'
 import {DiscardVersionDialog} from '../../../components'
+import {releasesLocaleNamespace} from '../../../i18n'
 import {type BundleDocumentRow} from '../ReleaseSummary'
 
 export const DocumentActions = memo(
-  function DocumentActions({
-    document,
-    releaseTitle,
-  }: {
-    document: BundleDocumentRow
-    releaseTitle: string
-  }) {
+  function DocumentActions({document}: {document: BundleDocumentRow}) {
     const [showDiscardDialog, setShowDiscardDialog] = useState(false)
-    const {t: coreT} = useTranslation()
+    const {t} = useTranslation(releasesLocaleNamespace)
 
     return (
       <>
@@ -28,7 +23,7 @@ export const DocumentActions = memo(
             menu={
               <Menu>
                 <MenuItem
-                  text={coreT('release.action.discard-version')}
+                  text={t('action.discard-version')}
                   icon={CloseIcon}
                   onClick={() => setShowDiscardDialog(true)}
                 />
@@ -46,6 +41,5 @@ export const DocumentActions = memo(
       </>
     )
   },
-  (prev, next) =>
-    prev.document.memoKey === next.document.memoKey && prev.releaseTitle === next.releaseTitle,
+  (prev, next) => prev.document.memoKey === next.document.memoKey,
 )


### PR DESCRIPTION

### Description

Noticed some translations could be moved to the releases namespace after components were moved to the releases folder
- moved discard action adjacent translations to the right place
- updated tests to match
- removed unused prop from document actions

### What to review

when discarding is there no broken translations?
do tests pass?

