### PR TITLE
fix(deps): bump `@sanity/presentation` to `1.19.5-release.3`

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -173,7 +173,7 @@
     "@sanity/logos": "^2.1.4",
     "@sanity/migrate": "3.65.1",
     "@sanity/mutator": "3.65.1",
-    "@sanity/presentation": "1.19.5-release.2",
+    "@sanity/presentation": "1.19.5-release.3",
     "@sanity/schema": "3.65.1",
     "@sanity/telemetry": "^0.7.7",
     "@sanity/types": "3.65.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1505,8 +1505,8 @@ importers:
         specifier: 3.65.1
         version: link:../@sanity/mutator
       '@sanity/presentation':
-        specifier: 1.19.5-release.2
-        version: 1.19.5-release.2(@sanity/color@3.0.6)(debug@4.3.7)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        specifier: 1.19.5-release.3
+        version: 1.19.5-release.3(@sanity/color@3.0.6)(debug@4.3.7)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/schema':
         specifier: 3.65.1
         version: link:../@sanity/schema
@@ -4450,8 +4450,8 @@ packages:
     resolution: {integrity: sha512-HV668xtHdm7qz9V5FbqRi8/2l1GPJr7puh05KQeGMSRlRAkKwTeG6Y5zbZ0d/6zUTQf2SB1As725JdCfCJ3bdg==}
     engines: {node: '>=18'}
 
-  '@sanity/comlink@2.0.1-release.2':
-    resolution: {integrity: sha512-c7DyuFhlPyklymz9LmSaq5ZwJGYEdRSytRuP0K+UcugAqb/IGBy8dgjeYGP0O4+2JXFCZ8AfBatzTYvs7/aC2A==}
+  '@sanity/comlink@2.0.1-release.3':
+    resolution: {integrity: sha512-JPJMQJElw/jpsk6VcUUcsrKw9lt+oYMpQmtATZqhVQ70G2JGpcWTZX5+xe0U1Lb6f77WEpZbO7lkjdj3JxmdXg==}
     engines: {node: '>=18'}
 
   '@sanity/core-loader@1.7.18':
@@ -4589,8 +4589,8 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  '@sanity/presentation@1.19.5-release.2':
-    resolution: {integrity: sha512-ATAR6pj40GAumT/53CGhFAvOOETnnA2Qox93r3JivIJTq0VB/TVBD98JFCgXHF/glK4QS2zv44f32QAJQX07+A==}
+  '@sanity/presentation@1.19.5-release.3':
+    resolution: {integrity: sha512-8GqTL4yxG1y0gqeAONXZbrysT+3ueMTFtk/Jhonmd9HDbrSAIQENOpKn+HdYew6uqLjv6WgMHo/cbCsFY3u2Aw==}
     engines: {node: '>=16.14'}
 
   '@sanity/prettier-config@1.0.3':
@@ -4604,8 +4604,8 @@ packages:
     peerDependencies:
       '@sanity/client': ^6.23.0
 
-  '@sanity/preview-url-secret@2.0.6-release.2':
-    resolution: {integrity: sha512-9koHNZualLiY6ZNgOGPJqTNaL21cR7wSbpMsAp59vTjuZwYhGPInyj2VWLynLiv8z4egUjhXpLhyl9O95OEsbg==}
+  '@sanity/preview-url-secret@2.0.6-release.3':
+    resolution: {integrity: sha512-GK/39ScYhvLKGR8AwhdlFsQnm3DZ7pM1CF5a2StPd7/WGUy5F7en26JuRLYGgsoUEWmjQWzb4ZaLE1rwUyHuSg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@sanity/client': ^6.24.1
@@ -14352,7 +14352,7 @@ snapshots:
       uuid: 10.0.0
       xstate: 5.19.0
 
-  '@sanity/comlink@2.0.1-release.2':
+  '@sanity/comlink@2.0.1-release.3':
     dependencies:
       rxjs: 7.8.1
       uuid: 10.0.0
@@ -14693,13 +14693,13 @@ snapshots:
       - debug
       - supports-color
 
-  '@sanity/presentation@1.19.5-release.2(@sanity/color@3.0.6)(debug@4.3.7)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@sanity/presentation@1.19.5-release.3(@sanity/color@3.0.6)(debug@4.3.7)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@sanity/client': 6.24.1(debug@4.3.7)
-      '@sanity/comlink': 2.0.1-release.2
+      '@sanity/comlink': 2.0.1-release.3
       '@sanity/icons': 3.5.0(react@18.3.1)
       '@sanity/logos': 2.1.13(@sanity/color@3.0.6)(react@18.3.1)
-      '@sanity/preview-url-secret': 2.0.6-release.2(@sanity/client@6.24.1(debug@4.3.7))
+      '@sanity/preview-url-secret': 2.0.6-release.3(@sanity/client@6.24.1(debug@4.3.7))
       '@sanity/ui': 2.9.0(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/uuid': 3.0.2
       fast-deep-equal: 3.1.3
@@ -14730,7 +14730,7 @@ snapshots:
       '@sanity/client': 6.24.1(debug@4.3.7)
       '@sanity/uuid': 3.0.2
 
-  '@sanity/preview-url-secret@2.0.6-release.2(@sanity/client@6.24.1(debug@4.3.7))':
+  '@sanity/preview-url-secret@2.0.6-release.3(@sanity/client@6.24.1(debug@4.3.7))':
     dependencies:
       '@sanity/client': 6.24.1(debug@4.3.7)
       '@sanity/uuid': 3.0.2


### PR DESCRIPTION
Fixes a minor issue where the preview iframe initially loads with `perspective=previewDrafts` regardless of `usePerspective().selectedPerspectiveName`, causing a "flash of draft content" before the `usePerspective().perspectiveStack` state is applied to the preview.