### PR TITLE
refactor(core): prevent updating release title and description if the user doesn't have permissions

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
@@ -84,9 +84,11 @@ const DescriptionTextArea = styled.textarea((props) => {
 export function TitleDescriptionForm({
   release,
   onChange,
+  disabled,
 }: {
   release: EditableReleaseDocument
   onChange: (changedValue: EditableReleaseDocument) => void
+  disabled?: boolean
 }): React.JSX.Element {
   const isReleaseOpen = release.state !== 'archived' && release.state !== 'published'
   const descriptionRef = useRef<HTMLTextAreaElement | null>(null)
@@ -156,6 +158,7 @@ export function TitleDescriptionForm({
         placeholder={t('release.placeholder-untitled-release')}
         data-testid="release-form-title"
         readOnly={!isReleaseOpen}
+        disabled={disabled}
       />
       {shouldShowDescription && (
         <DescriptionTextArea
@@ -169,6 +172,7 @@ export function TitleDescriptionForm({
             maxHeight: MAX_DESCRIPTION_HEIGHT,
           }}
           data-testid="release-form-description"
+          disabled={disabled}
         />
       )}
     </Stack>

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
@@ -1,11 +1,15 @@
-import {useCallback, useState} from 'react'
+import {useCallback, useEffect, useState} from 'react'
 
 import {TitleDescriptionForm} from '../../components/dialog/TitleDescriptionForm'
 import {type EditableReleaseDocument, type ReleaseDocument, useReleaseOperations} from '../../index'
+import {useReleasePermissions} from '../../store/useReleasePermissions'
 
 export function ReleaseDetailsEditor({release}: {release: ReleaseDocument}): React.JSX.Element {
   const {updateRelease} = useReleaseOperations()
   const [timer, setTimer] = useState<NodeJS.Timeout | undefined>(undefined)
+
+  const {checkWithPermissionGuard} = useReleasePermissions()
+  const [hasUpdatePermission, setHasUpdatePermission] = useState<boolean | null>(null)
 
   const handleOnChange = useCallback(
     (changedValue: EditableReleaseDocument) => {
@@ -13,13 +17,28 @@ export function ReleaseDetailsEditor({release}: {release: ReleaseDocument}): Rea
 
       /** @todo I wasn't able to get this working with the debouncer that we use in other parts */
       const newTimer = setTimeout(() => {
-        updateRelease(changedValue)
+        if (hasUpdatePermission) {
+          updateRelease(changedValue)
+        }
       }, 200)
 
       setTimer(newTimer)
     },
-    [timer, updateRelease],
+    [hasUpdatePermission, timer, updateRelease],
   )
 
-  return <TitleDescriptionForm key={release._id} release={release} onChange={handleOnChange} />
+  useEffect(() => {
+    checkWithPermissionGuard(updateRelease, release).then((hasPermission) =>
+      setHasUpdatePermission(hasPermission),
+    )
+  }, [checkWithPermissionGuard, release, release._id, updateRelease])
+
+  return (
+    <TitleDescriptionForm
+      key={release._id}
+      release={release}
+      onChange={handleOnChange}
+      disabled={Boolean(!hasUpdatePermission)}
+    />
+  )
 }

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
@@ -28,9 +28,15 @@ export function ReleaseDetailsEditor({release}: {release: ReleaseDocument}): Rea
   )
 
   useEffect(() => {
-    checkWithPermissionGuard(updateRelease, release).then((hasPermission) =>
-      setHasUpdatePermission(hasPermission),
-    )
+    let shouldUpdate = true
+
+    checkWithPermissionGuard(updateRelease, release).then((hasPermission) => {
+      if (shouldUpdate) setHasUpdatePermission(hasPermission)
+    })
+
+    return () => {
+      shouldUpdate = false
+    }
   }, [checkWithPermissionGuard, release, release._id, updateRelease])
 
   return (

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetailsEditor.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetailsEditor.test.tsx
@@ -3,6 +3,10 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
 import {type ReleaseDocument} from '../../../index'
+import {
+  mockUseReleasePermissions,
+  useReleasePermissionsMockReturn,
+} from '../../../store/__tests__/__mocks/useReleasePermissions.mock'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
 import {ReleaseDetailsEditor} from '../ReleaseDetailsEditor'
 // Mock the dependencies
@@ -12,62 +16,97 @@ vi.mock('../../../store/useReleaseOperations', () => ({
   }),
 }))
 
+vi.mock('../../../store/useReleasePermissions', () => ({
+  useReleasePermissions: vi.fn(() => useReleasePermissionsMockReturn),
+}))
+
 describe('ReleaseDetailsEditor', () => {
-  beforeEach(async () => {
-    const initialRelease = {
-      _id: 'release1',
-      metadata: {
-        title: 'Initial Title',
-        description: '',
-        releaseType: 'asap',
-        intendedPublishAt: undefined,
-      },
-    } as ReleaseDocument
-    const wrapper = await createTestProvider()
-    render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
+  describe('when there is permission', () => {
+    beforeEach(async () => {
+      const initialRelease = {
+        _id: 'release1',
+        metadata: {
+          title: 'Initial Title',
+          description: '',
+          releaseType: 'asap',
+          intendedPublishAt: undefined,
+        },
+      } as ReleaseDocument
+
+      mockUseReleasePermissions.mockReturnValue({
+        checkWithPermissionGuard: async () => true,
+      })
+      const wrapper = await createTestProvider()
+      render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
+    })
+
+    it('should call updateRelease after title change', () => {
+      const release = {
+        _id: 'release1',
+        metadata: {
+          title: 'New Title',
+          description: '',
+          releaseType: 'asap',
+          intendedPublishAt: undefined,
+        },
+      } as ReleaseDocument
+
+      const input = screen.getByTestId('release-form-title')
+      fireEvent.change(input, {target: {value: release.metadata.title}})
+
+      waitFor(
+        () => {
+          expect(useReleaseOperations().updateRelease).toHaveBeenCalledWith(release)
+        },
+        {timeout: 10_000},
+      )
+    })
+
+    it('should call updateRelease after description change', () => {
+      const release = {
+        _id: 'release1',
+        metadata: {
+          title: 'Initial Title',
+          description: 'woo hoo',
+          releaseType: 'asap',
+          intendedPublishAt: undefined,
+        },
+      } as ReleaseDocument
+
+      const input = screen.getByTestId('release-form-description')
+      fireEvent.change(input, {target: {value: release.metadata.description}})
+
+      waitFor(
+        () => {
+          expect(useReleaseOperations().updateRelease).toHaveBeenCalledWith(release)
+        },
+        {timeout: 10_000},
+      )
+    })
   })
 
-  it('should call updateRelease after title change', () => {
-    const release = {
-      _id: 'release1',
-      metadata: {
-        title: 'New Title',
-        description: '',
-        releaseType: 'asap',
-        intendedPublishAt: undefined,
-      },
-    } as ReleaseDocument
+  describe('when there is no permission', () => {
+    beforeEach(async () => {
+      const initialRelease = {
+        _id: 'release1',
+        metadata: {
+          title: 'Initial Title',
+          description: '',
+          releaseType: 'asap',
+          intendedPublishAt: undefined,
+        },
+      } as ReleaseDocument
 
-    const input = screen.getByTestId('release-form-title')
-    fireEvent.change(input, {target: {value: release.metadata.title}})
+      mockUseReleasePermissions.mockReturnValue({
+        checkWithPermissionGuard: async () => false,
+      })
+      const wrapper = await createTestProvider()
+      render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
+    })
 
-    waitFor(
-      () => {
-        expect(useReleaseOperations().updateRelease).toHaveBeenCalledWith(release)
-      },
-      {timeout: 10_000},
-    )
-  })
-
-  it('should call updateRelease after description change', () => {
-    const release = {
-      _id: 'release1',
-      metadata: {
-        title: 'Initial Title',
-        description: 'woo hoo',
-        releaseType: 'asap',
-        intendedPublishAt: undefined,
-      },
-    } as ReleaseDocument
-
-    const input = screen.getByTestId('release-form-description')
-    fireEvent.change(input, {target: {value: release.metadata.description}})
-
-    waitFor(
-      () => {
-        expect(useReleaseOperations().updateRelease).toHaveBeenCalledWith(release)
-      },
-      {timeout: 10_000},
-    )
+    it('when there is no permission, should not call updateRelease', async () => {
+      const input = screen.getByTestId('release-form-description')
+      expect(input).toBeDisabled()
+    })
   })
 })


### PR DESCRIPTION
### Description

If a user doesn't have user permissions, they will not be allowed to edit the title (or perceive that they could otherwise).
| With Permission    | Without Permission |
| -------- | ------- |
<video src="https://github.com/user-attachments/assets/a46d88e8-3547-4a02-a11c-764ef49c7a96">  |  <video src="https://github.com/user-attachments/assets/ec7ba185-70ed-4b1d-8055-71380c2a4c75">
   |






### What to review

Double check the code makes sense,
I thought that I could have done the check all the way in the ReleasesList (which also calls for the same method in the useEffect, however, I felt like it made more sense to cause a re-render further down _if_ it's needed than potentially re-rendering multiple things at a component at a higher level since that's not the only child that it has)

### Testing

Unit tests added
You should be able to manually test by following the video with a user that has no permissions

### Notes for release

Editing a Release title and description now respects role permissions
