### PR TITLE
fix(sanity): use recursive wildcards for release document listings

### DIFF
--- a/packages/sanity/src/core/releases/store/createReleaseMetadataAggregator.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseMetadataAggregator.ts
@@ -108,7 +108,7 @@ export const createReleaseMetadataAggregator = (client: SanityClient | null) => 
       .listen(
         `*[(${releaseIds.reduce(
           (accQuery, releaseId, index) =>
-            `${accQuery}${index === 0 ? '' : ' ||'} _id in path("versions.${releaseId}.*")`,
+            `${accQuery}${index === 0 ? '' : ' ||'} _id in path("versions.${releaseId}.**")`,
           '',
         )})]`,
         {},

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -74,7 +74,7 @@ const getActiveReleaseDocumentsObservable = ({
   const client = getClient(RELEASES_STUDIO_CLIENT_OPTIONS)
   const observableClient = client.observable
 
-  const groqFilter = `_id in path("versions.${releaseId}.*")`
+  const groqFilter = `_id in path("versions.${releaseId}.**")`
 
   return documentPreviewStore
     .unstable_observeDocumentIdSet(groqFilter, undefined, {


### PR DESCRIPTION
### Description
Currently, if you add a document with a dot-path, it won't show up in the listing of documents in a release.

This happens because the query that listens for documents was using `_id in path("versions.${releaseId}.*")` which only matches documents with one immediate path element. This PR fixes the issue by rewriting the filter to add a trailing `**`, which matches ids recursively

### What to review
- I think I caught all the relevant places, and did a round of manual testing.

### Testing
This release has a version of the document with `_id=dot.path.author` in it:
- Before: https://test-studio.sanity.dev/test/releases/rvwDnxsPf?perspective=rvwDnxsPf
- After: https://test-studio-git-fix-releases-query.sanity.dev/test/releases/rvwDnxsPf?perspective=rvwDnxsPf

### Notes for release
- Fixes an issue causing documents with nested dot-paths in them 