### PR TITLE
fix(structure): avoid spreading `key` into props, pass explicitly

### DIFF
--- a/packages/sanity/src/structure/panes/types.ts
+++ b/packages/sanity/src/structure/panes/types.ts
@@ -22,4 +22,9 @@ export interface BaseStructureToolPaneProps<T extends PaneNode['type']> {
     isReleaseLocked: boolean
     selectedReleaseId: ReleaseId | undefined
   }
+
+  /**
+   * @deprecated Avoid specifying a key, instead use `paneKey` if need be
+   */
+  key?: string
 }

--- a/packages/sanity/src/structure/panes/userComponent/UserComponentPane.tsx
+++ b/packages/sanity/src/structure/panes/userComponent/UserComponentPane.tsx
@@ -29,6 +29,8 @@ export function UserComponentPane(props: UserComponentPaneProps) {
   } | null>(null)
   const {title = ''} = useI18nText(pane)
 
+  const {key, ...componentProps} = {...restProps, ...restPane}
+
   return (
     <Pane id={paneKey} minWidth={320} selected={restProps.isSelected}>
       <UserComponentPaneHeader
@@ -42,8 +44,8 @@ export function UserComponentPane(props: UserComponentPaneProps) {
       <UserComponentPaneContent>
         {isValidElementType(UserComponent) && (
           <UserComponent
-            {...restProps}
-            {...restPane}
+            key={key}
+            {...componentProps}
             // NOTE: here we're utilizing the function form of refs so setting
             // the ref causes a re-render for `UserComponentPaneHeader`
             ref={setRef as any}


### PR DESCRIPTION
### Description

Edge case, but some plugins/setups apparently define a `key` property for structure `component` panes, which gives a warning about `A props object containing a "key" prop is being spread into JSX` when we render. This PR explicitly calls out `key` as being deprecated/should be avoided, but also picks it out of the props being spread and explicitly forwards it. This ensures backwards compatibility as well as avoiding the error, and potentially helps developers know not to pass it in the first place.

### What to review

User component panes still work as expected

### Testing

Very edge-case, so not adding a test here.

### Notes for release

None
