### PR TITLE
fix(sanity): relative dates incorrectly appearing to be in the future

### DIFF
--- a/packages/sanity/src/core/hooks/useRelativeTime.ts
+++ b/packages/sanity/src/core/hooks/useRelativeTime.ts
@@ -1,3 +1,5 @@
+'use no memo'
+
 import {
   differenceInDays,
   differenceInHours,


### PR DESCRIPTION
### Description

It appears React Compiler is failing to see the base comparison date (`now`) as a dependancy when using `useRelativeTime` to calculate a relative date. This causes the base comparison date (`now`) to become stale, resulting in the relative date incorrectly appearing to be in the future.

This affects the History inspector. Changes made externally (e.g. by another editor or the API) after the page loads may appear to be from the future:

![image (26)](https://github.com/user-attachments/assets/ba52ae2b-1111-46e1-ad4a-459ecb79eb58)

Spooky! 👻

Switching off auto-memoization for `useRelativeTime` appears to solve the problem for now.

### What to review

- Does this seem reasonable?

### Testing

1. When viewing a document, open the History inspector.
2. In another tab, or via the API, mutate the document you are viewing.
3. In the original tab, the change should never appear to be in the future.

### Notes for release

Fixed a bug that could cause relative timestamps, such as those shown in the document history inspector, to incorrectly appear to be in the future.