### PR TITLE
fix(sanity): fix issue where you could click the published chip even when the published doc didn't exist

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -114,7 +114,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
             )}
           </Text>
         }
-        disabled={editState?.liveEdit ? false : !editState?.published}
+        disabled={editState?.liveEdit || !editState?.published}
         onClick={handleBundleChange('published')}
         selected={
           /** the publish is selected when:

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveList.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveList.test.tsx
@@ -78,6 +78,7 @@ describe('DocumentPerspectiveList', () => {
       toggleExcludedPerspective: vi.fn(),
       setPerspectiveFromReleaseDocumentId: vi.fn(),
       setPerspectiveFromReleaseId: vi.fn(),
+      selectedReleaseId: undefined,
     })
 
     mockUseDocumentPane.mockReturnValue({


### PR DESCRIPTION
### Description

What it says on the tin :) 
- fix issue where you could click the published chip even when the published doc didn't exist

See video for a before:
https://github.com/user-attachments/assets/3acf5453-e9b2-4be8-89b3-e4703e127285


### What to review

Does it make sense? Did I miss something?

### Testing

Tests should be enough
