### PR TITLE
chore(core): update perspective menu

### DIFF
--- a/packages/sanity/src/core/perspective/ReleasesToolLink.tsx
+++ b/packages/sanity/src/core/perspective/ReleasesToolLink.tsx
@@ -19,17 +19,6 @@ const Dot = styled.div({
   boxShadow: '0 0 0 1px var(--card-bg-color)',
 })
 
-const Container = styled.div`
-  flex: none;
-
-  // The children in button is rendered inside a span, we need to absolutely position it.
-  span:has(> [data-ui='status-icon']) {
-    position: absolute;
-    top: 6px;
-    right: 6px;
-    padding: 0;
-  }
-`
 /**
  * represents the calendar icon for the releases tool.
  * It will be hidden if users have turned off releases.
@@ -48,29 +37,28 @@ export function ReleasesToolLink(): React.JSX.Element {
   )
 
   return (
-    <Container data-testid="releases-tool-link">
-      <Tooltip content={t('release.navbar.tooltip')}>
-        <Button
-          as={ToolLink}
-          name={RELEASES_TOOL_NAME}
-          data-as="a"
-          icon={CalendarIcon}
-          mode="bleed"
-          padding={2}
-          radius="full"
-          selected={activeToolName === RELEASES_TOOL_NAME}
-          space={2}
-        >
-          {hasError && (
-            <Dot
-              data-ui="status-icon"
-              style={{
-                backgroundColor: `var(--card-badge-critical-dot-color)`,
-              }}
-            />
-          )}
-        </Button>
-      </Tooltip>
-    </Container>
+    <Tooltip content={t('release.navbar.tooltip')}>
+      <Button
+        as={ToolLink}
+        name={RELEASES_TOOL_NAME}
+        data-as="a"
+        className="p-menu-btn"
+        icon={CalendarIcon}
+        mode="bleed"
+        padding={3}
+        radius="full"
+        data-testid="releases-tool-link"
+        selected={activeToolName === RELEASES_TOOL_NAME}
+      >
+        {hasError && (
+          <Dot
+            data-ui="error-status-icon"
+            style={{
+              backgroundColor: `var(--card-badge-critical-dot-color)`,
+            }}
+          />
+        )}
+      </Button>
+    </Tooltip>
   )
 }

--- a/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenu.tsx
+++ b/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenu.tsx
@@ -40,9 +40,9 @@ export function GlobalPerspectiveMenu({
             data-testid="global-perspective-menu-button"
             iconRight={ChevronDownIcon}
             mode="bleed"
-            padding={2}
+            padding={3}
             radius="full"
-            space={2}
+            className="p-menu-btn"
           />
         }
         id="releases-menu"

--- a/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
@@ -42,12 +42,12 @@ const ReleasesNavContainer = styled(Card)`
     z-index: 2;
   }
 
-  .p-menu-btn + .p-menu-btn {
+  .p-menu-btn:nth-child(2) {
     margin-left: -6px;
   }
-  .p-menu-btn + .p-menu-btn.small {
-    margin: -1px;
-    margin-left: -3px;
+
+  .p-menu-btn:nth-child(3) {
+    margin-left: -6px;
   }
 `
 export function ReleasesNav(): React.JSX.Element {
@@ -59,7 +59,6 @@ export function ReleasesNav(): React.JSX.Element {
     <ReleasesNavContainer flex="none" tone="inherit" radius="full" data-ui="ReleasesNav">
       <Flex>
         {areReleasesEnabled && <ReleasesToolLink />}
-
         <CurrentGlobalPerspectiveLabel selectedPerspective={selectedPerspective} />
         <GlobalPerspectiveMenu
           selectedReleaseId={selectedReleaseId}

--- a/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
@@ -1,53 +1,71 @@
-import {CloseIcon} from '@sanity/icons'
-// eslint-disable-next-line no-restricted-imports -- Bundle Button requires more fine-grained styling than studio button
-import {Box, Button, Card, Flex} from '@sanity/ui'
-import {AnimatePresence} from 'framer-motion'
+import {Card, Flex} from '@sanity/ui'
+import {styled} from 'styled-components'
 
 import {usePerspective} from '../../perspective/usePerspective'
-import {useSetPerspective} from '../../perspective/useSetPerspective'
-import {LATEST} from '../../releases/util/const'
-import {isDraftPerspective} from '../../releases/util/util'
 import {useWorkspace} from '../../studio'
 import {ReleasesToolLink} from '../ReleasesToolLink'
 import {CurrentGlobalPerspectiveLabel} from './currentGlobalPerspectiveLabel'
 import {GlobalPerspectiveMenu} from './GlobalPerspectiveMenu'
 
+const ReleasesNavContainer = styled(Card)`
+  position: relative;
+  --p-bg-color: var(--card-bg-color);
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border: 1px solid var(--card-border-color);
+    border-radius: 9999px;
+    pointer-events: none;
+    z-index: 3;
+  }
+
+  // The children in button is rendered inside a span, we need to absolutely position the dot for the error.
+  span:has(> [data-ui='error-status-icon']) {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    padding: 0;
+  }
+
+  .p-menu-btn {
+    margin: -1px;
+    box-shadow: inset 0 0 0 4px var(--p-bg-color) !important;
+  }
+
+  button.p-menu-btn:hover,
+  a.p-menu-btn:hover {
+    position: relative;
+    z-index: 2;
+  }
+
+  .p-menu-btn + .p-menu-btn {
+    margin-left: -6px;
+  }
+  .p-menu-btn + .p-menu-btn.small {
+    margin: -1px;
+    margin-left: -3px;
+  }
+`
 export function ReleasesNav(): React.JSX.Element {
   const areReleasesEnabled = !!useWorkspace().releases?.enabled
 
   const {selectedPerspective, selectedReleaseId} = usePerspective()
-  const setPerspective = useSetPerspective()
-
-  const handleClearPerspective = () => setPerspective(LATEST)
 
   return (
-    <Card flex="none" border marginRight={1} radius="full" tone="inherit" style={{margin: -1}}>
-      <Flex gap={0}>
-        {areReleasesEnabled && (
-          <Box data-testid="releases-tool-link" flex="none">
-            <ReleasesToolLink />
-          </Box>
-        )}
-        <AnimatePresence>
-          <CurrentGlobalPerspectiveLabel selectedPerspective={selectedPerspective} />
-        </AnimatePresence>
+    <ReleasesNavContainer flex="none" tone="inherit" radius="full" data-ui="ReleasesNav">
+      <Flex>
+        {areReleasesEnabled && <ReleasesToolLink />}
+
+        <CurrentGlobalPerspectiveLabel selectedPerspective={selectedPerspective} />
         <GlobalPerspectiveMenu
           selectedReleaseId={selectedReleaseId}
           areReleasesEnabled={areReleasesEnabled}
         />
-        {!isDraftPerspective(selectedPerspective) && (
-          <div>
-            <Button
-              icon={CloseIcon}
-              mode="bleed"
-              onClick={handleClearPerspective}
-              data-testid="clear-perspective-button"
-              padding={2}
-              radius="full"
-            />
-          </div>
-        )}
       </Flex>
-    </Card>
+    </ReleasesNavContainer>
   )
 }

--- a/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesNav.test.tsx
+++ b/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesNav.test.tsx
@@ -17,7 +17,6 @@ import {
   useReleasePermissionsMockReturn,
   useReleasesPermissionsMockReturnTrue,
 } from '../../../releases/store/__tests__/__mocks/useReleasePermissions.mock'
-import {LATEST} from '../../../releases/util/const'
 import {ReleasesNav} from '../ReleasesNav'
 
 vi.mock('../../../releases/store/useReleasePermissions', () => ({
@@ -94,17 +93,6 @@ describe('ReleasesNav', () => {
     expect(screen.queryByTestId('clear-perspective-button')).toBeNull()
   })
 
-  it('should have clear button to unset perspective when a perspective is chosen', async () => {
-    usePerspectiveMockReturn.selectedPerspective = activeScheduledRelease
-    usePerspectiveMockReturn.selectedReleaseId = 'rActive'
-
-    await renderTest()
-
-    fireEvent.click(screen.getByTestId('clear-perspective-button'))
-
-    expect(mockedSetPerspective).toHaveBeenCalledWith(LATEST)
-  })
-
   it('should list the title of the chosen perspective', async () => {
     usePerspectiveMockReturn.selectedPerspective = activeScheduledRelease
     usePerspectiveMockReturn.selectedReleaseId = 'rActive'
@@ -112,15 +100,6 @@ describe('ReleasesNav', () => {
     await renderTest()
 
     screen.getByText('active Release')
-  })
-
-  it('should show release avatar for chosen perspective', async () => {
-    usePerspectiveMockReturn.selectedPerspective = activeASAPRelease
-    usePerspectiveMockReturn.selectedReleaseId = 'rActive'
-
-    await renderTest()
-
-    screen.getByTestId('release-avatar-critical')
   })
 
   describe('global perspective menu', () => {

--- a/packages/sanity/src/core/perspective/navbar/currentGlobalPerspectiveLabel.tsx
+++ b/packages/sanity/src/core/perspective/navbar/currentGlobalPerspectiveLabel.tsx
@@ -1,30 +1,71 @@
 // eslint-disable-next-line no-restricted-imports -- Bundle Button requires more fine-grained styling than studio button
-import {Box, Button, Card, Flex, Stack, Text} from '@sanity/ui'
-import {motion} from 'framer-motion'
-import {type PropsWithChildren} from 'react'
+import {Button, Card, Text} from '@sanity/ui'
+import {type ForwardedRef, forwardRef, type ReactNode, useMemo} from 'react'
 import {IntentLink} from 'sanity/router'
 
 import {useTranslation} from '../../i18n/hooks/useTranslation'
-import {ReleaseAvatar} from '../../releases/components/ReleaseAvatar'
 import {RELEASES_INTENT} from '../../releases/plugin'
-import {isReleaseDocument} from '../../releases/store/types'
+import {isReleaseDocument, type ReleaseDocument} from '../../releases/store/types'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
-import {getReleaseTone} from '../../releases/util/getReleaseTone'
 import {isDraftPerspective, isPublishedPerspective} from '../../releases/util/util'
 import {type SelectedPerspective} from '../types'
 
-const AnimatedMotionDiv = ({children, ...props}: PropsWithChildren<any>) => (
-  <motion.div
-    {...props}
-    layout="preserve-aspect"
-    initial={{width: 0, opacity: 0}}
-    animate={{width: 'auto', opacity: 1}}
-    exit={{width: 0, opacity: 0}}
-    transition={{duration: 0.25, ease: 'easeInOut'}}
-  >
-    {children}
-  </motion.div>
-)
+// TODO: Restore animations
+// const AnimatedMotionDiv = ({children, ...props}: PropsWithChildren<any>) => (
+//   <motion.div
+//     {...props}
+//     layout="preserve-aspect"
+//     initial={{width: 0, opacity: 0}}
+//     animate={{width: 'auto', opacity: 1}}
+//     exit={{width: 0, opacity: 0}}
+//     transition={{duration: 0.25, ease: 'easeInOut'}}
+//   >
+//     {children}
+//   </motion.div>
+// )
+
+const ReleasesLink = ({selectedPerspective}: {selectedPerspective: ReleaseDocument}) => {
+  const {t} = useTranslation()
+
+  const ReleasesIntentLink = useMemo(
+    () =>
+      // eslint-disable-next-line @typescript-eslint/no-shadow
+      forwardRef(function ReleasesIntentLink(
+        {children, ...intentProps}: {children: ReactNode},
+        linkRef: ForwardedRef<HTMLAnchorElement>,
+      ) {
+        return (
+          <IntentLink
+            {...intentProps}
+            ref={linkRef}
+            intent={RELEASES_INTENT}
+            params={
+              isReleaseDocument(selectedPerspective)
+                ? {id: getReleaseIdFromReleaseDocumentId(selectedPerspective._id)}
+                : {}
+            }
+          >
+            {children}
+          </IntentLink>
+        )
+      }),
+    [selectedPerspective],
+  )
+
+  return (
+    <Button
+      as={ReleasesIntentLink}
+      data-as="a"
+      rel="noopener noreferrer"
+      mode="bleed"
+      padding={3}
+      className="p-menu-btn small"
+      radius="full"
+      style={{maxWidth: '180px'}}
+      text={selectedPerspective.metadata?.title || t('release.placeholder-untitled-release')}
+    />
+  )
+}
 
 export function CurrentGlobalPerspectiveLabel({
   selectedPerspective,
@@ -35,66 +76,17 @@ export function CurrentGlobalPerspectiveLabel({
 
   if (!selectedPerspective) return null
 
-  let displayTitle = t('release.placeholder-untitled-release')
-
-  if (isPublishedPerspective(selectedPerspective)) {
-    displayTitle = t('release.chip.published')
-  } else if (isDraftPerspective(selectedPerspective)) {
-    displayTitle = t('release.chip.global.drafts')
-  } else if (isReleaseDocument(selectedPerspective)) {
-    displayTitle = selectedPerspective.metadata?.title || t('release.placeholder-untitled-release')
-  }
-
-  const visibleLabelChildren = () => {
-    const labelContent = (
-      <Flex align="flex-start" gap={0}>
-        <Box flex="none">
-          <ReleaseAvatar padding={2} tone={getReleaseTone(selectedPerspective)} />
-        </Box>
-        <Stack flex={1} paddingY={2} paddingRight={2} space={2}>
-          <Text size={1} textOverflow="ellipsis" weight="medium">
-            {displayTitle}
-          </Text>
-        </Stack>
-      </Flex>
-    )
-
-    if (isPublishedPerspective(selectedPerspective) || isDraftPerspective(selectedPerspective)) {
-      return (
-        <Card tone="inherit" radius={5}>
-          {labelContent}
-        </Card>
-      )
-    }
-
-    const releasesIntentLink = ({children, ...intentProps}: PropsWithChildren) => (
-      <IntentLink
-        {...intentProps}
-        intent={RELEASES_INTENT}
-        params={
-          isReleaseDocument(selectedPerspective)
-            ? {id: getReleaseIdFromReleaseDocumentId(selectedPerspective._id)}
-            : {}
-        }
-      >
-        {children}
-      </IntentLink>
-    )
-
+  if (isPublishedPerspective(selectedPerspective) || isDraftPerspective(selectedPerspective)) {
     return (
-      <Button
-        as={releasesIntentLink}
-        data-as="a"
-        rel="noopener noreferrer"
-        mode="bleed"
-        padding={0}
-        radius="full"
-        style={{maxWidth: '180px'}}
-      >
-        {labelContent}
-      </Button>
+      <Card tone="inherit" padding={3} className="p-menu-btn" style={{userSelect: 'none'}}>
+        <Text size={1} textOverflow="ellipsis" weight="medium">
+          {isPublishedPerspective(selectedPerspective)
+            ? t('release.chip.published')
+            : t('release.chip.global.drafts')}
+        </Text>
+      </Card>
     )
   }
 
-  return <AnimatedMotionDiv>{visibleLabelChildren()}</AnimatedMotionDiv>
+  return <ReleasesLink selectedPerspective={selectedPerspective} />
 }

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -270,19 +270,17 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
                   </SearchProvider>
                 </LayerProvider>
 
+                <ReleasesNav />
+                {actionNodes}
                 {shouldRender.tools && <FreeTrial type="topbar" />}
+                <PresenceMenu />
                 {shouldRender.configIssues && <ConfigIssuesButton />}
                 {shouldRender.resources && <ResourcesButton />}
-
-                <PresenceMenu />
 
                 {/* Search button (mobile) */}
                 {shouldRender.searchFullscreen && (
                   <SearchButton onClick={handleOpenSearchFullscreen} ref={setSearchOpenButtonEl} />
                 )}
-
-                <ReleasesNav />
-                {actionNodes}
 
                 {shouldRender.tools && (
                   <Box flex="none" marginLeft={1}>


### PR DESCRIPTION
### Description

Updates the releases nav button,
main changes:
- Move perspective menu and tasks to the left
   Order:  perspective | tasks | presence | help
- Remove x button inside perspective menu
- Remove dot inside perspective menu button
- Use padding 0.5 around buttons inside perspective menu
- Increase hitarea of buttons with the perspective menu
- Add user-select: none on the Published / Drafts text in the collapsed menu, so that it's not possible to click or select this text.

Extra: updates width animation to scale from the previous width and not from 0, making it smoother.

https://github.com/user-attachments/assets/ac00c8de-da70-49a7-97cd-b524537a6bd9





<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Are the changes correct?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manually tested everything keeps working.
Existing tests are updated.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Updates the releases navigation button UI, increasing click area and removing the X button.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
