### PR TITLE
chore: temporarily downgrade compiler runtime

### DIFF
--- a/dev/page-building-studio/package.json
+++ b/dev/page-building-studio/package.json
@@ -15,7 +15,7 @@
     "@sanity/vision": "workspace:*",
     "babel-plugin-react-compiler": "19.0.0-beta-63e3235-20250105",
     "react": "^18.2.0",
-    "react-compiler-runtime": "19.0.0-beta-63e3235-20250105",
+    "react-compiler-runtime": "19.0.0-beta-55955c9-20241229",
     "react-dom": "^18.2.0",
     "react-icons": "^5.2.1",
     "sanity": "workspace:*",

--- a/dev/starter-studio/package.json
+++ b/dev/starter-studio/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "babel-plugin-react-compiler": "19.0.0-beta-63e3235-20250105",
     "react": "^18.3.1",
-    "react-compiler-runtime": "19.0.0-beta-63e3235-20250105",
+    "react-compiler-runtime": "19.0.0-beta-55955c9-20241229",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",
     "styled-components": "^6.1.0"

--- a/dev/studio-e2e-testing/package.json
+++ b/dev/studio-e2e-testing/package.json
@@ -22,7 +22,7 @@
     "@sanity/vision": "3.68.3",
     "babel-plugin-react-compiler": "19.0.0-beta-63e3235-20250105",
     "react": "^18.3.1",
-    "react-compiler-runtime": "19.0.0-beta-63e3235-20250105",
+    "react-compiler-runtime": "19.0.0-beta-55955c9-20241229",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",
     "sanity-plugin-markdown": "^5.0.0",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -52,7 +52,7 @@
     "lodash": "^4.17.21",
     "qs": "^6.10.2",
     "react": "^18.3.1",
-    "react-compiler-runtime": "19.0.0-beta-63e3235-20250105",
+    "react-compiler-runtime": "19.0.0-beta-55955c9-20241229",
     "react-dom": "^18.3.1",
     "react-refractor": "^2.1.6",
     "refractor": "^3.6.0",

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -70,7 +70,7 @@
     "json5": "^2.2.3",
     "lodash": "^4.17.21",
     "quick-lru": "^5.1.1",
