### PR TITLE
fix(releases): handling cases where no create release permissions whilst at limit of release in project

### DIFF
--- a/packages/sanity/src/core/error/types/isErrorWithDetails.ts
+++ b/packages/sanity/src/core/error/types/isErrorWithDetails.ts
@@ -1,0 +1,7 @@
+type ErrorWithDetails = {details?: {type?: string}}
+
+export const isErrorWithDetails = (error: unknown): error is ErrorWithDetails =>
+  typeof error === 'object' &&
+  error !== null &&
+  'details' in error &&
+  typeof (error as {details: unknown}).details === 'object'

--- a/packages/sanity/src/core/releases/contexts/upsell/ReleasesUpsellProvider.tsx
+++ b/packages/sanity/src/core/releases/contexts/upsell/ReleasesUpsellProvider.tsx
@@ -172,10 +172,10 @@ export function ReleasesUpsellProvider(props: {children: React.ReactNode}) {
   )
 
   const onReleaseLimitReached = useCallback(
-    (limit: number) => {
+    (limit: number, suppressDialogOpening: boolean = false) => {
       setReleaseLimit(limit)
 
-      if ((activeReleases?.length || 0) >= limit) {
+      if (!suppressDialogOpening && (activeReleases?.length || 0) >= limit) {
         handleOpenDialog()
       }
     },

--- a/packages/sanity/src/core/releases/contexts/upsell/types.ts
+++ b/packages/sanity/src/core/releases/contexts/upsell/types.ts
@@ -9,7 +9,7 @@ export interface ReleasesUpsellContextValue {
   mode: 'upsell' | 'default' | 'disabled'
   upsellDialogOpen: boolean
   guardWithReleaseLimitUpsell: (callback: () => void, throwError?: boolean) => false | void
-  onReleaseLimitReached: (limit: number) => void
+  onReleaseLimitReached: (limit: number, suppressDialogOpening: boolean) => void
   telemetryLogs: {
     dialogSecondaryClicked: () => void
     dialogPrimaryClicked: () => void

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -6,6 +6,7 @@ import {
 } from '@sanity/client'
 
 import {getPublishedId, getVersionId} from '../../util'
+import {type ReleasesUpsellContextValue} from '../contexts/upsell/types'
 import {getReleaseIdFromReleaseDocumentId, type ReleaseDocument} from '../index'
 import {type RevertDocument} from '../tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates'
 import {isReleaseLimitError} from './isReleaseLimitError'
@@ -51,7 +52,7 @@ const METADATA_PROPERTY_NAME = 'metadata'
 
 export function createReleaseOperationsStore(options: {
   client: SanityClient
-  onReleaseLimitReached: (limit: number) => void
+  onReleaseLimitReached: ReleasesUpsellContextValue['onReleaseLimitReached']
 }): ReleaseOperationsStore {
   const {client} = options
   const requestAction = createRequestAction(options.onReleaseLimitReached)
@@ -344,7 +345,9 @@ type ReleaseAction =
   | CreateVersionReleaseApiAction
   | UnpublishVersionReleaseApiAction
 
-export function createRequestAction(onReleaseLimitReached: (limit: number) => void) {
+export function createRequestAction(
+  onReleaseLimitReached: ReleasesUpsellContextValue['onReleaseLimitReached'],
+) {
   return async function requestAction(
     client: SanityClient,
     actions: ReleaseAction | ReleaseAction[],
@@ -363,7 +366,7 @@ export function createRequestAction(onReleaseLimitReached: (limit: number) => vo
     } catch (e) {
       if (isReleaseLimitError(e)) {
         // free accounts do not return limit, 0 is implied
-        onReleaseLimitReached(e.details.limit || 0)
+        onReleaseLimitReached(e.details.limit || 0, !!options?.dryRun)
       }
 
       throw e

--- a/packages/sanity/src/core/releases/store/isReleaseLimitError.ts
+++ b/packages/sanity/src/core/releases/store/isReleaseLimitError.ts
@@ -1,11 +1,6 @@
-type ErrorWithDetails = {details?: {type?: string}}
+import {isErrorWithDetails} from '../../error/types/isErrorWithDetails'
+
 type ReleaseLimitError = {details: {type: 'releaseLimitExceededError'; limit: number}}
 
-const hasDetails = (error: unknown): error is ErrorWithDetails =>
-  typeof error === 'object' &&
-  error !== null &&
-  'details' in error &&
-  typeof (error as {details: unknown}).details === 'object'
-
 export const isReleaseLimitError = (error: unknown): error is ReleaseLimitError =>
-  hasDetails(error) && error.details?.type === 'releaseLimitExceededError'
+  isErrorWithDetails(error) && error.details?.type === 'releaseLimitExceededError'

--- a/packages/sanity/src/core/releases/store/useReleasePermissions.ts
+++ b/packages/sanity/src/core/releases/store/useReleasePermissions.ts
@@ -1,9 +1,16 @@
+import {isErrorWithDetails} from '../../error/types/isErrorWithDetails'
+
 export interface useReleasePermissionsValue {
   checkWithPermissionGuard: <T extends (...args: any[]) => Promise<void> | void>(
     action: T,
     ...args: Parameters<T>
   ) => Promise<boolean>
 }
+
+type ReleasePermissionError = {details: {type: 'insufficientPermissionsError'}}
+
+export const isReleasePermissionError = (error: unknown): error is ReleasePermissionError =>
+  isErrorWithDetails(error) && error.details?.type === 'insufficientPermissionsError'
 
 /**
  * @internal
@@ -27,7 +34,7 @@ export function useReleasePermissions(): useReleasePermissionsValue {
       })
       return true
     } catch (e) {
-      return false
+      return !isReleasePermissionError(e)
     }
   }
   return {


### PR DESCRIPTION
### Description
With the new permission checks for releases (by running a `dryRun` release action to check for permissions, there were some issues when the project was already at the release limit for the plan.

> [!NOTE]
> The Upsell components here will be further updated for organisation level limit - this is a stopgap until then so will be very short lived

**No Permissions but at release limit**
Before:
The upsell would keep flashing repeatedly (because of the dryRun request triggering the dialog)
![noPermsAtLimitOLD](https://github.com/user-attachments/assets/bc7893bc-316e-4694-94dd-ebec1ae580c1)


After [FIXED]:
The create buttons are enabled (this is because content lake returns the limit error rather than the permission error - which will be changed shortly), but the upsell only shows when an action is attempted by the user
![noPermsAtLimitNEW](https://github.com/user-attachments/assets/ec53c72d-3e9d-4ee2-9568-e70101586d16)


**No Permissions but under the limit**
Before:
The create buttons are correctly disabled because of permissions
![noPermsUnderLimitNEW](https://github.com/user-attachments/assets/ca1bef72-46ac-495f-85ed-1f5cc3bf9e1e)


After [SAME]:
The create buttons are correctly disabled because of permissions
![noPermsUnderLimitNEW](https://github.com/user-attachments/assets/ca1bef72-46ac-495f-85ed-1f5cc3bf9e1e)


**Permissions but at release limit**
Before:
Upsell keeps flashing (because of the dryRun request triggering)
![permsAtLimitOLD](https://github.com/user-attachments/assets/b0f2ac5d-ad38-44de-a9c2-6face6c7a519)


After [FIXED]:
Will get upsell when trying to perform create action
![permsAtLimitNEW](https://github.com/user-attachments/assets/f9256e68-f0cc-4d3e-ac5a-da5367cf641d)


**Permissions but under the release limit**
Before:
Works as expected
![permsUnderLimitNEW](https://github.com/user-attachments/assets/87c49491-fe3a-489e-ac84-8f2227906c94)


After [SAME]:
Works as expected
![permsUnderLimitNEW](https://github.com/user-attachments/assets/87c49491-fe3a-489e-ac84-8f2227906c94)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* Abstracting away a check for `error.details` to `core/error/types` - this makes sense?
* Only Asserting that permissions don't exist when the error is specifically permissions related

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manually running through the above scenarios
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
