### PR TITLE
feat(core): updates archived releases overview

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
@@ -115,13 +115,12 @@ export function TitleDescriptionForm({
   const handleTitleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       event.preventDefault()
-      if (!isReleaseOpen) return
       const title = event.target.value
       onChange({...value, metadata: {...release.metadata, title}})
       // save the values to make input snappier while requests happen in the background
       setValue({...value, metadata: {...release.metadata, title}})
     },
-    [isReleaseOpen, onChange, release.metadata, value],
+    [onChange, release.metadata, value],
   )
 
   const handleDescriptionChange = useCallback(

--- a/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
@@ -115,17 +115,20 @@ export function TitleDescriptionForm({
   const handleTitleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       event.preventDefault()
+      if (!isReleaseOpen) return
       const title = event.target.value
       onChange({...value, metadata: {...release.metadata, title}})
       // save the values to make input snappier while requests happen in the background
       setValue({...value, metadata: {...release.metadata, title}})
     },
-    [onChange, release.metadata, value],
+    [isReleaseOpen, onChange, release.metadata, value],
   )
 
   const handleDescriptionChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
       event.preventDefault()
+      if (!isReleaseOpen) return
+
       const description = event.target.value
       onChange({...value, metadata: {...release.metadata, description}})
       // save the values to make input snappier while requests happen in the background
@@ -145,7 +148,7 @@ export function TitleDescriptionForm({
 
       setScrollHeight(event.currentTarget.scrollHeight)
     },
-    [onChange, release.metadata, value],
+    [isReleaseOpen, onChange, release.metadata, value],
   )
 
   const shouldShowDescription = isReleaseOpen || value.metadata.description
@@ -173,6 +176,7 @@ export function TitleDescriptionForm({
           }}
           data-testid="release-form-description"
           disabled={disabled}
+          readOnly={!isReleaseOpen}
         />
       )}
     </Stack>

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -21,7 +21,7 @@ const releasesLocaleStrings = {
   /** Action text for editing a release */
   'action.edit': 'Edit release',
   /** Action text for opening a release */
-  'action.open': 'Open',
+  'action.open': 'Active',
   /** Action text for scheduling a release */
   'action.schedule': 'Schedule for publishing...',
   /** Action text for unpublishing a document in a release in the context menu */

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -303,6 +303,8 @@ const releasesLocaleStrings = {
   /** Change action type that will be shown in the table*/
   'table-body.action.unpublish': 'Unpublish',
 
+  /** Header for the document table in the release tool - Archived */
+  'table-header.archivedAt': 'Archived',
   /** Header for the document table in the release tool - contributors */
   'table-header.contributors': 'Contributors',
   /** Header for the document table in the release tool - type */
@@ -315,6 +317,8 @@ const releasesLocaleStrings = {
   'table-header.documents': 'Documents',
   /** Header for the document table in the release tool - edited */
   'table-header.edited': 'Edited',
+  /** Header for the document table in the release tool - Published */
+  'table-header.publishedAt': 'Published',
   /** Header for the document table in the release tool - time */
   'table-header.time': 'Time',
 

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -61,7 +61,10 @@ export interface TableRelease extends ReleaseDocument {
 }
 
 const DEFAULT_RELEASES_OVERVIEW_SORT: TableSort = {column: 'publishAt', direction: 'asc'}
-
+const DEFAULT_ARCHIVED_RELEASES_OVERVIEW_SORT: TableSort = {
+  column: 'publishedAt',
+  direction: 'desc',
+}
 export function ReleasesOverview() {
   const {data: releases, loading: loadingReleases} = useActiveReleases()
   const {data: archivedReleases} = useArchivedReleases()
@@ -379,7 +382,11 @@ export function ReleasesOverview() {
               <Table<TableRelease>
                 // for resetting filter and sort on table when filer changed
                 key={releaseFilterDate ? 'by_date' : releaseGroupMode}
-                defaultSort={DEFAULT_RELEASES_OVERVIEW_SORT}
+                defaultSort={
+                  releaseGroupMode === 'archived'
+                    ? DEFAULT_ARCHIVED_RELEASES_OVERVIEW_SORT
+                    : DEFAULT_RELEASES_OVERVIEW_SORT
+                }
                 loading={loadingTableData}
                 data={filteredReleases}
                 columnDefs={tableColumns}

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -127,7 +127,7 @@ export function ReleasesOverview() {
   // switch to open mode if on archived mode and there are no archived releases
   useEffect(() => {
     if (releaseGroupMode === 'archived' && !loadingReleases && !archivedReleases.length) {
-      setReleaseGroupMode('open')
+      setReleaseGroupMode('active')
     }
   }, [releaseGroupMode, archivedReleases.length, loadingReleases])
 
@@ -154,7 +154,7 @@ export function ReleasesOverview() {
 
   const clearFilterDate = useCallback(() => {
     setReleaseFilterDate(undefined)
-    setReleaseGroupMode('open')
+    setReleaseGroupMode('active')
   }, [])
 
   useEffect(() => {
@@ -197,9 +197,9 @@ export function ReleasesOverview() {
           {...groupModeButtonBaseProps}
           key="open-group"
           onClick={handleReleaseGroupModeChange}
-          selected={releaseGroupMode === 'open'}
+          selected={releaseGroupMode === 'active'}
           text={t('action.open')}
-          value="open"
+          value="active"
         />
         <Tooltip
           disabled={archivedReleases.length !== 0}
@@ -278,7 +278,7 @@ export function ReleasesOverview() {
       if (release.isDeleted) return null
 
       const documentsCount =
-        (releaseGroupMode === 'open'
+        (releaseGroupMode === 'active'
           ? release.documentsMetadata?.documentCount
           : release.finalDocumentStates?.length) ?? 0
 
@@ -288,7 +288,7 @@ export function ReleasesOverview() {
   )
 
   const filteredReleases = useMemo(() => {
-    if (!releaseFilterDate) return releaseGroupMode === 'open' ? tableReleases : archivedReleases
+    if (!releaseFilterDate) return releaseGroupMode === 'active' ? tableReleases : archivedReleases
 
     const [startOfDayForTimeZone, endOfDayForTimeZone] =
       getTimezoneAdjustedDateTimeRange(releaseFilterDate)

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -322,6 +322,11 @@ export function ReleasesOverview() {
     )
   }, [loading, releases, releaseFilterDate, handleSelectFilterDate])
 
+  const tableColumns = useMemo(
+    () => releasesOverviewColumnDefs(t, releaseGroupMode),
+    [releaseGroupMode, t],
+  )
+
   return (
     <Flex direction="row" flex={1} style={{height: '100%'}}>
       <Flex flex={1}>
@@ -377,7 +382,7 @@ export function ReleasesOverview() {
                 defaultSort={DEFAULT_RELEASES_OVERVIEW_SORT}
                 loading={loadingTableData}
                 data={filteredReleases}
-                columnDefs={releasesOverviewColumnDefs(t)}
+                columnDefs={tableColumns}
                 emptyState={t('no-releases')}
                 // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
                 rowId="_id"

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -91,7 +91,7 @@ export const releasesOverviewColumnDefs: (
         id: 'publishedAt',
         sorting: true,
         sortTransform: (release) => {
-          if (!release.publishedAt) return Infinity
+          if (!release.publishedAt) return release._updatedAt
           return new Date(release.publishedAt).getTime()
         },
         width: 250,

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -84,7 +84,7 @@ export const releasesOverviewColumnDefs: (
           </Flex>
         ),
       },
-      'open',
+      'active',
     ),
     checkColumnMode(
       {
@@ -173,7 +173,7 @@ export const releasesOverviewColumnDefs: (
           )
         },
       },
-      'open',
+      'active',
     ),
     checkColumnMode(
       {

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -12,132 +12,221 @@ import {Headers} from '../components/Table/TableHeader'
 import {type Column} from '../components/Table/types'
 import {ReleaseDocumentsCounter} from './columnCells/ReleaseDocumentsCounter'
 import {ReleaseNameCell} from './columnCells/ReleaseName'
+import {type Mode} from './queryParamUtils'
 import {type TableRelease} from './ReleasesOverview'
+
+const enableColumnFormMode =
+  (currentMode: Mode) => (column: Column<TableRelease>, expectedMode: Mode | 'all') => {
+    if (!currentMode) throw new Error('currentMode is required')
+    if (expectedMode === 'all' || expectedMode === currentMode) {
+      return column
+    }
+    return undefined
+  }
 
 export const releasesOverviewColumnDefs: (
   t: TFunction<'releases', undefined>,
-) => Column<TableRelease>[] = (t) => {
+  releaseGroupMode: Mode,
+) => Column<TableRelease>[] = (t, releaseGroupMode) => {
+  const checkColumnMode = enableColumnFormMode(releaseGroupMode)
   return [
-    {
-      id: 'metadata.title',
-      sorting: true,
-      width: null,
-      style: {minWidth: '50%', maxWidth: '50%'},
-      header: (props) => (
-        <Flex
-          {...props.headerProps}
-          flex={1}
-          paddingLeft={6}
-          width={3}
-          paddingRight={2}
-          paddingY={3}
-          sizing="border"
-        >
-          <Headers.SortHeaderButton {...props} text={t('table-header.title')} />
-        </Flex>
-      ),
-      cell: ReleaseNameCell,
-    },
-    {
-      id: 'publishAt',
-      sorting: true,
-      sortTransform: (release) => {
-        if (release.metadata.releaseType === 'undecided') return Infinity
-
-        const publishDate = getPublishDateFromRelease(release)
-
-        if (release.metadata.releaseType === 'asap' || !publishDate) return 0
-        return new Date(publishDate).getTime()
+    checkColumnMode(
+      {
+        id: 'metadata.title',
+        sorting: true,
+        width: null,
+        style: {minWidth: '50%', maxWidth: '50%'},
+        header: (props) => (
+          <Flex
+            {...props.headerProps}
+            flex={1}
+            paddingLeft={6}
+            width={3}
+            paddingRight={2}
+            paddingY={3}
+            sizing="border"
+          >
+            <Headers.SortHeaderButton {...props} text={t('table-header.title')} />
+          </Flex>
+        ),
+        cell: ReleaseNameCell,
       },
-      width: 250,
-      header: (props) => (
-        <Flex {...props.headerProps} paddingY={3} sizing="border">
-          <Headers.SortHeaderButton text={t('table-header.time')} {...props} />
-        </Flex>
-      ),
-      cell: ({cellProps, datum: release}) => (
-        <Flex {...cellProps} align="center" paddingX={2} paddingY={3} gap={2} sizing="border">
-          <Text muted size={1}>
-            <ReleaseTime release={release} />
-          </Text>
-          {isReleaseScheduledOrScheduling(release) && (
-            <Text size={1} data-testid="release-lock-icon">
-              <LockIcon />
-            </Text>
-          )}
-        </Flex>
-      ),
-    },
-    {
-      id: 'documentsMetadata.updatedAt',
-      sorting: true,
-      width: 150,
-      header: (props) => (
-        <Flex {...props.headerProps} paddingY={3} sizing="border">
-          <Headers.SortHeaderButton text={t('table-header.edited')} {...props} />
-        </Flex>
-      ),
-      cell: ({datum: {documentsMetadata, _updatedAt}, cellProps}) => {
-        const updatedAtDate = documentsMetadata?.updatedAt ?? _updatedAt
-        return (
-          <Flex {...cellProps} align="center" gap={2} paddingX={2} paddingY={3} sizing="border">
+      'all',
+    ),
+    checkColumnMode(
+      {
+        id: 'publishAt',
+        sorting: true,
+        sortTransform: (release) => {
+          if (release.metadata.releaseType === 'undecided') return Infinity
+
+          const publishDate = getPublishDateFromRelease(release)
+
+          if (release.metadata.releaseType === 'asap' || !publishDate) return 0
+          return new Date(publishDate).getTime()
+        },
+        width: 250,
+        header: (props) => (
+          <Flex {...props.headerProps} paddingY={3} sizing="border">
+            <Headers.SortHeaderButton text={t('table-header.time')} {...props} />
+          </Flex>
+        ),
+        cell: ({cellProps, datum: release}) => (
+          <Flex {...cellProps} align="center" paddingX={2} paddingY={3} gap={2} sizing="border">
             <Text muted size={1}>
-              {updatedAtDate ? (
-                <RelativeTime time={updatedAtDate} useTemporalPhrase minimal />
+              <ReleaseTime release={release} />
+            </Text>
+            {isReleaseScheduledOrScheduling(release) && (
+              <Text size={1} data-testid="release-lock-icon">
+                <LockIcon />
+              </Text>
+            )}
+          </Flex>
+        ),
+      },
+      'open',
+    ),
+    checkColumnMode(
+      {
+        id: 'publishedAt',
+        sorting: true,
+        sortTransform: (release) => {
+          if (!release.publishedAt) return Infinity
+          return new Date(release.publishedAt).getTime()
+        },
+        width: 250,
+        header: (props) => (
+          <Flex {...props.headerProps} paddingY={3} sizing="border">
+            <Headers.SortHeaderButton text={t('table-header.publishedAt')} {...props} />
+          </Flex>
+        ),
+        cell: ({cellProps, datum: release}) => (
+          <Flex {...cellProps} align="center" paddingX={2} paddingY={3} gap={2} sizing="border">
+            <Text muted size={1}>
+              {release.publishedAt ? (
+                // Assuming releases are not updated after archiving.
+                // If we realize this is miss leading for customers and they have edited the release after archiving
+                // we can use the history endpoint to get the archived change.
+                <RelativeTime time={release.publishedAt} useTemporalPhrase minimal />
               ) : (
                 '-'
               )}
             </Text>
           </Flex>
-        )
+        ),
       },
-    },
-    {
-      id: 'error',
-      sorting: false,
-      width: 40,
-      header: () => <Fragment />,
-      cell: ({datum: {error, state}, cellProps}) => (
-        <Flex
-          {...cellProps}
-          align="center"
-          paddingX={2}
-          paddingY={3}
-          sizing="border"
-          data-testid="error-indicator"
-        >
-          {typeof error !== 'undefined' && state === 'active' && (
-            <Tooltip content={<Text size={1}>{t('failed-publish-title')}</Text>} portal>
-              <Text size={1}>
-                <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
+      'archived',
+    ),
+    checkColumnMode(
+      {
+        id: '_updatedAt',
+        sorting: true,
+        sortTransform: (release) => {
+          if (release.state !== 'archived') return Infinity
+          return new Date(release._updatedAt).getTime()
+        },
+        width: 250,
+        header: (props) => (
+          <Flex {...props.headerProps} paddingY={3} sizing="border">
+            <Headers.SortHeaderButton text={t('table-header.archivedAt')} {...props} />
+          </Flex>
+        ),
+        cell: ({cellProps, datum: release}) => (
+          <Flex {...cellProps} align="center" paddingX={2} paddingY={3} gap={2} sizing="border">
+            <Text muted size={1}>
+              {release.state === 'archived' ? (
+                // Assuming releases are not updated after archiving.
+                // If we later realize this is miss leading for customers and they have edited the release after archiving
+                // we can use the history endpoint to get the archived change.
+                <RelativeTime time={release._updatedAt} useTemporalPhrase minimal />
+              ) : (
+                '-'
+              )}
+            </Text>
+          </Flex>
+        ),
+      },
+      'archived',
+    ),
+    checkColumnMode(
+      {
+        id: 'documentsMetadata.updatedAt',
+        sorting: true,
+        width: 150,
+        header: (props) => (
+          <Flex {...props.headerProps} paddingY={3} sizing="border">
+            <Headers.SortHeaderButton text={t('table-header.edited')} {...props} />
+          </Flex>
+        ),
+        cell: ({datum: {documentsMetadata, _updatedAt}, cellProps}) => {
+          const updatedAtDate = documentsMetadata?.updatedAt ?? _updatedAt
+          return (
+            <Flex {...cellProps} align="center" gap={2} paddingX={2} paddingY={3} sizing="border">
+              <Text muted size={1}>
+                {updatedAtDate ? (
+                  <RelativeTime time={updatedAtDate} useTemporalPhrase minimal />
+                ) : (
+                  '-'
+                )}
               </Text>
-            </Tooltip>
-          )}
-        </Flex>
-      ),
-    },
-    {
-      id: 'documentCount',
-      sorting: false,
-      width: 120,
-      header: ({headerProps}) => (
-        <Flex {...headerProps} paddingY={3} sizing="border">
-          <Headers.BasicHeader text={t('table-header.documents')} />
-        </Flex>
-      ),
-      cell: ({datum: {isDeleted, state, finalDocumentStates, documentsMetadata}, cellProps}) => (
-        <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
-          {!isDeleted && (
-            <ReleaseDocumentsCounter
-              documentCount={
-                state === 'archived' || state === 'published'
-                  ? finalDocumentStates?.length
-                  : documentsMetadata?.documentCount
-              }
-            />
-          )}
-        </Flex>
-      ),
-    },
-  ]
+            </Flex>
+          )
+        },
+      },
+      'open',
+    ),
+    checkColumnMode(
+      {
+        id: 'error',
+        sorting: false,
+        width: 40,
+        header: () => <Fragment />,
+        cell: ({datum: {error, state}, cellProps}) => (
+          <Flex
+            {...cellProps}
+            align="center"
+            paddingX={2}
+            paddingY={3}
+            sizing="border"
+            data-testid="error-indicator"
+          >
+            {typeof error !== 'undefined' && state === 'active' && (
+              <Tooltip content={<Text size={1}>{t('failed-publish-title')}</Text>} portal>
+                <Text size={1}>
+                  <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
+                </Text>
+              </Tooltip>
+            )}
+          </Flex>
+        ),
+      },
+      'all',
+    ),
+    checkColumnMode(
+      {
+        id: 'documentCount',
+        sorting: false,
+        width: 120,
+        header: ({headerProps}) => (
+          <Flex {...headerProps} paddingY={3} sizing="border">
+            <Headers.BasicHeader text={t('table-header.documents')} />
+          </Flex>
+        ),
+        cell: ({datum: {isDeleted, state, finalDocumentStates, documentsMetadata}, cellProps}) => (
+          <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
+            {!isDeleted && (
+              <ReleaseDocumentsCounter
+                documentCount={
+                  state === 'archived' || state === 'published'
+                    ? finalDocumentStates?.length
+                    : documentsMetadata?.documentCount
+                }
+              />
+            )}
+          </Flex>
+        ),
+      },
+      'all',
+    ),
+  ].filter(Boolean) as Column<TableRelease>[]
 }

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -167,11 +167,11 @@ describe('ReleasesOverview', () => {
     it('does not allow for switching between history modes', async () => {
       await waitFor(
         () => {
-          screen.getByText('Open')
+          screen.getByText('Active')
         },
         {timeout: 4000},
       )
-      expect(screen.getByText('Open').closest('button')).toBeDisabled()
+      expect(screen.getByText('Active').closest('button')).toBeDisabled()
       expect(screen.getByText('Archived').closest('button')).toBeDisabled()
     })
 
@@ -202,7 +202,7 @@ describe('ReleasesOverview', () => {
     })
 
     it('does not show release history mode switch', () => {
-      expect(screen.queryByText('Open')).toBeNull()
+      expect(screen.queryByText('Active')).toBeNull()
       expect(screen.queryByText('Archived')).toBeNull()
     })
 
@@ -328,7 +328,7 @@ describe('ReleasesOverview', () => {
     })
 
     it('allows for switching between history modes', () => {
-      expect(screen.getByText('Open').closest('button')).not.toBeDisabled()
+      expect(screen.getByText('Active').closest('button')).not.toBeDisabled()
       expect(screen.getByText('Archived').closest('button')).not.toBeDisabled()
     })
 
@@ -378,7 +378,7 @@ describe('ReleasesOverview', () => {
         })
 
         it('does not show open and archive filter group buttons', () => {
-          expect(screen.queryByText('Open')).not.toBeInTheDocument()
+          expect(screen.queryByText('Active')).not.toBeInTheDocument()
           expect(screen.queryByText('Archived')).not.toBeInTheDocument()
         })
 

--- a/packages/sanity/src/core/releases/tool/overview/queryParamUtils.ts
+++ b/packages/sanity/src/core/releases/tool/overview/queryParamUtils.ts
@@ -1,6 +1,6 @@
 import {type RouterContextValue} from 'sanity/router'
 
-export type Mode = 'open' | 'archived'
+export type Mode = 'active' | 'archived'
 
 export const DATE_SEARCH_PARAM_KEY = 'date'
 export const GROUP_SEARCH_PARAM_KEY = 'group'
@@ -18,5 +18,5 @@ export const getInitialReleaseGroupMode = (router: RouterContextValue) => (): Mo
     GROUP_SEARCH_PARAM_KEY,
   )
 
-  return activeGroupMode === 'archived' ? 'archived' : 'open'
+  return activeGroupMode === 'archived' ? 'archived' : 'active'
 }


### PR DESCRIPTION
### Description

This PR updates the archived releases table overview.
Adding two columns that are exclusive for this view:
- **Published**
- **Archived**

This will be the anchor for users to make it possible to determine if a release was published or archived.
It also renames the **Open** tab to **Active**

And fixes a small oversight in were users could edit archived releases descriptions.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Are the changes correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
