### PR TITLE
chore(core): update message to be schedule or publish error

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -147,6 +147,8 @@ const releasesLocaleStrings = {
   'failed-edit-title': 'Failed to save changes',
   /** Title text displayed for releases that failed to publish  */
   'failed-publish-title': 'Failed to publish',
+  /** Title text displayed for releases that failed to schedule  */
+  'failed-schedule-title': 'Failed to schedule',
 
   /**The text that will be shown in the footer to indicate the time the release was archived */
   'footer.status.archived': 'Archived',

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -34,6 +34,7 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
   const setPerspective = useSetPerspective()
   const isSelected = releaseId === selectedReleaseId
   const shouldDisplayError = release.state === 'active' && typeof release.error !== 'undefined'
+  const isAtTimeRelease = release?.metadata?.releaseType === 'scheduled'
 
   const handlePinRelease = useCallback(() => {
     if (isSelected) {
@@ -66,7 +67,9 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
                 <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
               </Text>
               <TextWithTone size={1} tone="critical">
-                {tRelease('failed-publish-title')}
+                {isAtTimeRelease
+                  ? tRelease('failed-schedule-title')
+                  : tRelease('failed-publish-title')}
               </TextWithTone>
             </Flex>
           )}
@@ -81,7 +84,11 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
                 <ErrorOutlineIcon />
               </Text>
               <Stack space={4}>
-                <Text>{tRelease('failed-publish-title')}</Text>
+                <Text>
+                  {isAtTimeRelease
+                    ? tRelease('failed-schedule-title')
+                    : tRelease('failed-publish-title')}
+                </Text>
                 <Details title={tRelease('error-details-title')}>
                   <Text>
                     <code>{release.error?.message}</code>


### PR DESCRIPTION
### Description

Change the messages so that it'll show schedule if it's a release can can be scheduled or publish if it's a release that can be published

This is a more naive way of handling these errors without taking into account spceifically the error messages that come from the backend, however, it should be enough for now. If it needs a finer touch we can come back and adjust accordingly. A story has been created as a follow up.

### What to review

Do you agree with my assessment? The code?

### Testing

Existing tests should be fine

### Notes for release

Update translations for error messages in releases.