### PR TITLE
fix(cli): pin template validator version

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -60,7 +60,7 @@
     "@sanity/client": "^6.24.1",
     "@sanity/codegen": "3.68.3",
     "@sanity/telemetry": "^0.7.7",
-    "@sanity/template-validator": "^1.2.1",
+    "@sanity/template-validator": "1.2.1",
     "@sanity/util": "3.68.3",
     "chalk": "^4.1.2",
     "debug": "^4.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -813,7 +813,7 @@ importers:
         specifier: ^0.7.7
         version: 0.7.9(react@19.0.0-rc-f994737d14-20240522)
       '@sanity/template-validator':
-        specifier: ^1.2.1
+        specifier: 1.2.1
         version: 1.2.1(@types/babel__core@7.20.5)(@types/node@22.10.2)(debug@4.4.0)
       '@sanity/util':
         specifier: 3.68.3


### PR DESCRIPTION
### Description

Disabling flexible versioning for the @sanity/template-validator package i @sanity/cli

This PR won't really fix the issue before #8115 is released, but I think it's definitely worth pinning this dependency going forward to avoid this type of issue happening again. 

### Notes for release

Fixed an issue where initiating a project using a remote template crashed the CLI