### PR TITLE
feat(cli): add unattended mode flag to `sanity undeploy`

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/deploy/__tests__/undeployAction.test.ts
+++ b/packages/sanity/src/_internal/cli/actions/deploy/__tests__/undeployAction.test.ts
@@ -58,7 +58,12 @@ describe('undeployStudioAction', () => {
   it('does nothing if there is no user application', async () => {
     helpers.getUserApplication.mockResolvedValueOnce(null)
 
-    await undeployStudioAction({} as CliCommandArguments<UndeployStudioActionFlags>, mockContext)
+    await undeployStudioAction(
+      {
+        extOptions: {},
+      } as CliCommandArguments<UndeployStudioActionFlags>,
+      mockContext,
+    )
 
     expect(mockContext.output.print).toHaveBeenCalledWith(
       'Your project has not been assigned a studio hostname',
@@ -76,7 +81,12 @@ describe('undeployStudioAction', () => {
       true,
     ) // User confirms
 
-    await undeployStudioAction({} as CliCommandArguments<UndeployStudioActionFlags>, mockContext)
+    await undeployStudioAction(
+      {
+        extOptions: {},
+      } as CliCommandArguments<UndeployStudioActionFlags>,
+      mockContext,
+    )
 
     expect(mockContext.prompt.single).toHaveBeenCalledWith({
       type: 'confirm',
@@ -99,7 +109,12 @@ describe('undeployStudioAction', () => {
       false,
     ) // User cancels
 
-    await undeployStudioAction({} as CliCommandArguments<UndeployStudioActionFlags>, mockContext)
+    await undeployStudioAction(
+      {
+        extOptions: {},
+      } as CliCommandArguments<UndeployStudioActionFlags>,
+      mockContext,
+    )
 
     expect(mockContext.prompt.single).toHaveBeenCalledWith({
       type: 'confirm',
@@ -129,6 +144,7 @@ describe('undeployStudioAction', () => {
     expect(helpers.deleteUserApplication).toHaveBeenCalledWith({
       client: expect.anything(),
       applicationId: 'app-id',
+      appType: 'studio',
     })
     expect(mockContext.output.print).toHaveBeenCalledWith(
       expect.stringContaining('Studio undeploy scheduled.'),
@@ -144,7 +160,12 @@ describe('undeployStudioAction', () => {
     ) // User confirms
 
     await expect(
-      undeployStudioAction({} as CliCommandArguments<UndeployStudioActionFlags>, mockContext),
+      undeployStudioAction(
+        {
+          extOptions: {},
+        } as CliCommandArguments<UndeployStudioActionFlags>,
+        mockContext,
+      ),
     ).rejects.toThrow(errorMessage)
 
     expect(mockContext.output.spinner('').fail).toHaveBeenCalled()

--- a/packages/sanity/src/_internal/cli/actions/deploy/undeployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/deploy/undeployAction.ts
@@ -5,11 +5,17 @@ import {deleteUserApplication, getUserApplication} from './helpers'
 
 const debug = debugIt.extend('undeploy')
 
+export interface UndeployStudioActionFlags {
+  yes?: boolean
+  y?: boolean
+}
+
 export default async function undeployStudioAction(
-  _: CliCommandArguments<Record<string, unknown>>,
+  args: CliCommandArguments<UndeployStudioActionFlags>,
   context: CliCommandContext,
 ): Promise<void> {
   const {apiClient, chalk, output, prompt, cliConfig} = context
+  const flags = args.extOptions
 
   const client = apiClient({
     requireUser: true,
@@ -37,16 +43,25 @@ export default async function undeployStudioAction(
   output.print('')
 
   const url = `https://${chalk.yellow(userApplication.appHost)}.sanity.studio`
-  const shouldUndeploy = await prompt.single({
-    type: 'confirm',
-    default: false,
-    message: `This will undeploy ${url} and make it unavailable for your users.
+
+  /**
+   * Unattended mode means that if there are any prompts it will use `YES` for them but will no change anything that doesn't have a prompt
+   */
+  const unattendedMode = Boolean(flags.yes || flags.y)
+
+  // If it is in unattended mode, we don't want to prompt
+  if (!unattendedMode) {
+    const shouldUndeploy = await prompt.single({
+      type: 'confirm',
+      default: false,
+      message: `This will undeploy ${url} and make it unavailable for your users.
   The hostname will be available for anyone to claim.
   Are you ${chalk.red('sure')} you want to undeploy?`.trim(),
-  })
+    })
 
-  if (!shouldUndeploy) {
-    return
+    if (!shouldUndeploy) {
+      return
+    }
   }
 
   spinner = output.spinner('Undeploying studio').start()

--- a/packages/sanity/src/_internal/cli/commands/deploy/undeployCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/deploy/undeployCommand.ts
@@ -4,9 +4,15 @@ import {
   type CliCommandDefinition,
 } from '@sanity/cli'
 
+import {type UndeployStudioActionFlags} from '../../actions/deploy/undeployAction'
+
 const helpText = `
+Options
+  -y, --yes Unattended mode, answers "yes" to any "yes/no" prompt and otherwise uses defaults
+
 Examples
   sanity undeploy
+  sanity undeploy --yes
 `
 
 const undeployCommand: CliCommandDefinition = {
@@ -14,7 +20,7 @@ const undeployCommand: CliCommandDefinition = {
   signature: '',
   description: 'Removes the deployed Sanity Studio from Sanity hosting',
   action: async (
-    args: CliCommandArguments<Record<string, unknown>>,
+    args: CliCommandArguments<UndeployStudioActionFlags>,
     context: CliCommandContext,
   ) => {
     const mod = await import('../../actions/deploy/undeployAction')


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
Adds a `--yes` (or `-y`) flag to the `undeploy` command, enabling unattended mode:
```sh
sanity undeploy --yes
```

This flag is particularly useful for CI/CD workflows, such as deploying a feature branch of a Sanity Studio and automatically undeploying it when the corresponding pull request is closed.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

Updating documentation to include new flag. The help docs for the command have been updated with an example.
