### PR TITLE
fix(sanity): optimise getLeafWeights to not stack overflow

### DIFF
--- a/packages/sanity/src/core/search/common/__tests__/deriveSearchWeightsFromType.test.ts
+++ b/packages/sanity/src/core/search/common/__tests__/deriveSearchWeightsFromType.test.ts
@@ -433,4 +433,50 @@ describe('deriveSearchWeightsFromType', () => {
       ],
     })
   })
+
+  it('works for schemas that branch out a lot', () => {
+    // schema of 60 "components" with 10 fields each
+    const range = [...Array(60).keys()]
+
+    const componentRefs = range.map((index) => ({type: `component_${index}`}))
+    const components = range.map((index) =>
+      defineType({
+        name: `component_${index}`,
+        type: 'object',
+        fields: [
+          ...[...Array(10).keys()].map((fieldIndex) =>
+            defineField({name: `component_${index}_field_${fieldIndex}`, type: 'string'}),
+          ),
+          defineField({name: `children_${index}`, type: 'array', of: [...componentRefs]}),
+        ],
+      }),
+    )
+
+    const schema = createSchema({
+      name: 'default',
+      types: [
+        ...components,
+        defineType({
+          name: 'testType',
+          type: 'document',
+          fields: [
+            defineField({
+              name: 'components',
+              type: 'array',
+              of: [...componentRefs],
+            }),
+          ],
+        }),
+      ],
+    })
+
+    expect(
+      deriveSearchWeightsFromType({
+        schemaType: schema.get('testType')!,
+        maxDepth: 5,
+      }),
+    ).toMatchObject({
+      typeName: 'testType',
+    })
+  })
 })


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

When working on schemas that branch out a lot (i.e. have arrays that can hold many different types), the current `getLeafWeights` implementation throws with a `RangeError: Maximum call stack size exceeded` after a while.

This PR optimises the method to use an accumulator instead, which keeps the stack usage flat and no longer overflows for the same amount of data. I have also added a test to verify this (it used to explode with the previous version, see screenshots).

In addition, this PR optimises the method to be much more efficient by:
- Merging the loops for `objectTypes` and `arrayTypes` into one
- Adding a few extra tiny optimisations

As a result, this should be much faster and no longer explode the stack.

#### Before
<img width="957" alt="Screenshot 2024-12-09 at 18 26 37" src="https://github.com/user-attachments/assets/951fea58-477c-4b3b-af19-9b7b92e7e28f">

#### After
<img width="957" alt="Screenshot 2024-12-09 at 22 56 15" src="https://github.com/user-attachments/assets/a5fce41c-1171-47ea-9d02-e7bf2e25f3f5">


### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

* We originally ran into this when rendering a document list once the schema got "branchy" enough, for a lack of a better word

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

* Have added a unit test that would fail under the previous implementation but passes current one
* This should retain exactly the same functionality as before, just be faster and more memory conscious

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

Fixes a crash when rendering a document list within Studio given a schema that branches out a lot