### PR TITLE
fix(sanity): throw a better error if onChange called during initial render 

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/utils/TestForm.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/utils/TestForm.tsx
@@ -186,7 +186,9 @@ export function TestForm(props: TestFormProps) {
   }, [setFocusPath])
 
   const patchRef = useRef<(event: PatchEvent) => void>(() => {
-    throw new Error('Nope')
+    throw new Error(
+      'Attempted to patch the Sanity document during initial render. Input components should only call `onChange()` in an effect or a callback.',
+    )
   })
 
   patchRef.current = (event: PatchEvent) => {

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/useTasksFormBuilder.ts
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/useTasksFormBuilder.ts
@@ -81,7 +81,9 @@ export function useTasksFormBuilder(options: TasksFormBuilderOptions): TasksForm
 
   const {patch} = useDocumentOperation(documentId, documentType)
   const patchRef = useRef<(event: PatchEvent) => void>(() => {
-    throw new Error('Nope')
+    throw new Error(
+      'Attempted to patch the Sanity document during initial render. Input components should only call `onChange()` in an effect or a callback.',
+    )
   })
   useEffect(() => {
     patchRef.current = (event: PatchEvent) => {

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -296,7 +296,9 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   )
 
   const patchRef = useRef<(event: PatchEvent) => void>(() => {
-    throw new Error('Nope')
+    throw new Error(
+      'Attempted to patch the Sanity document during initial render. Input components should only call `onChange()` in an effect or a callback.',
+    )
   })
   useEffect(() => {
     patchRef.current = (event: PatchEvent) => {


### PR DESCRIPTION
### Description
If an input component calls onChange() during the initial render cycle a quite unhelpful error will be thrown currently.

This PR improves the error message, providing developers with a more precise description of the issue.

### What to review

Does the wording make sense?

### Testing

n/a - no code paths are changed

### Notes for release

n/a

