### PR TITLE
fix(sanity): remove Actions API override

### DIFF
--- a/packages/sanity/src/core/releases/plugin/index.ts
+++ b/packages/sanity/src/core/releases/plugin/index.ts
@@ -55,8 +55,4 @@ export const releases = definePlugin({
   document: {
     actions: (actions, context) => resolveDocumentActions(actions, context),
   },
-  // eslint-disable-next-line camelcase
-  __internal_serverDocumentActions: {
-    enabled: false,
-  },
 })


### PR DESCRIPTION
### Description

In the past, Content Releases did not work correctly with Actions API. Therefore, the Releases plugin ensured the Actions API was switched off when it was in use.

This has been fixed, and it is no longer necessary for Actions API to be switched off when Content Releases is in use.