### PR TITLE
fix(core): cannot find namespace 'vi'

### DIFF
--- a/packages/sanity/src/core/form/store/utils/__tests__/immutableReconcile.test.ts
+++ b/packages/sanity/src/core/form/store/utils/__tests__/immutableReconcile.test.ts
@@ -1,5 +1,5 @@
 import {defineField, defineType} from '@sanity/types'
-import {beforeEach, expect, test, vi} from 'vitest'
+import {beforeEach, expect, type Mock, test, vi} from 'vitest'
 
 import {createSchema} from '../../../../schema/createSchema'
 import {createImmutableReconcile} from '../immutableReconcile'
@@ -7,7 +7,7 @@ import {createImmutableReconcile} from '../immutableReconcile'
 const immutableReconcile = createImmutableReconcile({decorator: vi.fn})
 
 beforeEach(() => {
-  ;(immutableReconcile as vi.Mock).mockClear()
+  ;(immutableReconcile as Mock).mockClear()
 })
 
 test('it preserves previous value if shallow equal', () => {

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/validation.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/validation.test.ts
@@ -11,7 +11,7 @@ import {
   timer,
 } from 'rxjs'
 import {buffer, publish, takeWhile} from 'rxjs/operators'
-import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {createMockSanityClient} from '../../../../../../test/mocks/mockSanityClient'
 import {getFallbackLocaleSource} from '../../../../i18n/fallback'
@@ -21,7 +21,7 @@ import {editState, type EditStateFor} from './editState'
 import {validation} from './validation'
 
 // Mock `./editState`
-const mockEditState = editState as vi.Mock<typeof editState>
+const mockEditState = editState as Mock<typeof editState>
 vi.mock('./editState', () => ({editState: vi.fn()}))
 
 const schema = createSchema({

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.test.tsx
@@ -1,6 +1,6 @@
 import {render, waitFor} from '@testing-library/react'
 import {defineConfig, type SanityClient, unstable_useValuePreview as useValuePreview} from 'sanity'
-import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, type MockedFunction, vi} from 'vitest'
 
 import {createMockSanityClient} from '../../../../../../test/mocks/mockSanityClient'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
@@ -33,8 +33,8 @@ vi.mock('sanity', async () => {
 })
 
 describe('DocumentHeaderTitle', () => {
-  const mockUseDocumentPane = useDocumentPane as vi.MockedFunction<typeof useDocumentPane>
-  const mockUseValuePreview = useValuePreview as vi.MockedFunction<typeof useValuePreview>
+  const mockUseDocumentPane = useDocumentPane as MockedFunction<typeof useDocumentPane>
+  const mockUseValuePreview = useValuePreview as MockedFunction<typeof useValuePreview>
 
   const defaultProps = {
     connectionState: 'connected',


### PR DESCRIPTION
### Description
Fixes a type import issue in where using `vi.<Type>` would give the following error:
```
Cannot find namespace 'vi'
```
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is the change correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
It's only a type definition change, existing tests cover this.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a, internal only
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
