### PR TITLE
feat(cli): allow credentials when adding CORS entry

### DIFF
--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -301,7 +301,7 @@ export async function setCorsOrigin(
     await apiClient({api: {projectId}}).request({
       method: 'POST',
       url: '/cors',
-      body: {origin: origin, allowCredentials: true},
+      body: {origin: origin, allowCredentials: true}, // allowCredentials is true to allow for embedded studios if needed
     })
   } catch (error) {
     // Silent fail, it most likely means that the origin is already set

--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -301,7 +301,7 @@ export async function setCorsOrigin(
     await apiClient({api: {projectId}}).request({
       method: 'POST',
       url: '/cors',
-      body: {origin: origin, allowCredentials: false},
+      body: {origin: origin, allowCredentials: true},
     })
   } catch (error) {
     // Silent fail, it most likely means that the origin is already set


### PR DESCRIPTION
### Description

Allowing credentials when adding CORS entry on remote template init. This is because some of the remote templates embeds a Studio, which requires your CORS entry to allow for credentials. 

My initial idea was to somehow dynamically figure out if you need to allow for credentials, but given that we're only dealing with localhost entries here, I think it's fine to just hardcode it. 



### Testing

Run
```shell
sanity init --template sanity-io/sanity-template-nextjs-clean
```

Your project should have a CORS entry for localhost:3000 with credentials allowed

### Notes for release

N/A