### PR TITLE
fix: Scheduled publishing badge issue

### DIFF
--- a/packages/sanity/src/core/scheduledPublishing/plugin/documentBadges/scheduled/ScheduledBadge.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/plugin/documentBadges/scheduled/ScheduledBadge.tsx
@@ -16,8 +16,7 @@ export const ScheduledBadge: DocumentBadgeComponent = (props) => {
   debug('schedules', schedules)
 
   const upcomingSchedule = schedules?.[0]
-
-  if (!upcomingSchedule || !upcomingSchedule.executeAt) {
+  if (!upcomingSchedule || !upcomingSchedule.executeAt || !upcomingSchedule.action) {
     return null
   }
 


### PR DESCRIPTION
Added check for missing `upcomingSchedule.action`

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
fix for: [ScheduledBadge is rendered with an invalid state causing the component to crash the Studio](https://linear.app/sanity/issue/SAPP-2050/[sanity-studio]-scheduledbadge-is-rendered-with-an-invalid-state)

Added check for missing upcoming schedule action 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
Bug: When `upcomingSchedule.action` is `undefined`, the Studio breaks due to a missing check. 

[This line](https://github.com/sanity-io/sanity/blob/14c4315b7a87bdecd5810127c2cb41f692eeeae0/packages/sanity/src/core/scheduledPublishing/plugin/documentBadges/scheduled/ScheduledBadge.tsx#L20) causes it: 

``` ts
  if (!upcomingSchedule || !upcomingSchedule.executeAt || !upcomingSchedule.action) {
    return null
  }
```

Fix: 

``` ts
  if (!upcomingSchedule || !upcomingSchedule.executeAt || !upcomingSchedule.action) {
    return null
  }

```