### PR TITLE
chore: restricting scheduled release UI

### DIFF
--- a/packages/sanity/src/core/releases/util/util.ts
+++ b/packages/sanity/src/core/releases/util/util.ts
@@ -69,5 +69,8 @@ export function isDraftPerspective(
 
 /** @internal */
 export function isReleaseScheduledOrScheduling(release: ReleaseDocument): boolean {
-  return release.state === 'scheduled' || release.state === 'scheduling'
+  return (
+    release.metadata.releaseType === 'scheduled' &&
+    (release.state === 'scheduled' || release.state === 'scheduling')
+  )
 }


### PR DESCRIPTION
### Description
With upcoming changes to the state machine, an ASAP release will briefly pass through the `scheduling` and `scheduled` states before moving to `publishing` and `published`.

The condition we reuse for determining whether to show the scheduled release UI elements (eg CTAs to schedule/unschedule) currently only checks on the state. This won't be enough when the above state machine change is made - ASAP releases will wrongly at times be shows as scheduled releases.

This change just restricts the condition, requiring that `metadata.releaseType` is `scheduled` first.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Does restricting the conditions for a scheduled release with a `releaseType` assertion make sense?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
No regressions expected. Manually tested a few hot spots
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
