### PR TITLE
fix(sanity): prevent unexpected release type picker mutation

### DIFF
--- a/packages/sanity/src/core/releases/__fixtures__/release.fixture.ts
+++ b/packages/sanity/src/core/releases/__fixtures__/release.fixture.ts
@@ -10,7 +10,7 @@ export const activeScheduledRelease: ReleaseDocument = {
   metadata: {
     title: 'active Release',
     releaseType: 'scheduled',
-    intendedPublishAt: '2023-10-10T10:00:00Z',
+    intendedPublishAt: '2023-10-10T10:00:00.000Z',
     description: 'active Release description',
   },
 }

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseTypePicker.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseTypePicker.tsx
@@ -127,12 +127,16 @@ export function ReleaseTypePicker(props: {release: NotArchivedRelease}): React.J
     return <ReleaseTime release={release} />
   }, [getReleaseTime, isPublishDateInPast, publishDate, release, tRelease])
 
-  const handleButtonReleaseTypeChange = useCallback((pickedReleaseType: ReleaseType) => {
-    setReleaseType(pickedReleaseType)
-    const nextPublishAt = pickedReleaseType === 'scheduled' ? startOfMinute(new Date()) : undefined
-    setIntendedPublishAt(nextPublishAt)
-    setIsIntendedScheduleDateInPast(true)
-  }, [])
+  const handleButtonReleaseTypeChange = useCallback(
+    (pickedReleaseType: ReleaseType) => {
+      setReleaseType(pickedReleaseType)
+      const nextPublishAt =
+        pickedReleaseType === 'scheduled' ? startOfMinute(new Date()) : (publishDate ?? undefined)
+      setIntendedPublishAt(nextPublishAt)
+      setIsIntendedScheduleDateInPast(true)
+    },
+    [publishDate],
+  )
 
   const handlePublishAtCalendarChange = useCallback(
     (date: Date | null) => {

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseTypePicker.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseTypePicker.tsx
@@ -139,7 +139,9 @@ export function ReleaseTypePicker(props: {release: NotArchivedRelease}): React.J
     (pickedReleaseType: ReleaseType) => {
       setReleaseType(pickedReleaseType)
       const nextPublishAt =
-        pickedReleaseType === 'scheduled' ? startOfMinute(new Date()) : (publishDate ?? undefined)
+        pickedReleaseType === 'scheduled'
+          ? (publishDate ?? startOfMinute(new Date()))
+          : (publishDate ?? undefined)
       setIntendedPublishAt(nextPublishAt)
       setIsIntendedScheduleDateInPast(true)
     },

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseTypePicker.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseTypePicker.tsx
@@ -71,7 +71,15 @@ export function ReleaseTypePicker(props: {release: NotArchivedRelease}): React.J
     if (open && !dialog) {
       const newRelease = {
         ...release,
-        metadata: {...release.metadata, intendedPublishAt: updatedDate, releaseType},
+        metadata: {
+          ...release.metadata,
+          releaseType,
+          ...(typeof updatedDate === 'undefined'
+            ? {}
+            : {
+                intendedPublishAt: updatedDate,
+              }),
+        },
       }
 
       if (!isEqual(newRelease, release)) {

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
@@ -190,6 +190,72 @@ describe('ReleaseTypePicker', () => {
     })
   })
 
+  describe('noops if the release type is unchanged when the picker is closed', () => {
+    it('after returning to "ASAP" from "undecided"', async () => {
+      await renderComponent()
+
+      const pickerButton = screen.getByRole('button')
+      fireEvent.click(pickerButton)
+
+      const undecidedTab = within(screen.getByRole('tablist')).getByText('Undecided')
+      fireEvent.click(undecidedTab)
+
+      const asapTab = within(screen.getByRole('tablist')).getByText('ASAP')
+      fireEvent.click(asapTab)
+
+      fireEvent.click(screen.getByTestId('release-type-picker'))
+      fireEvent.click(pickerButton)
+
+      expect(mockUpdateRelease).not.toHaveBeenCalled()
+    })
+
+    it('after returning to "ASAP" from "at time"', async () => {
+      await renderComponent()
+
+      const pickerButton = screen.getByRole('button')
+      fireEvent.click(pickerButton)
+
+      const atTimeTab = within(screen.getByRole('tablist')).getByText('At time')
+      fireEvent.click(atTimeTab)
+
+      const asapTab = within(screen.getByRole('tablist')).getByText('ASAP')
+      fireEvent.click(asapTab)
+
+      fireEvent.click(screen.getByTestId('release-type-picker'))
+      fireEvent.click(pickerButton)
+
+      expect(mockUpdateRelease).not.toHaveBeenCalled()
+    })
+
+    it('after returning to "at time" from "ASAP" after the system time has incremented', async () => {
+      vi.useFakeTimers({shouldAdvanceTime: true})
+
+      const intendedPublishAt = new Date(activeScheduledRelease.metadata.intendedPublishAt ?? 0)
+
+      // 24 hours before `intendedPublishAt`.
+      vi.setSystemTime(new Date(intendedPublishAt.getTime() - 3_600 * 1_000 * 24))
+
+      await renderComponent(activeScheduledRelease)
+
+      const pickerButton = screen.getByRole('button')
+      fireEvent.click(pickerButton)
+
+      const asapTab = within(screen.getByRole('tablist')).getByText('ASAP')
+      fireEvent.click(asapTab)
+
+      // 23 hours before `intendedPublishAt` (one hour after picker opened).
+      vi.setSystemTime(new Date(intendedPublishAt.getTime() - 3_600 * 1_000 * 23))
+
+      const atTimeTab = within(screen.getByRole('tablist')).getByText('At time')
+      fireEvent.click(atTimeTab)
+
+      fireEvent.click(pickerButton)
+
+      expect(mockUpdateRelease).not.toHaveBeenCalled()
+      vi.useRealTimers()
+    })
+  })
+
   describe('picker behavior based on release state', () => {
     it('does not show button for picker when release is published state', async () => {
       await renderComponent(publishedASAPRelease)

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
@@ -183,7 +183,6 @@ describe('ReleaseTypePicker', () => {
         ...activeASAPRelease,
         metadata: expect.objectContaining({
           ...activeASAPRelease.metadata,
-          intendedPublishAt: undefined,
           releaseType: 'undecided',
         }),
       })


### PR DESCRIPTION
### Description

In some scenarios, the release type picker produces a changed release object, despite the user making no intentional changes.

For example: when transitioning from an "at time" to an "ASAP" release, and then back again (without first closing the picker), the initial `metadata.intendedPublishAt` value is lost. This causes a mutation to occur when the user closes the release type picker when no mutation was expected. This is problematic because it produces an unexpected spinner in the UI, and could cause subtle unintended mutations.

This branch fixes several scenarios that provoked this bug.

### What to review

The release type picker.

### Testing

Added component tests for the known scenarios that provoke this bug.

### Notes for release

Fixes a bug that caused the release type picker to unexpectedly enter a loading state.