### PR TITLE
chore(core): export EditPortal from sanity 

### DIFF
--- a/packages/sanity/src/core/form/components/EditPortal.tsx
+++ b/packages/sanity/src/core/form/components/EditPortal.tsx
@@ -8,16 +8,23 @@ import {VirtualizerScrollInstanceProvider} from '../inputs/arrays/ArrayOfObjects
 
 const PRESENCE_MARGINS: [number, number, number, number] = [0, 0, 1, 0]
 
-interface Props {
-  type: 'popover' | 'dialog'
-  width: ResponsiveWidthProps['width']
-  header: string
-  id?: string
-  onClose: () => void
+interface SharedProps {
   children?: ReactNode
+  header: string
+  width: ResponsiveWidthProps['width']
+}
+interface DialogProps extends SharedProps {
+  type: 'dialog'
+  id?: string
+  autofocus?: boolean
+  onClose?: () => void
+}
+
+interface PopoverProps extends SharedProps {
+  type: 'popover'
   // eslint-disable-next-line camelcase
   legacy_referenceElement: HTMLElement | null
-  autofocus?: boolean
+  onClose: () => void
 }
 
 function onDragEnter(event: DragEvent<HTMLDivElement>) {
@@ -28,17 +35,13 @@ function onDrop(event: DragEvent<HTMLDivElement>) {
   return event.stopPropagation()
 }
 
-export function EditPortal(props: Props): React.JSX.Element {
-  const {
-    children,
-    header,
-    id,
-    legacy_referenceElement: referenceElement,
-    onClose,
-    type,
-    width,
-    autofocus,
-  } = props
+/**
+ * @internal
+ * Creates a dialog or a popover for editing content.
+ * Handles presence and virtual scrolling.
+ */
+export function EditPortal(props: PopoverProps | DialogProps): React.JSX.Element {
+  const {children, header, onClose, type, width} = props
   const [documentScrollElement, setDocumentScrollElement] = useState<HTMLDivElement | null>(null)
   const containerElement = useRef<HTMLDivElement | null>(null)
 
@@ -55,11 +58,11 @@ export function EditPortal(props: Props): React.JSX.Element {
         containerElement={containerElement}
       >
         <Dialog
-          __unstable_autoFocus={autofocus}
+          __unstable_autoFocus={props.autofocus}
           contentRef={setDocumentScrollElement}
           data-testid="edit-portal-dialog"
           header={header}
-          id={id || ''}
+          id={props.id || ''}
           onClickOutside={onClose}
           onClose={onClose}
           onDragEnter={onDragEnter}
@@ -76,7 +79,7 @@ export function EditPortal(props: Props): React.JSX.Element {
     <PopoverDialog
       header={header}
       onClose={onClose}
-      referenceElement={referenceElement}
+      referenceElement={props.legacy_referenceElement}
       width={width}
       containerRef={setDocumentScrollElement}
     >

--- a/packages/sanity/src/core/form/components/index.ts
+++ b/packages/sanity/src/core/form/components/index.ts
@@ -1,2 +1,3 @@
+export * from './EditPortal'
 export * from './formField'
 export * from './FormInput'


### PR DESCRIPTION
### Description

Exporting `EditPortal` from `sanity` to allow users build custom Dialogs or Popover without having to care about Presence and Scroll Virtualizers.

Before this if a user needs to have a custom dialog, they need to include all of the Virtualizer Scroll element and Presence logic by themselves, for example:
```diff
+import React, {useRef, useState} from 'react'
+import {
+  ArrayOfObjectsInputProps,
+  FormInput,
+  Path,
+  PresenceOverlay,
+  VirtualizerScrollInstanceProvider,
+} from 'sanity'

+export function ScrollVirtualizerWrapper(props: {children: React.ReactNode}) {
+  const {children} = props
+  const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null)
+  const containerElement = useRef<HTMLDivElement | null>(null)
+
+  return (
+    <Box ref={setContentElement}>
+      <VirtualizerScrollInstanceProvider
+        scrollElement={contentElement}
+        containerElement={containerElement}
+      >
+        <PresenceOverlay margins={[0, 0, 1, 0]}>
+          <Box ref={containerElement}>{children}</Box>
+        </PresenceOverlay>
+      </VirtualizerScrollInstanceProvider>
+    </Box>
+  )
+}
+
 export const CustomFormDialog: React.FC<Props> = ({parentProps, paths, onClose}) => {
   return (
     <Dialog header="Edit Link" id="edit-link" animate width={600} onClose={onClose} zOffset={1000}>
+      <ScrollVirtualizerWrapper>
           ...rest
+      </ScrollVirtualizerWrapper>
     </Dialog>
```

By importing this component, they could just replace the `Dialog` for the `EditPortal` and will get all of the rest for free

```diff
+import React, {useRef, useState} from 'react'
+import { EditPortal } from 'sanity'

 export const CustomFormDialog: React.FC<Props> = ({parentProps, paths, onClose}) => {
   return (
-     <Dialog header="Edit Link" id="edit-link" animate width={600} onClose={onClose} zOffset={1000}>
+     <EditPortal header="Edit Link" id="edit-link" animate width={600} onClose={onClose} zOffset={1000}>
       ...rest
-      </Dialog>
+     </EditPortal>

```
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Exports edit portal which allow users to build custom `Dialogs` or `Popovers` with presence and scroll virtualizer included.
 
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
