### PR TITLE
fix(presentation): always show all documents in use

### DIFF
--- a/packages/sanity/src/presentation/editor/DocumentListPane.tsx
+++ b/packages/sanity/src/presentation/editor/DocumentListPane.tsx
@@ -50,7 +50,7 @@ export function DocumentListPane(props: {
     () =>
       refs
         .filter((r) => getPublishedId(r._id) !== mainDocumentState?.document?._id)
-        .map((r) => r._id),
+        .map((r) => getPublishedId(r._id)),
     [mainDocumentState, refs],
   )
 


### PR DESCRIPTION
### Description

Fixes a regression (I don't know exactly when this regressed) causing only published documents to show up in the list of documents in use in presentation.

### What to review

Does it make sense?

### Testing

When using the default `Drafts` perspective, notice the before and after (the right hand side is correct, the left hand side only shows documents that are published and have no drafts):

<img width="1486" alt="image" src="https://github.com/user-attachments/assets/7cbf50c7-86f0-4efd-95ed-6448907b9e4b" />

For the `Published` perspective it should only filter out documents that only have a draft variant:

<img width="1487" alt="image" src="https://github.com/user-attachments/assets/722ee4e0-89ee-4b29-bd62-91c38225b99e" />



### Notes for release

The Presentation Tool's "Documents in use" pane is now including draft documents, and unpublished documents. So that it actually shows all documents in use, and not just some of them.
