### PR TITLE
fix(core): re-subscribes to shared pair listener opens a new connection

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -252,8 +252,8 @@ export function checkoutPair(
       consistency$: published.consistency$,
       remoteSnapshot$: published.remoteSnapshot$.pipe(map(setVersion('published'))),
     },
-    // Use this to keep the listener connection active.
+    // Use this to keep the mutation pipeline active.
     // It won't ever emit any events, but it will prevent the eventsource connection from completing for as long as it is subscribed to
-    _keepalive: listenerEvents$.pipe(mergeMap(() => EMPTY)),
+    _keepalive: commits$.pipe(mergeMap(() => EMPTY)),
   }
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -2,7 +2,7 @@ import {type Action, type SanityClient} from '@sanity/client'
 import {type Mutation} from '@sanity/mutator'
 import {type SanityDocument} from '@sanity/types'
 import {omit} from 'lodash'
-import {EMPTY, from, merge, type Observable, Subject} from 'rxjs'
+import {EMPTY, from, merge, type Observable} from 'rxjs'
 import {filter, map, mergeMap, share, take, tap} from 'rxjs/operators'
 
 import {
@@ -65,7 +65,7 @@ export interface Pair {
   transactionsPendingEvents$: Observable<PendingMutationsEvent>
   published: DocumentVersion
   draft: DocumentVersion
-  complete: () => void
+  _keepalive: Observable<never>
 }
 
 function setVersion<T>(version: 'draft' | 'published') {
@@ -204,10 +204,7 @@ export function checkoutPair(
 ): Pair {
   const {publishedId, draftId} = idPair
 
-  const listenerEventsConnector = new Subject<ListenerEvent>()
-  const listenerEvents$ = getPairListener(client, idPair, pairListenerOptions).pipe(
-    share({connector: () => listenerEventsConnector}),
-  )
+  const listenerEvents$ = getPairListener(client, idPair, pairListenerOptions).pipe(share())
 
   const reconnect$ = listenerEvents$.pipe(
     filter((ev) => ev.type === 'reconnect'),
@@ -255,6 +252,8 @@ export function checkoutPair(
       consistency$: published.consistency$,
       remoteSnapshot$: published.remoteSnapshot$.pipe(map(setVersion('published'))),
     },
-    complete: () => listenerEventsConnector.complete(),
+    // Use this to keep the listener connection active.
+    // It won't ever emit any events, but it will prevent the eventsource connection from completing for as long as it is subscribed to
+    _keepalive: listenerEvents$.pipe(mergeMap(() => EMPTY)),
   }
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
@@ -1,12 +1,14 @@
 import {type SanityClient} from '@sanity/client'
-import {Observable} from 'rxjs'
-import {publishReplay, refCount} from 'rxjs/operators'
+import {merge, type Observable, of, ReplaySubject, share, timer} from 'rxjs'
 
 import {type PairListenerOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {checkoutPair, type Pair} from './checkoutPair'
 import {memoizeKeyGen} from './memoizeKeyGen'
+
+// How long to keep listener connected for after last unsubscribe
+const LISTENER_RESET_DELAY = 10_000
 
 export const memoizedPair: (
   client: SanityClient,
@@ -22,12 +24,18 @@ export const memoizedPair: (
     serverActionsEnabled: Observable<boolean>,
     pairListenerOptions?: PairListenerOptions,
   ): Observable<Pair> => {
-    return new Observable<Pair>((subscriber) => {
-      const pair = checkoutPair(client, idPair, serverActionsEnabled, pairListenerOptions)
-      subscriber.next(pair)
-
-      return pair.complete
-    }).pipe(publishReplay(1), refCount())
+    const pair = checkoutPair(client, idPair, serverActionsEnabled, pairListenerOptions)
+    return merge(
+      of(pair),
+      // makes sure the pair listener is kept alive for as long as there are subscribers
+      pair._keepalive,
+    ).pipe(
+      share({
+        connector: () => new ReplaySubject(1),
+        resetOnComplete: true,
+        resetOnRefCountZero: () => timer(LISTENER_RESET_DELAY),
+      }),
+    )
   },
   memoizeKeyGen,
 )

--- a/packages/sanity/src/core/store/_legacy/document/getPairListener.ts
+++ b/packages/sanity/src/core/store/_legacy/document/getPairListener.ts
@@ -2,10 +2,9 @@
 import {type SanityClient} from '@sanity/client'
 import {type SanityDocument} from '@sanity/types'
 import {groupBy} from 'lodash'
-import {defer, merge, type Observable, of, throwError, timer} from 'rxjs'
+import {defer, merge, type Observable, of, throwError} from 'rxjs'
 import {catchError, concatMap, filter, map, mergeMap, scan, share} from 'rxjs/operators'
 
-import {LISTENER_RESET_DELAY} from '../../../preview/constants'
 import {shareReplayLatest} from '../../../preview/utils/shareReplayLatest'
 import {debug} from './debug'
 import {
@@ -96,7 +95,6 @@ export function getPairListener(
         //filter((event) => Math.random() < 0.99 || event.type !== 'mutation'),
         shareReplayLatest({
           predicate: (event) => event.type === 'welcome' || event.type === 'reconnect',
-          resetOnRefCountZero: () => timer(LISTENER_RESET_DELAY),
         }),
       ),
   ) as Observable<WelcomeEvent | MutationEvent | ReconnectEvent>


### PR DESCRIPTION
### Description
While testing #8110 I noticed that even when preloading, clicking a document would cause a new listener request to be made. 

Tracked this down to being caused by the memoization of the shared document pair listener. This PR fixes the issue by:

- Replacing the `connector.complete()` trick with instead exposing a `_keepalive` stream that we merge in with the (memoized &  shared) stream of the pair listener. This ensures that the listener connection will be kept open for as long as there are subscribers to the pair object.
- Moving the delayed reset to the memoized function (returning a pair listener for keyed by document id). This ensures that the delayed reset happens on the memoized observable itself, rather than the connection stream.

### What to review
- Navigate to a document (A) in the Studio
- Make sure there is a single event source set up with the tag `sanity.studio.document.pair-listener`
- Navigate to another document (B)
- Make sure there is a single new event source set up with the tag `sanity.studio.document.pair-listener`
- Go back to document A before 10s has passed
- Verify that no request was made with the tag  `sanity.studio.document.pair-listener`
- Stay on document A for more than 10s
- Verify that the listener connection made for document B is now shut down (timing panel no longer says "Caution: request is not finished yet!")
- Now, going back to B should trigger a new listener connection again.

### Testing
Existing tests should be enough

### Notes for release

n/a