### PR TITLE
fix: release action dialog fixes; release overview style 

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -77,8 +77,6 @@ const releasesLocaleStrings = {
   /** Title for the dialog confirming the archive of a release */
   'archive-dialog.confirm-archive-title':
     "Are you sure you want to archive the <strong>'{{title}}'</strong> release?",
-  /** Description for the dialog confirming the archive of a release with no documents */
-  'archive-dialog.confirm-archive-description_zero': 'This will not archive any documents.',
   /** Description for the dialog confirming the archive of a release with one document */
   'archive-dialog.confirm-archive-description_one': 'This will archive 1 document version.',
   /** Description for the dialog confirming the archive of a release with more than one document */
@@ -105,8 +103,6 @@ const releasesLocaleStrings = {
 
   /** Header for deleting a release dialog */
   'delete-dialog.confirm-delete.header': "Are you sure you want to delete the '{{title}}' release?",
-  /** Description for the dialog confirming the deleting of a release with no documents */
-  'delete-dialog.confirm-delete-description_zero': 'This will not delete any documents.',
   /** Description for the dialog confirming the deleting of a release with one document */
   'delete-dialog.confirm-delete-description_one': 'This will delete 1 document version.',
   /** Description for the dialog confirming the deleting of a release with more than one document */
@@ -244,8 +240,7 @@ const releasesLocaleStrings = {
   'schedule-button-tooltip.already-scheduled': 'This release is already scheduled',
 
   /** Title for unschedule release dialog */
-  'schedule-dialog.confirm-title':
-    'Are you sure you want to schedule the release and all document versions for publishing?',
+  'schedule-dialog.confirm-title': 'Schedule the release for publishing',
   /** Description shown in unschedule relaease dialog */
   'schedule-dialog.confirm-description_one':
     "The '<strong>{{title}}</strong>' release and its document will be published on the selected date.",

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
@@ -134,7 +134,8 @@ export const ReleaseMenuButton = ({ignoreCTA, release, documentsCount}: ReleaseM
         id={confirmDialog.dialogId}
         data-testid={confirmDialog.dialogId}
         header={t(confirmDialog.dialogHeaderI18nKey, {title: releaseTitle})}
-        onClose={() => setSelectedAction(undefined)}
+        onClose={() => !isPerformingOperation && setSelectedAction(undefined)}
+        padding={false}
         footer={{
           confirmButton: {
             text: t(confirmDialog.dialogConfirmButtonI18nKey),
@@ -143,19 +144,24 @@ export const ReleaseMenuButton = ({ignoreCTA, release, documentsCount}: ReleaseM
             loading: isPerformingOperation,
             disabled: isPerformingOperation,
           },
+          cancelButton: {
+            disabled: isPerformingOperation,
+          },
         }}
       >
-        <Text muted size={1}>
-          {
-            <Translate
-              t={t}
-              i18nKey={confirmDialog.dialogDescriptionI18nKey}
-              values={{
-                count: documentsCount,
-              }}
-            />
-          }
-        </Text>
+        {!!documentsCount && (
+          <Text muted size={1}>
+            {
+              <Translate
+                t={t}
+                i18nKey={confirmDialog.dialogDescriptionI18nKey}
+                values={{
+                  count: documentsCount,
+                }}
+              />
+            }
+          </Text>
+        )}
       </Dialog>
     )
   }, [selectedAction, documentsCount, t, releaseTitle, isPerformingOperation, handleAction])

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -53,7 +53,8 @@ export const ReleaseScheduleButton = ({
 
   const isValidatingDocuments = documents.some(({validation}) => validation.isValidating)
   const hasDocumentValidationErrors = documents.some(({validation}) => validation.hasError)
-  const isScheduleButtonDisabled = disabled || isValidatingDocuments || !schedulePermission
+  const isScheduleButtonDisabled =
+    disabled || isValidatingDocuments || !schedulePermission || hasDocumentValidationErrors
 
   useEffect(() => {
     checkWithPermissionGuard(schedule, release._id, new Date()).then((hasPermission) =>
@@ -161,7 +162,7 @@ export const ReleaseScheduleButton = ({
           documentsLength: documents.length,
           count: documents.length,
         })}
-        onClose={() => setStatus('idle')}
+        onClose={() => status !== 'scheduling' && setStatus('idle')}
         footer={{
           confirmButton: {
             text: t('schedule-dialog.confirm-button'),
@@ -169,6 +170,9 @@ export const ReleaseScheduleButton = ({
             onClick: handleConfirmSchedule,
             loading: status === 'scheduling',
             disabled: _isScheduledDateInPast || status === 'scheduling',
+          },
+          cancelButton: {
+            disabled: status === 'scheduling',
           },
         }}
       >

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseUnscheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseUnscheduleButton.tsx
@@ -28,10 +28,6 @@ export const ReleaseUnscheduleButton = ({
   const telemetry = useTelemetry()
   const [status, setStatus] = useState<'idle' | 'confirm' | 'unscheduling'>('idle')
 
-  const isValidatingDocuments = documents.some(({validation}) => validation.isValidating)
-  const hasDocumentValidationErrors = documents.some(({validation}) => validation.hasError)
-  const isScheduleButtonDisabled = disabled || isValidatingDocuments || hasDocumentValidationErrors
-
   const handleConfirmSchedule = useCallback(async () => {
     try {
       setStatus('unscheduling')
@@ -76,13 +72,16 @@ export const ReleaseUnscheduleButton = ({
       <Dialog
         id="confirm-unschedule-dialog"
         header={t('unschedule-dialog.confirm-title')}
-        onClose={() => setStatus('idle')}
+        onClose={() => status !== 'unscheduling' && setStatus('idle')}
         footer={{
           confirmButton: {
             text: t('action.unschedule'),
             tone: 'default',
             onClick: handleConfirmSchedule,
             loading: status === 'unscheduling',
+            disabled: status === 'unscheduling',
+          },
+          cancelButton: {
             disabled: status === 'unscheduling',
           },
         }}
@@ -108,7 +107,7 @@ export const ReleaseUnscheduleButton = ({
     <>
       <Button
         icon={CloseCircleIcon}
-        disabled={isScheduleButtonDisabled || status === 'unscheduling'}
+        disabled={disabled || status === 'unscheduling'}
         text={t('action.unschedule')}
         onClick={() => setStatus('confirm')}
         loading={status === 'unscheduling'}

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -19,20 +19,21 @@ export const releasesOverviewColumnDefs: (
 ) => Column<TableRelease>[] = (t) => {
   return [
     {
-      id: 'title',
-      sorting: false,
+      id: 'metadata.title',
+      sorting: true,
       width: null,
       style: {minWidth: '50%', maxWidth: '50%'},
-      header: ({headerProps}) => (
+      header: (props) => (
         <Flex
-          {...headerProps}
+          {...props.headerProps}
           flex={1}
-          marginLeft={3}
+          paddingLeft={6}
+          width={3}
           paddingRight={2}
           paddingY={3}
           sizing="border"
         >
-          <Headers.BasicHeader text={t('table-header.title')} />
+          <Headers.SortHeaderButton {...props} text={t('table-header.title')} />
         </Flex>
       ),
       cell: ReleaseNameCell,

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseName.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseName.tsx
@@ -48,7 +48,7 @@ export const ReleaseNameCell: Column<TableRelease>['cell'] = ({cellProps, datum:
   const displayTitle = release.metadata.title || tCore('release.placeholder-untitled-release')
 
   return (
-    <Box {...cellProps} marginLeft={3} flex={1} paddingY={1} paddingRight={2} sizing={'border'}>
+    <Box {...cellProps} paddingLeft={3} flex={1} paddingY={1} paddingRight={2} sizing={'border'}>
       <Tooltip
         disabled={!release.isDeleted}
         content={
@@ -57,7 +57,7 @@ export const ReleaseNameCell: Column<TableRelease>['cell'] = ({cellProps, datum:
           </Text>
         }
       >
-        <Flex align="center" gap={4}>
+        <Flex align="center" gap={3}>
           <Button
             tooltipProps={{
               disabled: isArchived || release.state === 'published',


### PR DESCRIPTION
### Description
Various improvements including:
* Cannot schedule release with validation errors
* Cannot cancel scheduling/unscheduling of release whilst the action is in progress
* Cannot cancel archive/unarchive/delete of release whilst the action is in progress
* Action confirm dialog does not show description if there are no documents in release
* Release Overview header styles to align Release title header with preview card
* Release Overview can be sorted by release title

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
