### PR TITLE
chore(core): remove unnecessary exports

### DIFF
--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -23,10 +23,7 @@ export {useSetPerspective} from './perspective/useSetPerspective'
 export * from './presence'
 export * from './preview'
 export {
-  AddedVersion,
-  DiscardVersionDialog,
   formatRelativeLocalePublishDate,
-  getPublishDateFromRelease,
   getReleaseIdFromReleaseDocumentId,
   getReleaseTone,
   isDraftPerspective,

--- a/packages/sanity/src/core/releases/__telemetry__/releases.telemetry.ts
+++ b/packages/sanity/src/core/releases/__telemetry__/releases.telemetry.ts
@@ -29,7 +29,6 @@ export interface RevertInfo {
 
 /**
  * When a document (version) is successfully added to a release
- * @internal
  */
 export const AddedVersion = defineEvent<VersionInfo>({
   name: 'Version Document Added to Release ',
@@ -37,81 +36,63 @@ export const AddedVersion = defineEvent<VersionInfo>({
   description: 'User added a document to a release',
 })
 
-/** When a release is successfully created
- * @internal
- */
+/** When a release is successfully created */
 export const CreatedRelease = defineEvent<OriginInfo>({
   name: 'Release Created',
   version: 1,
   description: 'User created a release',
 })
 
-/** When a release is successfully updated
- * @internal
- */
+/** When a release is successfully updated */
 export const UpdatedRelease = defineEvent({
   name: 'Release Updated',
   version: 1,
   description: 'User updated a release',
 })
 
-/** When a release is successfully deleted
- * @internal
- */
+/** When a release is successfully deleted */
 export const DeletedRelease = defineEvent({
   name: 'Release Deleted',
   version: 1,
   description: 'User deleted a release',
 })
 
-/** When a release is successfully published
- * @internal
- */
+/** When a release is successfully published */
 export const PublishedRelease = defineEvent({
   name: 'Release Published',
   version: 1,
   description: 'User published a release',
 })
 
-/** When a release is successfully scheduled
- * @internal
- */
+/** When a release is successfully scheduled*/
 export const ScheduledRelease = defineEvent({
   name: 'Release Scheduled',
   version: 1,
   description: 'User scheduled a release',
 })
 
-/** When a release is successfully scheduled
- * @internal
- */
+/** When a release is successfully scheduled */
 export const UnscheduledRelease = defineEvent({
   name: 'Release Unscheduled',
   version: 1,
   description: 'User unscheduled a release',
 })
 
-/** When a release is successfully archived
- * @internal
- */
+/** When a release is successfully archived*/
 export const ArchivedRelease = defineEvent({
   name: 'Release Archived',
   version: 1,
   description: 'User archived a release',
 })
 
-/** When a release is successfully unarchived
- * @internal
- */
+/** When a release is successfully unarchived */
 export const UnarchivedRelease = defineEvent({
   name: 'Release Unarchived',
   version: 1,
   description: 'User unarchived a release',
 })
 
-/** When a release is successfully reverted
- * @internal
- */
+/** When a release is successfully reverted */
 export const RevertRelease = defineEvent<RevertInfo>({
   name: 'Release Reverted',
   version: 1,


### PR DESCRIPTION
### Description

Removes unnecessary exports and removes the `@internal` tag from the releases telemetry events to avoid exporting them in the future by mistake.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
