### PR TITLE
chore(CI): speedup gh workflows, reduce E2E flake

### DIFF
--- a/.github/workflows/are-we-compiled-yet.yml
+++ b/.github/workflows/are-we-compiled-yet.yml
@@ -19,33 +19,12 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
+      - uses: actions/setup-node@v4
         with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -33,38 +33,12 @@ jobs:
         #     experimental: true
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
+      - uses: actions/setup-node@v4
         with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: ${{ matrix.node }}
 
       - name: Install project dependencies
         run: pnpm install

--- a/.github/workflows/depCheck.yml
+++ b/.github/workflows/depCheck.yml
@@ -7,34 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install

--- a/.github/workflows/docReport.yml
+++ b/.github/workflows/docReport.yml
@@ -19,37 +19,12 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install

--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -17,60 +17,20 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # Be sure to update all instances in this file and `pr-cleanup.yml` if updated
-        project: [chromium, firefox, webkit]
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install
 
       - name: Build packages
+        # This warms up the turborepo remote cache
         run: pnpm build --output-logs=full --log-order=grouped
-
-      # Caches build from either PR or next
-      - name: Cache build
-        id: cache-e2e-build
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-e2e-build
-        with:
-          path: |
-            ./*
-            !**/node_modules/**
-          # Unique key for a workflow run. Should be invalidated in the next run
-          key: ${{ runner.os }}-${{ matrix.project }}-${{ env.cache-name }}-${{ github.run_id }}
 
   playwright-ct-test:
     timeout-minutes: 30
@@ -82,41 +42,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Be sure to update all instances in this file and `pr-cleanup.yml` if updated
         project: [chromium, firefox, webkit]
-        # Add more shards here if needed
+        # Add more shards here if needed, but remember that the github required checks will have to be updated as well
         shardIndex: [1, 2]
         shardTotal: [2]
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install
@@ -136,21 +72,12 @@ jobs:
       - name: Install Playwright Browsers
         # TODO: Fix webkit caching when downloading from cache
         # for some reason it doesn't work without installing again
-        # if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true' || matrix.project == 'webkit'
         run: npx playwright install --with-deps
 
-      - name: Restore build cache
-        uses: actions/cache/restore@v4
-        id: restore-build
-        env:
-          cache-name: cache-e2e-build
-        with:
-          path: |
-            ./*
-            !**/node_modules/**
-          key: ${{ runner.os }}-${{ matrix.project }}-${{ env.cache-name }}-${{ github.run_id }}
-          # If the cached build from the pervious step is not available. Fail the build
-          fail-on-cache-miss: true
+      - name: Build packages
+        # This should take only a few seconds as it'll restore the remote cache that got primed in the `install` job
+        run: pnpm build --output-logs=full --log-order=grouped
 
       - name: Run end-to-end tests
         env:
@@ -171,34 +98,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install
@@ -213,15 +117,6 @@ jobs:
       - name: Merge into HTML Report
         run: npx playwright merge-reports --reporter json ${{ github.workspace }}/packages/sanity/playwright-ct/playwright-ct-report >> ${{ github.workspace }}/packages/sanity/playwright-ct/playwright-ct-report/playwright-ct-test-results.json
 
-      - name: Get Current Job Log URL
-        uses: Tiryoh/gha-jobid-action@be260d8673c9211a84cdcf37794ebd654ba81eef # v1
-        id: job_html_url
-        if: always()
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Get the first run's ID even though it might be correct it should bring to the right place
-          job_name: "playwright-ct-test (chromium, 1, 2)"
-
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -231,35 +126,3 @@ jobs:
             ${{ github.workspace }}/packages/sanity/playwright-ct/playwright-ct-report
             ${{ github.workspace }}/packages/sanity/playwright-ct/results
           retention-days: 30
-
-  cleanup:
-    permissions:
-      contents: read
-      actions: write # needed to delete the cache
-    timeout-minutes: 30
-    name: Cleanup (${{ matrix.project }})
-    runs-on: ubuntu-latest
-    needs: [playwright-ct-test]
-
-    strategy:
-      # we want to know if a test fails on a specific node version
-      fail-fast: false
-      matrix:
-        # Be sure to update all instances in this file and `pr-cleanup.yml` if updated
-        project: [chromium, firefox, webkit]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-
-      # Delete the cache so it is only used once
-      - name: Delete Cache
-        run: gh cache delete ${{ runner.os }}-${{ matrix.project }}-${{ env.cache-name }}-${{ github.run_id }}
-        env:
-          cache-name: cache-e2e-build
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -20,7 +20,9 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
+          cache: pnpm
           node-version: lts/*
+
       - run: pnpm install
       - name: Patch increment version in package.json
         id: npm-version
@@ -37,7 +39,7 @@ jobs:
           if-no-files-found: error
           overwrite: true
 
-  cache-cli:
+  build-cli:
     needs: [prepare]
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -49,15 +51,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: sanity-io/sanity
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
+          cache: pnpm
+          node-version: lts/*
 
       - uses: actions/download-artifact@v4
         with:
@@ -68,10 +66,11 @@ jobs:
       - run: pnpm add -w ./artifacts/sanity-ui-*.tgz
 
       - name: Build CLI
+        # This warms up the turborepo remote cache
         run: pnpm build:cli --output-logs=full --log-order=grouped
 
   install:
-    needs: [prepare, cache-cli]
+    needs: [prepare, build-cli]
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
@@ -80,45 +79,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Be sure to update all instances in this file and `pr-cleanup.yml` if updated
+        # Be sure to update all instances in this file and `pr-cleanup.yml` if updated, as well as github required checks
         project: [chromium, firefox]
     steps:
       - uses: actions/checkout@v4
         with:
           repository: sanity-io/sanity
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
-
+          cache: pnpm
+          node-version: lts/*
       - uses: actions/download-artifact@v4
         with:
           name: pack-sanity-ui
           path: artifacts
+
       - name: Install project dependencies
         run: pnpm install
       - run: pnpm add -w ./artifacts/sanity-ui-*.tgz
@@ -142,20 +118,10 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Build CLI
+        # This should take only a few seconds as it'll restore the remote cache that got primed in the `install` job
         run: pnpm build:cli --output-logs=full --log-order=grouped
 
-      # - name: Build E2E test studio on next
-      #   if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
-      #   env:
-      #     # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
-      #     # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
-      #     # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
-      #     SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
-      #     SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID }}
-      #     SANITY_E2E_DATASET: ${{ vars.SANITY_E2E_DATASET }}
-      #   run: pnpm e2e:setup && pnpm e2e:build
-
-      - name: Build E2E test studio on PR
+      - name: Cache E2E test studio on PR
         # Always run with PRs logic, to ensure tests run by the UI repo doesn't conflict with tests run by the sanity repo
         # if: ${{ github.event_name == 'pull_request' }}
         env:
@@ -167,19 +133,6 @@ jobs:
           SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
         run: pnpm e2e:setup && pnpm e2e:build
 
-      # Caches build from either PR or next
-      - name: Cache build
-        id: cache-e2e-build
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-e2e-build
-        with:
-          path: |
-            ./*
-            !**/node_modules/**
-          # Unique key for a workflow run. Should be invalidated in the next run
-          key: ${{ runner.os }}-${{ matrix.project }}-${{ env.cache-name }}-${{ github.run_id }}
-
   playwright-test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -190,48 +143,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Be sure to update all instances in this file and `pr-cleanup.yml` if updated
+        # Be sure to update all instances in this file and `pr-cleanup.yml` if updated, as well as github required checks
         project: [chromium, firefox]
-        # Add more shards here if needed
+        # Add more shards here if needed, but remember that the github required checks will have to be updated as well
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
     steps:
       - uses: actions/checkout@v4
         with:
           repository: sanity-io/sanity
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
-
+          cache: pnpm
+          node-version: lts/*
       - uses: actions/download-artifact@v4
         with:
           name: pack-sanity-ui
           path: artifacts
+
       - name: Install project dependencies
         run: pnpm install
 
@@ -252,33 +182,6 @@ jobs:
       - name: Install Playwright Browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
-
-      - name: Restore build cache
-        uses: actions/cache/restore@v4
-        id: restore-build
-        env:
-          cache-name: cache-e2e-build
-        with:
-          path: |
-            ./*
-            !**/node_modules/**
-          key: ${{ runner.os }}-${{ matrix.project }}-${{ env.cache-name }}-${{ github.run_id }}
-          # If the cached build from the pervious step is not available. Fail the build
-          fail-on-cache-miss: true
-
-      # - name: Run E2E tests on next
-      #   if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
-      #   env:
-      #     # Missing in docs but in use
-      #     # here https://github.com/microsoft/playwright/blob/main/packages/playwright/src/reporters/blob.ts#L108
-      #     PWTEST_BLOB_REPORT_NAME: ${{ matrix.project }}
-      #     # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
-      #     # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
-      #     # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
-      #     SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
-      #     SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
-      #     SANITY_E2E_DATASET: ${{ secrets.SANITY_E2E_DATASET }}
-      #   run: pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Run E2E tests on PR
         # Always run with PRs logic, to ensure tests run by the UI repo doesn't conflict with tests run by the sanity repo
@@ -293,7 +196,8 @@ jobs:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
           SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
-        run: pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        # As e2e:build ran in the `install` job, turbopack restores it from cache here
+        run: pnpm e2e:build && pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - uses: actions/upload-artifact@v4
         if: always()
@@ -301,6 +205,7 @@ jobs:
           name: playwright-report-${{ matrix.project }}-${{ matrix.shardIndex }}
           path: blob-report
           retention-days: 30
+
   merge-reports:
     if: always()
     needs: [playwright-test]
@@ -309,34 +214,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: sanity-io/sanity
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install
@@ -357,35 +239,3 @@ jobs:
           name: full-html-report--attempt-${{ github.run_attempt }}
           path: playwright-report
           retention-days: 30
-
-  cleanup:
-    permissions:
-      contents: read
-      actions: write # needed to delete the cache
-    timeout-minutes: 30
-    name: Cleanup (${{ matrix.project }})
-    runs-on: ubuntu-latest
-    needs: [playwright-test]
-
-    strategy:
-      # we want to know if a test fails on a specific node version
-      fail-fast: false
-      matrix:
-        # Be sure to update all instances in this file and `pr-cleanup.yml` if updated
-        project: [chromium, firefox]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-
-      # Delete the cache so it is only used once
-      - name: Delete Cache
-        run: gh cache delete ${{ runner.os }}-${{ matrix.project }}-${{ env.cache-name }}-${{ github.run_id }}
-        env:
-          cache-name: cache-e2e-build
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,47 +13,46 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-cli:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: lts/*
+
+      - name: Install project dependencies
+        run: pnpm install
+
+      - name: Build CLI
+        # This warms up the turborepo remote cache
+        run: pnpm build:cli --output-logs=full --log-order=grouped
+
   install:
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    needs: [build-cli]
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     strategy:
       fail-fast: false
       matrix:
-        # Be sure to update all instances in this file and `pr-cleanup.yml` if updated
+        # Be sure to update all instances in this file and `pr-cleanup.yml` if updated, as well as github required checks
         project: [chromium, firefox]
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ vars.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ vars.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install
@@ -77,9 +76,10 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Build CLI
+        # This should take only a few seconds as it'll restore the remote cache that got primed in the `install` job
         run: pnpm build:cli --output-logs=full --log-order=grouped
 
-      - name: Build E2E test studio on next
+      - name: Cache E2E test studio on next
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
         env:
           # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
@@ -90,7 +90,7 @@ jobs:
           SANITY_E2E_DATASET: ${{ vars.SANITY_E2E_DATASET }}
         run: pnpm e2e:setup && pnpm e2e:build
 
-      - name: Build E2E test studio on PR
+      - name: Cache E2E test studio on PR
         if: ${{ github.event_name == 'pull_request' }}
         env:
           # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
@@ -100,19 +100,6 @@ jobs:
           SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID }}
           SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
         run: pnpm e2e:setup && pnpm e2e:build
-
-      # Caches build from either PR or next
-      - name: Cache build
-        id: cache-e2e-build
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-e2e-build
-        with:
-          path: |
-            ./*
-            !**/node_modules/**
-          # Unique key for a workflow run. Should be invalidated in the next run
-          key: ${{ runner.os }}-${{ matrix.project }}-${{ vars.cache-name }}-${{ github.run_id }}
 
   playwright-test:
     timeout-minutes: 30
@@ -124,41 +111,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Be sure to update all instances in this file and `pr-cleanup.yml` if updated
+        # Be sure to update all instances in this file and `pr-cleanup.yml` if updated, as well as github required checks
         project: [chromium, firefox]
-        # Add more shards here if needed
+        # Add more shards here if needed, but remember that the github required checks will have to be updated as well
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ vars.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ vars.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install
@@ -181,19 +145,6 @@ jobs:
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
-      - name: Restore build cache
-        uses: actions/cache/restore@v4
-        id: restore-build
-        env:
-          cache-name: cache-e2e-build
-        with:
-          path: |
-            ./*
-            !**/node_modules/**
-          key: ${{ runner.os }}-${{ matrix.project }}-${{ vars.cache-name }}-${{ github.run_id }}
-          # If the cached build from the pervious step is not available. Fail the build
-          fail-on-cache-miss: true
-
       - name: Run E2E tests on next
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
         env:
@@ -206,7 +157,8 @@ jobs:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
           SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID }}
           SANITY_E2E_DATASET: ${{ vars.SANITY_E2E_DATASET }}
-        run: pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        # As e2e:build ran in the `install` job, turbopack restores it from cache here
+        run: pnpm e2e:build && pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Run E2E tests on PR
         if: ${{ github.event_name == 'pull_request' }}
@@ -220,7 +172,8 @@ jobs:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
           SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID }}
           SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
-        run: pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        # As e2e:build ran in the `install` job, turbopack restores it from cache here
+        run: pnpm e2e:build && pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - uses: actions/upload-artifact@v4
         if: always()
@@ -228,40 +181,18 @@ jobs:
           name: playwright-report-${{ matrix.project }}-${{ matrix.shardIndex }}
           path: blob-report
           retention-days: 30
+
   merge-reports:
     if: always()
     needs: [playwright-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ vars.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ vars.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install
@@ -282,35 +213,3 @@ jobs:
           name: full-html-report--attempt-${{ github.run_attempt }}
           path: playwright-report
           retention-days: 30
-
-  cleanup:
-    permissions:
-      contents: read
-      actions: write # needed to delete the cache
-    timeout-minutes: 30
-    name: Cleanup (${{ matrix.project }})
-    runs-on: ubuntu-latest
-    needs: [playwright-test]
-
-    strategy:
-      # we want to know if a test fails on a specific node version
-      fail-fast: false
-      matrix:
-        # Be sure to update all instances in this file and `pr-cleanup.yml` if updated
-        project: [chromium, firefox]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-
-      # Delete the cache so it is only used once
-      - name: Delete Cache
-        run: gh cache delete ${{ runner.os }}-${{ matrix.project }}-${{ vars.cache-name }}-${{ github.run_id }}
-        env:
-          cache-name: cache-e2e-build
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -37,34 +37,11 @@ jobs:
         shardTotal: [3]
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install
@@ -110,34 +87,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -21,37 +21,12 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install

--- a/.github/workflows/formatCheck.yml
+++ b/.github/workflows/formatCheck.yml
@@ -17,34 +17,11 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install

--- a/.github/workflows/lint-fix-if-needed.yml
+++ b/.github/workflows/lint-fix-if-needed.yml
@@ -21,34 +21,11 @@ jobs:
     if: ${{ github.ref_name == 'next' }}
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
+          cache: pnpm
           node-version: lts/*
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
 
       - name: Install project dependencies
         run: pnpm install

--- a/.github/workflows/lintPr.yml
+++ b/.github/workflows/lintPr.yml
@@ -19,33 +19,12 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
+      - uses: actions/setup-node@v4
         with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -11,34 +11,11 @@ jobs:
     if: github.event_name == 'deployment_status' && github.event.deployment.environment == 'production' && github.event.deployment_status.state == 'success' && startsWith(github.event.deployment_status.target_url, 'https://performance-studio')
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install

--- a/.github/workflows/pnpm-if-needed.yml
+++ b/.github/workflows/pnpm-if-needed.yml
@@ -23,35 +23,11 @@ jobs:
     if: ${{ github.ref_name == 'next' }}
     steps:
       - uses: actions/checkout@v4
-
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install --config.ignore-scripts=true

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -13,37 +13,12 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install
@@ -64,33 +39,12 @@ jobs:
         project: [chromium, firefox]
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
+      - uses: actions/setup-node@v4
         with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install

--- a/.github/workflows/prettier-if-needed.yml
+++ b/.github/workflows/prettier-if-needed.yml
@@ -21,34 +21,11 @@ jobs:
     if: ${{ github.ref_name == 'next' }}
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
+          cache: pnpm
           node-version: lts/*
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
 
       - name: Install project dependencies
         run: pnpm install --config.ignore-scripts=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,39 +21,15 @@ jobs:
       PKG_VERSION: ${{ inputs.version }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetches all history for all branches and tags
-
-      - name: Setup node
-        uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
+          cache: pnpm
           node-version: lts/*
           registry-url: "https://registry.npmjs.org"
-
-      - name: Setup pnpm and install dependencies
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,38 +36,12 @@ jobs:
         #     experimental: true
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
+      - uses: actions/setup-node@v4
         with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: ${{ matrix.node }}
 
       - name: Install project dependencies
         run: pnpm install
@@ -100,38 +74,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
+      - uses: actions/setup-node@v4
         with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install

--- a/.github/workflows/testExports.yml
+++ b/.github/workflows/testExports.yml
@@ -10,34 +10,11 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
+          cache: pnpm
           node-version: lts/*
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
 
       - name: Install project dependencies
         run: pnpm install

--- a/.github/workflows/typeCheck.yml
+++ b/.github/workflows/typeCheck.yml
@@ -10,34 +10,11 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
-            v1-${{ runner.os }}-pnpm-store-
-            v1-${{ runner.os }}-
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install project dependencies
         run: pnpm install

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "docs:report": "node -r dotenv-flow/config -r esbuild-register scripts/doc-report/docReport",
     "docs:report:cleanup": "node -r dotenv-flow/config -r esbuild-register scripts/doc-report/docReportCleanup",
     "docs:report:create": "node -r dotenv-flow/config -r esbuild-register scripts/doc-report/docReportCreate",
-    "e2e:build": "pnpm --filter studio-e2e-testing build",
+    "e2e:build": "pnpm turbo run build --filter=studio-e2e-testing",
     "e2e:cleanup": "node -r dotenv-flow/config -r esbuild-register scripts/e2e/cleanup",
     "e2e:codegen": "node -r dotenv-flow/config ./node_modules/.bin/sanity-test codegen",
     "e2e:dev": "pnpm --filter studio-e2e-testing dev",

--- a/packages/sanity/playwright-ct.config.ts
+++ b/packages/sanity/playwright-ct.config.ts
@@ -22,8 +22,8 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: isCI,
-  /* Flaky tests require us to allow up to 6 retries */
-  retries: 6,
+  /* We allow 1 retry to root out flaky tests */
+  retries: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: isCI
     ? [['list'], ['blob']]
