### PR TITLE
chore(cli): run app dev command on different port

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/app/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/devAction.ts
@@ -1,0 +1,30 @@
+import {type CliCommandArguments, type CliCommandContext} from '@sanity/cli'
+
+import {startDevServer} from '../../server/devServer'
+import {gracefulServerDeath} from '../../util/servers'
+import {getDevServerConfig, type StartDevServerCommandFlags} from '../dev/devAction'
+
+export default async function startAppDevServer(
+  args: CliCommandArguments<StartDevServerCommandFlags>,
+  context: CliCommandContext,
+): Promise<void> {
+  const flags = args.extOptions
+  const {output, workDir, cliConfig} = context
+
+  // Try to load CLI configuration from sanity.cli.(js|ts)
+  const config = getDevServerConfig({
+    flags: {
+      ...flags,
+      port: flags.port || '3334',
+    },
+    workDir,
+    cliConfig,
+    output,
+  })
+
+  try {
+    await startDevServer(config)
+  } catch (err) {
+    gracefulServerDeath('dev', config.httpHost, config.httpPort, err)
+  }
+}

--- a/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
@@ -46,7 +46,7 @@ export default async function startSanityDevServer(
   }
 }
 
-function getDevServerConfig({
+export function getDevServerConfig({
   flags,
   workDir,
   cliConfig,

--- a/packages/sanity/src/_internal/cli/commands/app/devCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/app/devCommand.ts
@@ -11,7 +11,7 @@ Notes
   Changing the hostname or port number might require a new entry to the CORS-origins allow list.
 
 Options
-  --port <port> TCP port to start server on. [default: 3333]
+  --port <port> TCP port to start server on. [default: 3334]
   --host <host> The local network interface at which to listen. [default: "127.0.0.1"]
 
 Examples
@@ -45,12 +45,12 @@ export async function getDevAction(): Promise<
   // NOTE: this `if` statement is not included in the output bundle
   if (__DEV__) {
     // eslint-disable-next-line import/extensions,@typescript-eslint/consistent-type-imports
-    const mod: typeof import('../../actions/dev/devAction') = require('../../actions/dev/devAction.ts')
+    const mod: typeof import('../../actions/app/devAction') = require('../../actions/app/devAction.ts')
 
     return mod.default
   }
 
-  const mod = await import('../../actions/dev/devAction')
+  const mod = await import('../../actions/app/devAction')
 
   return mod.default
 }


### PR DESCRIPTION
### Description

FIXES SDK-178

Introduces a dedicated development server for Sanity applications that runs on port 3334 by default, separate from the main Sanity development server which runs on port 3333. This separation allows developers to run both servers simultaneously without port conflicts.

### What to review

- Verify the new `devAction.ts` implementation in the app directory
- Check that the default port configuration is set to 3334
- Ensure the command documentation reflects the correct default port
- Confirm the dev server initialization and error handling are properly implemented

### Testing

The changes can be tested by:
1. Running the new app dev server using `sanity app dev`
2. Verifying it starts on port 3334 by default
3. Confirming that both the main Sanity dev server and app dev server can run concurrently

### Notes for release

N/A