### PR TITLE
test(playwright-ct): bump number of retries for playwright ct tests

### DIFF
--- a/packages/sanity/playwright-ct.config.ts
+++ b/packages/sanity/playwright-ct.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 6 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
### Description
Bumping number of retries component tests on CI from 2 to 6 to mitigate flake.

### What to review
Does it make sense?

### Testing
Yep :)

### Notes for release
n/a