### PR TITLE
test(sanity): switch on content releases for test workspace

### DIFF
--- a/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
@@ -157,6 +157,9 @@ describe('resolveConfig', () => {
         projectId,
         auth: createMockAuthStore({client, currentUser: null}),
         plugins: [mockPlugin()],
+        releases: {
+          enabled: true,
+        },
       }),
     )
     expect(workspace.__internal.options.plugins).toMatchObject([
@@ -186,6 +189,9 @@ describe('resolveConfig', () => {
         projectId,
         auth: createMockAuthStore({client, currentUser: null}),
         plugins: [], // No plugins
+        releases: {
+          enabled: true,
+        },
       }),
     )
 

--- a/packages/sanity/test/testUtils/getMockWorkspaceFromConfig.ts
+++ b/packages/sanity/test/testUtils/getMockWorkspaceFromConfig.ts
@@ -41,6 +41,7 @@ const defaultMockConfig: SingleWorkspace = {
   dataset: 'mock-data-set',
   schema: defaultMockSchema,
   scheduledPublishing: {enabled: false},
+  releases: {enabled: true},
 }
 
 export interface MockWorkspaceOptions {


### PR DESCRIPTION
### Description

We recently made Content Releases opt-in, but we didn't opt in for the test environment, causing tests to fail.

This branch opts in the test environment.