### PR TITLE
chore: update compiler warnings counter

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check:deps": "pnpm --recursive --parallel exec depcheck",
     "check:format": "prettier . --check",
     "check:lint": "turbo run lint --continue -- --quiet",
-    "check:react-compiler": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 25 .",
+    "check:react-compiler": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [warn]' --ignore-path .eslintignore.react-compiler --max-warnings 24 .",
     "report:react-compiler-bailout": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --rule 'react-compiler/react-compiler: [error,{__unstable_donotuse_reportAllBailouts:true}]' --ignore-path .eslintignore.react-compiler -f ./scripts/reactCompilerBailouts.cjs . || true",
     "check:test": "run-s test -- --silent",
     "check:types": "tsc && turbo run check:types --filter='./packages/*' --filter='./packages/@sanity/*'",


### PR DESCRIPTION
### Description

#8513 fixed a react compiler [bailout](https://playground.react.dev/#N4Igzg9grgTgxgUxALhAegFQAIFgDYCWAdgC4C0AJgWAIYBGeCWAtjQB5lG4kIVlw08eOjTgBrMFgxoAOkQLMADhBgkswEgE9FTAMo15WgCIQ4UZglIBfLADMYEZlgDkAAVqHNaOIUslncgrKqupaOlgAqmAIMDb2ji7uBgRaaGG4AfJKKmrAkKoAQppxDk7OeBAUNGAAFplBOepQ0QCitrYIcCQANFjNCACyCMwQvf26JDQ8JQnOMAii-oHZIcBwEEQCPXYqYgBSEMS9rIrHMQDmgzSnWOlYAPJ00TAAbvSMvRC2vWAA7ilwGoDa4zMowNgAKzAmWWwVyciwt20TBMZgspAAaoIoAgAAoxZjUMAEDbdBFYc4wAwkMD4mCEsDEjb3IhkoiIu64hwQzokIxTGhsxH9LkQHldCYqBBCvrRKIxSXzNmglwAOlVaDAJCl9RWuSMLQAYgBBCIAGQAKgB9XQWiJGACS9ytAGEzQ6WgA5a33XEWp2e3Qq5zqzUkKBUCAu3ykXVwprRaMEPzBjX9JN+GGkZFYM0QGhVBgIAA8FoAfFgALzqclVSbILAWrAAHywRCgQnJMQcMAbLRgPZbbY7eHJFQLxHODboEAgjAMciscjkmAwCOwrjoCEm66wrhqBAoFEs69kXDY8bu8pgZuoJAA6ikanSGUyiGAABKzsRYvA4qu5vmhaMMW16PiQz4EkSJJEAA2gAuhWABkNbslgq5YL8NSWLcMA4r06zMOiNJYDU1QsH4MF2As4bzFgVC0EWFDklIe7EDwMBEIILHYNItbUO8vAAPzTrO85EIuy5EKuu6btuNCyQeR4nuyfHnvG7ExLYohMGBT4vtBGw4GwPBEBQkjXqhiKUtSvCiXOCwSUQS5Oes75qA6noOv6xpmjaFrGhaLQNtet5auBkH0oZ75fhAP7Ykw1bALWAoNghMrdioDbtkIMrjlQRBTrh+GSU5MmqXuW47qpZ4IBejSaTA2mIJEzxhQ++lQYyMFgPcigkD1Vn0aY5h+L+OINvonioqNpBDjlo5oToUXdRsDYzcR414l1b6lXIjBqAIgK8LomhasMADiDhQIoYBpfB80jgBC1SeVrFydVrEAErbrA75YDQWCEFqWBfLKMSSP8EG3NhWBgDocAELYyYUFgy2vlRRkQUwFAjcRqq7g6ththAw1on4WDUGjDgvIevCU2o-xCFg8y0eygh4ADkgAAY2aQdnFQg3OnnIdXxrYUCbANRn9KFd4RQZq3vgAFOSED9XdrUxO1Cs7T1fXS++bIAJQhW18udStb6ft+W1DW5IPALj5OYglvTo9FNjVurNJSYiDtqIo3K8oqiXg6K4okKHyvG+SAfgzAocAbLzzR7HaHxz4yZzdW6YxiQysGia5rWra9pOq67pej6foBro6dxxsIOwVqUzSnD24TG3D259EXc8KB5vhZbGNN7F8V-ggZbK553kOr5-mBS0DcZ03ajAyQAAkyfREMIzKzHVYVslaGImgaBYAAjKqWAXduMNMEHYq8hRzBbjAkgGKjyN4BxoNQGobGLMIAzjUP0D+LEsDxwsG-CGm8GyPGeG8IsxYI68n5JMWCzgYHv2hIhACT9I6h0gYiVUlwC7p0RFQrAqpFAEB0MrE4B95iazQV0DBNBjZHxZrgVUOCIZCVVD-DiB9mBcMrBWAAhMwVU1AvogIgCQY2yi-ZUPPlgAATDfYEigH6v1wbcUm4DJDagpPfEYdE6yAzBkA4xcMoCAi5vRagig8A0E0J6GgFgsDK36N-FQdgCC-xiJOShVD47GPgQ8J4MRkEgT0hBRWb4EIVmrPwj+m9aH0IQKrU+VC-gAiBNcZW1RNCbB8eksA4jj4kPCWvSm5kAKVL4cU5WwBDxWGqQ0sJ1D-b1LsdWGgvwaApATqHMh25rxgGVoeKptTESsz+gnMAtTOkymoUw5WLDqnzJ4WAFpigD7gK6W03ZiIGKuPcZ4iwDZwGqguW4jxXjpRnIabc54siKDrN6dZKk-MKANm0ngaI3zqGdONqCrAELIEr2oeogAzDfO+agOZ6LAGdHgThKTQFujfeUeijrYVRiw5Q74mBIwZsZO8JjSY0BeIcVGksuCIEZDQGAmgeEAEccRan2ZAzOogiUAUJSdDFl1rq3X5fU9F51mBXRxdvasIrUZCVBrYZWyquENizn4VUICkGCSEduQEytnAYFglaO4lZqwyHAGKmR2Kbq2vgs4WFaiL4ABYb4umwuISmxNbHPFIuReYBY0Z6yMljWGztZoorMh3QBsNeZ-J4BQbm1N1YxC0FK9yFIU1gCiYg2JglB4xF1lbGCKSAK2F2AcYgytYKRJ+Pa+VN1N7wWNlkhhtSLAwEuDokp6LykNuMb0R1t0O3cJPj8xEFLlaSM1UNGdUDBWitla226AFx0rLyWC1RPz458xIKKBkuAd4CIOYOspcAfHHKna8w9+at0Sv2Zs8dDYDCaC6dO5dVC53jr4cMXBsjNh-mPNMu5h5lFLt-Qs36nE804rIfm15iIXKoZ4WzLACFXmdP3TO+Otg3EkFMrwK61JJDVlguqZDFH4JCOIzHB99TgBHt4F7AGwzRlHtpBGogLJcmweFB8w8kKflEamKRig5HSBgDE70j2St5PUJjZtN2ry3XLsWQhn9sGaPgOU1QtjAK822S+bh3ZeGnLLoic8MA5bR7skGVxtQJ7qAIFVBzZWR63PREkM2VsCFNO9O0+yYxDnoqrOhXk4L6iACsN9dCNEDRDAGeBFBkSqgQAQQhNA5pBpvQQGX6Dbmy4IBBMTXglrzAWEtCTIqOZSak0zsnMl0O7bulgrTtncNOZ1xEmVezDlyrs-Kk5AWCBBbsqxDZ8gkCKFs3AvRnAPKuc811kLwXfOC6FrAhX0uZdKzl8kVheiwR1aQPVlW4nt1U2NN2GaiHaiVGM577dFNvg7ao-obQOhdAPt+-LahiApAIIIRVaqZ5eR8n5W0S8elQOlZMHgEO3JbBmYYMHeBN69A3pvYL8cwBQDoABVuKPVRE6eHAGABAtx9Z+eeEgs3O7I5eZ1wbDZlaDcB-1hN-cclO1Sth+CvRBu46AuNuwk2EBWZ+adyBVnIG7cPhImDiJKeqklpTsA1Pac5IRy5NDZ28dfes5hpZZOECLhAFYIAA).
This bailout were flagged as invalid/unsafe react, having a `cachedSystemGroups = groups` assignment as a side-effect inside a `useMemo` closure is dangerous and relies on internal React behaviour, which can change in a minor/patch version of React.

