### PR TITLE
fix(sanity): fix package.json formatting

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -179,7 +179,6 @@
     "@sanity/preview-url-secret": "^2.1.4",
     "@sanity/schema": "3.72.1",
     "@sanity/telemetry": "^0.7.7",
-    "@sanity/ui": "^2.11.6",
     "@sanity/types": "3.72.1",
     "@sanity/ui": "^2.11.7",
     "@sanity/util": "3.72.1",


### PR DESCRIPTION
### Description
A rebase process during a hotfix release left two @sanity/ui entries in a package.json. This PR resolves it.

### What to review
The changed file.

### Testing
That pnpm check:format runs successfully.
