### PR TITLE
fix(structure): make form readOnly in published view

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -587,6 +587,9 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     if (liveEdit && selectedPerspectiveName !== 'published') {
       return true
     }
+    if (!liveEdit && selectedPerspectiveName === 'published') {
+      return true
+    }
 
     // If a release is selected, validate that the document id matches the selected release id
     if (selectedReleaseId && getVersionFromId(value._id) !== selectedReleaseId) {


### PR DESCRIPTION
### Description
Makes form readOnly if the selected perspective is `published` and the document type is not live editable

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
