### PR TITLE
feat(cli): token command

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -62,6 +62,7 @@
     "@sanity/telemetry": "^0.7.7",
     "@sanity/util": "3.65.1",
     "chalk": "^4.1.2",
+    "cli-table3": "^0.6.5",
     "debug": "^4.3.4",
     "decompress": "^4.2.0",
     "esbuild": "0.21.5",

--- a/packages/@sanity/cli/src/actions/token/createToken.ts
+++ b/packages/@sanity/cli/src/actions/token/createToken.ts
@@ -1,0 +1,51 @@
+import {randomBytes} from 'node:crypto'
+
+import {debug} from '../../debug'
+import {type CliCommandArguments, type CliCommandContext} from '../../types'
+import {API_VERSION, fetchRoles, selectProject} from './tokenUtils'
+
+export async function createToken(
+  args: CliCommandArguments,
+  context: CliCommandContext,
+): Promise<void> {
+  const {output, cliConfig, prompt, apiClient} = context
+  const {print} = output
+  const client = apiClient({requireUser: true, requireProject: false})
+
+  const projectId = cliConfig?.api?.projectId || (await selectProject(client, prompt))
+  const roles = await fetchRoles(client, projectId)
+
+  debug('Filtering roles that apply to robots')
+  const robotRoles = roles.filter((role) => role.appliesToRobots)
+  const roleChoices = robotRoles.map((role) => ({
+    value: role.name,
+    name: `${role.title} (${role.name})`,
+  }))
+
+  debug('Prompting for token role')
+  const roleName = await prompt.single({
+    message: 'Choose access level for the token:',
+    type: 'list',
+    choices: roleChoices,
+    default: 'viewer',
+  })
+
+  debug('Prompting for token label')
+  const selectedRole = robotRoles.find((role) => role.name === roleName)
+  const label = await prompt.single({
+    message: 'Give this token a descriptive name:',
+    type: 'input',
+    default: `${selectedRole?.title} token (${randomBytes(2).toString('hex')})`,
+  })
+
+  debug('Creating token')
+  const {key} = await client.config({apiVersion: API_VERSION}).request<{key: string}>({
+    uri: `/projects/${projectId}/tokens`,
+    method: 'POST',
+    body: {label, roleName},
+  })
+
+  print("New token created. Make sure to copy it now - you won't see it again:")
+  print('')
+  print(key)
+}

--- a/packages/@sanity/cli/src/actions/token/deleteToken.ts
+++ b/packages/@sanity/cli/src/actions/token/deleteToken.ts
@@ -1,0 +1,56 @@
+import {debug} from '../../debug'
+import {type CliCommandArguments, type CliCommandContext} from '../../types'
+import {fetchTokens, selectProject} from './tokenUtils'
+
+export async function deleteToken(
+  args: CliCommandArguments,
+  context: CliCommandContext,
+): Promise<void> {
+  const {output, cliConfig, prompt, apiClient} = context
+  const {print} = output
+  const client = apiClient({requireUser: true, requireProject: false})
+
+  const projectId = cliConfig?.api?.projectId || (await selectProject(client, prompt))
+  let tokenId = args.argsWithoutOptions[0]
+
+  if (!tokenId) {
+    const tokens = await fetchTokens(client, projectId)
+
+    if (tokens.length === 0) {
+      print('No tokens found in project')
+      return
+    }
+
+    tokens.sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+
+    debug('No token ID provided, showing list of choices')
+    const tokenChoices = tokens.map((token) => ({
+      value: token.id,
+      name: `${token.label} (created ${new Date(token.createdAt).toLocaleString()})`,
+    }))
+
+    tokenId = await prompt.single({
+      message: 'Select token to delete',
+      type: 'list',
+      choices: tokenChoices,
+    })
+  }
+
+  const confirm = await prompt.single({
+    message: 'Are you sure you want to delete this token?',
+    type: 'confirm',
+  })
+
+  if (!confirm) {
+    print('Token deletion cancelled')
+    return
+  }
+
+  debug('Deleting token:', tokenId)
+  await client.config({apiVersion: 'v2021-06-07'}).request({
+    uri: `/projects/${projectId}/tokens/${tokenId}`,
+    method: 'DELETE',
+  })
+
+  print('Token deleted successfully')
+}

