### PR TITLE
fix(releases): when reverting, published versions are used to derive translog

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/usePostPublishTransactions.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/usePostPublishTransactions.ts
@@ -1,6 +1,7 @@
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
 import {catchError, from, map, of} from 'rxjs'
+import {getPublishedId} from 'sanity'
 
 import {useClient} from '../../../../../hooks/useClient'
 import {getTransactionsLogs} from '../../../../../store/translog/getTransactionLogs'
@@ -17,7 +18,7 @@ export const usePostPublishTransactions = (documents: DocumentInRelease[]) => {
     return from(
       getTransactionsLogs(
         client,
-        documents.map(({document}) => document._id),
+        documents.map(({document}) => getPublishedId(document._id)),
         {
           fromTransaction: transactionId,
           // publish transaction + at least one post publish transaction

--- a/packages/sanity/src/core/util/__tests__/draftUtils.test.ts
+++ b/packages/sanity/src/core/util/__tests__/draftUtils.test.ts
@@ -8,7 +8,7 @@ import {
   getVersionFromId,
   getVersionId,
   removeDupes,
-} from './draftUtils'
+} from '../draftUtils'
 
 test('collate()', () => {
   const foo = {_type: 'foo', _id: 'foo'}


### PR DESCRIPTION
### Description
Wrongly, the translog for the version of the document in the published release was being used to derive the revert state for each document. This worked in most cases because the first translog record for the version document is copying the existing publish document - but this fails when the published document is updated before publish but after release creation; or in other cases such as when a document is unpublished in a release.

This PR updates this so that the translog of the published document is always used to lookup the transaction of the release publish. As previously this will also:
1. `usePostPublishTransactions` checks if there are any transactions after the publish tranaction
2. `useDocumentRevertStates` which derives the revert state by looking at the transaction 1 prior to the publish trans
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Some minor test updates made to correct for the fact that the documents provided to the hooks are the version documents, and then additional mock updates to reflect the changes to logic
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
