### PR TITLE
feat(core): allow configuring PTE plugins

### DIFF
--- a/dev/test-studio/plugins/input/auto-close-brackets-plugin.tsx
+++ b/dev/test-studio/plugins/input/auto-close-brackets-plugin.tsx
@@ -1,0 +1,109 @@
+/* eslint-disable no-negated-condition */
+import {useEditor} from '@portabletext/editor'
+import {defineBehavior, execute} from '@portabletext/editor/behaviors'
+import {useEffect} from 'react'
+import {definePlugin, isArrayOfBlocksSchemaType} from 'sanity'
+
+/**
+ * This Studio Plugin shows how to:
+ *
+ * 1. Define a standalone and portable Behavior using `defineBehavior`
+ * 2. Register the Behavior using `editor.registerBehavior` inside a PTE React Plugin
+ * 3. Render the Plugin inside Studio using `renderPlugins`
+ */
+
+/**
+ * This Behavior will auto-close brackets when the user inserts an opening
+ * bracket. It will also move the cursor in between the brackets so the user
+ * can start typing immediately.
+ */
+const autoCloseBracketsBehavior = defineBehavior({
+  on: 'insert.text',
+  guard: ({event}) => {
+    const bracketPairs: Record<string, string | undefined> = {
+      '(': ')',
+      '[': ']',
+      '{': '}',
+    }
+    const lastInsertedChar = event.text.at(-1)
+    const closingBracket =
+      lastInsertedChar !== undefined ? bracketPairs[lastInsertedChar] : undefined
+
+    if (closingBracket !== undefined) {
+      // Passing the closing bracket to the actions for reuse
+      return {closingBracket}
+    }
+
+    return false
+  },
+  actions: [
+    ({event}) => [
+      // Execute the original event that includes the opening bracket
+      execute(event),
+    ],
+    /*
+     * New undo step so the auto-closing of the bracket can be undone.
+     * Notice how the step reuses the `closingBracket` derived in the `guard`.
+     */
+    (_, {closingBracket}) => [
+      // Execute a new `insert.text` event with a closing bracket
+      execute({
+        type: 'insert.text',
+        text: closingBracket,
+      }),
+      // Execute a `move.backward` event to move the cursor in between the brackets
+      execute({
+        type: 'move.backward',
+        distance: closingBracket.length,
+      }),
+    ],
+  ],
+})
+
+/**
+ * This PTE Plugin will register the auto-close brackets Behavior inside PTE.
+ */
+function AutoCloseBracketsBehaviorPlugin() {
+  const editor = useEditor()
+
+  useEffect(() => {
+    const unregisterBehavior = editor.registerBehavior({
+      behavior: autoCloseBracketsBehavior,
+    })
+
+    return () => {
+      unregisterBehavior()
+    }
+  }, [editor])
+
+  return null
+}
+
+/**
+ * This Studio Plugin will add the auto-close brackets Behavior to all PTE
+ * inputs inside Studio.
+ */
+export const autoCloseBrackets = definePlugin({
+  name: 'auto-close brackets',
+  form: {
+    components: {
+      input: (props) => {
+        if (!isArrayOfBlocksSchemaType(props.schemaType)) {
+          return props.renderDefault(props)
+        }
+
+        return props.renderDefault({
+          ...props,
+          renderPlugins: (pluginProps) => {
+            return (
+              <>
+                {pluginProps.renderDefault(pluginProps)}
+                <AutoCloseBracketsBehaviorPlugin />
+              </>
+            )
+          },
+        })
+      },
+    },
+  },
+})

--- a/dev/test-studio/plugins/input/auto-close-brackets-plugin.tsx
+++ b/dev/test-studio/plugins/input/auto-close-brackets-plugin.tsx
@@ -2,8 +2,7 @@
 import {useEditor} from '@portabletext/editor'
 import {defineBehavior, execute} from '@portabletext/editor/behaviors'
 import {useEffect} from 'react'
-import {definePlugin, isArrayOfBlocksSchemaType} from 'sanity'
-
+import {definePlugin} from 'sanity'
 /**
  * This Studio Plugin shows how to:
  *
@@ -87,22 +86,15 @@ export const autoCloseBrackets = definePlugin({
   name: 'auto-close brackets',
   form: {
     components: {
-      input: (props) => {
-        if (!isArrayOfBlocksSchemaType(props.schemaType)) {
-          return props.renderDefault(props)
-        }
-
-        return props.renderDefault({
-          ...props,
-          renderPlugins: (pluginProps) => {
-            return (
-              <>
-                {pluginProps.renderDefault(pluginProps)}
-                <AutoCloseBracketsBehaviorPlugin />
-              </>
-            )
-          },
-        })
+      pte: {
+        plugins: (props) => {
+          return (
+            <>
+              {props.renderDefault(props)}
+              <AutoCloseBracketsBehaviorPlugin />
+            </>
+          )
+        },
       },
     },
   },

--- a/dev/test-studio/plugins/input/auto-close-brackets-plugin.tsx
+++ b/dev/test-studio/plugins/input/auto-close-brackets-plugin.tsx
@@ -86,7 +86,7 @@ export const autoCloseBrackets = definePlugin({
   name: 'auto-close brackets',
   form: {
     components: {
-      pte: {
+      portableText: {
         plugins: (props) => {
           return (
             <>

--- a/dev/test-studio/plugins/input/wave-plugin.tsx
+++ b/dev/test-studio/plugins/input/wave-plugin.tsx
@@ -2,7 +2,7 @@
 import {useEditor} from '@portabletext/editor'
 import {defineBehavior, execute} from '@portabletext/editor/behaviors'
 import {useEffect} from 'react'
-import {definePlugin, isArrayOfBlocksSchemaType} from 'sanity'
+import {definePlugin} from 'sanity'
 
 /**
  * This Studio Plugin shows how to:
@@ -62,22 +62,15 @@ export const wave = definePlugin({
   name: 'wave',
   form: {
     components: {
-      input: (props) => {
-        if (!isArrayOfBlocksSchemaType(props.schemaType)) {
-          return props.renderDefault(props)
-        }
-
-        return props.renderDefault({
-          ...props,
-          renderPlugins: (pluginProps) => {
-            return (
-              <>
-                {pluginProps.renderDefault(pluginProps)}
-                <WaveBehaviorPlugin />
-              </>
-            )
-          },
-        })
+      pte: {
+        plugins: (props) => {
+          return (
+            <>
+              {props.renderDefault(props)}
+              <WaveBehaviorPlugin />
+            </>
+          )
+        },
       },
     },
   },

--- a/dev/test-studio/plugins/input/wave-plugin.tsx
+++ b/dev/test-studio/plugins/input/wave-plugin.tsx
@@ -1,0 +1,84 @@
+/* eslint-disable no-negated-condition */
+import {useEditor} from '@portabletext/editor'
+import {defineBehavior, execute} from '@portabletext/editor/behaviors'
+import {useEffect} from 'react'
+import {definePlugin, isArrayOfBlocksSchemaType} from 'sanity'
+
+/**
+ * This Studio Plugin shows how to:
+ *
+ * 1. Define a standalone and portable Behavior using `defineBehavior`
+ * 2. Register the Behavior using `editor.registerBehavior` inside a PTE React Plugin
+ * 3. Render the Plugin inside Studio using `renderPlugins`
+ */
+
+/**
+ * This Behavior will replace '👋' with 'Hello, world!' when the user inserts
+ * '👋'.
+ */
+const waveBehavior = defineBehavior({
+  on: 'insert.text',
+  guard: ({event}) => event.text === '👋',
+  actions: [
+    ({event}) => [
+      // Execute the original event that inserts '👋'
+      execute(event),
+    ],
+    /* Replace the '👋' with 'Hello, world!' in a separate undo step so the
+     * Behavior can be undone.
+     */
+    () => [
+      // Delete the '👋'
+      execute({type: 'delete.backward', unit: 'character'}),
+      // And insert 'Hello, world!'
+      execute({type: 'insert.text', text: 'Hello, world!'}),
+    ],
+  ],
+})
+
+/**
+ * This PTE Plugin will register the wave Behavior inside PTE.
+ */
+function WaveBehaviorPlugin() {
+  const editor = useEditor()
+
+  useEffect(() => {
+    const unregisterBehavior = editor.registerBehavior({
+      behavior: waveBehavior,
+    })
+
+    return () => {
+      unregisterBehavior()
+    }
+  }, [editor])
+
+  return null
+}
+
+/**
+ * This Studio Plugin will add the wave Behavior to all PTE inputs inside Studio.
+ */
+export const wave = definePlugin({
+  name: 'wave',
+  form: {
+    components: {
+      input: (props) => {
+        if (!isArrayOfBlocksSchemaType(props.schemaType)) {
+          return props.renderDefault(props)
+        }
+
+        return props.renderDefault({
+          ...props,
+          renderPlugins: (pluginProps) => {
+            return (
+              <>
+                {pluginProps.renderDefault(pluginProps)}
+                <WaveBehaviorPlugin />
+              </>
+            )
+          },
+        })
+      },
+    },
+  },
+})

