### PR TITLE
feat: add displayTimezone option to datetime input

### DIFF
--- a/packages/@sanity/types/src/schema/definition/type/datetime.ts
+++ b/packages/@sanity/types/src/schema/definition/type/datetime.ts
@@ -8,6 +8,7 @@ export interface DatetimeOptions extends BaseSchemaTypeOptions {
   dateFormat?: string
   timeFormat?: string
   timeStep?: number
+  displayTimezone?: string
 }
 
 /** @public */

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -125,6 +125,7 @@
     "@sanity/types": "3.68.3",
     "get-random-values-esm": "1.0.2",
     "moment": "^2.30.1",
+    "moment-timezone": "^0.5.46",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {

--- a/packages/@sanity/util/src/legacyDateFormat.ts
+++ b/packages/@sanity/util/src/legacyDateFormat.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-import moment from 'moment'
+import moment from 'moment-timezone'
 
 export const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD'
 export const DEFAULT_TIME_FORMAT = 'HH:mm'
@@ -12,16 +12,29 @@ export type ParseResult = {isValid: boolean; date?: Date; error?: string} & (
 // todo: find a way to get rid of moment there.
 // note: the format comes from peoples schema types, so we need to deprecate it for a while and
 // find a way to tell people that they need to change it
-export function format(input: Date, format: string, useUTC = false) {
+export function format(
+  input: Date,
+  format: string,
+  options: {useUTC?: boolean; timezone?: string} = {useUTC: false, timezone: 'UTC'},
+) {
+  const {useUTC, timezone} = options
   if (useUTC) return moment.utc(input).format(format)
-
-  return moment(input).format(format)
+  const m = timezone && isValidTimezoneString(timezone) ? moment(input).tz(timezone) : moment(input)
+  return m.format(format)
 }
 
-export function parse(dateString: string, format: string): ParseResult {
-  const parsed = moment(dateString, format, true)
+export function parse(dateString: string, format?: string, timezone?: string): ParseResult {
+  const parsed =
+    timezone && isValidTimezoneString(timezone)
+      ? moment(dateString, format, true).tz(timezone)
+      : moment(dateString, format, true)
+
   if (parsed.isValid()) {
     return {isValid: true, date: parsed.toDate()}
   }
   return {isValid: false, error: `Invalid date. Must be on the format "${format}"`}
+}
+
+export function isValidTimezoneString(timezone: string) {
+  return moment.tz.names().includes(timezone)
 }

--- a/packages/sanity/src/core/form/inputs/DateInputs/CommonDateTimeInput.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/CommonDateTimeInput.tsx
@@ -28,6 +28,7 @@ export interface CommonDateTimeInputProps {
   selectTime?: boolean
   serialize: (date: Date) => string
   timeStep?: number
+  timezone?: string
   value: string | undefined
   calendarLabels: CalendarLabels
 }
@@ -96,7 +97,6 @@ export const CommonDateTimeInput = forwardRef(function CommonDateTimeInput(
     forwardedRef,
     () => ref.current,
   )
-
   const parseResult = localValue ? parseInputValue(localValue) : value ? deserialize(value) : null
 
   const inputValue = localValue
@@ -122,6 +122,7 @@ export const CommonDateTimeInput = forwardRef(function CommonDateTimeInput(
       }
       ref={ref}
       value={parseResult?.date}
+      timezone={props.timezone}
       inputValue={inputValue || ''}
       readOnly={Boolean(readOnly)}
       onInputChange={handleDatePickerInputChange}

--- a/packages/sanity/src/core/form/inputs/DateInputs/__tests__/DateTimeInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/__tests__/DateTimeInput.test.tsx
@@ -69,3 +69,41 @@ test('formatting of deserialized value', async () => {
   // const {textInput} = renderInput({value: '2021-03-28T17:23:00.000Z'} as any)
   expect(input.value).toBe('2021-03-28 10:23')
 })
+
+test('time is shown in the display timezone if specified (utc+1 winter)', async () => {
+  const {result} = await renderStringInput({
+    fieldDefinition: defineField({
+      type: 'datetime',
+      name: 'test',
+      options: {displayTimezone: 'Europe/Oslo'},
+    }),
+    props: {documentValue: {test: '2021-01-15T12:00:00.000Z'}},
+    render: (inputProps) => <DateTimeInput {...inputProps} />,
+  })
+
+  const input = result.container.querySelector('input')!
+
+  userEvent.type(input, '2021-03-28 13:00')
+  expect(input.value).toBe('2021-03-28 13:00')
+  fireEvent.blur(input)
+  expect(input.value).toBe('2021-03-28 13:00')
+})
+
+test('time is shown in the display timezone if specified (utc+2 summer)', async () => {
+  const {result} = await renderStringInput({
+    fieldDefinition: defineField({
+      type: 'datetime',
+      name: 'test',
+      options: {displayTimezone: 'Europe/Oslo'},
+    }),
+    props: {documentValue: {test: '2021-06-15T12:00:00.000Z'}},
+    render: (inputProps) => <DateTimeInput {...inputProps} />,
+  })
+
+  const input = result.container.querySelector('input')!
+
+  userEvent.type(input, '2021-06-15 14:00')
+  expect(input.value).toBe('2021-06-15 14:00')
+  fireEvent.blur(input)
+  expect(input.value).toBe('2021-06-15 14:00')
+})

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -544,6 +544,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'inputs.boolean.disabled': 'Disabled',
   /** Placeholder value for datetime input */
   'inputs.datetime.placeholder': 'e.g. {{example}}',
+  /** Indicating timezone when a valid displayTimezone is set in the options of the input */
+  'inputs.datetime.timezone-information-text': 'Time is in {{timezone}} timezone',
   /** Acessibility label for button to open file options menu */
   'inputs.file.actions-menu.file-options.aria-label': 'Open file options menu',
   /** Browse */

--- a/packages/sanity/src/ui-components/inputs/DateInputs/DatePicker.tsx
+++ b/packages/sanity/src/ui-components/inputs/DateInputs/DatePicker.tsx
@@ -9,6 +9,7 @@ export const DatePicker = forwardRef(function DatePicker(
     onChange: (nextDate: Date) => void
     selectTime?: boolean
     timeStep?: number
+    timezone?: string
     calendarLabels: CalendarLabels
   },
   ref: ForwardedRef<HTMLDivElement>,
@@ -32,6 +33,7 @@ export const DatePicker = forwardRef(function DatePicker(
       selectedDate={value}
       onSelect={handleSelect}
       focusedDate={focusedDate || value}
+      timezone={props.timezone}
       onFocusedDateChange={setFocusedDay}
     />
   )

--- a/packages/sanity/src/ui-components/inputs/DateInputs/DateTimeInput.tsx
+++ b/packages/sanity/src/ui-components/inputs/DateInputs/DateTimeInput.tsx
@@ -28,6 +28,7 @@ export interface DateTimeInputProps {
   readOnly?: boolean
   selectTime?: boolean
   timeStep?: number
+  timezone?: string
   value?: Date
   calendarLabels: CalendarLabels
   constrainSize?: boolean
@@ -115,6 +116,7 @@ export const DateTimeInput = forwardRef(function DateTimeInput(
                       calendarLabels={calendarLabels}
                       selectTime={selectTime}
                       timeStep={timeStep}
+                      timezone={props.timezone}
                       onKeyUp={handleKeyUp}
                       value={value}
                       onChange={onChange}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,7 +122,7 @@ importers:
         version: 9.1.0(eslint@8.57.1)
       eslint-config-sanity:
         specifier: ^7.1.2
-        version: 7.1.3(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-plugin-import@2.31.0)(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1)
+        version: 7.1.3(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1)
       eslint-config-turbo:
         specifier: ^2.1.2
         version: 2.3.3(eslint@8.57.1)
@@ -131,7 +131,7 @@ importers:
         version: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-plugin-boundaries:
         specifier: ^4.2.2
-        version: 4.2.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+        version: 4.2.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.30.0
         version: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
@@ -176,7 +176,7 @@ importers:
         version: 4.1.0
       lerna:
         specifier: ^8.1.9
-        version: 8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.2))(@swc/core@1.10.1(@swc/helpers@0.5.15))(babel-plugin-macros@3.1.0)(encoding@0.1.13)
+        version: 8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.2))(@swc/core@1.10.1)(babel-plugin-macros@3.1.0)(encoding@0.1.13)
       lint-staged:
         specifier: ^12.1.2
         version: 12.5.0(enquirer@2.3.6)
@@ -1281,6 +1281,9 @@ importers:
       moment:
         specifier: ^2.30.1
         version: 2.30.1
+      moment-timezone:
+        specifier: ^0.5.46
+        version: 0.5.46
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -2067,7 +2070,7 @@ importers:
         version: 0.21.5
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@18.19.68)(typescript@5.7.2)
+        version: 10.9.2(@swc/core@1.10.1)(@types/node@18.19.68)(typescript@5.7.2)
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -9324,6 +9327,9 @@ packages:
   module-alias@2.2.3:
     resolution: {integrity: sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==}
 
+  moment-timezone@0.5.46:
+    resolution: {integrity: sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==}
+
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
@@ -14076,12 +14082,12 @@ snapshots:
 
   '@juggle/resize-observer@3.4.0': {}
 
-  '@lerna/create@8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.2))(@swc/core@1.10.1(@swc/helpers@0.5.15))(babel-plugin-macros@3.1.0)(encoding@0.1.13)(typescript@5.7.2)':
+  '@lerna/create@8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.2))(@swc/core@1.10.1)(babel-plugin-macros@3.1.0)(encoding@0.1.13)(typescript@5.7.2)':
     dependencies:
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.0
       '@npmcli/run-script': 8.1.0
-      '@nx/devkit': 20.2.2(nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.2))(@swc/core@1.10.1(@swc/helpers@0.5.15)))
+      '@nx/devkit': 20.2.2(nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.2))(@swc/core@1.10.1))
       '@octokit/plugin-enterprise-rest': 6.0.1
       '@octokit/rest': 19.0.11(encoding@0.1.13)
       aproba: 2.0.0
@@ -14120,7 +14126,7 @@ snapshots:
       npm-package-arg: 11.0.2
       npm-packlist: 8.0.2
       npm-registry-fetch: 17.1.0
-      nx: 20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.2))(@swc/core@1.10.1(@swc/helpers@0.5.15))
+      nx: 20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.2))(@swc/core@1.10.1)
       p-map: 4.0.0
       p-map-series: 2.1.0
       p-queue: 6.6.2
