### PR TITLE
chore(sanity): fix intent params links

### DIFF
--- a/packages/sanity/src/structure/structureBuilder/Intent.ts
+++ b/packages/sanity/src/structure/structureBuilder/Intent.ts
@@ -61,7 +61,7 @@ export const DEFAULT_INTENT_HANDLER = Symbol('Document type list canHandleIntent
 
 /**
  * Intent parameters
- * See {@link router.BaseIntentParams} and {@link router.IntentJsonParams}
+ * See {@link structure.BaseIntentParams} and {@link structure.IntentJsonParams}
  *
  * @public
  */


### PR DESCRIPTION
### Description

Updated the TSDoc links for Intents. They are currently pointing to `router.BaseIntentParams` and `router.IntentJsonParams`.  Those links don't resolve. 

This PR updates the the links to `structure.BaseIntentParams` and `structure.IntentJsonParams`. 
https://www.sanity.io/docs/reference/api/sanity/structure/BaseIntentParams
https://www.sanity.io/docs/reference/api/sanity/structure/IntentJsonParams


### What to review

### Testing

### Notes for release
related to DOCS-841
