### PR TITLE
fix(structure): add support to force a version for the pane provider

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentEventsPane.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentEventsPane.tsx
@@ -1,3 +1,4 @@
+import {type ReleaseId} from '@sanity/client'
 import {useMemo} from 'react'
 import {
   EventsProvider,
@@ -24,7 +25,8 @@ export const DocumentEventsPane = (props: DocumentPaneProviderProps) => {
 
   const {selectedPerspectiveName} = usePerspective()
   const {archivedReleases} = useReleases()
-  const {rev, since, historyVersion} = params
+  const {rev, since} = params
+  const historyVersion = params.historyVersion as ReleaseId | undefined
 
   const documentId = useMemo(() => {
     if (
@@ -69,9 +71,24 @@ export const DocumentEventsPane = (props: DocumentPaneProviderProps) => {
 
   const value = useMemo(() => eventsStore, [eventsStore])
 
+  const forcedProviderVersion = useMemo(() => {
+    if (historyVersion) {
+      return {
+        selectedPerspectiveName: historyVersion,
+        selectedReleaseId: historyVersion,
+        isReleaseLocked: true,
+      }
+    }
+    return undefined
+  }, [historyVersion])
+
   return (
     <EventsProvider value={value}>
-      <DocumentPaneProvider {...props} historyStore={historyStoreProps} />
+      <DocumentPaneProvider
+        {...props}
+        historyStore={historyStoreProps}
+        forcedVersion={forcedProviderVersion}
+      />
     </EventsProvider>
   )
 }

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable camelcase */
-import {type ReleaseId} from '@sanity/client'
 import {isActionEnabled} from '@sanity/schema/_internal'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {
@@ -81,7 +80,7 @@ interface DocumentPaneProviderProps extends DocumentPaneProviderWrapperProps {
  */
 // eslint-disable-next-line complexity, max-statements
 export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
-  const {children, index, pane, paneKey, onFocusPath, matchGlobalVersion = true} = props
+  const {children, index, pane, paneKey, onFocusPath, forcedVersion} = props
   const schema = useSchema()
   const templates = useTemplates()
   const {setDocumentMeta} = useCopyPaste()
@@ -116,20 +115,8 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const perspective = usePerspective()
 
   const {isReleaseLocked, selectedReleaseId, selectedPerspectiveName} = useMemo(() => {
-    if (!matchGlobalVersion) {
-      return {
-        selectedPerspectiveName: undefined,
-        isReleaseLocked: false,
-        selectedReleaseId: undefined,
-      }
-    }
-    const historyVersion = params.historyVersion as ReleaseId | undefined
-    if (historyVersion) {
-      return {
-        selectedPerspectiveName: historyVersion,
-        selectedReleaseId: historyVersion,
-        isReleaseLocked: true,
-      }
+    if (forcedVersion) {
+      return forcedVersion
     }
     return {
       selectedPerspectiveName: perspective.selectedPerspectiveName,
@@ -139,8 +126,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
         : false,
     }
   }, [
-    matchGlobalVersion,
-    params.historyVersion,
+    forcedVersion,
     perspective.selectedPerspectiveName,
     perspective.selectedReleaseId,
     perspective.selectedPerspective,

--- a/packages/sanity/src/structure/panes/types.ts
+++ b/packages/sanity/src/structure/panes/types.ts
@@ -1,3 +1,5 @@
+import {type ReleaseId} from '@sanity/client'
+
 import {type PaneNode} from '../types'
 
 export interface BaseStructureToolPaneProps<T extends PaneNode['type']> {
@@ -9,8 +11,12 @@ export interface BaseStructureToolPaneProps<T extends PaneNode['type']> {
   isActive?: boolean
   pane: Extract<PaneNode, {type: T}>
   /**
-   * Decides if the pane should check for the global version when determining the document id.
-   * default: true
+   * Allows to override the global version with a specific version or release.
+   * @beta
    */
-  matchGlobalVersion?: boolean
+  forcedVersion?: {
+    selectedPerspectiveName: ReleaseId | 'published' | undefined
+    isReleaseLocked: boolean
+    selectedReleaseId: ReleaseId | undefined
+  }
 }


### PR DESCRIPTION
### Description

`Sanity assist ` uses a document defined as liveEdit so not using the global version is not enough, we need to force the published one.

So, this removes the `matchGlobalVersion` prop and changes it for a `forcedVersion` allowing the user to define which version to link the paneProvider to.

See the use for when we have a history item selected. 

Assist should do the folllowing:
```
  <DocumentPaneProvider
        {...props}
        forcedVersion={{
     selectedPerspectiveName:"published",
        selectedReleaseId: undefined,
        isReleaseLocked: false,
       }}
      />
```
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is there a better naming we could use for the `forcedVersion` ?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
