### PR TITLE
fix: improve color scheme store perf

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check:deps": "pnpm --recursive --parallel exec depcheck",
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
-    "check:react-compiler": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 77 .",
+    "check:react-compiler": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 76 .",
     "report:react-compiler-bailout": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [error,{__unstable_donotuse_reportAllBailouts:true}]' --ignore-path .eslintignore.react-compiler -f ./scripts/reactCompilerBailouts.cjs . || true",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",

--- a/packages/sanity/src/core/studio/colorSchemeStore.ts
+++ b/packages/sanity/src/core/studio/colorSchemeStore.ts
@@ -1,0 +1,39 @@
+import {type StudioThemeColorSchemeKey} from '../theme/types'
+
+function getScheme(scheme: unknown): StudioThemeColorSchemeKey {
+  switch (scheme) {
+    case 'dark':
+    case 'light':
+      return scheme
+    default:
+      return 'system'
+  }
+}
+
+/** @internal */
+export const LOCAL_STORAGE_KEY = 'sanityStudio:ui:colorScheme'
+
+let snapshot: StudioThemeColorSchemeKey
+const subscribers = new Set<() => void>()
+
+/** @internal */
+export const subscribe = (onStoreChange: () => void) => {
+  if (!snapshot) {
+    snapshot = getScheme(localStorage.getItem(LOCAL_STORAGE_KEY)) || 'system'
+  }
+  subscribers.add(onStoreChange)
+  return (): void => {
+    subscribers.delete(onStoreChange)
+  }
+}
+/** @internal */
+export function getSnapshot(): StudioThemeColorSchemeKey {
+  return snapshot
+}
+/** @internal */
+export function setSnapshot(nextScheme: StudioThemeColorSchemeKey): void {
+  snapshot = getScheme(nextScheme)
+  for (const subscription of subscribers) {
+    subscription()
+  }
+}


### PR DESCRIPTION
### Description

This refactor is mostly about making the React Compiler support optimizing the `ColorSchemeProvider` component, so it can be excluded from Million Lint reports and not show up as false positives (as it re-renders only when the color scheme is changed manually, which is rare).

### What to review

Does it make sense?

### Testing

Tested manually, unsure if our E2E suite checks color scheme switching 🤔 

### Notes for release

N/A perf improvement too small to be worth calling out
