### PR TITLE
fix(releases): stabilising observable for archived and published version documents

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -8,6 +8,7 @@ import {filter, map, mergeMap, startWith, switchAll, switchMap, take, toArray} f
 import {mergeMapArray} from 'rxjs-mergemap-array'
 
 import {useClient, useSchema} from '../../../hooks'
+import {type LocaleSource} from '../../../i18n/types'
 import {
   type DocumentPreviewStore,
   getPreviewValueWithFallback,


### PR DESCRIPTION
### Description
| Before | After |
|--------|--------|
| ![summaryFlickerBeforePR](https://github.com/user-attachments/assets/6dbbb877-5fb5-4c50-bc48-96b37819285c) | ![summaryFlickerAfterPR](https://github.com/user-attachments/assets/985c3ecf-2766-490e-9c84-4d9a828be54e) | 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* Moved to using a getter style pattern for creating the observables eg:
```
const getObservable = () => ...

...

const memoObservable = useMemo(() => getObservable(), [])
```
* Using `releasesState` from `releasesStore` to drive the emission for the returned observable (this removed the dependency on the mutable `releases` which was causing the flicker by returning a new observable each time `releases` changed
* Moved the existing `ActiveReleaseDocumentsObservable` into a getter

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Existing tests act as regression
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
