### PR TITLE
feat: showing documents in archived and published releases

### DIFF
--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -10,33 +10,49 @@ import {
   useRef,
   useState,
 } from 'react'
-import {styled} from 'styled-components'
+import {css, styled} from 'styled-components'
 
 import {Button, Popover, Tooltip} from '../../../../ui-components'
 import {getVersionId} from '../../../util/draftUtils'
 import {useVersionOperations} from '../../hooks/useVersionOperations'
-import {type ReleaseDocument} from '../../store/types'
+import {type ReleaseDocument, type ReleaseState} from '../../store/types'
 import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
 import {DiscardVersionDialog} from '../dialog/DiscardVersionDialog'
 import {ReleaseAvatar} from '../ReleaseAvatar'
 import {VersionContextMenu} from './contextMenu/VersionContextMenu'
 import {CopyToNewReleaseDialog} from './dialog/CopyToNewReleaseDialog'
 
-const Chip = styled(Button)`
-  border-radius: 9999px !important;
-  transition: none;
-  text-decoration: none !important;
-  cursor: pointer;
+interface ChipStyleProps {
+  $isArchived?: boolean
+}
 
-  // target enabled state
-  &:not([data-disabled='true']) {
-    --card-border-color: var(--card-badge-default-bg-color);
-  }
+const Chip = styled(Button)<ChipStyleProps>(
+  ({$isArchived}) =>
+    `
+    border-radius: 9999px !important;
+    transition: none;
+    text-decoration: none !important;
+    cursor: pointer;
 
