### PR TITLE
feat(core): add default bold/italic markdown shortcuts to PTE

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -398,6 +398,10 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
               <UpdateValuePlugin value={value} />
               <MarkdownPlugin
                 config={{
+                  boldDecorator: ({schema}) =>
+                    schema.decorators.find((decorator) => decorator.value === 'strong')?.value,
+                  italicDecorator: ({schema}) =>
+                    schema.decorators.find((decorator) => decorator.value === 'em')?.value,
                   defaultStyle: ({schema}) =>
                     schema.styles.find((style) => style.value === 'normal')?.value,
                   blockquoteStyle: ({schema}) =>


### PR DESCRIPTION
### Description

The `MarkdownPlugin` now ships with automatic bold/italic shortcuts that you can opt in to by defining an `italicDecorator` and/or a `boldDecorator`. The italic decorator is then mapped to `*`/`_` pairs and the bold decorator is mapped to `**`/`__` pairs.

Following the standard behaviour that is observed in most other text editors, the mapping only occurs when the end char is inserted. For example, typing `*foo` and then `*` makes `foo` italic, but typing `foo*` and then adding a `*` before `foo*` does nothing.

After a mapping occurs, if you didn't like it, you can undo it as expected. And if you don't move your cursor, you can even undo it by hitting Backspace.

![hello-bold-world](https://github.com/user-attachments/assets/b5d69a2b-2584-4b4c-94f5-f86427001323)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Try it out and see if it works as expected :)
 
Note: There is one known flaw in the RegEx that is used. `*hello*world*` matches `*hello*` instead of `*world*`. A fix is coming `@portabeltext/editor@1.33.1`, which we can decide to merge before this PR.

Please do go nuts and see if you can find other edge cases that might not work.

### Testing

PTE has internal tests for the underlying logic.

### Notes for release

The Portable Text Input now includes bold and italic Markdown shortcuts for decorators named `strong` and `em` (respectively)