### PR TITLE
fix: add correct link to content releases banner

### DIFF
--- a/packages/sanity/src/core/scheduledPublishing/constants.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/constants.tsx
@@ -94,5 +94,4 @@ export const SCHEDULED_PUBLISHING_TOOL_NAME = 'schedules'
 
 export const TOOL_TITLE = 'Schedules'
 
-// TODO: Update once the docs are live
 export const RELEASES_DOCS_URL = 'https://www.sanity.io/blog/introducing-content-releases'

--- a/packages/sanity/src/core/scheduledPublishing/constants.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/constants.tsx
@@ -95,4 +95,4 @@ export const SCHEDULED_PUBLISHING_TOOL_NAME = 'schedules'
 export const TOOL_TITLE = 'Schedules'
 
 // TODO: Update once the docs are live
-export const RELEASES_DOCS_URL = 'https://www.sanity.io/docs/content-releases'
+export const RELEASES_DOCS_URL = 'https://www.sanity.io/blog/introducing-content-releases'


### PR DESCRIPTION
### Description

In the event that both content releases and scheduled publishing is enabled in the studio, we provide a warning banner. This PR updates the link to the documentation for getting help in resolving this.

### What to review

Link isn't live yet, but confirmed with editorial that this is correct.

### Testing

n/a

### Notes for release

n/a
