### PR TITLE
fix(core): support serverDocumentActions flag in plugins

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -153,7 +153,7 @@ const sharedSettings = definePlugin({
   ],
 })
 
-const defaultWorkspace = {
+const defaultWorkspace = defineConfig({
   name: 'default',
   title: 'Test Studio',
   projectId: 'ppsg7ml5',
@@ -179,7 +179,7 @@ const defaultWorkspace = {
   tasks: {
     enabled: true,
   },
-}
+})
 
 export default defineConfig([
   defaultWorkspace,

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -364,6 +364,29 @@ export const internalTasksReducer = (opts: {
   return result
 }
 
+export const serverDocumentActionsReducer = (opts: {
+  config: PluginOptions
+  initialValue: boolean | undefined
+}): boolean | undefined => {
+  const {config, initialValue} = opts
+  const flattenedConfig = flattenConfig(config, [])
+
+  const result = flattenedConfig.reduce((acc: boolean | undefined, {config: innerConfig}) => {
+    const enabled = innerConfig.__internal_serverDocumentActions?.enabled
+
+    if (typeof enabled === 'undefined') return acc
+    if (typeof enabled === 'boolean') return enabled
+
+    throw new Error(
+      `Expected \`__internal_serverDocumentActions\` to be a boolean, but received ${getPrintableType(
+        enabled,
+      )}`,
+    )
+  }, initialValue)
+
+  return result
+}
+
 export const partialIndexingEnabledReducer = (opts: {
   config: PluginOptions
   initialValue: boolean

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -39,6 +39,7 @@ import {
   resolveProductionUrlReducer,
   schemaTemplatesReducer,
   searchStrategyReducer,
+  serverDocumentActionsReducer,
   startInCreateEnabledReducer,
   toolsReducer,
 } from './configPropertyReducers'
@@ -209,8 +210,6 @@ export function prepareConfig(
       __internal: {
         sources: resolvedSources,
       },
-      // eslint-disable-next-line camelcase
-      __internal_serverDocumentActions: rawWorkspace.__internal_serverDocumentActions,
       ...defaultPluginsOptions,
     }
     preparedWorkspaces.set(rawWorkspace, workspaceSummary)
@@ -654,6 +653,10 @@ function resolveSource({
         startInCreateEnabled: startInCreateEnabledReducer({config, initialValue: true}),
         fallbackStudioOrigin: createFallbackOriginReducer(config),
       },
+    },
+    // eslint-disable-next-line camelcase
+    __internal_serverDocumentActions: {
+      enabled: serverDocumentActionsReducer({config, initialValue: undefined}),
     },
 
     announcements: {

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -407,6 +407,9 @@ export interface PluginOptions {
     enableLegacySearch?: boolean
   }
 
+  /** @internal */
+  __internal_serverDocumentActions?: WorkspaceOptions['__internal_serverDocumentActions']
+
   /** Configuration for studio beta features.
    * @internal
    */
@@ -862,7 +865,6 @@ export interface WorkspaceSummary extends DefaultPluginsWorkspaceOptions {
       source: Observable<Source>
     }>
   }
-  __internal_serverDocumentActions: WorkspaceOptions['__internal_serverDocumentActions']
 }
 
 /**


### PR DESCRIPTION
### Description

This PR includes some changes necessary to make it possible to opt out from the server document actions through a plugin config.
This will be used to disable this when using the `releases` plugin, because server actions don't yet support version documents.

This is already merged in `corel` https://github.com/sanity-io/sanity/pull/8233  , this PR moves this changes to `next`. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
