### PR TITLE
fix(structure): provide feedback as document is added to release

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -136,9 +136,18 @@ const structureLocaleStrings = defineLocalesResources('structure', {
     'This reference has been removed since you opened it.',
   /** The text that appears for the action button to add the current document to the global release */
   'banners.release.action.add-to-release': 'Add to release',
+  /** Toast description in case an error occurs when adding a document to a release  */
+  'banners.release.error.description':
+    'An error occurred when adding document to the release: {{message}}',
+  /** Toast title in case an error occurs when adding a document to a release  */
+  'banners.release.error.title': 'Error adding document to release',
   /** The text for the banner that appears when a document is not in the current global release */
   'banners.release.not-in-release': 'Not in the <VersionBadge>{{title}}</VersionBadge> release.',
-
+  /** Description of toast that will appear in case of latency between the user adding a document to a release and the UI reflecting it */
+  'banners.release.waiting.description':
+    'Please hold tight while the document is added to the release. It should not take longer than a few seconds.',
+  /** Title of toast that will appear in case of latency between the user adding a document to a release and the UI reflecting it */
+  'banners.release.waiting.title': 'Adding document to release…',
   /** The text content for the unpublished document banner when is part of a release */
   'banners.unpublished-release-banner.text':
     'This document will be unpublished as part of the <VersionBadge>{{title}}</VersionBadge> release',

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
@@ -117,9 +117,10 @@ export function AddToReleaseBanner({
 function useCurrentTime(updateIntervalMs: number): Date {
   const [currentTime, setCurrentTime] = useState(new Date())
   useEffect(() => {
-    setInterval(() => {
+    const intervalId = setInterval(() => {
       setCurrentTime(new Date())
     }, updateIntervalMs)
+    return () => clearInterval(intervalId)
   }, [updateIntervalMs])
   return currentTime
 }


### PR DESCRIPTION
### Description
Currently, when adding a document to a release there is no progress feedback in the UI. Usually it goes fast enough for you to notice, but in cases where it takes a little while, the button is kept active, and if you hit it again you'll eventually get an error. This fixes the issue by disabling the button as long as the action is in-flight, and also adds a sprinkle of error handling.

### What to review
Does it work as expected?

### Testing
- Try adding a document to a release – the add button should be disabled while adding. Can use network throttling in devtools to simulate latency/lossyness

### Notes for release
n/a
