### PR TITLE
fix(test): restore skipped tests

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/publish.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/publish.test.ts
@@ -12,8 +12,7 @@ beforeEach(() => {
   ;(isLiveEditEnabled as Mock).mockClear()
 })
 
-// TODO: Restore this test
-describe.skip('publish', () => {
+describe('publish', () => {
   describe('disabled', () => {
     // kind of a useless test but preserves the order at least
     it('returns with LIVE_EDIT_ENABLED if isLiveEditEnabled', () => {

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.test.ts
@@ -12,8 +12,7 @@ beforeEach(() => {
   ;(isLiveEditEnabled as Mock).mockClear()
 })
 
-// TODO: Restore this test
-describe.skip('publish', () => {
+describe('publish', () => {
   describe('disabled', () => {
     it('returns with LIVE_EDIT_ENABLED if isLiveEditEnabled', () => {
       ;(isLiveEditEnabled as Mock).mockImplementation(

--- a/test/e2e/tests/document-actions/unpublish.spec.ts
+++ b/test/e2e/tests/document-actions/unpublish.spec.ts
@@ -34,5 +34,8 @@ test(`should be able to unpublish a published document`, async ({page, createDra
   await expect(unpublishModal).toBeVisible()
   await page.getByTestId('confirm-button').click()
 
-  await expect(documentStatus).toContainText('')
+  // Check the published button is disabled that is the reference to determine the published document doesn't exist.
+  const button = await page.getByRole('button', {name: 'Published'})
+  await expect(button).toBeDisabled()
+  await expect(documentStatus).toContainText('Draft Edited just now')
 })


### PR DESCRIPTION
### Description

Restores tests that `corel` skipped.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Tests are restored they should pass on CI.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
