### PR TITLE
refactor: pass includeAllVersions to listeners

### DIFF
--- a/dev/test-studio/components/panes/JsonDocumentDump.tsx
+++ b/dev/test-studio/components/panes/JsonDocumentDump.tsx
@@ -40,7 +40,7 @@ export const JsonDocumentDump = forwardRef(function JsonDocumentDump(
       )
 
     sub2Ref.current = client.observable
-      .listen(query, params)
+      .listen(query, params, {includeAllVersions: true})
       .subscribe((mut) => setState({document: mut.result || undefined, isLoading: false}))
   }, [client, itemId])
 

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -595,7 +595,7 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     }
 
     this._listenSubscription = this._client
-      .listen(query, params, {events: ['mutation', 'welcome']})
+      .listen(query, params, {events: ['mutation', 'welcome'], includeAllVersions: true})
       .subscribe({
         next: this.handleListenerEvent,
         error: (error) =>

--- a/packages/sanity/src/core/comments/store/useCommentsStore.ts
+++ b/packages/sanity/src/core/comments/store/useCommentsStore.ts
@@ -33,6 +33,7 @@ const INITIAL_STATE: CommentsReducerState = {
 const LISTEN_OPTIONS: ListenOptions = {
   events: ['welcome', 'mutation', 'reconnect'],
   includeResult: true,
+  includeAllVersions: true,
   visibility: 'query',
   tag: 'comments-store',
 }

--- a/packages/sanity/src/core/preview/createGlobalListener.ts
+++ b/packages/sanity/src/core/preview/createGlobalListener.ts
@@ -18,6 +18,7 @@ export function createGlobalListener(client: SanityClient) {
         includeResult: false,
         includePreviousRevision: false,
         includeMutations: false,
+        includeAllVersions: true,
         visibility: 'query',
         effectFormat: 'mendoza',
         tag: 'preview.global',

--- a/packages/sanity/src/core/preview/liveDocumentIdSet.ts
+++ b/packages/sanity/src/core/preview/liveDocumentIdSet.ts
@@ -46,6 +46,7 @@ export function createDocumentIdSetObserver(client: SanityClient) {
         events: ['welcome', 'mutation', 'reconnect'],
         includeResult: false,
         includeMutations: false,
+        includeAllVersions: true,
         tag: 'preview.observe-document-set.listen',
       })
       .pipe(

--- a/packages/sanity/src/core/releases/store/createReleaseMetadataAggregator.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseMetadataAggregator.ts
@@ -114,6 +114,7 @@ export const createReleaseMetadataAggregator = (client: SanityClient | null) => 
         {},
         {
           includeResult: true,
+          includeAllVersions: true,
           visibility: 'query',
           events: ['mutation'],
           tag: 'release-docs.listen',

--- a/packages/sanity/src/core/store/_legacy/document/getPairListener.ts
+++ b/packages/sanity/src/core/store/_legacy/document/getPairListener.ts
@@ -92,6 +92,7 @@ export function getPairListener(
         },
         {
           includeResult: false,
+          includeAllVersions: true,
           events: ['welcome', 'mutation', 'reconnect'],
           effectFormat: 'mendoza',
           tag: options.tag || 'document.pair-listener',

--- a/packages/sanity/src/core/store/_legacy/document/listenQuery.ts
+++ b/packages/sanity/src/core/store/_legacy/document/listenQuery.ts
@@ -44,6 +44,7 @@ const listen = (
       events: ['welcome', 'mutation', 'reconnect'],
       includeResult: false,
       visibility: 'query',
+      includeAllVersions: true,
       tag: options.tag,
     }),
   ) as Observable<ReconnectEvent | WelcomeEvent | MutationEvent>

--- a/packages/sanity/src/core/tasks/store/useTasksStore.ts
+++ b/packages/sanity/src/core/tasks/store/useTasksStore.ts
@@ -23,6 +23,7 @@ const LISTEN_OPTIONS: ListenOptions = {
   events: ['welcome', 'mutation', 'reconnect'],
   includeResult: true,
   visibility: 'query',
+  includeAllVersions: true,
   tag: 'tasks-store',
 }
 

--- a/packages/sanity/src/presentation/overlays/PostMessageDocuments.tsx
+++ b/packages/sanity/src/presentation/overlays/PostMessageDocuments.tsx
@@ -33,6 +33,7 @@ const PostMessageDocuments: FunctionComponent<PostMessageDocumentsProps> = (prop
           events: ['welcome', 'mutation', 'reconnect'],
           includePreviousRevision: false,
           includeResult: false,
+          includeAllVersions: true,
           tag: 'presentation-documents',
           visibility: 'transaction',
         },

--- a/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
+++ b/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
@@ -72,6 +72,7 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Searc
   const events$ = defer(() => {
     return client.listen(`*[${filter}]`, params, {
       events: ['welcome', 'mutation', 'reconnect'],
+      includeAllVersions: true,
       includeResult: false,
       visibility: 'query',
       tag: 'listen-search-query',

--- a/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetListStore.ts
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/useDocumentSheetListStore.ts
@@ -105,6 +105,7 @@ const LISTEN_OPTIONS: ListenOptions = {
   events: ['welcome', 'mutation', 'reconnect'],
   includeResult: true,
   visibility: 'query',
+  includeAllVersions: true,
   tag: 'document-sheet-list-store',
 }
 


### PR DESCRIPTION
### Description
In order to prepare for an upcoming API change, we want to explicitly add `includeAllVersions` to all the /listen calls made by the Studio.

### What to review
- Ideally, after this PR, there shouldn't be any listen calls made from the studio that doesn't pass `includeAllVersions`. It's only a critical requirement for new code paths that will expect version documents, but for consistency it makes sense to use it everywhere.

### Testing
- A bit of manual testing required unfortunately; open the studio with these changes applied, make sure all listen requests going from the studio are passing `includeAllVersions=true`

### Notes for release
n/a – internal