### PR TITLE
feat(sanity): include drafts perspective in overlay visualisation

### DIFF
--- a/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
@@ -14,6 +14,7 @@ import {useReleasePermissions} from '../../releases/store/useReleasePermissions'
 import {LATEST} from '../../releases/util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
 import {getReleaseDefaults} from '../../releases/util/util'
+import {usePerspective} from '../usePerspective'
 import {
   getRangePosition,
   GlobalPerspectiveMenuItem,
@@ -68,6 +69,7 @@ export function ReleasesList({
   const {checkWithPermissionGuard} = useReleasePermissions()
   const [hasCreatePermission, setHasCreatePermission] = useState<boolean | null>(null)
   const createReleaseMetadata = useCreateReleaseMetadata()
+  const {selectedPerspectiveName} = usePerspective()
 
   const {t} = useTranslation()
 
@@ -104,7 +106,8 @@ export function ReleasesList({
   )
 
   const range: LayerRange = useMemo(() => {
-    let lastIndex = 0
+    const isDraftsPerspective = typeof selectedPerspectiveName === 'undefined'
+    let lastIndex = isDraftsPerspective ? 1 : 0
 
     const {asap, scheduled} = sortedReleaseTypeReleases
     const countAsapReleases = asap.length
@@ -135,7 +138,7 @@ export function ReleasesList({
       lastIndex,
       offsets,
     }
-  }, [selectedReleaseId, sortedReleaseTypeReleases])
+  }, [selectedPerspectiveName, selectedReleaseId, sortedReleaseTypeReleases])
 
   if (loading) {
     return (


### PR DESCRIPTION
### Description

This branch updates the release overlay visualisation to include the drafts perspective, because the drafts perspective overlays published documents.

| Before | After |
| --- | --- |
| <img width="298" alt="Screenshot 2025-03-07 at 12 07 29" src="https://github.com/user-attachments/assets/9f6e93b7-4853-456f-9212-58b8806a1104" />  | <img width="298" alt="Screenshot 2025-03-07 at 12 07 13" src="https://github.com/user-attachments/assets/479594a2-e363-47eb-8c68-8b3f76b4610d" /> |

### What to review

Any mistakes in the assumptions I've made in the code?

### Testing

Open the menu 🙂.