### PR TITLE
test(e2e): add missing plugins to e2e studio

### DIFF
--- a/dev/studio-e2e-testing/package.json
+++ b/dev/studio-e2e-testing/package.json
@@ -15,6 +15,7 @@
     "start": "sanity preview --port 3339"
   },
   "dependencies": {
+    "@sanity/color-input": "^4.0.1",
     "@sanity/google-maps-input": "^4.0.0",
     "@sanity/icons": "^3.5.0",
     "@sanity/ui": "^2.9.1",
@@ -24,6 +25,7 @@
     "react-compiler-runtime": "19.0.0-beta-df7b47d-20241124",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",
+    "sanity-plugin-markdown": "^5.0.0",
     "sanity-plugin-media": "^2.3.1",
     "sanity-plugin-mux-input": "^2.2.1",
     "sanity-test-studio": "workspace:*",

--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -1,8 +1,10 @@
+import {colorInput} from '@sanity/color-input'
 import {googleMapsInput} from '@sanity/google-maps-input'
 import {BookIcon} from '@sanity/icons'
 import {visionTool} from '@sanity/vision'
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
+import {markdownSchema} from 'sanity-plugin-markdown'
 import {media} from 'sanity-plugin-media'
 import {muxInput} from 'sanity-plugin-mux-input'
 import {imageAssetSource} from 'sanity-test-studio/assetSources'
@@ -87,12 +89,14 @@ export default defineConfig({
         lng: -74.1180863,
       },
     }),
+    colorInput(),
     visionTool({
       defaultApiVersion: '2022-08-08',
     }),
     // eslint-disable-next-line camelcase
     muxInput({mp4_support: 'standard'}),
     media(),
+    markdownSchema(),
   ],
   beta: {
     treeArrayEditing: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,6 +369,9 @@ importers:
 
   dev/studio-e2e-testing:
     dependencies:
+      '@sanity/color-input':
+        specifier: ^4.0.1
+        version: 4.0.1(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@19.0.0-rc-b01722d5-20241114)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/google-maps-input':
         specifier: ^4.0.0
         version: 4.0.1(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@19.0.0-rc-b01722d5-20241114)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -396,6 +399,9 @@ importers:
       sanity:
         specifier: workspace:*
         version: link:../../packages/sanity
+      sanity-plugin-markdown:
+        specifier: ^5.0.0
+        version: 5.0.0(@emotion/is-prop-valid@1.2.2)(easymde@2.18.0)(react-dom@18.3.1(react@18.3.1))(react-is@19.0.0-rc-b01722d5-20241114)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       sanity-plugin-media:
         specifier: ^2.3.1
         version: 2.3.2(@sanity/ui@2.10.1(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@19.0.0-rc-b01722d5-20241114)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))


### PR DESCRIPTION
### Description
 [#7502](https://github.com/sanity-io/sanity/issues/7502) & [#7475](https://github.com/sanity-io/sanity/issues/7475) broke the e2e test suite because the e2e Studio is importing the schema types from the `test-studio` but those PRs didn't add the required plugins to the e2e Studio config.

### What to review

If CI is happy we should be good


### Notes for release
n/a