### PR TITLE
fix(core): add permission limitation for create release

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1183,6 +1183,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
     '<strong>{{title}}</strong> version was successfully discarded',
   /** Action message for when a new release is created off an existing version, draft or published document */
   'release.action.new-release': 'New Release',
+  /** Tooltip message for not having permissions for creating new releases */
+  'release.action.permission.error': 'You do not have permission to perform this action',
   /** Error message for when a version is set to be unpublished */
   'release.action.unpublish-version.failure': 'Failed to set version to be unpublished on release',
   /** Action message for when a version is set to be unpublished successfully */

--- a/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesList.test.tsx
+++ b/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesList.test.tsx
@@ -115,4 +115,35 @@ describe('ReleasesList', () => {
       expect(screen.queryByTestId('create-new-release-button')).toBeNull()
     })
   })
+
+  describe('when releases are enabled without permissions', () => {
+    beforeEach(async () => {
+      mockUseActiveReleases.mockReturnValue({
+        ...useActiveReleasesMockReturn,
+        data: [activeASAPRelease, activeScheduledRelease, activeUndecidedRelease],
+      })
+      mockUseReleasePermissions.mockReturnValue({
+        checkWithPermissionGuard: async () => false,
+      })
+      const wrapper = await createTestProvider()
+      render(
+        <Menu>
+          <ReleasesList
+            setScrollContainer={vi.fn()}
+            onScroll={vi.fn()}
+            isRangeVisible={false}
+            selectedReleaseId={undefined}
+            setCreateBundleDialogOpen={setCreateBundleDialogOpen}
+            scrollElementRef={{current: null}}
+            areReleasesEnabled
+          />
+        </Menu>,
+        {wrapper},
+      )
+    })
+
+    it('calls doesnt open the create dialog user has no permissions', async () => {
+      await waitFor(() => expect(screen.getByTestId('create-new-release-button')).toBeDisabled())
+    })
+  })
 })

--- a/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesList.test.tsx
+++ b/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesList.test.tsx
@@ -13,10 +13,18 @@ import {
   mockUseActiveReleases,
   useActiveReleasesMockReturn,
 } from '../../../releases/store/__tests__/__mocks/useActiveReleases.mock'
