### PR TITLE
feat(cli): misc copy changes

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -121,7 +121,8 @@ export default async function initSanity(
   const cliFlags = args.extOptions
   const unattended = cliFlags.y || cliFlags.yes
   const print = unattended ? noop : output.print
-  const warn = (msg: string) => output.warn(chalk.yellow.bgBlack(msg))
+  const success = output.success
+  const warn = output.warn
 
   const intendedPlan = cliFlags['project-plan']
   const intendedCoupon = cliFlags.coupon
@@ -131,7 +132,6 @@ export default async function initSanity(
   const bareOutput = cliFlags.bare
   const env = cliFlags.env
   const packageManager = cliFlags['package-manager']
-  const check = chalk.green('✓')
 
   let remoteTemplateInfo: RepoInfo | undefined
   if (cliFlags.template && checkIsRemoteTemplate(cliFlags.template)) {
@@ -259,17 +259,17 @@ export default async function initSanity(
   if (hasToken) {
     trace.log({step: 'login', alreadyLoggedIn: true})
     const user = await getUserData(apiClient)
-    print(`${check} You are logged in as %s using %s`, user.email, getProviderName(user.provider))
+    success('You are logged in as %s using %s', user.email, getProviderName(user.provider))
   } else if (!unattended) {
     trace.log({step: 'login'})
     await getOrCreateUser()
   }
 
-  let introMessage = `${check} Fetching existing projects`
+  let introMessage = 'Fetching existing projects'
   if (cliFlags.quickstart) {
-    introMessage = `${check} Eject your existing project's Sanity configuration`
+    introMessage = "Eject your existing project's Sanity configuration"
   }
-  print(introMessage)
+  success(introMessage)
   print('')
 
   const flags = await prepareFlags()
@@ -282,7 +282,8 @@ export default async function initSanity(
 
   // If user doesn't want to output any template code
   if (bareOutput) {
-    print(`\n${chalk.green('Success!')} Below are your project details:\n`)
+    success('Below are your project details')
+    print('')
     print(`Project ID: ${chalk.cyan(projectId)}`)
     print(`Dataset: ${chalk.cyan(datasetName)}`)
     print(
@@ -706,16 +707,13 @@ export default async function initSanity(
   trace.complete()
 
   async function getOrCreateUser() {
-    print(`We can't find any auth credentials in your Sanity config`)
-    print('- log in or create a new account\n')
+    warn('No authentication credentials found in your Sanity config')
+    print('')
 
     // Provide login options (`sanity login`)
     const {extOptions, ...otherArgs} = args
     const loginArgs: CliCommandArguments<LoginFlags> = {...otherArgs, extOptions: {}}
     await login(loginArgs, {...context, telemetry: trace.newContext('login')})
-
-    print("Good stuff, you're now authenticated. You'll need a project to keep your")
-    print('datasets and collaborators safe and snug.')
   }
 
   async function getProjectDetails(): Promise<{
@@ -876,7 +874,6 @@ export default async function initSanity(
         new prompt.Separator(),
         ...projectChoices,
       ],
-      suffix: 'Use ↑↓ to select, Enter to confirm',
     })
 
     if (selected === 'new') {
@@ -1049,20 +1046,20 @@ export default async function initSanity(
       type: 'list',
       choices: [
         {
-          value: 'moviedb',
-          name: 'Movie project (schema + sample data)',
-        },
-        {
-          value: 'shopify',
-          name: 'E-commerce (Shopify)',
+          value: 'clean',
+          name: 'Clean project with no predefined schema types',
         },
         {
           value: 'blog',
           name: 'Blog (schema)',
         },
         {
-          value: 'clean',
-          name: 'Clean project with no predefined schema types',
+          value: 'shopify',
+          name: 'E-commerce (Shopify)',
+        },
+        {
+          value: 'moviedb',
+          name: 'Movie project (schema + sample data)',
         },
       ],
     })

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -131,6 +131,7 @@ export default async function initSanity(
   const bareOutput = cliFlags.bare
   const env = cliFlags.env
   const packageManager = cliFlags['package-manager']
+  const check = chalk.green('✓')
 
   let remoteTemplateInfo: RepoInfo | undefined
   if (cliFlags.template && checkIsRemoteTemplate(cliFlags.template)) {
@@ -258,25 +259,17 @@ export default async function initSanity(
   if (hasToken) {
     trace.log({step: 'login', alreadyLoggedIn: true})
     const user = await getUserData(apiClient)
-    print('')
-    print(
-      `${chalk.gray("  👤 You're logged in as %s using %s")}`,
-      user.name,
-      getProviderName(user.provider),
-    )
-    print('')
+    print(`${check} You are logged in as %s using %s`, user.email, getProviderName(user.provider))
   } else if (!unattended) {
     trace.log({step: 'login'})
     await getOrCreateUser()
   }
 
-  let introMessage = "Let's get you started with a new project"
+  let introMessage = `${check} Fetching existing projects`
   if (cliFlags.quickstart) {
-    introMessage = "Let's get you started with remote Sanity project"
-  } else if (remoteTemplateInfo) {
-    introMessage = "Let's get you started with a remote Sanity template"
+    introMessage = `${check} Eject your existing project's Sanity configuration`
   }
-  print(`  ➡️ ${chalk.gray(introMessage)}`)
+  print(introMessage)
   print('')
 
   const flags = await prepareFlags()
@@ -880,13 +873,14 @@ export default async function initSanity(
     }))
 
     const selected = await prompt.single({
-      message: 'Select project to use',
+      message: 'Create a new project or select an existing one',
       type: 'list',
       choices: [
         {value: 'new', name: 'Create new project'},
         new prompt.Separator(),
         ...projectChoices,
       ],
+      suffix: 'Use ↑↓ to select, Enter to confirm',
     })
 
     if (selected === 'new') {

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -654,7 +654,7 @@ export default async function initSanity(
 
     print('')
     print('If you want to delete the imported data, use')
-    print(`  ${chalk.cyan(`sanity dataset delete ${datasetName}`)}`)
+    print(`  ${chalk.cyan(`npx sanity dataset delete ${datasetName}`)}`)
     print('and create a new clean dataset with')
     print(`  ${chalk.cyan(`npx sanity dataset create <name>`)}\n`)
   }

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -1550,12 +1550,3 @@ function getImportCommand(
       !isCommandGroup(cmd) && cmd.name === 'import' && cmd.group === 'dataset',
   )
 }
-
-async function hasGlobalCli(): Promise<boolean> {
-  try {
-    const globalCliPath = await which('sanity')
-    return Boolean(globalCliPath)
-  } catch (err) {
-    return false
-  }
-}

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -652,13 +652,11 @@ export default async function initSanity(
       context,
     })
 
-    if (await hasGlobalCli()) {
-      print('')
-      print('If you want to delete the imported data, use')
-      print(`  ${chalk.cyan(`sanity dataset delete ${datasetName}`)}`)
-      print('and create a new clean dataset with')
-      print(`  ${chalk.cyan(`sanity dataset create <name>`)}\n`)
-    }
+    print('')
+    print('If you want to delete the imported data, use')
+    print(`  ${chalk.cyan(`sanity dataset delete ${datasetName}`)}`)
+    print('and create a new clean dataset with')
+    print(`  ${chalk.cyan(`npx sanity dataset create <name>`)}\n`)
   }
 
   const devCommandMap: Record<PackageManager, string> = {
@@ -680,12 +678,10 @@ export default async function initSanity(
     print(`Then: ${chalk.cyan(devCommand)} - to run Sanity Studio\n`)
   }
 
-  if (await hasGlobalCli()) {
-    print(`Other helpful commands`)
-    print(`sanity docs - to open the documentation in a browser`)
-    print(`sanity manage - to open the project settings in a browser`)
-    print(`sanity help - to explore the CLI manual`)
-  }
+  print(`Other helpful commands`)
+  print(`npx sanity docs - to open the documentation in a browser`)
+  print(`npx sanity manage - to open the project settings in a browser`)
+  print(`npx sanity help - to explore the CLI manual`)
 
   const sendInvite =
     isFirstProject &&

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -12,7 +12,6 @@ import pFilter from 'p-filter'
 import resolveFrom from 'resolve-from'
 import semver from 'semver'
 import {evaluate, patch} from 'silver-fleece'
-import which from 'which'
 
 import {CLIInitStepCompleted} from '../../__telemetry__/init.telemetry'
 import {type InitFlags} from '../../commands/init/initCommand'

--- a/packages/@sanity/cli/src/actions/login/login.ts
+++ b/packages/@sanity/cli/src/actions/login/login.ts
@@ -2,7 +2,6 @@ import http, {type Server} from 'node:http'
 import os from 'node:os'
 
 import {type SanityClient} from '@sanity/client'
-import chalk from 'chalk'
 import open from 'open'
 
 import {debug as debugIt} from '../../debug'

--- a/packages/@sanity/cli/src/actions/login/login.ts
+++ b/packages/@sanity/cli/src/actions/login/login.ts
@@ -146,7 +146,7 @@ export async function login(
       })
   }
 
-  output.print(chalk.green('Login successful'))
+  output.success('Login successful')
   trace.complete()
 }
 
@@ -335,7 +335,7 @@ async function promptProviders(
 
   const provider = await prompt.single({
     type: 'list',
-    message: 'Login type',
+    message: 'Please log in or create a new account',
     choices: providers.map((choice) => choice.title),
   })
 

--- a/packages/@sanity/cli/src/commands/logout/logoutCommand.ts
+++ b/packages/@sanity/cli/src/commands/logout/logoutCommand.ts
@@ -45,7 +45,7 @@ const logoutCommand: CliCommandDefinition = {
     // Clear cached telemetry consent
     cfg.delete(TELEMETRY_CONSENT_CONFIG_KEY)
 
-    output.print(chalk.green('Logged out'))
+    output.success('Logged out')
   },
 }
 

--- a/packages/@sanity/cli/src/outputters/cliOutputter.ts
+++ b/packages/@sanity/cli/src/outputters/cliOutputter.ts
@@ -38,7 +38,7 @@ export default {
 
   spinner(options: Options): Ora {
     const spinner = ora({...options, spinner: 'dots'})
-    // Override the default `succeed` method to use a green checkmark, instead of the default emoji
+    // Override the default status methods to use custom symbols instead of emojis
     spinner.succeed = (text?: string) => spinner.stopAndPersist({text, symbol: SYMBOL_CHECK})
     spinner.warn = (text?: string) => spinner.stopAndPersist({text, symbol: SYMBOL_WARN})
     spinner.fail = (text?: string) => spinner.stopAndPersist({text, symbol: SYMBOL_FAIL})

--- a/packages/@sanity/cli/src/outputters/cliOutputter.ts
+++ b/packages/@sanity/cli/src/outputters/cliOutputter.ts
@@ -23,7 +23,7 @@ export default {
 
   error(...args: unknown[]): void {
     if (args[0] instanceof Error) {
-      console.error(chalk.red(args[0].stack))
+      console.error(`${SYMBOL_FAIL} ${chalk.red(args[0].stack)}`)
     } else {
       console.error(`${SYMBOL_FAIL} ${args.join(' ')}`)
     }

--- a/packages/@sanity/cli/src/outputters/cliOutputter.ts
+++ b/packages/@sanity/cli/src/outputters/cliOutputter.ts
@@ -2,6 +2,10 @@
 import chalk from 'chalk'
 import ora, {type Options, type Ora} from 'ora'
 
+const SYMBOL_CHECK = chalk.green('✓')
+const SYMBOL_WARN = chalk.yellow('⚠')
+const SYMBOL_FAIL = chalk.red('✗')
+
 let isFirstClear = true
 
 export default {
@@ -9,15 +13,19 @@ export default {
     console.log(...args)
   },
 
+  success(...args: unknown[]): void {
+    console.log(`${SYMBOL_CHECK} ${args.join(' ')}`)
+  },
+
   warn(...args: unknown[]): void {
-    console.warn(...args)
+    console.warn(`${SYMBOL_WARN} ${args.join(' ')}`)
   },
 
   error(...args: unknown[]): void {
     if (args[0] instanceof Error) {
       console.error(chalk.red(args[0].stack))
     } else {
-      console.error(...args)
+      console.error(`${SYMBOL_FAIL} ${args.join(' ')}`)
     }
   },
 
@@ -28,7 +36,12 @@ export default {
     isFirstClear = false
   },
 
-  spinner(options: Options | string): Ora {
-    return ora(options)
+  spinner(options: Options): Ora {
+    const spinner = ora({...options, spinner: 'dots'})
+    // Override the default `succeed` method to use a green checkmark, instead of the default emoji
+    spinner.succeed = (text?: string) => spinner.stopAndPersist({text, symbol: SYMBOL_CHECK})
+    spinner.warn = (text?: string) => spinner.stopAndPersist({text, symbol: SYMBOL_WARN})
+    spinner.fail = (text?: string) => spinner.stopAndPersist({text, symbol: SYMBOL_FAIL})
+    return spinner
   },
 }

--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -150,6 +150,7 @@ export interface CommandRunnerOptions {
 
 export interface CliOutputter {
   print: (...args: unknown[]) => void
+  success: (...args: unknown[]) => void
   warn: (...args: unknown[]) => void
   error: (...args: unknown[]) => void
   clear: () => void

--- a/packages/@sanity/cli/src/util/generateCommandsDocumentation.ts
+++ b/packages/@sanity/cli/src/util/generateCommandsDocumentation.ts
@@ -27,7 +27,10 @@ export function generateCommandsDocumentation(
     'Commands:',
   ]
     .concat(commands.map((cmd) => `   ${padEnd(cmd.name, cmdLength + 1)} ${cmd.description}`))
-    .concat(['', `See 'sanity help${prefix} <command>' for specific information on a subcommand.`])
+    .concat([
+      '',
+      `See 'npx sanity help${prefix} <command>' for specific information on a subcommand.`,
+    ])
 
   return rows.join('\n')
 }
@@ -43,7 +46,7 @@ export function generateCommandDocumentation(
   if (!command) {
     throw new Error(
       subCommand
-        ? `"${subCommand}" is not a subcommand of "${group}". See 'sanity help ${group}'`
+        ? `"${subCommand}" is not a subcommand of "${group}". See 'npx sanity help ${group}'`
         : getNoSuchCommandText(group || command),
     )
   }

--- a/packages/@sanity/cli/src/util/generateCommandsDocumentation.ts
+++ b/packages/@sanity/cli/src/util/generateCommandsDocumentation.ts
@@ -22,7 +22,7 @@ export function generateCommandsDocumentation(
   const prefix = group === 'default' ? '' : ` ${group}`
 
   const rows = [
-    `usage: sanity${prefix} [--default] [-v|--version] [-d|--debug] [-h|--help] <command> [<args>]`,
+    `usage: npx sanity${prefix} [--default] [-v|--version] [-d|--debug] [-h|--help] <command> [<args>]`,
     '',
     'Commands:',
   ]
@@ -50,7 +50,7 @@ export function generateCommandDocumentation(
 
   const cmdParts = [group || command.name, subCommand].filter(Boolean).join(' ')
   return [
-    `usage: sanity ${cmdParts} ${command.signature}`,
+    `usage: npx sanity ${cmdParts} ${command.signature}`,
     '',
     `   ${command.description}`,
     '',


### PR DESCRIPTION
### Description

#### New output methods and adjustments:
- Added new method `success` in `cliOutputter`. This logs a message with a `chalk.green('✓')` in front
- Adjusted warn method to have `chalk.yellow('⚠')` in front
- Adjusted error method to have `chalk.red('✗')` in front

#### Copy changes
- Slight modification on intro message
- Modified login copy
- Modified logout print method to use success method instead
- Sanity command suggestions are now prefixed with `npx`

### What to review

- Are there any typos?
- Does the new copy make sense?

### Testing

Run 
```shell
sanity init
```

```shell
sanity logout
```

```shell
sanity login
```

### Notes for release

N/A