### PR TITLE
feat(cli): remove patching of tsconfig.json and thus silver-fleece dependency

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -72,7 +72,6 @@
     "pkg-dir": "^5.0.0",
     "prettier": "^3.3.0",
     "semver": "^7.3.5",
-    "silver-fleece": "1.1.0",
     "validate-npm-package-name": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -1,4 +1,4 @@
-import {existsSync, readFileSync} from 'node:fs'
+import {existsSync} from 'node:fs'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
@@ -11,7 +11,6 @@ import {deburr, noop} from 'lodash'
 import pFilter from 'p-filter'
 import resolveFrom from 'resolve-from'
 import semver from 'semver'
-import {evaluate, patch} from 'silver-fleece'
 
 import {CLIInitStepCompleted} from '../../__telemetry__/init.telemetry'
 import {type InitFlags} from '../../commands/init/initCommand'
@@ -433,21 +432,6 @@ export default async function initSanity(
     const templateToUse = unattended ? 'clean' : await promptForNextTemplate(prompt)
 
     await writeSourceFiles(sanityFolder(useTypeScript, templateToUse), undefined, hasSrcFolder)
-
-    // set tsconfig.json target to ES2017
-    const tsConfigPath = path.join(workDir, 'tsconfig.json')
-
-    if (useTypeScript && existsSync(tsConfigPath)) {
-      const tsConfigFile = readFileSync(tsConfigPath, 'utf8')
-      const config = evaluate(tsConfigFile)
-
-      if (config.compilerOptions.target?.toLowerCase() !== 'es2017') {
-        config.compilerOptions.target = 'ES2017'
-
-        const newConfig = patch(tsConfigFile, config)
-        await fs.writeFile(tsConfigPath, Buffer.from(newConfig))
-      }
-    }
 
     const appendEnv = unattended ? true : await promptForAppendEnv(prompt, envFilename)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -848,9 +848,6 @@ importers:
       semver:
         specifier: ^7.3.5
         version: 7.6.3
-      silver-fleece:
-        specifier: 1.1.0
-        version: 1.1.0
       validate-npm-package-name:
         specifier: ^3.0.0
         version: 3.0.0
@@ -10977,9 +10974,6 @@ packages:
   sigstore@2.3.1:
     resolution: {integrity: sha512-8G+/XDU8wNsJOQS5ysDVO0Etg9/2uA5gR9l4ZwijjlwxBcrU6RPfwi2+jJmbP+Ap1Hlp/nVAaEO4Fj22/SL2gQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
-
-  silver-fleece@1.1.0:
-    resolution: {integrity: sha512-V3vShUiLRVPMu9aSWpU5kLDoU/HO7muJKE236EO663po3YxivAkMLbRg+amV/FhbIfF5bWXX5TVX+VYmRaOBFA==}
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -23082,8 +23076,6 @@ snapshots:
       '@sigstore/verify': 1.2.1
     transitivePeerDependencies:
       - supports-color
-
-  silver-fleece@1.1.0: {}
 
   simple-swizzle@0.2.2:
     dependencies:


### PR DESCRIPTION
### Description

The primary motivation for this change is to get rid of silver-fleece as a dependency. See https://github.com/evertheylen/silver-fleece/issues/4 for more information about that problem.

This simply removes the functionality we used it for: Patching tsconfig.json to set `compilerOptions.target` to ES2017.

- The latest Next.js template already sets the target to ES2017.
- Even so, I've tested this against a newly configured Next.js app where I set `compilerOptions.target` to ES5 and `npm run dev` still worked. I'm not sure why this target is required anyway.

### What to review

Think about scenarios where `sanity init` will be executed and if this change could lead to more confusing onboarding experience.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

@RostiMelk tested this locally in his machine against a newly initialized Next.js project (Next.js 15).

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
