### PR TITLE
chore: upgrade vitest to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,6 @@ jobs:
       - name: Test
         id: test
         run: |
-          pnpm test:vitest --shard=${{ matrix.shardIndex}}/${{ matrix.shardTotal }}
+          pnpm test:vitest --test-timeout=60000 --retry 4 --shard=${{ matrix.shardIndex}}/${{ matrix.shardTotal }}
         env:
           GITHUB_SHARD_IDENTIFIER: ${{ matrix.shardIndex }}-${{ matrix.shardTotal }}

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "typescript": "5.7.3",
     "vite": "^6.0.11",
     "vite-tsconfig-paths": "^4.3.2",
-    "vitest": "^2.1.9",
+    "vitest": "^3.0.5",
     "yargs": "^17.3.0"
   },
   "optionalDependencies": {

--- a/packages/@repo/test-config/package.json
+++ b/packages/@repo/test-config/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@repo/dev-aliases": "workspace:*",
-    "vitest": "^2.1.9"
+    "vitest": "^3.0.5"
   }
 }

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -126,7 +126,7 @@
     "semver-compare": "^1.0.0",
     "tar": "^6.1.11",
     "vite": "^6.0.11",
-    "vitest": "^2.1.9",
+    "vitest": "^3.0.5",
     "which": "^2.0.2",
     "xdg-basedir": "^4.0.0"
   },

--- a/packages/@sanity/codegen/package.json
+++ b/packages/@sanity/codegen/package.json
@@ -75,7 +75,7 @@
     "@types/babel__traverse": "^7.20.5",
     "@types/debug": "^4.1.12",
     "rimraf": "^5.0.10",
-    "vitest": "^2.1.9"
+    "vitest": "^3.0.5"
   },
   "engines": {
     "node": ">=18"

--- a/packages/@sanity/migrate/package.json
+++ b/packages/@sanity/migrate/package.json
@@ -65,7 +65,7 @@
     "@repo/test-config": "workspace:*",
     "@types/debug": "^4.1.12",
     "rimraf": "^5.0.10",
-    "vitest": "^2.1.9"
+    "vitest": "^3.0.5"
   },
   "engines": {
     "node": ">=18"

--- a/packages/@sanity/mutator/package.json
+++ b/packages/@sanity/mutator/package.json
@@ -61,6 +61,6 @@
     "@types/debug": "^4.1.5",
     "@types/lodash": "^4.17.7",
     "rimraf": "^5.0.10",
-    "vitest": "^2.1.9"
+    "vitest": "^3.0.5"
   }
 }

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -80,6 +80,6 @@
     "@types/object-inspect": "^1.13.0",
     "@types/react": "^19.0.7",
     "rimraf": "^5.0.10",
-    "vitest": "^2.1.9"
+    "vitest": "^3.0.5"
   }
 }

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -59,7 +59,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "react": "^18.3.1",
     "rimraf": "^5.0.10",
