### PR TITLE
fix(sanity): add missing `useInsertionEffect` hook dependency `isCreateLinked`

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -677,7 +677,15 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
         patch.execute(toMutationPatches(event.patches), initialValue.value)
       }
     }
-  }, [editState.draft, editState.published, initialValue.value, patch, telemetry, readOnly])
+  }, [
+    editState.draft,
+    editState.published,
+    initialValue.value,
+    patch,
+    telemetry,
+    readOnly,
+    isCreateLinked,
+  ])
 
   const formState = useFormState({
     schemaType: schemaType!,


### PR DESCRIPTION
### Description

This `useInsertionEffect` hook was recently updated, but the new dependency was not added.

This mistake wasn't caught by our linter. We should investigate why.

### What to review

The new hook dependency.

### Testing

The document editor renders correctly.