### PR TITLE
chore(ci): auto cancel workflows on PRs

### DIFF
--- a/.github/workflows/are-we-compiled-yet.yml
+++ b/.github/workflows/are-we-compiled-yet.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [next]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [next]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   cli-test:
     timeout-minutes: 60

--- a/.github/workflows/docReport.yml
+++ b/.github/workflows/docReport.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [current, next]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   report:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -5,6 +5,11 @@ on:
   # Build on commits pushed to branches without a PR if it's in the allowlist
   push:
     branches: [next]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   install:
     timeout-minutes: 30

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,11 @@ on:
   # Build on commits pushed to branches without a PR if it's in the allowlist
   push:
     branches: [next]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   install:
     timeout-minutes: 30

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -18,6 +18,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   efps-test:
     timeout-minutes: 30

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -9,6 +9,10 @@ on:
   push:
     branches: [current]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   etl:
     runs-on: ubuntu-latest

--- a/.github/workflows/formatCheck.yml
+++ b/.github/workflows/formatCheck.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches: [next]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   formatCheck:
     timeout-minutes: 30

--- a/.github/workflows/lintPr.yml
+++ b/.github/workflows/lintPr.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [next]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [next]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
### Description

We have a lot of congestion and rebasing happening on PRs. Especially with renovatebot which auto rebases when a merge conflict is detected.
When this happens it's not necessary to wait for previous builds to complete, as we use GitHub required checks to control what PRs can merge anyway, and they only care about the checks on the latest commit on the branch.

### What to review

Does it make sense? The way `group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}` works is that a matching name will be cancelled if a new build starts. Thus `group` should be unique to each workflow file (that's what `github.workflow` ensures).
It should have a stable name for the lifecycle of a PR, `github.head_ref` does that by using the branch name. `head_ref` is only available on PRs, so `${{ github.head_ref || github.run_id }}` will resolve `github.run_id` when a workflow is run due to pushing to `next`. `github.run_id` has a new id on every run, this is how we avoid checks from cancelling on commits merged to `next`, as it's useful for bisecting purposes to have test suites complete on each commit landing there.

IOW on this PR the `cli-test.yml` workflow will have the group `CLI Unit tests-cancel-ci-jobs`. A push before the job completes will cancel it, as it did [here](https://github.com/sanity-io/sanity/actions/runs/13503250096?pr=8751):
```bash
[CLI Tests (ubuntu-latest / node 18)](https://github.com/sanity-io/sanity/actions/runs/13503250096/job/37726704137)
Canceling since a higher priority waiting request for 'CLI Unit tests-cancel-ci-jobs' exists
```

### Testing

The `concurrrency` feature is used on a lot of other repos already so it's a well-tested technique to reduce GitHub worker queues.

### Notes for release

N/A