### PR TITLE
fix(core): hide schedule publishing if not used and not enabled by users

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -176,6 +176,7 @@ const defaultWorkspace = defineConfig({
   scheduledPublishing: {
     enabled: true,
     inputDateTimeFormat: 'MM/dd/yy h:mm a',
+    showReleasesBanner: false,
   },
   tasks: {
     enabled: true,

--- a/packages/sanity/src/core/config/resolveDefaultPlugins.ts
+++ b/packages/sanity/src/core/config/resolveDefaultPlugins.ts
@@ -44,6 +44,9 @@ export function getDefaultPluginsOptions(
     scheduledPublishing: {
       ...DEFAULT_SCHEDULED_PUBLISH_PLUGIN_OPTIONS,
       ...workspace.scheduledPublishing,
+      // If the user has explicitly enabled scheduled publishing, we should respect that
+      // eslint-disable-next-line camelcase
+      __internal__workspaceEnabled: workspace.scheduledPublishing?.enabled ?? false,
     },
     releases: {
       ...workspace.releases,

--- a/packages/sanity/src/core/scheduledPublishing/components/infoCallout/InfoCallout.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/components/infoCallout/InfoCallout.tsx
@@ -1,0 +1,29 @@
+import {InfoOutlineIcon} from '@sanity/icons'
+import {Card, Flex, Inline, Text} from '@sanity/ui'
+
+interface Props {
+  description?: string | React.ReactNode
+  title: string | React.ReactNode
+}
+
+const InfoCallout = (props: Props) => {
+  const {description, title} = props
+
+  return (
+    <Card overflow="hidden" padding={4} radius={2} shadow={1} tone="suggest">
+      <Flex align="center" gap={4}>
+        <Text size={2}>
+          <InfoOutlineIcon />
+        </Text>
+        <Inline space={3}>
+          <Text size={1} weight="semibold">
+            {title}
+          </Text>
+          {description && <Text size={1}>{description}</Text>}
+        </Inline>
+      </Flex>
+    </Card>
+  )
+}
+
+export default InfoCallout

--- a/packages/sanity/src/core/scheduledPublishing/components/infoCallout/InfoCallout.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/components/infoCallout/InfoCallout.tsx
@@ -1,14 +1,11 @@
 import {InfoOutlineIcon} from '@sanity/icons'
-import {Card, Flex, Inline, Text} from '@sanity/ui'
+import {Card, Flex, Inline, Stack, Text} from '@sanity/ui'
 
-interface Props {
-  description?: string | React.ReactNode
-  title: string | React.ReactNode
-}
+import {RELEASES_DOCS_URL} from '../../constants'
 
-const InfoCallout = (props: Props) => {
-  const {description, title} = props
+// TODO: TBC with design and growth
 
+const InfoCallout = () => {
   return (
     <Card overflow="hidden" padding={4} radius={2} shadow={1} tone="suggest">
       <Flex align="center" gap={4}>
@@ -17,9 +14,31 @@ const InfoCallout = (props: Props) => {
         </Text>
         <Inline space={3}>
           <Text size={1} weight="semibold">
-            {title}
+            Schedule Publishing is not enabled
           </Text>
-          {description && <Text size={1}>{description}</Text>}
+          <Stack space={3} marginTop={2}>
+            <Text size={1}>
+              We recommend using{' '}
+              <a target="_blank" href={RELEASES_DOCS_URL} rel="noreferrer">
+                Releases
+              </a>
+              .
+            </Text>
+
+            <Text size={1}>
+              Scheduled Publishing is not enabled by default. It can be enabled in the config by
+              setting <code>scheduledPublishing.enabled = true</code>
+            </Text>
+            <Text size={1}>
+              <a
+                target="_blank"
+                href={'https://www.sanity.io/docs/scheduled-publishing'}
+                rel="noreferrer"
+              >
+                Read the docs
+              </a>
+            </Text>
+          </Stack>
         </Inline>
       </Flex>
     </Card>

--- a/packages/sanity/src/core/scheduledPublishing/components/warningBanner/WarningBanner.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/components/warningBanner/WarningBanner.tsx
@@ -1,0 +1,53 @@
+import {ArrowRightIcon, WarningOutlineIcon} from '@sanity/icons'
+import {Card, Flex, rem, Text, useMediaIndex} from '@sanity/ui'
+// eslint-disable-next-line camelcase
+import {getTheme_v2} from '@sanity/ui/theme'
+import {css, styled} from 'styled-components'
+
+import {RELEASES_DOCS_URL} from '../../constants'
+
+/**
+ * Updates the size of the icon to be used inside a Text size=1 to a Text size=0, without having to add a new
+ * Text element, allowing to sit inline in the same anchor element.
+ */
+const SmallIcon = styled(ArrowRightIcon)((props) => {
+  const {font} = getTheme_v2(props.theme)
+  const {ascenderHeight, descenderHeight, lineHeight, iconSize} = font.text.sizes[0]
+  const negHeight = ascenderHeight + descenderHeight
+  const capHeight = lineHeight - negHeight
+  const iconOffset = (capHeight - iconSize) / 2
+
+  return css`
+    &[data-sanity-icon] {
+      color: var(--card-link-color);
+      font-size: calc(${iconSize} / 16 * 1rem);
+      margin: ${rem(iconOffset)};
+      margin-bottom: ${rem(iconOffset)};
+    }
+  `
+})
+
+export function WarningBanner() {
+  const mediaIndex = useMediaIndex()
+  const showWarningIcon = mediaIndex >= 2
+
+  return (
+    <Card padding={4} tone="caution" width="fill">
+      <Flex gap={3} align="center" justify="center">
+        <Text hidden={!showWarningIcon}>
+          <WarningOutlineIcon />
+        </Text>
+
+        <Text size={1} weight="medium">
+          You are running both the new Releases and Scheduled Publishing
+        </Text>
+        <Text size={1} style={{whiteSpace: 'nowrap'}}>
+          <a href={RELEASES_DOCS_URL} target="_blank" rel="noreferrer">
+            Read more {` `}
+            <SmallIcon />
+          </a>
+        </Text>
+      </Flex>
+    </Card>
+  )
+}

--- a/packages/sanity/src/core/scheduledPublishing/constants.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/constants.tsx
@@ -81,13 +81,14 @@ export const DATE_FORMAT = {
   LARGE: `iiii',' d MMMM yyyy',' p`,
 }
 
-export const DEFAULT_SCHEDULED_PUBLISH_PLUGIN_OPTIONS: Required<ScheduledPublishingPluginOptions> =
-  {
-    enabled: true,
-    // 25/12/2022 22:00
-    inputDateTimeFormat: 'dd/MM/yyyy HH:mm',
-  }
+export const DEFAULT_SCHEDULED_PUBLISH_PLUGIN_OPTIONS: Required<
+  Omit<ScheduledPublishingPluginOptions, '__internal__workspaceEnabled'>
+> = {
+  enabled: true,
+  // 25/12/2022 22:00
+  inputDateTimeFormat: 'dd/MM/yyyy HH:mm',
+}
 
-export const TOOL_NAME = 'schedules'
+export const SCHEDULED_PUBLISHING_TOOL_NAME = 'schedules'
 
 export const TOOL_TITLE = 'Schedules'

--- a/packages/sanity/src/core/scheduledPublishing/constants.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/constants.tsx
@@ -87,8 +87,12 @@ export const DEFAULT_SCHEDULED_PUBLISH_PLUGIN_OPTIONS: Required<
   enabled: true,
   // 25/12/2022 22:00
   inputDateTimeFormat: 'dd/MM/yyyy HH:mm',
+  showReleasesBanner: true,
 }
 
 export const SCHEDULED_PUBLISHING_TOOL_NAME = 'schedules'
 
 export const TOOL_TITLE = 'Schedules'
+
+// TODO: Update once the docs are live
+export const RELEASES_DOCS_URL = 'https://www.sanity.io/docs/content-releases'

--- a/packages/sanity/src/core/scheduledPublishing/hooks/usePollSchedules.ts
+++ b/packages/sanity/src/core/scheduledPublishing/hooks/usePollSchedules.ts
@@ -50,7 +50,7 @@ function usePollSchedules({documentId, state}: {documentId?: string; state?: Sch
   isInitialLoading: boolean
   schedules: Schedule[]
 } {
-  const {mode} = useScheduledPublishingEnabled()
+  const {mode, enabled} = useScheduledPublishingEnabled()
 
   const swrOptions = useMemo(() => {
     const SWR_OPTIONS = {
@@ -73,7 +73,8 @@ function usePollSchedules({documentId, state}: {documentId?: string; state?: Sch
 
   const fetcher = useFetcher(queryKey)
 
-  const {data, error, mutate} = useSWR(queryKey, fetcher, swrOptions)
+  // Disables SWR if scheduled publishing is not enabled by not providing a key
+  const {data, error, mutate} = useSWR(enabled ? queryKey : null, fetcher, swrOptions)
 
   // Immediately remove schedule from SWR cache and revalidate
   const handleDelete = useCallback(

--- a/packages/sanity/src/core/scheduledPublishing/plugin/index.ts
+++ b/packages/sanity/src/core/scheduledPublishing/plugin/index.ts
@@ -2,7 +2,7 @@ import {CalendarIcon} from '@sanity/icons'
 import {route} from 'sanity/router'
 
 import {definePlugin} from '../../config'
-import {TOOL_NAME, TOOL_TITLE} from '../constants'
+import {SCHEDULED_PUBLISHING_TOOL_NAME, TOOL_TITLE} from '../constants'
 import Tool from '../tool/Tool'
 import resolveDocumentActions from './documentActions/schedule'
 import resolveDocumentBadges from './documentBadges/scheduled'
@@ -45,7 +45,7 @@ export const scheduledPublishing = definePlugin({
     return [
       ...prev,
       {
-        name: TOOL_NAME,
+        name: SCHEDULED_PUBLISHING_TOOL_NAME,
         title: TOOL_TITLE,
         icon: CalendarIcon,
         component: Tool,

--- a/packages/sanity/src/core/scheduledPublishing/tool/Tool.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/Tool.tsx
@@ -97,28 +97,7 @@ export default function Tool() {
     return (
       <Container width={1} paddingTop={4}>
         <Box paddingTop={4} paddingX={4}>
-          {hasUsedScheduledPublishing.loading ? (
-            <LoadingBlock />
-          ) : (
-            <InfoCallout
-              // TODO: TBC with design and growth
-              description={
-                <>
-                  Scheduled Publishing is not enabled. It can be enabled in the config. We recommend
-                  using{' '}
-                  <a
-                    target="_blank"
-                    href="https://www.sanity.io/content-releases?ref=release"
-                    rel="noreferrer"
-                  >
-                    "Releases"
-                  </a>
-                  .
-                </>
-              }
-              title="Scheduled Publishing is not enabled"
-            />
-          )}
+          {hasUsedScheduledPublishing.loading ? <LoadingBlock /> : <InfoCallout />}
         </Box>
       </Container>
     )

--- a/packages/sanity/src/core/scheduledPublishing/tool/Tool.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/Tool.tsx
@@ -10,6 +10,7 @@ import ErrorCallout from '../components/errorCallout/ErrorCallout'
 import InfoCallout from '../components/infoCallout/InfoCallout'
 import ButtonTimeZone from '../components/timeZoneButton/TimeZoneButton'
 import ButtonTimeZoneElementQuery from '../components/timeZoneButton/TimeZoneButtonElementQuery'
+import {WarningBanner} from '../components/warningBanner/WarningBanner'
 import {SCHEDULE_FILTERS, TOOL_HEADER_HEIGHT} from '../constants'
 import usePollSchedules from '../hooks/usePollSchedules'
 import useTimeZone from '../hooks/useTimeZone'
@@ -33,7 +34,8 @@ const DATE_SLUG_FORMAT = 'yyyy-MM-dd' // date-fns format
 
 export default function Tool() {
   const router = useRouter()
-  const {scheduledPublishing} = useWorkspace()
+  const {scheduledPublishing, releases} = useWorkspace()
+  const isReleasesEnabled = Boolean(releases?.enabled)
 
   const {sanity: theme} = useTheme()
   const {error, isInitialLoading, schedules = NO_SCHEDULE} = usePollSchedules()
@@ -105,6 +107,7 @@ export default function Tool() {
 
   return (
     <SchedulesProvider value={schedulesContext}>
+      {isReleasesEnabled && scheduledPublishing.showReleasesBanner && <WarningBanner />}
       <Flex direction="column" height="fill" flex={1} overflow="hidden">
         <Flex flex={1} height="fill">
           {/* LHS Column */}

--- a/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.test.tsx
@@ -1,8 +1,11 @@
 import {renderHook} from '@testing-library/react'
+import {of} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {useFeatureEnabled} from '../../../hooks'
+import {useClient} from '../../../hooks/useClient'
 import {useWorkspace} from '../../../studio/workspace'
+import {type Schedule} from '../../types'
 import {
   ScheduledPublishingEnabledProvider,
   useScheduledPublishingEnabled,
@@ -16,28 +19,57 @@ vi.mock('../../../studio/workspace', () => ({
   useWorkspace: vi.fn().mockReturnValue({}),
 }))
 
+vi.mock('../../../hooks/useClient')
+
+const useClientMock = useClient as ReturnType<typeof vi.fn>
+const mockObservableRequest = vi.fn((schedules) => of({schedules}))
+const scheduleResponse: Schedule[] = [
+  {
+    id: 'sch-2scsu4bVs6S66HXyCb8LYqpsrA9',
+    name: '2025-02-14T14:40:00.000Z',
+    description: '',
+    projectId: 'ppsg7ml5',
+    dataset: 'test',
+    author: 'pzAhBTkNX',
+    action: 'publish',
+    state: 'scheduled',
+    stateReason: 'created by user',
+    documents: [{documentId: '195138c7-4e0e-4914-a9b0-c8b1ede66236', documentType: 'book'}],
+    createdAt: '2025-02-05T14:40:16.423391Z',
+    executeAt: '2025-02-24T14:40:00Z',
+  },
+]
+
+const mockClient = (schedules: Schedule[]) => {
+  useClientMock.mockReturnValue({
+    config: () => ({dataset: 'dataset', projectId: 'projectId'}),
+    observable: {
+      request: () => mockObservableRequest(schedules),
+    },
+  })
+}
 const useFeatureEnabledMock = useFeatureEnabled as ReturnType<typeof vi.fn>
 const useWorkspaceMock = useWorkspace as ReturnType<typeof vi.fn>
 
-describe('ScheduledPublishingEnabledProvider', () => {
+describe('ScheduledPublishingEnabledProvider - previously used', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockClient(scheduleResponse)
   })
 
   it('should not show scheduled publishing if user opt out and the feature is not enabled (any plan)', async () => {
-    useFeatureEnabledMock.mockReturnValue({
-      enabled: false,
-      isLoading: false,
-    })
-    useWorkspaceMock.mockReturnValue({
-      scheduledPublishing: {enabled: false},
-    })
+    useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: false})
+    useWorkspaceMock.mockReturnValue({scheduledPublishing: {enabled: false}})
 
     const value = renderHook(useScheduledPublishingEnabled, {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({enabled: false, mode: null})
+    expect(value.result.current).toEqual({
+      enabled: false,
+      mode: null,
+      hasUsedScheduledPublishing: {used: true, loading: false},
+    })
   })
   it('should not show scheduled publishing  if user opt out and the feature is enabled (any plan)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: true, isLoading: false})
@@ -47,7 +79,11 @@ describe('ScheduledPublishingEnabledProvider', () => {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({enabled: false, mode: null})
+    expect(value.result.current).toEqual({
+      enabled: false,
+      mode: null,
+      hasUsedScheduledPublishing: {used: true, loading: false},
+    })
   })
 
   it('should show default mode if user hasnt opted out and the feature is enabled (growth or above)', () => {
@@ -58,7 +94,11 @@ describe('ScheduledPublishingEnabledProvider', () => {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({enabled: true, mode: 'default'})
+    expect(value.result.current).toEqual({
+      enabled: true,
+      mode: 'default',
+      hasUsedScheduledPublishing: {used: true, loading: false},
+    })
   })
 
   it('should show upsell mode if user has not opt out and the feature is not enabled (free plans)', () => {
@@ -69,7 +109,11 @@ describe('ScheduledPublishingEnabledProvider', () => {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({enabled: true, mode: 'upsell'})
+    expect(value.result.current).toEqual({
+      enabled: true,
+      mode: 'upsell',
+      hasUsedScheduledPublishing: {used: true, loading: false},
+    })
   })
 
   it('should not show tasks if it is loading the feature', () => {
@@ -80,7 +124,11 @@ describe('ScheduledPublishingEnabledProvider', () => {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({enabled: false, mode: null})
+    expect(value.result.current).toEqual({
+      enabled: false,
+      mode: null,
+      hasUsedScheduledPublishing: {used: true, loading: false},
+    })
   })
 
   it('should not show the plugin if useFeatureEnabled has an error', () => {
@@ -95,7 +143,11 @@ describe('ScheduledPublishingEnabledProvider', () => {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({enabled: false, mode: null})
+    expect(value.result.current).toEqual({
+      enabled: false,
+      mode: null,
+      hasUsedScheduledPublishing: {used: true, loading: false},
+    })
   })
 
   it('should call "useFeatureEnabled" with "scheduledPublishing"', () => {
@@ -107,5 +159,86 @@ describe('ScheduledPublishingEnabledProvider', () => {
     })
 
     expect(useFeatureEnabled).toHaveBeenCalledWith('scheduledPublishing')
+  })
+})
+
+describe('ScheduledPublishingEnabledProvider - not previously used', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockClient([])
+  })
+
+  it('should not show scheduled publishing  if user opt out and the feature is enabled (any plan)', () => {
+    useFeatureEnabledMock.mockReturnValue({enabled: true, isLoading: false})
+    useWorkspaceMock.mockReturnValue({
+      scheduledPublishing: {
+        enabled: false,
+        // eslint-disable-next-line camelcase
+        scheduledPublishing: {enabled: true, __internal__workspaceEnabled: false},
+      },
+    })
+
+    const value = renderHook(useScheduledPublishingEnabled, {
+      wrapper: ScheduledPublishingEnabledProvider,
+    })
+
+    expect(value.result.current).toEqual({
+      enabled: false,
+      mode: null,
+      hasUsedScheduledPublishing: {used: false, loading: false},
+    })
+  })
+
+  it('should not show if they have not used it before and have not opted in', () => {
+    useFeatureEnabledMock.mockReturnValue({enabled: true, isLoading: false})
+    useWorkspaceMock.mockReturnValue({
+      // eslint-disable-next-line camelcase
+      scheduledPublishing: {enabled: true, __internal__workspaceEnabled: false},
+    })
+
+    const value = renderHook(useScheduledPublishingEnabled, {
+      wrapper: ScheduledPublishingEnabledProvider,
+    })
+
+    expect(value.result.current).toEqual({
+      enabled: false,
+      mode: null,
+      hasUsedScheduledPublishing: {used: false, loading: false},
+    })
+  })
+
+  it('should  show default mode if they have not used it before and opted in', () => {
+    useFeatureEnabledMock.mockReturnValue({enabled: true, isLoading: false})
+    useWorkspaceMock.mockReturnValue({
+      // eslint-disable-next-line camelcase
+      scheduledPublishing: {enabled: true, __internal__workspaceEnabled: true},
+    })
+
+    const value = renderHook(useScheduledPublishingEnabled, {
+      wrapper: ScheduledPublishingEnabledProvider,
+    })
+
+    expect(value.result.current).toEqual({
+      enabled: true,
+      mode: 'default',
+      hasUsedScheduledPublishing: {used: false, loading: false},
+    })
+  })
+  it('should  show upsell mode if they have not used it before and opted in, and feature is not available (free plans)', () => {
+    useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: false})
+    useWorkspaceMock.mockReturnValue({
+      // eslint-disable-next-line camelcase
+      scheduledPublishing: {enabled: true, __internal__workspaceEnabled: true},
+    })
+
+    const value = renderHook(useScheduledPublishingEnabled, {
+      wrapper: ScheduledPublishingEnabledProvider,
+    })
+
+    expect(value.result.current).toEqual({
+      enabled: true,
+      mode: 'upsell',
+      hasUsedScheduledPublishing: {used: false, loading: false},
+    })
   })
 })

--- a/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx
@@ -7,12 +7,13 @@ import {useClient} from '../../../hooks/useClient'
 import {useFeatureEnabled} from '../../../hooks/useFeatureEnabled'
 import {useWorkspace} from '../../../studio/workspace'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
+import {type Schedule} from '../../types'
 
 interface HasUsedScheduledPublishing {
-  enabled: boolean
+  used: boolean
   loading: boolean
 }
-const HAS_USED_SCHEDULED_PUBLISHING: HasUsedScheduledPublishing = {enabled: false, loading: true}
+const HAS_USED_SCHEDULED_PUBLISHING: HasUsedScheduledPublishing = {used: false, loading: true}
 
 /**
  * @internal
@@ -51,15 +52,15 @@ export function ScheduledPublishingEnabledProvider({
   const hasUsedScheduledPublishing$: Observable<HasUsedScheduledPublishing> = useMemo(() => {
     const {dataset, projectId} = client.config()
     return client.observable
-      .request({
+      .request<{schedules: Schedule[]}>({
         uri: `/schedules/${projectId}/${dataset}?limit=1`,
         tag: 'scheduled-publishing-used',
       })
       .pipe(
         map((res) => {
-          return {enabled: res.schedules?.length > 0, loading: false}
+          return {used: res.schedules?.length > 0, loading: false}
         }),
-        catchError(() => of({enabled: false, loading: false})),
+        catchError(() => of({used: false, loading: false})),
       )
   }, [client])
 
@@ -83,7 +84,7 @@ export function ScheduledPublishingEnabledProvider({
         hasUsedScheduledPublishing,
       }
     }
-    if (!hasUsedScheduledPublishing.enabled) {
+    if (!hasUsedScheduledPublishing.used) {
       return {
         enabled: false,
         mode: null,

--- a/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx
@@ -1,8 +1,18 @@
 import {useContext, useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {catchError, map, type Observable, of} from 'rxjs'
 import {ScheduledPublishingEnabledContext} from 'sanity/_singletons'
 
+import {useClient} from '../../../hooks/useClient'
 import {useFeatureEnabled} from '../../../hooks/useFeatureEnabled'
 import {useWorkspace} from '../../../studio/workspace'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
+
+interface HasUsedScheduledPublishing {
+  enabled: boolean
+  loading: boolean
+}
+const HAS_USED_SCHEDULED_PUBLISHING: HasUsedScheduledPublishing = {enabled: false, loading: true}
 
 /**
  * @internal
@@ -11,13 +21,15 @@ export type ScheduledPublishingEnabledContextValue =
   | {
       enabled: false
       mode: null
+      hasUsedScheduledPublishing: HasUsedScheduledPublishing
     }
   | {
       enabled: true
       mode: 'default' | 'upsell'
+      hasUsedScheduledPublishing: HasUsedScheduledPublishing
     }
 
-interface TaksEnabledProviderProps {
+interface ScheduledPublishingEnabledProviderProps {
   children: React.ReactNode
 }
 
@@ -25,24 +37,65 @@ interface TaksEnabledProviderProps {
  * @internal
  */
 
-export function ScheduledPublishingEnabledProvider({children}: TaksEnabledProviderProps) {
+export function ScheduledPublishingEnabledProvider({
+  children,
+}: ScheduledPublishingEnabledProviderProps) {
+  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+
   const {enabled, isLoading, error} = useFeatureEnabled('scheduledPublishing')
   const {scheduledPublishing} = useWorkspace()
 
   const isWorkspaceEnabled = scheduledPublishing.enabled
+  const explicitEnabled = scheduledPublishing.__internal__workspaceEnabled
+
+  const hasUsedScheduledPublishing$: Observable<HasUsedScheduledPublishing> = useMemo(() => {
+    const {dataset, projectId} = client.config()
+    return client.observable
+      .request({
+        uri: `/schedules/${projectId}/${dataset}?limit=1`,
+        tag: 'scheduled-publishing-used',
+      })
+      .pipe(
+        map((res) => {
+          return {enabled: res.schedules?.length > 0, loading: false}
+        }),
+        catchError(() => of({enabled: false, loading: false})),
+      )
+  }, [client])
+
+  const hasUsedScheduledPublishing = useObservable(
+    hasUsedScheduledPublishing$,
+    HAS_USED_SCHEDULED_PUBLISHING,
+  )
 
   const value: ScheduledPublishingEnabledContextValue = useMemo(() => {
     if (!isWorkspaceEnabled || isLoading || error) {
       return {
         enabled: false,
         mode: null,
+        hasUsedScheduledPublishing,
+      }
+    }
+    if (explicitEnabled) {
+      return {
+        enabled: true,
+        mode: enabled ? 'default' : 'upsell',
+        hasUsedScheduledPublishing,
+      }
+    }
+    if (!hasUsedScheduledPublishing.enabled) {
+      return {
+        enabled: false,
+        mode: null,
+        hasUsedScheduledPublishing,
       }
     }
     return {
       enabled: true,
       mode: enabled ? 'default' : 'upsell',
+      hasUsedScheduledPublishing,
     }
-  }, [enabled, isLoading, isWorkspaceEnabled, error])
+  }, [enabled, isLoading, isWorkspaceEnabled, error, hasUsedScheduledPublishing, explicitEnabled])
 
   return (
     <ScheduledPublishingEnabledContext.Provider value={value}>

--- a/packages/sanity/src/core/scheduledPublishing/types.ts
+++ b/packages/sanity/src/core/scheduledPublishing/types.ts
@@ -23,6 +23,13 @@ export interface ScheduledPublishingPluginOptions {
    * @defaultValue 'dd/MM/yyyy HH:mm' make sure to specify minutes and hours if you are specifying a custom format
    */
   inputDateTimeFormat?: string
+
+  /**
+   * @hidden
+   * Whether scheduled publishing is enabled by the workspace.
+   * Sanity is enabling it by default in the config, {@link "../scheduledPublishing/constants.ts"}
+   */
+  __internal__workspaceEnabled?: boolean
 }
 
 export interface Schedule {

--- a/packages/sanity/src/core/scheduledPublishing/types.ts
+++ b/packages/sanity/src/core/scheduledPublishing/types.ts
@@ -30,6 +30,11 @@ export interface ScheduledPublishingPluginOptions {
    * Sanity is enabling it by default in the config, {@link "../scheduledPublishing/constants.ts"}
    */
   __internal__workspaceEnabled?: boolean
+  /**
+   * Whether to show the use releases warning banner in the tool.
+   * @defaultValue true
+   */
+  showReleasesBanner?: boolean
 }
 
 export interface Schedule {

--- a/packages/sanity/src/core/studio/components/navbar/tools/StudioToolMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/tools/StudioToolMenu.tsx
@@ -1,4 +1,8 @@
+import {useMemo} from 'react'
+
 import {type ToolMenuProps} from '../../../../config'
+import {SCHEDULED_PUBLISHING_TOOL_NAME} from '../../../../scheduledPublishing/constants'
+import {useScheduledPublishingEnabled} from '../../../../scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider'
 import {ToolCollapseMenu} from './ToolCollapseMenu'
 import {ToolVerticalMenu} from './ToolVerticalMenu'
 
@@ -9,13 +13,22 @@ const HIDDEN_STUDIO_MENU_TOOLS = ['releases']
  * @beta */
 export function StudioToolMenu(props: ToolMenuProps) {
   const {context, isSidebarOpen, tools, ...restProps} = props
+  const {enabled: scheduledPublishingEnabled} = useScheduledPublishingEnabled()
 
-  if (tools.length <= 1) {
+  const visibleTools = useMemo(
+    () =>
+      tools.filter((tool) => {
+        if (tool.name === SCHEDULED_PUBLISHING_TOOL_NAME && !scheduledPublishingEnabled) {
+          return false
+        }
+        return !HIDDEN_STUDIO_MENU_TOOLS.includes(tool.name)
+      }),
+    [scheduledPublishingEnabled, tools],
+  )
+
+  if (visibleTools.length <= 1) {
     return null
   }
-
-  const visibleTools = tools.filter((tool) => !HIDDEN_STUDIO_MENU_TOOLS.includes(tool.name))
-
   if (context === 'sidebar') {
     return <ToolVerticalMenu isVisible={isSidebarOpen} tools={visibleTools} {...restProps} />
   }


### PR DESCRIPTION
### Description

With the introduction of releases we want to start moving users into it and out of `scheduled publishing` , to do this we will make scheduled publishing opt in.
Scenarios considered:
- Workspaces that have previously used scheduled publishing.
- Workspaces that have not used scheduled publishing.
- Workspaces that have enabled scheduled publishing in the config (this is not required[ since this was moved into core](https://github.com/sanity-io/sanity/issues/6416))

#### How to detect if it was used

We rely on the information provided by the schedules endpoint `/schedules/<projectId>/<dataset>`. If this endpoint returns at least 1 schedule it means that the workspace has previously used it.

#### How do we handle each situation

**Workspaces that have previously used scheduled publishing.**
If they have previously used it we will continue showing the document action and the tool in the navbar, by setting the `ScheduledPublishingEnabled` context value to `{enabled:true}` [see code](https://github.com/sanity-io/sanity/blob/sapp-2161/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx#L93-L96)

**Workspaces that have not used scheduled publishing.**
For this workspaces the value in the context will be `{enabled: false}` this will hide the tool from the navbar and will also hide the action. [See code](https://github.com/sanity-io/sanity/blob/sapp-2161/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx#L86-L92)

**Workspaces that  explicitly opt in**
Until today users didn't need to opt in to **scheduled publishing** , from today they will need to do it if they want to start using the tool and they haven't use it before (see previous point), when they opt in, the `__internal__workspaceEnabled` flag will be set to `true` this allows us to continue showing the tool as in the first point. [see code](https://github.com/sanity-io/sanity/blob/sapp-2161/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx#L93-L97)


### UI Changes

**Schedule publishing is disabled**

The `schedules` navbar button will be hidden by [this change](https://github.com/sanity-io/sanity/blob/sapp-2161/packages/sanity/src/core/studio/components/navbar/tools/StudioToolMenu.tsx#L21-L23) and the schedule action is also hidden.

If the user lands in the `/schedules/` tool they will see a warning to understand why this change is happening.
<img width="989" alt="Screenshot 2025-02-12 at 10 14 10" src="https://github.com/user-attachments/assets/54c8887f-cd13-4800-9903-b7a6c82713c9" />


**Schedule is enabled** 

- Releases is enabled:
  In this case we show them a warning with a recommendation on using **Releases*
  <img width="600" alt="Screenshot 2025-02-12 at 09 58 20" src="https://github.com/user-attachments/assets/9e43209c-f21e-43fe-b180-04ee77248401" />

 This can be removed by setting the following config:
 ```diff
defineConfig({
  ...,
  schedulePublishing: {
     enabled: true,
+   showReleasesBanner: false
})
```

- Releases is not enabled:
  Nothing changes for them.




<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
This has to be tested locally by updating the config.
- Playground dataset:
   - Scheduled publishing is hidden by default (this dataset has not used it)
   - Enable it in the config, it should show the tool and the releases warning `scheduledPublishing.enabled=true`
   - Disable releases, it should remove the warning.

- Test dataset
   - Scheduled publishing is enabled by default (this dataset has used it), it should show the warning
   - Enable it in the config, nothing should change from the above
   - Disable releases, the warning is removed.
   - Explicitly disable it in the config  `scheduledPublishing.enabled=false`, schedule is hidden, even knowing they have used it.
   
   
Existing tests have been updated.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
**Scheduled Publishing is now opt-in**. Workspaces that have used it before will retain access, while new users must enable it explicitly. 

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