--- a/packages/@sanity/cli/src/actions/token/listTokens.ts
+++ b/packages/@sanity/cli/src/actions/token/listTokens.ts
@@ -1,0 +1,39 @@
+import Table from 'cli-table3'
+
+import {type CliCommandArguments, type CliCommandContext} from '../../types'
+import {fetchTokens, selectProject} from './tokenUtils'
+
+export async function listTokens(
+  args: CliCommandArguments,
+  context: CliCommandContext,
+): Promise<void> {
+  const {output, cliConfig, prompt, apiClient} = context
+  const {print} = output
+  const client = apiClient({requireUser: true, requireProject: false})
+
+  const projectId = cliConfig?.api?.projectId || (await selectProject(client, prompt))
+  const tokens = await fetchTokens(client, projectId)
+
+  if (tokens.length === 0) {
+    print('No tokens found in project')
+    return
+  }
+
+  const sortedTokens = tokens.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  )
+
+  const table = new Table({
+    head: ['ID', 'Label', 'Roles', 'Created'],
+    colWidths: [16, 32, 18, 14],
+    style: {head: []}, // Remove the default header style
+  })
+
+  for (const token of sortedTokens) {
+    const roles = token.roles.map((role) => role.title).join(', ')
+    const date = new Date(token.createdAt).toLocaleDateString()
+    table.push([token.id, token.label, roles, date])
+  }
+
+  print(table.toString())
+}

--- a/packages/@sanity/cli/src/actions/token/tokenUtils.ts
+++ b/packages/@sanity/cli/src/actions/token/tokenUtils.ts
@@ -1,0 +1,63 @@
+import {type SanityClient} from '@sanity/client'
+
+import {debug} from '../../debug'
+import {type CliPrompter} from '../../types'
+
+export const API_VERSION = 'v2021-06-07'
+
+export type Token = {
+  id: string
+  label: string
+  projectUserId: string
+  createdAt: string
+  roles: Array<{
+    name: string
+    title: string
+  }>
+}
+
+export type Role = {
+  name: string
+  title: string
+  description: string
+  isCustom: boolean
+  projectId: string
+  appliesToUsers: boolean
+  appliesToRobots: boolean
+}
+
+export async function selectProject(client: SanityClient, prompt: CliPrompter): Promise<string> {
+  debug('No project ID in config, fetching projects list')
+  const projects = await client.projects
+    .list({includeMembers: false})
+    .then((allProjects) => allProjects.sort((a, b) => b.createdAt.localeCompare(a.createdAt)))
+
+  debug(`User has ${projects.length} project(s) already, showing list of choices`)
+
+  const projectChoices = projects.map((project) => ({
+    value: project.id,
+    name: `${project.displayName} [${project.id}]`,
+  }))
+
+  return prompt.single({
+    message: 'Select project to use',
+    type: 'list',
+    choices: projectChoices,
+  })
+}
+
+export async function fetchTokens(client: SanityClient, projectId: string): Promise<Token[]> {
+  debug('Fetching tokens for project:', projectId)
+  return client.config({apiVersion: API_VERSION}).request<Token[]>({
+    uri: `/projects/${projectId}/tokens`,
+    method: 'GET',
+  })
+}
+
+export async function fetchRoles(client: SanityClient, projectId: string): Promise<Role[]> {
+  debug('Fetching roles for project:', projectId)
+  return client.config({apiVersion: API_VERSION}).request<Role[]>({
+    uri: `/projects/${projectId}/roles`,
+    method: 'GET',
+  })
+}

--- a/packages/@sanity/cli/src/commands/index.ts
+++ b/packages/@sanity/cli/src/commands/index.ts
@@ -15,6 +15,10 @@ import disableTelemetryCommand from './telemetry/disableTelemetryCommand'
 import enableTelemetryCommand from './telemetry/enableTelemetryCommand'
 import telemetryGroup from './telemetry/telemetryGroup'
 import telemetryStatusCommand from './telemetry/telemetryStatusCommand'
