### PR TITLE
fix(structure): live edit documents need to be editable in published …

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -604,10 +604,8 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     // there is a risk of data loss, so we disable editing in this case
     const isLiveEditAndDraftPerspective = liveEdit && !selectedPerspectiveName
     const isLiveEditAndPublishedPerspective = liveEdit && selectedPerspectiveName === 'published'
-
     const isSystemPerspectiveApplied =
-      isLiveEditAndPublishedPerspective ||
-      (selectedPerspectiveName ? selectedPerspectiveName : true)
+      isLiveEditAndPublishedPerspective || (selectedPerspectiveName ? existsInBundle : true)
 
     const isReleaseLocked =
       typeof selectedPerspective === 'object' && 'state' in selectedPerspective
@@ -615,7 +613,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
         : false
 
     return (
-      (selectedPerspectiveName && !existsInBundle) ||
       !isSystemPerspectiveApplied ||
       !ready ||
       revTime !== null ||

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -114,7 +114,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
             )}
           </Text>
         }
-        disabled={editState?.liveEdit || !editState?.published}
+        disabled={editState?.liveEdit ? false : !editState?.published}
         onClick={handleBundleChange('published')}
         selected={
           /** the publish is selected when:


### PR DESCRIPTION
### Description
Fixes a regression in which live edit documents were not editable.
To edit a live document you must have selected the `published` perspective.

| **Draft** (disabled)  | **Published** (enabled)|
|--------|--------|
|<img width="597" alt="Screenshot 2024-12-05 at 12 05 33" src="https://github.com/user-attachments/assets/bcd827ca-ab2c-47ee-bfd7-71f4c8d33ae1"> | <img width="610" alt="Screenshot 2024-12-05 at 12 05 38" src="https://github.com/user-attachments/assets/5a416617-3c24-41fb-bafc-251950102d14">|

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