@@ -14625,13 +14631,13 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@nx/devkit@20.2.2(nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.2))(@swc/core@1.10.1(@swc/helpers@0.5.15)))':
+  '@nx/devkit@20.2.2(nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.2))(@swc/core@1.10.1))':
     dependencies:
       ejs: 3.1.10
       enquirer: 2.3.6
       ignore: 5.3.2
       minimatch: 9.0.3
-      nx: 20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.2))(@swc/core@1.10.1(@swc/helpers@0.5.15))
+      nx: 20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.2))(@swc/core@1.10.1)
       semver: 7.6.3
       tmp: 0.2.3
       tslib: 2.8.1
@@ -16715,6 +16721,14 @@ snapshots:
     optionalDependencies:
       vite: 5.4.11(@types/node@22.10.2)(terser@5.37.0)
 
+  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@18.19.68)(terser@5.37.0))':
+    dependencies:
+      '@vitest/spy': 2.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.11(@types/node@18.19.68)(terser@5.37.0)
+
   '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0))':
     dependencies:
       '@vitest/spy': 2.1.8
@@ -18591,7 +18605,7 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-config-sanity@7.1.3(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-plugin-import@2.31.0)(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-sanity@7.1.3(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-simple-import-sort: 12.1.1(eslint@8.57.1)
@@ -18631,7 +18645,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -18642,7 +18656,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -18653,12 +18667,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-boundaries@4.2.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
+  eslint-plugin-boundaries@4.2.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       chalk: 4.1.2
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       micromatch: 4.0.7
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
@@ -18682,7 +18696,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.0
       is-glob: 4.0.3
@@ -20531,13 +20545,13 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  lerna@8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.2))(@swc/core@1.10.1(@swc/helpers@0.5.15))(babel-plugin-macros@3.1.0)(encoding@0.1.13):
+  lerna@8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.2))(@swc/core@1.10.1)(babel-plugin-macros@3.1.0)(encoding@0.1.13):
     dependencies:
