### PR TITLE
fix(cli): require projects to be part of an organization

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -115,7 +115,7 @@
     "minimist": "^1.2.5",
     "open": "^8.4.0",
     "ora": "^8.0.1",
-    "p-filter": "^2.1.0",
+    "p-map": "^4.0.0",
     "p-timeout": "^4.0.0",
     "preferred-pm": "^3.0.3",
     "promise-props-recursive": "^2.0.2",

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -101,7 +101,6 @@ export const initCommand: CliCommandDefinition<InitFlags> = {
   description: 'Initializes a new Sanity Studio and/or project',
   helpText,
   action: async (args, context) => {
-    const {output, chalk} = context
     const [type] = args.argsWithoutOptions
 
     // `sanity init whatever`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -874,9 +874,9 @@ importers:
       ora:
         specifier: ^8.0.1
         version: 8.2.0
-      p-filter:
-        specifier: ^2.1.0
-        version: 2.1.0
+      p-map:
+        specifier: ^4.0.0
+        version: 4.0.0
       p-timeout:
         specifier: ^4.0.0
         version: 4.1.0
@@ -9439,10 +9439,6 @@ packages:
   oxc-resolver@1.12.0:
     resolution: {integrity: sha512-YlaCIArvWNKCWZFRrMjhh2l5jK80eXnpYP+bhRc1J/7cW3TiyEY0ngJo73o/5n8hA3+4yLdTmXLNTQ3Ncz50LQ==}
 
-  p-filter@2.1.0:
-    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
-    engines: {node: '>=8'}
-
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
@@ -9486,10 +9482,6 @@ packages:
   p-map@1.2.0:
     resolution: {integrity: sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==}
     engines: {node: '>=4'}
-
-  p-map@2.1.0:
-    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
-    engines: {node: '>=6'}
 
   p-map@4.0.0:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
@@ -21155,10 +21147,6 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 1.12.0
       '@oxc-resolver/binding-win32-x64-msvc': 1.12.0
 
-  p-filter@2.1.0:
-    dependencies:
-      p-map: 2.1.0
-
   p-finally@1.0.0: {}
 
   p-finally@2.0.1: {}
@@ -21194,8 +21182,6 @@ snapshots:
   p-map-series@2.1.0: {}
 
   p-map@1.2.0: {}
-
-  p-map@2.1.0: {}
 
   p-map@4.0.0:
     dependencies:


### PR DESCRIPTION
### Description

From now on we want all projects to be part of an organization. This means the CLI flow should be a little different - no "None" option for selecting an organization. Instead, we want people to choose one or create one.

This PR modifies the flow so that:

* If a user is not part of any organizations, prompt them to create one
* It shows organizations you are a member of but do not have the sufficient grants to (helps people understand why they can't choose it)
* Removes the "none" option, replaces it with a "Create new organization" option

There are a few code paths (through flags/unattended mode) that may still send a project creation request without an organization - that's fine - the API will assign those projects to the users' organization (if they have one), otherwise creates a new one and assigns the project to it.

Also found and fixed a minor flow issue for new users, where there was no default value for project name, and accepting a blank name would lead to an unhelpful error. 

### What to review

- Flow still works, organization assignment works as expected

### Notes for release

None
