### PR TITLE
feat: reduce redundant success toast messages

### DIFF
--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -698,12 +698,6 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     try {
       el.select()
       document.execCommand('copy')
-      this.props.toast.push({
-        closable: true,
-        title: 'Copied to clipboard',
-        status: 'info',
-        id: 'vision-copy',
-      })
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('Unable to copy to clipboard :(')

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -522,12 +522,6 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
 
   handleListenerEvent(evt: ListenEvent<any>) {
     if (evt.type !== 'mutation') {
-      this.props.toast.push({
-        closable: true,
-        id: 'vision-listen',
-        status: 'success',
-        title: 'Listening for mutations…',
-      })
       return
     }
 

--- a/packages/sanity/src/core/comments/i18n/resources.ts
+++ b/packages/sanity/src/core/comments/i18n/resources.ts
@@ -33,8 +33,6 @@ const commentsLocaleStrings = defineLocalesResources('comments', {
 
   /** The inspector text when error copying link */
   'copy-link-error-message': 'Unable to copy link to clipboard',
-  /** The inspector successfully copied link text */
-  'copy-link-success-message': 'Copied link to clipboard',
 
   /** The delete dialog body for a comment */
   'delete-comment.body': 'Once deleted, a comment cannot be recovered.',

--- a/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
@@ -126,22 +126,13 @@ function CommentsInspectorInner(
     if (!getCommentLink) return undefined
 
     const copyLink = (id: string) => {
-      navigator.clipboard
-        .writeText(getCommentLink(id))
-        .then(() => {
-          pushToast({
-            closable: true,
-            status: 'info',
-            title: t('copy-link-success-message'),
-          })
+      navigator.clipboard.writeText(getCommentLink(id)).catch(() => {
+        pushToast({
+          closable: true,
+          status: 'error',
+          title: t('copy-link-error-message'),
         })
-        .catch(() => {
-          pushToast({
-            closable: true,
-            status: 'error',
-            title: t('copy-link-error-message'),
-          })
-        })
+      })
 
       telemetry.commentLinkCopied()
     }

--- a/packages/sanity/src/core/components/errorActions/strings.ts
+++ b/packages/sanity/src/core/components/errorActions/strings.ts
@@ -6,5 +6,4 @@ export const strings = {
   'copy-error-details.title': 'Copy error details',
   'copy-error-details.toast.get-failed': 'Failed to get error details',
   'copy-error-details.toast.copy-failed': 'Failed to copy error details',
-  'copy-error-details.toast.succeeded': 'Copied error details to clipboard',
 } as const

--- a/packages/sanity/src/core/components/errorActions/useCopyErrorDetails.ts
+++ b/packages/sanity/src/core/components/errorActions/useCopyErrorDetails.ts
@@ -28,14 +28,7 @@ export function useCopyErrorDetails(error: unknown, eventId?: string | null): ()
           })
           return EMPTY
         }),
-        tap((errorDetailsString) => {
-          navigator.clipboard.writeText(errorDetailsString)
-          toast.push({
-            status: 'success',
-            title: strings['copy-error-details.toast.succeeded'],
-            id: TOAST_ID,
-          })
-        }),
+        tap((errorDetailsString) => navigator.clipboard.writeText(errorDetailsString)),
         catchError((copyErrorError) => {
           console.error(copyErrorError)
           toast.push({

--- a/packages/sanity/src/core/i18n/bundles/copy-paste.ts
+++ b/packages/sanity/src/core/i18n/bundles/copy-paste.ts
@@ -78,12 +78,6 @@ const copyPasteLocaleStrings = defineLocalesResources('copy-paste', {
   /** The error message that is shown when the clipboard is not supported */
   'copy-paste.on-copy.validation.clipboard-not-supported.title':
     'Your browser does not support this action',
-  /** The success message that is shown when a document is copied */
-  'copy-paste.on-copy.validation.copy-document-success.title': 'Document "{{fieldNames}}" copied',
-  /** The success message that is shown when a field is copied */
-  'copy-paste.on-copy.validation.copy-field_one-success.title': 'Field "{{fieldName}}" copied',
-  /** The success message that is shown when a array item is copied */
-  'copy-paste.on-copy.validation.copy-item_one-success.title': 'Item "{{typeName}}" copied',
 })
 
 /**

--- a/packages/sanity/src/core/i18n/bundles/copy-paste.ts
+++ b/packages/sanity/src/core/i18n/bundles/copy-paste.ts
@@ -59,11 +59,6 @@ const copyPasteLocaleStrings = defineLocalesResources('copy-paste', {
     'Could not resolve schema type for path: {{path}}',
   /** The warning message that is shown when not all values can be pasted */
   'copy-paste.on-paste.validation.partial-warning.title': 'Could not paste all values',
-  /** The success message that is shown when a document is pasted */
-  'copy-paste.on-paste.validation.document-paste-success.title':
-    'Document "{{fieldNames}}" updated',
-  /** The success message that is shown when a field is pasted */
-  'copy-paste.on-paste.validation.field_one-paste-success.title': 'Field "{{fieldName}}" updated',
 
   /** The error message that is shown when the MIME type is not accepted */
   'copy-paste.on-paste.validation.mime-type-incompatible.description':

--- a/packages/sanity/src/core/scheduledPublishing/hooks/useTimeZone.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/hooks/useTimeZone.tsx
@@ -113,18 +113,6 @@ const useTimeZone = () => {
             localStorage.setItem(LOCAL_STORAGE_TZ_KEY, JSON.stringify(tz))
             window.dispatchEvent(new Event(TimeZoneEvents.update))
           }
-
-          toast.push({
-            closable: true,
-            description: (
-              <ToastDescription
-                body={`${tz.alternativeName} (${tz.namePretty})`}
-                title="Time zone updated"
-              />
-            ),
-            duration: 15000, // 15s
-            status: 'info',
-          })
         } catch (err) {
           console.error(err)
 

--- a/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
+++ b/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
@@ -140,27 +140,7 @@ export const CopyPasteProvider: React.FC<{
           status: 'error',
           title: t('copy-paste.on-copy.validation.clipboard-not-supported.title'),
         })
-        return
       }
-
-      const fields = schemaTypeAtPath.title || schemaType.name || 'unknown'
-
-      const fieldSuccessTitle = isArrayItem
-        ? t('copy-paste.on-copy.validation.copy-item_one-success.title', {
-            typeName: fields,
-          })
-        : t('copy-paste.on-copy.validation.copy-field_one-success.title', {
-            fieldName: fields,
-          })
-
-      toast.push({
-        status: 'success',
-        title: isDocument
-          ? t('copy-paste.on-copy.validation.copy-document-success.title', {
-              fieldNames: fields,
-            })
-          : fieldSuccessTitle,
-      })
     },
     [documentMeta, telemetry, toast, t],
   )

--- a/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
+++ b/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
@@ -331,32 +331,7 @@ export const CopyPasteProvider: React.FC<{
 
       if (updateItems.length) {
         const allPatches = flatten(updateItems.map(({patches}) => patches))
-        const allTargetNames = updateItems.map((i) => i.targetSchemaTypeTitle).join('", "')
-
         onChange(PatchEvent.from(allPatches))
-
-        if (clipboardItem.isDocument) {
-          toast.push({
-            status: 'success',
-            title: t('copy-paste.on-paste.validation.document-paste-success.title', {
-              fieldNames: allTargetNames,
-            }),
-          })
-
-          return
-        }
-
-        const isSingleField = updateItems.length === 1
-
-        if (isSingleField) {
-          toast.push({
-            status: 'success',
-            title: t('copy-paste.on-paste.validation.field_one-paste-success.title', {
-              fieldName: allTargetNames,
-            }),
-          })
-        }
-
         // TODO: missing case with multiple updated items?
       }
     },

--- a/packages/sanity/src/core/studio/copyPaste/__test__/useCopyPaste.test.tsx
+++ b/packages/sanity/src/core/studio/copyPaste/__test__/useCopyPaste.test.tsx
@@ -117,11 +117,6 @@ describe('useCopyPaste', () => {
     })
 
     expect(mockOnChange).toHaveBeenCalledWith(expect.any(PatchEvent))
-    expect(mockToast.push).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: 'success',
-      }),
-    )
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
         patches: [
@@ -371,12 +366,6 @@ describe('useCopyPaste', () => {
       )
     })
 
