### PR TITLE
feat(core): option to exclude draft perspective 

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1223,6 +1223,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Tooltip for button to hide release visibility */
   'release.layer.hide': 'Hide release',
   /** Label for published releases in navbar */
+  'release.navbar.drafts': 'Drafts',
+  /** Label for published releases in navbar */
   'release.navbar.published': 'Published',
   /** Tooltip for releases navigation in navbar */
   'release.navbar.tooltip': 'Releases',

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1222,7 +1222,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.form.placeholer-describe-release': 'Describe the release…',
   /** Tooltip for button to hide release visibility */
   'release.layer.hide': 'Hide release',
-  /** Label for published releases in navbar */
+  /** Label for draft perspective in navbar */
   'release.navbar.drafts': 'Drafts',
   /** Label for published releases in navbar */
   'release.navbar.published': 'Published',

--- a/packages/sanity/src/core/releases/hooks/usePerspective.tsx
+++ b/packages/sanity/src/core/releases/hooks/usePerspective.tsx
@@ -130,7 +130,6 @@ export function usePerspective(): PerspectiveValue {
 
   const toggleExcludedPerspective = useCallback(
     (excluded: string) => {
-      if (excluded === LATEST._id) return
       const existingPerspectives = excludedPerspectives || []
 
       const nextExcludedPerspectives = existingPerspectives.includes(excluded)

--- a/packages/sanity/src/core/releases/navbar/GlobalPerspectiveMenu.tsx
+++ b/packages/sanity/src/core/releases/navbar/GlobalPerspectiveMenu.tsx
@@ -10,6 +10,7 @@ import {CreateReleaseDialog} from '../components/dialog/CreateReleaseDialog'
 import {usePerspective} from '../hooks/usePerspective'
 import {type ReleaseDocument, type ReleaseType} from '../store/types'
 import {useReleases} from '../store/useReleases'
+import {LATEST} from '../util/const'
 import {
   getRangePosition,
   GlobalPerspectiveMenuItem,
@@ -124,6 +125,10 @@ export function GlobalPerspectiveMenu(): JSX.Element {
             <GlobalPerspectiveMenuItem
               rangePosition={isRangeVisible ? getRangePosition(range, 0) : undefined}
               release={'published'}
+            />
+            <GlobalPerspectiveMenuItem
+              rangePosition={isRangeVisible ? getRangePosition(range, 1) : undefined}
+              release={LATEST}
             />
           </StyledPublishedBox>
           <>

--- a/packages/sanity/src/core/releases/navbar/PerspectiveLayerIndicator.tsx
+++ b/packages/sanity/src/core/releases/navbar/PerspectiveLayerIndicator.tsx
@@ -10,9 +10,9 @@ export const GlobalPerspectiveMenuItemIndicator = styled.div<{
   $inRange: boolean
   $last: boolean
   $first: boolean
-  $isPublished: boolean
+  $isDraft: boolean
 }>(
-  ({$inRange, $last, $first, $isPublished}) => css`
+  ({$inRange, $last, $first, $isDraft}) => css`
     position: relative;
 
     --indicator-left: ${INDICATOR_LEFT_OFFSET}px;
@@ -32,9 +32,7 @@ export const GlobalPerspectiveMenuItemIndicator = styled.div<{
         left: var(--indicator-left);
         bottom: -var(--indicator-bottom);
         width: var(--indicator-width);
-        height: ${$isPublished
-          ? 'calc(var(--indicator-bottom) + 12px)'
-          : 'var(--indicator-bottom)'};
+        height: ${$isDraft ? 'calc(var(--indicator-bottom) + 12px)' : 'var(--indicator-bottom)'};
         background-color: var(--indicator-color);
       }
     `}

--- a/packages/sanity/src/core/releases/navbar/__tests__/ReleasesNav.test.tsx
+++ b/packages/sanity/src/core/releases/navbar/__tests__/ReleasesNav.test.tsx
@@ -196,10 +196,7 @@ describe('ReleasesNav', () => {
         })
 
         it('should set a given perspective from the menu', async () => {
-          expect(usePerspectiveMockReturn.setPerspectiveFromReleaseDocumentId).toHaveBeenCalledWith(
-            '_.releases.active-scheduled-2',
-          )
-          expect(usePerspectiveMockReturn.setPerspective).not.toHaveBeenCalled()
+          expect(usePerspectiveMockReturn.setPerspective).toHaveBeenCalledWith('active-scheduled-2')
         })
 
         it('should allow for hiding of any deeper layered releases', async () => {
@@ -228,6 +225,21 @@ describe('ReleasesNav', () => {
           expect(
             within(publishedRelease).queryByTestId('release-toggle-visibility'),
           ).not.toBeInTheDocument()
+        })
+
+        it('should allow for hiding of draft perspective', async () => {
+          const drafts = within(screen.getByTestId('release-menu'))
+            .getByText('Drafts')
+            .closest('button')!
+
+          expect(within(drafts).queryByTestId('release-toggle-visibility')).toBeInTheDocument()
+          // toggle to hide
+          fireEvent.click(within(drafts).getByTestId('release-toggle-visibility'))
+          expect(usePerspectiveMockReturn.toggleExcludedPerspective).toHaveBeenCalledWith('drafts')
+
+          // toggle to include
+          fireEvent.click(within(drafts).getByTestId('release-toggle-visibility'))
+          expect(usePerspectiveMockReturn.toggleExcludedPerspective).toHaveBeenCalledWith('drafts')
         })
 
         it('should not allow hiding of the current perspective', async () => {

--- a/packages/sanity/src/core/releases/navbar/useScrollIndicatorVisibility.ts
+++ b/packages/sanity/src/core/releases/navbar/useScrollIndicatorVisibility.ts
@@ -8,8 +8,8 @@ function isElementVisibleInContainer(container: ScrollElement, element: ScrollEl
   const containerRect = container.getBoundingClientRect()
   const elementRect = element.getBoundingClientRect()
 
-  // 32.5px is padding on published element + padding of perspective menu item
-  const isVisible = elementRect.top >= containerRect.top + 32.5
+  // 32.5px is padding on published/draft element + padding of perspective/draft menu item
+  const isVisible = elementRect.top >= containerRect.top + 32.5 * 2
 
   return isVisible
 }


### PR DESCRIPTION
### Description

Adds `drafts` to the perspective menu list and adds the ability to hide it.
This is specially useful when previewing content in `presentation` or other tools, to avoid adding the `drafts` to the list of perspective stack.


<img width="600" alt="Screenshot 2024-12-13 at 09 02 17" src="https://github.com/user-attachments/assets/edaae704-a5e2-40f7-b600-4580b6248c0b" />
<img width="600" alt="Screenshot 2024-12-13 at 09 02 28" src="https://github.com/user-attachments/assets/e5c84651-7c91-476a-bc07-f730847c3e35" />
<img width="600" alt="Screenshot 2024-12-13 at 09 02 36" src="https://github.com/user-attachments/assets/f92dd249-dbda-4efd-ae06-e7c1567eb678" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Are this changes correct?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
New tests added for this new behavior 
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
