### PR TITLE
refactor(core): remove publish2 and confirm-2

### DIFF
--- a/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
@@ -63,26 +63,9 @@ describe('createReleaseOperationsStore', () => {
     })
   })
 
-  it('should publish a release using new publish', async () => {
-    const store = createStore()
-    await store.publishRelease('_.releases.release-id', true)
-    expect(mockClient.request).toHaveBeenCalledWith({
-      uri: '/data/actions/test-dataset',
-      method: 'POST',
-      body: {
-        actions: [
-          {
-            actionType: 'sanity.action.release.publish2',
-            releaseId: 'release-id',
-          },
-        ],
-      },
-    })
-  })
-
   it('should publish a release using stable publish', async () => {
     const store = createStore()
-    await store.publishRelease('_.releases.release-id', false)
+    await store.publishRelease('_.releases.release-id')
     expect(mockClient.request).toHaveBeenCalledWith({
       uri: '/data/actions/test-dataset',
       method: 'POST',

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -17,11 +17,7 @@ interface operationsOptions {
   skipCrossDatasetValidation?: boolean
 }
 export interface ReleaseOperationsStore {
-  publishRelease: (
-    releaseId: string,
-    useUnstableAction?: boolean,
-    opts?: operationsOptions,
-  ) => Promise<void>
+  publishRelease: (releaseId: string, opts?: operationsOptions) => Promise<void>
   schedule: (releaseId: string, date: Date, opts?: operationsOptions) => Promise<void>
   //todo: reschedule: (releaseId: string, newDate: Date) => Promise<void>
   unschedule: (releaseId: string, opts?: operationsOptions) => Promise<void>
@@ -93,18 +89,12 @@ export function createReleaseOperationsStore(options: {
     )
   }
 
-  const handlePublishRelease = (
-    releaseId: string,
-    useUnstableAction?: boolean,
-    opts?: operationsOptions,
-  ) =>
+  const handlePublishRelease = (releaseId: string, opts?: operationsOptions) =>
     requestAction(
       client,
       [
         {
-          actionType: useUnstableAction
-            ? 'sanity.action.release.publish2'
-            : 'sanity.action.release.publish',
+          actionType: 'sanity.action.release.publish',
           releaseId: getReleaseIdFromReleaseDocumentId(releaseId),
         },
       ],
@@ -284,7 +274,7 @@ interface ScheduleApiAction {
 }
 
 interface PublishApiAction {
-  actionType: 'sanity.action.release.publish' | 'sanity.action.release.publish2'
+  actionType: 'sanity.action.release.publish'
   releaseId: string
 }
 

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -47,7 +47,7 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
   useEffect(() => {
     // only run if the release is active
     if (isActive) {
-      checkWithPermissionGuard(publishRelease, release._id, false).then((hasPermission) => {
+      checkWithPermissionGuard(publishRelease, release._id).then((hasPermission) => {
         setShouldDisplayPermissionWarning(!hasPermission)
       })
 

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
@@ -267,7 +267,6 @@ describe('after releases have loaded', () => {
 
         expect(useReleaseOperationsMockReturn.publishRelease).toHaveBeenCalledWith(
           activeASAPRelease._id,
-          false,
         )
       })
     })


### PR DESCRIPTION
### Description

Remove unstable (and no longer needed) publish 2 and confirm-2 mentions across the release feature.

### What to review

Did I miss something? Any odd behaviours that were missed?

### Testing

Publishing a release should work as it did before.

### Notes for release

N/A
