### PR TITLE
fix(core): make PTE active by default

### DIFF
--- a/dev/test-studio/schema/standard/portableText/customBlockEditors.tsx
+++ b/dev/test-studio/schema/standard/portableText/customBlockEditors.tsx
@@ -29,10 +29,10 @@ export const ptCustomBlockEditors = defineType({
     },
     {
       name: 'initialActive',
-      title: 'Activated on mount (no click required)',
+      title: 'Inactivate on mount (click required)',
       type: 'array',
       components: {
-        input: (props: PortableTextInputProps) => <BlockEditor {...props} initialActive />,
+        input: (props: PortableTextInputProps) => <BlockEditor {...props} initialActive={false} />,
       },
       of: [{type: 'block'}],
     },

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Input.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Input.spec.tsx
@@ -8,7 +8,7 @@ import {InputStory} from './InputStory'
 test.describe('Portable Text Input', () => {
   test.describe('Activation', () => {
     test(`Show call to action on focus`, async ({mount}) => {
-      const component = await mount(<InputStory />)
+      const component = await mount(<InputStory ptInputProps={{initialActive: false}} />)
       const $portableTextInput = component.getByTestId('field-body')
       const $activeOverlay = $portableTextInput.getByTestId('activate-overlay')
 
@@ -18,7 +18,7 @@ test.describe('Portable Text Input', () => {
     })
 
     test(`Show call to action on hover`, async ({mount}) => {
-      const component = await mount(<InputStory />)
+      const component = await mount(<InputStory ptInputProps={{initialActive: false}} />)
       const $portableTextInput = component.getByTestId('field-body')
       const $activeOverlay = $portableTextInput.getByTestId('activate-overlay')
 
@@ -29,6 +29,14 @@ test.describe('Portable Text Input', () => {
 
     test(`Immediately activate on mount when 'initialActive' is true`, async ({mount}) => {
       const component = await mount(<InputStory ptInputProps={{initialActive: true}} />)
+
+      const $portableTextInput = component.getByTestId('field-body')
+      const $activeOverlay = $portableTextInput.getByTestId('activate-overlay')
+      await expect($activeOverlay).not.toBeAttached()
+    })
+
+    test(`Immediately activate on mount when 'initialActive' is unset`, async ({mount}) => {
+      const component = await mount(<InputStory />)
 
       const $portableTextInput = component.getByTestId('field-body')
       const $activeOverlay = $portableTextInput.getByTestId('activate-overlay')

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/ToolbarStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/ToolbarStory.tsx
@@ -87,6 +87,15 @@ export function ToolbarStory(props: InputStoryProps) {
                                 ],
                               }),
                             ],
+                            components: {
+                              input: (inputProps: InputProps) => {
+                                const editorProps = {
+                                  ...inputProps,
+                                  initialActive: false,
+                                } as PortableTextInputProps
+                                return inputProps.renderDefault(editorProps)
+                              },
+                            },
                           }),
                         ],
                       }),

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -149,7 +149,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   const [ignoreValidationError, setIgnoreValidationError] = useState(false)
   const [invalidValue, setInvalidValue] = useState<InvalidValue | null>(null)
   const [isFullscreen, setIsFullscreen] = useState(initialFullscreen ?? false)
-  const [isActive, setIsActive] = useState(initialActive ?? false)
+  const [isActive, setIsActive] = useState(initialActive ?? true)
   const [hasFocusWithin, setHasFocusWithin] = useState(false)
   const [ready, setReady] = useState(false)
   const telemetry = useTelemetry()

--- a/packages/sanity/src/core/form/types/inputProps.ts
+++ b/packages/sanity/src/core/form/types/inputProps.ts
@@ -529,7 +529,7 @@ export interface PortableTextInputProps
   hotkeys?: HotkeyOptions
   /**
    * Whether the input is activated and should receive events on mount.
-   * By default, PTE inputs need to be manually activated by focusing them.
+   * By default, this value is set to `true`
    */
   initialActive?: boolean
   /**

--- a/test/e2e/tests/comments/inline.spec.ts
+++ b/test/e2e/tests/comments/inline.spec.ts
@@ -26,9 +26,9 @@ async function inlineCommentCreationTest(props: InlineCommentCreationTestProps) 
     // Wait for network to become idle to ensure document is fully loaded
     await page.waitForLoadState('load', {timeout: WAIT_OPTIONS.timeout * 2})
 
-    // 2. Click the overlay to active the editor.
-    await page.getByTestId('activate-overlay').waitFor(WAIT_OPTIONS)
-    await page.click('[data-testid="activate-overlay"]')
+    // 2. Click the editor.
+    const editor = page.locator('[data-testid="pt-editor"]')
+    await editor.click()
 
     // Wait for any network activity triggered by activating the editor to complete
     await page.waitForLoadState('load', {timeout: WAIT_OPTIONS.timeout * 2})


### PR DESCRIPTION
### Description

There's been some feedback internally and externally that it would be nice if
the Portable Text Input was active by default. So I think we should try it.

Therefore, the default value of the `PortableTextInput.initialActive` prop has
been flipped from `false` to `true`.

The only downside is that the editor might scrolljack you on a small
device/viewport, but this does not appear to be a good reason to make the
editor inactive by default for everyone, especially not when most users are on
desktop devices.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Does it work as expected? Is an input with `initialActive={false}` correctly made inactive on mount?

### Testing

Some existing component tests have been adjusted to match the new behaviour.

### Notes for release

The Portable Text Input is now active by default