### PR TITLE
chore: fix package.json formatting

### DIFF
--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -121,8 +121,8 @@
     "watch": "pkg-utils watch"
   },
   "dependencies": {
-    "@sanity/types": "3.75.1",
     "@sanity/client": "^6.28.0",
+    "@sanity/types": "3.75.1",
     "get-random-values-esm": "1.0.2",
     "moment": "^2.30.1",
     "rxjs": "^7.8.1"


### PR DESCRIPTION
### Description
Looks like a formatting issue with the `sanity` package's package.json managed to sneak into `next`. This patch should fix it.

### What to review
Fixed by sorting dependencies


### Testing
n/a

### Notes for release
n/a