### PR TITLE
feat(sanity): improve "pin release" button accessibility

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -99,6 +99,12 @@ export function ReleaseDashboardDetails({release}: {release: ReleaseDocument}) {
               onClick={handlePinRelease}
               radius="full"
               selected={isSelected}
+              aria-label={
+                isSelected
+                  ? `${tRelease('dashboard.details.unpin-release')}: "${release.metadata.title}"`
+                  : `${tRelease('dashboard.details.pin-release')}: "${release.metadata.title}"`
+              }
+              aria-live="assertive"
             />
           )}
           {isNotArchivedRelease(release) && <ReleaseTypePicker release={release} />}

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseName.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseName.tsx
@@ -72,6 +72,12 @@ export const ReleaseNameCell: Column<TableRelease>['cell'] = ({cellProps, datum:
             onClick={handlePinRelease}
             radius="full"
             selected={isReleasePinned}
+            aria-label={
+              isReleasePinned
+                ? `${t('dashboard.details.unpin-release')}: "${release.metadata.title}"`
+                : `${t('dashboard.details.pin-release')}: "${release.metadata.title}"`
+            }
+            aria-live="assertive"
           />
           <Card {...cardProps} padding={2} radius={2} flex={1}>
             <Flex align="center" gap={2}>


### PR DESCRIPTION
### Description

This branch adds an accessible name to release "pin" and "unpin" buttons. It also makes the button an ARIA live region so that the updated accessible name is announced when the button is toggled.

https://github.com/user-attachments/assets/42764464-61c3-4b44-bb76-7828695ecc4e

### What to review

I've made the ARIA live region _assertive_, meaning that it will interrupt other announcements. I made this decision because the previous value being read is irrelevant as soon as the button is toggled. Making the live region assertive means that the new value is announced as soon as it changes.

Does this seem resonable?

### Testing

Keyboard navigation when using macOS VoiceOver with Safari and Chrome.