### PR TITLE
feat(cli): remote template bootstrapper to support write token

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/bootstrapRemoteTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapRemoteTemplate.ts
@@ -74,10 +74,10 @@ export async function bootstrapRemoteTemplate(
 
   debug('Applying environment variables')
   const readToken = needsReadToken
-    ? await generateSanityApiToken(READ_TOKEN_LABEL, 'viewer', variables.projectId, apiClient)
+    ? await generateSanityApiToken(READ_TOKEN_LABEL, 'read', variables.projectId, apiClient)
     : undefined
   const writeToken = needsWriteToken
-    ? await generateSanityApiToken(WRITE_TOKEN_LABEL, 'editor', variables.projectId, apiClient)
+    ? await generateSanityApiToken(WRITE_TOKEN_LABEL, 'write', variables.projectId, apiClient)
     : undefined
 
   for (const pkg of packages ?? ['']) {

--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -21,6 +21,9 @@ const ENV_VAR = {
   WRITE_TOKEN: 'SANITY_API_WRITE_TOKEN',
 } as const
 
+const API_READ_TOKEN_ROLE = 'viewer'
+const API_WRITE_TOKEN_ROLE = 'editor'
+
 type EnvData = {
   projectId: string
   dataset: string
@@ -202,11 +205,7 @@ export async function checkIfNeedsApiToken(root: string, type: 'read' | 'write')
       }),
     )
     const templateContent = await readFile(join(root, templatePath), 'utf8')
-    const tokenEnvMap = {
-      read: ENV_VAR.READ_TOKEN,
-      write: ENV_VAR.WRITE_TOKEN,
-    }
-    return templateContent.includes(tokenEnvMap[type])
+    return templateContent.includes(type === 'read' ? ENV_VAR.READ_TOKEN : ENV_VAR.WRITE_TOKEN)
   } catch {
     return false
   }
@@ -285,7 +284,7 @@ export async function tryApplyPackageName(root: string, name: string): Promise<v
 
 export async function generateSanityApiToken(
   label: string,
-  roleName: 'viewer' | 'editor',
+  type: 'read' | 'write',
   projectId: string,
   apiClient: CliApiClient,
 ): Promise<string> {
@@ -296,7 +295,7 @@ export async function generateSanityApiToken(
       method: 'POST',
       body: {
         label: `${label} (${Date.now()})`,
-        roleName,
+        roleName: type === 'read' ? API_READ_TOKEN_ROLE : API_WRITE_TOKEN_ROLE,
       },
     })
   return response.key


### PR DESCRIPTION
### Description

Allow the remote template bootstrapper to generate a write token by specifying it in your .env.example. 

I'm using the earlier implementation of `generateSanityApiReadToken`, but renamed it to `generateSanityApiToken`, and added an arg for specifying the role of the token.

### What to review

- The copy, is the token naming and cli output ok? 
- Are the roles ok to use? 

### Testing

1. Checkout to this branch
2. `cd packages/@sanity/cli`
3. `pnpm install`
4. `pnpm run build && npm link`
5. In a projects folder, run `sanity init --template https://github.com/sanity-io/nextjs-blog-cms-sanity-v3` (this template expects a write token)
6. the .env.local should have a write token env set

### Notes for release

Tbd if we need one
