### PR TITLE
fix: prevent over-fetching in free trial provider

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
@@ -42,24 +42,21 @@ export const FreeTrialProvider = ({children}: FreeTrialProviderProps) => {
     }
   }, [showDialog, data, showOnLoad, telemetry])
 
-  // This is casted to a string to make it stable across renders so it doesn't trigger multiple times the effect.
-  const searchParamsAsString = new URLSearchParams(router.state._searchParams).toString()
+  // See if we have any parameters from the current route
+  // to pass onto our query
+  const searchParams = new URLSearchParams(router.state._searchParams)
+  // Allows us to override the current state of the trial to
+  // get back certain modals based on the current experience
+  // can be 'growth-trial', 'growth-trial-ending', or 'post-growth-trial'
+  const trialState = searchParams.get('trialState')
+  // Allows us to set whether we've seen the modals before
+  // or whether this is our first time seeing them (i.e. show a popup)
+  const seenBefore = searchParams.get('seenBefore')
 
   useEffect(() => {
-    // See if we have any parameters from the current route
-    // to pass onto our query
-    const searchParams = new URLSearchParams(searchParamsAsString)
-
     const queryParams = new URLSearchParams()
     queryParams.append('studioVersion', SANITY_VERSION)
-    // Allows us to override the current state of the trial to
-    // get back certain modals based on the current experience
-    // can be 'growth-trial', 'growth-trial-ending', or 'post-growth-trial'
-    const trialState = searchParams.get('trialState')
     if (trialState) queryParams.append('trialState', trialState)
-    // Allows us to set whether we've seen the modals before
-    // or whether this is our first time seeing them (i.e. show a popup)
-    const seenBefore = searchParams.get('seenBefore')
     if (seenBefore) queryParams.append('seenBefore', seenBefore)
     // If we have trialState, query the override endpoint so that we
     // get back trial modals for that state
@@ -84,7 +81,7 @@ export const FreeTrialProvider = ({children}: FreeTrialProviderProps) => {
     return () => {
       request.unsubscribe()
     }
-  }, [client, searchParamsAsString])
+  }, [client, seenBefore, trialState])
 
   const toggleShowContent = useCallback(
     (closeAndReOpen = false) => {

--- a/packages/sanity/src/core/tasks/context/navigation/TasksNavigationProvider.tsx
+++ b/packages/sanity/src/core/tasks/context/navigation/TasksNavigationProvider.tsx
@@ -135,26 +135,22 @@ export const TasksNavigationProvider = ({children}: {children: ReactNode}) => {
       })
   }, [state.selectedTask, state.viewMode, telemetry, toast])
 
-  // This is casted to a string to make it stable across renders so it doesn't trigger multiple times the effect.
-  const searchParamsAsString = new URLSearchParams(router.state._searchParams).toString()
+  const searchParams = new URLSearchParams(router.state._searchParams)
+  const sidebar = searchParams.get('sidebar')
+  const viewMode = searchParams.get('viewMode')
+  const selectedTask = searchParams.get('selectedTask')
+
   useEffect(() => {
     // listen to the URL to open the tasks view if the sidebar is set to task.
-    if (searchParamsAsString) {
-      const searchParams = new URLSearchParams(searchParamsAsString)
-
-      const sidebar = searchParams.get('sidebar')
-      if (sidebar !== 'tasks') {
-        return
-      }
-      dispatch({type: 'TOGGLE_TASKS_VIEW', payload: true})
-      const viewMode = searchParams.get('viewMode')
-      const selectedTask = searchParams.get('selectedTask')
-      if (viewMode === 'edit' && selectedTask) {
-        dispatch({type: 'EDIT_TASK', payload: {id: selectedTask}})
-        telemetry.log(TaskLinkOpened)
-      }
+    if (sidebar !== 'tasks') {
+      return
     }
-  }, [searchParamsAsString, telemetry])
+    dispatch({type: 'TOGGLE_TASKS_VIEW', payload: true})
+    if (viewMode === 'edit' && selectedTask) {
+      dispatch({type: 'EDIT_TASK', payload: {id: selectedTask}})
+      telemetry.log(TaskLinkOpened)
+    }
+  }, [selectedTask, sidebar, telemetry, viewMode])
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
### Description

The way the `router.state._searchParams` is parsed and handed to `useEffect` are leading to `useEffect` over-firing.
In the case of `FreeTrialProvider`, it's causing it to perform a network call that's only supposed to happen on mount, on every search param change. In Presentation Tool this means that every time you toggle the viewport size it performs a fetch:


https://github.com/user-attachments/assets/a19e5077-48b2-415d-9343-a9713202230a

The reason this happens is the underlying `useEffect` is reacting to _any_ change to `router.state._searchParams`. The fix is to extract the search params the `useEffect` is interested in, so it only reacts to those params changing ✨ 


### What to review

Are there enough context in the comments to explain the pattern used, that isn't resulting in over-fetching?

### Testing

The repro shown in the video can be manually verified [here](https://test-studio-1lwkadbjr.sanity.dev/presentation/presentation) (this link is better than using https://test-studio.sanity.dev, as it points to an immutable deployment that will keep demonstrating the repro, while https://test-studio.sanity.dev will deploy with the fix once this PR merges).

### Notes for release

A issue in how router state search params were handled lead to the Studio checking for your free trial state _every time you changed the viewport size in the Presentation Tool preview_. That doesn't make any sense! Nobody likes unnecessary network requests 😮‍💨 We've tightened the nuts and bolts necessary so the check is only performed _once_, on load 🤌
