### PR TITLE
fix(deps): bump `@sanity/presentation` to `1.19.8-release.0`

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -173,7 +173,7 @@
     "@sanity/logos": "^2.1.4",
     "@sanity/migrate": "3.65.1",
     "@sanity/mutator": "3.65.1",
-    "@sanity/presentation": "1.19.5-release.3",
+    "@sanity/presentation": "1.19.8-release.0",
     "@sanity/schema": "3.65.1",
     "@sanity/telemetry": "^0.7.7",
     "@sanity/types": "3.65.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1505,8 +1505,8 @@ importers:
         specifier: 3.65.1
         version: link:../@sanity/mutator
       '@sanity/presentation':
-        specifier: 1.19.5-release.3
-        version: 1.19.5-release.3(@sanity/color@3.0.6)(debug@4.3.7)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        specifier: 1.19.8-release.0
+        version: 1.19.8-release.0(@sanity/color@3.0.6)(debug@4.3.7)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/schema':
         specifier: 3.65.1
         version: link:../@sanity/schema
@@ -4450,8 +4450,8 @@ packages:
     resolution: {integrity: sha512-HV668xtHdm7qz9V5FbqRi8/2l1GPJr7puh05KQeGMSRlRAkKwTeG6Y5zbZ0d/6zUTQf2SB1As725JdCfCJ3bdg==}
     engines: {node: '>=18'}
 
-  '@sanity/comlink@2.0.1-release.3':
-    resolution: {integrity: sha512-JPJMQJElw/jpsk6VcUUcsrKw9lt+oYMpQmtATZqhVQ70G2JGpcWTZX5+xe0U1Lb6f77WEpZbO7lkjdj3JxmdXg==}
+  '@sanity/comlink@2.0.2-release.0':
+    resolution: {integrity: sha512-3/2qvb0j24JFf8F75BgxdUPpFW7xiV/VubTu0/fhBqUhP5IimS61AJ5nBBX3shxR1DX/PWmx249olcn39eHNQw==}
     engines: {node: '>=18'}
 
   '@sanity/core-loader@1.7.18':
@@ -4589,8 +4589,8 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  '@sanity/presentation@1.19.5-release.3':
-    resolution: {integrity: sha512-8GqTL4yxG1y0gqeAONXZbrysT+3ueMTFtk/Jhonmd9HDbrSAIQENOpKn+HdYew6uqLjv6WgMHo/cbCsFY3u2Aw==}
+  '@sanity/presentation@1.19.8-release.0':
+    resolution: {integrity: sha512-Q7qoF/hbWQivAYomXAOJtxoFWfPSuUi1FmCY900+9U7AQpZDCBp/ULcWnf5PIQIp3VmU8w/fbAumYujG+PXEOA==}
     engines: {node: '>=16.14'}
 
   '@sanity/prettier-config@1.0.3':
@@ -4604,8 +4604,8 @@ packages:
     peerDependencies:
       '@sanity/client': ^6.23.0
 
-  '@sanity/preview-url-secret@2.0.6-release.3':
-    resolution: {integrity: sha512-GK/39ScYhvLKGR8AwhdlFsQnm3DZ7pM1CF5a2StPd7/WGUy5F7en26JuRLYGgsoUEWmjQWzb4ZaLE1rwUyHuSg==}
+  '@sanity/preview-url-secret@2.0.6-release.0':
+    resolution: {integrity: sha512-RvCap24GMqZF40wb8G/xAhkd6j12oukwIjiHCRGff36cwwgqR5TjmfjcXR4GU4ZMbj02fVRk4ZLGrXJJyn6dsA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@sanity/client': ^6.24.1
@@ -4651,6 +4651,15 @@ packages:
 
   '@sanity/ui@2.9.0':
     resolution: {integrity: sha512-uuXji8a1myei3hUk67B36byHjZ/PEqnxgbEWACha4RCGptTIQJGZu005RUaQ7AQme0IuVmYPW9iJbpuyjcYT9w==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^18 || >=19.0.0-0
+      react-dom: ^18 || >=19.0.0-0
+      react-is: ^18 || >=19.0.0-0
+      styled-components: ^5.2 || ^6
+
+  '@sanity/ui@2.9.1':
+    resolution: {integrity: sha512-FwPuMTOJHlVyinK12d+VO7c6Uu4xhEoIzZxdiJPriRRRgyUNCtUkKObQKt7AUPGfUqood2AE2zYWdqCRPwkcOA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: ^18 || >=19.0.0-0
@@ -14352,7 +14361,7 @@ snapshots:
       uuid: 10.0.0
       xstate: 5.19.0
 
-  '@sanity/comlink@2.0.1-release.3':
+  '@sanity/comlink@2.0.2-release.0':
     dependencies:
       rxjs: 7.8.1
       uuid: 10.0.0
@@ -14693,14 +14702,14 @@ snapshots:
       - debug
       - supports-color
 
-  '@sanity/presentation@1.19.5-release.3(@sanity/color@3.0.6)(debug@4.3.7)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@sanity/presentation@1.19.8-release.0(@sanity/color@3.0.6)(debug@4.3.7)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@sanity/client': 6.24.1(debug@4.3.7)
-      '@sanity/comlink': 2.0.1-release.3
+      '@sanity/comlink': 2.0.2-release.0
       '@sanity/icons': 3.5.0(react@18.3.1)
       '@sanity/logos': 2.1.13(@sanity/color@3.0.6)(react@18.3.1)
-      '@sanity/preview-url-secret': 2.0.6-release.3(@sanity/client@6.24.1(debug@4.3.7))
-      '@sanity/ui': 2.9.0(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@sanity/preview-url-secret': 2.0.6-release.0(@sanity/client@6.24.1(debug@4.3.7))
+      '@sanity/ui': 2.9.1(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/uuid': 3.0.2
       fast-deep-equal: 3.1.3
       framer-motion: 11.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14730,7 +14739,7 @@ snapshots:
       '@sanity/client': 6.24.1(debug@4.3.7)
       '@sanity/uuid': 3.0.2
 
-  '@sanity/preview-url-secret@2.0.6-release.3(@sanity/client@6.24.1(debug@4.3.7))':
+  '@sanity/preview-url-secret@2.0.6-release.0(@sanity/client@6.24.1(debug@4.3.7))':
     dependencies:
       '@sanity/client': 6.24.1(debug@4.3.7)
       '@sanity/uuid': 3.0.2
@@ -15065,6 +15074,21 @@ snapshots:
       react-refractor: 2.2.0(react@19.0.0-rc-f994737d14-20240522)
       styled-components: 6.1.13(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522)
       use-effect-event: 1.0.2(react@19.0.0-rc-f994737d14-20240522)
+
+  '@sanity/ui@2.9.1(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@sanity/color': 3.0.6
+      '@sanity/icons': 3.5.0(react@18.3.1)
+      csstype: 3.1.3
+      framer-motion: 11.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-compiler-runtime: 19.0.0-beta-df7b47d-20241124(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-refractor: 2.2.0(react@18.3.1)
+      styled-components: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      use-effect-event: 1.0.2(react@18.3.1)
 
   '@sanity/util@3.37.2(debug@4.3.7)':
     dependencies:


### PR DESCRIPTION
Brings the same minor bugfixes to the content releases version of `@sanity/presentation` that shipped on the stable channel (#7966)