### PR TITLE
fix(releases): remounting the title/description form for release when release being shown changes

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
@@ -21,5 +21,5 @@ export function ReleaseDetailsEditor({release}: {release: ReleaseDocument}): JSX
     [timer, updateRelease],
   )
 
-  return <TitleDescriptionForm release={release} onChange={handleOnChange} />
+  return <TitleDescriptionForm key={release._id} release={release} onChange={handleOnChange} />
 }


### PR DESCRIPTION
### Description
| Before | After |
|--------|--------|
| https://github.com/user-attachments/assets/ff7e2ee0-081c-4817-aaa7-1a0d3ae3c034 | [9ea9222c-8d55-479b-ae48-d2a2d2ef59f3.webm](https://github.com/user-attachments/assets/d58c14ed-0c41-4f6a-9e55-901643071c8f) |

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