-  &[data-disabled='true'] {
-    color: var(--card-muted-fg-color);
-  }
-`
+    // target enabled state
+    &:not([data-disabled='true']) {
+      --card-border-color: var(--card-badge-default-bg-color);
+    }
+
+    &[data-disabled='true'] {
+      color: var(--card-muted-fg-color);
+      cursor: default;
+
+      // archived will be disabled but should have bg color
+      ${
+        $isArchived &&
+        css`
+          background-color: var(--card-badge-default-bg-color);
+        `
+      }
+    }
+  `,
+)
 
 /**
  * @internal
@@ -56,6 +72,7 @@ export const VersionChip = memo(function VersionChip(props: {
     documentType: string
     menuReleaseId: string
     fromRelease: string
+    releaseState?: ReleaseState
     isVersion: boolean
     disabled?: boolean
   }
@@ -75,6 +92,7 @@ export const VersionChip = memo(function VersionChip(props: {
       documentType,
       menuReleaseId,
       fromRelease,
+      releaseState,
       isVersion,
       disabled: contextMenuDisabled = false,
     },
@@ -162,6 +180,8 @@ export const VersionChip = memo(function VersionChip(props: {
     } as HTMLElement
   }, [contextMenuPoint])
 
+  const contextMenuHandler = disabled ? undefined : handleContextMenu
+
   return (
     <>
       <Tooltip content={tooltipContent} fallbackPlacements={[]} portal placement="bottom">
@@ -178,7 +198,8 @@ export const VersionChip = memo(function VersionChip(props: {
           tone={tone}
           icon={<ReleaseAvatar padding={1} tone={tone} />}
           iconRight={locked && LockIcon}
-          onContextMenu={handleContextMenu}
+          onContextMenu={contextMenuHandler}
+          $isArchived={releaseState === 'archived'}
         />
       </Tooltip>
 

--- a/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
@@ -15,6 +15,7 @@ interface ReleaseDocumentPreviewProps {
   releaseId: string
   previewValues: PreviewValue
   isLoading: boolean
+  revision?: string
   hasValidationError?: boolean
 }
 
@@ -24,6 +25,7 @@ export function ReleaseDocumentPreview({
   releaseId,
   previewValues,
   isLoading,
+  revision,
   hasValidationError,
 }: ReleaseDocumentPreviewProps) {
   const documentPresence = useDocumentPresence(documentId)

--- a/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
@@ -63,7 +63,7 @@ export function ReleaseDocumentPreview({
   if (revision) return preview
 
   return (
-    <Card tone="default" as={LinkComponent} radius={2} data-as={'a'}>
+    <Card tone="inherit" as={LinkComponent} radius={2} data-as="a">
       {preview}
     </Card>
   )

--- a/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
@@ -53,9 +53,16 @@ export function ReleaseDocumentPreview({
     [documentPresence],
   )
 
+  const preview = (
+    <SanityDefaultPreview {...previewValues} status={previewPresence} isPlaceholder={isLoading} />
+  )
+
+  /** @todo revision deeplink support for archived and published version docs */
+  if (revision) return preview
+
   return (
-    <Card tone="inherit" as={LinkComponent} radius={2} data-as="a">
-      <SanityDefaultPreview {...previewValues} status={previewPresence} isPlaceholder={isLoading} />
+    <Card tone="default" as={LinkComponent} radius={2} data-as={'a'}>
+      {preview}
     </Card>
   )
 }

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
@@ -177,7 +177,7 @@ export const ReleaseMenuButton = ({ignoreCTA, release}: ReleaseMenuButtonProps) 
   const confirmActionDialog = useMemo(() => {
     if (!selectedAction) return null
 
-    const {confirmDialog, ...actionValues} = RELEASE_ACTION_MAP[selectedAction]
+    const {confirmDialog} = RELEASE_ACTION_MAP[selectedAction]
 
     if (!confirmDialog) return null
 

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -54,8 +54,8 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
   )
 
   const documentTableColumnDefs = useMemo(
-    () => getDocumentTableColumnDefs(release._id, t),
-    [release._id, t],
+    () => getDocumentTableColumnDefs(release._id, release.state, t),
+    [release._id, release.state, t],
   )
 
   const filterRows = useCallback(

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -42,15 +42,16 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
     [documents, documentsHistory],
   )
 
-  const renderRowActions: ({datum}: {datum: BundleDocumentRow | unknown}) => JSX.Element =
-    useCallback(
-      ({datum}) => {
-        const document = datum as BundleDocumentRow
+  const renderRowActions: React.FC<{datum: BundleDocumentRow | unknown}> = useCallback(
+    ({datum}) => {
+      if (release.state !== 'active') return null
 
-        return <DocumentActions document={document} releaseTitle={release.metadata.title} />
-      },
-      [release.metadata.title],
-    )
+      const document = datum as BundleDocumentRow
+
+      return <DocumentActions document={document} releaseTitle={release.metadata.title} />
+    },
+    [release.metadata.title, release.state],
+  )
 
   const documentTableColumnDefs = useMemo(
     () => getDocumentTableColumnDefs(release._id, t),

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -20,21 +20,23 @@ const MemoReleaseDocumentPreview = memo(
   function MemoReleaseDocumentPreview({
     item,
     releaseId,
-    revision,
+    releaseState,
+    documentRevision,
   }: {
     item: DocumentInRelease
     releaseId: string
-    revision?: string
+    releaseState?: ReleaseState
+    documentRevision?: string
   }) {
     return (
       <ReleaseDocumentPreview
         documentId={item.document._id}
         documentTypeName={item.document._type}
         releaseId={releaseId}
-        revision={revision}
+        releaseState={releaseState}
+        documentRevision={documentRevision}
         previewValues={item.previewValues.values}
         isLoading={item.previewValues.isLoading}
-        hasValidationError={item.validation?.hasError}
       />
     )
   },
@@ -135,11 +137,8 @@ export const getDocumentTableColumnDefs: (
         <MemoReleaseDocumentPreview
           item={datum}
           releaseId={releaseId}
-          revision={
-            releaseState === 'archived' || releaseState === 'published'
-              ? datum.document._rev
-              : undefined
-          }
+          releaseState={releaseState}
+          documentRevision={datum.document._rev}
         />
       </Box>
     ),

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -20,15 +20,18 @@ const MemoReleaseDocumentPreview = memo(
   function MemoReleaseDocumentPreview({
     item,
     releaseId,
+    revision,
   }: {
     item: DocumentInRelease
     releaseId: string
+    revision?: string
   }) {
     return (
       <ReleaseDocumentPreview
         documentId={item.document._id}
         documentTypeName={item.document._type}
         releaseId={releaseId}
+        revision={revision}
         previewValues={item.previewValues.values}
         isLoading={item.previewValues.isLoading}
         hasValidationError={item.validation?.hasError}
@@ -129,7 +132,15 @@ export const getDocumentTableColumnDefs: (
     ),
     cell: ({cellProps, datum}) => (
       <Box {...cellProps} flex={1} padding={1} paddingRight={2} sizing="border">
-        <MemoReleaseDocumentPreview item={datum} releaseId={releaseId} />
+        <MemoReleaseDocumentPreview
+          item={datum}
+          releaseId={releaseId}
+          revision={
+            releaseState === 'archived' || releaseState === 'published'
+              ? datum.document._rev
+              : undefined
+          }
+        />
       </Box>
     ),
   },

--- a/packages/sanity/src/core/releases/tool/detail/review/DocumentReviewHeader.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/review/DocumentReviewHeader.tsx
@@ -55,7 +55,6 @@ export function DocumentReviewHeader({
             releaseId={releaseId}
             previewValues={previewValues}
             isLoading={isLoading}
-            hasValidationError={validation?.hasError}
           />
         </Box>
         <Flex gap={2} padding={3} style={{flexShrink: 0}}>

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -1,9 +1,10 @@
 import {isValidationErrorMarker, type SanityDocument} from '@sanity/types'
 import {uuid} from '@sanity/uuid'
+import {isBefore} from 'date-fns'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
-import {combineLatest, of} from 'rxjs'
-import {filter, map, startWith, switchAll, switchMap} from 'rxjs/operators'
+import {combineLatest, from, of} from 'rxjs'
+import {filter, map, mergeMap, startWith, switchAll, switchMap, take, toArray} from 'rxjs/operators'
 import {mergeMapArray} from 'rxjs-mergemap-array'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from 'sanity'
 
@@ -12,7 +13,7 @@ import {getPreviewValueWithFallback, prepareForPreview} from '../../../preview'
 import {useSource} from '../../../studio'
 import {getPublishedId} from '../../../util/draftUtils'
 import {validateDocumentWithReferences, type ValidationStatus} from '../../../validation'
-import {useDocumentPreviewStore} from '../../index'
+import {getReleaseIdFromReleaseDocumentId, useDocumentPreviewStore, useReleases} from '../../index'
 
 export interface DocumentValidationStatus extends ValidationStatus {
   hasError: boolean
@@ -25,17 +26,24 @@ export interface DocumentInRelease {
   previewValues: {isLoading: boolean; values: ReturnType<typeof prepareForPreview>}
 }
 
-export function useBundleDocuments(release: string): {
+export function useBundleDocuments(releaseId: string): {
   loading: boolean
   results: DocumentInRelease[]
 } {
-  const groqFilter = `_id in path("versions.${release}.*")`
+  const groqFilter = `_id in path("versions.${releaseId}.*")`
   const documentPreviewStore = useDocumentPreviewStore()
   const {getClient, i18n} = useSource()
   const schema = useSchema()
-  const observableClient = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS).observable
+  const {data: releases, archivedReleases} = useReleases()
 
-  const observable = useMemo(() => {
+  const release = releases
+    .concat(archivedReleases)
+    .find((candidate) => getReleaseIdFromReleaseDocumentId(candidate._id) === releaseId)
+  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  const observableClient = client.observable
+  const {dataset} = client.config()
+
+  const activeReleaseDocumentsObservable = useMemo(() => {
     return documentPreviewStore.unstable_observeDocumentIdSet(groqFilter).pipe(
       map((state) => (state.documentIds || []) as string[]),
       mergeMapArray((id) => {
@@ -91,7 +99,7 @@ export function useBundleDocuments(release: string): {
                   getPreviewValueWithFallback({
                     value: document,
                     version: version.snapshot,
-                    perspective: release,
+                    perspective: `bundle.${releaseId}`,
                   }),
                   schemaType,
                 ),
@@ -113,7 +121,120 @@ export function useBundleDocuments(release: string): {
       }),
       map((results) => ({loading: false, results})),
     )
-  }, [observableClient, documentPreviewStore, getClient, groqFilter, i18n, release, schema])
+  }, [documentPreviewStore, groqFilter, i18n, getClient, schema, observableClient, releaseId])
+
+  const publishedReleaseDocumentsObservable = useMemo(() => {
+    if (!release?.finalDocumentStates?.length) return of({loading: false, results: []})
+
+    const documentStates = release.finalDocumentStates
+
+    return combineLatest([
+      from(documentStates).pipe(
+        mergeMap(({id: documentId}) => {
+          const document$ = observableClient
+            .request<{documents: DocumentInRelease['document'][]}>({
+              url: `/data/history/${dataset}/documents/${documentId}?lastRevision=true`,
+            })
+            .pipe(map(({documents: [document]}) => document))
+
+          const previewValues$ = document$.pipe(
+            switchMap((document) => {
+              const schemaType = schema.get(document._type)
+              if (!schemaType) {
+                throw new Error(`Schema type not found for document type ${document._type}`)
+              }
+
+              return documentPreviewStore.observeForPreview(document, schemaType).pipe(
+                take(1),
+                // eslint-disable-next-line max-nested-callbacks
+                map((version) => ({
+                  isLoading: false,
+                  values: prepareForPreview(
+                    getPreviewValueWithFallback({
+                      value: document,
+                      version: version.snapshot || document,
+                      perspective: `bundle.${releaseId}`,
+                    }),
+                    schemaType,
+                  ),
+                })),
+                startWith({isLoading: true, values: {}}),
+              )
+            }),
+            filter(({isLoading}) => !isLoading),
+          )
+
+          return combineLatest([document$, previewValues$]).pipe(
+            map(([document, previewValues]) => ({
+              document,
+              previewValues,
+              memoKey: uuid(),
+              validation: {validation: [], hasError: false, isValidating: false},
+            })),
+          )
+        }),
+        toArray(),
+      ),
+
+      documentPreviewStore
+        .unstable_observeDocuments(documentStates.map(({id}) => `${getPublishedId(id)}`))
+        .pipe(take(1), filter(Boolean)),
+    ]).pipe(
+      // Combine results from both streams
+      map(([processedDocuments, observedDocuments]) =>
+        processedDocuments.map((result) => {
+          const documentId = result.document._id
+
+          const getIsNewDocument = () => {
+            // Check if the document exists in the observedDocuments array
+            const publishedDocumentExists = observedDocuments.find(
+              // eslint-disable-next-line max-nested-callbacks
+              (observedDoc) => observedDoc?._id === getPublishedId(documentId),
+            )
+
+            // this means that the pub doc has now been deleted...
+            // or potentially was deleted as part of this release
+            if (!publishedDocumentExists) return true
+
+            const releasePublishAt = release.publishAt
+            if (!releasePublishAt) return false
+
+            const publishedCreatedAtDate = new Date(publishedDocumentExists._createdAt)
+            const releasePublishAtDate = new Date(releasePublishAt)
+
+            return !isBefore(publishedCreatedAtDate, releasePublishAtDate)
+          }
+
+          return {
+            ...result,
+            document: {...result.document, isNewDocument: getIsNewDocument()},
+          }
+        }),
+      ),
+      map((results) => ({
+        loading: false,
+        results,
+      })),
+    )
+  }, [
+    dataset,
+    documentPreviewStore,
+    observableClient,
+    release?.finalDocumentStates,
+    release?.publishAt,
+    releaseId,
+    schema,
+  ])
+
+  const observable = useMemo(() => {
+    if (!release) return of({loading: true, results: []})
+
+    if (release.state === 'published' || release.state === 'archived') {
+      return publishedReleaseDocumentsObservable
+    }
+
+    return activeReleaseDocumentsObservable
+  }, [activeReleaseDocumentsObservable, publishedReleaseDocumentsObservable, release])
 
   return useObservable(observable, {loading: true, results: []})
 }

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -98,7 +98,7 @@ export function useBundleDocuments(releaseId: string): {
                   getPreviewValueWithFallback({
                     value: document,
                     version: version.snapshot,
-                    perspective: `bundle.${releaseId}`,
+                    perspective: releaseId,
                   }),
                   schemaType,
                 ),
@@ -151,7 +151,7 @@ export function useBundleDocuments(releaseId: string): {
                   getPreviewValueWithFallback({
                     value: document,
                     version: version.snapshot || document,
-                    perspective: `bundle.${releaseId}`,
+                    perspective: releaseId,
                   }),
                   schemaType,
                 ),

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -90,7 +90,7 @@ const structureLocaleStrings = defineLocalesResources('structure', {
     'This document has live edit enabled and cannot be unpublished',
   /** Description for the archived release banner, rendered when viewing the history of a version document from the publihed view */
   'banners.archived-release.description':
-    "You are viewing a read-only document that was published as part of <VersionBadge> a release</VersionBadge>. It can't be edited",
+    "You are viewing a read-only document that was archived as part of <VersionBadge> a release</VersionBadge>. It can't be edited",
   /** The text for the restore button on the deleted document banner */
   'banners.deleted-document-banner.restore-button.text': 'Restore most recent revision',
   /** The text content for the deleted document banner */
@@ -124,6 +124,9 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'banners.permission-check-banner.request-permission-button.sent': 'Editor request sent',
   /** The text for the request permission button that appears for viewer roles */
   'banners.permission-check-banner.request-permission-button.text': 'Ask to edit',
+  /** Description for the archived release banner, rendered when viewing the history of a version document from the publihed view */
+  'banners.published-release.description':
+    "You are viewing a read-only document that was published as part of <VersionBadge> a release</VersionBadge>. It can't be edited",
   /** The text for the reload button */
   'banners.reference-changed-banner.reason-changed.reload-button.text': 'Reload reference',
   /** The text for the reference change banner if the reason is that the reference has been changed */

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ArchivedReleaseDocumentBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ArchivedReleaseDocumentBanner.tsx
@@ -31,6 +31,12 @@ export function ArchivedReleaseDocumentBanner(): JSX.Element {
       (r) => getReleaseIdFromReleaseDocumentId(r._id) === params?.historyVersion,
     )
   }, [archivedReleases, params?.historyVersion])
+
+  const description =
+    release?.state === 'published'
+      ? 'banners.published-release.description'
+      : 'banners.archived-release.description'
+
   return (
     <Banner
       tone="caution"
@@ -40,7 +46,7 @@ export function ArchivedReleaseDocumentBanner(): JSX.Element {
           <Text size={1}>
             <Translate
               t={t}
-              i18nKey="banners.archived-release.description"
+              i18nKey={description}
               components={{
                 VersionBadge: ({children}) => {
                   if (!release) return children

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -124,7 +124,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
     return !editState?.published
   }, [editState?.liveEdit, editState?.published])
 
-  const getIsReleaseSelected = useCallback(
+  const getReleaseChipState = useCallback(
     (release: ReleaseDocument): {selected: boolean; disabled?: boolean} => {
       if (!params?.historyVersion)
         return {selected: release.name === getVersionFromId(displayed?._id || '')}
@@ -243,9 +243,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
           <VersionChip
             key={release._id}
             tooltipContent={<TooltipContent release={release} />}
-            {...getIsReleaseSelected(release)}
-            // selected
-            // disabled={false}
+            {...getReleaseChipState(release)}
             onClick={handleBundleChange(release.name)}
             text={release.metadata.title || t('release.placeholder-untitled-release')}
             tone={getReleaseTone(release)}

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -2,6 +2,7 @@ import {Text} from '@sanity/ui'
 import {memo, useCallback, useMemo} from 'react'
 import {
   formatRelativeLocalePublishDate,
+  getReleaseIdFromReleaseDocumentId,
   getReleaseTone,
   getVersionFromId,
   isReleaseScheduledOrScheduling,
@@ -14,6 +15,7 @@ import {
   VersionChip,
   versionDocumentExists,
 } from 'sanity'
+import {usePaneRouter} from 'sanity/structure'
 
 import {useDocumentPane} from '../../../useDocumentPane'
 
@@ -66,18 +68,19 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
   const {selectedPerspectiveName} = usePerspective()
   const {t} = useTranslation()
   const {setPerspective} = usePerspective()
+  const {params} = usePaneRouter()
   const dateTimeFormat = useDateTimeFormat({
     dateStyle: 'medium',
     timeStyle: 'short',
   })
-  const {data: releases, loading} = useReleases()
+  const {data: releases, loading, archivedReleases} = useReleases()
 
   const {documentVersions, editState, displayed, documentType} = useDocumentPane()
 
   const filteredReleases: FilterReleases = useMemo(() => {
     if (!documentVersions) return {notCurrentReleases: [], currentReleases: []}
 
-    return releases.reduce(
+    const activeReleases = releases.reduce(
       (acc: FilterReleases, release) => {
         const versionDocExists = versionDocumentExists(documentVersions, release._id)
         if (versionDocExists) {
@@ -89,7 +92,21 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
       },
       {notCurrentReleases: [], currentReleases: []},
     )
-  }, [documentVersions, releases])
+
+    // without historyVersion, version is not in an archived release
+    if (!params?.historyVersion) return activeReleases
+
+    const archivedRelease = archivedReleases.find(
+      (r) => getReleaseIdFromReleaseDocumentId(r._id) === params?.historyVersion,
+    )
+
+    // only for explicitly archived releases; published releases use published perspective
+    if (archivedRelease?.state === 'archived') {
+      activeReleases.currentReleases.push(archivedRelease)
+    }
+
+    return activeReleases
+  }, [archivedReleases, documentVersions, params?.historyVersion, releases])
 
   const handleBundleChange = useCallback(
     (bundleId: string) => () => {
@@ -106,6 +123,19 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
     // If it's not live edit, we want to check for the existence of the published doc.
     return !editState?.published
   }, [editState?.liveEdit, editState?.published])
+
+  const getIsReleaseSelected = useCallback(
+    (release: ReleaseDocument): {selected: boolean; disabled?: boolean} => {
+      if (!params?.historyVersion)
+        return {selected: release.name === getVersionFromId(displayed?._id || '')}
+
+      const isReleaseHistoryMatch =
+        getReleaseIdFromReleaseDocumentId(release._id) === params.historyVersion
+
+      return {selected: isReleaseHistoryMatch, disabled: isReleaseHistoryMatch}
+    },
+    [displayed?._id, params?.historyVersion],
+  )
 
   return (
     <>
@@ -177,18 +207,20 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
         }
         selected={
           /** the draft is selected when:
+           * not viewing a historical version,
            * when the document displayed is a draft,
            * when the perspective is null,
            * when the document is not published and the displayed version is draft,
            * when there is no draft (new document),
            */
           !!(
-            editState?.draft?._id === displayed?._id ||
-            !selectedPerspectiveName ||
-            (!editState?.published &&
-              editState?.draft &&
-              editState?.draft?._id === displayed?._id) ||
-            (!editState?.published && !editState?.draft)
+            !params?.historyVersion &&
+            (editState?.draft?._id === displayed?._id ||
+              !selectedPerspectiveName ||
+              (!editState?.published &&
+                editState?.draft &&
+                editState?.draft?._id === displayed?._id) ||
+              (!editState?.published && !editState?.draft))
           )
         }
         text={t('release.chip.draft')}
@@ -211,7 +243,9 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
           <VersionChip
             key={release._id}
             tooltipContent={<TooltipContent release={release} />}
-            selected={release.name === getVersionFromId(displayed?._id || '')}
+            {...getIsReleaseSelected(release)}
+            // selected
+            // disabled={false}
             onClick={handleBundleChange(release.name)}
             text={release.metadata.title || t('release.placeholder-untitled-release')}
             tone={getReleaseTone(release)}
@@ -223,6 +257,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
               releasesLoading: loading,
               documentType: documentType,
               fromRelease: release.name,
+              releaseState: release.state,
               isVersion: true,
             }}
           />


### PR DESCRIPTION
### Description
![archivedView](https://github.com/user-attachments/assets/9a0800a0-2576-4877-bccb-4211cc2bdf51)
For an archived release can view version documents; clicking through will show the historical version document and a temporary archived release chip

---
![publishedView](https://github.com/user-attachments/assets/0dce4d61-66e1-40fa-a72d-ac9912331985)
For a published release can view version documents; clicking through will show the historical version document within the published perspective

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
