### PR TITLE
fix(vision): upgrade react-split-pane to v1.0.0

### DIFF
--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -60,7 +60,7 @@
     "@juggle/resize-observer": "^3.3.1",
     "@lezer/highlight": "^1.0.0",
     "@rexxars/react-json-inspector": "^9.0.1",
-    "@rexxars/react-split-pane": "^0.1.93",
+    "@rexxars/react-split-pane": "^1.0.0",
     "@sanity/color": "^3.0.0",
     "@sanity/icons": "^3.5.2",
     "@sanity/ui": "^2.10.9",

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable complexity */
-import SplitPane from '@rexxars/react-split-pane'
+import {SplitPane} from '@rexxars/react-split-pane'
 import {type ListenEvent, type MutationEvent, type SanityClient} from '@sanity/client'
 import {CopyIcon, ErrorOutlineIcon, PlayIcon, StopIcon} from '@sanity/icons'
 import {
@@ -809,7 +809,6 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
           </Grid>
         </Header>
         <SplitpaneContainer flex="auto">
-          {/* @ts-expect-error: https://github.com/tomkp/react-split-pane/pull/819 */}
           <SplitPane
             // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
             split={narrowBreakpoint() ? 'vertical' : 'horizontal'}
@@ -828,10 +827,9 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
                   - Disables resize if the container height is less then 500px
                   This should ensure that we mostly avoid a pane to take up all the room, and for the controls to not be eaten up by the pane
                 */}
-              {/* @ts-expect-error: https://github.com/tomkp/react-split-pane/pull/819 */}
               <SplitPane
                 className="sidebarPanes"
-                split={'horizontal'}
+                split="horizontal"
                 defaultSize={
                   narrowBreakpoint() ? paneSizeOptions.defaultSize : paneSizeOptions.minSize
                 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1331,8 +1331,8 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1(react@18.3.1)
       '@rexxars/react-split-pane':
-        specifier: ^0.1.93
-        version: 0.1.93(react-dom@19.0.0-rc-f994737d14-20240522(react@18.3.1))(react@18.3.1)
+        specifier: ^1.0.0
+        version: 1.0.0(react-dom@19.0.0-rc-f994737d14-20240522(react@18.3.1))(react@18.3.1)
       '@sanity/color':
         specifier: ^3.0.0
         version: 3.0.6
@@ -4214,11 +4214,11 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@rexxars/react-split-pane@0.1.93':
-    resolution: {integrity: sha512-Pok8zATwd5ZpWnccJeSA/JM2MPmi3D04duYtrbMNRgzeAU2ANtq3r4w7ldbjpGyfJqggqn0wDNjRqaevXqSxQg==}
+  '@rexxars/react-split-pane@1.0.0':
+    resolution: {integrity: sha512-Ewl8ugA2VQd+idzcg65WFbYh/oCLPOFjeDKpebexPgFDDX8ZwsHZWy5jNwiIWI8txDidVmRP98lsnmBHlIywWA==}
     peerDependencies:
-      react: ^18
-      react-dom: ^18
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
 
   '@rollup/plugin-alias@5.1.1':
     resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
@@ -9903,9 +9903,6 @@ packages:
   react-is@19.0.0-rc.1:
     resolution: {integrity: sha512-D6AbvUGS+i2lK3yC1a+iSicqWhIenYGxYUd7j0JJxunlk0RSAy/yRo58Mh5JJcAVQfNhej20nCwJVehYpNwNiA==}
 
-  react-lifecycles-compat@3.0.4:
-    resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
-
   react-redux@7.2.9:
     resolution: {integrity: sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==}
     peerDependencies:
@@ -9945,9 +9942,6 @@ packages:
       easymde: '>= 2.0.0 < 3.0.0'
       react: '>=16.8.2'
       react-dom: '>=16.8.2'
-
-  react-style-proptype@3.2.2:
-    resolution: {integrity: sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==}
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -14218,13 +14212,10 @@ snapshots:
       md5-o-matic: 0.1.1
       react: 18.3.1
 
-  '@rexxars/react-split-pane@0.1.93(react-dom@19.0.0-rc-f994737d14-20240522(react@18.3.1))(react@18.3.1)':
+  '@rexxars/react-split-pane@1.0.0(react-dom@19.0.0-rc-f994737d14-20240522(react@18.3.1))(react@18.3.1)':
     dependencies:
-      prop-types: 15.8.1
       react: 18.3.1
       react-dom: 19.0.0-rc-f994737d14-20240522(react@18.3.1)
-      react-lifecycles-compat: 3.0.4
-      react-style-proptype: 3.2.2
 
   '@rollup/plugin-alias@5.1.1(rollup@4.28.1)':
     optionalDependencies:
@@ -21387,8 +21378,6 @@ snapshots:
 
   react-is@19.0.0-rc.1: {}
 
-  react-lifecycles-compat@3.0.4: {}
-
   react-redux@7.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.26.0
@@ -21448,10 +21437,6 @@ snapshots:
       easymde: 2.18.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  react-style-proptype@3.2.2:
-    dependencies:
-      prop-types: 15.8.1
 
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
### Description

I've reworked `react-split-pane` to be compatible with React 19, and also upgraded the tooling to be ESM-forward as well as use named exports, drop prop-types and other ancient reactisms. Still could use a proper refactoring/perhaps use a different module, but should at least progress the React 19 story.

### What to review

Vision still works, can resize panes. 

### Testing

No new tests

### Notes for release

None.
