### PR TITLE
fix(structure): enable published chip for live edit documents

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -14,7 +14,6 @@ import {
   VersionChip,
   versionDocumentExists,
 } from 'sanity'
-import {usePaneRouter} from 'sanity/structure'
 
 import {useDocumentPane} from '../../../useDocumentPane'
 
@@ -71,7 +70,6 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
     dateStyle: 'medium',
     timeStyle: 'short',
   })
-  const {setParams, params} = usePaneRouter()
   const {data: releases, loading} = useReleases()
 
   const {documentVersions, editState, displayed, documentType} = useDocumentPane()
@@ -101,18 +99,12 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
   )
 
   const isPublishedChipDisabled = useMemo(() => {
-    if (editState?.liveEdit) {
-      if (!editState?.published) {
-        return true
-      }
+    // If it's a live edit document the only option to edit it is through
+    // the published perspective, users should be able to select it.
+    if (editState?.liveEdit) return false
 
-      return false
-    }
-
-    if (!editState?.published) {
-      return true
-    }
-    return false
+    // If it's not live edit, we want to check for the existence of the published doc.
+    return !editState?.published
   }, [editState?.liveEdit, editState?.published])
 
   return (

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveList.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveList.test.tsx
@@ -129,7 +129,7 @@ describe('DocumentPerspectiveList', () => {
       expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled()
     })
 
-    it('should disable the "Published" chip when there is no published document and IS live edit', async () => {
+    it('should enable the "Published" chip when there is no published document and IS live edit', async () => {
       mockUseDocumentPane.mockReturnValue({
         ...mockUsePane,
         editState: {...mockUsePane.editState, liveEdit: true},
@@ -138,7 +138,7 @@ describe('DocumentPerspectiveList', () => {
       const wrapper = await createTestProvider()
       render(<DocumentPerspectiveList />, {wrapper})
 
-      expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled()
+      expect(screen.getByRole('button', {name: 'Published'})).not.toBeDisabled()
     })
 
     it('should enable the "Published" chip when the document is "liveEdit"', async () => {

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -7,6 +7,7 @@ import {type DocumentActionComponent, type DocumentActionDescription, Hotkeys} f
 import {Button, Tooltip} from '../../../../ui-components'
 import {RenderActionCollectionState} from '../../../components'
 import {HistoryRestoreAction} from '../../../documentActions'
+import {toLowerCaseNoSpaces} from '../../../util/toLowerCaseNoSpaces'
 import {useDocumentPane} from '../useDocumentPane'
 import {ActionMenuButton} from './ActionMenuButton'
 import {ActionStateDialog} from './ActionStateDialog'
@@ -61,7 +62,7 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
             <Stack>
               {!existsInBundle && (
                 <Button
-                  data-testid={`action-${firstActionState.label}`}
+                  data-testid={`action-${toLowerCaseNoSpaces(firstActionState.label)}`}
                   disabled={disabled || Boolean(firstActionState.disabled)}
                   icon={firstActionState.icon}
                   // eslint-disable-next-line react/jsx-handler-names


### PR DESCRIPTION
### Description
**Enables the **published chip** for `liveEdit` documents.**

Live edit documents are only editable through the published perspective, we need to enable it even if the published document doesn't exists.
For the rest of documents, validate if the `published` document exists.

**Update actions data-testid**
action tests were failing because the test id was not found, this updates them to match what we have in `next` .https://github.com/sanity-io/sanity/blob/next/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx#L62

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
