### PR TITLE
feat(vision): add API version 2025-02-19

### DIFF
--- a/packages/@sanity/vision/src/apiVersions.ts
+++ b/packages/@sanity/vision/src/apiVersions.ts
@@ -4,6 +4,7 @@ export const API_VERSIONS = [
   'v2021-03-25',
   'v2021-10-21',
   'v2022-03-07',
+  'v2025-02-19',
   `v${new Date().toISOString().split('T')[0]}`,
 ]
 export const [DEFAULT_API_VERSION] = API_VERSIONS.slice(-1)


### PR DESCRIPTION
### Description

Adds `v2025-02-19` to the API version dropdown list in Vision.

### Notes for release

* `v2025-02-19` brings breaking changes and should be one of the API versions in Vision's dropdown for testing.
* This should be released as part of the changes that make `published` the default perspective.
