### PR TITLE
feat(sanity): add Rendering Context Store

### DIFF
--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -9,6 +9,8 @@ import {createDocumentPreviewStore, type DocumentPreviewStore} from '../../previ
 import {useSource, useWorkspace} from '../../studio'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {createKeyValueStore, type KeyValueStore} from '../key-value'
+import {createRenderingContextStore} from '../renderingContext/createRenderingContextStore'
+import {type RenderingContextStore} from '../renderingContext/types'
 import {useCurrentUser} from '../user'
 import {
   type ConnectionStatusStore,
@@ -288,4 +290,25 @@ export function useKeyValueStore(): KeyValueStore {
 
     return keyValueStore
   }, [client, resourceCache, workspace])
+}
+
+/** @internal */
+export function useRenderingContextStore(): RenderingContextStore {
+  const resourceCache = useResourceCache()
+
+  return useMemo(() => {
+    const renderingContextStore =
+      resourceCache.get<RenderingContextStore>({
+        dependencies: [],
+        namespace: 'RenderingContextStore',
+      }) || createRenderingContextStore()
+
+    resourceCache.set({
+      dependencies: [],
+      namespace: 'RenderingContextStore',
+      value: renderingContextStore,
+    })
+
+    return renderingContextStore
+  }, [resourceCache])
 }

--- a/packages/sanity/src/core/store/renderingContext/coreUiRenderingContext.test.ts
+++ b/packages/sanity/src/core/store/renderingContext/coreUiRenderingContext.test.ts
@@ -1,0 +1,64 @@
+import {expect, it} from 'vitest'
+
+import {coreUiRenderingContext} from './coreUiRenderingContext'
+
+const coreUiProductionContext = {
+  mode: 'core-ui',
+  env: 'production',
+}
+
+const coreUiStagingContext = {
+  mode: 'core-ui',
+  env: 'staging',
+}
+
+const coreUiUnsupportedContext = {
+  mode: 'evil-mode',
+  env: 'production',
+}
+
+it('ignores the `_context` URL search parameter if the mode is not "core-ui"', () => {
+  expect(() => coreUiRenderingContext(urlSearch(coreUiUnsupportedContext))).toMatchEmissions([
+    [undefined, undefined],
+  ])
+})
+
+it('parses the `_context` URL search parameter', () => {
+  expect(() => coreUiRenderingContext(urlSearch(coreUiProductionContext))).toMatchEmissions([
+    [
+      undefined,
+      {
+        name: 'coreUi',
+        metadata: {
+          environment: 'production',
+        },
+      },
+    ],
+  ])
+
+  expect(() => coreUiRenderingContext(urlSearch(coreUiStagingContext))).toMatchEmissions([
+    [
+      undefined,
+      {
+        name: 'coreUi',
+        metadata: {
+          environment: 'staging',
+        },
+      },
+    ],
+  ])
+})
+
+it('fails gracefully if the `_context` URL search parameter cannot be parsed', () => {
+  const invalidCoreUiContextString = urlSearch(coreUiProductionContext).slice(0, -10)
+
+  expect(() => coreUiRenderingContext(invalidCoreUiContextString)).toMatchEmissions([
+    [undefined, undefined],
+  ])
+})
+
+function urlSearch(context: unknown): string {
+  return new URLSearchParams({
+    _context: JSON.stringify(context),
+  }).toString()
+}

--- a/packages/sanity/src/core/store/renderingContext/coreUiRenderingContext.ts
+++ b/packages/sanity/src/core/store/renderingContext/coreUiRenderingContext.ts
@@ -1,0 +1,66 @@
+import {
+  catchError,
+  distinctUntilChanged,
+  map,
+  of,
+  type OperatorFunction,
+  pipe,
+  switchMap,
+} from 'rxjs'
+
+import {isCoreUiRenderingContext, type StudioRenderingContext} from './types'
+
+// Core UI Rendering Context is provided via the URL query string, and remains static the entire
+// duration Studio is rendered inside the Core UI iframe.
+//
+// However, the URL query string is liable to be lost during Studio's lifecycle (for example, when
+// the user navigates to a different tool). Therefore, the URL query string is captured as soon as
+// this code is evaluated, and later referenced when a consumer subscribes to the store.
+const INITIAL_URL_SEARCH = typeof location === 'object' ? location.search : ''
+
+const CORE_UI_MODE_NAME = 'core-ui'
+const CORE_UI_CONTEXT_SEARCH_PARAM = '_context'
+
+/**
+ * @internal
+ */
+export function coreUiRenderingContext(
+  urlSearch: string = INITIAL_URL_SEARCH,
+): OperatorFunction<StudioRenderingContext | undefined, StudioRenderingContext | undefined> {
+  return pipe(
+    switchMap((renderingContext) => {
+      if (renderingContext) {
+        return of(renderingContext)
+      }
+
+      return of(urlSearch).pipe(
+        distinctUntilChanged(),
+        map((search) => new URLSearchParams(search).get(CORE_UI_CONTEXT_SEARCH_PARAM)),
+        map((serializedContext) => {
+          if (serializedContext === null) {
+            return undefined
+          }
+
+          const {mode, env} = JSON.parse(serializedContext)
+
+          const coreUirenderingContext = {
+            name: mode === CORE_UI_MODE_NAME ? 'coreUi' : undefined,
+            metadata: {
+              environment: env,
+            },
+          }
+
+          if (isCoreUiRenderingContext(coreUirenderingContext)) {
+            return coreUirenderingContext
+          }
+
+          return undefined
+        }),
+        catchError((error) => {
+          console.warn('Error parsing rendering context:', error)
+          return of(undefined)
+        }),
+      )
+    }),
+  )
+}

