### PR TITLE
fix(studio): handle document-level copy/paste reference mismatches

### DIFF
--- a/packages/sanity/src/core/studio/copyPaste/__test__/transferValue.test.ts
+++ b/packages/sanity/src/core/studio/copyPaste/__test__/transferValue.test.ts
@@ -526,6 +526,54 @@ describe('transferValue', () => {
       ])
       expect(transferValueResult?.targetValue).toEqual(undefined)
     })
+
+    test('will properly preserve _weak and _strengthenOnPublish when copying a whole document with references', async () => {
+      const sourceValue = {
+        _type: 'referencesDocument',
+        _id: 'doc1',
+        reference: {
+          _type: 'reference',
+          _ref: 'yyy',
+          _weak: true,
+          _strengthenOnPublish: {
+            type: 'editor',
+          },
+        },
+      }
+      const targetRootValue = {
+        _type: 'referencesDocument',
+        _id: 'doc2',
+      }
+
+      const transferValueResult = await transferValue({
+        sourceRootSchemaType: schema.get('referencesDocument')!,
+        sourcePath: [],
+        sourceValue,
+        targetDocumentSchemaType: schema.get('referencesDocument')!,
+        targetRootSchemaType: schema.get('referencesDocument')!,
+        targetPath: [],
+        targetRootValue,
+        targetRootPath: [],
+        currentUser,
+        options: {
+          validateReferences: true,
+          client: createMockClient([{_type: 'editor', _id: 'yyy', name: 'John Doe'}]),
+        },
+      })
+
+      expect(transferValueResult?.errors).toEqual([])
+      expect(transferValueResult?.targetValue).toMatchObject({
+        _type: 'referencesDocument',
+        reference: {
+          _type: 'reference',
+          _ref: 'yyy',
+          _weak: true,
+          _strengthenOnPublish: {
+            type: 'editor',
+          },
+        },
+      })
+    })
   })
 
   describe('booleans', () => {

--- a/packages/sanity/src/core/studio/copyPaste/transferValue.ts
+++ b/packages/sanity/src/core/studio/copyPaste/transferValue.ts
@@ -794,9 +794,13 @@ async function collateObjectValue({
     })
   }
 
-  // Special handling for weak references
-  if (isReferenceSchemaType(targetSchemaType) && targetSchemaType.weak) {
-    resultingValue._weak = true
+  // Special handling to avoid reference strength mismatches
+  if (isReferenceSchemaType(targetSchemaType)) {
+    if (targetSchemaType.weak) {
+      resultingValue._weak = true
+    } else {
+      delete resultingValue._weak
+    }
   }
 
   // Special handling for weak references that will be strengthened on publish
@@ -1034,7 +1038,7 @@ function collatePrimitiveValue({
 }
 
 function cleanObjectKeys(obj: TypedObject): TypedObject {
-  const disallowedKeys = ['_id', '_createdAt', '_updatedAt', '_rev', '_weak']
+  const disallowedKeys = ['_id', '_createdAt', '_updatedAt', '_rev']
   return Object.keys(obj).reduce((acc, key) => {
     if (disallowedKeys.includes(key)) {
       return acc


### PR DESCRIPTION
### Description
Copy-pasting a document with a reference ended up crashing the studio with an error like:
```
Mutation failed: Document "drafts.05a476fe-4995-4e3e-aa8c-771dca935f43" references non-existent document "d7ad5b07-5e6b-4de3-91c0-ce4fff3ea1bd"
```

In examining further, we were sending an action like:

```
  {
    "actionType": "sanity.action.document.edit",
    "draftId": "drafts.05a476fe-4995-4e3e-aa8c-771dca935f43",
    "publishedId": "05a476fe-4995-4e3e-aa8c-771dca935f43",
    "patch": {
      "set": {
        "author": {
          "_type": "reference",
          "_ref": "d7ad5b07-5e6b-4de3-91c0-ce4fff3ea1bd",
          "_strengthenOnPublish": {
            "type": "author"
          }
        }
      }
    }
  }
```

to the Content Lake. Although the pasted object included a `_strengthenOnPublish` parameter, it did not include a `_weak` parameter. I tracked this down to the `transferValue` function passing documents through the `cleanObjectKeys` function after all the reference-specific logic had run, removing the essential `_weak` key. This also happened when just pasting a document with a weak reference.

That logic was added in [this commit](https://github.com/sanity-io/sanity/pull/6856/commits/48c5f39539deea5a85aeb467fd467f3f41ad4b8a) of the original copy/paste PR to assist in copy/pasting field-level strong or weak references. 

This fix localizes that logic to where it is invoked, rather than it occurring in the `cleanObjectKeys` function.

### What to review
I'm tagging @skogsmaskin in this since he worked on the original commit and knows the scenarios in which this `_weak` key proves problematic. I ask that all reviewers please point out any other gotchas this might result in!

### Testing
An additional test was added for this case.

### Notes for release
Fixes an issue where pasting a document with a draft in a reference field would cause the studio to crash.