### PR TITLE
feat(presentation): include perspectiveStack and version in resolvers

### DIFF
--- a/packages/sanity/src/presentation/document/PresentationDocumentHeader.tsx
+++ b/packages/sanity/src/presentation/document/PresentationDocumentHeader.tsx
@@ -18,14 +18,15 @@ const LocationStack = styled(Stack)`
 
 export function PresentationDocumentHeader(props: {
   documentId: PublishedId
+  version: string | undefined
   options: PresentationPluginOptions
   schemaType: ObjectSchemaType
 }): ReactNode {
-  const {documentId, options, schemaType} = props
-
+  const {documentId, options, schemaType, version} = props
   const context = useContext(PresentationDocumentContext)
   const {state, status} = useDocumentLocations({
     id: documentId,
+    version,
     resolvers: options.resolve?.locations || options.locate,
     type: schemaType.name,
   })

--- a/packages/sanity/src/presentation/plugin.tsx
+++ b/packages/sanity/src/presentation/plugin.tsx
@@ -1,6 +1,12 @@
 import {type SanityDocument} from '@sanity/client'
 import {lazy, Suspense} from 'react'
-import {definePlugin, getPublishedId, type InputProps, isDocumentSchemaType} from 'sanity'
+import {
+  definePlugin,
+  getPublishedId,
+  getVersionFromId,
+  type InputProps,
+  isDocumentSchemaType,
+} from 'sanity'
 
 import {DEFAULT_TOOL_ICON, DEFAULT_TOOL_NAME, EDIT_INTENT_MODE} from './constants'
 import {PresentationDocumentHeader} from './document/PresentationDocumentHeader'
@@ -56,13 +62,14 @@ export const presentationTool = definePlugin<PresentationPluginOptions>((options
   function PresentationDocumentInput(props: InputProps) {
     const value = props.value as SanityDocument
     const documentId = value?._id ? getPublishedId(value?._id) : undefined
-
+    const documentVersion = value?._id ? getVersionFromId(value._id) : undefined
     if (isDocumentSchemaType(props.schemaType)) {
       return (
         <PresentationDocumentProvider options={options}>
           {hasLocationsResolver && documentId && (
             <PresentationDocumentHeader
               documentId={documentId}
+              version={documentVersion}
               options={options}
               schemaType={props.schemaType}
             />

--- a/packages/sanity/src/presentation/types.ts
+++ b/packages/sanity/src/presentation/types.ts
@@ -1,4 +1,4 @@
-import {type ClientPerspective} from '@sanity/client'
+import {type ClientPerspective, type StackablePerspective} from '@sanity/client'
 import {type ChannelInstance} from '@sanity/comlink'
 import {
   type LoaderControllerMsg,
@@ -56,7 +56,12 @@ export type DocumentLocationsStatus = 'empty' | 'resolving' | 'resolved'
  * @public
  */
 export type DocumentLocationResolver = (
-  params: {id: string; type: string},
+  params: {
+    id: string
+    type: string
+    version: string | undefined
+    perspectiveStack: StackablePerspective[]
+  },
   context: {documentStore: DocumentStore},
 ) =>
   | DocumentLocationsState

--- a/packages/sanity/src/presentation/useDocumentLocations.ts
+++ b/packages/sanity/src/presentation/useDocumentLocations.ts
@@ -10,6 +10,7 @@ import {
   type Previewable,
   type SanityDocument,
   useDocumentStore,
+  usePerspective,
 } from 'sanity'
 
 import {
@@ -128,14 +129,16 @@ function observeForLocations(
 
 export function useDocumentLocations(props: {
   id: string
+  version: string | undefined
   resolvers?: DocumentLocationResolver | DocumentLocationResolvers
   type: string
 }): {
   state: DocumentLocationsState
   status: DocumentLocationsStatus
 } {
-  const {id, resolvers, type} = props
+  const {id, resolvers, type, version} = props
   const documentStore = useDocumentStore()
+  const {perspectiveStack} = usePerspective()
   const [locationsState, setLocationsState] = useState<DocumentLocationsState>(INITIAL_STATE)
 
   const resolver = resolvers && (typeof resolvers === 'function' ? resolvers : resolvers[type])
@@ -149,7 +152,7 @@ export function useDocumentLocations(props: {
 
     // Original/advanced resolver which requires explicit use of Observables
     if (typeof resolver === 'function') {
-      const params = {id, type}
+      const params = {id, type, version, perspectiveStack}
       const context = {documentStore}
       const _result = resolver(params, context)
       return isObservable(_result) ? _result : of(_result)
@@ -162,7 +165,7 @@ export function useDocumentLocations(props: {
 
     // Resolver is explicitly provided state
     return of(resolver)
-  }, [documentStore, id, resolver, type])
+  }, [documentStore, id, resolver, type, version, perspectiveStack])
 
   useEffect(() => {
     const sub = result?.subscribe((state) => {


### PR DESCRIPTION
### Description

This PR adds to presentation resolvers two new options that are necessary for the resolvers to correctly resolve the queries when using releases.
`version`
`perspectiveStack``

The version is necessary to know if the document you are trying to resolve is a version document and which version it belongs to.
The stack is necessary to expose to users a way to query for the document, they can provide this value to the `client.perspective` 

Example of returned value:

```ts
{
  id: "5ca15b90-6317-4ab0-a757-54a961671661",
  perspectiveStack: ['rKM9a34iK', 'drafts'],
  type: "author",
  version: "rKM9a34iK"
}

```
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is this change correct? Is there any other place we need to update to expose this value?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

include `perspectiveStack` and `version` in presentation resolvers 

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
