### PR TITLE
chore(core): add fallback title to untitled releases

### DIFF
--- a/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
@@ -68,7 +68,7 @@ export function DocumentStatus({draft, published, versions, singleLine}: Documen
           <VersionStatus
             key={versionName}
             mode={snapshot?._updatedAt === snapshot?._createdAt ? 'created' : 'edited'}
-            title={release?.metadata.title}
+            title={release?.metadata.title || t('release.placeholder-untitled-release')}
             timestamp={snapshot?._updatedAt}
             tone={release ? getReleaseTone(release) : 'default'}
           />

--- a/packages/sanity/src/core/field/diff/components/Event.tsx
+++ b/packages/sanity/src/core/field/diff/components/Event.tsx
@@ -163,7 +163,7 @@ export function Event({event, showChangesBy = 'tooltip'}: TimelineItemProps) {
                 {' '}
                 {event.release ? (
                   <VersionInlineBadge $tone={getReleaseTone(event.release)}>
-                    {event.release.metadata.title}
+                    {event.release.metadata.title || t('release.placeholder-untitled-release')}
                   </VersionInlineBadge>
                 ) : (
                   <VersionInlineBadge $tone="caution">

--- a/packages/sanity/src/core/releases/components/dialog/UnpublishVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/UnpublishVersionDialog.tsx
@@ -33,14 +33,14 @@ export function UnpublishVersionDialog(props: {
   const {data} = useActiveReleases()
   const {data: archivedReleases} = useArchivedReleases()
 
-  const releaseInDetail = data
+  const release = data
     .concat(archivedReleases)
     .find(
       (candidate) =>
         getReleaseIdFromReleaseDocumentId(candidate._id) === getVersionFromId(documentVersionId),
     )
 
-  const tone = getReleaseTone(releaseInDetail as ReleaseDocument)
+  const tone = getReleaseTone(release as ReleaseDocument)
   const schemaType = schema.get(documentType)
 
   const preview = useValuePreview({schemaType, value: {_id: documentVersionId}})
@@ -99,7 +99,7 @@ export function UnpublishVersionDialog(props: {
             t={t}
             i18nKey="unpublish-dialog.description.to-draft"
             values={{
-              title: releaseInDetail?.metadata.title,
+              title: release?.metadata.title || coreT('release.placeholder-untitled-release'),
             }}
             components={{
               Label: ({children}) => {

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleasePreviewCard.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleasePreviewCard.tsx
@@ -1,18 +1,20 @@
 import {Card, Flex, Stack, Text} from '@sanity/ui'
 
+import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {ReleaseAvatar} from '../../../components'
 import {type ReleaseDocument} from '../../../store/types'
 import {getReleaseTone} from '../../../util/getReleaseTone'
 import {ReleaseTime} from '../ReleaseTime'
 
 export function ReleasePreviewCard({release}: {release: ReleaseDocument}) {
+  const {t} = useTranslation()
   return (
     <Card border padding={1} radius={2}>
       <Flex gap={3} padding={3}>
         <ReleaseAvatar tone={getReleaseTone(release)} padding={0} />
         <Stack space={2}>
           <Text weight="medium" size={1}>
-            {release.metadata.title}
+            {release.metadata.title || t('release.placeholder-untitled-release')}
           </Text>
           <Text muted size={1}>
             <ReleaseTime release={release} />

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
@@ -30,6 +30,7 @@ export const ReleasePublishAllButton = ({
   const {publishRelease} = useReleaseOperations()
   const {checkWithPermissionGuard} = useReleasePermissions()
   const {t} = useTranslation(releasesLocaleNamespace)
+  const {t: tCore} = useTranslation()
   const perspective = usePerspective()
   const setPerspective = useSetPerspective()
   const telemetry = useTelemetry()
@@ -74,7 +75,9 @@ export const ReleasePublishAllButton = ({
             <Translate
               t={t}
               i18nKey="toast.publish.success"
-              values={{title: release.metadata.title}}
+              values={{
+                title: release.metadata.title || tCore('release.placeholder-untitled-release'),
+              }}
             />
           </Text>
         ),
@@ -93,7 +96,9 @@ export const ReleasePublishAllButton = ({
             <Translate
               t={t}
               i18nKey="toast.publish.error"
-              values={{title: release.metadata.title}}
+              values={{
+                title: release.metadata.title || tCore('release.placeholder-untitled-release'),
+              }}
             />
           </Text>
         ),
@@ -108,6 +113,7 @@ export const ReleasePublishAllButton = ({
     telemetry,
     toast,
     t,
+    tCore,
     perspective.selectedPerspective,
     setPerspective,
   ])
@@ -136,7 +142,7 @@ export const ReleasePublishAllButton = ({
               t={t}
               i18nKey="publish-dialog.confirm-publish-description"
               values={{
-                title: release.metadata.title,
+                title: release.metadata.title || tCore('release.placeholder-untitled-release'),
                 releaseDocumentsLength: documents.length,
                 count: documents.length,
               }}
@@ -145,7 +151,7 @@ export const ReleasePublishAllButton = ({
         </Text>
       </Dialog>
     )
-  }, [publishBundleStatus, t, handleConfirmPublishAll, release, documents.length])
+  }, [publishBundleStatus, t, tCore, handleConfirmPublishAll, release, documents.length])
 
   const publishTooltipContent = useMemo(() => {
     if (!hasDocumentValidationErrors && !isValidatingDocuments && publishPermission) return null

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/ReleaseRevertButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/ReleaseRevertButton.tsx
@@ -42,6 +42,7 @@ const ConfirmReleaseDialog = ({
   release: ReleaseDocument
 }) => {
   const {t} = useTranslation(releasesLocaleNamespace)
+  const {t: tCore} = useTranslation()
   const hasPostPublishTransactions = usePostPublishTransactions(documents)
   const getDocumentRevertStates = useDocumentRevertStates(documents)
   const [stageNewRevertRelease, setStageNewRevertRelease] = useState(true)
@@ -71,8 +72,12 @@ const ConfirmReleaseDialog = ({
         revertReleaseId,
         documentRevertStates,
         {
-          title: t('revert-release.title', {title: release.metadata.title}),
-          description: t('revert-release.description', {title: release.metadata.title}),
+          title: t('revert-release.title', {
+            title: release.metadata.title || tCore('release.placeholder-untitled-release'),
+          }),
+          description: t('revert-release.description', {
+            title: release.metadata.title || tCore('release.placeholder-untitled-release'),
+          }),
           releaseType: 'asap',
         },
         stageNewRevertRelease ? 'staged' : 'immediate',
@@ -105,7 +110,9 @@ const ConfirmReleaseDialog = ({
                 }}
                 t={t}
                 i18nKey="toast.revert-stage.success"
-                values={{title: release.metadata.title}}
+                values={{
+                  title: release.metadata.title || tCore('release.placeholder-untitled-release'),
+                }}
               />
             </Text>
           ),
@@ -121,7 +128,9 @@ const ConfirmReleaseDialog = ({
               <Translate
                 t={t}
                 i18nKey="toast.immediate-revert.success"
-                values={{title: release.metadata.title}}
+                values={{
+                  title: release.metadata.title || tCore('release.placeholder-untitled-release'),
+                }}
               />
             </Text>
           ),
@@ -147,6 +156,7 @@ const ConfirmReleaseDialog = ({
     getDocumentRevertStates,
     revertRelease,
     t,
+    tCore,
     release.metadata.title,
     stageNewRevertRelease,
     telemetry,
@@ -162,7 +172,9 @@ const ConfirmReleaseDialog = ({
   return (
     <Dialog
       id="confirm-revert-dialog"
-      header={t('revert-dialog.confirm-revert.title', {title: release.metadata.title})}
+      header={t('revert-dialog.confirm-revert.title', {
+        title: release.metadata.title || tCore('release.placeholder-untitled-release'),
+      })}
       onClose={() => setRevertReleaseStatus('idle')}
       footer={{
         confirmButton: {

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -37,6 +37,7 @@ export const ReleaseScheduleButton = ({
   const [schedulePermission, setSchedulePermission] = useState<boolean>(false)
 
   const {t} = useTranslation(releasesLocaleNamespace)
+  const {t: tCore} = useTranslation()
   const telemetry = useTelemetry()
   const {utcToCurrentZoneDate, zoneDateToUtc} = useTimeZone()
   const [status, setStatus] = useState<'idle' | 'confirm' | 'scheduling'>('idle')
@@ -94,7 +95,9 @@ export const ReleaseScheduleButton = ({
             <Translate
               t={t}
               i18nKey="toast.schedule.success"
-              values={{title: release.metadata.title}}
+              values={{
+                title: release.metadata.title || tCore('release.placeholder-untitled-release'),
+              }}
             />
           </Text>
         ),
@@ -107,7 +110,10 @@ export const ReleaseScheduleButton = ({
             <Translate
               t={t}
               i18nKey="toast.schedule.error"
-              values={{title: release.metadata.title, error: schedulingError.message}}
+              values={{
+                title: release.metadata.title || tCore('release.placeholder-untitled-release'),
+                error: schedulingError.message,
+              }}
             />
           </Text>
         ),
@@ -125,10 +131,10 @@ export const ReleaseScheduleButton = ({
     telemetry,
     toast,
     t,
+    tCore,
   ])
 
-  const {t: coreT} = useTranslation()
-  const calendarLabels: CalendarLabels = useMemo(() => getCalendarLabels(coreT), [coreT])
+  const calendarLabels: CalendarLabels = useMemo(() => getCalendarLabels(tCore), [tCore])
 
   const handleBundlePublishAtCalendarChange = useCallback(
     (date: Date | null) => {
@@ -214,7 +220,7 @@ export const ReleaseScheduleButton = ({
               t={t}
               i18nKey="schedule-dialog.confirm-description"
               values={{
-                title: release.metadata.title,
+                title: release.metadata.title || tCore('release.placeholder-untitled-release'),
                 count: documents.length,
               }}
             />
@@ -227,6 +233,7 @@ export const ReleaseScheduleButton = ({
     isScheduledDateInPast,
     rerenderDialog,
     t,
+    tCore,
     documents.length,
     handleConfirmSchedule,
     handleBundlePublishAtCalendarChange,

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseUnscheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseUnscheduleButton.tsx
@@ -25,6 +25,7 @@ export const ReleaseUnscheduleButton = ({
   const toast = useToast()
   const {unschedule} = useReleaseOperations()
   const {t} = useTranslation(releasesLocaleNamespace)
+  const {t: tCore} = useTranslation()
   const telemetry = useTelemetry()
   const [status, setStatus] = useState<'idle' | 'confirm' | 'unscheduling'>('idle')
 
@@ -41,7 +42,9 @@ export const ReleaseUnscheduleButton = ({
             <Translate
               t={t}
               i18nKey="toast.unschedule.success"
-              values={{title: release.metadata.title}}
+              values={{
+                title: release.metadata.title || tCore('release.placeholder-untitled-release'),
+              }}
             />
           </Text>
         ),
@@ -54,7 +57,10 @@ export const ReleaseUnscheduleButton = ({
             <Translate
               t={t}
               i18nKey="toast.unschedule.error"
-              values={{title: release.metadata.title, error: schedulingError.message}}
+              values={{
+                title: release.metadata.title || tCore('release.placeholder-untitled-release'),
+                error: schedulingError.message,
+              }}
             />
           </Text>
         ),
@@ -63,7 +69,7 @@ export const ReleaseUnscheduleButton = ({
     } finally {
       setStatus('idle')
     }
-  }, [unschedule, release._id, release.metadata.title, telemetry, toast, t])
+  }, [unschedule, release._id, release.metadata.title, telemetry, toast, t, tCore])
 
   const confirmScheduleDialog = useMemo(() => {
     if (status === 'idle') return null
@@ -92,7 +98,7 @@ export const ReleaseUnscheduleButton = ({
               t={t}
               i18nKey="unschedule-dialog.confirm-description"
               values={{
-                title: release.metadata.title,
+                title: release.metadata.title || tCore('release.placeholder-untitled-release'),
                 documentsLength: documents.length,
                 count: documents.length,
               }}
@@ -101,7 +107,7 @@ export const ReleaseUnscheduleButton = ({
         </Text>
       </Dialog>
     )
-  }, [release.metadata.title, documents.length, handleConfirmSchedule, status, t])
+  }, [release.metadata.title, documents.length, handleConfirmSchedule, status, t, tCore])
 
   return (
     <>

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardActivityPanel.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardActivityPanel.tsx
@@ -10,7 +10,6 @@ import {Resizable} from '../../../components/resizer/Resizable'
 import {useTranslation} from '../../../i18n'
 import {releasesLocaleNamespace} from '../../i18n'
 import {type ReleaseDocument} from '../../store/types'
-import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
 import {type ReleaseEvents} from './events/useReleaseEvents'
 import {ReleaseActivityList} from './ReleaseActivityList'
 
@@ -32,6 +31,7 @@ export function ReleaseDashboardActivityPanel({
   show,
 }: ReleaseDashboardActivityPanelProps) {
   const {t} = useTranslation(releasesLocaleNamespace)
+  const {t: tCore} = useTranslation()
   return (
     <AnimatePresence>
       {show && (
@@ -68,7 +68,7 @@ export function ReleaseDashboardActivityPanel({
                 )}
                 <ReleaseActivityList
                   releaseTitle={
-                    release.metadata.title || getReleaseIdFromReleaseDocumentId(release._id)
+                    release.metadata.title || tCore('release.placeholder-untitled-release')
                   }
                   releaseId={release._id}
                   events={events.events}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardHeader.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardHeader.tsx
@@ -22,9 +22,9 @@ export function ReleaseDashboardHeader(props: {
   setInspector: Dispatch<SetStateAction<ReleaseInspector | undefined>>
 }) {
   const {inspector, release, setInspector} = props
-  const title = release.metadata.title
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: tCore} = useTranslation()
+  const title = release.metadata.title || tCore('release.placeholder-untitled-release')
   const router = useRouter()
 
   const handleNavigateToReleasesList = useCallback(() => {

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -55,6 +55,7 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
   const [pendingAddedDocument, setPendingAddedDocument] = useState<BundleDocumentRow[]>([])
 
   const {t} = useTranslation(releasesLocaleNamespace)
+  const {t: tCore} = useTranslation()
 
   const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
 
@@ -73,9 +74,14 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
       if (!isBundleDocumentRow(rowProps.datum)) return null
       if (rowProps.datum.isPending) return null
 
-      return <DocumentActions document={rowProps.datum} releaseTitle={release.metadata.title} />
+      return (
+        <DocumentActions
+          document={rowProps.datum}
+          releaseTitle={release.metadata.title || tCore('release.placeholder-untitled-release')}
+        />
+      )
     },
-    [release.metadata.title, release.state],
+    [release.metadata.title, release.state, tCore],
   )
 
   const documentTableColumnDefs = useMemo(

--- a/packages/sanity/src/structure/diffView/versionMode/components/VersionModeHeader.tsx
+++ b/packages/sanity/src/structure/diffView/versionMode/components/VersionModeHeader.tsx
@@ -289,7 +289,7 @@ const VersionMenuItem: ComponentType<VersionMenuItemProps> = ({
         <ReleaseAvatar padding={2} tone={tone} />
         <Stack flex={1} paddingY={2} paddingRight={2} space={2}>
           <Text size={1} weight="medium">
-            {release.metadata.title}
+            {release.metadata.title || tCore('release.placeholder-untitled-release')}
           </Text>
           {['asap', 'undecided'].includes(release.metadata.releaseType) && (
             <Text muted size={1}>
@@ -337,7 +337,7 @@ function getMenuButtonProps({
     const tone: ButtonTone = selected ? getReleaseTone(selected) : 'neutral'
 
     return {
-      text: selected?.metadata.title,
+      text: selected?.metadata.title || tCore('release.placeholder-untitled-release'),
       icon: <ReleaseAvatar padding={1} tone={tone} />,
       iconRight: selected && isReleaseScheduledOrScheduling(selected) ? <LockIcon /> : undefined,
       tone,

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DeletedDocumentBanners.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DeletedDocumentBanners.tsx
@@ -76,7 +76,7 @@ const ArchivedReleaseBanner = ({release}: {release: ReleaseDocument}) => {
           <Translate
             t={t}
             i18nKey="banners.deleted-release-banner.text"
-            values={{title: release.metadata?.title}}
+            values={{title: release.metadata?.title || t('release.placeholder-untitled-release')}}
           />
         </Text>
       }

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/OpenReleaseToEditBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/OpenReleaseToEditBanner.tsx
@@ -56,6 +56,8 @@ export function OpenReleaseToEditBannerInner({
     () => activeReleases.find((version) => version._id.includes(releaseId)),
     [activeReleases, releaseId],
   )
+  const {t: tCore} = useTranslation()
+
   const {data: documentVersions} = useDocumentVersions({documentId})
 
   const documentVersionsTitleList = useMemo(
@@ -67,8 +69,8 @@ export function OpenReleaseToEditBannerInner({
             return getReleaseIdFromReleaseDocumentId(version._id) === r
           })
         })
-        .map((version) => version.metadata.title),
-    [activeReleases, documentVersions],
+        .map((version) => version.metadata.title || tCore('release.placeholder-untitled-release')),
+    [activeReleases, documentVersions, tCore],
   )
   const tone = currentVersion && getReleaseTone(currentVersion)
   const {t} = useTranslation(structureLocaleNamespace)

--- a/packages/sanity/src/structure/panes/document/timeline/events/PublishedEventMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/events/PublishedEventMenu.tsx
@@ -89,7 +89,9 @@ export function PublishedEventMenu({event}: {event: PublishDocumentVersionEvent}
                         }}
                         i18nKey="events.open.release"
                         values={{
-                          releaseTitle: event.release.metadata.title,
+                          releaseTitle:
+                            event.release.metadata.title ||
+                            t('release.placeholder-untitled-release'),
                         }}
                         t={t}
                       />
@@ -106,7 +108,8 @@ export function PublishedEventMenu({event}: {event: PublishDocumentVersionEvent}
                       }}
                       i18nKey="events.inspect.release"
                       values={{
-                        releaseTitle: event.release.metadata.title,
+                        releaseTitle:
+                          event.release.metadata.title || t('release.placeholder-untitled-release'),
                       }}
                       t={t}
                     />


### PR DESCRIPTION
### Description
Adds fallback title to untitled releases.
It is possible to have a release without metadata.title, in this case we want to show the fallback "Untitled release" title.

This PR updates all the uses of `release.metadata.title` to use the fallback value if needed.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manually tested the scenarios I found in the code.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