-    "react-compiler-runtime": "19.0.0-beta-63e3235-20250105"
+    "react-compiler-runtime": "19.0.0-beta-55955c9-20241229"
   },
   "devDependencies": {
     "@repo/package.config": "workspace:*",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -237,7 +237,7 @@
     "pretty-ms": "^7.0.1",
     "quick-lru": "^5.1.1",
     "raf": "^3.4.1",
-    "react-compiler-runtime": "19.0.0-beta-63e3235-20250105",
+    "react-compiler-runtime": "19.0.0-beta-55955c9-20241229",
     "react-fast-compare": "^3.2.0",
     "react-focus-lock": "^2.13.5",
     "react-i18next": "14.0.2",

--- a/perf/efps/package.json
+++ b/perf/efps/package.json
@@ -31,7 +31,7 @@
     "ora": "^8.0.1",
     "playwright": "^1.46.1",
     "react": "^18.3.1",
-    "react-compiler-runtime": "19.0.0-beta-63e3235-20250105",
+    "react-compiler-runtime": "19.0.0-beta-55955c9-20241229",
     "react-dom": "^18.3.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "sanity": "workspace:*",

--- a/perf/studio/package.json
+++ b/perf/studio/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "babel-plugin-react-compiler": "19.0.0-beta-63e3235-20250105",
     "react": "^18.3.1",
-    "react-compiler-runtime": "19.0.0-beta-63e3235-20250105",
+    "react-compiler-runtime": "19.0.0-beta-55955c9-20241229",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",
     "styled-components": "^6.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,8 +298,8 @@ importers:
         specifier: ^18.2.0
         version: 18.3.1
       react-compiler-runtime:
-        specifier: 19.0.0-beta-63e3235-20250105
-        version: 19.0.0-beta-63e3235-20250105(react@18.3.1)
+        specifier: 19.0.0-beta-55955c9-20241229
+        version: 19.0.0-beta-55955c9-20241229(react@18.3.1)
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
@@ -340,8 +340,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
       react-compiler-runtime:
-        specifier: 19.0.0-beta-63e3235-20250105
-        version: 19.0.0-beta-63e3235-20250105(react@18.3.1)
+        specifier: 19.0.0-beta-55955c9-20241229
+        version: 19.0.0-beta-55955c9-20241229(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -391,8 +391,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
       react-compiler-runtime:
-        specifier: 19.0.0-beta-63e3235-20250105
-        version: 19.0.0-beta-63e3235-20250105(react@18.3.1)
+        specifier: 19.0.0-beta-55955c9-20241229
+        version: 19.0.0-beta-55955c9-20241229(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -577,8 +577,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
       react-compiler-runtime:
-        specifier: 19.0.0-beta-63e3235-20250105
-        version: 19.0.0-beta-63e3235-20250105(react@18.3.1)
+        specifier: 19.0.0-beta-55955c9-20241229
+        version: 19.0.0-beta-55955c9-20241229(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -1361,8 +1361,8 @@ importers:
         specifier: ^5.1.1
         version: 5.1.1
       react-compiler-runtime:
-        specifier: 19.0.0-beta-63e3235-20250105
-        version: 19.0.0-beta-63e3235-20250105(react@18.3.1)
+        specifier: 19.0.0-beta-55955c9-20241229
+        version: 19.0.0-beta-55955c9-20241229(react@18.3.1)
     devDependencies:
       '@repo/package.config':
         specifier: workspace:*
@@ -1698,8 +1698,8 @@ importers:
         specifier: ^3.4.1
         version: 3.4.1
       react-compiler-runtime:
-        specifier: 19.0.0-beta-63e3235-20250105
-        version: 19.0.0-beta-63e3235-20250105(react@18.3.1)
+        specifier: 19.0.0-beta-55955c9-20241229
+        version: 19.0.0-beta-55955c9-20241229(react@18.3.1)
       react-fast-compare:
         specifier: ^3.2.0
         version: 3.2.2
@@ -1978,8 +1978,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
       react-compiler-runtime:
-        specifier: 19.0.0-beta-63e3235-20250105
-        version: 19.0.0-beta-63e3235-20250105(react@18.3.1)
+        specifier: 19.0.0-beta-55955c9-20241229
+        version: 19.0.0-beta-55955c9-20241229(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -2011,8 +2011,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
       react-compiler-runtime:
-        specifier: 19.0.0-beta-63e3235-20250105
-        version: 19.0.0-beta-63e3235-20250105(react@18.3.1)
+        specifier: 19.0.0-beta-55955c9-20241229
+        version: 19.0.0-beta-55955c9-20241229(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -10278,11 +10278,6 @@ packages:
 
   react-compiler-runtime@19.0.0-beta-55955c9-20241229:
     resolution: {integrity: sha512-I8niUyydqnPVMjqsOEfFwiRlWbndSjgwGhbm5GZuKev3b0HAcUAqAoHNIpp0XSHInlwfn4Zvtbva5TLupEOw+Q==}
-    peerDependencies:
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental
-
-  react-compiler-runtime@19.0.0-beta-63e3235-20250105:
-    resolution: {integrity: sha512-ojqSg+8uNvomQKpZT+iPgUPWc/ZqFLt9wnoVSNiwVtX51pZgbcgRJnekSYGv0XuyCXQuy4zCz1IaEW+UXjf/ZQ==}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental
 
@@ -22182,10 +22177,6 @@ snapshots:
   react-compiler-runtime@19.0.0-beta-55955c9-20241229(react@19.0.0-rc-f994737d14-20240522):
     dependencies:
       react: 19.0.0-rc-f994737d14-20240522
-
-  react-compiler-runtime@19.0.0-beta-63e3235-20250105(react@18.3.1):
-    dependencies:
-      react: 18.3.1
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:


### PR DESCRIPTION
The latest version of `react-compiler-runtime` is ESM, which breaks some systems.
The runtime doesn't really change between versions anyway so it's fine to pin it for now.

https://github.com/facebook/react/pull/31993