### PR TITLE
fix: patching a readOnly document is blocked

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -542,10 +542,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   ])
 
   const patchRef = useRef<(event: PatchEvent) => void>(() => {
-    if (readOnly) {
-      throw new Error('Attempted to patch a read-only document')
-    }
-
     throw new Error(
       'Attempted to patch the Sanity document during initial render or in an `useInsertionEffect`. Input components should only call `onChange()` in a useEffect or an event handler.',
     )
@@ -554,7 +550,11 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const handleChange = useCallback((event: PatchEvent) => patchRef.current(event), [])
 
   useInsertionEffect(() => {
-    if (readOnly) return
+    if (readOnly) {
+      patchRef.current = () => {
+        throw new Error('Attempted to patch a read-only document')
+      }
+    }
 
     // note: this needs to happen in an insertion effect to make sure we're ready to receive patches from child components when they run their effects initially
     // in case they do e.g. `useEffect(() => props.onChange(set("foo")), [])`


### PR DESCRIPTION
### Description
| Before | After |
|--------|--------|
| ![patchReadOnlyBEFORE](https://github.com/user-attachments/assets/2d01ffcf-ef95-4897-b234-eee42ceb4408) | ![patchReadOnlyAFTER](https://github.com/user-attachments/assets/662a8162-aa68-4650-866f-a5e8daad412f) | 

Above shows a demo where a document is placed in readOnly mode, but the custom input still called the `onChange` callback. After refresh in 'Before' the change has persisted. In 'After' the change has not persisted
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixing issue where custom form inputs could wrongly patch a `readOnly` document by call `onChange`
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