-    expect(mockToast.push).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: 'success',
-      }),
-    )
-
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
         patches: [
@@ -486,11 +475,6 @@ describe('useCopyPaste', () => {
       )
     })
 
-    expect(mockToast.push).toHaveBeenCalledWith({
-      status: 'success',
-      title: 'Field "Best Author Friend" updated',
-    })
-
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
         patches: [
@@ -544,11 +528,6 @@ describe('useCopyPaste', () => {
           context: {source: 'fieldAction'},
         },
       )
-    })
-
-    expect(mockToast.push).toHaveBeenCalledWith({
-      status: 'success',
-      title: 'Field "Best Friend" updated',
     })
 
     expect(mockOnChange).toHaveBeenCalledWith(
@@ -608,11 +587,6 @@ describe('useCopyPaste', () => {
           context: {source: 'fieldAction'},
         },
       )
-    })
-
-    expect(mockToast.push).toHaveBeenCalledWith({
-      status: 'success',
-      title: 'Field "Array of references to editors" updated',
     })
 
     expect(mockOnChange).toHaveBeenCalledWith(
@@ -685,11 +659,6 @@ describe('useCopyPaste', () => {
       )
     })
 
-    expect(mockToast.push).toHaveBeenCalledWith({
-      status: 'success',
-      title: 'Field "Array of references to editors" updated',
-    })
-
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
         patches: [
@@ -760,11 +729,6 @@ describe('useCopyPaste', () => {
       )
     })
 
