### PR TITLE
chore(structure): remove `TimelineStore` from `<DocumentPaneProvider/>`

### DIFF
--- a/packages/sanity/src/core/store/_legacy/history/useTimelineSelector.ts
+++ b/packages/sanity/src/core/store/_legacy/history/useTimelineSelector.ts
@@ -9,9 +9,14 @@ import {type TimelineState, type TimelineStore} from './useTimelineStore'
  * @internal
  */
 export function useTimelineSelector<ReturnValue>(
-  timelineStore: TimelineStore,
+  timelineStore: TimelineStore | undefined,
   selector: (timelineState: TimelineState) => ReturnValue,
 ): ReturnValue {
+  if (!timelineStore) {
+    throw new Error(
+      'Passed timelineStore is undefined, if your are using the events timeline, call useEvents() instead. If you need to use this hook, opt in by setting the beta.eventsAPI.enabled feature flag to false',
+    )
+  }
   return useSyncExternalStoreWithSelector(
     timelineStore.subscribe,
     timelineStore.getSnapshot,

--- a/packages/sanity/src/structure/panes/document/DocumentPane.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPane.tsx
@@ -21,7 +21,7 @@ import {ErrorPane} from '../error'
 import {LoadingPane} from '../loading'
 import {CommentsWrapper} from './comments'
 import {useDocumentLayoutComponent} from './document-layout'
-import {DocumentPaneProvider} from './DocumentPaneProvider'
+import {DocumentPaneProviderWrapper} from './DocumentPaneProviderWrapper'
 import {type DocumentPaneProviderProps} from './types'
 
 type DocumentPaneOptions = DocumentPaneNode['options']
@@ -127,7 +127,7 @@ function DocumentPaneInner(props: DocumentPaneProviderProps) {
   }
 
   return (
-    <DocumentPaneProvider
+    <DocumentPaneProviderWrapper
       // this needs to be here to avoid formState from being re-used across (incompatible) document types
       // see https://github.com/sanity-io/sanity/discussions/3794 for a description of the problem
       key={`${documentType}-${options.id}`}
@@ -146,11 +146,14 @@ function DocumentPaneInner(props: DocumentPaneProviderProps) {
           <DocumentLayout documentId={options.id} documentType={options.type} />
         </CommentsWrapper>
       </ReferenceInputOptionsProvider>
-    </DocumentPaneProvider>
+    </DocumentPaneProviderWrapper>
   )
 }
 
-function usePaneOptions(
+/**
+ * @internal
+ */
+export function usePaneOptions(
   options: DocumentPaneOptions,
   params: Record<string, string | undefined> = {},
 ): DocumentPaneOptions {

--- a/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
@@ -21,7 +21,6 @@ import {
 
 import {type View} from '../../structureBuilder'
 import {type PaneMenuItem, type PaneMenuItemGroup} from '../../types'
-import {type TimelineMode} from './types'
 
 /** @internal */
 export interface DocumentPaneContextValue {
@@ -65,11 +64,17 @@ export interface DocumentPaneContextValue {
   previewUrl?: string | null
   ready: boolean
   schemaType: ObjectSchemaType
-  setTimelineMode: (mode: TimelineMode) => void
+  /**
+   * @deprecated not used anymore
+   * */
+  setTimelineMode?: undefined
+  /**
+   * @deprecated not used anymore
+   * */
+  timelineMode?: undefined
   setTimelineRange(since: string | null, rev: string | null): void
   setIsDeleting: (state: boolean) => void
   timelineError: Error | null
-  timelineMode: TimelineMode
   /**
    * Soon to be deprecated with the upcoming `releases` changes.
    */

--- a/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
@@ -70,7 +70,10 @@ export interface DocumentPaneContextValue {
   setIsDeleting: (state: boolean) => void
   timelineError: Error | null
   timelineMode: TimelineMode
-  timelineStore: TimelineStore
+  /**
+   * Soon to be deprecated with the upcoming `releases` changes.
+   */
+  timelineStore?: TimelineStore
   title: string | null
   validation: ValidationMarker[]
   value: SanityDocumentLike
@@ -85,4 +88,8 @@ export interface DocumentPaneContextValue {
   __internal_tasks?: {
     footerAction: React.ReactNode
   }
+
+  // History specific values
+  revisionId: string | null
+  lastNonDeletedRevId: string | null
 }

--- a/packages/sanity/src/structure/panes/document/DocumentPaneLegacyTimeline.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneLegacyTimeline.tsx
@@ -1,0 +1,61 @@
+import {type SanityDocument} from '@sanity/types'
+import {useMemo, useState} from 'react'
+import {getPublishedId, useTimelineSelector, useTimelineStore} from 'sanity'
+
+import {usePaneRouter} from '../../components'
+import {EMPTY_PARAMS} from './constants'
+import {usePaneOptions} from './DocumentPane'
+import {DocumentPaneProvider} from './DocumentPaneProvider'
+import {type DocumentPaneProviderProps} from './types'
+
+export const DocumentPaneWithLegacyTimelineStore = (props: DocumentPaneProviderProps) => {
+  const {pane} = props
+  const paneRouter = usePaneRouter()
+  const options = usePaneOptions(pane.options, paneRouter.params)
+
+  const params = paneRouter.params || EMPTY_PARAMS
+
+  const [timelineError, setTimelineError] = useState<Error | null>(null)
+
+  const store = useTimelineStore({
+    documentId: getPublishedId(options.id),
+    documentType: options.type,
+    onError: setTimelineError,
+    rev: params.rev,
+    since: params.since,
+  })
+
+  const onOlderRevision = useTimelineSelector(store, (state) => state.onOlderRevision)
+  const revTime = useTimelineSelector(store, (state) => state.revTime)
+  const sinceAttributes = useTimelineSelector(store, (state) => state.sinceAttributes)
+  const timelineDisplayed = useTimelineSelector(store, (state) => state.timelineDisplayed)
+  const timelineReady = useTimelineSelector(store, (state) => state.timelineReady)
+  const isPristine = useTimelineSelector(store, (state) => state.isPristine)
+  const lastNonDeletedRevId = useTimelineSelector(store, (state) => state.lastNonDeletedRevId)
+
+  const historyStoreProps = useMemo(
+    () => ({
+      store,
+      error: timelineError,
+      revisionId: revTime?.id || null,
+      onOlderRevision: onOlderRevision,
+      revisionDocument: timelineDisplayed as SanityDocument | null,
+      sinceDocument: sinceAttributes as SanityDocument | null,
+      ready: timelineReady,
+      isPristine: Boolean(isPristine),
+      lastNonDeletedRevId,
+    }),
+    [
+      store,
+      timelineError,
+      revTime?.id,
+      onOlderRevision,
+      timelineDisplayed,
+      sinceAttributes,
+      timelineReady,
+      isPristine,
+      lastNonDeletedRevId,
+    ],
+  )
+  return <DocumentPaneProvider {...props} historyStore={historyStoreProps} />
+}

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProviderWrapper.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProviderWrapper.tsx
@@ -1,0 +1,16 @@
+import {memo} from 'react'
+import {useSource} from 'sanity'
+
+import {DocumentPaneWithLegacyTimelineStore} from './DocumentPaneLegacyTimeline'
+import {type DocumentPaneProviderProps} from './types'
+
+/**
+ * @internal
+ */
+export const DocumentPaneProviderWrapper = memo((props: DocumentPaneProviderProps) => {
+  const source = useSource()
+  // TODO: This will add support for the new events timeline store, see https://github.com/sanity-io/sanity/blob/corel/packages/sanity/src/structure/panes/document/DocumentPaneProviderWrapper.tsx#L14-L15
+
+  return <DocumentPaneWithLegacyTimelineStore {...props} />
+})
+DocumentPaneProviderWrapper.displayName = 'Memo(DocumentPaneProviderWrapper)'

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -1,6 +1,6 @@
 import {BoundaryElementProvider, Box, Flex, PortalProvider, usePortal} from '@sanity/ui'
 import {useEffect, useMemo, useRef, useState} from 'react'
-import {ScrollContainer, useTimelineSelector, VirtualizerScrollInstanceProvider} from 'sanity'
+import {ScrollContainer, VirtualizerScrollInstanceProvider} from 'sanity'
 import {css, styled} from 'styled-components'
 
 import {PaneContent, usePane, usePaneLayout} from '../../../components'
@@ -61,7 +61,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     isPermissionsLoading,
     isDeleting,
     isDeleted,
-    timelineStore,
+    lastNonDeletedRevId,
   } = useDocumentPane()
   const {collapsed: layoutCollapsed} = usePaneLayout()
   const {collapsed} = usePane()
@@ -113,11 +113,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     }
     return false
   }, [activeView, displayed, documentId, editState?.draft, editState?.published, schemaType, value])
-
-  const lastNonDeletedRevId = useTimelineSelector(
-    timelineStore,
-    (state) => state.lastNonDeletedRevId,
-  )
 
   const isLiveEdit = isLiveEditEnabled(schemaType)
 

--- a/packages/sanity/src/structure/panes/document/index.ts
+++ b/packages/sanity/src/structure/panes/document/index.ts
@@ -1,3 +1,3 @@
 export * from './DocumentPane'
-export * from './DocumentPaneProvider'
+export {DocumentPaneProviderWrapper as DocumentPaneProvider} from './DocumentPaneProviderWrapper'
 export * from './useDocumentTitle'

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/HistorySelector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/HistorySelector.tsx
@@ -15,7 +15,7 @@ const Scroller = styled(ScrollContainer)`
 `
 
 export function HistorySelector({showList}: {showList: boolean}) {
-  const {timelineError, setTimelineMode, setTimelineRange, timelineStore} = useDocumentPane()
+  const {timelineError, setTimelineRange, timelineStore} = useDocumentPane()
   const [scrollRef, setScrollRef] = useState<HTMLDivElement | null>(null)
   const [listHeight, setListHeight] = useState(0)
 
@@ -39,8 +39,7 @@ export function HistorySelector({showList}: {showList: boolean}) {
   const selectRev = useCallback(
     (revChunk: Chunk) => {
       try {
-        const [sinceId, revId] = timelineStore.findRangeForRev(revChunk)
-        setTimelineMode('closed')
+        const [sinceId, revId] = timelineStore?.findRangeForRev(revChunk) || [null, null]
         setTimelineRange(sinceId, revId)
       } catch (err) {
         toast.push({
@@ -51,13 +50,13 @@ export function HistorySelector({showList}: {showList: boolean}) {
         })
       }
     },
-    [setTimelineMode, setTimelineRange, t, timelineStore, toast],
+    [setTimelineRange, t, timelineStore, toast],
   )
 
   const handleLoadMore = useCallback(() => {
     // If updated, be sure to update the TimeLineMenu component as well
     if (!loading) {
-      timelineStore.loadMore()
+      timelineStore?.loadMore()
     }
   }, [loading, timelineStore])
 

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
@@ -1,11 +1,6 @@
 import {Card, Flex} from '@sanity/ui'
 import {type Ref, useCallback, useState} from 'react'
-import {
-  type CreateLinkMetadata,
-  isSanityCreateLinked,
-  useSanityCreateConfig,
-  useTimelineSelector,
-} from 'sanity'
+import {type CreateLinkMetadata, isSanityCreateLinked, useSanityCreateConfig} from 'sanity'
 
 import {SpacerButton} from '../../../components/spacerButton'
 import {DOCUMENT_PANEL_PORTAL_ELEMENT} from '../../../constants'
@@ -26,14 +21,12 @@ const CONTAINER_BREAKPOINT = 480 // px
 
 export function DocumentStatusBar(props: DocumentStatusBarProps) {
   const {actionsBoxRef, createLinkMetadata} = props
-  const {editState, timelineStore, onChange: onDocumentChange} = useDocumentPane()
+  const {editState, revisionId, onChange: onDocumentChange} = useDocumentPane()
   const {title} = useDocumentTitle()
 
   const CreateLinkedActions = useSanityCreateConfig().components?.documentLinkedActions
 
-  // Subscribe to external timeline state changes
-  const showingRevision = useTimelineSelector(timelineStore, (state) => state.onOlderRevision)
-
+  const showingRevision = Boolean(revisionId)
   const [collapsed, setCollapsed] = useState<boolean | null>(null)
   const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null)
 

--- a/packages/sanity/src/structure/panes/document/timeline/__workshop__/DefaultStory.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/__workshop__/DefaultStory.tsx
@@ -2,7 +2,7 @@ import {Box, Card, Inline, Stack, Text} from '@sanity/ui'
 
 import {StructureToolProvider} from '../../../../StructureToolProvider'
 import {type DocumentPaneNode} from '../../../../types'
-import {DocumentPaneProvider} from '../../DocumentPaneProvider'
+import {DocumentPaneProviderWrapper} from '../../DocumentPaneProviderWrapper'
 import {TimelineMenu} from '../timelineMenu'
 
 const DOCUMENT_ID = 'test'
@@ -20,7 +20,7 @@ const PANE: DocumentPaneNode = {
 export default function DefaultStory() {
   return (
     <StructureToolProvider>
-      <DocumentPaneProvider index={0} itemId={DOCUMENT_ID} pane={PANE} paneKey={DOCUMENT_ID}>
+      <DocumentPaneProviderWrapper index={0} itemId={DOCUMENT_ID} pane={PANE} paneKey={DOCUMENT_ID}>
         <Box padding={2}>
           <Stack space={2}>
             <Card padding={3} shadow={1} tone="primary">
@@ -44,7 +44,7 @@ export default function DefaultStory() {
             </Card>
           </Stack>
         </Box>
-      </DocumentPaneProvider>
+      </DocumentPaneProviderWrapper>
     </StructureToolProvider>
   )
 }

--- a/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
@@ -72,7 +72,7 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
   const selectRev = useCallback(
     (revChunk: Chunk) => {
       try {
-        const [sinceId, revId] = timelineStore.findRangeForRev(revChunk)
+        const [sinceId, revId] = timelineStore?.findRangeForRev(revChunk) || [null, null]
         setTimelineMode('closed')
         setTimelineRange(sinceId, revId)
       } catch (err) {
@@ -90,7 +90,7 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
   const selectSince = useCallback(
     (sinceChunk: Chunk) => {
       try {
-        const [sinceId, revId] = timelineStore.findRangeForSince(sinceChunk)
+        const [sinceId, revId] = timelineStore?.findRangeForSince(sinceChunk) || [null, null]
         setTimelineMode('closed')
         setTimelineRange(sinceId, revId)
       } catch (err) {
@@ -107,7 +107,7 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
 
   const handleLoadMore = useCallback(() => {
     if (!loading) {
-      timelineStore.loadMore()
+      timelineStore?.loadMore()
     }
   }, [loading, timelineStore])
 

--- a/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
@@ -31,7 +31,7 @@ const Root = styled(Popover)`
 export const TIMELINE_MENU_PORTAL = 'timeline-menu'
 
 export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
-  const {setTimelineRange, setTimelineMode, timelineError, ready, timelineStore} = useDocumentPane()
+  const {setTimelineRange, timelineError, ready, timelineStore} = useDocumentPane()
   const [open, setOpen] = useState(false)
   const [button, setButton] = useState<HTMLButtonElement | null>(null)
   const [popoverRef, setPopoverRef] = useState<HTMLElement | null>(null)
@@ -47,14 +47,12 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
   const {t} = useTranslation('studio')
 
   const handleOpen = useCallback(() => {
-    setTimelineMode(mode)
     setOpen(true)
-  }, [mode, setTimelineMode])
+  }, [])
 
   const handleClose = useCallback(() => {
-    setTimelineMode('closed')
     setOpen(false)
-  }, [setTimelineMode])
+  }, [])
 
   const handleGlobalKeyDown = useCallback(
     (event: KeyboardEvent) => {
@@ -73,7 +71,6 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
     (revChunk: Chunk) => {
       try {
         const [sinceId, revId] = timelineStore?.findRangeForRev(revChunk) || [null, null]
-        setTimelineMode('closed')
         setTimelineRange(sinceId, revId)
       } catch (err) {
         toast.push({
@@ -84,14 +81,13 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
         })
       }
     },
-    [setTimelineMode, setTimelineRange, t, timelineStore, toast],
+    [setTimelineRange, t, timelineStore, toast],
   )
 
   const selectSince = useCallback(
     (sinceChunk: Chunk) => {
       try {
         const [sinceId, revId] = timelineStore?.findRangeForSince(sinceChunk) || [null, null]
-        setTimelineMode('closed')
         setTimelineRange(sinceId, revId)
       } catch (err) {
         toast.push({
@@ -102,7 +98,7 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
         })
       }
     },
-    [setTimelineMode, setTimelineRange, t, timelineStore, toast],
+    [setTimelineRange, t, timelineStore, toast],
   )
 
   const handleLoadMore = useCallback(() => {

--- a/packages/sanity/src/structure/panes/document/types.ts
+++ b/packages/sanity/src/structure/panes/document/types.ts
@@ -20,7 +20,6 @@ export interface HistoryStoreProps {
   ready: boolean
   /**
    * Whether this timeline is fully loaded and completely empty (true for new documents)
-   * It can be `null` when the chunks hasn't loaded / is not known
    */
   isPristine: boolean
   /**

--- a/packages/sanity/src/structure/panes/document/types.ts
+++ b/packages/sanity/src/structure/panes/document/types.ts
@@ -4,9 +4,6 @@ import {type TimelineStore} from 'sanity'
 import {type BaseStructureToolPaneProps} from '../types'
 
 /** @internal */
-export type TimelineMode = 'since' | 'rev' | 'closed'
-
-/** @internal */
 export type DocumentPaneProviderProps = {
   children?: React.ReactNode
   onFocusPath?: (path: Path) => void

--- a/packages/sanity/src/structure/panes/document/types.ts
+++ b/packages/sanity/src/structure/panes/document/types.ts
@@ -1,4 +1,5 @@
-import {type Path} from '@sanity/types'
+import {type Path, type SanityDocument} from '@sanity/types'
+import {type TimelineStore} from 'sanity'
 
 import {type BaseStructureToolPaneProps} from '../types'
 
@@ -10,3 +11,23 @@ export type DocumentPaneProviderProps = {
   children?: React.ReactNode
   onFocusPath?: (path: Path) => void
 } & BaseStructureToolPaneProps<'document'>
+
+/** @internal */
+export interface HistoryStoreProps {
+  store?: TimelineStore
+  error: Error | null
+  onOlderRevision: boolean
+  revisionId: string | null
+  revisionDocument: SanityDocument | null
+  sinceDocument: SanityDocument | null
+  ready: boolean
+  /**
+   * Whether this timeline is fully loaded and completely empty (true for new documents)
+   * It can be `null` when the chunks hasn't loaded / is not known
+   */
+  isPristine: boolean
+  /**
+   * The id of the _rev of the last non-deleted document.
+   */
+  lastNonDeletedRevId: string | null
+}


### PR DESCRIPTION
### Description

We have always had only one way to represent the Timeline, it has been defined by the TimelineStore, with the addition of releases we are adding a new store that builds on the events api.
This PR updates the `DocumentPaneProvider` to receive the timeline through the props, allowing us to inject either this Legacy Timeline or the new Events API. 
It also changes the `structure` export to expose the `DocumentPaneProviderWrapper` instead of the `DocumentPaneProvider` 

The wrapper now only inserts the legacy Timeline, but in `corel` it will check the feature flag and use the events store instead.

This PR also removes the `timelineMode` property from the document pane, given it's not used anywhere. This is a legacy property that was used before the [History UI updates](https://github.com/sanity-io/sanity/pull/7462)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is it ok to rename the export as done in [here](https://github.com/sanity-io/sanity/pull/8271/files#diff-713de4553c7111bfd0e61c82a8b2e1843894a13953ab165d6b077109e716647aR2)?
Is it ok to deprecate the TimelineMode property as this PR is doing it?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Existing tests should cover the functionalities, nothing new is added. This PR only moves things around to make it possible to inject a different timeline provider
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
fix(core): remove timelineMode from `documentPaneContext` and makes `TimelineStore` optional.
Deprecations: 
  `useDocumentPane().timelineMode` property is now deprecated, this hasn't been used since the updates to the [History UI]((https://github.com/sanity-io/sanity/pull/7462)).
 `useDocumentPane().timelineStore` possibly undefined, preparing for the introduction of the events API, this property could be undefined once `[corel](https://github.com/sanity-io/sanity/tree/corel)` is merged.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
