### PR TITLE
fix(core): add api version config to `observeDocuments`

### DIFF
--- a/packages/sanity/src/core/preview/documentPreviewStore.ts
+++ b/packages/sanity/src/core/preview/documentPreviewStore.ts
@@ -11,7 +11,7 @@ import {distinctUntilChanged, filter, map} from 'rxjs/operators'
 import {isRecord} from '../util'
 import {createPreviewAvailabilityObserver} from './availability'
 import {createGlobalListener} from './createGlobalListener'
-import {createObserveDocument} from './createObserveDocument'
+import {createObserveDocument, type ObserveDocumentAPIConfig} from './createObserveDocument'
 import {createPathObserver} from './createPathObserver'
 import {createPreviewObserver} from './createPreviewObserver'
 import {createObservePathsDocumentPair} from './documentPair'
@@ -97,13 +97,19 @@ export interface DocumentPreviewStore {
    * @hidden
    * @beta
    */
-  unstable_observeDocument: (id: string) => Observable<SanityDocument | undefined>
+  unstable_observeDocument: (
+    id: string,
+    clientConfig?: ObserveDocumentAPIConfig,
+  ) => Observable<SanityDocument | undefined>
   /**
    * Observe a list of complete documents with the given IDs
    * @hidden
    * @beta
    */
-  unstable_observeDocuments: (ids: string[]) => Observable<(SanityDocument | undefined)[]>
+  unstable_observeDocuments: (
+    ids: string[],
+    clientConfig?: ObserveDocumentAPIConfig,
+  ) => Observable<(SanityDocument | undefined)[]>
 }
 
 /** @internal */

--- a/packages/sanity/src/core/preview/useLiveDocumentSet.ts
+++ b/packages/sanity/src/core/preview/useLiveDocumentSet.ts
@@ -31,7 +31,9 @@ export function useLiveDocumentSet(
   const observable = useMemo(() => {
     return documentPreviewStore.unstable_observeDocumentIdSet(groqFilter, params, options).pipe(
       map((state) => (state.documentIds || []) as string[]),
-      mergeMapArray((id) => documentPreviewStore.unstable_observeDocument(id)),
+      mergeMapArray((id) =>
+        documentPreviewStore.unstable_observeDocument(id, {apiVersion: options.apiVersion}),
+      ),
       map((docs) => ({loading: false, documents: docs as SanityDocument[]})),
     )
   }, [documentPreviewStore, groqFilter, params, options])

--- a/packages/sanity/src/core/preview/useObserveDocument.ts
+++ b/packages/sanity/src/core/preview/useObserveDocument.ts
@@ -4,6 +4,7 @@ import {useObservable} from 'react-rx'
 import {map} from 'rxjs/operators'
 
 import {useDocumentPreviewStore} from '../store/_legacy/datastores'
+import {type ObserveDocumentAPIConfig} from './createObserveDocument'
 
 const INITIAL_STATE = {loading: true, document: null}
 
@@ -16,6 +17,7 @@ const INITIAL_STATE = {loading: true, document: null}
  */
 export function useObserveDocument<T extends SanityDocument>(
   documentId: string,
+  apiConfig?: ObserveDocumentAPIConfig,
 ): {
   document: T | null
   loading: boolean
@@ -24,9 +26,9 @@ export function useObserveDocument<T extends SanityDocument>(
   const observable = useMemo(
     () =>
       documentPreviewStore
-        .unstable_observeDocument(documentId)
+        .unstable_observeDocument(documentId, apiConfig)
         .pipe(map((document) => ({loading: false, document: document as T}))),
-    [documentId, documentPreviewStore],
+    [documentId, documentPreviewStore, apiConfig],
   )
   return useObservable(observable, INITIAL_STATE)
 }

--- a/packages/sanity/src/core/releases/tool/detail/events/getReleaseEvents.ts
+++ b/packages/sanity/src/core/releases/tool/detail/events/getReleaseEvents.ts
@@ -57,9 +57,9 @@ export function getReleaseEvents({
   documentPreviewStore,
   eventsAPIEnabled,
 }: getReleaseEventsOpts) {
-  const observeDocument$ = documentPreviewStore.unstable_observeDocument(releaseId) as Observable<
-    ReleaseDocument | undefined
-  >
+  const observeDocument$ = documentPreviewStore.unstable_observeDocument(releaseId, {
+    apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion,
+  }) as Observable<ReleaseDocument | undefined>
 
   const editEvents$ = getReleaseEditEvents({client, observeDocument$})
 


### PR DESCRIPTION
### Description

Updates the `unstable_observeDocuments` function to accept a apiPerspective param, given we need to query version documents using `vX` for now

When we worked on https://github.com/sanity-io/sanity/pull/8466 version documents were returned even when using a version prior to `2025-02-19` which is the stable version for releases.

Now a flag has been turned on in content lake and the version documents are not returned anymore unless you are using `2025-02-19` or above.

By updating this function and passing the apiVersion as a parameter, we can configure it so it uses `vX` when fetching for version documents.



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

would be amazing if you could help me review if there is other place that should be updated to include this change.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Navigate in the studio, queries should work as always, version documents should render

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
