### PR TITLE
fix: set strictRequires to auto when building auto updating studios

### DIFF
--- a/packages/sanity/src/_internal/cli/server/buildVendorDependencies.ts
+++ b/packages/sanity/src/_internal/cli/server/buildVendorDependencies.ts
@@ -223,6 +223,7 @@ export async function buildVendorDependencies({
     define: {'process.env.NODE_ENV': JSON.stringify('production')},
 
     build: {
+      commonjsOptions: {strictRequires: 'auto'},
       minify: true,
       emptyOutDir: false, // Rely on CLI to do this
       outDir: path.join(outputDir, VENDOR_DIR),


### PR DESCRIPTION
### Description
When building auto-updating Studios with Vite 6 we ran into an issue caused by the default of `commonjsOptions.strictRequires` that changed from `auto` to `true` between v5 and v6 (mentioned in the advanced section here: https://vite.dev/guide/migration#advanced)

This caused the vendorized react bundle to place all named exports on the `default` export instead of exporting them all individually which then broke named imports.

This PR explicitly sets `commonjsOptions.strictRequires` to `auto` which will produce the same output in both Vite v5 and v6.

We mitigated the earlier issue by reverting back to to Vite 5 (#8362). Now that we know the exact cause, and the fix, it would be good to have this merged so we can safely upgrade to Vite 6 again without affecting auto-updating Studios.

### Notes for release
n/a –internal