### PR TITLE
fix: replace `React.createElement` with jsx runtime

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -218,9 +218,9 @@ const config = {
               },
               {
                 name: 'react',
-                importNames: ['default', 'createContext'],
+                importNames: ['default', 'createContext', 'createElement'],
                 message:
-                  'Please use named imports, e.g. `import {useEffect, useMemo, type ComponentType} from "react"` instead.\nPlease place "context" in _singletons',
+                  'Please use named imports, e.g. `import {useEffect, useMemo, type ComponentType} from "react"` instead.\nPlease place "context" in _singletons\nPlease use JSX instead of createElement, for example `createElement(Icon)` should be `<Icon />`',
               },
             ],
           },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check:deps": "pnpm --recursive --parallel exec depcheck",
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
-    "check:react-compiler": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 28 .",
+    "check:react-compiler": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 27 .",
     "report:react-compiler-bailout": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [error,{__unstable_donotuse_reportAllBailouts:true}]' --ignore-path .eslintignore.react-compiler -f ./scripts/reactCompilerBailouts.cjs . || true",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",

--- a/packages/sanity/src/_internal/cli/server/renderDocument.tsx
+++ b/packages/sanity/src/_internal/cli/server/renderDocument.tsx
@@ -13,7 +13,6 @@ import {isMainThread, parentPort, Worker, workerData} from 'node:worker_threads'
 import chalk from 'chalk'
 import importFresh from 'import-fresh'
 import {parse as parseHtml} from 'node-html-parser'
-import {createElement} from 'react'
 import {renderToStaticMarkup} from 'react-dom/server'
 
 import {TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT} from './constants'
