### PR TITLE
feat: add runtime functions cli group

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -59,6 +59,7 @@
     "@babel/traverse": "^7.23.5",
     "@sanity/client": "^6.28.2",
     "@sanity/codegen": "3.78.0",
+    "@sanity/runtime-cli": "^1.0.3",
     "@sanity/telemetry": "^0.7.7",
     "@sanity/template-validator": "^2.4.0",
     "@sanity/util": "3.78.0",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -59,7 +59,7 @@
     "@babel/traverse": "^7.23.5",
     "@sanity/client": "^6.28.2",
     "@sanity/codegen": "3.78.0",
-    "@sanity/runtime-cli": "^1.0.3",
+    "@sanity/runtime-cli": "^1.1.0",
     "@sanity/telemetry": "^0.7.7",
     "@sanity/template-validator": "^2.4.0",
     "@sanity/util": "3.78.0",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -59,7 +59,7 @@
     "@babel/traverse": "^7.23.5",
     "@sanity/client": "^6.28.2",
     "@sanity/codegen": "3.78.0",
-    "@sanity/runtime-cli": "^1.1.0",
+    "@sanity/runtime-cli": "^1.1.1",
     "@sanity/telemetry": "^0.7.7",
     "@sanity/template-validator": "^2.4.0",
     "@sanity/util": "3.78.0",

--- a/packages/@sanity/cli/src/commands/functions/devFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/devFunctionsCommand.ts
@@ -1,3 +1,6 @@
+import {devAction} from '@sanity/runtime-cli'
+import open from 'open'
+
 import {type CliCommandDefinition} from '../../types'
 
 const helpText = `
@@ -12,6 +15,10 @@ Examples
   sanity functions dev --port 3333
 `
 
