### PR TITLE
docs(core): exposing `usePerspective` and updating tsDoc

### DIFF
--- a/packages/sanity/src/core/perspective/types.ts
+++ b/packages/sanity/src/core/perspective/types.ts
@@ -3,17 +3,17 @@ import {type ClientPerspective, type ReleaseId} from '@sanity/client'
 import {type ReleaseDocument} from '../releases/store/types'
 
 /**
- * @internal
+ * @beta
  */
 export type SelectedPerspective = ReleaseDocument | 'published' | 'drafts'
 
 /**
- * @internal
+ * @beta
  */
 export type PerspectiveStack = ExtractArray<ClientPerspective>
 
 /**
- * @internal
+ * @beta
  */
 export interface PerspectiveContextValue {
   /* The selected perspective name, it could be a release or Published */

--- a/packages/sanity/src/core/perspective/types.ts
+++ b/packages/sanity/src/core/perspective/types.ts
@@ -19,7 +19,7 @@ export interface PerspectiveContextValue {
   /* The selected perspective name, it could be a release or Published */
   selectedPerspectiveName: 'published' | ReleaseId | undefined
   /**
-   * The releaseId as r<string>; it will be undefined if the selected perspective is `published` or `drafts`
+   * The releaseId as `r<string>`; it will be undefined if the selected perspective is `published` or `drafts`
    */
   selectedReleaseId: ReleaseId | undefined
 

--- a/packages/sanity/src/core/perspective/usePerspective.ts
+++ b/packages/sanity/src/core/perspective/usePerspective.ts
@@ -4,7 +4,7 @@ import {PerspectiveContext} from 'sanity/_singletons'
 import {type PerspectiveContextValue} from './types'
 
 /**
- * @internal
+ * @beta
  */
 export function usePerspective(): PerspectiveContextValue {
   const context = useContext(PerspectiveContext)

--- a/packages/sanity/src/core/perspective/usePerspective.ts
+++ b/packages/sanity/src/core/perspective/usePerspective.ts
@@ -5,6 +5,17 @@ import {type PerspectiveContextValue} from './types'
 
 /**
  * @beta
+ *
+ * React hook that returns the current studio perspective and perspective stack.
+ *
+ * @returns See {@link PerspectiveContextValue}
+ * @example Reading the current perspective stack
+ * ```ts
+ * function MyComponent() {
+ *  const {perspectiveStack} = usePerspective()
+ *  // ... do something with the perspective stack ...
+ * }
+ * ```
  */
 export function usePerspective(): PerspectiveContextValue {
   const context = useContext(PerspectiveContext)

--- a/packages/sanity/src/core/releases/store/types.ts
+++ b/packages/sanity/src/core/releases/store/types.ts
@@ -7,15 +7,26 @@ import {RELEASE_DOCUMENT_TYPE} from './constants'
 import {type MetadataWrapper} from './createReleaseMetadataAggregator'
 import {type ReleasesReducerAction, type ReleasesReducerState} from './reducer'
 
-/** @internal */
+/**
+ * @beta
+ */
 export type ReleaseType = 'asap' | 'scheduled' | 'undecided'
 
 /**
- *@internal
+ * @beta
  */
-export type ReleaseState = 'active' | 'archived' | 'published' | 'scheduled' | 'scheduling'
+export type ReleaseState =
+  | 'active'
+  | 'archiving'
+  | 'unarchiving'
+  | 'archived'
+  | 'published'
+  | 'publishing'
+  | 'scheduled'
+  | 'scheduling'
+
 /**
- *@internal
+ * @beta
  */
 export type ReleaseFinalDocumentState = {
   /** Document ID */
@@ -24,8 +35,7 @@ export type ReleaseFinalDocumentState = {
 }
 
 /**
- * TODO: When made `beta`, update the PublishDocumentVersionEvent to use this type
- * @internal
+ * @beta
  */
 export interface ReleaseDocument extends SanityDocument {
   /**

--- a/packages/sanity/src/core/releases/store/types.ts
+++ b/packages/sanity/src/core/releases/store/types.ts
@@ -40,7 +40,7 @@ export type ReleaseFinalDocumentState = {
 export interface ReleaseDocument extends SanityDocument {
   /**
    * typically
-   * _.releases.<name>
+   * `_.releases.<name>`
    */
   _id: string
   _type: typeof RELEASE_DOCUMENT_TYPE


### PR DESCRIPTION
### Description
Making the `usePerspective` hook `@beta` for `tsdocs`. Also updating the associated types used in `PerspectiveContextValue`
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* Is it right to move to `@beta` for these types
* The comment added to `usePerspective` - does this look ok?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