-    "vitest": "^2.1.9"
+    "vitest": "^3.0.5"
   },
   "peerDependencies": {
     "@types/react": "18 || 19"

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -131,7 +131,7 @@
     "@repo/package.config": "workspace:*",
     "@repo/test-config": "workspace:*",
     "rimraf": "^5.0.10",
-    "vitest": "^2.1.9"
+    "vitest": "^3.0.5"
   },
   "engines": {
     "node": ">=18"

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -314,7 +314,7 @@
     "rxjs-etc": "^10.6.2",
     "styled-components": "^6.1.14",
     "swr": "2.2.5",
-    "vitest": "2.1.9"
+    "vitest": "^3.0.5"
   },
   "peerDependencies": {
     "react": "^18 || ^19.0.0",

--- a/perf/tests/package.json
+++ b/perf/tests/package.json
@@ -32,6 +32,6 @@
     "esbuild": "0.21.5",
     "ts-node": "^10.9.2",
     "typescript": "5.7.3",
-    "vitest": "^2.1.9"
+    "vitest": "^3.0.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,8 +224,8 @@ importers:
         specifier: ^4.3.2
         version: 4.3.2(typescript@5.7.3)(vite@6.0.11(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1))
       vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
+        specifier: ^3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
       yargs:
         specifier: ^17.3.0
         version: 17.3.0
@@ -648,8 +648,8 @@ importers:
         specifier: workspace:*
         version: link:../dev-aliases
       vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
+        specifier: ^3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
 
   packages/@repo/test-exports:
     dependencies:
@@ -901,8 +901,8 @@ importers:
         specifier: ^6.0.11
         version: 6.0.11(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1)
       vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
+        specifier: ^3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
       which:
         specifier: ^2.0.2
         version: 2.0.2
@@ -983,8 +983,8 @@ importers:
         specifier: ^5.0.10
         version: 5.0.10
       vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
+        specifier: ^3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
 
   packages/@sanity/diff:
     dependencies:
@@ -1042,8 +1042,8 @@ importers:
         specifier: ^5.0.10
         version: 5.0.10
       vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
+        specifier: ^3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
 
   packages/@sanity/mutator:
     dependencies:
@@ -1079,8 +1079,8 @@ importers:
         specifier: ^5.0.10
         version: 5.0.10
       vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
+        specifier: ^3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
 
   packages/@sanity/schema:
     dependencies:
@@ -1131,8 +1131,8 @@ importers:
         specifier: ^5.0.10
         version: 5.0.10
       vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
+        specifier: ^3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
 
   packages/@sanity/types:
     dependencies:
@@ -1162,8 +1162,8 @@ importers:
         specifier: ^5.0.10
         version: 5.0.10
       vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
+        specifier: ^3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
 
   packages/@sanity/util:
     dependencies:
@@ -1193,8 +1193,8 @@ importers:
         specifier: ^5.0.10
         version: 5.0.10
       vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
+        specifier: ^3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
 
   packages/@sanity/vision:
     dependencies:
@@ -1819,8 +1819,8 @@ importers:
         specifier: 2.2.5
         version: 2.2.5(react@18.3.1)
       vitest:
-        specifier: 2.1.9
-        version: 2.1.9(@types/node@22.10.2)(jsdom@23.2.0)(terser@5.37.0)(yaml@2.6.1)
+        specifier: ^3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@22.10.2)(jsdom@23.2.0)(terser@5.37.0)(yaml@2.6.1)
 
   packages/sanity/fixtures/examples/prj-with-react-18:
     dependencies:
@@ -1994,8 +1994,8 @@ importers:
         specifier: 5.7.3
         version: 5.7.3
       vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@18.19.68)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
+        specifier: ^3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@18.19.68)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1)
 
 packages:
 
@@ -5349,11 +5349,11 @@ packages:
     peerDependencies:
       vite: ^6.0.11
 
-  '@vitest/expect@2.1.9':
-    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+  '@vitest/expect@3.0.5':
+    resolution: {integrity: sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==}
 
