### PR TITLE
fix(cli): apply write token

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/bootstrapRemoteTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapRemoteTemplate.ts
@@ -97,7 +97,7 @@ export async function bootstrapRemoteTemplate(
     debug('Applying environment variables to %s', pkg)
     // Next.js uses `.env.local` for local environment variables
     const envName = packageFramework?.slug === 'nextjs' ? '.env.local' : '.env'
-    await applyEnvVariables(packagePath, {...variables, readToken}, envName)
+    await applyEnvVariables(packagePath, {...variables, readToken, writeToken}, envName)
   }
 
   debug('Setting package name to %s', packageName)

--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -229,7 +229,7 @@ export async function applyEnvVariables(
 
   try {
     const templateContent = await readFile(join(root, templatePath), 'utf8')
-    const {projectId, dataset, readToken = ''} = envData
+    const {projectId, dataset, readToken = '', writeToken = ''} = envData
 
     const findAndReplaceVariable = (
       content: string,
@@ -255,6 +255,7 @@ export async function applyEnvVariables(
       {pattern: ENV_VAR.PROJECT_ID, value: projectId},
       {pattern: ENV_VAR.DATASET, value: dataset},
       {pattern: ENV_VAR.READ_TOKEN, value: readToken},
+      {pattern: ENV_VAR.WRITE_TOKEN, value: writeToken},
     ]
     const useQuotes = templateContent.includes('="')
 


### PR DESCRIPTION
### Description

For some reason the generated token is not being applied after it's generated. I may or may not have a commit that i forgot to push earlier.

### Testing

1. Checkout to this branch
2. `cd packages/@sanity/cli`
3. `pnpm install`
4. `pnpm run build && npm link`
5. In a projects folder, run `sanity init --template https://github.com/sanity-io/nextjs-blog-cms-sanity-v3` (this template expects a write token)
6. the .env.local should have a write token env set

### Notes for release

Fixed write tokens not being set in .env file after initializing a remote template 
