### PR TITLE
fix(core): move searchProvider to wrap the item preview

### DIFF
--- a/packages/sanity/src/core/tasks/components/form/fields/TargetField.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/TargetField.tsx
@@ -197,43 +197,45 @@ export function TargetField(
       <FieldWrapperRoot>
         <LayerProvider zOffset={100}>
           <CurrentWorkspaceProvider>
-            <Stack space={2}>
-              {mode === 'create' && (
-                <Box data-ui="fieldHeaderContentBox">
-                  <FormFieldHeaderText
-                    description={props.description}
-                    inputId={props.inputId}
-                    title={props.title}
-                    validation={props.validation}
-                    deprecated={undefined}
-                  />
-                </Box>
-              )}
-
-              {value ? (
-                <Preview value={value} handleRemove={handleRemove} />
-              ) : (
-                <EmptyReferenceRoot
-                  border
-                  radius={2}
-                  paddingX={2}
-                  paddingY={3}
-                  onClick={handleOpenSearch}
-                  onKeyDown={handleKeyDown}
-                  tabIndex={0}
-                >
-                  <Flex gap={1} justify={'flex-start'} align={'center'}>
-                    <Box paddingX={1}>
-                      <Text size={1}>
-                        <DocumentIcon />
-                      </Text>
-                    </Box>
-                    <Placeholder size={1}>{t('form.input.target.search.placeholder')}</Placeholder>
-                  </Flex>
-                </EmptyReferenceRoot>
-              )}
-            </Stack>
             <SearchProvider>
+              <Stack space={2}>
+                {mode === 'create' && (
+                  <Box data-ui="fieldHeaderContentBox">
+                    <FormFieldHeaderText
+                      description={props.description}
+                      inputId={props.inputId}
+                      title={props.title}
+                      validation={props.validation}
+                      deprecated={undefined}
+                    />
+                  </Box>
+                )}
+
+                {value ? (
+                  <Preview value={value} handleRemove={handleRemove} />
+                ) : (
+                  <EmptyReferenceRoot
+                    border
+                    radius={2}
+                    paddingX={2}
+                    paddingY={3}
+                    onClick={handleOpenSearch}
+                    onKeyDown={handleKeyDown}
+                    tabIndex={0}
+                  >
+                    <Flex gap={1} justify={'flex-start'} align={'center'}>
+                      <Box paddingX={1}>
+                        <Text size={1}>
+                          <DocumentIcon />
+                        </Text>
+                      </Box>
+                      <Placeholder size={1}>
+                        {t('form.input.target.search.placeholder')}
+                      </Placeholder>
+                    </Flex>
+                  </EmptyReferenceRoot>
+                )}
+              </Stack>
               <SearchPopover
                 open={open}
                 onClose={handleCloseSearch}


### PR DESCRIPTION
### Description

Fixes an issue in `tasks` that when a document was added as the target then the task will fail to render due to the missing provider. 
<img width="345" alt="Screenshot 2025-01-28 at 17 20 05" src="https://github.com/user-attachments/assets/440f734f-2141-439c-a4ae-b959bd4b8ed6" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