-      '@lerna/create': 8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.2))(@swc/core@1.10.1(@swc/helpers@0.5.15))(babel-plugin-macros@3.1.0)(encoding@0.1.13)(typescript@5.7.2)
+      '@lerna/create': 8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.2))(@swc/core@1.10.1)(babel-plugin-macros@3.1.0)(encoding@0.1.13)(typescript@5.7.2)
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.0
       '@npmcli/run-script': 8.1.0
-      '@nx/devkit': 20.2.2(nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.2))(@swc/core@1.10.1(@swc/helpers@0.5.15)))
+      '@nx/devkit': 20.2.2(nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.2))(@swc/core@1.10.1))
       '@octokit/plugin-enterprise-rest': 6.0.1
       '@octokit/rest': 19.0.11(encoding@0.1.13)
       aproba: 2.0.0
@@ -20582,7 +20596,7 @@ snapshots:
       npm-package-arg: 11.0.2
       npm-packlist: 8.0.2
       npm-registry-fetch: 17.1.0
-      nx: 20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.2))(@swc/core@1.10.1(@swc/helpers@0.5.15))
+      nx: 20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.2))(@swc/core@1.10.1)
       p-map: 4.0.0
       p-map-series: 2.1.0
       p-pipe: 3.1.0
@@ -21103,6 +21117,10 @@ snapshots:
 
   module-alias@2.2.3: {}
 