--- a/packages/sanity/src/core/store/renderingContext/createRenderingContextStore.test.ts
+++ b/packages/sanity/src/core/store/renderingContext/createRenderingContextStore.test.ts
@@ -1,0 +1,22 @@
+import {firstValueFrom} from 'rxjs'
+import {describe, expect, it} from 'vitest'
+
+import {createRenderingContextStore} from './createRenderingContextStore'
+
+describe('renderingContext', () => {
+  it('emits rendering context', async () => {
+    const {renderingContext} = createRenderingContextStore()
+
+    expect(await firstValueFrom(renderingContext)).toEqual({
+      name: 'default',
+      metadata: {},
+    })
+  })
+})
+
+describe('capabilities', () => {
+  it('emits capabilities', async () => {
+    const {capabilities} = createRenderingContextStore()
+    expect(await firstValueFrom(capabilities)).toEqual({})
+  })
+})

--- a/packages/sanity/src/core/store/renderingContext/createRenderingContextStore.ts
+++ b/packages/sanity/src/core/store/renderingContext/createRenderingContextStore.ts
@@ -1,0 +1,30 @@
+import {of, shareReplay} from 'rxjs'
+
+import {coreUiRenderingContext} from './coreUiRenderingContext'
+import {defaultRenderingContext} from './defaultRenderingContext'
+import {listCapabilities} from './listCapabilities'
+import {type RenderingContextStore} from './types'
+
+/**
+ * Rendering Context Store provides information about where Studio is being rendered, and which
+ * capabilities are provided by the rendering context.
+ *
+ * This can be used to adapt parts of the Studio UI that are provided by the rendering context,
+ * such as the global user menu.
+ *
+ * @internal
+ */
+export function createRenderingContextStore(): RenderingContextStore {
+  const renderingContext = of(undefined).pipe(
+    coreUiRenderingContext(),
+    defaultRenderingContext(),
+    shareReplay(1),
+  )
+
+  const capabilities = renderingContext.pipe(listCapabilities(), shareReplay(1))
+
+  return {
+    renderingContext,
+    capabilities,
+  }
+}

--- a/packages/sanity/src/core/store/renderingContext/defaultRenderingContext.test.ts
+++ b/packages/sanity/src/core/store/renderingContext/defaultRenderingContext.test.ts
@@ -1,0 +1,34 @@
+import {expect, it} from 'vitest'
+
+import {defaultRenderingContext} from './defaultRenderingContext'
+
+it("emits the subject if it's not `undefined`", () => {
+  expect(defaultRenderingContext).toMatchEmissions([
+    [
+      {
+        name: 'coreUi',
+        metadata: {
+          environment: 'production',
+        },
+      },
+      {
+        name: 'coreUi',
+        metadata: {
+          environment: 'production',
+        },
+      },
+    ],
+  ])
+})
+
+it('emits the the default context if the subject is `undefined`', () => {
+  expect(defaultRenderingContext).toMatchEmissions([
+    [
+      undefined,
+      {
+        name: 'default',
+        metadata: {},
+      },
+    ],
+  ])
+})

--- a/packages/sanity/src/core/store/renderingContext/defaultRenderingContext.ts
+++ b/packages/sanity/src/core/store/renderingContext/defaultRenderingContext.ts
@@ -1,0 +1,18 @@
+import {map, type OperatorFunction} from 'rxjs'
+
+import {type DefaultRenderingContext, type StudioRenderingContext} from './types'
+
+const DEFAULT_RENDERING_CONTEXT: DefaultRenderingContext = {
+  name: 'default',
+  metadata: {},
+}
+
+/**
+ * @internal
+ */
+export function defaultRenderingContext(): OperatorFunction<
+  StudioRenderingContext | undefined,
+  StudioRenderingContext
+> {
+  return map((renderingContext) => renderingContext ?? DEFAULT_RENDERING_CONTEXT)
+}

