### PR TITLE
feat(vision): add release layering support

### DIFF
--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -70,7 +70,8 @@
     "json5": "^2.2.3",
     "lodash": "^4.17.21",
     "quick-lru": "^5.1.1",
-    "react-compiler-runtime": "19.0.0-beta-55955c9-20241229"
+    "react-compiler-runtime": "19.0.0-beta-55955c9-20241229",
+    "react-fast-compare": "^3.2.2"
   },
   "devDependencies": {
     "@repo/package.config": "workspace:*",

--- a/packages/@sanity/vision/src/SanityVision.tsx
+++ b/packages/@sanity/vision/src/SanityVision.tsx
@@ -1,4 +1,4 @@
-import {type Tool, useClient} from 'sanity'
+import {type Tool, useClient, usePerspective} from 'sanity'
 
 import {DEFAULT_API_VERSION} from './apiVersions'
 import {VisionContainer} from './containers/VisionContainer'
@@ -11,6 +11,7 @@ interface SanityVisionProps {
 
 function SanityVision(props: SanityVisionProps) {
   const client = useClient({apiVersion: '1'})
+  const perspective = usePerspective()
   const config: VisionConfig = {
     defaultApiVersion: DEFAULT_API_VERSION,
     ...props.tool.options,
@@ -18,7 +19,7 @@ function SanityVision(props: SanityVisionProps) {
 
   return (
     <VisionErrorBoundary>
-      <VisionContainer client={client} config={config} />
+      <VisionContainer client={client} config={config} pinnedPerspective={perspective} />
     </VisionErrorBoundary>
   )
 }

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -1,6 +1,11 @@
 /* eslint-disable complexity */
 import {SplitPane} from '@rexxars/react-split-pane'
-import {type ListenEvent, type MutationEvent, type SanityClient} from '@sanity/client'
+import {
+  type ClientPerspective,
+  type ListenEvent,
+  type MutationEvent,
+  type SanityClient,
+} from '@sanity/client'
 import {CopyIcon, ErrorOutlineIcon, PlayIcon, StopIcon} from '@sanity/icons'
 import {
   Box,
@@ -19,14 +24,23 @@ import {
 } from '@sanity/ui'
 import {isHotkey} from 'is-hotkey-esm'
 import {debounce} from 'lodash'
-import {type ChangeEvent, createRef, PureComponent, type RefObject} from 'react'
-import {type TFunction, Translate} from 'sanity'
+import {
+  type ChangeEvent,
+  type ComponentType,
+  createRef,
+  PureComponent,
+  type RefObject,
+  useMemo,
+} from 'react'
+import isEqual from 'react-fast-compare'
+import {type PerspectiveValue, type TFunction, Translate} from 'sanity'
 
 import {API_VERSIONS, DEFAULT_API_VERSION} from '../apiVersions'
 import {VisionCodeMirror} from '../codemirror/VisionCodeMirror'
 import {
   DEFAULT_PERSPECTIVE,
   isSupportedPerspective,
+  isVirtualPerspective,
   SUPPORTED_PERSPECTIVES,
   type SupportedPerspective,
 } from '../perspectives'
@@ -192,6 +206,14 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
       perspective = DEFAULT_PERSPECTIVE
     }
 
+    if (perspective == 'pinnedRelease' && !hasPinnedPerspective(this.props.pinnedPerspective)) {
+      perspective = DEFAULT_PERSPECTIVE
+    }
+
+    if (perspective !== 'pinnedRelease' && hasPinnedPerspective(this.props.pinnedPerspective)) {
+      perspective = 'pinnedRelease'
+    }
+
     if (typeof lastQuery !== 'string') {
       lastQuery = ''
     }
@@ -209,7 +231,10 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     this._client = props.client.withConfig({
       apiVersion: customApiVersion || apiVersion,
       dataset,
-      perspective: perspective,
+      perspective: getActivePerspective({
+        visionPerspective: perspective,
+        pinnedPerspective: this.props.pinnedPerspective,
+      }),
       allowReconfigure: true,
     })
 
@@ -264,6 +289,7 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     this.handleKeyDown = this.handleKeyDown.bind(this)
     this.handleResize = this.handleResize.bind(this)
     this.handleOnPasteCapture = this.handleOnPasteCapture.bind(this)
+    this.setPerspective = this.setPerspective.bind(this)
   }
 
   componentDidMount() {
@@ -278,6 +304,30 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     this.cancelListener()
     this.cancelEventListener()
     this.cancelResizeListener()
+  }
+
+  componentDidUpdate(prevProps: Readonly<VisionGuiProps>): void {
+    if (hasPinnedPerspectiveChanged(prevProps.pinnedPerspective, this.props.pinnedPerspective)) {
+      if (
+        this.state.perspective !== 'pinnedRelease' &&
+        hasPinnedPerspective(this.props.pinnedPerspective)
+      ) {
+        this.setPerspective('pinnedRelease')
+        return
+      }
+
+      if (
+        this.state.perspective === 'pinnedRelease' &&
+        !hasPinnedPerspective(this.props.pinnedPerspective)
+      ) {
+        this.setPerspective('raw')
+        return
+      }
+
+      if (this.state.perspective === 'pinnedRelease') {
+        this.setPerspective('pinnedRelease')
+      }
+    }
   }
 
   handleResizeListen() {
@@ -338,11 +388,17 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
       }
     }
 
-    const perspective = isSupportedPerspective(parts.options.perspective)
-      ? parts.options.perspective
-      : undefined
+    const perspective =
+      isSupportedPerspective(parts.options.perspective) &&
+      !isVirtualPerspective(parts.options.perspective)
+        ? parts.options.perspective
+        : undefined
 
-    if (perspective && !isSupportedPerspective(perspective)) {
+    if (
+      perspective &&
+      (!isSupportedPerspective(parts.options.perspective) ||
+        isVirtualPerspective(parts.options.perspective))
+    ) {
       this.props.toast.push({
         closable: true,
         id: 'vision-paste-unsupported-perspective',
@@ -378,7 +434,10 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
         this._client.config({
           dataset: this.state.dataset,
           apiVersion: customApiVersion || apiVersion,
-          perspective: this.state.perspective,
+          perspective: getActivePerspective({
+            visionPerspective: this.state.perspective,
+            pinnedPerspective: this.props.pinnedPerspective,
+          }),
         })
         this.handleQueryExecution()
         this.props.toast.push({
@@ -399,7 +458,6 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     if (!this._querySubscription) {
       return
     }
-
     this._querySubscription.unsubscribe()
     this._querySubscription = undefined
   }
@@ -466,6 +524,10 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
 
   handleChangePerspective(evt: ChangeEvent<HTMLSelectElement>) {
     const perspective = evt.target.value
+    this.setPerspective(perspective)
+  }
+
+  setPerspective(perspective: string): void {
     if (!isSupportedPerspective(perspective)) {
       return
     }
@@ -473,7 +535,10 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     this.setState({perspective}, () => {
       this._localStorage.set('perspective', this.state.perspective)
       this._client.config({
-        perspective: this.state.perspective,
+        perspective: getActivePerspective({
+          visionPerspective: this.state.perspective,
+          pinnedPerspective: this.props.pinnedPerspective,
+        }),
       })
       this.handleQueryExecution()
     })
@@ -598,9 +663,13 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
 
     this.ensureSelectedApiVersion()
 
-    const urlQueryOpts: Record<string, string> = {}
+    const urlQueryOpts: Record<string, string | string[]> = {}
     if (this.state.perspective !== 'raw') {
-      urlQueryOpts.perspective = this.state.perspective
+      urlQueryOpts.perspective =
+        getActivePerspective({
+          visionPerspective: this.state.perspective,
+          pinnedPerspective: this.props.pinnedPerspective,
+        }) ?? []
     }
 
     const url = this._client.getUrl(
@@ -613,20 +682,22 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     this._querySubscription = this._client.observable
       .fetch(query, params, {filterResponse: false, tag: 'vision'})
       .subscribe({
-        next: (res) =>
+        next: (res) => {
           this.setState({
             queryTime: res.ms,
             e2eTime: Date.now() - queryStart,
             queryResult: res.result,
             queryInProgress: false,
             error: undefined,
-          }),
-        error: (error) =>
+          })
+        },
+        error: (error) => {
           this.setState({
             error,
             query,
             queryInProgress: false,
-          }),
+          })
+        },
       })
 
     return true
@@ -670,7 +741,7 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
   }
 
   render() {
-    const {datasets, t} = this.props
+    const {datasets, t, pinnedPerspective} = this.props
     const {
       apiVersion,
       customApiVersion,
@@ -778,9 +849,21 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
                 </Card>
 
                 <Select value={perspective} onChange={this.handleChangePerspective}>
-                  {SUPPORTED_PERSPECTIVES.map((p) => (
-                    <option key={p}>{p}</option>
-                  ))}
+                  {SUPPORTED_PERSPECTIVES.map((perspectiveName) => {
+                    if (perspectiveName === 'pinnedRelease') {
+                      return (
+                        <>
+                          <PinnedReleasePerspectiveOption
+                            key="pinnedRelease"
+                            pinnedPerspective={pinnedPerspective}
+                            t={t}
+                          />
+                          <hr />
+                        </>
+                      )
+                    }
+                    return <option key={perspectiveName}>{perspectiveName}</option>
+                  })}
                 </Select>
               </Stack>
             </Box>
@@ -1026,4 +1109,63 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
       </Root>
     )
   }
+}
+
+function getActivePerspective({
+  visionPerspective,
+  pinnedPerspective,
+}: {
+  visionPerspective: ClientPerspective | SupportedPerspective
+  pinnedPerspective: PerspectiveValue
+}): ClientPerspective | undefined {
+  if (visionPerspective !== 'pinnedRelease') {
+    return visionPerspective
+  }
+
+  if (pinnedPerspective.perspectiveStack.length !== 0) {
+    return pinnedPerspective.perspectiveStack
+  }
+
+  if (typeof pinnedPerspective.selectedPerspectiveName !== 'undefined') {
+    return [pinnedPerspective.selectedPerspectiveName]
+  }
+
+  return undefined
+}
+
+const PinnedReleasePerspectiveOption: ComponentType<{
+  pinnedPerspective: PerspectiveValue
+  t: TFunction
+}> = ({pinnedPerspective, t}) => {
+  const name =
+    typeof pinnedPerspective.selectedPerspective === 'object'
+      ? pinnedPerspective.selectedPerspective.metadata.title
+      : pinnedPerspective.selectedPerspectiveName
+
+  const label = hasPinnedPerspective(pinnedPerspective)
+    ? `(${t('settings.perspectives.pinned-release-label')})`
+    : t('settings.perspectives.pinned-release-label')
+
+  const text = useMemo(
+    () => [name, label].filter((value) => typeof value !== 'undefined').join(' '),
+    [label, name],
+  )
+
+  return (
+    <option value="pinnedRelease" disabled={!hasPinnedPerspective(pinnedPerspective)}>
+      {text}
+    </option>
+  )
+}
+
+function hasPinnedPerspective({selectedPerspectiveName}: PerspectiveValue): boolean {
+  return typeof selectedPerspectiveName !== 'undefined'
+}
+
+function hasPinnedPerspectiveChanged(previous: PerspectiveValue, next: PerspectiveValue): boolean {
+  const hasPerspectiveStackChanged = !isEqual(previous.perspectiveStack, next.perspectiveStack)
+
+  return (
+    previous.selectedPerspectiveName !== next.selectedPerspectiveName || hasPerspectiveStackChanged
+  )
 }

--- a/packages/@sanity/vision/src/i18n/resources.ts
+++ b/packages/@sanity/vision/src/i18n/resources.ts
@@ -74,6 +74,8 @@ const visionLocaleStrings = defineLocalesResources('vision', {
   /** Description for popover that explains what "Perspectives" are */
   'settings.perspectives.description':
     'Perspectives allow your query to run against different "views" of the content in your dataset',
+  /** Label for the pinned release perspective */
+  'settings.perspectives.pinned-release-label': 'pinned release',
   /** Title for popover that explains what "Perspectives" are */
   'settings.perspectives.title': 'Perspectives',
 } as const)

--- a/packages/@sanity/vision/src/perspectives.ts
+++ b/packages/@sanity/vision/src/perspectives.ts
@@ -1,15 +1,36 @@
-import {type ClientPerspective} from '@sanity/client'
-
-export type SupportedPerspective = 'raw' | 'previewDrafts' | 'published' | 'drafts'
-
 export const SUPPORTED_PERSPECTIVES = [
+  'pinnedRelease',
   'raw',
   'previewDrafts',
   'published',
   'drafts',
-] satisfies ClientPerspective[]
-export const DEFAULT_PERSPECTIVE = SUPPORTED_PERSPECTIVES[0]
+] as const
+
+export type SupportedPerspective = (typeof SUPPORTED_PERSPECTIVES)[number]
+
+/**
+ * Virtual perspectives are recognised by Vision, but do not concretely reflect the names of real
+ * perspectives. Virtual perspectives are transformed into real perspectives before being used to
+ * interact with data.
+ *
+ * For example, the `pinnedRelease` virtual perspective is transformed to the real perspective
+ * currently pinned in Studio.
+ */
+export const VIRTUAL_PERSPECTIVES = ['pinnedRelease'] as const
+
+export type VirtualPerspective = (typeof VIRTUAL_PERSPECTIVES)[number]
+
+export const DEFAULT_PERSPECTIVE: SupportedPerspective = 'raw'
 
 export function isSupportedPerspective(p: string): p is SupportedPerspective {
   return SUPPORTED_PERSPECTIVES.includes(p as SupportedPerspective)
+}
+
+export function isVirtualPerspective(
+  maybeVirtualPerspective: unknown,
+): maybeVirtualPerspective is VirtualPerspective {
+  return (
+    typeof maybeVirtualPerspective === 'string' &&
+    VIRTUAL_PERSPECTIVES.includes(maybeVirtualPerspective as VirtualPerspective)
+  )
 }

--- a/packages/@sanity/vision/src/types.ts
+++ b/packages/@sanity/vision/src/types.ts
@@ -1,9 +1,11 @@
 import {type SanityClient} from '@sanity/client'
 import {type ComponentType} from 'react'
+import {type PerspectiveValue} from 'sanity'
 
 export interface VisionProps {
   client: SanityClient
   config: VisionConfig
+  pinnedPerspective: PerspectiveValue
 }
 
 export interface VisionConfig {

--- a/packages/@sanity/vision/src/util/encodeQueryString.ts
+++ b/packages/@sanity/vision/src/util/encodeQueryString.ts
@@ -1,7 +1,7 @@
 export function encodeQueryString(
   query: string,
   params: Record<string, unknown> = {},
-  options: Record<string, string> = {},
+  options: Record<string, string | string[]> = {},
 ): string {
   const searchParams = new URLSearchParams()
   searchParams.set('query', query)

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -34,6 +34,7 @@ export {
   isReleaseDocument,
   isReleaseScheduledOrScheduling,
   LATEST,
+  type PerspectiveValue,
   type ReleaseDocument,
   RELEASES_INTENT,
   useDocumentVersions,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,7 +121,7 @@ importers:
         version: 9.1.0(eslint@8.57.1)
       eslint-config-sanity:
         specifier: ^7.1.2
-        version: 7.1.3(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1)
+        version: 7.1.3(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-plugin-import@2.31.0)(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1)
       eslint-config-turbo:
         specifier: ^2.1.2
         version: 2.3.3(eslint@8.57.1)
@@ -130,7 +130,7 @@ importers:
         version: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-plugin-boundaries:
         specifier: ^4.2.2
-        version: 4.2.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+        version: 4.2.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.30.0
         version: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
@@ -175,7 +175,7 @@ importers:
         version: 4.1.0
       lerna:
         specifier: ^8.1.9
-        version: 8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.3))(@swc/core@1.10.1)(babel-plugin-macros@3.1.0)(encoding@0.1.13)
+        version: 8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.3))(@swc/core@1.10.1(@swc/helpers@0.5.15))(babel-plugin-macros@3.1.0)(encoding@0.1.13)
       lint-staged:
         specifier: ^12.1.2
         version: 12.5.0(enquirer@2.3.6)
@@ -1259,6 +1259,9 @@ importers:
       react-compiler-runtime:
         specifier: 19.0.0-beta-55955c9-20241229
         version: 19.0.0-beta-55955c9-20241229(react@18.3.1)
+      react-fast-compare:
+        specifier: ^3.2.2
+        version: 3.2.2
     devDependencies:
       '@repo/package.config':
         specifier: workspace:*
@@ -1957,7 +1960,7 @@ importers:
         version: 0.21.5
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.10.1)(@types/node@18.19.68)(typescript@5.7.3)
+        version: 10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@18.19.68)(typescript@5.7.3)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -13798,12 +13801,12 @@ snapshots:
 
   '@juggle/resize-observer@3.4.0': {}
 
