### PR TITLE
fix(core): handling cases where no dependencies are passed to a resourceCache value set

### DIFF
--- a/packages/sanity/src/core/store/_legacy/ResourceCacheProvider.tsx
+++ b/packages/sanity/src/core/store/_legacy/ResourceCacheProvider.tsx
@@ -22,6 +22,8 @@ export function ResourceCacheProvider({children}: ResourceCacheProviderProps) {
     // this is used to replace the `null` values in any `dependencies` so that
     // they can be used in the `MultiKeyWeakMap` which doesn't accept null
     const nullReplacer = {}
+    // this is used to replace `[]` dependencies to maintain the
+    // same referential integrity in the weak map lookup
     const emptyDependenciesReplacer = [nullReplacer]
 
     const removeNullDependencies = (dependencies: (object | null)[]) =>

--- a/packages/sanity/src/core/store/_legacy/ResourceCacheProvider.tsx
+++ b/packages/sanity/src/core/store/_legacy/ResourceCacheProvider.tsx
@@ -22,21 +22,23 @@ export function ResourceCacheProvider({children}: ResourceCacheProviderProps) {
     // this is used to replace the `null` values in any `dependencies` so that
     // they can be used in the `MultiKeyWeakMap` which doesn't accept null
     const nullReplacer = {}
+    const emptyDependenciesReplacer = [nullReplacer]
+
+    const removeNullDependencies = (dependencies: (object | null)[]) =>
+      dependencies.length
+        ? dependencies.map((dep) => (dep === null ? nullReplacer : dep))
+        : emptyDependenciesReplacer
 
     return {
       get: ({namespace, dependencies}) => {
-        const dependenciesWithoutNull = dependencies.map((dep) =>
-          dep === null ? nullReplacer : dep,
-        )
+        const dependenciesWithoutNull = removeNullDependencies(dependencies)
         const namespaceMap = namespaces.get(namespace)
         return namespaceMap?.get(dependenciesWithoutNull)
       },
 
       set: ({namespace, dependencies, value}) => {
         const namespaceMap = namespaces.get(namespace) || createMultiKeyWeakMap()
-        const dependenciesWithoutNull = dependencies.map((dep) =>
-          dep === null ? nullReplacer : dep,
-        )
+        const dependenciesWithoutNull = removeNullDependencies(dependencies)
         namespaces.set(namespace, namespaceMap)
         namespaceMap.set(dependenciesWithoutNull, value)
       },


### PR DESCRIPTION
### Description
In cases where resourceCache is `set` and `get` with no dependencies, eg:
```ts
      resourceCache.get({
        dependencies: [],
        namespace: 'myNamespace',
      })
```
Then the weak map key would be a different reference each time, meaning setting and getting wouldn't return the correct namespace value.

This change essentially maps the case of `dependencies: []` to become a weak map key of `[{}]`, where `{}` is always the same reference (`nullReplacer`).
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Testing manually by... seeing that it fixed the issue, whilst also regression testing that passing non empty dependencies doesn't break
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A - `ResourceCache` is internal only
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
