### PR TITLE
fix(core): add `isReleaseLocked` or `willBeUnpublished` to `useDocumentForm`

### DIFF
--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-statements */
 import {type SanityDocument} from '@sanity/client'
 import {isActionEnabled} from '@sanity/schema/_internal'
 import {useTelemetry} from '@sanity/telemetry/react'
@@ -28,8 +29,12 @@ import {useEditState} from '../hooks/useEditState'
 import {useSchema} from '../hooks/useSchema'
 import {useValidationStatus} from '../hooks/useValidationStatus'
 import {useTranslation} from '../i18n/hooks/useTranslation'
+import {getSelectedPerspective} from '../perspective/getSelectedPerspective'
 import {type ReleaseId} from '../perspective/types'
-import {isPublishedPerspective} from '../releases/util/util'
+import {isReleaseDocument} from '../releases/store/types'
+import {useActiveReleases} from '../releases/store/useActiveReleases'
+import {isGoingToUnpublish} from '../releases/util/isGoingToUnpublish'
+import {isPublishedPerspective, isReleaseScheduledOrScheduling} from '../releases/util/util'
 import {
   type DocumentPresence,
   type EditStateFor,
@@ -123,6 +128,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
   } = options
   const schema = useSchema()
   const presenceStore = usePresenceStore()
