### PR TITLE
fix(docs): replace `previewDrafts` with `drafts`

### DIFF
--- a/packages/sanity/src/presentation/PresentationTool.tsx
+++ b/packages/sanity/src/presentation/PresentationTool.tsx
@@ -105,11 +105,7 @@ export default function PresentationTool(props: {
     state: PresentationStateParams
   }
   const routerSearchParams = useUnique(Object.fromEntries(routerState._searchParams || []))
-  const {
-    perspectiveStack,
-    selectedPerspectiveName = 'previewDrafts',
-    selectedReleaseId,
-  } = usePerspective()
+  const {perspectiveStack, selectedPerspectiveName = 'drafts', selectedReleaseId} = usePerspective()
   const perspective = (
     selectedReleaseId ? perspectiveStack : selectedPerspectiveName
   ) as PresentationPerspective

--- a/packages/sanity/src/presentation/__tests__/usePreviewUrl.test.tsx
+++ b/packages/sanity/src/presentation/__tests__/usePreviewUrl.test.tsx
@@ -30,7 +30,7 @@ beforeEach(() => {
 })
 
 function TestPrinter(props: {previewUrl: PreviewUrlOption; previewSearchParam?: string | null}) {
-  return `${usePreviewUrl(props.previewUrl, 'presentation', 'previewDrafts', props.previewSearchParam || null, true)}`
+  return `${usePreviewUrl(props.previewUrl, 'presentation', 'drafts', props.previewSearchParam || null, true)}`
 }
 
 describe('previewUrl handling', () => {

--- a/packages/sanity/src/presentation/editor/PostMessagePreviewSnapshots.tsx
+++ b/packages/sanity/src/presentation/editor/PostMessagePreviewSnapshots.tsx
@@ -53,8 +53,10 @@ const PostMessagePreviews: FC<PostMessagePreviewsProps> = (props) => {
             refs.map((ref) => {
               const draftRef = {...ref, _id: getDraftId(ref._id)}
               const draft$ =
-                perspective === 'previewDrafts'
-                  ? documentPreviewStore
+                perspective === 'published'
+                  ? // Don't emit if not displaying drafts
+                    NEVER
+                  : documentPreviewStore
                       .observeForPreview(draftRef, schema.get(draftRef._type)!)
                       .pipe(
                         // Share to prevent double subscribe in the merge
@@ -63,8 +65,6 @@ const PostMessagePreviews: FC<PostMessagePreviewsProps> = (props) => {
                         // eslint-disable-next-line max-nested-callbacks
                         skipWhile((p) => p.snapshot === null),
                       )
-                  : // Don't emit if not displaying drafts
-                    NEVER
 
               const publishedRef = {...ref, _id: getPublishedId(ref._id)}
               const published$ = documentPreviewStore.observeForPreview(

--- a/packages/sanity/src/presentation/loader/__tests__/turboChargeResultIfSourceMap.test.ts
+++ b/packages/sanity/src/presentation/loader/__tests__/turboChargeResultIfSourceMap.test.ts
@@ -3,7 +3,7 @@ import {expect, test} from 'vitest'
 
 import {turboChargeResultIfSourceMap} from '../LiveQueries'
 
-const perspective = 'previewDrafts'
+const perspective = 'drafts'
 
 test('Can apply an array keyed field update', () => {
   const result = {

--- a/packages/sanity/src/presentation/loader/__tests__/useLiveQueries.test.ts
+++ b/packages/sanity/src/presentation/loader/__tests__/useLiveQueries.test.ts
@@ -6,7 +6,7 @@ import {initialState, reducer} from '../useLiveQueries'
 describe('useLiveQueries', () => {
   const query1 = `count(*)`
   const params1 = {}
-  const perspective1 = 'previewDrafts' satisfies ClientPerspective
+  const perspective1 = 'drafts' satisfies ClientPerspective
   const query2 = `count(*[_type == $type])`
   const params2 = {type: 'foo'}
   const perspective2 = ['rFOO', 'drafts'] satisfies ClientPerspective

--- a/packages/sanity/src/presentation/useMainDocument.ts
+++ b/packages/sanity/src/presentation/useMainDocument.ts
@@ -167,7 +167,7 @@ export function useMainDocument(props: {
         if (query) {
           const controller = new AbortController()
           const options: ResponseQueryOptions = {
-            perspective: 'previewDrafts',
+            perspective: 'drafts',
             signal: controller.signal,
           }
 


### PR DESCRIPTION
Since https://github.com/sanity-io/client/pull/1007 the client warns when using `perspective: 'previewDrafts'`. This PR refactors to the new `perspective: 'drafts'` approach.
