### PR TITLE
fix: search modal stays open with metaKey

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
@@ -1,5 +1,5 @@
 import {Card, Flex} from '@sanity/ui'
-import {useCallback} from 'react'
+import {type MouseEvent, useCallback} from 'react'
 import {styled} from 'styled-components'
 
 import {CommandList, type CommandListRenderItemCallback} from '../../../../../../components'
@@ -50,12 +50,12 @@ export function SearchResults({disableIntentLink, inputElement, onItemSelect}: S
    * Add current search to recent searches, trigger child item click and close search
    */
   const handleSearchResultClick = useCallback(
-    (event) => {
+    (e: MouseEvent<HTMLElement>) => {
       if (recentSearchesStore) {
         recentSearchesStore.addSearch(terms, filters)
       }
       // if the cmd key is pressed, we don't want to close the search
-      if (!event?.metaKey) {
+      if (!e?.metaKey) {
         onClose?.()
       }
     },

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
@@ -54,8 +54,8 @@ export function SearchResults({disableIntentLink, inputElement, onItemSelect}: S
       if (recentSearchesStore) {
         recentSearchesStore.addSearch(terms, filters)
       }
-      // if the cmd key is pressed, we don't want to close the search
-      if (!e?.metaKey) {
+      // we don't want to close the search if they are opening their result in a new tab
+      if (!e.metaKey && !e.ctrlKey) {
         onClose?.()
       }
     },

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
@@ -49,12 +49,18 @@ export function SearchResults({disableIntentLink, inputElement, onItemSelect}: S
   /**
    * Add current search to recent searches, trigger child item click and close search
    */
-  const handleSearchResultClick = useCallback(() => {
-    if (recentSearchesStore) {
-      recentSearchesStore.addSearch(terms, filters)
-    }
-    onClose?.()
-  }, [filters, onClose, recentSearchesStore, terms])
+  const handleSearchResultClick = useCallback(
+    (event) => {
+      if (recentSearchesStore) {
+        recentSearchesStore.addSearch(terms, filters)
+      }
+      // if the cmd key is pressed, we don't want to close the search
+      if (!event?.metaKey) {
+        onClose?.()
+      }
+    },
+    [filters, onClose, recentSearchesStore, terms],
+  )
 
   const handleEndReached = useCallback(() => {
     dispatch({type: 'PAGE_INCREMENT'})

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
@@ -54,7 +54,7 @@ export function SearchResults({disableIntentLink, inputElement, onItemSelect}: S
       if (recentSearchesStore) {
         recentSearchesStore.addSearch(terms, filters)
       }
-      // we don't want to close the search if they are opening their result in a new tab
+      // We don't want to close the search if they are opening their result in a new tab
       if (!e.metaKey && !e.ctrlKey) {
         onClose?.()
       }

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
@@ -15,7 +15,7 @@ interface SearchResultItemProps extends ResponsiveMarginProps, ResponsivePadding
   documentId: string
   documentType: string
   layout?: GeneralPreviewLayoutKey
-  onClick?: () => void
+  onClick?: (e: MouseEvent<HTMLElement>) => void
   onItemSelect?: ItemSelectHandler
 }
 
@@ -44,7 +44,7 @@ export function SearchResultItem({
       if (!disableIntentLink) {
         onIntentClick(e)
       }
-      onClick?.()
+      onClick?.(e)
     },
     [onItemSelect, documentId, documentType, disableIntentLink, onClick, onIntentClick],
   )


### PR DESCRIPTION
### Description

Added a check for the `metaKey` property flag on the `MouseEvent` event. The goal here is that when you open the global search, you should be able to open multiple tabs with relevant documents from your search without needing to reopen the model every time.

### What to review

As this is my first PR to the studio, I'm wondering if there are any things/flows I'm missing here. Seems like it should be ok, and I can't see any search related tests but please do let me know otherwise 😄

### Testing


### Notes for release

Probably not big enough to have anything here, but maybe something like `add more ergonomic search result handling for multiple documents`.
