### PR TITLE
fix: use raw perspective by default for search

### DIFF
--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
@@ -133,13 +133,9 @@ export function createSearchQuery(
   let activePerspective: string | string[] | undefined
 
   switch (true) {
-    // No perspective provided, use raw
-    case !perspective?.length:
-      activePerspective = 'raw'
-      break
     // Raw perspective provided.
     case isRaw:
-      activePerspective = 'raw'
+      activePerspective = undefined
       break
     // Any other perspective provided.
     case typeof perspective !== 'undefined':

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
@@ -133,9 +133,13 @@ export function createSearchQuery(
   let activePerspective: string | string[] | undefined
 
   switch (true) {
+    // No perspective provided, use raw
+    case !perspective?.length:
+      activePerspective = 'raw'
+      break
     // Raw perspective provided.
     case isRaw:
-      activePerspective = undefined
+      activePerspective = 'raw'
       break
     // Any other perspective provided.
     case typeof perspective !== 'undefined':

--- a/packages/sanity/src/core/search/weighted/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/weighted/createSearchQuery.ts
@@ -194,7 +194,7 @@ export function createSearchQuery(
     },
     options: {
       tag,
-      perspective: isRaw ? undefined : searchOpts.perspective,
+      perspective: isRaw || !searchOpts.perspective?.length ? 'raw' : searchOpts.perspective,
     },
     searchSpec: specs,
     terms,


### PR DESCRIPTION
### Description
This fixes an issue that caused drafts (and versions) not to appear in reference search by explicitly 

### What to review
- Does the fix make sense?

### Testing
- Create a draft document (without publishing it)
- Go to a reference field that can reference its type and search for it.

Prior to this PR, the draft document would not appear in search results
After this PR the draft should appear and you should be able to create a reference to it

### Notes for release
- Fixes an issue causing draft-only documents to not appear in reference search
