### PR TITLE
fix(preview): fix issue sometimes causing hotspot menu to stay a gray box after uploading

### DIFF
--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/assets.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/assets.ts
@@ -1,7 +1,7 @@
 import {type ProgressEvent, type SanityAssetDocument, type SanityClient} from '@sanity/client'
 import {type FileAsset, type ImageAsset} from '@sanity/types'
-import {Observable, of as observableOf, of} from 'rxjs'
-import {catchError, map, mergeMap, retry, switchMap} from 'rxjs/operators'
+import {Observable, of as observableOf} from 'rxjs'
+import {catchError, map, mergeMap} from 'rxjs/operators'
 
 import {type DocumentPreviewStore} from '../../../../preview'
 import {type UploadOptions} from '../../uploads/types'
@@ -84,43 +84,17 @@ export const uploadFileAsset = (client: SanityClient, file: File | Blob, options
  */
 // note: there's currently 100% overlap between the ImageAsset document and the FileAsset documents as per interface required by the image and file input
 function observeAssetDoc(documentPreviewStore: DocumentPreviewStore, id: string) {
-  return documentPreviewStore
-    .observePaths({_type: 'reference', _ref: id}, [
-      'originalFilename',
-      'url',
-      'metadata',
-      'label',
-      'title',
-      'description',
-      'creditLine',
-      'source',
-      'size',
-    ])
-    .pipe(
-      /**
-       * In some cases when uploading large media file we are getting an stale `null` response from content lake when fetching the reference that was just uploaded,
-       * making the UI not to react as it should.
-       * This retry logic is added to handle the case where the asset is not found in the initial fetch to the documentPreviewStore but it will eventually be found,
-       * because the asset has been just added.
-       * It has the downside that if this is being used to check if an asset exists, it will retry 5 times before returning null.
-       */
-      switchMap((result) => {
-        // If the result is null, throw an error to trigger retry
-        if (result === null) {
-          throw new Error(`No asset found in documentPreviewStore with id: ${id}`)
-        }
-        // If the result is not null, return the result
-        return of(result)
-      }),
-      retry({
-        count: 5,
-        delay: 1000,
-      }),
-      catchError((err) => {
-        console.error('Final error after retries, asset not found in documentPreviewStore:', err)
-        return of(null) // Return null if the asset is not found
-      }),
-    )
+  return documentPreviewStore.observePaths({_type: 'reference', _ref: id}, [
+    'originalFilename',
+    'url',
+    'metadata',
+    'label',
+    'title',
+    'description',
+    'creditLine',
+    'source',
+    'size',
+  ])
 }
 
 export function observeImageAsset(documentPreviewStore: DocumentPreviewStore, id: string) {

--- a/packages/sanity/src/core/preview/observeFields.ts
+++ b/packages/sanity/src/core/preview/observeFields.ts
@@ -7,7 +7,7 @@ import {
   fromEvent,
   merge,
   type Observable,
-  of as observableOf,
+  of,
   timer,
 } from 'rxjs'
 import {
@@ -100,20 +100,20 @@ export function createObserveFields(options: {
     return listen(id).pipe(
       switchMap((event) => {
         if (event.type === 'connected' || event.visibility === 'query') {
-          return fetchDocumentPathsFast(id, fields as any).pipe(
+          return fetchDocumentPathsFast(id, fields).pipe(
             mergeMap((result) => {
               return concat(
-                observableOf(result),
-                result === null // hack: if we get null as result here it can be because the document has
+                of(result),
+                result === null // hack: if we get undefined as result here it can be because the document has
                   ? // just been created and is not yet indexed. We therefore need to wait a bit
                     // and then re-fetch.
-                    fetchDocumentPathsSlow(id, fields as any)
+                    fetchDocumentPathsSlow(id, fields)
                   : [],
               )
             }),
           )
         }
-        return fetchDocumentPathsSlow(id, fields as any)
+        return fetchDocumentPathsSlow(id, fields)
       }),
     )
   }
@@ -157,7 +157,7 @@ export function createObserveFields(options: {
     // Note: `undefined` means the memo has not been set, while `null` means the memo is explicitly set to null (e.g. we did fetch, but got null back)
     let latest: T | undefined | null = undefined
     const changes$ = merge(
-      defer(() => (latest === undefined ? EMPTY : observableOf(latest))),
+      defer(() => (latest === undefined ? EMPTY : of(latest))),
       (apiConfig
         ? (crossDatasetListenFields(id, fields, apiConfig) as any)
         : currentDatasetListenFields(id, fields)) as Observable<T>,

--- a/packages/sanity/src/core/preview/observeFields.ts
+++ b/packages/sanity/src/core/preview/observeFields.ts
@@ -104,7 +104,7 @@ export function createObserveFields(options: {
             mergeMap((result) => {
               return concat(
                 observableOf(result),
-                result === undefined // hack: if we get undefined as result here it can be because the document has
+                result === null // hack: if we get null as result here it can be because the document has
                   ? // just been created and is not yet indexed. We therefore need to wait a bit
                     // and then re-fetch.
                     fetchDocumentPathsSlow(id, fields as any)


### PR DESCRIPTION
### Description
Occationally after uploading an image, the hotspot and crop icons remains greyed out forever.

Traced this down to being caused by us returning `null` from the batch fetcher we use to fetch previewed documents, in combination with a subsequent check for `undefined` to check if we need to refetch after document creations as a safeguard against initial indexing taking some time.

### What to review
Commits can be reviewed one-by-one.
- The fix is in the first commit
- The second removes moot error handling: We're connected to a shared ("hot") observable emitting the "current preview value" so the retrying logic won't trigger any refetches here
- The third cleans up the code slightly and removes some unneccesary `as any` casts

### Testing
A bit involved to add unit test for this particular case as it is highly dependent on backend index latency, but will do some follow improvements and see if I can include some unit tests with those.

### Notes for release
- Fixes an issue that could sometimes leave the hotspot and crop icons remains greyed out after uploading an image.
