### PR TITLE
fix(sanity): do not perform incremental search for exact tokens

### DIFF
--- a/packages/sanity/src/core/search/text-search/createTextSearch.test.ts
+++ b/packages/sanity/src/core/search/text-search/createTextSearch.test.ts
@@ -6,6 +6,7 @@ import {
   getDocumentTypeConfiguration,
   getOrder,
   getQueryString,
+  isExactMatchToken,
   isNegationToken,
   isPrefixToken,
   prefixLast,
@@ -268,7 +269,7 @@ describe('prefixLast', () => {
     expect(prefixLast('a b')).toBe('a b*')
     expect(prefixLast('a -b')).toBe('a* -b')
     expect(prefixLast('a "bc" d')).toBe('a "bc" d*')
-    expect(prefixLast('ab "cd"')).toBe('ab "cd"*')
+    expect(prefixLast('ab "cd"')).toBe('ab* "cd"')
     expect(prefixLast('a --')).toBe('a* --')
   })
 
@@ -288,7 +289,19 @@ describe('prefixLast', () => {
 
   it('preserves quoted tokens', () => {
     expect(prefixLast('"a b" c d')).toBe('"a b" c d*')
-    expect(prefixLast('"a   b"   c d  "ef" "g  "')).toBe('"a   b" c d "ef" "g  "*')
+    expect(prefixLast('"a   b"   c d  "ef" "g  "')).toBe('"a   b" c d* "ef" "g  "')
     expect(prefixLast('"a " b" c d')).toBe('"a " b c d*')
+  })
+})
+
+describe('isExactMatchToken', () => {
+  it('recognises that a token is encased in quote marks', () => {
+    expect(isExactMatchToken(undefined)).toBe(false)
+    expect(isExactMatchToken('"a"')).toBe(true)
+    expect(isExactMatchToken('"a b"')).toBe(true)
+    expect(isExactMatchToken('"a')).toBe(false)
+    expect(isExactMatchToken('a"')).toBe(false)
+    expect(isExactMatchToken('"a b')).toBe(false)
+    expect(isExactMatchToken('a b"')).toBe(false)
   })
 })

--- a/packages/sanity/src/core/search/text-search/createTextSearch.ts
+++ b/packages/sanity/src/core/search/text-search/createTextSearch.ts
@@ -94,21 +94,29 @@ export function isPrefixToken(token: string | undefined): boolean {
   return typeof token !== 'undefined' && token.trim().at(-1) === WILDCARD_TOKEN
 }
 
+export function isExactMatchToken(token: string | undefined): boolean {
+  return [token?.at(0), token?.at(-1)].every((character) => character === '"')
+}
+
 export function prefixLast(query: string): string {
   const tokens = (query.match(TOKEN_REGEX) ?? []).map((token) => token.trim())
-  const finalNonNegationTokenIndex = tokens.findLastIndex((token) => !isNegationToken(token))
-  const finalNonNegationToken = tokens[finalNonNegationTokenIndex]
+
+  const finalIncrementalTokenIndex = tokens.findLastIndex(
+    (token) => !isNegationToken(token) && !isExactMatchToken(token),
+  )
+
+  const finalIncrementalToken = tokens[finalIncrementalTokenIndex]
 
   if (tokens.length === 0) {
     return WILDCARD_TOKEN
   }
 
-  if (isPrefixToken(finalNonNegationToken) || typeof finalNonNegationToken === 'undefined') {
+  if (isPrefixToken(finalIncrementalToken) || typeof finalIncrementalToken === 'undefined') {
     return tokens.join(' ')
   }
 
   const prefixedTokens = [...tokens]
-  prefixedTokens.splice(finalNonNegationTokenIndex, 1, `${finalNonNegationToken}${WILDCARD_TOKEN}`)
+  prefixedTokens.splice(finalIncrementalTokenIndex, 1, `${finalIncrementalToken}${WILDCARD_TOKEN}`)
   return prefixedTokens.join(' ')
 }
 


### PR DESCRIPTION
### Description

When using the `textSearch` or (upcoming) `groq2024` search strategy, Studio provides an incremental (aka *search-as-you-type*) experience by appending a wildcard `*` operator to the final plain (e.g. non-negation) token found in the search query.

Currently, Studio appends this wildcard even if the token is an exact match (encased in quote marks). This behaviour is incorrect. It is both unexpected from a UX perspective to have an exact match token automatically given a wildcard suffix, and unsupported by the `groq2024` search backend.

### What to review

- Does the approach seem reasonable?

### Testing

- Tested various search queries.
- Updated unit tests in `packages/sanity/src/core/search/text-search/createTextSearch.test.ts`.
