### PR TITLE
fix(core): revise wording for releases schedule actions

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -23,13 +23,13 @@ const releasesLocaleStrings = {
   /** Action text for opening a release */
   'action.open': 'Open',
   /** Action text for scheduling a release */
-  'action.schedule': 'Schedule for publishing...',
+  'action.schedule': 'Schedule release...',
   /** Action text for unpublishing a document in a release in the context menu */
   'action.unpublish': 'Unpublish',
   /** Action message for scheduling an unpublished of a document  */
   'action.unpublish-doc-actions': 'Unpublish when releasing',
   /** Action text for unscheduling a release */
-  'action.unschedule': 'Unschedule for publishing',
+  'action.unschedule': 'Unschedule release',
   /** Action text for publishing all documents in a release (and the release itself) */
   'action.publish-all-documents': 'Run release',
   /** Text for the review changes button in release tool */
@@ -258,19 +258,19 @@ const releasesLocaleStrings = {
   'schedule-button-tooltip.already-scheduled': 'This release is already scheduled',
 
   /** Title for unschedule release dialog */
-  'schedule-dialog.confirm-title': 'Schedule the release for publishing',
+  'schedule-dialog.confirm-title': 'Schedule the release',
   /** Description shown in unschedule relaease dialog */
   'schedule-dialog.confirm-description_one':
     "The '<strong>{{title}}</strong>' release and its document will be published on the selected date.",
   /** Description for the dialog confirming the publish of a release with multiple documents */
   'schedule-dialog.confirm-description_other':
-    'The <strong>{{title}}</strong> release and its {{count}} document versions will be scheduled for publishing.',
+    'The <strong>{{title}}</strong> release and its {{count}} document versions will be scheduled.',
 
   /** Description for the confirm button for scheduling a release */
-  'schedule-dialog.confirm-button': 'Yes, schedule for publishing',
+  'schedule-dialog.confirm-button': 'Yes, schedule',
 
   /** Label for date picker when scheduling a release */
-  'schedule-dialog.select-publish-date-label': 'Schedule for publishing on',
+  'schedule-dialog.select-publish-date-label': 'Schedule on',
 
   /** Title for unschedule release dialog */
   'unschedule-dialog.confirm-title': 'Are you sure you want to unschedule the release?',

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDashboardFooter.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDashboardFooter.test.tsx
@@ -52,7 +52,7 @@ describe('ReleaseDashboardFooter', () => {
     test('shows unschedule button', async () => {
       await renderTest({release: activeScheduledRelease})
 
-      expect(screen.getByText('Schedule for publishing...')).toBeInTheDocument()
+      expect(screen.getByText('Schedule release...')).toBeInTheDocument()
     })
   })
 
@@ -81,7 +81,7 @@ describe('ReleaseDashboardFooter', () => {
     test('shows unschedule button', async () => {
       await renderTest({release: scheduledRelease})
 
-      expect(screen.getByText('Unschedule for publishing')).toBeInTheDocument()
+      expect(screen.getByText('Unschedule release')).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
### Description

Updates the text in release schedule actions .

<img width="952" alt="Screenshot 2025-02-18 at 15 27 23" src="https://github.com/user-attachments/assets/4deb89a3-1279-491b-85e1-d442983a52c9" />
<img width="952" alt="Screenshot 2025-02-18 at 15 27 33" src="https://github.com/user-attachments/assets/2a05f705-c568-4679-801b-307a22b07ae4" />
<img width="960" alt="Screenshot 2025-02-18 at 15 29 36" src="https://github.com/user-attachments/assets/7bdaaa13-f111-4489-8f28-7a291f45ed12" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
