### PR TITLE
test(e2e): update unpublish test to match update

### DIFF
--- a/test/e2e/tests/document-actions/unpublish.spec.ts
+++ b/test/e2e/tests/document-actions/unpublish.spec.ts
@@ -34,5 +34,5 @@ test(`should be able to unpublish a published document`, async ({page, createDra
   await expect(unpublishModal).toBeVisible()
   await page.getByTestId('confirm-button').click()
 
-  await expect(documentStatus).toContainText('Not published')
+  await expect(documentStatus).toContainText('')
 })


### PR DESCRIPTION
### Description

- Updated the test, the message has changed since the document pane and writing in documents has changed. It not longer shows a message once the unpublish goes through (in the footer)


### Testing

wow, can you believe a e2e test was failing NOT because it was flaky but because it captured a regression??
