### PR TITLE
feat(sanity): hide workspace switcher inside Core UI rendering context

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -10,6 +10,7 @@ import {
 import {styled} from 'styled-components'
 
 import {MenuButton, type MenuButtonProps, MenuItem, Tooltip} from '../../../../../ui-components'
+import {CapabilityGate} from '../../../../components/CapabilityGate'
 import {useTranslation} from '../../../../i18n'
 import {useActiveWorkspace} from '../../../activeWorkspaceMatcher'
 import {useWorkspaces} from '../../../workspaces'
@@ -53,9 +54,11 @@ export function WorkspaceMenuButton() {
                     {activeWorkspace.title}
                   </Text>
                 </Box>
-                <Text size={1}>
-                  <ChevronDownIcon />
-                </Text>
+                <CapabilityGate capability="globalWorkspaceControl">
+                  <Text size={1}>
+                    <ChevronDownIcon />
+                  </Text>
+                </CapabilityGate>
               </Flex>
             </UIButton>
           </Tooltip>
@@ -64,39 +67,41 @@ export function WorkspaceMenuButton() {
       id="workspace-menu"
       menu={
         !disabled && authStates ? (
-          <StyledMenu>
-            {workspaces.map((workspace) => {
-              const authState = authStates[workspace.name]
+          <CapabilityGate capability="globalWorkspaceControl">
+            <StyledMenu>
+              {workspaces.map((workspace) => {
+                const authState = authStates[workspace.name]
 
-              // eslint-disable-next-line no-nested-ternary
-              const state = authState.authenticated
-                ? 'logged-in'
-                : workspace.auth.LoginComponent
-                  ? 'logged-out'
-                  : 'no-access'
+                // eslint-disable-next-line no-nested-ternary
+                const state = authState.authenticated
+                  ? 'logged-in'
+                  : workspace.auth.LoginComponent
+                    ? 'logged-out'
+                    : 'no-access'
 
-              const isSelected = workspace.name === activeWorkspace.name
+                const isSelected = workspace.name === activeWorkspace.name
 
-              // we have a temporary need to make a hard direct link to the workspace
-              // because of possibly shared context between workspaces. When this is resolved,
-              // we can remove this and use setActiveWorkspace instead
-              return (
-                <MenuItem
-                  as="a"
-                  href={workspace.basePath}
-                  badgeText={STATE_TITLES[state]}
-                  iconRight={isSelected ? CheckmarkIcon : undefined}
-                  key={workspace.name}
-                  pressed={isSelected}
-                  preview={<WorkspacePreviewIcon icon={workspace.icon} size="small" />}
-                  selected={isSelected}
-                  __unstable_subtitle={workspace.subtitle}
-                  __unstable_space={1}
-                  text={workspace?.title || workspace.name}
-                />
-              )
-            })}
-          </StyledMenu>
+                // we have a temporary need to make a hard direct link to the workspace
+                // because of possibly shared context between workspaces. When this is resolved,
+                // we can remove this and use setActiveWorkspace instead
+                return (
+                  <MenuItem
+                    as="a"
+                    href={workspace.basePath}
+                    badgeText={STATE_TITLES[state]}
+                    iconRight={isSelected ? CheckmarkIcon : undefined}
+                    key={workspace.name}
+                    pressed={isSelected}
+                    preview={<WorkspacePreviewIcon icon={workspace.icon} size="small" />}
+                    selected={isSelected}
+                    __unstable_subtitle={workspace.subtitle}
+                    __unstable_space={1}
+                    text={workspace?.title || workspace.name}
+                  />
+                )
+              })}
+            </StyledMenu>
+          </CapabilityGate>
         ) : undefined
       }
       popover={POPOVER_PROPS}


### PR DESCRIPTION
### Description

This branch removes the workspace switcher when Studio is rendered inside Core UI. Core UI instead controls workspace selection.

<img width="1671" alt="Screenshot 2025-03-06 at 12 44 52" src="https://github.com/user-attachments/assets/d2d373cd-ec60-40fc-94a7-5863bc26c9ed" />

### What to review

Does the removal look okay?

Note: I'm aware the "Select workspace" tooltip is still present. I'd like to do a fast-follow that slightly changes the way we handle this. But I think this is _good enough for now_.

### Testing

This can be tested by running Studio locally and then accessing the local dev server using a Core UI preview deployment.