### PR TITLE
chore: add github problem matcher for PR linting

### DIFF
--- a/.github/eslint-compact.json
+++ b/.github/eslint-compact.json
@@ -13,6 +13,20 @@
           "code": 6
         }
       ]
+    },
+    {
+      "owner": "turbo-eslint-compact",
+      "pattern": [
+        {
+          "regexp": "^(?:[^:]+: )?([^:]+):\\sline\\s(\\d+),\\scol\\s(\\d+),\\s(Error|Warning|Info)\\s-\\s(.+)\\s\\((.+)\\)\\.?$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5,
+          "code": 6
+        }
+      ]
     }
   ]
 }

--- a/.github/workflows/lintPr.yml
+++ b/.github/workflows/lintPr.yml
@@ -46,5 +46,8 @@ jobs:
       - name: Install project dependencies
         run: pnpm install
 
+      - name: Register Problem Matcher for ESLint that handles -f compact and shows warnings inline on PRs
+        run: echo "::add-matcher::.github/eslint-compact.json"
+
       - name: Lint files
-        run: pnpm lint
+        run: pnpm turbo run lint --output-logs=full --continue -- -f compact

--- a/dev/design-studio/package.json
+++ b/dev/design-studio/package.json
@@ -27,7 +27,7 @@
     "build": "../.bin/sanity build",
     "clean": "rimraf .sanity dist",
     "dev": "../.bin/sanity dev --port 4000",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "start": "../.bin/sanity start --port 4000"
   },
   "dependencies": {

--- a/dev/page-building-studio/package.json
+++ b/dev/page-building-studio/package.json
@@ -8,7 +8,7 @@
     "build": "../.bin/sanity build",
     "clean": "rimraf .sanity dist",
     "dev": "../.bin/sanity dev",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "start": "../.bin/sanity start"
   },
   "dependencies": {

--- a/dev/starter-studio/package.json
+++ b/dev/starter-studio/package.json
@@ -8,7 +8,7 @@
     "build": "../.bin/sanity build",
     "clean": "rimraf .sanity dist",
     "dev": "../.bin/sanity dev --port 3337",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "start": "../.bin/sanity start --port 3337"
   },
   "dependencies": {

--- a/dev/strict-studio/package.json
+++ b/dev/strict-studio/package.json
@@ -8,7 +8,7 @@
     "build": "../.bin/sanity build",
     "clean": "rimraf .sanity dist",
     "dev": "../.bin/sanity dev",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "start": "../.bin/sanity start"
   },
   "dependencies": {

--- a/dev/studio-e2e-testing/package.json
+++ b/dev/studio-e2e-testing/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "sanity build",
     "dev": "sanity dev --port 3339",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "preview": "sanity preview --port 3339",
     "start": "sanity preview --port 3339"
   },

