### PR TITLE
feat(typegen): `sanity typegen` Whitespace Handling in Query Output

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -188,7 +188,7 @@ describe('findQueries with the groq template', () => {
     expect(queries.length).toBe(0)
   })
 
-  test('will ignore declarations if any of the leading comments are ignore tags', () => {
+  test('will ignore declerations if any of the leading comments are ignore tags', () => {
     const source = `
       import { groq } from "groq";
 
@@ -199,23 +199,6 @@ describe('findQueries with the groq template', () => {
 
     const queries = findQueriesInSource(source, __filename, undefined)
     expect(queries.length).toBe(0)
-  })
-
-  test('should remove unnecessary whitespace in queries', () => {
-    const source = `
-      import { groq } from "groq";
-      const messyQuery = groq\`
-        
-        *[_type == "author"]    
-        
-      \`
-      const res = sanity.fetch(messyQuery);
-    `
-
-    const queries = findQueriesInSource(source, 'test.ts')
-    const queryResult = queries[0]
-
-    expect(queryResult?.result).toEqual('*[_type == "author"]')
   })
 })
 
@@ -385,7 +368,7 @@ describe('findQueries with defineQuery', () => {
     expect(queries.length).toBe(0)
   })
 
-  test('will ignore declarations if any of the leading comments are ignore tags', () => {
+  test('will ignore declerations if any of the leading comments are ignore tags', () => {
     const source = `
       import {defineQuery} from "groq";
 

--- a/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
+++ b/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
@@ -72,8 +72,6 @@ export function findQueriesInSource(
           filename,
           resolver,
         })
-          .replace(/\s+/g, ' ')
-          .trim()
 
         const location = node.loc
           ? {

--- a/packages/@sanity/codegen/src/typescript/typeGenerator.ts
+++ b/packages/@sanity/codegen/src/typescript/typeGenerator.ts
@@ -152,8 +152,8 @@ export class TypeGenerator {
   }
 
   /**
-   * Since we are sanitizing identifiers we might end up with collisions. Ie there might be a type mux.video and muxVideo, both these
-   * types would be sanitized into MuxVideo. To avoid this we keep track of the generated type names and add a index to the name.
+   * Since we are sanitizing identifiers we migt end up with collisions. Ie there might be a type mux.video and muxVideo, both these
+   * types would be sanityized into MuxVideo. To avoid this we keep track of the generated type names and add a index to the name.
    * When we reference a type we also keep track of the original name so we can reference the correct type later.
    */
   private getTypeName(


### PR DESCRIPTION
`git revert df7bf5841309e94ae5037a69bd17004d5c14ce3d`

### Description

Unfortunately the change in #8648 breaks the typed query inference. Since it depends on the content of the defineQuery(..) being the same as the generated query.

This reverts commit df7bf5841309e94ae5037a69bd17004d5c14ce3d.

### What to review

N/A

### Testing

N/A

But we should add tests that prevents this from happening again

### Notes for release

Fixes automatic type inference with `@sanity/client` 