### PR TITLE
fix(core): show accurate history for live-edit documents

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentEventsPane.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentEventsPane.tsx
@@ -64,7 +64,7 @@ export const DocumentEventsPane = (props: DocumentPaneProviderProps) => {
     if (selectedPerspectiveName === 'published') {
       return getPublishedId(options.id)
     }
-    if (selectedPerspectiveName.startsWith('r')) {
+    if (selectedReleaseId) {
       return getVersionId(options.id, selectedPerspectiveName)
     }
     return options.id
@@ -74,6 +74,7 @@ export const DocumentEventsPane = (props: DocumentPaneProviderProps) => {
     selectedPerspectiveName,
     options.id,
     showingPublishedOnDraft,
+    selectedReleaseId,
   ])
 
   const eventsStore = useEventsStore({documentId, documentType: options.type, rev, since})

--- a/packages/sanity/src/structure/panes/document/DocumentEventsPane.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentEventsPane.tsx
@@ -1,4 +1,5 @@
 import {type ReleaseId} from '@sanity/client'
+import {type ObjectSchemaType} from '@sanity/types'
 import {useMemo} from 'react'
 import {
   EMPTY_ARRAY,
@@ -11,8 +12,10 @@ import {
   isDeleteDocumentVersionEvent,
   PerspectiveProvider,
   useArchivedReleases,
+  useEditState,
   useEventsStore,
   usePerspective,
+  useSchema,
 } from 'sanity'
 
 import {usePaneRouter} from '../../components'
@@ -24,14 +27,28 @@ import {type DocumentPaneProviderProps} from './types'
 export const DocumentEventsPane = (props: DocumentPaneProviderProps) => {
   const {params = EMPTY_PARAMS} = usePaneRouter()
   const options = usePaneOptions(props.pane.options, params)
+  const schema = useSchema()
+  const documentType = options.type
+  const schemaType = schema.get(options.type) as ObjectSchemaType | undefined
+  const liveEdit = Boolean(schemaType?.liveEdit)
 
-  const {selectedPerspectiveName} = usePerspective()
+  const {selectedPerspectiveName, selectedReleaseId, selectedPerspective} = usePerspective()
   const {data: archivedReleases} = useArchivedReleases()
+  const editState = useEditState(
+    getPublishedId(options.id),
+    documentType,
+    'default',
+    selectedReleaseId,
+  )
 
+  const showingPublishedOnDraft = liveEdit && selectedPerspective === 'drafts' && !editState?.draft
   const {rev, since} = params
   const historyVersion = params.historyVersion as ReleaseId | undefined
 
   const documentId = useMemo(() => {
+    if (showingPublishedOnDraft) {
+      return getPublishedId(options.id)
+    }
     if (
       historyVersion &&
       archivedReleases.some(
@@ -51,7 +68,13 @@ export const DocumentEventsPane = (props: DocumentPaneProviderProps) => {
       return getVersionId(options.id, selectedPerspectiveName)
     }
     return options.id
-  }, [archivedReleases, historyVersion, selectedPerspectiveName, options.id])
+  }, [
+    archivedReleases,
+    historyVersion,
+    selectedPerspectiveName,
+    options.id,
+    showingPublishedOnDraft,
+  ])
 
   const eventsStore = useEventsStore({documentId, documentType: options.type, rev, since})
 


### PR DESCRIPTION
### Description

Live edit documents are shown in the Form even if the release selected is not the `published` one, you can see a live edit document through the `drafts` perspective.

This PR updates how the id for the Events store is calculated, so the published Id is passed to the history store and not the draft when previewing a live edit document which is missing a draft

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
