### PR TITLE
fix(core): updating document version actions to match deviated API

### DIFF
--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -44,7 +44,6 @@ export interface ReleaseOperationsStore {
   unpublishVersion: (documentId: string, opts?: operationsOptions) => Promise<void>
 }
 
-const IS_CREATE_VERSION_ACTION_SUPPORTED = false
 const METADATA_PROPERTY_NAME = 'metadata'
 
 export function createReleaseOperationsStore(options: {
@@ -185,19 +184,17 @@ export function createReleaseOperationsStore(options: {
       _id: getVersionId(documentId, releaseId),
     }) as IdentifiedSanityDocumentStub
 
-    await (IS_CREATE_VERSION_ACTION_SUPPORTED
-      ? requestAction(
-          client,
-          [
-            {
-              actionType: 'sanity.action.document.createVersion',
-              releaseId,
-              attributes: versionDocument,
-            },
-          ],
-          opts,
-        )
-      : client.create(versionDocument, opts))
+    await requestAction(
+      client,
+      [
+        {
+          actionType: 'sanity.action.document.version.create',
+          publishedId: getPublishedId(documentId),
+          document: versionDocument,
+        },
+      ],
+      opts,
+    )
   }
 
   const handleDiscardVersion = (releaseId: string, documentId: string, opts?: operationsOptions) =>
@@ -205,8 +202,9 @@ export function createReleaseOperationsStore(options: {
       client,
       [
         {
-          actionType: 'sanity.action.document.discard',
-          draftId: getVersionId(documentId, releaseId),
+          actionType: 'sanity.action.document.version.discard',
+          versionId: getVersionId(documentId, releaseId),
+          purge: false, // keep document history
         },
       ],
       opts,
@@ -216,7 +214,7 @@ export function createReleaseOperationsStore(options: {
     requestAction(client, [
       {
         actionType: 'sanity.action.document.version.unpublish',
-        draftId: documentId,
+        versionId: documentId,
         publishedId: getPublishedId(documentId),
       },
     ])
@@ -301,7 +299,7 @@ interface CreateReleaseApiAction {
 }
 
 interface CreateVersionReleaseApiAction {
-  actionType: 'sanity.action.document.createVersion'
+  actionType: 'sanity.action.document.version.create'
   releaseId: string
   attributes: IdentifiedSanityDocumentStub
 }
@@ -310,6 +308,12 @@ interface UnpublishVersionReleaseApiAction {
   actionType: 'sanity.action.document.version.unpublish'
   draftId: string
   publishedId: string
+}
+
+interface DiscardVersionReleaseApiAction {
+  actionType: 'sanity.action.document.version.discard'
+  versionId: string
+  purge?: boolean
 }
 
 interface EditReleaseApiAction {
@@ -335,6 +339,7 @@ type ReleaseAction =
   | DeleteApiAction
   | CreateVersionReleaseApiAction
   | UnpublishVersionReleaseApiAction
+  | DiscardVersionReleaseApiAction
 
 export function createRequestAction(
   onReleaseLimitReached: ReleasesUpsellContextValue['onReleaseLimitReached'],

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -300,13 +300,13 @@ interface CreateReleaseApiAction {
 
 interface CreateVersionReleaseApiAction {
   actionType: 'sanity.action.document.version.create'
-  releaseId: string
-  attributes: IdentifiedSanityDocumentStub
+  publishedId: string
+  document: IdentifiedSanityDocumentStub
 }
 
 interface UnpublishVersionReleaseApiAction {
   actionType: 'sanity.action.document.version.unpublish'
-  draftId: string
+  versionId: string
   publishedId: string
 }
 


### PR DESCRIPTION
### Description
Some of the actions used in `createReleaseOperationsStore` (which is used by `useReleaseOperations` and `useVersionOperations`) have drifted from the actual APIs. 

This PR adjusts the types and updates the uses of these actions according to [the version actions](https://www.sanity.io/docs/http-actions#8c43ee58aa51) and [the release actions](https://www.sanity.io/docs/http-actions#a102448a3a7a) from content lake.

Additionally, since `version.create` is now supported by content lake, `handleCreateVersion` uses the version action rather than creating a document directly with the version `_id`.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Tests updated for `createReleaseOperationsStore.test`

Manual testing trying to use most of the actions that have been impacted
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Creating a new version of a document uses the [Sanity API](https://www.sanity.io/docs/http-actions#0511717e46fe) `version.create` action.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
