### PR TITLE
refactor(sanity): remove references to defunct `_version` field

### DIFF
--- a/packages/sanity/src/core/preview/documentPair.ts
+++ b/packages/sanity/src/core/preview/documentPair.ts
@@ -19,12 +19,7 @@ export function createObservePathsDocumentPair(options: {
 ) => Observable<DraftsModelDocument<T>> {
   const {observeDocumentPairAvailability, observePaths} = options
 
-  const ALWAYS_INCLUDED_SNAPSHOT_PATHS: PreviewPath[] = [
-    ['_updatedAt'],
-    ['_createdAt'],
-    ['_type'],
-    ['_version'],
-  ]
+  const ALWAYS_INCLUDED_SNAPSHOT_PATHS: PreviewPath[] = [['_updatedAt'], ['_createdAt'], ['_type']]
 
   return function observePathsDocumentPair<T extends SanityDocument = SanityDocument>(
     id: string,

--- a/packages/sanity/src/core/preview/documentPreviewStore.ts
+++ b/packages/sanity/src/core/preview/documentPreviewStore.ts
@@ -133,7 +133,7 @@ export function createDocumentPreviewStore({
     id: string,
     apiConfig?: ApiConfig,
   ): Observable<string | undefined> {
-    return observePaths({_type: 'reference', _ref: id}, ['_type', '_version'], apiConfig).pipe(
+    return observePaths({_type: 'reference', _ref: id}, ['_type'], apiConfig).pipe(
       map((res) => (isRecord(res) && typeof res._type === 'string' ? res._type : undefined)),
       distinctUntilChanged(),
     )

--- a/packages/sanity/src/core/preview/utils/getPreviewPaths.test.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewPaths.test.ts
@@ -32,7 +32,6 @@ describe('getPreviewPaths', () => {
       ['image'],
       ['_createdAt'],
       ['_updatedAt'],
-      ['_version'],
     ])
   })
 })

--- a/packages/sanity/src/core/preview/utils/getPreviewPaths.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewPaths.ts
@@ -1,6 +1,6 @@
 import {type PreviewableType, type PreviewPath} from '../types'
 
-const DEFAULT_PREVIEW_PATHS: PreviewPath[] = [['_createdAt'], ['_updatedAt'], ['_version']]
+const DEFAULT_PREVIEW_PATHS: PreviewPath[] = [['_createdAt'], ['_updatedAt']]
 
 /** @internal */
 export function getPreviewPaths(preview: PreviewableType['preview']): PreviewPath[] | undefined {

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseReview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseReview.test.tsx
@@ -49,7 +49,6 @@ const MOCKED_DOCUMENTS: DocumentInRelease[] = [
       values: {
         _createdAt: '2024-07-10T12:10:38Z',
         _updatedAt: '2024-07-15T10:46:02Z',
-        _version: {},
         title: 'William Faulkner added',
         subtitle: 'Designer',
       },
@@ -77,7 +76,6 @@ const MOCKED_DOCUMENTS: DocumentInRelease[] = [
       values: {
         _createdAt: '2024-07-10T12:10:38Z',
         _updatedAt: '2024-07-15T10:46:02Z',
-        _version: {},
         title: 'Virginia Woolf test',
         subtitle: 'Developer',
       },

--- a/packages/sanity/src/core/releases/tool/detail/review/DocumentDiff.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/review/DocumentDiff.tsx
@@ -13,9 +13,7 @@ import {ChangesWrapper, FieldWrapper} from './DocumentDiff.styled'
 
 const buildDocumentForDiffInput = (document: Partial<SanityDocument>) => {
   // Remove internal fields and undefined values
-  const {_id, _rev, _createdAt, _updatedAt, _type, _version, ...rest} = JSON.parse(
-    JSON.stringify(document),
-  )
+  const {_id, _rev, _createdAt, _updatedAt, _type, ...rest} = JSON.parse(JSON.stringify(document))
 
   return rest
 }

--- a/packages/sanity/src/core/search/text-search/createTextSearch.ts
+++ b/packages/sanity/src/core/search/text-search/createTextSearch.ts
@@ -136,9 +136,7 @@ export const createTextSearch: SearchStrategyFactory<TextSearchResults> = (
       },
       types: getDocumentTypeConfiguration(searchOptions, searchTerms),
       ...(searchOptions.sort ? {order: getOrder(searchOptions.sort)} : {}),
-      // Note: Text Search API does not currently expose fields containing an empty object, so
-      // we're not yet able to retrieve `_version` here.
-      includeAttributes: ['_id', '_type', '_version'],
+      includeAttributes: ['_id', '_type'],
       fromCursor: searchOptions.cursor,
       limit: searchOptions.limit ?? DEFAULT_LIMIT,
     }

--- a/packages/sanity/src/core/search/weighted/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/weighted/createSearchQuery.test.ts
@@ -49,7 +49,7 @@ describe('createSearchQuery', () => {
           '*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && !(_id in path("versions.**"))]' +
           '| order(_id asc)' +
           '[0...$__limit]' +
-          '{_type, _id, _version, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
+          '{_type, _id, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
       )
 
       expect(params).toEqual({
@@ -147,9 +147,9 @@ describe('createSearchQuery', () => {
 
       const result = [
         `// findability-mvi:${FINDABILITY_MVI}\n` +
-          '*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && !(_id in path("versions.**"))]{_type, _id, _version, object{field}}',
+          '*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && !(_id in path("versions.**"))]{_type, _id, object{field}}',
         '|order(_id asc)[0...$__limit]',
-        '{_type, _id, _version, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
+        '{_type, _id, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
       ].join('')
 
       expect(query).toBe(result)
@@ -244,7 +244,7 @@ describe('createSearchQuery', () => {
           '*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && !(_id in path("versions.**"))]' +
           '| order(exampleField desc)' +
           '[0...$__limit]' +
-          '{_type, _id, _version, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
+          '{_type, _id, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
       )
     })
 
@@ -277,7 +277,7 @@ describe('createSearchQuery', () => {
         `// findability-mvi:${FINDABILITY_MVI}\n`,
         '*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && !(_id in path("versions.**"))]| ',
         'order(exampleField desc,anotherExampleField asc,lower(mapWithField) asc)',
-        '[0...$__limit]{_type, _id, _version, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
+        '[0...$__limit]{_type, _id, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
       ].join('')
 
       expect(query).toEqual(result)
@@ -294,7 +294,7 @@ describe('createSearchQuery', () => {
           '*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && !(_id in path("versions.**"))]' +
           '| order(_id asc)' +
           '[0...$__limit]' +
-          '{_type, _id, _version, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
+          '{_type, _id, ...select(_type == "basic-schema-test" => { "w0": _id,"w1": _type,"w2": title })}',
       )
     })
 
@@ -410,7 +410,7 @@ describe('createSearchQuery', () => {
           // This solution was discarded at it would increase the size of the query payload by up to 50%
 
           // we still map out the path with number
-          '{_type, _id, _version, ...select(_type == "numbers-in-path" => { "w0": _id,"w1": _type,"w2": cover[].cards[].title })}',
+          '{_type, _id, ...select(_type == "numbers-in-path" => { "w0": _id,"w1": _type,"w2": cover[].cards[].title })}',
       )
     })
   })

--- a/packages/sanity/src/core/search/weighted/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/weighted/createSearchQuery.ts
@@ -152,7 +152,7 @@ export function createSearchQuery(
   // Default to `_id asc` (GROQ default) if no search sort is provided
   const sortOrder = toOrderClause(searchOpts?.sort || [{field: '_id', direction: 'asc'}])
 
-  const projectionFields = ['_type', '_id', '_version']
+  const projectionFields = ['_type', '_id']
   const selection = selections.length > 0 ? `...select(${selections.join(',\n')})` : ''
   const finalProjection = projectionFields.join(', ') + (selection ? `, ${selection}` : '')
 

--- a/packages/sanity/src/core/store/events/getDocumentChanges.ts
+++ b/packages/sanity/src/core/store/events/getDocumentChanges.ts
@@ -28,9 +28,7 @@ import {type EventsObservableValue} from './useEventsStore'
 const buildDocumentForDiffInput = (document?: Partial<SanityDocument> | null) => {
   if (!document) return {}
   // Remove internal fields and undefined values
-  const {_id, _rev, _createdAt, _updatedAt, _type, _version, ...rest} = JSON.parse(
-    JSON.stringify(document),
-  )
+  const {_id, _rev, _createdAt, _updatedAt, _type, ...rest} = JSON.parse(JSON.stringify(document))
 
   return rest
 }


### PR DESCRIPTION
### Description

The `_version` field is no longer used to signal that a document is a version (this is instead handled via the `versions.` id prefix). This branch removes defunct references to the `_version` field.