### PR TITLE
fix(core): arrays of references support disableActions

### DIFF
--- a/dev/test-studio/schema/debug/arrayCapabilities.ts
+++ b/dev/test-studio/schema/debug/arrayCapabilities.ts
@@ -85,7 +85,6 @@ export const arrayCapabilities = defineType({
         disableActions: DISABLED_ACTIONS,
       },
       of: [{type: 'reference', to: [{type: 'author'}]}],
-      // initialValue: [{_type: 'reference', _ref: '0154f201-bb53-4048-b9e3-7f7cdcad14fb'}],
     },
   ],
 })

--- a/dev/test-studio/schema/debug/arrayCapabilities.ts
+++ b/dev/test-studio/schema/debug/arrayCapabilities.ts
@@ -1,9 +1,9 @@
 import {defineType} from '@sanity/types'
 
-const DISABLED_ACTIONS = ['add', 'addBefore', 'addAfter', 'duplicate', 'remove', 'copy'] as const
+const DISABLED_ACTIONS = ['add', 'duplicate', 'addBefore', 'addAfter', 'remove', 'copy'] as const
 
 export const arrayCapabilities = defineType({
-  name: 'arrayCapabilitiesExample',
+  name: 'arrayCapabilities',
   type: 'document',
   title: 'Array Capabilities test',
   // icon,
@@ -31,6 +31,7 @@ export const arrayCapabilities = defineType({
           fields: [{name: 'first', type: 'string', title: 'First string'}],
         },
       ],
+      initialValue: [{_type: 'something', first: 'First'}],
     },
     {
       name: 'objectArrayAsGrid',
@@ -72,6 +73,19 @@ export const arrayCapabilities = defineType({
           title: 'A number',
         },
       ],
+    },
+    {
+      name: 'arrayOfReferences',
+      title: 'Array of references to authors',
+      description: `With disabledActions: ${DISABLED_ACTIONS.join(', ')}`,
+      type: 'array',
+      options: {
+        collapsible: true,
+        collapsed: true,
+        disableActions: DISABLED_ACTIONS,
+      },
+      of: [{type: 'reference', to: [{type: 'author'}]}],
+      initialValue: [{_type: 'reference', _ref: '0154f201-bb53-4048-b9e3-7f7cdcad15fb'}],
     },
   ],
 })

--- a/dev/test-studio/schema/debug/arrayCapabilities.ts
+++ b/dev/test-studio/schema/debug/arrayCapabilities.ts
@@ -85,7 +85,7 @@ export const arrayCapabilities = defineType({
         disableActions: DISABLED_ACTIONS,
       },
       of: [{type: 'reference', to: [{type: 'author'}]}],
-      initialValue: [{_type: 'reference', _ref: '0154f201-bb53-4048-b9e3-7f7cdcad15fb'}],
+      // initialValue: [{_type: 'reference', _ref: '0154f201-bb53-4048-b9e3-7f7cdcad14fb'}],
     },
   ],
 })

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -291,6 +291,7 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
       ),
     [
       OpenLink,
+      disableActions,
       handleCopy,
       handleDuplicate,
       handleReplace,
@@ -412,7 +413,6 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
   )
   return (
     <ChangeIndicator path={path} isChanged={changed} hasFocus={Boolean(focused)}>
-      <div>hooks</div>
       <Box paddingX={1}>{item}</Box>
     </ChangeIndicator>
   )

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -25,6 +25,7 @@ import {ContextMenuButton} from '../../../components/contextMenuButton'
 import {LoadingBlock} from '../../../components/loadingBlock'
 import {useTranslation} from '../../../i18n'
 import {FieldPresence} from '../../../presence'
+import {EMPTY_ARRAY} from '../../../util/empty'
 import {FormFieldSet, FormFieldValidationStatus} from '../../components/formField'
 import {useDidUpdate} from '../../hooks/useDidUpdate'
 import {useScrollIntoViewOnFocusWithin} from '../../hooks/useScrollIntoViewOnFocusWithin'
@@ -210,6 +211,8 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
     referenceElement: contextMenuButtonElement,
   })
 
