### PR TITLE
fix(structure): don't modify EMPTY_PARAMS object

### DIFF
--- a/packages/sanity/src/structure/constants.ts
+++ b/packages/sanity/src/structure/constants.ts
@@ -3,7 +3,7 @@
  */
 export const _DEBUG = false
 
-export const EMPTY_PARAMS = {}
+export const EMPTY_PARAMS = Object.freeze({})
 export const LOADING_PANE = Symbol('LOADING_PANE')
 
 export const DOCUMENT_PANEL_PORTAL_ELEMENT = 'documentPanelPortalElement'

--- a/packages/sanity/src/structure/getIntentState.ts
+++ b/packages/sanity/src/structure/getIntentState.ts
@@ -26,8 +26,6 @@ export function getIntentState(
   const panes = routerState?.panes || []
   const activePanes = state.activePanes || []
   const editDocumentId = params.id || uuid()
-  const isTemplate = intent === 'create' && params.template
-  const isVersion = intent === 'create' && params.version
 
   // Loop through open panes and see if any of them can handle the intent
   for (let i = activePanes.length - 1; i >= 0; i--) {
@@ -47,12 +45,7 @@ export function getIntentState(
         pane.schemaTypeName === params.type &&
         pane.options.filter === '_type == $type')
     ) {
-      const paneParams: {
-        template?: string
-        version?: string
-      } = EMPTY_PARAMS
-      if (isTemplate) paneParams.template = params.template
-      if (isVersion) paneParams.version = params.version
+      const paneParams = getPaneParams(intent, params)
 
       return {
         panes: panes
@@ -63,4 +56,15 @@ export function getIntentState(
   }
 
   return {intent: intent, params, payload}
+}
+
+function getPaneParams(
+  intent: string,
+  {template, version}: Record<string, string>,
+): {template?: string; version?: string} {
+  if (intent !== 'create') return EMPTY_PARAMS
+  if (template && version) return {template, version}
+  if (template) return {template}
+  if (version) return {version}
+  return EMPTY_PARAMS
 }


### PR DESCRIPTION
This fixes a bug where the EMPTY_PARAMS object is modified

### Notes for release

Fixes a bug that could cause initial value template parameters to carry over from an earlier document