### PR TITLE
fix(core): fix issues with PT-Input PopoverModal

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -3,6 +3,7 @@
 import {CloseIcon} from '@sanity/icons'
 import {Box, Flex, Text, useClickOutsideEvent, useGlobalKeyDown} from '@sanity/ui'
 import {type ReactNode, useCallback, useRef, useState} from 'react'
+import FocusLock from 'react-focus-lock'
 import {type PortableTextEditorElement} from 'sanity/_singletons'
 
 import {Button, type PopoverProps} from '../../../../../../ui-components'
@@ -42,26 +43,33 @@ export function PopoverEditDialog(props: PopoverEditDialogProps): ReactNode {
       referenceBoundary={referenceBoundary}
       referenceElement={referenceElement}
       width={width}
+      autoFocus
     />
   )
 }
 
 function Content(props: PopoverEditDialogProps) {
   const {onClose, referenceBoundary, referenceElement, title, autoFocus} = props
+  const isClosedRef = useRef(false)
+
+  const handleClose = useCallback(() => {
+    isClosedRef.current = true
+    onClose()
+  }, [onClose])
 
   useGlobalKeyDown(
     useCallback(
       (event: KeyboardEvent) => {
         if (event.key === 'Escape') {
-          onClose()
+          handleClose()
         }
       },
-      [onClose],
+      [handleClose],
     ),
   )
 
   useClickOutsideEvent(
-    onClose,
+    handleClose,
     () => [referenceElement],
     () => referenceBoundary,
   )
@@ -70,42 +78,44 @@ function Content(props: PopoverEditDialogProps) {
   const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null)
   const containerElement = useRef<HTMLDivElement | null>(null)
 
-  useEffect(() => {
-    // When rendered, focus on the first input element in the content
-    if (contentElement) {
-      contentElement.querySelector('input')?.focus()
-    }
-  }, [contentElement])
+  const handleFocusLockWhiteList = useCallback((element: HTMLElement) => {
+    // This is needed in order for focusLock not to trap focus in the
+    // popover when closing the popover and focus is to be returned to the editor
+    if (isClosedRef.current) return false
+    return Boolean(element.contentEditable) || Boolean(containerElement.current?.contains(element))
+  }, [])
 
   return (
     <VirtualizerScrollInstanceProvider
       scrollElement={contentElement}
       containerElement={containerElement}
     >
-      <Flex ref={containerElement} direction="column" height="fill">
-        <ContentHeaderBox flex="none" padding={1}>
-          <Flex align="center">
-            <Box flex={1} padding={2}>
-              <Text weight="medium">{title}</Text>
-            </Box>
+      <FocusLock autoFocus whiteList={handleFocusLockWhiteList}>
+        <Flex ref={containerElement} direction="column" height="fill">
+          <ContentHeaderBox flex="none" padding={1}>
+            <Flex align="center">
+              <Box flex={1} padding={2}>
+                <Text weight="medium">{title}</Text>
+              </Box>
 
-            <Button
-              autoFocus={Boolean(autoFocus)}
-              icon={CloseIcon}
-              mode="bleed"
-              onClick={onClose}
-              tooltipProps={{content: 'Close'}}
-            />
-          </Flex>
-        </ContentHeaderBox>
-        <ContentScrollerBox flex={1}>
-          <PresenceOverlay margins={[0, 0, 1, 0]}>
-            <Box padding={3} ref={setContentElement}>
-              {props.children}
-            </Box>
-          </PresenceOverlay>
-        </ContentScrollerBox>
-      </Flex>
+              <Button
+                autoFocus={Boolean(autoFocus)}
+                icon={CloseIcon}
+                mode="bleed"
+                onClick={handleClose}
+                tooltipProps={{content: 'Close'}}
+              />
+            </Flex>
+          </ContentHeaderBox>
+          <ContentScrollerBox flex={1}>
+            <PresenceOverlay margins={[0, 0, 1, 0]}>
+              <Box padding={3} ref={setContentElement}>
+                {props.children}
+              </Box>
+            </PresenceOverlay>
+          </ContentScrollerBox>
+        </Flex>
+      </FocusLock>
     </VirtualizerScrollInstanceProvider>
   )
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -2,7 +2,7 @@
 
 import {CloseIcon} from '@sanity/icons'
 import {Box, Flex, Text, useClickOutsideEvent, useGlobalKeyDown} from '@sanity/ui'
-import {type ReactNode, useCallback, useEffect, useRef, useState} from 'react'
+import {type ReactNode, useCallback, useRef, useState} from 'react'
 import {type PortableTextEditorElement} from 'sanity/_singletons'
 
 import {Button, type PopoverProps} from '../../../../../../ui-components'
@@ -24,18 +24,8 @@ interface PopoverEditDialogProps {
 
 const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['top', 'bottom']
 
-export function PopoverEditDialog(props: PopoverEditDialogProps) {
+export function PopoverEditDialog(props: PopoverEditDialogProps): ReactNode {
   const {floatingBoundary, referenceBoundary, referenceElement, width = 1} = props
-  const [open, setOpen] = useState(false)
-
-  // This hook is here to set open after the initial render.
-  // If rendered immediately, the popover will for a split second be
-  // visible in the top left of the boundaryElement before correctly
-  // placed pointing at the reference element.
-  useEffect(() => {
-    setOpen(true)
-  }, [])
-
   return (
     <RootPopover
       content={<Content {...props} />}
@@ -44,7 +34,7 @@ export function PopoverEditDialog(props: PopoverEditDialogProps) {
       data-ui="PopoverEditDialog"
       fallbackPlacements={POPOVER_FALLBACK_PLACEMENTS}
       floatingBoundary={floatingBoundary}
-      open={open}
+      open
       overflow="auto"
       placement="bottom"
       portal="default"


### PR DESCRIPTION
### Description

* Remove the workaround for the @sanity/ui issue (which has been fixed) with the initial rendering in the wrong position. This is no longer needed and can cause problems with assertions in tests.

* Implement focus locking inside the modal. The PopoverModal should have the same kind of focus locking as other dialogs


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That popover modals for links inside the Portable Text Input traps focus and work as expected.

The popover modal position is correct when first opened.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Open a Portable Text Editor with a link schema type and do the review steps above.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
* Keep tab focus inside Popover Dialogs for the Portable Text Input when editing links and similar.


<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
