### PR TITLE
fix(structure): disable publish and unpublish actions for releases

### DIFF
--- a/packages/sanity/src/structure/documentActions/UnpublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/UnpublishAction.tsx
@@ -28,12 +28,11 @@ export const UnpublishAction: DocumentActionComponent = ({
   liveEdit,
   release,
 }) => {
-  const {unpublish} = useDocumentOperation(id, type, release)
+  const {unpublish} = useDocumentOperation(id, type)
   const [isConfirmDialogOpen, setConfirmDialogOpen] = useState(false)
   const [permissions, isPermissionsLoading] = useDocumentPairPermissions({
     id,
     type,
-    version: release,
     permission: 'unpublish',
   })
   const currentUser = useCurrentUser()
@@ -72,6 +71,10 @@ export const UnpublishAction: DocumentActionComponent = ({
   }, [draft, id, handleCancel, handleConfirm, isConfirmDialogOpen, onComplete, type])
 
   return useMemo(() => {
+    if (release) {
+      // Version documents cannot be unpublished by this action, they should be unpublished as part of a release
+      return null
+    }
     if (liveEdit) {
       return null
     }
@@ -98,6 +101,7 @@ export const UnpublishAction: DocumentActionComponent = ({
       dialog,
     }
   }, [
+    release,
     currentUser,
     dialog,
     isPermissionsLoading,


### PR DESCRIPTION
### Description

Publish and unpublish actions are not available in version documents, this PR updates them to return `null` if it's being used in a version document.

This actions should happen through the release publish action, not individually in each document,.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
