### PR TITLE
fix: unset should unset readOnly date field

### DIFF
--- a/packages/sanity/src/core/form/inputs/DateInputs/CommonDateTimeInput.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/CommonDateTimeInput.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-nested-ternary */
 
-import {TextInput} from '@sanity/ui'
 import {
   type FocusEvent,
   type ForwardedRef,
@@ -105,9 +104,7 @@ export const CommonDateTimeInput = forwardRef(function CommonDateTimeInput(
       ? formatInputValue(parseResult.date)
       : value
 
-  return readOnly ? (
-    <TextInput value={inputValue} readOnly />
-  ) : (
+  return (
     <DateTimeInput
       {...restProps}
       calendarLabels={props.calendarLabels}

--- a/packages/sanity/src/ui-components/inputs/DateInputs/DateTimeInput.tsx
+++ b/packages/sanity/src/ui-components/inputs/DateInputs/DateTimeInput.tsx
@@ -45,6 +45,7 @@ export const DateTimeInput = forwardRef(function DateTimeInput(
     selectTime,
     timeStep,
     calendarLabels,
+    readOnly,
     constrainSize = true,
     ...rest
   } = props
@@ -77,7 +78,7 @@ export const DateTimeInput = forwardRef(function DateTimeInput(
 
   const handleClick = useCallback(() => setPickerOpen(true), [])
 
-  const suffix = (
+  const suffix = readOnly ? null : (
     <Flex style={{padding: '5px'}}>
       <Button
         aria-label={calendarLabels.ariaLabel}
@@ -96,6 +97,7 @@ export const DateTimeInput = forwardRef(function DateTimeInput(
     <LazyTextInput
       ref={ref}
       {...rest}
+      disabled={readOnly}
       value={inputValue}
       onChange={onInputChange}
       suffix={


### PR DESCRIPTION
### Description

At the moment if you create a custom input component for a `datetime` field or a `date` field, and perform `unset` in the custom input component when the field is `readOnly` the value will not update on the field.

This occurs because [this](https://github.com/sanity-io/sanity/blob/next/packages/sanity/src/core/form/inputs/DateInputs/CommonDateTimeInput.tsx)
Looks like it stores a local value, and when the field is read only, the input renders a plain text field which never triggers `handleDatePickerInputChange`.

In this PR, I have removed the plain text field and used the propagated `readOnly` flag to instead achieve this in the `DateTimeInput` component

### What to review

We think this is ok? I'm not sure of the reasons for using the `Text` component instead but this feels better to allow the `DateTimeInput` to be able to be read only, for usage in other scenarios too?

### Testing

Didn't add any tests for this, let me know if I should.

### Notes for release

`unset()` inside custom `datetime` `input` components will now shown the that the value has been unset in the Studio UI.
