### PR TITLE
fix(core): use `MarkdownPlugin` instead of `behaviors={[...]}`

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -14,7 +14,7 @@ import {
   useEditor,
   usePortableTextEditor,
 } from '@portabletext/editor'
-import {coreBehaviors, createMarkdownBehaviors} from '@portabletext/editor/behaviors'
+import {MarkdownPlugin} from '@portabletext/editor/plugins'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {isKeySegment, type Path, type PortableTextBlock} from '@sanity/types'
 import {Box, Flex, Text, useToast} from '@sanity/ui'
@@ -385,21 +385,6 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
           <PortableTextMemberItemsProvider memberItems={portableTextMemberItems}>
             <EditorProvider
               initialConfig={{
-                behaviors: [
-                  ...coreBehaviors,
-                  ...createMarkdownBehaviors({
-                    defaultStyle: ({schema}) =>
-                      schema.styles.find((style) => style.value === 'normal')?.value,
-                    blockquoteStyle: ({schema}) =>
-                      schema.styles.find((style) => style.value === 'blockquote')?.value,
-                    headingStyle: ({schema, level}) =>
-                      schema.styles.find((style) => style.value === `h${level}`)?.value,
-                    orderedListStyle: ({schema}) =>
-                      schema.lists.find((list) => list.value === 'number')?.value,
-                    unorderedListStyle: ({schema}) =>
-                      schema.lists.find((list) => list.value === 'bullet')?.value,
-                  }),
-                ],
                 initialValue: value,
                 readOnly: readOnly || !ready,
                 keyGenerator,
@@ -411,6 +396,20 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
               <PatchesPlugin path={path} />
               <UpdateReadOnlyPlugin readOnly={readOnly || !ready} />
               <UpdateValuePlugin value={value} />
+              <MarkdownPlugin
+                config={{
+                  defaultStyle: ({schema}) =>
+                    schema.styles.find((style) => style.value === 'normal')?.value,
+                  blockquoteStyle: ({schema}) =>
+                    schema.styles.find((style) => style.value === 'blockquote')?.value,
+                  headingStyle: ({schema, level}) =>
+                    schema.styles.find((style) => style.value === `h${level}`)?.value,
+                  orderedListStyle: ({schema}) =>
+                    schema.lists.find((list) => list.value === 'number')?.value,
+                  unorderedListStyle: ({schema}) =>
+                    schema.lists.find((list) => list.value === 'bullet')?.value,
+                }}
+              />
               <Compositor
                 {...props}
                 elementRef={elementRef}


### PR DESCRIPTION
### Description

PTE has a new concept of `@portabletext/editor/plugins` which, going forward, will be the preferred way to add additional Behaviors to the editor. The benefit is that you don't have to manually import and remember to spread the `coreBehaviors` when configuring the `initialConfig.behaviors` array.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Markdown Behaviors should still work, but feel free to take them for a spin to be sure.

### Testing

n/a

### Notes for release

n/a