### PR TITLE
chore(deps): upgrade vitest to v2.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "typescript": "5.7.2",
     "vite": "^5.4.11",
     "vite-tsconfig-paths": "^4.3.2",
-    "vitest": "^2.1.1",
+    "vitest": "^2.1.8",
     "yargs": "^17.3.0"
   },
   "optionalDependencies": {

--- a/packages/@repo/test-config/package.json
+++ b/packages/@repo/test-config/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@repo/dev-aliases": "workspace:*",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/@sanity/block-tools/package.json
+++ b/packages/@sanity/block-tools/package.json
@@ -63,7 +63,7 @@
     "@vercel/stega": "0.1.2",
     "@vitest/coverage-v8": "^2.1.1",
     "jsdom": "^23.0.1",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -127,7 +127,7 @@
     "semver-compare": "^1.0.0",
     "tar": "^6.1.11",
     "vite": "^5.4.11",
-    "vitest": "^2.1.1",
+    "vitest": "^2.1.8",
     "which": "^2.0.2",
     "xdg-basedir": "^4.0.0"
   },

--- a/packages/@sanity/codegen/package.json
+++ b/packages/@sanity/codegen/package.json
@@ -75,7 +75,7 @@
     "@types/babel__traverse": "^7.20.5",
     "@types/debug": "^4.1.12",
     "rimraf": "^5.0.10",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.8"
   },
   "engines": {
     "node": ">=18"

--- a/packages/@sanity/migrate/package.json
+++ b/packages/@sanity/migrate/package.json
@@ -66,7 +66,7 @@
     "@types/arrify": "^2.0.1",
     "@types/debug": "^4.1.12",
     "rimraf": "^5.0.10",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.8"
   },
   "engines": {
     "node": ">=18"

--- a/packages/@sanity/mutator/package.json
+++ b/packages/@sanity/mutator/package.json
@@ -61,6 +61,6 @@
     "@types/debug": "^4.1.5",
     "@types/lodash": "^4.17.7",
     "rimraf": "^5.0.10",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -81,6 +81,6 @@
     "@types/object-inspect": "^1.13.0",
     "@types/react": "^18.3.12",
     "rimraf": "^5.0.10",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -59,6 +59,6 @@
     "@vitejs/plugin-react": "^4.3.4",
     "react": "^18.3.1",
     "rimraf": "^5.0.10",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -131,7 +131,7 @@
     "@repo/package.config": "workspace:*",
     "@repo/test-config": "workspace:*",
     "rimraf": "^5.0.10",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.8"
   },
   "engines": {
     "node": ">=18"

--- a/perf/tests/package.json
+++ b/perf/tests/package.json
@@ -32,6 +32,6 @@
     "esbuild": "0.21.5",
     "ts-node": "^10.9.2",
     "typescript": "5.7.2",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,8 +223,8 @@ importers:
         specifier: ^4.3.2
         version: 4.3.2(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.1)(terser@5.37.0))
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
       yargs:
         specifier: ^17.3.0
         version: 17.3.0
@@ -701,8 +701,8 @@ importers:
         specifier: workspace:*
         version: link:../dev-aliases
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
 
   packages/@repo/test-exports:
     dependencies:
@@ -787,13 +787,13 @@ importers:
         version: 0.1.2
       '@vitest/coverage-v8':
         specifier: ^2.1.1
-        version: 2.1.8(vitest@2.1.1(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0))
+        version: 2.1.8(vitest@2.1.8(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0))
       jsdom:
         specifier: ^23.0.1
         version: 23.2.0
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
 
   packages/@sanity/cli:
     dependencies:
@@ -1003,8 +1003,8 @@ importers:
         specifier: ^5.4.11
         version: 5.4.11(@types/node@22.10.1)(terser@5.37.0)
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
       which:
         specifier: ^2.0.2
         version: 2.0.2
@@ -1085,8 +1085,8 @@ importers:
         specifier: ^5.0.10
         version: 5.0.10
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
 
   packages/@sanity/diff:
     dependencies:
@@ -1147,8 +1147,8 @@ importers:
         specifier: ^5.0.10
         version: 5.0.10
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
 
   packages/@sanity/mutator:
     dependencies:
@@ -1184,8 +1184,8 @@ importers:
         specifier: ^5.0.10
         version: 5.0.10
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
 
   packages/@sanity/schema:
     dependencies:
@@ -1239,8 +1239,8 @@ importers:
         specifier: ^5.0.10
         version: 5.0.10
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
 
   packages/@sanity/types:
     dependencies:
@@ -1270,8 +1270,8 @@ importers:
         specifier: ^5.0.10
         version: 5.0.10
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
 
   packages/@sanity/util:
     dependencies:
@@ -1301,8 +1301,8 @@ importers:
         specifier: ^5.0.10
         version: 5.0.10
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
 
   packages/@sanity/vision:
     dependencies:
@@ -2081,8 +2081,8 @@ importers:
         specifier: 5.7.2
         version: 5.7.2
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@18.19.67)(jsdom@23.2.0)(terser@5.37.0)
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@18.19.67)(jsdom@23.2.0)(terser@5.37.0)
 
 packages:
 
@@ -5283,11 +5283,25 @@ packages:
   '@vitest/expect@2.1.1':
     resolution: {integrity: sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==}
 
+  '@vitest/expect@2.1.8':
+    resolution: {integrity: sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==}
+
   '@vitest/mocker@2.1.1':
     resolution: {integrity: sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==}
     peerDependencies:
       '@vitest/spy': 2.1.1
       msw: ^2.3.5
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@2.1.8':
+    resolution: {integrity: sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==}
+    peerDependencies:
+      msw: ^2.4.9
       vite: ^5.0.0
     peerDependenciesMeta:
       msw:
@@ -5304,14 +5318,26 @@ packages:
   '@vitest/runner@2.1.1':
     resolution: {integrity: sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==}
 
+  '@vitest/runner@2.1.8':
+    resolution: {integrity: sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==}
+
   '@vitest/snapshot@2.1.1':
     resolution: {integrity: sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==}
+
+  '@vitest/snapshot@2.1.8':
+    resolution: {integrity: sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==}
 
   '@vitest/spy@2.1.1':
     resolution: {integrity: sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==}
 
+  '@vitest/spy@2.1.8':
+    resolution: {integrity: sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==}
+
   '@vitest/utils@2.1.1':
     resolution: {integrity: sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==}
+
+  '@vitest/utils@2.1.8':
+    resolution: {integrity: sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==}
 
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
@@ -7043,6 +7069,10 @@ packages:
   expand-tilde@2.0.2:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.1.0:
+    resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.1:
     resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
@@ -11416,6 +11446,11 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  vite-node@2.1.8:
+    resolution: {integrity: sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-tsconfig-paths@4.3.2:
     resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
     peerDependencies:
@@ -11532,6 +11567,31 @@ packages:
       '@types/node': ^18.0.0 || >=20.0.0
       '@vitest/browser': 2.1.1
       '@vitest/ui': 2.1.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@2.1.8:
+    resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.8
+      '@vitest/ui': 2.1.8
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -15828,7 +15888,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.8(vitest@2.1.1(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0))':
+  '@vitest/coverage-v8@2.1.8(vitest@2.1.8(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -15842,7 +15902,7 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.1(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
+      vitest: 2.1.8(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15853,9 +15913,24 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
+  '@vitest/expect@2.1.8':
+    dependencies:
+      '@vitest/spy': 2.1.8
+      '@vitest/utils': 2.1.8
+      chai: 5.1.2
+      tinyrainbow: 1.2.0
+
   '@vitest/mocker@2.1.1(@vitest/spy@2.1.1)(vite@5.4.11(@types/node@22.10.1)(terser@5.37.0))':
     dependencies:
       '@vitest/spy': 2.1.1
+      estree-walker: 3.0.3
+      magic-string: 0.30.14
+    optionalDependencies:
+      vite: 5.4.11(@types/node@22.10.1)(terser@5.37.0)
+
+  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.1)(terser@5.37.0))':
+    dependencies:
+      '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.14
     optionalDependencies:
@@ -15874,9 +15949,20 @@ snapshots:
       '@vitest/utils': 2.1.1
       pathe: 1.1.2
 
+  '@vitest/runner@2.1.8':
+    dependencies:
+      '@vitest/utils': 2.1.8
+      pathe: 1.1.2
+
   '@vitest/snapshot@2.1.1':
     dependencies:
       '@vitest/pretty-format': 2.1.1
+      magic-string: 0.30.14
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.8':
+    dependencies:
+      '@vitest/pretty-format': 2.1.8
       magic-string: 0.30.14
       pathe: 1.1.2
 
@@ -15884,9 +15970,19 @@ snapshots:
     dependencies:
       tinyspy: 3.0.2
 
+  '@vitest/spy@2.1.8':
+    dependencies:
+      tinyspy: 3.0.2
+
   '@vitest/utils@2.1.1':
     dependencies:
       '@vitest/pretty-format': 2.1.1
+      loupe: 3.1.2
+      tinyrainbow: 1.2.0
+
+  '@vitest/utils@2.1.8':
+    dependencies:
+      '@vitest/pretty-format': 2.1.8
       loupe: 3.1.2
       tinyrainbow: 1.2.0
 