+import tokenCreateCommand from './token/tokenCreateCommand'
+import tokenDeleteCommand from './token/tokenDeleteCommand'
+import tokenGroup from './token/tokenGroup'
+import tokenListCommand from './token/tokenListCommand'
 import generateTypegenCommand from './typegen/generateTypesCommand'
 import typegenGroup from './typegen/typegenGroup'
 import upgradeCommand from './upgrade/upgradeCommand'
@@ -41,4 +45,8 @@ export const baseCommands: (CliCommandDefinition | CliCommandGroupDefinition)[] 
   telemetryStatusCommand,
   generateTypegenCommand,
   typegenGroup,
+  tokenGroup,
+  tokenCreateCommand,
+  tokenDeleteCommand,
+  tokenListCommand,
 ]

--- a/packages/@sanity/cli/src/commands/token/tokenCreateCommand.ts
+++ b/packages/@sanity/cli/src/commands/token/tokenCreateCommand.ts
@@ -1,0 +1,13 @@
+import {createToken} from '../../actions/token/createToken'
+import {type CliCommandDefinition} from '../../types'
+
+const tokenCommand: CliCommandDefinition = {
+  name: 'create',
+  group: 'token',
+  signature: '',
+  helpText: 'Create a new API token for project',
+  description: 'Create a new API token for project',
+  action: createToken,
+}
+
+export default tokenCommand

--- a/packages/@sanity/cli/src/commands/token/tokenDeleteCommand.ts
+++ b/packages/@sanity/cli/src/commands/token/tokenDeleteCommand.ts
@@ -1,0 +1,13 @@
+import {deleteToken} from '../../actions/token/deleteToken'
+import {type CliCommandDefinition} from '../../types'
+
+const tokenDeleteCommand: CliCommandDefinition = {
+  name: 'delete',
+  group: 'token',
+  signature: '[id]',
+  helpText: 'Delete an API token from project',
+  description: 'Delete an API token from project',
+  action: deleteToken,
+}
+
+export default tokenDeleteCommand

--- a/packages/@sanity/cli/src/commands/token/tokenGroup.ts
+++ b/packages/@sanity/cli/src/commands/token/tokenGroup.ts
@@ -1,0 +1,10 @@
+import {type CliCommandGroupDefinition} from '../../types'
+
+const tokenGroup: CliCommandGroupDefinition = {
+  name: 'token',
+  signature: '[COMMAND]',
+  isGroupRoot: true,
+  description: 'Manages project API tokens',
+}
+
+export default tokenGroup

--- a/packages/@sanity/cli/src/commands/token/tokenListCommand.ts
+++ b/packages/@sanity/cli/src/commands/token/tokenListCommand.ts
@@ -1,0 +1,24 @@
+import {listTokens} from '../../actions/token/listTokens'
+import {type CliCommandDefinition} from '../../types'
+
+type Token = {
+  id: string
+  label: string
+  projectUserId: string
+  createdAt: string
+  roles: Array<{
+    name: string
+    title: string
+  }>
+}
+
+const tokenListCommand: CliCommandDefinition = {
+  name: 'list',
+  group: 'token',
+  signature: '',
+  helpText: 'List all API tokens in project',
+  description: 'List all API tokens in project',
+  action: listTokens,
+}
+
+export default tokenListCommand

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,7 +512,7 @@ importers:
         version: link:../../packages/@sanity/migrate
       '@sanity/preview-url-secret':
         specifier: ^2.0.0
-        version: 2.0.5(@sanity/client@6.24.1(debug@4.3.7))
+        version: 2.0.5(@sanity/client@6.24.1)
       '@sanity/react-loader':
         specifier: ^1.8.3
         version: 1.10.27(react@18.3.1)
@@ -787,7 +787,7 @@ importers:
     dependencies:
       '@babel/traverse':
         specifier: ^7.23.5
-        version: 7.25.9
+        version: 7.25.9(supports-color@5.5.0)
       '@sanity/client':
         specifier: ^6.24.1
         version: 6.24.1(debug@4.3.7)
