### PR TITLE
chore(core): tag getDocumentVariantType as @public

### DIFF
--- a/packages/sanity/src/core/util/getDocumentVariantType.ts
+++ b/packages/sanity/src/core/util/getDocumentVariantType.ts
@@ -5,7 +5,7 @@ import {isDraftId, isVersionId} from './draftUtils'
  * Draft documents are prefixed with `drafts.`.
  * Version documents are prefixed with `versions.<versionName>`
  * The rest are considered published documents.
- * @beta
+ * @public
  */
 export type DocumentVariantType = 'draft' | 'version' | 'published'
 
@@ -14,7 +14,7 @@ export type DocumentVariantType = 'draft' | 'version' | 'published'
  * If it's a document that starts with `version.` it's a `version` document.
  * If it's a document that starts with `drafts.` it's a `draft` document.
  * Otherwise, it's a `published` document.
- * @beta
+ * @public
  * */
 export function getDocumentVariantType(documentId: string): DocumentVariantType {
   if (isDraftId(documentId)) return 'draft'


### PR DESCRIPTION
### Description
Clients are asking to use this function in prod environments and they need it to be tagged as `@public`.
I think the function won't change so it can be moved to public.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is there any downside doing this?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
tag getDocumentVariantType as `@public`
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
