### PR TITLE
fix: resolveTypeForDocument should work with content releases

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/resolveTypeForDocument.ts
+++ b/packages/sanity/src/core/store/_legacy/document/resolveTypeForDocument.ts
@@ -2,8 +2,6 @@ import {type SanityClient} from '@sanity/client'
 import {type Observable, of} from 'rxjs'
 import {map} from 'rxjs/operators'
 
-import {getDraftId, getPublishedId} from '../../../util'
-
 export function resolveTypeForDocument(
   client: SanityClient,
   id: string,
@@ -14,9 +12,7 @@ export function resolveTypeForDocument(
     return of(specifiedType)
   }
 
-  const query = '*[_id in [$documentId, $draftId]]._type'
-  const documentId = getPublishedId(id)
-  const draftId = getDraftId(documentId)
+  const query = '*[sanity::versionOf($id)]._type'
 
-  return client.observable.fetch(query, {documentId, draftId}).pipe(map((types) => types[0]))
+  return client.observable.fetch(query, {id}).pipe(map((types) => types[0]))
 }

--- a/packages/sanity/src/structure/structureBuilder/util/resolveTypeForDocument.ts
+++ b/packages/sanity/src/structure/structureBuilder/util/resolveTypeForDocument.ts
@@ -1,22 +1,15 @@
 import {type SanityClient} from '@sanity/client'
-import {
-  DEFAULT_STUDIO_CLIENT_OPTIONS,
-  getDraftId,
-  getPublishedId,
-  type SourceClientOptions,
-} from 'sanity'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS, type SourceClientOptions} from 'sanity'
 
 export async function resolveTypeForDocument(
   getClient: (options: SourceClientOptions) => SanityClient,
   id: string,
 ): Promise<string | undefined> {
-  const query = '*[_id in [$documentId, $draftId]]._type'
-  const documentId = getPublishedId(id)
-  const draftId = getDraftId(id)
+  const query = '*[sanity::versionOf($id)]._type'
 
   const types = await getClient(DEFAULT_STUDIO_CLIENT_OPTIONS).fetch(
     query,
-    {documentId, draftId},
+    {id},
     {tag: 'structure.resolve-type'},
   )
 


### PR DESCRIPTION
### Description

This fixes #8761

### What to review

This assumes that all releases have a document with the same _type. If two releases have the same id but different version then things are going to break. This might only be a theoretical problem

### Testing

I have not added any automated tests for this (maybe there should have been, so that this problem didn't occur in the first case?)
