### PR TITLE
feat(cli): generate read token conditionally for remote template

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -1127,7 +1127,6 @@ export default async function initSanity(
           repoInfo: remoteTemplateInfo,
           bearerToken: cliFlags['template-token'],
           variables: bootstrapVariables,
-          isCI,
         },
         context,
       )

--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -420,6 +420,22 @@ export async function isNextJsTemplate(root: string): Promise<boolean> {
   }
 }
 
+export async function checkNeedsReadToken(root: string): Promise<boolean> {
+  try {
+    const templatePath = await Promise.any(
+      ENV_TEMPLATE_FILES.map(async (file) => {
+        await access(join(root, file))
+        return file
+      }),
+    )
+
+    const templateContent = await readFile(join(root, templatePath), 'utf8')
+    return templateContent.includes(ENV_VAR.READ_TOKEN)
+  } catch {
+    return false
+  }
+}
+
 export async function applyEnvVariables(
   root: string,
   envData: EnvData,

--- a/packages/@sanity/cli/test/test-template/.env.local.example
+++ b/packages/@sanity/cli/test/test-template/.env.local.example
@@ -1,4 +1,3 @@
 # https://github.com/vercel/next.js/tree/canary/examples/cms-sanity#using-the-sanity-cli
 NEXT_PUBLIC_SANITY_PROJECT_ID=
 NEXT_PUBLIC_SANITY_DATASET=
-SANITY_API_READ_TOKEN=


### PR DESCRIPTION
### Description

Generating read token conditionally for remote templates.
If a .env.example does not include `SANITY_API_READ_TOKEN` we don't generate one. 

I've also removed SANITY_API_READ_TOKEN from the test-template to avoid generating a new token per test running.

### What to review

- Are token still being generated if SANITY_API_READ_TOKEN is present?
- Are we skipping the step of generating read tokens if SANITY_API_READ_TOKEN is not present? 
- 
### Testing

N/A

### Notes for release

N/A
