### PR TITLE
fix(cli): add undeploy command back for apps

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/app/__tests__/undeployAction.test.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/__tests__/undeployAction.test.ts
@@ -51,8 +51,26 @@ describe('undeployCoreAppAction', () => {
         spinner: vi.fn().mockReturnValue(spinnerInstance),
       },
       prompt: {single: vi.fn()},
-      cliConfig: {},
+      cliConfig: {
+        // eslint-disable-next-line camelcase
+        __experimental_coreAppConfiguration: {
+          appId: 'app-id',
+        },
+      },
     } as unknown as CliCommandContext
+  })
+
+  it('prints an error if there is no appId', async () => {
+    await undeployCoreAppAction({} as CliCommandArguments<Record<string, unknown>>, {
+      ...mockContext,
+      cliConfig: {},
+    })
+
+    expect(mockContext.output.print).toHaveBeenCalledWith('No Core application ID provided.')
+    expect(mockContext.output.print).toHaveBeenCalledWith(
+      'Please set `__experimental_coreAppConfiguration` in sanity.cli.js or sanity.cli.ts.',
+    )
+    expect(mockContext.output.print).toHaveBeenCalledWith('Nothing to undeploy.')
   })
 
   it('does nothing if there is no user application', async () => {
@@ -61,10 +79,7 @@ describe('undeployCoreAppAction', () => {
     await undeployCoreAppAction({} as CliCommandArguments<Record<string, unknown>>, mockContext)
 
     expect(mockContext.output.print).toHaveBeenCalledWith(
-      'Your project has not been assigned a Core application ID',
-    )
-    expect(mockContext.output.print).toHaveBeenCalledWith(
-      'or you do not have __experimental_coreAppConfiguration set in sanity.cli.js or sanity.cli.ts.',
+      'Application with the given ID does not exist.',
     )
     expect(mockContext.output.print).toHaveBeenCalledWith('Nothing to undeploy.')
   })

--- a/packages/sanity/src/_internal/cli/actions/app/__tests__/undeployAction.test.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/__tests__/undeployAction.test.ts
@@ -68,7 +68,7 @@ describe('undeployCoreAppAction', () => {
 
     expect(mockContext.output.print).toHaveBeenCalledWith('No Core application ID provided.')
     expect(mockContext.output.print).toHaveBeenCalledWith(
-      'Please set `__experimental_coreAppConfiguration` in sanity.cli.js or sanity.cli.ts.',
+      'Please set appId in `__experimental_coreAppConfiguration` in sanity.cli.js or sanity.cli.ts.',
     )
     expect(mockContext.output.print).toHaveBeenCalledWith('Nothing to undeploy.')
   })

--- a/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts
@@ -29,7 +29,7 @@ export default async function undeployCoreAppAction(
     spinner.fail()
     output.print(`No Core application ID provided.`)
     output.print(
-      'Please set `__experimental_coreAppConfiguration` in sanity.cli.js or sanity.cli.ts.',
+      'Please set appId `__experimental_coreAppConfiguration` in sanity.cli.js or sanity.cli.ts.',
     )
     output.print('Nothing to undeploy.')
     return

--- a/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts
@@ -29,7 +29,7 @@ export default async function undeployCoreAppAction(
     spinner.fail()
     output.print(`No Core application ID provided.`)
     output.print(
-      'Please set appId `__experimental_coreAppConfiguration` in sanity.cli.js or sanity.cli.ts.',
+      'Please set appId in `__experimental_coreAppConfiguration` in sanity.cli.js or sanity.cli.ts.',
     )
     output.print('Nothing to undeploy.')
     return

--- a/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts
@@ -27,7 +27,7 @@ export default async function undeployCoreAppAction(
 
   if (!appId) {
     spinner.fail()
-    output.print(`No Core application ID found.`)
+    output.print(`No Core application ID provided.`)
     output.print(
       'Please set `__experimental_coreAppConfiguration` in sanity.cli.js or sanity.cli.ts.',
     )
@@ -43,6 +43,7 @@ export default async function undeployCoreAppAction(
   spinner.succeed()
 
   if (!userApplication) {
+    spinner.fail()
     output.print('Application with the given ID does not exist.')
     output.print('Nothing to undeploy.')
     return

--- a/packages/sanity/src/_internal/cli/actions/deploy/__tests__/undeployAction.test.ts
+++ b/packages/sanity/src/_internal/cli/actions/deploy/__tests__/undeployAction.test.ts
@@ -69,7 +69,7 @@ describe('undeployStudioAction', () => {
       'Your project has not been assigned a studio hostname',
     )
     expect(mockContext.output.print).toHaveBeenCalledWith(
-      'or you do not have studioHost set in sanity.cli.js or sanity.cli.ts.',
+      'or the `studioHost` provided does not exist.',
     )
     expect(mockContext.output.print).toHaveBeenCalledWith('Nothing to undeploy.')
   })

--- a/packages/sanity/src/_internal/cli/actions/deploy/undeployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/deploy/undeployAction.ts
@@ -34,7 +34,7 @@ export default async function undeployStudioAction(
 
   if (!userApplication) {
     output.print('Your project has not been assigned a studio hostname')
-    output.print('or you do not have studioHost set in sanity.cli.js or sanity.cli.ts.')
+    output.print('or the `studioHost` provided does not exist.')
     output.print('Nothing to undeploy.')
     return
   }

--- a/packages/sanity/src/_internal/cli/commands/deploy/undeployCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/deploy/undeployCommand.ts
@@ -5,6 +5,7 @@ import {
 } from '@sanity/cli'
 
 import {type UndeployStudioActionFlags} from '../../actions/deploy/undeployAction'
+import {determineIsCoreApp} from '../../util/determineIsCoreApp'
 
 const helpText = `
 Options
@@ -23,7 +24,20 @@ const undeployCommand: CliCommandDefinition = {
     args: CliCommandArguments<UndeployStudioActionFlags>,
     context: CliCommandContext,
   ) => {
-    const mod = await import('../../actions/deploy/undeployAction')
+    let mod: {
+      default: (
+        args: CliCommandArguments<UndeployStudioActionFlags>,
+        context: CliCommandContext,
+      ) => Promise<void>
+    }
+
+    const isCoreApp = determineIsCoreApp(context.cliConfig)
+
+    if (isCoreApp) {
+      mod = await import('../../actions/app/undeployAction')
+    } else {
+      mod = await import('../../actions/deploy/undeployAction')
+    }
 
     return mod.default(args, context)
   },


### PR DESCRIPTION
### Description

Improves error messaging and handling for the `sanity undeploy` command, particularly for Core applications. The changes provide clearer feedback when an application ID is missing or invalid, and standardizes error presentation across both Core and regular Studio deployments.

### What to review

- Error message updates in both Core and Studio undeploy flows
- The new application ID validation logic in the Core undeploy action
- The integration of Core app detection in the undeploy command
- The updated prompt messaging format and consistency

### Testing

Added new test cases covering:
- Scenarios where no app ID is provided
- Invalid application ID handling
- Updated error message verification

### Notes for release

N/A internal