### PR TITLE
fix(comments): set up listener with filter-only

### DIFF
--- a/packages/sanity/src/core/comments/store/useCommentsStore.ts
+++ b/packages/sanity/src/core/comments/store/useCommentsStore.ts
@@ -63,10 +63,8 @@ const QUERY_SORT_ORDER = `order(${SORT_FIELD} ${SORT_ORDER})`
 export function useCommentsStore(opts: CommentsStoreOptions): CommentsStoreReturnType {
   const {client, documentId, onLatestTransactionIdReceived, transactionsIdMap, releaseId} = opts
 
-  const query = useMemo(() => {
-    const filters = [...QUERY_FILTERS, releaseId ? VERSION_FILTER : NO_VERSION_FILTER]
-    return `*[${filters.join(' && ')}] ${QUERY_PROJECTION} | ${QUERY_SORT_ORDER}`
-  }, [releaseId])
+  const filters = [...QUERY_FILTERS, releaseId ? VERSION_FILTER : NO_VERSION_FILTER].join(' && ')
+  const query = useMemo(() => `*[${filters}] ${QUERY_PROJECTION} | ${QUERY_SORT_ORDER}`, [filters])
 
   const [state, dispatch] = useReducer(commentsReducer, INITIAL_STATE)
   const [loading, setLoading] = useState<boolean>(client !== null)
@@ -170,7 +168,7 @@ export function useCommentsStore(opts: CommentsStoreOptions): CommentsStoreRetur
   const listener$ = useMemo(() => {
     if (!client) return of()
 
-    const events$ = client.observable.listen(query, params, LISTEN_OPTIONS).pipe(
+    const events$ = client.observable.listen(`*[${filters}]`, params, LISTEN_OPTIONS).pipe(
       catchError((err) => {
         setError(err)
         return of(err)
@@ -178,7 +176,7 @@ export function useCommentsStore(opts: CommentsStoreOptions): CommentsStoreRetur
     )
 
     return events$
-  }, [client, params, query])
+  }, [client, filters, params])
 
   useEffect(() => {
     const sub = listener$.subscribe(handleListenerEvent)


### PR DESCRIPTION
The /listen endpoint only cares about the groq filter, so passing the order clause and projection has no effect, and also gives a false impression of it working. This PR uses the filter separately from the rest of the query when setting up the listener for comments.
