### PR TITLE
fix(core): update perspectiveStack, use it as the client perspective

### DIFF
--- a/packages/sanity/src/core/perspective/__mocks__/usePerspective.mock.ts
+++ b/packages/sanity/src/core/perspective/__mocks__/usePerspective.mock.ts
@@ -7,7 +7,7 @@ export const perspectiveContextValueMock: Mocked<PerspectiveContextValue> = {
   selectedPerspectiveName: undefined,
   selectedReleaseId: undefined,
   selectedPerspective: 'drafts',
-  perspectiveStack: [],
+  perspectiveStack: ['drafts'],
   excludedPerspectives: [],
 }
 export const usePerspectiveMockReturn = perspectiveContextValueMock

--- a/packages/sanity/src/core/perspective/types.ts
+++ b/packages/sanity/src/core/perspective/types.ts
@@ -32,7 +32,9 @@ export interface PerspectiveContextValue {
   /* Return the current global release */
   selectedPerspective: SelectedPerspective
   /**
-   * The stacked array of releases ids ordered chronologically to represent the state of documents at the given point in time.
+   * The stacked array of perspectives ids ordered chronologically to represent the state of documents at the given point in time.
+   * It can be used as the perspective param in the client to get the correct view of the documents.
+   * @returns ["published"] | ["drafts"] | ["releaseId2", "releaseId1", "drafts"]
    */
   perspectiveStack: PerspectiveStack
   /* The excluded perspectives */

--- a/packages/sanity/src/core/perspective/usePerspective.ts
+++ b/packages/sanity/src/core/perspective/usePerspective.ts
@@ -13,7 +13,7 @@ import {type PerspectiveContextValue} from './types'
  * ```ts
  * function MyComponent() {
  *  const {perspectiveStack} = usePerspective()
- *  // ... do something with the perspective stack ...
+ *  // ... do something with the perspective stack , like passing it to the client perspective.
  * }
  * ```
  */

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -38,33 +38,19 @@ function useDocumentPreview(props: {
 }): State {
   const {enabled = true, ordering, schemaType, value: previewValue} = props || {}
   const {observeForPreview} = useDocumentPreviewStore()
-  const {perspectiveStack, selectedPerspective} = usePerspective()
+  const {perspectiveStack} = usePerspective()
   const observable = useMemo<Observable<State>>(() => {
     // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
     if (!enabled || !previewValue || !schemaType) return of(IDLE_STATE)
 
     return observeForPreview(previewValue as Previewable, schemaType, {
-      perspective:
-        // eslint-disable-next-line no-nested-ternary
-        selectedPerspective === 'drafts'
-          ? ['drafts']
-          : selectedPerspective === 'published'
-            ? ['published']
-            : perspectiveStack,
+      perspective: perspectiveStack,
       viewOptions: {ordering: ordering},
     }).pipe(
       map((event) => ({isLoading: false, value: event.snapshot || undefined})),
       catchError((error) => of({isLoading: false, error})),
     )
-  }, [
-    enabled,
-    previewValue,
-    schemaType,
-    observeForPreview,
-    selectedPerspective,
-    perspectiveStack,
-    ordering,
-  ])
+  }, [enabled, previewValue, schemaType, observeForPreview, perspectiveStack, ordering])
 
   return useObservable(observable, INITIAL_STATE)
 }

