### PR TITLE
fix(core): flag `application/x-portable-text` as portable text 

### DIFF
--- a/packages/sanity/src/core/form/inputs/common/fileTarget/utils/extractFiles.ts
+++ b/packages/sanity/src/core/form/inputs/common/fileTarget/utils/extractFiles.ts
@@ -108,5 +108,5 @@ function walk(entry: Entry): Promise<File[]> {
 }
 
 export function isPortableTextItem(item: {type: string; kind: string}) {
-  return item.type === 'application/portable-text'
+  return item.type === 'application/portable-text' || item.type === 'application/x-portable-text'
 }


### PR DESCRIPTION
### Description

This makes it possible to drag inline objects in the editor without getting a
"Can't upload any of these files here" error.

---

Drag and drop in PTE is still very lackluster:

1. Block objects like images can be dragged around, but this is purely
   implemented by maintaining an internal drag state, and dragging these
   objects doesn't use the `application/x-portable-text` MIME type yet.
2. Inline objects can be dragged more freely. They are stored using
   `application/x-portable-text` and even support being dragged from one editor
   to another.

`application/x-portable-text` is what PTE uses when serializing and
deserializing to and from the clipboard. And it's also the MIME type used for
drag and drop going forward. And soon block objects will be stored on this MIME
type as well.

### What to review

Verify that you can now drag inline objects around in the editor.

### Testing

n/a

### Notes for release

It's now possible to drag and drop inline objects in the Portable Text Input.