### PR TITLE
fix: release document actions disabled tooltips only shown when relevant

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -68,6 +68,9 @@ export const DocumentActions = memo(
       t,
     ])
 
+    const isUnpublishActionDisabled =
+      noPermissionToUnpublish || !document.document.publishedDocumentExists || isAlreadyUnpublished
+
     return (
       <>
         <Card tone="default" display="flex">
@@ -81,7 +84,10 @@ export const DocumentActions = memo(
                   icon={CloseIcon}
                   onClick={() => setShowDiscardDialog(true)}
                   disabled={isDiscardVersionActionDisabled}
-                  tooltipProps={{content: t('permissions.error.discard-version')}}
+                  tooltipProps={{
+                    disabled: !isDiscardVersionActionDisabled,
+                    content: t('permissions.error.discard-version'),
+                  }}
                 />
                 <MenuDivider />
                 <Box padding={3} paddingBottom={2}>
@@ -90,12 +96,11 @@ export const DocumentActions = memo(
                 <MenuItem
                   text={t('action.unpublish')}
                   icon={UnpublishIcon}
-                  disabled={
-                    noPermissionToUnpublish ||
-                    !document.document.publishedDocumentExists ||
-                    isAlreadyUnpublished
-                  }
-                  tooltipProps={{content: unPublishTooltipContent}}
+                  disabled={isUnpublishActionDisabled}
+                  tooltipProps={{
+                    disabled: !isUnpublishActionDisabled,
+                    content: unPublishTooltipContent,
+                  }}
                   onClick={() => setShowUnpublishDialog(true)}
                 />
               </Menu>


### PR DESCRIPTION
### Description
The tooltips were wrongly showing all the time, even when the actions were enabled and the user had permissions
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