+  const disableActions = parentSchemaType.options?.disableActions || EMPTY_ARRAY
+
   const menu = useMemo(
     () =>
       readOnly ? null : (
@@ -230,12 +233,14 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
               <Menu ref={menuRef}>
                 {!readOnly && (
                   <>
-                    <MenuItem
-                      text={t('inputs.reference.action.remove')}
-                      tone="critical"
-                      icon={TrashIcon}
-                      onClick={onRemove}
-                    />
+                    {!disableActions.includes('remove') && (
+                      <MenuItem
+                        text={t('inputs.reference.action.remove')}
+                        tone="critical"
+                        icon={TrashIcon}
+                        onClick={onRemove}
+                      />
+                    )}
                     <MenuItem
                       text={t(
                         hasRef && isEditing
@@ -245,18 +250,25 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
                       icon={hasRef && isEditing ? CloseIcon : ReplaceIcon}
                       onClick={handleReplace}
                     />
-                    <MenuItem
-                      text={t('inputs.reference.action.copy')}
-                      icon={CopyIcon}
-                      onClick={handleCopy}
-                    />
-                    <MenuItem
-                      text={t('inputs.reference.action.duplicate')}
-                      icon={AddDocumentIcon}
-                      onClick={handleDuplicate}
-                    />
-                    {insertBefore.menuItem}
-                    {insertAfter.menuItem}
+                    {!disableActions.includes('copy') && (
+                      <MenuItem
+                        text={t('inputs.reference.action.copy')}
+                        icon={CopyIcon}
+                        onClick={handleCopy}
+                      />
+                    )}
+                    {!disableActions.includes('duplicate') && (
+                      <MenuItem
+                        text={t('inputs.reference.action.duplicate')}
+                        icon={AddDocumentIcon}
+                        onClick={handleDuplicate}
+                      />
+                    )}
+                    {!(disableActions.includes('add') || disableActions.includes('addBefore')) &&
+                      insertBefore.menuItem}
+                    {!disableActions.includes('add') &&
+                      !disableActions.includes('addAfter') &&
+                      insertAfter.menuItem}
                   </>
                 )}
 
@@ -400,6 +412,7 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
   )
   return (
     <ChangeIndicator path={path} isChanged={changed} hasFocus={Boolean(focused)}>
+      <div>hooks</div>
       <Box paddingX={1}>{item}</Box>
     </ChangeIndicator>
   )

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -413,6 +413,7 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
   )
   return (
     <ChangeIndicator path={path} isChanged={changed} hasFocus={Boolean(focused)}>
+      <div>hooks</div>
       <Box paddingX={1}>{item}</Box>
     </ChangeIndicator>
   )

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -413,7 +413,6 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
   )
   return (
     <ChangeIndicator path={path} isChanged={changed} hasFocus={Boolean(focused)}>
-      <div>hooks</div>
       <Box paddingX={1}>{item}</Box>
     </ChangeIndicator>
   )

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
@@ -27,7 +27,7 @@ export interface DocumentStatusBarProps {
 
 const CONTAINER_BREAKPOINT = 480 // px
 
-const AnimatedCard = motion(Card)
+const AnimatedCard = motion.create(Card)
 
 export function DocumentStatusBar(props: DocumentStatusBarProps) {
   const {actionsBoxRef, createLinkMetadata} = props

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -63,6 +63,7 @@ const playwrightConfig = createPlaywrightConfig({
       reporter: excludeGithub([['list'], ['blob']]),
       use: {
         ...config.use,
+        video: 'retain-on-failure',
         baseURL: 'http://localhost:3339',
         headless: HEADLESS,
         contextOptions: {reducedMotion: 'reduce'},

--- a/test/e2e/tests/inputs/array-capabilities.spec.ts
+++ b/test/e2e/tests/inputs/array-capabilities.spec.ts
@@ -4,6 +4,10 @@ import {test as base} from '@sanity/test'
 
 const test = base.extend<{testDoc: SanityDocument}>({
   testDoc: async ({page, sanityClient}, use) => {
+    const referenceDoc = await sanityClient.create({
+      _type: 'author',
+      name: 'Test Author',
+    })
     const testDoc = await sanityClient.create({
       _type: 'arrayCapabilities',
       title: 'e2e fixture',
@@ -16,14 +20,16 @@ const test = base.extend<{testDoc: SanityDocument}>({
         {_type: 'something', _key: '630ae68957fb', first: 'Second'},
       ],
       primitiveArray: ['First', 2],
+      arrayOfReferences: [{_type: 'reference', _ref: referenceDoc._id}],
     })
     await use(testDoc)
     await sanityClient.delete(testDoc._id)
+    await sanityClient.delete(referenceDoc._id)
   },
 })
 
 test(`Scenario: Disabling all array capabilities`, async ({page, testDoc}) => {
-  await page.goto(`/test/content/arrayCapabilities;${testDoc._id}`)
+  await page.goto(`/test/content/input-debug;arrayCapabilities;${testDoc._id}`)
   await expect(page.getByTestId('document-panel-scroller')).toBeAttached({
     timeout: 40000,
   })

--- a/test/e2e/tests/inputs/array-capabilities.spec.ts
+++ b/test/e2e/tests/inputs/array-capabilities.spec.ts
@@ -23,7 +23,7 @@ const test = base.extend<{testDoc: SanityDocument}>({
 })
 
 test(`Scenario: Disabling all array capabilities`, async ({page, testDoc}) => {
-  await page.goto(`/test/content/arrayCapabilitiesExample;${testDoc._id}`)
+  await page.goto(`/test/content/arrayCapabilities;${testDoc._id}`)
   await expect(page.getByTestId('document-panel-scroller')).toBeAttached({
     timeout: 40000,
   })

--- a/test/e2e/tests/inputs/array-capabilities.spec.ts
+++ b/test/e2e/tests/inputs/array-capabilities.spec.ts
@@ -5,7 +5,7 @@ import {test as base} from '@sanity/test'
 const test = base.extend<{testDoc: SanityDocument}>({
   testDoc: async ({page, sanityClient}, use) => {
     const testDoc = await sanityClient.create({
-      _type: 'arrayCapabilitiesExample',
+      _type: 'arrayCapabilities',
       title: 'e2e fixture',
       objectArray: [
         {_type: 'something', _key: '5b75c4005e47', first: 'First'},


### PR DESCRIPTION
### Description
| Before | After |
|--------|--------|
| <img width="701" alt="Screenshot 2025-03-11 at 04 20 26" src="https://github.com/user-attachments/assets/c041a6d0-1007-43dc-9ec5-2523b0e4672b" /> | <img width="688" alt="Screenshot 2025-03-11 at 04 19 03" src="https://github.com/user-attachments/assets/d0a13bba-89b8-4dbe-8147-5d882c3d2cb9" /> | 

The same logic that is used across other arrays of items eg `/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx`, has been added to the `menu` rendered in `ReferenceItem`, so that support for `options.disableActions` is brought to arrays of references.

There is a separate minor refactor that will be raised shortly which will consolidate all array item menus from a single hook that can be reused both here, in `ItemRow` and elsewhere that currently duplicates logic.

Note, the `arrayCapabilities` schema type has been updated and amended to expand its test usage
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manually verified
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
`options.disableActions` is supported on items in an array of references. More details on `disableActions` [here](https://www.sanity.io/docs/array-type#disableActions-3bb920850f4c)
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
