### PR TITLE
fix(structure): exclude documents outside of selected perspective from document lists

### DIFF
--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -76,7 +76,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   const {childItemId, isActive, pane, paneKey, sortOrder: sortOrderRaw, layout} = props
   const schema = useSchema()
   const releases = useActiveReleases()
-  const {perspectiveStack} = usePerspective()
+  const {perspectiveStack, selectedPerspective} = usePerspective()
   const {displayOptions, options} = pane
   const {apiVersion, filter} = options
   const params = useShallowUnique(options.params || EMPTY_RECORD)
@@ -113,7 +113,10 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   } = useDocumentList({
     apiVersion,
     filter,
-    perspective: perspectiveStack.length === 0 ? 'raw' : perspectiveStack,
+    perspective:
+      selectedPerspective === 'drafts' || selectedPerspective === 'published'
+        ? selectedPerspective
+        : perspectiveStack,
     params,
     searchQuery: searchQuery?.trim(),
     sortOrder,


### PR DESCRIPTION
### Description
Prior to this PR, document lists included all documents across all versions. This was never the original intention, so this reverts that behavior by applying the current perspective when fetching for document lists.

### What to review
Ensure that
- Using the default (drafts) perspective doesn't include documents that only exists in a release
- Selecting the "published" perspective doesn't include documents that exists only as drafts (or documents that only exists in a release)
- Selecting a release perspective doesn't include documents that exists only outside of the selected release stack
- Excluding a release from the global release dropdown correctly excludes documents that only exists in this release

### Testing
Not currently covered by tests afaik, but the review steps above should be a great starting point for e2e tests

### Notes for release
n/a - should already be covered by earlier release notes
