### PR TITLE
fix(sanity): allow patching via `handleChange` in Create-linked documents

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -647,7 +647,16 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const handleChange = useCallback((event: PatchEvent) => patchRef.current(event), [])
 
   useInsertionEffect(() => {
-    if (readOnly) {
+    // Create-linked documents enter a read-only state in Studio. However, unlinking a Create-linked
+    // document necessitates patching it. This renders it impossible to unlink a Create-linked
+    // document.
+    //
+    // Excluding Create-linked documents from this check is a simple way to ensure they can be
+    // unlinked.
+    //
+    // This does mean `handleChange` can be used to patch any part of a Create-linked document,
+    // which would otherwise be read-only.
+    if (readOnly && !isCreateLinked) {
       patchRef.current = () => {
         throw new Error('Attempted to patch a read-only document')
       }


### PR DESCRIPTION
### Description

Patches submitted to the `handleChange` provided by `DocumentPaneProvider` are currently disallowed when the document is in a read-only state. This renders it impossible to unlink a Create-linked document, which relies on a patch being created programmatically.

This branch sidesteps the issue by excluding Create-linked documents from the read-only check.

### What to review

- `handleChange` may now patch any part of a Create-link document that would otherwise be read-only. Is this acceptable?

### Testing

Unlink a Create-linked document.

### Notes for release

Fixes a bug preventing Sanity Create documents from being unlinked.