### PR TITLE
fix: scheduled published releases allow for reverting

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardFooter.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardFooter.tsx
@@ -22,15 +22,9 @@ export function ReleaseDashboardFooter(props: {
   const releaseActionButton = useMemo(() => {
     if (release.state === 'archived') return null
 
-    if (release.metadata.releaseType === 'scheduled') {
-      return isReleaseScheduledOrScheduling(release) ? (
+    if (isReleaseScheduledOrScheduling(release)) {
+      return (
         <ReleaseUnscheduleButton
-          release={release}
-          documents={documents}
-          disabled={!documents.length}
-        />
-      ) : (
-        <ReleaseScheduleButton
           release={release}
           documents={documents}
           disabled={!documents.length}
@@ -39,6 +33,16 @@ export function ReleaseDashboardFooter(props: {
     }
 
     if (release.state === 'active') {
+      if (release.metadata.releaseType === 'scheduled') {
+        return (
+          <ReleaseScheduleButton
+            release={release}
+            documents={documents}
+            disabled={!documents.length}
+          />
+        )
+      }
+
       return (
         <ReleasePublishAllButton
           release={release}

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDashboardFooter.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDashboardFooter.test.tsx
@@ -57,8 +57,19 @@ describe('ReleaseDashboardFooter', () => {
   })
 
   describe('for a published release', () => {
-    test('shows revert button', async () => {
+    test('shows revert button for asap release', async () => {
       await renderTest({release: publishedASAPRelease})
+
+      expect(screen.getByText('Revert release')).toBeInTheDocument()
+    })
+
+    test('shows revert button for scheduled release', async () => {
+      await renderTest({
+        release: {
+          ...publishedASAPRelease,
+          metadata: {...publishedASAPRelease.metadata, releaseType: 'scheduled'},
+        },
+      })
 
       expect(screen.getByText('Revert release')).toBeInTheDocument()
     })


### PR DESCRIPTION
### Description
| Before | After |
|--------|--------|
| <img width="1512" alt="Screenshot 2025-01-24 at 12 09 24" src="https://github.com/user-attachments/assets/525bbd11-f5e8-49f4-801b-73b1bf6dc1a2" /> | <img width="1512" alt="Screenshot 2025-01-24 at 12 10 33" src="https://github.com/user-attachments/assets/bf560e20-b961-43ac-9a61-eec42f51fc81" /> | 

Before: Wrongly, a scheduled published release was showing `schedule for publish` when it should have been showing revert release`
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Added a new test case for this particular scenario
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
