### PR TITLE
fix(core): use preview value title when unpublishing or discarding a document

### DIFF
--- a/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
+++ b/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
@@ -2,7 +2,7 @@ import {type ReleaseId} from '@sanity/client'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {useToast} from '@sanity/ui'
 
-import {Translate, useTranslation} from '../../i18n'
+import {useTranslation} from '../../i18n'
 import {useSetPerspective} from '../../perspective/useSetPerspective'
 import {getDocumentVariantType} from '../../util/getDocumentVariantType'
 import {AddedVersion} from '../__telemetry__/releases.telemetry'
@@ -53,18 +53,6 @@ export function useVersionOperations(): VersionOperationsValue {
   const handleDiscardVersion = async (releaseId: string, documentId: string) => {
     try {
       await discardVersion(releaseId, documentId)
-
-      toast.push({
-        closable: true,
-        status: 'success',
-        description: (
-          <Translate
-            t={t}
-            i18nKey={'release.action.discard-version.success'}
-            values={{title: document.title as string}}
-          />
-        ),
-      })
     } catch (err) {
       toast.push({
         closable: true,
@@ -78,18 +66,6 @@ export function useVersionOperations(): VersionOperationsValue {
   const handleUnpublishVersion = async (documentId: string) => {
     try {
       await unpublishVersion(documentId)
-
-      toast.push({
-        closable: true,
-        status: 'success',
-        description: (
-          <Translate
-            t={t}
-            i18nKey={'release.action.unpublish-version.success'}
-            values={{title: document.title as string}}
-          />
-        ),
-      })
     } catch (err) {
       toast.push({
         closable: true,


### PR DESCRIPTION
### Description

Fixes an issue when discarding or un-publishing documents, instead of the release document title we were sending to the toast the window.document.title , so it was showing an incorrect value.

This fixes it by passing the preview value to the toast.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Are the changes correct?


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Discard or un-publish a document inside a release, the document title should render in the toast.

https://github.com/user-attachments/assets/a9e13780-6217-4405-80b8-ce7d219fb030


<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
fixes an issue with incorrect titles shown in when discarding or un-publishing a document inside a release
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
