### PR TITLE
fix(core): add default values to releases metadata

### DIFF
--- a/packages/sanity/src/core/releases/store/createReleaseStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseStore.ts
@@ -21,7 +21,7 @@ import {listenQuery} from '../../store/_legacy'
 import {RELEASE_DOCUMENT_TYPE, RELEASE_DOCUMENTS_PATH} from './constants'
 import {createReleaseMetadataAggregator} from './createReleaseMetadataAggregator'
 import {releasesReducer, type ReleasesReducerAction, type ReleasesReducerState} from './reducer'
-import {type ReleaseDocument, type ReleaseStore} from './types'
+import {type ReleaseDocument, type ReleaseStore, type ReleaseType} from './types'
 
 type ActionWrapper = {action: ReleasesReducerAction}
 type ResponseWrapper = {response: ReleaseDocument[]}
@@ -31,6 +31,7 @@ export const SORT_ORDER = 'desc'
 
 const QUERY_FILTER = `_type=="${RELEASE_DOCUMENT_TYPE}" && _id in path("${RELEASE_DOCUMENTS_PATH}.*")`
 
+const DEFAULT_RELEASE_TYPE: ReleaseType = 'undecided'
 const QUERY_PROJECTION = `{
   _id,
   _type,
@@ -40,12 +41,10 @@ const QUERY_PROJECTION = `{
   state,
   finalDocumentStates,
   publishAt,
-  metadata {
-    title,
-    description,
-    intendedPublishAt,
-    releaseType
-  }
+  "metadata": coalesce(metadata, {
+    "title": "",
+    "releaseType": "${DEFAULT_RELEASE_TYPE}",
+  }),
 }`
 
 // Newest releases first


### PR DESCRIPTION
### Description

Releases metadata is not a system property, so in some cases this info could not exist.
This modifies the query we use to fetch them and adds default values if the object doesn't exist.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Create a release with no metadata outside of the studio, the studio should load with the default values.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
