### PR TITLE
fix(releases): improvements to archive release detail

### DIFF
--- a/packages/sanity/src/core/hooks/__mocks__/useProjectSubscriptions.mock.ts
+++ b/packages/sanity/src/core/hooks/__mocks__/useProjectSubscriptions.mock.ts
@@ -1,0 +1,73 @@
+import {type Mock, type Mocked} from 'vitest'
+
+import {useProjectSubscriptions} from '../useProjectSubscriptions'
+
+export const useProjectSubscriptionsMockReturn: Mocked<ReturnType<typeof useProjectSubscriptions>> =
+  {
+    error: null,
+    isLoading: false,
+    projectSubscriptions: {
+      id: 'sub_123',
+      projectId: 'proj_456',
+      productType: 'premium',
+      productId: 'prod_789',
+      customerId: 'cust_101',
+      planId: 'plan_202',
+      previousSubscriptionId: null,
+      status: 'active',
+      startedAt: '2024-02-01T00:00:00Z',
+      startedBy: 'user_303',
+      endedAt: null,
+      endedBy: null,
+      trialUntil: '2024-02-15T00:00:00Z',
+      plan: {
+        id: 'plan_202',
+        planTypeId: 'type_404',
+        variantId: null,
+        productType: 'premium',
+        variantOfPlanId: null,
+        name: 'Premium Plan',
+        variantName: null,
+        price: 49.99,
+        trialDays: 14,
+        createdAt: '2024-01-01T00:00:00Z',
+        supersededAt: null,
+        default: false,
+        public: true,
+        orderable: true,
+        isBasePlan: true,
+        pricingModel: 'flat-rate',
+        resources: {},
+        featureTypes: {},
+      },
+      resources: {},
+      featureTypes: {
+        retention: {
+          features: [
+            {
+              attributes: {
+                maxRetentionDays: 123,
+              },
+              id: '',
+              variantId: null,
+              name: '',
+              price: 0,
+              included: false,
+              custom: false,
+              startedAt: null,
+              startedBy: null,
+              endedAt: null,
+              endedBy: null,
+            },
+          ],
+          id: '',
+          name: '',
+          singular: false,
+        },
+      },
+    },
+  }
+
+export const mockUseProjectSubscriptions = useProjectSubscriptions as Mock<
+  typeof useProjectSubscriptions
+>

--- a/packages/sanity/src/core/hooks/useProjectSubscriptions.ts
+++ b/packages/sanity/src/core/hooks/useProjectSubscriptions.ts
@@ -1,0 +1,156 @@
+import {type SanityClient} from '@sanity/client'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {type Observable, of} from 'rxjs'
+import {catchError, map, shareReplay, startWith} from 'rxjs/operators'
+
+import {useSource} from '../studio'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../studioClient'
+import {useClient} from './useClient'
+
+type FeatureAttributes = Record<string, string | number | boolean | null>
+
+type Feature = {
+  id: string
+  variantId: string | null
+  name: string
+  price: number
+  included: boolean
+  attributes: FeatureAttributes
+  custom: boolean
+  startedAt: string | null
+  startedBy: string | null
+  endedAt: string | null
+  endedBy: string | null
+}
+
+type FeatureType = {
+  id: string
+  name: string
+  singular: boolean
+  features: Feature[]
+}
+
+type Resource = {
+  id: string
+  name: string
+  unit: string
+  type: string
+  quota: number | null
+  custom: boolean
+  overageAllowed: boolean
+  overageChunkSize: number
+  overageChunkPrice: number
+  maxOverageQuota: number | null
+}
+
+type Plan = {
+  id: string
+  planTypeId: string
+  variantId: string | null
+  productType: string
+  variantOfPlanId: string | null
+  name: string
+  variantName: string | null
+  price: number
+  trialDays: number
+  createdAt: string
+  supersededAt: string | null
+  default: boolean
+  public: boolean
+  orderable: boolean
+  isBasePlan: boolean
+  pricingModel: string
+  resources: Record<string, Resource>
+  featureTypes: Record<string, FeatureType>
+}
+
+export type ProjectSubscriptionsResponse = {
+  id: string
+  projectId: string
+  productType: string
+  productId: string
+  customerId: string | null
+  planId: string
+  previousSubscriptionId: string | null
+  status: string
+  startedAt: string
+  startedBy: string | null
+  endedAt: string | null
+  endedBy: string | null
+  trialUntil: string | null
+  plan: Plan
+  resources: Record<string, Resource>
+  featureTypes: Record<string, FeatureType>
+}
+
+type ProjectSubscriptions = {
+  error: Error | null
+  projectSubscriptions: ProjectSubscriptionsResponse | null
+  isLoading: boolean
+}
+
+const INITIAL_LOADING_STATE: ProjectSubscriptions = {
+  error: null,
+  projectSubscriptions: null,
+  isLoading: true,
+}
+
+/**
+ * fetches subscriptions for this project
+ */
+function fetchProjectSubscriptions({
+  versionedClient,
+}: {
+  versionedClient: SanityClient
+}): Observable<ProjectSubscriptionsResponse> {
+  return versionedClient.observable.request<ProjectSubscriptionsResponse>({
+    uri: `/subscriptions/project/${versionedClient.config().projectId}`,
+    tag: 'project-subscriptions',
+  })
+}
+
+const cachedProjectSubscriptionsRequest = new Map<
+  string,
+  Observable<ProjectSubscriptionsResponse>
+>()
+
+/** @internal */
+export function useProjectSubscriptions(): ProjectSubscriptions {
+  const versionedClient = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  const {projectId} = useSource()
+
+  if (!cachedProjectSubscriptionsRequest.get(projectId)) {
+    const projectSubscriptions = fetchProjectSubscriptions({versionedClient}).pipe(shareReplay())
+    cachedProjectSubscriptionsRequest.set(projectId, projectSubscriptions)
+  }
+
+  const projectSubscriptionsObservable = useMemo(() => {
+    const projectSubscriptions$ = cachedProjectSubscriptionsRequest.get(projectId)
+
+    if (!projectSubscriptions$)
+      return of<ProjectSubscriptions>({
+        isLoading: false,
+        error: null,
+        projectSubscriptions: null,
+      })
+
+    return projectSubscriptions$.pipe(
+      map((cachedSubscriptions) => ({
+        isLoading: false,
+        projectSubscriptions: cachedSubscriptions,
+        error: null,
+      })),
+      startWith(INITIAL_LOADING_STATE),
+      catchError((error: Error) =>
+        of<ProjectSubscriptions>({
+          isLoading: false,
+          projectSubscriptions: null,
+          error,
+        }),
+      ),
+    )
+  }, [projectId])
+
+  return useObservable(projectSubscriptionsObservable, INITIAL_LOADING_STATE)
+}

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1232,7 +1232,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Title for tooltip to explain release time */
   'release.dialog.tooltip.title': 'Approximate time of release',
   /** The placeholder text when the release doesn't have a description */
