### PR TITLE
Remove --legacy-peer-deps from new project initialization

### DIFF
--- a/packages/@sanity/cli/src/packageManager/installPackages.ts
+++ b/packages/@sanity/cli/src/packageManager/installPackages.ts
@@ -21,7 +21,7 @@ export async function installDeclaredPackages(
     stdio: 'inherit',
   }
 
-  const npmArgs = ['install', '--legacy-peer-deps']
+  const npmArgs = ['install']
   let result: ExecaReturnValue<string> | undefined
   if (packageManager === 'npm') {
     output.print(`Running 'npm ${npmArgs.join(' ')}'`)
@@ -60,7 +60,7 @@ export async function installNewPackages(
     stdio: 'inherit',
   }
 
-  const npmArgs = ['install', '--legacy-peer-deps', '--save', ...packages]
+  const npmArgs = ['install', '--save', ...packages]
   let result: ExecaReturnValue<string> | undefined
   if (packageManager === 'npm') {
     output.print(`Running 'npm ${npmArgs.join(' ')}'`)


### PR DESCRIPTION
Remove --legacy-peer-deps

### Description

The deps in our starting templates don't throw an error requiring `--legacy-peer-deps`, so this PR removes the `--legacy-peer-deps` flag from the install commands for new Sanity projects. 


