### PR TITLE
refactor(sanity): refine perspective stack types

### DIFF
--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -70,7 +70,8 @@
     "json5": "^2.2.3",
     "lodash": "^4.17.21",
     "quick-lru": "^5.1.1",
-    "react-compiler-runtime": "19.0.0-beta-55955c9-20241229"
+    "react-compiler-runtime": "19.0.0-beta-55955c9-20241229",
+    "react-fast-compare": "^3.2.2"
   },
   "devDependencies": {
     "@repo/package.config": "workspace:*",

--- a/packages/@sanity/vision/src/SanityVision.tsx
+++ b/packages/@sanity/vision/src/SanityVision.tsx
@@ -1,4 +1,4 @@
-import {type Tool, useClient} from 'sanity'
+import {type Tool, useClient, usePerspective} from 'sanity'
 
 import {DEFAULT_API_VERSION} from './apiVersions'
 import {VisionContainer} from './containers/VisionContainer'
@@ -11,6 +11,7 @@ interface SanityVisionProps {
 
 function SanityVision(props: SanityVisionProps) {
   const client = useClient({apiVersion: '1'})
+  const perspective = usePerspective()
   const config: VisionConfig = {
     defaultApiVersion: DEFAULT_API_VERSION,
     ...props.tool.options,
@@ -18,7 +19,7 @@ function SanityVision(props: SanityVisionProps) {
 
   return (
     <VisionErrorBoundary>
-      <VisionContainer client={client} config={config} />
+      <VisionContainer client={client} config={config} pinnedPerspective={perspective} />
     </VisionErrorBoundary>
   )
 }

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -1,6 +1,11 @@
 /* eslint-disable complexity */
 import {SplitPane} from '@rexxars/react-split-pane'
-import {type ListenEvent, type MutationEvent, type SanityClient} from '@sanity/client'
+import {
+  type ClientPerspective,
+  type ListenEvent,
+  type MutationEvent,
+  type SanityClient,
+} from '@sanity/client'
 import {CopyIcon, ErrorOutlineIcon, PlayIcon, StopIcon} from '@sanity/icons'
 import {
   Box,
@@ -19,14 +24,23 @@ import {
 } from '@sanity/ui'
 import {isHotkey} from 'is-hotkey-esm'
 import {debounce} from 'lodash'
-import {type ChangeEvent, createRef, PureComponent, type RefObject} from 'react'
-import {type TFunction, Translate} from 'sanity'
+import {
+  type ChangeEvent,
+  type ComponentType,
+  createRef,
+  PureComponent,
+  type RefObject,
+  useMemo,
+} from 'react'
+import isEqual from 'react-fast-compare'
+import {type PerspectiveValue, type TFunction, Translate} from 'sanity'
 
 import {API_VERSIONS, DEFAULT_API_VERSION} from '../apiVersions'
 import {VisionCodeMirror} from '../codemirror/VisionCodeMirror'
 import {
   DEFAULT_PERSPECTIVE,
   isSupportedPerspective,
+  isVirtualPerspective,
   SUPPORTED_PERSPECTIVES,
   type SupportedPerspective,
 } from '../perspectives'
@@ -192,6 +206,14 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
       perspective = DEFAULT_PERSPECTIVE
     }
 
+    if (perspective == 'pinnedRelease' && !hasPinnedPerspective(this.props.pinnedPerspective)) {
+      perspective = DEFAULT_PERSPECTIVE
+    }
+
+    if (perspective !== 'pinnedRelease' && hasPinnedPerspective(this.props.pinnedPerspective)) {
+      perspective = 'pinnedRelease'
+    }
+
     if (typeof lastQuery !== 'string') {
       lastQuery = ''
     }
@@ -209,7 +231,10 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     this._client = props.client.withConfig({
       apiVersion: customApiVersion || apiVersion,
       dataset,
-      perspective: perspective,
+      perspective: getActivePerspective({
+        visionPerspective: perspective,
+        pinnedPerspective: this.props.pinnedPerspective,
+      }),
       allowReconfigure: true,
     })
 
@@ -264,6 +289,7 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     this.handleKeyDown = this.handleKeyDown.bind(this)
     this.handleResize = this.handleResize.bind(this)
     this.handleOnPasteCapture = this.handleOnPasteCapture.bind(this)
+    this.setPerspective = this.setPerspective.bind(this)
   }
 
   componentDidMount() {
@@ -278,6 +304,30 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     this.cancelListener()
     this.cancelEventListener()
     this.cancelResizeListener()
+  }
+
+  componentDidUpdate(prevProps: Readonly<VisionGuiProps>): void {
+    if (hasPinnedPerspectiveChanged(prevProps.pinnedPerspective, this.props.pinnedPerspective)) {
+      if (
+        this.state.perspective !== 'pinnedRelease' &&
+        hasPinnedPerspective(this.props.pinnedPerspective)
+      ) {
+        this.setPerspective('pinnedRelease')
+        return
+      }
+
+      if (
+        this.state.perspective === 'pinnedRelease' &&
+        !hasPinnedPerspective(this.props.pinnedPerspective)
+      ) {
+        this.setPerspective('raw')
+        return
+      }
+
+      if (this.state.perspective === 'pinnedRelease') {
+        this.setPerspective('pinnedRelease')
+      }
+    }
   }
 
   handleResizeListen() {
@@ -338,11 +388,17 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
       }
     }
 
-    const perspective = isSupportedPerspective(parts.options.perspective)
-      ? parts.options.perspective
-      : undefined
+    const perspective =
+      isSupportedPerspective(parts.options.perspective) &&
+      !isVirtualPerspective(parts.options.perspective)
+        ? parts.options.perspective
+        : undefined
 
-    if (perspective && !isSupportedPerspective(perspective)) {
+    if (
+      perspective &&
+      (!isSupportedPerspective(parts.options.perspective) ||
+        isVirtualPerspective(parts.options.perspective))
+    ) {
       this.props.toast.push({
         closable: true,
         id: 'vision-paste-unsupported-perspective',
@@ -378,7 +434,10 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
         this._client.config({
           dataset: this.state.dataset,
           apiVersion: customApiVersion || apiVersion,
-          perspective: this.state.perspective,
+          perspective: getActivePerspective({
+            visionPerspective: this.state.perspective,
+            pinnedPerspective: this.props.pinnedPerspective,
+          }),
         })
         this.handleQueryExecution()
         this.props.toast.push({
@@ -399,7 +458,6 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     if (!this._querySubscription) {
       return
     }
-
     this._querySubscription.unsubscribe()
     this._querySubscription = undefined
   }
@@ -466,6 +524,10 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
 
   handleChangePerspective(evt: ChangeEvent<HTMLSelectElement>) {
     const perspective = evt.target.value
+    this.setPerspective(perspective)
+  }
+
+  setPerspective(perspective: string): void {
     if (!isSupportedPerspective(perspective)) {
       return
     }
@@ -473,7 +535,10 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     this.setState({perspective}, () => {
       this._localStorage.set('perspective', this.state.perspective)
       this._client.config({
-        perspective: this.state.perspective,
+        perspective: getActivePerspective({
+          visionPerspective: this.state.perspective,
+          pinnedPerspective: this.props.pinnedPerspective,
+        }),
       })
       this.handleQueryExecution()
     })
@@ -598,9 +663,13 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
 
     this.ensureSelectedApiVersion()
 
-    const urlQueryOpts: Record<string, string> = {}
+    const urlQueryOpts: Record<string, string | string[]> = {}
     if (this.state.perspective !== 'raw') {
-      urlQueryOpts.perspective = this.state.perspective
+      urlQueryOpts.perspective =
+        getActivePerspective({
+          visionPerspective: this.state.perspective,
+          pinnedPerspective: this.props.pinnedPerspective,
+        }) ?? []
     }
 
     const url = this._client.getUrl(
@@ -613,20 +682,22 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     this._querySubscription = this._client.observable
       .fetch(query, params, {filterResponse: false, tag: 'vision'})
       .subscribe({
-        next: (res) =>
+        next: (res) => {
           this.setState({
             queryTime: res.ms,
             e2eTime: Date.now() - queryStart,
             queryResult: res.result,
             queryInProgress: false,
             error: undefined,
-          }),
-        error: (error) =>
+          })
+        },
+        error: (error) => {
           this.setState({
             error,
             query,
             queryInProgress: false,
-          }),
+          })
+        },
       })
 
     return true
@@ -670,7 +741,7 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
   }
 
   render() {
-    const {datasets, t} = this.props
+    const {datasets, t, pinnedPerspective} = this.props
     const {
       apiVersion,
       customApiVersion,
@@ -778,9 +849,21 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
                 </Card>
 
                 <Select value={perspective} onChange={this.handleChangePerspective}>
-                  {SUPPORTED_PERSPECTIVES.map((p) => (
-                    <option key={p}>{p}</option>
-                  ))}
+                  {SUPPORTED_PERSPECTIVES.map((perspectiveName) => {
+                    if (perspectiveName === 'pinnedRelease') {
+                      return (
+                        <>
+                          <PinnedReleasePerspectiveOption
+                            key="pinnedRelease"
+                            pinnedPerspective={pinnedPerspective}
+                            t={t}
+                          />
+                          <hr />
+                        </>
+                      )
+                    }
+                    return <option key={perspectiveName}>{perspectiveName}</option>
+                  })}
                 </Select>
               </Stack>
             </Box>
@@ -1026,4 +1109,63 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
       </Root>
     )
   }
+}
+
+function getActivePerspective({
+  visionPerspective,
+  pinnedPerspective,
+}: {
+  visionPerspective: ClientPerspective | SupportedPerspective
+  pinnedPerspective: PerspectiveValue
+}): ClientPerspective | undefined {
+  if (visionPerspective !== 'pinnedRelease') {
+    return visionPerspective
+  }
+
+  if (pinnedPerspective.perspectiveStack.length !== 0) {
+    return pinnedPerspective.perspectiveStack
+  }
+
+  if (typeof pinnedPerspective.selectedPerspectiveName !== 'undefined') {
+    return [pinnedPerspective.selectedPerspectiveName]
+  }
+
+  return undefined
+}
+
+const PinnedReleasePerspectiveOption: ComponentType<{
+  pinnedPerspective: PerspectiveValue
+  t: TFunction
+}> = ({pinnedPerspective, t}) => {
+  const name =
+    typeof pinnedPerspective.selectedPerspective === 'object'
+      ? pinnedPerspective.selectedPerspective.metadata.title
+      : pinnedPerspective.selectedPerspectiveName
+
+  const label = hasPinnedPerspective(pinnedPerspective)
+    ? `(${t('settings.perspectives.pinned-release-label')})`
+    : t('settings.perspectives.pinned-release-label')
+
+  const text = useMemo(
+    () => [name, label].filter((value) => typeof value !== 'undefined').join(' '),
+    [label, name],
+  )
+
+  return (
+    <option value="pinnedRelease" disabled={!hasPinnedPerspective(pinnedPerspective)}>
+      {text}
+    </option>
+  )
+}
+
+function hasPinnedPerspective({selectedPerspectiveName}: PerspectiveValue): boolean {
+  return typeof selectedPerspectiveName !== 'undefined'
+}
+
+function hasPinnedPerspectiveChanged(previous: PerspectiveValue, next: PerspectiveValue): boolean {
+  const hasPerspectiveStackChanged = !isEqual(previous.perspectiveStack, next.perspectiveStack)
+
+  return (
+    previous.selectedPerspectiveName !== next.selectedPerspectiveName || hasPerspectiveStackChanged
+  )
 }

--- a/packages/@sanity/vision/src/i18n/resources.ts
+++ b/packages/@sanity/vision/src/i18n/resources.ts
@@ -74,6 +74,8 @@ const visionLocaleStrings = defineLocalesResources('vision', {
   /** Description for popover that explains what "Perspectives" are */
   'settings.perspectives.description':
     'Perspectives allow your query to run against different "views" of the content in your dataset',
+  /** Label for the pinned release perspective */
+  'settings.perspectives.pinned-release-label': 'pinned release',
   /** Title for popover that explains what "Perspectives" are */
   'settings.perspectives.title': 'Perspectives',
 } as const)

--- a/packages/@sanity/vision/src/perspectives.ts
+++ b/packages/@sanity/vision/src/perspectives.ts
@@ -1,15 +1,36 @@
-import {type ClientPerspective} from '@sanity/client'
-
-export type SupportedPerspective = 'raw' | 'previewDrafts' | 'published' | 'drafts'
-
 export const SUPPORTED_PERSPECTIVES = [
+  'pinnedRelease',
   'raw',
   'previewDrafts',
   'published',
   'drafts',
-] satisfies ClientPerspective[]
-export const DEFAULT_PERSPECTIVE = SUPPORTED_PERSPECTIVES[0]
+] as const
+
+export type SupportedPerspective = (typeof SUPPORTED_PERSPECTIVES)[number]
+
+/**
+ * Virtual perspectives are recognised by Vision, but do not concretely reflect the names of real
+ * perspectives. Virtual perspectives are transformed into real perspectives before being used to
+ * interact with data.
+ *
+ * For example, the `pinnedRelease` virtual perspective is transformed to the real perspective
+ * currently pinned in Studio.
+ */
+export const VIRTUAL_PERSPECTIVES = ['pinnedRelease'] as const
+
+export type VirtualPerspective = (typeof VIRTUAL_PERSPECTIVES)[number]
+
+export const DEFAULT_PERSPECTIVE: SupportedPerspective = 'raw'
 
 export function isSupportedPerspective(p: string): p is SupportedPerspective {
   return SUPPORTED_PERSPECTIVES.includes(p as SupportedPerspective)
+}
+
+export function isVirtualPerspective(
+  maybeVirtualPerspective: unknown,
+): maybeVirtualPerspective is VirtualPerspective {
+  return (
+    typeof maybeVirtualPerspective === 'string' &&
+    VIRTUAL_PERSPECTIVES.includes(maybeVirtualPerspective as VirtualPerspective)
+  )
 }

--- a/packages/@sanity/vision/src/types.ts
+++ b/packages/@sanity/vision/src/types.ts
@@ -1,9 +1,11 @@
 import {type SanityClient} from '@sanity/client'
 import {type ComponentType} from 'react'
+import {type PerspectiveValue} from 'sanity'
 
 export interface VisionProps {
   client: SanityClient
   config: VisionConfig
+  pinnedPerspective: PerspectiveValue
 }
 
 export interface VisionConfig {

--- a/packages/@sanity/vision/src/util/encodeQueryString.ts
+++ b/packages/@sanity/vision/src/util/encodeQueryString.ts
@@ -1,7 +1,7 @@
 export function encodeQueryString(
   query: string,
   params: Record<string, unknown> = {},
-  options: Record<string, string> = {},
+  options: Record<string, string | string[]> = {},
 ): string {
   const searchParams = new URLSearchParams()
   searchParams.set('query', query)

--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
@@ -10,6 +10,7 @@ import {
   type VersionsRecord,
   type VersionTuple,
 } from '../../../../preview/utils/getPreviewStateObservable'
+import {type PerspectiveStack} from '../../../../releases'
 import {createSearch} from '../../../../search'
 import {
   collate,
@@ -48,7 +49,10 @@ export function getReferenceInfo(
   id: string,
   referenceType: ReferenceSchemaType,
   {version}: {version?: string} = {},
-  perspective: {bundleIds: string[]; bundleStack: string[]} = {bundleIds: [], bundleStack: []},
+  perspective: {bundleIds: string[]; bundleStack: PerspectiveStack} = {
+    bundleIds: [],
+    bundleStack: [],
+  },
 ): Observable<ReferenceInfo> {
   const {publishedId, draftId, versionId} = getIdPair(id, {version})
 

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -34,6 +34,7 @@ export {
   isReleaseDocument,
   isReleaseScheduledOrScheduling,
   LATEST,
+  type PerspectiveValue,
   type ReleaseDocument,
   RELEASES_INTENT,
   useDocumentVersions,

--- a/packages/sanity/src/core/preview/utils/getPreviewStateObservable.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewStateObservable.ts
@@ -4,6 +4,7 @@ import {type ReactNode} from 'react'
 import {combineLatest, from, type Observable, of} from 'rxjs'
 import {map, mergeMap, scan, startWith} from 'rxjs/operators'
 
+import {type PerspectiveStack} from '../../releases/hooks/usePerspective'
 import {
   getDraftId,
   getPublishedId,
@@ -51,7 +52,7 @@ export function getPreviewStateObservable(
      * An array of release ids ordered chronologically to represent the state of documents at the
      * given point in time.
      */
-    bundleStack: string[]
+    bundleStack: PerspectiveStack
 
     /**
      * Perspective to use when fetching versions.

--- a/packages/sanity/src/core/releases/hooks/useIsReleaseActive.ts
+++ b/packages/sanity/src/core/releases/hooks/useIsReleaseActive.ts
@@ -1,3 +1,4 @@
+import {isReleaseDocument} from '../store/types'
 import {isDraftPerspective, isPublishedPerspective} from '../util/util'
 import {usePerspective} from './usePerspective'
 
@@ -7,6 +8,7 @@ export const useIsReleaseActive = () => {
 
   return (
     !isPublishedPerspective(selectedPerspective) &&
-    (isDraftPerspective(selectedPerspective) || selectedPerspective.state === 'active')
+    (isDraftPerspective(selectedPerspective) ||
+      (isReleaseDocument(selectedPerspective) && selectedPerspective.state === 'active'))
   )
 }

--- a/packages/sanity/src/core/releases/hooks/usePerspective.tsx
+++ b/packages/sanity/src/core/releases/hooks/usePerspective.tsx
@@ -1,4 +1,4 @@
-import {type ReleaseId} from '@sanity/client'
+import {type ClientPerspective, type ReleaseId} from '@sanity/client'
 import {Text, useToast} from '@sanity/ui'
 import {useCallback, useEffect, useMemo} from 'react'
 import {useRouter} from 'sanity/router'
@@ -16,6 +16,11 @@ import {getReleasesPerspectiveStack} from './utils'
  * @internal
  */
 export type SelectedPerspective = ReleaseDocument | 'published' | 'drafts'
+
+/**
+ * @internal
+ */
+export type PerspectiveStack = ExtractArray<ClientPerspective>
 
 /**
  * @internal
@@ -39,7 +44,7 @@ export interface PerspectiveValue {
   /**
    * The stacked array of releases ids ordered chronologically to represent the state of documents at the given point in time.
    */
-  perspectiveStack: string[]
+  perspectiveStack: PerspectiveStack
 }
 
 const EMPTY_ARRAY: string[] = []
@@ -188,3 +193,5 @@ export function usePerspective(): PerspectiveValue {
     ],
   )
 }
+
+type ExtractArray<Union> = Union extends unknown[] ? Union : never

--- a/packages/sanity/src/core/releases/hooks/utils.ts
+++ b/packages/sanity/src/core/releases/hooks/utils.ts
@@ -1,8 +1,9 @@
-import {type ReleaseId} from '@sanity/client'
+import {type ClientPerspective, type ReleaseId} from '@sanity/client'
 
 import {DRAFTS_FOLDER} from '../../util/draftUtils'
 import {type ReleaseDocument} from '../store/types'
 import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
+import {type PerspectiveStack} from '.'
 
 export function sortReleases(releases: ReleaseDocument[] = []): ReleaseDocument[] {
   // The order should always be:
@@ -57,11 +58,11 @@ export function getReleasesPerspectiveStack({
   selectedPerspectiveName: ReleaseId | undefined | 'published'
   releases: ReleaseDocument[]
   excludedPerspectives: string[]
-}): string[] {
+}): PerspectiveStack {
   if (!selectedPerspectiveName || selectedPerspectiveName === 'published') {
     return []
   }
-  const sorted: string[] = sortReleases(releases).map((release) =>
+  const sorted: ClientPerspective = sortReleases(releases).map((release) =>
     getReleaseIdFromReleaseDocumentId(release._id),
   )
   const selectedIndex = sorted.indexOf(selectedPerspectiveName)

--- a/packages/sanity/src/core/releases/navbar/ReleasesNav.tsx
+++ b/packages/sanity/src/core/releases/navbar/ReleasesNav.tsx
@@ -11,6 +11,7 @@ import {ToolLink} from '../../studio'
 import {ReleaseAvatar} from '../components/ReleaseAvatar'
 import {usePerspective} from '../hooks/usePerspective'
 import {RELEASES_INTENT, RELEASES_TOOL_NAME} from '../plugin'
+import {isReleaseDocument} from '../store/types'
 import {LATEST} from '../util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
 import {getReleaseTone} from '../util/getReleaseTone'
@@ -64,10 +65,11 @@ export function ReleasesNav(): React.JSX.Element {
   const currentGlobalPerspectiveLabel = useMemo(() => {
     if (!selectedPerspective || isDraftPerspective(selectedPerspective)) return null
 
-    let displayTitle
+    let displayTitle = t('release.placeholder-untitled-release')
+
     if (isPublishedPerspective(selectedPerspective)) {
       displayTitle = t('release.chip.published')
-    } else {
+    } else if (isReleaseDocument(selectedPerspective)) {
       displayTitle =
         selectedPerspective.metadata?.title || t('release.placeholder-untitled-release')
     }
@@ -94,7 +96,11 @@ export function ReleasesNav(): React.JSX.Element {
         <IntentLink
           {...intentProps}
           intent={RELEASES_INTENT}
-          params={{id: getReleaseIdFromReleaseDocumentId(selectedPerspective._id!)}}
+          params={
+            isReleaseDocument(selectedPerspective)
+              ? {id: getReleaseIdFromReleaseDocumentId(selectedPerspective._id)}
+              : {}
+          }
         >
           {children}
         </IntentLink>

--- a/packages/sanity/src/core/releases/util/getReleaseTone.ts
+++ b/packages/sanity/src/core/releases/util/getReleaseTone.ts
@@ -1,27 +1,31 @@
 import {type BadgeTone} from '@sanity/ui'
 
-import {type ReleaseDocument} from '../store/types'
+import {type SelectedPerspective} from '../hooks/usePerspective'
+import {isReleaseDocument} from '../store/types'
 import {isDraftPerspective, isPublishedPerspective} from './util'
 
 /** @internal */
-export function getReleaseTone(release: ReleaseDocument | 'published' | 'drafts'): BadgeTone {
+export function getReleaseTone(release: SelectedPerspective): BadgeTone {
   if (isPublishedPerspective(release)) return 'positive'
   if (isDraftPerspective(release)) return 'default'
 
-  if (release.state === 'archived') {
-    return 'default'
+  if (isReleaseDocument(release)) {
+    if (release.state === 'archived') {
+      return 'default'
+    }
+
+    if (release?.metadata?.releaseType === 'asap') {
+      return 'critical'
+    }
+
+    if (release?.metadata?.releaseType === 'undecided') {
+      return 'suggest'
+    }
+
+    if (release?.metadata?.releaseType === 'scheduled') {
+      return 'primary'
+    }
   }
 
-  if (release?.metadata?.releaseType === 'asap') {
-    return 'critical'
-  }
-
-  if (release?.metadata?.releaseType === 'undecided') {
-    return 'suggest'
-  }
-
-  if (release?.metadata?.releaseType === 'scheduled') {
-    return 'primary'
-  }
   return 'default'
 }

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
@@ -59,27 +59,26 @@ export function SearchResultItemPreview({
   const {state} = useSearchState()
   const isRaw = isPerspectiveRaw(state.perspective)
 
-  const observable = useMemo(
-    () =>
-      getPreviewStateObservable(documentPreviewStore, schemaType, documentId, '', {
-        bundleIds: releases.releasesIds,
-        /**
-         * if the perspective is defined in the state it means that there is a scope to the search
-         * and that the preview needs to take that into account
-         */
-        bundleStack: state.perspective && !isRaw ? state.perspective : perspectiveStack,
-        isRaw: isRaw,
-      }),
-    [
-      documentPreviewStore,
-      schemaType,
-      documentId,
-      releases.releasesIds,
-      state.perspective,
-      perspectiveStack,
-      isRaw,
-    ],
-  )
+  const observable = useMemo(() => {
+    const bundleStack = state.perspective && !isRaw ? state.perspective : perspectiveStack
+    return getPreviewStateObservable(documentPreviewStore, schemaType, documentId, '', {
+      bundleIds: releases.releasesIds,
+      /**
+       * if the perspective is defined in the state it means that there is a scope to the search
+       * and that the preview needs to take that into account
+       */
+      bundleStack: Array.isArray(bundleStack) ? bundleStack : [],
+      isRaw: isRaw,
+    })
+  }, [
+    documentPreviewStore,
+    schemaType,
+    documentId,
+    releases.releasesIds,
+    state.perspective,
+    perspectiveStack,
+    isRaw,
+  ])
 
   const {
     draft,

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
@@ -1,3 +1,4 @@
+import {type ClientPerspective} from '@sanity/client'
 import {isEqual} from 'lodash'
 import {type ReactNode, useEffect, useMemo, useReducer, useRef, useState} from 'react'
 import {SearchContext} from 'sanity/_singletons'
@@ -28,7 +29,7 @@ interface SearchProviderProps {
    * list of perspective ids
    * if provided, then it means that the search is being done using a specific list of perspectives
    */
-  perspective?: string[]
+  perspective?: ClientPerspective
   /**
    * list of document ids that should be be disabled in the search
    * if they are found to exist in the search results

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.ts
@@ -1,3 +1,4 @@
+import {type ClientPerspective} from '@sanity/client'
 import {type CurrentUser, type SchemaType, type SearchStrategy} from '@sanity/types'
 
 import {type SearchHit, type SearchTerms} from '../../../../../../search'
@@ -42,7 +43,7 @@ export type SearchReducerState = PaginationState & {
   terms: RecentSearch | SearchTerms
   strategy?: SearchStrategy
   disabledDocumentIds?: string[]
-  perspective?: string[]
+  perspective?: ClientPerspective
 }
 
 export interface SearchDefinitions {

--- a/packages/sanity/src/core/studio/components/navbar/search/types.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/types.ts
@@ -1,3 +1,4 @@
+import {type ClientPerspective} from '@sanity/client'
 import {type SchemaType} from '@sanity/types'
 import {type ButtonTone, type CardTone} from '@sanity/ui'
 
@@ -88,5 +89,5 @@ export interface SearchState {
   error: Error | null
   options?: SearchOptions
   terms: SearchTerms
-  perspective?: string[]
+  perspective?: ClientPerspective
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1261,6 +1261,9 @@ importers:
       react-compiler-runtime:
         specifier: 19.0.0-beta-55955c9-20241229
         version: 19.0.0-beta-55955c9-20241229(react@18.3.1)
+      react-fast-compare:
+        specifier: ^3.2.2
+        version: 3.2.2
     devDependencies:
       '@repo/package.config':
         specifier: workspace:*


### PR DESCRIPTION
### Description

There are some places across the codebase we could improve the typing of perspective stacks so that they're more precise and consistent. In a lot of places, these stacks are currently typed as `string[]`, which is not compatible with `ClientPerspective`. This code now uses the new type `PerspectiveStack`, which reflects only the array values accepted by `ClientPerspective`.

Note: It would be a good idea to export `PerspectiveStack` from `@sanity/client` in the future, rather than us extracting it from the `ClientPerspective` type.

This branch also adopts the `isReleaseDocument` type guard where applicable to determine whether the selected perspective is a system perspective (e.g. `published`) or a release document. In the past, this tended to be done by explicitly checking whether the string is `published` or `draft`, otherwise assuming the value is a release document. Like this:

```ts
if (
  !isPublishedPerspective(selectedPerspective) &&
  !isDraftPerspective(selectedPerspective)
) {
  // `selectedPerspective` should be a release document
}
```

This narrowing starts to fail if the value could be any other string (e.g. `previewDrafts`).

I think we probably do this because the code predates the existence of the isReleaseDocument type guard:

```ts
if (isReleaseDocument(selectedPerspective)) {
  // `selectedPerspective` should be a release document
}
```

### What to review

Does this seem reasonable?

### Testing

Existing test coverage of modified code passes.