### PR TITLE
chore(core): revert timeline changes added to support version documents.

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1718,6 +1718,12 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Title for error when the timeline for the given document can't be loaded */
   'timeline.error.load-document-changes-title':
     'An error occurred whilst retrieving document changes.',
+  /** Description for error when the timeline for the given document can't be loaded */
+  'timeline.error.load-document-changes-version-description':
+    'Enable the events API through the Studio config to view document history.',
+  /** Title for error when the timeline for the given version document can't be loaded */
+  'timeline.error.load-document-changes-version-title':
+    'Version documents history is only available through the Events API.',
   /** Error description for when the document doesn't have history */
   'timeline.error.no-document-history-description':
     'When changing the content of the document, the document versions will appear in this menu.',

--- a/packages/sanity/src/core/store/_legacy/history/createHistoryStore.ts
+++ b/packages/sanity/src/core/store/_legacy/history/createHistoryStore.ts
@@ -112,7 +112,7 @@ const getTimelineController = ({
 }): TimelineController => {
   const timeline = new Timeline({
     enableTrace: isDev,
-    documentId,
+    publishedId: documentId,
   })
   return new TimelineController({
     client,

--- a/packages/sanity/src/core/store/_legacy/history/history/Aligner.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/Aligner.ts
@@ -90,7 +90,7 @@ export class Aligner {
   constructor(timeline: Timeline) {
     this.timeline = timeline
     this._states = {
-      draft: emptyVersionState(timeline.versionId),
+      draft: emptyVersionState(timeline.draftId),
       published: emptyVersionState(timeline.publishedId),
     }
   }

--- a/packages/sanity/src/core/store/_legacy/history/history/TimelineController.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/TimelineController.ts
@@ -279,7 +279,7 @@ export class TimelineController {
 
   private async fetchMoreTransactions() {
     const publishedId = this.timeline.publishedId
-    const versionId = this.timeline.versionId
+    const draftId = this.timeline.draftId
     const clientConfig = this.client.config()
     const limit = TRANSLOG_ENTRY_LIMIT
 
@@ -290,7 +290,7 @@ export class TimelineController {
     }
 
     const transactionsUrl = this.client.getUrl(
-      `/data/history/${clientConfig.dataset}/transactions/${publishedId},${versionId}?${queryParams}`,
+      `/data/history/${clientConfig.dataset}/transactions/${publishedId},${draftId}?${queryParams}`,
     )
     const stream = await getJsonStream(transactionsUrl, clientConfig.token)
     const reader = stream.getReader()

--- a/packages/sanity/src/core/store/_legacy/history/history/chunker.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/chunker.ts
@@ -90,7 +90,7 @@ function getChunkState(effect?: MendozaEffectPair): ChunkState {
  * | published upsert   | liveEdit       | publish       | liveEdit     |
  */
 function getChunkType(transaction: Transaction): ChunkType {
-  const draftState = getChunkState(transaction.versionEffect)
+  const draftState = getChunkState(transaction.draftEffect)
   const publishedState = getChunkState(transaction.publishedEffect)
 
   if (publishedState === 'unedited') {
@@ -125,10 +125,10 @@ function getChunkType(transaction: Transaction): ChunkType {
 }
 
 export function chunkFromTransaction(transaction: Transaction): Chunk {
-  const modifiedDraft = Boolean(transaction.versionEffect)
+  const modifiedDraft = Boolean(transaction.draftEffect)
   const modifiedPublished = Boolean(transaction.publishedEffect)
 
-  const draftDeleted = transaction.versionEffect && isDeletePatch(transaction.versionEffect.apply)
+  const draftDeleted = transaction.draftEffect && isDeletePatch(transaction.draftEffect.apply)
   const publishedDeleted =
     transaction.publishedEffect && isDeletePatch(transaction.publishedEffect.apply)
 

--- a/packages/sanity/src/core/store/_legacy/history/history/replay.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/replay.ts
@@ -18,7 +18,7 @@ export function replay(events: TraceEvent[]): Timeline {
   if (fst?.type !== 'initial') throw new Error('no initial event')
 
   const timeline = new Timeline({
-    documentId: fst.publishedId,
+    publishedId: fst.publishedId,
   })
 
   /* eslint-disable no-console */

--- a/packages/sanity/src/core/store/_legacy/history/history/types.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/types.ts
@@ -26,6 +26,6 @@ export interface Transaction {
   id: string
   author: string
   timestamp: string
-  versionEffect?: MendozaEffectPair
+  draftEffect?: MendozaEffectPair
   publishedEffect?: MendozaEffectPair
 }

--- a/packages/sanity/src/structure/panes/document/DocumentPaneLegacyTimeline.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneLegacyTimeline.tsx
@@ -1,6 +1,6 @@
 import {type SanityDocument} from '@sanity/types'
 import {useMemo, useState} from 'react'
-import {getPublishedId, usePerspective, useTimelineSelector, useTimelineStore} from 'sanity'
+import {getPublishedId, useTimelineSelector, useTimelineStore} from 'sanity'
 
 import {usePaneRouter} from '../../components'
 import {EMPTY_PARAMS} from './constants'
@@ -11,7 +11,6 @@ import {type DocumentPaneProviderProps} from './types'
 export const DocumentPaneWithLegacyTimelineStore = (props: DocumentPaneProviderProps) => {
   const {pane} = props
   const paneRouter = usePaneRouter()
-  const {selectedReleaseId} = usePerspective()
   const options = usePaneOptions(pane.options, paneRouter.params)
 
   const params = paneRouter.params || EMPTY_PARAMS
@@ -24,7 +23,6 @@ export const DocumentPaneWithLegacyTimelineStore = (props: DocumentPaneProviderP
     onError: setTimelineError,
     rev: params.rev,
     since: params.since,
-    version: selectedReleaseId,
   })
 
   const revTime = useTimelineSelector(store, (state) => state.revTime)

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/ChangesInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/ChangesInspector.tsx
@@ -9,6 +9,7 @@ import {
   NoChanges,
   type ObjectSchemaType,
   ScrollContainer,
+  usePerspective,
   useTimelineSelector,
   useTranslation,
 } from 'sanity'
@@ -17,6 +18,7 @@ import {styled} from 'styled-components'
 
 import {structureLocaleNamespace} from '../../../../i18n'
 import {TimelineMenu} from '../../timeline'
+import {TimelineError} from '../../timeline/TimelineError'
 import {useDocumentPane} from '../../useDocumentPane'
 
 const Scroller = styled(ScrollContainer)`
@@ -37,6 +39,8 @@ const Grid = styled(Box)`
 
 export function ChangesInspector({showChanges}: {showChanges: boolean}): React.JSX.Element {
   const {documentId, schemaType, timelineError, timelineStore, value} = useDocumentPane()
+  const {selectedReleaseId} = usePerspective()
+
   const [scrollRef, setScrollRef] = useState<HTMLDivElement | null>(null)
 
   const rev = useTimelineSelector(timelineStore, (state) => state.revTime)
@@ -63,6 +67,16 @@ export function ChangesInspector({showChanges}: {showChanges: boolean}): React.J
     }),
     [documentId, diff, isComparingCurrent, schemaType, value],
   )
+
+  if (selectedReleaseId) {
+    return (
+      <Flex data-testid="review-changes-pane" direction="column" height="fill">
+        <Card flex={1} padding={2} paddingTop={0}>
+          <TimelineError versionError />
+        </Card>
+      </Flex>
+    )
+  }
 
   return (
     <Flex data-testid="review-changes-pane" direction="column" height="fill" overflow="hidden">

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/HistorySelector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/HistorySelector.tsx
@@ -1,6 +1,12 @@
 import {BoundaryElementProvider, Card, Flex, useToast} from '@sanity/ui'
 import {useCallback, useState} from 'react'
-import {type Chunk, ScrollContainer, useTimelineSelector, useTranslation} from 'sanity'
+import {
+  type Chunk,
+  ScrollContainer,
+  usePerspective,
+  useTimelineSelector,
+  useTranslation,
+} from 'sanity'
 import {styled} from 'styled-components'
 
 import {Timeline} from '../../timeline'
@@ -16,6 +22,7 @@ const Scroller = styled(ScrollContainer)`
 
 export function HistorySelector({showList}: {showList: boolean}) {
   const {timelineError, setTimelineRange, timelineStore} = useDocumentPane()
+  const {selectedReleaseId} = usePerspective()
   const [scrollRef, setScrollRef] = useState<HTMLDivElement | null>(null)
   const [listHeight, setListHeight] = useState(0)
 
@@ -63,8 +70,8 @@ export function HistorySelector({showList}: {showList: boolean}) {
   return (
     <Flex data-testid="review-changes-pane" direction="column" height="fill">
       <Card flex={1} padding={2} paddingTop={0}>
-        {timelineError ? (
-          <TimelineError />
+        {timelineError || selectedReleaseId ? (
+          <TimelineError versionError={Boolean(selectedReleaseId)} />
         ) : (
           <BoundaryElementProvider element={scrollRef}>
             <Scroller data-ui="Scroller" ref={getScrollerRef}>

--- a/packages/sanity/src/structure/panes/document/timeline/TimelineError.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/TimelineError.tsx
@@ -2,7 +2,7 @@ import {ErrorOutlineIcon} from '@sanity/icons'
 import {Flex, Stack} from '@sanity/ui'
 import {TextWithTone, useTranslation} from 'sanity'
 
-export function TimelineError() {
+export function TimelineError({versionError}: {versionError?: boolean}) {
   const {t} = useTranslation('studio')
 
   return (
@@ -12,10 +12,14 @@ export function TimelineError() {
       </TextWithTone>
       <Stack space={4}>
         <TextWithTone size={1} tone="critical" weight="medium">
-          {t('timeline.error.load-document-changes-title')}
+          {versionError
+            ? t('timeline.error.load-document-changes-version-title')
+            : t('timeline.error.load-document-changes-title')}
         </TextWithTone>
         <TextWithTone size={1} tone="critical">
-          {t('timeline.error.load-document-changes-description')}
+          {versionError
+            ? t('timeline.error.load-document-changes-version-description')
+            : t('timeline.error.load-document-changes-description')}
         </TextWithTone>
       </Stack>
     </Flex>


### PR DESCRIPTION
### Description

The legacy Timeline is soon to be deprecated once the events API has proven to be stable.
In `corel` we added some initial changes to support viewing version documents history through the legacy Timeline.
Later, we introduced the Events API which is the one that should be used to view version documents history, given it correctly supports them .

This PR removes the initial changes to clean the diff and remove risk on the Timeline.
It also adds a warning message if users try to see a version document history using the legacy timeline.

![Uploading Screenshot 2025-01-27 at 08.19.30.png…]()


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