@@ -38,17 +38,8 @@ export default defineConfig({
         ],
       ],
 
-  /* Maximum time one test can run for. */
-  timeout: 60 * 1000,
-  expect: {
-    // Maximum time expect() should wait for the condition to be met.
-    timeout: 40 * 1000,
-  },
-
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-    actionTimeout: 40 * 1000,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: isCI ? 'on-all-retries' : 'retain-on-failure',
     video: isCI ? 'on-first-retry' : 'retain-on-failure',

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Annotations.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Annotations.spec.tsx
@@ -62,9 +62,9 @@ test.describe('Portable Text Input', () => {
       await page.keyboard.press('Escape')
       await expect($pte).toBeFocused()
       await expect($toolbarPopover).toBeVisible()
-      await page.waitForTimeout(100)
+      await page.waitForTimeout(1_000)
       await page.keyboard.press('Escape')
-      await page.waitForTimeout(100)
+      await page.waitForTimeout(1_000)
       // Assertion: escape closes the toolbar popover
       await expect($toolbarPopover).not.toBeVisible()
     })

--- a/packages/sanity/playwright-ct/tests/formBuilder/utils/TestForm.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/utils/TestForm.tsx
@@ -76,7 +76,7 @@ export function TestForm(props: TestFormProps) {
   } = props
 
   const {setDocumentMeta} = useCopyPaste()
