### PR TITLE
fix(preview): pass filter only to liveDocumentIdSet listener

### DIFF
--- a/packages/sanity/src/core/preview/liveDocumentIdSet.ts
+++ b/packages/sanity/src/core/preview/liveDocumentIdSet.ts
@@ -41,7 +41,7 @@ export function createDocumentIdSetObserver(client: SanityClient) {
         )
     }
     return versionedClient(client, apiVersion)
-      .observable.listen(query, params, {
+      .observable.listen(`*[${queryFilter}]`, params, {
         visibility: 'transaction',
         events: ['welcome', 'mutation', 'reconnect'],
         includeResult: false,


### PR DESCRIPTION
### Description
Small cleanup removes projection with listener call, as they are ignored anyway.

### Notes for release
n/a