### PR TITLE
fix(cli): outputters should respect %s

### DIFF
--- a/packages/@sanity/cli/src/outputters/cliOutputter.ts
+++ b/packages/@sanity/cli/src/outputters/cliOutputter.ts
@@ -13,19 +13,19 @@ export default {
     console.log(...args)
   },
 
-  success(...args: unknown[]): void {
-    console.log(`${SYMBOL_CHECK} ${args.join(' ')}`)
+  success(firstPartOfMessage: unknown, ...args: unknown[]): void {
+    console.log(`${SYMBOL_CHECK} ${firstPartOfMessage}`, ...args)
   },
 
-  warn(...args: unknown[]): void {
-    console.warn(`${SYMBOL_WARN} ${args.join(' ')}`)
+  warn(firstPartOfMessage: unknown, ...args: unknown[]): void {
+    console.warn(`${SYMBOL_WARN} ${firstPartOfMessage}`, ...args)
   },
 
-  error(...args: unknown[]): void {
-    if (args[0] instanceof Error) {
-      console.error(`${SYMBOL_FAIL} ${chalk.red(args[0].stack)}`)
+  error(firstPartOfMessage: unknown, ...args: unknown[]): void {
+    if (firstPartOfMessage instanceof Error) {
+      console.error(`${SYMBOL_FAIL} ${chalk.red(firstPartOfMessage.stack)}`)
     } else {
-      console.error(`${SYMBOL_FAIL} ${args.join(' ')}`)
+      console.error(`${SYMBOL_FAIL} ${firstPartOfMessage}`, ...args)
     }
   },
 


### PR DESCRIPTION
### Description

Slight regression from #8003 where I started joining console arguments. 
This ended up breaking string format specifiers making prints like this: 
```ts
success('You are logged in as %s using %s', user.email, getProviderName(user.provider))
```
render like this:
```shell
✓ You are logged in as %s using %s rosti@sanity.io Google
```

### Testing

Run
```shell
sanity init
```
See if the intro command look like this again

```shell
✓ You are logged in as rosti@sanity.io using Google
```

### Notes for release

N/A, as #8003 hadn't reached a release yet.