-  '@vitest/mocker@2.1.9':
-    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+  '@vitest/mocker@3.0.5':
+    resolution: {integrity: sha512-CLPNBFBIE7x6aEGbIjaQAX03ZZlBMaWwAjBdMkIf/cAn6xzLTiM3zYqO/WAbieEjsAZir6tO71mzeHZoodThvw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.11
@@ -5363,20 +5363,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@2.1.9':
-    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+  '@vitest/pretty-format@3.0.5':
+    resolution: {integrity: sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==}
 
-  '@vitest/runner@2.1.9':
-    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+  '@vitest/runner@3.0.5':
+    resolution: {integrity: sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==}
 
-  '@vitest/snapshot@2.1.9':
-    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+  '@vitest/snapshot@3.0.5':
+    resolution: {integrity: sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==}
 
-  '@vitest/spy@2.1.9':
-    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+  '@vitest/spy@3.0.5':
+    resolution: {integrity: sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==}
 
-  '@vitest/utils@2.1.9':
-    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+  '@vitest/utils@3.0.5':
+    resolution: {integrity: sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==}
 
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
@@ -6808,6 +6808,9 @@ packages:
 
   es-module-lexer@1.5.4:
     resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
+
+  es-module-lexer@1.6.0:
+    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -9621,6 +9624,9 @@ packages:
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
+  pathe@2.0.2:
+    resolution: {integrity: sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==}
+
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
@@ -11154,8 +11160,8 @@ packages:
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
-  tinyexec@0.3.1:
-    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyglobby@0.2.10:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
@@ -11165,8 +11171,8 @@ packages:
     resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
-  tinyrainbow@1.2.0:
-    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@3.0.2:
@@ -11645,9 +11651,9 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite-node@2.1.9:
-    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite-node@3.0.5:
+    resolution: {integrity: sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   vite-tsconfig-paths@4.3.2:
@@ -11698,19 +11704,22 @@ packages:
       yaml:
         optional: true
 
-  vitest@2.1.9:
-    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vitest@3.0.5:
+    resolution: {integrity: sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.9
-      '@vitest/ui': 2.1.9
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.0.5
+      '@vitest/ui': 3.0.5
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -16213,45 +16222,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@2.1.9':
+  '@vitest/expect@3.0.5':
     dependencies:
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
+      '@vitest/spy': 3.0.5
+      '@vitest/utils': 3.0.5
       chai: 5.1.2
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
-  '@vitest/mocker@2.1.9(vite@6.0.11(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1))':
+  '@vitest/mocker@3.0.5(vite@6.0.11(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1))':
     dependencies:
-      '@vitest/spy': 2.1.9
+      '@vitest/spy': 3.0.5
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       vite: 6.0.11(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1)
 
-  '@vitest/pretty-format@2.1.9':
+  '@vitest/pretty-format@3.0.5':
     dependencies:
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
-  '@vitest/runner@2.1.9':
+  '@vitest/runner@3.0.5':
     dependencies:
-      '@vitest/utils': 2.1.9
-      pathe: 1.1.2
+      '@vitest/utils': 3.0.5
+      pathe: 2.0.2
 
-  '@vitest/snapshot@2.1.9':
+  '@vitest/snapshot@3.0.5':
     dependencies:
-      '@vitest/pretty-format': 2.1.9
+      '@vitest/pretty-format': 3.0.5
       magic-string: 0.30.17
-      pathe: 1.1.2
+      pathe: 2.0.2
 
-  '@vitest/spy@2.1.9':
+  '@vitest/spy@3.0.5':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/utils@2.1.9':
+  '@vitest/utils@3.0.5':
     dependencies:
-      '@vitest/pretty-format': 2.1.9
+      '@vitest/pretty-format': 3.0.5
       loupe: 3.1.2
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
   '@vue/compiler-core@3.5.13':
     dependencies:
@@ -17893,6 +17902,8 @@ snapshots:
       safe-array-concat: 1.1.3
 
   es-module-lexer@1.5.4: {}
+
+  es-module-lexer@1.6.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -21252,6 +21263,8 @@ snapshots:
 
   pathe@1.1.2: {}
 
+  pathe@2.0.2: {}
+
   pathval@2.0.0: {}
 
   peek-stream@1.1.3:
@@ -23125,7 +23138,7 @@ snapshots:
 
   tinycolor2@1.6.0: {}
 
-  tinyexec@0.3.1: {}
+  tinyexec@0.3.2: {}
 
   tinyglobby@0.2.10:
     dependencies:
@@ -23134,7 +23147,7 @@ snapshots:
 
   tinypool@1.0.2: {}
 
-  tinyrainbow@1.2.0: {}
+  tinyrainbow@2.0.0: {}
 
   tinyspy@3.0.2: {}
 
@@ -23583,12 +23596,12 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@2.1.9(@types/node@18.19.68)(terser@5.37.0)(yaml@2.6.1):
+  vite-node@3.0.5(@types/node@18.19.68)(terser@5.37.0)(yaml@2.6.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@9.4.0)
-      es-module-lexer: 1.5.4
-      pathe: 1.1.2
+      es-module-lexer: 1.6.0
+      pathe: 2.0.2
       vite: 6.0.11(@types/node@18.19.68)(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -23604,12 +23617,12 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@2.1.9(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1):
+  vite-node@3.0.5(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@9.4.0)
-      es-module-lexer: 1.5.4
-      pathe: 1.1.2
+      es-module-lexer: 1.6.0
+      pathe: 2.0.2
       vite: 6.0.11(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -23658,29 +23671,30 @@ snapshots:
       terser: 5.37.0
       yaml: 2.6.1
 
-  vitest@2.1.9(@types/node@18.19.68)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1):
+  vitest@3.0.5(@types/debug@4.1.12)(@types/node@18.19.68)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1):
     dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@6.0.11(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
+      '@vitest/expect': 3.0.5
+      '@vitest/mocker': 3.0.5(vite@6.0.11(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1))
+      '@vitest/pretty-format': 3.0.5
+      '@vitest/runner': 3.0.5
+      '@vitest/snapshot': 3.0.5
+      '@vitest/spy': 3.0.5
+      '@vitest/utils': 3.0.5
       chai: 5.1.2
       debug: 4.4.0(supports-color@9.4.0)
       expect-type: 1.1.0
       magic-string: 0.30.17
-      pathe: 1.1.2
+      pathe: 2.0.2
       std-env: 3.8.0
       tinybench: 2.9.0
-      tinyexec: 0.3.1
+      tinyexec: 0.3.2
       tinypool: 1.0.2
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
       vite: 6.0.11(@types/node@18.19.68)(terser@5.37.0)(yaml@2.6.1)
-      vite-node: 2.1.9(@types/node@18.19.68)(terser@5.37.0)(yaml@2.6.1)
+      vite-node: 3.0.5(@types/node@18.19.68)(terser@5.37.0)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/debug': 4.1.12
       '@types/node': 18.19.68
       jsdom: 25.0.1
     transitivePeerDependencies:
@@ -23697,29 +23711,30 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@2.1.9(@types/node@22.10.2)(jsdom@23.2.0)(terser@5.37.0)(yaml@2.6.1):
+  vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.10.2)(jsdom@23.2.0)(terser@5.37.0)(yaml@2.6.1):
     dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@6.0.11(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
+      '@vitest/expect': 3.0.5
+      '@vitest/mocker': 3.0.5(vite@6.0.11(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1))
+      '@vitest/pretty-format': 3.0.5
+      '@vitest/runner': 3.0.5
+      '@vitest/snapshot': 3.0.5
+      '@vitest/spy': 3.0.5
+      '@vitest/utils': 3.0.5
       chai: 5.1.2
       debug: 4.4.0(supports-color@9.4.0)
       expect-type: 1.1.0
       magic-string: 0.30.17
-      pathe: 1.1.2
+      pathe: 2.0.2
       std-env: 3.8.0
       tinybench: 2.9.0
-      tinyexec: 0.3.1
+      tinyexec: 0.3.2
       tinypool: 1.0.2
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
       vite: 6.0.11(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1)
-      vite-node: 2.1.9(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1)
+      vite-node: 3.0.5(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/debug': 4.1.12
       '@types/node': 22.10.2
       jsdom: 23.2.0
     transitivePeerDependencies:
@@ -23736,29 +23751,30 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@2.1.9(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1):
+  vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.10.2)(jsdom@25.0.1)(terser@5.37.0)(yaml@2.6.1):
     dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@6.0.11(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
+      '@vitest/expect': 3.0.5
+      '@vitest/mocker': 3.0.5(vite@6.0.11(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1))
+      '@vitest/pretty-format': 3.0.5
+      '@vitest/runner': 3.0.5
+      '@vitest/snapshot': 3.0.5
+      '@vitest/spy': 3.0.5
+      '@vitest/utils': 3.0.5
       chai: 5.1.2
       debug: 4.4.0(supports-color@9.4.0)
       expect-type: 1.1.0
       magic-string: 0.30.17
-      pathe: 1.1.2
+      pathe: 2.0.2
       std-env: 3.8.0
       tinybench: 2.9.0
-      tinyexec: 0.3.1
+      tinyexec: 0.3.2
       tinypool: 1.0.2
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
       vite: 6.0.11(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1)
-      vite-node: 2.1.9(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1)
+      vite-node: 3.0.5(@types/node@22.10.2)(terser@5.37.0)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/debug': 4.1.12
       '@types/node': 22.10.2
       jsdom: 25.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
### Description

New attempt at upgrading vitest to v3, rebased against next since previous review :)

Note: Tests seems to run significantly slower between vitest v2 and v3. Didn't seem worth spending time looking into why since simply increasing test timeouts seems to have fixed it (see c066b138813915fd337a471d3269c7f63c259f0e), and since tests are sharded they usually don't take more than a few mins anyway.

### What to review
Does the test pass?

### Testing
Tests should pass

### Notes for release

n/a – internal