### PR TITLE
refactor(telemetry): log workspace and dataset names

### DIFF
--- a/packages/sanity/src/core/studio/StudioTelemetryProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioTelemetryProvider.tsx
@@ -13,20 +13,6 @@ import {SANITY_VERSION} from '../version'
 
 const sessionId = createSessionId()
 
-// A list of common dataset / workspace names we can safely log without collecting private data
-const WELL_KNOWN_NAMES = [
-  'staging',
-  'stage',
-  'stg',
-  'production',
-  'prod',
-  'preprod',
-  'development',
-  'dev',
-  'qa',
-  'test',
-]
-
 const DEBUG_TELEMETRY = !!(
   typeof process !== 'undefined' && process.env?.SANITY_STUDIO_DEBUG_TELEMETRY
 )
@@ -114,22 +100,10 @@ export function StudioTelemetryProvider(props: {children: ReactNode; config: Con
       ),
       uniqueWorkspaceNames: new Set(workspaceNames).size,
       uniqueDatasetNames: new Set(datasetNames).size,
-      workspaceNames: workspaceNames.map(
-        (workspaceName) =>
-          // log only well known dataset names to avoid sending private data
-          getWellKnownName(workspaceName) || '<custom>',
-      ),
-      datasetNames: datasetNames.map(
-        (datasetName) =>
-          // log only well known dataset names to avoid sending private data
-          getWellKnownName(datasetName) || '<custom>',
-      ),
+      workspaceNames,
+      datasetNames,
     })
   }, [props.config, store.logger])
 
   return <TelemetryProvider store={store}>{props.children}</TelemetryProvider>
-}
-
-function getWellKnownName(name: string) {
-  return WELL_KNOWN_NAMES.find((wellKnownName) => name.toLowerCase().includes(wellKnownName))
 }


### PR DESCRIPTION
### Description
This removes the coercing of workspace names to well known names before logging to telemetry.

### Notes for release
n/a