### PR TITLE
test(e2e): add discard action test

### DIFF
--- a/test/e2e/tests/document-actions/discard.spec.ts
+++ b/test/e2e/tests/document-actions/discard.spec.ts
@@ -1,0 +1,51 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+test(`document panel displays correct title after discarding changes`, async ({
+  page,
+  createDraftDocument,
+}) => {
+  /** ---------- START OF PUBLISH ---------- */
+
+  const title = 'Test Title'
+  const changedTitle = 'Title changed'
+
+  await createDraftDocument('/test/content/book')
+  await page.getByTestId('field-title').getByTestId('string-input').fill(title)
+
+  // Ensure the correct title is displayed before publishing.
+  await expect(page.getByTestId('document-panel-document-title')).toHaveText(title)
+
+  // Focus the publish button to trigger the tooltip showing the keyboard shortcut
+  page.getByTestId('action-publish').focus()
+
+  // There is a delay before the tooltip opens, let's explicitly wait for it
+  await page.waitForTimeout(300)
+
+  // Wait for the document to be published.
+  page.getByTestId('action-publish').click()
+  await expect(page.getByText('Published just now')).toBeVisible()
+
+  // Ensure the correct title is displayed after publishing.
+  expect(page.getByTestId('document-panel-document-title')).toHaveText(title)
+
+  /** ---------- END OF PUBLISH ---------- */
+
+  // change title
+  await page.getByTestId('field-title').getByTestId('string-input').fill(changedTitle)
+
+  // open action menu
+  page.getByTestId('action-menu-button').click()
+  await expect(page.getByTestId('action-Discardchanges')).toBeVisible()
+
+  // Discard changes
+  page.getByTestId('action-Discardchanges').click()
+
+  // confirm discard
+  page.getByTestId('confirm-dialog-confirm-button').click()
+
+  // Ensure the correct title is displayed after discarding changes.
+
+  await expect(page.getByText('Published just now')).toBeVisible()
+  expect(page.getByTestId('document-panel-document-title')).toHaveText(title)
+})


### PR DESCRIPTION
### Description

Add e2e test for the discard document action

### What to review

Does the test make sense, should we implement it in a different way?

### Notes for release

N/A, it's internal testing