### PR TITLE
fix(@sanity/schema): allow Cross Dataset References in Portable Text blocks

### DIFF
--- a/dev/test-studio/schema/standard/crossDatasetReference.ts
+++ b/dev/test-studio/schema/standard/crossDatasetReference.ts
@@ -1,5 +1,5 @@
 import {BookIcon, MoonIcon, UserIcon} from '@sanity/icons'
-import {defineType} from 'sanity'
+import {defineArrayMember, defineField, defineType} from 'sanity'
 
 export const crossDatasetSubtype = defineType({
   type: 'crossDatasetReference',
@@ -185,19 +185,51 @@ export default defineType({
         },
       ],
     },
-    {
+    defineField({
       title: 'Cross Dataset reference in PTE',
       name: 'portableText',
       type: 'array',
       of: [
-        {type: 'block'},
+        defineArrayMember({
+          type: 'block',
+          of: [
+            // This array member was added in order to replicate the issue reported in CRX-981,
+            // in which inline Cross Dataset References added to Portable Text blocks cause a
+            // runtime error. It intentionally **does not use** the `crossDatasetSubtype` aliased
+            // type, because aliased types do not provoke this error.
+            defineArrayMember({
+              type: 'crossDatasetReference',
+              name: 'crossDatasetReferenceInline',
+              title: 'Inline Cross Dataset Reference',
+              dataset: 'playground',
+              to: [
+                {
+                  type: 'book',
+                  icon: BookIcon,
+                  preview: {
+                    select: {
+                      title: 'title',
+                      media: 'coverImage',
+                    },
+                    prepare(val) {
+                      return {
+                        title: val.title,
+                        media: val.coverImage,
+                      }
+                    },
+                  },
+                },
+              ],
+            }),
+          ],
+        }),
         {
           title: 'Cross Dataset reference subtype test',
           name: 'crossDatasetSubtype',
           type: 'crossDatasetSubtype',
         },
       ],
-    },
+    }),
     {
       title: 'Cross Dataset reference in array',
       name: 'array',

--- a/packages/@sanity/schema/src/sanity/validation/types/block.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/block.ts
@@ -23,7 +23,13 @@ const allowedMarkKeys = ['decorators', 'annotations']
 const allowedStyleKeys = ['blockEditor', 'title', 'value', 'icon', 'component']
 const allowedDecoratorKeys = ['blockEditor', 'title', 'value', 'icon', 'component']
 const allowedListKeys = ['title', 'value', 'icon', 'component']
-const supportedBuiltInObjectTypes = ['file', 'image', 'object', 'reference']
+const supportedBuiltInObjectTypes = [
+  'file',
+  'image',
+  'object',
+  'reference',
+  'crossDatasetReference',
+]
 
 export default function validateBlockType(typeDef: any, visitorContext: any) {
   const problems = []


### PR DESCRIPTION
### Description

This branch makes Cross Dataset References permissible inside Portable Text blocks. Adding `crossDatasetReference` types to a block's `of` option would previously cause Studio to crash, despite aliased Cross Dataset Reference types working correctly.

| Before | After |
| --- | --- |
| <img width="1536" alt="before" src="https://github.com/user-attachments/assets/3f8f052e-c68b-4a96-8ac3-d2fe7ca2176d" /> | <img width="1536" alt="after" src="https://github.com/user-attachments/assets/af85fcb4-d418-4a91-aae1-8f792fcd8550" /> |

### What to review

- Adding Cross Dataset Reference type to a Portable Text block's `of` option.
- Adding a Cross Dataset Reference to the document data using Studio.

### Testing

- Added replication to Test Studio. Therefore, prior to this fix, E2E tests fail.
- Inserting an **inline** Cross Dataset Reference in the "Cross Dataset reference in PTE" field [in Test Studio](http://localhost:3333/test/structure/crossDatasetReferenceTest;f497caae-8b1a-408c-b3bb-d88eb1472a21%2Ctemplate%3DcrossDatasetReferenceTest).

### Notes for release

Fixes bug preventing Cross Dataset References being used inside Portable Text blocks.
