### PR TITLE
fix: creating new release immediately pins as perspective

### DIFF
--- a/packages/sanity/src/core/perspective/useExcludedPerspective.tsx
+++ b/packages/sanity/src/core/perspective/useExcludedPerspective.tsx
@@ -18,7 +18,7 @@ export interface ExcludedPerspectiveValue {
  * @internal
  */
 export function useExcludedPerspective(): ExcludedPerspectiveValue {
-  const {navigateStickyParams} = useRouter()
+  const {navigate} = useRouter()
   const {excludedPerspectives} = usePerspective()
 
   const toggleExcludedPerspective = useCallback(
@@ -29,9 +29,9 @@ export function useExcludedPerspective(): ExcludedPerspectiveValue {
         ? existingPerspectives.filter((id) => id !== excluded)
         : [...existingPerspectives, excluded]
 
-      navigateStickyParams({excludedPerspectives: nextExcludedPerspectives.toString()})
+      navigate(null, {stickyParams: {excludedPerspectives: nextExcludedPerspectives.toString()}})
     },
-    [excludedPerspectives, navigateStickyParams],
+    [excludedPerspectives, navigate],
   )
 
   const isPerspectiveExcluded = useCallback(

--- a/packages/sanity/src/core/perspective/useExcludedPerspective.tsx
+++ b/packages/sanity/src/core/perspective/useExcludedPerspective.tsx
@@ -29,7 +29,7 @@ export function useExcludedPerspective(): ExcludedPerspectiveValue {
         ? existingPerspectives.filter((id) => id !== excluded)
         : [...existingPerspectives, excluded]
 
-      navigate(null, {stickyParams: {excludedPerspectives: nextExcludedPerspectives.toString()}})
+      navigate({stickyParams: {excludedPerspectives: nextExcludedPerspectives.toString()}})
     },
     [excludedPerspectives, navigate],
   )

--- a/packages/sanity/src/core/perspective/useSetPerspective.tsx
+++ b/packages/sanity/src/core/perspective/useSetPerspective.tsx
@@ -10,7 +10,7 @@ export function useSetPerspective() {
   const router = useRouter()
   const setPerspective = useCallback(
     (releaseId: 'published' | 'drafts' | ReleaseId | undefined) => {
-      router.navigate(null, {
+      router.navigate({
         stickyParams: {
           excludedPerspectives: '',
           perspective: releaseId === 'drafts' ? '' : releaseId,

--- a/packages/sanity/src/core/perspective/useSetPerspective.tsx
+++ b/packages/sanity/src/core/perspective/useSetPerspective.tsx
@@ -10,9 +10,11 @@ export function useSetPerspective() {
   const router = useRouter()
   const setPerspective = useCallback(
     (releaseId: 'published' | 'drafts' | ReleaseId | undefined) => {
-      router.navigateStickyParams({
-        excludedPerspectives: '',
-        perspective: releaseId === 'drafts' ? '' : releaseId,
+      router.navigate(null, {
+        stickyParams: {
+          excludedPerspectives: '',
+          perspective: releaseId === 'drafts' ? '' : releaseId,
+        },
       })
     },
     [router],

--- a/packages/sanity/src/core/perspective/useSetPerspective.tsx
+++ b/packages/sanity/src/core/perspective/useSetPerspective.tsx
@@ -12,7 +12,7 @@ export function useSetPerspective() {
     (releaseId: 'published' | 'drafts' | ReleaseId | undefined) => {
       router.navigate({
         stickyParams: {
-          excludedPerspectives: '',
+          excludedPerspectives: null,
           perspective: releaseId === 'drafts' ? '' : releaseId,
         },
       })

--- a/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
@@ -5,6 +5,7 @@ import {type FormEvent, useCallback, useState} from 'react'
 
 import {Button, Dialog} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
+import {useSetPerspective} from '../../../perspective/useSetPerspective'
 import {CreatedRelease, type OriginInfo} from '../../__telemetry__/releases.telemetry'
 import {useCreateReleaseMetadata} from '../../hooks/useCreateReleaseMetadata'
 import {isReleaseLimitError} from '../../store/isReleaseLimitError'
@@ -24,6 +25,7 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
   const {onCancel, onSubmit, origin} = props
   const toast = useToast()
   const {createRelease} = useReleaseOperations()
+  const setPerspective = useSetPerspective()
   const {t} = useTranslation()
   const telemetry = useTelemetry()
   const createReleaseMetadata = useCreateReleaseMetadata()
@@ -46,6 +48,8 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
         // TODO: Remove this! temporary fix to give some time for the release to be created and the releases store state updated before closing the dialog.
         await new Promise((resolve) => setTimeout(resolve, 1000))
         // TODO: Remove the upper part
+
+        setPerspective(getReleaseIdFromReleaseDocumentId(release._id))
 
         onSubmit(getReleaseIdFromReleaseDocumentId(release._id))
       } catch (err) {
@@ -70,6 +74,7 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
       createRelease,
       telemetry,
       origin,
+      setPerspective,
       onSubmit,
       onCancel,
       t,

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -279,7 +279,16 @@ export function ReleasesOverview() {
   const handleOnCreateRelease = useCallback(
     (createdReleaseId: string) => {
       setIsCreateReleaseDialogOpen(false)
-      router.navigate({releaseId: createdReleaseId})
+
+      router.navigate(
+        {releaseId: createdReleaseId},
+        {
+          stickyParams: {
+            excludedPerspectives: '',
+            perspective: createdReleaseId,
+          },
+        },
+      )
     },
     [router],
   )

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -284,7 +284,7 @@ export function ReleasesOverview() {
         {releaseId: createdReleaseId},
         {
           stickyParams: {
-            excludedPerspectives: '',
+            excludedPerspectives: null,
             perspective: createdReleaseId,
           },
         },

--- a/packages/sanity/src/router/RouteScope.tsx
+++ b/packages/sanity/src/router/RouteScope.tsx
@@ -76,6 +76,8 @@ export const RouteScope = function RouteScope(props: RouteScopeProps): React.JSX
 
   const resolveNextParentState = useCallback(
     (_nextState: RouterState | null) => {
+      if (_nextState === null) return null
+
       const {_searchParams, ...nextState} = _nextState || {}
       const nextParentState = addScope(parentStateRef.current, scope, nextState)
       if (__unsafe_disableScopedSearchParams) {
@@ -90,20 +92,16 @@ export const RouteScope = function RouteScope(props: RouteScopeProps): React.JSX
   )
 
   const resolvePathFromState = useCallback(
-    (nextState: RouterState) => parent_resolvePathFromState(resolveNextParentState(nextState)),
+    (nextState: RouterState | null) =>
+      parent_resolvePathFromState(resolveNextParentState(nextState)),
     [parent_resolvePathFromState, resolveNextParentState],
   )
 
   const navigate = useCallback(
     (nextState: RouterState | null, options?: NavigateOptions) =>
-      /**
-       * OH NO!! This isn't good
-       * There needs to be some special case to handle options.stickyParams
-       * But... not sure what
-       */
       parent_navigate(
-        // as in, if you are doing what navigateStickyParams does, then nextState is null
-        options?.stickyParams && nextState === null ? null : resolveNextParentState(nextState),
+        // options?.stickyParams && nextState === null ? null :
+        resolveNextParentState(nextState),
         options,
       ),
     [parent_navigate, resolveNextParentState],

--- a/packages/sanity/src/router/RouteScope.tsx
+++ b/packages/sanity/src/router/RouteScope.tsx
@@ -96,7 +96,15 @@ export const RouteScope = function RouteScope(props: RouteScopeProps): React.JSX
 
   const navigate = useCallback(
     (nextState: RouterState | null, options?: NavigateOptions) =>
-      parent_navigate(resolveNextParentState(nextState), options),
+      /**
+       * OH NO!! This isn't good
+       * There needs to be some special case to handle options.stickyParams
+       * But... not sure what
+       */
+      parent_navigate(
+        options?.stickyParams ? nextState : resolveNextParentState(nextState),
+        options,
+      ),
     [parent_navigate, resolveNextParentState],
   )
 

--- a/packages/sanity/src/router/RouteScope.tsx
+++ b/packages/sanity/src/router/RouteScope.tsx
@@ -2,7 +2,7 @@
 import {type ReactNode, useCallback, useEffect, useMemo, useRef} from 'react'
 import {RouterContext} from 'sanity/_singletons'
 
-import {type NavigateOptions, type RouterContextValue, type RouterState} from './types'
+import {type NavigateStickyParamsOptions, type RouterContextValue, type RouterState} from './types'
 import {useRouter} from './useRouter'
 
 function addScope(
@@ -95,7 +95,7 @@ export const RouteScope = function RouteScope(props: RouteScopeProps): React.JSX
   )
 
   const navigate = useCallback(
-    (nextState: RouterState, options?: NavigateOptions) =>
+    (nextState: RouterState, options?: NavigateStickyParamsOptions) =>
       parent_navigate(resolveNextParentState(nextState), options),
     [parent_navigate, resolveNextParentState],
   )

--- a/packages/sanity/src/router/RouteScope.tsx
+++ b/packages/sanity/src/router/RouteScope.tsx
@@ -2,7 +2,7 @@
 import {type ReactNode, useCallback, useEffect, useMemo, useRef} from 'react'
 import {RouterContext} from 'sanity/_singletons'
 
-import {type NavigateStickyParamsOptions, type RouterContextValue, type RouterState} from './types'
+import {type NavigateBaseOptions, type RouterContextValue, type RouterState} from './types'
 import {useRouter} from './useRouter'
 
 function addScope(
@@ -95,7 +95,7 @@ export const RouteScope = function RouteScope(props: RouteScopeProps): React.JSX
   )
 
   const navigate = useCallback(
-    (nextState: RouterState, options?: NavigateStickyParamsOptions) =>
+    (nextState: RouterState, options?: NavigateBaseOptions) =>
       parent_navigate(resolveNextParentState(nextState), options),
     [parent_navigate, resolveNextParentState],
   )

--- a/packages/sanity/src/router/RouteScope.tsx
+++ b/packages/sanity/src/router/RouteScope.tsx
@@ -102,7 +102,8 @@ export const RouteScope = function RouteScope(props: RouteScopeProps): React.JSX
        * But... not sure what
        */
       parent_navigate(
-        options?.stickyParams ? nextState : resolveNextParentState(nextState),
+        // as in, if you are doing what navigateStickyParams does, then nextState is null
+        options?.stickyParams && nextState === null ? null : resolveNextParentState(nextState),
         options,
       ),
     [parent_navigate, resolveNextParentState],

--- a/packages/sanity/src/router/RouteScope.tsx
+++ b/packages/sanity/src/router/RouteScope.tsx
@@ -2,7 +2,7 @@
 import {type ReactNode, useCallback, useEffect, useMemo, useRef} from 'react'
 import {RouterContext} from 'sanity/_singletons'
 
-import {type NavigateBaseOptions, type RouterContextValue, type RouterState} from './types'
+import {type NavigateOptions, type RouterContextValue, type RouterState} from './types'
 import {useRouter} from './useRouter'
 
 function addScope(
@@ -75,8 +75,8 @@ export const RouteScope = function RouteScope(props: RouteScopeProps): React.JSX
   }, [parentRouter.state])
 
   const resolveNextParentState = useCallback(
-    (_nextState: RouterState) => {
-      const {_searchParams, ...nextState} = _nextState
+    (_nextState: RouterState | null) => {
+      const {_searchParams, ...nextState} = _nextState || {}
       const nextParentState = addScope(parentStateRef.current, scope, nextState)
       if (__unsafe_disableScopedSearchParams) {
         // Move search params to parent scope
@@ -95,7 +95,7 @@ export const RouteScope = function RouteScope(props: RouteScopeProps): React.JSX
   )
 
   const navigate = useCallback(
-    (nextState: RouterState, options?: NavigateBaseOptions) =>
+    (nextState: RouterState | null, options?: NavigateOptions) =>
       parent_navigate(resolveNextParentState(nextState), options),
     [parent_navigate, resolveNextParentState],
   )

--- a/packages/sanity/src/router/RouteScope.tsx
+++ b/packages/sanity/src/router/RouteScope.tsx
@@ -4,9 +4,9 @@ import {RouterContext} from 'sanity/_singletons'
 
 import {
   isNavigateOptions,
-  type Navigate,
   type NavigateOptions,
   type NextStateOrOptions,
+  type RouterContextValue,
   type RouterState,
 } from './types'
 import {useRouter} from './useRouter'
@@ -103,7 +103,7 @@ export const RouteScope = function RouteScope(props: RouteScopeProps): React.JSX
     [parent_resolvePathFromState, resolveNextParentState],
   )
 
-  const navigate: Navigate = useCallback(
+  const navigate: RouterContextValue['navigate'] = useCallback(
     (nextStateOrOptions: NextStateOrOptions, maybeOptions?: NavigateOptions) => {
       // Check if it's the options-only pattern
       if (isNavigateOptions(nextStateOrOptions) && !maybeOptions) {
@@ -131,7 +131,7 @@ export const RouteScope = function RouteScope(props: RouteScopeProps): React.JSX
     [parent_navigate, resolveNextParentState],
   )
 
-  const childRouter = useMemo(() => {
+  const childRouter: RouterContextValue = useMemo(() => {
     const parentState = parentRouter.state
     const childState = {...(parentState[scope] || {})} as RouterState
     if (__unsafe_disableScopedSearchParams) {

--- a/packages/sanity/src/router/RouterProvider.tsx
+++ b/packages/sanity/src/router/RouterProvider.tsx
@@ -119,27 +119,6 @@ export function RouterProvider(props: RouterProviderProps): React.JSX.Element {
     [routerProp, state],
   )
 
-  /**
-   * Updates the router state and navigates to a new path.
-   * Allows specifying new state values and optionally merging sticky parameters.
-   *
-   * @public
-   *
-   * @example Navigate with router state only
-   * ```tsx
-   * router.navigate({foo: 'bar'})
-   * ```
-   *
-   * @example Navigate with router state and sticky params
-   * ```tsx
-   * router.navigate({foo: 'bar'}, {stickyParams: {baz: 'qux'}})
-   * ```
-   *
-   * @example Navigate with sticky params only
-   * ```tsx
-   * router.navigate(null, {stickyParams: {baz: 'qux'}})
-   * ```
-   */
   const navigate = useCallback(
     (nextState: Record<string, unknown> | null, options: NavigateOptions = {}) => {
       const currentParams = Array.isArray(state._searchParams) ? state._searchParams : []
@@ -166,9 +145,6 @@ export function RouterProvider(props: RouterProviderProps): React.JSX.Element {
     [onNavigate, resolvePathFromState, state],
   )
 
-  /**
-   * @deprecated Use `navigate(null, {stickyParams: params, ...options})` instead
-   */
   const handleNavigateStickyParams = useCallback(
     (params: NavigateOptions['stickyParams'], options: NavigateBaseOptions = {}) =>
       navigate(null, {stickyParams: params, ...options}),

--- a/packages/sanity/src/router/RouterProvider.tsx
+++ b/packages/sanity/src/router/RouterProvider.tsx
@@ -100,9 +100,9 @@ export function RouterProvider(props: RouterProviderProps): React.JSX.Element {
   )
 
   const resolvePathFromState = useCallback(
-    (nextState: RouterState): string => {
+    (nextState: RouterState | null): string => {
       const currentStateParams = state._searchParams || []
-      const nextStateParams = nextState._searchParams || []
+      const nextStateParams = nextState?._searchParams || []
       const nextParams = STICKY_PARAMS.reduce((acc, param) => {
         return replaceStickyParam(
           acc,

--- a/packages/sanity/src/router/RouterProvider.tsx
+++ b/packages/sanity/src/router/RouterProvider.tsx
@@ -126,10 +126,8 @@ export function RouterProvider(props: RouterProviderProps): React.JSX.Element {
         throw new Error('One or more parameters are not sticky')
       }
 
-      // Use helper to merge sticky params
       const searchParams = mergeStickyParams(state._searchParams || [], params)
 
-      // Trigger navigation with updated params
       onNavigate({
         path: resolvePathFromState({
           ...state,
@@ -146,14 +144,11 @@ export function RouterProvider(props: RouterProviderProps): React.JSX.Element {
       const currentParams = Array.isArray(state._searchParams) ? state._searchParams : []
       const nextParams = Array.isArray(nextState._searchParams) ? nextState._searchParams : []
 
-      // Merge sticky params using the helper function
       const mergedParams = mergeStickyParams(
-        nextParams, // Ensure it's always an array
+        nextParams,
         options.stickyParams ??
-          Object.fromEntries(currentParams.filter(([key]) => STICKY_PARAMS.includes(key))), // Preserve sticky params unless overridden
+          Object.fromEntries(currentParams.filter(([key]) => STICKY_PARAMS.includes(key))),
       )
-
-      // Construct new state
       const mergedState = {...nextState, _searchParams: mergedParams}
 
       onNavigate({path: resolvePathFromState(mergedState), replace: options.replace})

--- a/packages/sanity/src/router/RouterProvider.tsx
+++ b/packages/sanity/src/router/RouterProvider.tsx
@@ -151,7 +151,7 @@ export function RouterProvider(props: RouterProviderProps): React.JSX.Element {
 
   const handleNavigateStickyParams = useCallback(
     (params: NavigateOptions['stickyParams'], options: NavigateBaseOptions = {}) =>
-      navigate({stickyParams: params, ...options}),
+      navigate({stickyParams: params, ...options, state: undefined}),
     [navigate],
   )
 

--- a/packages/sanity/src/router/__test__/RouterProvider.test.tsx
+++ b/packages/sanity/src/router/__test__/RouterProvider.test.tsx
@@ -197,17 +197,13 @@ describe('RouterProvider', () => {
     it('should handle null state gracefully', () => {
       const {result} = renderHook(() => useRouter(), {wrapper})
 
-      // Reset the mock to ensure we only track the call we're interested in
       vi.mocked(mockRouter.encode).mockClear()
 
       result.current.resolvePathFromState(null)
 
-      // Verify encode was called with the expected state
       expect(mockRouter.encode).toHaveBeenCalledWith({
         _searchParams: [['stickyFirstParam', 'stickyFirstParamValue']],
       })
-
-      // We don't need to assert on the return value since it's just what mockRouter.encode returns
     })
 
     it('should properly merge search params when resolving path', () => {

--- a/packages/sanity/src/router/__test__/RouterProvider.test.tsx
+++ b/packages/sanity/src/router/__test__/RouterProvider.test.tsx
@@ -42,21 +42,6 @@ describe('RouterProvider', () => {
   })
 
   describe('navigate', () => {
-    it('should navigate with new state', () => {
-      const {result} = renderHook(() => useRouter(), {wrapper})
-
-      act(() => {
-        result.current.navigate({routeStateKey: 'routeStateValue'})
-      })
-
-      expect(mockOnNavigate).toHaveBeenCalledWith({
-        path: {
-          _searchParams: [['stickyFirstParam', 'stickyFirstParamValue']],
-          routeStateKey: 'routeStateValue',
-        },
-      })
-    })
-
     it('should update only the route state when navigating without stickyParams', () => {
       const {result} = renderHook(() => useRouter(), {wrapper})
 

--- a/packages/sanity/src/router/__test__/RouterProvider.test.tsx
+++ b/packages/sanity/src/router/__test__/RouterProvider.test.tsx
@@ -1,0 +1,210 @@
+import {act, renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {RouterProvider} from '../RouterProvider'
+import {type Router, type RouterState} from '../types'
+import {useRouter} from '../useRouter'
+
+vi.mock('../stickyParams', () => ({
+  STICKY_PARAMS: ['stickyFirstParam', 'anotherStickyParam'],
+}))
+
+const mockOnNavigate = vi.fn()
+
+const mockRouter: Router = {
+  encode: vi.fn((state) => state),
+  decode: vi.fn((path) => path),
+  _isRoute: false,
+  isNotFound: vi.fn(() => false),
+  getBasePath: vi.fn(() => '/'),
+  getRedirectBase: vi.fn(() => null),
+  isRoot: vi.fn(() => false),
+  route: {
+    raw: '/',
+    segments: [],
+  },
+  children: [],
+}
+
+const initialState: RouterState = {
+  _searchParams: [['stickyFirstParam', 'stickyFirstParamValue']],
+}
+
+const wrapper = ({children}: {children: React.ReactNode}) => (
+  <RouterProvider onNavigate={mockOnNavigate} router={mockRouter} state={initialState}>
+    {children}
+  </RouterProvider>
+)
+
+describe('RouterProvider', () => {
+  beforeEach(() => {
+    mockOnNavigate.mockClear()
+  })
+
+  describe('navigate', () => {
+    it('should navigate with new state', () => {
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate({routeStateKey: 'routeStateValue'})
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [['stickyFirstParam', 'stickyFirstParamValue']],
+          routeStateKey: 'routeStateValue',
+        },
+      })
+    })
+
+    it('should update only the route state when navigating without stickyParams', () => {
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate({routeStateKey: 'newRouteStateValue'})
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [['stickyFirstParam', 'stickyFirstParamValue']],
+          routeStateKey: 'newRouteStateValue',
+        },
+      })
+    })
+
+    it('should navigate with allowed sticky params', () => {
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate(null, {
+          stickyParams: {
+            anotherStickyParam: 'anotherStickyParamValue',
+          },
+        })
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [
+            ['stickyFirstParam', 'stickyFirstParamValue'],
+            ['anotherStickyParam', 'anotherStickyParamValue'],
+          ],
+        },
+      })
+    })
+
+    it('should update both the route state and stickyParams when navigating', () => {
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate(
+          {routeStateKey: 'newRouteStateValue'},
+          {
+            stickyParams: {
+              stickyFirstParam: 'updatedStickyFirstParamValue',
+              anotherStickyParam: 'anotherStickyParamValue',
+            },
+          },
+        )
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [
+            ['stickyFirstParam', 'updatedStickyFirstParamValue'],
+            ['anotherStickyParam', 'anotherStickyParamValue'],
+          ],
+          routeStateKey: 'newRouteStateValue',
+        },
+      })
+    })
+
+    it('should apply only stickyParams when navigating with null state', () => {
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate(null, {
+          stickyParams: {
+            stickyFirstParam: 'newStickyFirstParamValue',
+            anotherStickyParam: 'anotherStickyParamValue',
+          },
+        })
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [
+            ['stickyFirstParam', 'newStickyFirstParamValue'],
+            ['anotherStickyParam', 'anotherStickyParamValue'],
+          ],
+        },
+      })
+    })
+
+    it('should throw an error if stickyParams contains invalid keys', () => {
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      expect(() => {
+        act(() => {
+          result.current.navigate(null, {stickyParams: {invalidStickyParam: 'invalidValue'}})
+        })
+      }).toThrowError('One or more parameters are not sticky')
+    })
+
+    it('should throw an error if stickyParams contains disallowed keys', () => {
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      expect(() => {
+        act(() => {
+          result.current.navigate(null, {stickyParams: {disallowedParam: 'disallowedValue'}})
+        })
+      }).toThrowError('One or more parameters are not sticky')
+    })
+  })
+
+  describe('navigateStickyParams', () => {
+    it('should navigate using handleNavigateStickyParams with valid sticky params', () => {
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigateStickyParams({stickyFirstParam: 'updatedStickyFirstParamValue'})
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [['stickyFirstParam', 'updatedStickyFirstParamValue']],
+        },
+      })
+    })
+
+    it('should merge new stickyParams with existing stickyParams when navigatingStickyParams', () => {
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigateStickyParams({
+          stickyFirstParam: 'updatedStickyFirstParamValue',
+          anotherStickyParam: 'anotherStickyParamValue',
+        })
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [
+            ['stickyFirstParam', 'updatedStickyFirstParamValue'],
+            ['anotherStickyParam', 'anotherStickyParamValue'],
+          ],
+        },
+      })
+    })
+
+    it('should throw an error when navigateStickyParams is called with disallowed sticky params', () => {
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      expect(() => {
+        act(() => {
+          result.current.navigateStickyParams({disallowedParam: 'disallowedValue'})
+        })
+      }).toThrowError('One or more parameters are not sticky')
+    })
+  })
+})

--- a/packages/sanity/src/router/__test__/RouterProvider.test.tsx
+++ b/packages/sanity/src/router/__test__/RouterProvider.test.tsx
@@ -192,4 +192,41 @@ describe('RouterProvider', () => {
       }).toThrowError('One or more parameters are not sticky')
     })
   })
+
+  describe('resolvePathFromState', () => {
+    it('should handle null state gracefully', () => {
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      // Reset the mock to ensure we only track the call we're interested in
+      vi.mocked(mockRouter.encode).mockClear()
+
+      result.current.resolvePathFromState(null)
+
+      // Verify encode was called with the expected state
+      expect(mockRouter.encode).toHaveBeenCalledWith({
+        _searchParams: [['stickyFirstParam', 'stickyFirstParamValue']],
+      })
+
+      // We don't need to assert on the return value since it's just what mockRouter.encode returns
+    })
+
+    it('should properly merge search params when resolving path', () => {
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      vi.mocked(mockRouter.encode).mockClear()
+
+      result.current.resolvePathFromState({
+        testKey: 'testValue',
+        _searchParams: [['nonStickyParam', 'nonStickyValue']],
+      })
+
+      expect(mockRouter.encode).toHaveBeenCalledWith({
+        testKey: 'testValue',
+        _searchParams: [
+          ['nonStickyParam', 'nonStickyValue'],
+          ['stickyFirstParam', 'stickyFirstParamValue'],
+        ],
+      })
+    })
+  })
 })

--- a/packages/sanity/src/router/__test__/RouterProvider.test.tsx
+++ b/packages/sanity/src/router/__test__/RouterProvider.test.tsx
@@ -61,7 +61,7 @@ describe('RouterProvider', () => {
       const {result} = renderHook(() => useRouter(), {wrapper})
 
       act(() => {
-        result.current.navigate(null, {
+        result.current.navigate({
           stickyParams: {
             anotherStickyParam: 'anotherStickyParamValue',
           },
@@ -108,7 +108,7 @@ describe('RouterProvider', () => {
       const {result} = renderHook(() => useRouter(), {wrapper})
 
       act(() => {
-        result.current.navigate(null, {
+        result.current.navigate({
           stickyParams: {
             stickyFirstParam: 'newStickyFirstParamValue',
             anotherStickyParam: 'anotherStickyParamValue',
@@ -131,7 +131,7 @@ describe('RouterProvider', () => {
 
       expect(() => {
         act(() => {
-          result.current.navigate(null, {stickyParams: {invalidStickyParam: 'invalidValue'}})
+          result.current.navigate({stickyParams: {invalidStickyParam: 'invalidValue'}})
         })
       }).toThrowError('One or more parameters are not sticky')
     })
@@ -141,7 +141,7 @@ describe('RouterProvider', () => {
 
       expect(() => {
         act(() => {
-          result.current.navigate(null, {stickyParams: {disallowedParam: 'disallowedValue'}})
+          result.current.navigate({stickyParams: {disallowedParam: 'disallowedValue'}})
         })
       }).toThrowError('One or more parameters are not sticky')
     })
@@ -222,6 +222,173 @@ describe('RouterProvider', () => {
           ['nonStickyParam', 'nonStickyValue'],
           ['stickyFirstParam', 'stickyFirstParamValue'],
         ],
+      })
+    })
+  })
+
+  describe('new navigate API', () => {
+    it('should keep current state when navigating with options object only', () => {
+      const {result} = renderHook(() => useRouter(), {
+        wrapper: ({children}) => (
+          <RouterProvider
+            onNavigate={mockOnNavigate}
+            router={mockRouter}
+            state={{
+              existingKey: 'existingValue',
+              _searchParams: [['stickyFirstParam', 'stickyFirstParamValue']],
+            }}
+          >
+            {children}
+          </RouterProvider>
+        ),
+      })
+
+      act(() => {
+        result.current.navigate({
+          stickyParams: {
+            stickyFirstParam: 'newStickyValue',
+          },
+          replace: true,
+        })
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          existingKey: 'existingValue',
+          _searchParams: [['stickyFirstParam', 'newStickyValue']],
+        },
+        replace: true,
+      })
+    })
+
+    it('should go to root route when navigating with null state in options', () => {
+      const {result} = renderHook(() => useRouter(), {
+        wrapper: ({children}) => (
+          <RouterProvider
+            onNavigate={mockOnNavigate}
+            router={mockRouter}
+            state={{
+              existingKey: 'existingValue',
+              _searchParams: [['stickyFirstParam', 'stickyFirstParamValue']],
+            }}
+          >
+            {children}
+          </RouterProvider>
+        ),
+      })
+
+      act(() => {
+        result.current.navigate({
+          state: null,
+          stickyParams: {
+            stickyFirstParam: 'newStickyValue',
+          },
+        })
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [['stickyFirstParam', 'newStickyValue']],
+        },
+      })
+    })
+
+    it('should create new state when navigating with specific state in options', () => {
+      const {result} = renderHook(() => useRouter(), {
+        wrapper: ({children}) => (
+          <RouterProvider
+            onNavigate={mockOnNavigate}
+            router={mockRouter}
+            state={{
+              existingKey: 'existingValue',
+              _searchParams: [['stickyFirstParam', 'stickyFirstParamValue']],
+            }}
+          >
+            {children}
+          </RouterProvider>
+        ),
+      })
+
+      act(() => {
+        result.current.navigate({
+          state: {
+            newKey: 'newValue',
+          },
+          stickyParams: {
+            stickyFirstParam: 'newStickyValue',
+          },
+        })
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          newKey: 'newValue',
+          _searchParams: [['stickyFirstParam', 'newStickyValue']],
+        },
+      })
+    })
+
+    it('should create new state when navigating with state change and no sticky params', () => {
+      const {result} = renderHook(() => useRouter(), {
+        wrapper: ({children}) => (
+          <RouterProvider
+            onNavigate={mockOnNavigate}
+            router={mockRouter}
+            state={{
+              existingKey: 'existingValue',
+              _searchParams: [['stickyFirstParam', 'stickyFirstParamValue']],
+            }}
+          >
+            {children}
+          </RouterProvider>
+        ),
+      })
+
+      act(() => {
+        result.current.navigate({
+          state: {
+            newKey: 'newValue',
+          },
+        })
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          newKey: 'newValue',
+          _searchParams: [['stickyFirstParam', 'stickyFirstParamValue']],
+        },
+      })
+    })
+
+    it('should keep the current state when navigating with undefined state', () => {
+      const {result} = renderHook(() => useRouter(), {
+        wrapper: ({children}) => (
+          <RouterProvider
+            onNavigate={mockOnNavigate}
+            router={mockRouter}
+            state={{
+              existingKey: 'existingValue',
+              _searchParams: [['stickyFirstParam', 'stickyFirstParamValue']],
+            }}
+          >
+            {children}
+          </RouterProvider>
+        ),
+      })
+
+      act(() => {
+        result.current.navigate({
+          state: undefined,
+          replace: true,
+        })
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          existingKey: 'existingValue',
+          _searchParams: [['stickyFirstParam', 'stickyFirstParamValue']],
+        },
+        replace: true,
       })
     })
   })

--- a/packages/sanity/src/router/__test__/RouterScope.test.tsx
+++ b/packages/sanity/src/router/__test__/RouterScope.test.tsx
@@ -1,0 +1,311 @@
+import {act, renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {RouterProvider} from '../RouterProvider'
+import {RouteScope} from '../RouteScope'
+import {type Router, type RouterState} from '../types'
+import {useRouter} from '../useRouter'
+
+vi.mock('../stickyParams', () => ({
+  STICKY_PARAMS: ['stickyParam'],
+}))
+
+const mockOnNavigate = vi.fn()
+
+const mockRouter: Router = {
+  encode: vi.fn((state) => state),
+  decode: vi.fn((path) => path),
+  _isRoute: false,
+  isNotFound: vi.fn(() => false),
+  getBasePath: vi.fn(() => '/'),
+  getRedirectBase: vi.fn(() => null),
+  isRoot: vi.fn(() => false),
+  route: {
+    raw: '/',
+    segments: [],
+  },
+  children: [],
+}
+
+const initialState: RouterState = {
+  _searchParams: [['stickyParam', 'stickyValue']],
+  tool: 'desk',
+}
+
+interface WrapperProps {
+  children: React.ReactNode
+}
+
+const createWrapper = (disableScopedSearchParams = false) => {
+  const Wrapper = ({children}: WrapperProps) => (
+    <RouterProvider onNavigate={mockOnNavigate} router={mockRouter} state={initialState}>
+      <RouteScope scope="testScope" __unsafe_disableScopedSearchParams={disableScopedSearchParams}>
+        {children}
+      </RouteScope>
+    </RouterProvider>
+  )
+  Wrapper.displayName = 'TestWrapper'
+  return Wrapper
+}
+
+describe('RouteScope', () => {
+  beforeEach(() => {
+    mockOnNavigate.mockClear()
+  })
+
+  describe('state scoping', () => {
+    it('should scope router state to the provided scope', () => {
+      const wrapper = createWrapper()
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      expect(result.current.state).toEqual({
+        _searchParams: undefined,
+      })
+
+      expect(result.current.stickyParams).toEqual({
+        stickyParam: 'stickyValue',
+      })
+    })
+
+    it('should maintain parent state when navigating within scope', () => {
+      const wrapper = createWrapper()
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate({scopedKey: 'scopedValue'})
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [['stickyParam', 'stickyValue']],
+          tool: 'desk',
+          testScope: {
+            scopedKey: 'scopedValue',
+          },
+        },
+      })
+    })
+  })
+
+  describe('search params scoping', () => {
+    it('should scope search params when scoping is enabled', () => {
+      const wrapper = createWrapper(false)
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate({
+          _searchParams: [['testParam', 'testValue']],
+        })
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [['stickyParam', 'stickyValue']],
+          tool: 'desk',
+          testScope: {
+            _searchParams: [['testParam', 'testValue']],
+          },
+        },
+      })
+    })
+
+    it('should not scope search params when scoping is disabled', () => {
+      const wrapper = createWrapper(true)
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate({
+          _searchParams: [['testParam', 'testValue']],
+        })
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [
+            ['testParam', 'testValue'],
+            ['stickyParam', 'stickyValue'],
+          ],
+          tool: 'desk',
+          testScope: {},
+        },
+      })
+    })
+  })
+
+  describe('sticky params', () => {
+    it('should handle sticky params navigation within scope', () => {
+      const wrapper = createWrapper()
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate(null, {
+          stickyParams: {
+            stickyParam: 'newStickyValue',
+          },
+        })
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [['stickyParam', 'newStickyValue']],
+          tool: 'desk',
+        },
+      })
+    })
+
+    it('should throw an error when navigating with invalid sticky params', () => {
+      const wrapper = createWrapper()
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      expect(() => {
+        act(() => {
+          result.current.navigate(null, {
+            stickyParams: {invalidParam: 'invalidValue'},
+          })
+        })
+      }).toThrowError('One or more parameters are not sticky')
+    })
+
+    it('should merge new sticky params with existing ones', () => {
+      const wrapper = createWrapper()
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate(
+          {scopedValue: 'test'},
+          {
+            stickyParams: {
+              stickyParam: 'newStickyValue',
+            },
+          },
+        )
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [['stickyParam', 'newStickyValue']],
+          tool: 'desk',
+          testScope: {
+            scopedValue: 'test',
+          },
+        },
+      })
+    })
+  })
+
+  describe('nested scopes', () => {
+    it('should handle nested route scopes correctly', () => {
+      const NestedWrapper = ({children}: WrapperProps) => (
+        <RouterProvider onNavigate={mockOnNavigate} router={mockRouter} state={initialState}>
+          <RouteScope scope="parentScope">
+            <RouteScope scope="childScope">{children}</RouteScope>
+          </RouteScope>
+        </RouterProvider>
+      )
+      NestedWrapper.displayName = 'NestedWrapper'
+
+      const {result} = renderHook(() => useRouter(), {wrapper: NestedWrapper})
+
+      act(() => {
+        result.current.navigate({nestedValue: 'test'})
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [['stickyParam', 'stickyValue']],
+          tool: 'desk',
+          parentScope: {
+            childScope: {
+              nestedValue: 'test',
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe('intent handling', () => {
+    it('should preserve scope when navigating with intent', () => {
+      const wrapper = createWrapper()
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigateIntent('test', {id: 'test-id'})
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          intent: 'test',
+          params: {id: 'test-id'},
+          _searchParams: [['stickyParam', 'stickyValue']],
+        },
+      })
+    })
+  })
+
+  describe('resolvePathFromState', () => {
+    it('should correctly resolve path from scoped state', () => {
+      const wrapper = createWrapper()
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      const path = result.current.resolvePathFromState({
+        scopedValue: 'test',
+        _searchParams: [['testParam', 'testValue']],
+      })
+
+      expect(mockRouter.encode).toHaveBeenCalledWith({
+        _searchParams: [['stickyParam', 'stickyValue']],
+        tool: 'desk',
+        testScope: {
+          scopedValue: 'test',
+          _searchParams: [['testParam', 'testValue']],
+        },
+      })
+    })
+  })
+
+  describe('search params inheritance', () => {
+    it('should inherit parent search params when enabled', () => {
+      const wrapper = createWrapper(false)
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate({
+          _searchParams: [['scopedParam', 'scopedValue']],
+        })
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [['stickyParam', 'stickyValue']],
+          tool: 'desk',
+          testScope: {
+            _searchParams: [['scopedParam', 'scopedValue']],
+          },
+        },
+      })
+    })
+  })
+
+  describe('error handling', () => {
+    it('should handle null state gracefully', () => {
+      const wrapper = createWrapper()
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate(null)
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [['stickyParam', 'stickyValue']],
+          tool: 'desk',
+          testScope: {
+            _searchParams: undefined,
+          },
+        },
+        replace: undefined,
+      })
+    })
+  })
+})

--- a/packages/sanity/src/router/__test__/RouterScope.test.tsx
+++ b/packages/sanity/src/router/__test__/RouterScope.test.tsx
@@ -138,7 +138,7 @@ describe('RouteScope', () => {
       const {result} = renderHook(() => useRouter(), {wrapper})
 
       act(() => {
-        result.current.navigate(null, {
+        result.current.navigate({
           stickyParams: {
             stickyParam: 'newStickyValue',
           },
@@ -159,7 +159,7 @@ describe('RouteScope', () => {
 
       expect(() => {
         act(() => {
-          result.current.navigate(null, {
+          result.current.navigate({
             stickyParams: {invalidParam: 'invalidValue'},
           })
         })
@@ -295,16 +295,136 @@ describe('RouteScope', () => {
       const {result} = renderHook(() => useRouter(), {wrapper})
 
       act(() => {
-        result.current.navigate(null)
+        result.current.navigate({})
       })
 
       expect(mockOnNavigate).toHaveBeenCalledWith({
         path: {
           _searchParams: [['stickyParam', 'stickyValue']],
+          testScope: {
+            _searchParams: undefined,
+          },
           tool: 'desk',
         },
         replace: undefined,
       })
+    })
+  })
+
+  it('should keep current state when navigating with options object only', () => {
+    const wrapper = createWrapper()
+    const {result} = renderHook(() => useRouter(), {wrapper})
+
+    act(() => {
+      result.current.navigate({
+        stickyParams: {
+          stickyParam: 'newStickyValue',
+        },
+        replace: true,
+      })
+    })
+
+    expect(mockOnNavigate).toHaveBeenCalledWith({
+      path: {
+        _searchParams: [['stickyParam', 'newStickyValue']],
+        tool: 'desk',
+      },
+      replace: true,
+    })
+  })
+
+  it('should go to root route when navigating with null state in options', () => {
+    const wrapper = createWrapper()
+    const {result} = renderHook(() => useRouter(), {wrapper})
+
+    act(() => {
+      result.current.navigate({
+        state: null,
+        stickyParams: {
+          stickyParam: 'newStickyValue',
+        },
+      })
+    })
+
+    expect(mockOnNavigate).toHaveBeenCalledWith({
+      path: {
+        _searchParams: [['stickyParam', 'newStickyValue']],
+      },
+    })
+  })
+
+  it('should handle navigate with specific state in options', () => {
+    const wrapper = createWrapper()
+    const {result} = renderHook(() => useRouter(), {wrapper})
+
+    act(() => {
+      result.current.navigate({
+        state: {
+          scopedKey: 'scopedValue',
+        },
+        stickyParams: {
+          stickyParam: 'newStickyValue',
+        },
+      })
+    })
+
+    expect(mockOnNavigate).toHaveBeenCalledWith({
+      path: {
+        _searchParams: [['stickyParam', 'newStickyValue']],
+        tool: 'desk',
+        testScope: {
+          scopedKey: 'scopedValue',
+        },
+      },
+    })
+  })
+
+  it('should keep the current state when navigating with explicitly undefined state', () => {
+    const wrapper = createWrapper()
+    const {result} = renderHook(() => useRouter(), {wrapper})
+
+    act(() => {
+      result.current.navigate({
+        initialValue: 'test',
+      })
+    })
+
+    mockOnNavigate.mockClear()
+
+    act(() => {
+      result.current.navigate({
+        state: undefined,
+        stickyParams: {
+          stickyParam: 'newStickyValue',
+        },
+      })
+    })
+
+    expect(mockOnNavigate).toHaveBeenCalledWith({
+      path: {
+        _searchParams: [['stickyParam', 'newStickyValue']],
+        tool: 'desk',
+      },
+      replace: undefined,
+    })
+  })
+
+  it('should handle navigate with empty object state', () => {
+    const wrapper = createWrapper()
+    const {result} = renderHook(() => useRouter(), {wrapper})
+
+    act(() => {
+      result.current.navigate({
+        state: {},
+      })
+    })
+
+    expect(mockOnNavigate).toHaveBeenCalledWith({
+      path: {
+        _searchParams: [['stickyParam', 'stickyValue']],
+        tool: 'desk',
+        testScope: {},
+      },
     })
   })
 })

--- a/packages/sanity/src/router/__test__/RouterScope.test.tsx
+++ b/packages/sanity/src/router/__test__/RouterScope.test.tsx
@@ -13,7 +13,7 @@ vi.mock('../stickyParams', () => ({
 const mockOnNavigate = vi.fn()
 
 const mockRouter: Router = {
-  encode: vi.fn((state) => state),
+  encode: vi.fn((state) => state) as unknown as Router['encode'] & {mockClear: () => void},
   decode: vi.fn((path) => path),
   _isRoute: false,
   isNotFound: vi.fn(() => false),
@@ -248,7 +248,9 @@ describe('RouteScope', () => {
       const wrapper = createWrapper()
       const {result} = renderHook(() => useRouter(), {wrapper})
 
-      const path = result.current.resolvePathFromState({
+      vi.mocked(mockRouter.encode).mockClear()
+
+      result.current.resolvePathFromState({
         scopedValue: 'test',
         _searchParams: [['testParam', 'testValue']],
       })
@@ -300,9 +302,6 @@ describe('RouteScope', () => {
         path: {
           _searchParams: [['stickyParam', 'stickyValue']],
           tool: 'desk',
-          testScope: {
-            _searchParams: undefined,
-          },
         },
         replace: undefined,
       })

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -172,6 +172,9 @@ export interface NavigateStickyParamsOptions {
   replace?: boolean
 }
 
+/**
+ * @public
+ */
 export interface NavigateOptions extends NavigateStickyParamsOptions {
   stickyParams?: Record<string, string | undefined>
 }

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -212,7 +212,7 @@ export interface RouterContextValue {
   navigateUrl: (opts: {path: string; replace?: boolean}) => void
 
   /**
-   * @deprecated Use `navigate(null, {stickyParams: params, ...options})` instead
+   * @deprecated Use `navigate({stickyParams: params, ...options})` instead
    */
   navigateStickyParams: (
     params: NavigateOptions['stickyParams'],
@@ -227,28 +227,24 @@ export interface RouterContextValue {
    *
    * @public
    *
-   * @example Navigate with router state only
-   * ```tsx
-   * router.navigate({foo: 'bar'})
-   * ```
-   *
-   * @example Navigate with router state and sticky params
-   * ```tsx
-   * router.navigate({foo: 'bar'}, {stickyParams: {baz: 'qux'}})
-   * ```
-   *
-   * @example Navigate with sticky params only
+   * @example Navigate with sticky params only, staying on the current path
    * ```tsx
    * router.navigate({stickyParams: {baz: 'qux'}})
    * ```
+   * @remarks `null` sticky parameter value will remove the sticky parameter from the url
    *
    * @example Navigate with state and sticky params
+   * ```tsx
+   * router.navigate({stickyParams: {baz: 'qux'}, state: {foo: 'bar'}})
+   * ```
+   *
+   * @example Navigate to root path
    * ```tsx
    * router.navigate({stickyParams: {baz: 'qux'}, state: null})
    * ```
    */
   navigate: {
-    // State-first version - for when you want to navigate to a new state
+    // legacy, state-first version - for when you want to navigate to a new state
     (nextState: RouterState, options?: NavigateOptions): void
     // Options version - for staying where you are (omit state) or going to root (state: null)
     (options: NavigateOptions & {state?: RouterState | null}): void

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -255,7 +255,7 @@ export interface RouterContextValue {
   /**
    * Resolves the path from the given router state. See {@link RouterState}
    */
-  resolvePathFromState: (nextState: RouterState) => string
+  resolvePathFromState: (state: RouterState | null) => string
 
   /**
    * Resolves the intent link for the given intent name and parameters.

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -274,7 +274,7 @@ export interface RouterContextValue {
   navigateUrl: (opts: {path: string; replace?: boolean}) => void
 
   /**
-   * Navigates to the current URL with the sticky url search param set to the given values
+   * @deprecated Use `navigate(null, {stickyParams: params, ...options})` instead
    */
   navigateStickyParams: (
     params: NavigateOptions['stickyParams'],
@@ -282,8 +282,27 @@ export interface RouterContextValue {
   ) => void
 
   /**
-   * Navigates to the given router state.
+   * Updates the router state and navigates to a new path.
+   * Allows specifying new state values and optionally merging sticky parameters.
+   *
    * See {@link RouterState} and {@link NavigateOptions}
+   *
+   * @public
+   *
+   * @example Navigate with router state only
+   * ```tsx
+   * router.navigate({foo: 'bar'})
+   * ```
+   *
+   * @example Navigate with router state and sticky params
+   * ```tsx
+   * router.navigate({foo: 'bar'}, {stickyParams: {baz: 'qux'}})
+   * ```
+   *
+   * @example Navigate with sticky params only
+   * ```tsx
+   * router.navigate(null, {stickyParams: {baz: 'qux'}})
+   * ```
    */
   navigate: (nextState: RouterState | null, options?: NavigateOptions) => void
 

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -165,21 +165,115 @@ export type MatchResult = MatchError | MatchOk
 /**
  * @public
  */
-export interface NavigateOptions {
-  /**
-   * Indicates whether to replace the current state.
-   */
+export interface NavigateBaseOptions {
   replace?: boolean
-  /**
-   * Record of query parameters that should persist across navigation.
-   */
+}
+
+/**
+ * @public
+ */
+export interface NavigateOptions extends NavigateBaseOptions {
   stickyParams?: Record<string, string | undefined>
 }
 
 /**
  * @public
  */
-export type NavigateBaseOptions = Omit<NavigateOptions, 'stickyParams'>
+export interface NavigateOptionsWithState extends NavigateOptions {
+  state?: RouterState | null
+}
+
+/**
+ * @public
+ */
+export type Navigate = {
+  // State-first version - for when you want to navigate to a new state
+  (nextState: RouterState, options?: NavigateOptions): void
+  // Options version - for staying where you are (omit state) or going to root (state: null)
+  (options: NavigateOptions & {state?: RouterState | null}): void
+}
+
+/**
+ * @public
+ */
+export interface RouterContextValue {
+  /**
+   * Resolves the path from the given router state. See {@link RouterState}
+   *
+   * When state is null, it will resolve the path from the current state
+   * and navigate to the root path.
+   */
+  resolvePathFromState: (state: RouterState | null) => string
+
+  /**
+   * Resolves the intent link for the given intent name and parameters.
+   * See {@link IntentParameters}
+   */
+  resolveIntentLink: (
+    intentName: string,
+    params?: IntentParameters,
+    searchParams?: SearchParam[],
+  ) => string
+
+  /**
+   * Navigates to the given URL.
+   * The function requires an object that has a path and an optional replace property.
+   */
+  navigateUrl: (opts: {path: string; replace?: boolean}) => void
+
+  /**
+   * @deprecated Use `navigate(null, {stickyParams: params, ...options})` instead
+   */
+  navigateStickyParams: (
+    params: NavigateOptions['stickyParams'],
+    options?: NavigateBaseOptions,
+  ) => void
+
+  /**
+   * Updates the router state and navigates to a new path.
+   * Allows specifying new state values and optionally merging sticky parameters.
+   *
+   * See {@link RouterState} and {@link NavigateOptions}
+   *
+   * @public
+   *
+   * @example Navigate with router state only
+   * ```tsx
+   * router.navigate({foo: 'bar'})
+   * ```
+   *
+   * @example Navigate with router state and sticky params
+   * ```tsx
+   * router.navigate({foo: 'bar'}, {stickyParams: {baz: 'qux'}})
+   * ```
+   *
+   * @example Navigate with sticky params only
+   * ```tsx
+   * router.navigate({stickyParams: {baz: 'qux'}})
+   * ```
+   */
+  navigate: Navigate
+
+  /**
+   * Navigates to the given intent.
+   * See {@link RouterState} and {@link NavigateBaseOptions}
+   */
+  navigateIntent: (
+    intentName: string,
+    params?: IntentParameters,
+    options?: NavigateBaseOptions,
+  ) => void
+
+  /**
+   * The current router state. See {@link RouterState}
+   */
+  state: RouterState
+
+  /**
+   * The current router state. See {@link RouterState}
+   */
+  stickyParams: Record<string, string | undefined>
+}
 
 /**
  * Base intent parameters
@@ -249,80 +343,21 @@ export type SearchParam = [key: string, value: string]
 export type RouterState = Record<string, unknown> & {_searchParams?: SearchParam[]}
 
 /**
- * @public
+ * Guard to check if an argument is NavigateOptions with optional state
+ * @internal
  */
-export interface RouterContextValue {
-  /**
-   * Resolves the path from the given router state. See {@link RouterState}
-   */
-  resolvePathFromState: (state: RouterState | null) => string
+export const isNavigateOptions = (
+  maybeNavigateOptions: unknown,
+): maybeNavigateOptions is NavigateOptions & {state?: RouterState | null} =>
+  typeof maybeNavigateOptions === 'object' &&
+  maybeNavigateOptions !== null &&
+  !Array.isArray(maybeNavigateOptions) &&
+  ('replace' in maybeNavigateOptions ||
+    'stickyParams' in maybeNavigateOptions ||
+    'state' in maybeNavigateOptions)
 
-  /**
-   * Resolves the intent link for the given intent name and parameters.
-   * See {@link IntentParameters}
-   */
-  resolveIntentLink: (
-    intentName: string,
-    params?: IntentParameters,
-    searchParams?: SearchParam[],
-  ) => string
-
-  /**
-   * Navigates to the given URL.
-   * The function requires an object that has a path and an optional replace property.
-   */
-  navigateUrl: (opts: {path: string; replace?: boolean}) => void
-
-  /**
-   * @deprecated Use `navigate(null, {stickyParams: params, ...options})` instead
-   */
-  navigateStickyParams: (
-    params: NavigateOptions['stickyParams'],
-    options?: NavigateBaseOptions,
-  ) => void
-
-  /**
-   * Updates the router state and navigates to a new path.
-   * Allows specifying new state values and optionally merging sticky parameters.
-   *
-   * See {@link RouterState} and {@link NavigateOptions}
-   *
-   * @public
-   *
-   * @example Navigate with router state only
-   * ```tsx
-   * router.navigate({foo: 'bar'})
-   * ```
-   *
-   * @example Navigate with router state and sticky params
-   * ```tsx
-   * router.navigate({foo: 'bar'}, {stickyParams: {baz: 'qux'}})
-   * ```
-   *
-   * @example Navigate with sticky params only
-   * ```tsx
-   * router.navigate(null, {stickyParams: {baz: 'qux'}})
-   * ```
-   */
-  navigate: (nextState: RouterState | null, options?: NavigateOptions) => void
-
-  /**
-   * Navigates to the given intent.
-   * See {@link RouterState} and {@link NavigateBaseOptions}
-   */
-  navigateIntent: (
-    intentName: string,
-    params?: IntentParameters,
-    options?: NavigateBaseOptions,
-  ) => void
-
-  /**
-   * The current router state. See {@link RouterState}
-   */
-  state: RouterState
-
-  /**
-   * The current router state. See {@link RouterState}
-   */
-  stickyParams: Record<string, string | undefined>
-}
+/**
+ * Type representing either a new router state or navigation options with an optional state.
+ * @internal
+ */
+export type NextStateOrOptions = RouterState | (NavigateOptions & {state?: RouterState | null})

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -165,19 +165,21 @@ export type MatchResult = MatchError | MatchOk
 /**
  * @public
  */
-export interface NavigateStickyParamsOptions {
+export interface NavigateOptions {
   /**
    * Indicates whether to replace the current state.
    */
   replace?: boolean
+  /**
+   * Record of query parameters that should persist across navigation.
+   */
+  stickyParams?: Record<string, string | undefined>
 }
 
 /**
  * @public
  */
-export interface NavigateOptions extends NavigateStickyParamsOptions {
-  stickyParams?: Record<string, string | undefined>
-}
+export type NavigateBaseOptions = Omit<NavigateOptions, 'stickyParams'>
 
 /**
  * Base intent parameters
@@ -275,24 +277,24 @@ export interface RouterContextValue {
    * Navigates to the current URL with the sticky url search param set to the given values
    */
   navigateStickyParams: (
-    params: Record<string, string | undefined>,
-    options?: NavigateStickyParamsOptions,
+    params: NavigateOptions['stickyParams'],
+    options?: NavigateBaseOptions,
   ) => void
 
   /**
    * Navigates to the given router state.
    * See {@link RouterState} and {@link NavigateOptions}
    */
-  navigate: (nextState: RouterState, options?: NavigateOptions) => void
+  navigate: (nextState: RouterState | null, options?: NavigateOptions) => void
 
   /**
    * Navigates to the given intent.
-   * See {@link RouterState} and {@link NavigateStickyParamsOptions}
+   * See {@link RouterState} and {@link NavigateBaseOptions}
    */
   navigateIntent: (
     intentName: string,
     params?: IntentParameters,
-    options?: NavigateStickyParamsOptions,
+    options?: NavigateBaseOptions,
   ) => void
 
   /**

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -173,7 +173,7 @@ export interface NavigateBaseOptions {
  * @public
  */
 export interface NavigateOptions extends NavigateBaseOptions {
-  stickyParams?: Record<string, string | undefined>
+  stickyParams?: Record<string, string | undefined | null>
 }
 
 /**
@@ -181,16 +181,6 @@ export interface NavigateOptions extends NavigateBaseOptions {
  */
 export interface NavigateOptionsWithState extends NavigateOptions {
   state?: RouterState | null
-}
-
-/**
- * @public
- */
-export type Navigate = {
-  // State-first version - for when you want to navigate to a new state
-  (nextState: RouterState, options?: NavigateOptions): void
-  // Options version - for staying where you are (omit state) or going to root (state: null)
-  (options: NavigateOptions & {state?: RouterState | null}): void
 }
 
 /**
@@ -251,8 +241,18 @@ export interface RouterContextValue {
    * ```tsx
    * router.navigate({stickyParams: {baz: 'qux'}})
    * ```
+   *
+   * @example Navigate with state and sticky params
+   * ```tsx
+   * router.navigate({stickyParams: {baz: 'qux'}, state: null})
+   * ```
    */
-  navigate: Navigate
+  navigate: {
+    // State-first version - for when you want to navigate to a new state
+    (nextState: RouterState, options?: NavigateOptions): void
+    // Options version - for staying where you are (omit state) or going to root (state: null)
+    (options: NavigateOptions & {state?: RouterState | null}): void
+  }
 
   /**
    * Navigates to the given intent.
@@ -272,7 +272,7 @@ export interface RouterContextValue {
   /**
    * The current router state. See {@link RouterState}
    */
-  stickyParams: Record<string, string | undefined>
+  stickyParams: Record<string, string | undefined | null>
 }
 
 /**

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -165,11 +165,15 @@ export type MatchResult = MatchError | MatchOk
 /**
  * @public
  */
-export interface NavigateOptions {
+export interface NavigateStickyParamsOptions {
   /**
    * Indicates whether to replace the current state.
    */
   replace?: boolean
+}
+
+export interface NavigateOptions extends NavigateStickyParamsOptions {
+  stickyParams?: Record<string, string | undefined>
 }
 
 /**
@@ -269,7 +273,7 @@ export interface RouterContextValue {
    */
   navigateStickyParams: (
     params: Record<string, string | undefined>,
-    options?: NavigateOptions,
+    options?: NavigateStickyParamsOptions,
   ) => void
 
   /**
@@ -280,9 +284,13 @@ export interface RouterContextValue {
 
   /**
    * Navigates to the given intent.
-   * See {@link RouterState} and {@link NavigateOptions}
+   * See {@link RouterState} and {@link NavigateStickyParamsOptions}
    */
-  navigateIntent: (intentName: string, params?: IntentParameters, options?: NavigateOptions) => void
+  navigateIntent: (
+    intentName: string,
+    params?: IntentParameters,
+    options?: NavigateStickyParamsOptions,
+  ) => void
 
   /**
    * The current router state. See {@link RouterState}


### PR DESCRIPTION
### Description
A PR of 2 halves: 1 simple, 1 more involved:

Simple:
For pinning the new release when created from the perspective menu, or from the 'copy to new release' flow, it's possible to just `setPerspective` to assign the `perspective` sticky param. This is because we don't navigate elsewhere when a release is created in these flows.

More:
In the other flow where a release can be created - from 'create release' CTA in releases overview, we already navigate to the release detail page after creation.

This causes some issues - calling `router.navigateStickyParams` (which is used by `setPerspective`), followed immediately by `router.navigate` to navigate to the release detail, causes a race, where `navigate` knows nothing about the perspective `stickyParam`, so the end result is that the release is not pinned, but you are still navigated to the release details.

Therefore this PR updates the Router (!!) - it deprecates the `navigateStickyParams` and consolidates it's logic into `navigate` so that `navigate` can be used both for navigating (as it already is) but also for setting or unsetting sticky params. Importantly it can also be used for applying both at the same time, thus resolving this issue

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* Does extending the options on `router.navigate` make sense
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manually verified that pinning works in all places where a new release can be created.

**Added tests for `RouterScope` and `RouterProvider` - ran these tests (sans the changes for sticky params) against `next` to verify that no regressions have happened.**

Also added tests for `RouterProvider` given the adjustments there. Ran these tests against the `next` `RouterProvider` (only the relevant ones given no `stickyParam` support for `navigate` in `next`, and verified no regressions to functionality
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
`navigate` from `useRouter` now supports a `stickyParams` option to allow for navigating and updating param state in the studio at once.

`navigateStickyParams` is deprecated from `sanity/router` - instead use `navigate` as follows:
```ts
const router = useRouter()

router.navigate({stickyParams: {paramKey: 'paramValue'}, replace: false})
```

Additionally, it's now possible to update route state and set `stickyParams` together:
```ts
const router = useRouter()

router.navigate({stateKey: 'stateValue'}, {stickyParams: {paramKey: 'paramValue'}})
```
Or preferably pass a single argument of options for `navigate`:
```ts
const router = useRouter()

router.navigate({
  stickyParams: {paramKey: 'paramValue'},
  state: {
    stateKey: 'stateValue'
  }
})
```
NOTE: `state` is optional - if omitted then the `stickyParams` will be appended to the existing route; if `state: null` then there will be navigation back to the root path
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
