### PR TITLE
feat(structure): edit `liveEdit` documents through the global draft perspective

### DIFF
--- a/dev/test-studio/schema/debug/components/CreateDraft.tsx
+++ b/dev/test-studio/schema/debug/components/CreateDraft.tsx
@@ -1,0 +1,40 @@
+import {Button, Stack, Text} from '@sanity/ui'
+import {useCallback, useState} from 'react'
+import {getDraftId, useClient} from 'sanity'
+import {useDocumentPane} from 'sanity/structure'
+
+export function CreateDraft() {
+  const {documentId, documentType, value, editState} = useDocumentPane()
+
+  const client = useClient({apiVersion: '2025-01-30'})
+  const [creatingDraft, setCreatingDraft] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const createDraft = useCallback(async () => {
+    try {
+      setCreatingDraft(true)
+      await client.createIfNotExists({
+        ...value,
+        _id: getDraftId(documentId),
+        _type: documentType,
+        name: `${value.name} (draft)`,
+      })
+    } catch (e) {
+      setError(e)
+    } finally {
+      setCreatingDraft(false)
+    }
+  }, [client, documentId, documentType, value])
+
+  return (
+    <Stack space={2}>
+      <Button
+        loading={creatingDraft}
+        onClick={createDraft}
+        width="fill"
+        text={'Create Draft'}
+        disabled={Boolean(editState?.draft) || creatingDraft}
+      />
+      {error && <Text size={0}>{error.message}</Text>}
+    </Stack>
+  )
+}

--- a/dev/test-studio/schema/playlist.ts
+++ b/dev/test-studio/schema/playlist.ts
@@ -1,5 +1,7 @@
 import {defineType} from '@sanity/types'
 
