### PR TITLE
feat(sanity): skip strengthen-on-publish process for documents inside a release

### DIFF
--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -106,4 +106,7 @@ export default defineConfig({
   announcements: {
     enabled: false,
   },
+  releases: {
+    enabled: true,
+  },
 })

--- a/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
@@ -341,6 +341,174 @@ describe('createReleaseOperationsStore', () => {
     )
   })
 
+  it('should omit _weak from reference fields if _strengthenOnPublish is present when it creates a version of a document', async () => {
+    const store = createStore()
+
+    mockClient.getDocument.mockResolvedValue({
+      _id: 'doc-id',
+      artist: {
+        _ref: 'some-artist-id',
+        _strengthenOnPublish: {
+          template: {
+            id: 'artist',
+          },
+          type: 'artist',
+        },
+        _type: 'reference',
+        _weak: true,
+      },
+      expectedWeakReference: {
+        _ref: 'expected-weak-reference',
+        _type: 'reference',
+        _weak: true,
+        _strengthenOnPublish: {
+          template: {
+            id: 'some-document',
+          },
+          type: 'some-document',
+          weak: true,
+        },
+      },
+      plants: [
+        {
+          _ref: 'some-plant-id',
+          _strengthenOnPublish: {
+            template: {
+              id: 'plant',
+            },
+            type: 'plant',
+          },
+          _type: 'reference',
+          _weak: true,
+        },
+        {
+          _ref: 'some-plant-id',
+          _strengthenOnPublish: {
+            template: {
+              id: 'plant',
+            },
+            type: 'plant',
+          },
+          _type: 'reference',
+          _weak: true,
+        },
+      ],
+      stores: [
+        {
+          name: 'some-store',
+          inventory: {
+            products: [
+              {
+                _ref: 'some-product-id',
+                _strengthenOnPublish: {
+                  template: {
+                    id: 'product',
+                  },
+                  type: 'product',
+                },
+                _type: 'reference',
+                _weak: true,
+              },
+              {
+                _ref: 'some-product-id',
+                _strengthenOnPublish: {
+                  template: {
+                    id: 'product',
+                  },
+                  type: 'product',
+                },
+                _type: 'reference',
+                _weak: true,
+              },
+            ],
+          },
+        },
+      ],
+    })
+
+    await store.createVersion('release-id', 'doc-id')
+
+    expect(mockClient.create).toHaveBeenCalledWith(
+      {
+        _id: `versions.release-id.doc-id`,
+        artist: {
+          _ref: 'some-artist-id',
+          _strengthenOnPublish: {
+            template: {
+              id: 'artist',
+            },
+            type: 'artist',
+          },
+          _type: 'reference',
+        },
+        expectedWeakReference: {
+          _ref: 'expected-weak-reference',
+          _type: 'reference',
+          _weak: true,
+          _strengthenOnPublish: {
+            template: {
+              id: 'some-document',
+            },
+            type: 'some-document',
+            weak: true,
+          },
+        },
+        plants: [
+          {
+            _ref: 'some-plant-id',
+            _strengthenOnPublish: {
+              template: {
+                id: 'plant',
+              },
+              type: 'plant',
+            },
+            _type: 'reference',
+          },
+          {
+            _ref: 'some-plant-id',
+            _strengthenOnPublish: {
+              template: {
+                id: 'plant',
+              },
+              type: 'plant',
+            },
+            _type: 'reference',
+          },
+        ],
+        stores: [
+          {
+            name: 'some-store',
+            inventory: {
+              products: [
+                {
+                  _ref: 'some-product-id',
+                  _strengthenOnPublish: {
+                    template: {
+                      id: 'product',
+                    },
+                    type: 'product',
+                  },
+                  _type: 'reference',
+                },
+                {
+                  _ref: 'some-product-id',
+                  _strengthenOnPublish: {
+                    template: {
+                      id: 'product',
+                    },
+                    type: 'product',
+                  },
+                  _type: 'reference',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      undefined,
+    )
+  })
+
   it('should discard a version of a document', async () => {
     const store = createStore()
     await store.discardVersion('release-id', 'doc-id')

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -8,6 +8,7 @@ import {
 import {getPublishedId, getVersionId} from '../../util'
 import {getReleaseIdFromReleaseDocumentId, type ReleaseDocument} from '../index'
 import {type RevertDocument} from '../tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates'
+import {prepareVersionReferences} from '../util/prepareVersionReferences'
 import {isReleaseLimitError} from './isReleaseLimitError'
 import {type EditableReleaseDocument} from './types'
 
@@ -187,11 +188,11 @@ export function createReleaseOperationsStore(options: {
       throw new Error(`Document with id ${documentId} not found and no initial value provided`)
     }
 
-    const versionDocument = {
+    const versionDocument = prepareVersionReferences({
       ...(document || {}),
       ...(initialValue || {}),
       _id: getVersionId(documentId, releaseId),
-    } as IdentifiedSanityDocumentStub
+    }) as IdentifiedSanityDocumentStub
 
     await (IS_CREATE_VERSION_ACTION_SUPPORTED
       ? requestAction(

--- a/packages/sanity/src/core/releases/util/prepareVersionReferences.ts
+++ b/packages/sanity/src/core/releases/util/prepareVersionReferences.ts
@@ -1,0 +1,35 @@
+import {isReference} from '@sanity/types'
+import {omit} from 'lodash'
+
+/**
+ * This is almost identical to the existing `strengthenOnPublish` function, but it omits only the
+ * `_weak` property.
+ *
+ * The strengthen-on-publish process is not necessary for documents inside a release, and in fact
+ * must be skipped in order for release preflight checks to function. Therefore, when creating a
+ * version of a document, the `_weak` property must be removed from any existing reference that is
+ * set to strengthen on publish.
+ *
+ * The `_strengthenOnPublish` field itself is always set, regardless of whether the
+ * strengthen-on-publish process should be used. This is because the field is used to store details
+ * such as the non-existing document's type, which Studio uses to render reference previews.
+ *
+ * Content Lake will only strengthen the reference if **both** `_strengthenOnPublish` and `_weak`
+ * are truthy.
+ *
+ * Yes, this is confusing.
+ */
+export function prepareVersionReferences<T = any>(obj: T): T {
+  if (isReference(obj)) {
+    const isSchemaMandatedWeakReference = obj._strengthenOnPublish?.weak === true
+    if (!isSchemaMandatedWeakReference) {
+      return omit(obj, ['_weak']) as T
+    }
+    return obj
+  }
+  if (typeof obj !== 'object' || !obj) return obj
+  if (Array.isArray(obj)) return obj.map(prepareVersionReferences) as T
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [key, prepareVersionReferences(value)] as const),
+  ) as T
+}


### PR DESCRIPTION
### Description

The strengthen-on-publish process is not necessary for documents inside a release, and in fact must be skipped in order for release preflight checks to function.

Strengthen-on-publish is still necessary for drafts, and for documents in a bundle *that isn't a release* (this isn't a scenario Studio supports today, but it may need to in the future).

This branch prevents the `_weak` property being added to references in version documents **unless the reference is defined as weak in the schema**, thereby skipping the strengthen-on-publish process for documents inside a release.

The `_strengthenOnPublish` field is always set, regardless of whether the strengthen-on-publish process should be used. This is because the field is used to store details such as the non-existing document's type, which Studio uses to render reference previews.

Content Lake will only strengthen the reference if **both** `_strengthenOnPublish` and `_weak` are truthy.

Yes, this is confusing.

### What to review

- Does this seem reasonable?
- Have I missed any scenarios?

### Testing

Added E2E and unit tests to relevant existing test suites.