### PR TITLE
fix(releases): change usage of versionsOf to versionOf

### DIFF
--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -36,7 +36,7 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
 
   const observable = useMemo(() => {
     return documentPreviewStore
-      .unstable_observeDocumentIdSet(`sanity::versionsOf("${publishedId}")`, undefined, {
+      .unstable_observeDocumentIdSet(`sanity::versionOf("${publishedId}")`, undefined, {
         apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion,
       })
       .pipe(


### PR DESCRIPTION
### Description
The correct usage here should be singular `versionOf`

### Testing
existing tests should be enough

### Notes for release
n/a internal