### PR TITLE
fix(structure): do not set history inspector height to 0

### DIFF
--- a/packages/sanity/src/structure/panes/document/inspectors/changes/HistorySelector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/HistorySelector.tsx
@@ -20,12 +20,13 @@ export function HistorySelector({showList}: {showList: boolean}) {
   const [listHeight, setListHeight] = useState(0)
 
   const getScrollerRef = useCallback((el: HTMLDivElement | null) => {
+    if (!el?.clientHeight) return
     /**
      * Hacky solution, the list height needs to be defined, it cannot be obtained from the parent using a `max-height: 100%`
      * Because the scroller won't work properly and it won't scroll to the selected element on mount.
      * To fix this, this component will set the list height to the height of the parent element - 1px, to avoid a double scroll line.
      */
-    setListHeight(el?.clientHeight ? el.clientHeight - 1 : 0)
+    setListHeight(el.clientHeight - 1)
     setScrollRef(el)
   }, [])
 


### PR DESCRIPTION
### Description

The `getScrollerRef` function is called when the element is empty, this changes the height to 0 and it doesn't reset after selecting the tab.
This adds a check to validate that the height is only set if it exists.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
fixes an issue in which the history will not load if user open the History → Review Changes → History.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
