### PR TITLE
fix(core): simplify pin release  button on release detail screen

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -103,6 +103,8 @@ const releasesLocaleStrings = {
 
   /** Text for the releases detail screen in the pin release button. */
   'dashboard.details.pin-release': 'Pin release',
+  /** Text for the releases detail screen in the unpin release button. */
+  'dashboard.details.unpin-release': 'Unpin release',
 
   /** Activity inspector button text */
   'dashboard.details.activity': 'Activity',

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -5,19 +5,10 @@ import {
   PinIcon,
   WarningOutlineIcon,
 } from '@sanity/icons'
-import {
-  Box,
-  // Custom button with full radius used here
-  // eslint-disable-next-line no-restricted-imports
-  Button,
-  Card,
-  Container,
-  Flex,
-  Stack,
-  Text,
-} from '@sanity/ui'
+import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
 import {useCallback, useEffect, useState} from 'react'
 
+import {Button} from '../../../../ui-components/button/Button'
 import {ToneIcon} from '../../../../ui-components/toneIcon/ToneIcon'
 import {TextWithTone} from '../../../components/textWithTone/TextWithTone'
 import {Details} from '../../../form/components/Details'
@@ -30,7 +21,6 @@ import {useReleaseOperations} from '../../store'
 import {type ReleaseDocument} from '../../store/types'
 import {useReleasePermissions} from '../../store/useReleasePermissions'
 import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
-import {getReleaseTone} from '../../util/getReleaseTone'
 import {ReleaseDetailsEditor} from './ReleaseDetailsEditor'
 import {isNotArchivedRelease, ReleaseTypePicker} from './ReleaseTypePicker'
 
@@ -93,14 +83,16 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
           {isReleaseOpen && (
             <Button
               icon={isSelected ? PinFilledIcon : PinIcon}
+              tooltipProps={{
+                placement: 'top',
+                content: isSelected
+                  ? tRelease('dashboard.details.unpin-release')
+                  : tRelease('dashboard.details.pin-release'),
+              }}
               mode="bleed"
               onClick={handlePinRelease}
-              padding={2}
               radius="full"
               selected={isSelected}
-              space={2}
-              text={tRelease('dashboard.details.pin-release')}
-              tone={getReleaseTone(release)}
             />
           )}
           {isNotArchivedRelease(release) && <ReleaseTypePicker release={release} />}


### PR DESCRIPTION
### Description
Two images say more than 2.000 words

<img width="1421" alt="Screenshot 2025-02-14 at 11 49 04" src="https://github.com/user-attachments/assets/c458dfdb-06a3-423e-9334-a0718e2969c0" />
<img width="1427" alt="Screenshot 2025-02-14 at 11 49 13" src="https://github.com/user-attachments/assets/6bcca37c-96c6-43b8-9000-a5d11b593dc3" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
