### PR TITLE
feat(cli): copy additions for remote project bootstrapper

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -846,7 +846,7 @@ export default async function initSanity(
 
     const projectChoices = projects.map((project) => ({
       value: project.id,
-      name: `${project.displayName} [${project.id}]`,
+      name: `${project.displayName} (${project.id})`,
     }))
 
     const selected = await prompt.single({


### PR DESCRIPTION
### Description

- Added a success message for when a CORS entry is added
- Added a success message for when an API token is added

![image](https://github.com/user-attachments/assets/53f1c0b4-2a80-48f9-bd81-3bf5a7056c27)

Fixes: GRO-3076

### Testing

Run
```shell
sanity init --template sanity-io/sanity-template-nextjs-clean
```

You should see a message for both CORS and API token

### Notes for release

N/A or:

Adjusted copy in CLI