--- a/packages/sanity/src/core/releases/hooks/__tests__/utils.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/utils.test.ts
@@ -229,8 +229,8 @@ describe('getReleasesPerspectiveStack()', () => {
       excludedPerspectives: ['rfuture1', 'drafts'],
       expected: ['rundecided2', 'rfuture4', 'rasap2', 'rasap1'],
     },
-    {selectedPerspectiveName: 'published', excludedPerspectives: [], expected: []},
-    {selectedPerspectiveName: undefined, excludedPerspectives: [], expected: []},
+    {selectedPerspectiveName: 'published', excludedPerspectives: [], expected: ['published']},
+    {selectedPerspectiveName: undefined, excludedPerspectives: [], expected: ['drafts']},
   ]
   it.each(testCases)(
     'should return the correct release stack for %s',

--- a/packages/sanity/src/core/releases/hooks/utils.ts
+++ b/packages/sanity/src/core/releases/hooks/utils.ts
@@ -59,8 +59,11 @@ export function getReleasesPerspectiveStack({
   releases: ReleaseDocument[]
   excludedPerspectives: string[]
 }): PerspectiveStack {
-  if (!selectedPerspectiveName || selectedPerspectiveName === 'published') {
-    return []
+  if (!selectedPerspectiveName) {
+    return ['drafts']
+  }
+  if (selectedPerspectiveName === 'published') {
+    return ['published']
   }
   const sorted: ClientPerspective = sortReleases(releases).map((release) =>
     getReleaseIdFromReleaseDocumentId(release._id),

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
@@ -4,7 +4,6 @@ import {SearchContext} from 'sanity/_singletons'
 
 import {type CommandListHandle} from '../../../../../../components'
 import {useSchema} from '../../../../../../hooks'
-import {usePerspective} from '../../../../../../perspective/usePerspective'
 import {useActiveReleases} from '../../../../../../releases/store/useActiveReleases'
 import {type SearchTerms} from '../../../../../../search'
 import {useCurrentUser} from '../../../../../../store'
@@ -52,7 +51,6 @@ export function SearchProvider({
 }: SearchProviderProps) {
   const [onClose, setOnClose] = useState<(() => void) | null>(null)
   const [searchCommandList, setSearchCommandList] = useState<CommandListHandle | null>(null)
-  const {perspectiveStack} = usePerspective()
   const {data: releases} = useActiveReleases()
   const schema = useSchema()
   const currentUser = useCurrentUser()
@@ -186,7 +184,6 @@ export function SearchProvider({
     terms,
     cursor,
     strategy,
-    perspectiveStack,
     releases,
   ])
 

--- a/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
@@ -39,20 +39,15 @@ export function PaneItemPreview(props: PaneItemPreviewProps) {
 
   const versionsInfo = useDocumentVersionInfo(value._id)
 
-  const {perspectiveStack, selectedPerspective} = usePerspective()
+  const {perspectiveStack} = usePerspective()
   const previewStateObservable = useMemo(() => {
     return getPreviewStateObservable(
       props.documentPreviewStore,
       schemaType,
       value._id,
-      // eslint-disable-next-line no-nested-ternary
-      !selectedPerspective || selectedPerspective === 'drafts'
-        ? ['drafts']
-        : selectedPerspective === 'published'
-          ? ['published']
-          : perspectiveStack,
+      perspectiveStack,
     )
-  }, [props.documentPreviewStore, schemaType, value._id, selectedPerspective, perspectiveStack])
+  }, [props.documentPreviewStore, schemaType, value._id, perspectiveStack])
 
   const {
     snapshot,

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -76,7 +76,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   const {childItemId, isActive, pane, paneKey, sortOrder: sortOrderRaw, layout} = props
   const schema = useSchema()
   const releases = useActiveReleases()
-  const {perspectiveStack, selectedPerspective} = usePerspective()
+  const {perspectiveStack} = usePerspective()
   const {displayOptions, options} = pane
   const {apiVersion, filter} = options
   const params = useShallowUnique(options.params || EMPTY_RECORD)
@@ -113,10 +113,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   } = useDocumentList({
     apiVersion,
     filter,
-    perspective:
-      selectedPerspective === 'drafts' || selectedPerspective === 'published'
-        ? selectedPerspective
-        : perspectiveStack,
+    perspective: perspectiveStack,
     params,
     searchQuery: searchQuery?.trim(),
     sortOrder,

--- a/packages/sanity/src/structure/panes/documentList/__tests__/PaneContainer.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/PaneContainer.test.tsx
@@ -29,7 +29,7 @@ vi.mock('sanity', async (importOriginal) => ({
   useActiveReleases: vi.fn(() => ({})),
   usePerspective: vi.fn(
     (): PerspectiveContextValue => ({
-      perspectiveStack: [],
+      perspectiveStack: ['drafts'],
       excludedPerspectives: [],
       selectedPerspective: 'drafts',
       selectedPerspectiveName: undefined,


### PR DESCRIPTION
### Description
The `usePerspective` hook exposes the `perspectiveStack` but that is only valid as the `perspective` to use with the client when you have a release selected.
If no releases are selected then the `perspectiveStack` returns an empty array, blocking us from using it as intended and making us do all over the place things like this:
```ts
const {perspectiveStack, selectedPerspective} = usePerspective()
  const perspective = useMemo(
    () =>
      selectedPerspective === 'published'
        ? ['published'] // or "published" it returns the same result 
        : selectedPerspective === 'drafts'
          ? ['drafts']  // or "dradts" it returns the same result 
          : perspectiveStack,
    [selectedPerspective, perspectiveStack],
  )
client.fetch(query, {}, {perspective})
```

This PR updates the `perspectiveStack` to also return either `["published"]` or `["drafts"]`, so now we can use it directly

So now consumers can do the following, and it will just work.

```diff
+const {perspectiveStack, selectedPerspective} = usePerspective()
-  const perspective = useMemo(
-   () =>
-      selectedPerspective === 'published'
-        ? ['published'] // or "published" it returns the same result 
-        : selectedPerspective === 'drafts'
-          ? ['drafts']  // or "dradts" it returns the same result 
-          : perspectiveStack,
-    [selectedPerspective, perspectiveStack],
-  )
+ client.fetch(query, {}, {perspective: perspectiveStack})
```



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Are the results in the studio still correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manually tested it works in:
 - references
 - global search
 - raw search (adding a document into the releases plugin)

Existing tests are updated.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Now users can consume the `perspectiveStack` from the `usePerspective` hook and pass that down to the client.perspective without extra logic.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
