### PR TITLE
feat: make content releases opt out

### DIFF
--- a/packages/sanity/src/core/config/resolveDefaultPlugins.ts
+++ b/packages/sanity/src/core/config/resolveDefaultPlugins.ts
@@ -50,7 +50,7 @@ export function getDefaultPluginsOptions(
     },
     releases: {
       ...workspace.releases,
-      enabled: workspace.releases?.enabled ?? false,
+      enabled: workspace.releases?.enabled ?? true,
     },
   }
 }


### PR DESCRIPTION
### Description

Make content releases opt-out by flipping the default `releases.enabled` to be `true` in the studio config default resolver.

This is part of the larger public release of the content releases feature and will show the releases button by default on the top of the studio.

<img width="213" alt="Screenshot 2025-02-24 at 10 42 03" src="https://github.com/user-attachments/assets/8a225b92-4f51-4ce5-936d-3831e9e11cbd" />


### What to review

n/a

### Testing

n/a but lots of manual testing has been done and automated testing as part of the code that has already been merged behind this flag.

### Notes for release

Lots of notes here that are already in draft.
