### PR TITLE
Fix/sapp 1966

### DIFF
--- a/packages/@sanity/cli/src/cli.ts
+++ b/packages/@sanity/cli/src/cli.ts
@@ -110,6 +110,8 @@ export async function runCli(cliRoot: string, {cliVersion}: {cliVersion: string}
   if (core.v || core.version) {
     console.log(`${pkg.name} version ${pkg.version}`)
     process.exit()
+    // As the process.exit function is monkey patched above and is async, the return is necessary
+    return
   }
 
   // Translate `sanity -h <command>` to `sanity help <command>`

--- a/packages/@sanity/cli/test/basics.test.ts
+++ b/packages/@sanity/cli/test/basics.test.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 
 import {describe, expect} from 'vitest'
 
+import {generateCommandsDocumentation} from '../src/util/generateCommandsDocumentation'
 import {describeCliTest, testConcurrent} from './shared/describe'
 import {getCliUserEmail, runSanityCmdCommand, studioVersions} from './shared/environment'
 
@@ -45,6 +46,13 @@ describeCliTest('CLI: basic commands', () => {
     testConcurrent('sanity users list', async () => {
       const result = await runSanityCmdCommand(version, ['users', 'list'])
       expect(result.stdout).toContain('CLI Developers') // name of CI user
+      expect(result.code).toBe(0)
+    })
+
+    testConcurrent('sanity --version', async () => {
+      const result = await runSanityCmdCommand(version, ['--version'])
+      // Can just check that the template isn't there
+      expect(result.stdout).not.toContain(generateCommandsDocumentation({}))
       expect(result.code).toBe(0)
     })
   })


### PR DESCRIPTION
### Description


Found this interesting issue when looking into [SAPP-1966](https://linear.app/sanity/issue/SAPP-1966/cli-version-flag-returns-help-as-well). The `process.exit` function in the CLI is monkey patched so we can send telemetry before the process ends. This is fine in all other cases in `cli.ts` except for when we are checking whether the command is to simply check the version using the `--version` or `-v` flag.

I think that this is a bit dangerous to monkey patch `process.env` especially in a cli environment (the comment remarks this) so I thought I would give it a go to refactor a bit. We could obviously just add a `return` statement after the `process.exit` call in question but it seems like a recipe for problems if you go about using `process.exit` in some other file and assume that your code will stop executing at that point, but it won't.

### What to review

Is the approach ok? Happy to just leave the `return` or go ahead and create some sort of `async process.exit()` set-up, but it feels the risk is bigger than the reward.

### Testing

Added a test, tell me if it is in the wrong place.

### Notes for release

Not worth it.
