### PR TITLE
test(playwright-ct): fix issues and flake

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "prettier": "@sanity/prettier-config",
   "devDependencies": {
     "@google-cloud/storage": "^7.11.0",
-    "@playwright/test": "1.44.1",
+    "@playwright/test": "1.49.1",
     "@repo/dev-aliases": "workspace:*",
     "@repo/package.config": "workspace:*",
     "@repo/test-config": "workspace:*",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -266,8 +266,8 @@
     "yargs": "^17.3.0"
   },
   "devDependencies": {
-    "@playwright/experimental-ct-react": "1.44.1",
-    "@playwright/test": "1.44.1",
+    "@playwright/experimental-ct-react": "1.49.1",
+    "@playwright/test": "1.49.1",
     "@repo/dev-aliases": "workspace:*",
     "@repo/package.config": "workspace:*",
     "@repo/test-config": "workspace:*",

--- a/packages/sanity/playwright-ct.config.ts
+++ b/packages/sanity/playwright-ct.config.ts
@@ -39,10 +39,10 @@ export default defineConfig({
       ],
 
   /* Maximum time one test can run for. */
-  timeout: 30 * 1000,
+  timeout: 60 * 1000,
   expect: {
     // Maximum time expect() should wait for the condition to be met.
-    timeout: 10 * 1000,
+    timeout: 40 * 1000,
   },
 
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Decorators.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Decorators.spec.tsx
@@ -44,12 +44,6 @@ test.describe('Portable Text Input', () => {
       page,
       browserName,
     }) => {
-      // avoid flakiness to make sure the test has the best chance despite being slow
-      test.slow()
-
-      // For now, only test in Chromium due to flakiness in Firefox and WebKit
-      test.skip(browserName !== 'chromium')
-
       const {
         getModifierKey,
         getFocusedPortableTextEditor,
@@ -62,7 +56,7 @@ test.describe('Portable Text Input', () => {
       await mount(<DecoratorsStory />)
       const $portableTextInput = await getFocusedPortableTextInput('field-defaultDecorators')
       const $pte = await getFocusedPortableTextEditor('field-defaultDecorators')
-      const modifierKey = getModifierKey()
+      const modifierKey = getModifierKey({browserName})
 
       for (const decorator of DEFAULT_DECORATORS) {
         if (decorator.hotkey) {

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Toolbar.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Toolbar.spec.tsx
@@ -106,7 +106,7 @@ test.describe('Portable Text Input', () => {
     })
 
     // TODO - needs rewrite to avoid flakiness
-    test.skip('Opening block style', () => {
+    test.describe('Opening block style', () => {
       test('on a simple editor', async ({mount, page}) => {
         const {getFocusedPortableTextInput} = testHelpers({page})
         await mount(<ToolbarStory />)

--- a/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
+++ b/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
@@ -106,14 +106,19 @@ export function testHelpers({page}: {page: PlaywrightTestArgs['page']}) {
      * @returns The modifier key name ('Meta' for macOS, 'Control' for other platforms).
      */
     getModifierKey: (options?: {browserName?: string}) => {
-      if (process.platform === 'darwin') {
-        // There's a bug in Chromium on macOS where it use 'Control' instead of 'Meta' inside Playwright for some reason
-        if (options?.browserName && ['chromium', 'firefox'].includes(options.browserName)) {
-          return 'Control'
-        }
+      // There's a bug with Firefox and Chromium on macOS where it use 'Control' instead of 'Meta' inside Playwright for some reason
+      if (
+        process.platform === 'darwin' &&
+        options?.browserName &&
+        ['chromium', 'firefox'].includes(options.browserName)
+      ) {
+        return 'Control'
+      }
+      // Webkit on Linux uses 'Meta' instead of 'Control' as the modifier key for some reason
+      if (process.platform === 'linux' && options?.browserName === 'webkit') {
         return 'Meta'
       }
-      return 'Control'
+      return 'ControlOrMeta'
     },
     /**
      * Types text with a delay using `page.keyboard.type`. Default delay emulates a human typing.

--- a/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
+++ b/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
@@ -13,7 +13,7 @@ export function testHelpers({page}: {page: PlaywrightTestArgs['page']}) {
       await $overlay.press('Space')
     }
 
-    await expect($overlay).not.toBeVisible({timeout: 1500})
+    await expect($overlay).not.toBeVisible()
   }
   return {
     /**

--- a/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
+++ b/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
@@ -105,8 +105,12 @@ export function testHelpers({page}: {page: PlaywrightTestArgs['page']}) {
      * Gets the appropriate modifier key for the current platform.
      * @returns The modifier key name ('Meta' for macOS, 'Control' for other platforms).
      */
-    getModifierKey: () => {
+    getModifierKey: (options?: {browserName?: string}) => {
       if (process.platform === 'darwin') {
+        // There's a bug in Chromium on macOS where it use 'Control' instead of 'Meta' inside Playwright for some reason
+        if (options?.browserName && ['chromium', 'firefox'].includes(options.browserName)) {
+          return 'Control'
+        }
         return 'Meta'
       }
       return 'Control'

--- a/perf/tests/package.json
+++ b/perf/tests/package.json
@@ -15,7 +15,7 @@
     "studio:dev": "cd perf/studio && SANITY_STUDIO_DATASET=dev pnpm dev"
   },
   "dependencies": {
-    "@playwright/test": "1.44.1",
+    "@playwright/test": "1.49.1",
     "@sanity/client": "^6.24.1",
     "@sanity/uuid": "^3.0.1",
     "dotenv": "^16.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^7.11.0
         version: 7.14.0(encoding@0.1.13)
       '@playwright/test':
-        specifier: 1.44.1
-        version: 1.44.1
+        specifier: 1.49.1
+        version: 1.49.1
       '@repo/dev-aliases':
         specifier: workspace:*
         version: link:packages/@repo/dev-aliases
@@ -317,7 +317,7 @@ importers:
     dependencies:
       next:
         specifier: ^14.0.0
-        version: 14.2.20(@babel/core@7.26.0)(@playwright/test@1.44.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.20(@babel/core@7.26.0)(@playwright/test@1.49.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -443,7 +443,7 @@ importers:
         version: 19.0.0-beta-37ed2a7-20241206
       next:
         specifier: 15.0.4
-        version: 15.0.4(@babel/core@7.26.0)(@playwright/test@1.44.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206)(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)
+        version: 15.0.4(@babel/core@7.26.0)(@playwright/test@1.49.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206)(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)
       react:
         specifier: rc
         version: 19.0.0-rc.1
@@ -548,7 +548,7 @@ importers:
         version: link:../../packages/@sanity/vision
       '@sanity/visual-editing':
         specifier: 2.10.6
-        version: 2.10.6(@sanity/client@6.24.1)(next@15.0.4(@babel/core@7.26.0)(@playwright/test@1.44.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 2.10.6(@sanity/client@6.24.1)(next@15.0.4(@babel/core@7.26.0)(@playwright/test@1.49.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@turf/helpers':
         specifier: ^6.0.1
         version: 6.5.0
@@ -1786,11 +1786,11 @@ importers:
         version: 17.3.0
     devDependencies:
       '@playwright/experimental-ct-react':
-        specifier: 1.44.1
-        version: 1.44.1(@types/node@22.10.1)(terser@5.37.0)(vite@5.4.11(@types/node@22.10.1)(terser@5.37.0))
+        specifier: 1.49.1
+        version: 1.49.1(@types/node@22.10.1)(terser@5.37.0)(vite@5.4.11(@types/node@22.10.1)(terser@5.37.0))
       '@playwright/test':
-        specifier: 1.44.1
-        version: 1.44.1
+        specifier: 1.49.1
+        version: 1.49.1
       '@repo/dev-aliases':
         specifier: workspace:*
         version: link:../@repo/dev-aliases
@@ -2035,8 +2035,8 @@ importers:
   perf/tests:
     dependencies:
       '@playwright/test':
-        specifier: 1.44.1
-        version: 1.44.1
+        specifier: 1.49.1
+        version: 1.49.1
       '@sanity/client':
         specifier: ^6.24.1
         version: 6.24.1(debug@4.4.0)
@@ -4104,18 +4104,18 @@ packages:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/experimental-ct-core@1.44.1':
-    resolution: {integrity: sha512-IqeXzfmpHH8yHA0fGQ//l/tDJHzUmg2dQj3t28E1tCshvnYc9fVr53Na9+/B8ME//vw0UFpv+CSKcOTHwWrhQg==}
-    engines: {node: '>=16'}
+  '@playwright/experimental-ct-core@1.49.1':
+    resolution: {integrity: sha512-MZ0by8hLo/2qGHoo3SSbdxTNwKXrw06rqqA64TEiwOBjzpbYAaCuA3+BemXpMFfa0nU6ivO4h/sFdA8Zv9ns+g==}
+    engines: {node: '>=18'}
 
-  '@playwright/experimental-ct-react@1.44.1':
-    resolution: {integrity: sha512-qRhv2zmZVwtzAYWwQO4j+It0S5zLUuZg/7Ke61ymCC5jGqlwf2kYqogFxBiDdhAO1sz/dN0UtdU+6df0HK5yzw==}
-    engines: {node: '>=16'}
+  '@playwright/experimental-ct-react@1.49.1':
+    resolution: {integrity: sha512-kQTSzVkFd05x1kY8Q/XaF3xg3dd3AH31976N0zCVVQ3pw/qpa3jtdjoj7/30eblU5eVlg0ELMV7pjL5lUjJzzw==}
+    engines: {node: '>=18'}
     hasBin: true
 
-  '@playwright/test@1.44.1':
-    resolution: {integrity: sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==}
-    engines: {node: '>=16'}
+  '@playwright/test@1.49.1':
+    resolution: {integrity: sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==}
+    engines: {node: '>=18'}
     hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
@@ -9511,23 +9511,23 @@ packages:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
 
-  playwright-core@1.44.1:
-    resolution: {integrity: sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==}
-    engines: {node: '>=16'}
-    hasBin: true
-
   playwright-core@1.49.0:
     resolution: {integrity: sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.44.1:
-    resolution: {integrity: sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==}
-    engines: {node: '>=16'}
+  playwright-core@1.49.1:
+    resolution: {integrity: sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   playwright@1.49.0:
     resolution: {integrity: sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.49.1:
+    resolution: {integrity: sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -13961,10 +13961,10 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@playwright/experimental-ct-core@1.44.1(@types/node@22.10.1)(terser@5.37.0)':
+  '@playwright/experimental-ct-core@1.49.1(@types/node@22.10.1)(terser@5.37.0)':
     dependencies:
-      playwright: 1.44.1
-      playwright-core: 1.44.1
+      playwright: 1.49.1
+      playwright-core: 1.49.1
       vite: 5.4.11(@types/node@22.10.1)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -13976,9 +13976,9 @@ snapshots:
       - sugarss
       - terser
 
-  '@playwright/experimental-ct-react@1.44.1(@types/node@22.10.1)(terser@5.37.0)(vite@5.4.11(@types/node@22.10.1)(terser@5.37.0))':
+  '@playwright/experimental-ct-react@1.49.1(@types/node@22.10.1)(terser@5.37.0)(vite@5.4.11(@types/node@22.10.1)(terser@5.37.0))':
     dependencies:
-      '@playwright/experimental-ct-core': 1.44.1(@types/node@22.10.1)(terser@5.37.0)
+      '@playwright/experimental-ct-core': 1.49.1(@types/node@22.10.1)(terser@5.37.0)
       '@vitejs/plugin-react': 4.3.4(vite@5.4.11(@types/node@22.10.1)(terser@5.37.0))
     transitivePeerDependencies:
       - '@types/node'
@@ -13992,9 +13992,9 @@ snapshots:
       - terser
       - vite
 
-  '@playwright/test@1.44.1':
+  '@playwright/test@1.49.1':
     dependencies:
-      playwright: 1.44.1
+      playwright: 1.49.1
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -14775,7 +14775,7 @@ snapshots:
 
   '@sanity/test@0.0.1-alpha.1':
     dependencies:
-      '@playwright/test': 1.44.1
+      '@playwright/test': 1.49.1
       '@sanity/client': 6.24.1(debug@4.4.0)
       '@sanity/uuid': 3.0.2
       cac: 6.7.14
@@ -15108,7 +15108,7 @@ snapshots:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
 
-  '@sanity/visual-editing@2.10.6(@sanity/client@6.24.1)(next@15.0.4(@babel/core@7.26.0)(@playwright/test@1.44.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@sanity/visual-editing@2.10.6(@sanity/client@6.24.1)(next@15.0.4(@babel/core@7.26.0)(@playwright/test@1.49.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@sanity/comlink': 2.0.1
       '@sanity/mutate': 0.11.0-canary.3(xstate@5.19.0)
@@ -15125,7 +15125,7 @@ snapshots:
       xstate: 5.19.0
     optionalDependencies:
       '@sanity/client': 6.24.1(debug@4.4.0)
-      next: 15.0.4(@babel/core@7.26.0)(@playwright/test@1.44.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.0.4(@babel/core@7.26.0)(@playwright/test@1.49.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - debug
 
@@ -20089,7 +20089,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@14.2.20(@babel/core@7.26.0)(@playwright/test@1.44.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.20(@babel/core@7.26.0)(@playwright/test@1.49.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.20
       '@swc/helpers': 0.5.5
@@ -20110,12 +20110,12 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.20
       '@next/swc-win32-ia32-msvc': 14.2.20
       '@next/swc-win32-x64-msvc': 14.2.20
-      '@playwright/test': 1.44.1
+      '@playwright/test': 1.49.1
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.0.4(@babel/core@7.26.0)(@playwright/test@1.44.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.0.4(@babel/core@7.26.0)(@playwright/test@1.49.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 15.0.4
       '@swc/counter': 0.1.3
@@ -20135,7 +20135,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.0.4
       '@next/swc-win32-arm64-msvc': 15.0.4
       '@next/swc-win32-x64-msvc': 15.0.4
-      '@playwright/test': 1.44.1
+      '@playwright/test': 1.49.1
       babel-plugin-react-compiler: 19.0.0-beta-37ed2a7-20241206
       sharp: 0.33.5
     transitivePeerDependencies:
@@ -20143,7 +20143,7 @@ snapshots:
       - babel-plugin-macros
     optional: true
 
-  next@15.0.4(@babel/core@7.26.0)(@playwright/test@1.44.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206)(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1):
+  next@15.0.4(@babel/core@7.26.0)(@playwright/test@1.49.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206)(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1):
     dependencies:
       '@next/env': 15.0.4
       '@swc/counter': 0.1.3
@@ -20163,7 +20163,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.0.4
       '@next/swc-win32-arm64-msvc': 15.0.4
       '@next/swc-win32-x64-msvc': 15.0.4
-      '@playwright/test': 1.44.1
+      '@playwright/test': 1.49.1
       babel-plugin-react-compiler: 19.0.0-beta-37ed2a7-20241206
       sharp: 0.33.5
     transitivePeerDependencies:
@@ -20826,19 +20826,19 @@ snapshots:
     dependencies:
       find-up: 3.0.0
 
-  playwright-core@1.44.1: {}
-
   playwright-core@1.49.0: {}
 
-  playwright@1.44.1:
-    dependencies:
-      playwright-core: 1.44.1
-    optionalDependencies:
-      fsevents: 2.3.2
+  playwright-core@1.49.1: {}
 
   playwright@1.49.0:
     dependencies:
       playwright-core: 1.49.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.49.1:
+    dependencies:
+      playwright-core: 1.49.1
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
### Description

I have identified several issues that caused the `playwright-ct` tests to be flaky.

Some were real issues, some were with the library itself, and some were issues with the tests (see individual commits for details).

I have upgraded the Playwright packages used in the mono-repo.

There might still be flake, but this should help at least.

This PR is also tied into https://github.com/sanity-io/sanity/pull/8021 and https://github.com/sanity-io/sanity/pull/8022 which was moved into own separate PRs



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

* That the tests pass and have become less flaky.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Should be tested automatically.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
