### PR TITLE
fix(sanity): issue with the publish chip disable + update tests

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -98,6 +98,21 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
     [setPerspective],
   )
 
+  const isPublishedChipDisabled = useMemo(() => {
+    if (editState?.liveEdit) {
+      if (!editState?.published) {
+        return true
+      }
+
+      return false
+    }
+
+    if (!editState?.published) {
+      return true
+    }
+    return false
+  }, [editState?.liveEdit, editState?.published])
+
   return (
     <>
       <VersionChip
@@ -114,7 +129,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
             )}
           </Text>
         }
-        disabled={editState?.liveEdit || !editState?.published}
+        disabled={isPublishedChipDisabled}
         onClick={handleBundleChange('published')}
         selected={
           /** the publish is selected when:

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveList.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveList.test.tsx
@@ -99,26 +99,40 @@ describe('DocumentPerspectiveList', () => {
   })
 
   describe('disabled chips', () => {
-    it('should disable the "Published" chip when there is no published document', async () => {
-      mockUseDocumentPane.mockReturnValue({
-        documentVersions: [mockCurrent],
-        editState: {
-          id: 'document-id',
-          type: 'document-type',
-          transactionSyncLock: {enabled: false},
-          draft: null,
-          published: null, // make sure that there is no published doc in the mock
-          liveEdit: false,
-          ready: true,
-          version: {
-            _id: 'versions.release.document-id',
-            _type: 'document-type',
-            _createdAt: '2023-01-01T00:00:00Z',
-            _updatedAt: '2023-01-01T00:00:00Z',
-            _rev: '1',
-          },
-          liveEditSchemaType: false,
+    const mockUsePane = {
+      documentVersions: [mockCurrent],
+      editState: {
+        id: 'document-id',
+        type: 'document-type',
+        transactionSyncLock: {enabled: false},
+        draft: null,
+        published: null, // make sure that there is no published doc in the mock
+        liveEdit: false,
+        ready: true,
+        version: {
+          _id: 'versions.release.document-id',
+          _type: 'document-type',
+          _createdAt: '2023-01-01T00:00:00Z',
+          _updatedAt: '2023-01-01T00:00:00Z',
+          _rev: '1',
         },
+        liveEditSchemaType: false,
+      },
+    }
+
+    it('should disable the "Published" chip when there is no published document and not live edit', async () => {
+      mockUseDocumentPane.mockReturnValue(mockUsePane)
+
+      const wrapper = await createTestProvider()
+      render(<DocumentPerspectiveList />, {wrapper})
+
+      expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled()
+    })
+
+    it('should disable the "Published" chip when there is no published document and IS live edit', async () => {
+      mockUseDocumentPane.mockReturnValue({
+        ...mockUsePane,
+        editState: {...mockUsePane.editState, liveEdit: true},
       })
 
       const wrapper = await createTestProvider()
@@ -126,5 +140,35 @@ describe('DocumentPerspectiveList', () => {
 
       expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled()
     })
+
+    it('should enable the "Published" chip when the document is "liveEdit"', async () => {
+      mockUseDocumentPane.mockReturnValue({
+        ...mockUsePane,
+        editState: {
+          ...mockUsePane.editState,
+          published: {
+            _id: 'published-document-id',
+            _type: 'document-type',
+            _createdAt: '2023-01-01T00:00:00Z',
+            _updatedAt: '2023-01-01T00:00:00Z',
+            _rev: '1',
+          },
+        },
+      })
+
+      const wrapper = await createTestProvider()
+      render(<DocumentPerspectiveList />, {wrapper})
+
+      expect(screen.getByRole('button', {name: 'Published'})).toBeEnabled()
+    })
+  })
+
+  describe('selected chips', () => {
+    it.todo('the draft is selected when the document displayed is a draft')
+    it.todo('the draft is selected when the perspective is null')
+    it.todo(
+      'the draft is selected when when the document is not published and the displayed version is draft,',
+    )
+    it.todo('when there is no draft (new document)')
   })
 })


### PR DESCRIPTION
### Description

Fix issue where the publish disable wasn't working as expected.
I have added tests to match all the use cases that I could think of for when it is disabled :)

### What to review

Does it make sense? could I have done it in a different better way?

### Testing

The tests should be good enough but just to be sure go to the preview and try with documents **that don't** have published documents (from an existing version seeing if the chip is enabled when you know there is no published doc) and when there is.
