### PR TITLE
chore(e2e): retry e2e tests when running in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -59,6 +59,7 @@ const playwrightConfig = createPlaywrightConfig({
 
     return {
       ...config,
+      retries: process.env.CI ? 4 : 0,
       reporter: excludeGithub(config.reporter),
       use: {
         ...config.use,


### PR DESCRIPTION
### Description
Adds a small config change that retries failing e2e tests 4 times in the hopes of alleviating some recurring pains caused by flake.

### What to review
Does it make sense? Will it take effect?

### Testing
changes test config, so n/a

### Notes for release

n/a – internal