### PR TITLE
test(pte): properly wait for PTE to be editable

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/RangeDecoration.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/RangeDecoration.spec.tsx
@@ -45,7 +45,12 @@ test.describe('Portable Text Input', () => {
     //   await page.waitForTimeout(360000)
     // })
     test(`Draws range decoration around our selection`, async ({mount, page}) => {
+      const {getFocusedPortableTextEditor} = testHelpers({page})
+
       await mount(<RangeDecorationStory document={document} decorationData={decorationData} />)
+
+      await getFocusedPortableTextEditor('field-body')
+
       await expect(page.getByTestId('range-decoration')).toHaveText('there')
     })
 

--- a/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
+++ b/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
@@ -73,11 +73,11 @@ export function testHelpers({page}: {page: PlaywrightTestArgs['page']}) {
       // Wait for field to get ready (without this tests fails randomly on Webkit)
       await page.locator(`[data-testid='${testId}']`).waitFor()
       const $pteField: Locator = page.getByTestId(testId)
+      await $pteField.locator('[contenteditable="true"]').waitFor()
+      const $pteTextbox = $pteField.locator('[contenteditable="true"]')
       // Activate the input if needed
       await activatePTInputOverlay($pteField)
       // Ensure focus on the contentEditable element of the Portable Text Editor
-      const $pteTextbox = $pteField.getByRole('textbox')
-      await $pteTextbox.isEditable()
       await $pteTextbox.focus()
       return $pteField
     },
@@ -93,11 +93,11 @@ export function testHelpers({page}: {page: PlaywrightTestArgs['page']}) {
       // Wait for field to get ready (without this tests fails randomly on Webkit)
       await page.locator(`[data-testid='${testId}']`).waitFor()
       const $pteField: Locator = page.getByTestId(testId)
+      await $pteField.locator('[contenteditable="true"]').waitFor()
+      const $pteTextbox = $pteField.locator('[contenteditable="true"]')
       // Activate the input if needed
       await activatePTInputOverlay($pteField)
       // Ensure focus on the contentEditable element of the Portable Text Editor
-      const $pteTextbox = $pteField.getByRole('textbox')
-      await $pteTextbox.isEditable()
       await $pteTextbox.focus()
       return $pteTextbox
     },


### PR DESCRIPTION
### Description

Small improvement to make PTE tests less flaky.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
