### PR TITLE
feat(sanity): refine release creation dialogue

### DIFF
--- a/packages/sanity/src/core/releases/components/ScheduleDatePicker.tsx
+++ b/packages/sanity/src/core/releases/components/ScheduleDatePicker.tsx
@@ -1,5 +1,5 @@
 import {EarthGlobeIcon} from '@sanity/icons'
-import {Flex} from '@sanity/ui'
+import {Box, Flex} from '@sanity/ui'
 import {format, isValid, parse} from 'date-fns'
 import {useCallback, useMemo} from 'react'
 
@@ -48,20 +48,21 @@ export const ScheduleDatePicker = ({
   const calendarLabels: CalendarLabels = useMemo(() => getCalendarLabels(t), [t])
 
   return (
-    <Flex flex={1} justify="space-between">
-      <DateTimeInput
-        selectTime
-        monthPickerVariant={MONTH_PICKER_VARIANT.carousel}
-        onChange={handlePublishAtCalendarChange}
-        onInputChange={handlePublishAtInputChange}
-        calendarLabels={calendarLabels}
-        value={timezoneAdjustedValue}
-        inputValue={format(timezoneAdjustedValue, inputDateFormat)}
-        constrainSize={false}
-        padding={0}
-        isPastDisabled
-      />
-
+    <Flex gap={3}>
+      <Box flex={1}>
+        <DateTimeInput
+          selectTime
+          monthPickerVariant={MONTH_PICKER_VARIANT.carousel}
+          onChange={handlePublishAtCalendarChange}
+          onInputChange={handlePublishAtInputChange}
+          calendarLabels={calendarLabels}
+          value={timezoneAdjustedValue}
+          inputValue={format(timezoneAdjustedValue, inputDateFormat)}
+          constrainSize={false}
+          padding={0}
+          isPastDisabled
+        />
+      </Box>
       <Button
         icon={EarthGlobeIcon}
         mode="bleed"

--- a/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
@@ -1,6 +1,6 @@
 import {ArrowRightIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Box, Flex, useToast} from '@sanity/ui'
+import {Box, Card, Flex, useToast} from '@sanity/ui'
 import {type FormEvent, useCallback, useState} from 'react'
 
 import {Button, Dialog} from '../../../../ui-components'
@@ -89,23 +89,26 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
       id="create-release-dialog"
       onClose={onCancel}
       width={1}
+      padding={false}
     >
-      <form onSubmit={handleOnSubmit}>
-        <Box paddingX={4} paddingBottom={4}>
-          <ReleaseForm onChange={handleOnChange} value={release} />
-        </Box>
-        <Flex justify="flex-end" paddingTop={5}>
-          <Button
-            size="large"
-            disabled={isSubmitting}
-            iconRight={ArrowRightIcon}
-            type="submit"
-            text={dialogTitle}
-            loading={isSubmitting}
-            data-testid="submit-release-button"
-          />
-        </Flex>
-      </form>
+      <Card padding={4} borderTop>
+        <form onSubmit={handleOnSubmit}>
+          <Box paddingBottom={4}>
+            <ReleaseForm onChange={handleOnChange} value={release} />
+          </Box>
+          <Flex justify="flex-end" paddingTop={5}>
+            <Button
+              size="large"
+              disabled={isSubmitting}
+              iconRight={ArrowRightIcon}
+              type="submit"
+              text={dialogTitle}
+              loading={isSubmitting}
+              data-testid="submit-release-button"
+            />
+          </Flex>
+        </form>
+      </Card>
     </Dialog>
   )
 }

--- a/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
@@ -1,16 +1,45 @@
-import {InfoOutlineIcon} from '@sanity/icons'
-import {Card, Flex, Stack, TabList, TabPanel, Text} from '@sanity/ui'
+import {ChevronDownIcon, InfoOutlineIcon} from '@sanity/icons'
+import {
+  type BadgeTone,
+  // eslint-disable-next-line no-restricted-imports -- fine-grained control needed
+  Button,
+  Flex,
+  Menu,
+  // eslint-disable-next-line no-restricted-imports -- fine-grained control needed
+  MenuItem,
+  Stack,
+  TabPanel,
+  Text,
+} from '@sanity/ui'
 import {addHours, isValid, startOfHour} from 'date-fns'
-import {useCallback, useEffect, useState} from 'react'
+import {
+  type ComponentType,
+  type MouseEventHandler,
+  useCallback,
+  useEffect,
+  useId,
+  useState,
+} from 'react'
 
-import {Tab, Tooltip} from '../../../../ui-components'
+import {MenuButton, Tooltip} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
 import useTimeZone from '../../../scheduledPublishing/hooks/useTimeZone'
-import {type EditableReleaseDocument, type ReleaseType} from '../../store/types'
+import {type EditableReleaseDocument, isReleaseType, type ReleaseType} from '../../store/types'
+import {ReleaseAvatar} from '../ReleaseAvatar'
 import {ScheduleDatePicker} from '../ScheduleDatePicker'
 import {TitleDescriptionForm} from './TitleDescriptionForm'
 
-const RELEASE_TYPES: ReleaseType[] = ['asap', 'scheduled', 'undecided']
+const RELEASE_TYPES: Record<ReleaseType, {tone: BadgeTone}> = {
+  asap: {
+    tone: 'critical',
+  },
+  scheduled: {
+    tone: 'primary',
+  },
+  undecided: {
+    tone: 'suggest',
+  },
+}
 
 /** @internal */
 export function ReleaseForm(props: {
@@ -36,8 +65,14 @@ export function ReleaseForm(props: {
     [onChange, value],
   )
 
-  const handleButtonReleaseTypeChange = useCallback(
-    (pickedReleaseType: ReleaseType) => {
+  const handleButtonReleaseTypeChange = useCallback<MouseEventHandler<HTMLDivElement>>(
+    (event) => {
+      const pickedReleaseType = event.currentTarget.dataset.value
+
+      if (!isReleaseType(pickedReleaseType)) {
+        return
+      }
+
       setButtonReleaseType(pickedReleaseType)
 
       // select the start of the next hour
@@ -87,12 +122,17 @@ export function ReleaseForm(props: {
     }
   }, [currentTimezone, intendedPublishAt, timeZone, utcToCurrentZoneDate])
 
+  const menuButtonId = useId()
+  const [menuButton, setMenuButton] = useState<HTMLElement | null>(null)
+
   return (
     <Stack space={5}>
-      <Stack space={2} style={{margin: -1}}>
-        <Text muted size={1}>
-          {t('release.dialog.tooltip.title')}
-          <span style={{marginLeft: 10, opacity: 0.5}}>
+      <Stack space={4}>
+        <Flex gap={2} align="center">
+          <Text as="label" htmlFor={menuButtonId}>
+            {t('release.dialog.tooltip.title')}
+          </Text>
+          <Text muted size={1}>
             <Tooltip
               content={
                 <Stack space={3} style={{maxWidth: 320 - 16}}>
@@ -108,48 +148,66 @@ export function ReleaseForm(props: {
             >
               <InfoOutlineIcon />
             </Tooltip>
-          </span>
-        </Text>
-        <Flex gap={1}>
-          <Card
-            border
-            overflow="hidden"
-            padding={1}
-            style={{borderRadius: 3.5, alignSelf: 'baseline'}}
-            tone="inherit"
-          >
-            <Flex gap={1}>
-              <TabList space={0.5}>
-                {RELEASE_TYPES.map((type) => (
-                  <Tab
-                    aria-controls={`release-timing-${type}`}
-                    id={`release-timing-${type}-tab`}
-                    key={type}
-                    onClick={() => handleButtonReleaseTypeChange(type)}
-                    selected={buttonReleaseType === type}
-                    label={t(`release.type.${type}`)}
-                  />
-                ))}
-              </TabList>
-            </Flex>
-          </Card>
-          {buttonReleaseType === 'scheduled' && (
-            <TabPanel
-              aria-labelledby="release-timing-at-time-tab"
-              flex={1}
-              id="release-timing-at-time"
-              style={{outline: 'none'}}
-              tabIndex={-1}
-            >
-              <ScheduleDatePicker
-                initialValue={intendedPublishAt || new Date()}
-                onChange={handleBundlePublishAtCalendarChange}
-              />
-            </TabPanel>
-          )}
+          </Text>
         </Flex>
+        <Stack space={3}>
+          <MenuButton
+            id={menuButtonId}
+            ref={setMenuButton}
+            button={
+              <Button mode="ghost">
+                <Flex justify="space-between" align="center">
+                  <ReleaseTypeOption
+                    text={t(`release.type.${buttonReleaseType}`)}
+                    tone={RELEASE_TYPES[buttonReleaseType].tone}
+                  />
+                  <Text size={1}>
+                    <ChevronDownIcon />
+                  </Text>
+                </Flex>
+              </Button>
+            }
+            popover={{
+              placement: 'bottom',
+              matchReferenceWidth: true,
+              boundaryElement: menuButton,
+            }}
+            menu={
+              <Menu>
+                {Object.entries(RELEASE_TYPES).map(([type, {tone}]) => (
+                  <MenuItem key={type} data-value={type} onClick={handleButtonReleaseTypeChange}>
+                    <ReleaseTypeOption text={t(`release.type.${type}`)} tone={tone} />
+                  </MenuItem>
+                ))}
+              </Menu>
+            }
+          />
+          <Flex gap={1}>
+            {buttonReleaseType === 'scheduled' && (
+              <TabPanel
+                aria-labelledby="release-timing-at-time-tab"
+                flex={1}
+                id="release-timing-at-time"
+                style={{outline: 'none'}}
+                tabIndex={-1}
+              >
+                <ScheduleDatePicker
+                  initialValue={intendedPublishAt || new Date()}
+                  onChange={handleBundlePublishAtCalendarChange}
+                />
+              </TabPanel>
+            )}
+          </Flex>
+        </Stack>
       </Stack>
       <TitleDescriptionForm release={value} onChange={handleTitleDescriptionChange} />
     </Stack>
   )
 }
+
+const ReleaseTypeOption: ComponentType<{text: string; tone: BadgeTone}> = ({tone, text}) => (
+  <Flex gap={3} align="center">
+    <ReleaseAvatar padding={1} tone={tone} />
+    <Text>{text}</Text>
+  </Flex>
+)

--- a/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
@@ -156,7 +156,7 @@ export function TitleDescriptionForm({
   const shouldShowDescription = isReleaseOpen || value.metadata.description
 
   return (
-    <Stack space={4}>
+    <Stack space={3}>
       <TitleInput
         onChange={handleTitleChange}
         value={value.metadata.title}

--- a/packages/sanity/src/core/releases/store/types.ts
+++ b/packages/sanity/src/core/releases/store/types.ts
@@ -10,7 +10,21 @@ import {type ReleasesReducerAction, type ReleasesReducerState} from './reducer'
 /**
  * @beta
  */
-export type ReleaseType = 'asap' | 'scheduled' | 'undecided'
+export const releaseTypes = ['asap', 'scheduled', 'undecided'] as const
+
+/**
+ * @beta
+ */
+export type ReleaseType = (typeof releaseTypes)[number]
+
+/**
+ * @beta
+ */
+export function isReleaseType(maybeReleaseType: unknown): maybeReleaseType is ReleaseType {
+  return (
+    typeof maybeReleaseType === 'string' && releaseTypes.includes(maybeReleaseType as ReleaseType)
+  )
+}
 
 /**
  * @beta


### PR DESCRIPTION
### Description

This branch implements release creation dialogue and release form refinements.

Note that this branch does not move the timezone control into the date picker, as that change would be quite a lot wider in scope.

https://github.com/user-attachments/assets/5cd33647-f0d5-464e-b73a-12ddf8ddd160

### What to review

The release creation UI (dialogue and form).

### Testing

Existing tests pass.

### Notes for release

Refines release creation UI, making it easier to use across a wider range of viewport sizes.