### PR TITLE
fix(core): documents history fixes

### DIFF
--- a/packages/sanity/src/core/store/events/utils.ts
+++ b/packages/sanity/src/core/store/events/utils.ts
@@ -1,5 +1,8 @@
 import {type MendozaPatch, type TransactionLogEventWithEffects} from '@sanity/types'
 
+import {type ReleasesReducerState} from '../../releases/store/reducer'
+import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseDocumentIdFromReleaseId'
+import {getVersionFromId} from '../../util/draftUtils'
 import {type DocumentVariantType} from '../../util/getDocumentVariantType'
 import {type DocumentRemoteMutationEvent} from '../_legacy'
 import {
@@ -136,4 +139,39 @@ export function remoteMutationToTransaction(
       },
     },
   }
+}
+
+/**
+ * Updates the version publish document id.
+ */
+export function updateVersionEvents(events: DocumentGroupEvent[]) {
+  return events.map((event) => {
+    if (isPublishDocumentVersionEvent(event)) {
+      return {
+        ...event,
+        documentId: event.versionId,
+      }
+    }
+    return event
+  })
+}
+
+/**
+ * Adds the release information to the publish event.
+ */
+export function updatePublishedEvents(
+  events: DocumentGroupEvent[],
+  releases: ReleasesReducerState,
+) {
+  return events.map((event) => {
+    if (isPublishDocumentVersionEvent(event)) {
+      const releaseId = getVersionFromId(event.versionId)
+      if (releaseId) {
+        const release = releases.releases.get(getReleaseDocumentIdFromReleaseId(releaseId))
+        return {...event, release: release}
+      }
+      return event
+    }
+    return event
+  })
 }

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -90,7 +90,7 @@ const structureLocaleStrings = defineLocalesResources('structure', {
     'This document has live edit enabled and cannot be unpublished',
   /** Description for the archived release banner, rendered when viewing the history of a version document from the publihed view */
   'banners.archived-release.description':
-    "You are viewing a read-only document that was published in a release. It can't be edited",
+    "You are viewing a read-only document that was published as part of <VersionBadge> a release</VersionBadge>. It can't be edited",
   /** The text for the restore button on the deleted document banner */
   'banners.deleted-document-banner.restore-button.text': 'Restore most recent revision',
   /** The text content for the deleted document banner */

--- a/packages/sanity/src/structure/panes/document/DocumentEventsPane.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentEventsPane.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useRef} from 'react'
+import {useMemo} from 'react'
 import {
   EventsProvider,
   getDraftId,
@@ -8,7 +8,6 @@ import {
   usePerspective,
   useReleases,
 } from 'sanity'
-import {useEffectEvent} from 'use-effect-event'
 
 import {usePaneRouter} from '../../components'
 import {EMPTY_PARAMS} from './constants'
@@ -17,7 +16,7 @@ import {DocumentPaneProvider} from './DocumentPaneProvider'
 import {type DocumentPaneProviderProps} from './types'
 
 export const DocumentEventsPane = (props: DocumentPaneProviderProps) => {
-  const {params = EMPTY_PARAMS, setParams} = usePaneRouter()
+  const {params = EMPTY_PARAMS} = usePaneRouter()
   const options = usePaneOptions(props.pane.options, params)
 
   const {selectedPerspectiveName} = usePerspective()
@@ -40,29 +39,6 @@ export const DocumentEventsPane = (props: DocumentPaneProviderProps) => {
     }
     return options.id
   }, [archivedReleases, historyVersion, selectedPerspectiveName, options.id])
-
-  const isMounted = useRef(false)
-
-  const updateHistoryParams = useEffectEvent((_perspective?: string) => {
-    setParams({
-      ...params,
-      // Reset the history related params when the perspective changes, as they don't make sense
-      // in the context of the new perspective - preserveRev is used when setting draft revision.
-      rev: params.preserveRev === 'true' ? params.rev : undefined,
-      preserveRev: undefined,
-      since: undefined,
-      historyVersion: undefined,
-    })
-  })
-  useEffect(() => {
-    // Skip the first run to avoid resetting the params on initial load
-    if (isMounted.current) {
-      updateHistoryParams(selectedPerspectiveName)
-    } else {
-      isMounted.current = true
-    }
-    // TODO: Remove `updateHistoryParams` as a dependency when react eslint plugin is updated
-  }, [selectedPerspectiveName, updateHistoryParams])
 
   const eventsStore = useEventsStore({documentId, documentType: options.type, rev, since})
 

--- a/packages/sanity/src/structure/panes/document/DocumentPane.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPane.tsx
@@ -24,6 +24,7 @@ import {CommentsWrapper} from './comments'
 import {useDocumentLayoutComponent} from './document-layout'
 import {DocumentPaneProviderWrapper} from './DocumentPaneProviderWrapper'
 import {type DocumentPaneProviderProps} from './types'
+import {useResetHistoryParams} from './useResetHistoryParams'
 
 type DocumentPaneOptions = DocumentPaneNode['options']
 
@@ -49,7 +50,7 @@ function DocumentPaneInner(props: DocumentPaneProviderProps) {
   const paneRouter = usePaneRouter()
   const options = usePaneOptions(pane.options, paneRouter.params)
   const {documentType, isLoaded: isDocumentLoaded} = useDocumentType(options.id, options.type)
-
+  useResetHistoryParams()
   const DocumentLayout = useDocumentLayoutComponent()
 
   // The templates that should be creatable from inside this document pane.

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ArchivedReleaseDocumentBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ArchivedReleaseDocumentBanner.tsx
@@ -1,11 +1,20 @@
 import {Flex, Text} from '@sanity/ui'
-import {useTranslation} from 'sanity'
+import {useMemo} from 'react'
+import {
+  getReleaseIdFromReleaseDocumentId,
+  getReleaseTone,
+  Translate,
+  useReleases,
+  useTranslation,
+  VersionInlineBadge,
+} from 'sanity'
 import {structureLocaleNamespace, usePaneRouter} from 'sanity/structure'
 
 import {Banner} from './Banner'
 
 export function ArchivedReleaseDocumentBanner(): JSX.Element {
   const {t} = useTranslation(structureLocaleNamespace)
+  const {archivedReleases} = useReleases()
 
   const {params, setParams} = usePaneRouter()
   const handleGoBack = () => {
@@ -17,13 +26,33 @@ export function ArchivedReleaseDocumentBanner(): JSX.Element {
     })
   }
 
+  const release = useMemo(() => {
+    return archivedReleases.find(
+      (r) => getReleaseIdFromReleaseDocumentId(r._id) === params?.historyVersion,
+    )
+  }, [archivedReleases, params?.historyVersion])
   return (
     <Banner
       tone="caution"
       paddingY={2}
       content={
         <Flex align="center" justify="space-between" gap={1} flex={1}>
-          <Text size={1}>{t('banners.archived-release.description')}</Text>
+          <Text size={1}>
+            <Translate
+              t={t}
+              i18nKey="banners.archived-release.description"
+              components={{
+                VersionBadge: ({children}) => {
+                  if (!release) return children
+                  return (
+                    <VersionInlineBadge $tone={getReleaseTone(release)}>
+                      {release?.metadata.title}
+                    </VersionInlineBadge>
+                  )
+                },
+              }}
+            />
+          </Text>
         </Flex>
       }
       action={{

--- a/packages/sanity/src/structure/panes/document/useResetHistoryParams.ts
+++ b/packages/sanity/src/structure/panes/document/useResetHistoryParams.ts
@@ -1,0 +1,43 @@
+import {useEffect, useRef} from 'react'
+import {usePerspective} from 'sanity'
+import {useEffectEvent} from 'use-effect-event'
+
+import {usePaneRouter} from '../../components'
+import {EMPTY_PARAMS} from './constants'
+
+/**
+ * This hooks takes care of resetting the history related params when the perspective changes.
+ * It needs to be placed in a stable component, like the `DocumentPane`, which won't be unmounted when the perspective changes.
+ */
+export function useResetHistoryParams() {
+  const {params = EMPTY_PARAMS, setParams} = usePaneRouter()
+
+  const {selectedPerspectiveName} = usePerspective()
+  const isMounted = useRef(false)
+
+  const updateHistoryParams = useEffectEvent((_perspective?: string) => {
+    setParams({
+      ...params,
+      // Reset the history related params when the perspective changes, as they don't make sense
+      // in the context of the new perspective - preserveRev is used when setting draft revision.
+      rev: params.preserveRev === 'true' ? params.rev : undefined,
+      preserveRev: undefined,
+      since: undefined,
+      historyVersion: undefined,
+    })
+  })
+  useEffect(() => {
+    // Skip the first run to avoid resetting the params on initial load
+    if (isMounted.current) {
+      updateHistoryParams(selectedPerspectiveName)
+    }
+    // TODO: Remove `updateHistoryParams` as a dependency when react eslint plugin is updated
+  }, [selectedPerspectiveName, updateHistoryParams])
+
+  useEffect(() => {
+    isMounted.current = true
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+}


### PR DESCRIPTION
### Description
Fixes some issues with releases history:
- Refreshing the browser or linking to a revision parameter was not persisted. [fix(structure): reset historyParams only if selectedPerspective changes](https://github.com/sanity-io/sanity/commit/837089adb1fd086d95e7c0ebc6f91d0645f355fb)
- Version documents showing `draft` when inspecting them as part of an archived/published release  [fix(core): update version events documentId](https://github.com/sanity-io/sanity/commit/eb8e1054b0e6a2a57891d86a93b5a9bb2d2bc5f1)
- Adds the release title to the archived document banner



| Before | After |
|--------|--------|
| <img width="926" alt="Screenshot 2024-12-10 at 16 26 31" src="https://github.com/user-attachments/assets/17248bcf-334c-4878-84b2-87f64b27c1e2"> | <img width="960" alt="Screenshot 2024-12-10 at 16 25 40" src="https://github.com/user-attachments/assets/f74ad9ef-5fcf-4897-b765-21b94c0a0c41"> | 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
