### PR TITLE
fix(core): support searching references in same release

### DIFF
--- a/packages/@sanity/types/src/reference/types.ts
+++ b/packages/@sanity/types/src/reference/types.ts
@@ -30,6 +30,7 @@ export type ReferenceFilterSearchOptions = {
   tag?: string
   maxFieldDepth?: number
   strategy?: SearchStrategy
+  perspective?: string | string[]
 }
 
 /** @public */

--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
@@ -288,6 +288,13 @@ export function referenceSearch(
   })
   return search(textTerm, {includeDrafts: true}).pipe(
     map(({hits}) => hits.map(({hit}) => hit)),
+    map((docs) =>
+      docs.map((doc) => ({
+        ...doc,
+        // Pass the original id if available, it could be a `draftId` or a `versionId` , the _id will be the published one when using perspectives to query the data.
+        _id: (doc._originalId as string) || doc._id,
+      })),
+    ),
     map((docs) => collate(docs)),
     // pick the 100 best matches
     map((collated) => collated.slice(0, 100)),

--- a/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
@@ -14,6 +14,7 @@ import {catchError, mergeMap} from 'rxjs/operators'
 
 import {type FIXME} from '../../../../FIXME'
 import {useSchema} from '../../../../hooks'
+import {usePerspective} from '../../../../perspective/usePerspective'
 import {useDocumentPreviewStore} from '../../../../store'
 import {useSource} from '../../../../studio'
 import {useSearchMaxFieldDepth} from '../../../../studio/components/navbar/search/hooks/useSearchMaxFieldDepth'
@@ -62,6 +63,7 @@ type SearchError = {
 export function StudioReferenceInput(props: StudioReferenceInputProps) {
   const source = useSource()
   const searchClient = source.getClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  const {perspectiveStack} = usePerspective()
   const schema = useSchema()
   const maxFieldDepth = useSearchMaxFieldDepth()
   const documentPreviewStore = useDocumentPreviewStore()
@@ -92,6 +94,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
             tag: 'search.reference',
             maxFieldDepth,
             strategy: searchStrategy,
+            perspective: perspectiveStack,
           }),
         ),
 
@@ -104,7 +107,16 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
         }),
       ),
 
-    [schemaType, documentRef, path, getClient, searchClient, maxFieldDepth, searchStrategy],
+    [
+      schemaType,
+      documentRef,
+      path,
+      getClient,
+      searchClient,
+      maxFieldDepth,
+      searchStrategy,
+      perspectiveStack,
+    ],
   )
 
   const template = props.value?._strengthenOnPublish?.template

--- a/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
+++ b/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
@@ -5,6 +5,7 @@ import {PerspectiveContext} from 'sanity/_singletons'
 import {getReleasesPerspectiveStack} from '../releases/hooks/utils'
 import {useActiveReleases} from '../releases/store/useActiveReleases'
 import {getReleaseIdFromReleaseDocumentId} from '../releases/util/getReleaseIdFromReleaseDocumentId'
