### PR TITLE
chore(core): add `getTransactionLogs` helper

### DIFF
--- a/packages/sanity/src/core/store/translog/getTransactionsLogs.test.ts
+++ b/packages/sanity/src/core/store/translog/getTransactionsLogs.test.ts
@@ -1,0 +1,118 @@
+import {type SanityClient} from '@sanity/client'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+
+import {getJsonStream} from '../_legacy/history/history/getJsonStream'
+import {getTransactionsLogs} from './getTransactionsLogs'
+
+vi.mock('../_legacy/history/history/getJsonStream', () => ({
+  getJsonStream: vi.fn(),
+}))
+
+const getJsonStreamMock = getJsonStream as Mock
+
+describe('getTransactionsLogs', () => {
+  const mockClient = {
+    config: vi.fn(() => ({
+      dataset: 'mockDataset',
+      token: 'mockToken',
+    })),
+    getUrl: vi.fn((path) => `https://mock.sanity.api${path}`),
+  } as unknown as SanityClient
+
+  const mockStream = {
+    getReader: vi.fn(() => ({
+      async read() {
+        return {done: true}
+      },
+    })),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should fetch transaction logs with default parameters', async () => {
+    getJsonStreamMock.mockResolvedValueOnce(mockStream)
+
+    const documentId = 'doc1'
+    const result = await getTransactionsLogs(mockClient, documentId, {})
+
+    expect(mockClient.getUrl).toHaveBeenCalledWith(
+      '/data/history/mockDataset/transactions/doc1?tag=sanity.studio.transactions-log&excludeContent=true&limit=50&includeIdentifiedDocumentsOnly=true',
+    )
+    expect(getJsonStream).toHaveBeenCalledWith(
+      'https://mock.sanity.api/data/history/mockDataset/transactions/doc1?tag=sanity.studio.transactions-log&excludeContent=true&limit=50&includeIdentifiedDocumentsOnly=true',
+      'mockToken',
+    )
+    expect(result).toEqual([])
+  })
+
+  it('should handle multiple document IDs', async () => {
+    getJsonStreamMock.mockResolvedValueOnce(mockStream)
+
+    const documentIds = ['doc1', 'doc2']
+    await getTransactionsLogs(mockClient, documentIds, {})
+
+    expect(mockClient.getUrl).toHaveBeenCalledWith(
+      '/data/history/mockDataset/transactions/doc1,doc2?tag=sanity.studio.transactions-log&excludeContent=true&limit=50&includeIdentifiedDocumentsOnly=true',
+    )
+    expect(getJsonStream).toHaveBeenCalledWith(
+      'https://mock.sanity.api/data/history/mockDataset/transactions/doc1,doc2?tag=sanity.studio.transactions-log&excludeContent=true&limit=50&includeIdentifiedDocumentsOnly=true',
+      'mockToken',
+    )
+  })
+
+  it('should override default parameters with user-provided params', async () => {
+    getJsonStreamMock.mockResolvedValueOnce(mockStream)
+
+    const documentId = 'doc1'
+    await getTransactionsLogs(mockClient, documentId, {
+      tag: 'sanity.studio.custom-tag',
+      limit: 100,
+      fromTransaction: 'tx1',
+      toTransaction: 'tx3',
+    })
+
+    expect(mockClient.getUrl).toHaveBeenCalledWith(
+      '/data/history/mockDataset/transactions/doc1?tag=sanity.studio.custom-tag&excludeContent=true&limit=100&includeIdentifiedDocumentsOnly=true&fromTransaction=tx1&toTransaction=tx3',
+    )
+  })
+
+  it('should throw an error if the stream contains an error', async () => {
+    const mockErrorStream = {
+      getReader: vi.fn(() => ({
+        async read() {
+          return {done: false, value: {error: {description: 'Error occurred'}}}
+        },
+      })),
+    }
+    getJsonStreamMock.mockResolvedValueOnce(mockErrorStream)
+
+    const documentId = 'doc1'
+
+    await expect(getTransactionsLogs(mockClient, documentId, {})).rejects.toThrow('Error occurred')
+  })
+
+  it('should collect transactions from the stream', async () => {
+    const mockDataStream = {
+      getReader: vi.fn(() => {
+        let callCount = 0
+        return {
+          async read() {
+            if (callCount < 3) {
+              callCount++
+              return {done: false, value: {id: `txn${callCount}`}}
+            }
+            return {done: true}
+          },
+        }
+      }),
+    }
+    getJsonStreamMock.mockResolvedValueOnce(mockDataStream)
+
+    const documentId = 'doc1'
+    const result = await getTransactionsLogs(mockClient as any, documentId, {})
+
+    expect(result).toEqual([{id: 'txn1'}, {id: 'txn2'}, {id: 'txn3'}])
+  })
+})

