### PR TITLE
chore: fix flaky test on CI

### DIFF
--- a/packages/sanity/src/core/studio/Studio.test.tsx
+++ b/packages/sanity/src/core/studio/Studio.test.tsx
@@ -52,7 +52,7 @@ describe('Studio', () => {
     spy.mockReset()
     spy.mockRestore()
   })
-  it(`SSR to markup for hydration doesn't throw`, () => {
+  it(`SSR to markup for hydration doesn't throw`, async () => {
     const spy = vi.spyOn(console, 'error')
     const node = document.createElement('div')
     document.body.appendChild(node)
@@ -63,7 +63,8 @@ describe('Studio', () => {
       node.innerHTML = html
 
       document.head.innerHTML += sheet.getStyleTags()
-      act(() => hydrateRoot(node, <Studio config={config} />))
+      const root = await act(() => hydrateRoot(node, <Studio config={config} />))
+      await act(() => root.unmount())
     } finally {
       sheet.seal()
     }


### PR DESCRIPTION
### Description

Fixes a flaky test, that fails on almost every [single PR](https://github.com/sanity-io/sanity/actions/runs/13504557073/job/37731007799).
The core issue were that the `hydrateRoot` instance creates a React render tree that continues to live on after the test is tore down.
And in some cases it would try to re-render the `<Studio />` test after teardown, at which point globals like `window` were no longer there and thus created this confusing error on builds:
```bash
⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯

ReferenceError: window is not defined

This error originated in "src/core/studio/Studio.test.tsx" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
This error was caught after test environment was torn down. Make sure to cancel any running tasks before test finishes:
- cancel timeouts using clearTimeout and clearInterval
- wait for promises to resolve using the await keyword
```
There's both the case that `act` were missing an `await`, as well as no `root.unmount()` which lets react cleanup the test.
When using `@testing-library/react`, this cleanup happens automatically. However in this particular test we were calling `hydrateRoot` manually and thus have to do the cleanup ourselves.

### What to review

Does it make sense?

### Testing

If the CI passes every time, instead of some of the time, then we're good 👍 

### Notes for release

N/A