+const defaultFlags = {
+  port: 8080,
+}
+
 const devFunctionsCommand: CliCommandDefinition = {
   name: 'dev',
   group: 'functions',
@@ -21,8 +28,12 @@ const devFunctionsCommand: CliCommandDefinition = {
   async action(args, context) {
     const {output} = context
     const {print} = output
+    const flags = {...defaultFlags, ...args.extOptions}
 
-    print(`Functions stuff`)
+    devAction(flags.port)
+
+    print(`Server is running on port ${flags.port}\n`)
+    open(`http://localhost:${flags.port}`)
   },
 }
 

--- a/packages/@sanity/cli/src/commands/functions/devFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/devFunctionsCommand.ts
@@ -1,4 +1,3 @@
-import {devAction} from '@sanity/runtime-cli'
 import open from 'open'
 
 import {type CliCommandDefinition} from '../../types'
@@ -29,6 +28,8 @@ const devFunctionsCommand: CliCommandDefinition = {
     const {output} = context
     const {print} = output
     const flags = {...defaultFlags, ...args.extOptions}
+
+    const {devAction} = await import('@sanity/runtime-cli')
 
     devAction(flags.port)
 

--- a/packages/@sanity/cli/src/commands/functions/devFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/devFunctionsCommand.ts
@@ -24,6 +24,7 @@ const devFunctionsCommand: CliCommandDefinition = {
   helpText,
   signature: '',
   description: 'Start the Sanity Function emulator',
+  hideFromHelp: true,
   async action(args, context) {
     const {output} = context
     const {print} = output

--- a/packages/@sanity/cli/src/commands/functions/devFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/devFunctionsCommand.ts
@@ -1,0 +1,29 @@
+import {type CliCommandDefinition} from '../../types'
+
+const helpText = `
+Options
+  --port <port> Port to start emulator on
+
+Examples
+  # Start dev server on default port
+  sanity functions dev
+
+  # Start dev server on specific port
+  sanity functions dev --port 3333
+`
+
+const devFunctionsCommand: CliCommandDefinition = {
+  name: 'dev',
+  group: 'functions',
+  helpText,
+  signature: '',
+  description: 'Start the Sanity Function emulator',
+  async action(args, context) {
+    const {output} = context
+    const {print} = output
+
+    print(`Functions stuff`)
+  },
+}
+
+export default devFunctionsCommand

--- a/packages/@sanity/cli/src/commands/functions/functionsGroup.ts
+++ b/packages/@sanity/cli/src/commands/functions/functionsGroup.ts
@@ -5,6 +5,7 @@ const functionsGroup: CliCommandGroupDefinition = {
   signature: '[COMMAND]',
   isGroupRoot: true,
   description: 'Test Sanity Functions locally and retrieve logs',
+  hideFromHelp: true,
 }
 
 export default functionsGroup

--- a/packages/@sanity/cli/src/commands/functions/functionsGroup.ts
+++ b/packages/@sanity/cli/src/commands/functions/functionsGroup.ts
@@ -1,0 +1,10 @@
+import {type CliCommandGroupDefinition} from '../../types'
+
+const functionsGroup: CliCommandGroupDefinition = {
+  name: 'functions',
+  signature: '[COMMAND]',
+  isGroupRoot: true,
+  description: 'Test Sanity Functions locally and retrieve logs',
+}
+
+export default functionsGroup

--- a/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
@@ -32,9 +32,13 @@ const logsFunctionsCommand: CliCommandDefinition = {
     })
 
     if (flags.id) {
-      const result = await logsAction(flags.id, client.config().token)
-
-      print(JSON.stringify(result, null, 2))
+      const token = client.config().token
+      if (token) {
+        const result = await logsAction(flags.id, token)
+        print(JSON.stringify(result, null, 2))
+      }
+    } else {
+      print('You must provide a function ID')
     }
   },
 }

--- a/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
@@ -1,3 +1,5 @@
+import {logsAction} from '@sanity/runtime-cli'
+
 import {type CliCommandDefinition} from '../../types'
 
 const helpText = `
@@ -9,6 +11,10 @@ Examples
   sanity functions logs --id abcd1234
 `
 
+const defaultFlags = {
+  id: undefined,
+}
+
 const logsFunctionsCommand: CliCommandDefinition = {
   name: 'logs',
   group: 'functions',
@@ -16,10 +22,20 @@ const logsFunctionsCommand: CliCommandDefinition = {
   signature: '',
   description: 'Retrieve logs for a Sanity Function',
   async action(args, context) {
-    const {output} = context
+    const {apiClient, output} = context
     const {print} = output
+    const flags = {...defaultFlags, ...args.extOptions}
 
-    print(`Functions stuff`)
+    const client = apiClient({
+      requireUser: true,
+      requireProject: false,
+    })
+
+    if (flags.id) {
+      const result = await logsAction(flags.id, client.config().token)
+
+      print(JSON.stringify(result, null, 2))
+    }
   },
 }
 

--- a/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
@@ -1,0 +1,26 @@
+import {type CliCommandDefinition} from '../../types'
+
+const helpText = `
+Options
+  --id <id> The ID of the function to retrieve logs for
+
+Examples
+  # Retrieve logs for Sanity Function abcd1234
+  sanity functions logs --id abcd1234
+`
+
+const logsFunctionsCommand: CliCommandDefinition = {
+  name: 'logs',
+  group: 'functions',
+  helpText,
+  signature: '',
+  description: 'Retrieve logs for a Sanity Function',
+  async action(args, context) {
+    const {output} = context
+    const {print} = output
+
+    print(`Functions stuff`)
+  },
+}
+
+export default logsFunctionsCommand

--- a/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
@@ -1,5 +1,3 @@
-import {logsAction} from '@sanity/runtime-cli'
-
 import {type CliCommandDefinition} from '../../types'
 
 const helpText = `
@@ -34,6 +32,7 @@ const logsFunctionsCommand: CliCommandDefinition = {
     if (flags.id) {
       const token = client.config().token
       if (token) {
+        const {logsAction} = await import('@sanity/runtime-cli')
         const result = await logsAction(flags.id, token)
         print(JSON.stringify(result, null, 2))
       }

--- a/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
@@ -19,6 +19,7 @@ const logsFunctionsCommand: CliCommandDefinition = {
   helpText,
   signature: '',
   description: 'Retrieve logs for a Sanity Function',
+  hideFromHelp: true,
   async action(args, context) {
     const {apiClient, output} = context
     const {print} = output

--- a/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
@@ -1,21 +1,31 @@
+import {testAction} from '@sanity/runtime-cli'
+
 import {type CliCommandDefinition} from '../../types'
 
 const helpText = `
 Options
   --data <data> Data to send to the function
   --file <file> Read data from file and send to the function
+  --path <path> Path to your Sanity Function code
   --timeout <timeout> Execution timeout value in seconds
 
 Examples
   # Test function passing event data on command line
-  sanity functions test ./test.ts --data '{ "id": 1 }'
+  sanity functions test --path ./test.ts --data '{ "id": 1 }'
 
   # Test function passing event data via a file
-  sanity functions test ./test.js --file 'payload.json'
+  sanity functions test -path ./test.js --file 'payload.json'
 
   # Test function passing event data on command line and cap execution time to 60 seconds
-  sanity functions test ./test.ts --data '{ "id": 1 }' --timeout 60
+  sanity functions test -path ./test.ts --data '{ "id": 1 }' --timeout 60
 `
+
+const defaultFlags = {
+  data: undefined,
+  file: undefined,
+  path: undefined,
+  timeout: 5, // seconds
+}
 
 const testFunctionsCommand: CliCommandDefinition = {
   name: 'test',
@@ -26,8 +36,26 @@ const testFunctionsCommand: CliCommandDefinition = {
   async action(args, context) {
     const {output} = context
     const {print} = output
+    const flags = {...defaultFlags, ...args.extOptions}
 
-    print(`Functions stuff`)
+    if (flags.path) {
+      const {json, logs, error} = await testAction(flags.path, {
+        data: flags.data,
+        file: flags.file,
+        timeout: flags.timeout,
+      })
+
+      if (error) {
+        print(error.toString())
+      } else {
+        print('Logs:')
+        print(logs)
+        print('Response:')
+        print(JSON.stringify(json, null, 2))
+      }
+    } else {
+      print('You must provide a path to the Sanity Function code')
+    }
   },
 }
 

--- a/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
@@ -1,0 +1,34 @@
+import {type CliCommandDefinition} from '../../types'
+
+const helpText = `
+Options
+  --data <data> Data to send to the function
+  --file <file> Read data from file and send to the function
+  --timeout <timeout> Execution timeout value in seconds
+
+Examples
+  # Test function passing event data on command line
+  sanity functions test ./test.ts --data '{ "id": 1 }'
+
+  # Test function passing event data via a file
+  sanity functions test ./test.js --file 'payload.json'
+
+  # Test function passing event data on command line and cap execution time to 60 seconds
+  sanity functions test ./test.ts --data '{ "id": 1 }' --timeout 60
+`
+
+const testFunctionsCommand: CliCommandDefinition = {
+  name: 'test',
+  group: 'functions',
+  helpText,
+  signature: '',
+  description: 'Invoke a local Sanity Function',
+  async action(args, context) {
+    const {output} = context
+    const {print} = output
+
+    print(`Functions stuff`)
+  },
+}
+
+export default testFunctionsCommand

--- a/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
@@ -1,5 +1,3 @@
-import {testAction} from '@sanity/runtime-cli'
-
 import {type CliCommandDefinition} from '../../types'
 
 const helpText = `
@@ -39,6 +37,7 @@ const testFunctionsCommand: CliCommandDefinition = {
     const flags = {...defaultFlags, ...args.extOptions}
 
     if (flags.path) {
+      const {testAction} = await import('@sanity/runtime-cli')
       const {json, logs, error} = await testAction(flags.path, {
         data: flags.data,
         file: flags.file,

--- a/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
@@ -31,6 +31,7 @@ const testFunctionsCommand: CliCommandDefinition = {
   helpText,
   signature: '',
   description: 'Invoke a local Sanity Function',
+  hideFromHelp: true,
   async action(args, context) {
     const {output} = context
     const {print} = output

--- a/packages/@sanity/cli/src/commands/index.ts
+++ b/packages/@sanity/cli/src/commands/index.ts
@@ -2,6 +2,10 @@ import {type CliCommandDefinition, type CliCommandGroupDefinition} from '../type
 import codemodCommand from './codemod/codemodCommand'
 import debugCommand from './debug/debugCommand'
 import docsCommand from './docs/docsCommand'
+import devfunctionsCommand from './functions/devFunctionsCommand'
+import functionsGroup from './functions/functionsGroup'
+import logsfunctionsCommand from './functions/logsFunctionsCommand'
+import testfunctionsCommand from './functions/testFunctionsCommand'
 import helpCommand from './help/helpCommand'
 import initCommand from './init/initCommand'
 import installCommand from './install/installCommand'
@@ -39,4 +43,8 @@ export const baseCommands: (CliCommandDefinition | CliCommandGroupDefinition)[] 
   telemetryStatusCommand,
   generateTypegenCommand,
   typegenGroup,
+  functionsGroup,
+  devfunctionsCommand,
+  logsfunctionsCommand,
+  testfunctionsCommand,
 ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -711,6 +711,9 @@ importers:
       '@sanity/codegen':
         specifier: 3.78.0
         version: link:../codegen
+      '@sanity/runtime-cli':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@sanity/telemetry':
         specifier: ^0.7.7
         version: 0.7.9(react@19.0.0)
@@ -4015,6 +4018,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oclif/core@4.2.8':
+    resolution: {integrity: sha512-OWv4Va6bERxIhrYcnUGzyhGRqktc64lJO6cZ3UwkzJDpfR8ZrbCxRfKRBBah1i8kzUlOAeAXnpbMBMah3skKwA==}
+    engines: {node: '>=18.0.0'}
+
+  '@oclif/plugin-help@6.2.26':
+    resolution: {integrity: sha512-5KdldxEizbV3RsHOddN4oMxrX/HL6z79S94tbxEHVZ/dJKDWzfyCpgC9axNYqwmBF2pFZkozl/l7t3hCGOdalw==}
+    engines: {node: '>=18.0.0'}
+
+  '@oclif/plugin-plugins@5.4.34':
+    resolution: {integrity: sha512-19sX+tHyR6M24GHbnedqqtk6w9QBgFZoa1y4zPmHf6VYaBeBmMBaq2dsLsdG0zv8LnWxaqguocICoxZTrV9f6A==}
+    engines: {node: '>=18.0.0'}
+
   '@octokit/auth-token@4.0.0':
     resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
     engines: {node: '>= 18'}
@@ -4661,6 +4676,11 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18.3 || >=19.0.0-rc
+
+  '@sanity/runtime-cli@1.1.0':
+    resolution: {integrity: sha512-idYE5tas37DqCerGqyLnlJpT98YXCDyWb8ot3koxZ1Dh8eWylG1TGQmytAjNtAerOuTARJDbuPrpDQWojUcOrQ==}
+    engines: {node: '>=20.11.0'}
+    hasBin: true
 
   '@sanity/telemetry@0.7.9':
     resolution: {integrity: sha512-TBBRK2SUwiNND+ZJPwdWSu8tbEjdIz7UjagmCCBBWcfXtDKXXlWawC/DOEWuI4Q+WcA5OWLDjboxZT4ApWjVbw==}
@@ -5561,6 +5581,10 @@ packages:
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
+
+  ansis@3.16.0:
+    resolution: {integrity: sha512-sU7d/tfZiYrsIAXbdL/CNZld5bCkruzwT5KmqmadCJYxuLxHAOBjidxD5+iLmN/6xEfjcQq1l7OpsiCBlc4LzA==}
+    engines: {node: '>=14'}
 
   anymatch@1.3.2:
     resolution: {integrity: sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==}
@@ -7569,6 +7593,10 @@ packages:
     resolution: {integrity: sha512-Q6IBWr/zzw57zIkJmNhI23eRTw3nZ4BWWK034meLwOYU9L3J3IpXiyM73u2pYUwN6U7ahkerCwg2T0jlxiLwsw==}
     engines: {node: '>=14.18'}
 
+  get-package-type@0.1.0:
+    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
+    engines: {node: '>=8.0.0'}
+
   get-pkg-repo@4.2.1:
     resolution: {integrity: sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==}
     engines: {node: '>=6.9.0'}
@@ -7878,6 +7906,10 @@ packages:
 
   hono@4.7.0:
     resolution: {integrity: sha512-hV97aIR4WYbG30k234sD9B3VNr1ZWdQRmrVF76LKFlmI7O9Yo70mG9+mFwyQ6Sjrz4wH71GfnBxv6CPjcx3QNw==}
+    engines: {node: '>=16.9.0'}
+
+  hono@4.7.2:
+    resolution: {integrity: sha512-8V5XxoOF6SI12jkHkzX/6aLBMU5GEF5g387EjVSQipS0DlxWgWGSMeEayY3CRBjtTUQYwLHx9JYouWqKzy2Vng==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
@@ -8668,6 +8700,10 @@ packages:
     resolution: {integrity: sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==}
     engines: {node: '>=10'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -9241,6 +9277,10 @@ packages:
     resolution: {integrity: sha512-IGN0IAwmhDJwy13Wc8k+4PEbTPhpJnMtfR53ZbOyjkvmEcLS4nCwp6mvMWjS5sUjeiW3mpx6cHmuhKEu9XmcQw==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  npm-package-arg@11.0.3:
+    resolution: {integrity: sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
   npm-packlist@8.0.2:
     resolution: {integrity: sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -9270,6 +9310,84 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
+
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  npm@10.9.2:
+    resolution: {integrity: sha512-iriPEPIkoMYUy3F6f3wwSZAU93E0Eg6cHwIR6jzzOXWSy+SD/rOODEs74cVONHKSx2obXtuUoyidVEhISrisgQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+    bundledDependencies:
+      - '@isaacs/string-locale-compare'
+      - '@npmcli/arborist'
+      - '@npmcli/config'
+      - '@npmcli/fs'
+      - '@npmcli/map-workspaces'
+      - '@npmcli/package-json'
+      - '@npmcli/promise-spawn'
+      - '@npmcli/redact'
+      - '@npmcli/run-script'
+      - '@sigstore/tuf'
+      - abbrev
+      - archy
+      - cacache
+      - chalk
+      - ci-info
+      - cli-columns
+      - fastest-levenshtein
+      - fs-minipass
+      - glob
+      - graceful-fs
+      - hosted-git-info
+      - ini
+      - init-package-json
+      - is-cidr
+      - json-parse-even-better-errors
+      - libnpmaccess
+      - libnpmdiff
+      - libnpmexec
+      - libnpmfund
+      - libnpmhook
+      - libnpmorg
+      - libnpmpack
+      - libnpmpublish
+      - libnpmsearch
+      - libnpmteam
+      - libnpmversion
+      - make-fetch-happen
+      - minimatch
+      - minipass
+      - minipass-pipeline
+      - ms
+      - node-gyp
+      - nopt
+      - normalize-package-data
+      - npm-audit-report
+      - npm-install-checks
+      - npm-package-arg
+      - npm-pick-manifest
+      - npm-profile
+      - npm-registry-fetch
+      - npm-user-validate
+      - p-map
+      - pacote
+      - parse-conflict-json
+      - proc-log
+      - qrcode-terminal
+      - read
+      - semver
+      - spdx-expression-parse
+      - ssri
+      - supports-color
+      - tar
+      - text-table
+      - tiny-relative-date
+      - treeverse
+      - validate-npm-package-name
+      - which
+      - write-file-atomic
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -9304,6 +9422,10 @@ packages:
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
+
+  object-treeify@4.0.1:
+    resolution: {integrity: sha512-Y6tg5rHfsefSkfKujv2SwHulInROy/rCL5F4w0QOWxut8AnxYxf0YmNhTh95Zfyxpsudo66uqkux0ACFnyMSgQ==}
+    engines: {node: '>= 16'}
 
   object-visit@1.0.1:
     resolution: {integrity: sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==}
@@ -9605,6 +9727,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -11909,6 +12035,10 @@ packages:
     resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==}
     engines: {node: '>=8'}
 
+  xdg-basedir@5.1.0:
+    resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
+    engines: {node: '>=12'}
+
   xhr@2.6.0:
     resolution: {integrity: sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==}
 
@@ -11978,6 +12108,11 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yarn@1.22.22:
+    resolution: {integrity: sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -13598,6 +13733,10 @@ snapshots:
     dependencies:
       hono: 4.7.0
 
+  '@hono/node-server@1.13.8(hono@4.7.2)':
+    dependencies:
+      hono: 4.7.2
+
   '@hookform/resolvers@3.10.0(react-hook-form@7.54.2(react@19.0.0))':
     dependencies:
       react-hook-form: 7.54.2(react@19.0.0)
@@ -14234,6 +14373,47 @@ snapshots:
 
   '@nx/nx-win32-x64-msvc@20.4.2':
     optional: true
+
+  '@oclif/core@4.2.8':
+    dependencies:
+      ansi-escapes: 4.3.2
+      ansis: 3.16.0
+      clean-stack: 3.0.1
+      cli-spinners: 2.9.2
+      debug: 4.4.0(supports-color@8.1.1)
+      ejs: 3.1.10
+      get-package-type: 0.1.0
+      globby: 11.1.0
+      indent-string: 4.0.0
+      is-wsl: 2.2.0
+      lilconfig: 3.1.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      string-width: 4.2.3
+      supports-color: 8.1.1
+      widest-line: 3.1.0
+      wordwrap: 1.0.0
+      wrap-ansi: 7.0.0
+
+  '@oclif/plugin-help@6.2.26':
+    dependencies:
+      '@oclif/core': 4.2.8
+
+  '@oclif/plugin-plugins@5.4.34':
+    dependencies:
+      '@oclif/core': 4.2.8
+      ansis: 3.16.0
+      debug: 4.4.0(supports-color@9.4.0)
+      npm: 10.9.2
+      npm-package-arg: 11.0.3
+      npm-run-path: 5.3.0
+      object-treeify: 4.0.1
+      semver: 7.7.1
+      validate-npm-package-name: 5.0.1
+      which: 4.0.0
+      yarn: 1.22.22
+    transitivePeerDependencies:
+      - supports-color
 
   '@octokit/auth-token@4.0.0': {}
 
@@ -15184,6 +15364,17 @@ snapshots:
     transitivePeerDependencies:
       - '@sanity/types'
       - debug
+
+  '@sanity/runtime-cli@1.1.0':
+    dependencies:
+      '@hono/node-server': 1.13.8(hono@4.7.2)
+      '@oclif/core': 4.2.8
+      '@oclif/plugin-help': 6.2.26
+      '@oclif/plugin-plugins': 5.4.34
+      hono: 4.7.2
+      xdg-basedir: 5.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@sanity/telemetry@0.7.9(react@18.3.1)':
     dependencies:
@@ -16427,6 +16618,8 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
+  ansis@3.16.0: {}
+
   anymatch@1.3.2:
     dependencies:
       micromatch: 2.3.11
@@ -17450,6 +17643,12 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 5.5.0
+
+  debug@4.4.0(supports-color@8.1.1):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   debug@4.4.0(supports-color@9.4.0):
     dependencies:
@@ -18918,6 +19117,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  get-package-type@0.1.0: {}
+
   get-pkg-repo@4.2.1:
     dependencies:
       '@hutson/parse-repository-url': 3.0.2
@@ -19284,6 +19485,8 @@ snapshots:
       parse-passwd: 1.0.0
 
   hono@4.7.0: {}
+
+  hono@4.7.2: {}
 
   hosted-git-info@2.8.9: {}
 
@@ -20161,6 +20364,8 @@ snapshots:
 
   lilconfig@2.0.5: {}
 
+  lilconfig@3.1.3: {}
+
   lines-and-columns@1.2.4: {}
 
   lines-and-columns@2.0.3: {}
@@ -20781,6 +20986,13 @@ snapshots:
       semver: 7.7.1
       validate-npm-package-name: 5.0.1
 
+  npm-package-arg@11.0.3:
+    dependencies:
+      hosted-git-info: 7.0.2
+      proc-log: 4.2.0
+      semver: 7.7.1
+      validate-npm-package-name: 5.0.1
+
   npm-packlist@8.0.2:
     dependencies:
       ignore-walk: 6.0.5
@@ -20835,6 +21047,12 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
+
+  npm@10.9.2: {}
 
   nth-check@2.1.1:
     dependencies:
@@ -20905,6 +21123,8 @@ snapshots:
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
+
+  object-treeify@4.0.1: {}
 
   object-visit@1.0.1:
     dependencies:
@@ -21256,6 +21476,8 @@ snapshots:
   path-key@2.0.1: {}
 
   path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -23975,6 +24197,8 @@ snapshots:
 
   xdg-basedir@4.0.0: {}
 
+  xdg-basedir@5.1.0: {}
+
   xhr@2.6.0:
     dependencies:
       global: 4.4.0
@@ -24041,6 +24265,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yarn@1.22.22: {}
 
   yauzl@2.10.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -712,8 +712,8 @@ importers:
         specifier: 3.78.0
         version: link:../codegen
       '@sanity/runtime-cli':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.1.1
+        version: 1.1.1
       '@sanity/telemetry':
         specifier: ^0.7.7
         version: 0.7.9(react@19.0.0)
@@ -4677,8 +4677,8 @@ packages:
     peerDependencies:
       react: ^18.3 || >=19.0.0-rc
 
-  '@sanity/runtime-cli@1.1.0':
-    resolution: {integrity: sha512-idYE5tas37DqCerGqyLnlJpT98YXCDyWb8ot3koxZ1Dh8eWylG1TGQmytAjNtAerOuTARJDbuPrpDQWojUcOrQ==}
+  '@sanity/runtime-cli@1.1.1':
+    resolution: {integrity: sha512-8iScG1ZFz/hAIa4yRJmSleUsCj+Ej8GSNKL6xXJnAQFMhw7RWlKO0GQq3fkiCVbmqELSG76v7CH9uHNZ9nu+DQ==}
     engines: {node: '>=20.11.0'}
     hasBin: true
 
@@ -15365,7 +15365,7 @@ snapshots:
       - '@sanity/types'
       - debug
 
-  '@sanity/runtime-cli@1.1.0':
+  '@sanity/runtime-cli@1.1.1':
     dependencies:
       '@hono/node-server': 1.13.8(hono@4.7.2)
       '@oclif/core': 4.2.8


### PR DESCRIPTION
### Description

This PR introduces a new CLI command group `functions`. The group includes three commands `dev`, `logs` and `test`.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Testing for these code changes lives in `@sanity/runtime-cli` where the non-trivial code lives.

### Notes for release

Part of feature Sanity Functions

#### Docs

##### sanity functions dev

Start the Sanity Function emulator

```
Options
  --port <port> Port to start emulator on

Examples
  # Start dev server on default port
  sanity functions dev

  # Start dev server on specific port
  sanity functions dev --port 3333
```

#####  sanity functions logs

Retrieve logs for a Sanity Function

```
Options
  --id <id> The ID of the function to retrieve logs for

Examples
  # Retrieve logs for Sanity Function abcd1234
  sanity functions logs --id abcd1234
```

##### sanity functions test

Invoke a local Sanity Function

```
Options
  --data <data> Data to send to the function
  --file <file> Read data from file and send to the function
  --path <path> Path to your Sanity Function code
  --timeout <timeout> Execution timeout value in seconds

Examples
  # Test function passing event data on command line
  sanity functions test --path ./test.ts --data '{ "id": 1 }'

  # Test function passing event data via a file
  sanity functions test -path ./test.js --file 'payload.json'

  # Test function passing event data on command line and cap execution time to 60 seconds
  sanity functions test -path ./test.ts --data '{ "id": 1 }' --timeout 60
```
