### PR TITLE
chore: improving type definition for useProjectSubscriptions

### DIFF
--- a/packages/sanity/src/core/hooks/useProjectSubscriptions.ts
+++ b/packages/sanity/src/core/hooks/useProjectSubscriptions.ts
@@ -10,28 +10,23 @@ import {useClient} from './useClient'
 
 type FeatureAttributes = Record<string, string | number | boolean | null>
 
-type Feature = {
+interface Feature {
   id: string
-  variantId: string | null
+  variantId: string
   name: string
   price: number
   included: boolean
   attributes: FeatureAttributes
-  custom: boolean
-  startedAt: string | null
-  startedBy: string | null
-  endedAt: string | null
-  endedBy: string | null
 }
 
-type FeatureType = {
+interface FeatureType {
   id: string
   name: string
   singular: boolean
   features: Feature[]
 }
 
-type Resource = {
+interface Resource {
   id: string
   name: string
   unit: string
@@ -44,7 +39,7 @@ type Resource = {
   maxOverageQuota: number | null
 }
 
-type Plan = {
+interface Plan {
   id: string
   planTypeId: string
   variantId: string | null
@@ -65,7 +60,10 @@ type Plan = {
   featureTypes: Record<string, FeatureType>
 }
 
-export type ProjectSubscriptionsResponse = {
+/**
+ * @internal
+ */
+export interface ProjectSubscriptionsResponse {
   id: string
   projectId: string
   productType: string
@@ -75,16 +73,16 @@ export type ProjectSubscriptionsResponse = {
   previousSubscriptionId: string | null
   status: string
   startedAt: string
-  startedBy: string | null
-  endedAt: string | null
-  endedBy: string | null
+  startedBy: string
+  endedAt: string
+  endedBy: string
   trialUntil: string | null
   plan: Plan
   resources: Record<string, Resource>
   featureTypes: Record<string, FeatureType>
 }
 
-type ProjectSubscriptions = {
+interface ProjectSubscriptions {
   error: Error | null
   projectSubscriptions: ProjectSubscriptionsResponse | null
   isLoading: boolean
@@ -97,6 +95,7 @@ const INITIAL_LOADING_STATE: ProjectSubscriptions = {
 }
 
 /**
+ * @internal
  * fetches subscriptions for this project
  */
 function fetchProjectSubscriptions({


### PR DESCRIPTION
### Description
@bjoerge This resolved the comments you'd made in https://github.com/sanity-io/sanity/pull/8597

* Move to `interface` over `type`
* Correct some incorrect types on the subscription
* `@internal` for these types and the hook
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
N/A
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
