### PR TITLE
feat(releases): unschedule release from release menu button menu

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -23,7 +23,7 @@ const releasesLocaleStrings = {
   /** Action text for scheduling a release */
   'action.schedule': 'Schedule for publishing...',
   /** Action text for scheduling a release */
-  'action.unschedule': 'Unschedule',
+  'action.unschedule': 'Unschedule for publishing',
   /** Action text for publishing all documents in a release (and the release itself) */
   'action.publish-all-documents': 'Publish all documents',
   /** Text for the review changes button in release tool */

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -22,7 +22,7 @@ const releasesLocaleStrings = {
   'action.open': 'Open',
   /** Action text for scheduling a release */
   'action.schedule': 'Schedule for publishing...',
-  /** Action text for scheduling a release */
+  /** Action text for unscheduling a release */
   'action.unschedule': 'Unschedule for publishing',
   /** Action text for publishing all documents in a release (and the release itself) */
   'action.publish-all-documents': 'Publish all documents',

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardFooter.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardFooter.tsx
@@ -17,7 +17,7 @@ export function ReleaseDashboardFooter(props: {
   const {documents, release} = props
 
   const releaseActionButton = useMemo(() => {
-    if (release.state === 'scheduled' || release.state === 'scheduling') {
+    if (release.metadata.releaseType === 'scheduled') {
       return isReleaseScheduledOrScheduling(release) ? (
         <ReleaseUnscheduleButton
           release={release}
@@ -57,7 +57,7 @@ export function ReleaseDashboardFooter(props: {
 
         <Flex flex="none" gap={1}>
           {releaseActionButton}
-          <ReleaseMenuButton release={release} />
+          <ReleaseMenuButton release={release} ignoreCTA />
         </Flex>
       </Flex>
     </Card>


### PR DESCRIPTION
### Description
<img width="1191" alt="Screenshot 2024-12-05 at 12 27 25" src="https://github.com/user-attachments/assets/b37445e0-f43b-4a1a-b675-93eadb74d09c">

For scheduled or scheduling releases, the release menu button now gives an option to unschedule from the releases overview list
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Added a new test block for `ReleaseMenuButton`
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
