### PR TITLE
fix(core): remove `version` from `formBuilder`, replace for `usePerspective`

### DIFF
--- a/packages/sanity/src/core/form/FormBuilderContext.ts
+++ b/packages/sanity/src/core/form/FormBuilderContext.ts
@@ -58,5 +58,4 @@ export interface FormBuilderContextValue {
   renderItem: RenderItemCallback
   renderPreview: RenderPreviewCallback
   schemaType: ObjectSchemaType
-  version?: string
 }

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
@@ -17,6 +17,7 @@ import {MenuButton, MenuItem, TooltipDelayGroupProvider} from '../../../../ui-co
 import {ContextMenuButton} from '../../../components/contextMenuButton'
 import {type DocumentFieldActionNode} from '../../../config'
 import {useTranslation} from '../../../i18n'
+import {usePerspective} from '../../../perspective/usePerspective'
 import {EMPTY_ARRAY} from '../../../util/empty'
 import {FormField} from '../../components'
 import {usePublishedId} from '../../contexts/DocumentIdProvider'
@@ -25,7 +26,6 @@ import {useDidUpdate} from '../../hooks/useDidUpdate'
 import {useScrollIntoViewOnFocusWithin} from '../../hooks/useScrollIntoViewOnFocusWithin'
 import {set, unset} from '../../patch'
 import {type ObjectFieldProps, type RenderPreviewCallback} from '../../types'
-import {useFormBuilder} from '../../useFormBuilder'
 import {PreviewReferenceValue} from './PreviewReferenceValue'
 import {ReferenceFinalizeAlertStrip} from './ReferenceFinalizeAlertStrip'
 import {ReferenceLinkCard} from './ReferenceLinkCard'
@@ -63,7 +63,7 @@ export function ReferenceField(props: ReferenceFieldProps) {
   const elementRef = useRef<HTMLDivElement | null>(null)
   const {schemaType, path, open, inputId, children, inputProps} = props
   const {readOnly, focused, renderPreview, onChange} = props.inputProps
-  const {version} = useFormBuilder()
+  const {selectedReleaseId} = usePerspective()
 
   const [fieldActionsNodes, setFieldActionNodes] = useState<DocumentFieldActionNode[]>([])
   const documentId = usePublishedId()
@@ -76,7 +76,7 @@ export function ReferenceField(props: ReferenceFieldProps) {
       path,
       schemaType,
       value,
-      version,
+      version: selectedReleaseId,
     })
 
   // this is here to make sure the item is visible if it's being edited behind a modal

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -197,7 +197,6 @@ export function ReferenceInput(props: ReferenceInputProps) {
 
   const renderOption = useCallback(
     (option: AutocompleteOption) => {
-      // TODO: Account for checked-out version.
       const documentId = option.hit.draft?._id || option.hit.published?._id || option.value
 
       return (

--- a/packages/sanity/src/core/form/studio/FormBuilder.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilder.tsx
@@ -64,7 +64,6 @@ export interface FormBuilderProps
   schemaType: ObjectSchemaType
   validation: ValidationMarker[]
   value: FormDocumentValue | undefined
-  version?: string
 }
 
 /**
@@ -96,7 +95,6 @@ export function FormBuilder(props: FormBuilderProps) {
     schemaType,
     validation,
     value,
-    version,
   } = props
 
   const handleCollapseField = useCallback(
@@ -275,7 +273,6 @@ export function FormBuilder(props: FormBuilderProps) {
       validation={validation}
       readOnly={readOnly}
       schemaType={schemaType}
-      version={version}
     >
       <GetFormValueProvider value={value}>
         <FormValueProvider value={value}>

--- a/packages/sanity/src/core/form/studio/FormProvider.tsx
+++ b/packages/sanity/src/core/form/studio/FormProvider.tsx
@@ -55,7 +55,6 @@ export interface FormProviderProps {
   readOnly?: boolean
   schemaType: ObjectSchemaType
   validation: ValidationMarker[]
-  version?: string
 }
 
 /**
@@ -87,7 +86,6 @@ export function FormProvider(props: FormProviderProps) {
     readOnly,
     schemaType,
     validation,
-    version,
   } = props
 
   const {file, image} = useSource().form
@@ -166,7 +164,6 @@ export function FormProvider(props: FormProviderProps) {
       renderPreview={renderPreview}
       schemaType={schemaType}
       validation={validation}
-      version={version}
     >
       {children}
     </FormBuilderProvider>

--- a/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
@@ -14,6 +14,7 @@ import {catchError, mergeMap} from 'rxjs/operators'
 
 import {type FIXME} from '../../../../FIXME'
 import {useSchema} from '../../../../hooks'
+import {usePerspective} from '../../../../perspective/usePerspective'
 import {useDocumentPreviewStore} from '../../../../store'
 import {useSource} from '../../../../studio'
 import {useSearchMaxFieldDepth} from '../../../../studio/components/navbar/search/hooks/useSearchMaxFieldDepth'
@@ -26,7 +27,6 @@ import {
   type EditReferenceEvent,
 } from '../../../inputs/ReferenceInput/types'
 import {type ObjectInputProps} from '../../../types'
-import {useFormBuilder} from '../../../useFormBuilder'
 import {useReferenceInputOptions} from '../../contexts'
 import * as adapter from '../client-adapters/reference'
 import {resolveUserDefinedFilter} from './resolveUserDefinedFilter'
@@ -65,7 +65,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
   const schema = useSchema()
   const maxFieldDepth = useSearchMaxFieldDepth()
   const documentPreviewStore = useDocumentPreviewStore()
-  const {version} = useFormBuilder()
+  const {selectedReleaseId} = usePerspective()
   const {path, schemaType} = props
   const {EditReferenceLinkComponent, onEditReference, activePath, initialValueTemplateItems} =
     useReferenceInputOptions()
@@ -193,7 +193,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
       editReferenceLinkComponent={EditReferenceLink}
       createOptions={createOptions}
       onEditReference={handleEditReference}
-      version={version}
+      version={selectedReleaseId}
     />
   )
 }

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -218,7 +218,6 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
                   // but these should be compatible
                   formState.value as FormDocumentValue
                 }
-                version={selectedReleaseId}
               />
             </>
           )}


### PR DESCRIPTION
### Description

When we started with the `corel` branch `version` was added as a value that the `formBuilder` exposed, this was used by the internal fields when they needed to fetch data, like the `reference` inputs.

Later, we added the `<PerspectiveProvider>` with the `usePerspective` hook, this PR removes the `version` from the `formBuilder` to simplify the usage by devs and knowing which one to use. 
Allowing us to pick the same value from two different context could lead to hard to track bugs and code inconsistency.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
