### PR TITLE
fix: add missing tags for listen queries

### DIFF
--- a/packages/sanity/src/core/comments/store/useCommentsStore.ts
+++ b/packages/sanity/src/core/comments/store/useCommentsStore.ts
@@ -34,6 +34,7 @@ const LISTEN_OPTIONS: ListenOptions = {
   events: ['welcome', 'mutation', 'reconnect'],
   includeResult: true,
   visibility: 'query',
+  tag: 'comments-store',
 }
 
 export const SORT_FIELD = '_createdAt'

--- a/packages/sanity/src/core/tasks/store/useTasksStore.ts
+++ b/packages/sanity/src/core/tasks/store/useTasksStore.ts
@@ -23,6 +23,7 @@ const LISTEN_OPTIONS: ListenOptions = {
   events: ['welcome', 'mutation', 'reconnect'],
   includeResult: true,
   visibility: 'query',
+  tag: 'tasks-store',
 }
 
 export const SORT_FIELD = '_createdAt'

--- a/packages/sanity/src/presentation/useDocumentLocations.ts
+++ b/packages/sanity/src/presentation/useDocumentLocations.ts
@@ -55,6 +55,7 @@ function listen(id: string, fields: string[], store: DocumentStore) {
   const params = {id, draftId: getDraftId(id)}
   return store.listenQuery(query, params, {
     perspective: 'drafts',
+    tag: 'drafts',
   }) as Observable<SanityDocument | null>
 }
 

--- a/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
+++ b/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
@@ -74,6 +74,7 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Searc
       events: ['welcome', 'mutation', 'reconnect'],
       includeResult: false,
       visibility: 'query',
+      tag: 'listen-search-query',
     })
   }).pipe(
     mergeMap((ev, i) => {

--- a/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetListStore.ts
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetListStore.ts
@@ -105,6 +105,7 @@ const LISTEN_OPTIONS: ListenOptions = {
   events: ['welcome', 'mutation', 'reconnect'],
   includeResult: true,
   visibility: 'query',
+  tag: 'document-sheet-list-store',
 }
 
 /**


### PR DESCRIPTION
### Description

Added `tag` property to listen options across various store implementations

### What to review

- Verify tag names are descriptive and accurately represent their respective listeners
- Check that all relevant listen option configurations include the new tag property

### Testing

Existing functionality remains unchanged as this is a monitoring enhancement. The addition of tags does not affect the behavior of listeners.

### Notes for release

N/A