### PR TITLE
fix: delays rendering the Start in Create banner until document is ready

### DIFF
--- a/packages/sanity/src/core/create/components/StartInCreateBanner.tsx
+++ b/packages/sanity/src/core/create/components/StartInCreateBanner.tsx
@@ -55,7 +55,8 @@ export function StartInCreateBanner(props: StartInCreateBannerProps) {
 function StartInCreateBannerInner(props: StartInCreateBannerProps & {appIdCache: AppIdCache}) {
   const {studioApp} = useStudioAppIdStore(props.appIdCache)
 
-  if (!studioApp) {
+  // we check documentReady here and not in the top wrapper, to allow the cache code to run while the document is loading
+  if (!studioApp || !props.documentReady) {
     return null
   }
   return <StartInCreateBannerStudioApp {...props} studioApp={studioApp} />

--- a/packages/sanity/src/core/create/types.ts
+++ b/packages/sanity/src/core/create/types.ts
@@ -38,5 +38,6 @@ export interface StartInCreateBannerProps {
   documentType: ObjectSchemaType
   document: SanityDocumentLike
   isInitialValueLoading: boolean
+  documentReady: boolean
   panelPortalElementId: string
 }

--- a/packages/sanity/src/structure/panes/document/document-layout/DocumentLayout.tsx
+++ b/packages/sanity/src/structure/panes/document/document-layout/DocumentLayout.tsx
@@ -82,6 +82,7 @@ export function DocumentLayout() {
     schemaType,
     value,
     isInitialValueLoading,
+    ready,
   } = useDocumentPane()
   const {params: paneParams} = usePaneRouter()
   const {features} = useStructureTool()
@@ -259,6 +260,7 @@ export function DocumentLayout() {
                     document={value}
                     documentId={documentId}
                     documentType={schemaType}
+                    documentReady={ready}
                     isInitialValueLoading={!!isInitialValueLoading}
                     panelPortalElementId={DOCUMENT_PANEL_PORTAL_ELEMENT}
                   />


### PR DESCRIPTION
### Description

Currently, the Start in Create banner will appear when a document pane is loading:
![Banner Flashes v3 67 0](https://github.com/user-attachments/assets/ccf7377f-dbbb-4ac0-ab03-0e04256daae9)

With this fix, the banner should no longer appear when the document pane is in a loading state.

#### Background
Got a report that the Start in Create banner was breifly flashing (appearing and disappearing for < 500ms) on localhost.
I was unable to reproduce _that_ issue, but noticed that when running on 3G Network, the Create banner will render whilst the document is loading.

This PR delays rendering the banner until the document is ready. Opted for prop-drilling to get the ready state, as not to add any new useDocumentPane calls.

The ready check is done in the wrapper component where appId checks runs; this allows the initial requests to run in parallel with document load, so the data is ready as soon as possible.


### What to review

The code ;)

### Testing
 
* Go to https://create-integration-test.sanity.studio/fallback/structure/create-test-article
* Open up Network tab and put it into 3G mode.
* Create a new document. 
* While the pane is loading there should be no Create banner
* The banner should appear with the document (or shortly thereafter, on first document opened in a reloaded studio after which appId data is cached)


### Notes for release

N/A