+import {EMPTY_ARRAY} from '../util/empty'
 import {type PerspectiveContextValue, type SelectedPerspective} from './types'
 
 /**
@@ -13,12 +14,11 @@ import {type PerspectiveContextValue, type SelectedPerspective} from './types'
 export function PerspectiveProvider({
   children,
   selectedPerspectiveName,
-  excludedPerspectives,
+  excludedPerspectives = EMPTY_ARRAY,
 }: {
   children: React.ReactNode
-
   selectedPerspectiveName: 'published' | ReleaseId | undefined
-  excludedPerspectives: string[]
+  excludedPerspectives?: string[]
 }) {
   const {data: releases} = useActiveReleases()
 

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
@@ -44,7 +44,7 @@ describe('createSearchQuery', () => {
       expect(query).toMatchInlineSnapshot(
         `
         "// findability-mvi:5
-        *[_type in $__types && !(_id in path("versions.**"))] | score(boost(_type in ["basic-schema-test"] && title match text::query($__query), 10), [@, _id] match text::query($__query)) | order(_score desc) [_score > 0] [0...$__limit] {_score, _type, _id}"
+        *[_type in $__types && !(_id in path("versions.**"))] | score(boost(_type in ["basic-schema-test"] && title match text::query($__query), 10), [@, _id] match text::query($__query)) | order(_score desc) [_score > 0] [0...$__limit] {_score, _type, _id, _originalId}"
       `,
       )
 
@@ -188,7 +188,7 @@ describe('createSearchQuery', () => {
 
       expect(query).toMatchInlineSnapshot(`
         "// findability-mvi:5
-        *[_type in $__types && [@, _id] match text::query($__query) && !(_id in path("versions.**"))] | order(exampleField desc) [0...$__limit] {exampleField, _type, _id}"
+        *[_type in $__types && [@, _id] match text::query($__query) && !(_id in path("versions.**"))] | order(exampleField desc) [0...$__limit] {exampleField, _type, _id, _originalId}"
       `)
 
       expect(query).toContain('| order(exampleField desc)')
@@ -222,7 +222,7 @@ describe('createSearchQuery', () => {
 
       expect(query).toMatchInlineSnapshot(`
         "// findability-mvi:5
-        *[_type in $__types && [@, _id] match text::query($__query) && !(_id in path("versions.**"))] | order(exampleField desc,anotherExampleField asc,lower(mapWithField) asc) [0...$__limit] {exampleField, anotherExampleField, mapWithField, _type, _id}"
+        *[_type in $__types && [@, _id] match text::query($__query) && !(_id in path("versions.**"))] | order(exampleField desc,anotherExampleField asc,lower(mapWithField) asc) [0...$__limit] {exampleField, anotherExampleField, mapWithField, _type, _id, _originalId}"
       `)
 
       expect(query).toContain(
@@ -241,7 +241,7 @@ describe('createSearchQuery', () => {
 
       expect(query).toMatchInlineSnapshot(`
         "// findability-mvi:5
-        *[_type in $__types && !(_id in path("versions.**"))] | score(boost(_type in ["basic-schema-test"] && title match text::query($__query), 10), [@, _id] match text::query($__query)) | order(_score desc) [_score > 0] [0...$__limit] {_score, _type, _id}"
+        *[_type in $__types && !(_id in path("versions.**"))] | score(boost(_type in ["basic-schema-test"] && title match text::query($__query), 10), [@, _id] match text::query($__query)) | order(_score desc) [_score > 0] [0...$__limit] {_score, _type, _id, _originalId}"
       `)
 
       expect(query).toContain('| order(_score desc)')
@@ -319,7 +319,7 @@ describe('createSearchQuery', () => {
 
       expect(query).toMatchInlineSnapshot(`
         "// findability-mvi:5
-        *[_type in $__types && !(_id in path("versions.**"))] | score(boost(_type in ["numbers-in-path"] && cover[].cards[].title match text::query($__query), 5), [@, _id] match text::query($__query)) | order(_score desc) [_score > 0] [0...$__limit] {_score, _type, _id}"
+        *[_type in $__types && !(_id in path("versions.**"))] | score(boost(_type in ["numbers-in-path"] && cover[].cards[].title match text::query($__query), 5), [@, _id] match text::query($__query)) | order(_score desc) [_score > 0] [0...$__limit] {_score, _type, _id, _originalId}"
       `)
 
       expect(query).toContain('cover[].cards[].title match text::query($__query), 5)')

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
@@ -103,7 +103,7 @@ export function createSearchQuery(
     options.cursor ?? [],
   ].flat()
 
-  const projectionFields = sortOrder.map(({field}) => field).concat('_type', '_id')
+  const projectionFields = sortOrder.map(({field}) => field).concat('_type', '_id', '_originalId')
   const projection = projectionFields.join(', ')
 
   const query = [

--- a/packages/sanity/src/core/search/weighted/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/weighted/createSearchQuery.test.ts
@@ -49,7 +49,7 @@ describe('createSearchQuery', () => {
           '*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && !(_id in path("versions.**"))]' +
           '| order(_id asc)' +
           '[0...$__limit]' +
-          '{_type, _id, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
+          '{_type, _id, _originalId, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
       )
 
       expect(params).toEqual({
@@ -147,9 +147,9 @@ describe('createSearchQuery', () => {
 
       const result = [
         `// findability-mvi:${FINDABILITY_MVI}\n` +
-          '*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && !(_id in path("versions.**"))]{_type, _id, object{field}}',
+          '*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && !(_id in path("versions.**"))]{_type, _id, _originalId, object{field}}',
         '|order(_id asc)[0...$__limit]',
-        '{_type, _id, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
+        '{_type, _id, _originalId, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
       ].join('')
 
       expect(query).toBe(result)
@@ -244,7 +244,7 @@ describe('createSearchQuery', () => {
           '*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && !(_id in path("versions.**"))]' +
           '| order(exampleField desc)' +
           '[0...$__limit]' +
-          '{_type, _id, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
+          '{_type, _id, _originalId, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
       )
     })
 
@@ -277,7 +277,7 @@ describe('createSearchQuery', () => {
         `// findability-mvi:${FINDABILITY_MVI}\n`,
         '*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && !(_id in path("versions.**"))]| ',
         'order(exampleField desc,anotherExampleField asc,lower(mapWithField) asc)',
-        '[0...$__limit]{_type, _id, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
+        '[0...$__limit]{_type, _id, _originalId, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
       ].join('')
 
       expect(query).toEqual(result)
@@ -294,7 +294,7 @@ describe('createSearchQuery', () => {
           '*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && !(_id in path("versions.**"))]' +
           '| order(_id asc)' +
           '[0...$__limit]' +
-          '{_type, _id, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
+          '{_type, _id, _originalId, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
       )
     })
 
@@ -410,7 +410,7 @@ describe('createSearchQuery', () => {
           // This solution was discarded at it would increase the size of the query payload by up to 50%
 
           // we still map out the path with number
-          '{_type, _id, ...select(_type == "numbers-in-path" => { "w0": _id,"w1": _type,"w2": cover[].cards[].title })}',
+          '{_type, _id, _originalId, ...select(_type == "numbers-in-path" => { "w0": _id,"w1": _type,"w2": cover[].cards[].title })}',
       )
     })
   })

--- a/packages/sanity/src/core/search/weighted/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/weighted/createSearchQuery.ts
@@ -152,7 +152,7 @@ export function createSearchQuery(
   // Default to `_id asc` (GROQ default) if no search sort is provided
   const sortOrder = toOrderClause(searchOpts?.sort || [{field: '_id', direction: 'asc'}])
 
-  const projectionFields = ['_type', '_id']
+  const projectionFields = ['_type', '_id', '_originalId']
   const selection = selections.length > 0 ? `...select(${selections.join(',\n')})` : ''
   const finalProjection = projectionFields.join(', ') + (selection ? `, ${selection}` : '')
 


### PR DESCRIPTION
### Description

When searching to add a reference in a document, documents that are available in the same release should show.


https://github.com/user-attachments/assets/8958ee12-04a8-417b-9bfc-8fb76286f822


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manual testing for now:
- Create a document in a release.
- Go to a document that could reference the previously created document.
- The document should show in the list.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