-  'release.form.placeholer-describe-release': 'Describe the release…',
+  'release.form.placeholder-describe-release': 'Describe the release…',
   /** Tooltip for button to hide release visibility */
   'release.layer.hide': 'Hide release',
   /** Label for draft perspective in navbar */

--- a/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
@@ -88,6 +88,7 @@ export function TitleDescriptionForm({
   release: EditableReleaseDocument
   onChange: (changedValue: EditableReleaseDocument) => void
 }): React.JSX.Element {
+  const isReleaseOpen = release.state !== 'archived' && release.state !== 'published'
   const descriptionRef = useRef<HTMLTextAreaElement | null>(null)
 
   const [scrollHeight, setScrollHeight] = useState(46)
@@ -145,6 +146,8 @@ export function TitleDescriptionForm({
     [onChange, release.metadata, value],
   )
 
+  const shouldShowDescription = isReleaseOpen || value.metadata.description
+
   return (
     <Stack space={4}>
       <TitleInput
@@ -152,19 +155,22 @@ export function TitleDescriptionForm({
         value={value.metadata.title}
         placeholder={t('release.placeholder-untitled-release')}
         data-testid="release-form-title"
+        readOnly={!isReleaseOpen}
       />
-      <DescriptionTextArea
-        ref={descriptionRef}
-        autoFocus={!value}
-        value={value.metadata.description}
-        placeholder={t('release.form.placeholer-describe-release')}
-        onChange={handleDescriptionChange}
-        style={{
-          height: `${scrollHeight}px`,
-          maxHeight: MAX_DESCRIPTION_HEIGHT,
-        }}
-        data-testid="release-form-description"
-      />
+      {shouldShowDescription && (
+        <DescriptionTextArea
+          ref={descriptionRef}
+          autoFocus={!value}
+          value={value.metadata.description}
+          placeholder={t('release.form.placeholder-describe-release')}
+          onChange={handleDescriptionChange}
+          style={{
+            height: `${scrollHeight}px`,
+            maxHeight: MAX_DESCRIPTION_HEIGHT,
+          }}
+          data-testid="release-form-description"
+        />
+      )}
     </Stack>
   )
 }

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -85,6 +85,12 @@ const releasesLocaleStrings = {
   /** Label for the button to proceed with archiving a release */
   'archive-dialog.confirm-archive-button': 'Yes, archive now',
 
+  /** Title for information card on a archived release */
+  'archive-info.title': 'This release is archived',
+  /** Description for information card on a published or archived release to description retention effects */
+  'archive-info.description':
+    'Your plan supports a {{retentionDays}}-day retention period. After this period this release will be removed.',
+
   /** Title for changes to published documents */
   'changes-published-docs.title': 'Changes to published documents',
   /** Text for when a release / document was created */
@@ -202,6 +208,9 @@ const releasesLocaleStrings = {
   'publish-dialog.validation.loading': 'Validating documents...',
   /** Label for when documents in release have validation errors */
   'publish-dialog.validation.error': 'Some documents have validation errors',
+
+  /** Title for information card on a published release */
+  'publish-info.title': 'This release is published',
 
   /** Description for the review changes button in release tool */
   'review.description': 'Add documents to this release to review changes',

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -88,7 +88,7 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
 
   return (
     <Container width={3}>
-      <Stack padding={3} paddingBottom={[4, 4, 5, 6]}>
+      <Stack padding={3} paddingY={[3, 3, 4, 5]}>
         <Flex gap={1} align="center">
           {isReleaseOpen && (
             <Button

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -88,7 +88,7 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
 
   return (
     <Container width={3}>
-      <Stack padding={3} paddingY={[4, 4, 5, 6]} space={[3, 3, 4, 5]}>
+      <Stack padding={3} paddingBottom={[4, 4, 5, 6]}>
         <Flex gap={1} align="center">
           {isReleaseOpen && (
             <Button

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -169,7 +169,7 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
         )}
 
         {!isReleaseOpen && retentionDays && (
-          <Card padding={4} radius={4} tone="primary">
+          <Card padding={4} radius={4} tone="primary" data-testid="retention-policy-card">
             <Flex gap={3}>
               <Text size={1}>
                 <InfoOutlineIcon />

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -1,4 +1,10 @@
-import {ErrorOutlineIcon, PinFilledIcon, PinIcon, WarningOutlineIcon} from '@sanity/icons'
+import {
+  ErrorOutlineIcon,
+  InfoOutlineIcon,
+  PinFilledIcon,
+  PinIcon,
+  WarningOutlineIcon,
+} from '@sanity/icons'
 import {
   Box,
   // Custom button with full radius used here
@@ -15,6 +21,7 @@ import {useCallback, useEffect, useState} from 'react'
 import {ToneIcon} from '../../../../ui-components/toneIcon/ToneIcon'
 import {TextWithTone} from '../../../components/textWithTone/TextWithTone'
 import {Details} from '../../../form/components/Details'
+import {useProjectSubscriptions} from '../../../hooks/useProjectSubscriptions'
 import {useTranslation} from '../../../i18n'
 import {usePerspective} from '../../../perspective/usePerspective'
 import {useSetPerspective} from '../../../perspective/useSetPerspective'
@@ -25,7 +32,7 @@ import {useReleasePermissions} from '../../store/useReleasePermissions'
 import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
 import {getReleaseTone} from '../../util/getReleaseTone'
 import {ReleaseDetailsEditor} from './ReleaseDetailsEditor'
-import {ReleaseTypePicker} from './ReleaseTypePicker'
+import {isNotArchivedRelease, ReleaseTypePicker} from './ReleaseTypePicker'
 
 export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
   const {state} = release
@@ -36,8 +43,13 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
   const {t: tRelease} = useTranslation(releasesLocaleNamespace)
   const {selectedReleaseId} = usePerspective()
   const setPerspective = useSetPerspective()
+  const {projectSubscriptions} = useProjectSubscriptions()
+
+  const retentionDays =
+    projectSubscriptions?.featureTypes.retention.features[0].attributes.maxRetentionDays
   const isSelected = releaseId === selectedReleaseId
   const isAtTimeRelease = release?.metadata?.releaseType === 'scheduled'
+  const isReleaseOpen = state !== 'archived' && state !== 'published'
   const isActive = release.state === 'active'
   const shouldDisplayError = isActive && typeof release.error !== 'undefined'
   const [shouldDisplayPermissionWarning, setShouldDisplayPermissionWarning] = useState(false)
@@ -78,19 +90,20 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
     <Container width={3}>
       <Stack padding={3} paddingY={[4, 4, 5, 6]} space={[3, 3, 4, 5]}>
         <Flex gap={1} align="center">
-          <Button
-            disabled={state === 'archived' || state === 'published'}
-            icon={isSelected ? PinFilledIcon : PinIcon}
-            mode="bleed"
-            onClick={handlePinRelease}
-            padding={2}
-            radius="full"
-            selected={isSelected}
-            space={2}
-            text={tRelease('dashboard.details.pin-release')}
-            tone={getReleaseTone(release)}
-          />
-          <ReleaseTypePicker release={release} />
+          {isReleaseOpen && (
+            <Button
+              icon={isSelected ? PinFilledIcon : PinIcon}
+              mode="bleed"
+              onClick={handlePinRelease}
+              padding={2}
+              radius="full"
+              selected={isSelected}
+              space={2}
+              text={tRelease('dashboard.details.pin-release')}
+              tone={getReleaseTone(release)}
+            />
+          )}
+          {isNotArchivedRelease(release) && <ReleaseTypePicker release={release} />}
           {shouldDisplayError && (
             <Flex gap={2} padding={2} data-testid="release-error-details">
               <Text size={1}>
@@ -124,13 +137,13 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
                 <ErrorOutlineIcon />
               </Text>
               <Stack space={4}>
-                <Text>
+                <Text size={1} weight="semibold">
                   {isAtTimeRelease
                     ? tRelease('failed-schedule-title')
                     : tRelease('failed-publish-title')}
                 </Text>
                 <Details title={tRelease('error-details-title')}>
-                  <Text>
+                  <Text size={1} accent>
                     <code>{release.error?.message}</code>
                   </Text>
                 </Details>
@@ -149,6 +162,26 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
                 <Text size={1}>{tRelease('permission-missing-title')}</Text>
                 <Text size={1} muted>
                   {tRelease('permission-missing-description')}
+                </Text>
+              </Stack>
+            </Flex>
+          </Card>
+        )}
+
+        {!isReleaseOpen && retentionDays && (
+          <Card padding={4} radius={4} tone="primary">
+            <Flex gap={3}>
+              <Text size={1}>
+                <InfoOutlineIcon />
+              </Text>
+              <Stack space={4}>
+                <Text size={1} weight="semibold">
+                  {state === 'archived'
+                    ? tRelease('archive-info.title')
+                    : tRelease('publish-info.title')}
+                </Text>
+                <Text size={1} accent>
+                  {tRelease('archive-info.description', {retentionDays})}
                 </Text>
               </Stack>
             </Flex>

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardHeader.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardHeader.tsx
@@ -13,6 +13,7 @@ import {useRouter} from 'sanity/router'
 import {useTranslation} from '../../../i18n'
 import {releasesLocaleNamespace} from '../../i18n'
 import {type ReleaseDocument} from '../../index'
+import {GROUP_SEARCH_PARAM_KEY} from '../overview/queryParamUtils'
 import {type ReleaseInspector} from './ReleaseDetail'
 
 export function ReleaseDashboardHeader(props: {
@@ -25,17 +26,18 @@ export function ReleaseDashboardHeader(props: {
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: tCore} = useTranslation()
   const router = useRouter()
+
   const handleNavigateToReleasesList = useCallback(() => {
-    router.navigate({})
-  }, [router])
+    const isReleaseOpen = release.state !== 'archived' && release.state !== 'published'
+
+    router.navigate({
+      _searchParams: isReleaseOpen ? undefined : [[GROUP_SEARCH_PARAM_KEY, 'archived']],
+    })
+  }, [release.state, router])
 
   const handleActivityClick = useCallback(() => {
     setInspector((prev) => (prev === 'activity' ? undefined : 'activity'))
   }, [setInspector])
-
-  const handleTitleClick = useCallback(() => {
-    // TODO: Focus on the title when clicked once it's editable
-  }, [])
 
   return (
     <Flex align="flex-start">
@@ -61,7 +63,6 @@ export function ReleaseDashboardHeader(props: {
           />
           <Button
             mode="bleed"
-            onClick={handleTitleClick}
             text={title || tCore('release.placeholder-untitled-release')}
             // @ts-expect-error - pending @sanity/ui change
             textWeight="semibold"

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
@@ -191,13 +191,6 @@ describe('ReleaseTypePicker', () => {
   })
 
   describe('picker behavior based on release state', () => {
-    it('disables the picker for archived releases', async () => {
-      await renderComponent({...activeASAPRelease, state: 'archived'})
-
-      const pickerButton = screen.getByRole('button')
-      expect(pickerButton).toBeDisabled()
-    })
-
     it('does not show button for picker when release is published state', async () => {
       await renderComponent(publishedASAPRelease)
 


### PR DESCRIPTION
### Description
PR makes changes for archived and published release details:
* 'Release' breadcrumb links back to the archived grouping on release overview
* 'Pin release' hidden on archived and published release details
* Release Type picker hidden on archived release detail
* Published release type uses icon and updated style
* Release title and description are `readOnly` on archived and published release detail
* Retention card added on archived and published release detail

<img width="1508" alt="Screenshot 2025-02-11 at 18 37 23" src="https://github.com/user-attachments/assets/08b5f0d6-3dcb-4119-b36e-4e38a7dd256d" />
<img width="1509" alt="Screenshot 2025-02-11 at 18 37 43" src="https://github.com/user-attachments/assets/e81bf130-1403-44fb-b524-7a8a42e3f069" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* Adding `useProjectSubscription` to get the retention period - this is a close copy of `useFeatureEnabled`
* Style updates look ok?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
* Updated tests on `ReleaseDetail` to cover the new scenarios for archived and published releases
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
