### PR TITLE
fix(sanity): allow discovery of all document versions using groq2024 search

### DIFF
--- a/packages/sanity/src/core/search/groq2024/createGroq2024Search.ts
+++ b/packages/sanity/src/core/search/groq2024/createGroq2024Search.ts
@@ -23,6 +23,9 @@ function getSearchTerms(
 }
 
 /**
+ * Note: When using the `raw` persepctive, `groq2024` may emit uncollated documents, manifesting as
+ * duplicate search results. Consumers must collate the results.
+ *
  * @internal
  */
 export const createGroq2024Search: SearchStrategyFactory<Groq2024SearchResults> = (

--- a/packages/sanity/src/core/util/__tests__/draftUtils.test.ts
+++ b/packages/sanity/src/core/util/__tests__/draftUtils.test.ts
@@ -14,13 +14,30 @@ import {
 test('collate()', () => {
   const foo = {_type: 'foo', _id: 'foo'}
   const fooDraft = {_type: 'foo', _id: 'drafts.foo'}
+  const fooAlphaVersion = {_type: 'foo', _id: 'versions.alpha.foo'}
+  const fooBetaVersion = {_type: 'foo', _id: 'versions.beta.foo'}
   const barDraft = {_type: 'foo', _id: 'drafts.bar'}
   const baz = {_type: 'foo', _id: 'baz'}
 
-  expect(collate([foo, fooDraft, barDraft, baz])).toEqual([
-    {type: 'foo', id: 'foo', draft: fooDraft, published: foo},
-    {type: 'foo', id: 'bar', draft: barDraft},
-    {type: 'foo', id: 'baz', published: baz},
+  expect(collate([foo, fooDraft, barDraft, baz, fooAlphaVersion, fooBetaVersion])).toEqual([
+    {
+      type: 'foo',
+      id: 'foo',
+      draft: fooDraft,
+      published: foo,
+      versions: [
+        {
+          _id: 'versions.alpha.foo',
+          _type: 'foo',
+        },
+        {
+          _id: 'versions.beta.foo',
+          _type: 'foo',
+        },
+      ],
+    },
+    {type: 'foo', id: 'bar', draft: barDraft, versions: []},
+    {type: 'foo', id: 'baz', published: baz, versions: []},
   ])
 })
 

--- a/packages/sanity/src/structure/panes/documentList/helpers.ts
+++ b/packages/sanity/src/structure/panes/documentList/helpers.ts
@@ -10,7 +10,7 @@ import {
 } from '@sanity/types'
 import * as PathUtils from '@sanity/util/paths'
 import {type ExprNode, parse} from 'groq-js'
-import {collate, getPublishedId, isVersionId} from 'sanity'
+import {collate, getPublishedId} from 'sanity'
 
 import {type DocumentListPaneItem, type SortOrder} from './types'
 
@@ -21,14 +21,12 @@ export function getDocumentKey(value: DocumentListPaneItem, index: number): stri
 export function removePublishedWithDrafts(documents: SanityDocumentLike[]): DocumentListPaneItem[] {
   return collate(documents).map((entry) => {
     const doc = entry.draft || entry.published || entry.versions[0]
-    const isVersion = doc?.id && isVersionId(doc._id)
     const hasDraft = Boolean(entry.draft)
 
     return {
       ...doc,
       hasPublished: !!entry.published,
       hasDraft,
-      isVersion,
     }
   }) as any
 }

--- a/packages/sanity/src/structure/panes/documentList/helpers.ts
+++ b/packages/sanity/src/structure/panes/documentList/helpers.ts
@@ -20,7 +20,7 @@ export function getDocumentKey(value: DocumentListPaneItem, index: number): stri
 
 export function removePublishedWithDrafts(documents: SanityDocumentLike[]): DocumentListPaneItem[] {
   return collate(documents).map((entry) => {
-    const doc = entry.draft || entry.published
+    const doc = entry.draft || entry.published || entry.versions[0]
     const isVersion = doc?.id && isVersionId(doc._id)
     const hasDraft = Boolean(entry.draft)
 

--- a/packages/sanity/src/structure/panes/documentList/types.ts
+++ b/packages/sanity/src/structure/panes/documentList/types.ts
@@ -4,7 +4,6 @@ import {type SearchSort} from 'sanity'
 export interface DocumentListPaneItem extends SanityDocumentLike {
   hasPublished: boolean
   hasDraft: boolean
-  isVersion: boolean
 }
 
 export type SortOrder = {


### PR DESCRIPTION
### Description

The `groq2024` search strategy currently relies on Content Lake perspectives to collate documents. This means global search is unable to discover document versions outside of the selected perspective.

This branch changes back to the `raw` perspective and returns to client-side collation in order to make all document versions discoverable via global search, regardless of the selected perspective.

### What to review

Global search: discoverability of versions outside the selected perspective.
Document lists: should be unchanged.

### Testing

Updated unit tests and tested manually.