### PR TITLE
fix(presentation): don't remount header when props change

### DIFF
--- a/packages/sanity/src/presentation/preview/Preview.tsx
+++ b/packages/sanity/src/presentation/preview/Preview.tsx
@@ -40,7 +40,7 @@ import {
 import {usePresentationTool} from '../usePresentationTool'
 import {encodeStudioPerspective} from '../util/encodeStudioPerspective'
 import {IFrame} from './IFrame'
-import {usePresentationPreviewHeader} from './PreviewHeader'
+import {PreviewHeader} from './PreviewHeader'
 
 const MotionFlex = motion.create(Flex)
 
@@ -125,11 +125,7 @@ export const Preview = memo(
     const prefersReducedMotion = usePrefersReducedMotion()
     const ref = useRef<HTMLIFrameElement | null>(null)
 
-    const PreviewHeader = usePresentationPreviewHeader({
-      ...props,
-      iframeRef: ref,
-      options: header,
-    })
+    const previewHeader = <PreviewHeader {...props} iframeRef={ref} options={header} />
 
     // Forward the iframe ref to the parent component
     useImperativeHandle<HTMLIFrameElement | null, HTMLIFrameElement | null>(
@@ -279,7 +275,7 @@ export const Preview = memo(
     return (
       <MotionConfig transition={prefersReducedMotion ? {duration: 0} : undefined}>
         <TooltipDelayGroupProvider>
-          <PreviewHeader />
+          {previewHeader}
 
           {/* @TODO: Move this to <PreviewFrame /> */}
           <Card flex={1} tone="transparent">

--- a/packages/sanity/src/presentation/preview/PreviewHeader.tsx
+++ b/packages/sanity/src/presentation/preview/PreviewHeader.tsx
@@ -1,7 +1,7 @@
 import {DesktopIcon, MobileDeviceIcon, PanelLeftIcon, RefreshIcon} from '@sanity/icons'
 import {withoutSecretSearchParams} from '@sanity/preview-url-secret/without-secret-search-params'
 import {Box, Card, Flex, Hotkeys, Switch, Text} from '@sanity/ui'
-import {type ReactNode, type RefObject, useCallback, useMemo} from 'react'
+import {type RefObject, useCallback, useMemo} from 'react'
 import {useTranslation} from 'sanity'
 
 import {Button, Tooltip} from '../../ui-components'
@@ -222,9 +222,10 @@ const PreviewHeaderDefault = (props: Omit<PreviewHeaderProps, 'renderDefault'>) 
   )
 }
 
-function PreviewHeader(
+/** @internal */
+export function PreviewHeader(
   props: Omit<PreviewHeaderProps, 'renderDefault'> & {options?: HeaderOptions},
-) {
+): React.JSX.Element {
   // eslint-disable-next-line @typescript-eslint/no-shadow
   const renderDefault = useCallback((props: Omit<PreviewHeaderProps, 'renderDefault'>) => {
     return <PreviewHeaderDefault {...props} />
@@ -244,15 +245,4 @@ function PreviewHeader(
       </Flex>
     </Card>
   )
-}
-
-/** @internal */
-export function usePresentationPreviewHeader(
-  props: Omit<PreviewHeaderProps, 'renderDefault'> & {options?: HeaderOptions},
-): () => ReactNode {
-  const Component = useCallback(() => {
-    return <PreviewHeader {...props} />
-  }, [props])
-
-  return Component
 }


### PR DESCRIPTION
### Description

The Preview header in Presentation is constantly unmounting and remounting. Besides being inefficient and contributing to React having to perform more work (as mounting involves creating DOM elements and other DOM operations), it also affects the user experience.
Note how in this video that if you focus a field in a document, and then attempt to click a button in the toolbar, it's "ignored", and you have to "double click":

https://github.com/user-attachments/assets/1c196151-1cde-467d-9558-b72f1073eae6

The TL;DR of how the preview header renders is:
1. `<Preview>` in `Preview.tsx` renders the header and the iframe. The header is output as `<PreviewHeader />`
2. `PreviewHeader` is a component returned by `usePresentationPreviewHeader(props)`.
3. `usePresentationPreviewHeader` lives in `PreviewHeader.tsx`, it's a simple wrapper around the internal `<PreviewHeader>` component:
   ```tsx
    function usePresentationPreviewHeader(props) {
      const Component = useCallback(() => {
        return <PreviewHeader {...props} />
      }, [props])
    
      return Component
    }
   ```
4. The problem here is that whenever `props` changes in any way, the hook returns a brand new component. Let's go step by step to understand why this creates problems.

Here's what's happening:
1. Let's pretend you're in Presentation, editing a document with the id `abc123` and type `page`. The relative URL is `/presentation/page/abc123`.
5. You click on a `title` field, the URL changes to `/presentation/page/abc123/title`.
6. The Preview header unmounts and remounts, but since you're not trying to interact with it and it doesn't have focus, you won't notice it.
7. You then click the "Switch to narrow viewport" button, like in the above video.
8. React sees the click event on the element, and prepares to dispatch the `onClick` handler on the button.
9. The browser changes `document.activeElement` from the input that had focus, to the button that was clicked.
10. This triggers the `onBlur` handler for the input field, which causes Presentation to change the URL to `/presentation/page/abc123`.
11. Changing the URL causes `props` to change, which causes react to see a brand new `PreviewHeader` component. React unmounts `PreviewHeader`, and all the DOM elements related to it is destroyed, and replaced with brand new DOM elements.
12. Since the button were unmounted and destroyed, the `document.activeElement` is now changed by the browser to its default fallback value `document.body`.
13. Since the button element no longer exists, React skips calling `onClick`. It makes sense, imagine how odd it would be if your component had to handle scenarios where `event.target` is `null`, that makes no sense.


What React is doing here ties into its semantics for when it decides wether it should preserve state and dom nodes, and when it should reset.
Checkout the [Different components at the same position reset state](https://react.dev/learn/preserving-and-resetting-state#different-components-at-the-same-position-reset-state) section in the docs, especially the Pitfall box at the bottom:
![image](https://github.com/user-attachments/assets/34f6b680-1bd3-4470-912b-10bfde614de6)
[If you're familiar with changing the `key` prop to reset/remount a component](https://react.dev/learn/preserving-and-resetting-state#resetting-a-form-with-a-key), the bug we have here is the equivalent to this pattern:
```tsx
function usePresentationPreviewHeader(props) {
  return useMemo(() => {
    return <PreviewHeader key={`preview-header-${Math.random()}`} {...props} />
  }, [props])
}
```
In this case we're not returning a component, we're returning a memoized JSX of a rendered component. Every time `props` has changed, a random `key` is generated, the component is remounted. This is both easier to understand and to prevent, as an unstable `key` in this way takes work and isn't something you easily do by accident.
Returning a new component function having this effect on the other hand relates to implicit behaviors, and is probably why it took us this long to discover the bug and the cause.


### What to review

Hopefully this makes sense and has enough context. I didn't have time, or enough familiarity with the rest of the studio codebase, to assess if other cases where we have `props.renderDefault(props)` patterns might have hidden bugs like this.

### Testing

No automated tests cover this case. The reproduction shown in the video above can be performed on [this deployment](https://test-studio-1lwkadbjr.sanity.dev/presentation/presentation/simpleBlock/0f38296e-f6a0-4ba9-a928-6b87c23a2f9d?preview=/preview/index.html). Compare that to the build [for this branch](https://test-studio-git-fix-presentation-header-remounts.sanity.dev/presentation/presentation/simpleBlock/0f38296e-f6a0-4ba9-a928-6b87c23a2f9d/title?preview=/preview/index.html&viewport=mobile) which demonstrates the fix.

### Notes for release

The Presentation toolbar above the preview iframe had a sneaky codepath hiding a nasty bug. It caused it to constantly delete and create visually identical DOM nodes. Beyond giving React busywork it gave the user experience in Presentation lots of tiny paper cuts. If you wanted to reliably click a button in the toolbar you had double-click. Hello? Windows 95 called and wanted its double clicks back, single clicks are now enough.

[What if you're used to double clicking?!](https://xkcd.com/1172) We got you fam, double-clicks will count as a single single click, not two single clicks 😮‍💨
