### PR TITLE
chore(tests): disable flaky references e2e tests

### DIFF
--- a/test/e2e/tests/inputs/reference.spec.ts
+++ b/test/e2e/tests/inputs/reference.spec.ts
@@ -69,7 +69,9 @@ withDefaultClient((context) => {
   test(`_strengthenOnPublish and _weak properties exist when adding reference to a draft document`, async ({
     page,
     createDraftDocument,
+    browserName,
   }) => {
+    test.skip(browserName === 'firefox' || browserName === 'chromium')
     test.slow()
     const originalTitle = 'Initial Doc'
 
@@ -145,7 +147,9 @@ withDefaultClient((context) => {
   test(`_strengthenOnPublish and _weak properties are removed when the reference and document are published`, async ({
     page,
     createDraftDocument,
+    browserName,
   }) => {
+    test.skip(browserName === 'firefox' || browserName === 'chromium')
     // this is in a situation where the _strengthenOnPublish.weak is not set
 
     test.slow()


### PR DESCRIPTION
### Description
The reference tests are flaky.
Disable them for now.

We will come back to it in SAPP-2485
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