--- a/packages/sanity/src/core/store/renderingContext/listCapabilities.ts
+++ b/packages/sanity/src/core/store/renderingContext/listCapabilities.ts
@@ -1,0 +1,18 @@
+import {map, type OperatorFunction} from 'rxjs'
+
+import {type CapabilityRecord, type StudioRenderingContext} from './types'
+
+const capabilitiesByRenderingContext: Record<StudioRenderingContext['name'], CapabilityRecord> = {
+  coreUi: {
+    globalUserMenu: true,
+    globalWorkspaceControl: true,
+  },
+  default: {},
+}
+
+/**
+ * @internal
+ */
+export function listCapabilities(): OperatorFunction<StudioRenderingContext, CapabilityRecord> {
+  return map((renderingContext) => capabilitiesByRenderingContext[renderingContext.name])
+}

--- a/packages/sanity/src/core/store/renderingContext/types.ts
+++ b/packages/sanity/src/core/store/renderingContext/types.ts
@@ -1,0 +1,76 @@
+import {type Observable} from 'rxjs'
+
+/**
+ * @internal
+ */
+export type BaseStudioRenderingContext<
+  Name extends string = string,
+  Metadata = Record<PropertyKey, never>,
+> = {
+  name: Name
+  metadata: Metadata
+}
+
+/**
+ * @internal
+ */
+export type DefaultRenderingContext = BaseStudioRenderingContext<'default'>
+
+/**
+ * @internal
+ */
+export type CoreUiRenderingContext = BaseStudioRenderingContext<
+  'coreUi',
+  {
+    environment: string
+  }
+>
+
+/**
+ * @internal
+ */
+export type StudioRenderingContext = DefaultRenderingContext | CoreUiRenderingContext
+
+/**
+ * @internal
+ */
+export const capabilities = ['globalUserMenu', 'globalWorkspaceControl'] as const
+
+/**
+ * @internal
+ */
+export type Capability = (typeof capabilities)[number]
+
+/**
+ * @internal
+ */
+export type CapabilityRecord = Partial<Record<Capability, boolean>>
+
+/**
+ * @internal
+ */
+export type RenderingContextStore = {
+  renderingContext: Observable<StudioRenderingContext>
+  capabilities: Observable<CapabilityRecord>
+}
+
+/**
+ * Check whether the provided value satisfies the `CoreUiRenderingContext` type.
+ *
+ * @internal
+ */
+export function isCoreUiRenderingContext(
+  maybeCoreUiRenderingContext: unknown,
+): maybeCoreUiRenderingContext is CoreUiRenderingContext {
+  return (
+    typeof maybeCoreUiRenderingContext === 'object' &&
+    maybeCoreUiRenderingContext !== null &&
+    'name' in maybeCoreUiRenderingContext &&
+    maybeCoreUiRenderingContext.name === 'coreUi' &&
+    'metadata' in maybeCoreUiRenderingContext &&
+    typeof maybeCoreUiRenderingContext.metadata === 'object' &&
+    maybeCoreUiRenderingContext.metadata !== null &&
+    'environment' in maybeCoreUiRenderingContext.metadata &&
+    typeof maybeCoreUiRenderingContext.metadata.environment === 'string'
+  )
+}


### PR DESCRIPTION
### Description

This branch adds a data store to the global resource cache for keeping track of the _Studio Rendering Context_. This store reflects _where Studio is being rendered_, and which capabilities are provided by that context and therefore can be omitted from Studio UI.

#### Rendering contexts

There are currently two rendering contexts:

1. `coreUi` - when Studio is rendered inside the Core UI app.
2. `default` - when Studio is rendered anywhere else.

Each context can additionally provide metadata. For example, `coreUi` provides environment metadata (such as `"development"` or `"production"`).

#### Capabilities

This branch introduces two "capabilities". When these capabilities are provided by the parent context, they should be omitted from Studio UI:

1. `globalUserMenu` - the global user menu, typically represented by the user's avatar at the top-right of the UI.
2. `globalWorkspaceControl` - the workspace switcher, typically represented by the workspace name at the top-left of the UI.

### What to review

The mechanism for parsing and storing the rendering context.

### Testing

The added unit tests can be used to verify behaviour. If you'd like to see this change in action, checkout a downstream stack entry such as #8591.