### PR TITLE
fix: support react 19 type definitions

### DIFF
--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -49,16 +49,19 @@
     "watch": "pkg-utils watch"
   },
   "dependencies": {
-    "@sanity/client": "^6.24.1",
-    "@types/react": "^18.3.5"
+    "@sanity/client": "^6.24.1"
   },
   "devDependencies": {
     "@repo/package.config": "workspace:*",
     "@repo/test-config": "workspace:*",
     "@sanity/insert-menu": "1.0.16",
+    "@types/react": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",
     "react": "^18.3.1",
     "rimraf": "^5.0.10",
     "vitest": "^2.1.8"
+  },
+  "peerDependencies": {
+    "@types/react": "18 || 19"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1241,9 +1241,6 @@ importers:
       '@sanity/client':
         specifier: ^6.24.1
         version: 6.24.1(debug@4.4.0)
-      '@types/react':
-        specifier: ^18.3.5
-        version: 18.3.17
     devDependencies:
       '@repo/package.config':
         specifier: workspace:*
@@ -1254,6 +1251,9 @@ importers:
       '@sanity/insert-menu':
         specifier: 1.0.16
         version: 1.0.16(@emotion/is-prop-valid@1.3.1)(@sanity/types@packages+@sanity+types)(react-dom@19.0.0-rc-f994737d14-20240522(react@18.3.1))(react-is@19.0.0-rc.1)(react@18.3.1)(styled-components@6.1.13(react-dom@19.0.0-rc-f994737d14-20240522(react@18.3.1))(react@18.3.1))
+      '@types/react':
+        specifier: ^18.3.5
+        version: 18.3.17
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.0.3(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1))


### PR DESCRIPTION
### Description

On React 19 I'm seeing build errors like this:
```
Type error: Argument of type 'ComponentType | ReactNode' is not assignable to parameter of type 'ReactNode | ComponentType<{}>'.
  Type 'ComponentClass<{}, any>' is not assignable to type 'ReactNode | ComponentType<{}>'.
    Type 'import("/vercel/path1/node_modules/@sanity/types/node_modules/@types/react/index").ComponentClass<{}, any>' is not assignable to type 'React.ComponentClass<{}, any>'.
      Types of property 'contextType' are incompatible.
        Type 'import("/vercel/path1/node_modules/@sanity/types/node_modules/@types/react/index").Context<any> | undefined' is not assignable to type 'React.Context<any> | undefined'.
          Property '$$typeof' is missing in type 'import("/vercel/path1/node_modules/@sanity/types/node_modules/@types/react/index").Context<any>' but required in type 'React.Context<any>'.
```
And since `@sanity/types` has a direct dependency on `@types/react` there isn't an easy to solve it, userland has to resort to package manager overrides 😅 
It's always been bad to have direct deps on types that can have different majors that are incompatible, so the fix is to move it to a peer dep.

### What to review

Makes sense?

### Testing

If it builds it works.

### Notes for release

Improves React 19 compatibility for TypeScript users, by moving the `@types/react` direct dependency in `@sanity/types`, to a peer dependency.