--- a/dev/test-create-integration-studio/package.json
+++ b/dev/test-create-integration-studio/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf .sanity dist",
     "deploy": "npx sanity deploy",
     "dev": "../.bin/sanity dev",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "start": "../.bin/sanity start"
   },
   "dependencies": {

--- a/dev/test-next-studio/package.json
+++ b/dev/test-next-studio/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev -p 3333",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "start": "next start"
   },
   "dependencies": {

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -8,7 +8,7 @@
     "build": "run-s workshop:build sanity:build",
     "clean": "rimraf .sanity dist",
     "dev": "run-p workshop:dev sanity:dev",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "sanity:build": "../.bin/sanity build --source-maps",
     "sanity:dev": "../.bin/sanity dev",
     "start": "../.bin/sanity start",

--- a/examples/blog-studio/package.json
+++ b/examples/blog-studio/package.json
@@ -24,7 +24,7 @@
   "author": "Sanity.io <hello@sanity.io>",
   "main": "package.json",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "start": "sanity dev --port 3336"
   },
   "dependencies": {

--- a/examples/clean-studio/package.json
+++ b/examples/clean-studio/package.json
@@ -24,7 +24,7 @@
   "author": "Sanity.io <hello@sanity.io>",
   "main": "package.json",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "start": "sanity dev --port 3338"
   },
   "dependencies": {

--- a/examples/ecommerce-studio/package.json
+++ b/examples/ecommerce-studio/package.json
@@ -25,7 +25,7 @@
   "main": "package.json",
   "scripts": {
     "clean": "rimraf lib dest",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "start": "sanity dev --port 3337"
   },
   "dependencies": {

--- a/examples/movies-studio/package.json
+++ b/examples/movies-studio/package.json
@@ -25,7 +25,7 @@
   "main": "package.json",
   "scripts": {
     "clean": "rimraf lib dest",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "start": "sanity dev --port 3334"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prepublishOnly": "pnpm build",
     "example:movies-studio": "cd examples/blog-studio && pnpm start",
     "install:deps": "pnpm install",
-    "lint": "run-s check:lint",
+    "lint": "pnpm check:lint",
     "lint:fix": "run-s chore:lint:fix",
     "list:deps-updates": "npm-check-updates --workspaces --root -m",
     "normalize-pkgfields": "node -r esbuild-register scripts/normalizePackageFields",

--- a/packages/@sanity/block-tools/package.json
+++ b/packages/@sanity/block-tools/package.json
@@ -43,7 +43,7 @@
     "check:types": "tsc --project tsconfig.lib.json",
     "clean": "rimraf lib",
     "coverage": "NODE_ENV=test vitest --coverage",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "prepublishOnly": "turbo run build",
     "test": "vitest run",
     "watch": "pkg-utils watch"

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -49,7 +49,7 @@
     "build": "pkg-utils build --strict --check --clean",
     "check:types": "tsc --project tsconfig.lib.json",
     "clean": "rimraf lib",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "prepublishOnly": "turbo run build",
     "test": "vitest",
     "ts": "node -r esbuild-register",

--- a/packages/@sanity/codegen/package.json
+++ b/packages/@sanity/codegen/package.json
@@ -44,7 +44,7 @@
     "build": "pkg-utils build --strict --check --clean",
     "check:types": "tsc --project tsconfig.lib.json",
     "clean": "rimraf lib coverage",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "prepublishOnly": "turbo run build",
     "test": "vitest",
     "watch": "pkg-utils watch"

--- a/packages/@sanity/diff/package.json
+++ b/packages/@sanity/diff/package.json
@@ -42,7 +42,7 @@
     "build": "pkg-utils build --strict --check --clean",
     "check:types": "tsc --project tsconfig.lib.json",
     "clean": "rimraf lib coverage",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "prepublishOnly": "turbo run build",
     "watch": "pkg-utils watch"
   },

--- a/packages/@sanity/migrate/package.json
+++ b/packages/@sanity/migrate/package.json
@@ -44,7 +44,7 @@
     "build": "pkg-utils build --strict --check --clean",
     "check:types": "tsc --project tsconfig.lib.json",
     "clean": "rimraf lib coverage",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "prepublishOnly": "turbo run build",
     "test": "vitest",
     "watch": "pkg-utils watch"

--- a/packages/@sanity/mutator/package.json
+++ b/packages/@sanity/mutator/package.json
@@ -42,7 +42,7 @@
     "build": "pkg-utils build --strict --check --clean",
     "check:types": "tsc --project tsconfig.lib.json",
     "clean": "rimraf lib",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "perf": "node ./perf/run.js",
     "prepublishOnly": "turbo run build",
     "test": "vitest run",

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -56,7 +56,7 @@
     "build": "pkg-utils build --strict --check --clean",
     "check:types": "tsc --project tsconfig.lib.json",
     "clean": "rimraf _internal.js lib",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "prepublishOnly": "turbo run build",
     "test": "vitest run",
     "test:watch": "vitest watch",

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -45,7 +45,7 @@
     "build": "pkg-utils build --strict --check --clean",
     "check:types": "tsc --project tsconfig.lib.json",
     "clean": "rimraf lib",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "prepublishOnly": "turbo run build",
     "pretest": "run-s build",
     "test": "node --test",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -140,7 +140,7 @@
     "check:types": "tsc --project tsconfig.lib.json",
     "clean": "rimraf _internal.js _singletons.js _createContext.js cli.js desk.js migrate.js presentation.js router.js structure.js lib",
     "coverage": "vitest --coverage",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "prepublishOnly": "turbo run build",
     "test": "vitest run",
     "test:ct": "rimraf playwright-ct/template/.cache && playwright test -c playwright-ct.config.ts",

--- a/packages/sanity/src/core/form/studio/assetSource/file/AssetRow.tsx
+++ b/packages/sanity/src/core/form/studio/assetSource/file/AssetRow.tsx
@@ -128,7 +128,7 @@ const STYLES_ASSETMENU_WRAPPER = {
   marginBottom: '-0.5rem',
 }
 
-export const AssetRow = (props: RowProps) => {
+export const AssetRow = (props: RowProps): React.JSX.Element => {
   const versionedClient = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const toast = useToast()
   const deleteRef$ = useRef<Subscription>()
@@ -195,28 +195,31 @@ export const AssetRow = (props: RowProps) => {
     versionedClient.observable,
   ])
 
-  const handleDialogClose = () => {
+  const handleDialogClose = useCallback(() => {
     setShowUsageDialog(false)
     setShowDeleteDialog(false)
-  }
+  }, [])
 
-  const handleToggleUsageDialog = () => {
+  const handleToggleUsageDialog = useCallback(() => {
     setShowUsageDialog(true)
-  }
+  }, [])
 
-  const handleToggleOpen = () => {
-    setIsOpen(!isOpen)
-  }
+  const handleToggleOpen = useCallback(() => {
+    setIsOpen((prev) => !prev)
+  }, [])
 
-  const handleMenuAction = (action: AssetMenuAction) => {
-    if (action.type === 'delete') {
-      handleConfirmDelete()
-    }
+  const handleMenuAction = useCallback(
+    (action: AssetMenuAction) => {
+      if (action.type === 'delete') {
+        handleConfirmDelete()
+      }
 
-    if (action.type === 'showUsage') {
-      handleToggleUsageDialog()
-    }
-  }
+      if (action.type === 'showUsage') {
+        handleToggleUsageDialog()
+      }
+    },
+    [handleConfirmDelete, handleToggleUsageDialog],
+  )
 
   const usageDialog = useMemo(() => {
     return (
@@ -224,7 +227,7 @@ export const AssetRow = (props: RowProps) => {
         <AssetUsageDialog assetType="file" asset={asset} onClose={handleDialogClose} />
       )
     )
-  }, [asset, showUsageDialog])
+  }, [asset, handleDialogClose, showUsageDialog])
 
   const deleteDialog = useMemo(() => {
     return (
@@ -238,7 +241,7 @@ export const AssetRow = (props: RowProps) => {
         />
       )
     )
-  }, [asset, handleDeleteAsset, isDeleting, showDeleteDialog])
+  }, [asset, handleDeleteAsset, handleDialogClose, isDeleting, showDeleteDialog])
 
   if (isMobile) {
     return (

--- a/perf/studio/package.json
+++ b/perf/studio/package.json
@@ -9,7 +9,7 @@
     "build": "sanity build",
     "clean": "rimraf .sanity dist",
     "dev": "sanity dev --port 3300",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "preview": "pnpm build && pnpm start",
     "start": "sanity start --port 3300"
   },

--- a/perf/tests/package.json
+++ b/perf/tests/package.json
@@ -7,7 +7,7 @@
   "author": "Sanity.io <hello@sanity.io>",
   "scripts": {
     "build": "pnpm build:cli && (cd studio && pnpm build)",
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "perf:codegen": "ts-node --files -r dotenv/config codegen",
     "perf:test": "ts-node --files cli",
     "perf:test:ci": "ts-node --files cli",


### PR DESCRIPTION
### Description

Makes ESLint errors on PRs a lot easier to deal with, as they show up on PR "Files changed":
![image](https://github.com/user-attachments/assets/42513506-6095-481f-a0bf-2f3ab151939f)

### What to review

I thought about adding `--quiet` to silence warnings, like the regular `pnpm lint` command is doing. But decided against it as the linter warnings are really noisy right now and I don't want the CI to mask over it, I want it to be honest so it motivates brave souls to clean up our linter config so it's no longer so noisy.

### Testing

I tested this by introducing linter errors on `AssetRow.tsx`, like seen in the above screenshot. After seeing it working I fixed the linter issues and rebased.

### Notes for release

N/A - only applies to monorepo.
