### PR TITLE
chore(sanity): remove defunct `userMetadata` mapping

### DIFF
--- a/packages/sanity/src/core/releases/store/createReleaseStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseStore.ts
@@ -94,14 +94,6 @@ export function createReleaseStore(context: {
     concatWith(
       listenQuery(client, QUERY, {}, {tag: 'releases.listen'}).pipe(
         tap(() => fetchPending$.next(false)),
-        map((releases) =>
-          releases.map(
-            (releaseDoc: ReleaseDocument): ReleaseDocument => ({
-              ...releaseDoc,
-              metadata: {...(releaseDoc as any).userMetadata, ...releaseDoc.metadata},
-            }),
-          ),
-        ),
         map((releases) => ({response: releases})),
       ),
     ),


### PR DESCRIPTION
### Description

The `userMetadata` field is no longer used, nor is it loaded by the app. This commit removes the defunct mapping of this field.