### PR TITLE
fix: replace unsafe `useMemo` with `useState`

### DIFF
--- a/dev/test-studio/components/panes/debug/DebugPane.tsx
+++ b/dev/test-studio/components/panes/debug/DebugPane.tsx
@@ -1,7 +1,7 @@
 import {ChevronDownIcon, ChevronRightIcon, ControlsIcon, LinkIcon} from '@sanity/icons'
 import {Box, Card, Code, Flex, Stack, Text} from '@sanity/ui'
 import type * as React from 'react'
-import {useMemo} from 'react'
+import {useMemo, useState} from 'react'
 import {usePaneRouter, type UserComponent} from 'sanity/structure'
 
 function usePaneChildLinkComponent(props: {
@@ -48,7 +48,7 @@ export const DebugPane: UserComponent = function DebugPane(props) {
   // notice that the ID is only created on mount and should not change between
   // subsequent re-renders, therefore this ID will only change when the parent
   // component re-renders.
-  const randomId = useMemo(() => Math.floor(Math.random() * 10000000).toString(16), [])
+  const [randomId] = useState(() => Math.floor(Math.random() * 10000000).toString(16))
 
   return (
     <Box height="fill">

--- a/packages/sanity/playwright-ct/tests/formBuilder/utils/TestForm.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/utils/TestForm.tsx
@@ -96,7 +96,7 @@ export function TestForm(props: TestFormProps) {
     },
   )
   const [focusPath, setFocusPath] = useState<Path>(() => focusPathFromProps || [])
-  const patchChannel = useMemo(() => createPatchChannel(), [])
+  const [patchChannel] = useState(() => createPatchChannel())
 
   useGlobalCopyPasteElementHandler({
     element: wrapperRef.current,

--- a/packages/sanity/src/core/components/scroll/scrollContainer.tsx
+++ b/packages/sanity/src/core/components/scroll/scrollContainer.tsx
@@ -8,8 +8,8 @@ import {
   useContext,
   useEffect,
   useImperativeHandle,
-  useMemo,
   useRef,
+  useState,
 } from 'react'
 import {ScrollContext} from 'sanity/_singletons'
 
@@ -19,8 +19,6 @@ export interface ScrollContainerProps<T extends ElementType>
   as?: ElementType | keyof JSX.IntrinsicElements
   onScroll?: (event: Event) => () => void
 }
-
-const noop = () => undefined
 
 /**
  * This provides a utility function for use within Sanity Studios to create scrollable containers
@@ -41,22 +39,18 @@ export const ScrollContainer = forwardRef(function ScrollContainer<T extends Ele
   useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(forwardedRef, () => ref.current)
 
   const parentContext = useContext(ScrollContext)
-  const childContext = useMemo(() => createPubSub<Event>(), [])
+  const [childContext] = useState(() => createPubSub<Event>())
 
   useEffect(() => {
-    if (onScroll) {
-      // emit scroll events from children
-      return childContext.subscribe(onScroll)
-    }
-    return noop
+    if (!onScroll) return undefined
+    // emit scroll events from children
+    return childContext.subscribe(onScroll)
   }, [childContext, onScroll])
 
   useEffect(() => {
+    if (!parentContext) return undefined
     // let events bubble up
-    if (parentContext) {
-      return childContext.subscribe(parentContext.publish)
-    }
-    return noop
+    return childContext.subscribe(parentContext.publish)
   }, [parentContext, childContext])
 
   useEffect(() => {

--- a/packages/sanity/src/core/create/context/SanityCreateConfigProvider.tsx
+++ b/packages/sanity/src/core/create/context/SanityCreateConfigProvider.tsx
@@ -1,4 +1,4 @@
-import {type ReactNode, useMemo} from 'react'
+import {type ReactNode, useMemo, useState} from 'react'
 import {SanityCreateConfigContext} from 'sanity/_singletons'
 
 import {useSource} from '../../studio'
@@ -19,7 +19,7 @@ export function SanityCreateConfigProvider(props: SanityCreateConfigProviderProp
   const {children} = props
   const {beta} = useSource()
 
-  const appIdCache = useMemo(() => createAppIdCache(), [])
+  const [appIdCache] = useState(() => createAppIdCache())
 
   const value = useMemo((): SanityCreateConfigContextValue => {
     return {

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -138,10 +138,13 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   const toast = useToast()
 
   // Memoized patch stream
-  const patchSubject: Subject<{
-    patches: EditorPatch[]
-    snapshot: PortableTextBlock[] | undefined
-  }> = useMemo(() => new Subject(), [])
+  const [patchSubject] = useState(
+    () =>
+      new Subject<{
+        patches: EditorPatch[]
+        snapshot: PortableTextBlock[] | undefined
+      }>(),
+  )
   const patches$ = useMemo(() => patchSubject.asObservable(), [patchSubject])
 
   const handleToggleFullscreen = useCallback(() => {

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/useReferenceInfo.ts
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/useReferenceInfo.ts
@@ -1,5 +1,5 @@
 import {observableCallback} from 'observable-callback'
-import {useMemo} from 'react'
+import {useMemo, useState} from 'react'
 import {useObservable} from 'react-rx'
 import {concat, type Observable, of} from 'rxjs'
 import {catchError, concatMap, map, startWith} from 'rxjs/operators'
@@ -34,7 +34,7 @@ export function useReferenceInfo(
   getReferenceInfo: GetReferenceInfo,
 ): Loadable<ReferenceInfo> {
   // NOTE: this is a small message queue to handle retries
-  const [onRetry$, onRetry] = useMemo(() => observableCallback(), [])
+  const [[onRetry$, onRetry]] = useState(() => observableCallback())
 
   const referenceInfoObservable = useMemo(
     () =>

--- a/packages/sanity/src/core/form/store/useFormState.ts
+++ b/packages/sanity/src/core/form/store/useFormState.ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 
 import {type ObjectSchemaType, type Path, type ValidationMarker} from '@sanity/types'
-import {useMemo} from 'react'
+import {useMemo, useState} from 'react'
 
 import {type FormNodePresence} from '../../presence'
 import {useCurrentUser} from '../../store'
@@ -53,9 +53,9 @@ export function useFormState<
   // note: feel free to move these state pieces out of this hook
   const currentUser = useCurrentUser()
 
-  const prepareHiddenState = useMemo(() => createCallbackResolver({property: 'hidden'}), [])
-  const prepareReadOnlyState = useMemo(() => createCallbackResolver({property: 'readOnly'}), [])
-  const prepareFormState = useMemo(() => createPrepareFormState(), [])
+  const [prepareHiddenState] = useState(() => createCallbackResolver({property: 'hidden'}))
+  const [prepareReadOnlyState] = useState(() => createCallbackResolver({property: 'readOnly'}))
+  const [prepareFormState] = useState(() => createPrepareFormState())
 
   const reconcileFieldGroupState = useMemo(() => {
     let last: StateTree<string> | undefined

--- a/packages/sanity/src/core/form/studio/FormBuilder.test.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilder.test.tsx
@@ -2,7 +2,7 @@
 import {type SanityClient} from '@sanity/client'
 import {defineType, type Path} from '@sanity/types'
 import {render} from '@testing-library/react'
-import {useMemo} from 'react'
+import {useMemo, useState} from 'react'
 import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {createMockSanityClient} from '../../../../test/mocks/mockSanityClient'
@@ -77,7 +77,7 @@ describe('FormBuilder', () => {
         throw new Error('schema type is not an object')
       }
 
-      const patchChannel = useMemo(() => createPatchChannel(), [])
+      const [patchChannel] = useState(() => createPatchChannel())
 
       const formState = useFormState({
         schemaType,
@@ -174,7 +174,7 @@ describe('FormBuilder', () => {
         throw new Error('schema type is not an object')
       }
 
-      const patchChannel = useMemo(() => createPatchChannel(), [])
+      const [patchChannel] = useState(() => createPatchChannel())
 
       const formState = useFormState({
         schemaType,

--- a/packages/sanity/src/core/scheduledPublishing/hooks/useTimeZone.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/hooks/useTimeZone.tsx
@@ -1,7 +1,7 @@
 import {useToast} from '@sanity/ui'
 import {getTimeZones} from '@vvo/tzdb'
 import {formatInTimeZone, utcToZonedTime, zonedTimeToUtc} from 'date-fns-tz'
-import {useCallback, useEffect, useMemo, useState} from 'react'
+import {useCallback, useEffect, useState} from 'react'
 
 import ToastDescription from '../components/toastDescription/ToastDescription'
 import {DATE_FORMAT, LOCAL_STORAGE_TZ_KEY} from '../constants'
@@ -55,8 +55,7 @@ function getStoredTimeZone(): NormalizedTimeZone {
 }
 
 const useTimeZone = () => {
-  const initialTimeZone = useMemo(() => getStoredTimeZone(), [])
-  const [timeZone, setTimeZone] = useState<NormalizedTimeZone>(initialTimeZone)
+  const [timeZone, setTimeZone] = useState<NormalizedTimeZone>(() => getStoredTimeZone())
   const toast = useToast()
 
   useEffect(() => {

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/CommonDateRange.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/CommonDateRange.tsx
@@ -1,6 +1,6 @@
 import {Flex, Stack} from '@sanity/ui'
 import {addDays} from 'date-fns'
-import {useCallback, useMemo} from 'react'
+import {useCallback, useState} from 'react'
 
 import {useTranslation} from '../../../../../../../../../i18n'
 import {useSearchState} from '../../../../../contexts/search/useSearchState'
@@ -29,8 +29,8 @@ export function CommonDateRangeInput({
    * For placeholder values: Use the current date for the end date input, and an arbitrary date
    * in the past (e.g. -7 days from now) for the start date input.
    */
-  const placeholderStartDate = useMemo(() => addDays(new Date(), PLACEHOLDER_START_DATE_OFFSET), [])
-  const placeholderEndDate = useMemo(() => new Date(), [])
+  const [placeholderStartDate] = useState(() => addDays(new Date(), PLACEHOLDER_START_DATE_OFFSET))
+  const [placeholderEndDate] = useState(() => new Date())
 
   const handleDatePickerChange = useCallback(
     ({date, endDate}: {date?: Date | null; endDate?: Date | null}) => {

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/useTasksFormBuilder.ts
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/useTasksFormBuilder.ts
@@ -1,5 +1,5 @@
 import {type ObjectSchemaType, type Path} from '@sanity/types'
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {useCallback, useEffect, useRef, useState} from 'react'
 
 import {
   createPatchChannel,
@@ -113,7 +113,7 @@ export function useTasksFormBuilder(options: TasksFormBuilderOptions): TasksForm
 
   const ready = editState.ready && connectionState === 'connected'
 
-  const patchChannel = useMemo(() => createPatchChannel(), [])
+  const [patchChannel] = useState(() => createPatchChannel())
   if (formState === null || !ready) {
     return {loading: true}
   }

--- a/packages/sanity/src/router/RouterProvider.tsx
+++ b/packages/sanity/src/router/RouterProvider.tsx
@@ -47,7 +47,7 @@ export interface RouterProviderProps {
  * import {useCallback, useMemo} from 'react'
  *
  * function Root() {
- *   const router = useMemo(() => route.create('/'), [])
+ *   const [router] = useState(() => route.create('/'))
  *
  *   const [state, setState] = useState<RouterState>({})
  *

--- a/packages/sanity/src/structure/components/pane/PaneLayout.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneLayout.tsx
@@ -28,7 +28,7 @@ export function PaneLayout(
     Omit<HTMLProps<HTMLDivElement>, 'as' | 'height' | 'ref' | 'wrap'>,
 ) {
   const {children, minWidth, onCollapse, onExpand, ...restProps} = props
-  const controller = useMemo(() => createPaneLayoutController(), [])
+  const [controller] = useState(() => createPaneLayoutController())
   const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null)
   const rootRect = useElementRect(rootElement)
   const width = rootRect?.width || 0

--- a/packages/sanity/src/structure/components/pane/__workshop__/ResizeStory.tsx
+++ b/packages/sanity/src/structure/components/pane/__workshop__/ResizeStory.tsx
@@ -17,7 +17,7 @@ const PaneLayoutRoot = styled(Flex)`
 
 export default function ResizeStory() {
   const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null)
-  const controller = useMemo(() => createPaneLayoutController(), [])
+  const [controller] = useState(() => createPaneLayoutController())
   const collapsed = false
   const [state, setState] = useState<PaneLayoutState>({
     expandedElement: null,

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -61,7 +61,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
   // nodes about both remote and local patches.
   // - Used by the Portable Text input to modify selections.
   // - Used by `withDocument` to reset value.
-  const patchChannel = useMemo(() => createPatchChannel(), [])
+  const [patchChannel] = useState(() => createPatchChannel())
 
   const isLocked = editState?.transactionSyncLock?.enabled
   const {t} = useTranslation(structureLocaleNamespace)

--- a/packages/sanity/src/structure/panes/documentList/useDocumentList.ts
+++ b/packages/sanity/src/structure/panes/documentList/useDocumentList.ts
@@ -1,5 +1,5 @@
 import {observableCallback} from 'observable-callback'
-import {useMemo} from 'react'
+import {useMemo, useState} from 'react'
 import {useObservable} from 'react-rx'
 import {concat, fromEvent, merge, of} from 'rxjs'
 import {
@@ -75,8 +75,8 @@ export function useDocumentList(opts: UseDocumentListOpts): UseDocumentListHookV
     [searchFilter, paramsProp],
   )
 
-  const [onRetry$, onRetry] = useMemo(() => observableCallback(), [])
-  const [onFetchFullList$, onLoadFullList] = useMemo(() => observableCallback(), [])
+  const [[onRetry$, onRetry]] = useState(() => observableCallback())
+  const [[onFetchFullList$, onLoadFullList]] = useState(() => observableCallback())
 
   const queryResults$ = useMemo(() => {
     const listenSearchQueryArgs = {

--- a/packages/sanity/src/structure/structureResolvers/useResolvedPanes.ts
+++ b/packages/sanity/src/structure/structureResolvers/useResolvedPanes.ts
@@ -30,7 +30,7 @@ export interface Panes {
 }
 
 function useRouterPanesStream() {
-  const routerStateSubject = useMemo(() => new ReplaySubject<RouterState>(1), [])
+  const [routerStateSubject] = useState(() => new ReplaySubject<RouterState>(1))
   const routerPanes$ = useMemo(
     () =>
       routerStateSubject


### PR DESCRIPTION
### Description

[From the React docs on `useMemo`](https://react.dev/reference/react/useMemo#caveats):
> **React will not throw away the cached value unless there is a specific reason to do that.** For example, in development, React throws away the cache when you edit the file of your component. Both in development and in production, React will throw away the cache if your component suspends during the initial mount. In the future, React may add more features that take advantage of throwing away the cache—for example, if React adds built-in support for virtualized lists in the future, it would make sense to throw away the cache for items that scroll out of the virtualized table viewport. This should be fine if you rely on `useMemo` solely as a performance optimization. Otherwise, a [state variable](https://react.dev/reference/react/useState#avoiding-recreating-the-initial-state) or a [ref](https://react.dev/reference/react/useRef#avoiding-recreating-the-ref-contents) may be more appropriate.

We do have some cases where the code is relying on `useMemo` never throwing away its value, and for the memo function itself to only be executed once, since the dependencies array is empty.
In this PR I've refactored all of them to `useState`, as per the recommendations.
By doing so we remove subtle bugs from `sanity dev` and hot module reloading, make tests less flaky, and allow React Compiler to better optimize the code since it treats `useMemo` as purely a performance optimization that it should be safe to change. While `useState` is handled differently.

For example, compare the before:
- [If usage can't be traced, `useMemo` may be removed and it's called more frequently than before](https://playground.react.dev/#N4Igzg9grgTgxgUxALhASwLYAcIwC4AEwUYCAsghhAL4EBmMEGBA5DAgIZx4sA6AdgIQAPHPgIATBHQ5QANoTpR+3NBH4EyATwCCWLAAoAlEQEECcdWEL8IAdwIBeAiXKUIB404B8BACIceAgAdLZ2xgA0BADaALpGZgTseLAaADwSaABu3gASCHJyEFEA6rhyEgCEaQD0mTkA3ALUAiDUQA)
- [If usage is traced, it may behave exactly like before](https://playground.react.dev/#N4Igzg9grgTgxgUxALhASwLYAcIwC4AEwUYCAsghhAL4EBmMEGBA5DAgIZx4sA6AdgIQAPHPgIATBHQ5QANoTpR+3NBH4EyATwCCWLAAoAlEQEECcdWEL8IAdwIBeAiXKUIB404B8BACIceAgAdLZ2xgA0BADaALpGZgTseLAaADwSaABu3gASCHJyEFEA6rhyEgCEwGHUaQD0mTkA3ALUAiDUQA), but this isn't a guarantee based on wether the dependencies array in `useMemo` is empty or not, it's based on what's using it.

After, with `useState` it works exactly like before:
- [If it can't trace usage, it's still memoized correctly and the init runs only once](https://playground.react.dev/#N4Igzg9grgTgxgUxALhASwLYAcIwC4AEwUYCAyngIZ4IC+BAZjBBgQOQwKVx5sA6AO0EIAHjnwEAJggaUoAG0IMoAnmggCCAWQCeAQSxYAFAEoigggTgawhANoCIAdwC6BALwES5KjSOmPAD4CABFqBAA6RydTEwsCTjxYTQAeSTQAN0CACQR5eQgAGgIAdVx5SQBCFIB6dKyAbkFaQRBaIA)
- [When usage is traced, it optimizes it correctly](https://playground.react.dev/#N4Igzg9grgTgxgUxALhASwLYAcIwC4AEwUYCAyngIZ4IC+BAZjBBgQOQwKVx5sA6AO0EIAHjnwEAJggaUoAG0IMoAnmggCCAWQCeAQSxYAFAEoigggTgawhANoCIAdwC6BALwES5KjSOmPAD4CABFqBAA6RydTEwsCTjxYTQAeSTQAN0CACQR5eQgAGgIAdVx5SQBCYGjaFIB6dKyAbkFaQRBaIA)

### What to review

Does this make sense?

### Testing

Existing tests should be enough.

### Notes for release

N/A – it's the type of fix where lots of tiny things feel slightly faster and more stable than before, but due to the nature of how `useMemo` behaves, and exactly how it can throw away cache if a component suspends during the initial mount, it's difficult to reproduce the issue and thus point to the fix.
