### PR TITLE
test: Disabling hardware acceleration during e2es

### DIFF
--- a/packages/sanity/playwright-ct.config.ts
+++ b/packages/sanity/playwright-ct.config.ts
@@ -68,6 +68,9 @@ export default defineConfig({
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: ['--disable-gpu', '--disable-software-rasterizer'],
+        },
         permissions: ['clipboard-read', 'clipboard-write'],
         contextOptions: {
           reducedMotion: 'reduce',

--- a/perf/efps/runTest.ts
+++ b/perf/efps/runTest.ts
@@ -80,7 +80,10 @@ export async function runTest({
 
   try {
     log('Launching browser…')
-    browser = await chromium.launch({headless, args: ['--use-gl=egl']})
+    browser = await chromium.launch({
+      headless,
+      args: ['--disable-gpu', '--disable-software-rasterizer'],
+    })
     context = await browser.newContext({
       recordVideo: recordVideo ? {dir: testResultsDir} : undefined,
       reducedMotion: 'reduce',

--- a/perf/efps/runTest.ts
+++ b/perf/efps/runTest.ts
@@ -80,9 +80,10 @@ export async function runTest({
 
   try {
     log('Launching browser…')
-    browser = await chromium.launch({headless})
+    browser = await chromium.launch({headless, args: ['--use-gl=egl']})
     context = await browser.newContext({
       recordVideo: recordVideo ? {dir: testResultsDir} : undefined,
+      reducedMotion: 'reduce',
       storageState: {
         cookies: [],
         origins: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,9 +34,14 @@ const playwrightConfig = createPlaywrightConfig({
           return {
             ...projectConfig,
             permissions: ['clipboard-read', 'clipboard-write'],
+            launchOptions: {
+              args: ['--disable-gpu', '--disable-software-rasterizer'],
+            },
             contextOptions: {
+              ...projectConfig.use?.contextOptions,
               // chromium-specific permissions
               permissions: ['clipboard-read', 'clipboard-write'],
+              reducedMotion: 'reduce',
             },
           }
         }
@@ -49,6 +54,10 @@ const playwrightConfig = createPlaywrightConfig({
                 'dom.events.asyncClipboard.readText': true,
                 'dom.events.testing.asyncClipboard': true,
               },
+            },
+            contextOptions: {
+              ...projectConfig.use?.contextOptions,
+              reducedMotion: 'reduce',
             },
           }
         }


### PR DESCRIPTION
### Description
Disabling the GPU and software rasterizer helps make test runs more consistent by reducing visual or timing issues that can sometimes cause flaky E2E tests. 

This should lead to fewer random failures, especially in CI.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
The E2E tests still run
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
