### PR TITLE
fix: preload documents on hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check:deps": "pnpm --recursive --parallel exec depcheck",
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
-    "check:react-compiler": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 27 .",
+    "check:react-compiler": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 26 .",
     "report:react-compiler-bailout": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [error,{__unstable_donotuse_reportAllBailouts:true}]' --ignore-path .eslintignore.react-compiler -f ./scripts/reactCompilerBailouts.cjs . || true",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",

--- a/packages/sanity/src/structure/components/pane/Pane.tsx
+++ b/packages/sanity/src/structure/components/pane/Pane.tsx
@@ -5,8 +5,8 @@ import {
   type HTMLProps,
   type ReactNode,
   useCallback,
-  useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -89,7 +89,7 @@ export const Pane = forwardRef(function Pane(
     ref.current = refValue
   }, [])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!rootElement) return undefined
     return mount(rootElement, {
       currentMinWidth: currentMinWidthProp,

--- a/packages/sanity/src/structure/components/paneItem/PaneItem.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItem.tsx
@@ -10,6 +10,7 @@ import {
   type ComponentType,
   type MouseEvent,
   type ReactNode,
+  startTransition,
   useCallback,
   useEffect,
   useMemo,
@@ -22,6 +23,7 @@ import {
   SanityDefaultPreview,
   useDocumentPresence,
   useDocumentPreviewStore,
+  useEditState,
   useSchema,
 } from 'sanity'
 
@@ -124,14 +126,6 @@ export function PaneItem(props: PaneItemProps) {
     documentPresence,
   ])
 
-  const Link = useMemo(
-    () =>
-      function LinkComponent(linkProps: {children: ReactNode}) {
-        return <ChildLink {...linkProps} childId={id} />
-      },
-    [ChildLink, id],
-  )
-
   const handleClick = useCallback((e: MouseEvent<HTMLElement>) => {
     if (e.metaKey) {
       setClicked(false)
@@ -144,16 +138,26 @@ export function PaneItem(props: PaneItemProps) {
   // Reset `clicked` state when `selected` prop changes
   useEffect(() => setClicked(false), [selected])
 
+  // Preloads the edit state on hover, using concurrent rendering with `startTransition` so preloads can be interrupted and not block rendering
+  const [handleMouseEnter, handleMouseLeave, preload] = usePreloadEditState(
+    id,
+    value && isSanityDocument(value) ? schemaType?.name : undefined,
+  )
+
   return (
     <PreviewCard
       data-testid={`pane-item-${title}`}
       __unstable_focusRing
-      as={Link as FIXME}
+      as={ChildLink as FIXME}
+      // @ts-expect-error - `childId` is a valid prop on `ChildLink`
+      childId={id}
       data-as="a"
       margin={margin}
       marginBottom={marginBottom}
       marginTop={marginTop}
       onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
       pressed={pressed}
       radius={2}
       selected={selected || clicked}
@@ -162,6 +166,33 @@ export function PaneItem(props: PaneItemProps) {
       tone="inherit"
     >
       {preview}
+      {preload}
     </PreviewCard>
   )
 }
+
+function usePreloadEditState(
+  documentId: string,
+  documentType: string | undefined,
+): [() => void, () => void, ReactNode] {
+  const [preloading, setPreload] = useState(false)
+  const handleMouseEnter = useCallback(() => startTransition(() => setPreload(true)), [])
+  const handleMouseLeave = useCallback(() => startTransition(() => setPreload(false)), [])
+
+  return [
+    handleMouseEnter,
+    handleMouseLeave,
+    preloading && documentType && (
+      <PreloadDocumentPane documentId={documentId} documentType={documentType} />
+    ),
+  ] as const
+}
+
+function PreloadDocumentPane(props: {documentId: string; documentType: string}) {
+  const {documentId, documentType} = props
+  // Preload the edit state for the document, and keep it alive until mouse leave
+  useEditState(documentId, documentType)
+
+  return null
+}
+PreloadDocumentPane.displayName = 'PreloadDocumentPane'


### PR DESCRIPTION
### Description

By preloading the `editState` for a document it makes for a much snappier experience when navigating documents, here's a video demonstrating both side-by-side (with the new behavior on the left, and no preloading on the right):

https://github.com/user-attachments/assets/118162cb-0c06-4508-8c6d-774df83f5920




### What to review

Is there enough inline context or should I add code comments?

### Testing

Existing tests should capture regressions, otherwise the manual testing steps are demonstrated in the video 🙌 

### Notes for release

Added preloading of documents when hovering them in document list panes. This speeds up the experience of navigating between documents pretty significantly.
