### PR TITLE
feat(structure): add unpublish document as part of a release banner

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -139,6 +139,10 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text for the banner that appears when a document is not in the current global release */
   'banners.release.not-in-release': 'Not in the <Label>{{title}}</Label> release.',
 
+  /** The text content for the unpublished document banner when is part of a release */
+  'banners.unpublished-release-banner.text':
+    'This document will be unpublished as part of the <strong>{{title}}</strong> release',
+
   /** Browser/tab title when creating a new document of a given type */
   'browser-document-title.new-document': 'New {{schemaType}}',
   /** Browser/tab title when editing a document where the title cannot be resolved from preview configuration */

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -605,7 +605,14 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       return true
     }
 
+    const willBeUnpublished =
+      selectedReleaseId &&
+      value?._system &&
+      typeof value?._system === 'object' &&
+      'delete' in value._system
+
     return (
+      Boolean(willBeUnpublished) ||
       !ready ||
       revisionId !== null ||
       hasNoPermission ||
@@ -630,6 +637,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     selectedPerspectiveName,
     selectedReleaseId,
     value._id,
+    value._system,
     ready,
     revisionId,
     isDeleting,

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -27,6 +27,7 @@ import {AddToReleaseBanner} from './banners/AddToReleaseBanner'
 import {ArchivedReleaseDocumentBanner} from './banners/ArchivedReleaseDocumentBanner'
 import {DraftLiveEditBanner} from './banners/DraftLiveEditBanner'
 import {ScheduledReleaseBanner} from './banners/ScheduledReleaseBanner'
+import {UnpublishedDocumentBanner} from './banners/UnpublishedDocumentBanner'
 import {FormView} from './documentViews'
 
 interface DocumentPanelProps {
@@ -197,6 +198,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
         <ReferenceChangedBanner />
         <DeprecatedDocumentTypeBanner />
         <DeletedDocumentBanners />
+        <UnpublishedDocumentBanner />
       </>
     )
   }, [

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/UnpublishedDocumentBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/UnpublishedDocumentBanner.tsx
@@ -1,0 +1,42 @@
+import {UnpublishIcon} from '@sanity/icons'
+import {Text} from '@sanity/ui'
+import {isReleaseDocument, Translate, usePerspective, useTranslation} from 'sanity'
+
+import {structureLocaleNamespace} from '../../../../i18n'
+import {useDocumentPane} from '../../useDocumentPane'
+import {Banner} from './Banner'
+
+export function UnpublishedDocumentBanner() {
+  const {value} = useDocumentPane()
+  const {selectedPerspective, selectedReleaseId} = usePerspective()
+  const willBeUnpublished =
+    selectedReleaseId &&
+    value?._system &&
+    typeof value?._system === 'object' &&
+    'delete' in value._system &&
+    Boolean(value._system.delete)
+
+  const {t} = useTranslation(structureLocaleNamespace)
+
+  if (!selectedPerspective) return null
+  if (!willBeUnpublished) return null
+
+  if (isReleaseDocument(selectedPerspective) && willBeUnpublished) {
+    return (
+      <Banner
+        tone="critical"
+        content={
+          <Text size={1}>
+            <Translate
+              t={t}
+              i18nKey="banners.unpublished-release-banner.text"
+              values={{title: selectedPerspective.metadata?.title}}
+            />
+          </Text>
+        }
+        icon={UnpublishIcon}
+      />
+    )
+  }
+  return null
+}


### PR DESCRIPTION
### Description

Adds visual indicator for documents that will be unpublished as part of a release.
It also disables the document form from edits, by making it read only.

<img width="1167" alt="Screenshot 2025-02-17 at 18 16 35" src="https://github.com/user-attachments/assets/999112d0-f0b1-46c4-9310-60a75a6b7520" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