-  '@lerna/create@8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.3))(@swc/core@1.10.1)(babel-plugin-macros@3.1.0)(encoding@0.1.13)(typescript@5.7.3)':
+  '@lerna/create@8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.3))(@swc/core@1.10.1(@swc/helpers@0.5.15))(babel-plugin-macros@3.1.0)(encoding@0.1.13)(typescript@5.7.3)':
     dependencies:
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.0
       '@npmcli/run-script': 8.1.0
-      '@nx/devkit': 20.2.2(nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.3))(@swc/core@1.10.1))
+      '@nx/devkit': 20.2.2(nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.3))(@swc/core@1.10.1(@swc/helpers@0.5.15)))
       '@octokit/plugin-enterprise-rest': 6.0.1
       '@octokit/rest': 19.0.11(encoding@0.1.13)
       aproba: 2.0.0
@@ -13842,7 +13845,7 @@ snapshots:
       npm-package-arg: 11.0.2
       npm-packlist: 8.0.2
       npm-registry-fetch: 17.1.0
-      nx: 20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.3))(@swc/core@1.10.1)
+      nx: 20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.3))(@swc/core@1.10.1(@swc/helpers@0.5.15))
       p-map: 4.0.0
       p-map-series: 2.1.0
       p-queue: 6.6.2