+import {CreateDraft} from './debug/components/CreateDraft'
+
 export default defineType({
   name: 'playlist',
   title: 'Playlist',
@@ -7,6 +9,7 @@ export default defineType({
   // eslint-disable-next-line camelcase
   __experimental_formPreviewTitle: false,
   liveEdit: true,
+
   fields: [
     {
       name: 'name',
@@ -28,6 +31,16 @@ export default defineType({
       name: 'image',
       title: 'Image',
       type: 'image',
+    },
+    {
+      name: 'createDraft',
+      title: 'Create Draft',
+      type: 'string',
+      description:
+        "Clicking on the 'Create Draft' button will create a draft for this live edit document",
+      components: {
+        input: CreateDraft,
+      },
     },
   ],
 })

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1194,6 +1194,9 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.chip.published': 'Published',
   /** Label for tooltip in chip with the created date */
   'release.chip.tooltip.created-date': 'Created {{date}}',
+  /** Label for tooltip in draft chip when it's a live edit document */
+  'release.chip.tooltip.draft-disabled.live-edit':
+    'This document is in live edit mode, drafts are disabled',
   /** Label for tooltip in chip with the lasted edited date */
   'release.chip.tooltip.edited-date': 'Edited {{date}}',
   /** Label for tooltip in chip when document is intended for a future release that hasn't been scheduled */

--- a/packages/sanity/src/core/preview/utils/getPreviewStateObservable.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewStateObservable.ts
@@ -1,7 +1,7 @@
 import {type PreviewValue, type SanityDocument, type SchemaType} from '@sanity/types'
 import {omit} from 'lodash'
 import {type ReactNode} from 'react'
-import {combineLatest, from, type Observable, of} from 'rxjs'
+import {combineLatest, from, type Observable} from 'rxjs'
 import {map, mergeMap, scan, startWith} from 'rxjs/operators'
 
 import {type PerspectiveStack} from '../../perspective/types'
@@ -66,9 +66,7 @@ export function getPreviewStateObservable(
     isRaw: false,
   },
 ): Observable<PreviewState> {
-  const draft$ = isLiveEditEnabled(schemaType)
-    ? of({snapshot: null})
-    : documentPreviewStore.observeForPreview({_id: getDraftId(documentId)}, schemaType)
+  const draft$ = documentPreviewStore.observeForPreview({_id: getDraftId(documentId)}, schemaType)
 
   const versions$ = from(perspective.bundleIds).pipe(
     mergeMap<string, Observable<VersionTuple>>((bundleId) =>

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -187,20 +187,23 @@ export const VersionChip = memo(function VersionChip(props: {
   return (
     <>
       <Tooltip content={tooltipContent} fallbackPlacements={[]} portal placement="bottom">
-        <Chip
-          ref={chipRef}
-          disabled={disabled}
-          mode="bleed"
-          onClick={onClick}
-          selected={selected}
-          style={{flex: 'none'}}
-          text={text}
-          tone={tone}
-          icon={<ReleaseAvatar padding={1} tone={tone} />}
-          iconRight={locked && LockIcon}
-          onContextMenu={contextMenuHandler}
-          $isArchived={releaseState === 'archived'}
-        />
+        {/* This span is needed to make the tooltip work in disabled buttons */}
+        <span style={{display: 'inline-flex'}}>
+          <Chip
+            ref={chipRef}
+            disabled={disabled}
+            mode="bleed"
+            onClick={onClick}
+            selected={selected}
+            style={{flex: 'none'}}
+            text={text}
+            tone={tone}
+            icon={<ReleaseAvatar padding={1} tone={tone} />}
+            iconRight={locked && LockIcon}
+            onContextMenu={contextMenuHandler}
+            $isArchived={releaseState === 'archived'}
+          />
+        </span>
       </Tooltip>
 
       <Popover

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -99,9 +99,6 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'banners.deprecated-document-type-banner.text': 'This document type has been deprecated.',
   /** The text for publish action for discarding the version */
   'banners.live-edit-draft-banner.discard.tooltip': 'Discard draft',
-  /** The text content for the live edit document when viewed from the draft perspective */
-  'banners.live-edit-draft-banner.draft-perspective':
-    'The type <strong>{{schemaType}}</strong> has <code>liveEdit</code> enabled, select the published document to edit it.',
   /** The text for publish action for the draft banner */
   'banners.live-edit-draft-banner.publish.tooltip': 'Publish to continue editing',
 

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -595,7 +595,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     const reconnecting = connectionState === 'reconnecting'
     const isLocked = editState.transactionSyncLock?.enabled
     // in cases where the document has drafts but the schema is live edit, there is a risk of data loss, so we disable editing in this case
-    if (liveEdit && selectedPerspectiveName !== 'published') {
+    if (liveEdit && editState.draft?._id) {
       return true
     }
     if (!liveEdit && selectedPerspectiveName === 'published') {
@@ -627,10 +627,11 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     isNonExistent,
     connectionState,
     editState.transactionSyncLock?.enabled,
+    editState.draft?._id,
     liveEdit,
     selectedPerspectiveName,
-    value._id,
     selectedReleaseId,
+    value._id,
     ready,
     revisionId,
     isDeleting,

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -171,7 +171,13 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
       )
     }
 
-    if (activeView.type === 'form' && isLiveEdit && ready) {
+    if (
+      activeView.type === 'form' &&
+      isLiveEdit &&
+      ready &&
+      editState?.draft?._id &&
+      !selectedReleaseId
+    ) {
       return (
         <DraftLiveEditBanner
           displayed={displayed}
@@ -194,19 +200,20 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
       </>
     )
   }, [
-    activeView.type,
-    selectedPerspective,
+    params?.historyVersion,
     displayed,
-    documentId,
+    selectedPerspective,
+    selectedReleaseId,
+    ready,
+    activeView.type,
     isLiveEdit,
+    editState?.draft?._id,
     isPermissionsLoading,
     permissions?.granted,
-    ready,
     requiredPermission,
-    schemaType,
-    selectedReleaseId,
     value._id,
-    params,
+    documentId,
+    schemaType,
   ])
 
   return (

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -218,7 +218,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
 
   return (
     <PaneContent>
-      {banners}
       <Flex height="fill">
         {(features.resizablePanes || !showInspector) && (
           <DocumentBox flex={2} overflow="hidden">
@@ -231,6 +230,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
                   scrollElement={documentScrollElement}
                   containerElement={formContainerElement}
                 >
+                  {banners}
                   <Scroller
                     $disabled={layoutCollapsed || false}
                     data-testid="document-panel-scroller"

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DraftLiveEditBanner.tsx
@@ -3,14 +3,7 @@ import {ErrorOutlineIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Flex, Text} from '@sanity/ui'
 import {useCallback, useEffect, useState} from 'react'
-import {
-  isDraftId,
-  type ObjectSchemaType,
-  Translate,
-  useDocumentOperation,
-  usePerspective,
-  useTranslation,
-} from 'sanity'
+import {type ObjectSchemaType, Translate, useDocumentOperation, useTranslation} from 'sanity'
 
 import {Button} from '../../../../../ui-components'
 import {structureLocaleNamespace} from '../../../../i18n'
@@ -31,8 +24,6 @@ export function DraftLiveEditBanner({
   const {t} = useTranslation(structureLocaleNamespace)
   const [isPublishing, setPublishing] = useState(false)
   const [isDiscarding, setDiscarding] = useState(false)
-  const {selectedPerspectiveName} = usePerspective()
-
   const telemetry = useTelemetry()
 
   const {publish, discardChanges} = useDocumentOperation(documentId, displayed?._type || '')
@@ -56,42 +47,32 @@ export function DraftLiveEditBanner({
     }
   })
 
-  const hasDraft = displayed && displayed._id && isDraftId(displayed._id)
-  if (selectedPerspectiveName && !hasDraft) {
-    return null
-  }
   return (
     <Banner
+      paddingY={0}
       content={
-        <Flex align="center" justify="space-between" gap={1}>
+        <Flex align="center" justify="space-between" gap={2} paddingTop={1}>
           <Text size={1} weight="medium">
             <Translate
               t={t}
-              i18nKey={
-                hasDraft
-                  ? 'banners.live-edit-draft-banner.text'
-                  : 'banners.live-edit-draft-banner.draft-perspective'
-              }
+              i18nKey={'banners.live-edit-draft-banner.text'}
               values={{schemaType: schemaType.title}}
             />
           </Text>
-          {hasDraft && (
-            <>
-              <Button
-                onClick={handlePublish}
-                text={t('action.publish.live-edit.label')}
-                tooltipProps={{content: t('banners.live-edit-draft-banner.publish.tooltip')}}
-                loading={isPublishing}
-              />
 
-              <Button
-                onClick={handleDiscard}
-                text={t('banners.live-edit-draft-banner.discard.tooltip')}
-                tooltipProps={{content: t('banners.live-edit-draft-banner.discard.tooltip')}}
-                loading={isDiscarding}
-              />
-            </>
-          )}
+          <Button
+            onClick={handlePublish}
+            text={t('action.publish.live-edit.label')}
+            tooltipProps={{content: t('banners.live-edit-draft-banner.publish.tooltip')}}
+            loading={isPublishing}
+          />
+
+          <Button
+            onClick={handleDiscard}
+            text={t('banners.live-edit-draft-banner.discard.tooltip')}
+            tooltipProps={{content: t('banners.live-edit-draft-banner.discard.tooltip')}}
+            loading={isDiscarding}
+          />
         </Flex>
       }
       data-testid="live-edit-type-banner"

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveList.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveList.test.tsx
@@ -295,10 +295,14 @@ describe('DocumentPerspectiveList', () => {
         )
         const wrapper = await getTestProvider({liveEdit: true})
         render(<DocumentPerspectiveList />, {wrapper})
-        // draft is selected because no perspective is set
-        expect(screen.getByRole('button', {name: 'Draft'})).toHaveAttribute('data-selected')
-        // Published is not disabled because the user is creating a live edit document
-        expect(screen.getByRole('button', {name: 'Published'})).not.toBeDisabled()
+        const draftChip = screen.getByRole('button', {name: 'Draft'})
+        const publishedChip = screen.getByRole('button', {name: 'Published'})
+        // draft is not selected and disabled, the document is live edit and draft doesn't exist.
+        expect(draftChip).not.toHaveAttribute('data-selected')
+        expect(draftChip).toBeDisabled()
+        // Published is selected because the user is creating a live edit document
+        expect(publishedChip).not.toBeDisabled()
+        expect(publishedChip).toHaveAttribute('data-selected')
       })
       it('no draft and no published - perspective is published', async () => {
         mockUseDocumentPane.mockReturnValue(
@@ -314,9 +318,14 @@ describe('DocumentPerspectiveList', () => {
         })
         const wrapper = await getTestProvider({liveEdit: true})
         render(<DocumentPerspectiveList />, {wrapper})
-        // Perspective is published and the user is creating a live edit document, so the draft chip should be disabled
-        expect(screen.getByRole('button', {name: 'Draft'})).not.toBeEnabled()
-        expect(screen.getByRole('button', {name: 'Published'})).toHaveAttribute('data-selected')
+        const draftChip = screen.getByRole('button', {name: 'Draft'})
+        const publishedChip = screen.getByRole('button', {name: 'Published'})
+        // draft is not selected and disabled, the document is live edit and draft doesn't exist.
+        expect(draftChip).not.toHaveAttribute('data-selected')
+        expect(draftChip).toBeDisabled()
+        // Published is selected because the user is creating a live edit document
+        expect(publishedChip).not.toBeDisabled()
+        expect(publishedChip).toHaveAttribute('data-selected')
       })
       it('no draft and no published - perspective is version', async () => {
         mockUseDocumentPane.mockReturnValue(


### PR DESCRIPTION
### Description

This PR updates how the `liveEdit` documents behave and allows users to edit them while being on the `draft` perspective.
Instead of forcing them to switch to the `published` perspective it shows them with the **published badge** that they are gonna be editing the published document and not the draft. It also adds information in the draft badge on why that one is disabled.

We have two different scenarios to consider for the `liveEdit` documents, draft exists or not.
In most cases the draft won't exist, given it's a live edit.

#### No draft
| Publish perspective | Drafts perspective |
|--------|--------|
| <img width="1013" alt="Screenshot 2025-02-03 at 09 30 51" src="https://github.com/user-attachments/assets/f69c45b2-aa62-4e77-863d-68421d330323" />| <img width="1011" alt="Screenshot 2025-02-03 at 09 30 42" src="https://github.com/user-attachments/assets/cc852687-2cbb-489c-9315-53cfee0bf9d9" />| 

#### Draft exists
| Publish perspective | Drafts perspective |
|--------|--------|
|<img width="1008" alt="Screenshot 2025-02-03 at 09 31 43" src="https://github.com/user-attachments/assets/ce6f14d0-43b3-453b-874d-3a8dc308616b" />| <img width="1011" alt="Screenshot 2025-02-03 at 09 31 37" src="https://github.com/user-attachments/assets/d5ad7c36-a1aa-4f32-a29f-00c7f3b24f8f" />| 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
