### PR TITLE
feat(cli): make typegen idempotent

### DIFF
--- a/packages/@sanity/cli/src/workers/typegenGenerate.ts
+++ b/packages/@sanity/cli/src/workers/typegenGenerate.ts
@@ -156,6 +156,8 @@ async function main() {
   }
 
   if (opts.overloadClientMethods && allQueries.length > 0) {
+    // Sort to ensure consistent order between runs
+    allQueries.sort((a, b) => a.query.localeCompare(b.query))
     const typeMap = `${typeGenerator.generateQueryMap(allQueries).trim()}\n`
     parentPort?.postMessage({
       type: 'typemap',


### PR DESCRIPTION
### Description

This branch makes the `sanity typegen generate` command produce a file with its type definitions listed in a consistent order every time. Before this change, the order of entries within the file could change between runs on larger codebases as it was generated by a parallel process using multiple workers. This change should prevent unnecessary diffs introduced when running the command and closes https://github.com/sanity-io/sanity/issues/8521 .

The order is enforced by sorting the entries into the file before writing and by sorting the queries found within a file. Sorting uses the default Javascript array sort method.

### What to review

Changes are limited to the `typegen generate` command of the sanity cli. Review should focus on this.

### Testing

No testing was added, removed or changed. As the behaviour before this change was hard to reproduce consistently, since it is the result of the order in which read operations on the files in the user's repo finish, adding tests specific for the change introduced here is difficult.

Existing tests covering the type generation pass unchanged.

### Notes for release

Closes https://github.com/sanity-io/sanity/issues/8521
Makes the result of running more consistent between runs
