### PR TITLE
feat(sanity): hide global user menu inside Core UI Rendering Context

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -16,6 +16,7 @@ import {type RouterState, useRouterState} from 'sanity/router'
 import {styled} from 'styled-components'
 
 import {Button, TooltipDelayGroupProvider} from '../../../../ui-components'
+import {CapabilityGate} from '../../../components/CapabilityGate'
 import {type NavbarProps} from '../../../config/studio/types'
 import {isDev} from '../../../environment'
 import {useTranslation} from '../../../i18n'
@@ -285,9 +286,11 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
                 {actionNodes}
 
                 {shouldRender.tools && (
-                  <Box flex="none" marginLeft={1}>
-                    <UserMenu />
-                  </Box>
+                  <CapabilityGate capability="globalUserMenu">
+                    <Box flex="none" marginLeft={1}>
+                      <UserMenu />
+                    </Box>
+                  </CapabilityGate>
                 )}
               </Flex>
             </TooltipDelayGroupProvider>

--- a/packages/sanity/src/core/studio/components/navbar/navDrawer/NavDrawer.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/navDrawer/NavDrawer.tsx
@@ -7,6 +7,7 @@ import {styled} from 'styled-components'
 
 import {Button} from '../../../../../ui-components'
 import {UserAvatar} from '../../../../components'
+import {CapabilityGate} from '../../../../components/CapabilityGate'
 import {type NavbarAction, type Tool} from '../../../../config'
 import {useTranslation} from '../../../../i18n'
 import {useColorSchemeSetValue} from '../../../colorScheme'
@@ -162,18 +163,20 @@ export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
                   <Flex align="center">
                     {/* Current user */}
                     <Flex flex={1} align="center" paddingRight={2}>
-                      <Flex flex={1} align="center">
-                        <UserAvatar size={1} user="me" />
-                        <Box
-                          flex={1}
-                          marginLeft={3}
-                          title={currentUser?.name || currentUser?.email}
-                        >
-                          <Text size={1} textOverflow="ellipsis" weight="medium">
-                            {currentUser?.name || currentUser?.email}
-                          </Text>
-                        </Box>
-                      </Flex>
+                      <CapabilityGate capability="globalUserMenu">
+                        <Flex flex={1} align="center">
+                          <UserAvatar size={1} user="me" />
+                          <Box
+                            flex={1}
+                            marginLeft={3}
+                            title={currentUser?.name || currentUser?.email}
+                          >
+                            <Text size={1} textOverflow="ellipsis" weight="medium">
+                              {currentUser?.name || currentUser?.email}
+                            </Text>
+                          </Box>
+                        </Flex>
+                      </CapabilityGate>
                     </Flex>
 
                     <Button


### PR DESCRIPTION
### Description

This branch removes the global user menu when Studio is rendered inside Core UI. Core UI provides the global user menu capability, so Studio doesn't need to.

#### Small viewport

<img width="627" alt="Screenshot 2025-03-06 at 12 40 31" src="https://github.com/user-attachments/assets/89d016b2-f4f4-4512-8c64-13b0c53b75d7" />

#### Large viewport

<img width="1671" alt="Screenshot 2025-03-06 at 12 40 40" src="https://github.com/user-attachments/assets/72b0ba7d-7b58-46a2-87be-06e2745df183" />

### What to review

The removal of the global user menu.

### Testing

This can be tested by running Studio locally and then accessing the local dev server using a Core UI preview deployment.