### PR TITLE
test(e2e): refer to correct env variable for Playwright version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ vars.PLAYWRIGHT_VERSION }}
+          key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Install Playwright Browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'


### PR DESCRIPTION
The key here should be made from `env`, and not `vars`.

As proved by cache names under https://github.com/sanity-io/sanity/actions/caches

Invalid entry for e2e:

![image](https://github.com/user-attachments/assets/a6887cc3-80a5-4da5-b495-e49681d9e8b6)

Valid entry for component tests:

![image](https://github.com/user-attachments/assets/b652cb5d-80e8-4f5a-b210-bc0114eddcef)
