### PR TITLE
fix(core): reference to drafts not showing values

### DIFF
--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
@@ -230,12 +230,12 @@ export function getReferenceInfo(
                 id: publishedId,
                 availability,
                 preview: {
-                  draft: (isRecord(value.draft.snapshot) ? value.draft : undefined) as
+                  draft: (isRecord(value.draft.snapshot) ? value.draft.snapshot : undefined) as
                     | PreviewDocumentValue
                     | undefined,
-                  published: (isRecord(value.published.snapshot) ? value.published : undefined) as
-                    | PreviewDocumentValue
-                    | undefined,
+                  published: (isRecord(value.published.snapshot)
+                    ? value.published.snapshot
+                    : undefined) as PreviewDocumentValue | undefined,
                   version: (isRecord(value.version?.snapshot)
                     ? value.version.snapshot
                     : undefined) as PreviewDocumentValue | undefined,


### PR DESCRIPTION
### Description
References to documents that are only drafts are not showing in the `corel` branch.
This is because the `getReferenceInfo` function is returning an incorrect value, instead of the actual DocumentPreview is returning an object containing `{snapshot: DocumentPreview, type: string}`

This PR changes that and fixes the preview.
See for example in this page:

- [Corel](https://test-studio-git-corel.sanity.dev/test/structure/author;0aaedd66-6d0b-4eb3-b030-1090a36561fb)
- [Branch](https://test-studio-git-corel-fix-get-reference-info.sanity.dev/test/structure/author;0aaedd66-6d0b-4eb3-b030-1090a36561fb)

| Corel | Fixed |
|--------|--------|
| <img width="742" alt="Screenshot 2025-01-23 at 18 31 07" src="https://github.com/user-attachments/assets/a6dc116a-6275-4368-b095-67400a10e9c1" />| <img width="742" alt="Screenshot 2025-01-23 at 18 31 12" src="https://github.com/user-attachments/assets/b6f0ebf8-07d8-44bc-9370-b4446f46729c" /> | 


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
