### PR TITLE
fix(i18n): allow weeks to start on Saturday

### DIFF
--- a/packages/sanity/src/core/i18n/types.ts
+++ b/packages/sanity/src/core/i18n/types.ts
@@ -164,9 +164,10 @@ export interface Locale {
  */
 export interface LocaleWeekInfo {
   /**
-   * An integer indicating the first day of the week for the locale. Can be either 1 (Monday) or 7 (Sunday).
+   * An integer indicating the first day of the week for the locale.
+   * Can be either 1 (Monday), 6 (Saturday) or 7 (Sunday).
    */
-  firstDay: 1 | 7
+  firstDay: 1 | 6 | 7
 
   /**
    * An array of integers indicating the weekend days for the locale, where 1 is Monday and 7 is Sunday.

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/CalendarMonth.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/CalendarMonth.tsx
@@ -11,6 +11,9 @@ const WEEK_DAY_NAME_KEYS = {
   // Monday is start of the week
   1: SHORT_WEEK_DAY_KEYS,
 
+  // Saturday is start of week
+  6: [...SHORT_WEEK_DAY_KEYS.slice(5), ...SHORT_WEEK_DAY_KEYS.slice(0, 5)],
+
   // Sunday is start of the week
   7: [SHORT_WEEK_DAY_KEYS[6], ...SHORT_WEEK_DAY_KEYS.slice(0, 6)],
 }

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/contexts/CalendarContext.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/contexts/CalendarContext.ts
@@ -7,7 +7,7 @@ export interface CalendarContextValue {
 
   /**
    * An integer indicating the first day of the week.
-   * Can be either 1 (Monday) or 7 (Sunday).
+   * Can be either 1 (Monday), 6 (Saturday) or 7 (Sunday).
    */
-  firstWeekDay: 1 | 7
+  firstWeekDay: 1 | 6 | 7
 }

--- a/packages/sanity/src/ui-components/inputs/DateInputs/calendar/CalendarMonth.tsx
+++ b/packages/sanity/src/ui-components/inputs/DateInputs/calendar/CalendarMonth.tsx
@@ -27,10 +27,12 @@ export function CalendarMonth(props: CalendarMonthProps) {
     weekInfo: {firstDay: weekStartDay},
   } = useCurrentLocale()
 
-  const weekDayNames =
-    weekStartDay === 1
-      ? props.weekDayNames
-      : [props.weekDayNames[6], ...props.weekDayNames.slice(0, 6)]
+  let weekDayNames: Array<string> = props.weekDayNames
+  if (weekStartDay === 7) {
+    weekDayNames = [props.weekDayNames[6], ...props.weekDayNames.slice(0, 6)]
+  } else if (weekStartDay === 6) {
+    weekDayNames = [...props.weekDayNames.slice(5), ...props.weekDayNames.slice(0, 5)]
+  }
 
   return (
     <Box aria-hidden={props.hidden || false} data-ui="CalendarMonth">


### PR DESCRIPTION
### Description

Certain locales start their week on Saturdays - Nepal, Iran and certain other middle eastern cultures. This PR allows the studio to reflect this.

### What to review

Week day extractions seem correct

### Testing

No added tests, and we currently don't have any language packs to exercise this with.

### Notes for release

None
