### PR TITLE
fix(block-tools): "soft" deprecate in favour of @portabletext/block-tools

### DIFF
--- a/packages/@sanity/block-tools/README.md
+++ b/packages/@sanity/block-tools/README.md
@@ -1,5 +1,9 @@
 # Sanity Block Tools
 
+> **⚠ This package is deprecated**
+>
+> Please note that this package is deprecated and has been replaced by [@portabletext/block-tools](https://www.npmjs.com/package/@portabletext/block-tools)
+
 Various tools for processing Sanity block content. Mostly used internally in the Studio code, but it got some nice functions (especially `htmlToBlocks`) which is handy when you are importing data from HTML into your dataset as block text.
 
 **NOTE:** To use `@sanity/block-tools` in a Node.js script, you will need to provide a `parseHtml` method - generally using `JSDOM`. [Read more](#jsdom-example).


### PR DESCRIPTION
### Description

`@sanity/block-tools` has been moved to the `portabletext` org and has thus
been republished as `@portabletext/block-tools`. The source code of the new
package lives in https://github.com/portabletext/editor/tree/main/packages/block-tools.

In a subsequent commit and PR, `@sanity/block-tools` will be deleted from the
`sanity` repo and the few usages will be replaced with
`@portabletext/block-tools`.

But first, we need to mark the old `@sanity/block-tools` package as deprecated
and wait until the next release of the `sanity` repo is triggered.



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Does the outlined process make sense?

### Testing

n/a

### Notes for release

n/a