### PR TITLE
fix(core): rename internal `deepEquals` to `deepEqualsIgnoreKey`

### DIFF
--- a/packages/sanity/src/core/validation/util/deepEqualsIgnoreKey.ts
+++ b/packages/sanity/src/core/validation/util/deepEqualsIgnoreKey.ts
@@ -8,7 +8,7 @@
 // works when type predicate is called inline in the condition that starts the
 // control flow branch.
 // see here: https://www.typescriptlang.org/docs/handbook/2/narrowing.html
-export function deepEquals(a: unknown, b: unknown): boolean {
+export function deepEqualsIgnoreKey(a: unknown, b: unknown): boolean {
   if (a === b) {
     return true
   }
@@ -16,7 +16,7 @@ export function deepEquals(a: unknown, b: unknown): boolean {
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length != b.length) return false
     for (let i = 0; i < a.length; i++) {
-      if (!deepEquals(a[i], b[i])) {
+      if (!deepEqualsIgnoreKey(a[i], b[i])) {
         return false
       }
     }
@@ -65,7 +65,7 @@ export function deepEquals(a: unknown, b: unknown): boolean {
         continue
       }
 
-      if (!deepEquals(a[key], b[key])) {
+      if (!deepEqualsIgnoreKey(a[key], b[key])) {
         return false
       }
     }

--- a/packages/sanity/src/core/validation/validators/arrayValidator.ts
+++ b/packages/sanity/src/core/validation/validators/arrayValidator.ts
@@ -5,7 +5,7 @@ import {
   type Validators,
 } from '@sanity/types'
 
-import {deepEquals} from '../util/deepEquals'
+import {deepEqualsIgnoreKey} from '../util/deepEqualsIgnoreKey'
 import {genericValidators} from './genericValidator'
 
 export const arrayValidators: Validators = {
@@ -55,7 +55,7 @@ export const arrayValidators: Validators = {
     const paths: Path[] = []
     for (let i = 0; i < values.length; i++) {
       const value = values[i]
-      if (allowedValues.some((expected) => deepEquals(expected, value))) {
+      if (allowedValues.some((expected) => deepEqualsIgnoreKey(expected, value))) {
         continue
       }
 
@@ -80,7 +80,7 @@ export const arrayValidators: Validators = {
         const itemA = value[x]
         const itemB = value[y]
 
-        if (!deepEquals(itemA, itemB)) {
+        if (!deepEqualsIgnoreKey(itemA, itemB)) {
           continue
         }
 

--- a/packages/sanity/src/core/validation/validators/genericValidator.ts
+++ b/packages/sanity/src/core/validation/validators/genericValidator.ts
@@ -1,7 +1,7 @@
 import {type ValidationMarker, type Validators} from '@sanity/types'
 
 import {type LocaleSource} from '../../i18n'
-import {deepEquals} from '../util/deepEquals'
+import {deepEqualsIgnoreKey} from '../util/deepEqualsIgnoreKey'
 import {isLocalizedMessages, localizeMessage} from '../util/localizeMessage'
 import {pathToString} from '../util/pathToString'
 import {typeString} from '../util/typeString'
@@ -84,7 +84,7 @@ export const genericValidators: Validators = {
     const value = (valueType === 'number' || valueType === 'string') && `${actual}`
     const strValue = value && value.length > 30 ? `${value.slice(0, 30)}…` : value
 
-    return allowedValues.some((expected) => deepEquals(expected, actual))
+    return allowedValues.some((expected) => deepEqualsIgnoreKey(expected, actual))
       ? true
       : message ||
           i18n.t(


### PR DESCRIPTION
### Description

In the codebase we have uses of `deepEquals from "react-fast-compare"` and `deepEquals from "util/deepEquals"` , this could lead to hard to reason about errors or bugs given they both seem to do the same.

Our internal `deepEquals` ignore the value of `_key` (see [here](https://github.com/sanity-io/sanity/pull/8790/files#diff-1f840ffb1fed669b0a7bebf617ab1da2115a75605c05a8b0d7cfea13bdd9ca73R53) and [here](https://github.com/sanity-io/sanity/pull/8790/files#diff-1f840ffb1fed669b0a7bebf617ab1da2115a75605c05a8b0d7cfea13bdd9ca73R64)) 
This PR renames it to clearly express that this deepEquals function ignores the value of `_key` 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
