### PR TITLE
feat(core): add responsiveness to overview releases page

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -170,6 +170,8 @@ const releasesLocaleStrings = {
   /** Text for when a release is not found */
   'not-found': 'Release not found: {{releaseId}}',
 
+  /** Text for when a release is not found */
+  'overview.calendar.tooltip': 'View calendar',
   /** Description for the release tool */
   'overview.description':
     'Releases are collections of document versions which can be managed and published together.',

--- a/packages/sanity/src/core/releases/tool/overview/CalendarPopover.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/CalendarPopover.tsx
@@ -1,0 +1,40 @@
+import {CalendarIcon} from '@sanity/icons'
+// eslint-disable-next-line no-restricted-imports
+import {Button, useClickOutsideEvent} from '@sanity/ui'
+import {type ReactNode, useRef, useState} from 'react'
+
+import {Popover} from '../../../../ui-components/popover/Popover'
+import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
+import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {releasesLocaleNamespace} from '../../i18n'
+
+export function CalendarPopover({content}: {content: ReactNode}) {
+  const buttonRef = useRef<HTMLButtonElement | null>(null)
+  const popoverRef = useRef<HTMLDivElement | null>(null)
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false)
+  const {t} = useTranslation(releasesLocaleNamespace)
+
+  useClickOutsideEvent(
+    () => setIsCalendarOpen(false),
+    () => [buttonRef.current, popoverRef.current],
+  )
+
+  return (
+    <Popover content={content} placement="bottom" open={isCalendarOpen} ref={popoverRef}>
+      <Tooltip content={t('overview.calendar.tooltip')}>
+        <Button
+          name="calendar"
+          data-as="a"
+          icon={CalendarIcon}
+          mode="bleed"
+          padding={2}
+          radius="full"
+          selected={isCalendarOpen}
+          onClick={() => setIsCalendarOpen((prev) => !prev)}
+          ref={buttonRef}
+          space={2}
+        />
+      </Tooltip>
+    </Popover>
+  )
+}

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -7,6 +7,7 @@ import {
   Card,
   Container,
   Flex,
+  Inline,
   Stack,
   Text,
   useMediaIndex,
@@ -32,6 +33,7 @@ import {getReleaseTone} from '../../util/getReleaseTone'
 import {ReleaseMenuButton} from '../components/ReleaseMenuButton/ReleaseMenuButton'
 import {Table, type TableRowProps} from '../components/Table/Table'
 import {type TableSort} from '../components/Table/TableProvider'
+import {CalendarPopover} from './CalendarPopover'
 import {
   DATE_SEARCH_PARAM_KEY,
   getInitialFilterDate,
@@ -282,29 +284,36 @@ export function ReleasesOverview() {
     getTimezoneAdjustedDateTimeRange,
   ])
 
+  const RenderCalendarFilter = () => {
+    return (
+      <Flex flex="none">
+        <Card borderRight flex="none" disabled>
+          <CalendarFilter
+            disabled={loading || releases.length === 0}
+            renderCalendarDay={ReleaseCalendarFilterDay}
+            selectedDate={releaseFilterDate}
+            onSelect={handleSelectFilterDate}
+          />
+        </Card>
+      </Flex>
+    )
+  }
+
   return (
     <Flex direction="row" flex={1} style={{height: '100%'}}>
       <Flex flex={1}>
-        {showCalendar && (
-          <Flex flex="none">
-            <Card borderRight flex="none" disabled>
-              <CalendarFilter
-                disabled={loading || releases.length === 0}
-                renderCalendarDay={ReleaseCalendarFilterDay}
-                selectedDate={releaseFilterDate}
-                onSelect={handleSelectFilterDate}
-              />
-            </Card>
-          </Flex>
-        )}
+        {showCalendar && <RenderCalendarFilter />}
         <Flex direction="column" flex={1} style={{position: 'relative'}}>
           <Card flex="none" padding={3}>
             <Flex align="flex-start" flex={1} gap={3}>
-              <Stack padding={2} space={4}>
-                <Text as="h1" size={1} weight="semibold">
-                  {t('overview.title')}
-                </Text>
-              </Stack>
+              <Inline>
+                {!showCalendar && <CalendarPopover content={<RenderCalendarFilter />} />}
+                <Stack padding={2} space={4}>
+                  <Text as="h1" size={1} weight="semibold">
+                    {t('overview.title')}
+                  </Text>
+                </Stack>
+              </Inline>
 
               <Flex flex={1} gap={1}>
                 {loadingOrHasReleases &&

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -1,6 +1,16 @@
 import {AddIcon, ChevronDownIcon, EarthGlobeIcon} from '@sanity/icons'
-// eslint-disable-next-line no-restricted-imports
-import {Box, Button, type ButtonMode, Card, Container, Flex, Stack, Text} from '@sanity/ui'
+import {
+  Box,
+  // eslint-disable-next-line no-restricted-imports
+  Button,
+  type ButtonMode,
+  Card,
+  Container,
+  Flex,
+  Stack,
+  Text,
+  useMediaIndex,
+} from '@sanity/ui'
 import {format, isSameDay} from 'date-fns'
 import {AnimatePresence, motion} from 'framer-motion'
 import {type MouseEventHandler, useCallback, useEffect, useMemo, useRef, useState} from 'react'
@@ -65,6 +75,8 @@ export function ReleasesOverview() {
   const {selectedPerspective} = usePerspective()
   const {DialogTimeZone, dialogProps, dialogTimeZoneShow} = useDialogTimeZone()
   const getTimezoneAdjustedDateTimeRange = useTimezoneAdjustedDateTimeRange()
+
+  const mediaIndex = useMediaIndex()
 
   const getRowProps = useCallback(
     (datum: TableRelease): Partial<TableRowProps> =>
@@ -147,6 +159,8 @@ export function ReleasesOverview() {
   useEffect(() => {
     setHasMounted(true)
   }, [])
+
+  const showCalendar = mediaIndex > 2
 
   const currentArchivedPicker = useMemo(() => {
     const groupModeButtonBaseProps = {
@@ -271,16 +285,18 @@ export function ReleasesOverview() {
   return (
     <Flex direction="row" flex={1} style={{height: '100%'}}>
       <Flex flex={1}>
-        <Flex flex="none">
-          <Card borderRight flex="none" disabled>
-            <CalendarFilter
-              disabled={loading || releases.length === 0}
-              renderCalendarDay={ReleaseCalendarFilterDay}
-              selectedDate={releaseFilterDate}
-              onSelect={handleSelectFilterDate}
-            />
-          </Card>
-        </Flex>
+        {showCalendar && (
+          <Flex flex="none">
+            <Card borderRight flex="none" disabled>
+              <CalendarFilter
+                disabled={loading || releases.length === 0}
+                renderCalendarDay={ReleaseCalendarFilterDay}
+                selectedDate={releaseFilterDate}
+                onSelect={handleSelectFilterDate}
+              />
+            </Card>
+          </Flex>
+        )}
         <Flex direction="column" flex={1} style={{position: 'relative'}}>
           <Card flex="none" padding={3}>
             <Flex align="flex-start" flex={1} gap={3}>
@@ -289,6 +305,7 @@ export function ReleasesOverview() {
                   {t('overview.title')}
                 </Text>
               </Stack>
+
               <Flex flex={1} gap={1}>
                 {loadingOrHasReleases &&
                   (releaseFilterDate ? (

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -284,7 +284,7 @@ export function ReleasesOverview() {
     getTimezoneAdjustedDateTimeRange,
   ])
 
-  const RenderCalendarFilter = () => {
+  const renderCalendarFilter = useMemo(() => {
     return (
       <Flex flex="none">
         <Card borderRight flex="none" disabled>
@@ -297,17 +297,17 @@ export function ReleasesOverview() {
         </Card>
       </Flex>
     )
-  }
+  }, [loading, releases, releaseFilterDate, handleSelectFilterDate])
 
   return (
     <Flex direction="row" flex={1} style={{height: '100%'}}>
       <Flex flex={1}>
-        {showCalendar && <RenderCalendarFilter />}
+        {showCalendar && renderCalendarFilter}
         <Flex direction="column" flex={1} style={{position: 'relative'}}>
           <Card flex="none" padding={3}>
             <Flex align="flex-start" flex={1} gap={3}>
               <Inline>
-                {!showCalendar && <CalendarPopover content={<RenderCalendarFilter />} />}
+                {!showCalendar && <CalendarPopover content={renderCalendarFilter} />}
                 <Stack padding={2} space={4}>
                   <Text as="h1" size={1} weight="semibold">
                     {t('overview.title')}

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -60,6 +60,13 @@ vi.mock('sanity', () => ({
   useTranslation: vi.fn().mockReturnValue({t: vi.fn()}),
 }))
 
+vi.mock('@sanity/ui', async (importOriginal) => {
+  return {
+    ...(await importOriginal()),
+    useMediaIndex: vi.fn().mockReturnValue(3),
+  }
+})
+
 vi.mock('../../../store/useActiveReleases', () => ({
   useActiveReleases: vi.fn(() => useActiveReleasesMockReturn),
 }))

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -243,7 +243,6 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
                 />
               )}
             </Flex>
-
             {/** Right flex */}
             <TooltipDelayGroupProvider>
               <Flex align="center" gap={1} justify="flex-end">

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -243,6 +243,7 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
                 />
               )}
             </Flex>
+
             {/** Right flex */}
             <TooltipDelayGroupProvider>
               <Flex align="center" gap={1} justify="flex-end">


### PR DESCRIPTION
### Description

This has been cleared with Marius!

- When the screen is smaller (and the text starts getting crunched), we hide the calendar and leave it in a popover next to the page title. see video

https://github.com/user-attachments/assets/78edded8-2f02-46ba-97a3-7d7c74252b20

### What to review

Looks good?
