### PR TITLE
feat: detect and warn if using http1 against API

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1109,6 +1109,14 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Unexpected error: `{{error}}` */
   'member-field-error.unexpected-error': 'Unexpected error: {{error}}',
 
+  /** Text shown in warning when browser is using HTTP1 to communicate with the Sanity API */
+  'network-check.slow-protocol-warning.description':
+    'Your browser is using an outdated HTTP protocol to communicate with Sanity. This may result in greatly degraded performance.',
+  /** Text for link that takes the user to the Sanity documentation to learn more about the HTTP1 issue */
+  'network-check.slow-protocol-warning.learn-more': 'Learn more',
+  /** Title text for the warning dialog when browser is using HTTP1 to communicate with the Sanity API */
+  'network-check.slow-protocol-warning.title': "You've got your breaks on",
+
   /** Button label for "Create new document" button */
   'new-document.button': 'Create',
   /**

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -11,6 +11,7 @@ export * from './FIXME'
 export * from './form'
 export * from './hooks'
 export * from './i18n'
+export {isUsingModernHttp} from './network/isUsingModernHttp'
 export {PerspectiveProvider} from './perspective/PerspectiveProvider'
 export {
   type PerspectiveContextValue,

--- a/packages/sanity/src/core/network/isUsingModernHttp.ts
+++ b/packages/sanity/src/core/network/isUsingModernHttp.ts
@@ -1,0 +1,128 @@
+import {type SanityClient} from '@sanity/client'
+import {from, Observable, of, race, timer} from 'rxjs'
+import {map, take} from 'rxjs/operators'
+
+/**
+ * The /ping route is special in that it allows any origin to access it, and crucially
+ * for this case: also allows _timing_ requests through the `timing-allow-origin` header.
+ * This is what allows us to detect the protocol used for the request by using the
+ * browser Performance API.
+ */
+const checkPath = '/ping'
+
+/**
+ * The tag to use for the request to the /ping route. This is used to identify the
+ * request in the Performance API as well as in the server logs.
+ */
+const checkRequestTag = 'protocol-check'
+
+/**
+ * Preferably we want to use a client, since that will have both a configured URL (the
+ * user may have configured a custom API URL) and also uses the client for _requesting_
+ * the URL. While this last part _shouldn't_ make a difference, there is a theoretical
+ * possibility that XMLHttpRequest (potentially used by the client) uses a different
+ * protocol than the fetch API.
+ */
+const fallbackApiUrl = `https://api.sanity.io/v2025-03-01/ping?tag=sanity.studio.${checkRequestTag}`
+
+/**
+ * Checks whether a request to the API is using a modern HTTP protocol (HTTP/2 or later).
+ * Can emit `undefined` if the protocol could not be detected.
+ *
+ * @param client - The client to use for the request. If not provided, a fetch request
+ * will be made to the fallback API URL. Prefer using a client, as it will have the
+ * correct URL configured.
+ * @returns An Observable that emits `true` if the API request is using a modern HTTP
+ * protocol, `false` if it is not, or `undefined` if it could not be detected.
+ * @public
+ */
+export function isUsingModernHttp(client?: SanityClient): Observable<boolean | undefined> {
+  return getProtocolForApi(client).pipe(
+    map((protocol) => {
+      if (!protocol) {
+        return undefined
+      }
+
+      // Typical values for protocol are "http/0.9", "http/1.0", "http/1.1", "h2", "h2c", "h3", etc.
+      // We consider anything `http/0*` or `http/1*` to be non-modern.
+      return !protocol.startsWith('http/0') && !protocol.startsWith('http/1')
+    }),
+  )
+}
+
+/**
+ * Detects the protocol used for the API request by using the browser Performance API.
+ * This is useful for detecting whether the API request is using HTTP/2 or not.
+ *
+ * @param client - The client to use for the request. If not provided, a fetch request
+ * will be made to the fallback API URL. Prefer using a client, as it will have the
+ * correct URL configured.
+ * @returns An Observable that emits the protocol used for the API request, or `undefined`
+ * if it could not be detected.
+ * @internal
+ */
+function getProtocolForApi(client?: SanityClient): Observable<string | undefined> {
+  if (
+    typeof PerformanceObserver === 'undefined' ||
+    typeof PerformanceResourceTiming === 'undefined'
+  ) {
+    // If we don't have the necessary APIs, we can't do the check
+    return of(undefined)
+  }
+
+  const checkUrl = client ? client.getUrl(checkPath) : `${fallbackApiUrl}${checkPath}`
+
+  // Race the actual timing detection against a 2.5s timer.
+  // If the timer wins, we emit undefined to indicate we couldn’t detect the protocol.
+  return race(detectProtocol(checkUrl, client), timer(2500).pipe(map(() => undefined))).pipe(
+    take(1),
+  )
+}
+
+/**
+ * Creates an Observable that sets up a PerformanceObserver, issues the network request,
+ * and emits the `nextHopProtocol` once the resource timing shows up. If the request
+ * fails, the Observable will emit an error.
+ *
+ * @internal
+ */
+function detectProtocol(checkUrl: string, client?: SanityClient): Observable<string | undefined> {
+  return new Observable<string | undefined>((subscriber) => {
+    const observer = new PerformanceObserver((list, obs) => {
+      for (const entry of list.getEntries()) {
+        if (
+          !(entry instanceof PerformanceResourceTiming) ||
+          !entry.name.includes(checkRequestTag) ||
+          !entry.name.includes(checkPath)
+        ) {
+          return
+        }
+
+        obs.disconnect()
+        subscriber.next(entry.nextHopProtocol)
+        subscriber.complete()
+      }
+    })
+
+    observer.observe({
+      type: 'resource',
+      buffered: true,
+    })
+
+    const request$ = client
+      ? client.observable.request({uri: checkPath, withCredentials: false, tag: checkRequestTag})
+      : from(fetch(checkUrl))
+
+    const requestSub = request$.subscribe({
+      error: (err) => {
+        observer.disconnect()
+        subscriber.error(err)
+      },
+    })
+
+    return () => {
+      requestSub.unsubscribe()
+      observer.disconnect()
+    }
+  })
+}

