### PR TITLE
test(releases): add unit tests for createReleaseMetadataAggregator and useActiveReleases hooks

### DIFF
--- a/packages/sanity/src/core/releases/store/__tests__/createReleaseMetadataAggregator.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/createReleaseMetadataAggregator.test.ts
@@ -1,0 +1,134 @@
+import {type SanityClient} from '@sanity/client'
+import {catchError, firstValueFrom, Observable, of, Subject, take, toArray} from 'rxjs'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+
+import {createReleaseMetadataAggregator} from '../createReleaseMetadataAggregator'
+
+describe('createReleaseMetadataAggregator', () => {
+  const mockClient = {
+    observable: {
+      fetch: vi.fn(),
+      listen: vi.fn(),
+    },
+  } as unknown as SanityClient & {
+    observable: {
+      fetch: Mock<SanityClient['observable']['fetch']>
+      listen: Mock<SanityClient['observable']['listen']>
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockClient.observable.listen.mockReturnValue(new Subject())
+  })
+
+  it('should emit empty state when no release ids provided', async () => {
+    const result = await firstValueFrom(createReleaseMetadataAggregator(mockClient)([]))
+    expect(result).toEqual({data: null, error: null, loading: false})
+  })
+
+  it('should emit metadata for releases with loading states', async () => {
+    mockClient.observable.fetch.mockReturnValue(
+      of({
+        ms: 0,
+        result: {
+          '_.releases.release-1': {
+            updatedAt: '2024-01-01T00:00:00Z',
+            documentCount: 1,
+          },
+        },
+      }),
+    )
+
+    const values = await createReleaseMetadataAggregator(mockClient)(['_.releases.release-1'])
+      .pipe(take(2), toArray())
+      .toPromise()
+
+    expect(values).toEqual([
+      {loading: true, data: null, error: null},
+      {
+        loading: false,
+        error: null,
+        data: {
+          ms: {documentCount: 0},
+          result: {
+            '_.releases.release-1': {
+              updatedAt: '2024-01-01T00:00:00Z',
+              documentCount: 1,
+            },
+            'documentCount': 0,
+          },
+        },
+      },
+    ])
+  })
+
+  it('should handle fetch errors with loading states', async () => {
+    const error = new Error('Fetch failed')
+    mockClient.observable.fetch.mockReturnValue(
+      new Observable((subscriber) => subscriber.error(error)),
+    )
+
+    const values = await createReleaseMetadataAggregator(mockClient)(['_.releases.release-1'])
+      .pipe(
+        take(2),
+        toArray(),
+        catchError((err) =>
+          of([
+            {loading: true, data: null, error: null},
+            {loading: false, data: null, error: err},
+          ]),
+        ),
+      )
+      .toPromise()
+
+    expect(values).toEqual([
+      {loading: true, data: null, error: null},
+      {loading: false, data: null, error},
+    ])
+  })
+
+  it('should handle null client', async () => {
+    const result = await firstValueFrom(
+      createReleaseMetadataAggregator(null)(['_.releases.release-1']),
+    )
+    expect(result).toEqual({data: null, error: null, loading: false})
+  })
+
+  it('should fetch metadata for multiple releases', async () => {
+    mockClient.observable.fetch.mockReturnValue(
+      of({
+        ms: 0,
+        result: {
+          '_.releases.release-1': {updatedAt: '2024-01-01T00:00:00Z', documentCount: 1},
+          '_.releases.release-2': {updatedAt: '2024-01-02T00:00:00Z', documentCount: 2},
+        },
+      }),
+    )
+
+    const values: any[] = []
+    const subscription = createReleaseMetadataAggregator(mockClient)([
+      '_.releases.release-1',
+      '_.releases.release-2',
+    ]).subscribe((value) => values.push(value))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    subscription.unsubscribe()
+
+    expect(values).toEqual([
+      {loading: true, data: null, error: null},
+      {
+        loading: false,
+        error: null,
+        data: {
+          ms: {documentCount: 0},
+          result: {
+            '_.releases.release-1': {updatedAt: '2024-01-01T00:00:00Z', documentCount: 1},
+            '_.releases.release-2': {updatedAt: '2024-01-02T00:00:00Z', documentCount: 2},
+            'documentCount': 0,
+          },
+        },
+      },
+    ])
+  })
+})

