### PR TITLE
fix(core): update releases navbar menu spacing and click area

### DIFF
--- a/packages/sanity/src/core/perspective/ReleasesToolLink.tsx
+++ b/packages/sanity/src/core/perspective/ReleasesToolLink.tsx
@@ -11,6 +11,7 @@ import {Tooltip} from '../../ui-components/tooltip/Tooltip'
 import {RELEASES_TOOL_NAME} from '../releases/plugin'
 import {useReleasesStore} from '../releases/store/useReleasesStore'
 import {ToolLink} from '../studio/components/navbar/tools/ToolLink'
+import {oversizedButtonStyle} from './styles'
 
 const Dot = styled.div({
   width: 4,
@@ -18,6 +19,10 @@ const Dot = styled.div({
   borderRadius: 3,
   boxShadow: '0 0 0 1px var(--card-bg-color)',
 })
+
+const OversizedButton = styled(ToolLink)`
+  ${oversizedButtonStyle}
+`
 
 /**
  * represents the calendar icon for the releases tool.
@@ -39,13 +44,12 @@ export function ReleasesToolLink(): React.JSX.Element {
   return (
     <Tooltip content={t('release.navbar.tooltip')}>
       <Button
-        as={ToolLink}
+        as={OversizedButton}
         name={RELEASES_TOOL_NAME}
         data-as="a"
-        className="p-menu-btn"
         icon={CalendarIcon}
         mode="bleed"
-        padding={3}
+        padding={2}
         radius="full"
         data-testid="releases-tool-link"
         selected={activeToolName === RELEASES_TOOL_NAME}

--- a/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenu.tsx
+++ b/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenu.tsx
@@ -6,6 +6,7 @@ import {styled} from 'styled-components'
 
 import {MenuButton} from '../../../ui-components'
 import {CreateReleaseDialog} from '../../releases/components/dialog/CreateReleaseDialog'
+import {oversizedButtonStyle} from '../styles'
 import {type ReleaseId} from '../types'
 import {ReleasesList} from './ReleasesList'
 import {useScrollIndicatorVisibility} from './useScrollIndicatorVisibility'
@@ -13,6 +14,9 @@ import {useScrollIndicatorVisibility} from './useScrollIndicatorVisibility'
 const StyledMenu = styled(Menu)`
   min-width: 200px;
   max-width: 320px;
+`
+const OversizedButton = styled(Button)`
+  ${oversizedButtonStyle}
 `
 
 export function GlobalPerspectiveMenu({
@@ -36,13 +40,12 @@ export function GlobalPerspectiveMenu({
     <>
       <MenuButton
         button={
-          <Button
+          <OversizedButton
             data-testid="global-perspective-menu-button"
             iconRight={ChevronDownIcon}
             mode="bleed"
-            padding={3}
+            padding={2}
             radius="full"
-            className="p-menu-btn"
           />
         }
         id="releases-menu"

--- a/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
@@ -1,4 +1,4 @@
-import {Card, Flex} from '@sanity/ui'
+import {Card} from '@sanity/ui'
 import {styled} from 'styled-components'
 
 import {usePerspective} from '../../perspective/usePerspective'
@@ -9,19 +9,13 @@ import {GlobalPerspectiveMenu} from './GlobalPerspectiveMenu'
 
 const ReleasesNavContainer = styled(Card)`
   position: relative;
-  --p-bg-color: var(--card-bg-color);
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    border: 1px solid var(--card-border-color);
-    border-radius: 9999px;
-    pointer-events: none;
-    z-index: 3;
+  display: flex;
+  &:not([hidden]) {
+    display: flex;
   }
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
 
   // The children in button is rendered inside a span, we need to absolutely position the dot for the error.
   span:has(> [data-ui='error-status-icon']) {
@@ -31,23 +25,10 @@ const ReleasesNavContainer = styled(Card)`
     padding: 0;
   }
 
-  .p-menu-btn {
-    margin: -1px;
-    box-shadow: inset 0 0 0 4px var(--p-bg-color) !important;
-  }
-
-  button.p-menu-btn:hover,
-  a.p-menu-btn:hover {
+  a:hover,
+  button:hover {
     position: relative;
     z-index: 2;
-  }
-
-  .p-menu-btn:nth-child(2) {
-    margin-left: -6px;
-  }
-
-  .p-menu-btn:nth-child(3) {
-    margin-left: -6px;
   }
 `
 export function ReleasesNav(): React.JSX.Element {
@@ -56,15 +37,13 @@ export function ReleasesNav(): React.JSX.Element {
   const {selectedPerspective, selectedReleaseId} = usePerspective()
 
   return (
-    <ReleasesNavContainer flex="none" tone="inherit" radius="full" data-ui="ReleasesNav">
-      <Flex>
-        {areReleasesEnabled && <ReleasesToolLink />}
-        <CurrentGlobalPerspectiveLabel selectedPerspective={selectedPerspective} />
-        <GlobalPerspectiveMenu
-          selectedReleaseId={selectedReleaseId}
-          areReleasesEnabled={areReleasesEnabled}
-        />
-      </Flex>
+    <ReleasesNavContainer flex="none" tone="inherit" radius="full" data-ui="ReleasesNav" border>
+      {areReleasesEnabled && <ReleasesToolLink />}
+      <CurrentGlobalPerspectiveLabel selectedPerspective={selectedPerspective} />
+      <GlobalPerspectiveMenu
+        selectedReleaseId={selectedReleaseId}
+        areReleasesEnabled={areReleasesEnabled}
+      />
     </ReleasesNavContainer>
   )
 }

--- a/packages/sanity/src/core/perspective/styles.ts
+++ b/packages/sanity/src/core/perspective/styles.ts
@@ -1,0 +1,17 @@
+import {css} from 'styled-components'
+
+/**
+ * A CSS helper that extends the clickable area of a component by adding a pseudo-element.
+ * This creates a larger hit area for better usability without affecting the visual size.
+ */
+export const oversizedButtonStyle = css`
+  position: relative;
+  cursor: default;
+  &::before {
+    content: '';
+    position: absolute;
+    display: block;
+    inset: -4px;
+    border-radius: 9999px;
+  }
+`


### PR DESCRIPTION
### Description

This PR updates the spacing for the releases navbar menu.
It refactors the initial implementation by applying a pseudo element to expand the clickable area of the elements, thank you @juice49 for the suggestion.

| Before | After |
|--------|--------|
| <img width="187" alt="Screenshot 2025-03-14 at 09 47 29" src="https://github.com/user-attachments/assets/f7014c01-d583-4cc6-bf4d-dcb408505ca7" />| <img width="183" alt="Screenshot 2025-03-14 at 09 47 57" src="https://github.com/user-attachments/assets/4fdc76fb-1469-4a21-bcb1-7b42f6e69e7b" />| 
| <img width="131" alt="Screenshot 2025-03-14 at 09 47 20" src="https://github.com/user-attachments/assets/b9821f16-e863-4b2b-9862-9180e42597ba" />| <img width="141" alt="Screenshot 2025-03-14 at 09 47 48" src="https://github.com/user-attachments/assets/02f2e0a0-ceff-4d62-92eb-e83a82f717ba" />| 


We want this button to take a reduced visual spacing but the clickable area needs to be bigger, this is where this pseudo element comes into play, the clickable area extends beyond the element visual space.

<img width="434" alt="Screenshot 2025-03-14 at 09 54 07" src="https://github.com/user-attachments/assets/43a5ff87-6c47-4496-92fd-7d9912fdc28c" />




<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The changes make sense
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
It follows the UI proposed [here](https://www.sanity.io/ui/arcade?mode=jsx&jsx=eJytVFFv0zAQfudXHHlpKxS6jgmJkBRpm5B4QQiQeJ2bXFszx45sp%2BsW5b9zTprE6VY0wdKH5r6zL99399nxZ4F7YIJvZBKkKC3qALbIN1ubBGsuRAC%2FS2P5%2Br5PL18BxMbeC1xWN%2FQO8LYIc5QlVE0EEIZFuNqEqRJKR7BjehqGKdNZD84%2BHlYWynDLlYxAo2CW77DN1K%2F8wlHE1vTlvn6qiIi0EUwmjwuxlVGitNhlrCoiOOsigWvrhdoJ9eKVslblI0BnSCIWxR6oLs9GcprkkaQDqFnGSxPBB3qK%2FUCTux6GuCP%2BlJVK9kQfQi4z3Edw3vUAwO9CuLKyb0HO9IaT2nAxFF%2BpfWi2LFN3EXBp0MJZ87sg7i3rYSwzeM3zQmnLpH2q5e5j0VbtvK6fmpXHfHGqFLz5i4qwHUr4vpPilN%2FU8bw1mSsWO5s2ubFVGyjjGlPHjGAafS5beMOKpLqom%2FdjDxO4bBJN4Xbpol4eaMWXJdlAHiKiqTJMgpVAzIIeVPJK8PQ2qaYzSJZA7f6G2hSOyQ6nk0yTZ81kVvcbCpZlXG6S6nzADAragFlSFcNmSJIEugLDWot7OpPXDdzRmL8kZRorMoP%2FwbmrcEz6e4sfsY7nrvnL1izxFZ0oSAUz5ivLiXtrlwDag0SXUUmXUS%2B33dl95Vg9PC7kfBd4CzhdIkl1xQTKjOkvFNVe9sn2wZhLj88HIifHCJ9g6hVq1HrxMwh7w3hXj%2FDmmCRVVRrUP5rh0M3obpZJ7S9cjjbFP2kyYPgDOufD3eHKz5EU5sF4LUDrunGBuavgL4znTtWAzCAai340pWfJPjGLU9NwT%2Bu6S8HSW%2FiFeDvOdgb2QG%2BEnvv%2F3VZb3Gklr9WdfBlndUdl3OYO7f7%2FANeTFbg%3D&hook=eJxLzs8rLlGILkgtKi5ITS7JLEvVUShOLQlA8GMVbBVKi1ODSxJLUjXUU4oS00qK1TUBY%2BYUug%3D%3D&title=Perspective%20menu%20hit%20area%20styling) 

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
