### PR TITLE
refactor(preview): clean up preview with fallback logic

### DIFF
--- a/packages/sanity/src/core/preview/utils/getPreviewValueWithFallback.tsx
+++ b/packages/sanity/src/core/preview/utils/getPreviewValueWithFallback.tsx
@@ -13,7 +13,10 @@ function getMissingDocumentFallback(document: Partial<SanityDocument> | PreviewV
   }
 }
 
-export type Values = {
+/**
+ * @internal
+ */
+export type Sources = {
   /**
    * Preview snapshot with current perspective applied
    * This takes priority of original and fallback
@@ -38,6 +41,6 @@ const EMPTY: {[key: string]: never} = {}
  *
  * @internal
  */
-export function getPreviewValueWithFallback({snapshot, original, fallback}: Values) {
+export function getPreviewValueWithFallback({snapshot, original, fallback}: Sources) {
   return snapshot || original || getMissingDocumentFallback(fallback || EMPTY)
 }

--- a/packages/sanity/src/core/preview/utils/getPreviewValueWithFallback.tsx
+++ b/packages/sanity/src/core/preview/utils/getPreviewValueWithFallback.tsx
@@ -1,8 +1,7 @@
 import {WarningOutlineIcon} from '@sanity/icons'
 import {type PreviewValue, type SanityDocument} from '@sanity/types'
-import {assignWith} from 'lodash'
 
-export function getMissingDocumentFallback(document: Partial<SanityDocument> | PreviewValue) {
+function getMissingDocumentFallback(document: Partial<SanityDocument> | PreviewValue) {
   return {
     title: <em>{document.title ? String(document.title) : 'Missing document'}</em>,
     subtitle: (
@@ -14,25 +13,31 @@ export function getMissingDocumentFallback(document: Partial<SanityDocument> | P
   }
 }
 
+export type Values = {
+  /**
+   * Preview snapshot with current perspective applied
+   * This takes priority of original and fallback
+   */
+  snapshot?: Partial<SanityDocument> | PreviewValue | null | undefined
+  /**
+   * Preview of the original document (e.g. without current perspective applied)
+   */
+  original?: Partial<SanityDocument> | PreviewValue | null | undefined
+  /**
+   * last resort fallback in case we don't have anything to preview
+   * this can be a hard-coded preview value, or a document stub
+   */
+  fallback?: Partial<SanityDocument> | PreviewValue
+}
+
+const EMPTY: {[key: string]: never} = {}
+
 /**
  * Obtain document preview values used in <SanityPreview> and <SanityDefaultPreview> components.
  * Also displays fallback values if the document cannot be found.
  *
  * @internal
  */
-export function getPreviewValueWithFallback({
-  snapshot,
-  original,
-  document,
-}: {
-  document?: Partial<SanityDocument> | PreviewValue | null | undefined
-  snapshot?: Partial<SanityDocument> | PreviewValue | null | undefined
-  original?: Partial<SanityDocument> | PreviewValue | null | undefined
-}) {
-  if (document && !original && !snapshot) {
-    return getMissingDocumentFallback(document)
-  }
-  return assignWith({}, snapshot, original, (objValue, srcValue) => {
-    return typeof srcValue === 'undefined' ? objValue : srcValue
-  }) as PreviewValue
+export function getPreviewValueWithFallback({snapshot, original, fallback}: Values) {
+  return snapshot || original || getMissingDocumentFallback(fallback || EMPTY)
 }

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -229,7 +229,7 @@ const getPublishedArchivedReleaseDocumentsObservable = ({
             map(({snapshot}) => ({
               isLoading: false,
               values: prepareForPreview(
-                getPreviewValueWithFallback({snapshot, original: document}),
+                getPreviewValueWithFallback({snapshot, fallback: document}),
                 schemaType,
               ),
             })),

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -87,7 +87,7 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
     searchOpen,
   } = useContext(NavbarContext)
 
-  const {selectedPerspective} = usePerspective()
+  const {selectedPerspective, perspectiveStack} = usePerspective()
 
   const ToolMenu = useToolMenuComponent()
 
@@ -265,6 +265,7 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
                           onClose={handleCloseSearch}
                           onOpen={handleOpenSearch}
                           open={searchOpen}
+                          previewPerspective={perspectiveStack}
                         />
                       )}
                     </BoundaryElementProvider>

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
@@ -69,10 +69,14 @@ export function SearchResultItem({
   // should the search items be disasabled
   const disabledAction = (!hasCreatePermission && state.canDisableAction) || existsInRelease
 
+  const documentStub = useMemo(
+    () => ({_id: documentId, _type: documentType}),
+    [documentId, documentType],
+  )
   const preview = useValuePreview({
     enabled: true,
     schemaType: type,
-    value: {_id: documentId},
+    value: documentStub,
   })
 
   const handleClick = useCallback(
@@ -105,6 +109,7 @@ export function SearchResultItem({
       >
         <SearchResultItemPreview
           documentId={documentId}
+          documentType={documentType}
           layout={layout}
           perspective={previewPerspective}
           presence={documentPresence}

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
@@ -19,6 +19,7 @@ import {type DocumentPresence, useDocumentPreviewStore} from '../../../../../../
 
 interface SearchResultItemPreviewProps {
   documentId: string
+  documentType: string
   layout?: GeneralPreviewLayoutKey
   presence?: DocumentPresence[]
   perspective?: PerspectiveStack
@@ -43,6 +44,7 @@ const SearchResultItemPreviewBox = styled(Box)`
  */
 export function SearchResultItemPreview({
   documentId,
+  documentType,
   layout,
   presence,
   schemaType,
@@ -54,6 +56,11 @@ export function SearchResultItemPreview({
   const observable = useMemo(() => {
     return getPreviewStateObservable(documentPreviewStore, schemaType, documentId, perspective)
   }, [documentPreviewStore, schemaType, documentId, perspective])
+
+  const documentStub = useMemo(
+    () => ({_id: documentId, _type: documentType}),
+    [documentId, documentType],
+  )
 
   const {isLoading, snapshot, original} = useObservable(observable, {
     snapshot: null,
@@ -97,7 +104,7 @@ export function SearchResultItemPreview({
   return (
     <SearchResultItemPreviewBox>
       <SanityDefaultPreview
-        {...getPreviewValueWithFallback({snapshot, original})}
+        {...getPreviewValueWithFallback({snapshot, original, fallback: documentStub})}
         isPlaceholder={isLoading ?? true}
         layout={layout || 'default'}
         icon={schemaType.icon}

--- a/packages/sanity/src/core/tasks/components/form/fields/TargetField.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/TargetField.tsx
@@ -122,6 +122,7 @@ function Preview(props: {value: TaskTarget; handleRemove: () => void}) {
       <Flex gap={1} align={'center'} justify={'space-between'}>
         <Card as={CardLink} radius={2} data-as="button">
           <SearchResultItemPreview
+            documentType={documentType}
             documentId={value.document._ref}
             layout={'compact'}
             presence={documentPresence}

--- a/packages/sanity/src/presentation/editor/ContentEditor.tsx
+++ b/packages/sanity/src/presentation/editor/ContentEditor.tsx
@@ -6,7 +6,6 @@ import {
   type Path,
   PreviewCard,
   SanityDefaultPreview,
-  type SanityDocument,
   Translate,
   useSchema,
   useTranslation,
@@ -77,8 +76,8 @@ export function ContentEditor(props: {
     return (
       <SanityDefaultPreview
         {...getPreviewValueWithFallback({
-          document: mainDocumentState!.document! as SanityDocument,
           snapshot: previewState.snapshot,
+          fallback: mainDocumentState!.document,
         })}
         schemaType={schemaType}
         status={

--- a/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
@@ -84,7 +84,7 @@ export function PaneItemPreview(props: PaneItemPreviewProps) {
 
   return (
     <SanityDefaultPreview
-      {...getPreviewValueWithFallback({document, snapshot, original})}
+      {...getPreviewValueWithFallback({snapshot, original, fallback: value})}
       isPlaceholder={isLoading}
       icon={icon}
       layout={layout}


### PR DESCRIPTION
### Description

Fixes a couple of issues:

### 1. Search previews didn't reflect current perspective
#### Before
![image](https://github.com/user-attachments/assets/aac5bfc5-6ba5-4223-8957-223397517535)
#### After
![image](https://github.com/user-attachments/assets/93694a32-5f73-4ae6-bb44-5bd48f9d004d)

### 2. Document list previews didn't reflect current perspective
#### Before

![image](https://github.com/user-attachments/assets/e6fb8457-3d30-414f-8844-a7b33e2df90c)
#### After
![image](https://github.com/user-attachments/assets/81e7f0c5-7d20-4251-be21-92c81ebac1be)

### What to review
Took the opportunity to clean up and document the logic related to getting preview values and fallback
Also fixed a bug that leaked document.title in previews for cases where the document was missing.

### Testing
Switching between release/draft/published should use the correct preview for search results (global search, reference search), document lists etc.

### Notes for release
- Fixed an issue where list previews sometimes did not reflect the current release.