### PR TITLE
fix(vision): scroll jump - transform vision code mirror to uncontrolled

### DIFF
--- a/packages/@sanity/vision/src/codemirror/VisionCodeMirror.tsx
+++ b/packages/@sanity/vision/src/codemirror/VisionCodeMirror.tsx
@@ -1,19 +1,66 @@
 import {useTheme} from '@sanity/ui'
-import CodeMirror, {type ReactCodeMirrorProps} from '@uiw/react-codemirror'
+import CodeMirror, {
+  EditorSelection,
+  type ReactCodeMirrorProps,
+  type ReactCodeMirrorRef,
+} from '@uiw/react-codemirror'
+import {forwardRef, useCallback, useImperativeHandle, useRef, useState} from 'react'
 
 import {codemirrorExtensions} from './extensions'
 import {useCodemirrorTheme} from './useCodemirrorTheme'
 import {EditorRoot} from './VisionCodeMirror.styled'
 
-export function VisionCodeMirror(
-  props: Omit<ReactCodeMirrorProps, 'basicSetup' | 'theme' | 'extensions'>,
-) {
+export interface VisionCodeMirrorHandle {
+  resetEditorContent: (newContent: string) => void
+}
+
+export const VisionCodeMirror = forwardRef<
+  VisionCodeMirrorHandle,
+  Pick<ReactCodeMirrorProps, 'onChange'> & {
+    initialValue: ReactCodeMirrorProps['value']
+  }
+>((props, ref) => {
+  // The value prop is only passed for initial value, and is not updated when the parent component updates the value.
+  // If you need to update the value, use the resetEditorContent function.
+  const [initialValue] = useState(props.initialValue)
   const sanityTheme = useTheme()
   const theme = useCodemirrorTheme(sanityTheme)
+  const codeMirrorRef = useRef<ReactCodeMirrorRef>(null)
+
+  const resetEditorContent = useCallback((newContent: string) => {
+    const editorView = codeMirrorRef.current?.view
+    if (!editorView) return
+
+    const currentDoc = editorView.state.doc.toString()
+    if (newContent !== currentDoc) {
+      editorView.dispatch({
+        changes: {from: 0, to: currentDoc.length, insert: newContent},
+        selection: EditorSelection.cursor(newContent.length), // Place cursor at end
+      })
+    }
+  }, [])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      resetEditorContent,
+    }),
+    [resetEditorContent],
+  )
 
   return (
     <EditorRoot>
-      <CodeMirror basicSetup={false} theme={theme} extensions={codemirrorExtensions} {...props} />
+      <CodeMirror
+        ref={codeMirrorRef}
+        basicSetup={false}
+        theme={theme}
+        extensions={codemirrorExtensions}
+        value={initialValue}
+        onChange={props.onChange}
+      />
     </EditorRoot>
   )
-}
+})
+
+// Add display name
+VisionCodeMirror.displayName = 'VisionCodeMirror'

--- a/packages/@sanity/vision/src/components/ParamsEditor.tsx
+++ b/packages/@sanity/vision/src/components/ParamsEditor.tsx
@@ -2,7 +2,7 @@ import {debounce} from 'lodash'
 import {useCallback, useEffect, useMemo, useState} from 'react'
 import {type TFunction, useTranslation} from 'sanity'
 
-import {VisionCodeMirror} from '../codemirror/VisionCodeMirror'
+import {VisionCodeMirror, type VisionCodeMirrorHandle} from '../codemirror/VisionCodeMirror'
 import {visionLocaleNamespace} from '../i18n'
 import {tryParseParams} from '../util/tryParseParams'
 
