### PR TITLE
fix(sanity): use raw as default perspective

### DIFF
--- a/packages/sanity/src/core/hooks/useClient.ts
+++ b/packages/sanity/src/core/hooks/useClient.ts
@@ -26,9 +26,9 @@ export function useClient(clientOptions?: SourceClientOptions): SanityClient {
   const source = useSource()
   if (!clientOptions) {
     console.warn(
-      'Calling `useClient()` without specifying an API version is deprecated and will stop working in the next dev-preview release - please migrate to use `useClient({apiVersion: "2021-06-07"})`.',
+      'Calling `useClient()` without specifying an API version is deprecated and will stop working in the next major version - please specify a date, e.g. `useClient({apiVersion: "2025-02-10"})`.',
     )
-    return source.getClient({apiVersion: '2021-06-07'})
+    return source.getClient({apiVersion: 'v2025-02-07'})
   }
 
   return source.getClient(clientOptions)

--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -161,6 +161,7 @@ export function _createAuthStore({
         useCdn: false,
         ...(token && {token}),
         withCredentials: true,
+        perspective: 'raw',
         requestTagPrefix: 'sanity.studio',
         ignoreBrowserTokenWarning: true,
         allowReconfigure: false,

--- a/packages/sanity/src/presentation/useDocumentLocations.ts
+++ b/packages/sanity/src/presentation/useDocumentLocations.ts
@@ -54,7 +54,7 @@ function listen(id: string, fields: string[], store: DocumentStore) {
   }
   const params = {id, draftId: getDraftId(id)}
   return store.listenQuery(query, params, {
-    perspective: 'previewDrafts',
+    perspective: 'drafts',
   }) as Observable<SanityDocument | null>
 }
 

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -113,7 +113,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   } = useDocumentList({
     apiVersion,
     filter,
-    perspective: perspectiveStack,
+    perspective: perspectiveStack.length === 0 ? 'raw' : perspectiveStack,
     params,
     searchQuery: searchQuery?.trim(),
     sortOrder,

--- a/packages/sanity/src/structure/panes/documentList/__tests__/PaneContainer.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/PaneContainer.test.tsx
@@ -1,5 +1,5 @@
 import {act, render, screen, waitFor} from '@testing-library/react'
-import {defineConfig, useSearchState} from 'sanity'
+import {defineConfig, type PerspectiveContextValue, useSearchState} from 'sanity'
 import {type DocumentListPaneNode, type StructureToolContextValue} from 'sanity/structure'
 import {describe, expect, it, type Mock, vi} from 'vitest'
 
@@ -27,7 +27,15 @@ vi.mock('sanity', async (importOriginal) => ({
   ...(await importOriginal()),
   useSearchState: vi.fn(),
   useActiveReleases: vi.fn(() => ({})),
-  usePerspective: vi.fn(() => ({perspective: undefined})),
+  usePerspective: vi.fn(
+    (): PerspectiveContextValue => ({
+      perspectiveStack: [],
+      excludedPerspectives: [],
+      selectedPerspective: 'drafts',
+      selectedPerspectiveName: undefined,
+      selectedReleaseId: undefined,
+    }),
+  ),
 }))
 vi.mock('sanity/router', async (importOriginal) => ({
   ...(await importOriginal()),


### PR DESCRIPTION
(meta: wrong ticket id, should've been sapp-2049)

### Description
This explicitly uses `raw` as perspective unless overridden (e.g. by perspective stack)

This change should be safe, given that raw is currently the default on existing API versions.

### What to review
Does the change make sense? As of this PR, Studio should longer do `/query` requests without a perspective param.

### Testing
Everything should work as before

### Notes for release
n/a - not user facing