### PR TITLE
feat(cli): remove .github dirs when initializing with a remote template

### DIFF
--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -181,6 +181,11 @@ export async function downloadAndExtractRepo(
           const pathSegments = posixPath.split(posix.sep)
           rootPath = pathSegments.length ? pathSegments[0] : null
         }
+        // Exclude files in the .github directory to prevent potential security risks
+        // from running unknown actions if the repository is pushed to GitHub
+        if (posixPath.includes('/.github/')) {
+          return false
+        }
         return posixPath.startsWith(`${rootPath}${filePath ? `/${filePath}/` : '/'}`)
       },
     }),

--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -14,6 +14,11 @@ import {x} from 'tar'
 
 import {type CliApiClient, type PackageJson} from '../types'
 
+const DISALLOWED_PATHS = [
+  // Prevent security risks from unknown GitHub Actions
+  '/.github/',
+]
+
 const ENV_VAR = {
   ...REQUIRED_ENV_VAR,
   READ_TOKEN: 'SANITY_API_READ_TOKEN',
@@ -181,10 +186,8 @@ export async function downloadAndExtractRepo(
           const pathSegments = posixPath.split(posix.sep)
           rootPath = pathSegments.length ? pathSegments[0] : null
         }
-        // Exclude files in the .github directory to prevent potential security risks
-        // from running unknown actions if the repository is pushed to GitHub
-        if (posixPath.includes('/.github/')) {
-          return false
+        for (const disallowedPath of DISALLOWED_PATHS) {
+          if (posixPath.includes(disallowedPath)) return false
         }
         return posixPath.startsWith(`${rootPath}${filePath ? `/${filePath}/` : '/'}`)
       },


### PR DESCRIPTION
### Description

Filter away .github directories when initializing with a remote template. This is to prevent potential security risks from running unknown actions if the user decides to push their project to GitHub

Fixes GRO-3053

### Questions

Are there any more directories we should omit?

### Testing

Run
```shell
sanity init --template sanity-io/sanity-template-nextjs-clean
```
See if the directory includes a .github folder

### Notes for release

N/A