-    expect(mockToast.push).toHaveBeenCalledWith({
-      status: 'success',
-      title: 'Field "Array of references to editors" updated',
-    })
-
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
         patches: [
@@ -832,11 +796,6 @@ describe('useCopyPaste', () => {
           context: {source: 'fieldAction'},
         },
       )
-    })
-
-    expect(mockToast.push).toHaveBeenCalledWith({
-      status: 'success',
-      title: 'Field "Array of predefined options" updated',
     })
 
     expect(mockOnChange).toHaveBeenCalledWith(
@@ -1011,11 +970,6 @@ describe('useCopyPaste', () => {
       )
     })
 
-    expect(mockToast.push).toHaveBeenCalledWith({
-      status: 'success',
-      title: 'Item "String" copied',
-    })
-
     expect(await getClipboardItem()).toEqual({
       patchType: 'append',
       type: 'sanityClipboardItem',
@@ -1061,11 +1015,6 @@ describe('useCopyPaste', () => {
           context: {source: 'fieldAction'},
         },
       )
-    })
-
-    expect(mockToast.push).toHaveBeenCalledWith({
-      status: 'success',
-      title: 'Field "Favorite Strings" updated',
     })
 
     expect(mockOnChange).toHaveBeenCalledWith(

--- a/packages/sanity/src/core/tasks/context/navigation/TasksNavigationProvider.tsx
+++ b/packages/sanity/src/core/tasks/context/navigation/TasksNavigationProvider.tsx
@@ -124,11 +124,6 @@ export const TasksNavigationProvider = ({children}: {children: ReactNode}) => {
     navigator.clipboard
       .writeText(url.toString())
       .then(() => {
-        toast.push({
-          closable: true,
-          status: 'info',
-          title: 'Copied link to clipboard',
-        })
         telemetry.log(TaskLinkCopied)
       })
       .catch(() => {

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -241,24 +241,14 @@ export function ConfirmDeleteDialogBody({
                                   }}
                                   // eslint-disable-next-line react/jsx-no-bind
                                   onClick={() => {
-                                    navigator.clipboard
-                                      .writeText(documentId)
-                                      .then(() => {
-                                        toast.push({
-                                          status: 'success',
-                                          title: t(
-                                            'confirm-delete-dialog.cdr-table.id-copied-toast.title',
-                                          ),
-                                        })
+                                    navigator.clipboard.writeText(documentId).catch(() => {
+                                      toast.push({
+                                        status: 'error',
+                                        title: t(
+                                          'confirm-delete-dialog.cdr-table.id-copied-toast.title-failed',
+                                        ),
                                       })
-                                      .catch(() => {
-                                        toast.push({
-                                          status: 'error',
-                                          title: t(
-                                            'confirm-delete-dialog.cdr-table.id-copied-toast.title-failed',
-                                          ),
-                                        })
-                                      })
+                                    })
                                   }}
                                 />
                               )}

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -189,8 +189,6 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'confirm-delete-dialog.cdr-table.dataset.label': 'Dataset',
   /** The header for the document ID column in the list of cross-dataset references found */
   'confirm-delete-dialog.cdr-table.document-id.label': 'Document ID',
-  /** The toast title when the copy button has been clicked */
-  'confirm-delete-dialog.cdr-table.id-copied-toast.title': 'Copied document ID to clipboard!',
   /** The toast title when the copy button has been clicked but copying failed */
   'confirm-delete-dialog.cdr-table.id-copied-toast.title-failed': 'Failed to copy document ID',
   /** The header for the project ID column in the list of cross-dataset references found */


### PR DESCRIPTION
### Description

This branch removes a handful of success toast messages across the Studio codebase that are arguably redundant because they can largely be expected to succeed immediately and reliably.

### What to review

There is a commit for each affected toast. Do they all seem reasonable? Note: Marius has reviewed and approved the removals.

### Testing

Existing tests pass.

### Notes for release

Some success toast messages have been removed in order to streamline Studio UI. These removals have been made where there is a reasonable expectation the operation will succeed immediately and reliably (for example, when copying a value to the clipboard). Error toast messages remain as they were before.