### PR TITLE
fix(core): create new doc button tooltip updated for when perspective is published and not a release

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1114,7 +1114,9 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
    * when there are templates/types available for creation
    */
   'new-document.create-new-document-label': 'New document…',
-  /** Tooltip message for add document button when the selected perspective is for published or inactive release */
+  /** Tooltip message for add document button when the selected perspective is published  */
+  'new-document.disabled-published.tooltip': 'You cannot create new published documents',
+  /** Tooltip message for add document button when the selected perspective is for inactive release */
   'new-document.disabled-release.tooltip': 'You cannot add documents to this release',
   /** Placeholder for the "filter" input within the new document menu */
   'new-document.filter-placeholder': 'Search document types',

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
@@ -16,7 +16,9 @@ import {Button, type ButtonProps, Tooltip, type TooltipProps} from '../../../../
 import {InsufficientPermissionsMessage} from '../../../../components'
 import {useSchema} from '../../../../hooks'
 import {useGetI18nText, useTranslation} from '../../../../i18n'
+import {usePerspective} from '../../../../perspective/usePerspective'
 import {useIsReleaseActive} from '../../../../releases/hooks/useIsReleaseActive'
+import {isPublishedPerspective} from '../../../../releases/util/util'
 import {useCurrentUser} from '../../../../store'
 import {useColorSchemeValue} from '../../../colorScheme'
 import {filterOptions} from './filter'
@@ -48,6 +50,7 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
   const {canCreateDocument, modal = 'popover', loading, options} = props
 
   const isReleaseActive = useIsReleaseActive()
+  const {selectedPerspective} = usePerspective()
   const [open, setOpen] = useState<boolean>(false)
   const [searchQuery, setSearchQuery] = useState<string>('')
   const popoverRef = useRef<HTMLDivElement | null>(null)
@@ -177,7 +180,11 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
   // Tooltip content for the open button
   const tooltipContent: TooltipProps['content'] = useMemo(() => {
     if (!isReleaseActive) {
-      return <Text size={1}>{t('new-document.disabled-release.tooltip')}</Text>
+      const tooltipText = isPublishedPerspective(selectedPerspective)
+        ? t('new-document.disabled-published.tooltip')
+        : t('new-document.disabled-release.tooltip')
+
+      return <Text size={1}>{tooltipText}</Text>
     }
     if (!hasNewDocumentOptions) {
       return <Text size={1}>{t('new-document.no-document-types-label')}</Text>
@@ -190,7 +197,14 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
     return (
       <InsufficientPermissionsMessage currentUser={currentUser} context="create-any-document" />
     )
-  }, [canCreateDocument, currentUser, hasNewDocumentOptions, isReleaseActive, t])
+  }, [
+    canCreateDocument,
+    currentUser,
+    hasNewDocumentOptions,
+    isReleaseActive,
+    selectedPerspective,
+    t,
+  ])
 
   // Shared tooltip props for the popover and dialog
   const sharedTooltipProps: TooltipProps = useMemo(


### PR DESCRIPTION
### Description
| Before | After |
|--------|--------|
| <img width="331" alt="Screenshot 2025-02-12 at 16 55 44" src="https://github.com/user-attachments/assets/1f3d3a1f-a48c-4b26-8308-51a8817bff56" /> | <img width="350" alt="Screenshot 2025-02-12 at 16 55 24" src="https://github.com/user-attachments/assets/5d533920-d75c-4de1-b8d9-cd577bdf1203" /> | 

When the perspective is published, the tooltip on create new document is more appropriate named
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
N/A
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
