### PR TITLE
feat(core): add default markdown behaviors to PTE

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -14,6 +14,7 @@ import {
   useEditor,
   usePortableTextEditor,
 } from '@portabletext/editor'
+import {coreBehaviors, createMarkdownBehaviors} from '@portabletext/editor/behaviors'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {isKeySegment, type Path, type PortableTextBlock} from '@sanity/types'
 import {Box, Flex, Text, useToast} from '@sanity/ui'
@@ -384,6 +385,21 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
           <PortableTextMemberItemsProvider memberItems={portableTextMemberItems}>
             <EditorProvider
               initialConfig={{
+                behaviors: [
+                  ...coreBehaviors,
+                  ...createMarkdownBehaviors({
+                    defaultStyle: ({schema}) =>
+                      schema.styles.find((style) => style.value === 'normal')?.value,
+                    blockquoteStyle: ({schema}) =>
+                      schema.styles.find((style) => style.value === 'blockquote')?.value,
+                    headingStyle: ({schema, level}) =>
+                      schema.styles.find((style) => style.value === `h${level}`)?.value,
+                    orderedListStyle: ({schema}) =>
+                      schema.lists.find((list) => list.value === 'number')?.value,
+                    unorderedListStyle: ({schema}) =>
+                      schema.lists.find((list) => list.value === 'bullet')?.value,
+                  }),
+                ],
                 initialValue: value,
                 readOnly: readOnly || !ready,
                 keyGenerator,


### PR DESCRIPTION
### Description

This change extends the core behaviors of PTE with default markdown behaviors for a more pleasant writing experience. This allows you to:

1. Use `#` characters to create headings
2. Use `>` to create a blockquote
3. Use `Backspace` at the beginning of block to clear its style
4. Use `-`, `*`, `_` or `1.` to initiate a list

This is achieved by providing the `behaviors` configuration for PTE where the `coreBehaviors` are first spread into the array (to preserve core behaviors) and the additional markdown behaviors are added afterwards. The markdown behaviors require us to define what styles to use, and here we just default to the most common names for these. Later, we can figure out how to allow you to configure markdown behaviors through the Schema, but for now these sensible defaults are hard-coded.

The only downsides here is that:

1. You can't opt out of markdown behaviors if you for some reason don't like them
2. You can't change the configuration if for example your lists are named something else
3. Things could potentially get confusing if you use unconventional names for styles and lists, for example if `h1` means something completely different in your context.

These are downsides we'll have to live with for now.



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Test the new writing experience and see if you like it!

### Testing

These markdown behaviors are already used in Create and are backed by automatic tests in the PTE repo: https://github.com/portabletext/editor/blob/main/packages/editor/gherkin-spec/behavior.markdown.feature

### Notes for release

The Portable Text Editor now ships with markdown keyboard shortcuts for headings, block quotes and lists

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
