### PR TITLE
chore(test-studio): move experimental search api to playground workspace

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -78,9 +78,6 @@ const sharedSettings = definePlugin({
       enabled: true,
     },
   },
-  search: {
-    strategy: 'groq2024',
-  },
   document: {
     actions: documentActions,
     inspectors: (prev, ctx) => {
@@ -240,6 +237,9 @@ export default defineConfig([
       eventsAPI: {
         releases: true,
       },
+    },
+    search: {
+      strategy: 'groq2024',
     },
     releases: {
       enabled: true,


### PR DESCRIPTION
### Description
Switching back to using the common search strategy for our day-to-day development Studio and instead enabling `groq2024` for the playground workspace.

### Notes for release
n/a – internal