### PR TITLE
chore(sanity): update release time tooltip

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1225,10 +1225,9 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.dialog.create.title': 'New release',
   /** Label for description in tooltip to explain release types */
   'release.dialog.tooltip.description':
-    'This makes it possible to show whether documents are in conflict when working on multiple versions.',
+    'The intended release time is used to create better previews and hints about whether documents conflict.',
   /** Label for noting that a release time is not final */
-  'release.dialog.tooltip.note':
-    'NOTE: You may change the time of release and set an exact time for scheduled publishing later.',
+  'release.dialog.tooltip.note': 'You can always change it later.',
   /** Title for tooltip to explain release time */
   'release.dialog.tooltip.title': 'Approximate time of release',
   /** The placeholder text when the release doesn't have a description */

--- a/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
@@ -95,7 +95,7 @@ export function ReleaseForm(props: {
           <span style={{marginLeft: 10, opacity: 0.5}}>
             <Tooltip
               content={
-                <Stack space={4} style={{maxWidth: 320 - 16}}>
+                <Stack space={3} style={{maxWidth: 320 - 16}}>
                   <Text size={1}>{t('release.dialog.tooltip.description')}</Text>
                   <Text muted size={1}>
                     {t('release.dialog.tooltip.note')}


### PR DESCRIPTION
### Description

This branch updates tooltip copy and reduces its stack spacing a little to make it a bit more visually comfortable.

<img width="617" alt="Screenshot 2025-02-13 at 15 34 34" src="https://github.com/user-attachments/assets/daa0eb69-5d75-41e0-8ece-574c489ca0be" />

### What to review

_The tooltip_ [waves arms in air]

### Testing

Try the new tooltip. I think you're going to love it.
