### PR TITLE
fix(releases): specify apiVersion in useClient calls

### DIFF
--- a/packages/sanity/src/core/releases/store/useOrgActiveReleaseCount.ts
+++ b/packages/sanity/src/core/releases/store/useOrgActiveReleaseCount.ts
@@ -77,7 +77,7 @@ function createOrgActiveReleaseCountStore(
 export const useOrgActiveReleaseCount = () => {
   const resourceCache = useResourceCache()
   const {data: activeReleases} = useActiveReleases()
-  const client = useClient()
+  const client = useClient({apiVersion: 'v2025-02-19'})
 
   const activeReleasesCount = activeReleases?.length || 0
 

--- a/packages/sanity/src/core/releases/store/useReleaseLimits.ts
+++ b/packages/sanity/src/core/releases/store/useReleaseLimits.ts
@@ -44,7 +44,7 @@ function createReleaseLimitsStore(client: SanityClient): ReleaseLimitsStore {
  */
 export const useReleaseLimits: () => ReleaseLimitsStore = () => {
   const resourceCache = useResourceCache()
-  const client = useClient()
+  const client = useClient({apiVersion: 'v2025-02-19'})
 
   return useMemo(() => {
     const releaseLimitsStore =


### PR DESCRIPTION
### Description
We had a couple of useClient() calls that didn't specify `apiVersion` causing a bit of warning-spam in the console.

### Testing

After checking out this branch there should be no more warnings about useClient() calls not specifying version

### Notes for release
- Removes a few console warnings