### PR TITLE
fix(core): references to documents on same release are valid

### DIFF
--- a/packages/sanity/src/core/preview/availability.ts
+++ b/packages/sanity/src/core/preview/availability.ts
@@ -6,7 +6,7 @@ import {combineLatest, defer, from, type Observable, of} from 'rxjs'
 import {distinctUntilChanged, map, mergeMap, reduce, switchMap} from 'rxjs/operators'
 import shallowEquals from 'shallow-equals'
 
-import {createSWR, getDraftId, getPublishedId, getVersionId, isRecord, isVersionId} from '../util'
+import {createSWR, getDraftId, getPublishedId, getVersionId, isRecord} from '../util'
 import {
   AVAILABILITY_NOT_FOUND,
   AVAILABILITY_PERMISSION_DENIED,
@@ -150,7 +150,7 @@ export function createPreviewAvailabilityObserver(
   ): Observable<DraftsModelDocumentAvailability> {
     const draftId = getDraftId(id)
     const publishedId = getPublishedId(id)
-    const versionId = isVersionId(id) && version ? getVersionId(id, version) : undefined
+    const versionId = version ? getVersionId(id, version) : undefined
     return combineLatest([
       observeDocumentAvailability(draftId),
       observeDocumentAvailability(publishedId),


### PR DESCRIPTION
### Description

Validates that references to documents in the same release are valid.
Previously we only considered as valid references the references to documents that are published, with the introduction of releases now references to documents that will be part of the same release, but not published yet, are valid, because they will be released at the same time.

This PR fixes that, allowing us to reference documents from the same release.

**What this doesn't fix?**
It doesn't fix references to documents that are part of other releases which will be released before this one, following the stack criteria.


Example:
This document is referencing a document that only exists in the same release:
[Validation passing in preview ](https://test-studio-git-corel-validate-references.sanity.dev/test/structure/author;66c88564-7b53-41ab-8827-99bc64ab0d04?perspective=rO2NP9B76)
[Validation NOT passing in `corel`](https://test-studio-git-corel.sanity.dev/test/structure/author;66c88564-7b53-41ab-8827-99bc64ab0d04?perspective=rO2NP9B76)



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is this change correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Create a document that only exists in a release, reference that document from another document in the same release, the validation should pass.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
