### PR TITLE
fix: silence context warnings in jsdom environments

### DIFF
--- a/packages/sanity/src/_createContext/createGlobalScopedContext.ts
+++ b/packages/sanity/src/_createContext/createGlobalScopedContext.ts
@@ -18,9 +18,15 @@ export function createGlobalScopedContext<ContextType, const T extends ContextTy
   const symbol = Symbol.for(key)
 
   /**
-   * Prevent errors about re-renders on React SSR on Next.js App Router
+   * Prevent errors about re-renders on React SSR on Next.js App Router, as well as JSDOM-based
+   * environments such as when we extract schemas etc from the studio configuration.
    */
-  if (typeof document === 'undefined') {
+  if (
+    typeof document === 'undefined' ||
+    (typeof window !== 'undefined' &&
+      typeof window.navigator !== 'undefined' &&
+      window.navigator.userAgent.includes('jsdom'))
+  ) {
     return createContext<ContextType>(defaultValue)
   }
 


### PR DESCRIPTION
### Description

While working on some CLI improvements, I am seeing the context warnings being emitted when loading the studio configuration through a JSDOM-enriched environment, such as from `sanity schema extract` etc. This PR silences these as they are not actionable.

### What to review

Do the new checks seem safe and logical? JSDOM user agent note here: https://github.com/jsdom/jsdom?tab=readme-ov-file#advanced-configuration

> It defaults to `Mozilla/5.0 (${process.platform || "unknown OS"}) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/${jsdomVersion}`.

### Notes for release

None
