### PR TITLE
fix: version operations error toast

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/UnpublishVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/UnpublishVersionDialog.tsx
@@ -48,19 +48,29 @@ export function UnpublishVersionDialog(props: {
   const handleUnpublish = useCallback(async () => {
     setIsUnpublishing(true)
 
-    await unpublishVersion(documentVersionId)
+    try {
+      await unpublishVersion(documentVersionId)
+      toast.push({
+        closable: true,
+        status: 'success',
+        description: (
+          <Translate
+            t={coreT}
+            i18nKey={'release.action.unpublish-version.success'}
+            values={{title: preview?.value?.title || documentVersionId}}
+          />
+        ),
+      })
+    } catch (err) {
+      toast.push({
+        closable: true,
+        status: 'error',
+        title: coreT('release.action.unpublish-version.failure'),
+        description: err.message,
+      })
+    }
+
     setIsUnpublishing(false)
-    toast.push({
-      closable: true,
-      status: 'success',
-      description: (
-        <Translate
-          t={coreT}
-          i18nKey={'release.action.unpublish-version.success'}
-          values={{title: preview?.value?.title || documentVersionId}}
-        />
-      ),
-    })
 
     onClose()
   }, [coreT, documentVersionId, onClose, preview?.value?.title, toast, unpublishVersion])

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -7,6 +7,7 @@ import {
   Text,
   useClickOutsideEvent,
   useGlobalKeyDown,
+  useToast,
 } from '@sanity/ui'
 // eslint-disable-next-line camelcase
 import {
@@ -22,6 +23,7 @@ import {
 import {css, styled} from 'styled-components'
 
 import {Popover, Tooltip} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {getVersionId} from '../../../util/draftUtils'
 import {useReleasesUpsell} from '../../contexts/upsell/useReleasesUpsell'
 import {useVersionOperations} from '../../hooks/useVersionOperations'
@@ -121,6 +123,8 @@ export const VersionChip = memo(function VersionChip(props: {
   const docId = isVersion ? getVersionId(documentId, fromRelease) : documentId // operations recognises publish and draft as empty
 
   const {createVersion} = useVersionOperations()
+  const toast = useToast()
+  const {t} = useTranslation()
 
   const close = useCallback(() => setContextMenuPoint(undefined), [])
 
@@ -161,10 +165,20 @@ export const VersionChip = memo(function VersionChip(props: {
 
   const handleAddVersion = useCallback(
     async (targetRelease: string) => {
-      await createVersion(getReleaseIdFromReleaseDocumentId(targetRelease), docId)
+      try {
+        await createVersion(getReleaseIdFromReleaseDocumentId(targetRelease), docId)
+      } catch (err) {
+        toast.push({
+          closable: true,
+          status: 'error',
+          title: t('release.action.create-version.failure'),
+          description: err.message,
+        })
+      }
+
       close()
     },
-    [createVersion, docId, close],
+    [close, createVersion, docId, t, toast],
   )
 
   const referenceElement = useMemo(() => {

--- a/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
+++ b/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
@@ -1,7 +1,5 @@
 import {useTelemetry} from '@sanity/telemetry/react'
-import {useToast} from '@sanity/ui'
 
-import {useTranslation} from '../../i18n'
 import {type ReleaseId} from '../../perspective/types'
 import {useSetPerspective} from '../../perspective/useSetPerspective'
 import {getDocumentVariantType} from '../../util/getDocumentVariantType'
@@ -25,56 +23,24 @@ export function useVersionOperations(): VersionOperationsValue {
 
   const setPerspective = useSetPerspective()
 
-  const toast = useToast()
-  const {t} = useTranslation()
-
   const handleCreateVersion = async (
     releaseId: ReleaseId,
     documentId: string,
     initialValue?: Record<string, unknown>,
   ) => {
     const origin = getDocumentVariantType(documentId)
-    try {
-      await createVersion(releaseId, documentId, initialValue)
-      setPerspective(releaseId)
-      telemetry.log(AddedVersion, {
-        documentOrigin: origin,
-      })
-    } catch (err) {
-      toast.push({
-        closable: true,
-        status: 'error',
-        title: t('release.action.create-version.failure'),
-        description: err.message,
-      })
-    }
+    await createVersion(releaseId, documentId, initialValue)
+    setPerspective(releaseId)
+    telemetry.log(AddedVersion, {
+      documentOrigin: origin,
+    })
   }
 
-  const handleDiscardVersion = async (releaseId: string, documentId: string) => {
-    try {
-      await discardVersion(releaseId, documentId)
-    } catch (err) {
-      toast.push({
-        closable: true,
-        status: 'error',
-        title: t('release.action.discard-version.failure'),
-        description: err.message,
-      })
-    }
-  }
+  const handleDiscardVersion = async (releaseId: string, documentId: string) =>
+    discardVersion(releaseId, documentId)
 
-  const handleUnpublishVersion = async (documentId: string) => {
-    try {
-      await unpublishVersion(documentId)
-    } catch (err) {
-      toast.push({
-        closable: true,
-        status: 'error',
-        title: t('release.action.unpublish-version.failure'),
-        description: err.message,
-      })
-    }
-  }
+  const handleUnpublishVersion = async (documentId: string) => unpublishVersion(documentId)
+
   return {
     createVersion: handleCreateVersion,
     discardVersion: handleDiscardVersion,

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -5,7 +5,7 @@ import {
   type SanityClient,
 } from '@sanity/client'
 
-import {getPublishedId, getVersionId} from '../../util'
+import {getVersionId} from '../../util'
 import {type ReleasesUpsellContextValue} from '../contexts/upsell/types'
 import {getReleaseIdFromReleaseDocumentId, type ReleaseDocument} from '../index'
 import {type RevertDocument} from '../tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates'
@@ -217,7 +217,7 @@ export function createReleaseOperationsStore(options: {
       {
         actionType: 'sanity.action.document.version.unpublish',
         draftId: documentId,
-        publishedId: getPublishedId(documentId),
+        publishedId: documentId,
       },
     ])
 

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -5,7 +5,7 @@ import {
   type SanityClient,
 } from '@sanity/client'
 
-import {getVersionId} from '../../util'
+import {getPublishedId, getVersionId} from '../../util'
 import {type ReleasesUpsellContextValue} from '../contexts/upsell/types'
 import {getReleaseIdFromReleaseDocumentId, type ReleaseDocument} from '../index'
 import {type RevertDocument} from '../tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates'
@@ -217,7 +217,7 @@ export function createReleaseOperationsStore(options: {
       {
         actionType: 'sanity.action.document.version.unpublish',
         draftId: documentId,
-        publishedId: documentId,
+        publishedId: getPublishedId(documentId),
       },
     ])
 


### PR DESCRIPTION
### Description
| Before | After |
|--------|--------|
| <img width="446" alt="Screenshot 2025-03-13 at 11 43 27" src="https://github.com/user-attachments/assets/57e9ce64-3176-4880-ad6e-163f4f56b3bf" /> | <img width="467" alt="Screenshot 2025-03-13 at 11 42 21" src="https://github.com/user-attachments/assets/a8dc7a36-e706-4903-b521-63560de0653a" /> | 

Before: the error was caught in `useVersionOperations` and so callers would handle operation like it had resolved.
After: `useVersionOperations` delegates to the caller to show all success and error toast
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* Does it make sense to move the toast showing to the caller and away from the operations store hook (this is how `useReleaseOperations`/`createReleaseOperationsStore` also works)?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manually tested and verified to be working against failure and success version operations
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
