### PR TITLE
fix(structure): fix issue with locked icon

### DIFF
--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -202,20 +202,25 @@ export const VersionChip = memo(function VersionChip(props: {
             onClick={onClick}
             selected={selected}
             tone={tone}
-            iconRight={locked && LockIcon}
             onContextMenu={contextMenuHandler}
-            padding={1}
-            paddingRight={2}
+            padding={2}
+            paddingRight={3}
             radius="full"
             $isArchived={releaseState === 'archived'}
-          >
-            <Flex align="center" gap={0}>
-              <ReleaseAvatar padding={1} tone={tone} />
-              <Box flex="none" padding={1}>
-                <Text size={1}>{text}</Text>
-              </Box>
-            </Flex>
-          </ChipButton>
+            text={
+              <Flex align="center" gap={1}>
+                <ReleaseAvatar padding={1} tone={tone} />
+                <Box flex="none" padding={1}>
+                  <Text size={1}>{text}</Text>
+                </Box>
+                {locked && (
+                  <Box paddingRight={1}>
+                    <LockIcon />
+                  </Box>
+                )}
+              </Flex>
+            }
+          />
         </span>
       </Tooltip>
 


### PR DESCRIPTION
### Description

| Before    | After |
| -------- | ------- |
| <img width="439" alt="image" src="https://github.com/user-attachments/assets/6ad072ca-0b3e-433d-8581-172e406030b5" />  | <img width="196" alt="image" src="https://github.com/user-attachments/assets/902b7ddf-8a0b-4f24-8db5-c04b5a22a450" />  |

### What to review

The change

### Testing

N/A

### Notes for release

Update visual bug when a release was locked in the document header chip