@@ -803,9 +803,12 @@ importers:
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
+      cli-table3:
+        specifier: ^0.6.5
+        version: 0.6.5
       debug:
         specifier: ^4.3.4
-        version: 4.3.7(supports-color@9.4.0)
+        version: 4.3.7(supports-color@5.5.0)
       decompress:
         specifier: ^4.2.0
         version: 4.2.1
@@ -1028,13 +1031,13 @@ importers:
         version: 7.25.9(@babel/core@7.26.0)
       '@babel/traverse':
         specifier: ^7.23.5
-        version: 7.25.9
+        version: 7.25.9(supports-color@5.5.0)
       '@babel/types':
         specifier: ^7.23.9
         version: 7.26.0
       debug:
         specifier: ^4.3.4
-        version: 4.3.7(supports-color@9.4.0)
+        version: 4.3.7(supports-color@5.5.0)
       globby:
         specifier: ^10.0.0
         version: 10.0.2
@@ -1114,7 +1117,7 @@ importers:
         version: 2.0.1
       debug:
         specifier: ^4.3.4
-        version: 4.3.7(supports-color@9.4.0)
+        version: 4.3.7(supports-color@5.5.0)
       fast-fifo:
         specifier: ^1.3.2
         version: 1.3.2
@@ -1157,7 +1160,7 @@ importers:
         version: 3.0.2
       debug:
         specifier: ^4.3.4
-        version: 4.3.7(supports-color@9.4.0)
+        version: 4.3.7(supports-color@5.5.0)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1594,7 +1597,7 @@ importers:
         version: 2.30.0
       debug:
         specifier: ^4.3.4
-        version: 4.3.7(supports-color@9.4.0)
+        version: 4.3.7(supports-color@5.5.0)
       esbuild:
         specifier: 0.21.5
         version: 0.21.5
@@ -11788,10 +11791,10 @@ snapshots:
       '@babel/helpers': 7.26.0
       '@babel/parser': 7.26.2
       '@babel/template': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       '@babel/types': 7.26.0
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -11828,7 +11831,7 @@ snapshots:
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.25.9':
     dependencies:
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
@@ -11849,7 +11852,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.25.9
       '@babel/helper-replace-supers': 7.25.9(@babel/core@7.26.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -11866,7 +11869,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -11874,14 +11877,7 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.25.9':
     dependencies:
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-imports@7.25.9':
-    dependencies:
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
@@ -11896,9 +11892,9 @@ snapshots:
   '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
       '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11913,7 +11909,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-wrap-function': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11922,20 +11918,20 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-member-expression-to-functions': 7.25.9
       '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-simple-access@7.25.9':
     dependencies:
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
     dependencies:
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
@@ -11949,7 +11945,7 @@ snapshots:
   '@babel/helper-wrap-function@7.25.9':
     dependencies:
       '@babel/template': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
@@ -11967,7 +11963,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11994,7 +11990,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12038,14 +12034,14 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.26.0)
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-async-to-generator@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.26.0)
     transitivePeerDependencies:
@@ -12084,7 +12080,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-replace-supers': 7.25.9(@babel/core@7.26.0)
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -12148,7 +12144,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12195,7 +12191,7 @@ snapshots:
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12309,7 +12305,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.0)
       '@babel/types': 7.26.0
@@ -12525,18 +12521,6 @@ snapshots:
       '@babel/parser': 7.26.2
       '@babel/types': 7.26.0
 
