### PR TITLE
fix(presentation): perspective switching regression

### DIFF
--- a/packages/sanity/src/presentation/preview/Preview.tsx
+++ b/packages/sanity/src/presentation/preview/Preview.tsx
@@ -82,11 +82,15 @@ export const Preview = memo(
       vercelProtectionBypass,
     } = props
 
+    const [stablePerspective, setStablePerspective] = useState<typeof perspective | null>(null)
+    const urlPerspective = encodeStudioPerspective(
+      stablePerspective === null ? perspective : stablePerspective,
+    )
     const previewUrl = useMemo(() => {
       const url = new URL(initialUrl)
       // Always set the perspective that's being used, even if preview mode isn't configured
       if (!url.searchParams.get(urlSearchParamPreviewPerspective)) {
-        url.searchParams.set(urlSearchParamPreviewPerspective, encodeStudioPerspective(perspective))
+        url.searchParams.set(urlSearchParamPreviewPerspective, urlPerspective)
       }
 
       if (vercelProtectionBypass || url.searchParams.get(urlSearchParamVercelProtectionBypass)) {
@@ -102,7 +106,19 @@ export const Preview = memo(
       }
 
       return url
-    }, [initialUrl, perspective, vercelProtectionBypass])
+    }, [initialUrl, urlPerspective, vercelProtectionBypass])
+
+    useEffect(() => {
+      /**
+       * If the preview iframe is connected to the loader, we know that switching the perspective can be done without reloading the iframe.
+       */
+      if (loadersConnection === 'connected') {
+        /**
+         * Only set the stable perspective if it hasn't been set yet.
+         */
+        setStablePerspective((prev) => (prev === null ? perspective : prev))
+      }
+    }, [loadersConnection, perspective])
 
     const {t} = useTranslation(presentationLocaleNamespace)
     const {devMode} = usePresentationTool()


### PR DESCRIPTION
### Description

This applies the same fix as #8383, but with semantics for handling perspectives that can be an array of strings.

Here's the before:


https://github.com/user-attachments/assets/98739f1f-7474-4e75-9242-e1e170bb8a00

And after:


https://github.com/user-attachments/assets/3daf6fb4-60f6-4a17-835f-2103090da689



### What to review

Enough code comments? Does it make sense?

### Testing

We don't have E2E tests for this yet so it's manual, as shown in the videos attached here.



### Notes for release

Fixes a regression causing the perspective switcher in Presentation Tool to reload the iframe and lose connection with loaders, causing the perspective to fail switching. It now actually switches the perspective ❤