### PR TITLE
fix(structure): add opt out option from releases in DocumentPaneProvider

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
@@ -1,3 +1,4 @@
+import {type ReleaseId} from '@sanity/client'
 import {
   type ObjectSchemaType,
   type Path,
@@ -84,8 +85,7 @@ export interface DocumentPaneContextValue {
   title: string | null
   validation: ValidationMarker[]
   value: SanityDocumentLike
-  selectedReleaseName?: `r${string}`
-  selectedVersionName?: string // 'published'
+  selectedReleaseId: ReleaseId | undefined
   views: View[]
   formState: DocumentFormNode | null
   permissions?: PermissionCheckResult | null

--- a/packages/sanity/src/structure/panes/document/comments/CommentsWrapper.tsx
+++ b/packages/sanity/src/structure/panes/document/comments/CommentsWrapper.tsx
@@ -38,13 +38,13 @@ function CommentsProviderWrapper(props: CommentsWrapperProps) {
   const {children, documentId, documentType} = props
 
   const {enabled} = useCommentsEnabled()
-  const {connectionState, onPathOpen, inspector, openInspector, selectedReleaseName} =
+  const {connectionState, onPathOpen, inspector, openInspector, selectedReleaseId} =
     useDocumentPane()
   const {params, setParams, createPathWithParams} = usePaneRouter()
   const {selectedPerspectiveName} = usePerspective()
   const versionOrPublishedId = useMemo(
-    () => (selectedReleaseName ? getVersionId(documentId, selectedReleaseName) : documentId),
-    [documentId, selectedReleaseName],
+    () => (selectedReleaseId ? getVersionId(documentId, selectedReleaseId) : documentId),
+    [documentId, selectedReleaseId],
   )
 
   const selectedCommentId = params?.comment

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -40,8 +40,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     editState,
     documentId,
     documentType,
-    selectedVersionName,
-    selectedReleaseName,
+    selectedReleaseId,
     fieldActions,
     onChange,
     validation,
@@ -84,7 +83,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
 
   useEffect(() => {
     const sub = documentStore.pair
-      .documentEvents(documentId, documentType, selectedReleaseName)
+      .documentEvents(documentId, documentType, selectedReleaseId)
       .pipe(
         tap((event) => {
           if (event.type === 'mutation') {
@@ -101,14 +100,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     return () => {
       sub.unsubscribe()
     }
-  }, [
-    documentId,
-    documentStore,
-    documentType,
-    patchChannel,
-    selectedReleaseName,
-    selectedVersionName,
-  ])
+  }, [documentId, documentStore, documentType, patchChannel, selectedReleaseId])
 
   const hasRev = Boolean(value?._rev)
   useEffect(() => {
@@ -223,7 +215,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
                   // but these should be compatible
                   formState.value as FormDocumentValue
                 }
-                version={selectedReleaseName}
+                version={selectedReleaseId}
               />
             </>
           )}

--- a/packages/sanity/src/structure/panes/types.ts
+++ b/packages/sanity/src/structure/panes/types.ts
@@ -8,4 +8,9 @@ export interface BaseStructureToolPaneProps<T extends PaneNode['type']> {
   isSelected?: boolean
   isActive?: boolean
   pane: Extract<PaneNode, {type: T}>
+  /**
+   * Decides if the pane should check for the global version when determining the document id.
+   * default: true
+   */
+  matchGlobalVersion?: boolean
 }


### PR DESCRIPTION
### Description

Adds an option for the `DocumentPaneProvider` to opt out from checking the global release or version when determining the document id.
This is useful in cases where plugins need to use the `DocumentPaneProvider` but not have it checking for the global version, like in the case of `sanity-assist` which has a PaneProvider inside a inspector which allows you to edit a document that will give the actions to the assist ai

Updates the return type of the `DocumentPaneValue` and verifies that the value is correctly returned by the provider with the `satisfies` validation.
 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is the new prop naming correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
