### PR TITLE
feat: releases overview shows total docs in release

### DIFF
--- a/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
@@ -6,8 +6,8 @@ import {type DocumentPreviewStore} from '../../../preview'
 import {type DocumentIdSetObserverState} from '../../../preview/liveDocumentIdSet'
 import {useDocumentPreviewStore} from '../../../store'
 import {getPublishedId, type PublishedId} from '../../../util/draftUtils'
+import {activeASAPRelease, activeScheduledRelease} from '../../__fixtures__/release.fixture'
 import {type ReleaseDocument, useReleases} from '../../store'
-import {RELEASE_DOCUMENTS_PATH} from '../../store/constants'
 import {useDocumentVersions} from '../useDocumentVersions'
 
 vi.mock('../../store', () => ({
@@ -23,35 +23,6 @@ vi.mock('../../../util/draftUtils', async (importOriginal) => ({
   ...(await importOriginal()),
   getPublishedId: vi.fn(),
 }))
-
-const mockReleases = [
-  {
-    _id: `${RELEASE_DOCUMENTS_PATH}.rSpring`,
-    _type: 'system.release',
-    _updatedAt: '2024-07-12T10:39:32Z',
-    _createdAt: '2024-07-02T11:37:51Z',
-    createdBy: 'pzAhBTkNX',
-    state: 'active',
-    metadata: {
-      description: 'What a spring drop, allergies galore 🌸',
-      title: 'Spring Drop',
-      releaseType: 'asap',
-    },
-  },
-  {
-    _id: `${RELEASE_DOCUMENTS_PATH}.rWinter`,
-    _type: 'system.release',
-    _createdAt: '2024-07-02T11:37:51Z',
-    _updatedAt: '2024-07-12T10:39:32Z',
-    createdBy: 'pzAhBTkNX',
-    state: 'active',
-    metadata: {
-      description: 'What a winter drop',
-      title: 'Winter Drop',
-      releaseType: 'asap',
-    },
-  },
-] satisfies ReleaseDocument[]
 
 async function setupMocks({
   releases,
@@ -88,7 +59,7 @@ async function setupMocks({
 
 describe('useDocumentVersions', () => {
   it('should return initial state', async () => {
-    await setupMocks({releases: mockReleases, versionIds: []})
+    await setupMocks({releases: [activeASAPRelease, activeScheduledRelease], versionIds: []})
 
     const {result} = renderHook(() => useDocumentVersions({documentId: 'document-1'}))
     expect(result.current.loading).toBe(true)
@@ -97,19 +68,19 @@ describe('useDocumentVersions', () => {
   })
 
   it('should return an empty array if no versions are found', async () => {
-    await setupMocks({releases: mockReleases, versionIds: []})
+    await setupMocks({releases: [activeASAPRelease, activeScheduledRelease], versionIds: []})
     const {result} = renderHook(() => useDocumentVersions({documentId: 'document-1'}))
     expect(result.current.data).toEqual([])
   })
 
   it('should return the releases if versions are found', async () => {
     await setupMocks({
-      releases: [mockReleases[0]],
-      versionIds: ['versions.rSpring.document-1'],
+      releases: [activeASAPRelease],
+      versionIds: ['versions.rASAP.document-1'],
     })
     const {result} = renderHook(() => useDocumentVersions({documentId: 'document-1'}))
     await waitFor(() => {
-      expect(result.current.data).toEqual([mockReleases[0]])
+      expect(result.current.data).toEqual([activeASAPRelease])
     })
   })
 })

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -122,21 +122,17 @@ const releasesLocaleStrings = {
   /** Title for dialog for discarding a version of a document */
   'discard-version-dialog.title': 'Discard version',
 
-  /** Label for the count of added documents in to a release */
-  'document-count.added': '{{count}} added documents',
-  /** Label for the count of added documents in to a release when only 1 document added*/
-  'document-count.added-singular': '{{count}} added document',
-  /** Label for the count of changed documents in a release */
-  'document-count.changed': '{{count}} changed documents',
-  /** Label for the count of changed documents in a release when only 1 document changed */
-  'document-count.changed-singular': '{{count}} changed document',
+  /** Label for the count of documents in to a release when only 1 document added */
+  'document-count_one': '{{count}} document',
+  /** Label for the count of documents in to a release */
+  'document-count_other': '{{count}} documents',
 
   /** Text for when documents of a release are loading */
   'document-loading': 'Loading documents',
   /** Label for when a document in a release has multiple validation warnings */
-  'document-validation.error': '{{count}} validation errors',
+  'document-validation.error_other': '{{count}} validation errors',
   /** Label for when a document in a release has a single validation warning */
-  'document-validation.error-singular': '{{count}} validation error',
+  'document-validation.error_one': '{{count}} validation error',
 
   /** Label when a release has been deleted by a different user */
   'deleted-release': "The '<strong>{{title}}</strong>' release has been deleted",

--- a/packages/sanity/src/core/releases/store/useReleasesMetadata.ts
+++ b/packages/sanity/src/core/releases/store/useReleasesMetadata.ts
@@ -8,11 +8,6 @@ export interface ReleasesMetadata {
    */
   documentCount: number
   /**
-   * The number of subset documents with the release version as a prefix
-   * that are already published
-   */
-  existingDocumentCount: number
-  /**
    * The last time a document in the release was edited
    */
   updatedAt: string | null

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -189,8 +189,8 @@ export const getDocumentTableColumnDefs: (
                     <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
                     {t(
                       validationErrorCount === 1
-                        ? 'document-validation.error-singular'
-                        : 'document-validation.error',
+                        ? 'document-validation.error_one'
+                        : 'document-validation.error_other',
                       {count: validationErrorCount},
                     )}
                   </Flex>

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -71,7 +71,7 @@ export const releasesOverviewColumnDefs: (
           <Headers.SortHeaderButton text={t('table-header.edited')} {...props} />
         </Flex>
       ),
-      cell: ({datum: {documentsMetadata}, cellProps}) => (
+      cell: ({datum: {documentsMetadata, ...r}, cellProps}) => (
         <Flex {...cellProps} align="center" gap={2} paddingX={2} paddingY={3} sizing="border">
           <Text muted size={1}>
             {documentsMetadata?.updatedAt ? (

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -1,134 +1,15 @@
-import {LockIcon, PinFilledIcon, PinIcon} from '@sanity/icons'
-import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
-import {format} from 'date-fns'
+import {LockIcon} from '@sanity/icons'
+import {Flex, Text} from '@sanity/ui'
 import {type TFunction} from 'i18next'
-import {useCallback, useMemo} from 'react'
-import {useRouter} from 'sanity/router'
 
-import {Button, Tooltip} from '../../../../ui-components'
 import {RelativeTime} from '../../../components'
-import {Translate, useTranslation} from '../../../i18n'
-import useTimeZone, {getLocalTimeZone} from '../../../scheduledPublishing/hooks/useTimeZone'
-import {ReleaseAvatar} from '../../components/ReleaseAvatar'
-import {usePerspective} from '../../hooks/usePerspective'
-import {releasesLocaleNamespace} from '../../i18n'
-import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
-import {getReleaseTone} from '../../util/getReleaseTone'
 import {getPublishDateFromRelease, isReleaseScheduledOrScheduling} from '../../util/util'
-import {type TableRowProps} from '../components/Table/Table'
 import {Headers} from '../components/Table/TableHeader'
 import {type Column} from '../components/Table/types'
-import {ReleaseDocumentsCounter} from './ReleaseDocumentsCounter'
+import {ReleaseDocumentsCounter} from './columnCells/ReleaseDocumentsCounter'
+import {ReleaseNameCell} from './columnCells/ReleaseName'
+import {ReleaseTime} from './columnCells/ReleaseTime'
 import {type TableRelease} from './ReleasesOverview'
-
-const ReleaseTime = ({release}: {release: TableRelease}) => {
-  const {t} = useTranslation()
-  const {timeZone, utcToCurrentZoneDate} = useTimeZone()
-  const {abbreviation: localeTimeZoneAbbreviation} = getLocalTimeZone()
-
-  const {metadata} = release
-
-  const getTimezoneAbbreviation = useCallback(
-    () =>
-      timeZone.abbreviation === localeTimeZoneAbbreviation ? '' : `(${timeZone.abbreviation})`,
-    [localeTimeZoneAbbreviation, timeZone.abbreviation],
-  )
-
-  const timeString = useMemo(() => {
-    if (metadata.releaseType === 'asap') {
-      return t('release.type.asap')
-    }
-    if (metadata.releaseType === 'undecided') {
-      return t('release.type.undecided')
-    }
-
-    const publishDate = getPublishDateFromRelease(release)
-
-    return publishDate
-      ? `${format(utcToCurrentZoneDate(publishDate), 'PPpp')} ${getTimezoneAbbreviation()}`
-      : null
-  }, [metadata.releaseType, release, utcToCurrentZoneDate, getTimezoneAbbreviation, t])
-
-  return (
-    <Text muted size={1}>
-      {timeString}
-    </Text>
-  )
-}
-
-const ReleaseNameCell: Column<TableRelease>['cell'] = ({cellProps, datum: release}) => {
-  const router = useRouter()
-  const {t} = useTranslation(releasesLocaleNamespace)
-  const {t: tCore} = useTranslation()
-  const {selectedReleaseId, setPerspective} = usePerspective()
-  const {state} = release
-  const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
-  const isArchived = state === 'archived'
-  const isReleasePinned = releaseId === selectedReleaseId
-
-  const handlePinRelease = useCallback(() => {
-    if (isReleasePinned) {
-      setPerspective('drafts')
-    } else {
-      setPerspective(releaseId)
-    }
-  }, [isReleasePinned, releaseId, setPerspective])
-
-  const cardProps: TableRowProps = release.isDeleted
-    ? {tone: 'transparent'}
-    : {
-        as: 'a',
-        // navigate to release detail
-        onClick: () => router.navigate({releaseId: releaseId}),
-        tone: 'inherit',
-      }
-
-  const pinButtonIcon = isReleasePinned ? PinFilledIcon : PinIcon
-  const displayTitle = release.metadata.title || tCore('release.placeholder-untitled-release')
-
-  return (
-    <Box {...cellProps} marginLeft={3} flex={1} paddingY={1} paddingRight={2} sizing={'border'}>
-      <Tooltip
-        disabled={!release.isDeleted}
-        content={
-          <Text size={1}>
-            <Translate t={t} i18nKey="deleted-release" values={{title: displayTitle}} />
-          </Text>
-        }
-      >
-        <Flex align="center" gap={4}>
-          <Button
-            tooltipProps={{
-              disabled: isArchived || release.state === 'published',
-              content: t('dashboard.details.pin-release'),
-            }}
-            disabled={isArchived || release.state === 'published'}
-            icon={pinButtonIcon}
-            mode="bleed"
-            data-testid="pin-release-button"
-            onClick={handlePinRelease}
-            radius="full"
-            selected={isReleasePinned}
-          />
-          <Card {...cardProps} padding={2} radius={2} flex={1}>
-            <Flex align="center" gap={2}>
-              <Box flex="none">
-                <ReleaseAvatar tone={getReleaseTone(release)} />
-              </Box>
-              <Stack flex={1} space={2}>
-                <Flex align="center" gap={2}>
-                  <Text size={1} weight="medium">
-                    {displayTitle}
-                  </Text>
-                </Flex>
-              </Stack>
-            </Flex>
-          </Card>
-        </Flex>
-      </Tooltip>
-    </Box>
-  )
-}
 
 export const releasesOverviewColumnDefs: (
   t: TFunction<'releases', undefined>,
@@ -208,13 +89,19 @@ export const releasesOverviewColumnDefs: (
       width: 100,
       header: ({headerProps}) => (
         <Flex {...headerProps} paddingY={3} sizing="border">
-          <Headers.BasicHeader text={''} />
+          <Headers.BasicHeader text="" />
         </Flex>
       ),
-      cell: ({datum: {isDeleted, documentsMetadata}, cellProps}) => (
+      cell: ({datum: {isDeleted, state, finalDocumentStates, documentsMetadata}, cellProps}) => (
         <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
-          {!isDeleted && documentsMetadata && (
-            <ReleaseDocumentsCounter releaseDocumentMetadata={documentsMetadata} />
+          {!isDeleted && (
+            <ReleaseDocumentsCounter
+              documentCount={
+                state === 'archived' || state === 'published'
+                  ? finalDocumentStates?.length
+                  : documentsMetadata?.documentCount
+              }
+            />
           )}
         </Flex>
       ),

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -71,7 +71,7 @@ export const releasesOverviewColumnDefs: (
           <Headers.SortHeaderButton text={t('table-header.edited')} {...props} />
         </Flex>
       ),
-      cell: ({datum: {documentsMetadata, ...r}, cellProps}) => (
+      cell: ({datum: {documentsMetadata}, cellProps}) => (
         <Flex {...cellProps} align="center" gap={2} paddingX={2} paddingY={3} sizing="border">
           <Text muted size={1}>
             {documentsMetadata?.updatedAt ? (

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/columnCells/ReleaseDocumentsCounter.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/columnCells/ReleaseDocumentsCounter.test.tsx
@@ -1,0 +1,39 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {type ComponentProps} from 'react'
+import {describe, expect, it} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {releasesUsEnglishLocaleBundle} from '../../../../i18n'
+import {ReleaseDocumentsCounter} from '../../columnCells/ReleaseDocumentsCounter'
+
+const renderTest = async (props: ComponentProps<typeof ReleaseDocumentsCounter>) => {
+  const wrapper = await createTestProvider({
+    resources: [releasesUsEnglishLocaleBundle],
+  })
+
+  render(<ReleaseDocumentsCounter {...props} />, {wrapper})
+
+  await waitFor(() => {
+    expect(screen.queryByTestId('loading-block')).not.toBeInTheDocument()
+  })
+}
+
+describe('ReleaseDocumentsCounter', () => {
+  it('renders "-" when documentCount is undefined', async () => {
+    await renderTest({documentCount: undefined})
+
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+
+  it('renders the singular text when documentCount is 1', async () => {
+    await renderTest({documentCount: 1})
+
+    expect(screen.getByText('1 document')).toBeInTheDocument()
+  })
+
+  it('renders the plural text when documentCount is greater than 1', async () => {
+    await renderTest({documentCount: 5})
+
+    expect(screen.getByText('5 documents')).toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/columnCells/ReleaseName.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/columnCells/ReleaseName.test.tsx
@@ -1,0 +1,93 @@
+import {fireEvent, render, screen, waitFor} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {mockUseRouterReturn} from '../../../../../../../test/mocks/useRouter.mock'
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {activeASAPRelease, archivedScheduledRelease} from '../../../../__fixtures__/release.fixture'
+import {
+  mockUsePerspective,
+  usePerspectiveMockReturn,
+} from '../../../../hooks/__tests__/__mocks__/usePerspective.mock'
+import {releasesUsEnglishLocaleBundle} from '../../../../i18n'
+import {type InjectedTableProps} from '../../../components/Table/types'
+import {ReleaseNameCell} from '../../columnCells/ReleaseName'
+import {type TableRelease} from '../../ReleasesOverview'
+
+vi.mock('../../../../hooks/usePerspective', () => ({
+  usePerspective: vi.fn(() => usePerspectiveMockReturn),
+}))
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRouter: () => mockUseRouterReturn,
+}))
+
+const renderTest = async (release: TableRelease) => {
+  const wrapper = await createTestProvider({
+    resources: [releasesUsEnglishLocaleBundle],
+  })
+
+  render(<ReleaseNameCell cellProps={{} as InjectedTableProps} datum={release} sorting={false} />, {
+    wrapper,
+  })
+
+  await waitFor(() => {
+    expect(screen.queryByTestId('loading-block')).not.toBeInTheDocument()
+  })
+}
+
+describe('ReleaseNameCell', () => {
+  it('renders the release title correctly', async () => {
+    await renderTest(activeASAPRelease)
+
+    expect(screen.getByText('active asap Release')).toBeInTheDocument()
+  })
+
+  it('renders the placeholder title for an untitled release', async () => {
+    const untitledRelease = {...activeASAPRelease, metadata: {title: ''}} as TableRelease
+    await renderTest(untitledRelease)
+
+    expect(screen.getByText('Untitled release')).toBeInTheDocument()
+  })
+
+  it('disables the pin button for archived releases', async () => {
+    await renderTest(archivedScheduledRelease)
+
+    const pinButton = screen.getByTestId('pin-release-button')
+    expect(pinButton).toBeDisabled()
+  })
+
+  it('enables the pin button for draft releases', async () => {
+    await renderTest(activeASAPRelease)
+
+    const pinButton = screen.getByTestId('pin-release-button')
+    expect(pinButton).not.toBeDisabled()
+  })
+
+  it('handles pinning a release', async () => {
+    await renderTest(activeASAPRelease)
+
+    const pinButton = screen.getByTestId('pin-release-button')
+    fireEvent.click(pinButton)
+
+    expect(usePerspectiveMockReturn.setPerspective).toHaveBeenCalledWith('rASAP')
+  })
+
+  it('handles unpinning a release', async () => {
+    mockUsePerspective.mockReturnValue({...usePerspectiveMockReturn, selectedReleaseId: 'rASAP'})
+    await renderTest(activeASAPRelease)
+
+    const pinButton = screen.getByTestId('pin-release-button')
+    fireEvent.click(pinButton)
+
+    expect(usePerspectiveMockReturn.setPerspective).toHaveBeenCalledWith('drafts')
+  })
+
+  it('navigates to the release detail page on click', async () => {
+    await renderTest(activeASAPRelease)
+
+    fireEvent.click(screen.getByText('active asap Release'))
+
+    expect(mockUseRouterReturn.navigate).toHaveBeenCalledWith({releaseId: 'rASAP'})
+  })
+})

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/columnCells/ReleaseTime.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/columnCells/ReleaseTime.test.tsx
@@ -1,0 +1,66 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {format} from 'date-fns'
+import {type ComponentProps} from 'react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {useTimeZoneMockReturn} from '../../../../../scheduledPublishing/hooks/__tests__/__mocks__/useTimeZone.mock'
+import {
+  activeASAPRelease,
+  activeUndecidedRelease,
+  scheduledRelease,
+} from '../../../../__fixtures__/release.fixture'
+import {releasesUsEnglishLocaleBundle} from '../../../../i18n'
+import {ReleaseTime} from '../../columnCells/ReleaseTime'
+import {type TableRelease} from '../../ReleasesOverview'
+
+vi.mock('../../../../scheduledPublishing/hooks/useTimeZone', () => useTimeZoneMockReturn)
+
+const renderTest = async (props: ComponentProps<typeof ReleaseTime>) => {
+  const wrapper = await createTestProvider({
+    resources: [releasesUsEnglishLocaleBundle],
+  })
+
+  const rendered = render(<ReleaseTime {...props} />, {wrapper})
+
+  await waitFor(() => {
+    expect(screen.queryByTestId('loading-block')).not.toBeInTheDocument()
+  })
+
+  return rendered
+}
+
+describe('ReleaseTime', () => {
+  it('renders "ASAP" when releaseType is "asap"', async () => {
+    await renderTest({release: activeASAPRelease})
+
+    expect(screen.getByText('ASAP')).toBeInTheDocument()
+  })
+
+  it('renders "Undecided" when releaseType is "undecided"', async () => {
+    await renderTest({release: activeUndecidedRelease})
+
+    expect(screen.getByText('Undecided')).toBeInTheDocument()
+  })
+
+  it('renders the formatted date with timezone abbreviation when releaseType is scheduled', async () => {
+    await renderTest({
+      release: scheduledRelease,
+    })
+
+    expect(screen.getByText('Oct 10, 2023', {exact: false})).toBeInTheDocument()
+  })
+
+  it('renders nothing when releaseType is "scheduled" and publishDate is not available', async () => {
+    await renderTest({
+      release: {
+        ...scheduledRelease,
+        publishAt: undefined,
+        metadata: {...scheduledRelease.metadata, intendedPublishAt: undefined},
+      } as TableRelease,
+    })
+
+    const formattedDate = `${format(new Date(), 'PPpp')}`
+    expect(screen.getByText(formattedDate, {exact: false})).toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseDocumentsCounter.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseDocumentsCounter.tsx
@@ -1,12 +1,12 @@
 import {AddIcon, EditIcon} from '@sanity/icons'
 import {Badge, Box, Flex, Stack, Text} from '@sanity/ui'
 
-import {Tooltip} from '../../../../ui-components'
-import {ToneIcon} from '../../../../ui-components/toneIcon/ToneIcon'
-import {useTranslation} from '../../../i18n/hooks/useTranslation'
-import {Translate} from '../../../i18n/Translate'
-import {releasesLocaleNamespace} from '../../i18n'
-import {type ReleasesMetadata} from '../../store/useReleasesMetadata'
+import {Tooltip} from '../../../../../ui-components'
+import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
+import {useTranslation} from '../../../../i18n/hooks/useTranslation'
+import {Translate} from '../../../../i18n/Translate'
+import {releasesLocaleNamespace} from '../../../i18n'
+import {type ReleasesMetadata} from '../../../store/useReleasesMetadata'
 
 type Props = {
   releaseDocumentMetadata: ReleasesMetadata

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseDocumentsCounter.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseDocumentsCounter.tsx
@@ -14,13 +14,7 @@ export const ReleaseDocumentsCounter = ({documentCount}: Props) => {
   const count = useMemo(() => {
     if (!documentCount) return '-'
 
-    return (
-      <Translate
-        t={t}
-        i18nKey={documentCount > 1 ? `document-count_other` : `document-count_one`}
-        values={{count: documentCount}}
-      />
-    )
+    return <Translate t={t} i18nKey="document-count" values={{count: documentCount}} />
   }, [documentCount, t])
 
   return (

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseDocumentsCounter.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseDocumentsCounter.tsx
@@ -1,90 +1,31 @@
-import {AddIcon, EditIcon} from '@sanity/icons'
-import {Badge, Box, Flex, Stack, Text} from '@sanity/ui'
+import {Text} from '@sanity/ui'
+import {useMemo} from 'react'
 
-import {Tooltip} from '../../../../../ui-components'
-import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
-import {useTranslation} from '../../../../i18n/hooks/useTranslation'
-import {Translate} from '../../../../i18n/Translate'
+import {Translate, useTranslation} from '../../../../i18n'
 import {releasesLocaleNamespace} from '../../../i18n'
-import {type ReleasesMetadata} from '../../../store/useReleasesMetadata'
 
 type Props = {
-  releaseDocumentMetadata: ReleasesMetadata
+  documentCount: number | undefined
 }
 
-interface CategoryChange {
-  type: 'added' | 'changed'
-  tone: React.ComponentProps<typeof ToneIcon>['tone']
-  count: number
-}
-
-const CHANGE_ICON_MAP: Record<CategoryChange['type'], React.FC> = {
-  added: AddIcon,
-  changed: EditIcon,
-}
-
-export const ReleaseDocumentsCounter = ({releaseDocumentMetadata}: Props) => {
-  const {documentCount, existingDocumentCount: changedExistingDocumentCount} =
-    releaseDocumentMetadata
-  const newDocumentCount = documentCount - changedExistingDocumentCount
-
+export const ReleaseDocumentsCounter = ({documentCount}: Props) => {
   const {t} = useTranslation(releasesLocaleNamespace)
 
-  const documentCountGroups: CategoryChange[] = [
-    {type: 'added', tone: 'primary', count: newDocumentCount},
-    {type: 'changed', tone: 'caution', count: changedExistingDocumentCount},
-  ]
+  const count = useMemo(() => {
+    if (!documentCount) return '-'
+
+    return (
+      <Translate
+        t={t}
+        i18nKey={documentCount > 1 ? `document-count_other` : `document-count_one`}
+        values={{count: documentCount}}
+      />
+    )
+  }, [documentCount, t])
 
   return (
-    <Tooltip
-      content={
-        <Stack space={1}>
-          {documentCountGroups.map(
-            ({type, tone, count}) =>
-              count > 0 && (
-                <Flex key={type} gap={3} padding={2}>
-                  <Box flex="none">
-                    <Text size={1}>
-                      <ToneIcon icon={CHANGE_ICON_MAP[type]} tone={tone} />
-                    </Text>
-                  </Box>
-                  <Box flex={1}>
-                    <Text size={1}>
-                      <Translate
-                        t={t}
-                        i18nKey={
-                          newDocumentCount > 1
-                            ? `document-count.${type}`
-                            : `document-count.${type}-singular`
-                        }
-                        values={{count}}
-                      />
-                    </Text>
-                  </Box>
-                </Flex>
-              ),
-          )}
-        </Stack>
-      }
-      portal
-    >
-      <Flex gap={1}>
-        {documentCountGroups.map(
-          ({type, tone, count}) =>
-            count > 0 && (
-              <Badge
-                key={type}
-                tone={tone}
-                style={{
-                  minWidth: 9,
-                  textAlign: 'center',
-                }}
-              >
-                {count}
-              </Badge>
-            ),
-        )}
-      </Flex>
-    </Tooltip>
+    <Text muted size={1}>
+      {count}
+    </Text>
   )
 }

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseName.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseName.tsx
@@ -1,0 +1,91 @@
+import {PinFilledIcon, PinIcon} from '@sanity/icons'
+import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {useCallback} from 'react'
+import {useTranslation} from 'react-i18next'
+import {useRouter} from 'sanity/router'
+
+import {Button, Tooltip} from '../../../../../ui-components'
+import {Translate} from '../../../../i18n'
+import {ReleaseAvatar} from '../../../components/ReleaseAvatar'
+import {usePerspective} from '../../../hooks/usePerspective'
+import {releasesLocaleNamespace} from '../../../i18n'
+import {getReleaseIdFromReleaseDocumentId} from '../../../util/getReleaseIdFromReleaseDocumentId'
+import {getReleaseTone} from '../../../util/getReleaseTone'
+import {type TableRowProps} from '../../components/Table/Table'
+import {type Column} from '../../components/Table/types'
+import {type TableRelease} from '../ReleasesOverview'
+
+export const ReleaseNameCell: Column<TableRelease>['cell'] = ({cellProps, datum: release}) => {
+  const router = useRouter()
+  const {t} = useTranslation(releasesLocaleNamespace)
+  const {t: tCore} = useTranslation()
+  const {selectedReleaseId, setPerspective} = usePerspective()
+  const {state} = release
+  const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
+  const isArchived = state === 'archived'
+  const isReleasePinned = releaseId === selectedReleaseId
+
+  const handlePinRelease = useCallback(() => {
+    if (isReleasePinned) {
+      setPerspective('drafts')
+    } else {
+      setPerspective(releaseId)
+    }
+  }, [isReleasePinned, releaseId, setPerspective])
+
+  const cardProps: TableRowProps = release.isDeleted
+    ? {tone: 'transparent'}
+    : {
+        as: 'a',
+        // navigate to release detail
+        onClick: () => router.navigate({releaseId: releaseId}),
+        tone: 'inherit',
+      }
+
+  const pinButtonIcon = isReleasePinned ? PinFilledIcon : PinIcon
+  const displayTitle = release.metadata.title || tCore('release.placeholder-untitled-release')
+
+  return (
+    <Box {...cellProps} marginLeft={3} flex={1} paddingY={1} paddingRight={2} sizing={'border'}>
+      <Tooltip
+        disabled={!release.isDeleted}
+        content={
+          <Text size={1}>
+            <Translate t={t} i18nKey="deleted-release" values={{title: displayTitle}} />
+          </Text>
+        }
+      >
+        <Flex align="center" gap={4}>
+          <Button
+            tooltipProps={{
+              disabled: isArchived || release.state === 'published',
+              content: t('dashboard.details.pin-release'),
+            }}
+            disabled={isArchived || release.state === 'published'}
+            icon={pinButtonIcon}
+            mode="bleed"
+            data-testid="pin-release-button"
+            onClick={handlePinRelease}
+            padding={2}
+            round
+            selected={isReleasePinned}
+          />
+          <Card {...cardProps} padding={2} radius={2} flex={1}>
+            <Flex align="center" gap={2}>
+              <Box flex="none">
+                <ReleaseAvatar tone={getReleaseTone(release)} />
+              </Box>
+              <Stack flex={1} space={2}>
+                <Flex align="center" gap={2}>
+                  <Text size={1} weight="medium">
+                    {displayTitle}
+                  </Text>
+                </Flex>
+              </Stack>
+            </Flex>
+          </Card>
+        </Flex>
+      </Tooltip>
+    </Box>
+  )
+}

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseName.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseName.tsx
@@ -66,8 +66,7 @@ export const ReleaseNameCell: Column<TableRelease>['cell'] = ({cellProps, datum:
             mode="bleed"
             data-testid="pin-release-button"
             onClick={handlePinRelease}
-            padding={2}
-            round
+            radius="full"
             selected={isReleasePinned}
           />
           <Card {...cardProps} padding={2} radius={2} flex={1}>

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseTime.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseTime.tsx
@@ -1,0 +1,43 @@
+import {Text} from '@sanity/ui'
+import {format} from 'date-fns'
+import {useCallback, useMemo} from 'react'
+
+import {useTranslation} from '../../../../i18n'
+import useTimeZone, {getLocalTimeZone} from '../../../../scheduledPublishing/hooks/useTimeZone'
+import {getPublishDateFromRelease} from '../../../util/util'
+import {type TableRelease} from '../ReleasesOverview'
+
+export const ReleaseTime = ({release}: {release: TableRelease}) => {
+  const {t} = useTranslation()
+  const {timeZone, utcToCurrentZoneDate} = useTimeZone()
+  const {abbreviation: localeTimeZoneAbbreviation} = getLocalTimeZone()
+
+  const {metadata} = release
+
+  const getTimezoneAbbreviation = useCallback(
+    () =>
+      timeZone.abbreviation === localeTimeZoneAbbreviation ? '' : `(${timeZone.abbreviation})`,
+    [localeTimeZoneAbbreviation, timeZone.abbreviation],
+  )
+
+  const timeString = useMemo(() => {
+    if (metadata.releaseType === 'asap') {
+      return t('release.type.asap')
+    }
+    if (metadata.releaseType === 'undecided') {
+      return t('release.type.undecided')
+    }
+
+    const publishDate = getPublishDateFromRelease(release)
+
+    return publishDate
+      ? `${format(utcToCurrentZoneDate(publishDate), 'PPpp')} ${getTimezoneAbbreviation()}`
+      : null
+  }, [metadata.releaseType, release, utcToCurrentZoneDate, getTimezoneAbbreviation, t])
+
+  return (
+    <Text muted size={1}>
+      {timeString}
+    </Text>
+  )
+}


### PR DESCRIPTION
### Description
| Scenario | Before | After |
|--------|--------|--------|
| Active releases | <img width="1208" alt="Screenshot 2025-01-10 at 16 03 46" src="https://github.com/user-attachments/assets/76fdafd7-40ca-446d-b7fc-2694530de5a1" /> | <img width="1204" alt="Screenshot 2025-01-10 at 16 02 31" src="https://github.com/user-attachments/assets/99ad9f95-8cc6-4d75-ad60-ea33a9bcc6be" /> |
| Archived/Published releases | <img width="1206" alt="Screenshot 2025-01-10 at 16 04 20" src="https://github.com/user-attachments/assets/4145b3a0-3761-4b28-a215-54468c70be97" /> | <img width="1206" alt="Screenshot 2025-01-10 at 16 03 08" src="https://github.com/user-attachments/assets/9c89aa6e-8773-4da4-b7c3-f94257ce7b97" /> | 

* Split out the cell components for `ReleasesOverview` into separate components rather than all inside the column defs
* Added tests for these cell components
* Updated the cell component for the document count (`ReleaseDocumentsCount`), to:
  * use the `documentsMetadata` count for active releases
  * use the `finalDocumentStates` count for published or archived releases
* Removed `existingDocumentCount` from the release metadata aggregator store as it's no longer needed

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Added tests to the cell components
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
