### PR TITLE
fix: remove `process.env.SANITY_STUDIO_PRESENTATION_ENABLE_LIVE_DRAFT_EVENTS`

### DIFF
--- a/packages/sanity/src/presentation/constants.ts
+++ b/packages/sanity/src/presentation/constants.ts
@@ -32,4 +32,4 @@ declare global {
 export const LIVE_DRAFT_EVENTS_ENABLED =
   typeof PRESENTATION_ENABLE_LIVE_DRAFT_EVENTS === 'string'
     ? PRESENTATION_ENABLE_LIVE_DRAFT_EVENTS === 'true'
-    : process.env.SANITY_STUDIO_PRESENTATION_ENABLE_LIVE_DRAFT_EVENTS === 'true'
+    : false

--- a/turbo.json
+++ b/turbo.json
@@ -17,8 +17,7 @@
     "EXTRACT_SANITY_PROJECT_ID",
     "EXTRACT_SANITY_DATASET",
     "EXTRACT_SANITY_API_TOKEN",
-    "PRESENTATION_ENABLE_LIVE_DRAFT_EVENTS",
-    "SANITY_STUDIO_PRESENTATION_ENABLE_LIVE_DRAFT_EVENTS"
+    "PRESENTATION_ENABLE_LIVE_DRAFT_EVENTS"
   ],
   // Variables that should be passed through but not invalidate the cache
   "globalPassThroughEnv": [


### PR DESCRIPTION
### Description

Fixes #8381

### What to review
The `SANITY_STUDIO_PRESENTATION_ENABLE_LIVE_DRAFT_EVENTS` isn't really used anywhere so it should be fine to remove. Once Live Content for Drafts goes GA we'll remove this feature flag as well.

### Testing

Checked the build output in `packages/sanity/lib`, after this change there's no longer a `process.env`.

### Notes for release

Fixes an issue where Shopify Hydrogen apps that embed studios and use Presentation would see an error about `calling env on undefined`. The undefined stowaway var was `process` and walked the plank. Let us know if you see any other stowaways though! 🫡