-  '@babel/traverse@7.25.9':
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.2
-      '@babel/parser': 7.26.2
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.0
-      debug: 4.3.7(supports-color@9.4.0)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/traverse@7.25.9(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -12735,7 +12719,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.12.0':
     dependencies:
-      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
       '@babel/runtime': 7.26.0
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -13108,7 +13092,7 @@ snapshots:
   '@eslint/config-array@0.18.0':
     dependencies:
       '@eslint/object-schema': 2.1.4
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -13116,7 +13100,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -13130,7 +13114,7 @@ snapshots:
   '@eslint/eslintrc@3.2.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -13219,7 +13203,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -14030,7 +14014,7 @@ snapshots:
       '@sanity/schema': link:packages/@sanity/schema
       '@sanity/types': link:packages/@sanity/types
       '@xstate/react': 5.0.0(@types/react@18.3.12)(react@18.3.1)(xstate@5.19.0)
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       get-random-values-esm: 1.0.2
       lodash: 4.17.21
       lodash.startcase: 4.4.0
@@ -14107,7 +14091,7 @@ snapshots:
   '@rollup/plugin-babel@6.0.4(@babel/core@7.26.0)(@types/babel__core@7.20.5)(rollup@4.28.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
       '@rollup/pluginutils': 5.1.0(rollup@4.28.0)
     optionalDependencies:
       '@types/babel__core': 7.20.5
@@ -14415,7 +14399,7 @@ snapshots:
       '@sanity/client': 6.24.1(debug@4.3.7)
       '@sanity/util': 3.37.2(debug@4.3.7)
       archiver: 7.0.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       get-it: 8.6.5(debug@4.3.7)
       lodash: 4.17.21
       mississippi: 4.0.0
@@ -14466,7 +14450,7 @@ snapshots:
       '@sanity/generate-help-url': 3.0.0
       '@sanity/mutator': 3.37.2
       '@sanity/uuid': 3.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       file-url: 2.0.2
       get-it: 8.6.5(debug@4.3.7)
       get-uri: 2.0.4
@@ -14571,7 +14555,7 @@ snapshots:
     dependencies:
       '@sanity/diff-match-patch': 3.1.1
       '@sanity/uuid': 3.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -14686,7 +14670,7 @@ snapshots:
       '@sanity/comlink': 2.0.0
       '@sanity/icons': 3.5.0(react@18.3.1)
       '@sanity/logos': 2.1.13(@sanity/color@3.0.6)(react@18.3.1)
-      '@sanity/preview-url-secret': 2.0.5(@sanity/client@6.24.1(debug@4.3.7))
+      '@sanity/preview-url-secret': 2.0.5(@sanity/client@6.24.1)
       '@sanity/ui': 2.9.1(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/uuid': 3.0.2
       '@types/lodash.isequal': 4.5.8
@@ -14713,7 +14697,7 @@ snapshots:
       prettier: 3.4.1
       prettier-plugin-packagejson: 2.5.3(prettier@3.4.1)
 
-  '@sanity/preview-url-secret@2.0.5(@sanity/client@6.24.1(debug@4.3.7))':
+  '@sanity/preview-url-secret@2.0.5(@sanity/client@6.24.1)':
     dependencies:
       '@sanity/client': 6.24.1(debug@4.3.7)
       '@sanity/uuid': 3.0.2
@@ -15068,7 +15052,7 @@ snapshots:
     dependencies:
       '@sanity/comlink': 2.0.0
       '@sanity/mutate': 0.11.0-canary.3(xstate@5.19.0)
-      '@sanity/preview-url-secret': 2.0.5(@sanity/client@6.24.1(debug@4.3.7))
+      '@sanity/preview-url-secret': 2.0.5(@sanity/client@6.24.1)
       '@vercel/stega': 0.1.2
       get-random-values-esm: 1.0.2
       react: 18.3.1
@@ -15167,7 +15151,7 @@ snapshots:
       '@swc-node/sourcemap-support': 0.5.1
       '@swc/core': 1.7.14(@swc/helpers@0.5.13)
       colorette: 2.0.20
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       oxc-resolver: 1.10.2
       pirates: 4.0.6
       tslib: 2.8.1
@@ -15655,7 +15639,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.2)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.7.2
@@ -15668,7 +15652,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.2)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 9.10.0
     optionalDependencies:
       typescript: 5.7.2
@@ -15684,7 +15668,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.2)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.7.2)
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.7.2)
     optionalDependencies:
@@ -15696,7 +15680,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.2)
       '@typescript-eslint/utils': 7.18.0(eslint@9.10.0)(typescript@5.7.2)
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 9.10.0
       ts-api-utils: 1.3.0(typescript@5.7.2)
     optionalDependencies:
@@ -15710,7 +15694,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -15863,7 +15847,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
@@ -16010,13 +15994,13 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17222,12 +17206,12 @@ snapshots:
   depcheck@1.4.7:
     dependencies:
       '@babel/parser': 7.26.2
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.25.9(supports-color@5.5.0)
       '@vue/compiler-sfc': 3.4.37
       callsite: 1.0.0
       camelcase: 6.3.0
       cosmiconfig: 7.1.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       deps-regex: 0.2.0
       findup-sync: 5.0.0
       ignore: 5.3.2
@@ -17529,21 +17513,21 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.19.12):
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       esbuild: 0.19.12
     transitivePeerDependencies:
       - supports-color
 
   esbuild-register@3.6.0(esbuild@0.21.5):
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       esbuild: 0.21.5
     transitivePeerDependencies:
       - supports-color
 
   esbuild-register@3.6.0(esbuild@0.24.0):
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       esbuild: 0.24.0
     transitivePeerDependencies:
       - supports-color
@@ -17693,7 +17677,7 @@ snapshots:
   eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.7.2))(eslint-plugin-import@2.30.0)(eslint@8.57.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
       eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
@@ -17969,7 +17953,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -18013,7 +17997,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.2.0
       eslint-visitor-keys: 4.2.0
@@ -18401,7 +18385,7 @@ snapshots:
 
   follow-redirects@1.15.6(debug@4.3.7):
     optionalDependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
 
   for-each@0.3.3:
     dependencies:
@@ -18833,7 +18817,7 @@ snapshots:
 
   groq-js@1.14.1:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18981,28 +18965,28 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.5:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -19423,7 +19407,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -21685,7 +21669,7 @@ snapshots:
   rollup-plugin-esbuild@6.1.1(esbuild@0.24.0)(rollup@4.28.0):
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.28.0)
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       es-module-lexer: 1.5.4
       esbuild: 0.24.0
       get-tsconfig: 4.8.0
@@ -22135,7 +22119,7 @@ snapshots:
   socks-proxy-agent@8.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -22766,7 +22750,7 @@ snapshots:
   tuf-js@2.2.1:
     dependencies:
       '@tufjs/models': 2.0.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       make-fetch-happen: 13.0.1
     transitivePeerDependencies:
       - supports-color
@@ -23060,7 +23044,7 @@ snapshots:
   vite-node@2.1.1(@types/node@18.19.44)(terser@5.32.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       pathe: 1.1.2
       vite: 5.4.11(@types/node@18.19.44)(terser@5.32.0)
     transitivePeerDependencies:
@@ -23077,7 +23061,7 @@ snapshots:
   vite-node@2.1.1(@types/node@22.10.0)(terser@5.32.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       pathe: 1.1.2
       vite: 5.4.11(@types/node@22.10.0)(terser@5.32.0)
     transitivePeerDependencies:
@@ -23093,7 +23077,7 @@ snapshots:
 
   vite-tsconfig-paths@4.3.2(typescript@5.7.2)(vite@4.5.5(@types/node@22.10.0)(terser@5.32.0)):
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.1.1(typescript@5.7.2)
     optionalDependencies:
@@ -23153,7 +23137,7 @@ snapshots:
       '@vitest/spy': 2.1.1
       '@vitest/utils': 2.1.1
       chai: 5.1.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       magic-string: 0.30.11
       pathe: 1.1.2
       std-env: 3.7.0
@@ -23188,7 +23172,7 @@ snapshots:
       '@vitest/spy': 2.1.1
       '@vitest/utils': 2.1.1
       chai: 5.1.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       magic-string: 0.30.11
       pathe: 1.1.2
       std-env: 3.7.0


### PR DESCRIPTION
### Description

Introducing a `token` command to the CLI. This allows you to list, create and delete Sanity API tokens for a given project.

```shell
Commands:
   create  Create a new API token for project
   delete  Delete an API token from project
   list    List all API tokens in project
```

### What to review

Are there any edge cases I am not taking into account?

### Testing

Not sure what the best practice is for testing here.

### Notes for release

N/A
