### PR TITLE
revert(cli): use default ora options in spinner method

### DIFF
--- a/packages/@sanity/cli/src/outputters/cliOutputter.ts
+++ b/packages/@sanity/cli/src/outputters/cliOutputter.ts
@@ -37,7 +37,7 @@ export default {
   },
 
   spinner(options: Options): Ora {
-    const spinner = ora({...options, spinner: 'dots'})
+    const spinner = ora(options)
     // Override the default status methods to use custom symbols instead of emojis
     spinner.succeed = (text?: string) => spinner.stopAndPersist({text, symbol: SYMBOL_CHECK})
     spinner.warn = (text?: string) => spinner.stopAndPersist({text, symbol: SYMBOL_WARN})


### PR DESCRIPTION
### Description

Revert a change to the spinner method that was done in #8003 to make the spinner label visible again. 

We're passing the label directly as an option to ora (the spinner lib) in multiple places. Luckily 'dots' is set as the default spinner anyway so this doesn't affect anything.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Run
```shell
sanity init
```

As a project starts bootstrapping, the spinner should now have a label beside it again.

### Notes for release

No notes as #8003 hasn't reached a release yet.
