### PR TITLE
feat(test-studio): add Cross Dataset Reference error replication

### DIFF
--- a/dev/test-studio/schema/standard/crossDatasetReference.ts
+++ b/dev/test-studio/schema/standard/crossDatasetReference.ts
@@ -1,5 +1,5 @@
 import {BookIcon, MoonIcon, UserIcon} from '@sanity/icons'
-import {defineType} from 'sanity'
+import {defineArrayMember, defineField, defineType} from 'sanity'
 
 export const crossDatasetSubtype = defineType({
   type: 'crossDatasetReference',
@@ -185,19 +185,51 @@ export default defineType({
         },
       ],
     },
-    {
+    defineField({
       title: 'Cross Dataset reference in PTE',
       name: 'portableText',
       type: 'array',
       of: [
-        {type: 'block'},
+        defineArrayMember({
+          type: 'block',
+          of: [
+            // This array member was added in order to replicate the issue reported in CRX-981,
+            // in which inline Cross Dataset References added to Portable Text blocks cause a
+            // runtime error. It intentionally **does not use** the `crossDatasetSubtype` aliased
+            // type, because aliased types do not provoke this error.
+            defineArrayMember({
+              type: 'crossDatasetReference',
+              name: 'crossDatasetReferenceInline',
+              title: 'Inline Cross Dataset Reference',
+              dataset: 'playground',
+              to: [
+                {
+                  type: 'book',
+                  icon: BookIcon,
+                  preview: {
+                    select: {
+                      title: 'title',
+                      media: 'coverImage',
+                    },
+                    prepare(val) {
+                      return {
+                        title: val.title,
+                        media: val.coverImage,
+                      }
+                    },
+                  },
+                },
+              ],
+            }),
+          ],
+        }),
         {
           title: 'Cross Dataset reference subtype test',
           name: 'crossDatasetSubtype',
           type: 'crossDatasetSubtype',
         },
       ],
-    },
+    }),
     {
       title: 'Cross Dataset reference in array',
       name: 'array',


### PR DESCRIPTION
Replicates runtime error provoked when adding an inline Cross Dataset Reference to Portable Text schema.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
