### PR TITLE
refactor(vision): simplify perspective handling, no default perspective

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -140,7 +140,8 @@ const sharedSettings = definePlugin({
       ],
     }),
     visionTool({
-      defaultApiVersion: '2022-08-08',
+      // uncomment to test
+      //defaultApiVersion: '2025-02-05',
     }),
     // eslint-disable-next-line camelcase
     muxInput({mp4_support: 'standard'}),

--- a/packages/@sanity/vision/src/apiVersions.ts
+++ b/packages/@sanity/vision/src/apiVersions.ts
@@ -1,2 +1,9 @@
-export const API_VERSIONS = ['v1', 'vX', 'v2021-03-25', 'v2021-10-21', 'v2022-03-07']
+export const API_VERSIONS = [
+  'v1',
+  'vX',
+  'v2021-03-25',
+  'v2021-10-21',
+  'v2022-03-07',
+  `v${new Date().toISOString().split('T')[0]}`,
+]
 export const [DEFAULT_API_VERSION] = API_VERSIONS.slice(-1)

--- a/packages/@sanity/vision/src/components/PerspectivePopover.tsx
+++ b/packages/@sanity/vision/src/components/PerspectivePopover.tsx
@@ -1,10 +1,29 @@
 import {HelpCircleIcon} from '@sanity/icons'
-import {Badge, Button, Card, Inline, Popover, Stack, Text, useClickOutsideEvent} from '@sanity/ui'
+import {
+  Badge,
+  Button,
+  Card,
+  type CardTone,
+  Inline,
+  Popover,
+  Stack,
+  Text,
+  useClickOutsideEvent,
+} from '@sanity/ui'
 import {useCallback, useRef, useState} from 'react'
-import {useTranslation} from 'sanity'
+import {Translate, useTranslation} from 'sanity'
+import {styled} from 'styled-components'
 
 import {visionLocaleNamespace} from '../i18n'
 import {PerspectivePopoverContent, PerspectivePopoverLink} from './PerspectivePopover.styled'