-  const wrapperRef = useRef<HTMLDivElement | null>(null)
+  const [wrapperElement, setWrapperElement] = useState<HTMLDivElement | null>(null)
   const [validation, setValidation] = useState<ValidationMarker[]>([])
   const [openPath, onSetOpenPath] = useState<Path>(openPathFromProps)
   const [fieldGroupState, onSetFieldGroupState] = useState<StateTree<string>>()
@@ -99,7 +99,7 @@ export function TestForm(props: TestFormProps) {
   const [patchChannel] = useState(() => createPatchChannel())
 
   useGlobalCopyPasteElementHandler({
-    element: wrapperRef.current,
+    element: wrapperElement,
     focusPath,
     value: document,
   })
@@ -171,7 +171,9 @@ export function TestForm(props: TestFormProps) {
   })
 
   const formStateRef = useRef(formState)
-  formStateRef.current = formState
+  useEffect(() => {
+    formStateRef.current = formState
+  }, [formState])
 
   const handleFocus = useCallback(
     (nextFocusPath: Path) => {
@@ -185,13 +187,7 @@ export function TestForm(props: TestFormProps) {
     setFocusPath([])
   }, [setFocusPath])
 
-  const patchRef = useRef<(event: PatchEvent) => void>(() => {
-    throw new Error(
-      'Attempted to patch the Sanity document during initial render. Input components should only call `onChange()` in an effect or a callback.',
-    )
-  })
-
-  patchRef.current = (event: PatchEvent) => {
+  const patchRef = useRef<(event: PatchEvent) => void>((event: PatchEvent) => {
     setDocument((currentDocumentValue) => {
       const result = applyAll(currentDocumentValue, event.patches)
 
@@ -200,7 +196,7 @@ export function TestForm(props: TestFormProps) {
 
       return result
     })
-  }
+  })
 
   const handleChange = useCallback((event: PatchEvent) => patchRef.current(event), [])
 
@@ -302,7 +298,7 @@ export function TestForm(props: TestFormProps) {
     ],
   )
   return (
-    <div ref={wrapperRef}>
+    <div ref={setWrapperElement}>
       <BoundaryElementProvider element={documentScrollElement}>
         <VirtualizerScrollInstanceProvider
           scrollElement={documentScrollElement}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -59,7 +59,8 @@ const playwrightConfig = createPlaywrightConfig({
 
     return {
       ...config,
-      retries: 4,
+      /* We allow 1 retry to root out flaky tests */
+      retries: 1,
       reporter: excludeGithub([['list'], ['blob']]),
       use: {
         ...config.use,

--- a/test/e2e/tests/document-actions/delete.spec.ts
+++ b/test/e2e/tests/document-actions/delete.spec.ts
@@ -6,6 +6,10 @@ const name = 'Test Name'
 test(`unpublished documents can be deleted`, async ({page, createDraftDocument}) => {
   await createDraftDocument('/test/content/author')
   await page.getByTestId('field-name').getByTestId('string-input').fill(name)
+  const paneFooter = page.getByTestId('pane-footer-document-status')
+
+  // Wait for the document to save before deleting.
+  await expect(paneFooter).toContainText(/created/i, {useInnerText: true, timeout: 30_000})
 
   await page.getByTestId('action-menu-button').click()
   await page.getByTestId('action-Delete').click()
@@ -18,14 +22,14 @@ test(`published documents can be deleted`, async ({page, createDraftDocument}) =
   await createDraftDocument('/test/content/author')
   await page.getByTestId('field-name').getByTestId('string-input').fill(name)
   const paneFooter = page.getByTestId('pane-footer-document-status')
+  const publishButton = page.getByTestId('action-publish')
 
-  // `.fill` and `.click` can cause the draft creation and publish to happen at the same exact time.
-  // We are waiting for 1s to make sure the draft actually gets created and click action is not too eager
-  await page.waitForTimeout(1000)
+  // Wait for the document to save before publishing.
+  await expect(paneFooter).toContainText(/created/i, {useInnerText: true, timeout: 30_000})
 
   // Wait for the document to be published.
-  await page.getByTestId('action-publish').click()
-  expect(await paneFooter.textContent()).toMatch(/published/i)
+  await publishButton.click()
+  await expect(paneFooter).toContainText(/published/i, {useInnerText: true, timeout: 30_000})
 
   await page.getByTestId('action-menu-button').click()
   await page.getByTestId('action-Delete').click()

--- a/test/e2e/tests/document-actions/discardChanges.spec.ts
+++ b/test/e2e/tests/document-actions/discardChanges.spec.ts
@@ -29,13 +29,20 @@ test(`is possible to discard changes if a changed document has a published versi
   const publishButton = page.getByTestId('action-publish')
   const actionMenuButton = page.getByTestId('action-menu-button')
   const discardChangesButton = page.getByTestId('action-Discardchanges')
+  const paneFooterDocumentStatusPulse = page.getByTestId('pane-footer-document-status-pulse')
 
   await titleInput.fill('This is a book')
+  // Wait for the document to finish saving
+  await expect(paneFooterDocumentStatusPulse).toBeHidden()
 
-  // Wait for the document to be published.
-  await page.waitForTimeout(1_000)
+  // Wait for the document to be publishable
+  await expect(publishButton).toBeEnabled({timeout: 30_000})
   await publishButton.click()
-  await expect(page.getByTestId('pane-footer-document-status')).toContainText('Published just now')
+  // Wait for the document to be published.
+  await expect(page.getByTestId('pane-footer-document-status')).toContainText(
+    'Published just now',
+    {useInnerText: true, timeout: 30_000},
+  )
 
   await titleInput.fill('This is not a book')
 
@@ -54,16 +61,26 @@ test(`displays the published document state after discarding changes`, async ({
   const actionMenuButton = page.getByTestId('action-menu-button')
   const discardChangesButton = page.getByTestId('action-Discardchanges')
   const confirmButton = page.getByTestId('confirm-dialog-confirm-button')
+  const paneFooterDocumentStatusPulse = page.getByTestId('pane-footer-document-status-pulse')
+  const paneFooterDocumentStatus = page.getByTestId('pane-footer-document-status')
 
   await titleInput.fill('This is a book')
+  // Wait for the document to finish saving
+  await expect(paneFooterDocumentStatusPulse).toBeHidden()
 
-  // Wait for the document to be published.
-  await page.waitForTimeout(1_000)
+  // Wait for the document to be publishable
+  await expect(publishButton).toBeEnabled()
   await publishButton.click()
-  await expect(page.getByTestId('pane-footer-document-status')).toContainText('Published just now')
+  // Wait for the document to be published.
+  await expect(paneFooterDocumentStatus).toContainText('Published just now', {
+    useInnerText: true,
+    timeout: 30_000,
+  })
 
   // Change the title.
   await titleInput.fill('This is not a book')
+  // Wait for the document to finish saving
+  await expect(paneFooterDocumentStatusPulse).toBeHidden()
 
   // Discard the change.
   await actionMenuButton.click()

--- a/test/e2e/tests/document-actions/liveEdit.spec.ts
+++ b/test/e2e/tests/document-actions/liveEdit.spec.ts
@@ -11,10 +11,17 @@ test(`liveEdited document can be created, edited, and deleted`, async ({
   await page.getByText('select the publish document to edit it')
   // Navigate to the published perspective
   await page.getByRole('button', {name: 'Published'}).click()
+  // Wait a little bit for the document to load
+  await page.waitForTimeout(2_000)
+
   await page.getByTestId('field-name').getByTestId('string-input').fill(name)
+
+  // Wait a little bit for the document to start saving
+  await page.waitForTimeout(2_000)
 
   await page.getByTestId('action-menu-button').click()
   await page.getByTestId('action-Delete').click()
+  await expect(page.getByTestId('pane-footer-document-status')).toBeHidden()
   await page.getByRole('button', {name: 'Delete now'}).click()
 
   await expect(page.getByText('The document was successfully deleted')).toBeVisible()

--- a/test/e2e/tests/document-actions/publish.spec.ts
+++ b/test/e2e/tests/document-actions/publish.spec.ts
@@ -29,7 +29,7 @@ test(`document panel displays correct title for published document`, async ({
 
   // Wait for the document to be published.
   page.getByTestId('action-publish').click()
-  await expect(page.getByText('Published just now')).toBeVisible()
+  await expect(page.getByText('Published just now')).toBeVisible({timeout: 30_000})
 
   // Ensure the correct title is displayed after publishing.
   expect(page.getByTestId('document-panel-document-title')).toHaveText(title)
@@ -45,16 +45,19 @@ test(`custom publish action can patch document before publication`, async ({
   const documentStatus = page.getByTestId('pane-footer-document-status')
   const titleInput = page.getByTestId('field-title').getByTestId('string-input')
   const publishedAtInput = page.getByTestId('field-publishedAt').getByTestId('date-input')
+  const paneFooter = page.getByTestId('pane-footer-document-status')
 
   await createDraftDocument('/test/content/input-debug;documentActionsTest')
   await titleInput.fill(title)
+
+  // Wait for the document to save before publishing.
+  await expect(paneFooter).toContainText(/created/i, {useInnerText: true, timeout: 30_000})
 
   // Wait for the document to be published.
   //
   // Note: This is invoked using the publish keyboard shortcut, because the publish document action
   // has been overridden for the `documentActionsTest` type, and is not visible without opening the
   // document actions menu.
-  await page.waitForTimeout(1_000)
   await publishKeypress()
   await expect(documentStatus).toContainText('Published just now')
 

--- a/test/e2e/tests/document-actions/restore.spec.ts
+++ b/test/e2e/tests/document-actions/restore.spec.ts
@@ -2,6 +2,7 @@ import {expect} from '@playwright/test'
 import {test} from '@sanity/test'
 
 test(`documents can be restored to an earlier revision`, async ({page, createDraftDocument}) => {
+  test.slow()
   const titleA = 'Title A'
   const titleB = 'Title B'
 
@@ -21,9 +22,10 @@ test(`documents can be restored to an earlier revision`, async ({page, createDra
 
   await createDraftDocument('/test/content/book')
   await titleInput.fill(titleA)
+  // Wait for the document to finish saving
+  await expect(documentStatus).toContainText(/created/i, {useInnerText: true, timeout: 60_000})
 
   // Wait for the document to be published.
-  await page.waitForTimeout(1_000)
   await publishButton.click()
   await expect(documentStatus).toContainText('Published just now')
 
@@ -32,7 +34,7 @@ test(`documents can be restored to an earlier revision`, async ({page, createDra
   await expect(titleInput).toHaveValue(titleB)
 
   // Wait for the document to be published.
-  await page.waitForTimeout(1_000)
+  await page.waitForTimeout(2_000)
   await publishButton.click()
   await expect(documentStatus).toContainText('Published just now')
 
@@ -81,13 +83,14 @@ test(`respects overridden restore action`, async ({page, createDraftDocument}) =
   })
 
   await titleInput.fill(titleA)
+  // Wait for the document to finish saving
+  await expect(documentStatus).toContainText(/created/i, {useInnerText: true, timeout: 30_000})
 
   // Wait for the document to be published.
   //
   // Note: This is invoked using the publish keyboard shortcut, because the publish document action
   // has been overridden for the `documentActionsTest` type, and is not visible without opening the
   // document actions menu.
-  await page.waitForTimeout(1_000)
   await publishKeypress()
   await expect(documentStatus).toContainText('Published just now')
 
@@ -96,7 +99,7 @@ test(`respects overridden restore action`, async ({page, createDraftDocument}) =
   await expect(titleInput).toHaveValue(titleB)
 
   // Wait for the document to be published.
-  await page.waitForTimeout(1_000)
+  await page.waitForTimeout(2_000)
   await publishKeypress()
   await expect(documentStatus).toContainText('Published just now')
 
@@ -148,9 +151,10 @@ test(`respects removed restore action`, async ({page, createDraftDocument}) => {
 
   await createDraftDocument('/test/content/input-debug;removeRestoreActionTest')
   await titleInput.fill(titleA)
+  // Wait for the document to finish saving
+  await expect(documentStatus).toContainText(/created/i, {useInnerText: true, timeout: 30_000})
 
   // Wait for the document to be published.
-  await page.waitForTimeout(1_000)
   await publishButton.click()
   await expect(documentStatus).toContainText('Published just now')
 
@@ -159,7 +163,7 @@ test(`respects removed restore action`, async ({page, createDraftDocument}) => {
   await expect(titleInput).toHaveValue(titleB)
 
   // Wait for the document to be published.
-  await page.waitForTimeout(1_000)
+  await page.waitForTimeout(2_000)
   await publishButton.click()
   await expect(documentStatus).toContainText('Published just now')
 

--- a/test/e2e/tests/document-actions/unpublish.spec.ts
+++ b/test/e2e/tests/document-actions/unpublish.spec.ts
@@ -19,9 +19,10 @@ test(`should be able to unpublish a published document`, async ({page, createDra
 
   await createDraftDocument('/test/content/book')
   await titleInput.fill(titleA)
+  // Wait for the document to finish saving
+  await expect(documentStatus).toContainText(/created/i, {useInnerText: true, timeout: 30_000})
 
   // Wait for the document to be published.
-  await page.waitForTimeout(1_000)
   await publishButton.click()
   await expect(documentStatus).toContainText('Published just now')
 
@@ -29,7 +30,7 @@ test(`should be able to unpublish a published document`, async ({page, createDra
   await expect(unpublishButton).toBeVisible()
   await unpublishButton.click()
 
-  await page.waitForTimeout(1_000)
+  await page.waitForTimeout(2_000)
 
   await expect(unpublishModal).toBeVisible()
   await page.getByTestId('confirm-button').click()

--- a/test/e2e/tests/inputs/datetime.spec.ts
+++ b/test/e2e/tests/inputs/datetime.spec.ts
@@ -70,5 +70,5 @@ test(`datetime inputs shows validation on entering date in the textfield and onB
 
   await expect(
     page.getByTestId('field-requiredDatetime').getByTestId('input-validation-icon-error'),
-  ).toBeVisible()
+  ).toBeVisible({timeout: 5_000})
 })

--- a/test/e2e/tests/inputs/reference.spec.ts
+++ b/test/e2e/tests/inputs/reference.spec.ts
@@ -47,7 +47,7 @@ withDefaultClient((context) => {
 
     // Wait for the document to be published.
     publishButton.click()
-    await expect(paneFooter).toContainText('Published just now')
+    await expect(paneFooter).toContainText('Published just now', {timeout: 30_000})
 
     // Open the Author reference input.
     await page.locator('#author-menuButton').click()
@@ -59,11 +59,11 @@ withDefaultClient((context) => {
     // Select the next document in the list.
     await page.keyboard.press('ArrowDown')
     await page.keyboard.press('Enter')
-    await expect(paneFooter).toContainText('Saved')
+    await expect(paneFooter).toContainText('Saved', {timeout: 30_000})
 
     // Wait for the document to be published.
     publishButton.click()
-    await expect(paneFooter).toContainText('Published just now')
+    await expect(paneFooter).toContainText('Published just now', {timeout: 30_000})
   })
 
   test(`_strengthenOnPublish and _weak properties exist when adding reference to a draft document`, async ({

--- a/test/e2e/tests/navbar/appearanceMenu.spec.ts
+++ b/test/e2e/tests/navbar/appearanceMenu.spec.ts
@@ -6,14 +6,15 @@ const COLOR_SCHEME_KEY = 'sanityStudio:ui:colorScheme'
 //some flakiness around local storage initial state, so add timeout and isolate
 test('default color scheme is system', async ({page, baseURL}) => {
   await page.goto(baseURL ?? '/test/content')
-  await page.waitForTimeout(2000)
+  await page.waitForTimeout(2_000)
   const localStorage = await page.evaluate(() => window.localStorage)
   expect(localStorage[COLOR_SCHEME_KEY]).toBe('system')
 })
 
 test('color scheme changes and persists', async ({page, baseURL}) => {
+  test.slow()
   await page.goto(baseURL ?? '/test/content')
-
+  await page.waitForTimeout(2_000)
   await page.locator(`[id='user-menu']`).click()
   await expect(await page.getByTestId('user-menu')).toBeVisible()
   await expect(await page.getByTestId('color-scheme-dark')).toBeVisible()

--- a/turbo.json
+++ b/turbo.json
@@ -27,7 +27,8 @@
     // these is for the perf/efps perf suite and should not be cached
     "VITE_PERF_EFPS_PROJECT_ID",
     "VITE_PERF_EFPS_DATASET",
-    "PERF_EFPS_SANITY_TOKEN"
+    "PERF_EFPS_SANITY_TOKEN",
+    "SANITY_E2E_SESSION_TOKEN"
   ],
   "globalDependencies": [
     ".npmrc",


### PR DESCRIPTION
### Description

- Removes `run_install: false` as this is the default option of `pnpm/action-setup@v4`.
uses `cache: pnpm` on `actions/setup-node@v4`, which replaces custom `cache-node-modules` commands, and leaves it to github to know the best way to cache pnpm.
- In order to use `cache: pnpm` we need to run `pnpm/action-setup` _before_ `actions/setup-node`.
- Uses `node-version: lts/*` so we automatically are on the last stable LTS release of Node.js, so we don't have to manually bump majors every year. A lot of jobs are on Node.js v18, instead of the faster v22.
- The `e2e-ct.yml`, uses turborepo to cache build output, which is much faster than the custom `actions/cache` steps, and doesn't require cleanup steps or garbage collection.
- The `e2e-ct.yml` now caches install for chromium and firefox, webkit still needs to run install on every run for it to be successful, although it's still unclear why.
- The `e2e:build` command now uses turborepo, significantly speeding up the e2e suite as it no longer needs to run `sanity build` on every single git push, only on changes that might affect the suite.
- The `playwright-ct.config.ts` is adjusted to make flake easier to detect, and tests fail faster instead of spending up to 30 mins on the CI before failing. Retries is set to just 1, as our options for `trace` and `video`, assume at least 1 retry on errors (for example `on-first-retry`). 
- `TestForm.tsx`, used by `e2e-ct`, is updated with the same fixes related to unstable `useRef` usage as in the production document providers/
- Regular e2e also has 1 retry now, instead of 4, to better catch flaky and failing tests (we shouldn't allow tests to regularly need 4 retries to pass).
- Refactored a bunch of tests so they're more resilient and less flaky, especially on FireFox

### What to review

Hopefully the changes makes sense and have helpful inline code comments.
In general the idea of setting retries to just `1`, instead of `4` or `6`, is that global limits like these makes it hard to track down flake, since the CI might regularly retry flaky tests 4+ times before they pass. It's better to set higher retry limits on specific flaky tests, as it also makes them easier to find and to keep track of.

### Testing

If existing tests pass we're good 🤞 

### Notes for release

N/A
