### PR TITLE
fix(cli): correct the default port for Astro app

### DIFF
--- a/packages/@sanity/cli/src/util/frameworkPort.ts
+++ b/packages/@sanity/cli/src/util/frameworkPort.ts
@@ -5,7 +5,7 @@ const portMap: Record<string, number> = {
   'blitzjs': 3000,
   'gatsby': 8000,
   'remix': 3000,
-  'astro': 3000,
+  'astro': 4321,
   'hexo': 4000,
   'eleventy': 8080,
   'docusaurus': 3000,


### PR DESCRIPTION
### Description

Update the default port assigned to Astro when setting CORS origin during the --template CLI initiation.

### What to review

You could review that `4321` is the correct port.  [Astro Docs](https://docs.astro.build/en/reference/cli-reference/#--port-number)

To replicate this, you can try installing the Astro template with `npm create sanity@latest -- --template sanity-io/sanity-template-astro-clean` and them viewing the manage console to see that `http://localhost:3000` was added as a CORS origin.

### Testing

Im not totally sure.

### Notes for release
