### PR TITLE
feat(core): corel  publish 2 action - test

### DIFF
--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -10,7 +10,7 @@ import {getReleaseIdFromReleaseDocumentId, type ReleaseDocument} from '../index'
 import {type EditableReleaseDocument} from './types'
 
 export interface ReleaseOperationsStore {
-  publishRelease: (releaseId: string) => Promise<void>
+  publishRelease: (releaseId: string, useUnstableAction?: boolean) => Promise<void>
   schedule: (releaseId: string, date: Date) => Promise<void>
   //todo: reschedule: (releaseId: string, newDate: Date) => Promise<void>
   unschedule: (releaseId: string) => Promise<void>
@@ -60,10 +60,12 @@ export function createReleaseOperationsStore(options: {
     })
   }
 
-  const handlePublishRelease = (releaseId: string) =>
+  const handlePublishRelease = (releaseId: string, useUnstableAction?: boolean) =>
     requestAction(client, [
       {
-        actionType: 'sanity.action.release.publish',
+        actionType: useUnstableAction
+          ? 'sanity.action.release.publish2'
+          : 'sanity.action.release.publish',
         releaseId: getReleaseIdFromReleaseDocumentId(releaseId),
       },
     ])
@@ -179,7 +181,7 @@ interface ScheduleApiAction {
 }
 
 interface PublishApiAction {
-  actionType: 'sanity.action.release.publish'
+  actionType: 'sanity.action.release.publish' | 'sanity.action.release.publish2'
   releaseId: string
 }
 

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
@@ -7,6 +7,7 @@ import {useRouter} from 'sanity/router'
 import {Button, Dialog} from '../../../../../ui-components'
 import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
 import {Translate, useTranslation} from '../../../../i18n'
+import {supportsLocalStorage} from '../../../../util/supportsLocalStorage'
 import {PublishedRelease} from '../../../__telemetry__/releases.telemetry'
 import {usePerspective} from '../../../hooks/usePerspective'
 import {releasesLocaleNamespace} from '../../../i18n'
@@ -31,6 +32,13 @@ export const ReleasePublishAllButton = ({
   const {t} = useTranslation(releasesLocaleNamespace)
   const perspective = usePerspective()
   const telemetry = useTelemetry()
+  const publish2 = useMemo(() => {
+    if (supportsLocalStorage) {
+      return localStorage.getItem('publish2') === 'true'
+    }
+    return false
+  }, [])
+
   const [publishBundleStatus, setPublishBundleStatus] = useState<
     'idle' | 'confirm' | 'confirm-2' | 'publishing'
   >('idle')
@@ -151,21 +159,23 @@ export const ReleasePublishAllButton = ({
 
   return (
     <>
-      <Button
-        tooltipProps={{
-          disabled: !isPublishButtonDisabled,
-          content: publishTooltipContent,
-          placement: 'bottom',
-        }}
-        icon={PublishIcon}
-        disabled={isPublishButtonDisabled || publishBundleStatus === 'publishing'}
-        // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
-        text={'Unstable Publish'}
-        onClick={() => setPublishBundleStatus('confirm-2')}
-        loading={publishBundleStatus === 'publishing'}
-        data-testid="publish-all-button"
-        tone="suggest"
-      />
+      {publish2 && (
+        <Button
+          tooltipProps={{
+            disabled: !isPublishButtonDisabled,
+            content: publishTooltipContent,
+            placement: 'bottom',
+          }}
+          icon={PublishIcon}
+          disabled={isPublishButtonDisabled || publishBundleStatus === 'publishing'}
+          // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
+          text={'Unstable Publish'}
+          onClick={() => setPublishBundleStatus('confirm-2')}
+          loading={publishBundleStatus === 'publishing'}
+          data-testid="publish-all-button"
+          tone="suggest"
+        />
+      )}
       <Button
         tooltipProps={{
           disabled: !isPublishButtonDisabled,

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
@@ -31,9 +31,9 @@ export const ReleasePublishAllButton = ({
   const {t} = useTranslation(releasesLocaleNamespace)
   const perspective = usePerspective()
   const telemetry = useTelemetry()
-  const [publishBundleStatus, setPublishBundleStatus] = useState<'idle' | 'confirm' | 'publishing'>(
-    'idle',
-  )
+  const [publishBundleStatus, setPublishBundleStatus] = useState<
+    'idle' | 'confirm' | 'confirm-2' | 'publishing'
+  >('idle')
 
   const isValidatingDocuments = documents.some(({validation}) => validation.isValidating)
   const hasDocumentValidationErrors = documents.some(({validation}) => validation.hasError)
@@ -44,8 +44,9 @@ export const ReleasePublishAllButton = ({
     if (!release) return
 
     try {
+      const useUnstableAction = publishBundleStatus === 'confirm-2'
       setPublishBundleStatus('publishing')
-      await publishRelease(release._id)
+      await publishRelease(release._id, useUnstableAction)
       telemetry.log(PublishedRelease)
       toast.push({
         closable: true,
@@ -85,7 +86,7 @@ export const ReleasePublishAllButton = ({
     } finally {
       setPublishBundleStatus('idle')
     }
-  }, [release, publishRelease, telemetry, toast, t, router, perspective])
+  }, [release, publishBundleStatus, publishRelease, telemetry, toast, t, router, perspective])
 
   const confirmPublishDialog = useMemo(() => {
     if (publishBundleStatus === 'idle') return null
@@ -150,6 +151,21 @@ export const ReleasePublishAllButton = ({
 
   return (
     <>
+      <Button
+        tooltipProps={{
+          disabled: !isPublishButtonDisabled,
+          content: publishTooltipContent,
+          placement: 'bottom',
+        }}
+        icon={PublishIcon}
+        disabled={isPublishButtonDisabled || publishBundleStatus === 'publishing'}
+        // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
+        text={'Unstable Publish'}
+        onClick={() => setPublishBundleStatus('confirm-2')}
+        loading={publishBundleStatus === 'publishing'}
+        data-testid="publish-all-button"
+        tone="suggest"
+      />
       <Button
         tooltipProps={{
           disabled: !isPublishButtonDisabled,

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
@@ -242,6 +242,7 @@ describe('after releases have loaded', () => {
 
         expect(useReleaseOperationsMockReturn.publishRelease).toHaveBeenCalledWith(
           activeASAPRelease._id,
+          false,
         )
       })
     })


### PR DESCRIPTION
### Description

Adds a second publish action using the new action `sanity.action.release.publish2`. which is being developed.

To enable it, you need to add `publish2: true` in local storage

<img width="1724" alt="Screenshot 2024-12-11 at 17 12 58" src="https://github.com/user-attachments/assets/c1949448-3787-42d1-9e3b-b001708ec455" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
