### PR TITLE
fix(core): guard against missing process variable

### DIFF
--- a/packages/sanity/src/core/studio/StudioTelemetryProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioTelemetryProvider.tsx
@@ -27,7 +27,9 @@ const WELL_KNOWN_NAMES = [
   'test',
 ]
 
-const DEBUG_TELEMETRY = process.env.SANITY_STUDIO_DEBUG_TELEMETRY
+const DEBUG_TELEMETRY = !!(
+  typeof process !== 'undefined' && process.env?.SANITY_STUDIO_DEBUG_TELEMETRY
+)
 
 /* eslint-disable no-console */
 export const debugLoggingStore: CreateBatchedStoreOptions = {


### PR DESCRIPTION
### Description

#7958 seems to have caused an issue (see #7964) in environments that doesn't define `process` globally.

Fixes #7964

### Notes for release
 - Fixes an issue causing the Studio to crash in an environment that doesn't provide a global `process` variable