### PR TITLE
feat: Updated Navbar link for Tasks tool

### DIFF
--- a/packages/sanity/src/core/config/studio/types.ts
+++ b/packages/sanity/src/core/config/studio/types.ts
@@ -18,19 +18,29 @@ export interface LogoProps {
   renderDefault: (props: LogoProps) => React.JSX.Element
 }
 
+interface NavbarActionBase {
+  icon?: React.ComponentType
+  location: 'topbar' | 'sidebar'
+  name: string
+}
+
+interface ActionWithCustomRender extends NavbarActionBase {
+  render: () => React.ReactElement
+}
+
+interface Action extends NavbarActionBase {
+  onAction: () => void
+  selected: boolean
+  title: string
+  render?: undefined
+}
+
 /**
  * @internal
  * @beta
  * An internal API for defining actions in the navbar.
  */
-export interface NavbarAction {
-  icon?: React.ComponentType
-  location: 'topbar' | 'sidebar'
-  name: string
-  onAction: () => void
-  selected: boolean
-  title: string
-}
+export type NavbarAction = Action | ActionWithCustomRender
 
 /**
  * @hidden

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -164,6 +164,10 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
     return actions
       ?.filter((v) => v.location === 'topbar')
       ?.map((action) => {
+        const {render: ActionComponent} = action
+
+        if (ActionComponent) return <ActionComponent key={action.name} />
+
         return (
           <Button
             iconRight={action?.icon}
@@ -237,46 +241,41 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
             {/** Right flex */}
             <TooltipDelayGroupProvider>
               <Flex align="center" gap={1} justify="flex-end">
-                <Flex gap={1}>
-                  {/* Search */}
-                  <LayerProvider>
-                    <SearchProvider fullscreen={shouldRender.searchFullscreen}>
-                      <BoundaryElementProvider element={document.body}>
-                        {shouldRender.searchFullscreen ? (
-                          <PortalProvider element={searchFullscreenPortalEl}>
-                            <SearchDialog
-                              onClose={handleCloseSearchFullscreen}
-                              onOpen={handleOpenSearchFullscreen}
-                              open={searchFullscreenOpen}
-                            />
-                          </PortalProvider>
-                        ) : (
-                          <SearchPopover
-                            onClose={handleCloseSearch}
-                            onOpen={handleOpenSearch}
-                            open={searchOpen}
+                {/* Search */}
+                <LayerProvider>
+                  <SearchProvider fullscreen={shouldRender.searchFullscreen}>
+                    <BoundaryElementProvider element={document.body}>
+                      {shouldRender.searchFullscreen ? (
+                        <PortalProvider element={searchFullscreenPortalEl}>
+                          <SearchDialog
+                            onClose={handleCloseSearchFullscreen}
+                            onOpen={handleOpenSearchFullscreen}
+                            open={searchFullscreenOpen}
                           />
-                        )}
-                      </BoundaryElementProvider>
-                    </SearchProvider>
-                  </LayerProvider>
+                        </PortalProvider>
+                      ) : (
+                        <SearchPopover
+                          onClose={handleCloseSearch}
+                          onOpen={handleOpenSearch}
+                          open={searchOpen}
+                        />
+                      )}
+                    </BoundaryElementProvider>
+                  </SearchProvider>
+                </LayerProvider>
 
-                  {shouldRender.tools && <FreeTrial type="topbar" />}
-                  {shouldRender.configIssues && <ConfigIssuesButton />}
-                  {shouldRender.resources && <ResourcesButton />}
+                {shouldRender.tools && <FreeTrial type="topbar" />}
+                {shouldRender.configIssues && <ConfigIssuesButton />}
+                {shouldRender.resources && <ResourcesButton />}
 
-                  <PresenceMenu />
+                <PresenceMenu />
 
-                  {/* Search button (mobile) */}
-                  {shouldRender.searchFullscreen && (
-                    <SearchButton
-                      onClick={handleOpenSearchFullscreen}
-                      ref={setSearchOpenButtonEl}
-                    />
-                  )}
+                {/* Search button (mobile) */}
+                {shouldRender.searchFullscreen && (
+                  <SearchButton onClick={handleOpenSearchFullscreen} ref={setSearchOpenButtonEl} />
+                )}
 