+  moment-timezone@0.5.46:
+    dependencies:
+      moment: 2.30.1
+
   moment@2.30.1: {}
 
   motion-dom@11.14.3: {}
@@ -21410,7 +21428,7 @@ snapshots:
 
   nwsapi@2.2.16: {}
 
-  nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.2))(@swc/core@1.10.1(@swc/helpers@0.5.15)):
+  nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.2))(@swc/core@1.10.1):
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
       '@yarnpkg/lockfile': 1.1.0
@@ -23817,7 +23835,7 @@ snapshots:
     dependencies:
       typescript: 5.7.2
 
-  ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@18.19.68)(typescript@5.7.2):
+  ts-node@10.9.2(@swc/core@1.10.1)(@types/node@18.19.68)(typescript@5.7.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -24328,7 +24346,7 @@ snapshots:
   vitest@2.1.8(@types/node@18.19.68)(jsdom@25.0.1)(terser@5.37.0):
     dependencies:
       '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0))
+      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@18.19.68)(terser@5.37.0))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.8
       '@vitest/snapshot': 2.1.8


### PR DESCRIPTION
### Description

Adding the ability to add a `displayTimezone` option to the `datetime` input. This allows you to specify the timezone in which the stored UTC string from content lake will be displayed.

A common use case here could be anything local that you would be working on in another timezone, for example concert times, apartment viewing times etc. etc. which are hard to work with today as the studio (just like the Date API) respects only the browsers relative display of the UTC string.

We have lots of signal on this one in [this thread](https://github.com/sanity-io/sanity/issues/1923), as well as directly from users.

### What to review

* The naming of `displayTimezone` is worth a discussion.
* The UI that I have chosen, with the text below should also be taken into consideration as to whether that is the best approach.
* I have decided to go forward with the datetime tooling within each of the relevant packages and then I have included their timezome handling counterpart (for `moment`, it is `moment-timezone` and for `date-fns`, it is `date-fns-tz`). I don't believe that this task is big enough to warrant us going down the route of removing these in favour of, for example the [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) API, but I hope that we do that before long.

### Testing

I added two tests where I thought they should go that take account for this being in place and for Winter and Summer timezones. Happy to add more should we sit fit!

### Notes for release

Might actually be worth mentioning: "The ability to specify the display timezone for your `datetime` fields".
