### PR TITLE
fix(core): change publish now release action wording

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -31,7 +31,7 @@ const releasesLocaleStrings = {
   /** Action text for unscheduling a release */
   'action.unschedule': 'Unschedule for publishing',
   /** Action text for publishing all documents in a release (and the release itself) */
-  'action.publish-all-documents': 'Publish all documents',
+  'action.publish-all-documents': 'Run release',
   /** Text for the review changes button in release tool */
   'action.review': 'Review changes',
   /** Action text for reverting a release */


### PR DESCRIPTION
### Description
Updates the text for the Publish now action in releases from "Publish all documents" to "Run release"

<img width="913" alt="Screenshot 2025-02-14 at 12 19 15" src="https://github.com/user-attachments/assets/a1fbda76-5e03-477c-b038-09d7c5a02a8f" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
