### PR TITLE
feat(core): update events api routes and config flags, fix events sorting

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -225,7 +225,11 @@ export default defineConfig([
     dataset: 'playground',
     plugins: [sharedSettings()],
     basePath: '/playground',
-    beta: {eventsAPI: {enabled: true}},
+    beta: {
+      eventsAPI: {
+        releases: true,
+      },
+    },
   },
   {
     name: 'listener-events',
@@ -254,7 +258,6 @@ export default defineConfig([
     plugins: [sharedSettings()],
     basePath: '/staging',
     apiHost: 'https://api.sanity.work',
-    beta: {eventsAPI: {enabled: true}},
     auth: {
       loginMethod: 'token',
     },

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -364,18 +364,29 @@ export const internalTasksReducer = (opts: {
   return result
 }
 
-export const eventsAPIReducer = (opts: {config: PluginOptions; initialValue: boolean}): boolean => {
+export const eventsAPIReducer = (opts: {
+  config: PluginOptions
+  initialValue: boolean
+  key: 'releases' | 'documents'
+}): boolean => {
   const {config, initialValue} = opts
   const flattenedConfig = flattenConfig(config, [])
 
   const result = flattenedConfig.reduce((acc: boolean, {config: innerConfig}) => {
-    const enabled = innerConfig.beta?.eventsAPI?.enabled
+    // @ts-expect-error enabled is a legacy option we want to warn beta testers in case they have enabled it.
+    if (innerConfig.beta?.eventsAPI?.enabled) {
+      throw new Error(
+        `The \`beta.eventsAPI.enabled\` option has been removed. Use \`beta.eventsAPI.${opts.key}\` instead.`,
+      )
+    }
+
+    const enabled = innerConfig.beta?.eventsAPI?.[opts.key]
 
     if (typeof enabled === 'undefined') return acc
     if (typeof enabled === 'boolean') return enabled
 
     throw new Error(
-      `Expected \`beta.eventsAPI.enabled\` to be a boolean, but received ${getPrintableType(
+      `Expected \`beta.eventsAPI.${opts.key}\` to be a boolean, but received ${getPrintableType(
         enabled,
       )}`,
     )

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -647,7 +647,8 @@ function resolveSource({
 
     beta: {
       eventsAPI: {
-        enabled: eventsAPIReducer({config, initialValue: false}),
+        documents: eventsAPIReducer({config, initialValue: true, key: 'documents'}),
+        releases: eventsAPIReducer({config, initialValue: false, key: 'releases'}),
       },
       treeArrayEditing: {
         // This beta feature is no longer available.

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -1020,6 +1020,7 @@ export interface BetaFeatures {
    * If it is not enabled, it will continue using the legacy Timeline.
    */
   eventsAPI?: {
-    enabled: boolean
+    documents?: boolean
+    releases?: boolean
   }
 }

--- a/packages/sanity/src/core/releases/tool/detail/events/getReleaseActivityEvents.ts
+++ b/packages/sanity/src/core/releases/tool/detail/events/getReleaseActivityEvents.ts
@@ -59,7 +59,7 @@ export function getReleaseActivityEvents({client, releaseId}: InitialFetchEvents
         events: Omit<ReleaseEvent, 'id' | 'origin'>[]
         nextCursor: string
       }>({
-        url: `/data/events/${client.config().dataset}/releases/${getReleaseIdFromReleaseDocumentId(releaseId)}?${params.toString()}`,
+        url: `/data/history/${client.config().dataset}/events/releases/${getReleaseIdFromReleaseDocumentId(releaseId)}?${params.toString()}`,
         tag: 'get-release-events',
       })
       .pipe(

--- a/packages/sanity/src/core/releases/tool/detail/events/useReleaseEvents.ts
+++ b/packages/sanity/src/core/releases/tool/detail/events/useReleaseEvents.ts
@@ -23,7 +23,7 @@ export function useReleaseEvents(releaseId: string): ReleaseEvents {
   const documentPreviewStore = useDocumentPreviewStore()
   const {state$: releasesState$} = useReleasesStore()
   const source = useSource()
-  const eventsAPIEnabled = Boolean(source.beta?.eventsAPI?.enabled)
+  const eventsAPIEnabled = Boolean(source.beta?.eventsAPI?.releases)
 
   const releaseEvents = useMemo(
     () =>

--- a/packages/sanity/src/core/releases/tool/detail/events/useReleaseEvents.ts
+++ b/packages/sanity/src/core/releases/tool/detail/events/useReleaseEvents.ts
@@ -4,7 +4,6 @@ import {useObservable} from 'react-rx'
 import {useClient} from '../../../../hooks/useClient'
 import {useDocumentPreviewStore} from '../../../../store/_legacy/datastores'
 import {useSource} from '../../../../studio/source'
-import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../../studioClient'
 import {useReleasesStore} from '../../../store/useReleasesStore'
 import {getReleaseDocumentIdFromReleaseId} from '../../../util/getReleaseDocumentIdFromReleaseId'
 import {EVENTS_INITIAL_VALUE, getReleaseEvents} from './getReleaseEvents'
@@ -19,7 +18,8 @@ export interface ReleaseEvents {
 }
 
 export function useReleaseEvents(releaseId: string): ReleaseEvents {
-  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  // Needs vX version of the API
+  const client = useClient({apiVersion: 'X'})
   const documentPreviewStore = useDocumentPreviewStore()
   const {state$: releasesState$} = useReleasesStore()
   const source = useSource()

--- a/packages/sanity/src/core/store/events/README.md
+++ b/packages/sanity/src/core/store/events/README.md
@@ -7,7 +7,7 @@ The **Events API** introduces a new mechanism for accessing `DocumentGroupEvent`
 This events are accessible through:
 
 ```
-/data/events/<dataset/documents/<documentId>
+/data/history/<datasetName>/events/documents/<documentsIds>
 ```
 
 This API is designed to be lightweight, providing only the essential data required to render the UI. Additionally, it offers insights into the document variants impacted by each event.

--- a/packages/sanity/src/core/store/events/createEventsObservable.ts
+++ b/packages/sanity/src/core/store/events/createEventsObservable.ts
@@ -6,6 +6,7 @@ import {type EventsObservableValue} from './getInitialFetchEvents'
 import {type EditDocumentVersionEvent, type UpdateLiveDocumentEvent} from './types'
 import {
   addParentToEvents,
+  sortEvents,
   squashLiveEditEvents,
   updatePublishedEvents,
   updateVersionEvents,
@@ -29,10 +30,7 @@ export function createEventsObservable({
   const documentVariantType = getDocumentVariantType(documentId)
   return combineLatest([releases$, events$, remoteEdits$, expandedEvents$]).pipe(
     map(([releases, {events, nextCursor, loading, error}, remoteEdits, expandedEvents]) => {
-      const eventsWithRemoteEdits = [...remoteEdits, ...events, ...expandedEvents].sort(
-        // Sort by timestamp, newest first
-        (a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp),
-      )
+      const eventsWithRemoteEdits = sortEvents({remoteEdits, events, expandedEvents})
 
       if (documentVariantType === 'published') {
         return {

--- a/packages/sanity/src/core/store/events/getInitialFetchEvents.ts
+++ b/packages/sanity/src/core/store/events/getInitialFetchEvents.ts
@@ -47,7 +47,7 @@ export function getInitialFetchEvents({client, documentId}: InitialFetchEventsOp
         events: Record<string, Omit<DocumentGroupEvent, 'id'>[]>
         nextCursor: string
       }>({
-        url: `/data/events/${client.config().dataset}/documents/${documentId}?${params.toString()}`,
+        url: `/data/history/${client.config().dataset}/events/documents/${documentId}?${params.toString()}`,
         tag: 'get-document-events',
       })
       .pipe(

--- a/packages/sanity/src/core/store/events/useEventsStore.ts
+++ b/packages/sanity/src/core/store/events/useEventsStore.ts
@@ -6,7 +6,6 @@ import {of} from 'rxjs'
 import {useClient, useSchema} from '../../hooks'
 import {useReleasesStore} from '../../releases/store/useReleasesStore'
 import {useWorkspace} from '../../studio/workspace'
-import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {getDocumentVariantType} from '../../util/getDocumentVariantType'
 import {fetchFeatureToggle} from '../_legacy/document/document-pair/utils/fetchFeatureToggle'
 import {createEventsStore} from './createEventsStore'
@@ -45,7 +44,8 @@ export function useEventsStore({
   rev?: string | '@lastEdited'
   since?: string | '@lastPublished'
 }): EventsStore {
-  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  // Needs vX version of the API to get the events
+  const client = useClient({apiVersion: 'X'})
   const {state$: releases$} = useReleasesStore()
   const workspace = useWorkspace()
 

--- a/packages/sanity/src/core/store/events/utils.test.ts
+++ b/packages/sanity/src/core/store/events/utils.test.ts
@@ -1,0 +1,383 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  type DocumentGroupEvent,
+  type EditDocumentVersionEvent,
+  type UpdateLiveDocumentEvent,
+} from './types'
+import {addParentToEvents, sortEvents} from './utils'
+
+describe('addParentToEvents', () => {
+  it('should add the correct parentId to the events', () => {})
+})
+
+describe('sortEvents', () => {
+  it('should sort events in the right order, if published and edited have same timestamp, published goes first ', () => {
+    const remoteEdits: (UpdateLiveDocumentEvent | EditDocumentVersionEvent)[] = []
+    const events: DocumentGroupEvent[] = [
+      {
+        author: 'p8xDvUMxC',
+        type: 'publishDocumentVersion',
+        timestamp: '2025-01-23T11:46:10Z',
+        documentId: 'b149d8d0-a4eb-451e-8160-4e489380b670',
+        revisionId: '5IENz7UduDBgah5qw8P7st',
+        releaseId: '',
+        versionId: 'drafts.b149d8d0-a4eb-451e-8160-4e489380b670',
+        versionRevisionId: 'b3075281-d9f1-41d0-9304-bca31a6ec958',
+        publishCause: 'document.publish',
+        id: 'b3075281-d9f1-41d0-9304-bca31a6ec958',
+      },
+      {
+        author: 'p8xDvUMxC',
+        type: 'createDocumentVersion',
+        timestamp: '2025-01-23T11:46:05Z',
+        documentId: 'b149d8d0-a4eb-451e-8160-4e489380b670',
+        releaseId: '',
+        versionId: 'drafts.b149d8d0-a4eb-451e-8160-4e489380b670',
+        versionRevisionId: 'a45d633f-f692-409a-8b5a-423eab31dd9f',
+        id: 'a45d633f-f692-409a-8b5a-423eab31dd9f',
+        parentId: 'b3075281-d9f1-41d0-9304-bca31a6ec958',
+      },
+    ]
+    const expandedEvents: EditDocumentVersionEvent[] = [
+      {
+        type: 'editDocumentVersion',
+        documentId: 'drafts.b149d8d0-a4eb-451e-8160-4e489380b670',
+        id: 'b3075281-d9f1-41d0-9304-bca31a6ec958',
+        timestamp: '2025-01-23T11:46:10.620240Z',
+        author: 'p8xDvUMxC',
+        contributors: ['p8xDvUMxC'],
+        revisionId: 'b3075281-d9f1-41d0-9304-bca31a6ec958',
+        transactions: [
+          {
+            type: 'editTransaction',
+            author: 'p8xDvUMxC',
+            timestamp: '2025-01-23T11:46:10.620240Z',
+            revisionId: 'b3075281-d9f1-41d0-9304-bca31a6ec958',
+          },
+          {
+            type: 'editTransaction',
+            author: 'p8xDvUMxC',
+            timestamp: '2025-01-23T11:46:06.415469Z',
+            revisionId: 'caa420f8-fae4-41c1-9e68-057e5cc0b3cd',
+          },
+        ],
+        parentId: 'b3075281-d9f1-41d0-9304-bca31a6ec958',
+      },
+    ]
+    const result = sortEvents({events, remoteEdits, expandedEvents})
+    expect(result[0].type).toBe('publishDocumentVersion')
+    expect(result[1].type).toBe('editDocumentVersion')
+    expect(result[2].type).toBe('createDocumentVersion')
+  })
+  it('should handle remote edits correctly', () => {
+    const remoteEdits: (UpdateLiveDocumentEvent | EditDocumentVersionEvent)[] = [
+      {
+        type: 'editDocumentVersion',
+        documentId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        id: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
+        timestamp: '2025-01-23T13:37:13.450Z',
+        author: 'p8xDvUMxC',
+        contributors: ['p8xDvUMxC'],
+        revisionId: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
+        transactions: [
+          {
+            type: 'editTransaction',
+            author: 'p8xDvUMxC',
+            timestamp: '2025-01-23T13:37:13.450Z',
+            revisionId: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
+          },
+          {
+            type: 'editTransaction',
+            author: 'p8xDvUMxC',
+            timestamp: '2025-01-23T13:37:09.416Z',
+            revisionId: '45a3edd4-3975-4fa2-89ce-77d40b8de86f',
+          },
+          {
+            type: 'editTransaction',
+            author: 'p8xDvUMxC',
+            timestamp: '2025-01-23T13:37:07.984Z',
+            revisionId: 'd16f0b19-8aeb-4628-a377-0153c48828aa',
+          },
+        ],
+      },
+    ]
+    const events: DocumentGroupEvent[] = [
+      {
+        author: 'p8xDvUMxC',
+        type: 'createDocumentVersion',
+        timestamp: '2025-01-23T13:37:12Z',
+        documentId: 'bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        releaseId: '',
+        versionId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        versionRevisionId: '1fc72aa1-9870-4020-8a88-9ad18f199840',
+        id: '1fc72aa1-9870-4020-8a88-9ad18f199840',
+        parentId: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
+      },
+      {
+        author: 'p8xDvUMxC',
+        type: 'publishDocumentVersion',
+        timestamp: '2025-01-23T13:37:17Z',
+        documentId: 'bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        revisionId: 'Fa2iQBQggalMSxRpi8pie2',
+        releaseId: '',
+        versionId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        versionRevisionId: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
+        publishCause: 'document.publish',
+        id: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
+      },
+    ]
+    const expandedEvents: EditDocumentVersionEvent[] = []
+    const result = sortEvents({events, remoteEdits, expandedEvents})
+    expect(result[0].type).toBe('publishDocumentVersion')
+    expect(result[1].type).toBe('editDocumentVersion')
+    expect(result[2].type).toBe('createDocumentVersion')
+  })
+})
+
+describe('addParentToEvents', () => {
+  it('should add the parents', () => {
+    const events: DocumentGroupEvent[] = [
+      {
+        type: 'editDocumentVersion',
+        documentId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        id: '0d2e2557-d165-48f7-866e-31231232',
+        timestamp: '2025-01-23T15:00:05.081Z',
+        author: 'p8xDvUMxC',
+        contributors: ['p8xDvUMxC'],
+        revisionId: '0d2e2557-d165-48f7-866e-31231232',
+        transactions: [
+          {
+            type: 'editTransaction',
+            author: 'p8xDvUMxC',
+            timestamp: '2025-01-23T15:00:05.081Z',
+            revisionId: '0d2e2557-d165-48f7-866e-31231232',
+          },
+          {
+            type: 'editTransaction',
+            author: 'p8xDvUMxC',
+            timestamp: '2025-01-23T15:00:03.842Z',
+            revisionId: 'f3d6993d-3147-4b2e-8e98-b7e09e69de82',
+          },
+        ],
+      },
+      {
+        author: 'p8xDvUMxC',
+        type: 'publishDocumentVersion',
+        timestamp: '2025-01-23T14:00:08Z',
+        documentId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        revisionId: 'Fa2iQBQggalMSxRpi8prWU',
+        releaseId: '',
+        versionId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        versionRevisionId: '0d2e2557-d165-48f7-866e-1b664f25a5a5',
+        publishCause: 'document.publish',
+        id: '0d2e2557-d165-48f7-866e-1b664f25a5a5',
+      },
+      {
+        type: 'editDocumentVersion',
+        documentId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        id: '0d2e2557-d165-48f7-866e-1b664f25a5a5',
+        timestamp: '2025-01-23T14:00:05.081Z',
+        author: 'p8xDvUMxC',
+        contributors: ['p8xDvUMxC'],
+        revisionId: '0d2e2557-d165-48f7-866e-1b664f25a5a5',
+        transactions: [
+          {
+            type: 'editTransaction',
+            author: 'p8xDvUMxC',
+            timestamp: '2025-01-23T14:00:05.081Z',
+            revisionId: '0d2e2557-d165-48f7-866e-1b664f25a5a5',
+          },
+          {
+            type: 'editTransaction',
+            author: 'p8xDvUMxC',
+            timestamp: '2025-01-23T14:00:03.842Z',
+            revisionId: 'f3d6993d-3147-4b2e-8e98-b7e09e69de82',
+          },
+        ],
+      },
+      {
+        type: 'editDocumentVersion',
+        documentId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        id: '625db1c4-24a8-4f58-b60a-d70574624dd9',
+        timestamp: '2025-01-23T13:57:15.574671Z',
+        author: 'p8xDvUMxC',
+        contributors: ['p8xDvUMxC'],
+        revisionId: '625db1c4-24a8-4f58-b60a-d70574624dd9',
+        transactions: [
+          {
+            type: 'editTransaction',
+            author: 'p8xDvUMxC',
+            timestamp: '2025-01-23T13:57:15.574671Z',
+            revisionId: '625db1c4-24a8-4f58-b60a-d70574624dd9',
+          },
+        ],
+      },
+      {
+        author: 'p8xDvUMxC',
+        type: 'createDocumentVersion',
+        timestamp: '2025-01-23T13:57:14Z',
+        documentId: 'bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        releaseId: '',
+        versionId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        versionRevisionId: '6818a2df-ad70-460f-b827-6e40beeb1518',
+        id: '6818a2df-ad70-460f-b827-6e40beeb1518',
+        parentId: '0d2e2557-d165-48f7-866e-1b664f25a5a5',
+      },
+      {
+        author: 'p8xDvUMxC',
+        type: 'publishDocumentVersion',
+        timestamp: '2025-01-23T13:37:17Z',
+        documentId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        revisionId: 'Fa2iQBQggalMSxRpi8pie2',
+        releaseId: '',
+        versionId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        versionRevisionId: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
+        publishCause: 'document.publish',
+        id: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
+        creationEvent: {
+          author: 'p8xDvUMxC',
+          type: 'createDocumentVersion',
+          timestamp: '2025-01-23T13:37:12Z',
+          documentId: 'bcbfdedd-a719-4959-98fb-f68c8851d32f',
+          releaseId: '',
+          versionId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+          versionRevisionId: '1fc72aa1-9870-4020-8a88-9ad18f199840',
+          id: '1fc72aa1-9870-4020-8a88-9ad18f199840',
+          parentId: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
+        },
+      },
+      {
+        author: 'p8xDvUMxC',
+        type: 'createDocumentVersion',
+        timestamp: '2025-01-23T13:37:12Z',
+        documentId: 'bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        releaseId: '',
+        versionId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        versionRevisionId: '1fc72aa1-9870-4020-8a88-9ad18f199840',
+        id: '1fc72aa1-9870-4020-8a88-9ad18f199840',
+        parentId: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
+      },
+    ]
+    const result = addParentToEvents(events)
+    expect(result).toEqual([
+      // This event is not modified
+      events[0],
+      {
+        author: 'p8xDvUMxC',
+        type: 'publishDocumentVersion',
+        timestamp: '2025-01-23T14:00:08Z',
+        documentId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        revisionId: 'Fa2iQBQggalMSxRpi8prWU',
+        releaseId: '',
+        versionId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        versionRevisionId: '0d2e2557-d165-48f7-866e-1b664f25a5a5',
+        publishCause: 'document.publish',
+        id: '0d2e2557-d165-48f7-866e-1b664f25a5a5',
+        // Creation event is added given his is a published event
+        creationEvent: {
+          author: 'p8xDvUMxC',
+          type: 'createDocumentVersion',
+          timestamp: '2025-01-23T13:57:14Z',
+          documentId: 'bcbfdedd-a719-4959-98fb-f68c8851d32f',
+          releaseId: '',
+          versionId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+          versionRevisionId: '6818a2df-ad70-460f-b827-6e40beeb1518',
+          id: '6818a2df-ad70-460f-b827-6e40beeb1518',
+          parentId: '0d2e2557-d165-48f7-866e-1b664f25a5a5',
+        },
+      },
+      {
+        type: 'editDocumentVersion',
+        documentId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        id: 'f3d6993d-3147-4b2e-8e98-b7e09e69de82',
+        timestamp: '2025-01-23T14:00:05.081Z',
+        author: 'p8xDvUMxC',
+        contributors: ['p8xDvUMxC'],
+        revisionId: '0d2e2557-d165-48f7-866e-1b664f25a5a5',
+        transactions: [
+          {
+            type: 'editTransaction',
+            author: 'p8xDvUMxC',
+            timestamp: '2025-01-23T14:00:05.081Z',
+            revisionId: '0d2e2557-d165-48f7-866e-1b664f25a5a5',
+          },
+          {
+            type: 'editTransaction',
+            author: 'p8xDvUMxC',
+            timestamp: '2025-01-23T14:00:03.842Z',
+            revisionId: 'f3d6993d-3147-4b2e-8e98-b7e09e69de82',
+          },
+        ],
+        // Parent id is added given this is an edit event
+        parentId: '0d2e2557-d165-48f7-866e-1b664f25a5a5',
+      },
+      {
+        type: 'editDocumentVersion',
+        documentId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        id: '625db1c4-24a8-4f58-b60a-d70574624dd9',
+        timestamp: '2025-01-23T13:57:15.574671Z',
+        author: 'p8xDvUMxC',
+        contributors: ['p8xDvUMxC'],
+        revisionId: '625db1c4-24a8-4f58-b60a-d70574624dd9',
+        transactions: [
+          {
+            type: 'editTransaction',
+            author: 'p8xDvUMxC',
+            timestamp: '2025-01-23T13:57:15.574671Z',
+            revisionId: '625db1c4-24a8-4f58-b60a-d70574624dd9',
+          },
+        ],
+        // Parent id is added given this is an edit event
+        parentId: '0d2e2557-d165-48f7-866e-1b664f25a5a5',
+      },
+      {
+        author: 'p8xDvUMxC',
+        type: 'createDocumentVersion',
+        timestamp: '2025-01-23T13:57:14Z',
+        documentId: 'bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        releaseId: '',
+        versionId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        versionRevisionId: '6818a2df-ad70-460f-b827-6e40beeb1518',
+        id: '6818a2df-ad70-460f-b827-6e40beeb1518',
+        // Parent id is added given this is a create event
+        parentId: '0d2e2557-d165-48f7-866e-1b664f25a5a5',
+      },
+      {
+        author: 'p8xDvUMxC',
+        type: 'publishDocumentVersion',
+        timestamp: '2025-01-23T13:37:17Z',
+        documentId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        revisionId: 'Fa2iQBQggalMSxRpi8pie2',
+        releaseId: '',
+        versionId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        versionRevisionId: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
+        publishCause: 'document.publish',
+        id: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
+        creationEvent: {
+          author: 'p8xDvUMxC',
+          type: 'createDocumentVersion',
+          timestamp: '2025-01-23T13:37:12Z',
+          documentId: 'bcbfdedd-a719-4959-98fb-f68c8851d32f',
+          releaseId: '',
+          versionId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+          versionRevisionId: '1fc72aa1-9870-4020-8a88-9ad18f199840',
+          id: '1fc72aa1-9870-4020-8a88-9ad18f199840',
+          parentId: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
+        },
+      },
+      {
+        author: 'p8xDvUMxC',
+        type: 'createDocumentVersion',
+        timestamp: '2025-01-23T13:37:12Z',
+        documentId: 'bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        releaseId: '',
+        versionId: 'drafts.bcbfdedd-a719-4959-98fb-f68c8851d32f',
+        versionRevisionId: '1fc72aa1-9870-4020-8a88-9ad18f199840',
+        id: '1fc72aa1-9870-4020-8a88-9ad18f199840',
+        // Parent id is added given this is a create event
+        parentId: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
+      },
+    ])
+  })
+})

--- a/packages/sanity/src/core/store/events/utils.ts
+++ b/packages/sanity/src/core/store/events/utils.ts
@@ -7,6 +7,7 @@ import {type DocumentVariantType} from '../../util/getDocumentVariantType'
 import {type DocumentRemoteMutationEvent} from '../_legacy'
 import {
   type DocumentGroupEvent,
+  type EditDocumentVersionEvent,
   isCreateDocumentVersionEvent,
   isCreateLiveDocumentEvent,
   isDeleteDocumentGroupEvent,
@@ -17,6 +18,7 @@ import {
   isUnpublishDocumentEvent,
   isUnscheduleDocumentVersionEvent,
   isUpdateLiveDocumentEvent,
+  type UpdateLiveDocumentEvent,
 } from './types'
 
 export function removeDupes(
@@ -81,18 +83,24 @@ export function addParentToEvents(events: DocumentGroupEvent[]): DocumentGroupEv
   eventsWithParent.forEach((event, index) => {
     if (isPublishDocumentVersionEvent(event)) {
       event.documentId = event.versionId
-      // Find the creation event for this published event
-      const creationEvent = events.slice(index + 1).find((e) => isCreateDocumentVersionEvent(e))
-      if (creationEvent) {
-        // If we found a creation event, we should add it to the publish event
-        event.creationEvent = creationEvent
-        creationEvent.parentId = event.id
+      // Find the creation event and edit events for this published event
+      for (let i = index; i <= eventsWithParent.length; i++) {
+        const nextEvent = eventsWithParent[i]
+        if (isEditDocumentVersionEvent(nextEvent)) {
+          nextEvent.parentId = event.id
+        }
+        if (isCreateDocumentVersionEvent(nextEvent)) {
+          event.creationEvent = nextEvent
+          nextEvent.parentId = event.id
+          // When we find the create event we should stop the loop. Events are ordered
+          break
+        }
       }
     }
     if (isEditDocumentVersionEvent(event)) {
       // If it's the first edit event after expanding a publish, the id of this event will be shared with the id of the published event, we need to use the following transaction id.
       if (event.parentId === event.id && event.transactions[1]?.revisionId) {
-        event.id = event.transactions[1]?.revisionId
+        event.id = event.transactions[1].revisionId
       }
     }
   })
@@ -174,4 +182,37 @@ export function updatePublishedEvents(
     }
     return event
   })
+}
+
+export function sortEvents({
+  remoteEdits,
+  events,
+  expandedEvents,
+}: {
+  remoteEdits: (UpdateLiveDocumentEvent | EditDocumentVersionEvent)[]
+  events: DocumentGroupEvent[]
+  expandedEvents: EditDocumentVersionEvent[]
+}): DocumentGroupEvent[] {
+  const eventsWithRemoteEdits = [...remoteEdits, ...events, ...expandedEvents].sort(
+    // Sort by timestamp, newest first unless is an edit event that has a corresponding publish event
+    (a, b) => {
+      if (
+        isPublishDocumentVersionEvent(a) &&
+        isEditDocumentVersionEvent(b) &&
+        a.versionRevisionId === b.revisionId
+      ) {
+        return -1
+      }
+      if (
+        isPublishDocumentVersionEvent(b) &&
+        isEditDocumentVersionEvent(a) &&
+        b.versionRevisionId === a.revisionId
+      ) {
+        return +1
+      }
+
+      return Date.parse(b.timestamp) - Date.parse(a.timestamp)
+    },
+  )
+  return eventsWithRemoteEdits
 }

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProviderWrapper.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProviderWrapper.tsx
@@ -10,7 +10,7 @@ import {type DocumentPaneProviderProps} from './types'
  */
 export const DocumentPaneProviderWrapper = memo((props: DocumentPaneProviderProps) => {
   const source = useSource()
-  if (source.beta?.eventsAPI?.enabled) {
+  if (source.beta?.eventsAPI?.documents) {
     return <DocumentEventsPane {...props} />
   }
   return <DocumentPaneWithLegacyTimelineStore {...props} />

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/ChangesTabs.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/ChangesTabs.tsx
@@ -79,7 +79,7 @@ export function ChangesTabs(props: DocumentInspectorProps) {
         hidden={paneRouterTab !== 'history'}
         id="history-panel"
       >
-        {source.beta?.eventsAPI?.enabled ? (
+        {source.beta?.eventsAPI?.documents ? (
           <EventsSelector showList={paneRouterTab === 'history'} />
         ) : (
           <HistorySelector showList={paneRouterTab === 'history'} />
@@ -92,7 +92,7 @@ export function ChangesTabs(props: DocumentInspectorProps) {
         id="review-panel"
         height="fill"
       >
-        {source.beta?.eventsAPI?.enabled ? (
+        {source.beta?.eventsAPI?.documents ? (
           <>
             {paneRouterTab === 'review' ? (
               <EventsInspector showChanges={paneRouterTab === 'review'} />


### PR DESCRIPTION
### Description
This PR updates the events api routes that we were using.
The routes now will be:
- Documents events: `data/history/{datasetName}/events/documents/{ids}` 
- Release events `data/history/{datasetName}/events/releases/{id}`

It also modifies the config flag we have added for the events api and **enables** it by default for documents events for all the studios.
It's kept as a flag in case we need to turn it off.

Releases events are not ready to be used by everyone yet, so a new flag has been added to handle this. It will be enabled by default in the `playground` studio.


It also updates the sort algorithm for the events, given the timestamp validation is not the only check necessary, because edit and publish events now have the same timestamp and the order was incorrect. 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
