### PR TITLE
chore: exclude mocks and fixtures from bundle

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -126,6 +126,8 @@
     "static",
     "!**/__test__/**",
     "!**/__tests__/**",
+    "!**/__mocks__/**",
+    "!**/__fixtures__/**",
     "!**/__workshop__/**",
     "desk.js",
     "presentation.js",


### PR DESCRIPTION
### Description
`mocks` and `fixtures` were being included in the generated tarball for `sanity`, [see here](https://www.npmjs.com/package/sanity?activeTab=code) where you can find these dirs.

This change excludes them.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Tested by `pnpm build` and `pnpm pack` within `packages/sanity` and verifying that these dirs are no longer included
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
