### PR TITLE
fix(core): merge in listenerEvents in _keepalive stream

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -254,6 +254,6 @@ export function checkoutPair(
     },
     // Use this to keep the mutation pipeline active.
     // It won't ever emit any events, but it will prevent the eventsource connection from completing for as long as it is subscribed to
-    _keepalive: commits$.pipe(mergeMap(() => EMPTY)),
+    _keepalive: merge(listenerEvents$, commits$).pipe(mergeMap(() => EMPTY)),
   }
 }


### PR DESCRIPTION
### Description
Small follow up from #8120 – I mistakenly thought subscribing to commit stream was sufficient because I thought it built upon the listener, but turns out it wasn't so. This fix merges in listener stream with _keepalive.

### What to review
The review procedure from #8120 should still hold water:
- Navigate to a document (A) in the Studio
- Make sure there is a single event source set up with the tag `sanity.studio.document.pair-listener`
- Navigate to another document (B)
- Make sure there is a single new event source set up with the tag `sanity.studio.document.pair-listener`
- Go back to document A before 10s has passed
- Verify that no request was made with the tag  `sanity.studio.document.pair-listener`
- Stay on document A for more than 10s
- Verify that the listener connection made for document B is now shut down (timing panel no longer says "Caution: request is not finished yet!")
- Now, going back to B should trigger a new listener connection again.

### Notes for release
n/a