### PR TITLE
fix(core): memoize scheduledPublishing calls, trigger only once

### DIFF
--- a/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.test.tsx
@@ -10,6 +10,7 @@ import {
   ScheduledPublishingEnabledProvider,
   useScheduledPublishingEnabled,
 } from './ScheduledPublishingEnabledProvider'
+import {cachedUsedScheduledPublishing} from './useHasUsedScheduledPublishing'
 
 vi.mock('../../../hooks/useFeatureEnabled', () => ({
   useFeatureEnabled: vi.fn().mockReturnValue({}),
@@ -55,6 +56,7 @@ describe('ScheduledPublishingEnabledProvider - previously used', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockClient(scheduleResponse)
+    cachedUsedScheduledPublishing.clear()
   })
 
   it('should not show scheduled publishing if user opt out and the feature is not enabled (any plan)', async () => {
@@ -68,7 +70,8 @@ describe('ScheduledPublishingEnabledProvider - previously used', () => {
     expect(value.result.current).toEqual({
       enabled: false,
       mode: null,
-      hasUsedScheduledPublishing: {used: true, loading: false},
+      // Workspace is not enabled, so we won't do a request to check if they have used it or not.
+      hasUsedScheduledPublishing: {used: false, loading: false},
     })
   })
   it('should not show scheduled publishing  if user opt out and the feature is enabled (any plan)', () => {
@@ -82,7 +85,8 @@ describe('ScheduledPublishingEnabledProvider - previously used', () => {
     expect(value.result.current).toEqual({
       enabled: false,
       mode: null,
-      hasUsedScheduledPublishing: {used: true, loading: false},
+      // Workspace is not enabled, so we won't do a request to check if they have used it or not.
+      hasUsedScheduledPublishing: {used: false, loading: false},
     })
   })
 
@@ -166,6 +170,7 @@ describe('ScheduledPublishingEnabledProvider - not previously used', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockClient([])
+    cachedUsedScheduledPublishing.clear()
   })
 
   it('should not show scheduled publishing  if user opt out and the feature is enabled (any plan)', () => {
@@ -221,7 +226,8 @@ describe('ScheduledPublishingEnabledProvider - not previously used', () => {
     expect(value.result.current).toEqual({
       enabled: true,
       mode: 'default',
-      hasUsedScheduledPublishing: {used: false, loading: false},
+      // Users have opted in, so we are not checking if they used it, we are just returning a default true value
+      hasUsedScheduledPublishing: {used: true, loading: false},
     })
   })
   it('should  show upsell mode if they have not used it before and opted in, and feature is not available (free plans)', () => {
@@ -238,7 +244,8 @@ describe('ScheduledPublishingEnabledProvider - not previously used', () => {
     expect(value.result.current).toEqual({
       enabled: true,
       mode: 'upsell',
-      hasUsedScheduledPublishing: {used: false, loading: false},
+      // Users have opted in, so we are not checking if they used it, we are just returning a default true value
+      hasUsedScheduledPublishing: {used: true, loading: false},
     })
   })
 })

--- a/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/contexts/ScheduledPublishingEnabledProvider.tsx
@@ -1,19 +1,12 @@
 import {useContext, useMemo} from 'react'
-import {useObservable} from 'react-rx'
-import {catchError, map, type Observable, of} from 'rxjs'
 import {ScheduledPublishingEnabledContext} from 'sanity/_singletons'
 
-import {useClient} from '../../../hooks/useClient'
 import {useFeatureEnabled} from '../../../hooks/useFeatureEnabled'
 import {useWorkspace} from '../../../studio/workspace'
-import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
-import {type Schedule} from '../../types'
-
-interface HasUsedScheduledPublishing {
-  used: boolean
-  loading: boolean
-}
-const HAS_USED_SCHEDULED_PUBLISHING: HasUsedScheduledPublishing = {used: false, loading: true}
+import {
+  type HasUsedScheduledPublishing,
+  useHasUsedScheduledPublishing,
+} from './useHasUsedScheduledPublishing'
 
 /**
  * @internal
@@ -41,33 +34,15 @@ interface ScheduledPublishingEnabledProviderProps {
 export function ScheduledPublishingEnabledProvider({
   children,
 }: ScheduledPublishingEnabledProviderProps) {
-  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
-
   const {enabled, isLoading, error} = useFeatureEnabled('scheduledPublishing')
   const {scheduledPublishing} = useWorkspace()
 
   const isWorkspaceEnabled = scheduledPublishing.enabled
   const explicitEnabled = scheduledPublishing.__internal__workspaceEnabled
-
-  const hasUsedScheduledPublishing$: Observable<HasUsedScheduledPublishing> = useMemo(() => {
-    const {dataset, projectId} = client.config()
-    return client.observable
-      .request<{schedules: Schedule[]}>({
-        uri: `/schedules/${projectId}/${dataset}?limit=1`,
-        tag: 'scheduled-publishing-used',
-      })
-      .pipe(
-        map((res) => {
-          return {used: res.schedules?.length > 0, loading: false}
-        }),
-        catchError(() => of({used: false, loading: false})),
-      )
-  }, [client])
-
-  const hasUsedScheduledPublishing = useObservable(
-    hasUsedScheduledPublishing$,
-    HAS_USED_SCHEDULED_PUBLISHING,
-  )
+  const hasUsedScheduledPublishing = useHasUsedScheduledPublishing({
+    explicitEnabled,
+    isWorkspaceEnabled,
+  })
 
   const value: ScheduledPublishingEnabledContextValue = useMemo(() => {
     if (!isWorkspaceEnabled || isLoading || error) {

--- a/packages/sanity/src/core/scheduledPublishing/tool/contexts/useHasUsedScheduledPublishing.ts
+++ b/packages/sanity/src/core/scheduledPublishing/tool/contexts/useHasUsedScheduledPublishing.ts
@@ -1,0 +1,67 @@
+import {type SanityClient} from '@sanity/client'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {catchError, map, type Observable, of, shareReplay} from 'rxjs'
+
+import {useClient} from '../../../hooks/useClient'
+import {useWorkspace} from '../../../studio/workspace'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
+import {type Schedule} from '../../types'
+
+export interface HasUsedScheduledPublishing {
+  used: boolean
+  loading: boolean
+}
+
+const HAS_USED_SCHEDULED_PUBLISHING: HasUsedScheduledPublishing = {used: false, loading: true}
+
+export const cachedUsedScheduledPublishing = new Map<
+  string,
+  Observable<HasUsedScheduledPublishing>
+>()
+
+function fetchUsedScheduledPublishing(
+  client: SanityClient,
+): Observable<HasUsedScheduledPublishing> {
+  const {dataset, projectId} = client.config()
+  return client.observable
+    .request<{
+      schedules: Schedule[]
+    }>({uri: `/schedules/${projectId}/${dataset}?limit=1`, tag: 'scheduled-publishing-used'})
+    .pipe(
+      map((res) => {
+        return {used: res.schedules?.length > 0, loading: false}
+      }),
+      catchError(() => of({used: false, loading: false})),
+    )
+}
+
+export function useHasUsedScheduledPublishing({
+  explicitEnabled,
+  isWorkspaceEnabled,
+}: {
+  explicitEnabled?: boolean
+  isWorkspaceEnabled?: boolean
+}) {
+  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  const {projectId, dataset} = useWorkspace()
+  const key = `${projectId}-${dataset}`
+  if (!cachedUsedScheduledPublishing.get(key)) {
+    const hasUsed = fetchUsedScheduledPublishing(client).pipe(shareReplay())
+    cachedUsedScheduledPublishing.set(key, hasUsed)
+  }
+  const hasUsedScheduledPublishing$ = useMemo(() => {
+    // If the feature is explicitly enabled, we don't need to check if it has been used
+    if (explicitEnabled) {
+      return of({used: true, loading: false})
+    }
+    // If the workspace has turned off the feature is explicitly enabled, we don't need to check if it has been used
+    if (!isWorkspaceEnabled) {
+      return of({used: false, loading: false})
+    }
+
+    return cachedUsedScheduledPublishing.get(key) || of(HAS_USED_SCHEDULED_PUBLISHING)
+  }, [key, explicitEnabled, isWorkspaceEnabled])
+
+  return useObservable(hasUsedScheduledPublishing$, HAS_USED_SCHEDULED_PUBLISHING)
+}


### PR DESCRIPTION
### Description
This PR updates the `hasUsedScheduledPublishing` check to trigger only once by memoizing the observable that will do the request.
It also adds a check in the case that users have opted out from the feature, if they have opted out ` scheduledPublishing.enabled = false` we won't do a request to check if they have used it before or not, because it will be off by default anyways.

If they have explicitly opted in, we won't check this, because it will be true anyways.



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is the approach correct?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open the studio, you should see only one request.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
