### PR TITLE
fix: add fallback context value for scheduled publish enablement

### DIFF
--- a/packages/sanity/src/_singletons/context/ScheduledPublishingEnabledContext.ts
+++ b/packages/sanity/src/_singletons/context/ScheduledPublishingEnabledContext.ts
@@ -2,11 +2,20 @@ import {createContext} from 'sanity/_createContext'
 
 import type {ScheduledPublishingEnabledContextValue} from '../../core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider'
 
+const DEFAULT: ScheduledPublishingEnabledContextValue = {
+  enabled: false,
+  mode: null,
+  hasUsedScheduledPublishing: {
+    used: false,
+    loading: false,
+  },
+}
+
 /**
  * @internal
  */
 export const ScheduledPublishingEnabledContext =
-  createContext<ScheduledPublishingEnabledContextValue | null>(
+  createContext<ScheduledPublishingEnabledContextValue>(
     'sanity/_singletons/context/scheduled-publishing-enabled',
-    null,
+    DEFAULT,
   )

--- a/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx
@@ -110,10 +110,5 @@ export function ScheduledPublishingEnabledProvider({
  */
 export function useScheduledPublishingEnabled(): ScheduledPublishingEnabledContextValue {
   const context = useContext(ScheduledPublishingEnabledContext)
-  if (!context) {
-    throw new Error(
-      'useScheduledPublishingEnabled must be used within a ScheduledPublishingEnabledProvider',
-    )
-  }
   return context
 }


### PR DESCRIPTION
Fixes #8712

### Description
The scheduled publishing plugin currently inserts a context provider, but if the plugin is not enabled specifically, this context provider won't be inserted in the layout, causing the useScheduledPublishingEnabled() to throw due to missing context value.

### What to review

Does this make sense as a fix? Are there better ways of solving this?

### Testing
A Studio that does not enable scheduled publishing should not fail because of missing context.

### Notes for release

- Fixes an issue that could cause an error for Studios without Scheduled publishing enabled.
