### PR TITLE
chore: swap to ubuntu-latest

### DIFF
--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   efps-test:
     timeout-minutes: 30
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -103,7 +103,7 @@ jobs:
   merge-reports:
     if: always()
     needs: [efps-test]
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
The `ubuntu-latest-m` machines have been changed from 4 cores to 2 cores, and it seems like their RAM is no longer sufficient to run the EFPS suite.