### PR TITLE
fix(sanity): editing version document using Actions API

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -168,6 +168,10 @@ const defaultWorkspace = defineConfig({
   },
   basePath: '/test',
   icon: SanityMonogram,
+  // eslint-disable-next-line camelcase
+  __internal_serverDocumentActions: {
+    enabled: true,
+  },
   scheduledPublishing: {
     enabled: true,
     inputDateTimeFormat: 'MM/dd/yy h:mm a',

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -117,7 +117,7 @@ function toActions(idPair: IdPair, mutationParams: Mutation['params']): Action[]
     if (mutations.patch) {
       return {
         actionType: 'sanity.action.document.edit',
-        draftId: idPair.draftId,
+        draftId: idPair.versionId ?? idPair.draftId,
         publishedId: idPair.publishedId,
         patch: omit(mutations.patch, 'id'),
       }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/patch.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/patch.ts
@@ -9,9 +9,8 @@ export const patch: OperationImpl<[patches: any[], initialDocument?: Record<stri
     patches = [],
     initialDocument,
   ): void => {
-    // TODO: This is exactly the same strategy as live-editing. Can we avoid duplication?
     if (version) {
-      // No drafting, so patch and commit the published document
+      // No drafting, so patch and commit the version document.
       version.mutate([
         version.createIfNotExists({
           _type: typeName,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.test.ts
@@ -1,0 +1,169 @@
+import {type SanityClient} from '@sanity/client'
+import {of} from 'rxjs'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+
+import {createMockSanityClient} from '../../../../../../../test/mocks/mockSanityClient'
+import {type IdPair} from '../../types'
+import {checkoutPair} from '../checkoutPair'
+import {type OperationArgs} from '../operations/types'
+import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
+import {patch} from './patch'
+
+vi.mock('../utils/isLiveEditEnabled', () => ({isLiveEditEnabled: vi.fn()}))
+
+beforeEach(() => {
+  ;(isLiveEditEnabled as Mock).mockClear()
+})
+
+describe('patch', () => {
+  describe('draft exists, version not checked-out', () => {
+    it('operates on the draft document only', () => {
+      const client = createMockSanityClient() as unknown as SanityClient
+
+      const idPair: IdPair = {
+        draftId: 'drafts.my-id',
+        publishedId: 'my-id',
+      }
+
+      const pair = checkoutPair(client, idPair, of(true))
+      const versionMutate = vi.fn()
+      const draftMutate = vi.fn()
+      const publishedMutate = vi.fn()
+
+      if (typeof pair.version !== 'undefined') {
+        pair.version.mutate = versionMutate
+      }
+
+      pair.draft.mutate = draftMutate
+      pair.published.mutate = publishedMutate
+
+      patch.execute(
+        {
+          client,
+          idPair,
+          snapshots: {
+            draft: {
+              _createdAt: '2021-09-14T22:48:02.303Z',
+              _rev: 'exampleRev',
+              _id: 'drafts.my-id',
+              _type: 'example',
+              _updatedAt: '2021-09-14T22:48:02.303Z',
+              newValue: 'hey',
+            },
+            published: {
+              _createdAt: '2021-09-14T22:48:02.303Z',
+              _rev: 'exampleRev',
+              _id: 'drafts.my-id',
+              _type: 'example',
+              _updatedAt: '2021-09-14T22:48:02.303Z',
+            },
+          },
+          serverActionsEnabled: true,
+          ...pair,
+        } as unknown as OperationArgs,
+        [
+          {
+            unset: ['newValue'],
+          },
+        ],
+      )
+
+      expect(draftMutate).toHaveBeenCalledOnce()
+
+      expect(draftMutate).toHaveBeenCalledWith([
+        {
+          createIfNotExists: {
+            _createdAt: '2021-09-14T22:48:02.303Z',
+            _id: 'drafts.my-id',
+          },
+        },
+        {
+          patch: {
+            id: 'drafts.my-id',
+            unset: ['newValue'],
+          },
+        },
+      ])
+
+      expect(publishedMutate).not.toHaveBeenCalled()
+      expect(versionMutate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('draft exists, version checked-out', () => {
+    it('operates on the version document only', () => {
+      const client = createMockSanityClient() as unknown as SanityClient
+
+      const idPair: IdPair = {
+        draftId: 'drafts.my-id',
+        publishedId: 'my-id',
+        versionId: 'versions.x.my-id',
+      }
+
+      const pair = checkoutPair(client, idPair, of(true))
+      const versionMutate = vi.fn()
+      const draftMutate = vi.fn()
+      const publishedMutate = vi.fn()
+
+      if (typeof pair.version !== 'undefined') {
+        pair.version.mutate = versionMutate
+      }
+
+      pair.draft.mutate = draftMutate
+      pair.published.mutate = publishedMutate
+
+      patch.execute(
+        {
+          client,
+          idPair,
+          snapshots: {
+            draft: {
+              _createdAt: '2021-09-14T22:48:02.303Z',
+              _rev: 'exampleRev',
+              _id: 'drafts.my-id',
+              _type: 'example',
+              _updatedAt: '2021-09-14T22:48:02.303Z',
+              newValue: 'hey',
+            },
+            published: {
+              _createdAt: '2021-09-14T22:48:02.303Z',
+              _rev: 'exampleRev',
+              _id: 'drafts.my-id',
+              _type: 'example',
+              _updatedAt: '2021-09-14T22:48:02.303Z',
+            },
+            version: {
+              _createdAt: '2021-09-14T22:48:02.303Z',
+              _rev: 'exampleRev',
+              _id: 'versions.x.my-id',
+              _type: 'example',
+              _updatedAt: '2021-09-14T22:48:02.303Z',
+              newValue: 'hey',
+            },
+          },
+          serverActionsEnabled: true,
+          ...pair,
+        } as unknown as OperationArgs,
+        [
+          {
+            unset: ['newValue'],
+          },
+        ],
+      )
+
+      expect(versionMutate).toHaveBeenCalledOnce()
+
+      expect(versionMutate).toHaveBeenCalledWith([
+        {
+          patch: {
+            id: 'versions.x.my-id',
+            unset: ['newValue'],
+          },
+        },
+      ])
+
+      expect(draftMutate).not.toHaveBeenCalled()
+      expect(publishedMutate).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
@@ -8,10 +8,8 @@ export const patch: OperationImpl<[patches: any[], initialDocument?: Record<stri
     patches = [],
     initialDocument,
   ): void => {
-    // TODO: Actions API can't edit versions (yet).
-    // TODO: This is exactly the same strategy as live-editing. Can we avoid duplication?
     if (version) {
-      // No drafting, so patch and commit the published document
+      // No drafting, so patch and commit the version document.
       const patchMutation = version.patch(patches)
       // Note: if the document doesn't exist on the server yet, we need to create it first. We only want to do this if we can't see it locally
       // if it's been deleted on the server we want that to become a mutation error when submitting.

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/utils/actionsApiClient.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/utils/actionsApiClient.ts
@@ -1,6 +1,6 @@
 import {type SanityClient} from '@sanity/client'
 
-const ACTIONS_API_MINIMUM_VERSION = '2024-05-23'
+const ACTIONS_API_MINIMUM_VERSION = 'vX'
 
 export function actionsApiClient(client: SanityClient): SanityClient {
   return client.withConfig({


### PR DESCRIPTION
### Description

This branch fixes version editing when using the Actions API, and  enables the Actions API in the default workspace in Test Studio.

When using the Actions API to edit a version document, the `draftId` option must refer to the version id. Previously, the draft document would be patched instead, which is incorrect.

This branch also temporarily changes the API version to `vX` when executing Actions API actions. At this point in time, the Actions API can only execute certain actions for version documents (e.g. `sanity.action.document.edit`) in `vX`.

### What to review

Editing a version document successfully calls the edit action for the version document. The draft and published documents must not be affected.

### Testing

Added unit test in `packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.test.ts`.