### PR TITLE
fix: readOnly pane overrides patch

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -554,18 +554,18 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       patchRef.current = () => {
         throw new Error('Attempted to patch a read-only document')
       }
-    }
+    } else {
+      // note: this needs to happen in an insertion effect to make sure we're ready to receive patches from child components when they run their effects initially
+      // in case they do e.g. `useEffect(() => props.onChange(set("foo")), [])`
+      // Note: although we discourage patch-on-mount, we still support it.
+      patchRef.current = (event: PatchEvent) => {
+        // when creating a new draft
+        if (!editState.draft && !editState.published) {
+          telemetry.log(CreatedDraft)
+        }
 
-    // note: this needs to happen in an insertion effect to make sure we're ready to receive patches from child components when they run their effects initially
-    // in case they do e.g. `useEffect(() => props.onChange(set("foo")), [])`
-    // Note: although we discourage patch-on-mount, we still support it.
-    patchRef.current = (event: PatchEvent) => {
-      // when creating a new draft
-      if (!editState.draft && !editState.published) {
-        telemetry.log(CreatedDraft)
+        patch.execute(toMutationPatches(event.patches), initialValue.value)
       }
-
-      patch.execute(toMutationPatches(event.patches), initialValue.value)
     }
   }, [editState.draft, editState.published, initialValue.value, patch, telemetry, readOnly])
 


### PR DESCRIPTION
### Description
Resolved a bug in https://github.com/sanity-io/sanity/pull/8292
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Verified this works locally with the markdown plugin using content releases
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A - Noted in https://github.com/sanity-io/sanity/pull/8292
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
