### PR TITLE
fix: ensures comments permission check only requests project memberships once

### DIFF
--- a/packages/sanity/src/core/hooks/useUserListWithPermissions.ts
+++ b/packages/sanity/src/core/hooks/useUserListWithPermissions.ts
@@ -3,7 +3,7 @@ import {type SanityDocument} from '@sanity/client'
 import {type User} from '@sanity/types'
 import {sortBy} from 'lodash'
 import {useEffect, useMemo, useState} from 'react'
-import {concat, forkJoin, map, mergeMap, type Observable, of, switchMap} from 'rxjs'
+import {concat, forkJoin, map, mergeMap, type Observable, of, shareReplay, switchMap} from 'rxjs'
 
 import {
   type DocumentValuePermission,
@@ -54,8 +54,6 @@ export interface UserListWithPermissionsOptions {
   permission: DocumentValuePermission
 }
 
-let cachedSystemGroups: [] | null = null
-
 /**
  * @beta
  * Returns a list of users with the specified permission on the document.
@@ -72,14 +70,15 @@ export function useUserListWithPermissions(
 
   const [state, setState] = useState<UserListWithPermissionsHookValue>(INITIAL_STATE)
 
-  const list$ = useMemo(() => {
+  const [users$, systemGroup$] = useMemo(() => {
     // 1. Get the project members and filter out the robot users
     const members$: Observable<ProjectData['members']> = projectStore
       .get()
       .pipe(map((res: ProjectData) => res.members?.filter((m) => !m.isRobot)))
+      .pipe(shareReplay(1))
 
     // 2. Map the members to users to get more data of the users such as displayName (used for filtering)
-    const users$: Observable<UserWithPermission[]> = members$.pipe(
+    const _users$: Observable<UserWithPermission[]> = members$.pipe(
       switchMap(async (members) => {
         const ids = members.map(({id}) => id)
         const users = await userStore.getUsers(ids)
@@ -95,16 +94,14 @@ export function useUserListWithPermissions(
     )
 
     // 3. Get all the system groups. Use the cached response if it exists to avoid unnecessary requests.
-    const cached = cachedSystemGroups
-    const systemGroup$ = cached ? of(cached) : client.observable.fetch('*[_type == "system.group"]')
+    const _systemGroup$ = client.observable.fetch('*[_type == "system.group"]').pipe(shareReplay(1))
+    return [_users$, _systemGroup$]
+  }, [client.observable, projectStore, userStore])
 
+  const list$ = useMemo(() => {
     // 4. Check if the user has read permission on the document and set the `granted` property
     const grants$: Observable<UserWithPermission[]> = forkJoin([users$, systemGroup$]).pipe(
       mergeMap(async ([users, groups]) => {
-        if (!cached) {
-          cachedSystemGroups = groups
-        }
-
         const grantPromises = users?.map(async (user) => {
           const grants = groups.map((group: any) => {
             if (group.members.includes(user.id)) {
@@ -128,9 +125,7 @@ export function useUserListWithPermissions(
           }
         })
 
-        const usersWithPermission = await Promise.all(grantPromises || [])
-
-        return usersWithPermission
+        return await Promise.all(grantPromises || [])
       }),
     )
 
@@ -144,7 +139,7 @@ export function useUserListWithPermissions(
     )
 
     return $alphabetical
-  }, [client.observable, documentValue, projectStore, userStore, permission])
+  }, [documentValue, permission, users$, systemGroup$])
 
   useEffect(() => {
     const initial$ = of(INITIAL_STATE)


### PR DESCRIPTION
### Description

Currently, every time document form value updates, comments-enabled projects will re-fetch `/projects/<projectId>` via `projectStore.get()`.

Furthermore, `useUserListWithPermissions` uses a global grants cache which could/will cause problem in a multi-workspace studio setting.

This PR reworks `useUserListWithPermissions` so it only fetches projects _once_, as well as removes the global cache in favor of rxjs `shareReply` as a cache layer instead.


### What to review

Scrutinize the rxjs changes.I am a rxjs noob.
* Is it ok to use `shareReply` to cache like this?
* Are we ok with caching project & grants like this in the first place? 
* As written, memberships and grants will _not_ be kept up to date until the component that runs `useUserListWithPermissions`(`CommentsProvider`) is remounted. Personally, I think this is an ok real-time concession.

### Testing

* Network tab
* Edit a document
* there should no longer be a /projects/<projectId> request every time the document changes

### Notes for release

Not needed.
