### PR TITLE
fix(core): issue opening references with published perspective

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx
@@ -33,7 +33,7 @@ interface ParentReferenceInfo {
 
 export const ReferenceChangedBanner = memo(() => {
   const documentPreviewStore = useDocumentPreviewStore()
-  const {selectedPerspectiveName} = usePerspective()
+  const {selectedReleaseId} = usePerspective()
   const {params, groupIndex, routerPanesState, replaceCurrent, BackLink} = usePaneRouter()
   const routerReferenceId = routerPanesState[groupIndex]?.[0].id
   const parentGroup = routerPanesState[groupIndex - 1] as RouterPaneGroup | undefined
@@ -81,7 +81,7 @@ export const ReferenceChangedBanner = memo(() => {
           publishedId,
           (keyedSegmentIndex === -1 ? path : path.slice(0, keyedSegmentIndex)) as string[][],
           {
-            version: selectedPerspectiveName,
+            version: selectedReleaseId,
           },
         )
         .pipe(
@@ -112,7 +112,7 @@ export const ReferenceChangedBanner = memo(() => {
           ),
         ),
     )
-  }, [selectedPerspectiveName, documentPreviewStore, parentId, parentRefPath])
+  }, [selectedReleaseId, documentPreviewStore, parentId, parentRefPath])
   const referenceInfo = useObservable(referenceInfoObservable, {loading: true})
 
   const handleReloadReference = useCallback(() => {


### PR DESCRIPTION
### Description

When opening a reference from a document in `published` perspective the studio crashes.
This happens because the `observeDocumentPair` function was receiving the `selectedPerspectiveName` which could be "published". instead of the `releaseId` which is what we want here.

This updates and fixes the issue. 

See how it crashes here: https://test-studio-git-corel.sanity.dev/test/structure/author;f219b738-f1b9-410c-8c26-d9eb8925dc34;b8512898-d875-4331-a27a-ab915a559a99%2Ctype%3Dauthor%2CparentRefPath%3DbestFriend?perspective=published

But it passes here:  https://test-studio-git-corel-354.sanity.dev/test/structure/author;f219b738-f1b9-410c-8c26-d9eb8925dc34;b8512898-d875-4331-a27a-ab915a559a99%2Ctype%3Dauthor%2CparentRefPath%3DbestFriend?perspective=published
 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
