### PR TITLE
test(cli): add retry for cli tests

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Test
         id: test
-        run: pnpm test:vitest --silent --project=@sanity/cli
+        run: pnpm test:vitest --retry 4 --silent --project=@sanity/cli
         env:
           # Update token in github and change below to ${{ secrets.SANITY_CI_CLI_AUTH_TOKEN }} after merge to next
           SANITY_CI_CLI_AUTH_TOKEN_STAGING: ${{ secrets.SANITY_CI_CLI_AUTH_TOKEN_STAGING }}


### PR DESCRIPTION
### Description
CLI tests are sometimes flaky. This adds retrying to cli tests similar to what we did for e2e tests in #8501, and unit tests in #8371

### What to review
Makes sense?


### Notes for release
n/a – internal