### PR TITLE
fix(structure): only reset history params if needed

### DIFF
--- a/packages/sanity/src/core/field/diff/contexts/DocumentChangeContext.tsx
+++ b/packages/sanity/src/core/field/diff/contexts/DocumentChangeContext.tsx
@@ -8,9 +8,6 @@ export type DocumentChangeContextInstance = {
   documentId: string
   schemaType: SchemaType
   rootDiff: ObjectDiff | null
-  /**
-   * This decides if the diff shows the reverting changes button or not.
-   */
   isComparingCurrent: boolean
   FieldWrapper: ComponentType<{path: Path; children: ReactNode; hasHover: boolean}>
   value: Partial<SanityDocument>

--- a/packages/sanity/src/structure/panes/document/useResetHistoryParams.ts
+++ b/packages/sanity/src/structure/panes/document/useResetHistoryParams.ts
@@ -16,6 +16,11 @@ export function useResetHistoryParams() {
   const isMounted = useRef(false)
 
   const updateHistoryParams = useEffectEvent((_perspective?: string) => {
+    // Check if any of the history related params are set, and reset them, don't unnecessarily update the params
+    const PARAMS_TO_UPDATE = ['since', 'historyVersion', 'rev', 'preserveRev']
+    const shouldUpdateParams = PARAMS_TO_UPDATE.some((param) => params[param])
+    if (!shouldUpdateParams) return
+
     setParams({
       ...params,
       // Reset the history related params when the perspective changes, as they don't make sense


### PR DESCRIPTION
### Description

History params need to be reseted when the perspective changes, that's the reason for the `useResetHistoryParams` hook, however, this hook was triggering unnecessary `setParams` and that was creating a glitch in which the router starts jumping between perspectives when the user changes them fast.
See video:

https://github.com/user-attachments/assets/5e5e5d1e-6553-4209-b46f-9756eb3c07b9

This updates the useResetHistoryParams hook to only trigger the `setParams` function when a param needs to be updated, preventing this bug.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
