### PR TITLE
fix(core): duplicate should work with version documents

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
@@ -45,7 +45,7 @@ export interface EditStateFor {
   /**
    * When editing a version, the name of the release the document belongs to.
    */
-  release?: string
+  release: string | undefined
 }
 const LOCKED: TransactionSyncLockState = {enabled: true}
 const NOT_LOCKED: TransactionSyncLockState = {enabled: false}
@@ -98,7 +98,7 @@ export const editState = memoize(
           liveEditSchemaType,
           ready: !fromCache,
           transactionSyncLock: fromCache ? null : transactionSyncLock,
-          bundleId: idPair.versionId ? getVersionFromId(idPair.versionId) : undefined,
+          release: idPair.versionId ? getVersionFromId(idPair.versionId) : undefined,
         }),
       ),
       startWith({
@@ -111,7 +111,7 @@ export const editState = memoize(
         liveEditSchemaType,
         ready: false,
         transactionSyncLock: null,
-        bundleId: idPair.versionId ? getVersionFromId(idPair.versionId) : undefined,
+        release: idPair.versionId ? getVersionFromId(idPair.versionId) : undefined,
       }),
       publishReplay(1),
       refCount(),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/duplicate.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/duplicate.ts
@@ -1,3 +1,4 @@
+import {type SanityDocument} from '@sanity/types'
 import {omit} from 'lodash'
 
 import {getDraftId, getVersionFromId, getVersionId} from '../../../../../util'
@@ -6,9 +7,31 @@ import {type OperationImpl} from './types'
 
 const omitProps = ['_createdAt', '_updatedAt']
 
+const getDocumentToDuplicateId = ({
+  versionSnapshot,
+  dupeId,
+  liveEdit,
+}: {
+  versionSnapshot?: SanityDocument | null | undefined
+  dupeId: string
+  liveEdit: boolean
+}) => {
+  if (versionSnapshot) {
+    // When duplicating a version document we need to create it with a version id.
+    // We get the version from the snapshot id and create a new version id for the duplicate.
+    const versionId = getVersionFromId(versionSnapshot._id)
+    if (versionId) return getVersionId(dupeId, versionId)
+  }
+
+  if (liveEdit) {
+    return dupeId
+  }
+
+  return getDraftId(dupeId)
+}
+
 export const duplicate: OperationImpl<[baseDocumentId: string], 'NOTHING_TO_DUPLICATE'> = {
   disabled: ({snapshots}) => {
-    if (snapshots.version) return false
     return snapshots.published || snapshots.draft || snapshots.version
       ? false
       : 'NOTHING_TO_DUPLICATE'
@@ -20,14 +43,11 @@ export const duplicate: OperationImpl<[baseDocumentId: string], 'NOTHING_TO_DUPL
       throw new Error('cannot execute on empty document')
     }
 
-    // When duplicating a version document we need to create it with a version id
-    const versionId = snapshots.version?._id ? getVersionFromId(snapshots.version._id) : null
-    // eslint-disable-next-line no-nested-ternary
-    const _id = versionId
-      ? getVersionId(dupeId, versionId)
-      : isLiveEditEnabled(schema, typeName)
-        ? dupeId
-        : getDraftId(dupeId)
+    const _id = getDocumentToDuplicateId({
+      versionSnapshot: snapshots.version,
+      dupeId,
+      liveEdit: isLiveEditEnabled(schema, typeName),
+    })
 
     return client.observable.create(
       {

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/duplicate.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/duplicate.ts
@@ -1,6 +1,6 @@
 import {omit} from 'lodash'
 
-import {getDraftId} from '../../../../../util'
+import {getDraftId, getVersionFromId, getVersionId} from '../../../../../util'
 import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
 import {type OperationImpl} from './types'
 
@@ -8,7 +8,10 @@ const omitProps = ['_createdAt', '_updatedAt']
 
 export const duplicate: OperationImpl<[baseDocumentId: string], 'NOTHING_TO_DUPLICATE'> = {
   disabled: ({snapshots}) => {
-    return snapshots.published || snapshots.draft ? false : 'NOTHING_TO_DUPLICATE'
+    if (snapshots.version) return false
+    return snapshots.published || snapshots.draft || snapshots.version
+      ? false
+      : 'NOTHING_TO_DUPLICATE'
   },
   execute: ({schema, client, snapshots, typeName}, dupeId) => {
     const source = snapshots.version || snapshots.draft || snapshots.published
@@ -17,10 +20,19 @@ export const duplicate: OperationImpl<[baseDocumentId: string], 'NOTHING_TO_DUPL
       throw new Error('cannot execute on empty document')
     }
 
+    // When duplicating a version document we need to create it with a version id
+    const versionId = snapshots.version?._id ? getVersionFromId(snapshots.version._id) : null
+    // eslint-disable-next-line no-nested-ternary
+    const _id = versionId
+      ? getVersionId(dupeId, versionId)
+      : isLiveEditEnabled(schema, typeName)
+        ? dupeId
+        : getDraftId(dupeId)
+
     return client.observable.create(
       {
         ...omit(source, omitProps),
-        _id: isLiveEditEnabled(schema, typeName) ? dupeId : getDraftId(dupeId),
+        _id,
         _type: source._type,
       },
       {


### PR DESCRIPTION
### Description
Duplicate action should work with versions.
This PR updates how the id is created for the new document created by the duplicate action, if it's a version id it will preserve the version and it won't create a draft document.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is this correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open a version document.
Click on duplicate, it should create a new document in the same release.

Non version documents should continue being created as draft or live documents.


<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
