### PR TITLE
feat(sanity): use document layout middleware chain when rendering `DiffViewPane`

### DIFF
--- a/packages/sanity/src/structure/panes/document/document-layout/pickDocumentLayoutComponent.ts
+++ b/packages/sanity/src/structure/panes/document/document-layout/pickDocumentLayoutComponent.ts
@@ -1,0 +1,11 @@
+import {type ComponentType} from 'react'
+import {type DocumentLayoutProps, type PluginOptions} from 'sanity'
+
+/**
+ * Pick the document layout component when composing the component middleware chain.
+ */
+export function pickDocumentLayoutComponent(plugin: PluginOptions) {
+  return plugin.document?.components?.unstable_layout as ComponentType<
+    Omit<DocumentLayoutProps, 'renderDefault'>
+  >
+}

--- a/packages/sanity/src/structure/panes/document/document-layout/useDocumentLayoutComponent.ts
+++ b/packages/sanity/src/structure/panes/document/document-layout/useDocumentLayoutComponent.ts
@@ -1,13 +1,8 @@
 import {type ComponentType} from 'react'
-import {type DocumentLayoutProps, type PluginOptions, useMiddlewareComponents} from 'sanity'
+import {type DocumentLayoutProps, useMiddlewareComponents} from 'sanity'
 
 import {DocumentLayout} from './DocumentLayout'
-
-function pick(plugin: PluginOptions) {
-  return plugin.document?.components?.unstable_layout as ComponentType<
-    Omit<DocumentLayoutProps, 'renderDefault'>
-  >
-}
+import {pickDocumentLayoutComponent} from './pickDocumentLayoutComponent'
 
 /**
  * A hook that returns the document layout composed
@@ -17,7 +12,7 @@ export function useDocumentLayoutComponent(): ComponentType<
   Omit<DocumentLayoutProps, 'renderDefault'>
 > {
   return useMiddlewareComponents({
-    pick,
+    pick: pickDocumentLayoutComponent,
     defaultComponent: DocumentLayout,
   })
 }


### PR DESCRIPTION
### Description

`DiffViewPane` does not currently use the document layout middleware chain when it's rendered. This is problematic for plugins that rely on the `document.components.unstable_layout` option to inject context providers, such as `@sanity/assist`, which crashes inside `DiffViewPane` due to the absent context provider.

This branch wraps the `DiffViewPane`'s `FormBuilder` in the entire document layout middleware chain to solve the issue.

Note: I did consider adding the middleware chain to `FormBuilder` itself, but decided against this, because `FormBuilder` may be used in places where the document layout middleware chain is not desired. For example: when rendering the task form we likely do not wish to wrap it with components that were intended to influence the document editor layout.

We may want to consider adding an API explicitly for injecting context providers and other non-visual components so plugins do not need to misuse `document.components.unstable_layout`.

### What to review

Any issues with rendering the document layout component middleware chain inside `DiffViewPane`?

### Testing

Try opening the diff view with `@sanity/assist` enabled. It should work now. You can do this in Test Studio by navigating to the AI Assist workspace: `/ai-assist/structure/book;056e02e8-bc68-44b1-b882-98dcb95454b1?structure[diffView]=version&structure[previousDocument]=book%2C056e02e8-bc68-44b1-b882-98dcb95454b1&structure[nextDocument]=book%2Cdrafts.056e02e8-bc68-44b1-b882-98dcb95454b1`.

### Notes for release

Fixes a bug causing the document comparison view to crash when `@sanity/assist` is enabled.