### PR TITLE
fix(vision): debounce type setState to fix cursor jump

### DIFF
--- a/packages/@sanity/vision/src/components/ParamsEditor.tsx
+++ b/packages/@sanity/vision/src/components/ParamsEditor.tsx
@@ -1,5 +1,5 @@
 import {debounce} from 'lodash'
-import {useCallback, useEffect, useMemo, useState} from 'react'
+import {type ClipboardEvent, useCallback, useEffect, useMemo, useState} from 'react'
 import {type TFunction, useTranslation} from 'sanity'
 
 import {VisionCodeMirror} from '../codemirror/VisionCodeMirror'
@@ -18,6 +18,7 @@ export interface ParamsEditorChangeEvent {
 export interface ParamsEditorProps {
   value: string
   onChange: (changeEvt: ParamsEditorChangeEvent) => void
+  onPasteCapture: (event: ClipboardEvent<HTMLDivElement>) => void
 }
 
 export interface ParamsEditorChange {
@@ -25,7 +26,7 @@ export interface ParamsEditorChange {
 }
 
 export function ParamsEditor(props: ParamsEditorProps) {
-  const {onChange} = props
+  const {onChange, onPasteCapture} = props
   const {t} = useTranslation(visionLocaleNamespace)
   const {raw: value, error, parsed, valid} = eventFromValue(props.value, t)
   const [isValid, setValid] = useState(valid)
@@ -49,7 +50,13 @@ export function ParamsEditor(props: ParamsEditorProps) {
   )
 
   const handleChange = useMemo(() => debounce(handleChangeRaw, 333), [handleChangeRaw])
-  return <VisionCodeMirror value={props.value || defaultValue} onChange={handleChange} />
+  return (
+    <VisionCodeMirror
+      value={props.value || defaultValue}
+      onChange={handleChange}
+      onPasteCapture={onPasteCapture}
+    />
+  )
 }
 
 function eventFromValue(


### PR DESCRIPTION
### Description

When typing in `vision` , in some cases, you could get into an scenario in which the cursor jumped to the beginning of the editor.
So user was typing:
```
a
ab
abc
``` 
and when typed `d`, the cursor jumps to the start
```
dabc
```

I identified this as an issue generated by multiple setStates called when typing, adding a debounce helps with this, so the setState will only be executed 300ms after the user finishes typing.

The onPaste handle needs to be modified, so that when the CodeMirror component captures an onPaste event this one is not propagated to the global, neither to the CodeMirror component, applying the event only once and not triggering a subsequent queryChange.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

fixes **Vision** cursor jump
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
