### PR TITLE
feat: creating new scheduled release defaults time to start of next hour

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
@@ -1,6 +1,6 @@
 import {InfoOutlineIcon} from '@sanity/icons'
 import {Card, Flex, Stack, TabList, TabPanel, Text} from '@sanity/ui'
-import {addMinutes, isValid} from 'date-fns'
+import {addHours, isValid, startOfHour} from 'date-fns'
 import {useCallback, useEffect, useState} from 'react'
 
 import {Tab, Tooltip} from '../../../../ui-components'
@@ -39,10 +39,11 @@ export function ReleaseForm(props: {
   const handleButtonReleaseTypeChange = useCallback(
     (pickedReleaseType: ReleaseType) => {
       setButtonReleaseType(pickedReleaseType)
-      // select time 1 minute from now so that form doesn't immediately
-      // evaluate to error
-      const nextInputValue = addMinutes(new Date().setSeconds(0, 0), 1)
+
       if (pickedReleaseType === 'scheduled') {
+        // select the start of the next hour
+        const nextInputValue = startOfHour(addHours(new Date(), 1))
+
         setIntendedPublishAt(nextInputValue)
       }
 

--- a/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
@@ -40,10 +40,10 @@ export function ReleaseForm(props: {
     (pickedReleaseType: ReleaseType) => {
       setButtonReleaseType(pickedReleaseType)
 
-      if (pickedReleaseType === 'scheduled') {
-        // select the start of the next hour
-        const nextInputValue = startOfHour(addHours(new Date(), 1))
+      // select the start of the next hour
+      const nextInputValue = startOfHour(addHours(new Date(), 1))
 
+      if (pickedReleaseType === 'scheduled') {
         setIntendedPublishAt(nextInputValue)
       }
 


### PR DESCRIPTION
### Description
Before: Creating a new scheduled release will set the default scheduled time **to be the next minute**
After: Creating a new scheduled release will set the default scheduled time **to be the start of the next hour**

| Before | After |
|--------|--------|
| <img width="496" alt="Screenshot 2025-02-10 at 17 54 27" src="https://github.com/user-attachments/assets/d4390404-5b9e-4710-89b3-15e3ba3a5236" /> | <img width="507" alt="Screenshot 2025-02-10 at 17 54 02" src="https://github.com/user-attachments/assets/3c8e123e-8810-4252-a240-7c8d5da0a5a7" /> | 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
There aren't currently any tests covering this story
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
