### PR TITLE
feat: switch create integration to opt-out flow

### DIFF
--- a/dev/test-create-integration-studio/sanity.config.ts
+++ b/dev/test-create-integration-studio/sanity.config.ts
@@ -20,7 +20,6 @@ export default defineConfig([
     basePath: '/fallback',
     beta: {
       create: {
-        startInCreateEnabled: true,
         fallbackStudioOrigin: 'create-integration-test.sanity.studio',
       },
     },
@@ -30,11 +29,6 @@ export default defineConfig([
     title: 'No fallback origin',
     name: 'no-fallback',
     basePath: '/no-fallback',
-    beta: {
-      create: {
-        startInCreateEnabled: true,
-      },
-    },
   },
   {
     ...baseConfig,
@@ -43,7 +37,6 @@ export default defineConfig([
     basePath: '/invalid-fallback',
     beta: {
       create: {
-        startInCreateEnabled: true,
         fallbackStudioOrigin: 'does-not-exist',
       },
     },

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -657,7 +657,7 @@ function resolveSource({
         enabled: false,
       },
       create: {
-        startInCreateEnabled: startInCreateEnabledReducer({config, initialValue: false}),
+        startInCreateEnabled: startInCreateEnabledReducer({config, initialValue: true}),
         fallbackStudioOrigin: createFallbackOriginReducer(config),
       },
     },

--- a/packages/sanity/src/core/create/components/StartInCreateDevInfoButton.tsx
+++ b/packages/sanity/src/core/create/components/StartInCreateDevInfoButton.tsx
@@ -118,7 +118,11 @@ export function StartInCreateDevInfoButton(props: {studioApp?: CompatibleStudioA
 
             <Text size={1} weight="medium">
               For more details, please refer to{' '}
-              <a href="https://snty.link/create-config-guide" target="_blank" rel="noreferrer">
+              <a
+                href="https://snty.link/create-config-guide?ref=studio"
+                target="_blank"
+                rel="noreferrer"
+              >
                 our configuration guide
               </a>
               .

--- a/packages/sanity/src/core/create/components/StartInCreateDevInfoButton.tsx
+++ b/packages/sanity/src/core/create/components/StartInCreateDevInfoButton.tsx
@@ -118,11 +118,7 @@ export function StartInCreateDevInfoButton(props: {studioApp?: CompatibleStudioA
 
             <Text size={1} weight="medium">
               For more details, please refer to{' '}
-              <a
-                href={'https://www.sanity.io/docs/create-content-mapping'}
-                target="_blank"
-                rel="noreferrer"
-              >
+              <a href="https://snty.link/create-config-guide" target="_blank" rel="noreferrer">
                 our configuration guide
               </a>
               .

--- a/packages/sanity/src/core/create/components/constants.ts
+++ b/packages/sanity/src/core/create/components/constants.ts
@@ -1,1 +1,1 @@
-export const createUserDocumentationUrl = 'https://www.sanity.io/docs/create?ref=studio'
+export const createUserDocumentationUrl = 'https://snty.link/create-docs?ref=studio'


### PR DESCRIPTION
### Description

This PR enables the "Start in Create" banner by default for all documents (essentially running back #7884). Please note that Create is still in early access.

This also updates a few Create links to now use URLs provided by our link management service (should they need to be updated in future).

### What to review

- In the test studio, all documents will now include this banner by default.
- In the test create integration studio (`dev/test-create-integration-studio`), you can find an example where this has been disabled for a specific workspace.

### Notes for release

This is in-flight and will be added separately by @mmgj