### PR TITLE
feat(sanity): refine release toasts

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1180,9 +1180,6 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.action.discard-version': 'Discard version',
   /** Description for toast when version discarding failed */
   'release.action.discard-version.failure': 'Failed to discard version',
-  /** Description for toast when version deletion is successfully discarded */
-  'release.action.discard-version.success':
-    '<strong>{{title}}</strong> version was successfully discarded',
   /** Action message for when a new release is created off an existing version, draft or published document */
   'release.action.new-release': 'New Release',
   /** Tooltip message for not having permissions for creating new releases */

--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -1,12 +1,12 @@
-import {Box, Stack, Text, useToast} from '@sanity/ui'
+import {Box, Stack, Text} from '@sanity/ui'
 import {useCallback, useState} from 'react'
 
 import {Dialog} from '../../../../ui-components'
 import {LoadingBlock} from '../../../components'
 import {useDocumentOperation, useSchema} from '../../../hooks'
-import {Translate, useTranslation} from '../../../i18n'
+import {useTranslation} from '../../../i18n'
 import {usePerspective} from '../../../perspective/usePerspective'
-import {Preview, unstable_useValuePreview as useValuePreview} from '../../../preview'
+import {Preview} from '../../../preview'
 import {getPublishedId, getVersionFromId, isVersionId} from '../../../util/draftUtils'
 import {useVersionOperations} from '../../hooks'
 import {releasesLocaleNamespace} from '../../i18n'
