### PR TITLE
fix(core): batch requests for archived releases view

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -130,8 +130,6 @@ const releasesLocaleStrings = {
   /** Title for dialog for discarding a version of a document */
   'discard-version-dialog.title': 'Yes, discard version',
 
-  /** Text for when documents of a release are loading */
-  'document-loading': 'Loading documents',
   /** Label for when a document in a release has multiple validation warnings */
   'document-validation.error_other': '{{count}} validation errors',
   /** Label for when a document in a release has a single validation warning */
@@ -161,6 +159,14 @@ const releasesLocaleStrings = {
   'footer.status.unarchived': 'Unarchived',
   /** Label text for the loading state whilst release is being loaded */
   'loading-release': 'Loading release',
+
+  /** Text for when documents of a release are loading */
+  'loading-release-documents': 'Loading documents',
+  /** Title text for when loading documents on a release failed */
+  'loading-release-documents.error.title': 'Something went wrong',
+  /** Description text for when loading documents on a release failed */
+  'loading-release-documents.error.description':
+    "We're unable to load the documents for this release. Please try again later.",
 
   /** Label for the release menu */
   'menu.label': 'Release menu',

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
@@ -1,4 +1,6 @@
-import {Card, Container, Flex, Heading, Stack} from '@sanity/ui'
+import {ErrorOutlineIcon} from '@sanity/icons'
+import {Box, Card, Container, Flex, Heading, Stack, Text} from '@sanity/ui'
+import {motion} from 'framer-motion'
 import {useMemo, useRef, useState} from 'react'
 import {useRouter} from 'sanity/router'
 
@@ -19,18 +21,22 @@ import {ReleaseSummary} from './ReleaseSummary'
 import {useBundleDocuments} from './useBundleDocuments'
 
 export type ReleaseInspector = 'activity'
+const MotionCard = motion(Card)
 
 export const ReleaseDetail = () => {
   const router = useRouter()
   const [inspector, setInspector] = useState<ReleaseInspector | undefined>(undefined)
   const {t} = useTranslation(releasesLocaleNamespace)
-
   const {releaseId: releaseIdRaw}: ReleasesRouterState = router.state
   const releaseId = decodeURIComponent(releaseIdRaw || '')
   const {data, loading} = useActiveReleases()
   const {data: archivedReleases} = useArchivedReleases()
 
-  const {loading: documentsLoading, results} = useBundleDocuments(releaseId)
+  const {
+    loading: documentsLoading,
+    results,
+    error: bundleDocumentsError,
+  } = useBundleDocuments(releaseId)
   const releaseEvents = useReleaseEvents(releaseId)
 
   const documentIds = results.map((result) => result.document?._id)
@@ -43,8 +49,33 @@ export const ReleaseDetail = () => {
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
 
   const detailContent = useMemo(() => {
+    if (bundleDocumentsError) {
+      return (
+        <Box padding={3}>
+          <MotionCard
+            initial={{opacity: 0}}
+            animate={{opacity: 1}}
+            tone="critical"
+            padding={4}
+            radius={4}
+          >
+            <Flex gap={3}>
+              <Text size={1}>
+                <ErrorOutlineIcon />
+              </Text>
+              <Stack space={4}>
+                <Text size={1} weight="semibold">
+                  {t('loading-release-documents.error.title')}
+                </Text>
+                <Text size={1}>{t('loading-release-documents.error.description')}</Text>
+              </Stack>
+            </Flex>
+          </MotionCard>
+        </Box>
+      )
+    }
     if (documentsLoading) {
-      return <LoadingBlock title={t('document-loading')} />
+      return <LoadingBlock title={t('loading-release-documents')} showText />
     }
     if (!releaseInDetail) return null
 
@@ -56,7 +87,14 @@ export const ReleaseDetail = () => {
         scrollContainerRef={scrollContainerRef}
       />
     )
-  }, [releaseInDetail, documentsLoading, history.documentsHistory, results, t])
+  }, [
+    bundleDocumentsError,
+    documentsLoading,
+    releaseInDetail,
+    results,
+    history.documentsHistory,
+    t,
+  ])
 
   if (loading) {
     return (


### PR DESCRIPTION
### Description

We were doing one request to the history endpoint per document in the archived releases view, this doesn't scale well and in releases with 40 documents the archived view doesn't load because of rate limiting.

This PR removes the 1 request per doc solution and implements a batching strategy, fetching 10 documents per time and waiting for the previous response to end before getting the next one.

So instead of doing N requests (1 per document)
```
https://ppsg7ml5.api.sanity.io/v2025-02-19/data/history/test/documents/doc1
https://ppsg7ml5.api.sanity.io/v2025-02-19/data/history/test/documents/doc2
https://ppsg7ml5.api.sanity.io/v2025-02-19/data/history/test/documents/doc3
```

it does the following request:
```
https://ppsg7ml5.api.sanity.io/v2025-02-19/data/history/test/documents/doc1,doc2,doc3
```
https://test-studio.sanity.dev/test/releases/rIEqtiYbg       doesn't load ❌ 
https://test-studio-git-sapp-2450.sanity.dev/test/releases/rIEqtiYbg loads ✅ 



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is the batch good enough?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
