### PR TITLE
fix(core): add permission limitation for adding new version in the release details search

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/AddDocumentSearch.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/AddDocumentSearch.tsx
@@ -63,7 +63,7 @@ export function AddDocumentSearch({
   return (
     <LayerProvider zOffset={1}>
       {/* eslint-disable-next-line @sanity/i18n/no-attribute-string-literals*/}
-      <SearchProvider perspective={['raw']} disabledDocumentIds={idsInRelease}>
+      <SearchProvider perspective={['raw']} disabledDocumentIds={idsInRelease} canDisableAction>
         <PortalProvider>
           <SearchPopover
             onClose={handleClose}

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
@@ -1,6 +1,6 @@
 import {type SanityDocumentLike} from '@sanity/types'
 import {Box, type ResponsiveMarginProps, type ResponsivePaddingProps} from '@sanity/ui'
-import {type MouseEvent, useCallback, useMemo} from 'react'
+import {type MouseEvent, useCallback, useEffect, useMemo, useState} from 'react'
 import {useIntentLink, useRouter} from 'sanity/router'
 
 import {Tooltip} from '../../../../../../../../ui-components'
@@ -8,7 +8,11 @@ import {type GeneralPreviewLayoutKey, PreviewCard} from '../../../../../../../co
 import {useSchema} from '../../../../../../../hooks'
 import {useTranslation} from '../../../../../../../i18n/hooks/useTranslation'
 import {unstable_useValuePreview as useValuePreview} from '../../../../../../../preview/useValuePreview'
-import {useDocumentPresence} from '../../../../../../../store'
+import {
+  type PermissionCheckResult,
+  useDocumentPresence,
+  useGrantsStore,
+} from '../../../../../../../store'
 import {getPublishedId} from '../../../../../../../util/draftUtils'
 import {useSearchState} from '../../../contexts/search/useSearchState'
 import {SearchResultItemPreview} from './SearchResultItemPreview'
@@ -44,6 +48,15 @@ export function SearchResultItem({
   })
   const {state} = useSearchState()
   const {t} = useTranslation()
+  const grantsStore = useGrantsStore()
+  const [createPermission, setCreatePermission] = useState<PermissionCheckResult | null>(null)
+  const hasCreatePermission = createPermission?.granted
+
+  useEffect(() => {
+    grantsStore
+      .checkDocumentPermission('create', {_id: documentId, _type: documentType})
+      .subscribe(setCreatePermission)
+  }, [documentId, documentType, grantsStore])
 
   // if the perspective is set within the searchState then it means it should override the router perspective
   const pickedPerspective = state.perspective ? state.perspective[0] : perspective
@@ -52,6 +65,8 @@ export function SearchResultItem({
   const existsInRelease = state.disabledDocumentIds?.some((id) =>
     id.includes(getPublishedId(documentId)),
   )
+  // should the search items be disasabled
+  const disabledAction = (!hasCreatePermission && state.disabledDocumentIds) || existsInRelease
 
   const preview = useValuePreview({
     enabled: true,
@@ -75,16 +90,16 @@ export function SearchResultItem({
   const content = (
     <Box {...rest}>
       <PreviewCard
-        as={existsInRelease ? undefined : 'a'}
+        as={disabledAction ? undefined : 'a'}
         data-as="a"
         flex={1}
-        href={disableIntentLink || existsInRelease ? undefined : href}
+        href={disabledAction || disableIntentLink ? undefined : href}
         onClick={handleClick}
         radius={2}
         tabIndex={-1}
         style={{
-          pointerEvents: existsInRelease ? 'none' : undefined,
-          opacity: existsInRelease ? 0.5 : 1,
+          pointerEvents: disabledAction ? 'none' : undefined,
+          opacity: disabledAction ? 0.5 : 1,
         }}
       >
         <SearchResultItemPreview
@@ -98,8 +113,12 @@ export function SearchResultItem({
     </Box>
   )
 
-  return existsInRelease ? (
-    <Tooltip content={t('release.tooltip.already-added')} placement="top">
+  const tooltipContent = existsInRelease
+    ? t('search.disabledItem')
+    : t('release.action.permission.error')
+
+  return disabledAction ? (
+    <Tooltip content={tooltipContent} placement="top">
       {content}
     </Tooltip>
   ) : (

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
@@ -53,10 +53,12 @@ export function SearchResultItem({
   const hasCreatePermission = createPermission?.granted
 
   useEffect(() => {
-    grantsStore
-      .checkDocumentPermission('create', {_id: documentId, _type: documentType})
-      .subscribe(setCreatePermission)
-  }, [documentId, documentType, grantsStore])
+    if (state.canDisableAction) {
+      grantsStore
+        .checkDocumentPermission('create', {_id: documentId, _type: documentType})
+        .subscribe(setCreatePermission)
+    }
+  }, [documentId, documentType, grantsStore, state.canDisableAction])
 
   // if the perspective is set within the searchState then it means it should override the router perspective
   const pickedPerspective = state.perspective ? state.perspective[0] : perspective
@@ -66,7 +68,7 @@ export function SearchResultItem({
     id.includes(getPublishedId(documentId)),
   )
   // should the search items be disasabled
-  const disabledAction = (!hasCreatePermission && state.disabledDocumentIds) || existsInRelease
+  const disabledAction = (!hasCreatePermission && state.canDisableAction) || existsInRelease
 
   const preview = useValuePreview({
     enabled: true,

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
@@ -36,6 +36,10 @@ interface SearchProviderProps {
    * if provided, then ids should be checked against this list
    */
   disabledDocumentIds?: string[]
+  /**
+   * If true, the search action (such as adding a document to a release list, for example) should be allowed to disable under the right conditions
+   */
+  canDisableAction?: boolean
 }
 
 /**
@@ -46,6 +50,7 @@ export function SearchProvider({
   fullscreen,
   perspective,
   disabledDocumentIds,
+  canDisableAction,
 }: SearchProviderProps) {
   const [onClose, setOnClose] = useState<(() => void) | null>(null)
   const [searchCommandList, setSearchCommandList] = useState<CommandListHandle | null>(null)
@@ -216,9 +221,18 @@ export function SearchProvider({
         fullscreen,
         perspective,
         disabledDocumentIds,
+        canDisableAction,
       },
     }),
-    [fullscreen, disabledDocumentIds, onClose, perspective, searchCommandList, state],
+    [
+      fullscreen,
+      disabledDocumentIds,
+      canDisableAction,
+      onClose,
+      perspective,
+      searchCommandList,
+      state,
+    ],
   )
 
   return <SearchContext.Provider value={value}>{children}</SearchContext.Provider>

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.ts
@@ -43,6 +43,7 @@ export type SearchReducerState = PaginationState & {
   strategy?: SearchStrategy
   disabledDocumentIds?: string[]
   perspective?: ClientPerspective
+  canDisableAction?: boolean
 }
 
 export interface SearchDefinitions {


### PR DESCRIPTION
### Description

If a user doesn't have create permissions they will have the action disabled in the search for the release details. **Searching should still work**

https://github.com/user-attachments/assets/f0192bf9-b543-47ab-9c46-d25f9cd6e351

### What to review

Thoughts? Concerns?

### Testing

Existing tests should be enough

### Notes for release

Search items in a Release Detail now respect role permissions
