### PR TITLE
feat: use eslint 9 for new studios

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapLocalTemplate.ts
@@ -138,8 +138,8 @@ export async function bootstrapLocalTemplate(
     writeFileIfNotExists(`sanity.cli.${codeExt}`, cliConfig),
     writeFileIfNotExists('package.json', packageManifest),
     writeFileIfNotExists(
-      '.eslintrc',
-      `${JSON.stringify({extends: '@sanity/eslint-config-studio'}, null, 2)}\n`,
+      'eslint.config.mjs',
+      `import studio from '@sanity/eslint-config-studio'\n\nexport default [...studio]\n`,
     ),
   ])
 

--- a/packages/@sanity/cli/src/studioDependencies.ts
+++ b/packages/@sanity/cli/src/studioDependencies.ts
@@ -18,7 +18,7 @@ export const studioDependencies = {
     '@sanity/eslint-config-studio': 'latest',
     // When using typescript, we'll want the these types too, so might as well install them
     '@types/react': '^18.0.25',
-    'eslint': '^8.6.0',
+    'eslint': '^9.9.0',
     'prettier': '^3.0.2',
     'typescript': '^5.1.6', // Peer dependency of eslint-config-studio (implicitly)
   },


### PR DESCRIPTION
### Description

Depends on https://github.com/sanity-io/eslint-config-studio/pull/41

Bootstrap new studios with ESLint 9 and the new version of the studio ESLint configuration.

Part of SAPP-1961
Part of SAPP-1690

### What to review

- Bootstrapped files look correct

### Testing

Should be able to test this out by building and bootstrapping a new studio, but changes are also small enough that upgrading and replacing the config file as per the PR will let you test this out

### Notes for release

- Use ESLint 9 for new studios
