### PR TITLE
fix: handle motion.create warning

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
@@ -21,7 +21,7 @@ import {ReleaseSummary} from './ReleaseSummary'
 import {useBundleDocuments} from './useBundleDocuments'
 
 export type ReleaseInspector = 'activity'
-const MotionCard = motion(Card)
+const MotionCard = motion.create(Card)
 
 export const ReleaseDetail = () => {
   const router = useRouter()


### PR DESCRIPTION
### Description

Fixes `motion() is deprecated. Use motion.create() instead.` warnings on `sanity dev` as well as in the test suite log output (CMD + F "motion()" [here](https://github.com/sanity-io/sanity/actions/runs/13590063088/job/37993996651))

### What to review

Assigning you @pedrobonamin since you showed up on the `git blame` ❤ 

### Testing

N/A

### Notes for release

N/A
