### PR TITLE
fix(sanity): don't show Live edit badge for versions

### DIFF
--- a/packages/sanity/src/structure/documentBadges/LiveEditBadge.ts
+++ b/packages/sanity/src/structure/documentBadges/LiveEditBadge.ts
@@ -2,9 +2,9 @@ import {type DocumentBadgeComponent} from 'sanity'
 
 /** @internal */
 export const LiveEditBadge: DocumentBadgeComponent = (props) => {
-  const {liveEditSchemaType} = props
+  const {liveEditSchemaType, version} = props
 
-  if (liveEditSchemaType) {
+  if (liveEditSchemaType && !version) {
     return {
       label: 'Live',
       color: 'danger',

--- a/packages/sanity/src/structure/documentBadges/LiveEditBadge.ts
+++ b/packages/sanity/src/structure/documentBadges/LiveEditBadge.ts
@@ -2,9 +2,9 @@ import {type DocumentBadgeComponent} from 'sanity'
 
 /** @internal */
 export const LiveEditBadge: DocumentBadgeComponent = (props) => {
-  const {liveEdit} = props
+  const {liveEditSchemaType} = props
 
-  if (liveEdit) {
+  if (liveEditSchemaType) {
     return {
       label: 'Live',
       color: 'danger',


### PR DESCRIPTION
### Description
Currently, when editing a version document, we'll show a "Live" badge. This fixes the issue by using the `liveEditSchemaType` instead, which reflects the schema config instead of the "mode" of the selected document

### What to review
- The "Live"-badge should not show in the footer when editing a version (even if the schema has liveEdit enabled)
- The "Live"-badge should show in the footer when editing a document where the schema has live edit enabled
 
### Testing


### Notes for release
n/a