### PR TITLE
fix(deps): upgrade react-json-inspector

### DIFF
--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -59,7 +59,7 @@
     "@codemirror/view": "^6.1.1",
     "@juggle/resize-observer": "^3.3.1",
     "@lezer/highlight": "^1.0.0",
-    "@rexxars/react-json-inspector": "^8.0.1",
+    "@rexxars/react-json-inspector": "^9.0.1",
     "@rexxars/react-split-pane": "^0.1.93",
     "@sanity/color": "^3.0.0",
     "@sanity/icons": "^3.5.2",

--- a/packages/@sanity/vision/src/components/ResultView.tsx
+++ b/packages/@sanity/vision/src/components/ResultView.tsx
@@ -1,4 +1,4 @@
-import JSONInspector from '@rexxars/react-json-inspector'
+import {JsonInspector} from '@rexxars/react-json-inspector'
 import {LinkIcon} from '@sanity/icons'
 import {Code} from '@sanity/ui'
 import LRU from 'quick-lru'
@@ -16,7 +16,7 @@ export function ResultView(props: {data: unknown; datasetName: string}): JSX.Ele
   if (isRecord(data) || Array.isArray(data)) {
     return (
       <ResultViewWrapper>
-        <JSONInspector
+        <JsonInspector
           data={data}
           search={false}
           isExpanded={isExpanded}

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -155,7 +155,7 @@
     "@juggle/resize-observer": "^3.3.1",
     "@portabletext/editor": "^1.15.3",
     "@portabletext/react": "^3.0.0",
-    "@rexxars/react-json-inspector": "^8.0.1",
+    "@rexxars/react-json-inspector": "^9.0.1",
     "@sanity/asset-utils": "^2.0.6",
     "@sanity/bifur-client": "^0.4.1",
     "@sanity/block-tools": "3.67.1",

--- a/packages/sanity/src/structure/panes/document/inspectDialog/InspectDialog.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectDialog/InspectDialog.tsx
@@ -1,4 +1,4 @@
-import JSONInspector from '@rexxars/react-json-inspector'
+import {JsonInspector} from '@rexxars/react-json-inspector'
 import {type SanityDocument} from '@sanity/types'
 import {Card, Code, Flex, TabList, TabPanel} from '@sanity/ui'
 import {useCallback} from 'react'
@@ -106,7 +106,7 @@ export function InspectDialog(props: InspectDialogProps) {
         >
           {viewMode === VIEW_MODE_PARSED && (
             <JSONInspectorWrapper>
-              <JSONInspector
+              <JsonInspector
                 data={value}
                 isExpanded={isExpanded}
                 onClick={toggleExpanded}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1334,8 +1334,8 @@ importers:
         specifier: ^1.0.0
         version: 1.2.1
       '@rexxars/react-json-inspector':
-        specifier: ^8.0.1
-        version: 8.0.1(react@18.3.1)
+        specifier: ^9.0.1
+        version: 9.0.1(react@18.3.1)
       '@rexxars/react-split-pane':
         specifier: ^0.1.93
         version: 0.1.93(react-dom@19.0.0-rc-f994737d14-20240522(react@18.3.1))(react@18.3.1)
@@ -1458,8 +1458,8 @@ importers:
         specifier: ^3.0.0
         version: 3.2.0(react@18.3.1)
       '@rexxars/react-json-inspector':
-        specifier: ^8.0.1
-        version: 8.0.1(react@18.3.1)
+        specifier: ^9.0.1
+        version: 9.0.1(react@18.3.1)
       '@sanity/asset-utils':
         specifier: ^2.0.6
         version: 2.2.1
@@ -4173,10 +4173,10 @@ packages:
     resolution: {integrity: sha512-+/fA3IOwEw4IWjON1FVumvemdEBsAosk1aoy+2Y6l2FqDuxOSGSxjgehLuydfNXG62s0p/z9hzvv2pv7TL3UWQ==}
     engines: {node: '>=12.0.0'}
 
-  '@rexxars/react-json-inspector@8.0.1':
-    resolution: {integrity: sha512-XAsgQwqG8fbDGpWnsvOesRMgPfvwuU7Cx3/cUf/fNIRmGP8lj2YYIf5La/4ayvZLWlSw4tTb4BPCKdmK9D8RuQ==}
+  '@rexxars/react-json-inspector@9.0.1':
+    resolution: {integrity: sha512-4uZ4RnrVoOGOShIKKcPoF+qhwDCZJsPPqyoEoW/8HRdzNknN9Q2yhlbEgTX1lMZunF1fv7iHzAs+n1vgIgfg/g==}
     peerDependencies:
-      react: ^15 || ^16 || ^17 || ^18
+      react: ^18 || ^19
 
   '@rexxars/react-split-pane@0.1.93':
     resolution: {integrity: sha512-Pok8zATwd5ZpWnccJeSA/JM2MPmi3D04duYtrbMNRgzeAU2ANtq3r4w7ldbjpGyfJqggqn0wDNjRqaevXqSxQg==}
@@ -6218,9 +6218,6 @@ packages:
   crc32-stream@6.0.0:
     resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
     engines: {node: '>= 14'}
-
-  create-react-class@15.7.0:
-    resolution: {integrity: sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -14070,9 +14067,8 @@ snapshots:
     dependencies:
       ini: 1.3.8
 
-  '@rexxars/react-json-inspector@8.0.1(react@18.3.1)':
+  '@rexxars/react-json-inspector@9.0.1(react@18.3.1)':
     dependencies:
-      create-react-class: 15.7.0
       debounce: 1.0.0
       md5-o-matic: 0.1.1
       react: 18.3.1
@@ -16931,11 +16927,6 @@ snapshots:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 4.5.2
-
-  create-react-class@15.7.0:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
 
   create-require@1.1.1: {}
 


### PR DESCRIPTION
### Description

Upgrades `@rexxars/react-json-inspector` to the latest version, which is compatible with React 19 and drops lifecycle events that are deprecated. The conversion was a bit quick and dirty, but from what I can tell things seems to work fine.

### What to review

"Inspect document" and vision results works as expected

### Testing

Check out the preview deployment, see that it matches current look/behavior

### Notes for release

None
