### PR TITLE
refactor(core): move usePerspective useEffect to its own logic and provider

### DIFF
--- a/packages/sanity/src/core/releases/hooks/usePerspective.tsx
+++ b/packages/sanity/src/core/releases/hooks/usePerspective.tsx
@@ -1,15 +1,10 @@
 import {type ReleaseId} from '@sanity/client'
-import {Text, useToast} from '@sanity/ui'
-import {useCallback, useEffect, useMemo} from 'react'
+import {useCallback, useMemo} from 'react'
 import {useRouter} from 'sanity/router'
 
-import {useTranslation} from '../../i18n/hooks/useTranslation'
-import {Translate} from '../../i18n/Translate'
 import {type ReleaseDocument} from '../store/types'
 import {useReleases} from '../store/useReleases'
-import {LATEST} from '../util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
-import {isPublishedPerspective} from '../util/util'
 import {getReleasesPerspectiveStack} from './utils'
 
 /**
@@ -49,10 +44,8 @@ const EMPTY_ARRAY: string[] = []
  */
 export function usePerspective(): PerspectiveValue {
   const router = useRouter()
-  const toast = useToast()
-  const {t} = useTranslation()
 
-  const {data: releases, archivedReleases, loading: releasesLoading} = useReleases()
+  const {data: releases} = useReleases()
   const selectedPerspectiveName = router.stickyParams.perspective as
     | 'published'
     | ReleaseId
@@ -82,52 +75,6 @@ export function usePerspective(): PerspectiveValue {
     },
     [router],
   )
-
-  useEffect(() => {
-    // clear the perspective param when it is not an active release
-    if (
-      releasesLoading ||
-      !selectedPerspectiveName ||
-      isPublishedPerspective(selectedPerspectiveName)
-    )
-      return
-    const isCurrentPerspectiveValid = releases.some(
-      (release) => getReleaseIdFromReleaseDocumentId(release._id) === selectedPerspectiveName,
-    )
-    if (!isCurrentPerspectiveValid) {
-      setPerspective(LATEST)
-      const archived = archivedReleases.find(
-        (r) => getReleaseIdFromReleaseDocumentId(r._id) === selectedPerspectiveName,
-      )
-
-      toast.push({
-        id: `bundle-deleted-toast-${selectedPerspectiveName}`,
-        status: 'warning',
-        title: (
-          <Text muted size={1}>
-            <Translate
-              t={t}
-              i18nKey={
-                archived
-                  ? 'release.toast.archived-release.title'
-                  : 'release.toast.not-found-release.title'
-              }
-              values={{title: archived?.metadata?.title || selectedPerspectiveName}}
-            />
-          </Text>
-        ),
-        duration: 10000,
-      })
-    }
-  }, [
-    archivedReleases,
-    selectedPerspectiveName,
-    releases,
-    releasesLoading,
-    setPerspective,
-    toast,
-    t,
-  ])
 
   const selectedPerspective: SelectedPerspective = useMemo(() => {
     if (!selectedPerspectiveName) return 'drafts'

--- a/packages/sanity/src/core/studio/PerspectiveProvider.tsx
+++ b/packages/sanity/src/core/studio/PerspectiveProvider.tsx
@@ -1,0 +1,65 @@
+import {Text, useToast} from '@sanity/ui'
+import {type ReactNode, useEffect} from 'react'
+
+import {useTranslation} from '../i18n/hooks/useTranslation'
+import {Translate} from '../i18n/Translate'
+import {usePerspective} from '../releases/hooks/usePerspective'
+import {useReleases} from '../releases/store/useReleases'
+import {LATEST} from '../releases/util/const'
+import {getReleaseIdFromReleaseDocumentId} from '../releases/util/getReleaseIdFromReleaseDocumentId'
+import {isPublishedPerspective} from '../releases/util/util'
+
+export function PerspectiveProvider({children}: {children: ReactNode}) {
+  const toast = useToast()
+  const {t} = useTranslation()
+  const {data: releases, archivedReleases, loading: releasesLoading} = useReleases()
+  const {selectedPerspectiveName, setPerspective} = usePerspective()
+
+  useEffect(() => {
+    // clear the perspective param when it is not an active release
+    if (
+      releasesLoading ||
+      !selectedPerspectiveName ||
+      isPublishedPerspective(selectedPerspectiveName)
+    )
+      return
+    const isCurrentPerspectiveValid = releases.some(
+      (release) => getReleaseIdFromReleaseDocumentId(release._id) === selectedPerspectiveName,
+    )
+    if (!isCurrentPerspectiveValid) {
+      setPerspective(LATEST)
+      const archived = archivedReleases.find(
+        (r) => getReleaseIdFromReleaseDocumentId(r._id) === selectedPerspectiveName,
+      )
+
+      toast.push({
+        id: `bundle-deleted-toast-${selectedPerspectiveName}`,
+        status: 'warning',
+        title: (
+          <Text muted size={1}>
+            <Translate
+              t={t}
+              i18nKey={
+                archived
+                  ? 'release.toast.archived-release.title'
+                  : 'release.toast.not-found-release.title'
+              }
+              values={{title: archived?.metadata?.title || selectedPerspectiveName}}
+            />
+          </Text>
+        ),
+        duration: 10000,
+      })
+    }
+  }, [
+    archivedReleases,
+    selectedPerspectiveName,
+    releases,
+    releasesLoading,
+    setPerspective,
+    toast,
+    t,
+  ])
+
+  return <>{children}</>
+}

--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -19,6 +19,7 @@ import {ColorSchemeProvider} from './colorScheme'
 import {Z_OFFSET} from './constants'
 import {MaybeEnableErrorReporting} from './MaybeEnableErrorReporting'
 import {PackageVersionStatusProvider} from './packageVersionStatus/PackageVersionStatusProvider'
+import {PerspectiveProvider} from './PerspectiveProvider'
 import {
   AuthenticateScreen,
   ConfigErrorsScreen,
@@ -71,7 +72,9 @@ export function StudioProvider({
             <PackageVersionStatusProvider>
               <MaybeEnableErrorReporting errorReporter={errorReporter} />
               <ResourceCacheProvider>
-                <StudioAnnouncementsProvider>{children}</StudioAnnouncementsProvider>
+                <StudioAnnouncementsProvider>
+                  <PerspectiveProvider>{children}</PerspectiveProvider>
+                </StudioAnnouncementsProvider>
               </ResourceCacheProvider>
             </PackageVersionStatusProvider>
           </LocaleProvider>


### PR DESCRIPTION
### Description

What says on the tin, this is part of the perf work to make the useEffect not run as frequently

I considered adding the useEffect in the StudioProvider directly or creating a hook that calls the useEffect, however, I think that given how the rest of the logic in that space happens, that it makes to have it in a provider. I am more than happy to change my approach

### What to review

Does this make sense? Is there a better way of doing it?
Did I break something without realising?
