### PR TITLE
fix(core): releases edit events error when calculating differences

### DIFF
--- a/packages/sanity/src/core/preview/createGlobalListener.ts
+++ b/packages/sanity/src/core/preview/createGlobalListener.ts
@@ -11,7 +11,7 @@ import {shareReplayLatest} from './utils/shareReplayLatest'
 export function createGlobalListener(client: SanityClient) {
   return client
     .listen(
-      '*[]',
+      '*',
       {},
       {
         events: ['welcome', 'mutation', 'reconnect'],

--- a/packages/sanity/src/core/preview/createGlobalListener.ts
+++ b/packages/sanity/src/core/preview/createGlobalListener.ts
@@ -11,7 +11,7 @@ import {shareReplayLatest} from './utils/shareReplayLatest'
 export function createGlobalListener(client: SanityClient) {
   return client
     .listen(
-      '*[!(_id in path("_.**"))]',
+      '*[]',
       {},
       {
         events: ['welcome', 'mutation', 'reconnect'],

--- a/packages/sanity/src/core/releases/tool/detail/events/getReleaseEditEvents.ts
+++ b/packages/sanity/src/core/releases/tool/detail/events/getReleaseEditEvents.ts
@@ -18,7 +18,7 @@ import {
 } from 'rxjs'
 
 import {getTransactionsLogs} from '../../../../store/translog/getTransactionsLogs'
-import {type ReleasesReducerState} from '../../../store/reducer'
+import {type ReleaseDocument} from '../../../store/types'
 import {buildReleaseEditEvents} from './buildReleaseEditEvents'
 import {type CreateReleaseEvent, type EditReleaseEvent} from './types'
 
@@ -120,23 +120,20 @@ export const INITIAL_VALUE: EditEventsObservableValue = {
 
 interface getReleaseActivityEventsOpts {
   client: SanityClient
-  releaseId: string
-  releasesState$: Observable<ReleasesReducerState>
+  observeDocument$: Observable<ReleaseDocument | undefined>
 }
+
 export function getReleaseEditEvents({
   client,
-  releaseId,
-  releasesState$,
+  observeDocument$,
 }: getReleaseActivityEventsOpts): Observable<EditEventsObservableValue> {
-  return releasesState$.pipe(
-    map((releasesState) => releasesState.releases.get(releaseId)),
-    // Don't emit if the release is not found
+  return observeDocument$.pipe(
     filter(Boolean),
     distinctUntilChanged((prev, next) => prev._rev === next._rev),
     switchMap((release) => {
       return getReleaseTransactions({
         client,
-        documentId: releaseId,
+        documentId: release._id,
         toTransaction: release._rev,
       }).pipe(
         map((transactions) => {


### PR DESCRIPTION
### Description

### **Pre-read**
The Releases Activity Panel was previously relying on release documents from the **releases store**. Initially, these documents were complete. However, we recently introduced a [projection to the documents](https://github.com/sanity-io/sanity/blob/sapp-2101/packages/sanity/src/core/releases/store/createReleaseStore.ts#L39-L60), which means they are now **partial**.

The activity panel retrieves changes using the **transactions endpoint** and applies **Mendoza patches** to the documents. However, Mendoza patches require **complete documents** to function correctly—they **do not** work with partial documents.

---

### **Fix**
This PR refactors the `getReleaseEditEvents` observable to use the new `observeDocument` observable, which ensures that **complete** documents are returned. This resolves the issue where Mendoza patches failed due to incomplete data.

---

### **Other Changes**
- The **global listener** was filtering out **system documents**, and since **releases** are classified as system documents, they were also being excluded.
- To allow `observeDocument` to function correctly, this PR **removes that filter**, ensuring system documents (including releases) are properly observed.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Any side effect to consider on the listener change?


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

The corresponding tests are updated.
Opening a release activity panel should not error in any case.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an error when getting the release edit events in the release activity panel
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
