### PR TITLE
fix(presentation): avoid duplicate key warning

### DIFF
--- a/packages/sanity/src/presentation/loader/LoaderQueries.tsx
+++ b/packages/sanity/src/presentation/loader/LoaderQueries.tsx
@@ -262,8 +262,12 @@ const Turbo = memo(function Turbo(props: TurboProps) {
       }
     }
     const nextBatchSlice = [...nextBatch].slice(0, LIVE_QUERY_CACHE_BATCH_SIZE)
-    if (nextBatchSlice.length === 0) return
-    setBatch((prevBatch) => [...prevBatch.slice(-LIVE_QUERY_CACHE_BATCH_SIZE), nextBatchSlice])
+    if (nextBatchSlice.length === 0) return undefined
+    const raf = requestAnimationFrame(() =>
+      // eslint-disable-next-line max-nested-callbacks
+      setBatch((prevBatch) => [...prevBatch.slice(-LIVE_QUERY_CACHE_BATCH_SIZE), nextBatchSlice]),
+    )
+    return () => cancelAnimationFrame(raf)
   }, [batch, cache, turboIds])
 
   // Use the same listen instance and patch documents as they come in


### PR DESCRIPTION
Fixes #8309
Fixes #8310

### Description

When React is in strict mode there's a warning coming from Presentation.
When using `sanity dev` strict mode is opt-in:
```ts
// sanity.cli.ts
import {defineCliConfig} from 'sanity/cli'

export default defineCliConfig({
  reactStrictMode: true,
})
```
While on Next.js App Router it's opt-out.

### What to review

The fix is to wrap the `useEffect` that batches documents to fetch in a `requestAnimationFrame`, which is cancelled if we're in React Strict Mode which double-fires `useEffect`.
This isn't a good long term fix in general, but in this case it's ok. The code where this happens is presentation's `<LoaderQueries />` driver, which uses the legacy way of live updating user provided GROQ queries.
As soon as https://www.sanity.io/live becomes stable for draft content we have another implementation that will take it's place: `<LiveQueries />`.
The new implementation doesn't need to batch fetch full documents, and thus is unaffected by this strict mode issue.

### Testing

Tested manually by running `pnpm dev` and checking `http://localhost:3333/presentation/presentation/`.
On `next` it'll currently warn about duplicate keys, while on this branch there is no warning, and there's only a single instance of `GetDocuments` in the React DevTools:
<img width="743" alt="image" src="https://github.com/user-attachments/assets/df85deaa-c02a-4d37-ae72-c65f7f34ae68" />


### Notes for release

No longer warns about duplicate keys when using Presentation on `sanity dev` with react strict mode, or embedded studios on Next.js App Router.
