### PR TITLE
fix(core): support serverDocumentActions flag in plugins

### DIFF
--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -106,7 +106,4 @@ export default defineConfig({
   announcements: {
     enabled: false,
   },
-  releases: {
-    enabled: false,
-  },
 })

--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -106,4 +106,7 @@ export default defineConfig({
   announcements: {
     enabled: false,
   },
+  releases: {
+    enabled: false,
+  },
 })

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -153,7 +153,7 @@ const sharedSettings = definePlugin({
   ],
 })
 
-const defaultWorkspace = {
+const defaultWorkspace = defineConfig({
   name: 'default',
   title: 'Test Studio',
   projectId: 'ppsg7ml5',
@@ -168,11 +168,6 @@ const defaultWorkspace = {
   },
   basePath: '/test',
   icon: SanityMonogram,
-  // eslint-disable-next-line camelcase
-  __internal_serverDocumentActions: {
-    // TODO: Switched off because Actions API doesn't support versions (yet).
-    enabled: false,
-  },
   scheduledPublishing: {
     enabled: true,
     inputDateTimeFormat: 'MM/dd/yy h:mm a',
@@ -180,8 +175,7 @@ const defaultWorkspace = {
   tasks: {
     enabled: true,
   },
-  beta: {eventsAPI: {enabled: true}},
-}
+})
 
 export default defineConfig([
   defaultWorkspace,
@@ -227,11 +221,6 @@ export default defineConfig([
     dataset: 'playground',
     plugins: [sharedSettings()],
     basePath: '/playground',
-    // eslint-disable-next-line camelcase
-    __internal_serverDocumentActions: {
-      // TODO: Switched off because Actions API doesn't support versions (yet).
-      enabled: false,
-    },
     beta: {eventsAPI: {enabled: true}},
   },
   {
@@ -261,11 +250,6 @@ export default defineConfig([
     plugins: [sharedSettings()],
     basePath: '/staging',
     apiHost: 'https://api.sanity.work',
-    // eslint-disable-next-line camelcase
-    __internal_serverDocumentActions: {
-      // TODO: Switched off because Actions API doesn't support versions (yet).
-      enabled: false,
-    },
     beta: {eventsAPI: {enabled: true}},
     auth: {
       loginMethod: 'token',
@@ -364,11 +348,6 @@ export default defineConfig([
     title: 'Presentation Studio',
     projectId: 'ppsg7ml5',
     dataset: 'playground',
-    // eslint-disable-next-line camelcase
-    __internal_serverDocumentActions: {
-      // TODO: Switched off because Actions API doesn't support versions (yet).
-      enabled: false,
-    },
     plugins: [
       debugSecrets(),
       presentationTool({

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -375,7 +375,30 @@ export const eventsAPIReducer = (opts: {config: PluginOptions; initialValue: boo
     if (typeof enabled === 'boolean') return enabled
 
     throw new Error(
-      `Expected \`beta.eventsAPI.enabled\` to be an object with footerAction, but received ${getPrintableType(
+      `Expected \`beta.eventsAPI.enabled\` to be a boolean, but received ${getPrintableType(
+        enabled,
+      )}`,
+    )
+  }, initialValue)
+
+  return result
+}
+
+export const serverDocumentActionsReducer = (opts: {
+  config: PluginOptions
+  initialValue: boolean | undefined
+}): boolean | undefined => {
+  const {config, initialValue} = opts
+  const flattenedConfig = flattenConfig(config, [])
+
+  const result = flattenedConfig.reduce((acc: boolean | undefined, {config: innerConfig}) => {
+    const enabled = innerConfig.__internal_serverDocumentActions?.enabled
+
+    if (typeof enabled === 'undefined') return acc
+    if (typeof enabled === 'boolean') return enabled
+
+    throw new Error(
+      `Expected \`__internal_serverDocumentActions\` to be a boolean, but received ${getPrintableType(
         enabled,
       )}`,
     )

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -40,6 +40,7 @@ import {
   resolveProductionUrlReducer,
   schemaTemplatesReducer,
   searchStrategyReducer,
+  serverDocumentActionsReducer,
   startInCreateEnabledReducer,
   toolsReducer,
 } from './configPropertyReducers'
@@ -210,8 +211,6 @@ export function prepareConfig(
       __internal: {
         sources: resolvedSources,
       },
-      // eslint-disable-next-line camelcase
-      __internal_serverDocumentActions: rawWorkspace.__internal_serverDocumentActions,
       ...defaultPluginsOptions,
     }
     preparedWorkspaces.set(rawWorkspace, workspaceSummary)
@@ -658,6 +657,10 @@ function resolveSource({
         startInCreateEnabled: startInCreateEnabledReducer({config, initialValue: true}),
         fallbackStudioOrigin: createFallbackOriginReducer(config),
       },
+    },
+    // eslint-disable-next-line camelcase
+    __internal_serverDocumentActions: {
+      enabled: serverDocumentActionsReducer({config, initialValue: undefined}),
     },
 
     announcements: {

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -407,6 +407,9 @@ export interface PluginOptions {
     enableLegacySearch?: boolean
   }
 
+  /** @internal */
+  __internal_serverDocumentActions?: WorkspaceOptions['__internal_serverDocumentActions']
+
   /** Configuration for studio beta features.
    * @internal
    */
@@ -878,7 +881,6 @@ export interface WorkspaceSummary extends DefaultPluginsWorkspaceOptions {
       source: Observable<Source>
     }>
   }
-  __internal_serverDocumentActions: WorkspaceOptions['__internal_serverDocumentActions']
 }
 
 /**

--- a/packages/sanity/src/core/releases/plugin/index.ts
+++ b/packages/sanity/src/core/releases/plugin/index.ts
@@ -57,4 +57,8 @@ export const releases = definePlugin({
   document: {
     actions: (actions, context) => resolveDocumentActions(actions, context),
   },
+  // eslint-disable-next-line camelcase
+  __internal_serverDocumentActions: {
+    enabled: false,
+  },
 })

--- a/test/e2e/tests/document-actions/fetchFeatureToggle.spec.ts
+++ b/test/e2e/tests/document-actions/fetchFeatureToggle.spec.ts
@@ -3,7 +3,9 @@ import {test} from '@sanity/test'
 
 import {mockActionsFeatureToggle} from '../../helpers/mockActionsFeatureToggle'
 
-test('Actions API should be used if the feature toggle is enabled and the Studio version satisfies the `compatibleStudioVersions` constraint', async ({
+// This test is skipped because the feature toggle is disable by the use of `releases`, see https://github.com/sanity-io/sanity/blob/corel/packages/sanity/src/core/releases/plugin/index.ts#L61-L62
+// Re enable once the feature toggle is removed and we support serverDocumentActions with releases.
+test.skip('Actions API should be used if the feature toggle is enabled and the Studio version satisfies the `compatibleStudioVersions` constraint', async ({
   page,
   createDraftDocument,
 }) => {

--- a/test/e2e/tests/inputs/text.spec.ts
+++ b/test/e2e/tests/inputs/text.spec.ts
@@ -85,21 +85,18 @@ test.describe('inputs: text', () => {
     await expect(page.getByTestId('document-panel-scroller')).toBeAttached()
 
     await titleInput.fill('Title A')
-
-    // generally waiting for timeouts is not a good idea but for this specific instance
-    // since we are using `.fill` and `.click` they can cause the draft creation and publish to happen at the same exact time.
-    // We are waiting for 1s to make sure the draft actually gets created and click action is not too eager
-    await page.waitForTimeout(1000)
+    await expect(paneFooter).toHaveText(/draft Edited just now/i)
 
     // Wait for the document to be published.
     publishButton.click()
-    expect(await paneFooter.textContent()).toMatch(/published/i)
+    await expect(paneFooter).toHaveText(/published/i)
 
     // Change the title.
     await titleInput.fill('Title B')
+    await expect(paneFooter).toHaveText(/draft Edited just now/i)
 
     // Wait for the document to be published.
     publishButton.click()
-    expect(await paneFooter.textContent()).toMatch(/published/i)
+    await expect(paneFooter).toHaveText(/published/i)
   })
 })


### PR DESCRIPTION
### Description

Server actions don't yet support version documents. 
This PR includes some changes necessary to make it possible to opt out from the server document actions through a plugin config.
It also disables that flag in the releases plugin, so users using releases will get this value and they will not use server actions.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is there any missing change?


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
