### PR TITLE
fix(deps): upgrade `@tanstack/react-virtual` to v3.11.2

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -182,7 +182,7 @@
     "@sanity/uuid": "^3.0.1",
     "@sentry/react": "^8.33.0",
     "@tanstack/react-table": "^8.16.0",
-    "@tanstack/react-virtual": "3.0.0-beta.54",
+    "@tanstack/react-virtual": "^3.11.2",
     "@types/react-is": "^18.3.0",
     "@types/shallow-equals": "^1.0.0",
     "@types/speakingurl": "^13.0.3",

--- a/packages/sanity/src/core/components/commandList/CommandList.tsx
+++ b/packages/sanity/src/core/components/commandList/CommandList.tsx
@@ -114,6 +114,7 @@ const CommandListComponent = forwardRef<CommandListHandle, CommandListProps>(fun
     onlyShowSelectionWhenActive,
     overscan,
     renderItem,
+    testId,
     wrapAround = true,
     ...responsivePaddingProps
   },
@@ -583,6 +584,7 @@ const CommandListComponent = forwardRef<CommandListHandle, CommandListProps>(fun
       ref={setVirtualListElement}
       sizing="border"
       tabIndex={rootTabIndex}
+      data-testid={testId}
       {...responsivePaddingProps}
     >
       {canReceiveFocus && <FocusOverlayDiv offset={focusRingOffset} />}

--- a/packages/sanity/src/core/components/commandList/__tests__/CommandList.test.tsx
+++ b/packages/sanity/src/core/components/commandList/__tests__/CommandList.test.tsx
@@ -1,11 +1,14 @@
+import {afterEach} from 'node:test'
+
 import {studioTheme, ThemeProvider} from '@sanity/ui'
-import {render, screen} from '@testing-library/react'
+import {render, screen, waitFor} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {useCallback} from 'react'
-import {describe, expect, it} from 'vitest'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {CommandList} from '../CommandList'
 
+const COMMAND_LIST_TEST_ID = 'command-list'
 const CUSTOM_ACTIVE_ATTR = 'my-active-data-attribute'
 
 type Item = number
@@ -52,6 +55,7 @@ function TestComponent(props: TestComponentProps) {
           // same as the number of items for the tests to pass
           overscan={items.length}
           renderItem={renderItem}
+          testId={COMMAND_LIST_TEST_ID}
         />
       </div>
     </ThemeProvider>
@@ -59,13 +63,44 @@ function TestComponent(props: TestComponentProps) {
 }
 
 describe('core/components: CommandList', () => {
-  it('should change active item on pressing arrow keys', () => {
+  const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect
+
+  const getDOMRect = (width: number, height: number) => ({
+    width,
+    height,
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => {},
+  })
+
+  beforeEach(() => {
+    // Virtual list will return an empty list of items unless we have some size,
+    // so we need to mock getBoundingClientRect to return a size for the list.
+    // Not pretty, but it's what they recommend for testing outside of browsers:
+    // https://github.com/TanStack/virtual/issues/641
+    Element.prototype.getBoundingClientRect = vi.fn(function (this: Element) {
+      if (this.getAttribute('data-testid') === COMMAND_LIST_TEST_ID) {
+        return getDOMRect(350, 800)
+      }
+      return getDOMRect(0, 0)
+    })
+  })
+
+  afterEach(() => {
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect
+  })
+
+  it('should change active item on pressing arrow keys', async () => {
     render(<TestComponent items={[0, 1, 2, 3]} />)
 
     const buttons = screen.getAllByTestId('button')
 
     // First button should be active on render
-    expect(buttons[0]).toHaveAttribute(CUSTOM_ACTIVE_ATTR)
+    await waitFor(() => expect(buttons[0]).toHaveAttribute(CUSTOM_ACTIVE_ATTR))
 
     // Set second button as active on arrow down
     userEvent.keyboard('[ArrowDown]')
@@ -96,13 +131,13 @@ describe('core/components: CommandList', () => {
     expect(buttons[3]).not.toHaveAttribute(CUSTOM_ACTIVE_ATTR)
   })
 
-  it('should set the initial active item based on the initialIndex prop', () => {
+  it('should set the initial active item based on the initialIndex prop', async () => {
     render(<TestComponent initialIndex={2} items={[0, 1, 3, 4]} />)
 
     const buttons = screen.getAllByTestId('button')
 
     // Button with index 2 should be active on render
-    expect(buttons[0]).not.toHaveAttribute(CUSTOM_ACTIVE_ATTR)
+    await waitFor(() => expect(buttons[0]).not.toHaveAttribute(CUSTOM_ACTIVE_ATTR))
     expect(buttons[1]).not.toHaveAttribute(CUSTOM_ACTIVE_ATTR)
     expect(buttons[2]).toHaveAttribute(CUSTOM_ACTIVE_ATTR)
     expect(buttons[3]).not.toHaveAttribute(CUSTOM_ACTIVE_ATTR)
@@ -123,13 +158,13 @@ describe('core/components: CommandList', () => {
     expect(buttons[0]).toHaveAttribute(CUSTOM_ACTIVE_ATTR)
   })
 
-  it('should skip disabled elements', () => {
+  it('should skip disabled elements', async () => {
     render(<TestComponent items={[0, 1, 2, 3]} withDisabledItems />)
 
     const buttons = screen.getAllByTestId('button')
 
     // Second button should be active since the first button is disabled
-    expect(buttons[1]).toHaveAttribute(CUSTOM_ACTIVE_ATTR)
+    await waitFor(() => expect(buttons[1]).toHaveAttribute(CUSTOM_ACTIVE_ATTR))
 
     // Fourth button should be active since the third is disabled
     userEvent.keyboard('[ArrowDown]')

--- a/packages/sanity/src/core/components/commandList/types.ts
+++ b/packages/sanity/src/core/components/commandList/types.ts
@@ -78,6 +78,8 @@ export interface CommandListProps<T = any> extends ResponsivePaddingProps {
   overscan?: number
   /** Rendered component in virtual lists */
   renderItem: CommandListRenderItemCallback<T>
+  /** `data-testid` to apply to outermost container */
+  testId?: string
   /** Allow wraparound keyboard navigation between first and last items */
   wrapAround?: boolean
 }

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
@@ -33,7 +33,6 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
     elementProps,
     members,
     onChange,
-    onInsert,
     onItemMove,
     onUpload,
     focusPath,
@@ -113,7 +112,7 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
 
       const scroll = instance.scrollElement
 
-      const handleScroll = () => {
+      const handleScroll = (evt?: Event) => {
         const containerElementTop = containerElement.current?.getBoundingClientRect().top ?? 0
         const parentElementTop = parentRef.current?.getBoundingClientRect().top ?? 0
 
@@ -122,7 +121,7 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
         // We pass a component that we have more control over to avoid issues when wrapped in custom component
         const itemOffset = Math.floor(parentElementTop - containerElementTop)
 
-        callback(scroll.scrollTop - itemOffset)
+        callback(scroll.scrollTop - itemOffset, Boolean(evt))
       }
 
       handleScroll()
@@ -225,7 +224,7 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
                   top: 0,
                   left: 0,
                   width: '100%',
-                  transform: `translateY(${items[0].start}px)`,
+                  transform: items.length > 0 ? `translateY(${items[0].start}px)` : undefined,
                 }}
               >
                 {items.map((virtualRow) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1536,8 +1536,8 @@ importers:
         specifier: ^8.16.0
         version: 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-virtual':
-        specifier: 3.0.0-beta.54
-        version: 3.0.0-beta.54(react@18.3.1)
+        specifier: ^3.11.2
+        version: 3.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react-is':
         specifier: ^18.3.0
         version: 18.3.1
@@ -5169,17 +5169,18 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react-virtual@3.0.0-beta.54':
-    resolution: {integrity: sha512-D1mDMf4UPbrtHRZZriCly5bXTBMhylslm4dhcHqTtDJ6brQcgGmk8YD9JdWBGWfGSWPKoh2x1H3e7eh+hgPXtQ==}
+  '@tanstack/react-virtual@3.11.2':
+    resolution: {integrity: sha512-OuFzMXPF4+xZgx8UzJha0AieuMihhhaWG0tCqpp6tDzlFwOmNBPYMuLOtMJ1Tr4pXLHmgjcWhG6RlknY2oNTdQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@tanstack/table-core@8.20.5':
     resolution: {integrity: sha512-P9dF7XbibHph2PFRz8gfBKEXEY/HJPOhym8CHmjF8y3q5mWpKx9xtZapXQUWCgkqvsK0R46Azuz+VaxD4Xl+Tg==}
     engines: {node: '>=12'}
 
-  '@tanstack/virtual-core@3.0.0-beta.54':
-    resolution: {integrity: sha512-jtkwqdP2rY2iCCDVAFuaNBH3fiEi29aTn2RhtIoky8DTTiCdc48plpHHreLwmv1PICJ4AJUUESaq3xa8fZH8+g==}
+  '@tanstack/virtual-core@3.11.2':
+    resolution: {integrity: sha512-vTtpNt7mKCiZ1pwU9hfKPhpdVO2sVzFQsxoVBGtOSHxlrRRzYr8iQ2TlwbAcRYCcEiZ9ECAM8kBzH0v2+VzfKw==}
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -16272,14 +16273,15 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@tanstack/react-virtual@3.0.0-beta.54(react@18.3.1)':
+  '@tanstack/react-virtual@3.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tanstack/virtual-core': 3.0.0-beta.54
+      '@tanstack/virtual-core': 3.11.2
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@tanstack/table-core@8.20.5': {}
 
-  '@tanstack/virtual-core@3.0.0-beta.54': {}
+  '@tanstack/virtual-core@3.11.2': {}
 
   '@testing-library/dom@10.4.0':
     dependencies:


### PR DESCRIPTION
### Description

Moves the dependency out of the beta range, and **brings React 19 support** which is why this is happening _now_.

@binoy14 There were some minor crashes in the array input after upgrading - the `observeElementOffset` seems to need a second argument, `isScrolling`. I assumed that since we were calling this from a scroll handler it would be safe to set this to always be `true`, but we're also calling it once on "mount", at which point I am giving it `false`. Additionally, the virtual items seems to start at an empty array now, which crashed when attempting to use the first element in the styles. Can you see that things works as expected? I did some testing and to my eyes it appears to work fine.

@robinpyon I am requesting a review from you since you have been involved in multiple components that utilize this library: scheduled publishing and CommandList being the two I can find. CommandList is being used quite a number of places, and from what I can tell things seems to work fine - but would really appreciate a quick run through to double check.

### What to review

That things still work as expected. Surfaces affected are (at least):
- "New document" list (scrollable list of schema types)
- Scheduled publishing tool (list of schedules)
- Array of objects input
- Comments/tasks mentions list
- Search (add filter)
- Search (recent searches)
- Search (results)
- Document list pane
- List panes
- Document timeline (history)

### Testing

No new tests were added - relying on existing tests and manual review.

### Notes for release

None
