### PR TITLE
fix(comments): make target ref point at published id and add document…

### DIFF
--- a/packages/sanity/src/core/comments/context/comments/CommentsProvider.tsx
+++ b/packages/sanity/src/core/comments/context/comments/CommentsProvider.tsx
@@ -7,7 +7,7 @@ import {CommentsContext} from 'sanity/_singletons'
 import {useEditState, useSchema, useUserListWithPermissions} from '../../../hooks'
 import {useCurrentUser} from '../../../store'
 import {useAddonDataset, useWorkspace} from '../../../studio'
-import {getPublishedId, getVersionId} from '../../../util'
+import {getPublishedId} from '../../../util'
 import {
   type CommentOperationsHookOptions,
   useCommentOperations,
@@ -89,7 +89,7 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
   const [status, setStatus] = useState<CommentStatus>('open')
   const {client, createAddonDataset, isCreatingDataset} = useAddonDataset()
   const publishedId = getPublishedId(documentId)
-  const versionOrPublishedId = releaseId ? getVersionId(documentId, releaseId) : publishedId
+
   const editState = useEditState(publishedId, documentType, 'low', releaseId)
   const schemaType = useSchema().get(documentType)
   const currentUser = useCurrentUser()
@@ -238,7 +238,9 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
         client,
         currentUser,
         dataset,
-        documentId: versionOrPublishedId,
+        documentId: publishedId,
+        // use the current release id as document version id of the target
+        documentVersionId: releaseId,
         documentRevisionId,
         documentType,
         getComment,
@@ -266,7 +268,8 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
         client,
         currentUser,
         dataset,
-        versionOrPublishedId,
+        publishedId,
+        releaseId,
         documentRevisionId,
         documentType,
         getComment,
@@ -286,7 +289,7 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
 
   const ctxValue = useMemo(
     (): CommentsContextValue => ({
-      documentId: versionOrPublishedId,
+      documentId,
       documentType,
 
       isCreatingDataset,
@@ -322,7 +325,7 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
       },
     }),
     [
-      versionOrPublishedId,
+      documentId,
       documentType,
       isCreatingDataset,
       status,

--- a/packages/sanity/src/core/comments/hooks/use-comment-operations/createOperation.ts
+++ b/packages/sanity/src/core/comments/hooks/use-comment-operations/createOperation.ts
@@ -21,6 +21,7 @@ interface CreateOperationProps {
   documentId: string
   documentRevisionId?: string
   documentType: string
+  documentVersionId?: string
   getComment?: (id: string) => CommentDocument | undefined
   getIntent?: CommentIntentGetter
   getNotificationValue: (comment: {commentId: string}) => CommentContext['notification']
@@ -42,6 +43,7 @@ export async function createOperation(props: CreateOperationProps): Promise<void
     documentId,
     documentRevisionId,
     documentType,
+    documentVersionId,
     getIntent,
     getNotificationValue,
     getThreadLength,
@@ -90,6 +92,7 @@ export async function createOperation(props: CreateOperationProps): Promise<void
           _type: 'reference',
           _weak: true,
         },
+        documentVersionId,
         documentType,
       },
     }
@@ -154,6 +157,7 @@ export async function createOperation(props: CreateOperationProps): Promise<void
           _weak: true,
         },
         documentType,
+        documentVersionId,
       },
     }
   }

--- a/packages/sanity/src/core/comments/hooks/use-comment-operations/useCommentOperations.ts
+++ b/packages/sanity/src/core/comments/hooks/use-comment-operations/useCommentOperations.ts
@@ -32,6 +32,7 @@ export interface CommentOperationsHookOptions {
   documentId: string
   documentRevisionId?: string
   documentType: string
+  documentVersionId?: string
   getComment?: (id: string) => CommentDocument | undefined
   getThreadLength?: (threadId: string) => number
   onCreate?: (comment: CommentPostPayload) => void
@@ -56,6 +57,7 @@ export function useCommentOperations(
     documentId,
     documentRevisionId,
     documentType,
+    documentVersionId,
     getComment,
     getThreadLength,
     onCreate,
@@ -102,6 +104,7 @@ export function useCommentOperations(
         documentId,
         documentRevisionId,
         documentType,
+        documentVersionId,
         getIntent,
         getNotificationValue,
         getThreadLength,
@@ -120,6 +123,7 @@ export function useCommentOperations(
       documentId,
       documentRevisionId,
       documentType,
+      documentVersionId,
       getIntent,
       getNotificationValue,
       getThreadLength,

--- a/packages/sanity/src/core/comments/types.ts
+++ b/packages/sanity/src/core/comments/types.ts
@@ -215,6 +215,7 @@ export interface CommentDocument {
     path?: CommentPath
 
     documentRevisionId?: string
+    documentVersionId?: string
     documentType: string
     document:
       | {

--- a/packages/sanity/src/core/tasks/components/form/utils.ts
+++ b/packages/sanity/src/core/tasks/components/form/utils.ts
@@ -1,6 +1,6 @@
 import {isPortableTextTextBlock} from '@sanity/types'
 
-import {getPublishedId, isVersionId} from '../../../util'
+import {getPublishedId} from '../../../util'
 import {type TaskDocument, type TaskTarget} from '../../types'
 
 interface GetTargetValueOptions {
@@ -16,10 +16,9 @@ export function getTargetValue({
   projectId,
 }: GetTargetValueOptions): TaskTarget {
   return {
-    documentType: documentType,
+    documentType,
     document: {
-      // Version documents should be referenced by their version id.
-      _ref: isVersionId(documentId) ? documentId : getPublishedId(documentId),
+      _ref: getPublishedId(documentId),
       _type: 'crossDatasetReference',
       _dataset: dataset,
       _projectId: projectId,


### PR DESCRIPTION
### Description

This changes the way comments and tasks reference their targets. Previosly, a _ref to the _version id_ would be made, but with these changes we instead:

- Always reference the *published* id of the target (i.e. `_ref: 'versions.*'` is disallowed the same way as `_ref: drafts.*` is)
- When fetching comments for a particular version, we explicitly opt-in using a groq filter. If we're not fetching for a version, the groq filter will exclude comments where `target.documentVersionId` is set.

### What to review
Did I cover all the cases?

Note: I wasn't actually able to make a task that produced a reference to a version id, but I removed the code that seemingly should have make sure that we set the ref to the version id.


### Testing


### Notes for release
n/a