@@ -14337,13 +14340,13 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@nx/devkit@20.2.2(nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.3))(@swc/core@1.10.1))':
+  '@nx/devkit@20.2.2(nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.3))(@swc/core@1.10.1(@swc/helpers@0.5.15)))':
     dependencies:
       ejs: 3.1.10
       enquirer: 2.3.6
       ignore: 5.3.2
       minimatch: 9.0.3
-      nx: 20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.3))(@swc/core@1.10.1)
+      nx: 20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.3))(@swc/core@1.10.1(@swc/helpers@0.5.15))
       semver: 7.6.3
       tmp: 0.2.3
       tslib: 2.8.1
@@ -16417,14 +16420,6 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@18.19.68)(terser@5.37.0))':
-    dependencies:
-      '@vitest/spy': 2.1.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 5.4.11(@types/node@18.19.68)(terser@5.37.0)
-
   '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0))':
     dependencies:
       '@vitest/spy': 2.1.8
@@ -18287,7 +18282,7 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-config-sanity@7.1.3(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-sanity@7.1.3(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-plugin-import@2.31.0)(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-simple-import-sort: 12.1.1(eslint@8.57.1)
@@ -18327,7 +18322,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -18338,7 +18333,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -18349,12 +18344,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-boundaries@4.2.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-boundaries@4.2.2(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
       chalk: 4.1.2
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       micromatch: 4.0.7
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
@@ -18378,7 +18373,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.0
       is-glob: 4.0.3
@@ -20204,13 +20199,13 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  lerna@8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.3))(@swc/core@1.10.1)(babel-plugin-macros@3.1.0)(encoding@0.1.13):
+  lerna@8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.3))(@swc/core@1.10.1(@swc/helpers@0.5.15))(babel-plugin-macros@3.1.0)(encoding@0.1.13):
     dependencies:
