### PR TITLE
fix(structure): preload should use published id

### DIFF
--- a/packages/sanity/src/structure/components/paneItem/PaneItem.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItem.tsx
@@ -19,6 +19,7 @@ import {
 import {
   type FIXME,
   type GeneralPreviewLayoutKey,
+  getPublishedId,
   PreviewCard,
   SanityDefaultPreview,
   useDocumentPresence,
@@ -181,7 +182,7 @@ export function PaneItem(props: PaneItemProps) {
 function PreloadDocumentPane(props: {documentId: string; documentType: string}) {
   const {documentId, documentType} = props
   // Preload the edit state for the document, and keep it alive until mouse leave
-  useEditState(documentId, documentType)
+  useEditState(getPublishedId(documentId), documentType)
 
   return null
 }


### PR DESCRIPTION
### Description
Fixes: SAPP-2455
If the `<PreloadPane>` gets a draft id instead of a published, it will throw an error.

`useEditState` should always use the `publishedId` this Pr updates the Preload to pass the published id.
and fix the following error

<img width="800" alt="Screenshot 2025-02-28 at 11 51 24" src="https://github.com/user-attachments/assets/335318e2-f16d-4681-93e6-6125e92db30d" />



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Fixes an issue in which in some cases the document list could crash when hovering over a document.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
