### PR TITLE
fix: ensures singleworkspace falls back to the name 'default' as expected in all contexts

### DIFF
--- a/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
@@ -39,7 +39,8 @@ describe('resolveConfig', () => {
 
     const [workspace] = await firstValueFrom(
       resolveConfig({
-        name: 'default',
+        //the default name should be 'default', in both the workspace and the unstable_sources
+        //name: 'default',
         dataset,
         projectId,
         auth: createMockAuthStore({client, currentUser: null}),

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -103,7 +103,7 @@ export function prepareConfig(
   const rootPath = getRootPath(options?.basePath)
   const workspaceOptions: WorkspaceOptions[] | [SingleWorkspace] = Array.isArray(config)
     ? config
-    : [config]
+    : [{...config, name: config.name ?? 'default'}]
 
   try {
     validateWorkspaces({workspaces: workspaceOptions})


### PR DESCRIPTION
### Description

I honestly cant tell you how this slipped through when building Start in Create, but here we go:

Turns out that if you `definedConfig({})` without providing a name, then `useWorkspace().name` will be undefined.

In other contexts, the name will be `default` (for instance when building the create manifest).

This is not a problem in multi-workspace settings, where `name` is required for each config. I suspect I've overindexed on testing multi-workspace.

In short, this ensures that resolved workspace summary and unstable_sources gets a name, by setting single workspace name to `'default'` as soon as possible, when it is missing.

The bug occurs in WorkspaceLoader, where the values in `unstable_sources` are spread over the current workspace config (the former had undefined name property, the latter the value `'default'`)

Some relevant lines:
* Spreading destroying name: https://github.com/sanity-io/sanity/blob/fb1cf5b936f4457be8dbd1cf359e673667aa121a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceLoader.tsx#L60
* 'default' is set here previously: https://github.com/sanity-io/sanity/blob/fb1cf5b936f4457be8dbd1cf359e673667aa121a/packages/sanity/src/core/config/prepareConfig.tsx#L204
* But not here, which is the value used in unstable_sources: https://github.com/sanity-io/sanity/blob/fb1cf5b936f4457be8dbd1cf359e673667aa121a/packages/sanity/src/core/config/prepareConfig.tsx#L182

### Current consequence
This bug specifically breaks "Start in Create" integration for single workspace studios without `name`.

Current workaround:  `defineConfig({name: 'default, /* everything else */})`

#### More context
After checking what I've used to test, it turns out my single workspace repos all have `name: 'default'`set in config.

So this has been a problem for templates or configurations that _have not_ set `name`. 
The config we have in the core tempaltes DO have name, but I suspect some of our next templates dont.

### What to review

Is there any problems with this approach?
For the record, the return value of useWorkspace().name is defined as required, so from a type perspective this is not a breaking change, but a bugfix.

### Testing

The changed unit test breaks if the code change is reverted. I think it covers everything.

### Notes for release

N/A