--- a/dev/test-studio/plugins/input/wave-plugin.tsx
+++ b/dev/test-studio/plugins/input/wave-plugin.tsx
@@ -62,7 +62,7 @@ export const wave = definePlugin({
   name: 'wave',
   form: {
     components: {
-      pte: {
+      portableText: {
         plugins: (props) => {
           return (
             <>

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -45,6 +45,8 @@ import {resolveInitialValueTemplates} from './initialValueTemplates'
 import {customInspector} from './inspectors/custom'
 import {testStudioLocaleBundles} from './locales'
 import {errorReportingTestPlugin} from './plugins/error-reporting-test'
+import {autoCloseBrackets} from './plugins/input/auto-close-brackets-plugin'
+import {wave} from './plugins/input/wave-plugin'
 import {languageFilter} from './plugins/language-filter'
 import {routerDebugTool} from './plugins/router-debug'
 import {theme as tailwindTheme} from './sanity.theme.mjs'
@@ -189,6 +191,8 @@ const sharedSettings = ({projectId}: {projectId: string}) => {
       tsdoc(),
       media(),
       markdownSchema(),
+      wave(),
+      autoCloseBrackets(),
     ],
   })()
 }

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -106,6 +106,7 @@ import {ptAllTheBellsAndWhistlesType} from './standard/portableText/allTheBellsA
 import blocks from './standard/portableText/blocks'
 import {ptCustomBlockEditors} from './standard/portableText/customBlockEditors'
 import {ptCustomMarkersTestType} from './standard/portableText/customMarkers'
+import {customPlugins} from './standard/portableText/customPlugins'
 import manyEditors from './standard/portableText/manyEditors'
 import richTextObject from './standard/portableText/richTextObject'
 import simpleBlock from './standard/portableText/simpleBlock'
@@ -173,6 +174,7 @@ export function createSchemaTypes(projectId: string) {
     ptCustomMarkersTestType,
     richTextObject,
     ...Object.values(scrollBugTypes),
+    customPlugins,
     simpleBlock,
     manyEditors,
     simpleBlockNote,

--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -1,0 +1,246 @@
+/* eslint-disable react/jsx-no-bind */
+import {defineBehavior, effect, forward} from '@portabletext/editor/behaviors'
+import {BehaviorPlugin, DecoratorShortcutPlugin, OneLinePlugin} from '@portabletext/editor/plugins'
+import {defineType, type PortableTextInputProps} from 'sanity'
+
+export const customPlugins = defineType({
+  name: 'customPlugins',
+  title: 'Custom Plugins',
+  type: 'document',
+  fields: [
+    {
+      type: 'string',
+      name: 'title',
+    },
+
+    /**
+     * One-Line Editor
+     *
+     * Uses the `OneLinePlugin` to restrict the editor to one line of text.
+     */
+    {
+      type: 'array',
+      name: 'oneLineEditor',
+      title: 'One-Line Editor',
+      description: 'The editor is restricted to one line of text using the <OneLinePlugin />',
+      of: [
+        {
+          type: 'block',
+        },
+      ],
+      components: {
+        input: (props: PortableTextInputProps) => {
+          return props.renderDefault({
+            ...props,
+            renderPlugins: (pluginProps) => {
+              return (
+                <>
+                  {pluginProps.renderDefault(pluginProps)}
+                  <OneLinePlugin />
+                </>
+              )
+            },
+          })
+        },
+      },
+    },
+
+    /**
+     * Custom Markdown Config
+     *
+     * Uses `renderMarkdownPlugin` to reconfigure the `MarkdownPlugin`.
+     */
+    {
+      type: 'array',
+      name: 'customMarkdownConfig',
+      title: 'Custom Markdown Config',
+      description:
+        'Only a "bold" decorator is allowed and the <MarkdownPlugin /> has been reconfigured to support this',
+      of: [
+        {
+          type: 'block',
+          marks: {
+            decorators: [
+              {
+                value: 'bold',
+                title: 'Bold',
+                component: ({children}) => <strong>{children}</strong>,
+              },
+            ],
+          },
+        },
+      ],
+      components: {
+        input: (props: PortableTextInputProps) => {
+          return props.renderDefault({
+            ...props,
+            renderPlugins: (pluginProps) => (
+              <>
+                {pluginProps.renderDefault({
+                  ...pluginProps,
+                  renderMarkdownPlugin: (markdownPluginProps) => {
+                    return markdownPluginProps.renderDefault({
+                      config: {
+                        ...markdownPluginProps.config,
+                        boldDecorator: ({schema}) =>
+                          schema.decorators.find((decorator) => decorator.value === 'bold')?.value,
+                      },
+                    })
+                  },
+                })}
+              </>
+            ),
+          })
+        },
+      },
+    },
+
+    /**
+     * Custom Decorator Shortcuts
+     *
+     * Uses the `DecoratorShortcutPlugin` add custom decorator shortcuts in the
+     * editor.
+     */
+    {
+      type: 'array',
+      name: 'customDecoratorShortcuts',
+      title: 'Custom Decorator Shortcuts',
+      description: 'The markdown shortcuts for bold and italic have been replaced with 👻 and 🕹️',
+      of: [
+        {
+          type: 'block',
+        },
+      ],
+      components: {
+        input: (props: PortableTextInputProps) => {
+          return props.renderDefault({
+            ...props,
+            renderPlugins: (pluginProps) => (
+              <>
+                <DecoratorShortcutPlugin
+                  decorator={({schema}) =>
+                    schema.decorators.find((decorator) => decorator.name === 'strong')?.name
+                  }
+                  pair={{
+                    char: '👻',
+                    amount: 2,
+                  }}
+                />
+                <DecoratorShortcutPlugin
+                  decorator={({schema}) =>
+                    schema.decorators.find((decorator) => decorator.name === 'strong')?.name
+                  }
+                  pair={{
+                    char: '🕹️',
+                    amount: 2,
+                  }}
+                />
+                <DecoratorShortcutPlugin
+                  decorator={({schema}) =>
+                    schema.decorators.find((decorator) => decorator.name === 'em')?.name
+                  }
+                  pair={{
+                    char: '👻',
+                    amount: 1,
+                  }}
+                />
+                <DecoratorShortcutPlugin
+                  decorator={({schema}) =>
+                    schema.decorators.find((decorator) => decorator.name === 'em')?.name
+                  }
+                  pair={{
+                    char: '🕹️',
+                    amount: 1,
+                  }}
+                />
+                {pluginProps.renderDefault({
+                  ...pluginProps,
+                  renderMarkdownPlugin: (markdownPluginProps) => {
+                    return markdownPluginProps.renderDefault({
+                      config: {
+                        ...markdownPluginProps.config,
+                        boldDecorator: undefined,
+                        italicDecorator: undefined,
+                      },
+                    })
+                  },
+                })}
+              </>
+            ),
+          })
+        },
+      },
+    },
+
+    /**
+     * No Plugins
+     *
+     * Removes all plugins from the editor.
+     */
+    {
+      type: 'array',
+      name: 'noPlugins',
+      title: 'No Plugins',
+      description: 'All plugins are removed, even the default ones',
+      of: [
+        {
+          type: 'block',
+        },
+      ],
+      components: {
+        input: (props: PortableTextInputProps) => {
+          return props.renderDefault({
+            ...props,
+            renderPlugins: () => <></>,
+          })
+        },
+      },
+    },
+
+    /**
+     * Custom Behavior
+     *
+     * Uses the `BehaviorPlugin` to add a custom behavior to the editor
+     * without much boilerplate.
+     */
+    {
+      type: 'array',
+      name: 'customBehavior',
+      title: 'Custom Behavior',
+      description: 'Custom "log text insertions" Behavior using the <BehaviorPlugin />',
+      of: [
+        {
+          type: 'block',
+        },
+      ],
+      components: {
+        input: (props: PortableTextInputProps) => {
+          return props.renderDefault({
+            ...props,
+            renderPlugins: (pluginProps) => (
+              <>
+                <BehaviorPlugin
+                  behaviors={[
+                    defineBehavior({
+                      on: 'insert.text',
+                      actions: [
+                        ({event}) => [
+                          effect(() => {
+                            // eslint-disable-next-line no-console
+                            console.log(event)
+                          }),
+                          forward(event),
+                        ],
+                      ],
+                    }),
+                  ]}
+                />
+                {pluginProps.renderDefault(pluginProps)}
+              </>
+            ),
+          })
+        },
+      },
+    },
+  ],
+})

--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-no-bind */
 import {defineBehavior, effect, forward} from '@portabletext/editor/behaviors'
 import {BehaviorPlugin, DecoratorShortcutPlugin, OneLinePlugin} from '@portabletext/editor/plugins'
-import {defineType, type PortableTextInputProps} from 'sanity'
+import {defineType} from 'sanity'
 
 export const customPlugins = defineType({
   name: 'customPlugins',
@@ -29,18 +29,15 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        input: (props: PortableTextInputProps) => {
-          return props.renderDefault({
-            ...props,
-            renderPlugins: (pluginProps) => {
-              return (
-                <>
-                  {pluginProps.renderDefault(pluginProps)}
-                  <OneLinePlugin />
-                </>
-              )
-            },
-          })
+        pte: {
+          plugins: (props) => {
+            return (
+              <>
+                {props.renderDefault(props)}
+                <OneLinePlugin />
+              </>
+            )
+          },
         },
       },
     },
@@ -71,26 +68,18 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        input: (props: PortableTextInputProps) => {
-          return props.renderDefault({
-            ...props,
-            renderPlugins: (pluginProps) => (
-              <>
-                {pluginProps.renderDefault({
-                  ...pluginProps,
-                  renderMarkdownPlugin: (markdownPluginProps) => {
-                    return markdownPluginProps.renderDefault({
-                      config: {
-                        ...markdownPluginProps.config,
-                        boldDecorator: ({schema}) =>
-                          schema.decorators.find((decorator) => decorator.value === 'bold')?.value,
-                      },
-                    })
-                  },
-                })}
-              </>
-            ),
-          })
+        pte: {
+          plugins: (props) => {
+            return props.renderDefault({
+              ...props,
+              markdownPluginProps: {
+                config: {
+                  boldDecorator: ({schema}) =>
+                    schema.decorators.find((decorator) => decorator.value === 'bold')?.value,
+                },
+              },
+            })
+          },
         },
       },
     },
@@ -112,62 +101,59 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        input: (props: PortableTextInputProps) => {
-          return props.renderDefault({
-            ...props,
-            renderPlugins: (pluginProps) => (
+        pte: {
+          plugins: (props) => {
+            return (
               <>
-                <DecoratorShortcutPlugin
-                  decorator={({schema}) =>
-                    schema.decorators.find((decorator) => decorator.name === 'strong')?.name
-                  }
-                  pair={{
-                    char: '👻',
-                    amount: 2,
-                  }}
-                />
-                <DecoratorShortcutPlugin
-                  decorator={({schema}) =>
-                    schema.decorators.find((decorator) => decorator.name === 'strong')?.name
-                  }
-                  pair={{
-                    char: '🕹️',
-                    amount: 2,
-                  }}
-                />
-                <DecoratorShortcutPlugin
-                  decorator={({schema}) =>
-                    schema.decorators.find((decorator) => decorator.name === 'em')?.name
-                  }
-                  pair={{
-                    char: '👻',
-                    amount: 1,
-                  }}
-                />
-                <DecoratorShortcutPlugin
-                  decorator={({schema}) =>
-                    schema.decorators.find((decorator) => decorator.name === 'em')?.name
-                  }
-                  pair={{
-                    char: '🕹️',
-                    amount: 1,
-                  }}
-                />
-                {pluginProps.renderDefault({
-                  ...pluginProps,
-                  renderMarkdownPlugin: (markdownPluginProps) => {
-                    return markdownPluginProps.renderDefault({
-                      config: {
-                        ...markdownPluginProps.config,
-                        boldDecorator: undefined,
-                        italicDecorator: undefined,
-                      },
-                    })
+                {props.renderDefault({
+                  ...props,
+                  markdownPluginProps: {
+                    config: {
+                      ...props.markdownPluginProps.config,
+                      boldDecorator: undefined,
+                      italicDecorator: undefined,
+                    },
                   },
                 })}
+                <DecoratorShortcutPlugin
+                  decorator={({schema}) =>
+                    schema.decorators.find((decorator) => decorator.name === 'strong')?.name
+                  }
+                  pair={{
+                    char: '👻',
+                    amount: 2,
+                  }}
+                />
+                <DecoratorShortcutPlugin
+                  decorator={({schema}) =>
+                    schema.decorators.find((decorator) => decorator.name === 'strong')?.name
+                  }
+                  pair={{
+                    char: '🕹️',
+                    amount: 2,
+                  }}
+                />
+                <DecoratorShortcutPlugin
+                  decorator={({schema}) =>
+                    schema.decorators.find((decorator) => decorator.name === 'em')?.name
+                  }
+                  pair={{
+                    char: '👻',
+                    amount: 1,
+                  }}
+                />
+                <DecoratorShortcutPlugin
+                  decorator={({schema}) =>
+                    schema.decorators.find((decorator) => decorator.name === 'em')?.name
+                  }
+                  pair={{
+                    char: '🕹️',
+                    amount: 1,
+                  }}
+                />
               </>
-            ),
-          })
+            )
+          },
         },
       },
     },
@@ -188,11 +174,10 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        input: (props: PortableTextInputProps) => {
-          return props.renderDefault({
-            ...props,
-            renderPlugins: () => <></>,
-          })
+        pte: {
+          plugins: (props) => {
+            return null
+          },
         },
       },
     },
@@ -214,11 +199,11 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        input: (props: PortableTextInputProps) => {
-          return props.renderDefault({
-            ...props,
-            renderPlugins: (pluginProps) => (
+        pte: {
+          plugins: (props) => {
+            return (
               <>
+                {props.renderDefault(props)}
                 <BehaviorPlugin
                   behaviors={[
                     defineBehavior({
@@ -235,10 +220,9 @@ export const customPlugins = defineType({
                     }),
                   ]}
                 />
-                {pluginProps.renderDefault(pluginProps)}
               </>
-            ),
-          })
+            )
+          },
         },
       },
     },

--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -29,7 +29,7 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        pte: {
+        portableText: {
           plugins: (props) => {
             return (
               <>
@@ -68,7 +68,7 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        pte: {
+        portableText: {
           plugins: (props) => {
             return props.renderDefault({
               ...props,
@@ -101,7 +101,7 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        pte: {
+        portableText: {
           plugins: (props) => {
             return (
               <>
@@ -174,7 +174,7 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        pte: {
+        portableText: {
           plugins: (props) => {
             return null
           },
@@ -199,7 +199,7 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        pte: {
+        portableText: {
           plugins: (props) => {
             return (
               <>

--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -72,10 +72,12 @@ export const customPlugins = defineType({
           plugins: (props) => {
             return props.renderDefault({
               ...props,
-              markdownPluginProps: {
-                config: {
-                  boldDecorator: ({schema}) =>
-                    schema.decorators.find((decorator) => decorator.value === 'bold')?.value,
+              plugins: {
+                markdown: {
+                  config: {
+                    boldDecorator: ({schema}) =>
+                      schema.decorators.find((decorator) => decorator.value === 'bold')?.value,
+                  },
                 },
               },
             })
@@ -107,11 +109,13 @@ export const customPlugins = defineType({
               <>
                 {props.renderDefault({
                   ...props,
-                  markdownPluginProps: {
-                    config: {
-                      ...props.markdownPluginProps.config,
-                      boldDecorator: undefined,
-                      italicDecorator: undefined,
+                  plugins: {
+                    markdown: {
+                      config: {
+                        ...props.plugins.markdown.config,
+                        boldDecorator: undefined,
+                        italicDecorator: undefined,
+                      },
                     },
                   },
                 })}

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -21,6 +21,7 @@ export const STANDARD_PORTABLE_TEXT_INPUT_TYPES = [
   'pt_customMarkersTest',
   'blocksTest',
   // 'richTextObject',
+  'customPlugins',
   'simpleBlock',
   'manyEditors',
   'documentWithHoistedPt',

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -227,6 +227,7 @@ export interface BaseSchemaType extends Partial<DeprecationConfiguration> {
     input?: ComponentType<any>
     item?: ComponentType<any>
     preview?: ComponentType<any>
+    ptePlugins?: ComponentType<any>
   }
 
   /**

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -227,7 +227,9 @@ export interface BaseSchemaType extends Partial<DeprecationConfiguration> {
     input?: ComponentType<any>
     item?: ComponentType<any>
     preview?: ComponentType<any>
-    ptePlugins?: ComponentType<any>
+    pte?: {
+      plugins?: ComponentType<any>
+    }
   }
 
   /**

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -227,7 +227,7 @@ export interface BaseSchemaType extends Partial<DeprecationConfiguration> {
     input?: ComponentType<any>
     item?: ComponentType<any>
     preview?: ComponentType<any>
-    pte?: {
+    portableText?: {
       plugins?: ComponentType<any>
     }
   }

--- a/packages/sanity/src/core/config/form/types.ts
+++ b/packages/sanity/src/core/config/form/types.ts
@@ -7,6 +7,7 @@ import {
   type FieldProps,
   type InputProps,
   type ItemProps,
+  type PtePluginsProps,
 } from '../../form'
 
 /**
@@ -20,4 +21,7 @@ export interface FormComponents {
   input?: ComponentType<InputProps>
   item?: ComponentType<ItemProps>
   preview?: ComponentType<PreviewProps>
+  pte?: {
+    plugins?: ComponentType<PtePluginsProps>
+  }
 }

--- a/packages/sanity/src/core/config/form/types.ts
+++ b/packages/sanity/src/core/config/form/types.ts
@@ -7,7 +7,7 @@ import {
   type FieldProps,
   type InputProps,
   type ItemProps,
-  type PortableTextPluginProps,
+  type PortableTextPluginsProps,
 } from '../../form'
 
 /**
@@ -22,6 +22,6 @@ export interface FormComponents {
   item?: ComponentType<ItemProps>
   preview?: ComponentType<PreviewProps>
   portableText?: {
-    plugins?: ComponentType<PortableTextPluginProps>
+    plugins?: ComponentType<PortableTextPluginsProps>
   }
 }

--- a/packages/sanity/src/core/config/form/types.ts
+++ b/packages/sanity/src/core/config/form/types.ts
@@ -7,7 +7,7 @@ import {
   type FieldProps,
   type InputProps,
   type ItemProps,
-  type PtePluginsProps,
+  type PortableTextPluginProps,
 } from '../../form'
 
 /**
@@ -21,7 +21,7 @@ export interface FormComponents {
   input?: ComponentType<InputProps>
   item?: ComponentType<ItemProps>
   preview?: ComponentType<PreviewProps>
-  pte?: {
-    plugins?: ComponentType<PtePluginsProps>
+  portableText?: {
+    plugins?: ComponentType<PortableTextPluginProps>
   }
 }

--- a/packages/sanity/src/core/form/form-components-hooks/picks.ts
+++ b/packages/sanity/src/core/form/form-components-hooks/picks.ts
@@ -8,6 +8,7 @@ import {
   type FieldProps,
   type InputProps,
   type ItemProps,
+  type PtePluginsProps,
 } from '../types'
 
 export function pickInputComponent(
@@ -51,5 +52,13 @@ export function pickAnnotationComponent(
 ): ComponentType<Omit<BlockAnnotationProps, 'renderDefault'>> {
   return plugin.form?.components?.annotation as ComponentType<
     Omit<BlockAnnotationProps, 'renderDefault'>
+  >
+}
+
+export function pickPTEPluginsComponent(
+  plugin: PluginOptions,
+): ComponentType<Omit<PtePluginsProps, 'renderDefault'>> {
+  return plugin.form?.components?.pte?.plugins as ComponentType<
+    Omit<PtePluginsProps, 'renderDefault'>
   >
 }

--- a/packages/sanity/src/core/form/form-components-hooks/picks.ts
+++ b/packages/sanity/src/core/form/form-components-hooks/picks.ts
@@ -8,7 +8,7 @@ import {
   type FieldProps,
   type InputProps,
   type ItemProps,
-  type PortableTextPluginProps,
+  type PortableTextPluginsProps,
 } from '../types'
 
 export function pickInputComponent(
@@ -57,8 +57,8 @@ export function pickAnnotationComponent(
 
 export function pickPortableTextEditorPluginsComponent(
   plugin: PluginOptions,
-): ComponentType<Omit<PortableTextPluginProps, 'renderDefault'>> {
+): ComponentType<Omit<PortableTextPluginsProps, 'renderDefault'>> {
   return plugin.form?.components?.portableText?.plugins as ComponentType<
-    Omit<PortableTextPluginProps, 'renderDefault'>
+    Omit<PortableTextPluginsProps, 'renderDefault'>
   >
 }

--- a/packages/sanity/src/core/form/form-components-hooks/picks.ts
+++ b/packages/sanity/src/core/form/form-components-hooks/picks.ts
@@ -8,7 +8,7 @@ import {
   type FieldProps,
   type InputProps,
   type ItemProps,
-  type PtePluginsProps,
+  type PortableTextPluginProps,
 } from '../types'
 
 export function pickInputComponent(
@@ -55,10 +55,10 @@ export function pickAnnotationComponent(
   >
 }
 
-export function pickPTEPluginsComponent(
+export function pickPortableTextEditorPluginsComponent(
   plugin: PluginOptions,
-): ComponentType<Omit<PtePluginsProps, 'renderDefault'>> {
-  return plugin.form?.components?.pte?.plugins as ComponentType<
-    Omit<PtePluginsProps, 'renderDefault'>
+): ComponentType<Omit<PortableTextPluginProps, 'renderDefault'>> {
+  return plugin.form?.components?.portableText?.plugins as ComponentType<
+    Omit<PortableTextPluginProps, 'renderDefault'>
   >
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -11,11 +11,7 @@ import {
   useEditor,
   usePortableTextEditor,
 } from '@portabletext/editor'
-import {
-  EventListenerPlugin,
-  MarkdownPlugin,
-  type MarkdownPluginConfig,
-} from '@portabletext/editor/plugins'
+import {EventListenerPlugin} from '@portabletext/editor/plugins'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {isKeySegment, type Path, type PortableTextBlock} from '@sanity/types'
 import {Box, Flex, Text, useToast} from '@sanity/ui'
@@ -50,6 +46,7 @@ import {PortableTextMarkersProvider} from './contexts/PortableTextMarkers'
 import {PortableTextMemberItemsProvider} from './contexts/PortableTextMembers'
 import {usePortableTextMemberItemsFromProps} from './hooks/usePortableTextMembers'
 import {InvalidValue as RespondToInvalidContent} from './InvalidValue'
+import {PTEPlugins} from './object/Plugins'
 import {
   type PresenceCursorDecorationsHookProps,
   usePresenceCursorDecorations,
@@ -91,19 +88,6 @@ export interface PortableTextMemberItem {
 }
 
 /**
- * @beta
- */
-export interface RenderPortableTextInputPluginsProps {
-  renderMarkdownPlugin: (props: {config: MarkdownPluginConfig}) => ReactNode
-  renderDefault: (props: {
-    renderMarkdownPlugin: (props: {
-      config: MarkdownPluginConfig
-      renderDefault: (props: {config: MarkdownPluginConfig}) => ReactNode
-    }) => ReactNode
-  }) => ReactNode
-}
-
-/**
  * Input component for editing block content
  * ({@link https://github.com/portabletext/portabletext | Portable Text}) in the Sanity Studio.
  *
@@ -136,7 +120,6 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
     rangeDecorations: rangeDecorationsProp,
     renderBlockActions,
     renderCustomMarkers,
-    renderPlugins,
     schemaType,
     value,
     resolveUploader,
@@ -406,7 +389,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
               <PatchesPlugin path={path} />
               <UpdateReadOnlyPlugin readOnly={readOnly || !ready} />
               <UpdateValuePlugin value={value} />
-              <RenderPlugins renderPlugins={renderPlugins} />
+              <PTEPlugins schemaType={schemaType} />
               <Compositor
                 {...props}
                 elementRef={elementRef}
@@ -431,41 +414,6 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
       )}
     </Box>
   )
-}
-
-const markdownConfig: MarkdownPluginConfig = {
-  boldDecorator: ({schema}) =>
-    schema.decorators.find((decorator) => decorator.name === 'strong')?.name,
-  codeDecorator: ({schema}) =>
-    schema.decorators.find((decorator) => decorator.name === 'code')?.name,
-  italicDecorator: ({schema}) =>
-    schema.decorators.find((decorator) => decorator.name === 'em')?.name,
-  strikeThroughDecorator: ({schema}) =>
-    schema.decorators.find((decorator) => decorator.name === 'strike-through')?.name,
-  defaultStyle: ({schema}) => schema.styles.find((style) => style.name === 'normal')?.name,
-  blockquoteStyle: ({schema}) => schema.styles.find((style) => style.name === 'blockquote')?.name,
-  headingStyle: ({schema, level}) =>
-    schema.styles.find((style) => style.name === `h${level}`)?.name,
-  orderedListStyle: ({schema}) => schema.lists.find((list) => list.name === 'number')?.name,
-  unorderedListStyle: ({schema}) => schema.lists.find((list) => list.name === 'bullet')?.name,
-}
-
-function RenderPlugins(props: {renderPlugins?: PortableTextInputProps['renderPlugins']}) {
-  if (!props.renderPlugins) {
-    return <MarkdownPlugin config={markdownConfig} />
-  }
-
-  return props.renderPlugins({
-    renderMarkdownPlugin: (markdownPluginProps) => <MarkdownPlugin {...markdownPluginProps} />,
-    renderDefault: (defaultProps) => (
-      <>
-        {defaultProps.renderMarkdownPlugin({
-          config: markdownConfig,
-          renderDefault: (markdownPluginProps) => <MarkdownPlugin {...markdownPluginProps} />,
-        })}
-      </>
-    ),
-  })
 }
 
 /**

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -11,7 +11,11 @@ import {
   useEditor,
   usePortableTextEditor,
 } from '@portabletext/editor'
-import {EventListenerPlugin, MarkdownPlugin} from '@portabletext/editor/plugins'
+import {
+  EventListenerPlugin,
+  MarkdownPlugin,
+  type MarkdownPluginConfig,
+} from '@portabletext/editor/plugins'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {isKeySegment, type Path, type PortableTextBlock} from '@sanity/types'
 import {Box, Flex, Text, useToast} from '@sanity/ui'
@@ -87,6 +91,19 @@ export interface PortableTextMemberItem {
 }
 
 /**
+ * @beta
+ */
+export interface RenderPortableTextInputPluginsProps {
+  renderMarkdownPlugin: (props: {config: MarkdownPluginConfig}) => ReactNode
+  renderDefault: (props: {
+    renderMarkdownPlugin: (props: {
+      config: MarkdownPluginConfig
+      renderDefault: (props: {config: MarkdownPluginConfig}) => ReactNode
+    }) => ReactNode
+  }) => ReactNode
+}
+
+/**
  * Input component for editing block content
  * ({@link https://github.com/portabletext/portabletext | Portable Text}) in the Sanity Studio.
  *
@@ -119,6 +136,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
     rangeDecorations: rangeDecorationsProp,
     renderBlockActions,
     renderCustomMarkers,
+    renderPlugins,
     schemaType,
     value,
     resolveUploader,
@@ -388,29 +406,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
               <PatchesPlugin path={path} />
               <UpdateReadOnlyPlugin readOnly={readOnly || !ready} />
               <UpdateValuePlugin value={value} />
-              <MarkdownPlugin
-                config={{
-                  boldDecorator: ({schema}) =>
-                    schema.decorators.find((decorator) => decorator.name === 'strong')?.name,
-                  codeDecorator: ({schema}) =>
-                    schema.decorators.find((decorator) => decorator.name === 'code')?.name,
-                  italicDecorator: ({schema}) =>
-                    schema.decorators.find((decorator) => decorator.name === 'em')?.name,
-                  strikeThroughDecorator: ({schema}) =>
-                    schema.decorators.find((decorator) => decorator.name === 'strike-through')
-                      ?.name,
-                  defaultStyle: ({schema}) =>
-                    schema.styles.find((style) => style.name === 'normal')?.name,
-                  blockquoteStyle: ({schema}) =>
-                    schema.styles.find((style) => style.name === 'blockquote')?.name,
-                  headingStyle: ({schema, level}) =>
-                    schema.styles.find((style) => style.name === `h${level}`)?.name,
-                  orderedListStyle: ({schema}) =>
-                    schema.lists.find((list) => list.name === 'number')?.name,
-                  unorderedListStyle: ({schema}) =>
-                    schema.lists.find((list) => list.name === 'bullet')?.name,
-                }}
-              />
+              <RenderPlugins renderPlugins={renderPlugins} />
               <Compositor
                 {...props}
                 elementRef={elementRef}
@@ -435,6 +431,41 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
       )}
     </Box>
   )
+}
+
+const markdownConfig: MarkdownPluginConfig = {
+  boldDecorator: ({schema}) =>
+    schema.decorators.find((decorator) => decorator.name === 'strong')?.name,
+  codeDecorator: ({schema}) =>
+    schema.decorators.find((decorator) => decorator.name === 'code')?.name,
+  italicDecorator: ({schema}) =>
+    schema.decorators.find((decorator) => decorator.name === 'em')?.name,
+  strikeThroughDecorator: ({schema}) =>
+    schema.decorators.find((decorator) => decorator.name === 'strike-through')?.name,
+  defaultStyle: ({schema}) => schema.styles.find((style) => style.name === 'normal')?.name,
+  blockquoteStyle: ({schema}) => schema.styles.find((style) => style.name === 'blockquote')?.name,
+  headingStyle: ({schema, level}) =>
+    schema.styles.find((style) => style.name === `h${level}`)?.name,
+  orderedListStyle: ({schema}) => schema.lists.find((list) => list.name === 'number')?.name,
+  unorderedListStyle: ({schema}) => schema.lists.find((list) => list.name === 'bullet')?.name,
+}
+
+function RenderPlugins(props: {renderPlugins?: PortableTextInputProps['renderPlugins']}) {
+  if (!props.renderPlugins) {
+    return <MarkdownPlugin config={markdownConfig} />
+  }
+
+  return props.renderPlugins({
+    renderMarkdownPlugin: (markdownPluginProps) => <MarkdownPlugin {...markdownPluginProps} />,
+    renderDefault: (defaultProps) => (
+      <>
+        {defaultProps.renderMarkdownPlugin({
+          config: markdownConfig,
+          renderDefault: (markdownPluginProps) => <MarkdownPlugin {...markdownPluginProps} />,
+        })}
+      </>
+    ),
+  })
 }
 
 /**

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -46,7 +46,7 @@ import {PortableTextMarkersProvider} from './contexts/PortableTextMarkers'
 import {PortableTextMemberItemsProvider} from './contexts/PortableTextMembers'
 import {usePortableTextMemberItemsFromProps} from './hooks/usePortableTextMembers'
 import {InvalidValue as RespondToInvalidContent} from './InvalidValue'
-import {PTEPlugins} from './object/Plugins'
+import {PortableTextEditorPlugins} from './object/Plugins'
 import {
   type PresenceCursorDecorationsHookProps,
   usePresenceCursorDecorations,
@@ -389,7 +389,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
               <PatchesPlugin path={path} />
               <UpdateReadOnlyPlugin readOnly={readOnly || !ready} />
               <UpdateValuePlugin value={value} />
-              <PTEPlugins schemaType={schemaType} />
+              <PortableTextEditorPlugins schemaType={schemaType} />
               <Compositor
                 {...props}
                 elementRef={elementRef}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -32,7 +32,7 @@ export const PTEPlugins = (props: {schemaType: ArraySchemaType<PortableTextBlock
     [],
   )
 
-  const CustomComponent = props.schemaType.components?.ptePlugins as
+  const CustomComponent = props.schemaType.components?.pte?.plugins as
     | ComponentType<PtePluginsProps>
     | undefined
 

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -1,0 +1,56 @@
+import {MarkdownPlugin, type MarkdownPluginConfig} from '@portabletext/editor/plugins'
+import {type ArraySchemaType, type PortableTextBlock} from '@sanity/types'
+import {type ComponentType, useMemo} from 'react'
+
+import {useMiddlewareComponents} from '../../../../config/components/useMiddlewareComponents'
+import {pickPTEPluginsComponent} from '../../../form-components-hooks/picks'
+import {type PtePluginsProps} from '../../../types/blockProps'
+
+const markdownConfig: MarkdownPluginConfig = {
+  boldDecorator: ({schema}) =>
+    schema.decorators.find((decorator) => decorator.name === 'strong')?.name,
+  codeDecorator: ({schema}) =>
+    schema.decorators.find((decorator) => decorator.name === 'code')?.name,
+  italicDecorator: ({schema}) =>
+    schema.decorators.find((decorator) => decorator.name === 'em')?.name,
+  strikeThroughDecorator: ({schema}) =>
+    schema.decorators.find((decorator) => decorator.name === 'strike-through')?.name,
+  defaultStyle: ({schema}) => schema.styles.find((style) => style.name === 'normal')?.name,
+  blockquoteStyle: ({schema}) => schema.styles.find((style) => style.name === 'blockquote')?.name,
+  headingStyle: ({schema, level}) =>
+    schema.styles.find((style) => style.name === `h${level}`)?.name,
+  orderedListStyle: ({schema}) => schema.lists.find((list) => list.name === 'number')?.name,
+  unorderedListStyle: ({schema}) => schema.lists.find((list) => list.name === 'bullet')?.name,
+}
+
+export const PTEPlugins = (props: {schemaType: ArraySchemaType<PortableTextBlock>}) => {
+  const componentProps = useMemo(
+    (): PtePluginsProps => ({
+      markdownPluginProps: {config: markdownConfig},
+      renderDefault: RenderDefault,
+    }),
+    [],
+  )
+
+  const CustomComponent = props.schemaType.components?.ptePlugins as
+    | ComponentType<PtePluginsProps>
+    | undefined
+
+  return CustomComponent ? (
+    <CustomComponent {...componentProps} />
+  ) : (
+    <RenderDefault {...componentProps} />
+  )
+}
+
+export const DefaultPTEPlugins = (props: Omit<PtePluginsProps, 'renderDefault'>) => {
+  return <MarkdownPlugin config={props.markdownPluginProps.config} />
+}
+
+export const RenderDefault = (props: Omit<PtePluginsProps, 'renderDefault'>) => {
+  const RenderPlugins = useMiddlewareComponents({
+    defaultComponent: DefaultPTEPlugins,
+    pick: pickPTEPluginsComponent,
+  })
+  return <RenderPlugins {...props} />
+}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -28,7 +28,7 @@ export const PortableTextEditorPlugins = (props: {
 }) => {
   const componentProps = useMemo(
     (): PortableTextPluginProps => ({
-      markdownPluginProps: {config: markdownConfig},
+      plugins: {markdown: {config: markdownConfig}},
       renderDefault: RenderDefault,
     }),
     [],
@@ -48,7 +48,7 @@ export const PortableTextEditorPlugins = (props: {
 export const DefaultPortableTextEditorPlugins = (
   props: Omit<PortableTextPluginProps, 'renderDefault'>,
 ) => {
-  return <MarkdownPlugin config={props.markdownPluginProps.config} />
+  return <MarkdownPlugin config={props.plugins.markdown.config} />
 }
 
 export const RenderDefault = (props: Omit<PortableTextPluginProps, 'renderDefault'>) => {

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -4,7 +4,7 @@ import {type ComponentType, useMemo} from 'react'
 
 import {useMiddlewareComponents} from '../../../../config/components/useMiddlewareComponents'
 import {pickPortableTextEditorPluginsComponent} from '../../../form-components-hooks/picks'
-import {type PortableTextPluginProps} from '../../../types/blockProps'
+import {type PortableTextPluginsProps} from '../../../types/blockProps'
 
 const markdownConfig: MarkdownPluginConfig = {
   boldDecorator: ({schema}) =>
@@ -27,7 +27,7 @@ export const PortableTextEditorPlugins = (props: {
   schemaType: ArraySchemaType<PortableTextBlock>
 }) => {
   const componentProps = useMemo(
-    (): PortableTextPluginProps => ({
+    (): PortableTextPluginsProps => ({
       plugins: {markdown: {config: markdownConfig}},
       renderDefault: RenderDefault,
     }),
@@ -35,7 +35,7 @@ export const PortableTextEditorPlugins = (props: {
   )
 
   const CustomComponent = props.schemaType.components?.portableText?.plugins as
-    | ComponentType<PortableTextPluginProps>
+    | ComponentType<PortableTextPluginsProps>
     | undefined
 
   return CustomComponent ? (
@@ -46,12 +46,12 @@ export const PortableTextEditorPlugins = (props: {
 }
 
 export const DefaultPortableTextEditorPlugins = (
-  props: Omit<PortableTextPluginProps, 'renderDefault'>,
+  props: Omit<PortableTextPluginsProps, 'renderDefault'>,
 ) => {
   return <MarkdownPlugin config={props.plugins.markdown.config} />
 }
 
-export const RenderDefault = (props: Omit<PortableTextPluginProps, 'renderDefault'>) => {
+export const RenderDefault = (props: Omit<PortableTextPluginsProps, 'renderDefault'>) => {
   const RenderPlugins = useMiddlewareComponents({
     defaultComponent: DefaultPortableTextEditorPlugins,
     pick: pickPortableTextEditorPluginsComponent,

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -3,8 +3,8 @@ import {type ArraySchemaType, type PortableTextBlock} from '@sanity/types'
 import {type ComponentType, useMemo} from 'react'
 
 import {useMiddlewareComponents} from '../../../../config/components/useMiddlewareComponents'
-import {pickPTEPluginsComponent} from '../../../form-components-hooks/picks'
-import {type PtePluginsProps} from '../../../types/blockProps'
+import {pickPortableTextEditorPluginsComponent} from '../../../form-components-hooks/picks'
+import {type PortableTextPluginProps} from '../../../types/blockProps'
 
 const markdownConfig: MarkdownPluginConfig = {
   boldDecorator: ({schema}) =>
@@ -23,17 +23,19 @@ const markdownConfig: MarkdownPluginConfig = {
   unorderedListStyle: ({schema}) => schema.lists.find((list) => list.name === 'bullet')?.name,
 }
 
-export const PTEPlugins = (props: {schemaType: ArraySchemaType<PortableTextBlock>}) => {
+export const PortableTextEditorPlugins = (props: {
+  schemaType: ArraySchemaType<PortableTextBlock>
+}) => {
   const componentProps = useMemo(
-    (): PtePluginsProps => ({
+    (): PortableTextPluginProps => ({
       markdownPluginProps: {config: markdownConfig},
       renderDefault: RenderDefault,
     }),
     [],
   )
 
-  const CustomComponent = props.schemaType.components?.pte?.plugins as
-    | ComponentType<PtePluginsProps>
+  const CustomComponent = props.schemaType.components?.portableText?.plugins as
+    | ComponentType<PortableTextPluginProps>
     | undefined
 
   return CustomComponent ? (
@@ -43,14 +45,16 @@ export const PTEPlugins = (props: {schemaType: ArraySchemaType<PortableTextBlock
   )
 }
 
-export const DefaultPTEPlugins = (props: Omit<PtePluginsProps, 'renderDefault'>) => {
+export const DefaultPortableTextEditorPlugins = (
+  props: Omit<PortableTextPluginProps, 'renderDefault'>,
+) => {
   return <MarkdownPlugin config={props.markdownPluginProps.config} />
 }
 
-export const RenderDefault = (props: Omit<PtePluginsProps, 'renderDefault'>) => {
+export const RenderDefault = (props: Omit<PortableTextPluginProps, 'renderDefault'>) => {
   const RenderPlugins = useMiddlewareComponents({
-    defaultComponent: DefaultPTEPlugins,
-    pick: pickPTEPluginsComponent,
+    defaultComponent: DefaultPortableTextEditorPlugins,
+    pick: pickPortableTextEditorPluginsComponent,
   })
   return <RenderPlugins {...props} />
 }

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -1,3 +1,4 @@
+import {type MarkdownPluginConfig} from '@portabletext/editor/plugins'
 import {
   type ArraySchemaType,
   type BlockDecoratorDefinition,
@@ -434,4 +435,14 @@ export interface BlockProps {
    * Value of the block.
    */
   value: PortableTextBlock
+}
+
+/**
+ * Props for rendering Portable Text plugins
+ *
+ * @beta
+ */
+export interface PtePluginsProps {
+  renderDefault: (props: PtePluginsProps) => React.JSX.Element
+  markdownPluginProps: {config: MarkdownPluginConfig}
 }

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -442,7 +442,7 @@ export interface BlockProps {
  *
  * @beta
  */
-export interface PortableTextPluginProps {
-  renderDefault: (props: PortableTextPluginProps) => React.JSX.Element
+export interface PortableTextPluginsProps {
+  renderDefault: (props: PortableTextPluginsProps) => React.JSX.Element
   plugins: {markdown: {config: MarkdownPluginConfig}}
 }

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -442,7 +442,7 @@ export interface BlockProps {
  *
  * @beta
  */
-export interface PtePluginsProps {
-  renderDefault: (props: PtePluginsProps) => React.JSX.Element
+export interface PortableTextPluginProps {
+  renderDefault: (props: PortableTextPluginProps) => React.JSX.Element
   markdownPluginProps: {config: MarkdownPluginConfig}
 }

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -444,5 +444,5 @@ export interface BlockProps {
  */
 export interface PortableTextPluginProps {
   renderDefault: (props: PortableTextPluginProps) => React.JSX.Element
-  markdownPluginProps: {config: MarkdownPluginConfig}
+  plugins: {markdown: {config: MarkdownPluginConfig}}
 }

--- a/packages/sanity/src/core/form/types/definitionExtensions.ts
+++ b/packages/sanity/src/core/form/types/definitionExtensions.ts
@@ -16,6 +16,7 @@ import {
   type BlockListItemProps,
   type BlockProps,
   type BlockStyleProps,
+  type PtePluginsProps,
 } from './blockProps'
 import {
   type ArrayFieldProps,
@@ -51,6 +52,7 @@ declare module '@sanity/types' {
     input?: ComponentType<ArrayOfObjectsInputProps>
     item?: ComponentType<ObjectItemProps>
     preview?: ComponentType<PreviewProps>
+    pte?: {plugins: ComponentType<PtePluginsProps>}
   }
 
   /**

--- a/packages/sanity/src/core/form/types/definitionExtensions.ts
+++ b/packages/sanity/src/core/form/types/definitionExtensions.ts
@@ -16,7 +16,7 @@ import {
   type BlockListItemProps,
   type BlockProps,
   type BlockStyleProps,
-  type PtePluginsProps,
+  type PortableTextPluginProps,
 } from './blockProps'
 import {
   type ArrayFieldProps,
@@ -52,7 +52,7 @@ declare module '@sanity/types' {
     input?: ComponentType<ArrayOfObjectsInputProps>
     item?: ComponentType<ObjectItemProps>
     preview?: ComponentType<PreviewProps>
-    pte?: {plugins: ComponentType<PtePluginsProps>}
+    portableText?: {plugins: ComponentType<PortableTextPluginProps>}
   }
 
   /**

--- a/packages/sanity/src/core/form/types/definitionExtensions.ts
+++ b/packages/sanity/src/core/form/types/definitionExtensions.ts
@@ -16,7 +16,7 @@ import {
   type BlockListItemProps,
   type BlockProps,
   type BlockStyleProps,
-  type PortableTextPluginProps,
+  type PortableTextPluginsProps,
 } from './blockProps'
 import {
   type ArrayFieldProps,
@@ -52,7 +52,7 @@ declare module '@sanity/types' {
     input?: ComponentType<ArrayOfObjectsInputProps>
     item?: ComponentType<ObjectItemProps>
     preview?: ComponentType<PreviewProps>
-    portableText?: {plugins: ComponentType<PortableTextPluginProps>}
+    portableText?: {plugins: ComponentType<PortableTextPluginsProps>}
   }
 
   /**

--- a/packages/sanity/src/core/form/types/inputProps.ts
+++ b/packages/sanity/src/core/form/types/inputProps.ts
@@ -31,7 +31,6 @@ import {
   type ReactNode,
 } from 'react'
 
-import {type RenderPortableTextInputPluginsProps} from '../inputs'
 import {type FormPatch, type PatchEvent} from '../patch'
 import {type FormFieldGroup} from '../store'
 import {
@@ -576,10 +575,6 @@ export interface PortableTextInputProps
    * Array of {@link RangeDecoration} that can be used to decorate the content.
    */
   rangeDecorations?: RangeDecoration[]
-  /**
-   * @beta
-   */
-  renderPlugins?: (props: RenderPortableTextInputPluginsProps) => ReactNode
 }
 
 /**

--- a/packages/sanity/src/core/form/types/inputProps.ts
+++ b/packages/sanity/src/core/form/types/inputProps.ts
@@ -31,6 +31,7 @@ import {
   type ReactNode,
 } from 'react'
 
+import {type RenderPortableTextInputPluginsProps} from '../inputs'
 import {type FormPatch, type PatchEvent} from '../patch'
 import {type FormFieldGroup} from '../store'
 import {
@@ -575,6 +576,10 @@ export interface PortableTextInputProps
    * Array of {@link RangeDecoration} that can be used to decorate the content.
    */
   rangeDecorations?: RangeDecoration[]
+  /**
+   * @beta
+   */
+  renderPlugins?: (props: RenderPortableTextInputPluginsProps) => ReactNode
 }
 
 /**


### PR DESCRIPTION
### Description

**UPDATE**: @pedrobonamin has made subsequent commits to the branch which lets PTE (Portable Text Editor) plugins be configured under `form.components.portableText.plugins`:

```ts
export const autoCloseBrackets = definePlugin({
  name: 'auto-close brackets',
  form: {
    components: {
      portableText: {
        plugins: (props) => {
          return (
            <>
              {props.renderDefault(props)}
              <AutoCloseBracketsBehaviorPlugin />
            </>
          )
        },
      },
    },
  },
})
```

The improved API makes sure that plugins are added recursively so a Studio plugin like the one above can add a PTE plugin and then a document-level array field config further down can add its own and in the end, both will be registered in PTE:

```ts
    /**
     * One-Line Editor
     *
     * Uses the `OneLinePlugin` to restrict the editor to one line of text.
     */
    {
      type: 'array',
      name: 'oneLineEditor',
      title: 'One-Line Editor',
      description: 'The editor is restricted to one line of text using the <OneLinePlugin />',
      of: [
        {
          type: 'block',
        },
      ],
      components: {
        portableText: {
          plugins: (props) => {
            return (
              <>
                {props.renderDefault(props)}
                <OneLinePlugin />
              </>
            )
          },
        },
      },
    },
```

---

This commit adds a `portableText` property into the components,  that can be
used to inject Portable Text Editor Plugins in the editor.

PTE Plugins are just React components. And the reason for this is that for
complex Plugins, you'll want to maintain some local state and the most
idiomatic way to do that is using React. The `DecoratorShortcutPlugin` is an
example of such plugin (it contains an entire XState state machine). Another
reason is that, down the line, we want to render UI elements through Plugins
(think: Emoji Picker).

It should be noted that rendering UI elements in PTE Plugins hasn't been fully
thought through. For example, we might want to expose some affordance to
control *where* the UI elements are rendered. I think, we can address this
later as the `renderPlugins` is marked as `@beta` and isn't intended to be
publically announced yet.

The most important thing right now is that you have an entry point to
get the `Editor` instance using `useEditor()` and add Behaviors using
`editor.registerBehavior(...)`.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
