### PR TITLE
fix: tooltip position in announcements popup

### DIFF
--- a/packages/sanity/src/core/studio/studioAnnouncements/StudioAnnouncementsDialog.tsx
+++ b/packages/sanity/src/core/studio/studioAnnouncements/StudioAnnouncementsDialog.tsx
@@ -36,12 +36,13 @@ const DialogHeader = styled(Grid)`
   background: var(--card-bg-color);
 `
 
-const FloatingButton = styled(Button)`
+const FloatingButtonBox = styled(Box)`
   position: absolute;
   top: 12px;
   right: 24px;
   z-index: 2;
 `
+const FloatingButton = styled(Button)``
 
 interface AnnouncementProps {
   announcement: StudioAnnouncementDocument
@@ -193,15 +194,17 @@ export function StudioAnnouncementsDialog({
             {index < announcements.length - 1 && <Divider parentRef={dialogRef} />}
           </Fragment>
         ))}
-        <FloatingButton
-          aria-label={t('announcement.dialog.close-label')}
-          icon={CloseIcon}
-          mode="bleed"
-          onClick={onClose}
-          tooltipProps={{
-            content: t('announcement.dialog.close'),
-          }}
-        />
+        <FloatingButtonBox>
+          <FloatingButton
+            aria-label={t('announcement.dialog.close-label')}
+            icon={CloseIcon}
+            mode="bleed"
+            onClick={onClose}
+            tooltipProps={{
+              content: t('announcement.dialog.close'),
+            }}
+          />
+        </FloatingButtonBox>
       </Root>
     </Dialog>
   )


### PR DESCRIPTION
### Description

Here is a video of what was happening before this change, you can see that the _Close_ tooltip is rendering at the end of the announcements dialog. I noticed also that now that we have more announcements and scroll that this is causing some layout shift.

https://github.com/user-attachments/assets/9ae5fac0-889d-4248-9efc-2a7e8099d455

It seems as though the container for the button component should have an extra `position: relative` in the container to stop the tooltip from flying around, what I have done to remedy this is to just add a container around the button in the dialog.

### What to review

Whether this is something that should be tackled in `@sanity/ui` or whether we are ok to proceed with this approach.

### Testing

n/a

### Notes for release

n/a
