### PR TITLE
fix(preview): prefer snapshot over original when previewing

### DIFF
--- a/packages/sanity/src/core/preview/utils/getPreviewValueWithFallback.tsx
+++ b/packages/sanity/src/core/preview/utils/getPreviewValueWithFallback.tsx
@@ -32,7 +32,7 @@ export function getPreviewValueWithFallback({
   if (document && !original && !snapshot) {
     return getMissingDocumentFallback(document)
   }
-  return assignWith({}, original, snapshot, (objValue, srcValue) => {
+  return assignWith({}, snapshot, original, (objValue, srcValue) => {
     return typeof srcValue === 'undefined' ? objValue : srcValue
   }) as PreviewValue
 }


### PR DESCRIPTION
### Description
Fixes an oversight with #8655 that picked the "original" preview value over the "snapshot" (which has the current perspective applied)
This should be the other way around: we always want to preview in current perspective, but in case we cant (e.g. the document we're trying to preview exists only outside of the current perspective, we want to fallback to the original)

Notice "this is the published" before vs "this is the draft" after – these are draft and published of the same document.
### Before

![image](https://github.com/user-attachments/assets/96a8fd12-b597-41c9-ba26-89d6370215d7)

###  After
![image](https://github.com/user-attachments/assets/9809dd64-12fa-4a49-a59a-073df07caf65)

### What to review
Looks ok?

### Notes for release
n/a