--- a/packages/sanity/src/core/studio/StudioLayout.tsx
+++ b/packages/sanity/src/core/studio/StudioLayout.tsx
@@ -7,6 +7,7 @@ import {RouteScope, useRouter, useRouterState} from 'sanity/router'
 import {styled} from 'styled-components'
 
 import {LoadingBlock} from '../components/loadingBlock'
+import {useNetworkProtocolCheck} from './networkCheck/useNetworkProtocolCheck'
 import {NoToolsScreen} from './screens/NoToolsScreen'
 import {RedirectingScreen} from './screens/RedirectingScreen'
 import {ToolNotFoundScreen} from './screens/ToolNotFoundScreen'
@@ -81,6 +82,11 @@ export function StudioLayout() {
  * */
 export function StudioLayoutComponent() {
   const {name, title, tools} = useWorkspace()
+
+  // In the background, check if the network protocol used to communicate with the
+  // Sanity API is modern (HTTP/2 or newer). Shows a toast if it's not.
+  useNetworkProtocolCheck()
+
   const router = useRouter()
   const activeToolName = useRouterState(
     useCallback(

--- a/packages/sanity/src/core/studio/networkCheck/useNetworkProtocolCheck.tsx
+++ b/packages/sanity/src/core/studio/networkCheck/useNetworkProtocolCheck.tsx
@@ -1,0 +1,54 @@
+import {generateHelpUrl} from '@sanity/generate-help-url'
+import {useToast} from '@sanity/ui'
+import {useEffect} from 'react'
+import {filter} from 'rxjs'
+
+import {useClient} from '../../hooks/useClient'
+import {useTranslation} from '../../i18n/hooks/useTranslation'
+import {isUsingModernHttp} from '../../network/isUsingModernHttp'
+
+const HTTP_HELP_URL = generateHelpUrl('http1-performance-issues')
+
+/**
+ * Checks the network protocol used to communicate with the Sanity API and shows a
+ * warning toast if it's not using a modern protocol (HTTP/2 or later).
+ *
+ * @internal
+ */
+export function useNetworkProtocolCheck(): undefined {
+  const {push: pushToast} = useToast()
+  const {t} = useTranslation()
+  const client = useClient({apiVersion: '2025-03-01'})
+  const title = t('network-check.slow-protocol-warning.title')
+
+  useEffect(() => {
+    const sub = isUsingModernHttp(client)
+      .pipe(filter((isOnModernHttp) => isOnModernHttp === false))
+      .subscribe(() =>
+        pushToast({
+          id: 'network-protocol-check',
+          status: 'warning',
+          closable: true,
+          // Do not auto-close this one
+          duration: +Infinity,
+          title,
+          description: <WarningDescription />,
+        }),
+      )
+    return () => sub.unsubscribe()
+  }, [client, pushToast, title])
+}
+
+function WarningDescription() {
+  const {t} = useTranslation()
+  const description = t('network-check.slow-protocol-warning.description')
+  const readMore = t('network-check.slow-protocol-warning.learn-more')
+  return (
+    <>
+      {description}
+      <a href={HTTP_HELP_URL} target="_blank" rel="noreferrer">
+        {readMore}
+      </a>
+    </>
+  )
+}


### PR DESCRIPTION
### Description

Note: Leaving this as draft for now, hoping that someone can take this over if need be.

Runs a request against `/ping` which allow for performance timing info to be returned. This allows us to read the protocol. If it is not using HTTP2/3, we pop open a toast.

There are a bunch of things here that could use some design work and consideration:

- Should it be a toast or a banner or a developer warning…?
- When closing the toast/banner, should we persist that to localStorage or user preferences?
- Should we wait to do the check with `requestIdleCallback` or similar (to avoid any potential performance overhead)?
- Where should it be mounted/run?
- Someone needs to actually write the help article
- Wording of the toast

### What to review
 
You'll need to manually go in and have the check return 'http/1' or something instead of `entry.nextHopProtocol` to test this - alternatively you can disable HTTP2/HTTP3 in your browser if it supports that.

The code is kinda quickly thrown together - if there's any glaring issues here feel free to correct/change as you see fit.

### Testing

Testing this is very hard! I could not find any reasonable way to tell playwright to disable HTTP2 reliably, so I am honestly not sure what we can do here.

### Notes for release

- Show a warning if the studio is using HTTP1 to communicate with the Sanity API
