### PR TITLE
fix(presentation): remove explicit check for `r` in perspectives

### DIFF
--- a/packages/sanity/src/core/perspective/useSetPerspective.tsx
+++ b/packages/sanity/src/core/perspective/useSetPerspective.tsx
@@ -9,19 +9,9 @@ export function useSetPerspective() {
   const router = useRouter()
   const setPerspective = useCallback(
     (releaseId: 'published' | 'drafts' | ReleaseId | undefined) => {
-      let perspectiveParam = ''
-
-      if (!releaseId || releaseId === 'drafts') {
-        perspectiveParam = ''
-      } else if (releaseId === 'published' || releaseId.startsWith('r')) {
-        perspectiveParam = releaseId
-      } else {
-        throw new Error(`Invalid releaseId: ${releaseId}`)
-      }
-
       router.navigateStickyParams({
         excludedPerspectives: '',
-        perspective: perspectiveParam,
+        perspective: releaseId === 'drafts' ? '' : releaseId,
       })
     },
     [router],

--- a/packages/sanity/src/core/releases/util/getReleaseIdFromReleaseDocumentId.ts
+++ b/packages/sanity/src/core/releases/util/getReleaseIdFromReleaseDocumentId.ts
@@ -15,8 +15,5 @@ export function getReleaseIdFromReleaseDocumentId(releaseDocumentId: string): Re
     )
   }
   const releaseId = releaseDocumentId.slice(PATH_ID_PREFIX.length)
-  if (!releaseId.startsWith('r')) {
-    throw new Error(`Release id was ${releaseId} but should start with "r"`)
-  }
   return releaseId as ReleaseId
 }

--- a/packages/sanity/src/presentation/PresentationTool.tsx
+++ b/packages/sanity/src/presentation/PresentationTool.tsx
@@ -105,9 +105,13 @@ export default function PresentationTool(props: {
     state: PresentationStateParams
   }
   const routerSearchParams = useUnique(Object.fromEntries(routerState._searchParams || []))
-  const {perspectiveStack, selectedPerspectiveName = 'previewDrafts'} = usePerspective()
+  const {
+    perspectiveStack,
+    selectedPerspectiveName = 'previewDrafts',
+    selectedReleaseId,
+  } = usePerspective()
   const perspective = (
-    selectedPerspectiveName.startsWith('r') ? perspectiveStack : selectedPerspectiveName
+    selectedReleaseId ? perspectiveStack : selectedPerspectiveName
   ) as PresentationPerspective
 
   const initialPreviewUrl = usePreviewUrl(


### PR DESCRIPTION
### Description

Initially we decided that releases ids will be required to start with `r` , this is no longer true, so this removes that explicit check from `presentation` and uses the `selectedReleaseId` to determine if we are viewing a release
It also removes the client side validations applied in `core` 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
