### PR TITLE
fix(core): get previews for documents in archived releases

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -27,7 +27,11 @@ import {mergeMapArray} from 'rxjs-mergemap-array'
 
 import {useSchema} from '../../../hooks'
 import {type LocaleSource} from '../../../i18n/types'
-import {type DocumentPreviewStore} from '../../../preview'
+import {
+  type DocumentPreviewStore,
+  getPreviewValueWithFallback,
+  prepareForPreview,
+} from '../../../preview'
 import {useDocumentPreviewStore} from '../../../store/_legacy/datastores'
 import {useSource} from '../../../studio'
 import {getPublishedId} from '../../../util/draftUtils'
@@ -224,7 +228,10 @@ const getPublishedArchivedReleaseDocumentsObservable = ({
             take(1),
             map(({snapshot}) => ({
               isLoading: false,
-              values: snapshot,
+              values: prepareForPreview(
+                getPreviewValueWithFallback({snapshot, original: document}),
+                schemaType,
+              ),
             })),
             startWith({isLoading: true, values: {}}),
             filter(({isLoading}) => !isLoading),


### PR DESCRIPTION
### Description
With the introduction of [this change ](https://github.com/sanity-io/sanity/pull/8655/files#diff-77381a56ed78633b5c6d76f75e0d73a6719de12047c2e395c587fbba7d5616ae) the archived releases view stopped working as expected and it started showing incorrect previews for the archived documents.

See for example in `next` https://test-studio.sanity.dev/test/releases/rIEqtiYbg
<img width="800" alt="Screenshot 2025-03-06 at 16 43 36" src="https://github.com/user-attachments/assets/63862710-3eba-4c40-b086-ef1f8977cb27" />

This PR fixes this issue by restoring the previous `getPreviewValuesWithFallback` function, and now the previews load again
<img width="800" alt="Screenshot 2025-03-06 at 16 44 09" src="https://github.com/user-attachments/assets/1c6d2145-4ce4-44b0-8921-a52e1931dd6e" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue with archived releases in where document previews were not loading correctly.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
