### PR TITLE
fix: make header new and error text customisable

### DIFF
--- a/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
+++ b/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
@@ -1,5 +1,6 @@
-import {unstable_useValuePreview as useValuePreview} from 'sanity'
+import {unstable_useValuePreview as useValuePreview, useTranslation} from 'sanity'
 
+import {structureLocaleNamespace} from '../../i18n'
 import {useDocumentPane} from './useDocumentPane'
 
 /**
@@ -25,6 +26,7 @@ export function useDocumentTitle(): UseDocumentTitle {
   const {connectionState, schemaType, title, editState} = useDocumentPane()
   const documentValue = editState?.draft || editState?.published
   const subscribed = Boolean(documentValue)
+  const {t} = useTranslation(structureLocaleNamespace)
 
   const {error, value} = useValuePreview({
     enabled: subscribed,
@@ -41,11 +43,19 @@ export function useDocumentTitle(): UseDocumentTitle {
   }
 
   if (!documentValue) {
-    return {error: undefined, title: `New ${schemaType?.title || schemaType?.name}`}
+    return {
+      error: undefined,
+      title: t('panes.document-header-title.new.text', {
+        schemaType: schemaType?.title || schemaType?.name,
+      }),
+    }
   }
 
   if (error) {
-    return {error: `Error: ${error.message}`, title: undefined}
+    return {
+      error: t('panes.document-list-pane.error.text', {error: error.message}),
+      title: undefined,
+    }
   }
 
   return {error: undefined, title: value?.title}


### PR DESCRIPTION
### Description

Before you could not edit the strings for `New {{ schemaType }} `or `Error: {{ schemaType }}` but now you can. 

### What to review

Make sure there are no other places you can think of this happening that doesn't make sense and should also be changed.

### Testing

I looked at the `Translate.test.tsx` to see if it was worth doing but it seems that the tests aren't covering specific translations but more that the core concepts of translation in the app are working. Therefore this doesn't seem needed. 

### Notes for release
 N/A
