### PR TITLE
fix(WIP): slugValidator constraint updated to be logically consistent with content releases

### DIFF
--- a/packages/sanity/src/core/validation/validators/slugValidator.ts
+++ b/packages/sanity/src/core/validation/validators/slugValidator.ts
@@ -54,8 +54,11 @@ const defaultIsUnique: SlugIsUniqueValidator = (slug, context) => {
 
   const constraints = [
     '_type == $docType',
-    `!(_id in [$draft, $published])`,
-    `!(_id in path("${VERSION_FOLDER}.**.${published}"))`,
+    `!( 
+      _id == $published || 
+      _id == $draft || 
+      _id in path("${VERSION_FOLDER}.**.${published}")
+    )`,
     `${atPath} == $slug`,
   ].join(' && ')
 

--- a/packages/sanity/test/validation/infer.test.ts
+++ b/packages/sanity/test/validation/infer.test.ts
@@ -146,7 +146,7 @@ describe('schema validation inference', () => {
 
       expect(client.fetch).toHaveBeenCalledTimes(1)
       expect(client.fetch.mock.calls[0]).toEqual([
-        '!defined(*[_type == $docType && !(_id in [$draft, $published]) && !(_id in path("versions.**.mockDocument")) && slugField.current == $slug][0]._id)',
+        '!defined(*[_type == $docType && !(_id == $published || _id == $draft || _id in path("versions.**.mockDocument")) && slugField.current == $slug][0]._id)',
         {
           docType: 'documentWithSlug',
           draft: 'drafts.mockDocument',
@@ -185,7 +185,7 @@ describe('schema validation inference', () => {
 
       expect(client.fetch).toHaveBeenCalledTimes(1)
       expect(client.fetch.mock.calls[0]).toEqual([
-        '!defined(*[_type == $docType && !(_id in [$draft, $published]) && !(_id in path("versions.**.mockDocument")) && slugField.current == $slug][0]._id)',
+        '!defined(*[_type == $docType && !(_id == $published || _id == $draft || _id in path("versions.**.mockDocument")) && slugField.current == $slug][0]._id)',
         {
           docType: 'documentWithSlug',
           draft: 'drafts.mockDocument',


### PR DESCRIPTION
### Description

A quick attempt at dealing with #8724 
I'm not setup with a full test config etc for the studio so will need somebody's help in finishing this one.

### What to review

Are slugs correctly validated as unique with and without content releases enabled?

### Testing

The test only checks if the generated query matches the query constraints... they don't actually test if the query itself will be giving valid results against any fixtures etc which would be ideal.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
