### PR TITLE
fix: use consistent `framer-motion` semver range

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -206,7 +206,7 @@
     "execa": "^2.0.0",
     "exif-component": "^1.0.1",
     "form-data": "^4.0.0",
-    "framer-motion": "11.15.0",
+    "framer-motion": "^11.15.0",
     "get-it": "^8.6.5",
     "get-random-values-esm": "1.0.2",
     "groq-js": "^1.14.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1608,7 +1608,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1
       framer-motion:
-        specifier: 11.15.0
+        specifier: ^11.15.0
         version: 11.15.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       get-it:
         specifier: ^8.6.5


### PR DESCRIPTION
### Description

Uses the same semver range as in [`@sanity/presentation`](https://github.com/sanity-io/visual-editing/blob/f46626032fc42c8eda2075b0badb489307f5cccd/packages/presentation/package.json#L59) and [`@sanity/ui`](https://github.com/sanity-io/ui/blob/a8935003d110c15404cb43098a0164d25fa7f438/package.json#L112).
It ensures that once `framer-motion` v11.16 and later comes out we won't have duplicate versions of `framer-motion` being loaded up.


### What to review

Should make sense?

### Testing

Existing tests enough.

### Notes for release

Probably unnecessary since we just bumped `framer-motion` for react 19 support, unless we publish a studio release of that before merging this PR 🤔 