@@ -231,7 +230,7 @@ function getDocumentHtml(
 
   debug('Rendering document component using React')
   const result = addTimestampedImportMapScriptToHtml(
-    renderToStaticMarkup(createElement(Document, {...defaultProps, ...props, css})),
+    renderToStaticMarkup(<Document {...defaultProps} {...props} css={css} />),
     importMap,
   )
 

--- a/packages/sanity/src/_internal/manifest/Icon.tsx
+++ b/packages/sanity/src/_internal/manifest/Icon.tsx
@@ -1,6 +1,6 @@
 import {ThemeProvider} from '@sanity/ui'
 import {buildTheme} from '@sanity/ui/theme'
-import {type ComponentType, createElement, isValidElement, type ReactNode} from 'react'
+import {type ComponentType, isValidElement, type ReactNode} from 'react'
 import {isValidElementType} from 'react-is'
 import {createDefaultIcon} from 'sanity'
 
@@ -17,12 +17,12 @@ const SchemaIcon = ({icon, title, subtitle}: SchemaIconProps): JSX.Element => {
 }
 
 function normalizeIcon(
-  icon: ComponentType | ReactNode | undefined,
+  Icon: ComponentType | ReactNode | undefined,
   title: string,
   subtitle = '',
 ): JSX.Element {
-  if (isValidElementType(icon)) return createElement(icon)
-  if (isValidElement(icon)) return icon
+  if (isValidElementType(Icon)) return <Icon />
+  if (isValidElement(Icon)) return Icon
   return createDefaultIcon(title, subtitle)
 }
 

--- a/packages/sanity/src/_internal/manifest/extractWorkspaceManifest.tsx
+++ b/packages/sanity/src/_internal/manifest/extractWorkspaceManifest.tsx
@@ -1,6 +1,5 @@
 import DOMPurify from 'isomorphic-dompurify'
 import startCase from 'lodash/startCase'
-import {createElement} from 'react'
 import {renderToString} from 'react-dom/server'
 import {
   type ArraySchemaType,
@@ -543,7 +542,7 @@ const resolveIcon = (props: SchemaIconProps): string | null => {
      * You must render the element first so
      * the style-sheet above can be populated
      */
-    const element = renderToString(sheet.collectStyles(createElement(SchemaIcon, props)))
+    const element = renderToString(sheet.collectStyles(<SchemaIcon {...props} />))
     const styleTags = sheet.getStyleTags()
 
     /**

--- a/packages/sanity/src/core/comments/utils/transform-children/linkMiddleware.tsx
+++ b/packages/sanity/src/core/comments/utils/transform-children/linkMiddleware.tsx
@@ -1,4 +1,4 @@
-import {createElement, type MouseEvent, type ReactNode} from 'react'
+import {type MouseEvent, type ReactNode} from 'react'
 
 import {type Middleware} from './types'
 
@@ -10,9 +10,12 @@ export function onClick(event: MouseEvent<HTMLAnchorElement>): void {
 
 function createLinkElement(url: string): ReactNode {
   const href = url.startsWith('http') ? url : `https://${url}`
-  const props = {href, target: '_blank', rel: 'noopener noreferrer', key: url, onClick}
 
-  return createElement('a', props, url)
+  return (
+    <a key={url} href={href} target="_blank" rel="noopener noreferrer" onClick={onClick}>
+      {url}
+    </a>
+  )
 }
 
 /**

--- a/packages/sanity/src/core/components/previews/__workshop__/GeneralPreviewStory.tsx
+++ b/packages/sanity/src/core/components/previews/__workshop__/GeneralPreviewStory.tsx
@@ -1,7 +1,7 @@
 import {DocumentIcon, EditIcon} from '@sanity/icons'
 import {Card, Container, Flex, Text} from '@sanity/ui'
 import {useBoolean, useNumber, useSelect, useString, useText} from '@sanity/ui-workshop'
-import {type ComponentType, createElement, useMemo} from 'react'
+import {type ComponentType, useMemo} from 'react'
 
 import {PREVIEW_SIZES} from '../constants'
 import {CompactPreview} from '../general/CompactPreview'
@@ -84,9 +84,10 @@ export default function GeneralPreviewStory() {
     [description, isPlaceholder, media, progress, status, subtitle, title],
   )
 
-  const component = layout && previewComponents[layout]
+  const Component =
+    layout && (previewComponents[layout] as ComponentType<Omit<PreviewProps, 'renderDefault'>>)
 
-  if (!component) {
+  if (!Component) {
     return (
       <Flex align="center" height="fill" justify="center" padding={4} sizing="border">
         <Text>Unknown layout: {layout}</Text>
@@ -103,10 +104,7 @@ export default function GeneralPreviewStory() {
             selected={interactive ? selected : undefined}
             style={{lineHeight: 0}}
           >
-            {createElement(
-              component as ComponentType<Omit<PreviewProps, 'renderDefault'>>,
-              previewProps,
-            )}
+            <Component {...previewProps} />
           </Card>
         </Container>
       </Flex>

--- a/packages/sanity/src/core/components/previews/__workshop__/PortableTextPreviewStory.tsx
+++ b/packages/sanity/src/core/components/previews/__workshop__/PortableTextPreviewStory.tsx
@@ -1,7 +1,7 @@
 import {DocumentIcon, EditIcon} from '@sanity/icons'
 import {Card, Container, Flex, Text} from '@sanity/ui'
 import {useBoolean, useSelect, useString} from '@sanity/ui-workshop'
-import {type ComponentType, createElement, useMemo} from 'react'
+import {type ComponentType, useMemo} from 'react'
 
 import {ContextMenuButton} from '../../contextMenuButton'
 import {PREVIEW_SIZES} from '../constants'
@@ -87,9 +87,10 @@ export default function PortableTextPreviewStory() {
     [isPlaceholder, media, status, subtitle, title, withActions],
   )
 
-  const component = layout && previewComponents[layout]
+  const Component =
+    layout && (previewComponents[layout] as ComponentType<Omit<PreviewProps, 'renderDefault'>>)
 
-  if (!component) {
+  if (!Component) {
     return (
       <Flex align="center" height="fill" justify="center" padding={4} sizing="border">
         <Text>Unknown layout: {layout}</Text>
@@ -102,10 +103,7 @@ export default function PortableTextPreviewStory() {
       <Flex align="center" height="fill" justify="center" padding={4} sizing="border">
         <Container width={1}>
           <Card border padding={padding[layout]} radius={1} style={{lineHeight: 0}}>
-            {createElement(
-              component as ComponentType<Omit<PreviewProps, 'renderDefault'>>,
-              previewProps,
-            )}
+            <Component {...previewProps} />
           </Card>
         </Container>
       </Flex>

--- a/packages/sanity/src/core/components/previews/__workshop__/TemplatePreviewStory.tsx
+++ b/packages/sanity/src/core/components/previews/__workshop__/TemplatePreviewStory.tsx
@@ -1,7 +1,7 @@
 import {DocumentIcon} from '@sanity/icons'
 import {Card, Container, Flex, Text} from '@sanity/ui'
 import {useBoolean, useSelect, useString, useText} from '@sanity/ui-workshop'
-import {type ComponentType, createElement, type ReactNode} from 'react'
+import {type ComponentType, type ReactNode} from 'react'
 
 import {TemplatePreview, type TemplatePreviewProps} from '../template/TemplatePreview'
 
@@ -36,9 +36,9 @@ export default function TemplatePreviewStory() {
   const description = useText('Description', undefined, 'Props')
 
   const media = mediaValues[mediaKey] || false
-  const component = layout && previewComponents[layout]
+  const Component = layout && previewComponents[layout]
 
-  if (!component) {
+  if (!Component) {
     return (
       <Flex align="center" height="fill" justify="center" padding={4} sizing="border">
         <Text>Unknown layout: {layout}</Text>
@@ -51,13 +51,13 @@ export default function TemplatePreviewStory() {
       <Flex align="center" height="fill" justify="center" padding={4} sizing="border">
         <Container width={0}>
           <Card padding={3} radius={2}>
-            {createElement(component, {
-              description,
-              isPlaceholder,
-              media,
-              title,
-              subtitle,
-            })}
+            <Component
+              description={description}
+              isPlaceholder={isPlaceholder}
+              media={media}
+              title={title}
+              subtitle={subtitle}
+            />
           </Card>
         </Container>
       </Flex>

--- a/packages/sanity/src/core/components/previews/_common/Media.tsx
+++ b/packages/sanity/src/core/components/previews/_common/Media.tsx
@@ -1,5 +1,5 @@
 import {Text} from '@sanity/ui'
-import {createElement, isValidElement, type ReactNode} from 'react'
+import {isValidElement, type ReactNode} from 'react'
 import {isValidElementType} from 'react-is'
 
 import {type PreviewLayoutKey, type PreviewMediaDimensions, type PreviewProps} from '../types'
@@ -48,7 +48,14 @@ function renderMedia(props: {
   const {dimensions, layout, media, styles} = props
 
   if (isValidElementType(media)) {
-    return createElement(media, {dimensions, layout})
+    const MediaComponent = media
+    return (
+      <MediaComponent
+        // @ts-expect-error - @TODO fix typings
+        dimensions={dimensions}
+        layout={layout}
+      />
+    )
   }
 
   if (typeof media === 'string') {

--- a/packages/sanity/src/core/components/previews/helpers.tsx
+++ b/packages/sanity/src/core/components/previews/helpers.tsx
@@ -1,4 +1,4 @@
-import {createElement, type ElementType, type ReactNode} from 'react'
+import {type ElementType, type ReactNode} from 'react'
 import {isValidElementType} from 'react-is'
 
 import {type PreviewLayoutKey, type PreviewMediaDimensions} from './types'
@@ -9,7 +9,14 @@ export function renderPreviewMedia<Layout = PreviewLayoutKey>(
   dimensions: PreviewMediaDimensions,
 ): ReactNode {
   if (isValidElementType(value)) {
-    return createElement(value, {layout, dimensions})
+    const Value = value
+    return (
+      <Value
+        // @ts-expect-error - @TODO fix typings
+        layout={layout}
+        dimensions={dimensions}
+      />
+    )
   }
 
   if (typeof value === 'string') {
@@ -30,7 +37,13 @@ export function renderPreviewNode<Layout = PreviewLayoutKey>(
   }
 
   if (isValidElementType(value)) {
-    return createElement(value, {layout})
+    const Value = value
+    return (
+      <Value
+        // @ts-expect-error - @TODO fix typings
+        layout={layout}
+      />
+    )
   }
 
   // @todo: find out why `value` isn't infered as `ReactNode` here

--- a/packages/sanity/src/core/components/previews/template/TemplatePreview.tsx
+++ b/packages/sanity/src/core/components/previews/template/TemplatePreview.tsx
@@ -1,5 +1,5 @@
 import {Box, Flex, rem, Stack, Text, TextSkeleton} from '@sanity/ui'
-import {createElement, type ElementType, isValidElement, type ReactNode} from 'react'
+import {type ElementType, isValidElement, type ReactNode} from 'react'
 import {isValidElementType} from 'react-is'
 import {styled} from 'styled-components'
 import {getDevicePixelRatio} from 'use-device-pixel-ratio'
@@ -63,8 +63,8 @@ export function TemplatePreview(props: TemplatePreviewProps) {
     isPlaceholder,
     media,
     mediaDimensions = DEFAULT_MEDIA_DIMENSION,
-    subtitle,
-    title = 'Untitled',
+    subtitle: Subtitle,
+    title: Title = 'Untitled',
   } = props
 
   if (isPlaceholder) {
@@ -84,19 +84,27 @@ export function TemplatePreview(props: TemplatePreviewProps) {
     <Root>
       <HeaderFlex>
         <Stack flex={1} space={2}>
-          {isValidElementType(title) && (
-            <Text textOverflow="ellipsis">{createElement(title, {layout: 'default'})}</Text>
-          )}
-          {isValidElement(title) && <Text textOverflow="ellipsis">{title}</Text>}
-
-          {isValidElementType(subtitle) && (
-            <Text muted size={1} textOverflow="ellipsis">
-              {createElement(subtitle, {layout: 'default'})}
+          {isValidElementType(Title) && (
+            <Text textOverflow="ellipsis">
+              <Title
+                // @ts-expect-error - @todo fix typings
+                layout="default"
+              />
             </Text>
           )}
-          {isValidElement(subtitle) && (
+          {isValidElement(Title) && <Text textOverflow="ellipsis">{Title}</Text>}
+
+          {isValidElementType(Subtitle) && (
             <Text muted size={1} textOverflow="ellipsis">
-              {subtitle}
+              <Subtitle
+                // @ts-expect-error - @todo fix typings
+                layout="default"
+              />
+            </Text>
+          )}
+          {isValidElement(Subtitle) && (
+            <Text muted size={1} textOverflow="ellipsis">
+              {Subtitle}
             </Text>
           )}
         </Stack>

--- a/packages/sanity/src/core/components/scroll/scrollContainer.tsx
+++ b/packages/sanity/src/core/components/scroll/scrollContainer.tsx
@@ -1,6 +1,5 @@
 import createPubSub from 'nano-pubsub'
 import {
-  createElement,
   type ElementType,
   type ForwardedRef,
   forwardRef,
@@ -20,8 +19,6 @@ export interface ScrollContainerProps<T extends ElementType>
   onScroll?: (event: Event) => () => void
 }
 
-const noop = () => undefined
-
 /**
  * This provides a utility function for use within Sanity Studios to create scrollable containers
  * It also provides a way for components inside a scrollable container to track onScroll on their first parent scroll container
@@ -35,7 +32,7 @@ export const ScrollContainer = forwardRef(function ScrollContainer<T extends Ele
   props: ScrollContainerProps<T>,
   forwardedRef: ForwardedRef<HTMLDivElement>,
 ) {
-  const {as = 'div', onScroll, ...rest} = props
+  const {as: As = 'div', onScroll, ...rest} = props
   const ref = useRef<HTMLDivElement | null>(null)
 
   useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(forwardedRef, () => ref.current)
@@ -44,19 +41,15 @@ export const ScrollContainer = forwardRef(function ScrollContainer<T extends Ele
   const childContext = useMemo(() => createPubSub<Event>(), [])
 
   useEffect(() => {
-    if (onScroll) {
-      // emit scroll events from children
-      return childContext.subscribe(onScroll)
-    }
-    return noop
+    if (!onScroll) return undefined
+    // emit scroll events from children
+    return childContext.subscribe(onScroll)
   }, [childContext, onScroll])
 
   useEffect(() => {
+    if (!parentContext) return undefined
     // let events bubble up
-    if (parentContext) {
-      return childContext.subscribe(parentContext.publish)
-    }
-    return noop
+    return childContext.subscribe(parentContext.publish)
   }, [parentContext, childContext])
 
   useEffect(() => {
@@ -82,7 +75,7 @@ export const ScrollContainer = forwardRef(function ScrollContainer<T extends Ele
 
   return (
     <ScrollContext.Provider value={childContext}>
-      {createElement(as, {'ref': ref, 'data-testid': 'scroll-container', ...rest})}
+      <As data-testid="scroll-container" {...rest} ref={ref} />
     </ScrollContext.Provider>
   )
 })

--- a/packages/sanity/src/core/config/components/useMiddlewareComponents.tsx
+++ b/packages/sanity/src/core/config/components/useMiddlewareComponents.tsx
@@ -1,28 +1,28 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import {type ComponentType, createElement, Fragment, useMemo} from 'react'
+import {type ComponentType, Fragment, useMemo} from 'react'
 
-import {flattenConfig} from '../../config'
 import {useSource} from '../../studio'
+import {flattenConfig} from '..'
 import {type PluginOptions} from '../types'
 
-const emptyRender = () => createElement(Fragment)
+const emptyRender = () => <Fragment />
 
 function _createMiddlewareComponent<T extends {}>(
-  defaultComponent: ComponentType<T>,
+  DefaultComponent: ComponentType<T>,
   middlewareComponents: ComponentType<T>[],
 ): ComponentType<T> {
   return (outerProps: T) => {
     // This is the inner "layer" of the middleware chain
     // Here we render the _default_ component (typically Sanity's component)
-    let next = (props: T) => createElement(defaultComponent, props)
+    let next = (props: T) => <DefaultComponent {...props} />
 
-    for (const middleware of middlewareComponents) {
+    for (const Middleware of middlewareComponents) {
       // As we progress through the chain, the meaning of "renderDefault" changes.
       // At a given layer in the chain, the _next_ layer is the "default".
       const renderDefault = next
 
       // Here we replace `next` so that the _previous_ layer may use this as its _next_.
-      next = (props) => createElement(middleware, {...props, renderDefault})
+      next = (props) => <Middleware {...props} renderDefault={renderDefault} />
     }
 
     return next({

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -4,13 +4,7 @@ import {type CurrentUser, type Schema, type SchemaValidationProblem} from '@sani
 import {studioTheme} from '@sanity/ui'
 import {type i18n} from 'i18next'
 import {startCase} from 'lodash'
-import {
-  type ComponentType,
-  createElement,
-  type ElementType,
-  type ErrorInfo,
-  isValidElement,
-} from 'react'
+import {type ComponentType, type ElementType, type ErrorInfo, isValidElement} from 'react'
 import {isValidElementType} from 'react-is'
 import {map, shareReplay} from 'rxjs/operators'
 
@@ -73,12 +67,12 @@ type InternalSource = WorkspaceSummary['__internal']['sources'][number]
 const isError = (p: SchemaValidationProblem) => p.severity === 'error'
 
 function normalizeIcon(
-  icon: ComponentType | ElementType | undefined,
+  Icon: ComponentType | ElementType | undefined,
   title: string,
   subtitle = '',
 ): JSX.Element {
-  if (isValidElementType(icon)) return createElement(icon)
-  if (isValidElement(icon)) return icon
+  if (isValidElementType(Icon)) return <Icon />
+  if (isValidElement(Icon)) return Icon
   return createDefaultIcon(title, subtitle)
 }
 

--- a/packages/sanity/src/core/field/diff/components/DiffFromTo.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffFromTo.tsx
@@ -1,5 +1,5 @@
 import {type Path, type SchemaType} from '@sanity/types'
-import {createElement, type CSSProperties} from 'react'
+import {type CSSProperties} from 'react'
 
 import {type FieldPreviewComponent} from '../../preview'
 import {type Diff} from '../../types'
@@ -28,27 +28,35 @@ const cardStyles: CSSProperties = {
 
 /** @internal */
 export function DiffFromTo(props: DiffFromToProps) {
-  const {align, cardClassName, diff, layout, path, previewComponent, schemaType} = props
+  const {
+    align,
+    cardClassName,
+    diff,
+    layout,
+    path,
+    previewComponent: PreviewComponent,
+    schemaType,
+  } = props
   const {action} = diff
   const changeVerb = useChangeVerb(diff)
 
   if (action === 'unchanged') {
     return (
       <DiffCard className={cardClassName} style={cardStyles}>
-        {createElement(previewComponent, {schemaType, value: diff.toValue})}
+        <PreviewComponent schemaType={schemaType} value={diff.toValue} />
       </DiffCard>
     )
   }
 
   const from = diff.fromValue !== undefined && diff.fromValue !== null && (
     <DiffCard as="del" className={cardClassName} diff={diff} path={path} style={cardStyles}>
-      {createElement(previewComponent, {schemaType, value: diff.fromValue})}
+      <PreviewComponent schemaType={schemaType} value={diff.fromValue} />
     </DiffCard>
   )
 
   const to = diff.toValue !== undefined && diff.toValue !== null && (
     <DiffCard as="ins" className={cardClassName} diff={diff} path={path} style={cardStyles}>
-      {createElement(previewComponent, {schemaType, value: diff.toValue})}
+      <PreviewComponent schemaType={schemaType} value={diff.toValue} />
     </DiffCard>
   )
 

--- a/packages/sanity/src/core/field/diff/components/FromToArrow.tsx
+++ b/packages/sanity/src/core/field/diff/components/FromToArrow.tsx
@@ -1,6 +1,6 @@
 import {ArrowDownIcon, ArrowRightIcon} from '@sanity/icons'
 import {Text, type TextProps} from '@sanity/ui'
-import {createElement, type HTMLProps} from 'react'
+import {type HTMLProps} from 'react'
 
 /** @internal */
 export type FromToArrowDirection = 'down' | 'right'
@@ -16,11 +16,11 @@ export function FromToArrow(
     Omit<HTMLProps<HTMLDivElement>, 'children' | 'ref'>,
 ) {
   const {direction = 'right', ...restProps} = props
-  const arrowComponent = arrowComponents[direction]
+  const ArrowComponent = arrowComponents[direction]
 
   return (
     <Text muted size={1} {...restProps}>
-      {createElement(arrowComponent)}
+      <ArrowComponent />
     </Text>
   )
 }

--- a/packages/sanity/src/core/field/diff/components/MetaInfo.tsx
+++ b/packages/sanity/src/core/field/diff/components/MetaInfo.tsx
@@ -1,5 +1,5 @@
 import {Box, Flex, Stack, Text} from '@sanity/ui'
-import {type ComponentType, createElement, type ReactNode} from 'react'
+import {type ComponentType, type ReactNode} from 'react'
 import {styled} from 'styled-components'
 
 /** @internal */
@@ -17,14 +17,14 @@ const MetaText = styled(Text)`
 
 /** @internal */
 export function MetaInfo(props: MetaInfoProps) {
-  const {title, action, icon, children, markRemoved} = props
+  const {title, action, icon: Icon, children, markRemoved} = props
 
   return (
     <Flex padding={2} align="center">
-      {icon && (
+      {Icon && (
         <Box padding={2}>
           <MetaText size={4} forwardedAs={markRemoved ? 'del' : 'div'}>
-            {createElement(icon)}
+            <Icon />
           </MetaText>
         </Box>
       )}

--- a/packages/sanity/src/core/field/types/portableText/diff/components/PortableText.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/PortableText.tsx
@@ -6,7 +6,7 @@ import {
   type SpanSchemaType,
 } from '@sanity/types'
 import {uniq, xor} from 'lodash'
-import {createElement, type ReactElement, type ReactNode, useCallback, useMemo} from 'react'
+import {type ReactElement, type ReactNode, useCallback, useMemo} from 'react'
 
 import {type TFunction, useTranslation} from '../../../../../i18n'
 import {DiffCard} from '../../../../diff'
@@ -228,7 +228,7 @@ export function PortableText(props: Props): JSX.Element {
             }
           } // end if seg.text
         })
-        return createElement('div', {key: block._key}, ...returnedChildren)
+        return <div key={block._key}>{returnedChildren}</div>
       }
       throw new Error("'span' schemaType not found")
     },

--- a/packages/sanity/src/core/form/form-components-hooks/components.tsx
+++ b/packages/sanity/src/core/form/form-components-hooks/components.tsx
@@ -1,5 +1,5 @@
 import {type SchemaType} from '@sanity/types'
-import {type ComponentType, createElement, type ReactElement, useCallback} from 'react'
+import {type ComponentType, type ReactElement, useCallback} from 'react'
 
 import {type PreviewProps} from '../../components/previews'
 import {
@@ -33,7 +33,7 @@ function useResolveDefaultComponent<T extends {schemaType?: SchemaType}>(props: 
     throw new Error('the `schemaType` property must be defined')
   }
 
-  const defaultResolvedComponent = componentResolver(componentProps.schemaType)
+  const DefaultResolvedComponent = componentResolver(componentProps.schemaType)
 
   const renderDefault = useCallback(
     (parentTypeProps: T) => {
@@ -46,16 +46,13 @@ function useResolveDefaultComponent<T extends {schemaType?: SchemaType}>(props: 
       // in order to prevent that a component is render itself
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const {components, ...restSchemaType} = parentTypeProps.schemaType
-      const parentTypeResolvedComponent = componentResolver(restSchemaType)
-      return createElement(parentTypeResolvedComponent, parentTypeProps)
+      const ParentTypeResolvedComponent = componentResolver(restSchemaType)
+      return <ParentTypeResolvedComponent {...parentTypeProps} />
     },
     [componentResolver],
   )
 
-  return createElement(defaultResolvedComponent, {
-    ...componentProps,
-    renderDefault,
-  }) as ReactElement<T>
+  return <DefaultResolvedComponent {...componentProps} renderDefault={renderDefault} />
 }
 
 /**

--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferencePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferencePreview.tsx
@@ -3,7 +3,7 @@ import {AccessDeniedIcon, HelpCircleIcon, LaunchIcon} from '@sanity/icons'
 import imageUrlBuilder from '@sanity/image-url'
 import {type CrossDatasetType, type PreviewValue} from '@sanity/types'
 import {Badge, Box, Flex, Inline, Text} from '@sanity/ui'
-import {createElement, isValidElement as ReactIsValidElement, useMemo} from 'react'
+import {isValidElement as ReactIsValidElement, useMemo} from 'react'
 
 import {Tooltip} from '../../../../ui-components'
 import {DefaultPreview, type PreviewMediaDimensions, TextWithTone} from '../../../components'
@@ -71,7 +71,9 @@ export function CrossDatasetReferencePreview(props: {
         )
       }
     }
-    return refType?.icon ? createElement(refType.icon) : null
+    if (!refType?.icon) return null
+    const Icon = refType.icon
+    return <Icon />
   }, [previewMedia, dataset, projectId, refType?.icon, t])
 
   return (

--- a/packages/sanity/src/core/form/studio/defaults.tsx
+++ b/packages/sanity/src/core/form/studio/defaults.tsx
@@ -1,5 +1,3 @@
-import {createElement} from 'react'
-
 import {Preview} from '../../preview/components/Preview'
 import {
   type RenderAnnotationCallback,
@@ -20,35 +18,41 @@ import {defaultResolveItemComponent} from './inputResolver/itemResolver'
 
 /** @internal */
 export const defaultRenderAnnotation: RenderAnnotationCallback = (props) => {
-  return createElement(defaultResolveAnnotationComponent(props.schemaType), props)
+  const Annotation = defaultResolveAnnotationComponent(props.schemaType)
+  return <Annotation {...props} />
 }
 
 /** @internal */
 export const defaultRenderBlock: RenderBlockCallback = (props) => {
-  return createElement(defaultResolveBlockComponent(props.schemaType), props)
+  const Block = defaultResolveBlockComponent(props.schemaType)
+  return <Block {...props} />
 }
 
 /** @internal */
 export const defaultRenderInlineBlock: RenderBlockCallback = (props) => {
-  return createElement(defaultResolveInlineBlockComponent(props.schemaType), props)
+  const InlineBlock = defaultResolveInlineBlockComponent(props.schemaType)
+  return <InlineBlock {...props} />
 }
 
 /** @internal */
 export const defaultRenderField: RenderFieldCallback = (props) => {
-  return createElement(defaultResolveFieldComponent(props.schemaType), props)
+  const Field = defaultResolveFieldComponent(props.schemaType)
+  return <Field {...props} />
 }
 
 /** @internal */
 export const defaultRenderInput: RenderInputCallback = (props) => {
-  return createElement(defaultResolveInputComponent(props.schemaType), props)
+  const Input = defaultResolveInputComponent(props.schemaType)
+  return <Input {...props} />
 }
 
 /** @internal */
 export const defaultRenderItem: RenderItemCallback = (props) => {
-  return createElement(defaultResolveItemComponent(props.schemaType), props)
+  const Item = defaultResolveItemComponent(props.schemaType)
+  return <Item {...props} />
 }
 
 /** @internal */
 export const defaultRenderPreview: RenderPreviewCallback = (props) => {
-  return createElement(Preview, props)
+  return <Preview {...props} />
 }

--- a/packages/sanity/src/core/i18n/Translate.tsx
+++ b/packages/sanity/src/core/i18n/Translate.tsx
@@ -1,5 +1,5 @@
 import {type TFunction} from 'i18next'
-import {type ComponentType, createElement, type ReactNode, useMemo} from 'react'
+import {type ComponentType, type ReactNode, useMemo} from 'react'
 
 import {useListFormat} from '../hooks/useListFormat'
 import {type CloseTagToken, simpleParser, type TextToken, type Token} from './simpleParser'
@@ -182,14 +182,10 @@ function render(
     const children = tail.slice(0, nextCloseIdx) as TextToken[]
     const remaining = tail.slice(nextCloseIdx + 1)
 
-    return Component ? (
+    const As = Component ? Component : head.name
+    return (
       <>
-        <Component>{render(children, values, componentMap, formatters)}</Component>
-        {render(remaining, values, componentMap, formatters)}
-      </>
-    ) : (
-      <>
-        {createElement(head.name, {}, render(children, values, componentMap, formatters))}
+        <As>{render(children, values, componentMap, formatters)}</As>
         {render(remaining, values, componentMap, formatters)}
       </>
     )

--- a/packages/sanity/src/core/preview/components/PreviewLoader.tsx
+++ b/packages/sanity/src/core/preview/components/PreviewLoader.tsx
@@ -1,11 +1,4 @@
-import {
-  type ComponentType,
-  createElement,
-  type CSSProperties,
-  type ReactElement,
-  useMemo,
-  useState,
-} from 'react'
+import {type ComponentType, type CSSProperties, type ReactElement, useMemo, useState} from 'react'
 
 import {type PreviewProps} from '../../components'
 import {type RenderPreviewCallbackProps} from '../../form'
@@ -31,7 +24,7 @@ export function PreviewLoader(
   const {
     layout,
     value,
-    component,
+    component: Component,
     style: styleProp,
     schemaType,
     skipVisibilityCheck,
@@ -87,15 +80,15 @@ export function PreviewLoader(
 
   return (
     <div ref={setElement} style={style}>
-      {createElement(component, {
-        ...restProps,
-        ...(preview?.value || {}),
-        media,
-        error: preview?.error,
-        isPlaceholder: preview?.isLoading,
-        layout,
-        schemaType,
-      })}
+      <Component
+        {...restProps}
+        {...(preview?.value || {})}
+        media={media}
+        error={preview?.error}
+        isPlaceholder={preview?.isLoading}
+        layout={layout}
+        schemaType={schemaType}
+      />
     </div>
   )
 }

--- a/packages/sanity/src/core/preview/components/SanityDefaultPreview.tsx
+++ b/packages/sanity/src/core/preview/components/SanityDefaultPreview.tsx
@@ -5,7 +5,6 @@ import {type SanityImageSource} from '@sanity/image-url/lib/types/types'
 import {type ImageUrlFitMode} from '@sanity/types'
 import {
   type ComponentType,
-  createElement,
   type ElementType,
   isValidElement,
   type ReactElement,
@@ -38,7 +37,7 @@ export interface SanityDefaultPreviewProps extends Omit<PreviewProps, 'renderDef
  * @internal
  * */
 export function SanityDefaultPreview(props: SanityDefaultPreviewProps): ReactElement {
-  const {icon, layout, media: mediaProp, imageUrl, title, tooltip, ...restProps} = props
+  const {icon: Icon, layout, media: mediaProp, imageUrl, title, tooltip, ...restProps} = props
 
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const imageBuilder = useMemo(() => imageUrlBuilder(client), [client])
@@ -74,11 +73,11 @@ export function SanityDefaultPreview(props: SanityDefaultPreviewProps): ReactEle
   )
 
   const renderIcon = useCallback(() => {
-    return createElement(icon || FallbackIcon)
-  }, [icon])
+    return Icon ? <Icon /> : <FallbackIcon />
+  }, [Icon])
 
   const media = useMemo(() => {
-    if (icon === false) {
+    if (Icon === false) {
       // Explicitly disabled
       return false
     }
@@ -108,7 +107,7 @@ export function SanityDefaultPreview(props: SanityDefaultPreviewProps): ReactEle
 
     // Render fallback icon
     return renderIcon
-  }, [icon, imageUrl, mediaProp, renderIcon, renderMedia, title])
+  }, [Icon, imageUrl, mediaProp, renderIcon, renderMedia, title])
 
   const previewProps: Omit<PreviewProps, 'renderDefault'> = useMemo(
     () => ({
@@ -120,12 +119,11 @@ export function SanityDefaultPreview(props: SanityDefaultPreviewProps): ReactEle
     [media, restProps, title],
   )
 
-  const layoutComponent = _previewComponents[layout || 'default']
+  const LayoutComponent = _previewComponents[layout || 'default'] as ComponentType<
+    Omit<PreviewProps, 'renderDefault'>
+  >
 
-  const children = createElement(
-    layoutComponent as ComponentType<Omit<PreviewProps, 'renderDefault'>>,
-    previewProps,
-  )
+  const children = <LayoutComponent {...previewProps} />
 
   if (tooltip) {
     return (

--- a/packages/sanity/src/core/studio/components/navbar/StudioActiveToolLayout.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioActiveToolLayout.tsx
@@ -1,5 +1,3 @@
-import {createElement} from 'react'
-
 import {type Tool} from '../../../config'
 
 interface StudioActiveToolLayoutProps {
@@ -8,5 +6,6 @@ interface StudioActiveToolLayoutProps {
 
 export function StudioActiveToolLayout(props: StudioActiveToolLayoutProps) {
   const {activeTool} = props
-  return createElement(activeTool.component, {tool: activeTool})
+  const Component = activeTool.component
+  return <Component tool={activeTool} />
 }

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/common/FilterIcon.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/common/FilterIcon.tsx
@@ -1,5 +1,4 @@
 import {UnknownIcon} from '@sanity/icons'
-import {createElement} from 'react'
 
 import {useSearchState} from '../../../contexts/search/useSearchState'
 import {getFilterDefinition} from '../../../definitions/filters'
@@ -14,9 +13,9 @@ export function FilterIcon({filter}: FilterIconProps) {
     state: {definitions},
   } = useSearchState()
 
-  const icon = getFilterDefinition(definitions.filters, filter.filterName)?.icon
-  if (icon) {
-    return createElement(icon)
+  const Icon = getFilterDefinition(definitions.filters, filter.filterName)?.icon
+  if (Icon) {
+    return <Icon />
   }
   return <UnknownIcon />
 }

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
@@ -1,6 +1,6 @@
 import {CheckmarkIcon} from '@sanity/icons'
 import {Box, Flex, Stack, Text} from '@sanity/ui'
-import {type ComponentType, createElement, isValidElement, type ReactNode, useMemo} from 'react'
+import {type ComponentType, isValidElement, type ReactNode, useMemo} from 'react'
 import {isValidElementType} from 'react-is'
 import {styled} from 'styled-components'
 
@@ -37,9 +37,9 @@ export const WorkspacePreviewIcon = ({
   return <Media $size={size}>{iconComponent}</Media>
 }
 
-const createIcon = (icon: ComponentType | ReactNode) => {
-  if (isValidElementType(icon)) return createElement(icon)
-  if (isValidElement(icon)) return icon
+const createIcon = (Icon: ComponentType | ReactNode) => {
+  if (isValidElementType(Icon)) return <Icon />
+  if (isValidElement(Icon)) return Icon
   return undefined
 }
 

--- a/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorPanel.tsx
@@ -1,5 +1,5 @@
 import {Box} from '@sanity/ui'
-import {createElement, type ReactElement, useCallback} from 'react'
+import {type ReactElement, useCallback} from 'react'
 
 import {usePane} from '../../../components'
 import {useStructureTool} from '../../../useStructureTool'
@@ -25,11 +25,10 @@ export function DocumentInspectorPanel(props: DocumentInspectorPanelProps): Reac
 
   if (collapsed || !inspector) return null
 
-  const element = createElement(inspector.component, {
-    onClose: handleClose,
-    documentId,
-    documentType,
-  })
+  const Component = inspector.component
+  const element = (
+    <Component onClose={handleClose} documentId={documentId} documentType={documentType} />
+  )
 
   if (features.resizablePanes) {
     return (

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -1,7 +1,6 @@
 import {ArrowLeftIcon, CloseIcon, SplitVerticalIcon} from '@sanity/icons'
 import {Flex} from '@sanity/ui'
 import {
-  createElement,
   type ForwardedRef,
   forwardRef,
   memo,
@@ -146,12 +145,14 @@ export const DocumentPanelHeader = memo(
             <Flex align="center" gap={1}>
               {unstable_languageFilter.length > 0 && (
                 <>
-                  {unstable_languageFilter.map((languageFilterComponent, idx) => {
-                    return createElement(languageFilterComponent, {
-                      // eslint-disable-next-line react/no-array-index-key
-                      key: `language-filter-${idx}`,
-                      schemaType,
-                    })
+                  {unstable_languageFilter.map((LanguageFilterComponent, idx) => {
+                    return (
+                      <LanguageFilterComponent
+                        // eslint-disable-next-line react/no-array-index-key
+                        key={`language-filter-${idx}`}
+                        schemaType={schemaType}
+                      />
+                    )
                   })}
                 </>
               )}

--- a/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
@@ -12,7 +12,7 @@ import {
   type ValidationMarker,
 } from '@sanity/types'
 import {Box, Card, type CardTone, Flex, Stack, Text} from '@sanity/ui'
-import {createElement, type ErrorInfo, Fragment, useCallback, useMemo, useState} from 'react'
+import {type ErrorInfo, Fragment, useCallback, useMemo, useState} from 'react'
 import {type DocumentInspectorProps, useTranslation} from 'sanity'
 
 import {ErrorBoundary} from '../../../../../ui-components'
@@ -92,6 +92,7 @@ function ValidationCard(props: {
   const {marker, onOpen, schemaType, value} = props
   const handleOpen = useCallback(() => onOpen(marker.path), [marker, onOpen])
   const [errorInfo, setErrorInfo] = useState<{error: Error; info: ErrorInfo} | null>(null)
+  const Icon = MARKER_ICON[marker.level]
 
   return (
     <ErrorBoundary onCatch={setErrorInfo}>
@@ -112,7 +113,9 @@ function ValidationCard(props: {
         >
           <Flex align="flex-start" gap={3}>
             <Box flex="none">
-              <Text size={1}>{createElement(MARKER_ICON[marker.level])}</Text>
+              <Text size={1}>
+                <Icon />
+              </Text>
             </Box>
 
             <Stack flex={1} space={2}>

--- a/packages/sanity/src/structure/panes/document/keyboardShortcuts/DocumentActionShortcuts.tsx
+++ b/packages/sanity/src/structure/panes/document/keyboardShortcuts/DocumentActionShortcuts.tsx
@@ -1,6 +1,5 @@
 import {isHotkey} from 'is-hotkey-esm'
 import {
-  createElement,
   type ElementType,
   type HTMLProps,
   memo,
@@ -34,7 +33,7 @@ const KeyboardShortcutResponder = memo(function KeyboardShortcutResponder(
   const {
     actionsBoxElement,
     activeIndex,
-    as = 'div',
+    as: As = 'div',
     children,
     id,
     onActionStart,
@@ -75,23 +74,15 @@ const KeyboardShortcutResponder = memo(function KeyboardShortcutResponder(
     [onActionStart, onKeyDown, states],
   )
 
-  return createElement(
-    as,
-    {
-      id,
-      onKeyDown: handleKeyDown,
-      tabIndex: -1,
-      ...rest,
-      ref: rootRef,
-    },
-    [
-      children,
-      activeAction && activeAction.dialog && (
+  return (
+    <As id={id} onKeyDown={handleKeyDown} tabIndex={-1} {...rest} ref={rootRef}>
+      {children}
+      {activeAction && activeAction.dialog && (
         <LegacyLayerProvider zOffset="paneFooter">
           <ActionStateDialog dialog={activeAction.dialog} referenceElement={actionsBoxElement} />
         </LegacyLayerProvider>
-      ),
-    ],
+      )}
+    </As>
   )
 })
 

--- a/packages/sanity/src/structure/panes/document/statusBar/RevisionStatusLine.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/RevisionStatusLine.tsx
@@ -1,7 +1,6 @@
 import {RestoreIcon} from '@sanity/icons'
 import {Box, Flex, Text} from '@sanity/ui'
 import {format} from 'date-fns'
-import {createElement} from 'react'
 import {Translate, useTranslation} from 'sanity'
 import {styled} from 'styled-components'
 
@@ -24,7 +23,6 @@ export function RevisionStatusLine(): JSX.Element {
 
   const message = {
     name: 'revision',
-    icon: RestoreIcon,
     text: date ? (
       <Translate
         t={t}
@@ -41,7 +39,9 @@ export function RevisionStatusLine(): JSX.Element {
     <>
       <Flex flex={1} gap={3} padding={2}>
         <Box flex="none">
-          <Text size={1}>{createElement(message.icon)}</Text>
+          <Text size={1}>
+            <RestoreIcon />
+          </Text>
         </Box>
         <Box flex={1}>
           <StatusText size={1} textOverflow="ellipsis">

--- a/packages/sanity/src/structure/panes/document/timeline/timelineItem.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/timelineItem.tsx
@@ -1,7 +1,7 @@
 import {Box, Card, Flex, Skeleton, Stack, Text} from '@sanity/ui'
 // eslint-disable-next-line camelcase
 import {getTheme_v2, type ThemeColorAvatarColorKey} from '@sanity/ui/theme'
-import {createElement, type MouseEvent, useCallback, useMemo} from 'react'
+import {type MouseEvent, useCallback, useMemo} from 'react'
 import {
   type ChunkType,
   type RelativeTimeOptions,
@@ -123,7 +123,7 @@ export function TimelineItem({
 }: TimelineItemProps) {
   const {t} = useTranslation('studio')
   const {type, endTimestamp: timestamp} = chunk
-  const iconComponent = getTimelineEventIconComponent(type)
+  const IconComponent = getTimelineEventIconComponent(type)
   const authorUserIds = Array.from(chunk.authors)
   const collaboratorsUsersIds = collaborators ? Array.from(collaborators) : []
   const isSelectable = type !== 'delete'
@@ -167,7 +167,7 @@ export function TimelineItem({
           <div style={{position: 'relative'}}>
             <UserAvatarStack maxLength={3} userIds={authorUserIds} size={2} />
             <IconBox align="center" justify="center" $color={TIMELINE_ITEM_EVENT_TONE[type]}>
-              <Text size={0}>{iconComponent && createElement(iconComponent)}</Text>
+              <Text size={0}>{IconComponent && <IconComponent />}</Text>
             </IconBox>
           </div>
           <Stack space={2}>

--- a/packages/sanity/src/structure/panes/userComponent/UserComponentPane.tsx
+++ b/packages/sanity/src/structure/panes/userComponent/UserComponentPane.tsx
@@ -1,4 +1,4 @@
-import {createElement, isValidElement, useState} from 'react'
+import {isValidElement, useState} from 'react'
 import {isValidElementType} from 'react-is'
 import {useI18nText} from 'sanity'
 
@@ -17,7 +17,7 @@ export function UserComponentPane(props: UserComponentPaneProps) {
   const {index, pane, paneKey, ...restProps} = props
   const {
     child,
-    component,
+    component: UserComponent,
     menuItems,
     menuItemGroups,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -40,18 +40,19 @@ export function UserComponentPane(props: UserComponentPaneProps) {
       />
 
       <UserComponentPaneContent>
-        {isValidElementType(component) &&
-          createElement(component, {
-            ...restProps,
-            ...restPane,
+        {isValidElementType(UserComponent) && (
+          <UserComponent
+            {...restProps}
+            {...restPane}
             // NOTE: here we're utilizing the function form of refs so setting
             // the ref causes a re-render for `UserComponentPaneHeader`
-            ...({ref: setRef} as any),
-            child: child as any, // @todo: Fix typings
-            paneKey,
-          })}
-
-        {isValidElement(component) && component}
+            ref={setRef as any}
+            // @ts-expect-error - @TODO Fix typings
+            child={child}
+            paneKey={paneKey}
+          />
+        )}
+        {isValidElement(UserComponent) && UserComponent}
       </UserComponentPaneContent>
     </Pane>
   )

--- a/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
+++ b/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
@@ -9,7 +9,6 @@ import {
   Text,
 } from '@sanity/ui'
 import {
-  createElement,
   forwardRef,
   type HTMLProps,
   isValidElement,
@@ -92,8 +91,8 @@ export const MenuItem = forwardRef(function MenuItem(
     children: childrenProp,
     disabled,
     hotkeys,
-    icon,
-    iconRight,
+    icon: Icon,
+    iconRight: IconRight,
     preview = null,
     renderMenuItem,
     text,
@@ -118,11 +117,11 @@ export const MenuItem = forwardRef(function MenuItem(
             </Flex>
           </PreviewWrapper>
         )}
-        {icon && (
+        {Icon && (
           <Box paddingRight={1}>
             <Text size={FONT_SIZE}>
-              {isValidElement(icon) && icon}
-              {isValidElementType(icon) && createElement(icon)}
+              {isValidElement(Icon) && Icon}
+              {isValidElementType(Icon) && <Icon />}
             </Text>
           </Box>
         )}
@@ -142,7 +141,7 @@ export const MenuItem = forwardRef(function MenuItem(
             )}
           </Stack>
         )}
-        {(badgeText || hotkeys || iconRight) && (
+        {(badgeText || hotkeys || IconRight) && (
           <Flex align="center" gap={3} marginLeft={3}>
             {hotkeys && <Hotkeys keys={hotkeys} style={{marginTop: -4, marginBottom: -4}} />}
 
@@ -152,10 +151,10 @@ export const MenuItem = forwardRef(function MenuItem(
               </Badge>
             )}
 
-            {iconRight && (
+            {IconRight && (
               <Text size={FONT_SIZE}>
-                {isValidElement(iconRight) && iconRight}
-                {isValidElementType(iconRight) && createElement(iconRight)}
+                {isValidElement(IconRight) && IconRight}
+                {isValidElementType(IconRight) && <IconRight />}
               </Text>
             )}
           </Flex>
@@ -166,12 +165,12 @@ export const MenuItem = forwardRef(function MenuItem(
     preview,
     disabled,
     __unstable_space,
-    icon,
+    Icon,
     text,
     __unstable_subtitle,
     badgeText,
     hotkeys,
-    iconRight,
+    IconRight,
   ])
 
   const renderWrapper = useCallback<ConditionalWrapperRenderWrapperCallback>(


### PR DESCRIPTION
### Description

Before the [JSX transform were introduced](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) it didn't really matter if you called `React.createElement` directly, or if you used JSX.
With
```tsx
export default function Component(props) {
  const {icon: Icon} = props

  return <Icon />
}
```
as input, you got
```tsx
export default function Component(props) {
  var Icon = props.icon;
  return /*#__PURE__*/ React.createElement(Icon, null);
}
```
as output. In that world you might as well call it directly, as it's functionally equivalent:
```tsx
import {createElement} from 'react'

export default function Component(props) {
  return createElement(props.icon)
}
```

Since then the entire ecosystem has moved to the jsx transform, that includes our vite when using `sanity dev|build|deploy`, as well as publishing libraries with `@sanity/pkg-utils`, and most other build tooling like Parcel, tsup etc etc.

With the new transform it's not just a new function being used, it's from a different, standalone export, and its function argument semantics are different:
```tsx
import { jsx as _jsx } from "react/jsx-runtime";
export default function Component(props) {
  var Icon = props.icon;
  return /*#__PURE__*/ _jsx(Icon, {});
}
```

On top of that, React 19 introduces new features that are only available if the `jsx-runtime` transform is used, which isn't supported with `createElement`.
[For example using `ref` as a prop, instead of using `React.forwardRef`, requires it](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#new-jsx-transform-is-now-required):
```tsx
// React 18 requires a wrapper in function components to forward refs to the dom node
const LoadingIcon = React.forwardRef(
  function(props, ref) {
    return <svg ref={ref} />
  }
)

// React 19 supports ref as a prop
function LoadingIcon(props) {
  return <svg ref={props.ref} />
}
```

The React 19 `<LoadingIcon />` only works if the JSX transform is used ([repl](https://babeljs.io/repl#?browsers=&build=&builtIns=false&corejs=false&spec=false&loose=false&code_lz=JYWwDg9gTgLgBAbwK4GcCmAlNAzAvnbKCEOAcijQEMBjGUgKHrQA9JY4ATHSpAG3mxIAdrWAQhcAMLFIQtEJgAKMETAoAlInpw41cSngJgeoQC44ASRP4AvHBUQ123fvgVscO6kw5F6xjoUMEhQEgA8VuJw7jYI7vgA9AB89LiMgiIwYhIAMhCUHMBCAOaRQsqqGlqBaMGhcGEoAG7F0TixDmoAdPFwyalAA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=true&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact&prettier=true&targets=&version=7.26.4&externalPlugins=&assumptions=%7B%7D)):
```tsx
export default function Component(props) {
  const {icon: Icon} = props
  const ref = useRef()

  return <Icon ref={ref} />
}

// Called as <Component icon={LoadingIcon} />
```
When using `createElement` it fails ([repl](https://babeljs.io/repl#?browsers=&build=&builtIns=false&corejs=false&spec=false&loose=false&code_lz=JYWwDg9gTgLgBAbwMZQKYEMaoKIBtUioB2MANHAK4DOqASqgGYC-cDUEIcA5GukjFwBQg1AA9IsOABNG6CrngMKRfsAhE4AYQ6QixGAAow7MFQCUiQXDhJ1VeGgZwAvJRr0GBs8OsB6X3AAIhSocDAQcAAGKBhYeAT6kXAARqjARADmbqhS5DAAFqGRjkkA7upc8KlwNPBU6UhFADIQ6FLpGQCStkRJwFRElXClUOhgYDlw6VH0fDAAdAzQpehQUh6RVnBoMBRQGjGYOPiEJEYmVPPAPeQIjkzeTMJKKjBqGi1tHd3q5xCmFgQWx2ew0AB4qAA3LKOZwIYz_S73OC-AB8giYQA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=true&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact&prettier=true&targets=&version=7.26.4&externalPlugins=&assumptions=%7B%7D)):
```tsx
import {createElement, useRef} from 'react'

export default function Component(props) {
  const ref = useRef()

  // Due to `createElement` being used, the `ref` won't be set since `LoadingIcon` isn't wrapped in `React.forwardRef`
  return createElement(props.icon, {ref})
}
```

### What to review

Is the linter rule addition that blocks `React.createElement` clear enough?

### Testing

If tests pass we should be good.

### Notes for release

Replaced `React.createElement` calls in internals with the JSX runtime, unlocking the React 19 performance improvements to JSX, as well as the ability to use `ref` as a prop instead of `React.forwardRef` wrappers.
