### PR TITLE
fix(structure): update archived and published docs in release links

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1202,6 +1202,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.chip.global.drafts': 'Drafts',
   /** Label for Published chip in document header */
   'release.chip.published': 'Published',
+  /** Label for tooltip in chip when document is in an archived release */
+  'release.chip.tooltip.archived': 'This release is archived and cannot be edited.',
   /** Label for tooltip in chip with the created date */
   'release.chip.tooltip.created-date': 'Created {{date}}',
   /** Label for tooltip in draft chip when it's a live edit document */

--- a/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
@@ -23,6 +23,9 @@ interface ReleaseDocumentPreviewProps {
   layout?: PreviewLayoutKey
 }
 
+const isArchivedRelease = (releaseState: ReleaseState | undefined) =>
+  releaseState === 'archived' || releaseState === 'archiving' || releaseState === 'unarchiving'
+
 export function ReleaseDocumentPreview({
   documentId,
   documentTypeName,
@@ -71,12 +74,23 @@ export function ReleaseDocumentPreview({
               type: documentTypeName,
               ...intentParams,
             }}
-            searchParams={releaseState === 'published' ? [['perspective', 'published']] : undefined}
+            searchParams={
+              isArchivedRelease(releaseState)
+                ? undefined
+                : [
+                    [
+                      'perspective',
+                      releaseState === 'published'
+                        ? 'published'
+                        : getReleaseIdFromReleaseDocumentId(releaseId),
+                    ],
+                  ]
+            }
             ref={ref}
           />
         )
       }),
-    [documentId, documentTypeName, intentParams, releaseState],
+    [documentId, documentTypeName, intentParams, releaseState, releaseId],
   )
 
   const previewPresence = useMemo(

--- a/packages/sanity/src/core/releases/tool/components/__tests__/ReleaseDocumentPreview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/__tests__/ReleaseDocumentPreview.test.tsx
@@ -123,4 +123,19 @@ describe('ReleaseDocumentPreview', () => {
     const searchParams = JSON.parse(link.getAttribute('data-search-params'))
     expect(searchParams).toContainEqual(['perspective', 'rActive'])
   })
+
+  it('creates link with release ID perspective when release state is not published', async () => {
+    const {container} = await renderTest({
+      documentId: 'doc123',
+      documentTypeName: 'post',
+      releaseId: activeScheduledRelease._id,
+      previewValues: mockPreviewValues,
+      isLoading: false,
+      releaseState: 'archived',
+    })
+
+    const link = container.querySelector('a')
+    const searchParams = JSON.parse(link.getAttribute('data-search-params'))
+    expect(searchParams).toBeNull()
+  })
 })

