### PR TITLE
fix(core): tasks UpdatedTimeAgo should be a hook

### DIFF
--- a/packages/sanity/src/core/tasks/components/activity/TaskActivityEditedAt.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/TaskActivityEditedAt.tsx
@@ -2,7 +2,7 @@ import {Box, Flex, Text} from '@sanity/ui'
 import {memo} from 'react'
 
 import {Tooltip} from '../../../../ui-components'
-import {getChangeDetails, NoWrap, UpdatedTimeAgo, UserName} from './helpers'
+import {getChangeDetails, NoWrap, UserName, useUpdatedTimeAgo} from './helpers'
 import {type FieldChange} from './helpers/parseTransactions'
 
 interface EditedAtProps {
@@ -12,7 +12,7 @@ interface EditedAtProps {
 export const EditedAt = memo(
   function EditedAt(props: EditedAtProps) {
     const {activity} = props
-    const {formattedDate, timeAgo} = UpdatedTimeAgo(activity.timestamp)
+    const {formattedDate, timeAgo} = useUpdatedTimeAgo(activity.timestamp)
     const {icon, text, changeTo} = getChangeDetails(activity)
 
     return (

--- a/packages/sanity/src/core/tasks/components/activity/TasksActivityCreatedAt.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/TasksActivityCreatedAt.tsx
@@ -6,7 +6,7 @@ import {Tooltip} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
 import {useUser} from '../../../store'
 import {tasksLocaleNamespace} from '../../i18n'
-import {NoWrap, UpdatedTimeAgo} from './helpers'
+import {NoWrap, useUpdatedTimeAgo} from './helpers'
 import {ActivityItem} from './TasksActivityItem'
 
 const UserSkeleton = styled(TextSkeleton)`
@@ -23,7 +23,7 @@ export const TasksActivityCreatedAt = memo(
   function TasksActivityCreatedAt(props: TasksActivityCreatedAtProps) {
     const {createdAt, authorId} = props
     const [user, loading] = useUser(authorId)
-    const {timeAgo, formattedDate} = UpdatedTimeAgo(createdAt)
+    const {timeAgo, formattedDate} = useUpdatedTimeAgo(createdAt)
     const {t} = useTranslation(tasksLocaleNamespace)
     return (
       <ActivityItem userId={authorId}>

--- a/packages/sanity/src/core/tasks/components/activity/helpers/index.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/helpers/index.tsx
@@ -37,7 +37,7 @@ export const NoWrap = styled.span`
   white-space: nowrap;
 `
 
-export function UpdatedTimeAgo(timestamp: string) {
+export function useUpdatedTimeAgo(timestamp: string) {
   const date = new Date(timestamp)
   const dateFormatter = useDateTimeFormat(DATE_FORMAT_OPTIONS)
   const formattedDate = dateFormatter.format(date)


### PR DESCRIPTION
### Description

`UpdatedTimeAgo` was breaking the hook rules by not using the keyword `use` . 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manual testing, opening tasks now works.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue when opening tasks details.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