--- a/packages/sanity/src/core/store/translog/getTransactionsLogs.ts
+++ b/packages/sanity/src/core/store/translog/getTransactionsLogs.ts
@@ -1,0 +1,108 @@
+import {type SanityClient} from '@sanity/client'
+import {type TransactionLogEventWithEffects} from '@sanity/types'
+
+import {getJsonStream} from '../_legacy/history/history/getJsonStream'
+
+/**
+ * Fetches transaction logs for the specified document IDs from the translog
+ * It adds the default query parameters to the request and also reads the stream of transactions.
+ * @internal
+ */
+export async function getTransactionsLogs(
+  client: SanityClient,
+  /**
+   * 1 or more document IDs to fetch transaction logs   */
+  documentIds: string | string[],
+  /**
+   * {@link https://www.sanity.io/docs/history-api#45ac5eece4ca}
+   */
+  params: {
+    /**
+     * The tag that will be use when fetching the transactions.
+     * (Default: sanity.studio.transactions-log)
+     */
+    tag?: `sanity.studio.${string}`
+    /**
+     * Exclude the document contents from the responses. (You are required to set excludeContent as true for now.)
+     * (Default: true)
+     */
+    excludeContent?: true
+    /**
+     * Limit the number of returned transactions. (Default: 50)
+     */
+    limit?: number
+
+    /**
+     * Only include the documents that are part of the document ids list
+     * (Default: true)
+     */
+    includeIdentifiedDocumentsOnly?: boolean
+
+    /**
+     * How the effects are formatted in the response.
+     * "mendoza": Super efficient format for expressing differences between JSON documents. {@link https://www.sanity.io/blog/mendoza}
+     */
+    effectFormat?: 'mendoza' | undefined
+    /**
+     * Return transactions in reverse order.
+     */
+    reverse?: boolean
+    /**
+     * Time from which the transactions are fetched.
+     */
+    fromTime?: string
+    /**
+     * Time until the transactions are fetched.
+     */
+    toTime?: string
+    /**
+     * Transaction ID (Or, Revision ID) from which the transactions are fetched.
+     */
+    fromTransaction?: string
+    /**
+     * Transaction ID (Or, Revision ID) until the transactions are fetched.
+     */
+    toTransaction?: string
+    /**
+     * Comma separated list of authors to filter the transactions by.
+     */
+    authors?: string
+  },
+): Promise<TransactionLogEventWithEffects[]> {
+  const clientConfig = client.config()
+  const dataset = clientConfig.dataset
+  const queryParams = new URLSearchParams({
+    // Default values
+    tag: 'sanity.studio.transactions-log',
+    excludeContent: 'true',
+    limit: '50',
+    includeIdentifiedDocumentsOnly: 'true',
+  })
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined) {
+      queryParams.set(key, value.toString())
+    }
+  })
+
+  const transactionsUrl = client.getUrl(
+    `/data/history/${dataset}/transactions/${
+      Array.isArray(documentIds) ? documentIds.join(',') : documentIds
+    }?${queryParams.toString()}`,
+  )
+
+  const stream = await getJsonStream(transactionsUrl, clientConfig.token)
+  const transactions: TransactionLogEventWithEffects[] = []
+
+  const reader = stream.getReader()
+  for (;;) {
+    // eslint-disable-next-line no-await-in-loop
+    const result = await reader.read()
+    if (result.done) break
+
+    if ('error' in result.value) {
+      throw new Error(result.value.error.description || result.value.error.type)
+    }
+    transactions.push(result.value)
+  }
+  return transactions
+}


### PR DESCRIPTION
### Description
Adds `getTransactionsLogs` reusable helper function.
This function takes care of fetching transactions from the history api and simplifying the logic involved in reading it. 

It adds supports for all the parameters defined in the docs https://www.sanity.io/docs/history-api#b14b7df441a8 and sets some sensible default values.

```diff
-  const transactionsUrl = client.getUrl(`/data/history/${dataset}/transactions/${publishedId}?${queryParams}` )
-      const transactions: TransactionLogEventWithEffects[] = []
-        const stream = await getJsonStream(transactionsUrl, token)
-        const reader = stream.getReader()
-         let result
-        for (;;) {
-          result = await reader.read()
-          if (result.done) {
-            break
-          }
-          if ('error' in result.value) {
-            throw new Error(result.value.error.description || result.value.error.type)
-          }
-          transactions.push(result.value)
-        }

+     const transactions = await getTransactionsLogs(client, publishedId, {
+          tag: 'sanity.studio.tasks.history',
+          effectFormat: 'mendoza',
+          reverse: true,
+        })

```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Tests have been added for the new functionality.
Manually tested tasks history to validate it works as expected.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
adds `getTransactionLogs` helper function to fetch documents history.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
