### PR TITLE
fix(core): update getIdPair to calculate the new id given the version

### DIFF
--- a/packages/sanity/src/core/util/__tests__/draftUtils.test.ts
+++ b/packages/sanity/src/core/util/__tests__/draftUtils.test.ts
@@ -4,6 +4,7 @@ import {describe, expect, it, test} from 'vitest'
 import {
   collate,
   documentIdEquals,
+  getIdPair,
   getPublishedId,
   getVersionFromId,
   getVersionId,
@@ -80,5 +81,46 @@ describe('getVersionFromId', () => {
 
   it('should return the undefined if no bundle slug is found and document is published', () => {
     expect(getVersionFromId('my-document-id')).toBe(undefined)
+  })
+})
+
+describe('getIdPair', () => {
+  test.each([
+    ['foo', undefined, {draftId: 'drafts.foo', publishedId: 'foo'}],
+    ['drafts.foo', undefined, {draftId: 'drafts.foo', publishedId: 'foo'}],
+    ['versions.r1.foo', undefined, {draftId: 'drafts.foo', publishedId: 'foo'}],
+    [
+      'foo',
+      {version: 'r1'},
+      {draftId: 'drafts.foo', publishedId: 'foo', versionId: 'versions.r1.foo'},
+    ],
+    [
+      'drafts.foo',
+      {version: 'r1'},
+      {draftId: 'drafts.foo', publishedId: 'foo', versionId: 'versions.r1.foo'},
+    ],
+    [
+      'versions.r1.foo',
+      {version: 'r1'},
+      {draftId: 'drafts.foo', publishedId: 'foo', versionId: 'versions.r1.foo'},
+    ],
+    [
+      'versions.r1.foo',
+      {version: 'r2'},
+      // Id is converted to the version specified in the options
+      {draftId: 'drafts.foo', publishedId: 'foo', versionId: 'versions.r2.foo'},
+    ],
+  ])('documentIdEquals(): %s', (id, options, result) => {
+    expect(getIdPair(id, options)).toEqual(result)
+  })
+  it("should return error if version is 'drafts'", () => {
+    expect(() => getIdPair('foo', {version: 'drafts'})).toThrowError(
+      'Version can not be "published" or "drafts"',
+    )
+  })
+  it("should return error if version is 'published'", () => {
+    expect(() => getIdPair('foo', {version: 'published'})).toThrowError(
+      'Version can not be "published" or "drafts"',
+    )
   })
 })

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -87,7 +87,7 @@ export function getIdPair(
     draftId: getDraftId(id),
     ...(version
       ? {
-          versionId: isVersionId(id) ? id : getVersionId(id, version),
+          versionId: getVersionId(id, version),
         }
       : {}),
   }


### PR DESCRIPTION
### Description
While working on the [reference changes](https://github.com/sanity-io/sanity/pull/8324) I noticed the that getIdPair function returns the same id for a version document even if you are passing a different version.

Example:
```
getIdPair("versions.r1.foo", {version: "r2"})
resolves to: 
{
  publishedId: "foo",
  draftId: "drafts.foo"
  versionId: "versions.r1.foo"
 }
 
``` 

I think this could be miss leading, given if you provide a version you would want that version to be applied to the id.

So with this update:
```
getIdPair("versions.r1.foo", {version: "r2"})
resolves to: 
{
  publishedId: "foo",
  draftId: "drafts.foo"
  versionId: "versions.r2.foo"
 }
 
``` 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
