### PR TITLE
fix(cli): use `api.sanity.local` for CLI dev environment

### DIFF
--- a/packages/@sanity/cli/src/util/clientWrapper.ts
+++ b/packages/@sanity/cli/src/util/clientWrapper.ts
@@ -15,7 +15,7 @@ import {getUserConfig} from './getUserConfig'
 
 const apiHosts: Record<string, string | undefined> = {
   staging: 'https://api.sanity.work',
-  development: 'http://api.sanity.wtf',
+  development: 'http://api.sanity.local',
 }
 
 /**


### PR DESCRIPTION
### Description

Minor: changes an outdated URL in the CLI that's generally not used, but also points to a domain we no longer use

### Testing

None (this isn't tested and probably doesn't need to be)

### Notes for release

None
