### PR TITLE
feat(cli): select org and add to sanity.cli.ts on initialization

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapLocalTemplate.ts
@@ -130,7 +130,10 @@ export async function bootstrapLocalTemplate(
 
   // ...and a CLI config (`sanity.cli.[ts|js]`)
   const cliConfig = isCoreAppTemplate
-    ? createCoreAppCliConfig({appLocation: template.appLocation!})
+    ? createCoreAppCliConfig({
+        appLocation: template.appLocation!,
+        organizationId: variables.organizationId,
+      })
     : createCliConfig({
         projectId: variables.projectId,
         dataset: variables.dataset,

--- a/packages/@sanity/cli/src/actions/init-project/createCoreAppCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init-project/createCoreAppCliConfig.ts
@@ -5,7 +5,8 @@ import {defineCliConfig} from 'sanity/cli'
 
 export default defineCliConfig({
   __experimental_coreAppConfiguration: {
-    appLocation: '%appLocation%'
+    organizationId: '%organizationId%',
+    appLocation: '%appLocation%',
   },
 })
 `

--- a/packages/@sanity/cli/src/actions/init-project/createStudioConfig.ts
+++ b/packages/@sanity/cli/src/actions/init-project/createStudioConfig.ts
@@ -36,6 +36,7 @@ export interface GenerateConfigOptions {
     projectName?: string
     sourceName?: string
     sourceTitle?: string
+    organizationId?: string
   }
 }
 

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -277,8 +277,9 @@ export default async function initSanity(
   // skip project / dataset prompting
   const isCoreAppTemplate = cliFlags.template ? determineCoreAppTemplate(cliFlags.template) : false // Default to false
 
-  // We're authenticated, now lets select or create a project
-  const {projectId, displayName, isFirstProject, datasetName, schemaUrl} = await getProjectDetails()
+  // We're authenticated, now lets select or create a project (for studios) or org (for core apps)
+  const {projectId, displayName, isFirstProject, datasetName, schemaUrl, organizationId} =
+    await getProjectDetails()
 
   const sluggedName = deburr(displayName.toLowerCase())
     .replace(/\s+/g, '-')
@@ -715,6 +716,7 @@ export default async function initSanity(
     displayName: string
     isFirstProject: boolean
     schemaUrl?: string
+    organizationId?: string
   }> {
     // If we're doing a quickstart, we don't need to prompt for project details
     if (flags.quickstart) {
@@ -731,11 +733,17 @@ export default async function initSanity(
     }
 
     if (isCoreAppTemplate) {
+      const client = apiClient({requireUser: true, requireProject: false})
+      const organizations = await client.request({uri: '/organizations'})
+
+      const coreAppOrganizationId = await getOrganizationId(organizations)
+
       return {
         projectId: '',
         displayName: '',
-        isFirstProject: false,
         datasetName: '',
+        isFirstProject: false,
+        organizationId: coreAppOrganizationId,
       }
     }
 
@@ -1091,6 +1099,7 @@ export default async function initSanity(
       dataset: datasetName,
       projectId,
       projectName: displayName || answers.projectName,
+      organizationId,
     }
 
     if (remoteTemplateInfo) {
@@ -1230,12 +1239,12 @@ export default async function initSanity(
   }
 
   async function getOrganizationId(organizations: ProjectOrganization[]) {
-    let organizationId = flags.organization
+    let orgId = flags.organization
     if (unattended) {
-      return organizationId || undefined
+      return orgId || undefined
     }
 
-    const shouldPrompt = organizations.length > 0 && !organizationId
+    const shouldPrompt = organizations.length > 0 && !orgId
     if (shouldPrompt) {
       debug(`User has ${organizations.length} organization(s), checking attach access`)
       const withGrant = await getOrganizationsWithAttachGrant(organizations)
@@ -1261,18 +1270,18 @@ export default async function initSanity(
       })
 
       if (chosenOrg && chosenOrg !== 'none') {
-        organizationId = chosenOrg
+        orgId = chosenOrg
       }
-    } else if (organizationId) {
-      debug(`User has defined organization flag explicitly (%s)`, organizationId)
+    } else if (orgId) {
+      debug(`User has defined organization flag explicitly (%s)`, orgId)
     } else if (organizations.length === 0) {
       debug('User has no organizations, skipping selection prompt')
     }
 
-    return organizationId || undefined
+    return orgId || undefined
   }
 
-  async function hasProjectAttachGrant(organizationId: string) {
+  async function hasProjectAttachGrant(orgId: string) {
     const requiredGrantGroup = 'sanity.organization.projects'
     const requiredGrant = 'attach'
 
@@ -1280,7 +1289,7 @@ export default async function initSanity(
       .clone()
       .config({apiVersion: 'v2021-06-07'})
 
-    const grants = await client.request({uri: `organizations/${organizationId}/grants`})
+    const grants = await client.request({uri: `organizations/${orgId}/grants`})
     const group: {grants: {name: string}[]}[] = grants[requiredGrantGroup] || []
     return group.some(
       (resource) =>

--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -352,6 +352,7 @@ export interface CliConfig {
    * @internal
    */
   __experimental_coreAppConfiguration?: {
+    organizationId?: string
     appLocation?: string
   }
 }


### PR DESCRIPTION
### Description
FIXES SDK-180
Since core applications will not be attached to specific projects, they need to be attached to organizations instead. This PR updates the `sanity init --template core-app` process to use the "select organization" part of the CLI flow and pass the resulting organization ID to the `sanity.cli.ts` template.

### What to review
This should hopefully be straightforward. I had to update some variable names in legacy code because of an ESLint `no-shadow` rule. If you disagree with this choice, please let me know!

### Testing
1. Run `pnpx sanity@3.74.2-canary.67+a9a66e73d5 init --template core-app`
2. Verify that you are prompted for an organization.
3. Verify that the organization ID is in your `sanity.cli.ts`

### Notes for release
None, should be internal.