The new code has a different [bailout](https://playground.react.dev/#N4Igzg9grgTgxgUxALhAegFQAIFgDYCWAdgC4C0AJgWAIYBGeCWAtjQB5lG4kIVlw08eOjTgBrMFgxoAOkQLMADhBgkswEgE9FTAMo15WgCIQ4UZglIBfLADMYEZlgDkAAVqHNaOIUslncgrKqupaOlgAqmAIMDb2ji7uBgRaaGG4AfJKKmrAkKoAQppxDk7OeBAUNGAAFplBOepQ0QCitrYIcCQANFjNCACyCMwQvf26JDQ8JQnOMAii-oHZIcBwEEQCPXYqYgBSEMS9rIrHMQDmgzSnWOlYAPJ00TAAbvSMvRC2vbU08wBKCEUeBomh+AHcUnAagNrjMyjA2AArMCZZbBXJyLC3bRMExmCykABqgigCAACjFmNQwAQNt0sVhzjADCQwJSYNSwLSNvciAyiNi7uSHEjOiQjFMaALsf0RRAxV0JioEDK+tEojFlfMBfCXAA6fVoMAkFX1Fa5IwtABiAEEIgAZAAqAH1dE6IkYAJL3F0AYQdXpaADlXfdyU6fcHdHrnIbjSQoFQIH7fKRzRimtFUwQ-LGjf0c340aRcVgHRAaFUGAgADxOgB8WAAvOpGVVJsgsE6sAAfLBEKBCRkxBwwLstGBjvsDod4RkVKvEc5dugQCCMAxyKxyOSYDBY7CuOgISaHrCuGoECgUSyH2RcNiZu6amAO6gkADqKRqHK5PKIMAAAl1zEEk8DJFty0ratGFrV9vxIX8qRpOkiAAbQAXSbAAyNtBSwfcsHBGpLFuGAyV6dZmEJNksBqaoWD8NC7AWRN5iwKhaBrChGSkC9iB4GAiEEPjsGkdtqHeXgAH5V3XTciG3XciH3c9j1PGh1KvG870FCTH0zQSYlsUQmAQn8-1QjYcDYHgiAoSRX3w7FmVZXh5I3BYlKIHcfPWQC1C9YMvUjW0HTdJ1bSdFou1fd8TUQ5DOWswCQIgMDSSYVtgHbKUuywtVRxULtByENVFyoIgV3IyjlJ8tT9IvE8z30h8ECfRpjJgUzEEiZ4Eq-SyUO5NCwHuRQSDGlzONMcw-HAsku30Tx8Xm0gZzK+cCJ0FLRo2Ls1toxaKRGgD6r3DADyajTWv4wF2MArAaCwQgTSwL51RiSRISQ25SKwMAdDgAhbFzCgsF2-8WJspCmAoObaP1c8vVsAcIFmgk-CwahIYcF5r14HG1EhIQsHmR7nrJxiAAM3NIDzaoQGn7zkDrM1sKBNimmz+nij8kqs-bAIACkZCBJrAOKBoF4a9oA8bJrGgUAEppZiQbBbOsb0syiCmFygiAve4AEax4kst6KHUpsVsJbZFTsWNtRFFFcVtWyr75UVEgPZFlXGWdr6YA9qC+eeP2A6NjZ3p8XMNtbQs0xIEWrTtR1XXdT0fX9QMQzDCMo10KPA5jtR0JNKZVUB08JirzCw+iOueHgmXErl6GY91k6GxF4LQq9cLIuiloS+jwKsHQ-oYDAAASH5NBNYYAHEHCgRRZ4bxPoiGEYRf9lsm0N7FsTQNAsAARn1LBl9Pf6mFdhVxSY5gTxn56HLsAg8CEj6oDUOG5MIBrjUNPMAfEsBBwsK-b6s8uyPGeG8GstZvbiklJMdCzhoFv1RNhKCj8fYewgdifUlwU5RxPiffUigCA6BFicfe8wpZYFQV0dBNAVaH3JrgfU2DvoyX1GDH+MR97ME4c2JsABCZg+pqD-GARAEgKtlHEKwNQ2hCARa-ABECEEmgRYXxUT5ShZ8sAACZr6wkUPfF+ODbgYzAfYpkd8RgcQ7C9T6gDHFgCgNCZ6kguLAlBMGGgFgsAi36BDWwKgv7CJgMuChJ8g4ujAXAh4TwYhILghZJCQsAJYSbK2PhM9Z7qLoaosAv1oRWJFtUTQmxwnFLAOIo+qinZlxxo5KCTTeHXH3sAa8VgWmdMSZQ9pE9HGthoOCGgKRg4e1IaeV8YARbXmaW07hlMwGqKGWqShDCRZMJaRsphvTFD72nsMkWx8xmUMCXokJFguzT31Pc4JoTVQbOxNeZ5zxZEUD2bcpkLIGYUC7KZPA0RAWUKGSraFWA4UQLHiY8+ABma+t81CCDwDYsAi8eBOGZNARQYBr6ahsQIaERMmHKEAkwUGxNbIfkkKaZ6LxDgQy5lwRA3I-iaG4QARzJCaUlEDkl4qXswVexLZ5QTjn4fUwDEHSUEaeaEItnAYHQi6O4zZWwyHAPi4YpC16KANZhZwKsymaO0QgQEQT9GGNGZs2AgptWpN6C6CVBLpXr03oyKwvR0LytIIqjJrxpJWzdkqU0Op5mxoQJhZFkCOlvRILK7egxhgQH3sMm5p9z4ABZr5+lIuIHGaMvHPHooxeYVZIbaxsrDAGZt1pYs-tEABAM6Ygp4BQGmeMJYxC0GKjp9M2RpIQZk6SrcYha3lmhApUFokwH2IcIgIsp7PDngvSVvqN5JutWLAi+yLhXHOXUhpm6wG9CJevMASauH5rGUHcd8ouS4Ebvws5tS8VXsuU+r5KaJ7jskK2O9JKf0iwg12Awmg81Ae+WjaDpreHDBwbIzYEFbwrJedeZRM0gVjIpq64FxKTWsnASeojWA-KIZdcJSemEgNDMdjRoOtgQQkHsrwVelGoLoUNBR0gD7BFcf9kBoOwBx28Fts9GZczQN5LQnyY9NGT54YBfRzjUweMUD4yJ+FtzrbCyM2M1tx1LZAeTURkjjHn1EaE9PMzlCZNguBe5LT1Hbl+SI6x4xQK7OCmmbMtQ77qAIH1NilDrJwvREkL2fsWFnXYl2UitjBasAAFZr66EaFW76VNFAMRagQAQQhNCjonrPQQxX6CnjK4IeB4asl1grFWGdOTkqdwwthQpHmROlJoeU7zLA+mHNwFchzJ9irjlnOVDZlVlzgsEFCjZ7iuz5BIEUCbYBejODeZoR5CBLXwthYCmzDHBQ1bwHV0r5WA1BoswtS2DaF30mDjuwGRqpWms3sm-obQOhdFzYB6jQdiApAIIIDNH1bB9xCmFCK7oR7OqDpXHgsOApbFWYYaHeB56vQ-LPS76OoB0CghjhApSfFPDgPEk81zVGPhIJt2ukweDwtm12EWs2EOjexJ25umjTb5SY70WbvQlvVRW5ChA-mfOAv8xAoL4T+e3Np-qLmtOwD04IIz51vnaNBrTf9tjquqfbhAFYIAA), it's not actionable though as the code is valid. The compiler is simply seeing that the memoization it creates looks different than the manual `useMemo` code, and so it bails out due to an abundance of caution. We can expect it to stop bailing out by the time the compiler reaches a stable release (it's currently in beta).

### What to review

```diff
- --max-warnings 25
+ --max-warnings 24
```

### Testing

I ran `pnpm check:react-compiler` and noted down the new count of warnings.

### Notes for release

N/A
