### PR TITLE
fix(sanity): fix race condition introduced by #8120

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -2,7 +2,7 @@ import {type Action, type SanityClient} from '@sanity/client'
 import {type Mutation} from '@sanity/mutator'
 import {type SanityDocument} from '@sanity/types'
 import {omit} from 'lodash'
-import {EMPTY, from, merge, type Observable, Subject} from 'rxjs'
+import {EMPTY, from, merge, type Observable} from 'rxjs'
 import {filter, map, mergeMap, share, take, tap} from 'rxjs/operators'
 
 import {
@@ -65,7 +65,6 @@ export interface Pair {
   transactionsPendingEvents$: Observable<PendingMutationsEvent>
   published: DocumentVersion
   draft: DocumentVersion
-  complete: () => void
 }
 
 function setVersion<T>(version: 'draft' | 'published') {
@@ -204,10 +203,7 @@ export function checkoutPair(
 ): Pair {
   const {publishedId, draftId} = idPair
 
-  const listenerEventsConnector = new Subject<ListenerEvent>()
-  const listenerEvents$ = getPairListener(client, idPair, pairListenerOptions).pipe(
-    share({connector: () => listenerEventsConnector}),
-  )
+  const listenerEvents$ = getPairListener(client, idPair, pairListenerOptions).pipe(share())
 
   const reconnect$ = listenerEvents$.pipe(
     filter((ev) => ev.type === 'reconnect'),
@@ -255,6 +251,5 @@ export function checkoutPair(
       consistency$: published.consistency$,
       remoteSnapshot$: published.remoteSnapshot$.pipe(map(setVersion('published'))),
     },
-    complete: () => listenerEventsConnector.complete(),
   }
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
@@ -1,5 +1,5 @@
 import {type SanityClient} from '@sanity/client'
-import {merge, type Observable, of, ReplaySubject, share, timer} from 'rxjs'
+import {Observable, ReplaySubject, share, timer} from 'rxjs'
 
 import {type PairListenerOptions} from '../getPairListener'
 import {type IdPair} from '../types'
@@ -24,12 +24,12 @@ export const memoizedPair: (
     serverActionsEnabled: Observable<boolean>,
     pairListenerOptions?: PairListenerOptions,
   ): Observable<Pair> => {
-    const pair = checkoutPair(client, idPair, serverActionsEnabled, pairListenerOptions)
-    return merge(
-      of(pair),
-      // makes sure the pair listener is kept alive for as long as there are subscribers
-      pair._keepalive,
-    ).pipe(
+    return new Observable<Pair>((subscriber) => {
+      const pair = checkoutPair(client, idPair, serverActionsEnabled, pairListenerOptions)
+      subscriber.next(pair)
+
+      return pair.complete
+    }).pipe(
       share({
         connector: () => new ReplaySubject(1),
         resetOnComplete: true,


### PR DESCRIPTION
### Description

#8120 introduced a regression that would occationally cause the document to be stuck at loading. Huge thanks @pedrobonamin for catching this! I believe this issue appeared because the `_keepalive` stream would start start pulling events from the pair listener immediately, but callers of memoizedPair will typically start subscribing to the draft.events and published.events streams a little later, and when they did, they sometimes wouldn’t get the listener events, because they have already been consumed by `_keepalive`.

This fixes the issue by partially reverting the PR to the way it was before #8120. Both the issue fixed by #8120 and the initial loading issues should be fixed by this.

### What to review

- The initial loading issue should be fixed
- The issue in #8120 should still be fixed (the steps to verify that one should still hold true)

### Testing
Manual testing for now

### Notes for release
n/a – the regression in #8120 didn't get released before this was discovered.