### PR TITLE
refactor(core): add document title to the toast when adding document to release

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/AddDocumentSearch.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/AddDocumentSearch.tsx
@@ -28,14 +28,14 @@ export function AddDocumentSearch({
   const idsInRelease: string[] = results.map((doc) => doc.document._id)
 
   const addDocument = useCallback(
-    async (item: Pick<SanityDocumentLike, '_id' | '_type'>) => {
+    async (item: Pick<SanityDocumentLike, '_id' | '_type' | 'title'>) => {
       try {
         await createVersion(getReleaseIdFromReleaseDocumentId(releaseId), item._id)
 
         toast.push({
           closable: true,
           status: 'success',
-          title: 'Document added to release',
+          title: `${item.title} added to release`,
         })
 
         const origin = getDocumentVariantType(item._id)

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
@@ -7,12 +7,13 @@ import {Tooltip} from '../../../../../../../../ui-components'
 import {type GeneralPreviewLayoutKey, PreviewCard} from '../../../../../../../components'
 import {useSchema} from '../../../../../../../hooks'
 import {useTranslation} from '../../../../../../../i18n/hooks/useTranslation'
+import {unstable_useValuePreview as useValuePreview} from '../../../../../../../preview/useValuePreview'
 import {useDocumentPresence} from '../../../../../../../store'
 import {getPublishedId} from '../../../../../../../util/draftUtils'
 import {useSearchState} from '../../../contexts/search/useSearchState'
 import {SearchResultItemPreview} from './SearchResultItemPreview'
 
-export type ItemSelectHandler = (item: Pick<SanityDocumentLike, '_id' | '_type'>) => void
+export type ItemSelectHandler = (item: Pick<SanityDocumentLike, '_id' | '_type' | 'title'>) => void
 
 interface SearchResultItemProps extends ResponsiveMarginProps, ResponsivePaddingProps {
   disableIntentLink?: boolean
@@ -52,15 +53,21 @@ export function SearchResultItem({
     id.includes(getPublishedId(documentId)),
   )
 
+  const preview = useValuePreview({
+    enabled: true,
+    schemaType: type,
+    value: {_id: documentId},
+  })
+
   const handleClick = useCallback(
     (e: MouseEvent<HTMLElement>) => {
-      onItemSelect?.({_id: documentId, _type: documentType})
+      onItemSelect?.({_id: documentId, _type: documentType, title: preview.value?.title})
       if (!disableIntentLink) {
         onIntentClick(e)
       }
       onClick?.(e)
     },
-    [onItemSelect, documentId, documentType, disableIntentLink, onClick, onIntentClick],
+    [preview, onItemSelect, documentId, documentType, disableIntentLink, onClick, onIntentClick],
   )
 
   if (!type) return null


### PR DESCRIPTION
### Description

Added document title to the toast when adding document to a release from the search in the release details. 
This is from feedback from knut

https://github.com/user-attachments/assets/c6d1dcf4-bd13-4fc6-942a-9aa90638046f


### What to review

I found this solution a bit more forceful than it probably needs to be, however, when I tried adding it directly on the addDocumentSearch, I found that it would need to pull a lot more information than it easily has access to. Open to hearing any thoughts

### Testing

Existing ones should exist.

### Notes for release

N/A