### PR TITLE
fix(core): abort file target drag events for portable text items

### DIFF
--- a/packages/sanity/src/core/form/inputs/common/fileTarget/fileTarget.tsx
+++ b/packages/sanity/src/core/form/inputs/common/fileTarget/fileTarget.tsx
@@ -126,6 +126,19 @@ export function fileTarget<ComponentProps>(
     const handleDrop = useCallback(
       (event: DragEvent) => {
         enteredElements.current = []
+
+        const fileTypes = Array.from(event.dataTransfer.items).map((item) => ({
+          type: item.type,
+          kind: item.kind,
+        }))
+
+        // Skip items that is PTE blocks
+        const isPortableTextBlock = fileTypes.some((item) => isPortableTextItem(item))
+
+        if (isPortableTextBlock) {
+          return
+        }
+
         event.preventDefault()
         event.stopPropagation()
         const dataTransfer = event.nativeEvent.dataTransfer
@@ -144,6 +157,18 @@ export function fileTarget<ComponentProps>(
     const handleDragOver = useCallback(
       (event: DragEvent) => {
         if (onFiles) {
+          const fileTypes = Array.from(event.dataTransfer.items).map((item) => ({
+            type: item.type,
+            kind: item.kind,
+          }))
+
+          // Skip items that is PTE blocks
+          const isPortableTextBlock = fileTypes.some((item) => isPortableTextItem(item))
+
+          if (isPortableTextBlock) {
+            return
+          }
+
           event.preventDefault()
           event.stopPropagation()
         }
@@ -181,6 +206,18 @@ export function fileTarget<ComponentProps>(
 
     const handleDragLeave = useCallback(
       (event: DragEvent) => {
+        const fileTypes = Array.from(event.dataTransfer.items).map((item) => ({
+          type: item.type,
+          kind: item.kind,
+        }))
+
+        // Skip items that is PTE blocks
+        const isPortableTextBlock = fileTypes.some((item) => isPortableTextItem(item))
+
+        if (isPortableTextBlock) {
+          return
+        }
+
         event.stopPropagation()
         const idx = enteredElements.current.indexOf(event.currentTarget)
         if (idx > -1) {


### PR DESCRIPTION
### Description

Before this change, the file target drag/drop events would interfere with the internal drag/drop events of PTE. The `handleDragEnter` event handler allows the event to propagate if any of the dragged items are portable text. This lets PTE (and Slate) enter their internal drag state. However, because `handleDrop` (and possibly the other event handlers too) later hijack other drag events, PTE and Slate are unable to exit the internal drag state. This causes the editor to be stuck in a very confusing mode where selection changes aren't fired and the cursor starts jumping as you type. Aborting all file target drag/drop event handlers if portable text is dragged solves this issue.

### What to review

Here's a Loom showing the issue this is now fixed: https://www.loom.com/share/33a2dffe24f041bb86de516b04fc5178

Add an inline object to a PTE input and drag/drop it in the editor. Verify that the editor now works correctly, without cursor jumping issues.

![Screenshot 2025-02-25 at 10 01 59](https://github.com/user-attachments/assets/9723a1d0-f9b5-4a7c-b5c4-a4ee79156e4d)


### Testing

n/a

### Notes for release

Fixes a cursor jumping issue in the Portable Text Input that would occur after dragging an inline object in the editor