### PR TITLE
fix(core): clarify 'discard version' message for better understanding

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -1,4 +1,4 @@
-import {Box, useToast} from '@sanity/ui'
+import {Box, Stack, Text, useToast} from '@sanity/ui'
 import {useCallback, useState} from 'react'
 
 import {Dialog} from '../../../../ui-components'
@@ -94,13 +94,18 @@ export function DiscardVersionDialog(props: {
         },
       }}
     >
-      <Box paddingX={3} marginBottom={2}>
+      <Stack space={3} paddingX={3} marginBottom={2}>
         {schemaType ? (
           <Preview value={{_id: documentId}} schemaType={schemaType} />
         ) : (
           <LoadingBlock />
         )}
-      </Box>
+        <Box paddingX={2}>
+          <Text size={1} muted>
+            {t('discard-version-dialog.description')}
+          </Text>
+        </Box>
+      </Stack>
     </Dialog>
   )
 }

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -124,11 +124,12 @@ const releasesLocaleStrings = {
   'diff.list-empty': 'Changes list is empty, see document',
   /** Description for discarding a version of a document dialog */
   'discard-version-dialog.description':
-    "The '<strong>{{title}}</strong>' version of this document will be permanently deleted.",
+    'This will also permanently remove the changes made to this document within this release.',
   /** Header for discarding a version of a document dialog */
-  'discard-version-dialog.header': 'Are you sure you want to discard the document version?',
+  'discard-version-dialog.header':
+    'Are you sure you want to remove this document from the release?',
   /** Title for dialog for discarding a version of a document */
-  'discard-version-dialog.title': 'Discard version',
+  'discard-version-dialog.title': 'Yes, discard version',
 
   /** Text for when documents of a release are loading */
   'document-loading': 'Loading documents',


### PR DESCRIPTION
### Description
Updates the wording for the discard version dialog

| Before | After |
|--------|--------|
| <img width="1170" alt="Screenshot 2025-02-17 at 18 38 30" src="https://github.com/user-attachments/assets/924514e0-6a38-441b-a8fe-20059e8d1a1c" /> | <img width="1168" alt="Screenshot 2025-02-17 at 18 36 48" src="https://github.com/user-attachments/assets/fdcded53-49e7-4a9c-99f9-4b007c117421" /> | 




<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