--- a/packages/sanity/src/core/releases/store/__tests__/useActiveReleases.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/useActiveReleases.test.ts
@@ -1,0 +1,137 @@
+import {act, renderHook, waitFor} from '@testing-library/react'
+import {BehaviorSubject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {
+  activeASAPRelease,
+  activeScheduledRelease,
+  archivedScheduledRelease,
+} from '../../__fixtures__/release.fixture'
+import {type ReleaseDocument} from '../types'
+import {useActiveReleases} from '../useActiveReleases'
+
+interface ReleasesState {
+  releases: Map<string, ReleaseDocument>
+  error?: Error
+  state: 'initialising' | 'loading' | 'loaded' | 'error'
+}
+
+const initialState: ReleasesState = {
+  releases: new Map(),
+  state: 'initialising',
+}
+
+const mockState$ = new BehaviorSubject<ReleasesState>(initialState)
+const mockDispatch = vi.fn()
+
+const mockUseReleasesStore = vi.fn(() => ({
+  state$: mockState$,
+  dispatch: mockDispatch,
+}))
+
+vi.mock('../useReleasesStore', () => ({
+  useReleasesStore: () => mockUseReleasesStore(),
+}))
+
+describe('useActiveReleases', () => {
+  beforeEach(() => {
+    mockState$.next(initialState)
+    vi.clearAllMocks()
+  })
+
+  it('should return initial loading state', async () => {
+    const wrapper = await createTestProvider()
+    const {result} = renderHook(() => useActiveReleases(), {wrapper})
+
+    expect(result.current).toEqual({
+      loading: true,
+      data: [],
+      error: undefined,
+      dispatch: mockDispatch,
+    })
+  })
+
+  it('should return error state', async () => {
+    const wrapper = await createTestProvider()
+    const {result} = renderHook(() => useActiveReleases(), {wrapper})
+
+    const testError = new Error('Test error')
+    act(() => {
+      mockState$.next({
+        releases: new Map(),
+        error: testError,
+        state: 'error',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        loading: false,
+        data: [],
+        error: testError,
+        dispatch: mockDispatch,
+      })
+    })
+  })
+
+  it('should filter out archived releases', async () => {
+    const wrapper = await createTestProvider()
+    const {result} = renderHook(() => useActiveReleases(), {wrapper})
+
+    const mockReleases = [activeASAPRelease, archivedScheduledRelease]
+
+    act(() => {
+      mockState$.next({
+        releases: new Map(mockReleases.map((release) => [release._id, release])),
+        error: undefined,
+        state: 'loaded',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        loading: false,
+        data: [activeASAPRelease],
+        error: undefined,
+        dispatch: mockDispatch,
+      })
+    })
+  })
+
+  it('should sort releases in reverse order', async () => {
+    const wrapper = await createTestProvider()
+    const {result} = renderHook(() => useActiveReleases(), {wrapper})
+
+    const mockReleases = [activeASAPRelease, activeScheduledRelease]
+
+    act(() => {
+      mockState$.next({
+        releases: new Map(mockReleases.map((release) => [release._id, release])),
+        error: undefined,
+        state: 'loaded',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        loading: false,
+        data: mockReleases,
+        error: undefined,
+        dispatch: mockDispatch,
+      })
+    })
+  })
+
+  it('should expose dispatch function', async () => {
+    const wrapper = await createTestProvider()
+    const {result} = renderHook(() => useActiveReleases(), {wrapper})
+
+    expect(result.current).toEqual({
+      loading: true,
+      data: [],
+      error: undefined,
+      dispatch: mockDispatch,
+    })
+  })
+})


### PR DESCRIPTION

### Description
Some more tests to fill in gaps around the releases store and hooks
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
This is just tests
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
