### PR TITLE
refactor(core): update managing permissions 2

### DIFF
--- a/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
@@ -71,9 +71,17 @@ export function ReleasesList({
   const {t} = useTranslation()
 
   useEffect(() => {
+    let shouldUpdate = true
+
     checkWithPermissionGuard(createRelease, createReleaseMetadata(DEFAULT_RELEASE)).then(
-      setHasCreatePermission,
+      (hasPermission) => {
+        if (shouldUpdate) setHasCreatePermission(hasPermission)
+      },
     )
+
+    return () => {
+      shouldUpdate = false
+    }
   }, [checkWithPermissionGuard, createRelease, createReleaseMetadata])
 
   const handleCreateBundleClick = useCallback(

--- a/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
@@ -1,6 +1,6 @@
 import {AddIcon} from '@sanity/icons'
 import {Box, Flex, MenuDivider, Spinner} from '@sanity/ui'
-import {type RefObject, useCallback, useEffect, useMemo, useState} from 'react'
+import {type RefObject, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {css, styled} from 'styled-components'
 
 import {MenuItem} from '../../../ui-components/menuItem/MenuItem'
@@ -70,17 +70,18 @@ export function ReleasesList({
 
   const {t} = useTranslation()
 
+  const isMounted = useRef(false)
   useEffect(() => {
-    let shouldUpdate = true
+    isMounted.current = true
 
     checkWithPermissionGuard(createRelease, createReleaseMetadata(DEFAULT_RELEASE)).then(
       (hasPermission) => {
-        if (shouldUpdate) setHasCreatePermission(hasPermission)
+        if (isMounted.current) setHasCreatePermission(hasPermission)
       },
     )
 
     return () => {
-      shouldUpdate = false
+      isMounted.current = false
     }
   }, [checkWithPermissionGuard, createRelease, createReleaseMetadata])
 

--- a/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesList.test.tsx
+++ b/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesList.test.tsx
@@ -16,6 +16,8 @@ import {
 import {
   mockUseReleasePermissions,
   useReleasePermissionsMockReturn,
+  useReleasesPermissionsMockReturnFalse,
+  useReleasesPermissionsMockReturnTrue,
 } from '../../../releases/store/__tests__/__mocks/useReleasePermissions.mock'
 import {ReleasesList} from '../ReleasesList'
 
@@ -40,9 +42,7 @@ describe('ReleasesList', () => {
         ...useActiveReleasesMockReturn,
         data: [activeASAPRelease, activeScheduledRelease, activeUndecidedRelease],
       })
-      mockUseReleasePermissions.mockReturnValue({
-        checkWithPermissionGuard: async () => true,
-      })
+      mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
       const wrapper = await createTestProvider()
       render(
         <Menu>
@@ -122,9 +122,7 @@ describe('ReleasesList', () => {
         ...useActiveReleasesMockReturn,
         data: [activeASAPRelease, activeScheduledRelease, activeUndecidedRelease],
       })
-      mockUseReleasePermissions.mockReturnValue({
-        checkWithPermissionGuard: async () => false,
-      })
+      mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnFalse)
       const wrapper = await createTestProvider()
       render(
         <Menu>

--- a/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesNav.test.tsx
+++ b/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesNav.test.tsx
@@ -15,6 +15,7 @@ import {useActiveReleasesMockReturn} from '../../../releases/store/__tests__/__m
 import {
   mockUseReleasePermissions,
   useReleasePermissionsMockReturn,
+  useReleasesPermissionsMockReturnTrue,
 } from '../../../releases/store/__tests__/__mocks/useReleasePermissions.mock'
 import {LATEST} from '../../../releases/util/const'
 import {ReleasesNav} from '../ReleasesNav'
@@ -70,9 +71,7 @@ describe('ReleasesNav', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    mockUseReleasePermissions.mockReturnValue({
-      checkWithPermissionGuard: async () => true,
-    })
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
   })
   it('should have link to releases tool', async () => {
     await renderTest()
@@ -211,9 +210,7 @@ describe('ReleasesNav', () => {
       })
 
       it('disables button when no permissions are met', async () => {
-        mockUseReleasePermissions.mockReturnValue({
-          checkWithPermissionGuard: async () => true,
-        })
+        mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
       })
     })
 

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
@@ -70,7 +70,15 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: {
   const hasDiscardPermission = !isPermissionsLoading && permissions?.granted
 
   useEffect(() => {
-    checkWithPermissionGuard(createRelease, DEFAULT_RELEASE).then(setHasCreatePermission)
+    let shouldUpdate = true
+
+    checkWithPermissionGuard(createRelease, DEFAULT_RELEASE).then((hasPermission) => {
+      if (shouldUpdate) setHasCreatePermission(hasPermission)
+    })
+
+    return () => {
+      shouldUpdate = false
+    }
   }, [checkWithPermissionGuard, createRelease])
 
   return (

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
@@ -1,6 +1,6 @@
 import {AddIcon, CalendarIcon, CopyIcon, TrashIcon} from '@sanity/icons'
 import {Menu, MenuDivider, Spinner, Stack} from '@sanity/ui'
-import {memo, useEffect, useState} from 'react'
+import {memo, useEffect, useRef, useState} from 'react'
 import {IntentLink} from 'sanity/router'
 import {styled} from 'styled-components'
 
@@ -69,15 +69,16 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: {
   })
   const hasDiscardPermission = !isPermissionsLoading && permissions?.granted
 
+  const isMounted = useRef(false)
   useEffect(() => {
-    let shouldUpdate = true
+    isMounted.current = true
 
     checkWithPermissionGuard(createRelease, DEFAULT_RELEASE).then((hasPermission) => {
-      if (shouldUpdate) setHasCreatePermission(hasPermission)
+      if (isMounted.current) setHasCreatePermission(hasPermission)
     })
 
     return () => {
-      shouldUpdate = false
+      isMounted.current = false
     }
   }, [checkWithPermissionGuard, createRelease])
 

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -6,6 +6,7 @@ import {createTestProvider} from '../../../../../../../test/testUtils/TestProvid
 import {
   mockUseReleasePermissions,
   useReleasePermissionsMockReturn,
+  useReleasesPermissionsMockReturnTrue,
 } from '../../../../store/__tests__/__mocks/useReleasePermissions.mock'
 import {type ReleaseDocument} from '../../../../store/types'
 import {VersionContextMenu} from '../VersionContextMenu'
@@ -72,9 +73,7 @@ describe('VersionContextMenu', () => {
   }
 
   it('renders the menu items correctly', async () => {
-    mockUseReleasePermissions.mockReturnValue({
-      checkWithPermissionGuard: async () => true,
-    })
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
     const wrapper = await createTestProvider()
 
@@ -97,9 +96,7 @@ describe('VersionContextMenu', () => {
   })
 
   it('calls onCreateRelease when "New release" is clicked', async () => {
-    mockUseReleasePermissions.mockReturnValue({
-      checkWithPermissionGuard: async () => true,
-    })
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
     const wrapper = await createTestProvider()
 
@@ -122,9 +119,7 @@ describe('VersionContextMenu', () => {
   })
 
   it('hides discard version on published chip', async () => {
-    mockUseReleasePermissions.mockReturnValue({
-      checkWithPermissionGuard: async () => true,
-    })
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
     const wrapper = await createTestProvider()
     const publishedProps = {
@@ -139,9 +134,7 @@ describe('VersionContextMenu', () => {
   })
 
   it('calls onDiscard when "Discard version" is clicked', async () => {
-    mockUseReleasePermissions.mockReturnValue({
-      checkWithPermissionGuard: async () => true,
-    })
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
     const wrapper = await createTestProvider()
 
@@ -158,9 +151,7 @@ describe('VersionContextMenu', () => {
   })
 
   it('calls onCreateRelease when a "new release" is clicked', async () => {
-    mockUseReleasePermissions.mockReturnValue({
-      checkWithPermissionGuard: async () => true,
-    })
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
     const wrapper = await createTestProvider()
 
@@ -183,9 +174,7 @@ describe('VersionContextMenu', () => {
   })
 
   it('calls onCreateVersion when a release is clicked and sets the perspective to the release', async () => {
-    mockUseReleasePermissions.mockReturnValue({
-      checkWithPermissionGuard: async () => true,
-    })
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
     const wrapper = await createTestProvider()
 

--- a/packages/sanity/src/core/releases/store/__tests__/__mocks/useReleasePermissions.mock.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/__mocks/useReleasePermissions.mock.ts
@@ -4,6 +4,21 @@ import {useReleasePermissions} from '../../useReleasePermissions'
 
 export const useReleasePermissionsMockReturn: Mocked<ReturnType<typeof useReleasePermissions>> = {
   checkWithPermissionGuard: vi.fn(),
+  permissions: {},
+}
+
+export const useReleasesPermissionsMockReturnTrue: Mocked<
+  ReturnType<typeof useReleasePermissions>
+> = {
+  checkWithPermissionGuard: vi.fn().mockResolvedValue(true),
+  permissions: {},
+}
+
+export const useReleasesPermissionsMockReturnFalse: Mocked<
+  ReturnType<typeof useReleasePermissions>
+> = {
+  checkWithPermissionGuard: vi.fn().mockResolvedValue(false),
+  permissions: {},
 }
 
 export const mockUseReleasePermissions = useReleasePermissions as Mock<typeof useReleasePermissions>

--- a/packages/sanity/src/core/releases/store/__tests__/createReleasePermissionsStore.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/createReleasePermissionsStore.test.ts
@@ -1,12 +1,15 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {useReleasePermissions} from '../useReleasePermissions'
+import {createReleasePermissionsStore} from '../createReleasePermissionsStore'
+import {type useReleasePermissionsValue} from '../useReleasePermissions'
+
+const createStore = () => createReleasePermissionsStore()
 
 describe('useReleasePermissions', () => {
-  let store: ReturnType<typeof useReleasePermissions>
+  let store: useReleasePermissionsValue
 
   beforeEach(() => {
-    store = useReleasePermissions()
+    store = createStore()
   })
 
   it('should return true when action succeeds', async () => {

--- a/packages/sanity/src/core/releases/store/createReleasePermissionsStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleasePermissionsStore.ts
@@ -28,7 +28,7 @@ export function createReleasePermissionsStore(): useReleasePermissionsValue {
   /**
    * Checks if a release action can be performed by running a dry run of the given action
    *
-   * @param action - any of the actions from the ReleaseOperationStore, e.g. publishRelease should send in also the needed props
+   * @param action - any of the actions from the {@link ReleaseOperationStore}, e.g. publishRelease should send in also the needed props
    * @param args - the arguments to pass to the action (release id, etc)
    * @returns true or false depending if the user can perform the action
    */

--- a/packages/sanity/src/core/releases/store/createReleasePermissionsStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleasePermissionsStore.ts
@@ -1,0 +1,61 @@
+import {isErrorWithDetails} from '../../error/types/isErrorWithDetails'
+import {type useReleasePermissionsValue} from './useReleasePermissions'
+
+type ReleasePermissionError = {details: {type: 'insufficientPermissionsError'}}
+
+/**
+ * Checks if the error is a permission error
+ *
+ * @param error - the error to check
+ * @returns true if the error is a permission error
+ */
+export const isReleasePermissionError = (error: unknown): error is ReleasePermissionError =>
+  isErrorWithDetails(error) && error.details?.type === 'insufficientPermissionsError'
+
+/**
+ * Store that contains if the user has permissions to perform a release action
+ * And a guardrail to dry run requests to check if the user has permissions
+ *
+ * @returns an object with the following properties:
+ * * checkWithPermissionGuard - a function that checks if the user has permissions to perform a release action by adding dryRun properties
+ * * permissions - an object with the permissions for each action
+ *
+ * @internal
+ */
+export function createReleasePermissionsStore(): useReleasePermissionsValue {
+  let permissions: {[key: string]: boolean} = {}
+
+  /**
+   * Checks if a release action can be performed by running a dry run of the given action
+   *
+   * @param action - any of the actions from the ReleaseOperationStore, e.g. publishRelease should send in also the needed props
+   * @param args - the arguments to pass to the action (release id, etc)
+   * @returns true or false depending if the user can perform the action
+   */
+  const checkWithPermissionGuard = async <T extends (...args: any[]) => Promise<void> | void>(
+    action: T,
+    ...args: Parameters<T>
+  ): Promise<boolean> => {
+    if (permissions[action.name] === undefined) {
+      try {
+        await action(...args, {
+          dryRun: true,
+          skipCrossDatasetReferenceValidation: true,
+        })
+        permissions = {...permissions, [action.name]: true}
+
+        return true
+      } catch (e) {
+        permissions = {...permissions, [action.name]: false}
+
+        return !isReleasePermissionError(e)
+      }
+    } else {
+      return permissions[action.name]
+    }
+  }
+  return {
+    checkWithPermissionGuard: checkWithPermissionGuard,
+    permissions,
+  }
+}

--- a/packages/sanity/src/core/releases/store/useReleasePermissions.ts
+++ b/packages/sanity/src/core/releases/store/useReleasePermissions.ts
@@ -1,21 +1,30 @@
+import {useMemo} from 'react'
+
 import {isErrorWithDetails} from '../../error/types/isErrorWithDetails'
+import {useResourceCache} from '../../store/_legacy/ResourceCacheProvider'
 
 export interface useReleasePermissionsValue {
   checkWithPermissionGuard: <T extends (...args: any[]) => Promise<void> | void>(
     action: T,
     ...args: Parameters<T>
   ) => Promise<boolean>
+  permissions: {[key: string]: boolean}
 }
 
 type ReleasePermissionError = {details: {type: 'insufficientPermissionsError'}}
+
+const RELEASE_PERMISSIONS_RESOURCE_CACHE_NAMESPACE = 'ReleasePermissions'
 
 export const isReleasePermissionError = (error: unknown): error is ReleasePermissionError =>
   isErrorWithDetails(error) && error.details?.type === 'insufficientPermissionsError'
 
 /**
+ *
  * @internal
  */
-export function useReleasePermissions(): useReleasePermissionsValue {
+function createReleasePermissionsStore(): useReleasePermissionsValue {
+  let permissions: {[key: string]: boolean} = {}
+
   /**
    * Checks if a release action can be performed by running a dry run of the given action
    *
@@ -27,17 +36,49 @@ export function useReleasePermissions(): useReleasePermissionsValue {
     action: T,
     ...args: Parameters<T>
   ): Promise<boolean> => {
-    try {
-      await action(...args, {
-        dryRun: true,
-        skipCrossDatasetReferenceValidation: true,
-      })
-      return true
-    } catch (e) {
-      return !isReleasePermissionError(e)
+    if (permissions[action.name] === undefined) {
+      try {
+        await action(...args, {
+          dryRun: true,
+          skipCrossDatasetReferenceValidation: true,
+        })
+        permissions = {...permissions, [action.name]: true}
+
+        return true
+      } catch (e) {
+        permissions = {...permissions, [action.name]: false}
+
+        return !isReleasePermissionError(e)
+      }
+    } else {
+      return permissions[action.name]
     }
   }
   return {
     checkWithPermissionGuard: checkWithPermissionGuard,
+    permissions,
   }
+}
+
+/**
+ * @internal
+ */
+export function useReleasePermissions(): useReleasePermissionsValue {
+  const resourceCache = useResourceCache()
+
+  return useMemo(() => {
+    const releasePermissionsStore =
+      resourceCache.get<useReleasePermissionsValue>({
+        dependencies: [null],
+        namespace: RELEASE_PERMISSIONS_RESOURCE_CACHE_NAMESPACE,
+      }) || createReleasePermissionsStore()
+
+    resourceCache.set({
+      namespace: RELEASE_PERMISSIONS_RESOURCE_CACHE_NAMESPACE,
+      value: releasePermissionsStore,
+      dependencies: [null],
+    })
+
+    return releasePermissionsStore
+  }, [resourceCache])
 }

--- a/packages/sanity/src/core/releases/store/useReleasePermissions.ts
+++ b/packages/sanity/src/core/releases/store/useReleasePermissions.ts
@@ -1,7 +1,9 @@
 import {useMemo} from 'react'
 
-import {isErrorWithDetails} from '../../error/types/isErrorWithDetails'
 import {useResourceCache} from '../../store/_legacy/ResourceCacheProvider'
+import {createReleasePermissionsStore} from './createReleasePermissionsStore'
+
+const RELEASE_PERMISSIONS_RESOURCE_CACHE_NAMESPACE = 'ReleasePermissions'
 
 export interface useReleasePermissionsValue {
   checkWithPermissionGuard: <T extends (...args: any[]) => Promise<void> | void>(
@@ -9,55 +11,6 @@ export interface useReleasePermissionsValue {
     ...args: Parameters<T>
   ) => Promise<boolean>
   permissions: {[key: string]: boolean}
-}
-
-type ReleasePermissionError = {details: {type: 'insufficientPermissionsError'}}
-
-const RELEASE_PERMISSIONS_RESOURCE_CACHE_NAMESPACE = 'ReleasePermissions'
-
-export const isReleasePermissionError = (error: unknown): error is ReleasePermissionError =>
-  isErrorWithDetails(error) && error.details?.type === 'insufficientPermissionsError'
-
-/**
- *
- * @internal
- */
-function createReleasePermissionsStore(): useReleasePermissionsValue {
-  let permissions: {[key: string]: boolean} = {}
-
-  /**
-   * Checks if a release action can be performed by running a dry run of the given action
-   *
-   * @param action - any of the actions from the ReleaseOperationStore, e.g. publishRelease should send in also the needed props
-   * @param args - the arguments to pass to the action (release id, etc)
-   * @returns true or false depending if the user can perform the action
-   */
-  const checkWithPermissionGuard = async <T extends (...args: any[]) => Promise<void> | void>(
-    action: T,
-    ...args: Parameters<T>
-  ): Promise<boolean> => {
-    if (permissions[action.name] === undefined) {
-      try {
-        await action(...args, {
-          dryRun: true,
-          skipCrossDatasetReferenceValidation: true,
-        })
-        permissions = {...permissions, [action.name]: true}
-
-        return true
-      } catch (e) {
-        permissions = {...permissions, [action.name]: false}
-
-        return !isReleasePermissionError(e)
-      }
-    } else {
-      return permissions[action.name]
-    }
-  }
-  return {
-    checkWithPermissionGuard: checkWithPermissionGuard,
-    permissions,
-  }
 }
 
 /**

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenu.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenu.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react'
 
@@ -38,31 +39,32 @@ export const ReleaseMenu = ({
   const [hasUnarchivePermission, setHasUnarchivePermission] = useState<boolean | null>(null)
   const [hasDeletePermission, setHasDeletePermission] = useState<boolean | null>(null)
 
+  const isMounted = useRef(false)
   useEffect(() => {
-    let shouldUpdate = true
+    isMounted.current = true
 
     if (!releaseMenuDisabled) {
       if (release.state !== 'published') {
         if (release.state === 'archived') {
           checkWithPermissionGuard(unarchive, release._id).then((hasPermission) => {
-            if (shouldUpdate) setHasUnarchivePermission(hasPermission)
+            if (isMounted.current) setHasUnarchivePermission(hasPermission)
           })
         } else {
           checkWithPermissionGuard(archive, release._id).then((hasPermission) => {
-            if (shouldUpdate) setHasArchivePermission(hasPermission)
+            if (isMounted.current) setHasArchivePermission(hasPermission)
           })
         }
       }
 
       if (release.state === 'archived' || release.state == 'published') {
         checkWithPermissionGuard(deleteRelease, release._id).then((hasPermission) => {
-          if (shouldUpdate) setHasDeletePermission(hasPermission)
+          if (isMounted.current) setHasDeletePermission(hasPermission)
         })
       }
     }
 
     return () => {
-      shouldUpdate = false
+      isMounted.current = false
     }
   }, [
     release._id,

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/__tests__/ReleaseMenuButton.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/__tests__/ReleaseMenuButton.test.tsx
@@ -18,6 +18,8 @@ import {
 import {
   mockUseReleasePermissions,
   useReleasePermissionsMockReturn,
+  useReleasesPermissionsMockReturnFalse,
+  useReleasesPermissionsMockReturnTrue,
 } from '../../../../store/__tests__/__mocks/useReleasePermissions.mock'
 import {useReleaseOperations} from '../../../../store/useReleaseOperations'
 import {
@@ -61,9 +63,7 @@ describe('ReleaseMenuButton', () => {
 
       mockUseBundleDocuments.mockRestore()
 
-      mockUseReleasePermissions.mockReturnValue({
-        checkWithPermissionGuard: vi.fn().mockResolvedValue(true),
-      })
+      mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
     })
 
     describe('archive release', () => {
@@ -373,9 +373,7 @@ describe('ReleaseMenuButton', () => {
 
       mockUseBundleDocuments.mockRestore()
 
-      mockUseReleasePermissions.mockReturnValue({
-        checkWithPermissionGuard: vi.fn().mockResolvedValue(false),
-      })
+      mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnFalse)
     })
 
     test('will disable archive menu', async () => {

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
@@ -1,7 +1,7 @@
 import {ErrorOutlineIcon, PublishIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Flex, Text, useToast} from '@sanity/ui'
-import {useCallback, useEffect, useMemo, useState} from 'react'
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 
 import {Button, Dialog} from '../../../../../ui-components'
 import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
@@ -46,15 +46,16 @@ export const ReleasePublishAllButton = ({
   const isPublishButtonDisabled =
     disabled || isValidatingDocuments || hasDocumentValidationErrors || !publishPermission
 
+  const isMounted = useRef(false)
   useEffect(() => {
-    let shouldUpdate = true
+    isMounted.current = true
 
     checkWithPermissionGuard(publishRelease, release._id).then((hasPermission) => {
-      if (shouldUpdate) setPublishPermission(hasPermission)
+      if (isMounted.current) setPublishPermission(hasPermission)
     })
 
     return () => {
-      shouldUpdate = false
+      isMounted.current = false
     }
   }, [checkWithPermissionGuard, publishRelease, release._id, release.metadata.intendedPublishAt])
 

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
@@ -47,9 +47,15 @@ export const ReleasePublishAllButton = ({
     disabled || isValidatingDocuments || hasDocumentValidationErrors || !publishPermission
 
   useEffect(() => {
-    checkWithPermissionGuard(publishRelease, release._id).then((hasPermission) =>
-      setPublishPermission(hasPermission),
-    )
+    let shouldUpdate = true
+
+    checkWithPermissionGuard(publishRelease, release._id).then((hasPermission) => {
+      if (shouldUpdate) setPublishPermission(hasPermission)
+    })
+
+    return () => {
+      shouldUpdate = false
+    }
   }, [checkWithPermissionGuard, publishRelease, release._id, release.metadata.intendedPublishAt])
 
   const handleConfirmPublishAll = useCallback(async () => {

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -2,7 +2,7 @@ import {ClockIcon, ErrorOutlineIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Card, Flex, Stack, Text, useToast} from '@sanity/ui'
 import {format, isBefore, isValid, parse, startOfMinute} from 'date-fns'
-import {useCallback, useEffect, useMemo, useState} from 'react'
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 
 import {Button, Dialog} from '../../../../../ui-components'
 import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
@@ -56,15 +56,16 @@ export const ReleaseScheduleButton = ({
   const isScheduleButtonDisabled =
     disabled || isValidatingDocuments || !schedulePermission || hasDocumentValidationErrors
 
+  const isMounted = useRef(false)
   useEffect(() => {
-    let shouldUpdate = true
+    isMounted.current = true
 
     checkWithPermissionGuard(schedule, release._id, new Date()).then((hasPermission) => {
-      if (shouldUpdate) setSchedulePermission(hasPermission)
+      if (isMounted.current) setSchedulePermission(hasPermission)
     })
 
     return () => {
-      shouldUpdate = false
+      isMounted.current = false
     }
   }, [checkWithPermissionGuard, release._id, release.metadata.intendedPublishAt, schedule])
 

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -57,9 +57,15 @@ export const ReleaseScheduleButton = ({
     disabled || isValidatingDocuments || !schedulePermission || hasDocumentValidationErrors
 
   useEffect(() => {
-    checkWithPermissionGuard(schedule, release._id, new Date()).then((hasPermission) =>
-      setSchedulePermission(hasPermission),
-    )
+    let shouldUpdate = true
+
+    checkWithPermissionGuard(schedule, release._id, new Date()).then((hasPermission) => {
+      if (shouldUpdate) setSchedulePermission(hasPermission)
+    })
+
+    return () => {
+      shouldUpdate = false
+    }
   }, [checkWithPermissionGuard, release._id, release.metadata.intendedPublishAt, schedule])
 
   const isScheduledDateInPast = useCallback(() => {

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -45,18 +45,23 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
   const [shouldDisplayPermissionWarning, setShouldDisplayPermissionWarning] = useState(false)
   const shouldDisplayWarnings = isActive && shouldDisplayPermissionWarning
   useEffect(() => {
+    let shouldUpdate = true
+
     // only run if the release is active
     if (isActive) {
       checkWithPermissionGuard(publishRelease, release._id).then((hasPermission) => {
-        setShouldDisplayPermissionWarning(!hasPermission)
+        if (shouldUpdate) setShouldDisplayPermissionWarning(!hasPermission)
       })
 
       // if it's a release that can be scheduled, check if it can be scheduled
       if (release.metadata.intendedPublishAt && isAtTimeRelease) {
         checkWithPermissionGuard(schedule, release._id, new Date()).then((hasPermission) => {
-          setShouldDisplayPermissionWarning(!hasPermission)
+          if (shouldUpdate) setShouldDisplayPermissionWarning(!hasPermission)
         })
       }
+    }
+    return () => {
+      shouldUpdate = false
     }
   }, [
     checkWithPermissionGuard,

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -6,7 +6,7 @@ import {
   WarningOutlineIcon,
 } from '@sanity/icons'
 import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
-import {useCallback, useEffect, useState} from 'react'
+import {useCallback, useEffect, useRef, useState} from 'react'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {ToneIcon} from '../../../../ui-components/toneIcon/ToneIcon'
@@ -44,24 +44,25 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
   const shouldDisplayError = isActive && typeof release.error !== 'undefined'
   const [shouldDisplayPermissionWarning, setShouldDisplayPermissionWarning] = useState(false)
   const shouldDisplayWarnings = isActive && shouldDisplayPermissionWarning
+  const isMounted = useRef(false)
   useEffect(() => {
-    let shouldUpdate = true
+    isMounted.current = true
 
     // only run if the release is active
     if (isActive) {
       checkWithPermissionGuard(publishRelease, release._id).then((hasPermission) => {
-        if (shouldUpdate) setShouldDisplayPermissionWarning(!hasPermission)
+        if (isMounted.current) setShouldDisplayPermissionWarning(!hasPermission)
       })
 
       // if it's a release that can be scheduled, check if it can be scheduled
       if (release.metadata.intendedPublishAt && isAtTimeRelease) {
         checkWithPermissionGuard(schedule, release._id, new Date()).then((hasPermission) => {
-          if (shouldUpdate) setShouldDisplayPermissionWarning(!hasPermission)
+          if (isMounted.current) setShouldDisplayPermissionWarning(!hasPermission)
         })
       }
     }
     return () => {
-      shouldUpdate = false
+      isMounted.current = false
     }
   }, [
     checkWithPermissionGuard,

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from 'react'
+import {useCallback, useEffect, useRef, useState} from 'react'
 
 import {TitleDescriptionForm} from '../../components/dialog/TitleDescriptionForm'
 import {type EditableReleaseDocument, type ReleaseDocument, useReleaseOperations} from '../../index'
@@ -27,15 +27,16 @@ export function ReleaseDetailsEditor({release}: {release: ReleaseDocument}): Rea
     [hasUpdatePermission, timer, updateRelease],
   )
 
+  const isMounted = useRef(false)
   useEffect(() => {
-    let shouldUpdate = true
+    isMounted.current = true
 
     checkWithPermissionGuard(updateRelease, release).then((hasPermission) => {
-      if (shouldUpdate) setHasUpdatePermission(hasPermission)
+      if (isMounted.current) setHasUpdatePermission(hasPermission)
     })
 
     return () => {
-      shouldUpdate = false
+      isMounted.current = false
     }
   }, [checkWithPermissionGuard, release, release._id, updateRelease])
 

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
@@ -21,6 +21,8 @@ import {useReleaseOperationsMockReturn} from '../../../store/__tests__/__mocks/u
 import {
   mockUseReleasePermissions,
   useReleasePermissionsMockReturn,
+  useReleasesPermissionsMockReturnFalse,
+  useReleasesPermissionsMockReturnTrue,
 } from '../../../store/__tests__/__mocks/useReleasePermissions.mock'
 import {getReleaseIdFromReleaseDocumentId} from '../../../util/getReleaseIdFromReleaseDocumentId'
 import {ReleaseDetail} from '../ReleaseDetail'
@@ -121,9 +123,7 @@ describe('ReleaseDetail', () => {
         loading: true,
       })
 
-      mockUseReleasePermissions.mockReturnValue({
-        checkWithPermissionGuard: async () => true,
-      })
+      mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
       await renderTest()
     })
@@ -153,9 +153,7 @@ describe('ReleaseDetail', () => {
         ...useActiveReleasesMockReturn,
         data: [activeASAPRelease],
       })
-      mockUseReleasePermissions.mockReturnValue({
-        checkWithPermissionGuard: async () => true,
-      })
+      mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
       mockUseRouterReturn.state = {
         releaseId: getReleaseIdFromReleaseDocumentId(activeASAPRelease._id),
@@ -180,9 +178,7 @@ describe('after releases have loaded', () => {
     beforeEach(async () => {
       vi.clearAllMocks()
 
-      mockUseReleasePermissions.mockReturnValue({
-        checkWithPermissionGuard: async () => true,
-      })
+      mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
     })
 
     const loadedReleaseAndDocumentsTests = () => {
@@ -205,9 +201,7 @@ describe('after releases have loaded', () => {
             },
           ],
         })
-        mockUseReleasePermissions.mockReturnValue({
-          checkWithPermissionGuard: async () => true,
-        })
+        mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
         await renderTest()
       })
@@ -228,9 +222,8 @@ describe('after releases have loaded', () => {
           loading: false,
           results: [documentsInRelease],
         })
-        mockUseReleasePermissions.mockReturnValue({
-          checkWithPermissionGuard: async () => true,
-        })
+        mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
+
         await renderTest()
       })
 
@@ -292,9 +285,8 @@ describe('after releases have loaded', () => {
             },
           ],
         })
-        mockUseReleasePermissions.mockReturnValue({
-          checkWithPermissionGuard: async () => true,
-        })
+        mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
+
         await renderTest()
       })
 
@@ -362,9 +354,7 @@ describe('after releases have loaded', () => {
         releaseId: getReleaseIdFromReleaseDocumentId(publishedASAPRelease._id),
       }
 
-      mockUseReleasePermissions.mockReturnValue({
-        checkWithPermissionGuard: async () => true,
-      })
+      mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
       await renderTest()
     })
@@ -463,9 +453,7 @@ describe('after releases have loaded', () => {
         releaseId: getReleaseIdFromReleaseDocumentId(activeUndecidedRelease._id),
       }
 
-      mockUseReleasePermissions.mockReturnValue({
-        checkWithPermissionGuard: async () => false,
-      })
+      mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnFalse)
 
       await renderTest()
     })

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetailsEditor.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetailsEditor.test.tsx
@@ -6,6 +6,8 @@ import {type ReleaseDocument} from '../../../index'
 import {
   mockUseReleasePermissions,
   useReleasePermissionsMockReturn,
+  useReleasesPermissionsMockReturnFalse,
+  useReleasesPermissionsMockReturnTrue,
 } from '../../../store/__tests__/__mocks/useReleasePermissions.mock'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
 import {ReleaseDetailsEditor} from '../ReleaseDetailsEditor'
@@ -33,9 +35,8 @@ describe('ReleaseDetailsEditor', () => {
         },
       } as ReleaseDocument
 
-      mockUseReleasePermissions.mockReturnValue({
-        checkWithPermissionGuard: async () => true,
-      })
+      mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
+
       const wrapper = await createTestProvider()
       render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
     })
@@ -97,9 +98,8 @@ describe('ReleaseDetailsEditor', () => {
         },
       } as ReleaseDocument
 
-      mockUseReleasePermissions.mockReturnValue({
-        checkWithPermissionGuard: async () => false,
-      })
+      mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnFalse)
+
       const wrapper = await createTestProvider()
       render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
     })

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -121,7 +121,14 @@ export function ReleasesOverview() {
   }, [hasReleases, releasesMetadata, releases])
 
   useEffect(() => {
-    checkWithPermissionGuard(createRelease, DEFAULT_RELEASE).then(setHasCreatePermission)
+    let shouldUpdate = true
+    checkWithPermissionGuard(createRelease, DEFAULT_RELEASE).then((hasPermissions) => {
+      if (shouldUpdate) setHasCreatePermission(hasPermissions)
+    })
+
+    return () => {
+      shouldUpdate = false
+    }
   }, [checkWithPermissionGuard, createRelease])
 
   // switch to open mode if on archived mode and there are no archived releases

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -120,14 +120,15 @@ export function ReleasesOverview() {
     ]
   }, [hasReleases, releasesMetadata, releases])
 
+  const isMounted = useRef(false)
   useEffect(() => {
-    let shouldUpdate = true
+    isMounted.current = true
     checkWithPermissionGuard(createRelease, DEFAULT_RELEASE).then((hasPermissions) => {
-      if (shouldUpdate) setHasCreatePermission(hasPermissions)
+      if (isMounted.current) setHasCreatePermission(hasPermissions)
     })
 
     return () => {
-      shouldUpdate = false
+      isMounted.current = false
     }
   }, [checkWithPermissionGuard, createRelease])
 

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -42,6 +42,7 @@ import {
 import {
   mockUseReleasePermissions,
   useReleasePermissionsMockReturn,
+  useReleasesPermissionsMockReturnTrue,
 } from '../../../store/__tests__/__mocks/useReleasePermissions.mock'
 import {
   mockUseReleasesMetadata,
@@ -141,9 +142,7 @@ describe('ReleasesOverview', () => {
   beforeEach(() => {
     mockUseActiveReleases.mockRestore()
 
-    mockUseReleasePermissions.mockReturnValue({
-      checkWithPermissionGuard: async () => true,
-    })
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
   })
 
   setupVirtualListEnv()


### PR DESCRIPTION
### Description

- Updates permissions hook logic to use a store that takes advantage of the resourceCache in the studio
- A lot of file changes are related to updating mocks and making things in tests a bit smoother. Don't be scared by the number of files changed

This will then mean that there is no need to make needless dryRun requests multiple times exponentially reducing the number of calls in the release package.

### What to review

Everything make sense?

### Testing

Updated the tests and mocks, everything should work as expected.

### Notes for release

N/A
