### PR TITLE
fix(core): do not throw if schemaType is not found

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -1,4 +1,9 @@
-import {isValidationErrorMarker, type SanityDocument, type Schema} from '@sanity/types'
+import {
+  isValidationErrorMarker,
+  type PreviewValue,
+  type SanityDocument,
+  type Schema,
+} from '@sanity/types'
 import {uuid} from '@sanity/uuid'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
@@ -108,7 +113,18 @@ const getActiveReleaseDocumentsObservable = ({
         map((document) => {
           const schemaType = schema.get(document._type)
           if (!schemaType) {
-            throw new Error(`Schema type not found for document type ${document._type}`)
+            console.error(
+              `Schema type not found for document type ${document._type} (document ID: ${document._id})`,
+            )
+            return of({
+              isLoading: false,
+              values: {
+                _id: document._id,
+                title: `Document type "${document._type}" not found`,
+                _createdAt: document._createdAt,
+                _updatedAt: document._updatedAt,
+              } satisfies PreviewValue,
+            })
           }
 
           return documentPreviewStore.observeForPreview(document, schemaType).pipe(


### PR DESCRIPTION
### Description
Fixes an issue in `useBundleDocuments` when a document schema is not found.
The studio is throwing an error and not allowing users to continue working:

```
{
  "error": {
    "stack": "Error: Schema type not found for document type "<type>"
    "message": "Schema type not found for document type "<type>""
  },
  "eventId": null
}
```
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
