### PR TITLE
fix(sanity): apply recursion fix to `deriveSearchWeightsFromType2024`

### DIFF
--- a/packages/sanity/src/core/search/common/__tests__/deriveSearchWeightsFromType2024.test.ts
+++ b/packages/sanity/src/core/search/common/__tests__/deriveSearchWeightsFromType2024.test.ts
@@ -1,0 +1,53 @@
+import {defineField, defineType} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+
+import {createSchema} from '../../../schema'
+import {deriveSearchWeightsFromType2024} from '../deriveSearchWeightsFromType2024'
+
+describe('deriveSearchWeightsFromType2024', () => {
+  it('works for schemas that branch out a lot', () => {
+    // schema of 60 "components" with 10 fields each
+    const range = [...Array(60).keys()]
+
+    const componentRefs = range.map((index) => ({type: `component_${index}`}))
+    const components = range.map((index) =>
+      defineType({
+        name: `component_${index}`,
+        type: 'object',
+        fields: [
+          ...[...Array(10).keys()].map((fieldIndex) =>
+            defineField({name: `component_${index}_field_${fieldIndex}`, type: 'string'}),
+          ),
+          defineField({name: `children_${index}`, type: 'array', of: [...componentRefs]}),
+        ],
+      }),
+    )
+
+    const schema = createSchema({
+      name: 'default',
+      types: [
+        ...components,
+        defineType({
+          name: 'testType',
+          type: 'document',
+          fields: [
+            defineField({
+              name: 'components',
+              type: 'array',
+              of: [...componentRefs],
+            }),
+          ],
+        }),
+      ],
+    })
+
+    expect(
+      deriveSearchWeightsFromType2024({
+        schemaType: schema.get('testType')!,
+        maxDepth: 5,
+      }),
+    ).toMatchObject({
+      typeName: 'testType',
+    })
+  })
+})

--- a/packages/sanity/src/core/search/common/deriveSearchWeightsFromType2024.ts
+++ b/packages/sanity/src/core/search/common/deriveSearchWeightsFromType2024.ts
@@ -75,52 +75,56 @@ function getLeafWeights(
     type: SchemaType | undefined,
     path: string,
     depth: number,
+    accumulator: SearchWeightEntry[] = [], // use accumulator to avoid stack overflow
   ): SearchWeightEntry[] {
-    if (!type) return []
-    if (depth > maxDepth) return []
+    if (!type) return accumulator
+    if (depth > maxDepth) return accumulator
 
     const typeChain = getTypeChain(type)
 
     if (isStringField(type) || isPtField(type)) {
       const weight = getWeight(type, path)
 
-      if (typeof weight !== 'number') return []
-      return [{path, weight}]
+      if (typeof weight === 'number') {
+        accumulator.push({path, weight})
+      }
+      return accumulator
     }
 
     if (isSlugField(type)) {
       const weight = getWeight(type, path)
-      if (typeof weight !== 'number') return []
-      return [{path: getFullyQualifiedPath(type, path), weight}]
+      if (typeof weight === 'number') {
+        accumulator.push({
+          path: getFullyQualifiedPath(type, path),
+          weight,
+        })
+      }
+      return accumulator
     }
 
-    const results: SearchWeightEntry[] = []
-
-    const objectTypes = typeChain.filter(
-      (t): t is Extract<SchemaType, {jsonType: 'object'}> =>
+    let recursiveResult = accumulator
+    for (const t of typeChain) {
+      if (
         t.jsonType === 'object' &&
         !!t.fields?.length &&
-        !ignoredBuiltInObjectTypes.includes(t.name),
-    )
-    for (const objectType of objectTypes) {
-      for (const field of objectType.fields) {
-        const nextPath = pathToString([path, field.name].filter(Boolean))
-        results.push(...traverse(field.type, nextPath, depth + 1))
+        !ignoredBuiltInObjectTypes.includes(t.name)
+      ) {
+        for (const field of t.fields) {
+          recursiveResult = traverse(
+            field.type,
+            pathToString([path, field.name].filter(Boolean)),
+            depth + 1,
+            recursiveResult,
+          )
+        }
+      } else if (t.jsonType === 'array' && !!t.of?.length) {
+        for (const arrayItemType of t.of) {
+          // eslint-disable-next-line no-param-reassign
+          recursiveResult = traverse(arrayItemType, `${path}[]`, depth + 1, recursiveResult)
+        }
       }
     }
-
-    const arrayTypes = typeChain.filter(
-      (t): t is Extract<SchemaType, {jsonType: 'array'}> =>
-        t.jsonType === 'array' && !!t.of?.length,
-    )
-    for (const arrayType of arrayTypes) {
-      for (const arrayItemType of arrayType.of) {
-        const nextPath = `${path}[]`
-        results.push(...traverse(arrayItemType, nextPath, depth + 1))
-      }
-    }
-
-    return results
+    return recursiveResult
   }
 
   // Cross Dataset Reference are not part of the schema, so we should not attempt to reconcile them.


### PR DESCRIPTION
### Description

This branch ports the recursion fixes contributed by Nikas in #7999 to `deriveSearchWeightsFromType2024`.

### What to review

- All Studio search surfaces should respect weights configured in schema.

### Testing

- Adds unit test contributed by Nikas.