### PR TITLE
chore(core): remove `releaseStack` from releasesStore

### DIFF
--- a/packages/sanity/src/core/releases/store/createReleaseStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseStore.ts
@@ -47,7 +47,6 @@ const QUERY = `*[${QUERY_FILTER}] ${QUERY_PROJECTION} | ${QUERY_SORT_ORDER}`
 const INITIAL_STATE: ReleasesReducerState = {
   releases: new Map(),
   state: 'initialising' as const,
-  releaseStack: [],
 }
 
 const RELEASE_METADATA_TMP_DOC_PATH = 'system-tmp-releases'

--- a/packages/sanity/src/core/releases/store/reducer.ts
+++ b/packages/sanity/src/core/releases/store/reducer.ts
@@ -41,12 +41,6 @@ export interface ReleasesReducerState {
   releases: Map<string, ReleaseDocument>
   state: 'initialising' | 'loading' | 'loaded' | 'error'
   error?: Error
-
-  /**
-   * An array of release ids ordered chronologically to represent the state of documents at the
-   * given point in time.
-   */
-  releaseStack: string[]
 }
 
 function createReleasesSet(releases: ReleaseDocument[] | null) {


### PR DESCRIPTION
### Description 
Removes unused  `releaseStack` from releasesStore.
We are using the `perspective` from `usePerspective` for this, nothing is populating the `releaseStack` value.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
