### PR TITLE
feat(sanity): include `_id` field in `groq2024` searches

### DIFF
--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
@@ -44,7 +44,7 @@ describe('createSearchQuery', () => {
       expect(query).toMatchInlineSnapshot(
         `
         "// findability-mvi:5
-        *[_type in $__types && !(_id in path("versions.**"))] | score(boost(_type in ["basic-schema-test"] && title match text::query($__query), 10), @ match text::query($__query)) | order(_score desc) [_score > 0] [0...$__limit] {_score, _type, _id}"
+        *[_type in $__types && !(_id in path("versions.**"))] | score(boost(_type in ["basic-schema-test"] && title match text::query($__query), 10), [@, _id] match text::query($__query)) | order(_score desc) [_score > 0] [0...$__limit] {_score, _type, _id}"
       `,
       )
 
@@ -145,7 +145,7 @@ describe('createSearchQuery', () => {
 
       expect(query).toMatchInlineSnapshot(`
         "// findability-mvi:5
-        *[_type in $__types && @ match text::query($__query) && !(_id in path("versions.**"))] | order(exampleField desc) [0...$__limit] {exampleField, _type, _id}"
+        *[_type in $__types && [@, _id] match text::query($__query) && !(_id in path("versions.**"))] | order(exampleField desc) [0...$__limit] {exampleField, _type, _id}"
       `)
 
       expect(query).toContain('| order(exampleField desc)')
@@ -179,7 +179,7 @@ describe('createSearchQuery', () => {
 
       expect(query).toMatchInlineSnapshot(`
         "// findability-mvi:5
-        *[_type in $__types && @ match text::query($__query) && !(_id in path("versions.**"))] | order(exampleField desc,anotherExampleField asc,lower(mapWithField) asc) [0...$__limit] {exampleField, anotherExampleField, mapWithField, _type, _id}"
+        *[_type in $__types && [@, _id] match text::query($__query) && !(_id in path("versions.**"))] | order(exampleField desc,anotherExampleField asc,lower(mapWithField) asc) [0...$__limit] {exampleField, anotherExampleField, mapWithField, _type, _id}"
       `)
 
       expect(query).toContain(
@@ -198,7 +198,7 @@ describe('createSearchQuery', () => {
 
       expect(query).toMatchInlineSnapshot(`
         "// findability-mvi:5
-        *[_type in $__types && !(_id in path("versions.**"))] | score(boost(_type in ["basic-schema-test"] && title match text::query($__query), 10), @ match text::query($__query)) | order(_score desc) [_score > 0] [0...$__limit] {_score, _type, _id}"
+        *[_type in $__types && !(_id in path("versions.**"))] | score(boost(_type in ["basic-schema-test"] && title match text::query($__query), 10), [@, _id] match text::query($__query)) | order(_score desc) [_score > 0] [0...$__limit] {_score, _type, _id}"
       `)
 
       expect(query).toContain('| order(_score desc)')
@@ -276,7 +276,7 @@ describe('createSearchQuery', () => {
 
       expect(query).toMatchInlineSnapshot(`
         "// findability-mvi:5
-        *[_type in $__types && !(_id in path("versions.**"))] | score(boost(_type in ["numbers-in-path"] && cover[].cards[].title match text::query($__query), 5), @ match text::query($__query)) | order(_score desc) [_score > 0] [0...$__limit] {_score, _type, _id}"
+        *[_type in $__types && !(_id in path("versions.**"))] | score(boost(_type in ["numbers-in-path"] && cover[].cards[].title match text::query($__query), 5), [@, _id] match text::query($__query)) | order(_score desc) [_score > 0] [0...$__limit] {_score, _type, _id}"
       `)
 
       expect(query).toContain('cover[].cards[].title match text::query($__query), 5)')

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
@@ -75,7 +75,7 @@ export function createSearchQuery(
   // Note: Computing this is unnecessary when `!isScored`.
   const groupedSpecs = groupBy(flattenedSpecs, (entry) => [entry.path, entry.weight].join(':'))
 
-  const baseMatch = '@ match text::query($__query)'
+  const baseMatch = '[@, _id] match text::query($__query)'
 
   // Note: Computing this is unnecessary when `!isScored`.
   const score = Object.entries(groupedSpecs)


### PR DESCRIPTION
### Description

In GROQ, when the `@` operator is used to match a text query, the content of the `_id` field is not included. Explicitly adding a match on `_id`  allows users to find documents by id.

### What to review

It should be possible to find a document in Test Studio (where `groq2024` search is enabled) by searching for its id.

### Testing

Updated relevant unit tests.