### PR TITLE
fix(core): reset all releaseDetail states when switching the release

### DIFF
--- a/packages/sanity/src/core/releases/tool/ReleasesTool.tsx
+++ b/packages/sanity/src/core/releases/tool/ReleasesTool.tsx
@@ -6,8 +6,8 @@ import {ReleasesOverview} from './overview/ReleasesOverview'
 export function ReleasesTool() {
   const router = useRouter()
 
-  const {releaseId} = router.state
-  if (releaseId) return <ReleaseDetail />
+  const {releaseId} = router.state as {releaseId?: string}
+  if (releaseId) return <ReleaseDetail key={releaseId} />
 
   return <ReleasesOverview />
 }


### PR DESCRIPTION
### Description

Changing the `<ReleaseDetail >` component `key` when switching release ensures all local states are updated, preventing bugs like the time picker not updating correctly.

This bug is reproducible when switching the release from the detail screen by clicking in the global picker.


https://github.com/user-attachments/assets/22c8fa44-9fbf-4bf7-88f6-bf0698684a3b




<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Open the release dashboard, navigate to another release using the global release picker, states should not be mixed between releases.


<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

fixes an issue that when switching releases in the dashboard some local states are not updating accordingly.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
