### PR TITLE
fix(core): add breathing space for release create button in picker

### DIFF
--- a/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
@@ -122,7 +122,7 @@ export function ReleasesList({
   }
 
   return (
-    <Box>
+    <>
       <StyledBox ref={setScrollContainer} onScroll={onScroll}>
         <StyledPublishedBox
           $reducePadding={!releases.length || !areReleasesEnabled}
@@ -163,6 +163,6 @@ export function ReleasesList({
           />
         </>
       )}
-    </Box>
+    </>
   )
 }


### PR DESCRIPTION
### Description

Removes the  `<Box>` that is wrapping the list and the button, this box was blocking the gap property the menu has, so the items were rendering without space between them.
**See New release button**

| Before | After |
|--------|--------|
|<img width="339" alt="Screenshot 2025-02-07 at 15 07 27" src="https://github.com/user-attachments/assets/2475182d-7581-4e22-9fb0-29a6eb596091" />|<img width="347" alt="Screenshot 2025-02-07 at 15 06 43" src="https://github.com/user-attachments/assets/ab020840-c96f-4700-ab36-82cd7a2b0b6a" />|


This do not affect users with releases disabled.

<img width="327" alt="Screenshot 2025-02-07 at 15 08 32" src="https://github.com/user-attachments/assets/4ef032b6-ee80-49f6-a479-91e0fe66deff" />
 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