-      '@lerna/create': 8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.3))(@swc/core@1.10.1)(babel-plugin-macros@3.1.0)(encoding@0.1.13)(typescript@5.7.3)
+      '@lerna/create': 8.1.9(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.3))(@swc/core@1.10.1(@swc/helpers@0.5.15))(babel-plugin-macros@3.1.0)(encoding@0.1.13)(typescript@5.7.3)
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.0
       '@npmcli/run-script': 8.1.0
-      '@nx/devkit': 20.2.2(nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.3))(@swc/core@1.10.1))
+      '@nx/devkit': 20.2.2(nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.3))(@swc/core@1.10.1(@swc/helpers@0.5.15)))
       '@octokit/plugin-enterprise-rest': 6.0.1
       '@octokit/rest': 19.0.11(encoding@0.1.13)
       aproba: 2.0.0
@@ -20255,7 +20250,7 @@ snapshots:
       npm-package-arg: 11.0.2
       npm-packlist: 8.0.2
       npm-registry-fetch: 17.1.0
-      nx: 20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.3))(@swc/core@1.10.1)
+      nx: 20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.3))(@swc/core@1.10.1(@swc/helpers@0.5.15))
       p-map: 4.0.0
       p-map-series: 2.1.0
       p-pipe: 3.1.0
