### PR TITLE
fix(structure): collapsed document show document title

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
@@ -1,4 +1,3 @@
-import {DocumentIcon} from '@sanity/icons'
 import {Flex, Text} from '@sanity/ui'
 import {unstable_useValuePreview as useValuePreview, useTranslation} from 'sanity'
 import {styled} from 'styled-components'
@@ -44,29 +43,22 @@ export function DocumentHeaderTitle({collapsed = false}: {collapsed?: boolean}):
     return <>{t('panes.document-header-title.error.text', {error: error.message})}</>
   }
 
-  const Icon = schemaType?.options?.icon || DocumentIcon
-
   return (
-    <Flex flex={1} align="center" gap={collapsed ? 3 : 1} paddingX={collapsed ? 2 : 0}>
+    <Flex flex={1} align="center" gap={collapsed ? 3 : 1} paddingX={collapsed ? 2 : 0} paddingY={1}>
       {collapsed ? (
-        <>
-          <Text size={1}>
-            <Icon />
-          </Text>
-          <TitleContainer
-            muted={!value?.title}
-            size={1}
-            textOverflow="ellipsis"
-            weight={value?.title ? 'semibold' : undefined}
-            title={value?.title}
-          >
-            {value?.title || (
-              <span style={{color: 'var(--card-muted-fg-color)'}}>
-                {t('panes.document-header-title.untitled.text')}
-              </span>
-            )}
-          </TitleContainer>
-        </>
+        <TitleContainer
+          muted={!value?.title}
+          size={1}
+          textOverflow="ellipsis"
+          weight={value?.title ? 'semibold' : undefined}
+          title={value?.title}
+        >
+          {value?.title || (
+            <span style={{color: 'var(--card-muted-fg-color)'}}>
+              {t('panes.document-header-title.untitled.text')}
+            </span>
+          )}
+        </TitleContainer>
       ) : (
         <DocumentPerspectiveList />
       )}

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -121,7 +121,7 @@ export const DocumentPanelHeader = memo(
       [contextMenuNodes, referenceElement],
     )
 
-    const title = useMemo(() => <DocumentHeaderTitle />, [])
+    const title = useMemo(() => <DocumentHeaderTitle collapsed={collapsed} />, [collapsed])
     const tabs = useMemo(() => showTabs && <DocumentHeaderTabs />, [showTabs])
     const backButton = useMemo(
       () =>

--- a/test/e2e/tests/inputs/reference.spec.ts
+++ b/test/e2e/tests/inputs/reference.spec.ts
@@ -83,7 +83,7 @@ withDefaultClient((context) => {
     await expect(page.getByTestId('document-panel-document-title').nth(1)).toContainText('Untitled')
 
     // switch to original doc
-    page.getByText('PublishedDraft').first().click()
+    page.locator('[data-testid="document-pane"]', {hasText: originalTitle}).click()
 
     // open the context menu
     page.getByTestId('pane-context-menu-button').first().click()
@@ -127,7 +127,7 @@ withDefaultClient((context) => {
     await expect(documentStatus.nth(1)).toContainText('Published just now')
 
     /** --- IN ORIGINAL DOC --- */
-    page.getByText('PublishedDraft').first().click()
+    page.locator('[data-testid="document-pane"]', {hasText: originalTitle}).click()
 
     page.getByTestId('action-publish').first().click() // publish reference
 
@@ -176,7 +176,7 @@ withDefaultClient((context) => {
     await expect(documentStatus.nth(1)).toContainText('Published just now')
 
     /** --- IN ORIGINAL DOC --- */
-    page.getByText('PublishedDraft').first().click()
+    page.locator('[data-testid="document-pane"]', {hasText: originalTitle}).click()
 
     page.getByTestId('action-publish').first().click() // publish reference
 


### PR DESCRIPTION
### Description

collapsed document should show document title, not the releases the document belongs to.
<img width="1299" alt="Screenshot 2025-01-21 at 14 03 47" src="https://github.com/user-attachments/assets/c9883982-6aea-47e9-845a-03c516d81f54" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
