### PR TITLE
test(e2e): add checks for properties in reference tests

### DIFF
--- a/dev/test-studio/schema/debug/simpleReferences.js
+++ b/dev/test-studio/schema/debug/simpleReferences.js
@@ -20,5 +20,13 @@ export const simpleReferences = {
       type: 'reference',
       to: [{type: 'simpleReferences'}],
     },
+    {
+      name: 'referenceFieldWeak',
+      title: 'Reference field',
+      description: 'A simple reference field where weak is set to true',
+      type: 'reference',
+      weak: true,
+      to: [{type: 'simpleReferences'}],
+    },
   ],
 }

--- a/test/e2e/tests/inputs/reference.spec.ts
+++ b/test/e2e/tests/inputs/reference.spec.ts
@@ -104,6 +104,8 @@ withDefaultClient((context) => {
     page,
     createDraftDocument,
   }) => {
+    // this is in a situation where the _strengthenOnPublish.weak is not set
+
     test.slow()
     const originalTitle = 'Initial Doc'
     const documentStatus = page.getByTestId('pane-footer-document-status')


### PR DESCRIPTION
### Description
Tests added after the latest round of Actions API feedback

- Add e2e to check that properties are being added when reference is created
- Add e2e to check that the properties are being removed when the reference and document are published
- Add e2e to check that the properties are not removed when the weak property is set in the schema


### What to review

Do the tests make sense?


### Notes for release

N/A internal test