### PR TITLE
fix(cli): fix issue where core sanity types were appearing in the validation for schemas and documents

### DIFF
--- a/packages/sanity/src/_internal/cli/threads/__tests__/validateDocuments.test.ts
+++ b/packages/sanity/src/_internal/cli/threads/__tests__/validateDocuments.test.ts
@@ -70,6 +70,13 @@ const documents: SanityDocument[] = [
     _updatedAt: '2024-01-18T19:18:39.048Z',
     _rev: 'rev6',
   },
+  {
+    _id: 'some-sanity-internal-document.foo',
+    _type: 'sanity.some-sanity-internal-document',
+    _createdAt: '2024-01-18T19:18:39.048Z',
+    _updatedAt: '2024-01-18T19:18:39.048Z',
+    _rev: 'rev7',
+  },
 ]
 
 describe('validateDocuments', () => {
@@ -243,7 +250,10 @@ describe('validateDocuments', () => {
 
     expect(await receiver.event.exportFinished()).toEqual({
       totalDocumentsToValidate:
-        documents.length - documents.filter((doc) => doc._type.startsWith('system.')).length,
+        documents.length -
+        documents.filter(
+          (doc) => doc._type.startsWith('system.') || doc._type.startsWith('sanity.'),
+        ).length,
     })
     await receiver.event.loadedReferenceIntegrity()
 

--- a/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
+++ b/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
@@ -117,8 +117,8 @@ const idRegex = /^[^-][A-Z0-9._-]*$/i
 // during testing, the `doc` endpoint 502'ed if given an invalid ID
 const isValidId = (id: unknown) => typeof id === 'string' && idRegex.test(id)
 const shouldIncludeDocument = (document: SanityDocument) => {
-  // Filter out system documents
-  return !document._type.startsWith('system.')
+  // Filter out system documents and sanity documents
+  return !document._type.startsWith('system.') && !document._type.startsWith('sanity.')
 }
 
 async function* readerToGenerator(reader: ReadableStreamDefaultReader<Uint8Array>) {


### PR DESCRIPTION
### Description

Add condition to hide internal types in the 

### What to review

Should we add more tests? 
Anything glaring in the code where we should also add this condition?

### Testing

Pulling from the branch you should be able to run `~[path to your monorepo]/packages/@sanity/cli/bin/sanity schema validate` or `~[path to your monorepo]/packages/@sanity/cli/bin/sanity document validate` and see that no sanity.[name] appears when you run those commands.

The way I was able to debug with minimal work was by going into the `examples/blog-studio` and run the documents command

### Notes for release

Internal document types will no longer appear in validation results in the CLI
