### PR TITLE
feat(cli): use `@vercel/frameworks` in `bootstrapRemoteTemplate`

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/bootstrapRemoteTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapRemoteTemplate.ts
@@ -1,5 +1,7 @@
 import {mkdir} from 'node:fs/promises'
 import {join} from 'node:path'
+import {detectFrameworkRecord, LocalFileSystemDetector} from '@vercel/fs-detectors'
+import {type Framework, frameworks} from '@vercel/frameworks'
 
 import {debug} from '../../debug'
 import {type CliCommandContext} from '../../types'
@@ -9,7 +11,6 @@ import {
   downloadAndExtractRepo,
   generateSanityApiReadToken,
   getMonoRepo,
-  isNextJsTemplate,
   type RepoInfo,
   tryApplyPackageName,
   validateRemoteTemplate,
@@ -56,12 +57,16 @@ export async function bootstrapRemoteTemplate(
   const readToken = needsReadToken
     ? await generateSanityApiReadToken('API Read Token', variables.projectId, apiClient)
     : undefined
-  const isNext = await isNextJsTemplate(outputPath)
-  const envName = isNext ? '.env.local' : '.env'
 
-  for (const folder of packages ?? ['']) {
-    const path = join(outputPath, folder)
-    await applyEnvVariables(path, {...variables, readToken}, envName)
+  for (const pkg of packages ?? ['']) {
+    const packagePath = join(outputPath, pkg)
+    const packageFramework: Framework | null = await detectFrameworkRecord({
+      fs: new LocalFileSystemDetector(packagePath),
+      frameworkList: frameworks as readonly Framework[],
+    })
+    // Next.js uses `.env.local` for local environment variables
+    const envName = packageFramework?.slug === 'next' ? '.env.local' : '.env'
+    await applyEnvVariables(packagePath, {...variables, readToken}, envName)
   }
 
   debug('Setting package name to %s', packageName)

--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -410,16 +410,6 @@ export async function validateRemoteTemplate(
   }
 }
 
-export async function isNextJsTemplate(root: string): Promise<boolean> {
-  try {
-    const packageJson = await readFile(join(root, 'package.json'), 'utf8')
-    const pkg = JSON.parse(packageJson)
-    return !!(pkg.dependencies?.next || pkg.devDependencies?.next)
-  } catch {
-    return false
-  }
-}
-
 export async function checkNeedsReadToken(root: string): Promise<boolean> {
   try {
     const templatePath = await Promise.any(


### PR DESCRIPTION
### Description

- detecting a framework per package, instead of just checking the root. This also fixes an issue with Next.js in monorepos. 
- using `@vercel/frameworks` in `bootstrapRemoteTemplate` for detecting the framework.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Run

```shell
sanity init --template vercel/next.js/examples/cms-sanity
```

See if the directory includes a .env.local file

### Notes for release

N/A