### PR TITLE
fix(migrate): always use raw perspective for migrations

### DIFF
--- a/packages/@sanity/migrate/src/fetch-utils/__test__/sanityRequestOptions.test.ts
+++ b/packages/@sanity/migrate/src/fetch-utils/__test__/sanityRequestOptions.test.ts
@@ -1,0 +1,24 @@
+import {expect, test} from 'vitest'
+
+import {endpoints} from '../endpoints'
+import {toFetchOptions} from '../sanityRequestOptions'
+
+test('toFetchOptions', () => {
+  expect(
+    toFetchOptions({
+      projectId: 'xyz',
+      apiVersion: 'v2025-01-31',
+      apiHost: 'api.sanity.io',
+      endpoint: endpoints.data.query('my-dataset'),
+    }),
+  ).toEqual({
+    init: {
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': '@sanity/migrate@3.72.1',
+      },
+      method: 'GET',
+    },
+    url: 'https://xyz.api.sanity.io//v2025-01-31/query/my-dataset?perspective=raw',
+  })
+})

--- a/packages/@sanity/migrate/src/fetch-utils/endpoints.ts
+++ b/packages/@sanity/migrate/src/fetch-utils/endpoints.ts
@@ -20,7 +20,7 @@ export const endpoints = {
       global: false,
       method: 'GET',
       path: `/query/${dataset}`,
-      searchParams: [],
+      searchParams: [['perspective', 'raw']],
     }),
     export: (dataset: string, documentTypes?: string[]): Endpoint => ({
       global: false,


### PR DESCRIPTION

### Description
`perspective=raw` is currently default for all current API versions, but that might not be true in for all _future_ API versions. 

For migrations in particular, `perspective=raw` is the most sensible default (and currently what's being used), so this PR explicitly sets `perspective=raw` when fetching documents for migration.

Note: If there's a compelling use case for having user-provided perspectives, we can always consider adding support for that that later, but this change ensures that `perspective=raw` is always used, no matter what the default is backend side.

### What to review
- Does it makes sense?

### Testing
unit test included

### Notes for release
n/a - not visible to end users