### PR TITLE
fix(sanity): ambient types for custom Vitest matchers

### DIFF
--- a/packages/sanity/test/matchers/toMatchEmissions.ts
+++ b/packages/sanity/test/matchers/toMatchEmissions.ts
@@ -3,23 +3,6 @@ import {firstValueFrom, type OperatorFunction, Subject, toArray} from 'rxjs'
 
 export const NO_EMISSION = Symbol('NO_EMISSION')
 
-type Snapshot<A, B> = [A, B | typeof NO_EMISSION]
-
-interface OperatorFunctionMatchers<Type = unknown> {
-  /**
-   * Ensure each entry in the provided array results in the expected value being emitted when piped
-   * to the observable.
-   */
-  toMatchEmissions: Type extends () => OperatorFunction<infer A, infer B>
-    ? (snapshots: Snapshot<A, B>[]) => Promise<Type>
-    : never
-}
-
-declare module 'vitest' {
-  interface Assertion<T = any> extends OperatorFunctionMatchers<T> {}
-  interface AsymmetricMatchersContaining extends OperatorFunctionMatchers {}
-}
-
 export async function toMatchEmissions(
   this: MatcherState,
   createOperator: () => OperatorFunction<unknown, unknown>,

--- a/packages/sanity/typings/vitest.d.ts
+++ b/packages/sanity/typings/vitest.d.ts
@@ -1,0 +1,20 @@
+import {type OperatorFunction} from 'rxjs'
+
+type Snapshot<A, B> = [A, B | typeof NO_EMISSION]
+
+interface OperatorFunctionMatchers<Type = unknown> {
+  /**
+   * Ensure each entry in the provided array results in the expected value being emitted when piped
+   * to the observable.
+   */
+  toMatchEmissions: Type extends () => OperatorFunction<infer A, infer B>
+    ? (snapshots: Snapshot<A, B>[]) => Promise<Type>
+    : never
+}
+
+declare module 'vitest' {
+  interface Assertion<T = any> extends OperatorFunctionMatchers<T> {}
+  interface AsymmetricMatchersContaining extends OperatorFunctionMatchers {}
+}
+
+export {}


### PR DESCRIPTION
### Description

This branch moves the ambient type definitions for custom Vitest matchers to `packages/sanity/typings`, ensuring the types are available inside `packages/sanity`. Prior to this change, the `toMatchEmissions` matcher was available at runtime, but the type itself was not.

### What to review

Does it seem reasonable to load the ambient type definitions in this way?

### Testing

The `toMatchEmissions` matcher should be available in the assertion type when the subject is a function that returns an RxJS `OperatorFunction`.