### PR TITLE
refactor(core): adds confirmation when there are no documents in a release (for archiving and delete)

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -77,6 +77,8 @@ const releasesLocaleStrings = {
   /** Title for the dialog confirming the archive of a release */
   'archive-dialog.confirm-archive-title':
     "Are you sure you want to archive the <strong>'{{title}}'</strong> release?",
+  /** Description for the dialog confirming the archive of a release with no documents */
+  'archive-dialog.confirm-archive-description_zero': 'This will not archive any documents.',
   /** Description for the dialog confirming the archive of a release with one document */
   'archive-dialog.confirm-archive-description_one': 'This will archive 1 document version.',
   /** Description for the dialog confirming the archive of a release with more than one document */
@@ -103,6 +105,8 @@ const releasesLocaleStrings = {
 
   /** Header for deleting a release dialog */
   'delete-dialog.confirm-delete.header': "Are you sure you want to delete the '{{title}}' release?",
+  /** Description for the dialog confirming the deleting of a release with no documents */
+  'delete-dialog.confirm-delete-description_zero': 'This will not delete any documents.',
   /** Description for the dialog confirming the deleting of a release with one document */
   'delete-dialog.confirm-delete-description_one': 'This will delete 1 document version.',
   /** Description for the dialog confirming the deleting of a release with more than one document */

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
@@ -109,12 +109,11 @@ export const ReleaseMenuButton = ({ignoreCTA, release, documentsCount}: ReleaseM
   useEffect(() => {
     if (!selectedAction) return
 
-    if (!RELEASE_ACTION_MAP[selectedAction].confirmDialog || !documentsCount)
-      handleAction(selectedAction)
+    if (!RELEASE_ACTION_MAP[selectedAction].confirmDialog) handleAction(selectedAction)
   }, [documentsCount, handleAction, selectedAction])
 
   const confirmActionDialog = useMemo(() => {
-    if (!selectedAction || !documentsCount) return null
+    if (!selectedAction) return null
 
     const {confirmDialog} = RELEASE_ACTION_MAP[selectedAction]
 

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
@@ -119,11 +119,6 @@ export const ReleaseMenuButton = ({ignoreCTA, release, documentsCount}: ReleaseM
 
     if (!confirmDialog) return null
 
-    const dialogDescription =
-      documentsCount === 1
-        ? confirmDialog.dialogDescriptionSingularI18nKey
-        : confirmDialog.dialogDescriptionMultipleI18nKey
-
     return (
       <Dialog
         id={confirmDialog.dialogId}
@@ -144,7 +139,7 @@ export const ReleaseMenuButton = ({ignoreCTA, release, documentsCount}: ReleaseM
           {
             <Translate
               t={t}
-              i18nKey={dialogDescription}
+              i18nKey={confirmDialog.dialogDescriptionI18nKey}
               values={{
                 count: documentsCount,
               }}

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/__tests__/ReleaseMenuButton.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/__tests__/ReleaseMenuButton.test.tsx
@@ -95,7 +95,7 @@ describe('ReleaseMenuButton', () => {
       expect(screen.queryByTestId('archive-release-menu-item-menu-item')).not.toBeInTheDocument()
     })
 
-    test('does not require confirmation when no documents in release', async () => {
+    test('requires confirmation when no documents in release', async () => {
       mockUseBundleDocuments.mockReturnValue(useBundleDocumentsMockReturn)
 
       await renderTest({release: activeScheduledRelease, documentsCount: 0})
@@ -111,8 +111,13 @@ describe('ReleaseMenuButton', () => {
         fireEvent.click(screen.getByTestId('archive-release-menu-item'))
       })
 
-      expect(screen.queryByTestId('confirm-archive-dialog')).not.toBeInTheDocument()
-      expect(useReleaseOperations().archive).toHaveBeenCalledWith(activeScheduledRelease._id)
+      expect(screen.queryByTestId('confirm-archive-dialog')).toBeInTheDocument()
+      await act(() => {
+        fireEvent.click(screen.getByTestId('confirm-button'))
+      })
+      expect(useReleaseOperationsMockReturn.archive).toHaveBeenCalledWith(
+        activeScheduledRelease._id,
+      )
     })
 
     test('can reject archiving', async () => {
@@ -191,7 +196,7 @@ describe('ReleaseMenuButton', () => {
       expect(screen.queryByTestId('delete-release-menu-item')).not.toBeInTheDocument()
     })
 
-    test('does not require confirmation when no documents in release', async () => {
+    test('requires confirmation when no documents in release', async () => {
       mockUseBundleDocuments.mockReturnValue(useBundleDocumentsMockReturn)
 
       // verifying that delete supported for published releases too
@@ -208,8 +213,13 @@ describe('ReleaseMenuButton', () => {
         fireEvent.click(screen.getByTestId('delete-release-menu-item'))
       })
 
-      expect(screen.queryByTestId('confirm-delete-dialog')).not.toBeInTheDocument()
-      expect(useReleaseOperations().deleteRelease).toHaveBeenCalledWith(publishedASAPRelease._id)
+      expect(screen.queryByTestId('confirm-delete-dialog')).toBeInTheDocument()
+      await act(() => {
+        fireEvent.click(screen.getByTestId('confirm-button'))
+      })
+      expect(useReleaseOperationsMockReturn.deleteRelease).toHaveBeenCalledWith(
+        publishedASAPRelease._id,
+      )
     })
 
     test('can reject deleting', async () => {

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/releaseActions.ts
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/releaseActions.ts
@@ -19,8 +19,7 @@ interface DialogActionsMap extends BaseReleaseActionsMap {
   confirmDialog: {
     dialogId: string
     dialogHeaderI18nKey: string
-    dialogDescriptionSingularI18nKey: string
-    dialogDescriptionMultipleI18nKey: string
+    dialogDescriptionI18nKey: string
     dialogConfirmButtonI18nKey: string
   }
 }
@@ -33,8 +32,7 @@ export const RELEASE_ACTION_MAP: Record<
     confirmDialog: {
       dialogId: 'confirm-delete-dialog',
       dialogHeaderI18nKey: 'delete-dialog.confirm-delete.header',
-      dialogDescriptionSingularI18nKey: 'delete-dialog.confirm-delete-description_one',
-      dialogDescriptionMultipleI18nKey: 'delete-dialog.confirm-delete-description_other',
+      dialogDescriptionI18nKey: 'delete-dialog.confirm-delete-description',
       dialogConfirmButtonI18nKey: 'delete-dialog.confirm-delete-button',
     },
     toastSuccessI18nKey: 'toast.delete.success',
@@ -45,8 +43,7 @@ export const RELEASE_ACTION_MAP: Record<
     confirmDialog: {
       dialogId: 'confirm-archive-dialog',
       dialogHeaderI18nKey: 'archive-dialog.confirm-archive-header',
-      dialogDescriptionSingularI18nKey: 'archive-dialog.confirm-archive-description_one',
-      dialogDescriptionMultipleI18nKey: 'archive-dialog.confirm-archive-description_other',
+      dialogDescriptionI18nKey: 'archive-dialog.confirm-archive-description',
       dialogConfirmButtonI18nKey: 'archive-dialog.confirm-archive-button',
     },
     toastSuccessI18nKey: 'toast.archive.success',


### PR DESCRIPTION
### Description

- Added the ability to open the confirmation dialog even when there are no documents in a release
- Updated the translation approach for plural approach + added new translations for when it's zero

### What to review

Does this make sense? 

### Testing

Nothing needed outside of what currently exist

