### PR TITLE
chore: use `useEffectEvent` aware linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.36.1",
     "eslint-plugin-react-compiler": "19.0.0-beta-30d8a17-20250209",
-    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-hooks": "experimental",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-tsdoc": "^0.3.0",
     "eslint-plugin-unicorn": "^52.0.0",
@@ -192,6 +192,7 @@
       "@sanity/ui@2": "$@sanity/ui",
       "@typescript-eslint/eslint-plugin": "$@typescript-eslint/eslint-plugin",
       "@typescript-eslint/parser": "$@typescript-eslint/parser",
+      "eslint-plugin-react-hooks": "$eslint-plugin-react-hooks",
       "vite": "$vite"
     }
   },

--- a/packages/sanity/playwright-ct/tests/fixtures/copyPasteFixture.ts
+++ b/packages/sanity/playwright-ct/tests/fixtures/copyPasteFixture.ts
@@ -6,7 +6,7 @@ export const test = base.extend<{
   getClipboardItems: () => Promise<ClipboardItem[]>
   getClipboardItemsAsText: () => Promise<string>
 }>({
-  page: async ({page}, use) => {
+  page: async ({page}, _use) => {
     const setupClipboardMocks = async () => {
       await page.addInitScript(() => {
         const mockClipboard = {
@@ -45,23 +45,23 @@ export const test = base.extend<{
       await setupClipboardMocks()
     })
 
-    await use(page)
+    await _use(page)
   },
 
-  setClipboardItems: async ({page}, use) => {
-    await use(async (items: ClipboardItem[]) => {
+  setClipboardItems: async ({page}, _use) => {
+    await _use(async (items: ClipboardItem[]) => {
       ;(window as any).__clipboardItems = items
     })
   },
 
-  getClipboardItems: async ({page}, use) => {
-    await use(() => {
+  getClipboardItems: async ({page}, _use) => {
+    await _use(() => {
       return page.evaluate(() => navigator.clipboard.read())
     })
   },
 
-  getClipboardItemsAsText: async ({page}, use) => {
-    await use(async () => {
+  getClipboardItemsAsText: async ({page}, _use) => {
+    await _use(async () => {
       return page.evaluate(async () => {
         const items = await navigator.clipboard.read()
         const textItem = items.find((item) => item.types.includes('text/plain'))
@@ -73,8 +73,8 @@ export const test = base.extend<{
     })
   },
 
-  getClipboardItemByMimeTypeAsText: async ({page}, use) => {
-    await use(async (mimeType: string) => {
+  getClipboardItemByMimeTypeAsText: async ({page}, _use) => {
+    await _use(async (mimeType: string) => {
       return page.evaluate(async (mime) => {
         const items = await navigator.clipboard.read()
         const textItem = items.find((item) => item.types.includes(mime))

--- a/packages/sanity/playwright-ct/tests/fixtures/debugFixture.ts
+++ b/packages/sanity/playwright-ct/tests/fixtures/debugFixture.ts
@@ -9,8 +9,8 @@ export const test = base.extend<{
     attributes: Record<string, string>
   }>
 }>({
-  logActiveElement: async ({page}, use) => {
-    await use(async () => {
+  logActiveElement: async ({page}, _use) => {
+    await _use(async () => {
       const activeElementInfo = await page.evaluate(() => {
         const active = document.activeElement as HTMLElement
         return {

--- a/packages/sanity/playwright-ct/tests/fixtures/scrollToTopFixture.ts
+++ b/packages/sanity/playwright-ct/tests/fixtures/scrollToTopFixture.ts
@@ -5,7 +5,7 @@ type ScrollToTop = (locator: Locator) => Promise<void>
 export const test = baseTest.extend<{
   scrollToTop: ScrollToTop
 }>({
-  scrollToTop: async ({page}, use) => {
+  scrollToTop: async ({page}, _use) => {
     const scrollToTop: ScrollToTop = async (locator: Locator) => {
       await locator.evaluate((element) => {
         element.scrollIntoView({block: 'start', inline: 'nearest'})
@@ -15,6 +15,6 @@ export const test = baseTest.extend<{
       await expect(boundingBox?.y).toBeLessThanOrEqual(1)
     }
 
-    await use(scrollToTop)
+    await _use(scrollToTop)
   },
 })

--- a/packages/sanity/src/core/hooks/useGlobalCopyPasteElementHandler.ts
+++ b/packages/sanity/src/core/hooks/useGlobalCopyPasteElementHandler.ts
@@ -69,5 +69,5 @@ export function useGlobalCopyPasteElementHandler({
     return () => {
       element?.removeEventListener('keydown', handleKeydown)
     }
-  }, [element, handleKeydown, onPaste])
+  }, [element, onPaste])
 }

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/FormCreate.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/FormCreate.tsx
@@ -69,7 +69,7 @@ export function FormCreate(props: ObjectInputProps) {
     if (creating && savedTask?.createdByUser) {
       handleCreatingSuccess()
     }
-  }, [creating, handleCreatingSuccess, savedTask?.createdByUser])
+  }, [creating, savedTask?.createdByUser])
 
   const handleCreatingTimeout = useEffectEvent(() => {
     setCreating(false)
@@ -89,7 +89,7 @@ export function FormCreate(props: ObjectInputProps) {
     return () => {
       if (timeoutId) clearTimeout(timeoutId)
     }
-  }, [creating, handleCreatingTimeout])
+  }, [creating])
 
   const handleCreate = useCallback(async () => {
     setCreating(true)

--- a/packages/sanity/src/core/tasks/hooks/useActivityLog.ts
+++ b/packages/sanity/src/core/tasks/hooks/useActivityLog.ts
@@ -55,6 +55,6 @@ export function useActivityLog(task: TaskDocument): {
   useEffect(() => {
     // Task is updated on every change, wait until the revision changes to update the activity log.
     handleFetchAndParse(task._rev)
-  }, [handleFetchAndParse, task._rev])
+  }, [task._rev])
   return {changes}
 }

--- a/packages/sanity/src/presentation/PresentationTool.tsx
+++ b/packages/sanity/src/presentation/PresentationTool.tsx
@@ -310,7 +310,7 @@ export default function PresentationTool(props: {
       stop()
       setVisualEditingComlink(null)
     }
-  }, [controller, handleNavigate, setDocumentsOnPage, setOverlaysConnection, targetOrigin])
+  }, [controller, setDocumentsOnPage, setOverlaysConnection, targetOrigin])
 
   useEffect(() => {
     if (!controller) return undefined

--- a/packages/sanity/src/presentation/document/PresentationDocumentProvider.tsx
+++ b/packages/sanity/src/presentation/document/PresentationDocumentProvider.tsx
@@ -44,7 +44,7 @@ export function PresentationDocumentProvider(props: {
   const registerEffectEvent = useEffectEvent((options: PresentationPluginOptions) =>
     register(options),
   )
-  useLayoutEffect(() => registerEffectEvent(options), [registerEffectEvent, options])
+  useLayoutEffect(() => registerEffectEvent(options), [options])
 
   return (
     <PresentationDocumentContext.Provider value={context}>

--- a/packages/sanity/src/presentation/loader/LiveQueries.tsx
+++ b/packages/sanity/src/presentation/loader/LiveQueries.tsx
@@ -233,7 +233,7 @@ function QuerySubscriptionComponent(props: QuerySubscriptionProps) {
       handleQueryChange(comlink, perspective, query, params, result, resultSourceMap, tags)
     }
     return undefined
-  }, [comlink, handleQueryChange, params, perspective, query, result, resultSourceMap, tags])
+  }, [comlink, params, perspective, query, result, resultSourceMap, tags])
 
   return null
 }

--- a/packages/sanity/src/presentation/useMainDocument.ts
+++ b/packages/sanity/src/presentation/useMainDocument.ts
@@ -188,7 +188,7 @@ export function useMainDocument(props: {
     setMainDocumentState(undefined)
     mainDocumentIdRef.current = undefined
     return undefined
-  }, [client, handleResponse, previewUrl, relativeUrl, resolvers])
+  }, [client, previewUrl, relativeUrl, resolvers])
 
   return mainDocumentState
 }

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -121,7 +121,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
       handleInitialValue()
     }
     // React to changes in hasRev only
-  }, [handleInitialValue, hasRev])
+  }, [hasRev])
 
   const [formRef, setFormRef] = useState<null | HTMLDivElement>(null)
 

--- a/packages/sanity/src/structure/panes/document/useResetHistoryParams.ts
+++ b/packages/sanity/src/structure/panes/document/useResetHistoryParams.ts
@@ -36,8 +36,7 @@ export function useResetHistoryParams() {
     if (isMounted.current) {
       updateHistoryParams(selectedPerspectiveName)
     }
-    // TODO: Remove `updateHistoryParams` as a dependency when react eslint plugin is updated
-  }, [selectedPerspectiveName, updateHistoryParams])
+  }, [selectedPerspectiveName])
 
   useEffect(() => {
     isMounted.current = true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@sanity/ui@2': ^2.12.3
   '@typescript-eslint/eslint-plugin': ^7.18.0
   '@typescript-eslint/parser': ^7.18.0
+  eslint-plugin-react-hooks: experimental
   vite: ^6.1.0
 
 importers:
@@ -126,7 +127,7 @@ importers:
         version: 9.1.0(eslint@8.57.1)
       eslint-config-sanity:
         specifier: ^7.1.2
-        version: 7.1.4(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-plugin-import@2.31.0)(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.4(eslint@8.57.1))(eslint@8.57.1)
+        version: 7.1.4(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-plugin-import@2.31.0)(eslint-plugin-react-hooks@0.0.0-experimental-f83903bf-20250212(eslint@8.57.1))(eslint-plugin-react@7.37.4(eslint@8.57.1))(eslint@8.57.1)
       eslint-config-turbo:
         specifier: ^2.1.2
         version: 2.4.1(eslint@8.57.1)(turbo@2.4.1)
@@ -149,8 +150,8 @@ importers:
         specifier: 19.0.0-beta-30d8a17-20250209
         version: 19.0.0-beta-30d8a17-20250209(eslint@8.57.1)
       eslint-plugin-react-hooks:
-        specifier: ^4.6.2
-        version: 4.6.2(eslint@8.57.1)
+        specifier: experimental
+        version: 0.0.0-experimental-f83903bf-20250212(eslint@8.57.1)
       eslint-plugin-simple-import-sort:
         specifier: ^12.1.1
         version: 12.1.1(eslint@8.57.1)
@@ -6906,11 +6907,11 @@ packages:
     peerDependencies:
       eslint: '>=7'
 
-  eslint-plugin-react-hooks@4.6.2:
-    resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
+  eslint-plugin-react-hooks@0.0.0-experimental-f83903bf-20250212:
+    resolution: {integrity: sha512-Gocp51zTs74zTaeqrqD+DZkM88+JoQNoMZ4+Q/vfnTH9vpuaTpU7gn4lwcIoden5Kw28khGiNRgGptRD7uIeMg==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
   eslint-plugin-react@7.37.4:
     resolution: {integrity: sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==}
@@ -14709,7 +14710,7 @@ snapshots:
       confusing-browser-globals: 1.0.11
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
-      eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
+      eslint-plugin-react-hooks: 0.0.0-experimental-f83903bf-20250212(eslint@8.57.1)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -17911,7 +17912,7 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-config-sanity@7.1.4(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-plugin-import@2.31.0)(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.4(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-sanity@7.1.4(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-plugin-import@2.31.0)(eslint-plugin-react-hooks@0.0.0-experimental-f83903bf-20250212(eslint@8.57.1))(eslint-plugin-react@7.37.4(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
       eslint-plugin-simple-import-sort: 12.1.1(eslint@8.57.1)
@@ -17920,7 +17921,7 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.7.3)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
-      eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
+      eslint-plugin-react-hooks: 0.0.0-experimental-f83903bf-20250212(eslint@8.57.1)
 
   eslint-config-turbo@2.4.1(eslint@8.57.1)(turbo@2.4.1):
     dependencies:
@@ -18061,7 +18062,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@4.6.2(eslint@8.57.1):
+  eslint-plugin-react-hooks@0.0.0-experimental-f83903bf-20250212(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
 


### PR DESCRIPTION
### Description

The `eslint-plugin-react-hooks` linter now supports `useEffectEvent`, when using the experimental release. More info: https://react.dev/reference/react/experimental_useEffectEvent

### What to review

The renaming of `use` to `_use` in the tests are due to some red herrings where the linter thought it was related to `React.use`:
```bash
error  React Hook "use" is called in function "page" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use"   
```

### Testing

CI linter is enough.

### Notes for release

N/A
