### PR TITLE
fix(core): adds proper check for vite dev server stop

### DIFF
--- a/packages/sanity/src/core/error/ErrorLogger.tsx
+++ b/packages/sanity/src/core/error/ErrorLogger.tsx
@@ -1,4 +1,5 @@
 import {useToast} from '@sanity/ui'
+import {isObject} from 'lodash'
 import {useEffect} from 'react'
 
 import {ConfigResolutionError, SchemaError} from '../config'
@@ -51,7 +52,7 @@ export function ErrorLogger(): null {
   return null
 }
 
-function isKnownError(err: Error): boolean {
+export function isKnownError(err: Error): boolean {
   if (err instanceof SchemaError) {
     return true
   }
@@ -64,7 +65,8 @@ function isKnownError(err: Error): boolean {
     return true
   }
 
-  if ('ViteDevServerStoppedError' in err && err.ViteDevServerStoppedError) {
+  // This is a special case for the Vite dev server stopping error
+  if (isObject(err) && 'ViteDevServerStoppedError' in err && err.ViteDevServerStoppedError) {
     return true
   }
 

--- a/packages/sanity/src/core/error/__tests__/ErrorLogger.test.tsx
+++ b/packages/sanity/src/core/error/__tests__/ErrorLogger.test.tsx
@@ -1,0 +1,68 @@
+import {describe, expect, test} from 'vitest'
+
+import {ConfigResolutionError} from '../../config/ConfigResolutionError'
+import {SchemaError} from '../../config/SchemaError'
+import {CorsOriginError} from '../../store/_legacy/cors/CorsOriginError'
+import {ViteDevServerStoppedError} from '../../studio/ViteDevServerStopped'
+import {isKnownError} from '../ErrorLogger'
+
+describe('#isKnownError', () => {
+  test('should return true for SchemaError errors', () => {
+    expect(
+      isKnownError(
+        new SchemaError({
+          _registry: {},
+          name: 'test',
+          get: () => undefined,
+          has: () => false,
+          getTypeNames: () => [],
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  test('should return true for CorsOriginError errors', () => {
+    expect(
+      isKnownError(
+        new CorsOriginError({
+          projectId: 'test',
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  test('should return true for ConfigResolutionError errors', () => {
+    expect(
+      isKnownError(
+        new ConfigResolutionError({
+          name: 'test',
+          type: 'test',
+          causes: [],
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  test('should return true for ViteDevServerStoppedError errors', () => {
+    expect(isKnownError(new ViteDevServerStoppedError())).toBe(true)
+  })
+
+  test('should return false for unknown errors', () => {
+    expect(isKnownError(new Error('unknown'))).toBe(false)
+  })
+
+  test('should return false for null', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(isKnownError(null as any)).toBe(false)
+  })
+
+  test('should return false for undefined', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(isKnownError(undefined as any)).toBe(false)
+  })
+
+  test('should return false for an object that does not have a ViteDevServerStoppedError property', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(isKnownError({} as any)).toBe(false)
+  })
+})

--- a/packages/sanity/src/core/studio/StudioErrorBoundary.tsx
+++ b/packages/sanity/src/core/studio/StudioErrorBoundary.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable i18next/no-literal-string */
 /* eslint-disable @sanity/i18n/no-attribute-string-literals */
 import {Box, Card, Code, Container, type ErrorBoundaryProps, Heading, Stack, Text} from '@sanity/ui'
+import {isObject} from 'lodash'
 import {
   type ComponentType,
   type ErrorInfo,
@@ -90,7 +91,12 @@ export const StudioErrorBoundary: ComponentType<StudioErrorBoundaryProps> = ({
     return <SchemaErrorsScreen schema={error.schema} />
   }
 
-  if (error && 'ViteDevServerStoppedError' in error && error.ViteDevServerStoppedError) {
+  if (
+    error &&
+    isObject(error) &&
+    'ViteDevServerStoppedError' in error &&
+    error.ViteDevServerStoppedError
+  ) {
     return <DevServerStoppedErrorScreen />
   }
 

--- a/packages/sanity/src/core/studio/ViteDevServerStopped.tsx
+++ b/packages/sanity/src/core/studio/ViteDevServerStopped.tsx
@@ -7,7 +7,7 @@ const ERROR_TITLE = 'Dev server stopped'
 const ERROR_DESCRIPTION =
   'The development server has stopped. You may need to restart it to continue working.'
 
-class ViteDevServerStoppedError extends Error {
+export class ViteDevServerStoppedError extends Error {
   ViteDevServerStoppedError: boolean
 
   constructor() {


### PR DESCRIPTION
### Description

Improves error handling for Vite dev server errors by adding type checking to ensure the error object is properly validated before accessing its properties. This prevents potential runtime errors when checking for `ViteDevServerStoppedError`.

### What to review

- Error handling logic in `ErrorLogger.tsx` and `StudioErrorBoundary.tsx`
- Type checking implementation for the error object before accessing `ViteDevServerStoppedError` property
- Consistency of error handling between both files

### Testing

The changes have been tested by verifying error handling behavior when:
- Vite dev server stops unexpectedly
- Different types of errors are thrown
- Invalid error objects are passed

### Notes for release

Fixed an edge case where Vite dev server error handling could fail due to improper checking.