### PR TITLE
fix(structure): click on published chip should take you back to document

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -77,7 +77,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
   const {selectedReleaseId, selectedPerspectiveName} = usePerspective()
   const {t} = useTranslation()
   const setPerspective = useSetPerspective()
-  const {params} = usePaneRouter()
+  const {params, setParams} = usePaneRouter()
   const dateTimeFormat = useDateTimeFormat(DATE_TIME_FORMAT)
   const {loading} = useActiveReleases()
   const schema = useSchema()
@@ -88,9 +88,17 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
 
   const handlePerspectiveChange = useCallback(
     (perspective: Parameters<typeof setPerspective>[0]) => () => {
+      if (perspective === 'published' && params?.historyVersion) {
+        setParams({
+          ...params,
+          rev: params?.historyEvent || undefined,
+          since: undefined,
+          historyVersion: undefined,
+        })
+      }
       setPerspective(perspective)
     },
-    [setPerspective],
+    [setPerspective, setParams, params],
   )
 
   const schemaType = schema.get(documentType)


### PR DESCRIPTION
### Description

When viewing a document from an archived release users expect to click the published chip and get back to the published document, not only by clicking the button in the banner.
This PR updates the change perspective action to remove the history params when clicking the published if you are in a history version.

See video for details:

https://github.com/user-attachments/assets/982893dd-a1d0-4fd0-a14d-5f5d493891ff




<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
fix: clicking published badge on version 
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
