### PR TITLE
chore: playwright test wrapper creates router context

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/utils/TestWrapper.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/utils/TestWrapper.tsx
@@ -1,6 +1,7 @@
 import {type SanityClient} from '@sanity/client'
 import {Card, LayerProvider, ThemeProvider, ToastProvider} from '@sanity/ui'
 import {buildTheme, type RootTheme} from '@sanity/ui/theme'
+import {noop} from 'lodash'
 import {type ReactNode, Suspense, useEffect, useState} from 'react'
 import {
   ChangeConnectorRoot,
@@ -18,6 +19,8 @@ import {
 import {Pane, PaneContent, PaneLayout} from 'sanity/structure'
 import {styled} from 'styled-components'
 
+import {route} from '../../../../src/router'
+import {RouterProvider} from '../../../../src/router/RouterProvider'
 import {createMockSanityClient} from '../../../../test/mocks/mockSanityClient'
 import {getMockWorkspace} from '../../../../test/testUtils/getMockWorkspaceFromConfig'
 
@@ -35,6 +38,8 @@ const StyledChangeConnectorRoot = styled(ChangeConnectorRoot)`
   min-height: 0;
   min-width: 0;
 `
+
+const router = route.create('/')
 
 /**
  * @description This component is used to wrap all tests in the providers it needs to be able to run successfully.
@@ -72,37 +77,39 @@ export const TestWrapper = (props: TestWrapperProps): React.JSX.Element | null =
 
   return (
     <Suspense fallback={null}>
-      <ThemeProvider theme={studioThemeConfig}>
-        <ToastProvider>
-          <LayerProvider>
-            <WorkspaceProvider workspace={mockWorkspace}>
-              <ResourceCacheProvider>
-                <SourceProvider source={mockWorkspace.unstable_sources[0]}>
-                  <CopyPasteProvider>
-                    <ColorSchemeProvider>
-                      <UserColorManagerProvider>
-                        <StyledChangeConnectorRoot
-                          isReviewChangesOpen={false}
-                          onOpenReviewChanges={() => {}}
-                          onSetFocus={() => {}}
-                        >
-                          <PaneLayout height="fill">
-                            <Pane id="test-pane">
-                              <PaneContent>
-                                <Card padding={3}>{children}</Card>
-                              </PaneContent>
-                            </Pane>
-                          </PaneLayout>
-                        </StyledChangeConnectorRoot>
-                      </UserColorManagerProvider>
-                    </ColorSchemeProvider>
-                  </CopyPasteProvider>
-                </SourceProvider>
-              </ResourceCacheProvider>
-            </WorkspaceProvider>
-          </LayerProvider>
-        </ToastProvider>
-      </ThemeProvider>
+      <RouterProvider router={router} state={{}} onNavigate={noop}>
+        <ThemeProvider theme={studioThemeConfig}>
+          <ToastProvider>
+            <LayerProvider>
+              <WorkspaceProvider workspace={mockWorkspace}>
+                <ResourceCacheProvider>
+                  <SourceProvider source={mockWorkspace.unstable_sources[0]}>
+                    <CopyPasteProvider>
+                      <ColorSchemeProvider>
+                        <UserColorManagerProvider>
+                          <StyledChangeConnectorRoot
+                            isReviewChangesOpen={false}
+                            onOpenReviewChanges={() => {}}
+                            onSetFocus={() => {}}
+                          >
+                            <PaneLayout height="fill">
+                              <Pane id="test-pane">
+                                <PaneContent>
+                                  <Card padding={3}>{children}</Card>
+                                </PaneContent>
+                              </Pane>
+                            </PaneLayout>
+                          </StyledChangeConnectorRoot>
+                        </UserColorManagerProvider>
+                      </ColorSchemeProvider>
+                    </CopyPasteProvider>
+                  </SourceProvider>
+                </ResourceCacheProvider>
+              </WorkspaceProvider>
+            </LayerProvider>
+          </ToastProvider>
+        </ThemeProvider>
+      </RouterProvider>
     </Suspense>
   )
 }


### PR DESCRIPTION
### Description
Adds the router context to the test wrapper used in the e2e playwright tests
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Does it make sense for us to also default to having our e2e test wrapper create a router state
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
