### PR TITLE
fix(core): update responsive design on navbar

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -56,7 +56,7 @@ const RootCard = styled(Card)`
 
 const NavGrid = styled(Grid)`
   grid-template-columns: auto auto auto;
-  @media screen and (min-width: ${({theme}) => `${theme.sanity.media[3]}px`}) {
+  @media screen and (min-width: ${({theme}) => `${theme.sanity.media[4]}px`}) {
     grid-template-columns: 1fr auto 1fr;
   }
 `


### PR DESCRIPTION
### Description

The navbar will now react at an earlier point so that the menu items don't overlap
This took me too embarrassingly long to figure out where I need to make the change 🫠 

Before
<img width="813" alt="Dashboard" src="https://github.com/user-attachments/assets/3e87873a-737c-4ee8-8073-d4dba700fcf8" />  

After
<video src="https://github.com/user-attachments/assets/30bf880e-fede-440c-95a7-a142b98ebe8d">

### What to review

You can test it out on the preview deployment

### Testing

N/A

### Notes for release

Responsible improvements on the nav ba