### PR TITLE
fix: remove react-hooks linter suppression

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check:deps": "pnpm --recursive --parallel exec depcheck",
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
-    "check:react-compiler": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 30 .",
+    "check:react-compiler": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 25 .",
     "report:react-compiler-bailout": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [error,{__unstable_donotuse_reportAllBailouts:true}]' --ignore-path .eslintignore.react-compiler -f ./scripts/reactCompilerBailouts.cjs . || true",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",

--- a/packages/sanity/src/core/tasks/hooks/useActivityLog.ts
+++ b/packages/sanity/src/core/tasks/hooks/useActivityLog.ts
@@ -1,5 +1,6 @@
 import {type TransactionLogEventWithEffects} from '@sanity/types'
 import {useCallback, useEffect, useState} from 'react'
+import {useEffectEvent} from 'use-effect-event'
 
 import {useClient} from '../../hooks'
 import {getJsonStream} from '../../store/_legacy/history/history/getJsonStream'
@@ -65,10 +66,11 @@ export function useActivityLog(task: TaskDocument): {
     [transactionsUrl, token, publishedId],
   )
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
+  const handleFetchAndParse = useEffectEvent((rev: string) => fetchAndParse(task))
   useEffect(() => {
-    fetchAndParse(task)
     // Task is updated on every change, wait until the revision changes to update the activity log.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchAndParse, task._rev])
+    handleFetchAndParse(task._rev)
+  }, [handleFetchAndParse, task._rev])
   return {changes}
 }

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx
@@ -247,10 +247,6 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
         </CommandListBox>
       </RootBox>
     )
-    // Explicitly don't include `noDocumentsContent` in the deps array, as it's
-    // causing a visual bug where the "No documents" message is shown for a split second
-    // when clearing a search query with no results
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     collapsed,
     error,
@@ -260,11 +256,13 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
     items,
     layout,
     loadingVariant,
-    // noDocumentsContent,
+    noDocumentsContent,
     onRetry,
+    paneTitle,
     renderItem,
     searchInputElement,
     shouldRender,
+    t,
   ])
 
   return (


### PR DESCRIPTION
### Description

Suppressing the linter on `react-hooks/exhaustive-deps` causes React Compiler to bail, as it can no longer determine if the optimization it plans to do will preserve the original behavior of how often and when `useEffect` hooks will fire.
It's also a bit dangerous to leave in the codebase as what may have started off as omitting a single value from the dependencies array, can over time lead to other values being omitted that would otherwise been caught be the linter.
For example `DocumentListPaneContent` have had its linter suppression for a long long time, and since then we have added `const {t} = useTranslation(structureLocaleNamespace)` and `t` should be a dependency, but it's not.

This PR removes all of them, and in the case of `useEffect` the `useEffectEvent` ponyfill is used to preserve the original intent of only having the effect fire when specific dependencies have changed, while no longer suppressing the linter.

### What to review

Is there enough context?

### Testing

Existing tests are sufficient?

### Notes for release

Removed `react-hooks/exhaustive-deps` ESLint suppressions, allowing React Compiler to auto-memoize components that were previously skipped over.
