### PR TITLE
fix(presentation): perspective switching regression

### DIFF
--- a/packages/sanity/src/presentation/preview/Preview.tsx
+++ b/packages/sanity/src/presentation/preview/Preview.tsx
@@ -82,11 +82,13 @@ export const Preview = memo(
       vercelProtectionBypass,
     } = props
 
+    const [stablePerspective, setStablePerspective] = useState<typeof perspective | null>(null)
+    const urlPerspective = stablePerspective === null ? perspective : stablePerspective
     const previewUrl = useMemo(() => {
       const url = new URL(initialUrl)
       // Always set the perspective that's being used, even if preview mode isn't configured
       if (!url.searchParams.get(urlSearchParamPreviewPerspective)) {
-        url.searchParams.set(urlSearchParamPreviewPerspective, perspective)
+        url.searchParams.set(urlSearchParamPreviewPerspective, urlPerspective)
       }
 
       if (vercelProtectionBypass || url.searchParams.get(urlSearchParamVercelProtectionBypass)) {
@@ -102,7 +104,19 @@ export const Preview = memo(
       }
 
       return url
-    }, [initialUrl, perspective, vercelProtectionBypass])
+    }, [initialUrl, urlPerspective, vercelProtectionBypass])
+
+    useEffect(() => {
+      /**
+       * If the preview iframe is connected to the loader, we know that switching the perspective can be done without reloading the iframe.
+       */
+      if (loadersConnection === 'connected') {
+        /**
+         * Only set the stable perspective if it hasn't been set yet.
+         */
+        setStablePerspective((prev) => (prev === null ? perspective : prev))
+      }
+    }, [loadersConnection, perspective])
 
     const {t} = useTranslation(presentationLocaleNamespace)
     const {devMode} = usePresentationTool()


### PR DESCRIPTION
### Description

When [adding the Vercel Bypass Tool](https://github.com/sanity-io/visual-editing/pull/2479/files), I started forwarding the current perspective [while at it](https://github.com/sanity-io/visual-editing/pull/2479/files#diff-80fbc13cc919843352bf73130ac5964233caaebf4fe49d11bbc4e652103e9dc0R94-R97):
https://github.com/sanity-io/visual-editing/blob/d26635224057fcdf237bb187a3416c92a762ecd1/packages/presentation/src/preview/Preview.tsx#L94-L97
This caused a regression that lead to the iframe reloading and losing connection with Presentation Tool when switching perspectives and ultimately failing to swap the perspective in loaders' live mode:


https://github.com/user-attachments/assets/8eab26f8-4919-4995-9270-422a059100f7

Here's with the fix applied, restoring the previous behavior:



https://github.com/user-attachments/assets/ddfc655c-4de6-4224-bde3-4ef6c2aee832



### What to review

Enough code comments?

### Testing

We don't have E2E tests for this yet so it's manual, as shown in the videos attached here.

### Notes for release

Fixes a regression causing the perspective switcher in Presentation Tool to reload the iframe and lose connection with loaders, causing the perspective to fail switching. It now actually switches the perspective ❤ 
