### PR TITLE
fix(ci): pin ubuntu version for e2e component tests to 22.04

### DIFF
--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   install:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -70,7 +70,7 @@ jobs:
   playwright-ct-test:
     timeout-minutes: 30
     needs: [install]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -162,7 +162,7 @@ jobs:
   merge-reports:
     if: always()
     needs: [playwright-ct-test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -245,7 +245,7 @@ jobs:
       actions: write # needed to delete the cache
     timeout-minutes: 30
     name: Cleanup (${{ matrix.project }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [playwright-ct-test]
 
     strategy:


### PR DESCRIPTION
### Description
Looks like latest ubuntu has issues with missing libraries required by webkit. See recent comments at
https://github.com/microsoft/playwright/issues/30368

### What to review
Component tests should pass again

### Testing
n/a

### Notes for release
n/a