### PR TITLE
chore(core): use displayed value for document title

### DIFF
--- a/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
+++ b/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
@@ -23,15 +23,14 @@ interface UseDocumentTitle {
  * @returns The document title or error. See {@link UseDocumentTitle}
  */
 export function useDocumentTitle(): UseDocumentTitle {
-  const {connectionState, schemaType, title, editState} = useDocumentPane()
-  const documentValue = editState?.draft || editState?.published
-  const subscribed = Boolean(documentValue)
+  const {connectionState, schemaType, title, displayed} = useDocumentPane()
   const {t} = useTranslation(structureLocaleNamespace)
+  const subscribed = Boolean(displayed)
 
   const {error, value} = useValuePreview({
     enabled: subscribed,
     schemaType,
-    value: documentValue,
+    value: displayed,
   })
 
   if (connectionState === 'connecting' && !subscribed) {
@@ -42,7 +41,7 @@ export function useDocumentTitle(): UseDocumentTitle {
     return {error: undefined, title}
   }
 
-  if (!documentValue) {
+  if (!displayed) {
     return {
       error: undefined,
       title: t('panes.document-header-title.new.text', {


### PR DESCRIPTION
### Description

`useDocumentTitle` is checking for the existence of `editState.draft` | `editState.published` 
With the introduction of `releases` this is error prone, because now we can display different values, not only draft or published inside the document pane.

This changes the hook to depend on the `displayed` value, which will be the value shown in the form. 



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing


<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
chore(core): use displayed value for document title 
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