-                  {actionNodes}
-                </Flex>
+                {actionNodes}
 
                 {shouldRender.tools && (
                   <Box flex="none" marginLeft={1}>

--- a/packages/sanity/src/core/studio/components/navbar/navDrawer/NavDrawer.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/navDrawer/NavDrawer.tsx
@@ -111,6 +111,10 @@ export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
     return actions
       ?.filter((v) => v.location === 'sidebar')
       ?.map((action) => {
+        const {render: ActionComponent} = action
+
+        if (ActionComponent) return <ActionComponent key={action.name} />
+
         return (
           <Button
             icon={action?.icon}

--- a/packages/sanity/src/core/tasks/i18n/resources.ts
+++ b/packages/sanity/src/core/tasks/i18n/resources.ts
@@ -155,12 +155,15 @@ const tasksLocaleStrings = defineLocalesResources('tasks', {
   'panel.navigation.tooltip': 'Open tasks',
   /** Title of the Tasks panel   */
   'panel.title': 'Tasks',
+
   /** Label for the Assigned Tab */
   'tab.assigned.label': 'Assigned',
   /** Label for the Active Document Tab */
   'tab.document.label': 'Active Document',
   /** Label for the Subscribed Tab */
   'tab.subscribed.label': 'Subscribed',
+  /** Tooltip for the tasks navbar icon */
+  'toolbar.tooltip': 'Tasks',
 })
 
 /**

--- a/packages/sanity/src/core/tasks/plugin/TasksStudioNavbar.tsx
+++ b/packages/sanity/src/core/tasks/plugin/TasksStudioNavbar.tsx
@@ -1,12 +1,29 @@
-import {PanelRightIcon, TaskIcon} from '@sanity/icons'
+import {CheckmarkCircleIcon} from '@sanity/icons'
 import {useCallback, useMemo} from 'react'
 
+import {Button} from '../../../ui-components'
 import {type NavbarProps} from '../../config'
 import {useTranslation} from '../../i18n'
 import {useTasksEnabled, useTasksNavigation} from '../context'
 import {tasksLocaleNamespace} from '../i18n'
 
 const EMPTY_ARRAY: [] = []
+
+const TasksToolbar = ({onClick, isOpen}: {onClick: () => void; isOpen: boolean}) => {
+  const {t} = useTranslation(tasksLocaleNamespace)
+
+  return (
+    <Button
+      tooltipProps={{
+        content: t('toolbar.tooltip'),
+      }}
+      icon={CheckmarkCircleIcon}
+      mode="bleed"
+      onClick={onClick}
+      selected={isOpen}
+    />
+  )
+}
 
 function TasksStudioNavbarInner(props: NavbarProps) {
   const {
@@ -25,19 +42,21 @@ function TasksStudioNavbarInner(props: NavbarProps) {
     }
   }, [isOpen, handleOpenTasks, handleCloseTasks])
 
+  const renderTasksNav = useCallback(
+    () => <TasksToolbar onClick={handleClick} isOpen={isOpen} />,
+    [handleClick, isOpen],
+  )
+
   const actions = useMemo((): NavbarProps['__internal_actions'] => {
     return [
       ...(props?.__internal_actions || EMPTY_ARRAY),
       {
-        icon: PanelRightIcon,
         location: 'topbar',
         name: 'tasks-topbar',
-        onAction: handleClick,
-        selected: isOpen,
-        title: t('actions.open.text'),
+        render: renderTasksNav,
       },
       {
-        icon: TaskIcon,
+        icon: CheckmarkCircleIcon,
         location: 'sidebar',
         name: 'tasks-sidebar',
         onAction: handleClick,
@@ -45,7 +64,7 @@ function TasksStudioNavbarInner(props: NavbarProps) {
         title: t('actions.open.text'),
       },
     ]
-  }, [handleClick, isOpen, props?.__internal_actions, t])
+  }, [handleClick, isOpen, props?.__internal_actions, renderTasksNav, t])
 
   return props.renderDefault({
     ...props,


### PR DESCRIPTION
### Description
| Scenario | Before | After |
|--------|--------|--------|
| Desktop navbar | <img width="240" alt="Screenshot 2025-01-14 at 10 03 04" src="https://github.com/user-attachments/assets/19b57da9-f7be-49f9-8f53-228a04883da7" /> | <img width="152" alt="Screenshot 2025-01-14 at 10 02 31" src="https://github.com/user-attachments/assets/4c8c4fc0-1f57-4718-a598-61bd7ce2d130" /> |
| Mobile tray | <img width="329" alt="Screenshot 2025-01-14 at 10 03 14" src="https://github.com/user-attachments/assets/ad4045f6-3519-4e85-a242-c32d6b79e1e7" /> | <img width="327" alt="Screenshot 2025-01-14 at 10 02 47" src="https://github.com/user-attachments/assets/521cdd99-32be-4dd5-b777-6ed1a9596e87" /> | 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* There is now support for a custom rendered for plugin navbar links, in addition to just defining a string and icon. This is used by the new tasks navbar link
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
No new tests needed, same functionality as before
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Studio plugins may now define a custom render method for navbar icons and actions
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
