### PR TITLE
fix(core): in release documents rows only show errors count

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -175,7 +175,9 @@ export const getDocumentTableColumnDefs: (
       </Flex>
     ),
     cell: ({cellProps, datum}) => {
-      const validationErrorCount = datum.validation.validation.length
+      const validationErrorCount = datum.validation.validation.filter(
+        (validation) => validation.level === 'error',
+      ).length
 
       return (
         <Flex {...cellProps} flex={1} padding={1} justify="center" align="center" sizing="border">


### PR DESCRIPTION
### Description

Only show errors for the error count in the release documents row.

<img width="1917" alt="Screenshot 2025-02-13 at 15 56 34" src="https://github.com/user-attachments/assets/67211f5c-1250-4277-92b0-ed7259c0700c" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open a release in which a document has both error and warnings or info, the document should only account for the number of errors.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