+
+const Dot = styled.div<{tone: CardTone}>`
+  width: 4px;
+  height: 4px;
+  border-radius: 3px;
+  box-shadow: 0 0 0 1px var(--card-bg-color);
+  background-color: ${({tone}) => `var(--card-badge-${tone}-dot-color)`};
+`
 
 export function PerspectivePopover() {
   const [open, setOpen] = useState(false)
@@ -27,11 +46,18 @@ export function PerspectivePopover() {
           <Stack space={4}>
             <Inline space={2}>
               <Text weight="medium">{t('settings.perspectives.title')}</Text>
-              <Badge tone="primary">{t('label.new')}</Badge>
             </Inline>
 
             <Card>
               <Text muted>{t('settings.perspectives.description')}</Text>
+            </Card>
+            <Card>
+              <Badge tone="caution">{t('label.new')}</Badge>
+              <Card>
+                <Text muted>
+                  <Translate t={t} i18nKey="settings.perspectives.new-default.description" />
+                </Text>
+              </Card>
             </Card>
 
             <Card>
@@ -54,12 +80,15 @@ export function PerspectivePopover() {
         icon={HelpCircleIcon}
         mode="bleed"
         padding={2}
+        paddingRight={1}
         tone="primary"
         fontSize={1}
         ref={buttonRef}
         onClick={handleClick}
         selected={open}
-      />
+      >
+        <Dot tone="caution" />
+      </Button>
     </Popover>
   )
 }

--- a/packages/@sanity/vision/src/components/PerspectivePopover.tsx
+++ b/packages/@sanity/vision/src/components/PerspectivePopover.tsx
@@ -1,6 +1,7 @@
 import {HelpCircleIcon} from '@sanity/icons'
 import {
   Badge,
+  Box,
   Button,
   Card,
   type CardTone,
@@ -24,6 +25,8 @@ const Dot = styled.div<{tone: CardTone}>`
   box-shadow: 0 0 0 1px var(--card-bg-color);
   background-color: ${({tone}) => `var(--card-badge-${tone}-dot-color)`};
 `
+
+const SHOW_DEFAULT_PERSPECTIVE_NOTIFICATION = false
 
 export function PerspectivePopover() {
   const [open, setOpen] = useState(false)
@@ -52,13 +55,28 @@ export function PerspectivePopover() {
               <Text muted>{t('settings.perspectives.description')}</Text>
             </Card>
             <Card>
-              <Badge tone="caution">{t('label.new')}</Badge>
-              <Card>
+              <Stack space={2}>
+                <Box>
+                  <Badge tone="primary">{t('label.new')}</Badge>
+                </Box>
                 <Text muted>
-                  <Translate t={t} i18nKey="settings.perspectives.new-default.description" />
+                  <Translate
+                    t={t}
+                    i18nKey="settings.perspective.preview-drafts-renamed-to-drafts.description"
+                  />
                 </Text>
-              </Card>
+              </Stack>
             </Card>
+            {SHOW_DEFAULT_PERSPECTIVE_NOTIFICATION ? (
+              <Card>
+                <Badge tone="caution">{t('label.new')}</Badge>
+                <Card>
+                  <Text muted>
+                    <Translate t={t} i18nKey="settings.perspectives.new-default.description" />
+                  </Text>
+                </Card>
+              </Card>
+            ) : null}
 
             <Card>
               <Text>
@@ -87,7 +105,7 @@ export function PerspectivePopover() {
         onClick={handleClick}
         selected={open}
       >
-        <Dot tone="caution" />
+        <Dot tone={SHOW_DEFAULT_PERSPECTIVE_NOTIFICATION ? 'caution' : 'primary'} />
       </Button>
     </Popover>
   )

--- a/packages/@sanity/vision/src/i18n/resources.ts
+++ b/packages/@sanity/vision/src/i18n/resources.ts
@@ -69,6 +69,9 @@ const visionLocaleStrings = defineLocalesResources('vision', {
    * @see {@link https://www.sanity.io/docs/perspectives}
    */
   'settings.perspective-label': 'Perspective',
+  /** Notification about previewDrafts to drafts rename */
+  'settings.perspective.preview-drafts-renamed-to-drafts.description':
+    'The "<code>previewDrafts</code>" perspective has been renamed to "<code>drafts</code>" and is now deprecated. This change is effective for all versions with perspective support (>= v2021-03-25).',
   /** Call to action to read the docs related to "Perspectives" */
   'settings.perspectives.action.docs-link': 'Read docs',
   /** Option for selecting default perspective */

--- a/packages/@sanity/vision/src/i18n/resources.ts
+++ b/packages/@sanity/vision/src/i18n/resources.ts
@@ -78,7 +78,7 @@ const visionLocaleStrings = defineLocalesResources('vision', {
     'Perspectives allow your query to run against different "views" of the content in your dataset',
   /** Description for upcoming default perspective change */
   'settings.perspectives.new-default.description':
-    'The default perspective is changing from "<code>raw</code>" to "<code>published</code>" starting from v[TBD]',
+    'The default perspective will change from "<code>raw</code>" to "<code>published</code>" in an upcoming API version. Please consult docs for more details.',
   /** Label for the pinned release perspective */
   'settings.perspectives.pinned-release-label': 'Pinned release',
   /** Title for popover that explains what "Perspectives" are */

--- a/packages/@sanity/vision/src/i18n/resources.ts
+++ b/packages/@sanity/vision/src/i18n/resources.ts
@@ -71,11 +71,18 @@ const visionLocaleStrings = defineLocalesResources('vision', {
   'settings.perspective-label': 'Perspective',
   /** Call to action to read the docs related to "Perspectives" */
   'settings.perspectives.action.docs-link': 'Read docs',
+  /** Option for selecting default perspective */
+  'settings.perspectives.default': 'No perspective (API default)',
   /** Description for popover that explains what "Perspectives" are */
   'settings.perspectives.description':
     'Perspectives allow your query to run against different "views" of the content in your dataset',
+  /***/
+  'settings.perspectives.new-default': 'New default in v[TBD]',
+  /***/
+  'settings.perspectives.new-default.description':
+    'The default perspective is changing from "<code>raw</code>" to "<code>published</code>" starting from v[TBD]',
   /** Label for the pinned release perspective */
-  'settings.perspectives.pinned-release-label': 'pinned release',
+  'settings.perspectives.pinned-release-label': 'Pinned release',
   /** Title for popover that explains what "Perspectives" are */
   'settings.perspectives.title': 'Perspectives',
 } as const)

--- a/packages/@sanity/vision/src/i18n/resources.ts
+++ b/packages/@sanity/vision/src/i18n/resources.ts
@@ -76,9 +76,7 @@ const visionLocaleStrings = defineLocalesResources('vision', {
   /** Description for popover that explains what "Perspectives" are */
   'settings.perspectives.description':
     'Perspectives allow your query to run against different "views" of the content in your dataset',
-  /***/
-  'settings.perspectives.new-default': 'New default in v[TBD]',
-  /***/
+  /** Description for upcoming default perspective change */
   'settings.perspectives.new-default.description':
     'The default perspective is changing from "<code>raw</code>" to "<code>published</code>" starting from v[TBD]',
   /** Label for the pinned release perspective */

--- a/packages/@sanity/vision/src/perspectives.ts
+++ b/packages/@sanity/vision/src/perspectives.ts
@@ -1,10 +1,4 @@
-export const SUPPORTED_PERSPECTIVES = [
-  'pinnedRelease',
-  'raw',
-  'previewDrafts',
-  'published',
-  'drafts',
-] as const
+export const SUPPORTED_PERSPECTIVES = ['pinnedRelease', 'raw', 'published', 'drafts'] as const
 
 export type SupportedPerspective = (typeof SUPPORTED_PERSPECTIVES)[number]
 

--- a/packages/@sanity/vision/src/perspectives.ts
+++ b/packages/@sanity/vision/src/perspectives.ts
@@ -20,8 +20,6 @@ export const VIRTUAL_PERSPECTIVES = ['pinnedRelease'] as const
 
 export type VirtualPerspective = (typeof VIRTUAL_PERSPECTIVES)[number]
 
-export const DEFAULT_PERSPECTIVE: SupportedPerspective = 'raw'
-
 export function isSupportedPerspective(p: string): p is SupportedPerspective {
   return SUPPORTED_PERSPECTIVES.includes(p as SupportedPerspective)
 }


### PR DESCRIPTION
### Description

This adds some smaller changes to Vision as part of the upcoming default perspective change (from `raw` => `published`):

- Currently, raw is selected as the default. With these changes, the default becomes "unspecified" (i.e. no perspective param is sent with the request, effecively using the default for the given API version). I can imagine this can be useful for debugging. This also means published will soon become the default.
- In accordance with the above, it should then also be possible to select “No perspective” from the dropdown.
- With these changes, you'll get today’s date as the default API version. Currently, we’re using the last element in a [hard coded array of dates](https://github.com/sanity-io/sanity/blob/next/packages/@sanity/vision/src/apiVersions.ts#L2). This means you'll get `v2022-03-07` at the moment, and chances are you'll be given an outdated default until we remember to update this list. I can’t think of any issue with using a rolling date here. The default can always be customized on a per-studio basis if that's desirable. Let me know if I've missed a reason we should keep it hard coded.

### What to review
Note: This is is ready for review, ~but not yet ready to merge~. Should be ready to go now!

### Testing
Tests in this repo is sparse, so please look at the code and give it a go in the preview build.

### Notes for release
n/a