--- a/packages/sanity/src/core/store/events/useEventsStore.ts
+++ b/packages/sanity/src/core/store/events/useEventsStore.ts
@@ -89,11 +89,19 @@ export function useEventsStore({
       return publishEvent?.id || null
     }
     if (rev === '@lastEdited') {
-      const editEvent = events.find((event) => isEditDocumentVersionEvent(event))
+      const editEvent = events.find(isEditDocumentVersionEvent)
       if (editEvent) return editEvent.revisionId
     }
+    if (rev?.startsWith('@release:')) {
+      const releaseId = rev.split(':')[1]
+      const releaseEvent = events.find(
+        (event) => isPublishDocumentVersionEvent(event) && event.releaseId === releaseId,
+      )
+      if (releaseEvent) return releaseEvent.id
+      if (events.length > 0 && !loading) eventsStore.loadMoreEvents()
+    }
     return rev
-  }, [events, rev])
+  }, [events, rev, eventsStore, loading])
 
   const revision$ = useMemo(
     () =>

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -92,7 +92,7 @@ const structureLocaleStrings = defineLocalesResources('structure', {
     'This document has live edit enabled and cannot be unpublished',
   /** Description for the archived release banner, rendered when viewing the history of a version document from the publihed view */
   'banners.archived-release.description':
-    "You are viewing a read-only document that was archived as part of <VersionBadge>{{title}}</VersionBadge>. It can't be edited",
+    'This document version belongs to the archived <VersionBadge>{{title}}</VersionBadge> release',
   /** The text for the restore button on the deleted document banner */
   'banners.deleted-document-banner.restore-button.text': 'Restore most recent revision',
   /** The text content for the deleted document banner */

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ArchivedReleaseDocumentBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ArchivedReleaseDocumentBanner.tsx
@@ -59,10 +59,14 @@ export function ArchivedReleaseDocumentBanner(): React.JSX.Element {
           </Text>
         </Flex>
       }
-      action={{
-        text: 'Go back to published version',
-        onClick: handleGoBack,
-      }}
+      action={
+        params?.archivedRelease
+          ? undefined
+          : {
+              text: 'Go back to published version',
+              onClick: handleGoBack,
+            }
+      }
     />
   )
 }

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -31,6 +31,9 @@ import {useDocumentPane} from '../../../useDocumentPane'
 const TooltipContent = ({release}: {release: ReleaseDocument}) => {
   const {t} = useTranslation()
 
+  if (release.state === 'archived') {
+    return <Text size={1}>{t('release.chip.tooltip.archived')}</Text>
+  }
   if (release.metadata.releaseType === 'asap') {
     return <Text size={1}>{t('release.type.asap')}</Text>
   }

--- a/packages/sanity/src/structure/panes/document/timeline/events/PublishedEventMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/events/PublishedEventMenu.tsx
@@ -9,6 +9,7 @@ import {
 import {useCallback} from 'react'
 import {
   ContextMenuButton,
+  getReleaseIdFromReleaseDocumentId,
   getReleaseTone,
   getVersionFromId,
   type PublishDocumentVersionEvent,
@@ -77,7 +78,7 @@ export function PublishedEventMenu({event}: {event: PublishDocumentVersionEvent}
             <>
               <IntentLink
                 intent={RELEASES_INTENT}
-                params={{id: event.release?.name}}
+                params={{id: getReleaseIdFromReleaseDocumentId(event.release._id)}}
                 style={{textDecoration: 'none'}}
               >
                 <MenuItem padding={3}>

--- a/packages/sanity/src/structure/panes/document/timeline/events/PublishedEventMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/events/PublishedEventMenu.tsx
@@ -82,11 +82,11 @@ export function PublishedEventMenu({event}: {event: PublishDocumentVersionEvent}
                 style={{textDecoration: 'none'}}
               >
                 <MenuItem padding={3}>
-                  <Flex align={'center'}>
+                  <Flex align={'center'} justify="flex-start">
                     <Text size={1} style={{textDecoration: 'none'}}>
                       <Translate
                         components={{
-                          VersionBadge: ({children}) => <VersionBadge>{children} </VersionBadge>,
+                          VersionBadge: ({children}) => <VersionBadge>{children}</VersionBadge>,
                         }}
                         i18nKey="events.open.release"
                         values={{
@@ -101,11 +101,11 @@ export function PublishedEventMenu({event}: {event: PublishDocumentVersionEvent}
                 </MenuItem>
               </IntentLink>
               <MenuItem onClick={handleOpenReleaseDocument}>
-                <Flex align={'center'}>
+                <Flex align={'center'} justify="flex-start">
                   <Text size={1}>
                     <Translate
                       components={{
-                        VersionBadge: ({children}) => <VersionBadge>{children} </VersionBadge>,
+                        VersionBadge: ({children}) => <VersionBadge>{children}</VersionBadge>,
                       }}
                       i18nKey="events.inspect.release"
                       values={{


### PR DESCRIPTION
### Description

This PR updates how the links on published and archived releases work:
**Published releases**
Now when clicking on a document as part of a published release, instead of opening the document in the detailed view for that release it will open the published view with the history having selected that release:


https://github.com/user-attachments/assets/0132e4ff-46e6-4240-8316-c2fc1909b607


**Archived releases**
Clicking a document as part of releases that are archived we cannot show the document from the published view, we instead open the document "faking" that the release exists, and it will show the badge in the document for that release, but the badge will be disabled.

https://github.com/user-attachments/assets/3d640659-dc7a-41fe-a6fe-f923ab6ce011


This PR also fixes an issue with the open release links from the document events, now releases will open when clicking  the menu item. (as expected)
<img width="381" alt="Screenshot 2025-03-13 at 18 33 18" src="https://github.com/user-attachments/assets/932572fd-7bdb-4615-8f2c-7c8ff6568efa" />


**What it doesn't solve:**

View of documents **unpublished** by a release, it is not possible do it just now because content lake is generating the incorrect events for it, once the events are solved we will look back into solving this.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Everything works as expected.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Update archived and published docs in release links.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
