### PR TITLE
fix(core): release events types are lowercase

### DIFF
--- a/packages/sanity/src/core/field/diff/components/Event.tsx
+++ b/packages/sanity/src/core/field/diff/components/Event.tsx
@@ -5,6 +5,8 @@ import {createElement, useMemo} from 'react'
 import {
   type DocumentGroupEvent,
   getReleaseTone,
+  isEditDocumentVersionEvent,
+  isPublishDocumentVersionEvent,
   type RelativeTimeOptions,
   useDateTimeFormat,
   UserAvatar,
@@ -143,7 +145,7 @@ export function Event({event, showChangesBy = 'tooltip'}: TimelineItemProps) {
     return formattedDate
   }, [timestamp, dateFormat])
 
-  const userIds = event.type === 'EditDocumentVersion' ? event.contributors : [event.author]
+  const userIds = isEditDocumentVersionEvent(event) ? event.contributors : [event.author]
 
   return (
     <>
@@ -157,7 +159,7 @@ export function Event({event, showChangesBy = 'tooltip'}: TimelineItemProps) {
         <Stack space={2}>
           <Text size={1} weight="medium">
             {t(TIMELINE_ITEM_I18N_KEY_MAPPING[type])}
-            {event.type === 'PublishDocumentVersion' && documentVariantType === 'published' && (
+            {isPublishDocumentVersionEvent(event) && documentVariantType === 'published' && (
               <>
                 {' '}
                 {event.release ? (

--- a/packages/sanity/src/core/field/diff/components/constants.ts
+++ b/packages/sanity/src/core/field/diff/components/constants.ts
@@ -13,30 +13,30 @@ import {type ThemeColorAvatarColorKey} from '@sanity/ui/theme'
 import {type DocumentVersionEventType, type StudioLocaleResourceKeys} from 'sanity'
 
 export const TIMELINE_ICON_COMPONENTS: Record<DocumentVersionEventType, IconComponent> = {
-  CreateDocumentVersion: AddCircleIcon,
-  CreateLiveDocument: AddCircleIcon,
-  DeleteDocumentGroup: TrashIcon,
-  DeleteDocumentVersion: CloseIcon,
-  EditDocumentVersion: EditIcon,
-  UpdateLiveDocument: EditIcon,
-  PublishDocumentVersion: PublishIcon,
-  UnpublishDocument: UnpublishIcon,
-  ScheduleDocumentVersion: CalendarIcon,
-  UnscheduleDocumentVersion: CircleIcon,
+  createDocumentVersion: AddCircleIcon,
+  createLiveDocument: AddCircleIcon,
+  deleteDocumentGroup: TrashIcon,
+  deleteDocumentVersion: CloseIcon,
+  editDocumentVersion: EditIcon,
+  updateLiveDocument: EditIcon,
+  publishDocumentVersion: PublishIcon,
+  unpublishDocument: UnpublishIcon,
+  scheduleDocumentVersion: CalendarIcon,
+  unscheduleDocumentVersion: CircleIcon,
 }
 
 export const TIMELINE_ITEM_EVENT_TONE: Record<DocumentVersionEventType, ThemeColorAvatarColorKey> =
   {
-    CreateDocumentVersion: 'green',
-    CreateLiveDocument: 'blue',
-    UpdateLiveDocument: 'green',
-    EditDocumentVersion: 'yellow',
-    UnpublishDocument: 'orange',
-    DeleteDocumentVersion: 'orange',
-    DeleteDocumentGroup: 'orange',
-    ScheduleDocumentVersion: 'cyan',
-    UnscheduleDocumentVersion: 'cyan',
-    PublishDocumentVersion: 'green',
+    createDocumentVersion: 'green',
+    createLiveDocument: 'blue',
+    updateLiveDocument: 'green',
+    editDocumentVersion: 'yellow',
+    unpublishDocument: 'orange',
+    deleteDocumentVersion: 'orange',
+    deleteDocumentGroup: 'orange',
+    scheduleDocumentVersion: 'cyan',
+    unscheduleDocumentVersion: 'cyan',
+    publishDocumentVersion: 'green',
   }
 
 /**
@@ -47,14 +47,14 @@ export const TIMELINE_ITEM_I18N_KEY_MAPPING: Record<
   DocumentVersionEventType,
   StudioLocaleResourceKeys
 > = {
-  CreateDocumentVersion: 'timeline.operation.created',
-  PublishDocumentVersion: 'timeline.operation.published',
-  UpdateLiveDocument: 'timeline.operation.edited-live',
-  EditDocumentVersion: 'timeline.operation.edited-draft',
-  UnpublishDocument: 'timeline.operation.unpublished',
-  DeleteDocumentVersion: 'timeline.operation.draft-discarded',
-  DeleteDocumentGroup: 'timeline.operation.deleted',
-  ScheduleDocumentVersion: 'timeline.operation.published',
-  UnscheduleDocumentVersion: 'timeline.operation.published',
-  CreateLiveDocument: 'timeline.operation.created',
+  createDocumentVersion: 'timeline.operation.created',
+  publishDocumentVersion: 'timeline.operation.published',
+  updateLiveDocument: 'timeline.operation.edited-live',
+  editDocumentVersion: 'timeline.operation.edited-draft',
+  unpublishDocument: 'timeline.operation.unpublished',
+  deleteDocumentVersion: 'timeline.operation.draft-discarded',
+  deleteDocumentGroup: 'timeline.operation.deleted',
+  scheduleDocumentVersion: 'timeline.operation.published',
+  unscheduleDocumentVersion: 'timeline.operation.published',
+  createLiveDocument: 'timeline.operation.created',
 }

--- a/packages/sanity/src/core/store/events/getDocumentChanges.ts
+++ b/packages/sanity/src/core/store/events/getDocumentChanges.ts
@@ -21,6 +21,7 @@ import {
   type DocumentGroupEvent,
   type EventsStoreRevision,
   isCreateDocumentVersionEvent,
+  isEditDocumentVersionEvent,
 } from './types'
 import {type EventsObservableValue} from './useEventsStore'
 
@@ -133,7 +134,7 @@ function calculateDiff({
       transactionIndex: index,
       event: events.find(
         (event) =>
-          event.type !== 'EditDocumentVersion' &&
+          !isEditDocumentVersionEvent(event) &&
           'revisionId' in event &&
           event.revisionId === transaction.id,
       ),

--- a/packages/sanity/src/core/store/events/getEditEvents.test.ts
+++ b/packages/sanity/src/core/store/events/getEditEvents.test.ts
@@ -52,7 +52,7 @@ describe('getEditEvents()', () => {
   ]
   describe('when the document is not liveEdit', () => {
     const expectedEvent: EditDocumentVersionEvent = {
-      type: 'EditDocumentVersion',
+      type: 'editDocumentVersion',
       id: 'edit-tx-2',
       documentId: 'versions.rkaihDvC1.f8dece19-c458-4cff-bf76-732b00617183',
       timestamp: '2024-11-19T08:27:33.251404Z',
@@ -62,13 +62,13 @@ describe('getEditEvents()', () => {
       revisionId: 'edit-tx-2',
       transactions: [
         {
-          type: 'EditTransaction',
+          type: 'editTransaction',
           author: 'p8xDvUMxC',
           timestamp: '2024-11-19T08:27:33.251404Z',
           revisionId: 'edit-tx-2',
         },
         {
-          type: 'EditTransaction',
+          type: 'editTransaction',
           author: 'p8xDvUMxC',
           timestamp: '2024-11-19T08:27:27.753746Z',
           revisionId: 'edit-tx-1',
@@ -99,7 +99,7 @@ describe('getEditEvents()', () => {
         },
       }
       const newEvent: EditDocumentVersionEvent = {
-        type: 'EditDocumentVersion',
+        type: 'editDocumentVersion',
         documentId: 'versions.rkaihDvC1.f8dece19-c458-4cff-bf76-732b00617183',
         timestamp: '2024-11-19T08:35:27.753746Z',
         id: 'new-tx',
@@ -109,7 +109,7 @@ describe('getEditEvents()', () => {
         revisionId: 'new-tx',
         transactions: [
           {
-            type: 'EditTransaction',
+            type: 'editTransaction',
             author: 'p8xDvUMxC',
             timestamp: '2024-11-19T08:35:27.753746Z',
             revisionId: 'new-tx',
@@ -170,7 +170,7 @@ describe('getEditEvents()', () => {
   })
   describe('when the document is liveEdit', () => {
     const expectedEvent: UpdateLiveDocumentEvent = {
-      type: 'UpdateLiveDocument',
+      type: 'updateLiveDocument',
       id: 'edit-tx-2',
       documentId: 'versions.rkaihDvC1.f8dece19-c458-4cff-bf76-732b00617183',
       timestamp: '2024-11-19T08:27:33.251404Z',
@@ -200,7 +200,7 @@ describe('getEditEvents()', () => {
         },
       }
       const newEvent: UpdateLiveDocumentEvent = {
-        type: 'UpdateLiveDocument',
+        type: 'updateLiveDocument',
         documentId: 'versions.rkaihDvC1.f8dece19-c458-4cff-bf76-732b00617183',
         timestamp: '2024-11-19T08:35:27.753746Z',
         id: 'new-tx',

--- a/packages/sanity/src/core/store/events/getEditEvents.ts
+++ b/packages/sanity/src/core/store/events/getEditEvents.ts
@@ -41,7 +41,7 @@ const getEditTransaction = (
   transaction: TransactionLogEventWithEffects,
 ): EditDocumentVersionEvent['transactions'][number] => {
   return {
-    type: 'EditTransaction',
+    type: 'editTransaction',
     author: transaction.author,
     timestamp: transaction.timestamp,
     revisionId: transaction.id,
@@ -86,13 +86,13 @@ export function getEditEvents(
       ? ({
           id: transaction.id,
           timestamp: transaction.timestamp,
-          type: 'UpdateLiveDocument',
+          type: 'updateLiveDocument',
           documentId: documentId,
           revisionId: transaction.id,
           author: transaction.author,
         } satisfies UpdateLiveDocumentEvent)
       : ({
-          type: 'EditDocumentVersion',
+          type: 'editDocumentVersion',
           documentId: documentId,
           id: transaction.id,
           timestamp: transaction.timestamp,

--- a/packages/sanity/src/core/store/events/types.ts
+++ b/packages/sanity/src/core/store/events/types.ts
@@ -161,7 +161,7 @@ export type DocumentGroupEvent =
  */
 export const isCreateDocumentVersionEvent = (
   event: Partial<DocumentGroupEvent>,
-): event is CreateDocumentVersionEvent => event.type === 'CreateDocumentVersion'
+): event is CreateDocumentVersionEvent => event.type === 'createDocumentVersion'
 
 /**
  * @hidden
@@ -169,7 +169,7 @@ export const isCreateDocumentVersionEvent = (
  */
 export const isDeleteDocumentVersionEvent = (
   event: Partial<DocumentGroupEvent>,
-): event is DeleteDocumentVersionEvent => event.type === 'DeleteDocumentVersion'
+): event is DeleteDocumentVersionEvent => event.type === 'deleteDocumentVersion'
 
 /**
  * @hidden
@@ -177,7 +177,7 @@ export const isDeleteDocumentVersionEvent = (
  */
 export const isPublishDocumentVersionEvent = (
   event: Partial<DocumentGroupEvent>,
-): event is PublishDocumentVersionEvent => event.type === 'PublishDocumentVersion'
+): event is PublishDocumentVersionEvent => event.type === 'publishDocumentVersion'
 
 /**
  * @hidden
@@ -185,7 +185,7 @@ export const isPublishDocumentVersionEvent = (
  */
 export const isUnpublishDocumentEvent = (
   event: Partial<DocumentGroupEvent>,
-): event is UnpublishDocumentEvent => event.type === 'UnpublishDocument'
+): event is UnpublishDocumentEvent => event.type === 'unpublishDocument'
 
 /**
  * @hidden
@@ -193,7 +193,7 @@ export const isUnpublishDocumentEvent = (
  */
 export const isScheduleDocumentVersionEvent = (
   event: Partial<DocumentGroupEvent>,
-): event is ScheduleDocumentVersionEvent => event.type === 'ScheduleDocumentVersion'
+): event is ScheduleDocumentVersionEvent => event.type === 'scheduleDocumentVersion'
 
 /**
  * @hidden
@@ -201,7 +201,7 @@ export const isScheduleDocumentVersionEvent = (
  */
 export const isUnscheduleDocumentVersionEvent = (
   event: Partial<DocumentGroupEvent>,
-): event is UnscheduleDocumentVersionEvent => event.type === 'UnscheduleDocumentVersion'
+): event is UnscheduleDocumentVersionEvent => event.type === 'unscheduleDocumentVersion'
 
 /**
  * @hidden
@@ -209,7 +209,7 @@ export const isUnscheduleDocumentVersionEvent = (
  */
 export const isDeleteDocumentGroupEvent = (
   event: Partial<DocumentGroupEvent>,
-): event is DeleteDocumentGroupEvent => event.type === 'DeleteDocumentGroup'
+): event is DeleteDocumentGroupEvent => event.type === 'deleteDocumentGroup'
 
 /**
  * @hidden
@@ -217,7 +217,7 @@ export const isDeleteDocumentGroupEvent = (
  */
 export const isCreateLiveDocumentEvent = (
   event: Partial<DocumentGroupEvent>,
-): event is CreateLiveDocumentEvent => event.type === 'CreateLiveDocument'
+): event is CreateLiveDocumentEvent => event.type === 'createLiveDocument'
 
 /**
  * @hidden
@@ -225,7 +225,7 @@ export const isCreateLiveDocumentEvent = (
  */
 export const isUpdateLiveDocumentEvent = (
   event: Partial<DocumentGroupEvent>,
-): event is UpdateLiveDocumentEvent => event.type === 'UpdateLiveDocument'
+): event is UpdateLiveDocumentEvent => event.type === 'updateLiveDocument'
 
 /**
  * @hidden
@@ -233,7 +233,7 @@ export const isUpdateLiveDocumentEvent = (
  */
 export const isEditDocumentVersionEvent = (
   event: Partial<DocumentGroupEvent>,
-): event is EditDocumentVersionEvent => event.type === 'EditDocumentVersion'
+): event is EditDocumentVersionEvent => event.type === 'editDocumentVersion'
 
 /**
  * A generic event with a type and a timestamp.
@@ -251,7 +251,7 @@ export interface BaseEvent {
  * @beta
  */
 export interface CreateDocumentVersionEvent extends BaseEvent {
-  type: 'CreateDocumentVersion'
+  type: 'createDocumentVersion'
   documentId: string
 
   releaseId?: string
@@ -274,7 +274,7 @@ export interface CreateDocumentVersionEvent extends BaseEvent {
  * @beta
  */
 export interface DeleteDocumentVersionEvent extends BaseEvent {
-  type: 'DeleteDocumentVersion'
+  type: 'deleteDocumentVersion'
   documentId: string
 
   releaseId?: string
@@ -287,7 +287,7 @@ export interface DeleteDocumentVersionEvent extends BaseEvent {
  * @beta
  */
 export interface PublishDocumentVersionEvent extends BaseEvent {
-  type: 'PublishDocumentVersion'
+  type: 'publishDocumentVersion'
   documentId: string
   revisionId: string
 
@@ -320,7 +320,7 @@ export interface PublishDocumentVersionEvent extends BaseEvent {
  * @beta
  */
 export interface UnpublishDocumentEvent extends BaseEvent {
-  type: 'UnpublishDocument'
+  type: 'unpublishDocument'
   documentId: string
 
   /** The version that was created based on it */
@@ -336,7 +336,7 @@ export interface UnpublishDocumentEvent extends BaseEvent {
  * @beta
  */
 export interface ScheduleDocumentVersionEvent extends BaseEvent {
-  type: 'ScheduleDocumentVersion'
+  type: 'scheduleDocumentVersion'
   documentId: string
 
   releaseId: string
@@ -355,7 +355,7 @@ export interface ScheduleDocumentVersionEvent extends BaseEvent {
  * @beta
  */
 export interface UnscheduleDocumentVersionEvent extends BaseEvent {
-  type: 'UnscheduleDocumentVersion'
+  type: 'unscheduleDocumentVersion'
   documentId: string
 
   releaseId: string
@@ -370,7 +370,7 @@ export interface UnscheduleDocumentVersionEvent extends BaseEvent {
  * @beta
  */
 export interface DeleteDocumentGroupEvent extends BaseEvent {
-  type: 'DeleteDocumentGroup'
+  type: 'deleteDocumentGroup'
   documentId: string
 
   author: string
@@ -381,7 +381,7 @@ export interface DeleteDocumentGroupEvent extends BaseEvent {
  * @beta
  */
 export interface CreateLiveDocumentEvent extends BaseEvent {
-  type: 'CreateLiveDocument'
+  type: 'createLiveDocument'
   documentId: string
   revisionId: string
 
@@ -393,7 +393,7 @@ export interface CreateLiveDocumentEvent extends BaseEvent {
  * @beta
  */
 export interface UpdateLiveDocumentEvent extends BaseEvent {
-  type: 'UpdateLiveDocument'
+  type: 'updateLiveDocument'
   documentId: string
   revisionId: string
 
@@ -408,7 +408,7 @@ export interface UpdateLiveDocumentEvent extends BaseEvent {
  * Or a create event and a publish event.
  */
 export interface EditDocumentVersionEvent extends BaseEvent {
-  type: 'EditDocumentVersion'
+  type: 'editDocumentVersion'
   documentId: string
   // Given this event could be a result of multiple edits, we could have more than one author.
   contributors: string[]
@@ -419,7 +419,7 @@ export interface EditDocumentVersionEvent extends BaseEvent {
    */
   revisionId: string
   transactions: {
-    type: 'EditTransaction'
+    type: 'editTransaction'
     author: string
     timestamp: string
     revisionId: string

--- a/packages/sanity/src/structure/panes/document/DocumentEventsPane.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentEventsPane.tsx
@@ -4,6 +4,8 @@ import {
   getDraftId,
   getPublishedId,
   getVersionId,
+  isDeleteDocumentGroupEvent,
+  isDeleteDocumentVersionEvent,
   useEventsStore,
   usePerspective,
   useReleases,
@@ -53,7 +55,7 @@ export const DocumentEventsPane = (props: DocumentPaneProviderProps) => {
       isPristine: Boolean(eventsStore.events.length === 0),
       lastNonDeletedRevId:
         eventsStore.events.find(
-          (e) => e.type !== 'DeleteDocumentGroup' && e.type !== 'DeleteDocumentVersion',
+          (e) => !isDeleteDocumentGroupEvent(e) && !isDeleteDocumentVersionEvent(e),
         )?.id || null,
     }),
     [eventsStore],

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/EventsSelector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/EventsSelector.tsx
@@ -2,6 +2,11 @@ import {BoundaryElementProvider, Card, Flex, useToast} from '@sanity/ui'
 import {useCallback, useState} from 'react'
 import {
   type DocumentGroupEvent,
+  isDeleteDocumentGroupEvent,
+  isDeleteDocumentVersionEvent,
+  isScheduleDocumentVersionEvent,
+  isUnpublishDocumentEvent,
+  isUnscheduleDocumentVersionEvent,
   LoadingBlock,
   ScrollContainer,
   useEvents,
@@ -56,11 +61,11 @@ export function EventsSelector({showList}: {showList: boolean}) {
     (event: DocumentGroupEvent) => {
       try {
         if (
-          event.type === 'DeleteDocumentVersion' ||
-          event.type === 'DeleteDocumentGroup' ||
-          event.type === 'UnpublishDocument' ||
-          event.type === 'ScheduleDocumentVersion' ||
-          event.type === 'UnscheduleDocumentVersion'
+          isDeleteDocumentVersionEvent(event) ||
+          isDeleteDocumentGroupEvent(event) ||
+          isUnpublishDocumentEvent(event) ||
+          isScheduleDocumentVersionEvent(event) ||
+          isUnscheduleDocumentVersionEvent(event)
         ) {
           console.error('Event is not selectable')
           return

--- a/packages/sanity/src/structure/panes/document/timeline/events/EventTimelineItem.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/events/EventTimelineItem.tsx
@@ -1,6 +1,15 @@
 import {Card, Flex} from '@sanity/ui'
 import {type MouseEvent, useCallback} from 'react'
-import {type DocumentGroupEvent, Event, useTranslation} from 'sanity'
+import {
+  type DocumentGroupEvent,
+  Event,
+  isDeleteDocumentGroupEvent,
+  isDeleteDocumentVersionEvent,
+  isScheduleDocumentVersionEvent,
+  isUnpublishDocumentEvent,
+  isUnscheduleDocumentVersionEvent,
+  useTranslation,
+} from 'sanity'
 
 import {Tooltip} from '../../../../../ui-components'
 
@@ -12,13 +21,12 @@ export interface TimelineItemProps {
 }
 
 const getIsSelectable = (event: DocumentGroupEvent) => {
-  const {type} = event
   return (
-    type !== 'DeleteDocumentVersion' &&
-    type !== 'DeleteDocumentGroup' &&
-    type !== 'UnpublishDocument' &&
-    type !== 'ScheduleDocumentVersion' &&
-    type !== 'UnscheduleDocumentVersion'
+    !isDeleteDocumentVersionEvent(event) &&
+    !isDeleteDocumentGroupEvent(event) &&
+    !isUnpublishDocumentEvent(event) &&
+    !isScheduleDocumentVersionEvent(event) &&
+    !isUnscheduleDocumentVersionEvent(event)
   )
 }
 

--- a/packages/sanity/src/structure/panes/document/timeline/events/EventsTimeline.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/events/EventsTimeline.tsx
@@ -8,6 +8,7 @@ import {
   getDocumentVariantType,
   isCreateDocumentVersionEvent,
   isEditDocumentVersionEvent,
+  isPublishDocumentVersionEvent,
   LoadingBlock,
   useTranslation,
 } from 'sanity'
@@ -128,11 +129,11 @@ export const EventsTimeline = ({
   const renderOptionsMenu = useCallback(
     (event: DocumentGroupEvent) => {
       const documentVariantType = getDocumentVariantType(event.documentId)
-      if (event.type === 'PublishDocumentVersion' && documentVariantType === 'published') {
+      if (isPublishDocumentVersionEvent(event) && documentVariantType === 'published') {
         return <PublishedEventMenu event={event} />
       }
       if (
-        event.type === 'PublishDocumentVersion' &&
+        isPublishDocumentVersionEvent(event) &&
         documentVariantType === 'draft' &&
         event.creationEvent
       ) {

--- a/packages/sanity/src/structure/panes/document/timeline/events/EventsTimelineMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/events/EventsTimelineMenu.tsx
@@ -10,6 +10,11 @@ import {
 import {useCallback, useMemo, useState} from 'react'
 import {
   type DocumentGroupEvent,
+  isDeleteDocumentGroupEvent,
+  isDeleteDocumentVersionEvent,
+  isScheduleDocumentVersionEvent,
+  isUnpublishDocumentEvent,
+  isUnscheduleDocumentVersionEvent,
   TIMELINE_ITEM_I18N_KEY_MAPPING,
   useEvents,
   useTranslation,
@@ -82,11 +87,11 @@ export function EventsTimelineMenu({event, events, mode, placement}: TimelineMen
     (revEvent: DocumentGroupEvent) => {
       try {
         if (
-          revEvent.type === 'DeleteDocumentVersion' ||
-          revEvent.type === 'DeleteDocumentGroup' ||
-          revEvent.type === 'UnpublishDocument' ||
-          revEvent.type === 'ScheduleDocumentVersion' ||
-          revEvent.type == 'UnscheduleDocumentVersion'
+          isDeleteDocumentVersionEvent(revEvent) ||
+          isDeleteDocumentGroupEvent(revEvent) ||
+          isUnpublishDocumentEvent(revEvent) ||
+          isScheduleDocumentVersionEvent(revEvent) ||
+          isUnscheduleDocumentVersionEvent(revEvent)
         ) {
           console.error('Event is not selectable')
           return


### PR DESCRIPTION
### Description
Content lake has renamed the events types that are returned from the events api to camel case.
This reflects that update in the studio.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
