### PR TITLE
fix(core): reconnection title was missing

### DIFF
--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -498,7 +498,7 @@ const useConnectionToast = (connectionState: ConnectionState) => {
         pushToast({
           id: 'sanity/reconnecting',
           status: 'warning',
-          title: t('panes.document-pane-provider.reconnecting.title'),
+          title: t('form.reconnecting.toast.title'),
         })
       }, 2000) // 2 seconds, we can iterate on the value
     }


### PR DESCRIPTION
### Description
Fixes the title for the reconnection toast.
<img width="800" alt="Screenshot 2025-03-05 at 11 14 56" src="https://github.com/user-attachments/assets/bc7edf44-1ba2-4e9d-9c94-4b4517623a1c" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