@@ -17989,6 +18085,8 @@ snapshots:
   expand-tilde@2.0.2:
     dependencies:
       homedir-polyfill: 1.0.3
+
+  expect-type@1.1.0: {}
 
   exponential-backoff@3.1.1: {}
 
@@ -22964,10 +23062,28 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@2.1.1(@types/node@18.19.67)(terser@5.37.0):
+  vite-node@2.1.1(@types/node@22.10.1)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@9.4.0)
+      pathe: 1.1.2
+      vite: 5.4.11(@types/node@22.10.1)(terser@5.37.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite-node@2.1.8(@types/node@18.19.67)(terser@5.37.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0(supports-color@9.4.0)
+      es-module-lexer: 1.5.4
       pathe: 1.1.2
       vite: 5.4.11(@types/node@18.19.67)(terser@5.37.0)
     transitivePeerDependencies:
@@ -22981,10 +23097,11 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.1(@types/node@22.10.1)(terser@5.37.0):
+  vite-node@2.1.8(@types/node@22.10.1)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@9.4.0)
+      es-module-lexer: 1.5.4
       pathe: 1.1.2
       vite: 5.4.11(@types/node@22.10.1)(terser@5.37.0)
     transitivePeerDependencies:
@@ -23050,41 +23167,6 @@ snapshots:
       terser: 5.37.0
       yaml: 2.6.1
 
-  vitest@2.1.1(@types/node@18.19.67)(jsdom@23.2.0)(terser@5.37.0):
-    dependencies:
-      '@vitest/expect': 2.1.1
-      '@vitest/mocker': 2.1.1(@vitest/spy@2.1.1)(vite@5.4.11(@types/node@22.10.1)(terser@5.37.0))
-      '@vitest/pretty-format': 2.1.8
-      '@vitest/runner': 2.1.1
-      '@vitest/snapshot': 2.1.1
-      '@vitest/spy': 2.1.1
-      '@vitest/utils': 2.1.1
-      chai: 5.1.2
-      debug: 4.4.0(supports-color@9.4.0)
-      magic-string: 0.30.14
-      pathe: 1.1.2
-      std-env: 3.8.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.1
-      tinypool: 1.0.2
-      tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@18.19.67)(terser@5.37.0)
-      vite-node: 2.1.1(@types/node@18.19.67)(terser@5.37.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 18.19.67
-      jsdom: 23.2.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vitest@2.1.1(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0):
     dependencies:
       '@vitest/expect': 2.1.1
@@ -23105,6 +23187,78 @@ snapshots:
       tinyrainbow: 1.2.0
       vite: 5.4.11(@types/node@22.10.1)(terser@5.37.0)
       vite-node: 2.1.1(@types/node@22.10.1)(terser@5.37.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.10.1
+      jsdom: 23.2.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.8(@types/node@18.19.67)(jsdom@23.2.0)(terser@5.37.0):
+    dependencies:
+      '@vitest/expect': 2.1.8
+      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.1)(terser@5.37.0))
+      '@vitest/pretty-format': 2.1.8
+      '@vitest/runner': 2.1.8
+      '@vitest/snapshot': 2.1.8
+      '@vitest/spy': 2.1.8
+      '@vitest/utils': 2.1.8
+      chai: 5.1.2
+      debug: 4.4.0(supports-color@9.4.0)
+      expect-type: 1.1.0
+      magic-string: 0.30.14
+      pathe: 1.1.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.2
+      tinyrainbow: 1.2.0
+      vite: 5.4.11(@types/node@18.19.67)(terser@5.37.0)
+      vite-node: 2.1.8(@types/node@18.19.67)(terser@5.37.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 18.19.67
+      jsdom: 23.2.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.8(@types/node@22.10.1)(jsdom@23.2.0)(terser@5.37.0):
+    dependencies:
+      '@vitest/expect': 2.1.8
+      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.1)(terser@5.37.0))
+      '@vitest/pretty-format': 2.1.8
+      '@vitest/runner': 2.1.8
+      '@vitest/snapshot': 2.1.8
+      '@vitest/spy': 2.1.8
+      '@vitest/utils': 2.1.8
+      chai: 5.1.2
+      debug: 4.4.0(supports-color@9.4.0)
+      expect-type: 1.1.0
+      magic-string: 0.30.14
+      pathe: 1.1.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.2
+      tinyrainbow: 1.2.0
+      vite: 5.4.11(@types/node@22.10.1)(terser@5.37.0)
+      vite-node: 2.1.8(@types/node@22.10.1)(terser@5.37.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.10.1


### PR DESCRIPTION
### Description

Gets rid of some peer dependency warnings.

### What to review

Tests still run as before.

### Testing

No changes needed.

### Notes for release

None.
