### PR TITLE
chore: test larger gh runners

### DIFF
--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   install:
     timeout-minutes: 30
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-m
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -70,7 +70,7 @@ jobs:
   playwright-ct-test:
     timeout-minutes: 30
     needs: [install]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-m
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -162,7 +162,7 @@ jobs:
   merge-reports:
     if: always()
     needs: [playwright-ct-test]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-m
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -246,7 +246,7 @@ jobs:
       actions: write # needed to delete the cache
     timeout-minutes: 30
     name: Cleanup (${{ matrix.project }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-m
     needs: [playwright-ct-test]
 
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   install:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -110,7 +110,7 @@ jobs:
 
   playwright-test:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     needs: [install]
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -224,7 +224,7 @@ jobs:
   merge-reports:
     if: always()
     needs: [playwright-test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -282,7 +282,7 @@ jobs:
       actions: write # needed to delete the cache
     timeout-minutes: 30
     name: Cleanup (${{ matrix.project }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     needs: [playwright-test]
 
     strategy:

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   efps-test:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -102,7 +102,7 @@ jobs:
   merge-reports:
     if: always()
     needs: [efps-test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       # we want to know if a test fails on a specific node version
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest-m]
         node: [18, 20, 22]
         experimental: [false]
         shardIndex: [1, 2, 3, 4]
@@ -93,7 +93,7 @@ jobs:
   report-coverage:
     if: ${{ !cancelled() }}
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description

We often get congestion and bottlenecks if there's a lot of PRs being worked on, as the default `ubuntu-latest` runner has a 60 concurrent builds limit. Current queue status is visible here: https://github.com/organizations/sanity-io/settings/actions/hosted-runners

![image](https://github.com/user-attachments/assets/854fbd55-410b-4e02-a93c-a794a54b9b99)


Based on the stats [here](https://github.com/sanity-io/sanity/actions/metrics/performance?sort=jobs), I picked the jobs that use the most resources on two new images, `ubuntu-latest-m` and `ubuntu-22.04-m`, which have their own separate 60 concurrent builds limits, and have more memory and more CPU cores (as well as faster ones).


### What to review

Everything should work like before, only faster and less bottlenecks on the PR checks.

### Testing

If the status checks behave exactly like before (but faster) then we're good to go 👍 

### Notes for release

N/A
