### PR TITLE
fix(cli): explicitly exit workers when they're done

### DIFF
--- a/packages/sanity/src/_internal/cli/threads/extractManifest.ts
+++ b/packages/sanity/src/_internal/cli/threads/extractManifest.ts
@@ -9,15 +9,15 @@ export interface ExtractManifestWorkerData {
   workDir: string
 }
 
-if (isMainThread || !parentPort) {
-  throw new Error('This module must be run as a worker thread')
-}
-
-const opts = _workerData as ExtractManifestWorkerData
-
-const cleanup = mockBrowserEnvironment(opts.workDir)
-
 async function main() {
+  if (isMainThread || !parentPort) {
+    throw new Error('This module must be run as a worker thread')
+  }
+
+  const opts = _workerData as ExtractManifestWorkerData
+
+  const cleanup = mockBrowserEnvironment(opts.workDir)
+
   try {
     const workspaces = await getStudioWorkspaces({basePath: opts.workDir})
 
@@ -30,4 +30,4 @@ async function main() {
   }
 }
 
-main()
+main().then(() => process.exit())

--- a/packages/sanity/src/_internal/cli/threads/extractSchema.ts
+++ b/packages/sanity/src/_internal/cli/threads/extractSchema.ts
@@ -19,14 +19,14 @@ export interface ExtractSchemaWorkerResult {
   schema: ReturnType<typeof extractSchema>
 }
 
-if (isMainThread || !parentPort) {
-  throw new Error('This module must be run as a worker thread')
-}
-
-const opts = _workerData as ExtractSchemaWorkerData
-const cleanup = mockBrowserEnvironment(opts.workDir)
-
 async function main() {
+  if (isMainThread || !parentPort) {
+    throw new Error('This module must be run as a worker thread')
+  }
+
+  const opts = _workerData as ExtractSchemaWorkerData
+  const cleanup = mockBrowserEnvironment(opts.workDir)
+
   try {
     if (opts.format !== 'groq-type-nodes') {
       throw new Error(`Unsupported format: "${opts.format}"`)
@@ -48,7 +48,7 @@ async function main() {
   }
 }
 
-main()
+main().then(() => process.exit())
 
 function getWorkspace({
   workspaces,

--- a/packages/sanity/src/_internal/cli/threads/getGraphQLAPIs.ts
+++ b/packages/sanity/src/_internal/cli/threads/getGraphQLAPIs.ts
@@ -9,11 +9,15 @@ import {type Workspace} from 'sanity'
 import {type SchemaDefinitionish, type TypeResolvedGraphQLAPI} from '../actions/graphql/types'
 import {getStudioWorkspaces} from '../util/getStudioWorkspaces'
 
-if (isMainThread || !parentPort) {
-  throw new Error('This module must be run as a worker thread')
+async function main() {
+  if (isMainThread || !parentPort) {
+    throw new Error('This module must be run as a worker thread')
+  }
+
+  await getGraphQLAPIsForked(parentPort)
 }
 
-getGraphQLAPIsForked(parentPort)
+main().then(() => process.exit())
 
 async function getGraphQLAPIsForked(parent: MessagePort): Promise<void> {
   const {cliConfig, cliConfigPath, workDir} = workerData

--- a/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
+++ b/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
@@ -129,7 +129,7 @@ async function* readerToGenerator(reader: ReadableStreamDefaultReader<Uint8Array
   }
 }
 
-validateDocuments()
+main().then(() => process.exit())
 
 async function loadWorkspace() {
   const workspaces = await getStudioWorkspaces({basePath: workDir, configPath})
@@ -302,7 +302,7 @@ async function checkReferenceExistence({
   return {existingIds}
 }
 
-async function validateDocuments() {
+async function main() {
   // note: this is dynamically imported because this module is ESM only and this
   // file gets compiled to CJS at this time
   const {default: pMap} = await import('p-map')

--- a/packages/sanity/src/_internal/cli/threads/validateSchema.ts
+++ b/packages/sanity/src/_internal/cli/threads/validateSchema.ts
@@ -25,53 +25,57 @@ const {
   level = 'warning',
 } = _workerData as ValidateSchemaWorkerData
 
-if (isMainThread || !parentPort) {
-  throw new Error('This module must be run as a worker thread')
+async function main() {
+  if (isMainThread || !parentPort) {
+    throw new Error('This module must be run as a worker thread')
+  }
+
+  const cleanup = mockBrowserEnvironment(workDir)
+
+  try {
+    const workspaces = getStudioConfig({basePath: workDir})
+
+    if (!workspaces.length) {
+      throw new Error(`Configuration did not return any workspaces.`)
+    }
+
+    let workspace
+    if (workspaceName) {
+      workspace = workspaces.find((w) => w.name === workspaceName)
+      if (!workspace) {
+        throw new Error(`Could not find any workspaces with name \`${workspaceName}\``)
+      }
+    } else {
+      if (workspaces.length !== 1) {
+        throw new Error(
+          "Multiple workspaces found. Please specify which workspace to use with '--workspace'.",
+        )
+      }
+      workspace = workspaces[0]
+    }
+
+    const schemaTypes = resolveSchemaTypes({
+      config: workspace,
+      context: {dataset: workspace.dataset, projectId: workspace.projectId},
+    })
+
+    const validation = groupProblems(validateSchema(schemaTypes).getTypes())
+
+    const result: ValidateSchemaWorkerResult = {
+      validation: validation
+        .map((group) => ({
+          ...group,
+          problems: group.problems.filter((problem) =>
+            level === 'error' ? problem.severity === 'error' : true,
+          ),
+        }))
+        .filter((group) => group.problems.length),
+    }
+
+    parentPort?.postMessage(result)
+  } finally {
+    cleanup()
+  }
 }
 
-const cleanup = mockBrowserEnvironment(workDir)
-
-try {
-  const workspaces = getStudioConfig({basePath: workDir})
-
-  if (!workspaces.length) {
-    throw new Error(`Configuration did not return any workspaces.`)
-  }
-
-  let workspace
-  if (workspaceName) {
-    workspace = workspaces.find((w) => w.name === workspaceName)
-    if (!workspace) {
-      throw new Error(`Could not find any workspaces with name \`${workspaceName}\``)
-    }
-  } else {
-    if (workspaces.length !== 1) {
-      throw new Error(
-        "Multiple workspaces found. Please specify which workspace to use with '--workspace'.",
-      )
-    }
-    workspace = workspaces[0]
-  }
-
-  const schemaTypes = resolveSchemaTypes({
-    config: workspace,
-    context: {dataset: workspace.dataset, projectId: workspace.projectId},
-  })
-
-  const validation = groupProblems(validateSchema(schemaTypes).getTypes())
-
-  const result: ValidateSchemaWorkerResult = {
-    validation: validation
-      .map((group) => ({
-        ...group,
-        problems: group.problems.filter((problem) =>
-          level === 'error' ? problem.severity === 'error' : true,
-        ),
-      }))
-      .filter((group) => group.problems.length),
-  }
-
-  parentPort?.postMessage(result)
-} finally {
-  cleanup()
-}
+main().then(() => process.exit())


### PR DESCRIPTION


### Description

A Node script only exists once all pending handles/requests are completed. It's quite common for dependencies to open various handles and thus prevent the script for naturally exiting. This changes all the scripts which we run inside worker threads to explicitly exit when they're done.

This impacts the following commands: `schema extract`, `manifest extract`, `graphql deploy`, `documents validate`, `schema validate`.

This also now unifies the commands so that they all have a `main` function.

### What to review

`schema extract`, `manifest extract`, `graphql deploy`, `documents validate`, `schema validate`.

### Testing

I've tested `schema extract` and `manifest extract` on a custom Studio linked to this version locally. I've not tested the other ones.

### Notes for release

Fixes a case where the commands `schema extract`, `manifest extract`, `graphql deploy`, `documents validate` or `schema validate` would never complete.
