### PR TITLE
feat(core): add default `code` and `strike-through` markdown shortcuts to PTE

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -399,8 +399,13 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
                 config={{
                   boldDecorator: ({schema}) =>
                     schema.decorators.find((decorator) => decorator.value === 'strong')?.value,
+                  codeDecorator: ({schema}) =>
+                    schema.decorators.find((decorator) => decorator.value === 'code')?.value,
                   italicDecorator: ({schema}) =>
                     schema.decorators.find((decorator) => decorator.value === 'em')?.value,
+                  strikeThroughDecorator: ({schema}) =>
+                    schema.decorators.find((decorator) => decorator.value === 'strike-through')
+                      ?.value,
                   defaultStyle: ({schema}) =>
                     schema.styles.find((style) => style.value === 'normal')?.value,
                   blockquoteStyle: ({schema}) =>


### PR DESCRIPTION
### Description

The `MarkdownPlugin` now also handles the conversion of "\`" pairs as well as
the conversion of "~~" pairs. All you need to do is tell it what decorator to
use for the conversion. In our case, we go with the default decorator names so
anyone who has these configured get the shortcuts.

![code-and-strike-through-markdown-shortcuts](https://github.com/user-attachments/assets/9e9f0904-6667-431d-ab5b-b6232b456d24)


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Do the shortcuts work as expected?

### Testing

The Portable Text Editor has internal tests for these behaviors.

### Notes for release

The Portable Text Input now includes Markdown shortcuts for decorators named `code` and `strike-through`

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
