### PR TITLE
fix: speed up hovered field provider

### DIFF
--- a/packages/sanity/src/_singletons/context/HoveredFieldContext.ts
+++ b/packages/sanity/src/_singletons/context/HoveredFieldContext.ts
@@ -3,7 +3,10 @@ import {createContext} from 'sanity/_createContext'
 
 /** @internal */
 export interface HoveredFieldContextValue {
-  hoveredStack: string[]
+  store: {
+    subscribe: (onStoreCallback: () => void) => () => void
+    getSnapshot: () => string[]
+  }
   onMouseEnter: (path: Path) => void
   onMouseLeave: (path: Path) => void
 }
@@ -12,7 +15,10 @@ export interface HoveredFieldContextValue {
 export const HoveredFieldContext = createContext<HoveredFieldContextValue>(
   'sanity/_singletons/context/hovered-field',
   {
-    hoveredStack: [],
+    store: {
+      subscribe: () => () => undefined,
+      getSnapshot: () => [],
+    },
     onMouseEnter: () => undefined,
     onMouseLeave: () => undefined,
   },


### PR DESCRIPTION
### Description

Every time a field is hovered, every field rerenders, even though each field is only interested if its hover state is `true` or `false`:

https://github.com/user-attachments/assets/8897e931-0ccd-4d75-a67f-b07e2ced7aa4

This is due to the context provider broadcasting the current field that has focus, to all its `useContext` subscribers. Even though each field only wants to know a boolean, they rerender even if the boolean haven't changed.
By refactoring to a simple `useSyncExternalStore`, we're able to use `getSnapshot` to control when renders happen. Since `getSnapshot` returns a boolean, it'll only re-render when the returned boolean actually changes. In other words, even if `getSnapshot` is called every time a field is hovered, the components subscribed to the store won't rerender unless the boolean it cares about has changed.


https://github.com/user-attachments/assets/ba4a6e19-c79c-4399-822f-37ebdda4d089




### What to review

Are the code comments and this PR enough to explain this pattern?

### Testing

Existing tests are sufficient.

### Notes for release

Improved render performance when hovering fields, no more everything renders all at once on every hover 😮‍💨 
