### PR TITLE
fix(core): fix issue with different Webkit tab order in forms

### DIFF
--- a/packages/sanity/src/core/form/field/actions/FieldActionMenu.tsx
+++ b/packages/sanity/src/core/form/field/actions/FieldActionMenu.tsx
@@ -137,11 +137,11 @@ function RootFieldActionMenuGroup(props: {
     <MenuButton
       button={
         <Button
-          tabIndex={0}
-          icon={node.icon}
           aria-label={open ? undefined : title}
           data-testid="field-actions-trigger"
+          icon={node.icon}
           mode="bleed"
+          tabIndex={0}
           tooltipProps={{
             ...STATUS_BUTTON_TOOLTIP_PROPS,
             content: node.title,

--- a/packages/sanity/src/core/form/field/actions/FieldActionMenu.tsx
+++ b/packages/sanity/src/core/form/field/actions/FieldActionMenu.tsx
@@ -137,6 +137,7 @@ function RootFieldActionMenuGroup(props: {
     <MenuButton
       button={
         <Button
+          tabIndex={0}
           icon={node.icon}
           aria-label={open ? undefined : title}
           data-testid="field-actions-trigger"


### PR DESCRIPTION
### Description

Chromium and Firefox will tab to the FieldActions menu without tabIndex=0, but Webkit needs to have it explicitly set to include it in the tab flow. Add it so all browsers follow the same tab order, and WebKit users can access the field actions with the keyboard.

This will also prevent issues with Playwright tests that rely on tabbing through forms.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That WebKit can tab into the field actions menus.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Test any form with multiple fields.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
* Fixed an issue where WebKit was unable to tab into a form field's action menu.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
