### PR TITLE
chore(sanity): upgrade react-focus-lock to ^2.13.6

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -247,7 +247,7 @@
     "raf": "^3.4.1",
     "react-compiler-runtime": "19.0.0-beta-40c6c23-20250301",
     "react-fast-compare": "^3.2.0",
-    "react-focus-lock": "^2.13.5",
+    "react-focus-lock": "^2.13.6",
     "react-i18next": "14.0.2",
     "react-is": "^18.2.0",
     "react-refractor": "^2.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1627,7 +1627,7 @@ importers:
         specifier: ^3.2.0
         version: 3.2.2
       react-focus-lock:
-        specifier: ^2.13.5
+        specifier: ^2.13.6
         version: 2.13.6(@types/react@19.0.10)(react@18.3.1)
       react-i18next:
         specifier: 14.0.2


### PR DESCRIPTION
### Description

Adds (explicit) React 19 support  

### What to review

Focus locking still works

### Testing

No new tests. Dependency update.

### Notes for release

 None
