### PR TITLE
fix: fixing issue with counting documents in archived or published releases

### DIFF
--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -232,18 +232,21 @@ export function ReleasesOverview() {
     )
   }
 
-  const renderRowActions = useCallback(({datum}: {datum: TableRelease | unknown}) => {
-    const release = datum as TableRelease
+  const renderRowActions = useCallback(
+    ({datum}: {datum: TableRelease | unknown}) => {
+      const release = datum as TableRelease
 
-    if (release.isDeleted) return null
+      if (release.isDeleted) return null
 
-    return (
-      <ReleaseMenuButton
-        release={release}
-        documentsCount={release.documentsMetadata?.documentCount ?? 0}
-      />
-    )
-  }, [])
+      const documentsCount =
+        (releaseGroupMode === 'open'
+          ? release.documentsMetadata?.documentCount
+          : release.finalDocumentStates?.length) ?? 0
+
+      return <ReleaseMenuButton release={release} documentsCount={documentsCount} />
+    },
+    [releaseGroupMode],
+  )
 
   const filteredReleases = useMemo(() => {
     if (!releaseFilterDate) return releaseGroupMode === 'open' ? tableReleases : archivedReleases


### PR DESCRIPTION
### Description
Inside the release overview table, for an open release the count of documents is read from `release.documentsMetadata.documentCount`. This was currently being used correctly for open releases, however for archived (archived or published) releases, this should be read from `release.finalDocumentStates`.

This PR adds in the conditional key
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Tested by verifying that for an archived release that has documents, when trying to delete the release from the overview list, a dialog appears confirming that all the document versions will be deleted (previously this was never showing for archived and published releases since incorrectly the releases appeared as though it was empty)
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