@@ -21026,7 +21021,7 @@ snapshots:
 
   nwsapi@2.2.16: {}
 
-  nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1)(typescript@5.7.3))(@swc/core@1.10.1):
+  nx@20.2.2(@swc-node/register@1.10.9(@swc/core@1.10.1(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.7.3))(@swc/core@1.10.1(@swc/helpers@0.5.15)):
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
       '@yarnpkg/lockfile': 1.1.0
@@ -23426,7 +23421,7 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
-  ts-node@10.9.2(@swc/core@1.10.1)(@types/node@18.19.68)(typescript@5.7.3):
+  ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@18.19.68)(typescript@5.7.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -23897,7 +23892,7 @@ snapshots:
   vitest@2.1.8(@types/node@18.19.68)(jsdom@25.0.1)(terser@5.37.0):
     dependencies:
       '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@18.19.68)(terser@5.37.0))
+      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.8
       '@vitest/snapshot': 2.1.8


### PR DESCRIPTION
### Description

This branch adds perspective support to `@sanity/vision` by adding a new "pinned release" perspective option to the Vision UI. When this perspective is selected, Vision will inherit the release stack that is pinned in Studio.

<img width="1322" alt="Screenshot 2025-01-16 at 14 37 10" src="https://github.com/user-attachments/assets/d70b9b1f-82b0-4095-acd1-d0739a85d602" />

- When there is a pinned release, the "pinned release" perspective is selected by default.
- When there is no pinned release, the "pinned release" perspective is inactive.
- Users can choose to use system perspectives in Vision even when there is a pinned release.
- The selected Vision perspective is set in `localStorage` and restored when Vision mounts.
  - If Vision mounts while there **is** a pinned release, but the last perspective stored to `localStorage` **was not** `pinnedRelease`, `pinnedRelease` will override the last perspective stored.
  - If Vision mounts while there is **no** pinned release, but the last perspective stored to `localStorage` **was** `pinnedRelease`, the default perspective will override the last perspective stored.

### What to review

Does this UI and implementation seem reasonable?

### Testing

There are no existing tests for `@sanity/vision`. I haven't had time to boostrap this, but it would be great to do so in the future.

This can be tested manually by alternately changing the pinned release and the perspective option in Vision. Whichever was set most recently takes precedence.