### PR TITLE
feat(sanity): add `CapabilityGate` component

### DIFF
--- a/packages/sanity/src/core/components/CapabilityGate.test.tsx
+++ b/packages/sanity/src/core/components/CapabilityGate.test.tsx
@@ -1,0 +1,59 @@
+import {render, screen} from '@testing-library/react'
+import {of} from 'rxjs'
+import {beforeEach, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../test/testUtils/TestProvider'
+import {useRenderingContextStore} from '../store/_legacy/datastores'
+import {CapabilityGate} from './CapabilityGate'
+
+vi.mock('../store/_legacy/datastores.ts')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+it('renders the child if the capability is not provided by the rendering context', async () => {
+  const wrapper = await createTestProvider()
+
+  vi.mocked(useRenderingContextStore).mockReturnValue({
+    renderingContext: of({
+      name: 'default',
+      metadata: {},
+    } as const),
+    capabilities: of({}),
+  })
+
+  render(
+    <CapabilityGate capability="globalUserMenu">
+      <div data-testid="user-menu">User</div>
+    </CapabilityGate>,
+    {wrapper},
+  )
+
+  expect(screen.getByTestId('user-menu')).toBeTruthy()
+})
+
+it('does not render the child if the capability is provided by the rendering context', async () => {
+  const wrapper = await createTestProvider()
+
+  vi.mocked(useRenderingContextStore).mockReturnValue({
+    renderingContext: of({
+      name: 'coreUi',
+      metadata: {
+        environment: 'production',
+      },
+    } as const),
+    capabilities: of({
+      globalUserMenu: true,
+    }),
+  })
+
+  render(
+    <CapabilityGate capability="globalUserMenu">
+      <div data-testid="user-menu">User</div>
+    </CapabilityGate>,
+    {wrapper},
+  )
+
+  expect(screen.queryByTestId('user-menu')).toBeFalsy()
+})

--- a/packages/sanity/src/core/components/CapabilityGate.tsx
+++ b/packages/sanity/src/core/components/CapabilityGate.tsx
@@ -1,0 +1,29 @@
+import {type ComponentType, type PropsWithChildren} from 'react'
+import {useObservable} from 'react-rx'
+
+import {useRenderingContextStore} from '../store/_legacy/datastores'
+import {type Capability} from '../store/renderingContext/types'
+
+type Props = PropsWithChildren<{
+  capability: Capability
+}>
+
+/**
+ * `CapabilityGate` only renders its children if the current Studio rendering context does not
+ * provide the specified capability.
+ *
+ * This allows consumers of the component to conveniently mark a portion of the React tree as
+ * providing a capability that may be overriden by the Studio rendering context. If the rendering
+ * context provides this capability, the local implementation will not be rendered.
+ */
+export const CapabilityGate: ComponentType<Props> = ({children, capability}) => {
+  const renderingContextStore = useRenderingContextStore()
+  const renderingContextCapabilities = useObservable(renderingContextStore.capabilities, {})
+  const renderingContextHasCapability = renderingContextCapabilities[capability] === true
+
+  if (renderingContextHasCapability) {
+    return null
+  }
+
+  return children
+}


### PR DESCRIPTION
### Description

This branch adds a `CapabilityGate` component that can be used to conditionally render other components based on the current rendering context. For example, to prevent the global user menu from rendering when the rendering context provides this capability. You can see this exact scenario in #8591.

### What to review

Any issues with the component implementation?

### Testing

There are added unit tests, and you can see the changes in action in #8591.
