### PR TITLE
feat(structure): document status updates

### DIFF
--- a/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
@@ -37,7 +37,6 @@ export function DocumentStatus({draft, published, versions, singleLine}: Documen
   return (
     <Flex
       align={singleLine ? 'center' : 'flex-start'}
-      data-testid="pane-footer-document-status"
       direction={singleLine ? 'row' : 'column'}
       gap={3}
       wrap="nowrap"

--- a/packages/sanity/src/core/create/components/StartInCreateBanner.tsx
+++ b/packages/sanity/src/core/create/components/StartInCreateBanner.tsx
@@ -15,6 +15,7 @@ import {useCallback, useState} from 'react'
 import {TextWithTone} from '../../components/textWithTone/TextWithTone'
 import {isDev} from '../../environment'
 import {useTranslation} from '../../i18n'
+import {usePerspective} from '../../perspective/usePerspective'
 import {useWorkspace} from '../../studio'
 import {useSanityCreateConfig} from '../context'
 import {getCreateLinkUrl} from '../createDocumentUrls'
@@ -33,12 +34,16 @@ import {StartInCreateDevInfoButton} from './StartInCreateDevInfoButton'
 export function StartInCreateBanner(props: StartInCreateBannerProps) {
   const {document, isInitialValueLoading} = props
   const {appIdCache, startInCreateEnabled} = useSanityCreateConfig()
-
+  const {selectedPerspectiveName} = usePerspective()
   const isExcludedByOption = isSanityCreateExcludedType(props.documentType)
   const isNewPristineDoc = !document._createdAt
   const isStartCreateCompatible = isSanityCreateStartCompatibleDoc(props.document)
 
+  const liveEdit = Boolean(props.documentType?.liveEdit)
+
+  const excludeOnPublished = selectedPerspectiveName === 'published' && !liveEdit
   if (
+    excludeOnPublished ||
     !isNewPristineDoc ||
     !startInCreateEnabled ||
     isExcludedByOption ||

--- a/packages/sanity/src/core/store/events/utils.ts
+++ b/packages/sanity/src/core/store/events/utils.ts
@@ -32,6 +32,12 @@ export function removeDupes(
         // Replaces the edit event with the none edit event, the publish event and the last edit event before the publish have the same id.
         acc.set(event.id, event)
       }
+
+      if (existingEvent.type !== event.type) {
+        // In the strange case two events got the same id but different types, we need to add a unique key to the map so both events are available
+        // This could happen with a document that is created and published with the same revision id, for example in our e2e tests.
+        acc.set(`${event.id}-${event.type}`, event)
+      }
       return acc
     }
     return acc.set(event.id, event)

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -200,9 +200,9 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
      * when there is no draft (new document),
      */
     if (params?.historyVersion) return false
-    if (isDraftId(displayedId)) return true
     if (selectedPerspectiveName) return false
     if (isVersionId(displayedId)) return false
+    if (isDraftId(displayedId)) return true
     if (
       isPublishedId(displayedId) &&
       editState?.published &&

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -281,7 +281,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
         selected={isDraftSelected}
         disabled={isDraftDisabled}
         text={t('release.chip.draft')}
-        tone="caution"
+        tone={editState?.draft ? 'caution' : 'neutral'}
         onClick={handlePerspectiveChange('drafts')}
         contextValues={{
           documentId: editState?.draft?._id || editState?.published?._id || editState?.id || '',

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
@@ -1,6 +1,13 @@
 import {Card, Flex} from '@sanity/ui'
-import {type Ref, useCallback, useState} from 'react'
-import {type CreateLinkMetadata, isSanityCreateLinked, useSanityCreateConfig} from 'sanity'
+import {type Ref, useCallback, useMemo, useState} from 'react'
+import {
+  type CreateLinkMetadata,
+  isPublishedPerspective,
+  isReleaseDocument,
+  isSanityCreateLinked,
+  usePerspective,
+  useSanityCreateConfig,
+} from 'sanity'
 
 import {SpacerButton} from '../../../components/spacerButton'
 import {DOCUMENT_PANEL_PORTAL_ELEMENT} from '../../../constants'
@@ -22,6 +29,7 @@ const CONTAINER_BREAKPOINT = 480 // px
 export function DocumentStatusBar(props: DocumentStatusBarProps) {
   const {actionsBoxRef, createLinkMetadata} = props
   const {editState, revisionId, onChange: onDocumentChange} = useDocumentPane()
+  const {selectedPerspective} = usePerspective()
   const {title} = useDocumentTitle()
 
   const CreateLinkedActions = useSanityCreateConfig().components?.documentLinkedActions
@@ -36,7 +44,18 @@ export function DocumentStatusBar(props: DocumentStatusBarProps) {
 
   useResizeObserver({element: rootElement, onResize: handleResize})
 
-  const shouldRender = editState?.ready && typeof collapsed === 'boolean'
+  const shouldRender = useMemo(() => {
+    const isReady = Boolean(editState?.ready && typeof collapsed === 'boolean')
+    if (selectedPerspective) {
+      if (isPublishedPerspective(selectedPerspective)) {
+        return isReady && Boolean(editState?.published)
+      }
+      if (isReleaseDocument(selectedPerspective)) {
+        return isReady && Boolean(editState?.version)
+      }
+    }
+    return isReady
+  }, [collapsed, editState?.published, editState?.ready, editState?.version, selectedPerspective])
 
   let actions: React.JSX.Element | null = null
   if (createLinkMetadata && isSanityCreateLinked(createLinkMetadata) && CreateLinkedActions) {

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
@@ -59,6 +59,7 @@ const DocumentStatusButton = ({
 
   return (
     <MotionButton
+      data-testid="pane-footer-document-status"
       animate={{opacity: 1}}
       initial={{opacity: 0}} // Width of the skeleton
       mode="bleed"

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
@@ -1,22 +1,123 @@
-import {Flex} from '@sanity/ui'
-import {useEffect, useLayoutEffect, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
-import {of} from 'rxjs'
 import {
-  DocumentStatus,
-  getPreviewStateObservable,
-  getReleaseIdFromReleaseDocumentId,
-  isPublishedPerspective,
-  useActiveReleases,
-  useDocumentPreviewStore,
-  usePerspective,
-  useSchema,
+  // eslint-disable-next-line no-restricted-imports
+  Button,
+  Flex,
+  Skeleton,
+  Text,
+} from '@sanity/ui'
+import {motion} from 'framer-motion'
+import {useEffect, useLayoutEffect, useState} from 'react'
+import {
+  AvatarSkeleton,
+  TIMELINE_ITEM_I18N_KEY_MAPPING,
+  useEvents,
+  UserAvatar,
+  useRelativeTime,
+  useSource,
   useSyncState,
+  useTimelineSelector,
+  useTranslation,
 } from 'sanity'
 
-import {Tooltip} from '../../../../ui-components'
+import {HISTORY_INSPECTOR_NAME} from '../constants'
+import {TIMELINE_ITEM_I18N_KEY_MAPPING as TIMELINE_ITEM_I18N_KEY_MAPPING_LEGACY} from '../timeline'
 import {useDocumentPane} from '../useDocumentPane'
 import {DocumentStatusPulse} from './DocumentStatusPulse'
+
+const RELATIVE_TIME_OPTIONS = {
+  minimal: true,
+  useTemporalPhrase: true,
+} as const
+
+const MotionButton = motion(Button)
+
+const ButtonSkeleton = () => {
+  return (
+    <Flex align="center" gap={3} paddingLeft={1} paddingRight={2} paddingY={2}>
+      <div style={{margin: -5}}>
+        <AvatarSkeleton $size={0} animated />
+      </div>
+      <Skeleton animated style={{width: '80px', height: '15px'}} radius={2} />
+    </Flex>
+  )
+}
+
+const DocumentStatusButton = ({
+  author,
+  translationKey,
+  timestamp = '',
+}: {
+  author: string
+  translationKey: string
+  timestamp?: string
+}) => {
+  const {onHistoryOpen, inspector, onHistoryClose} = useDocumentPane()
+  const {t} = useTranslation()
+  const relativeTime = useRelativeTime(timestamp, RELATIVE_TIME_OPTIONS)
+
+  return (
+    <MotionButton
+      animate={{opacity: 1}}
+      initial={{opacity: 0}} // Width of the skeleton
+      mode="bleed"
+      onClick={inspector?.name === HISTORY_INSPECTOR_NAME ? onHistoryClose : onHistoryOpen}
+      padding={2}
+      muted
+    >
+      <Flex align="center" flex="none" gap={3}>
+        <div style={{margin: -5}}>
+          <UserAvatar user={author} size={0} />
+        </div>
+        <Text muted size={1}>
+          {t(translationKey)} {relativeTime}
+        </Text>
+      </Flex>
+    </MotionButton>
+  )
+}
+
+const EventsStatus = () => {
+  const {events, loading} = useEvents()
+  const event = events?.[0]
+
+  if (!event && loading) {
+    return <ButtonSkeleton />
+  }
+  if (!event) {
+    return null
+  }
+
+  return (
+    <DocumentStatusButton
+      author={event.author}
+      translationKey={TIMELINE_ITEM_I18N_KEY_MAPPING[event.type]}
+      timestamp={event.timestamp}
+    />
+  )
+}
+
+const TimelineStatus = () => {
+  const {timelineStore} = useDocumentPane()
+  const chunks = useTimelineSelector(timelineStore, (state) => state.chunks)
+  const loading = useTimelineSelector(timelineStore, (state) => state.isLoading)
+  const event = chunks?.[0]
+
+  if (!event && loading) {
+    return <ButtonSkeleton />
+  }
+  if (!event) {
+    return null
+  }
+
+  const author = Array.from(event.authors)[0]
+  return (
+    <DocumentStatusButton
+      author={author}
+      translationKey={TIMELINE_ITEM_I18N_KEY_MAPPING_LEGACY[event.type]}
+      timestamp={event.endTimestamp}
+    />
+  )
+}
 
 const SYNCING_TIMEOUT = 1000
 const SAVED_TIMEOUT = 3000
@@ -24,27 +125,10 @@ const SAVED_TIMEOUT = 3000
 export function DocumentStatusLine() {
   const {documentId, documentType, editState, value} = useDocumentPane()
   const [status, setStatus] = useState<'saved' | 'syncing' | null>(null)
+  const source = useSource()
+  const eventsEnabled = source.beta?.eventsAPI?.documents
 
   const syncState = useSyncState(documentId, documentType, {version: editState?.release})
-
-  const documentPreviewStore = useDocumentPreviewStore()
-  const schema = useSchema()
-  const schemaType = schema.get(documentType)
-  const releases = useActiveReleases()
-  const {selectedPerspective, selectedReleaseId, perspectiveStack} = usePerspective()
-  const previewStateObservable = useMemo(
-    () =>
-      schemaType
-        ? getPreviewStateObservable(documentPreviewStore, schemaType, value._id, 'Untitled', {
-            bundleIds: (releases.data ?? []).map((release) =>
-              getReleaseIdFromReleaseDocumentId(release._id),
-            ),
-            bundleStack: perspectiveStack,
-          })
-        : of({versions: {}}),
-    [documentPreviewStore, schemaType, value._id, releases.data, perspectiveStack],
-  )
-  const {versions} = useObservable(previewStateObservable, {versions: {}})
 
   const lastUpdated = value?._updatedAt
 
@@ -75,50 +159,13 @@ export function DocumentStatusLine() {
     }
   }, [syncState.isSyncing, lastUpdated])
 
-  const getMode = () => {
-    if (isPublishedPerspective(selectedPerspective)) {
-      return 'published'
-    }
-    if (editState?.version) {
-      return 'version'
-    }
-    if (editState?.draft) {
-      return 'draft'
-    }
-    return 'published'
-  }
-  const mode = getMode()
-
   if (status) {
     return <DocumentStatusPulse status={status || undefined} />
   }
-  return (
-    <Tooltip
-      content={
-        <DocumentStatus
-          draft={editState?.draft}
-          published={editState?.published}
-          versions={versions}
-        />
-      }
-      placement="top"
-    >
-      <Flex align="center" gap={3} data-ui="document-status-line">
-        {/* Shows only 1 line of document status */}
-        <DocumentStatus
-          draft={mode === 'draft' ? editState?.draft : undefined}
-          published={mode === 'published' ? editState?.published : undefined}
-          versions={
-            mode === 'version' && selectedReleaseId && editState?.version
-              ? {
-                  [selectedReleaseId]: {
-                    snapshot: editState?.version,
-                  },
-                }
-              : undefined
-          }
-        />
-      </Flex>
-    </Tooltip>
-  )
+
+  if (eventsEnabled) {
+    return <EventsStatus />
+  }
+
+  return <TimelineStatus />
 }

--- a/packages/sanity/src/structure/panes/document/timeline/index.ts
+++ b/packages/sanity/src/structure/panes/document/timeline/index.ts
@@ -1,3 +1,4 @@
 export * from './helpers'
 export * from './timeline'
+export * from './timelineI18n'
 export * from './timelineMenu'

--- a/test/e2e/tests/document-actions/unpublish.spec.ts
+++ b/test/e2e/tests/document-actions/unpublish.spec.ts
@@ -35,7 +35,7 @@ test(`should be able to unpublish a published document`, async ({page, createDra
   await page.getByTestId('confirm-button').click()
 
   // Check the published button is disabled that is the reference to determine the published document doesn't exist.
-  const button = await page.getByRole('button', {name: 'Published'})
+  const button = await page.getByRole('button', {name: 'Published', exact: true})
   await expect(button).toBeDisabled()
-  await expect(documentStatus).toContainText('Draft Edited just now')
+  await expect(documentStatus).toContainText('Unpublished just now')
 })

--- a/test/e2e/tests/inputs/text.spec.ts
+++ b/test/e2e/tests/inputs/text.spec.ts
@@ -85,7 +85,11 @@ test.describe('inputs: text', () => {
     await expect(page.getByTestId('document-panel-scroller')).toBeAttached()
 
     await titleInput.fill('Title A')
-    await expect(paneFooter).toHaveText(/draft Edited just now/i)
+    // The creation is happening in the same transaction as the first edit, so this will show that the document was created just now.
+    await expect(paneFooter).toHaveText(/Created just now/i)
+    await titleInput.fill('Title A updated')
+    // A subsequent edit will show that the document was edited just now.
+    await expect(paneFooter).toHaveText(/Edited just now/i)
 
     // Wait for the document to be published.
     publishButton.click()
@@ -93,7 +97,7 @@ test.describe('inputs: text', () => {
 
     // Change the title.
     await titleInput.fill('Title B')
-    await expect(paneFooter).toHaveText(/draft Edited just now/i)
+    await expect(paneFooter).toHaveText(/Created just now/i)
 
     // Wait for the document to be published.
     publishButton.click()


### PR DESCRIPTION
### Description

This PR updates how the document status will be shown depending if the document exists or not for the current perspective, it also updates the document status line to use the history events if available, to display information about the last user who did an update to the document.

### What is changing on each perspective?

**Published perspective**

- If the document doesn't have a `published` variant yet, it will show as empty, the `draft` chip will not show as selected
  <img width="600" alt="Screenshot 2025-01-29 at 09 58 23" src="https://github.com/user-attachments/assets/e53c9ae9-56e0-4419-8fc0-62bac58de937" />

- If the document has a `published` variant it will show the published value
   <img width="600" alt="Screenshot 2025-01-29 at 10 07 21" src="https://github.com/user-attachments/assets/4435d210-d822-4280-b9e1-88ec2631f654" />

---

**Draft perspective**

- If the document is **in creation** it won't display the status chip and it will show the chip in a light gray color
   
<img width="600" alt="Screenshot 2025-01-29 at 10 09 12" src="https://github.com/user-attachments/assets/d8aa6cb2-1813-489f-9d25-d7ae5bac0e61" />

- If the document doesn't have a `draft`  but it has a `published`, it will show the value of the `published`, the chip will change it's tone to a light gray to help emphasize that the document doesn't exist as a draft yet.
  <img width="600" alt="Screenshot 2025-01-29 at 10 01 36" src="https://github.com/user-attachments/assets/d639f937-fc4f-4197-8d96-ba3198951d28" />

- If the document has a `draft` it will show the last time it was edited and the author, it will also show the chip in yellow
   <img width="600" alt="Screenshot 2025-01-29 at 09 59 37" src="https://github.com/user-attachments/assets/db9ba289-f46e-4f02-85cc-bcc67b4b248b" />

---

**Version perspective**

- If the document doesn't exist in that `version` it will hide the footer and show the add to release button, future changes will update the value shown in the form.
  <img width="600" alt="Screenshot 2025-01-29 at 10 03 02" src="https://github.com/user-attachments/assets/ff2811a5-156a-478e-99df-0b461a920a80" />

-  If the document exists in that version it will show the correct value and the chip will be shown as selected. The footer will display the last history event.
   <img width="600" alt="Screenshot 2025-01-29 at 10 03 20" src="https://github.com/user-attachments/assets/81e48d21-7878-4d23-9254-7a749253b83b" />

---


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
