### PR TITLE
fix: `WebSocket is closed before the connection is established` warning

### DIFF
--- a/packages/sanity/src/core/store/_legacy/ResourceCacheProvider.tsx
+++ b/packages/sanity/src/core/store/_legacy/ResourceCacheProvider.tsx
@@ -1,4 +1,4 @@
-import {type ReactNode, useContext, useMemo} from 'react'
+import {type ReactNode, useContext, useState} from 'react'
 import {ResourceCacheContext} from 'sanity/_singletons'
 
 import {createMultiKeyWeakMap, type MultiKeyWeakMap} from './createMultiKeyWeakMap'
@@ -16,7 +16,7 @@ export interface ResourceCacheProviderProps {
 
 /** @internal */
 export function ResourceCacheProvider({children}: ResourceCacheProviderProps) {
-  const resourceCache = useMemo((): ResourceCache => {
+  const [resourceCache] = useState((): ResourceCache => {
     const namespaces = new Map<string, MultiKeyWeakMap>()
 
     // this is used to replace the `null` values in any `dependencies` so that
@@ -41,7 +41,7 @@ export function ResourceCacheProvider({children}: ResourceCacheProviderProps) {
         namespaceMap.set(dependenciesWithoutNull, value)
       },
     }
-  }, [])
+  })
 
   return (
     <ResourceCacheContext.Provider value={resourceCache}>{children}</ResourceCacheContext.Provider>

--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -20,7 +20,7 @@ import {fetchFeatureToggle} from './document/document-pair/utils/fetchFeatureTog
 import {type OutOfSyncError} from './document/utils/sequentializeListenerEvents'
 import {createGrantsStore, type GrantsStore} from './grants'
 import {createHistoryStore, type HistoryStore} from './history'
-import {__tmp_wrap_presenceStore, type PresenceStore} from './presence/presence-store'
+import {createPresenceStore, type PresenceStore} from './presence/presence-store'
 import {createProjectStore, type ProjectStore} from './project'
 import {useResourceCache} from './ResourceCacheProvider'
 import {createUserStore, type UserStore} from './user'
@@ -231,7 +231,7 @@ export function usePresenceStore(): PresenceStore {
       resourceCache.get<PresenceStore>({
         namespace: 'presenceStore',
         dependencies: [bifur, connectionStatusStore, userStore],
-      }) || __tmp_wrap_presenceStore({bifur, connectionStatusStore, userStore})
+      }) || createPresenceStore({bifur, connectionStatusStore, userStore})
 
     resourceCache.set({
       namespace: 'presenceStore',

--- a/packages/sanity/src/core/store/_legacy/presence/presence-store.ts
+++ b/packages/sanity/src/core/store/_legacy/presence/presence-store.ts
@@ -114,7 +114,7 @@ function setSessionId(id: string) {
 export const SESSION_ID = getSessionId() || setSessionId(generate())
 
 /** @internal */
-export function __tmp_wrap_presenceStore(context: {
+export function createPresenceStore(context: {
   bifur: BifurClient
   connectionStatusStore: ConnectionStatusStore
   userStore: UserStore

--- a/packages/sanity/src/core/store/_legacy/presence/useDocumentPresence.tsx
+++ b/packages/sanity/src/core/store/_legacy/presence/useDocumentPresence.tsx
@@ -1,19 +1,19 @@
-import {useEffect, useState} from 'react'
+import {startTransition, useEffect, useReducer} from 'react'
+import {useObservable} from 'react-rx'
+import {of} from 'rxjs'
 
 import {usePresenceStore} from '../datastores'
 import {type DocumentPresence} from './types'
 
+const initial: DocumentPresence[] = []
+const fallback = of(initial)
+
 /** @internal */
 export function useDocumentPresence(documentId: string): DocumentPresence[] {
+  const [mounted, mount] = useReducer(() => true, false)
+  // Using `startTransition` here ensures that rapid re-renders that affect the deps used by `usePresenceStore` delay the transition to `mounted=true`, thus avoiding creating websocket connections that will be closed immediately.
+  useEffect(() => startTransition(mount), [])
+
   const presenceStore = usePresenceStore()
-  const [presence, setPresence] = useState<DocumentPresence[]>([])
-
-  useEffect(() => {
-    const subscription = presenceStore.documentPresence(documentId).subscribe(setPresence)
-    return () => {
-      subscription.unsubscribe()
-    }
-  }, [documentId, presenceStore])
-
-  return presence
+  return useObservable(mounted ? presenceStore.documentPresence(documentId) : fallback, initial)
 }

--- a/packages/sanity/src/core/store/_legacy/presence/useGlobalPresence.tsx
+++ b/packages/sanity/src/core/store/_legacy/presence/useGlobalPresence.tsx
@@ -1,20 +1,19 @@
-import {useEffect, useState} from 'react'
+import {startTransition, useEffect, useReducer} from 'react'
+import {useObservable} from 'react-rx'
+import {of} from 'rxjs'
 
 import {usePresenceStore} from '../datastores'
 import {type GlobalPresence} from './types'
 
+const initial: GlobalPresence[] = []
+const fallback = of(initial)
+
 /** @internal */
 export function useGlobalPresence(): GlobalPresence[] {
-  const [presence, setPresence] = useState<GlobalPresence[]>([])
+  const [mounted, mount] = useReducer(() => true, false)
+  // Using `startTransition` here ensures that rapid re-renders that affect the deps used by `usePresenceStore` delay the transition to `mounted=true`, thus avoiding creating websocket connections that will be closed immediately.
+  useEffect(() => startTransition(mount), [])
+
   const presenceStore = usePresenceStore()
-
-  useEffect(() => {
-    const subscription = presenceStore.globalPresence$.subscribe(setPresence)
-
-    return () => {
-      subscription.unsubscribe()
-    }
-  }, [presenceStore])
-
-  return presence
+  return useObservable(mounted ? presenceStore.globalPresence$ : fallback, initial)
 }


### PR DESCRIPTION
### Description

Ever since I gave up on #7227 it's been in the back of my mind, and taunting me every time I've been in a studio and seen this warning:

```
WebSocket connection to 'wss://:projectId.api.sanity.io/v2022-06-30/socket/:dataset?tag=sanity.studio' failed: WebSocket is closed before the connection is established.
```

That ends today, I've finally found a stable workaround!
At some point we should dive into `@sanity/bifur-client` and find out exactly why [the observable teardown](https://github.com/sanity-io/bifur-client/blob/b6062c27c87b130fa179704885d42d96361027d7/src/createConnect.ts#L70) calling `ws.close` causes the warning, maybe we have to check `ws.readyState`? Maybe we can't avoid this warning if the observable is unsubscribed to before the connection is established, and while the warning is annoying it remains the right thing to do.
Or maybe we should wait a tick `Promise.resolve().then` before creating the WebSocket, in case react does a new render as `userStore` changed so we avoid creating a resource that will be immediately closed anyway (we use this technique in `react-rx`, as well as in `@sanity/client` for its `client.listen()` observable).
I don't know, I'm not an WebSocket expert.

What I do know is that in #7227 the regression that lead to the WebSocket warning showing 3 times instead of just once, was because it shifted `useGlobalPresence` and `useDocumentPresence` completely away from `useEffect` to `useObservable` from `react-rx`.
The benefits of `react-rx`'s `useObservable` are many:
- In React Strict Mode it's unaffected by the double useEffect invocations, as it uses `useSyncExternalStore`.
- It has built in error management that integrates with react error boundaries.
- [Advanced and performant cache mechanics that follows best practice for `rxjs`, in a way that works with React 18 and 19 semantics and concurrent modes.](https://github.com/sanity-io/react-rx/blob/b5a59063f896d9fbdf7d3eb5b41ab2b37e654eba/src/useObservable.ts#L56-L87)
- It's pre-compiled by React Compiler, ensuring a lower memory footprint and faster rerenders.

But, since `useObservable` is designed to allow synchronous emits, it warms up the observable you give it, and subscribes to it during render.
Previously `useGlobalPresence` and `useDocumentPresence` subscribed much later, in a `useEffect`, causing the bifur websocket to be setup after react is done with initial renders.

The reason why the issue is resolved this time around is because the observables aren't subscribed to until after an initial `useEffect` runs and tracks mounted state. By the time this happens the dependencies for `usePresenceStore` (`bifur`, `connectionStatusStore`, and `userStore`) have stabilized and we no longer see eager closing of the WebSocket.

### What to review

Hopefully this makes sense 🙌 

### Testing

I've tested manually with `pnpm dev`, as well as the [preview deployment](https://test-studio-git-fix-websocket-disconnect-warning.sanity.dev/test/structure) and I've verified that the warning no longer happens.
I've also verified on network devtools that there's only one websocket resource related to bifur.
Here's the before screenshot, that shows the eagerly closed resource with its `Finished` status, in addition to the live one with status 101, and with `Time` set to `Pending` (indicating it's open and active):
<img width="807" alt="image" src="https://github.com/user-attachments/assets/5ca4d65e-117d-41f8-9006-504090634128" />
And here's the after, showing only a single resource:

<img width="807" alt="image" src="https://github.com/user-attachments/assets/ad7e4efb-435a-4a4f-8e3e-56b778beacbb" />


### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
