### PR TITLE
fix(core): update releases permissions for main release action

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -225,6 +225,8 @@ const releasesLocaleStrings = {
   /** Title o unschedule release dialog */
   'schedule-button.tooltip': 'Are you sure you want to unschedule the release?',
 
+  /** Schedule release button tooltip when user has no permissions to schedule */
+  'schedule-button-tooltip.validation.no-permission': 'You do not have permission to schedule',
   /** Schedule release button tooltip when validation is loading */
   'schedule-button-tooltip.validation.loading': 'Validating documents...',
   /** Schedule release button tooltip when there are validation errors */

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -194,6 +194,8 @@ const releasesLocaleStrings = {
   /** Description for the dialog confirming the publish of a release with multiple documents */
   'publish-dialog.confirm-publish-description_other':
     "The '<strong>{{title}}</strong>' release and its {{releaseDocumentsLength}} documents will be published.",
+  /** Label for the button when the user doesn't have permissions to publish a release */
+  'publish-dialog.validation.no-permission': 'You do not have permission to publish',
   /** Label for when documents are being validated */
   'publish-dialog.validation.loading': 'Validating documents...',
   /** Label for when documents in release have validation errors */

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -185,6 +185,11 @@ const releasesLocaleStrings = {
   /** Title for the release tool */
   'overview.title': 'Releases',
 
+  /** Text for when a user doesn't have publish or schedule releases */
+  'permission-missing-title': 'Limited access',
+  /** Description for when a user doesn't have publish or schedule releases */
+  'permission-missing-description':
+    'This release is not yet published. Only users with access to this release can view it.',
   /** Title for the dialog confirming the publish of a release */
   'publish-dialog.confirm-publish.title':
     'Are you sure you want to publish the release and all document versions?',

--- a/packages/sanity/src/core/releases/store/__tests__/__mocks/useReleaseOperations.mock.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/__mocks/useReleaseOperations.mock.ts
@@ -16,6 +16,8 @@ export const useReleaseOperationsMockReturn: Mocked<ReleaseOperationsStore> = {
   deleteRelease: vi.fn(),
   revertRelease: vi.fn(),
   unpublishVersion: vi.fn(),
+  canPublish: vi.fn(),
+  canSchedule: vi.fn(),
 }
 
 export const mockUseReleaseOperations = useReleaseOperations as Mock<typeof useReleaseOperations>

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -35,6 +35,7 @@ export interface ReleaseOperationsStore {
   discardVersion: (releaseId: string, documentId: string) => Promise<void>
   unpublishVersion: (documentId: string) => Promise<void>
   canSchedule: (releaseId: string, publishAt: Date) => Promise<boolean>
+  canPublish: (releaseId: string, useUnstableAction?: boolean) => Promise<boolean>
 }
 
 const IS_CREATE_VERSION_ACTION_SUPPORTED = false
@@ -224,6 +225,30 @@ export function createReleaseOperationsStore(options: {
     }
   }
 
+  const canPublish = async (releaseId: string, useUnstableAction?: boolean) => {
+    try {
+      await requestAction(
+        client,
+        [
+          {
+            actionType: useUnstableAction
+              ? 'sanity.action.release.publish2'
+              : 'sanity.action.release.publish',
+            releaseId: getReleaseIdFromReleaseDocumentId(releaseId),
+          },
+        ],
+        {
+          dryRun: true,
+          skipCrossDatasetReferenceValidation: true,
+        },
+      )
+
+      return true
+    } catch (e) {
+      return false
+    }
+  }
+
   return {
     archive: handleArchiveRelease,
     unarchive: handleUnarchiveRelease,
@@ -238,6 +263,7 @@ export function createReleaseOperationsStore(options: {
     discardVersion: handleDiscardVersion,
     unpublishVersion: handleUnpublishVersion,
     canSchedule: canSchedule,
+    canPublish: canPublish,
   }
 }
 

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -2,7 +2,7 @@ import {ClockIcon, ErrorOutlineIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Card, Flex, Stack, Text, useToast} from '@sanity/ui'
 import {format, isBefore, isValid, parse, startOfMinute} from 'date-fns'
-import {useCallback, useMemo, useState} from 'react'
+import {useCallback, useEffect, useMemo, useState} from 'react'
 
 import {Button, Dialog} from '../../../../../ui-components'
 import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
@@ -30,7 +30,10 @@ export const ReleaseScheduleButton = ({
   documents,
 }: ReleaseScheduleButtonProps) => {
   const toast = useToast()
-  const {schedule} = useReleaseOperations()
+  const {schedule, canSchedule} = useReleaseOperations()
+
+  const [schedulePermission, setSchedulePermission] = useState<boolean>(false)
+
   const {t} = useTranslation(releasesLocaleNamespace)
   const telemetry = useTelemetry()
   const {utcToCurrentZoneDate, zoneDateToUtc} = useTimeZone()
@@ -48,7 +51,16 @@ export const ReleaseScheduleButton = ({
 
   const isValidatingDocuments = documents.some(({validation}) => validation.isValidating)
   const hasDocumentValidationErrors = documents.some(({validation}) => validation.hasError)
-  const isScheduleButtonDisabled = disabled || isValidatingDocuments
+  const isScheduleButtonDisabled = disabled || isValidatingDocuments || !schedulePermission
+
+  useEffect(() => {
+    canSchedule(
+      release._id,
+      release.metadata.intendedPublishAt
+        ? new Date(release.metadata.intendedPublishAt)
+        : new Date(),
+    ).then((response) => setSchedulePermission(response))
+  }, [canSchedule, release._id, release.metadata.intendedPublishAt])
 
   const isScheduledDateInPast = useCallback(() => {
     return isBefore(zoneDateToUtc(publishAt || new Date()), new Date())
@@ -224,6 +236,10 @@ export const ReleaseScheduleButton = ({
   }, [release.metadata.intendedPublishAt])
 
   const tooltipText = useMemo(() => {
+    if (!schedulePermission) {
+      return t('schedule-button-tooltip.validation.no-permission')
+    }
+
     if (isValidatingDocuments) {
       return t('schedule-button-tooltip.validation.loading')
     }
@@ -236,7 +252,7 @@ export const ReleaseScheduleButton = ({
       return t('schedule-button-tooltip.already-scheduled')
     }
     return null
-  }, [hasDocumentValidationErrors, isValidatingDocuments, release, t])
+  }, [hasDocumentValidationErrors, isValidatingDocuments, release, schedulePermission, t])
 
   // TODO: this is a duplicate of logic in ReleasePublishAllButton
   const scheduleTooltipContent = useMemo(() => {


### PR DESCRIPTION
### Description

- Add a permissions banner in the release permissions to warn a user
- Disable publish / schedule main button in the release

<img width="1011" alt="image" src="https://github.com/user-attachments/assets/9645658d-5f02-47de-bc32-e8726e61b0de" />
<img width="394" alt="image" src="https://github.com/user-attachments/assets/aa4e226c-dfd8-4d32-a212-ba72cd749884" />
<img width="394" alt="image" src="https://github.com/user-attachments/assets/2fd54932-9c7d-432f-bc49-8a7a214e1a36" />


### What to review

Does this make sense? Should we do this a different way?

### Testing

Have updated the tests
To manually test you should use a user that doesn't have permissions (viewer), the debug roles don't work consistently.

### Notes for release

Update permissions in the release details