### PR TITLE
feat(core): create references from version documents and new version documents.

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -8,6 +8,7 @@ import {catchError, filter, map, scan, switchMap, tap} from 'rxjs/operators'
 import {Button} from '../../../../ui-components'
 import {ReferenceInputPreviewCard} from '../../../components'
 import {Translate, useTranslation} from '../../../i18n'
+import {usePerspective} from '../../../releases/hooks/usePerspective'
 import {getPublishedId, isNonNullable} from '../../../util'
 import {Alert} from '../../components/Alert'
 import {useDidUpdate} from '../../hooks/useDidUpdate'
@@ -58,6 +59,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
     elementProps,
     focusPath,
   } = props
+  const {selectedReleaseId} = usePerspective()
 
   const {getReferenceInfo} = useReferenceInput({
     path,
@@ -84,10 +86,15 @@ export function ReferenceInput(props: ReferenceInputProps) {
 
       onChange(patches)
 
-      onEditReference({id: newDocumentId, type: option.type, template: option.template})
+      onEditReference({
+        id: newDocumentId,
+        type: option.type,
+        template: option.template,
+        version: selectedReleaseId,
+      })
       onPathFocus([])
     },
-    [onChange, onEditReference, onPathFocus, schemaType],
+    [onChange, onEditReference, onPathFocus, schemaType.name, schemaType.weak, selectedReleaseId],
   )
 
   const handleChange = useCallback(

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/types.ts
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/types.ts
@@ -1,3 +1,4 @@
+import {type ReleaseId} from '@sanity/client'
 import {
   type I18nTextRecord,
   type Path,
@@ -39,6 +40,7 @@ export interface EditReferenceEvent {
   id: string
   type: string
   template: ReferenceTemplate
+  version?: ReleaseId
 }
 
 export interface CreateReferenceOption {

--- a/packages/sanity/src/core/form/studio/contexts/ReferenceInputOptions.tsx
+++ b/packages/sanity/src/core/form/studio/contexts/ReferenceInputOptions.tsx
@@ -1,3 +1,4 @@
+import {type ReleaseId} from '@sanity/client'
 import {type Path} from '@sanity/types'
 import {type ComponentType, type HTMLProps, type ReactNode, useContext, useMemo} from 'react'
 import {ReferenceInputOptionsContext} from 'sanity/_singletons'
@@ -18,6 +19,7 @@ export interface EditReferenceOptions {
   type: string
   parentRefPath: Path
   template: TemplateOption
+  version?: ReleaseId
 }
 
 /** @internal */

--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
@@ -65,7 +65,7 @@ export function getReferenceInfo(
       if (
         !pairAvailability.draft.available &&
         !pairAvailability.published.available &&
-        !pairAvailability.published.available
+        !pairAvailability.version?.available
       ) {
         // combine availability of draft + published
         const availability =

--- a/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
@@ -133,6 +133,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
         id: event.id,
         type: event.type,
         template: event.template,
+        version: event.version,
       })
     },
     [onEditReference, path],

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -45,7 +45,6 @@ export {
   useReleasesIds,
   useVersionOperations,
   VersionChip,
-  versionDocumentExists,
   VersionInlineBadge,
 } from './releases'
 export * from './scheduledPublishing'

--- a/packages/sanity/src/core/preview/documentPair.ts
+++ b/packages/sanity/src/core/preview/documentPair.ts
@@ -35,7 +35,11 @@ export function createObservePathsDocumentPair(options: {
 
     return observeDocumentPairAvailability(draftId, {version}).pipe(
       switchMap((availability) => {
-        if (!availability.draft.available && !availability.published.available) {
+        if (
+          !availability.draft.available &&
+          !availability.published.available &&
+          !availability.version?.available
+        ) {
           // short circuit, neither draft nor published is available so no point in trying to get a snapshot
           return of({
             id: publishedId,

--- a/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
@@ -5,10 +5,8 @@ import {describe, expect, it, type Mock, vi} from 'vitest'
 import {type DocumentPreviewStore} from '../../../preview'
 import {type DocumentIdSetObserverState} from '../../../preview/liveDocumentIdSet'
 import {useDocumentPreviewStore} from '../../../store'
-import {getPublishedId, type PublishedId} from '../../../util/draftUtils'
 import {activeASAPRelease, activeScheduledRelease} from '../../__fixtures__/release.fixture'
-import {type ReleaseDocument, useActiveReleases} from '../../store'
-import {useReleasesIds} from '../../store/useReleasesIds'
+import {type ReleaseDocument} from '../../store'
 import {useDocumentVersions} from '../useDocumentVersions'
 
 vi.mock('../../store', () => ({
@@ -24,34 +22,8 @@ vi.mock('../../../store', () => ({
   useDocumentPreviewStore: vi.fn(),
 }))
 
-vi.mock('../../../util/draftUtils', async (importOriginal) => ({
-  ...(await importOriginal()),
-  getPublishedId: vi.fn(),
-}))
-
-async function setupMocks({
-  releases,
-  versionIds,
-}: {
-  releases: ReleaseDocument[]
-  versionIds: string[]
-}) {
-  const mockUseActiveReleases = useActiveReleases as Mock<typeof useActiveReleases>
-  const mockUseReleasesIds = useReleasesIds as Mock<typeof useReleasesIds>
+async function setupMocks({versionIds}: {releases: ReleaseDocument[]; versionIds: string[]}) {
   const mockDocumentPreviewStore = useDocumentPreviewStore as Mock<typeof useDocumentPreviewStore>
-  const mockedGetPublishedId = getPublishedId as Mock<typeof getPublishedId>
-
-  mockUseActiveReleases.mockReturnValue({
-    data: releases,
-    loading: false,
-    dispatch: vi.fn(),
-  })
-
-  mockUseReleasesIds.mockReturnValue({
-    releasesIds: [],
-  })
-
-  mockedGetPublishedId.mockReturnValue('document-1' as PublishedId)
 
   mockDocumentPreviewStore.mockReturnValue({
     unstable_observeDocumentIdSet: vi
@@ -88,7 +60,7 @@ describe('useDocumentVersions', () => {
     })
     const {result} = renderHook(() => useDocumentVersions({documentId: 'document-1'}))
     await waitFor(() => {
-      expect(result.current.data).toEqual([activeASAPRelease])
+      expect(result.current.data).toEqual(['versions.rASAP.document-1'])
     })
   })
 })

--- a/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
@@ -33,6 +33,7 @@ export const DiscardVersionAction = (
     setDialogOpen(true)
   }, [])
 
+  if (!version) return null
   const insufficientPermissions = !isPermissionsLoading && !permissions?.granted
 
   if (insufficientPermissions) {
@@ -45,17 +46,16 @@ export const DiscardVersionAction = (
   }
 
   return {
-    dialog: dialogOpen &&
-      version && {
-        type: 'custom',
-        component: (
-          <DiscardVersionDialog
-            documentId={version._id}
-            documentType={type}
-            onClose={() => setDialogOpen(false)}
-          />
-        ),
-      },
+    dialog: dialogOpen && {
+      type: 'custom',
+      component: (
+        <DiscardVersionDialog
+          documentId={version._id}
+          documentType={type}
+          onClose={() => setDialogOpen(false)}
+        />
+      ),
+    },
     /** @todo translate */
     label: 'Discard version',
     icon: TrashIcon,

--- a/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
@@ -38,6 +38,8 @@ export const UnpublishVersionAction = (
     setDialogOpen(true)
   }, [])
 
+  if (!version) return null
+
   const insufficientPermissions = !isPermissionsLoading && !permissions?.granted
 
   if (insufficientPermissions) {
@@ -52,17 +54,16 @@ export const UnpublishVersionAction = (
   }
 
   return {
-    dialog: dialogOpen &&
-      version && {
-        type: 'custom',
-        component: (
-          <UnpublishVersionDialog
-            documentVersionId={version._id}
-            documentType={type}
-            onClose={() => setDialogOpen(false)}
-          />
-        ),
-      },
+    dialog: dialogOpen && {
+      type: 'custom',
+      component: (
+        <UnpublishVersionDialog
+          documentVersionId={version._id}
+          documentType={type}
+          onClose={() => setDialogOpen(false)}
+        />
+      ),
+    },
     /** @todo should be switched once we have the document actions updated */
     label: t('action.unpublish-doc-actions'),
     icon: UnpublishIcon,

--- a/packages/sanity/src/core/releases/util/util.ts
+++ b/packages/sanity/src/core/releases/util/util.ts
@@ -31,14 +31,6 @@ export function getDocumentIsInPerspective(
   return releaseId === perspective
 }
 
-/** @internal */
-export function versionDocumentExists(
-  documentVersions: ReleaseDocument[] = [],
-  releaseId: string,
-): boolean {
-  return documentVersions.some((version) => version._id === releaseId)
-}
-
 export function isDraftOrPublished(versionName: string): boolean {
   return versionName === 'drafts' || versionName === 'published'
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.test.ts
@@ -157,6 +157,12 @@ describe('patch', () => {
         {
           patch: {
             id: 'versions.x.my-id',
+            unset: ['_empty_action_guard_pseudo_field_'],
+          },
+        },
+        {
+          patch: {
+            id: 'versions.x.my-id',
             unset: ['newValue'],
           },
         },

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
@@ -16,7 +16,7 @@ export const patch: OperationImpl<[patches: any[], initialDocument?: Record<stri
       const mutations = snapshots.version
         ? patchMutation
         : [
-            version.createIfNotExists({
+            version.create({
               _type: typeName,
               ...initialDocument,
             }),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
@@ -13,16 +13,21 @@ export const patch: OperationImpl<[patches: any[], initialDocument?: Record<stri
       const patchMutation = version.patch(patches)
       // Note: if the document doesn't exist on the server yet, we need to create it first. We only want to do this if we can't see it locally
       // if it's been deleted on the server we want that to become a mutation error when submitting.
-      const mutations = snapshots.version
-        ? patchMutation
+      const ensureVersion = snapshots.version
+        ? version.patch([
+            {
+              unset: ['_empty_action_guard_pseudo_field_'],
+            },
+          ])
         : [
             version.create({
-              _type: typeName,
               ...initialDocument,
+              _id: idPair.draftId,
+              _type: typeName,
             }),
           ]
       // No drafting, so patch and commit the published document
-      version.mutate(mutations)
+      version.mutate([...ensureVersion, ...patchMutation])
 
       return
     }

--- a/packages/sanity/src/structure/components/paneRouter/PaneRouterProvider.tsx
+++ b/packages/sanity/src/structure/components/paneRouter/PaneRouterProvider.tsx
@@ -99,14 +99,19 @@ export function PaneRouterProvider(props: {
   )
 
   const handleEditReference: PaneRouterContextValue['handleEditReference'] = useCallback(
-    ({id, parentRefPath, type, template}) => {
+    ({id, parentRefPath, type, template, version}) => {
       navigate({
         panes: [
           ...routerPaneGroups.slice(0, groupIndex + 1),
           [
             {
               id,
-              params: {template: template.id, parentRefPath: pathToString(parentRefPath), type},
+              params: {
+                template: template.id,
+                parentRefPath: pathToString(parentRefPath),
+                type,
+                version,
+              },
               payload: template.params,
             },
           ],

--- a/packages/sanity/src/structure/components/paneRouter/types.ts
+++ b/packages/sanity/src/structure/components/paneRouter/types.ts
@@ -1,3 +1,4 @@
+import {type ReleaseId} from '@sanity/client'
 import {type Path} from '@sanity/types'
 import {type ComponentType, type ReactNode} from 'react'
 
@@ -46,6 +47,7 @@ export interface EditReferenceOptions {
   parentRefPath: Path
   id: string
   type: string
+  version?: ReleaseId
   template: {id: string; params?: Record<string, string | number | boolean>}
 }
 

--- a/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
@@ -16,7 +16,6 @@ import {
   type EditStateFor,
   type PatchEvent,
   type PermissionCheckResult,
-  type ReleaseDocument,
   type StateTree,
   type TimelineStore,
 } from 'sanity'
@@ -39,7 +38,6 @@ export interface DocumentPaneContextValue {
   documentId: string
   documentIdRaw: string
   documentType: string
-  documentVersions: ReleaseDocument[] | null
   editState: EditStateFor | null
   /**
    * Whether the document being edited exists in the checked-out release.

--- a/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
@@ -39,10 +39,6 @@ export interface DocumentPaneContextValue {
   documentIdRaw: string
   documentType: string
   editState: EditStateFor | null
-  /**
-   * Whether the document being edited exists in the checked-out release.
-   */
-  existsInBundle: boolean
   fieldActions: DocumentFieldAction[]
   focusPath: Path
   index: number

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -160,7 +160,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     documentType,
     templateName,
     templateParams,
-    version: selectedReleaseId,
+    version: params.version,
   })
 
   const initialValue = useUnique(initialValueRaw)
@@ -587,15 +587,17 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     const createActionDisabled = isNonExistent && !isActionEnabled(schemaType!, 'create')
     const reconnecting = connectionState === 'reconnecting'
     const isLocked = editState.transactionSyncLock?.enabled
-    // in cases where the document has drafts but the schema is live edit,
-    // there is a risk of data loss, so we disable editing in this case
-    const isLiveEditAndDraftPerspective = liveEdit && !selectedPerspectiveName
-    const isLiveEditAndPublishedPerspective = liveEdit && selectedPerspectiveName === 'published'
-    const isSystemPerspectiveApplied =
-      isLiveEditAndPublishedPerspective || (selectedPerspectiveName ? existsInBundle : true)
+    // in cases where the document has drafts but the schema is live edit, there is a risk of data loss, so we disable editing in this case
+    if (liveEdit && selectedPerspectiveName !== 'published') {
+      return true
+    }
+
+    // If a release is selected, validate that the document id matches the selected release id
+    if (selectedReleaseId && getVersionFromId(value._id) !== selectedReleaseId) {
+      return true
+    }
 
     return (
-      !isSystemPerspectiveApplied ||
       !ready ||
       revisionId !== null ||
       hasNoPermission ||
@@ -605,7 +607,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       isLocked ||
       isDeleting ||
       isDeleted ||
-      isLiveEditAndDraftPerspective ||
       isCreateLinked ||
       isReleaseLocked
     )
@@ -618,7 +619,8 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     editState.transactionSyncLock?.enabled,
     liveEdit,
     selectedPerspectiveName,
-    existsInBundle,
+    value._id,
+    selectedReleaseId,
     ready,
     revisionId,
     isDeleting,

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -575,11 +575,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
   const isCreateLinked = isSanityCreateLinkedDocument(value)
   const isNonExistent = !value?._id
-  const existsInBundle = Boolean(
-    selectedReleaseId &&
-      editState?.version &&
-      getVersionFromId(editState.version._id) === selectedReleaseId,
-  )
 
   const readOnly = useMemo(() => {
     const hasNoPermission = !isPermissionsLoading && !permissions?.granted
@@ -756,7 +751,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
         documentIdRaw,
         documentType,
         editState,
-        existsInBundle,
         fieldActions,
         focusPath,
         inspector: currentInspector || null,
@@ -820,7 +814,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       documentIdRaw,
       documentType,
       editState,
-      existsInBundle,
       fieldActions,
       focusPath,
       currentInspector,

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -22,7 +22,7 @@ import {
   getDraftId,
   getExpandOperations,
   getPublishedId,
-  getReleaseIdFromReleaseDocumentId,
+  getVersionFromId,
   isReleaseDocument,
   isReleaseScheduledOrScheduling,
   isSanityCreateLinkedDocument,
@@ -37,7 +37,6 @@ import {
   useCopyPaste,
   useDocumentOperation,
   useDocumentValuePermissions,
-  useDocumentVersions,
   useEditState,
   useFormState,
   useInitialValue,
@@ -178,7 +177,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const connectionState = useConnectionState(documentId, documentType, {
     version: selectedReleaseId,
   })
-  const {data: documentVersions} = useDocumentVersions({documentId})
 
   let value: SanityDocumentLike = initialValue.value
 
@@ -577,11 +575,11 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
   const isCreateLinked = isSanityCreateLinkedDocument(value)
   const isNonExistent = !value?._id
-  const existsInBundle =
-    typeof selectedReleaseId !== 'undefined' &&
-    documentVersions.some(
-      (version) => getReleaseIdFromReleaseDocumentId(version._id) === selectedReleaseId,
-    )
+  const existsInBundle = Boolean(
+    selectedReleaseId &&
+      editState?.version &&
+      getVersionFromId(editState.version._id) === selectedReleaseId,
+  )
 
   const readOnly = useMemo(() => {
     const hasNoPermission = !isPermissionsLoading && !permissions?.granted
@@ -755,7 +753,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
         documentId,
         documentIdRaw,
         documentType,
-        documentVersions,
         editState,
         existsInBundle,
         fieldActions,
@@ -820,7 +817,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       documentId,
       documentIdRaw,
       documentType,
-      documentVersions,
       editState,
       existsInBundle,
       fieldActions,

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -150,9 +150,8 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
       return <ArchivedReleaseDocumentBanner />
     }
     const isCreatingDocument = displayed && !displayed._createdAt
-    const isScheduledRelease = isReleaseDocument(selectedPerspective)
-      ? isReleaseScheduledOrScheduling(selectedPerspective)
-      : false
+    const isScheduledRelease =
+      isReleaseDocument(selectedPerspective) && isReleaseScheduledOrScheduling(selectedPerspective)
 
     if (isScheduledRelease) {
       return <ScheduledReleaseBanner currentRelease={selectedPerspective as ReleaseDocument} />

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -158,8 +158,8 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
       return <ScheduledReleaseBanner currentRelease={selectedPerspective as ReleaseDocument} />
     }
     if (
-      displayed &&
-      getVersionFromId(displayed?._id || '') !== selectedReleaseId &&
+      displayed?._id &&
+      getVersionFromId(displayed._id) !== selectedReleaseId &&
       ready &&
       !isCreatingDocument
     ) {

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -1,6 +1,8 @@
 import {BoundaryElementProvider, Box, Flex, PortalProvider, usePortal} from '@sanity/ui'
 import {useEffect, useMemo, useRef, useState} from 'react'
 import {
+  getVersionFromId,
+  isReleaseDocument,
   isReleaseScheduledOrScheduling,
   type ReleaseDocument,
   ScrollContainer,
@@ -24,6 +26,7 @@ import {
 import {AddToReleaseBanner} from './banners/AddToReleaseBanner'
 import {ArchivedReleaseDocumentBanner} from './banners/ArchivedReleaseDocumentBanner'
 import {DraftLiveEditBanner} from './banners/DraftLiveEditBanner'
+import {ScheduledReleaseBanner} from './banners/ScheduledReleaseBanner'
 import {FormView} from './documentViews'
 
 interface DocumentPanelProps {
@@ -67,7 +70,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     schemaType,
     permissions,
     isPermissionsLoading,
-    existsInBundle,
   } = useDocumentPane()
   const {params} = usePaneRouter()
   const {collapsed: layoutCollapsed} = usePaneLayout()
@@ -143,16 +145,24 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
   const showInspector = Boolean(!collapsed && inspector)
   const {selectedPerspective, selectedReleaseId} = usePerspective()
 
-  const isScheduledRelease =
-    typeof selectedPerspective === 'object' && 'state' in selectedPerspective
-      ? isReleaseScheduledOrScheduling(selectedPerspective)
-      : false
-
   const banners = useMemo(() => {
     if (params?.historyVersion) {
       return <ArchivedReleaseDocumentBanner />
     }
-    if ((!existsInBundle && selectedReleaseId) || isScheduledRelease) {
+    const isCreatingDocument = displayed && !displayed._createdAt
+    const isScheduledRelease = isReleaseDocument(selectedPerspective)
+      ? isReleaseScheduledOrScheduling(selectedPerspective)
+      : false
+
+    if (isScheduledRelease) {
+      return <ScheduledReleaseBanner currentRelease={selectedPerspective as ReleaseDocument} />
+    }
+    if (
+      displayed &&
+      getVersionFromId(displayed?._id || '') !== selectedReleaseId &&
+      ready &&
+      !isCreatingDocument
+    ) {
       return (
         <AddToReleaseBanner
           documentId={value._id}
@@ -190,10 +200,8 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     selectedPerspective,
     displayed,
     documentId,
-    existsInBundle,
     isLiveEdit,
     isPermissionsLoading,
-    isScheduledRelease,
     permissions?.granted,
     ready,
     requiredPermission,

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
@@ -1,11 +1,8 @@
-import {LockIcon} from '@sanity/icons'
 import {Flex, Text} from '@sanity/ui'
 import {type CSSProperties, useCallback} from 'react'
 import {
-  formatRelativeLocalePublishDate,
   getReleaseIdFromReleaseDocumentId,
   getReleaseTone,
-  isReleaseScheduledOrScheduling,
   LATEST,
   type ReleaseDocument,
   Translate,
@@ -32,10 +29,6 @@ export function AddToReleaseBanner({
 
   const {createVersion} = useVersionOperations()
 
-  const isScheduled =
-    isReleaseScheduledOrScheduling(currentRelease) &&
-    currentRelease.metadata.releaseType === 'scheduled'
-
   const handleAddToRelease = useCallback(async () => {
     if (currentRelease._id) {
       await createVersion(getReleaseIdFromReleaseDocumentId(currentRelease._id), documentId, value)
@@ -49,56 +42,41 @@ export function AddToReleaseBanner({
       content={
         <Flex align="center" justify="space-between" gap={1} flex={1}>
           <Text size={1}>
-            {isScheduled ? (
-              <Flex align="center" justify="center" gap={2}>
-                <LockIcon />{' '}
-                <Translate
-                  t={tCore}
-                  i18nKey="release.banner.scheduled-for-publishing-on"
-                  values={{
-                    date: formatRelativeLocalePublishDate(currentRelease),
-                  }}
-                />
-              </Flex>
-            ) : (
-              <Translate
-                i18nKey="banners.release.not-in-release"
-                t={t}
-                values={{
-                  title:
-                    currentRelease.metadata.title || tCore('release.placeholder-untitled-release'),
-                }}
-                components={{
-                  Label: ({children}) => {
-                    return (
-                      <span
-                        style={
-                          {
-                            color: `var(--card-badge-${tone ?? 'default'}-fg-color)`,
-                            backgroundColor: `var(--card-badge-${tone ?? 'default'}-bg-color)`,
-                            borderRadius: 3,
-                            textDecoration: 'none',
-                            padding: '0px 2px',
-                            fontWeight: 500,
-                          } as CSSProperties
-                        }
-                      >
-                        {children}
-                      </span>
-                    )
-                  },
-                }}
-              />
-            )}
+            <Translate
+              i18nKey="banners.release.not-in-release"
+              t={t}
+              values={{
+                title:
+                  currentRelease.metadata.title || tCore('release.placeholder-untitled-release'),
+              }}
+              components={{
+                Label: ({children}) => {
+                  return (
+                    <span
+                      style={
+                        {
+                          color: `var(--card-badge-${tone ?? 'default'}-fg-color)`,
+                          backgroundColor: `var(--card-badge-${tone ?? 'default'}-bg-color)`,
+                          borderRadius: 3,
+                          textDecoration: 'none',
+                          padding: '0px 2px',
+                          fontWeight: 500,
+                        } as CSSProperties
+                      }
+                    >
+                      {children}
+                    </span>
+                  )
+                },
+              }}
+            />
           </Text>
 
-          {!isScheduled && (
-            <Button
-              text={t('banners.release.action.add-to-release')}
-              tone={tone}
-              onClick={handleAddToRelease}
-            />
-          )}
+          <Button
+            text={t('banners.release.action.add-to-release')}
+            tone={tone}
+            onClick={handleAddToRelease}
+          />
         </Flex>
       }
     />

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ScheduledReleaseBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ScheduledReleaseBanner.tsx
@@ -1,0 +1,45 @@
+import {LockIcon} from '@sanity/icons'
+import {Flex, Text} from '@sanity/ui'
+import {
+  formatRelativeLocalePublishDate,
+  getReleaseTone,
+  LATEST,
+  type ReleaseDocument,
+  Translate,
+  useTranslation,
+} from 'sanity'
+
+import {Banner} from './Banner'
+
+export function ScheduledReleaseBanner({
+  currentRelease,
+}: {
+  currentRelease: ReleaseDocument
+}): React.JSX.Element {
+  const tone = getReleaseTone(currentRelease ?? LATEST)
+
+  const {t: tCore} = useTranslation()
+
+  return (
+    <Banner
+      tone={tone}
+      paddingY={0}
+      content={
+        <Flex align="center" justify="space-between" gap={1} flex={1}>
+          <Text size={1}>
+            <Flex align="center" justify="center" gap={2}>
+              <LockIcon />{' '}
+              <Translate
+                t={tCore}
+                i18nKey="release.banner.scheduled-for-publishing-on"
+                values={{
+                  date: formatRelativeLocalePublishDate(currentRelease),
+                }}
+              />
+            </Flex>
+          </Text>
+        </Flex>
+      }
+    />
+  )
+}

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -296,7 +296,6 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
         <VersionChip
           tooltipContent={<TooltipContent release={filteredReleases.inCreation} />}
           selected
-          // disabled
           onClick={() => {}}
           locked={false}
           tone={getReleaseTone(filteredReleases.inCreation)}

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveList.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveList.test.tsx
@@ -1,8 +1,25 @@
+import {type ReleaseId} from '@sanity/client'
 import {render, screen} from '@testing-library/react'
 import {type HTMLProps} from 'react'
-import {type ReleaseDocument, useActiveReleases, useArchivedReleases} from 'sanity'
+import {
+  getDraftId,
+  getVersionId,
+  type ReleaseDocument,
+  useDocumentVersions,
+  usePerspective,
+  useActiveReleases,
+} from 'sanity'
 import {type IntentLinkProps} from 'sanity/router'
-import {beforeEach, describe, expect, it, type Mock, type MockedFunction, vi} from 'vitest'
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  type Mocked,
+  type MockedFunction,
+  vi,
+} from 'vitest'
 
 import {createTestProvider} from '../../../../../../../../test/testUtils/TestProvider'
 import {type DocumentPaneContextValue} from '../../../../DocumentPaneContext'
@@ -11,9 +28,10 @@ import {DocumentPerspectiveList} from '../DocumentPerspectiveList'
 
 vi.mock('sanity', async (importOriginal) => ({
   ...(await importOriginal()),
+  useDocumentVersions: vi.fn(),
+  usePerspective: vi.fn(),
   useActiveReleases: vi.fn().mockReturnValue({data: [], loading: false}),
-  useAllReleases: vi.fn().mockReturnValue({data: [], loading: false}),
-  useArchivedReleases: vi.fn().mockReturnValue({archivedReleases: []}),
+  useArchivedReleases: vi.fn().mockReturnValue({data: [], loading: false}),
   SANITY_VERSION: '0.0.0',
 }))
 
@@ -45,7 +63,8 @@ const mockUseDocumentPane = useDocumentPane as MockedFunction<
   () => Partial<DocumentPaneContextValue>
 >
 const mockUseActiveReleases = useActiveReleases as Mock<typeof useActiveReleases>
-const mockUseArchivedReleases = useArchivedReleases as Mock<typeof useArchivedReleases>
+const mockUseDocumentVersions = useDocumentVersions as Mock<typeof useDocumentVersions>
+const mockUsePerspective = usePerspective as Mock<typeof usePerspective>
 const mockCurrent: ReleaseDocument = {
   _updatedAt: '2024-07-12T10:39:32Z',
   _id: '_.releases.rSpringDrop',
@@ -60,108 +79,172 @@ const mockCurrent: ReleaseDocument = {
   state: 'scheduled',
 }
 
+const getTestProvider = async ({liveEdit}: {liveEdit?: boolean} = {}) => {
+  const wrapper = await createTestProvider({
+    config: {
+      schema: {
+        types: [
+          {
+            type: 'document',
+            name: 'testAuthor',
+            liveEdit,
+            fields: [{name: 'title', type: 'string'}],
+          },
+        ],
+      },
+    },
+  })
+  return wrapper
+}
+
+const usePerspectiveMockValue: Mocked<ReturnType<typeof usePerspective>> = {
+  selectedPerspectiveName: undefined,
+  selectedReleaseId: undefined,
+  setPerspective: vi.fn(),
+  selectedPerspective: 'drafts',
+  toggleExcludedPerspective: vi.fn(),
+  isPerspectiveExcluded: vi.fn(),
+  perspectiveStack: [],
+} as const
+
+const getPaneMock = ({
+  isCreatingDocument,
+  displayedVersion = 'draft',
+  editStateDocuments,
+}: {
+  isCreatingDocument?: boolean
+  displayedVersion?: ReleaseId | 'published' | 'draft'
+  editStateDocuments?: Array<'draft' | 'published' | 'version'>
+} = {}) => {
+  const publishedId = 'foo'
+  const editStateDocument = {
+    _id: publishedId,
+    _type: 'testAuthor',
+    _createdAt: '2023-01-01T00:00:00Z',
+    _updatedAt: '2023-01-01T00:00:00Z',
+    _rev: 'r1',
+    name: 'John Doe',
+  }
+  return {
+    documentType: 'testAuthor',
+    documentId: publishedId,
+    editState: {
+      id: publishedId,
+      type: 'testAuthor',
+      transactionSyncLock: {enabled: false},
+      liveEdit: false,
+      ready: true,
+
+      published: editStateDocuments?.includes('published') ? editStateDocument : null,
+      draft: editStateDocuments?.includes('draft') ? editStateDocument : null,
+      version: editStateDocuments?.includes('version') ? editStateDocument : null,
+
+      liveEditSchemaType: false,
+      release: displayedVersion.startsWith('r') ? displayedVersion : undefined,
+    },
+    displayed: {
+      _id:
+        // eslint-disable-next-line no-nested-ternary
+        displayedVersion === 'published'
+          ? publishedId
+          : displayedVersion === 'draft'
+            ? getDraftId(publishedId)
+            : getVersionId(publishedId, displayedVersion),
+      _type: 'testAuthor',
+      _createdAt: isCreatingDocument ? undefined : '2023-01-01T00:00:00Z',
+    },
+  }
+}
+
 describe('DocumentPerspectiveList', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-
-    /** @todo create a useDocumentPane fixture */
-    mockUseDocumentPane.mockReturnValue({
-      documentVersions: [],
-    })
-
-    global.HTMLElement.prototype.scrollIntoView = vi.fn()
-  })
-
-  it('should render "Published" and "Draft" chips when it has no other version', async () => {
-    const wrapper = await createTestProvider()
-    render(<DocumentPerspectiveList />, {wrapper})
-    expect(screen.getByRole('button', {name: 'Published'})).toBeInTheDocument()
-    expect(screen.getByRole('button', {name: 'Draft'})).toBeInTheDocument()
-  })
-
-  it('should render the release chip when it has a release version', async () => {
+    mockUsePerspective.mockReturnValue(usePerspectiveMockValue)
     mockUseActiveReleases.mockReturnValue({
       loading: false,
       data: [mockCurrent],
       dispatch: vi.fn(),
     })
-    mockUseArchivedReleases.mockReturnValue({
-      data: [],
+    mockUseDocumentVersions.mockReturnValue({
+      data: ['versions.rSpringDrop.KJAiOpAH5r6P3dWt1df9ql'],
       loading: false,
-      error: undefined,
-    })
-    mockUseDocumentPane.mockReturnValue({
-      documentVersions: [mockCurrent],
-      displayed: {
-        _id: 'versions.spring-drop.KJAiOpAH5r6P3dWt1df9ql',
-      },
+      error: null,
     })
 
-    const wrapper = await createTestProvider()
-    render(<DocumentPerspectiveList />, {wrapper})
+    global.HTMLElement.prototype.scrollIntoView = vi.fn()
+  })
+  describe('enabled chips', () => {
+    it('should render "Published" and "Draft" chips when it has no other version', async () => {
+      mockUseDocumentPane.mockReturnValue(getPaneMock())
+      const wrapper = await getTestProvider()
+      render(<DocumentPerspectiveList />, {wrapper})
+      expect(screen.getByRole('button', {name: 'Published'})).toBeInTheDocument()
+      expect(screen.getByRole('button', {name: 'Draft'})).toBeInTheDocument()
+    })
 
-    expect(screen.getByRole('button', {name: 'Spring Drop'})).toBeInTheDocument()
+    it('should render the release chip when it has a release version', async () => {
+      mockUseDocumentPane.mockReturnValue(getPaneMock())
+
+      const wrapper = await getTestProvider()
+      render(<DocumentPerspectiveList />, {wrapper})
+      expect(screen.getByRole('button', {name: 'Published'})).toBeInTheDocument()
+      expect(screen.getByRole('button', {name: 'Draft'})).toBeInTheDocument()
+      expect(screen.getByRole('button', {name: 'Spring Drop'})).toBeInTheDocument()
+    })
+    it('should render the release chip when it is creating a release version and user is in that release', async () => {
+      mockUseDocumentPane.mockReturnValue(
+        getPaneMock({isCreatingDocument: true, displayedVersion: 'rSpringDrop'}),
+      )
+      // no document versions are available, but the user is creating this document, so we want to show the chip anyways.
+      mockUseDocumentVersions.mockReturnValue({data: [], loading: false, error: null})
+      // the selected perspective is the release perspective
+      mockUsePerspective.mockReturnValue({
+        ...usePerspectiveMockValue,
+        selectedReleaseId: 'rSpringDrop',
+        selectedPerspectiveName: 'rSpringDrop',
+      })
+
+      const wrapper = await getTestProvider()
+      render(<DocumentPerspectiveList />, {wrapper})
+      expect(screen.getByRole('button', {name: 'Published'})).toBeInTheDocument()
+      expect(screen.getByRole('button', {name: 'Draft'})).toBeInTheDocument()
+      expect(screen.getByRole('button', {name: 'Spring Drop'})).toBeInTheDocument()
+    })
   })
 
   describe('disabled chips', () => {
-    const mockUsePane = {
-      documentVersions: [mockCurrent],
-      editState: {
-        id: 'document-id',
-        type: 'document-type',
-        transactionSyncLock: {enabled: false},
-        draft: null,
-        published: null, // make sure that there is no published doc in the mock
-        liveEdit: false,
-        ready: true,
-        version: {
-          _id: 'versions.release.document-id',
-          _type: 'document-type',
-          _createdAt: '2023-01-01T00:00:00Z',
-          _updatedAt: '2023-01-01T00:00:00Z',
-          _rev: '1',
-        },
-        liveEditSchemaType: false,
-      },
-    }
+    it('should disable the "Published" chip when there is no published document and not live edit, draft should be enabled', async () => {
+      mockUseDocumentPane.mockReturnValue(getPaneMock())
 
-    it('should disable the "Published" chip when there is no published document and not live edit', async () => {
-      mockUseDocumentPane.mockReturnValue(mockUsePane)
-
-      const wrapper = await createTestProvider()
+      const wrapper = await getTestProvider()
       render(<DocumentPerspectiveList />, {wrapper})
 
       expect(screen.getByRole('button', {name: 'Published'})).toBeDisabled()
+      expect(screen.getByRole('button', {name: 'Draft'})).not.toBeDisabled()
     })
 
-    it('should enable the "Published" chip when there is no published document and IS live edit', async () => {
-      mockUseDocumentPane.mockReturnValue({
-        ...mockUsePane,
-        editState: {...mockUsePane.editState, liveEdit: true},
+    it('should enable the "Published" chip when there is no published document and IS live edit, draft should be disabled', async () => {
+      mockUseDocumentPane.mockReturnValue(
+        getPaneMock({
+          displayedVersion: 'published',
+          editStateDocuments: ['published'],
+        }),
+      )
+      mockUsePerspective.mockReturnValue({
+        ...usePerspectiveMockValue,
+        selectedPerspectiveName: 'published',
       })
+      const wrapper = await getTestProvider({liveEdit: true})
 
-      const wrapper = await createTestProvider()
       render(<DocumentPerspectiveList />, {wrapper})
 
       expect(screen.getByRole('button', {name: 'Published'})).not.toBeDisabled()
+      expect(screen.getByRole('button', {name: 'Draft'})).toBeDisabled()
     })
 
-    it('should enable the "Published" chip when the document is "liveEdit"', async () => {
-      mockUseDocumentPane.mockReturnValue({
-        ...mockUsePane,
-        editState: {
-          ...mockUsePane.editState,
-          published: {
-            _id: 'published-document-id',
-            _type: 'document-type',
-            _createdAt: '2023-01-01T00:00:00Z',
-            _updatedAt: '2023-01-01T00:00:00Z',
-            _rev: '1',
-          },
-        },
-      })
-
-      const wrapper = await createTestProvider()
+    it('should enable the "Published" chip when the document is "liveEdit" and published exists', async () => {
+      mockUseDocumentPane.mockReturnValue(getPaneMock({editStateDocuments: ['published']}))
+      const wrapper = await getTestProvider({liveEdit: true})
       render(<DocumentPerspectiveList />, {wrapper})
 
       expect(screen.getByRole('button', {name: 'Published'})).toBeEnabled()
@@ -169,11 +252,255 @@ describe('DocumentPerspectiveList', () => {
   })
 
   describe('selected chips', () => {
-    it.todo('the draft is selected when the document displayed is a draft')
-    it.todo('the draft is selected when the perspective is null')
-    it.todo(
-      'the draft is selected when when the document is not published and the displayed version is draft,',
-    )
-    it.todo('when there is no draft (new document)')
+    it('the draft is selected when the document displayed is a draft', async () => {
+      mockUseDocumentPane.mockReturnValue(
+        getPaneMock({editStateDocuments: ['draft'], displayedVersion: 'draft'}),
+      )
+      const wrapper = await getTestProvider()
+      render(<DocumentPerspectiveList />, {wrapper})
+      expect(screen.getByRole('button', {name: 'Draft'})).toHaveAttribute('data-selected')
+      expect(screen.getByRole('button', {name: 'Published'})).not.toBeEnabled()
+    })
+
+    it('the draft is selected when the perspective is null, even if draft is missing', async () => {
+      mockUseDocumentPane.mockReturnValue(
+        getPaneMock({editStateDocuments: ['published'], displayedVersion: 'published'}),
+      )
+      const wrapper = await getTestProvider()
+      render(<DocumentPerspectiveList />, {wrapper})
+      expect(screen.getByRole('button', {name: 'Draft'})).toHaveAttribute('data-selected')
+      // Publish is enabled, users should be able to navigate to the published document
+      expect(screen.getByRole('button', {name: 'Published'})).toBeEnabled()
+    })
+    it('when there is no draft (new document)', async () => {
+      mockUseDocumentPane.mockReturnValue(
+        getPaneMock({editStateDocuments: [], displayedVersion: 'published'}),
+      )
+      const wrapper = await getTestProvider()
+      render(<DocumentPerspectiveList />, {wrapper})
+      expect(screen.getByRole('button', {name: 'Draft'})).toHaveAttribute('data-selected')
+      expect(screen.getByRole('button', {name: 'Published'})).not.toBeEnabled()
+    })
+  })
+
+  describe('editState and perspectives permutations', () => {
+    describe('liveEditDocument', () => {
+      it('no draft and no published - perspective is undefined', async () => {
+        mockUseDocumentPane.mockReturnValue(
+          getPaneMock({
+            editStateDocuments: [],
+            displayedVersion: 'published',
+            isCreatingDocument: true,
+          }),
+        )
+        const wrapper = await getTestProvider({liveEdit: true})
+        render(<DocumentPerspectiveList />, {wrapper})
+        // draft is selected because no perspective is set
+        expect(screen.getByRole('button', {name: 'Draft'})).toHaveAttribute('data-selected')
+        // Published is not disabled because the user is creating a live edit document
+        expect(screen.getByRole('button', {name: 'Published'})).not.toBeDisabled()
+      })
+      it('no draft and no published - perspective is published', async () => {
+        mockUseDocumentPane.mockReturnValue(
+          getPaneMock({
+            editStateDocuments: [],
+            displayedVersion: 'published',
+            isCreatingDocument: true,
+          }),
+        )
+        mockUsePerspective.mockReturnValue({
+          ...usePerspectiveMockValue,
+          selectedPerspectiveName: 'published',
+        })
+        const wrapper = await getTestProvider({liveEdit: true})
+        render(<DocumentPerspectiveList />, {wrapper})
+        // Perspective is published and the user is creating a live edit document, so the draft chip should be disabled
+        expect(screen.getByRole('button', {name: 'Draft'})).not.toBeEnabled()
+        expect(screen.getByRole('button', {name: 'Published'})).toHaveAttribute('data-selected')
+      })
+      it('no draft and no published - perspective is version', async () => {
+        mockUseDocumentPane.mockReturnValue(
+          getPaneMock({
+            editStateDocuments: [],
+            displayedVersion: 'rSpringDrop',
+            isCreatingDocument: true,
+          }),
+        )
+        mockUsePerspective.mockReturnValue({
+          ...usePerspectiveMockValue,
+          selectedPerspectiveName: 'rSpringDrop',
+          selectedReleaseId: 'rSpringDrop',
+        })
+        const wrapper = await getTestProvider({liveEdit: true})
+        render(<DocumentPerspectiveList />, {wrapper})
+        // Perspective is published and the user is creating a live edit document, so the draft chip should be disabled
+        expect(screen.getByRole('button', {name: 'Draft'})).not.toBeEnabled()
+        expect(screen.getByRole('button', {name: 'Published'})).not.toBeEnabled()
+        expect(screen.getByRole('button', {name: 'Spring Drop'})).toHaveAttribute('data-selected')
+      })
+      it('draft and no published - perspective is undefined', async () => {
+        mockUseDocumentPane.mockReturnValue(getPaneMock({editStateDocuments: ['draft']}))
+        const wrapper = await getTestProvider({liveEdit: true})
+        render(<DocumentPerspectiveList />, {wrapper})
+        expect(screen.getByRole('button', {name: 'Draft'})).toHaveAttribute('data-selected')
+        expect(screen.getByRole('button', {name: 'Published'})).toBeEnabled()
+      })
+      it('draft and published - perspective is undefined', async () => {
+        mockUseDocumentPane.mockReturnValue(
+          getPaneMock({editStateDocuments: ['draft', 'published']}),
+        )
+        const wrapper = await getTestProvider({liveEdit: true})
+        render(<DocumentPerspectiveList />, {wrapper})
+        expect(screen.getByRole('button', {name: 'Draft'})).toHaveAttribute('data-selected')
+        expect(screen.getByRole('button', {name: 'Published'})).toBeEnabled()
+      })
+    })
+    describe('not liveEditDocument', () => {
+      it('no draft and no published - perspective is undefined', async () => {
+        mockUseDocumentPane.mockReturnValue(
+          getPaneMock({
+            editStateDocuments: [],
+            displayedVersion: 'published',
+            isCreatingDocument: true,
+          }),
+        )
+        const wrapper = await getTestProvider({liveEdit: false})
+        render(<DocumentPerspectiveList />, {wrapper})
+        expect(screen.getByRole('button', {name: 'Draft'})).toHaveAttribute('data-selected')
+        expect(screen.getByRole('button', {name: 'Published'})).not.toBeEnabled()
+      })
+      it('draft and no published - perspective is undefined', async () => {
+        mockUseDocumentPane.mockReturnValue(
+          getPaneMock({
+            editStateDocuments: ['draft'],
+            displayedVersion: 'draft',
+          }),
+        )
+        const wrapper = await getTestProvider({liveEdit: false})
+        render(<DocumentPerspectiveList />, {wrapper})
+        expect(screen.getByRole('button', {name: 'Draft'})).toHaveAttribute('data-selected')
+        expect(screen.getByRole('button', {name: 'Published'})).not.toBeEnabled()
+      })
+      it('no draft and published - perspective is undefined', async () => {
+        mockUseDocumentPane.mockReturnValue(
+          getPaneMock({
+            editStateDocuments: ['published'],
+            displayedVersion: 'published',
+          }),
+        )
+        const wrapper = await getTestProvider({liveEdit: false})
+        render(<DocumentPerspectiveList />, {wrapper})
+        expect(screen.getByRole('button', {name: 'Draft'})).toHaveAttribute('data-selected')
+        expect(screen.getByRole('button', {name: 'Published'})).toBeEnabled()
+      })
+      it('draft and published - perspective is undefined', async () => {
+        mockUseDocumentPane.mockReturnValue(
+          getPaneMock({
+            editStateDocuments: ['published', 'draft'],
+            displayedVersion: 'published',
+          }),
+        )
+        const wrapper = await getTestProvider({liveEdit: false})
+        render(<DocumentPerspectiveList />, {wrapper})
+        expect(screen.getByRole('button', {name: 'Draft'})).toHaveAttribute('data-selected')
+        expect(screen.getByRole('button', {name: 'Published'})).toBeEnabled()
+      })
+      it('no draft, no published and no version - perspective is version', async () => {
+        mockUseDocumentPane.mockReturnValue(
+          getPaneMock({
+            editStateDocuments: [],
+            displayedVersion: 'rSpringDrop',
+            isCreatingDocument: true,
+          }),
+        )
+        mockUsePerspective.mockReturnValue({
+          ...usePerspectiveMockValue,
+          selectedPerspectiveName: 'rSpringDrop',
+          selectedReleaseId: 'rSpringDrop',
+        })
+        mockUseDocumentVersions.mockReturnValue({data: [], loading: false, error: null})
+        const wrapper = await getTestProvider({liveEdit: false})
+        render(<DocumentPerspectiveList />, {wrapper})
+        expect(screen.getByRole('button', {name: 'Draft'})).not.toBeEnabled()
+        expect(screen.getByRole('button', {name: 'Published'})).not.toBeEnabled()
+        expect(screen.getByRole('button', {name: 'Spring Drop'})).toHaveAttribute('data-selected')
+      })
+      it('draft, no published and no version - perspective is version', async () => {
+        mockUseDocumentPane.mockReturnValue(
+          getPaneMock({
+            editStateDocuments: ['draft'],
+            displayedVersion: 'rSpringDrop',
+            isCreatingDocument: true,
+          }),
+        )
+        mockUsePerspective.mockReturnValue({
+          ...usePerspectiveMockValue,
+          selectedPerspectiveName: 'rSpringDrop',
+          selectedReleaseId: 'rSpringDrop',
+        })
+        mockUseDocumentVersions.mockReturnValue({data: [], loading: false, error: null})
+        const wrapper = await getTestProvider({liveEdit: false})
+        render(<DocumentPerspectiveList />, {wrapper})
+        expect(screen.getByRole('button', {name: 'Draft'})).toBeEnabled()
+        expect(screen.getByRole('button', {name: 'Published'})).not.toBeEnabled()
+        expect(screen.getByRole('button', {name: 'Spring Drop'})).toHaveAttribute('data-selected')
+      })
+      it('no draft, published and no version - perspective is version', async () => {
+        mockUseDocumentPane.mockReturnValue(
+          getPaneMock({
+            editStateDocuments: ['published'],
+            displayedVersion: 'rSpringDrop',
+            isCreatingDocument: true,
+          }),
+        )
+        mockUsePerspective.mockReturnValue({
+          ...usePerspectiveMockValue,
+          selectedPerspectiveName: 'rSpringDrop',
+          selectedReleaseId: 'rSpringDrop',
+        })
+        mockUseDocumentVersions.mockReturnValue({data: [], loading: false, error: null})
+        const wrapper = await getTestProvider({liveEdit: false})
+        render(<DocumentPerspectiveList />, {wrapper})
+        expect(screen.getByRole('button', {name: 'Draft'})).not.toBeEnabled()
+        expect(screen.getByRole('button', {name: 'Published'})).toBeEnabled()
+        expect(screen.getByRole('button', {name: 'Spring Drop'})).toHaveAttribute('data-selected')
+      })
+      it('no draft, published and version - perspective is version', async () => {
+        mockUseDocumentPane.mockReturnValue(
+          getPaneMock({
+            editStateDocuments: ['published', 'version'],
+            displayedVersion: 'rSpringDrop',
+          }),
+        )
+        mockUsePerspective.mockReturnValue({
+          ...usePerspectiveMockValue,
+          selectedPerspectiveName: 'rSpringDrop',
+          selectedReleaseId: 'rSpringDrop',
+        })
+        const wrapper = await getTestProvider({liveEdit: false})
+        render(<DocumentPerspectiveList />, {wrapper})
+        expect(screen.getByRole('button', {name: 'Draft'})).toBeEnabled()
+        expect(screen.getByRole('button', {name: 'Published'})).toBeEnabled()
+        expect(screen.getByRole('button', {name: 'Spring Drop'})).toHaveAttribute('data-selected')
+      })
+      it('draft, no published and version - perspective is version', async () => {
+        mockUseDocumentPane.mockReturnValue(
+          getPaneMock({
+            editStateDocuments: ['draft', 'version'],
+            displayedVersion: 'rSpringDrop',
+          }),
+        )
+        mockUsePerspective.mockReturnValue({
+          ...usePerspectiveMockValue,
+          selectedPerspectiveName: 'rSpringDrop',
+          selectedReleaseId: 'rSpringDrop',
+        })
+        const wrapper = await getTestProvider({liveEdit: false})
+        render(<DocumentPerspectiveList />, {wrapper})
+        expect(screen.getByRole('button', {name: 'Draft'})).toBeEnabled()
+        expect(screen.getByRole('button', {name: 'Published'})).not.toBeEnabled()
+        expect(screen.getByRole('button', {name: 'Spring Drop'})).toHaveAttribute('data-selected')
+      })
+    })
   })
 })

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveList.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveList.test.tsx
@@ -5,9 +5,9 @@ import {
   getDraftId,
   getVersionId,
   type ReleaseDocument,
+  useActiveReleases,
   useDocumentVersions,
   usePerspective,
-  useActiveReleases,
 } from 'sanity'
 import {type IntentLinkProps} from 'sanity/router'
 import {

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
@@ -1,13 +1,6 @@
 import {Card, Flex} from '@sanity/ui'
 import {type Ref, useCallback, useState} from 'react'
-import {
-  type CreateLinkMetadata,
-  isDraftPerspective,
-  isPublishedPerspective,
-  isSanityCreateLinked,
-  usePerspective,
-  useSanityCreateConfig,
-} from 'sanity'
+import {type CreateLinkMetadata, isSanityCreateLinked, useSanityCreateConfig} from 'sanity'
 
 import {SpacerButton} from '../../../components/spacerButton'
 import {DOCUMENT_PANEL_PORTAL_ELEMENT} from '../../../constants'
@@ -28,14 +21,12 @@ const CONTAINER_BREAKPOINT = 480 // px
 
 export function DocumentStatusBar(props: DocumentStatusBarProps) {
   const {actionsBoxRef, createLinkMetadata} = props
-  const {editState, revisionId, onChange: onDocumentChange, existsInBundle} = useDocumentPane()
-  const {selectedPerspective} = usePerspective()
+  const {editState, revisionId, onChange: onDocumentChange} = useDocumentPane()
   const {title} = useDocumentTitle()
 
   const CreateLinkedActions = useSanityCreateConfig().components?.documentLinkedActions
 
   const showingRevision = Boolean(revisionId)
-  const showingVersion = editState?.version !== null
 
   const [collapsed, setCollapsed] = useState<boolean | null>(null)
   const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null)
@@ -60,11 +51,7 @@ export function DocumentStatusBar(props: DocumentStatusBarProps) {
     )
   } else if (showingRevision) {
     actions = <HistoryStatusBarActions />
-  } else if (
-    (existsInBundle && showingVersion) ||
-    isDraftPerspective(selectedPerspective) ||
-    isPublishedPerspective(selectedPerspective)
-  ) {
+  } else {
     actions = <DocumentStatusBarActions />
   }
 

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -89,7 +89,7 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
 })
 
 export const DocumentStatusBarActions = memo(function DocumentStatusBarActions() {
-  const {actions: allActions, connectionState, documentId, editState, displayed} = useDocumentPane()
+  const {actions: allActions, connectionState, documentId, editState} = useDocumentPane()
   // const [isMenuOpen, setMenuOpen] = useState(false)
   // const handleMenuOpen = useCallback(() => setMenuOpen(true), [])
   // const handleMenuClose = useCallback(() => setMenuOpen(false), [])

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -2,7 +2,12 @@
 /* eslint-disable camelcase */
 import {Flex, LayerProvider, Stack, Text} from '@sanity/ui'
 import {memo, useCallback, useMemo, useState} from 'react'
-import {type DocumentActionComponent, type DocumentActionDescription, Hotkeys} from 'sanity'
+import {
+  type DocumentActionComponent,
+  type DocumentActionDescription,
+  Hotkeys,
+  usePerspective,
+} from 'sanity'
 
 import {Button, Tooltip} from '../../../../ui-components'
 import {RenderActionCollectionState} from '../../../components'
@@ -22,8 +27,8 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
   props: DocumentStatusBarActionsInnerProps,
 ) {
   const {disabled, showMenu, states} = props
-  const {__internal_tasks, existsInBundle} = useDocumentPane()
-
+  const {__internal_tasks} = useDocumentPane()
+  const {selectedReleaseId} = usePerspective()
   const [firstActionState, ...menuActionStates] = states
   const [buttonElement, setButtonElement] = useState<HTMLButtonElement | null>(null)
 
@@ -49,36 +54,34 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
   }, [firstActionState])
 
   const sideMenuItems = useMemo(() => {
-    return existsInBundle ? [firstActionState, ...menuActionStates] : menuActionStates
-  }, [existsInBundle, firstActionState, menuActionStates])
+    return selectedReleaseId ? [firstActionState, ...menuActionStates] : menuActionStates
+  }, [selectedReleaseId, firstActionState, menuActionStates])
 
   /* Version / Bundling handling */
   return (
     <Flex align="center" gap={1}>
       {__internal_tasks && __internal_tasks.footerAction}
-      {firstActionState && (
+      {firstActionState && !selectedReleaseId && (
         <LayerProvider zOffset={200}>
           <Tooltip disabled={!tooltipContent} content={tooltipContent} placement="top">
             <Stack>
-              {!existsInBundle && (
-                <Button
-                  data-testid={`action-${toLowerCaseNoSpaces(firstActionState.label)}`}
-                  disabled={disabled || Boolean(firstActionState.disabled)}
-                  icon={firstActionState.icon}
-                  // eslint-disable-next-line react/jsx-handler-names
-                  onClick={firstActionState.onHandle}
-                  ref={setButtonElement}
-                  size="large"
-                  text={firstActionState.label}
-                  tone={firstActionState.tone || 'primary'}
-                />
-              )}
+              <Button
+                data-testid={`action-${toLowerCaseNoSpaces(firstActionState.label)}`}
+                disabled={disabled || Boolean(firstActionState.disabled)}
+                icon={firstActionState.icon}
+                // eslint-disable-next-line react/jsx-handler-names
+                onClick={firstActionState.onHandle}
+                ref={setButtonElement}
+                size="large"
+                text={firstActionState.label}
+                tone={firstActionState.tone || 'primary'}
+              />
             </Stack>
           </Tooltip>
         </LayerProvider>
       )}
       {/* if it's in version we always only want to show the items on the side menu and not on the main action */}
-      {((showMenu && menuActionStates.length > 0) || existsInBundle) && (
+      {((showMenu && menuActionStates.length > 0) || selectedReleaseId) && (
         <ActionMenuButton actionStates={sideMenuItems} disabled={disabled} />
       )}
       {firstActionState && firstActionState.dialog && (

--- a/packages/sanity/test/testUtils/TestProvider.tsx
+++ b/packages/sanity/test/testUtils/TestProvider.tsx
@@ -20,7 +20,7 @@ import {route, RouterProvider} from '../../src/router'
 import {getMockWorkspace} from './getMockWorkspaceFromConfig'
 
 export interface TestProviderOptions {
-  config?: SingleWorkspace
+  config?: Partial<SingleWorkspace>
   client?: SanityClient
   resources?: LocaleResourceBundle[]
 }


### PR DESCRIPTION
### Description

When working with releases it should be possible to create a document that only lives inside a release.
This could happen in two different places:
1) Clicking the **New Document Button**

https://github.com/user-attachments/assets/9f1b19ca-6be0-407c-a1b8-04281f02b941


2) Clicking on the **Create reference** button. 

https://github.com/user-attachments/assets/069c57b2-841b-44b8-9fb2-2d9e52a5d703



In both cases the document that will be created needs to belong to the release and it should not create a draft.

This PR fixes that, allowing us to create version inside releases.
To do this, it adds a `version` parameter to the pane router, when that parameter exists, the initial value id will be the correct version id.

When working on this update I noticed that we don't need anymore the `existsInBundle` property inside DocumentPaneProvider, so I removed that and replaced the uses of it.
Also, I noticed that we were using the `AddToReleaseBanner` for releases that are scheduled, which is a bit miss leading, so I refactored that and created a `ScheduledReleaseBanner` for ease of use.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Are this changes correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Navigate to a release and create a new document from the Add document button or from the create new reference button.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a, this goes to the `corel` branch
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
