### PR TITLE
fix: handle `motion()` deprecation warning

### DIFF
--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
@@ -31,7 +31,7 @@ const RELATIVE_TIME_OPTIONS = {
   useTemporalPhrase: true,
 } as const
 
-const MotionButton = motion(Button)
+const MotionButton = motion.create(Button)
 
 const ButtonSkeleton = () => {
   return (


### PR DESCRIPTION
### Description

Fixes this warning:
![image](https://github.com/user-attachments/assets/cc2a90f9-f11f-46af-bcca-45c783efcf21)


### What to review

In `framer-motion` v12 the `motion()` utility is deprecated, and `motion.create()` should be used instead. Maybe we should add a linter rule to prevent it from sneaking back in?

### Testing

`pnpm dev`, as the warning isn't shown in production only on `sanity dev` or `next dev`.

### Notes for release

Annoying, and unactionable, `motion() is deprecated. Use motion.create() instead.` warnings are handled and should no longer spam your developer console ❤ 
