### PR TITLE
feat(sanity): add granular release error icons to global switcher

### DIFF
--- a/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenuItem.tsx
+++ b/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenuItem.tsx
@@ -1,9 +1,10 @@
-import {DotIcon, EyeClosedIcon, EyeOpenIcon, LockIcon} from '@sanity/icons'
+import {DotIcon, ErrorOutlineIcon, EyeClosedIcon, EyeOpenIcon, LockIcon} from '@sanity/icons'
 // eslint-disable-next-line no-restricted-imports -- custom use for MenuItem & Button not supported by ui-components
 import {Box, Button, Flex, MenuItem, Stack, Text} from '@sanity/ui'
 import {type CSSProperties, forwardRef, type MouseEvent, useCallback, useMemo} from 'react'
 import {css, styled} from 'styled-components'
 
+import {ToneIcon} from '../../../ui-components/toneIcon/ToneIcon'
 import {Tooltip} from '../../../ui-components/tooltip'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {useExcludedPerspective} from '../../perspective/useExcludedPerspective'
@@ -168,9 +169,18 @@ export const GlobalPerspectiveMenuItem = forwardRef<
               opacity: isReleasePerspectiveExcluded ? 0.5 : undefined,
             }}
           >
-            <Text size={1} weight="medium">
-              {displayTitle}
-            </Text>
+            <Flex gap={3} align="center">
+              <Text size={1} weight="medium">
+                {displayTitle}
+              </Text>
+              {isReleaseDocument(release) &&
+                typeof release.error !== 'undefined' &&
+                release.state === 'active' && (
+                  <Text size={1} data-testid="release-error-icon">
+                    <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
+                  </Text>
+                )}
+            </Flex>
             {isReleaseDocument(release) &&
               release.metadata.releaseType === 'scheduled' &&
               (release.publishAt || release.metadata.intendedPublishAt) && (

--- a/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesNav.test.tsx
+++ b/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesNav.test.tsx
@@ -5,6 +5,7 @@ import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {useExcludedPerspectiveMockReturn} from '../../../perspective/__mocks__/useExcludedPerspective.mock'
 import {usePerspectiveMockReturn} from '../../../perspective/__mocks__/usePerspective.mock'
 import {
+  activeASAPErrorRelease,
   activeASAPRelease,
   activeScheduledRelease,
   scheduledRelease,
@@ -145,6 +146,7 @@ describe('ReleasesNav', () => {
         activeASAPRelease,
 
         {...scheduledRelease, publishAt: '2023-10-10T09:00:00Z'},
+        activeASAPErrorRelease,
       ]
     })
 
@@ -191,6 +193,15 @@ describe('ReleasesNav', () => {
         within(scheduledMenuItem).getByText(/\b\d{1,2}\/\d{1,2}\/\d{4}\b/)
         within(scheduledMenuItem).getByTestId('release-lock-icon')
         within(scheduledMenuItem).getByTestId('release-avatar-primary')
+      })
+
+      it('should show the error icon if the release is active and has an error', () => {
+        const releaseMenu = screen.getByTestId('release-menu')
+        const releaseTitle = within(releaseMenu).getByText('active asap Error Release')
+        const releaseButton = releaseTitle?.closest('button')
+
+        expect(releaseButton).toBeTruthy()
+        within(releaseButton!).getByTestId('release-error-icon')
       })
 
       it('allows for new release to be created', async () => {

--- a/packages/sanity/src/core/releases/__fixtures__/release.fixture.ts
+++ b/packages/sanity/src/core/releases/__fixtures__/release.fixture.ts
@@ -45,6 +45,23 @@ export const activeASAPRelease: ReleaseDocument = {
   },
 }
 
+export const activeASAPErrorRelease: ReleaseDocument = {
+  _rev: 'activeASAPErrorRev',
+  _id: '_.releases.rASAPError',
+  _type: 'system.release',
+  _createdAt: '2023-10-01T08:00:00Z',
+  _updatedAt: '2023-10-01T09:00:00Z',
+  state: 'active',
+  metadata: {
+    title: 'active asap Error Release',
+    releaseType: 'asap',
+    description: 'active Error Release description',
+  },
+  error: {
+    message: 'An unexpected error occurred during publication.',
+  },
+}
+
 export const archivedScheduledRelease: ReleaseDocument = {
   _rev: 'archivedRev',
   _id: '_.releases.rArchived',


### PR DESCRIPTION
### Description

This branch adds release error indicators to the global perspective menu.

<img width="309" alt="Screenshot 2025-02-17 at 10 18 08" src="https://github.com/user-attachments/assets/1277e208-b04c-46e1-b0aa-7d9f954e7036" />

### What to review

- The global perspective menu for releases in an error state.

### Testing

- Added unit test.
- Manually tested with a release that has an error.
- Manually tested with a locked release that has an error, to ensure the states combine harmoniously.