### PR TITLE
fix(cli): update core app template

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -1268,7 +1268,7 @@ export default async function initSanity(
       ]
 
       const chosenOrg = await prompt.single({
-        message: 'Select organization to attach project to',
+        message: `Select organization to attach ${isCoreAppTemplate ? 'application' : 'project'} to`,
         type: 'list',
         choices: organizationChoices,
       })

--- a/packages/@sanity/cli/templates/core-app/src/App.tsx
+++ b/packages/@sanity/cli/templates/core-app/src/App.tsx
@@ -1,9 +1,10 @@
-import {createSanityInstance} from '@sanity/sdk'
-import {SanityProvider} from '@sanity/sdk-react/context'
+import {type SanityConfig} from '@sanity/sdk'
+import {SanityApp} from '@sanity/sdk-react/components'
+import {ExampleComponent} from './ExampleComponent'
 
 export function App() {
 
-  const sanityConfig = {
+  const sanityConfig: SanityConfig = {
     auth: {
       authScope: 'global'
     }
@@ -15,11 +16,11 @@ export function App() {
     // dataset: 'my-dataset',
   }
 
-  const sanityInstance = createSanityInstance(sanityConfig)
   return (
-    <SanityProvider sanityInstance={sanityInstance}>
-      Hello world!
-    </SanityProvider>
+    <SanityApp sanityConfig={sanityConfig}>
+      {/* add your own components here! */}
+      <ExampleComponent />
+    </SanityApp>
   )
 }
 

--- a/packages/@sanity/cli/templates/core-app/src/ExampleComponent.tsx
+++ b/packages/@sanity/cli/templates/core-app/src/ExampleComponent.tsx
@@ -1,0 +1,11 @@
+export function ExampleComponent() {
+  return (
+    <div>
+      <h1>Welcome to Your Sanity App!</h1>
+      <p>
+        This is an example component. You can replace this with your own content
+        by creating a new component and importing it in App.tsx.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
### Description
This updates the core app template to use the proper components for wrapping a core app. This is iterative, and likely not the final state of what this template looks like.

### What to review
Does this seem all right as an initial intro to core apps for internal parties?

### Testing
1. Run `pnpx sanity@3.75.1-canary.151+ccab07e8db init --template core-app`
2. Run `pnpm dev`
3. Note no crashes and the usage of `SanityProvider` in the repository

### Notes for release
None, internal.