+import {
+  mockUseReleasePermissions,
+  useReleasePermissionsMockReturn,
+} from '../../../releases/store/__tests__/__mocks/useReleasePermissions.mock'
 import {ReleasesList} from '../ReleasesList'
 
 vi.mock('../../../releases/contexts/upsell/useReleasesUpsell', () => ({
   useReleasesUpsell: vi.fn(() => useReleasesUpsellMockReturn),
+}))
+
+vi.mock('../../../releases/store/useReleasePermissions', () => ({
+  useReleasePermissions: vi.fn(() => useReleasePermissionsMockReturn),
 }))
 
 vi.mock('../../../releases/store/useActiveReleases', () => ({
@@ -31,6 +39,9 @@ describe('ReleasesList', () => {
       mockUseActiveReleases.mockReturnValue({
         ...useActiveReleasesMockReturn,
         data: [activeASAPRelease, activeScheduledRelease, activeUndecidedRelease],
+      })
+      mockUseReleasePermissions.mockReturnValue({
+        checkWithPermissionGuard: async () => true,
       })
       const wrapper = await createTestProvider()
       render(
@@ -55,7 +66,11 @@ describe('ReleasesList', () => {
       expect(screen.getByText('undecided Release')).toBeInTheDocument()
     })
 
-    it('calls setCreateBundleDialogOpen when create new release button is clicked', () => {
+    it('calls setCreateBundleDialogOpen when create new release button is clicked', async () => {
+      await waitFor(() =>
+        expect(screen.getByTestId('create-new-release-button')).not.toBeDisabled(),
+      )
+
       fireEvent.click(screen.getByTestId('create-new-release-button'))
       expect(setCreateBundleDialogOpen).toHaveBeenCalledWith(true)
     })

--- a/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesNav.test.tsx
+++ b/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesNav.test.tsx
@@ -11,8 +11,16 @@ import {
 } from '../../../releases/__fixtures__/release.fixture'
 import {useReleasesUpsellMockReturn} from '../../../releases/contexts/upsell/__mocks__/useReleasesUpsell.mock'
 import {useActiveReleasesMockReturn} from '../../../releases/store/__tests__/__mocks/useActiveReleases.mock'
+import {
+  mockUseReleasePermissions,
+  useReleasePermissionsMockReturn,
+} from '../../../releases/store/__tests__/__mocks/useReleasePermissions.mock'
 import {LATEST} from '../../../releases/util/const'
 import {ReleasesNav} from '../ReleasesNav'
+
+vi.mock('../../../releases/store/useReleasePermissions', () => ({
+  useReleasePermissions: vi.fn(() => useReleasePermissionsMockReturn),
+}))
 
 vi.mock('../../../releases/contexts/upsell/useReleasesUpsell', () => ({
   useReleasesUpsell: vi.fn(() => useReleasesUpsellMockReturn),
@@ -60,6 +68,10 @@ const renderTest = async () => {
 describe('ReleasesNav', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+
+    mockUseReleasePermissions.mockReturnValue({
+      checkWithPermissionGuard: async () => true,
+    })
   })
   it('should have link to releases tool', async () => {
     await renderTest()

--- a/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesNav.test.tsx
+++ b/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesNav.test.tsx
@@ -198,6 +198,12 @@ describe('ReleasesNav', () => {
 
         expect(screen.getByRole('dialog')).toHaveAttribute('id', 'create-release-dialog')
       })
+
+      it('disables button when no permissions are met', async () => {
+        mockUseReleasePermissions.mockReturnValue({
+          checkWithPermissionGuard: async () => true,
+        })
+      })
     })
 
     describe('release layering', () => {

--- a/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
@@ -11,8 +11,7 @@ import {releasesLocaleNamespace} from '../../i18n'
 import {isReleaseLimitError} from '../../store/isReleaseLimitError'
 import {type EditableReleaseDocument} from '../../store/types'
 import {useReleaseOperations} from '../../store/useReleaseOperations'
-import {DEFAULT_RELEASE_TYPE} from '../../util/const'
-import {createReleaseId} from '../../util/createReleaseId'
+import {DEFAULT_RELEASE} from '../../util/const'
 import {getIsScheduledDateInPast} from '../../util/getIsScheduledDateInPast'
 import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
 import {ReleaseForm} from './ReleaseForm'
@@ -33,14 +32,7 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
   const createReleaseMetadata = useCreateReleaseMetadata()
 
   const [release, setRelease] = useState((): EditableReleaseDocument => {
-    return {
-      _id: createReleaseId(),
-      metadata: {
-        title: '',
-        description: '',
-        releaseType: DEFAULT_RELEASE_TYPE,
-      },
-    } as const
+    return DEFAULT_RELEASE
   })
   const [isSubmitting, setIsSubmitting] = useState(false)
   /**

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -232,6 +232,7 @@ export const VersionChip = memo(function VersionChip(props: {
             disabled={contextMenuDisabled}
             onCreateVersion={handleAddVersion}
             locked={locked}
+            type={documentType}
           />
         }
         fallbackPlacements={[]}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
@@ -93,7 +93,10 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: {
           popover={{placement: 'right-start'}}
           text={t('release.action.copy-to')}
           disabled={disabled || !hasCreatePermission}
-          tooltipProps={{content: !hasCreatePermission && t('release.action.permission.error')}}
+          tooltipProps={{
+            disabled: !hasCreatePermission,
+            content: t('release.action.permission.error'),
+          }}
         >
           <ReleasesList key={fromRelease} space={1}>
             {optionsReleaseList.map((option) => {
@@ -105,7 +108,10 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: {
                   onClick={() => onCreateVersion(option.value._id)}
                   renderMenuItem={() => <VersionContextMenuItem release={option.value} />}
                   disabled={disabled || isReleaseScheduled}
-                  tooltipProps={{content: isReleaseScheduled && t('release.tooltip.locked')}}
+                  tooltipProps={{
+                    disabled: isReleaseScheduled,
+                    content: t('release.tooltip.locked'),
+                  }}
                 />
               )
             })}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -1,6 +1,7 @@
 import {act, fireEvent, render, screen, waitFor} from '@testing-library/react'
 import {describe, expect, it, vi} from 'vitest'
 
+import {useDocumentPairPermissionsMockReturn} from '../../../../../../../test/mocks/useDocumentPairPermissions.mock'
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
 import {
   mockUseReleasePermissions,
@@ -19,6 +20,10 @@ vi.mock('sanity/router', async (importOriginal) => ({
 
 vi.mock('../../../../store/useReleasePermissions', () => ({
   useReleasePermissions: vi.fn(() => useReleasePermissionsMockReturn),
+}))
+
+vi.mock('../../../../../store/_legacy/grants/documentPairPermissions', () => ({
+  useDocumentPairPermissions: vi.fn(() => useDocumentPairPermissionsMockReturn),
 }))
 
 describe('VersionContextMenu', () => {
@@ -63,6 +68,7 @@ describe('VersionContextMenu', () => {
     onCreateRelease: vi.fn(),
     onCreateVersion: vi.fn(),
     disabled: false,
+    type: 'document',
   }
 
   it('renders the menu items correctly', async () => {
@@ -94,6 +100,7 @@ describe('VersionContextMenu', () => {
     mockUseReleasePermissions.mockReturnValue({
       checkWithPermissionGuard: async () => true,
     })
+
     const wrapper = await createTestProvider()
 
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
@@ -118,6 +125,7 @@ describe('VersionContextMenu', () => {
     mockUseReleasePermissions.mockReturnValue({
       checkWithPermissionGuard: async () => true,
     })
+
     const wrapper = await createTestProvider()
     const publishedProps = {
       ...defaultProps,
@@ -134,11 +142,16 @@ describe('VersionContextMenu', () => {
     mockUseReleasePermissions.mockReturnValue({
       checkWithPermissionGuard: async () => true,
     })
+
     const wrapper = await createTestProvider()
 
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
 
     await waitFor(() => {
+      expect(screen.getByText('Discard version')).not.toBeDisabled()
+    })
+
+    await act(() => {
       fireEvent.click(screen.getByText('Discard version'))
     })
     expect(defaultProps.onDiscard).toHaveBeenCalled()
@@ -148,6 +161,7 @@ describe('VersionContextMenu', () => {
     mockUseReleasePermissions.mockReturnValue({
       checkWithPermissionGuard: async () => true,
     })
+
     const wrapper = await createTestProvider()
 
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
@@ -172,6 +186,7 @@ describe('VersionContextMenu', () => {
     mockUseReleasePermissions.mockReturnValue({
       checkWithPermissionGuard: async () => true,
     })
+
     const wrapper = await createTestProvider()
 
     render(<VersionContextMenu {...defaultProps} />, {wrapper})

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -1,7 +1,11 @@
-import {fireEvent, render, screen, waitFor} from '@testing-library/react'
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react'
 import {describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {
+  mockUseReleasePermissions,
+  useReleasePermissionsMockReturn,
+} from '../../../../store/__tests__/__mocks/useReleasePermissions.mock'
 import {type ReleaseDocument} from '../../../../store/types'
 import {VersionContextMenu} from '../VersionContextMenu'
 
@@ -11,6 +15,10 @@ vi.mock('sanity/router', async (importOriginal) => ({
   route: {
     create: vi.fn(),
   },
+}))
+
+vi.mock('../../../../store/useReleasePermissions', () => ({
+  useReleasePermissions: vi.fn(() => useReleasePermissionsMockReturn),
 }))
 
 describe('VersionContextMenu', () => {
@@ -58,12 +66,23 @@ describe('VersionContextMenu', () => {
   }
 
   it('renders the menu items correctly', async () => {
+    mockUseReleasePermissions.mockReturnValue({
+      checkWithPermissionGuard: async () => true,
+    })
+
     const wrapper = await createTestProvider()
 
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
 
     expect(screen.getByText('Copy version to')).toBeInTheDocument()
-    fireEvent.click(screen.getByText('Copy version to'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Copy version to')).not.toBeDisabled()
+    })
+
+    await act(() => {
+      fireEvent.click(screen.getByText('Copy version to'))
+    })
     await waitFor(() => {
       expect(screen.getByText('New Release')).toBeInTheDocument()
       expect(screen.getByText('Release 1')).toBeInTheDocument()
@@ -72,11 +91,23 @@ describe('VersionContextMenu', () => {
   })
 
   it('calls onCreateRelease when "New release" is clicked', async () => {
+    mockUseReleasePermissions.mockReturnValue({
+      checkWithPermissionGuard: async () => true,
+    })
     const wrapper = await createTestProvider()
 
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
 
-    fireEvent.click(screen.getByText('Copy version to'))
+    expect(screen.getByText('Copy version to')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText('Copy version to')).not.toBeDisabled()
+    })
+
+    await act(() => {
+      fireEvent.click(screen.getByText('Copy version to'))
+    })
+
     await waitFor(() => {
       fireEvent.click(screen.getByText('New Release'))
     })
@@ -84,6 +115,9 @@ describe('VersionContextMenu', () => {
   })
 
   it('hides discard version on published chip', async () => {
+    mockUseReleasePermissions.mockReturnValue({
+      checkWithPermissionGuard: async () => true,
+    })
     const wrapper = await createTestProvider()
     const publishedProps = {
       ...defaultProps,
@@ -97,6 +131,9 @@ describe('VersionContextMenu', () => {
   })
 
   it('calls onDiscard when "Discard version" is clicked', async () => {
+    mockUseReleasePermissions.mockReturnValue({
+      checkWithPermissionGuard: async () => true,
+    })
     const wrapper = await createTestProvider()
 
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
@@ -108,11 +145,23 @@ describe('VersionContextMenu', () => {
   })
 
   it('calls onCreateRelease when a "new release" is clicked', async () => {
+    mockUseReleasePermissions.mockReturnValue({
+      checkWithPermissionGuard: async () => true,
+    })
     const wrapper = await createTestProvider()
 
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
 
-    fireEvent.click(screen.getByText('Copy version to'))
+    expect(screen.getByText('Copy version to')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText('Copy version to')).not.toBeDisabled()
+    })
+
+    await act(() => {
+      fireEvent.click(screen.getByText('Copy version to'))
+    })
+
     await waitFor(() => {
       fireEvent.click(screen.getByText('New Release'))
     })
@@ -120,11 +169,23 @@ describe('VersionContextMenu', () => {
   })
 
   it('calls onCreateVersion when a release is clicked and sets the perspective to the release', async () => {
+    mockUseReleasePermissions.mockReturnValue({
+      checkWithPermissionGuard: async () => true,
+    })
     const wrapper = await createTestProvider()
 
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
 
-    fireEvent.click(screen.getByText('Copy version to'))
+    expect(screen.getByText('Copy version to')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText('Copy version to')).not.toBeDisabled()
+    })
+
+    await act(() => {
+      fireEvent.click(screen.getByText('Copy version to'))
+    })
+
     await waitFor(() => {
       fireEvent.click(screen.getByText('Release 2'))
     })

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
@@ -147,6 +147,9 @@ describe('ReleaseDetail', () => {
         ...useActiveReleasesMockReturn,
         data: [activeASAPRelease],
       })
+      mockUseReleasePermissions.mockReturnValue({
+        checkWithPermissionGuard: async () => true,
+      })
 
       mockUseRouterReturn.state = {
         releaseId: getReleaseIdFromReleaseDocumentId(activeASAPRelease._id),
@@ -170,6 +173,10 @@ describe('after releases have loaded', () => {
   describe('with unpublished release', () => {
     beforeEach(async () => {
       vi.clearAllMocks()
+
+      mockUseReleasePermissions.mockReturnValue({
+        checkWithPermissionGuard: async () => true,
+      })
     })
 
     const loadedReleaseAndDocumentsTests = () => {
@@ -192,6 +199,10 @@ describe('after releases have loaded', () => {
             },
           ],
         })
+        mockUseReleasePermissions.mockReturnValue({
+          checkWithPermissionGuard: async () => true,
+        })
+
         await renderTest()
       })
 
@@ -210,6 +221,9 @@ describe('after releases have loaded', () => {
         mockUseBundleDocuments.mockReturnValue({
           loading: false,
           results: [documentsInRelease],
+        })
+        mockUseReleasePermissions.mockReturnValue({
+          checkWithPermissionGuard: async () => true,
         })
         await renderTest()
       })
@@ -273,6 +287,9 @@ describe('after releases have loaded', () => {
             },
           ],
         })
+        mockUseReleasePermissions.mockReturnValue({
+          checkWithPermissionGuard: async () => true,
+        })
         await renderTest()
       })
 
@@ -298,6 +315,10 @@ describe('after releases have loaded', () => {
       mockUseRouterReturn.state = {
         releaseId: getReleaseIdFromReleaseDocumentId(publishedASAPRelease._id),
       }
+
+      mockUseReleasePermissions.mockReturnValue({
+        checkWithPermissionGuard: async () => true,
+      })
 
       await renderTest()
     })

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -40,6 +40,10 @@ import {
   useArchivedReleasesMockReturn,
 } from '../../../store/__tests__/__mocks/useArchivedReleases.mock'
 import {
+  mockUseReleasePermissions,
+  useReleasePermissionsMockReturn,
+} from '../../../store/__tests__/__mocks/useReleasePermissions.mock'
+import {
   mockUseReleasesMetadata,
   useReleasesMetadataMockReturn,
 } from '../../../store/__tests__/__mocks/useReleasesMetadata.mock'
@@ -88,6 +92,10 @@ vi.mock('../../detail/useBundleDocuments', () => ({
   useBundleDocuments: vi.fn(() => useBundleDocumentsMockReturnWithResults),
 }))
 
+vi.mock('../../../store/useReleasePermissions', () => ({
+  useReleasePermissions: vi.fn(() => useReleasePermissionsMockReturn),
+}))
+
 vi.mock('sanity/router', async (importOriginal) => ({
   ...(await importOriginal()),
   useRouter: vi.fn().mockReturnValue({state: {}, navigate: vi.fn()}),
@@ -132,6 +140,10 @@ const TestComponent = () => {
 describe('ReleasesOverview', () => {
   beforeEach(() => {
     mockUseActiveReleases.mockRestore()
+
+    mockUseReleasePermissions.mockReturnValue({
+      checkWithPermissionGuard: async () => true,
+    })
   })
 
   setupVirtualListEnv()

--- a/packages/sanity/src/core/releases/util/const.ts
+++ b/packages/sanity/src/core/releases/util/const.ts
@@ -1,5 +1,8 @@
 /*  TEMPORARY  DUMMY DATA */
 
+import {type EditableReleaseDocument} from '../store/types'
+import {createReleaseId} from './createReleaseId'
+
 /**
  * @internal
  */
@@ -12,3 +15,12 @@ export const PUBLISHED = 'published' as const
 export const DEFAULT_RELEASE_TYPE = 'asap'
 
 export const ARCHIVED_RELEASE_STATES = ['archived', 'published']
+
+export const DEFAULT_RELEASE: EditableReleaseDocument = {
+  _id: createReleaseId(),
+  metadata: {
+    title: '',
+    description: '',
+    releaseType: DEFAULT_RELEASE_TYPE,
+  },
+}

--- a/packages/sanity/src/ui-components/menuGroup/MenuGroup.tsx
+++ b/packages/sanity/src/ui-components/menuGroup/MenuGroup.tsx
@@ -1,6 +1,12 @@
 /* eslint-disable no-restricted-imports */
 import {MenuGroup as UIMenuGroup, type MenuGroupProps as UIMenuGroupProps} from '@sanity/ui'
-import {type HTMLProps} from 'react'
+import {type HTMLProps, useCallback} from 'react'
+
+import {
+  ConditionalWrapper,
+  type ConditionalWrapperRenderWrapperCallback,
+} from '../conditionalWrapper/ConditionalWrapper'
+import {Tooltip, type TooltipProps} from '../tooltip/Tooltip'
 
 /** @internal */
 export type MenuGroupProps = Pick<UIMenuGroupProps, 'icon' | 'popover' | 'text' | 'tone'>
@@ -12,7 +18,27 @@ export type MenuGroupProps = Pick<UIMenuGroupProps, 'icon' | 'popover' | 'text' 
  */
 export const MenuGroup = (
   props: MenuGroupProps &
-    Omit<HTMLProps<HTMLDivElement>, 'as' | 'height' | 'ref' | 'tabIndex' | 'popover'>,
+    Omit<HTMLProps<HTMLDivElement>, 'as' | 'height' | 'ref' | 'tabIndex' | 'popover'> & {
+      tooltipProps?: TooltipProps | null
+    },
 ) => {
-  return <UIMenuGroup {...props} fontSize={1} padding={3} />
+  const {tooltipProps} = props
+
+  const renderWrapper = useCallback<ConditionalWrapperRenderWrapperCallback>(
+    (children) => {
+      return (
+        <Tooltip content={tooltipProps?.content} portal {...tooltipProps}>
+          {/* This div is needed to make the tooltip work in disabled menu items */}
+          <div>{children}</div>
+        </Tooltip>
+      )
+    },
+    [tooltipProps],
+  )
+
+  return (
+    <ConditionalWrapper condition={!!tooltipProps} wrapper={renderWrapper}>
+      <UIMenuGroup {...props} fontSize={1} padding={3} />
+    </ConditionalWrapper>
+  )
 }

--- a/packages/sanity/test/mocks/useDocumentPairPermissions.mock.ts
+++ b/packages/sanity/test/mocks/useDocumentPairPermissions.mock.ts
@@ -1,0 +1,11 @@
+import {type Mock, type Mocked} from 'vitest'
+
+import {useDocumentPairPermissions} from '../../src/core/store/_legacy/grants/documentPairPermissions'
+
+export const useDocumentPairPermissionsMockReturn: Mocked<
+  ReturnType<typeof useDocumentPairPermissions>
+> = [{granted: true, reason: ''}, false]
+
+export const mockUseDocumentPairPermissions = useDocumentPairPermissions as Mock<
+  typeof useDocumentPairPermissions
+>


### PR DESCRIPTION
### Description

Prevent create release
- [x] In Global Menu
- [x] In document headers
- [x] In the release list

<img width="395" alt="image" src="https://github.com/user-attachments/assets/c7370f71-6678-4c6e-977e-f4f2f685e2bb" />
<img width="509" alt="image" src="https://github.com/user-attachments/assets/1c7bddff-af21-4753-97ce-6ffd8fbf5f47" />
<img width="433" alt="image" src="https://github.com/user-attachments/assets/77828a60-77ec-4e3e-a0e7-28077f1a59e6" />

Discard version discard
- [ ] Prevent discard version in document header
<img width="643" alt="image" src="https://github.com/user-attachments/assets/6d16cce4-7828-4a4f-8f4b-97062eb67e8b" />

### What to review

Anything could be improved?

### Testing

The existing test should be enough.
Can manually test by following the screenshots

### Notes for release

Discard version and create releases action menus and buttons for releases now respect permissions.