@@ -18,6 +18,7 @@ export interface ParamsEditorChangeEvent {
 export interface ParamsEditorProps {
   value: string
   onChange: (changeEvt: ParamsEditorChangeEvent) => void
+  editorRef: React.RefObject<VisionCodeMirrorHandle | null>
 }
 
 export interface ParamsEditorChange {
@@ -49,7 +50,13 @@ export function ParamsEditor(props: ParamsEditorProps) {
   )
 
   const handleChange = useMemo(() => debounce(handleChangeRaw, 333), [handleChangeRaw])
-  return <VisionCodeMirror value={props.value || defaultValue} onChange={handleChange} />
+  return (
+    <VisionCodeMirror
+      initialValue={props.value || defaultValue}
+      onChange={handleChange}
+      ref={props.editorRef}
+    />
+  )
 }
 
 function eventFromValue(

--- a/packages/@sanity/vision/src/components/ParamsEditor.tsx
+++ b/packages/@sanity/vision/src/components/ParamsEditor.tsx
@@ -1,5 +1,5 @@
 import {debounce} from 'lodash'
-import {type ClipboardEvent, useCallback, useEffect, useMemo, useState} from 'react'
+import {useCallback, useEffect, useMemo, useState} from 'react'
 import {type TFunction, useTranslation} from 'sanity'
 
 import {VisionCodeMirror} from '../codemirror/VisionCodeMirror'
@@ -18,7 +18,6 @@ export interface ParamsEditorChangeEvent {
 export interface ParamsEditorProps {
   value: string
   onChange: (changeEvt: ParamsEditorChangeEvent) => void
-  onPasteCapture: (event: ClipboardEvent<HTMLDivElement>) => void
 }
 
 export interface ParamsEditorChange {
@@ -26,7 +25,7 @@ export interface ParamsEditorChange {
 }
 
 export function ParamsEditor(props: ParamsEditorProps) {
-  const {onChange, onPasteCapture} = props
+  const {onChange} = props
   const {t} = useTranslation(visionLocaleNamespace)
   const {raw: value, error, parsed, valid} = eventFromValue(props.value, t)
   const [isValid, setValid] = useState(valid)
@@ -50,13 +49,7 @@ export function ParamsEditor(props: ParamsEditorProps) {
   )
 
   const handleChange = useMemo(() => debounce(handleChangeRaw, 333), [handleChangeRaw])
-  return (
-    <VisionCodeMirror
-      value={props.value || defaultValue}
-      onChange={handleChange}
-      onPasteCapture={onPasteCapture}
-    />
-  )
+  return <VisionCodeMirror value={props.value || defaultValue} onChange={handleChange} />
 }
 
 function eventFromValue(

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -23,7 +23,6 @@ import {
   Tooltip,
 } from '@sanity/ui'
 import {isHotkey} from 'is-hotkey-esm'
-import {debounce} from 'lodash'
 import {
   type ChangeEvent,
   type ComponentType,
@@ -272,13 +271,12 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     this.handleListenExecution = this.handleListenExecution.bind(this)
     this.handleListenerEvent = this.handleListenerEvent.bind(this)
     this.handleQueryExecution = this.handleQueryExecution.bind(this)
-    this.handleQueryChange = debounce(this.handleQueryChange, 300).bind(this)
+    this.handleQueryChange = this.handleQueryChange.bind(this)
     this.handleParamsChange = this.handleParamsChange.bind(this)
     this.handleCopyUrl = this.handleCopyUrl.bind(this)
     this.handlePaste = this.handlePaste.bind(this)
     this.handleKeyDown = this.handleKeyDown.bind(this)
     this.handleResize = this.handleResize.bind(this)
-    this.handleOnPasteCapture = this.handleOnPasteCapture.bind(this)
     this.setPerspective = this.setPerspective.bind(this)
   }
 
@@ -330,8 +328,8 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     }
   }
 
-  handlePaste(evt: React.ClipboardEvent<HTMLDivElement> | ClipboardEvent, stopPropagation = false) {
-    if (!evt?.clipboardData) {
+  handlePaste(evt: ClipboardEvent) {
+    if (!evt.clipboardData) {
       return
     }
 
@@ -384,10 +382,6 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
     }
 
     evt.preventDefault()
-    if (stopPropagation) {
-      // Stops propagation for the pasteEvent that occurs in the CodeMirror element if it has a match
-      evt.stopPropagation()
-    }
     this.setState(
       (prevState) => ({
         dataset: this.props.datasets.includes(usedDataset) ? usedDataset : prevState.dataset,
@@ -424,10 +418,6 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
         })
       },
     )
-  }
-
-  handleOnPasteCapture(ev: React.ClipboardEvent<HTMLDivElement>) {
-    this.handlePaste(ev, true)
   }
 
   cancelQuery() {
@@ -904,11 +894,7 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
                         <StyledLabel muted>{t('query.label')}</StyledLabel>
                       </Flex>
                     </InputBackgroundContainerLeft>
-                    <VisionCodeMirror
-                      value={query}
-                      onChange={this.handleQueryChange}
-                      onPasteCapture={this.handleOnPasteCapture}
-                    />
+                    <VisionCodeMirror value={query} onChange={this.handleQueryChange} />
                   </Box>
                 </InputContainer>
                 <InputContainer display="flex" ref={this._paramsEditorContainer}>
@@ -927,11 +913,7 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
                         )}
                       </Flex>
                     </InputBackgroundContainerLeft>
-                    <ParamsEditor
-                      value={rawParams}
-                      onChange={this.handleParamsChange}
-                      onPasteCapture={this.handleOnPasteCapture}
-                    />
+                    <ParamsEditor value={rawParams} onChange={this.handleParamsChange} />
                   </Card>
                   {/* Controls (listen/run) */}
                   <ControlsContainer>


### PR DESCRIPTION
### Description
fixes: https://github.com/sanity-io/sanity/issues/8827
Linear issue: SAPP-2009

This PR does two different things:
By one side it reverts the change introduced in https://github.com/sanity-io/sanity/pull/8238 because it didn't fix the underlying issue and it introduced a new one (hitting enter after just finishing writing was not triggering the correct query).

Instead, it takes a new approach of transforming the component to an uncontrolled editor, it does that by setting only an initial value, any subsequent change that is needed, like for example when pasting a url to process the query and get the correct values it's done by the `resetEditorContent` function which is exposed by the imperative handle.

https://github.com/user-attachments/assets/9522acf9-eeae-48c5-aec9-9e1ae5e855d7

I have a follow up PR https://github.com/sanity-io/sanity/pull/8879 which refactors the vision gui component, divides it into smaller pieces and transforms it to a functional component instead.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Are the changes correct?
Does vision scroll jump stopped? 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manually tested the editor by copy and pasting values to verify this continue working.
Manually tested reloading, the saved query is persisted.
Manually tested scroll jump, I found out that when pressing 5 or 6 keys at **the same time** in the keyboard the scroll jumped to the start, after the change, it is not jumping anymore.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
fixes vision scroll jump.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