@@ -23,17 +23,13 @@ export function DiscardVersionDialog(props: {
 }): React.JSX.Element {
   const {onClose, documentId, documentType} = props
   const {t} = useTranslation(releasesLocaleNamespace)
-  const {t: coreT} = useTranslation()
   const {discardChanges} = useDocumentOperation(getPublishedId(documentId), documentType)
-  const toast = useToast()
   const {selectedPerspective} = usePerspective()
   const {discardVersion} = useVersionOperations()
   const schema = useSchema()
   const [isDiscarding, setIsDiscarding] = useState(false)
 
   const schemaType = schema.get(documentType)
-
-  const preview = useValuePreview({schemaType, value: {_id: documentId}})
 
   const handleDiscardVersion = useCallback(async () => {
     setIsDiscarding(true)
@@ -44,18 +40,6 @@ export function DiscardVersionDialog(props: {
           getReleaseIdFromReleaseDocumentId((selectedPerspective as ReleaseDocument)._id),
         documentId,
       )
-
-      toast.push({
-        closable: true,
-        status: 'success',
-        description: (
-          <Translate
-            t={coreT}
-            i18nKey={'release.action.discard-version.success'}
-            values={{title: preview.value?.title || documentId}}
-          />
-        ),
-      })
     } else {
       // on the document header you can also discard the draft
       discardChanges.execute()
@@ -64,16 +48,7 @@ export function DiscardVersionDialog(props: {
     setIsDiscarding(false)
 
     onClose()
-  }, [
-    documentId,
-    onClose,
-    discardVersion,
-    selectedPerspective,
-    toast,
-    coreT,
-    preview.value?.title,
-    discardChanges,
-  ])
+  }, [documentId, onClose, discardVersion, selectedPerspective, discardChanges])
 
   return (
     <Dialog

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -330,8 +330,6 @@ const releasesLocaleStrings = {
 
   /** Text for toast when release failed to archive */
   'toast.archive.error': "Failed to archive '<strong>{{title}}</strong>': {{error}}",
-  /** Description for toast when new version  of document is created in release */
-  'toast.create-version.success': '{{documentTitle}} added to release',
   /** Description for toast when creating new version of document in release failed */
   'toast.create-version.error': 'Failed to add document to release: {{error}}',
   /** Description for toast when release deletion failed */

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -328,8 +328,6 @@ const releasesLocaleStrings = {
   /** Header for the document table in the release tool - time */
   'table-header.time': 'Time',
 
-  /** Text for toast when release has been archived */
-  'toast.archive.success': "The '<strong>{{title}}</strong>' release was archived.",
   /** Text for toast when release failed to archive */
   'toast.archive.error': "Failed to archive '<strong>{{title}}</strong>': {{error}}",
   /** Description for toast when new version  of document is created in release */

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -338,8 +338,6 @@ const releasesLocaleStrings = {
   'toast.delete.success': "The '<strong>{{title}}</strong>' release was successfully deleted",
   /** Text for toast when release failed to publish */
   'toast.publish.error': "Failed to publish '<strong>{{title}}</strong>': {{error}}",
-  /** Text for toast when release has been published */
-  'toast.publish.success': "The '<strong>{{title}}</strong>' release was published.",
   /** Text for toast when release failed to schedule */
   'toast.schedule.error': "Failed to schedule '<strong>{{title}}</strong>': {{error}}",
   /** Text for toast when release has been scheduled */

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -346,8 +346,6 @@ const releasesLocaleStrings = {
   'toast.schedule.success': "The '<strong>{{title}}</strong>' release was scheduled.",
   /** Text for toast when release failed to unschedule */
   'toast.unschedule.error': "Failed to unscheduled '<strong>{{title}}</strong>': {{error}}",
-  /** Text for toast when release has been unschedule */
-  'toast.unschedule.success': "The '<strong>{{title}}</strong>' release was unscheduled.",
   /** Text for toast when release failed to unarchive */
   'toast.unarchive.error': "Failed to unarchive '<strong>{{title}}</strong>': {{error}}",
   /** Description for toast when release deletion failed */

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -350,8 +350,6 @@ const releasesLocaleStrings = {
   'toast.unschedule.error': "Failed to unscheduled '<strong>{{title}}</strong>': {{error}}",
   /** Text for toast when release has been unschedule */
   'toast.unschedule.success': "The '<strong>{{title}}</strong>' release was unscheduled.",
-  /** Text for toast when release has been unarchived */
-  'toast.unarchive.success': "The '<strong>{{title}}</strong>' release was unarchived.",
   /** Text for toast when release failed to unarchive */
   'toast.unarchive.error': "Failed to unarchive '<strong>{{title}}</strong>': {{error}}",
   /** Description for toast when release deletion failed */

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
@@ -68,34 +68,39 @@ export const ReleaseMenuButton = ({ignoreCTA, release, documentsCount}: ReleaseM
         await actionLookup[action](release._id)
 
         telemetry.log(actionValues.telemetry)
-        toast.push({
-          closable: true,
-          status: 'success',
-          title: (
-            <Text muted size={1}>
-              <Translate
-                t={t}
-                i18nKey={actionValues.toastSuccessI18nKey}
-                values={{title: releaseTitle}}
-              />
-            </Text>
-          ),
-        })
+
+        if (typeof actionValues.toastSuccessI18nKey !== 'undefined') {
+          toast.push({
+            closable: true,
+            status: 'success',
+            title: (
+              <Text muted size={1}>
+                <Translate
+                  t={t}
+                  i18nKey={actionValues.toastSuccessI18nKey}
+                  values={{title: releaseTitle}}
+                />
+              </Text>
+            ),
+          })
+        }
       } catch (actionError) {
         if (isReleaseLimitError(actionError)) return
 
-        toast.push({
-          status: 'error',
-          title: (
-            <Text muted size={1}>
-              <Translate
-                t={t}
-                i18nKey={actionValues.toastFailureI18nKey}
-                values={{title: releaseTitle, error: actionError.toString()}}
-              />
-            </Text>
-          ),
-        })
+        if (typeof actionValues.toastFailureI18nKey !== 'undefined') {
+          toast.push({
+            status: 'error',
+            title: (
+              <Text muted size={1}>
+                <Translate
+                  t={t}
+                  i18nKey={actionValues.toastFailureI18nKey}
+                  values={{title: releaseTitle, error: actionError.toString()}}
+                />
+              </Text>
+            ),
+          })
+        }
         console.error(actionError)
       } finally {
         setIsPerformingOperation(false)

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/releaseActions.ts
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/releaseActions.ts
@@ -60,7 +60,6 @@ export const RELEASE_ACTION_MAP: Record<
   },
   unschedule: {
     confirmDialog: false,
-    toastSuccessI18nKey: 'toast.unschedule.success',
     toastFailureI18nKey: 'toast.unschedule.error',
     telemetry: UnscheduledRelease,
   },

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/releaseActions.ts
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/releaseActions.ts
@@ -11,8 +11,8 @@ import {
 export type ReleaseAction = 'archive' | 'unarchive' | 'delete' | 'unschedule'
 
 interface BaseReleaseActionsMap {
-  toastSuccessI18nKey: string
-  toastFailureI18nKey: string
+  toastSuccessI18nKey?: string
+  toastFailureI18nKey?: string
   telemetry: DefinedTelemetryLog<void>
 }
 

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/releaseActions.ts
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/releaseActions.ts
@@ -50,7 +50,6 @@ export const RELEASE_ACTION_MAP: Record<
       dialogConfirmButtonI18nKey: 'archive-dialog.confirm-archive-button',
       confirmButtonTone: 'critical',
     },
-    toastSuccessI18nKey: 'toast.archive.success',
     toastFailureI18nKey: 'toast.archive.error',
     telemetry: ArchivedRelease,
   },

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/releaseActions.ts
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/releaseActions.ts
@@ -55,7 +55,6 @@ export const RELEASE_ACTION_MAP: Record<
   },
   unarchive: {
     confirmDialog: false,
-    toastSuccessI18nKey: 'toast.unarchive.success',
     toastFailureI18nKey: 'toast.unarchive.error',
     telemetry: UnarchivedRelease,
   },

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
@@ -67,21 +67,6 @@ export const ReleasePublishAllButton = ({
       setPublishBundleStatus('publishing')
       await publishRelease(release._id)
       telemetry.log(PublishedRelease)
-      toast.push({
-        closable: true,
-        status: 'success',
-        title: (
-          <Text muted size={1}>
-            <Translate
-              t={t}
-              i18nKey="toast.publish.success"
-              values={{
-                title: release.metadata.title || tCore('release.placeholder-untitled-release'),
-              }}
-            />
-          </Text>
-        ),
-      })
       if (
         isReleaseDocument(perspective.selectedPerspective) &&
         perspective.selectedPerspective?._id === release._id

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -89,7 +89,7 @@ export const ReleaseScheduleButton = ({
       telemetry.log(ScheduledRelease)
       toast.push({
         closable: true,
-        status: 'success',
+        status: 'info',
         title: (
           <Text muted size={1}>
             <Translate

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseUnscheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseUnscheduleButton.tsx
@@ -34,21 +34,6 @@ export const ReleaseUnscheduleButton = ({
       setStatus('unscheduling')
       await unschedule(release._id)
       telemetry.log(UnscheduledRelease)
-      toast.push({
-        closable: true,
-        status: 'success',
-        title: (
-          <Text muted size={1}>
-            <Translate
-              t={t}
-              i18nKey="toast.unschedule.success"
-              values={{
-                title: release.metadata.title || tCore('release.placeholder-untitled-release'),
-              }}
-            />
-          </Text>
-        ),
-      })
     } catch (schedulingError) {
       toast.push({
         status: 'error',

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -162,12 +162,6 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
       if (
         documents.find(({document}) => `${document._id}-pending` === pendingDocument.document._id)
       ) {
-        toast.push({
-          id: `add-version-to-release-${pendingDocument.document._id}`,
-          closable: true,
-          status: 'success',
-          title: t('toast.create-version.success', {documentTitle: pendingDocument.document.title}),
-        })
         documentsNoLongerPending.push(pendingDocument.document._id)
       }
     })


### PR DESCRIPTION
### Description

This branch continues the work of refining toasts, focusing on Content Releases. Primarily, this means removing success toasts when it's apparent in the UI that the operation was successful.

### What to review

Do all the removals make sense? The commits are atomic, so it's probably easiest to look over them to see the individual changes.

### Testing

Tested in browser. Existing tests succeed.