+  const {data: releases} = useActiveReleases()
 
   const schemaType = schema.get(documentType) as ObjectSchemaType | undefined
   if (!schemaType) {
@@ -223,12 +229,25 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
 
   const ready = connectionState === 'connected' && editState.ready
 
+  const selectedPerspective = useMemo(() => {
+    return getSelectedPerspective(selectedPerspectiveName, releases)
+  }, [selectedPerspectiveName, releases])
+
+  const isReleaseLocked = useMemo(
+    () =>
+      isReleaseDocument(selectedPerspective)
+        ? isReleaseScheduledOrScheduling(selectedPerspective)
+        : false,
+    [selectedPerspective],
+  )
+
   const readOnly = useMemo(() => {
     const hasNoPermission = !isPermissionsLoading && !permissions?.granted
     const updateActionDisabled = !isActionEnabled(schemaType!, 'update')
     const createActionDisabled = isNonExistent && !isActionEnabled(schemaType!, 'create')
     const reconnecting = connectionState === 'reconnecting'
     const isLocked = editState.transactionSyncLock?.enabled
+    const willBeUnpublished = value ? isGoingToUnpublish(value) : false
 
     // in cases where the document has drafts but the schema is live edit, there is a risk of data loss, so we disable editing in this case
     if (liveEdit && editState.draft?._id) {
@@ -250,7 +269,9 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
       createActionDisabled ||
       reconnecting ||
       isLocked ||
-      isCreateLinked
+      isCreateLinked ||
+      willBeUnpublished ||
+      isReleaseLocked
 
     if (isReadOnly) return true
     if (typeof readOnlyProp === 'function') return readOnlyProp(editState)
@@ -269,6 +290,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     ready,
     isCreateLinked,
     readOnlyProp,
+    isReleaseLocked,
   ])
 
   const {patch} = useDocumentOperation(documentId, documentType, releaseId)

--- a/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
+++ b/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
@@ -3,8 +3,8 @@ import {PerspectiveContext} from 'sanity/_singletons'
 
 import {getReleasesPerspectiveStack} from '../releases/hooks/utils'
 import {useActiveReleases} from '../releases/store/useActiveReleases'
-import {getReleaseIdFromReleaseDocumentId} from '../releases/util/getReleaseIdFromReleaseDocumentId'
 import {EMPTY_ARRAY} from '../util/empty'
+import {getSelectedPerspective} from './getSelectedPerspective'
 import {type PerspectiveContextValue, type ReleaseId, type SelectedPerspective} from './types'
 
 /**
@@ -21,14 +21,10 @@ export function PerspectiveProvider({
 }) {
   const {data: releases} = useActiveReleases()
 
-  const selectedPerspective: SelectedPerspective = useMemo(() => {
-    if (!selectedPerspectiveName) return 'drafts'
-    if (selectedPerspectiveName === 'published') return 'published'
-    const selectedRelease = releases.find(
-      (release) => getReleaseIdFromReleaseDocumentId(release._id) === selectedPerspectiveName,
-    )
-    return selectedRelease || 'drafts'
-  }, [selectedPerspectiveName, releases])
+  const selectedPerspective: SelectedPerspective = useMemo(
+    () => getSelectedPerspective(selectedPerspectiveName, releases),
+    [selectedPerspectiveName, releases],
+  )
 
   const perspectiveStack = useMemo(
     () =>

--- a/packages/sanity/src/core/perspective/getSelectedPerspective.ts
+++ b/packages/sanity/src/core/perspective/getSelectedPerspective.ts
@@ -1,0 +1,15 @@
+import {type ReleaseDocument} from '../releases/store/types'
+import {getReleaseIdFromReleaseDocumentId} from '../releases/util/getReleaseIdFromReleaseDocumentId'
+import {type ReleaseId, type SelectedPerspective} from './types'
+
+export function getSelectedPerspective(
+  selectedPerspectiveName: 'published' | ReleaseId | undefined,
+  releases: ReleaseDocument[],
+): SelectedPerspective {
+  if (!selectedPerspectiveName) return 'drafts'
+  if (selectedPerspectiveName === 'published') return 'published'
+  const selectedRelease = releases.find(
+    (release) => getReleaseIdFromReleaseDocumentId(release._id) === selectedPerspectiveName,
+  )
+  return selectedRelease || 'drafts'
+}

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -11,9 +11,6 @@ import {
   type EditStateFor,
   EMPTY_ARRAY,
   getPublishedId,
-  isGoingToUnpublish,
-  isReleaseDocument,
-  isReleaseScheduledOrScheduling,
   isVersionId,
   type PartialContext,
   useCopyPaste,
@@ -90,7 +87,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
   const perspective = usePerspective()
 
-  const {isReleaseLocked, selectedReleaseId, selectedPerspectiveName} = useMemo(() => {
+  const {selectedReleaseId, selectedPerspectiveName} = useMemo(() => {
     // TODO: COREL - Remove this after updating sanity-assist to use <PerspectiveProvider>
     if (forcedVersion) {
       return forcedVersion
@@ -98,16 +95,8 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     return {
       selectedPerspectiveName: perspective.selectedPerspectiveName,
       selectedReleaseId: perspective.selectedReleaseId,
-      isReleaseLocked: isReleaseDocument(perspective.selectedPerspective)
-        ? isReleaseScheduledOrScheduling(perspective.selectedPerspective)
-        : false,
     }
-  }, [
-    forcedVersion,
-    perspective.selectedPerspectiveName,
-    perspective.selectedReleaseId,
-    perspective.selectedPerspective,
-  ])
+  }, [forcedVersion, perspective.selectedPerspectiveName, perspective.selectedReleaseId])
 
   const initialValue = useDocumentPaneInitialValue({
     paneOptions,
@@ -165,16 +154,11 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
   const getIsReadOnly = useCallback(
     (editState: EditStateFor): boolean => {
-      const value = editState?.version || editState?.draft || editState?.published
-      const willBeUnpublished = value ? isGoingToUnpublish(value) : false
-
       const isDeleted = getIsDeleted(editState)
       const seeingHistoryDocument = revisionId !== null
-      return (
-        seeingHistoryDocument || isDeleting || isDeleted || isReleaseLocked || willBeUnpublished
-      )
+      return seeingHistoryDocument || isDeleting || isDeleted
     },
-    [getIsDeleted, isDeleting, isReleaseLocked, revisionId],
+    [getIsDeleted, isDeleting, revisionId],
   )
 
   const getDisplayed = useCallback(


### PR DESCRIPTION
### Description
In some cases the documents should have a read only state either because the release is locked or the document will be unpublished.
We are doing this check in the `<DocumentPaneProvider>` but this should be part of `useDocumentForm` so consumers don't need to care about this.

If a release is locked, editing the document will end in an error.
documents that will be unpublished are in theory possible to edit them, but it doesn't make sense from an user perspective and we are disabling this in the document pane.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
does the changes makes sense?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
