### PR TITLE
chore(core): add `<AvatarSkeleton />` component

### DIFF
--- a/packages/sanity/src/core/components/loadingBlock/LoadingBlock.tsx
+++ b/packages/sanity/src/core/components/loadingBlock/LoadingBlock.tsx
@@ -121,7 +121,7 @@ const StyledText = styled(Text)`
  */
 export function LoadingBlock({fill, showText, title}: LoadingTestProps) {
   return (
-    <StyledCard $fill={fill} as={fill ? Layer : 'div'}>
+    <StyledCard $fill={fill} as={fill ? Layer : 'div'} data-testid="loading-block">
       <StyledSpinner $animatePosition={!!showText} muted />
       {showText && <LoadingText title={title} />}
     </StyledCard>

--- a/packages/sanity/src/core/components/userAvatar/UserAvatar.tsx
+++ b/packages/sanity/src/core/components/userAvatar/UserAvatar.tsx
@@ -5,13 +5,35 @@ import {
   type AvatarProps,
   type AvatarSize,
   type AvatarStatus,
+  Skeleton,
 } from '@sanity/ui'
+// eslint-disable-next-line camelcase
+import {getTheme_v2} from '@sanity/ui/theme'
 import {type ForwardedRef, forwardRef, useState} from 'react'
+import {css, styled} from 'styled-components'
 
 import {Tooltip} from '../../../ui-components'
 import {useUser} from '../../store'
 import {useUserColor} from '../../user-color'
 import {isRecord} from '../../util'
+
+interface AvatarSkeletonProps {
+  $size?: AvatarSize
+}
+
+/**
+ * A loading skeleton element representing a user avatar
+ * @beta
+ */
+export const AvatarSkeleton = styled(Skeleton)<AvatarSkeletonProps>((props) => {
+  const theme = getTheme_v2(props.theme)
+  const size = props.$size ?? 1
+  return css`
+    border-radius: 50%;
+    width: ${theme.avatar.sizes[size].size}px;
+    height: ${theme.avatar.sizes[size].size}px;
+  `
+})
 
 /**
  * @hidden
@@ -106,11 +128,13 @@ const StaticUserAvatar = forwardRef(function StaticUserAvatar(
 })
 
 function UserAvatarLoader({user, ...loadedProps}: Omit<UserAvatarProps, 'user'> & {user: string}) {
-  const [value] = useUser(user)
+  const [value, loading] = useUser(user)
 
+  if (loading) {
+    return <AvatarSkeleton $size={loadedProps.size} animated />
+  }
   if (!value) {
-    // @todo How do we handle this?
-    return null
+    return <AvatarSkeleton $size={loadedProps.size} animated={false} />
   }
 
   return <UserAvatar {...loadedProps} user={value} />

--- a/packages/sanity/src/core/tasks/components/TasksUserAvatar.tsx
+++ b/packages/sanity/src/core/tasks/components/TasksUserAvatar.tsx
@@ -1,12 +1,12 @@
 import {UserIcon} from '@sanity/icons'
 import {type User} from '@sanity/types'
-import {type AvatarSize, Skeleton, Text} from '@sanity/ui'
+import {type AvatarSize, Text} from '@sanity/ui'
 // eslint-disable-next-line camelcase
 import {getTheme_v2} from '@sanity/ui/theme'
 import {css, styled} from 'styled-components'
 
 import {Tooltip} from '../../../ui-components'
-import {UserAvatar} from '../../components'
+import {AvatarSkeleton, UserAvatar} from '../../components'
 import {useUser} from '../../store'
 
 const AvatarRoot = styled.div<{$size: AvatarSize; $border?: boolean; $removeBg?: boolean}>(
@@ -24,16 +24,6 @@ const AvatarRoot = styled.div<{$size: AvatarSize; $border?: boolean; $removeBg?:
     `
   },
 )
-
-const AvatarSkeleton = styled(Skeleton)<{$size: AvatarSize}>((props) => {
-  const theme = getTheme_v2(props.theme)
-
-  return css`
-    height: ${theme.avatar.sizes[props.$size]?.size}px;
-    width: ${theme.avatar.sizes[props.$size]?.size}px;
-    border-radius: 50%;
-  `
-})
 
 export function TasksUserAvatar(props: {
   user?: User


### PR DESCRIPTION
### Description

This PR adds a reusable `AvatarSkeleton` component, which is useful to display in loading states when using the `UserAvatar` component.

Usage example:

https://github.com/user-attachments/assets/0123d68c-edd7-4994-8725-b90008b40361



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

chore(core): adds reusable AvatarSkeleton component
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
