### PR TITLE
feat: updating document count for release overview cells

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -126,11 +126,6 @@ const releasesLocaleStrings = {
   /** Title for dialog for discarding a version of a document */
   'discard-version-dialog.title': 'Discard version',
 
-  /** Label for the count of documents in to a release when only 1 document added */
-  'document-count_one': '{{count}} document',
-  /** Label for the count of documents in to a release */
-  'document-count_other': '{{count}} documents',
-
   /** Text for when documents of a release are loading */
   'document-loading': 'Loading documents',
   /** Label for when a document in a release has multiple validation warnings */

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -121,7 +121,7 @@ export const releasesOverviewColumnDefs: (
       width: 120,
       header: ({headerProps}) => (
         <Flex {...headerProps} paddingY={3} sizing="border">
-          <Headers.BasicHeader text="" />
+          <Headers.BasicHeader text={t('table-header.documents')} />
         </Flex>
       ),
       cell: ({datum: {isDeleted, state, finalDocumentStates, documentsMetadata}, cellProps}) => (

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -246,10 +246,10 @@ describe('ReleasesOverview', () => {
       mockUseReleasesMetadata.mockReturnValue({
         ...useReleasesMetadataMockReturn,
         data: Object.fromEntries(
-          releases.map((release) => [
+          releases.map((release, index) => [
             release._id,
             {
-              documentCount: 1,
+              documentCount: index + 1,
             } as ReleasesMetadata,
           ]),
         ),
@@ -271,6 +271,11 @@ describe('ReleasesOverview', () => {
       within(unsortedFirstRelease).getByText(activeASAPRelease.metadata.title)
       within(unsortedSecondRelease).getByText(scheduledRelease.metadata.title)
       within(unsortedThirdRelease).getByText(activeScheduledRelease.metadata.title)
+
+      // document count
+      within(unsortedFirstRelease).getByText('2')
+      within(unsortedSecondRelease).getByText('4')
+      within(unsortedThirdRelease).getByText('1')
     })
 
     it('shows time as ASAP for asap release types', () => {

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/columnCells/ReleaseDocumentsCounter.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/columnCells/ReleaseDocumentsCounter.test.tsx
@@ -28,12 +28,12 @@ describe('ReleaseDocumentsCounter', () => {
   it('renders the singular text when documentCount is 1', async () => {
     await renderTest({documentCount: 1})
 
-    expect(screen.getByText('1 document')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
   })
 
   it('renders the plural text when documentCount is greater than 1', async () => {
     await renderTest({documentCount: 5})
 
-    expect(screen.getByText('5 documents')).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
   })
 })

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseDocumentsCounter.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseDocumentsCounter.tsx
@@ -1,25 +1,11 @@
 import {Text} from '@sanity/ui'
-import {useMemo} from 'react'
-
-import {Translate, useTranslation} from '../../../../i18n'
-import {releasesLocaleNamespace} from '../../../i18n'
 
 type Props = {
   documentCount: number | undefined
 }
 
-export const ReleaseDocumentsCounter = ({documentCount}: Props) => {
-  const {t} = useTranslation(releasesLocaleNamespace)
-
-  const count = useMemo(() => {
-    if (!documentCount) return '-'
-
-    return <Translate t={t} i18nKey="document-count" values={{count: documentCount}} />
-  }, [documentCount, t])
-
-  return (
-    <Text muted size={1}>
-      {count}
-    </Text>
-  )
-}
+export const ReleaseDocumentsCounter = ({documentCount}: Props) => (
+  <Text muted size={1}>
+    {documentCount || '-'}
+  </Text>
+)


### PR DESCRIPTION
### Description
In releases Overview the documents row has:
* 'Documents' header
* Just show the count in the cells

| Before | After |
|--------|--------|
| <img width="369" alt="Screenshot 2025-02-10 at 17 48 43" src="https://github.com/user-attachments/assets/06e845a1-e524-45cd-ad30-c8ca513796c9" /> | <img width="348" alt="Screenshot 2025-02-10 at 17 49 47" src="https://github.com/user-attachments/assets/b83d7bfd-4dd2-48a4-ada0-52b4d404fd98" /> | 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Updated the existing tests
Added a few tests for the document counts
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
