### PR TITLE
fix(core): add _updated date if the document doesn't have _updatedDate (archived/releases)

### DIFF
--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -71,17 +71,20 @@ export const releasesOverviewColumnDefs: (
           <Headers.SortHeaderButton text={t('table-header.edited')} {...props} />
         </Flex>
       ),
-      cell: ({datum: {documentsMetadata}, cellProps}) => (
-        <Flex {...cellProps} align="center" gap={2} paddingX={2} paddingY={3} sizing="border">
-          <Text muted size={1}>
-            {documentsMetadata?.updatedAt ? (
-              <RelativeTime time={documentsMetadata.updatedAt} useTemporalPhrase minimal />
-            ) : (
-              '-'
-            )}
-          </Text>
-        </Flex>
-      ),
+      cell: ({datum: {documentsMetadata, _updatedAt}, cellProps}) => {
+        const updatedAtDate = documentsMetadata?.updatedAt ?? _updatedAt
+        return (
+          <Flex {...cellProps} align="center" gap={2} paddingX={2} paddingY={3} sizing="border">
+            <Text muted size={1}>
+              {updatedAtDate ? (
+                <RelativeTime time={updatedAtDate} useTemporalPhrase minimal />
+              ) : (
+                '-'
+              )}
+            </Text>
+          </Flex>
+        )
+      },
     },
     {
       id: 'documentCount',


### PR DESCRIPTION
### Description

The archived / published releases never showed an edited date.

<img width="1230" alt="image" src="https://github.com/user-attachments/assets/3617e8a5-464e-4e92-b6c4-03e8eb0a07a9" />

### What to review

Does this make sense?
