### PR TITLE
chore: speed up e2e tests

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -193,8 +193,8 @@ jobs:
         # Be sure to update all instances in this file and `pr-cleanup.yml` if updated
         project: [chromium, firefox]
         # Add more shards here if needed
-        shardIndex: [1, 2]
-        shardTotal: [2]
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -127,8 +127,8 @@ jobs:
         # Be sure to update all instances in this file and `pr-cleanup.yml` if updated
         project: [chromium, firefox]
         # Add more shards here if needed
-        shardIndex: [1, 2]
-        shardTotal: [2]
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/packages/sanity/playwright-ct.config.ts
+++ b/packages/sanity/playwright-ct.config.ts
@@ -24,8 +24,6 @@ export default defineConfig({
   forbidOnly: isCI,
   /* Flaky tests require us to allow up to 6 retries */
   retries: 6,
-  /* Opt out of parallel tests on CI. */
-  workers: isCI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: isCI
     ? [['list'], ['blob']]

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -60,7 +60,7 @@ const playwrightConfig = createPlaywrightConfig({
     return {
       ...config,
       retries: 4,
-      reporter: excludeGithub(config.reporter),
+      reporter: excludeGithub([['list'], ['blob']]),
       use: {
         ...config.use,
         baseURL: 'http://localhost:3339',


### PR DESCRIPTION
1. Doubles shards for e2e tests, they currently run 40-ish tests each so now it's down to 20. Making it easier to find and isolate slow and flaky tests.
2. E2E suite is setup to use the `line` playwright reporter, like the e2e-ct suite. This makes it much easier to see what's wrong if something fails (unless you're able to decrypt `Running 44 tests using 2 workers, shard 2 of 2 °·············×··±°···°·····°·×··±·······°°°°·`). It also reports test results progressively, so you don't have to wait 15 mins to see which test failed.
3. e2e-ct suite is no longer opting out of parallelism, like the e2e suite. This should make them about twice as fast since our runners has 2 vCPU's.