### PR TITLE
chore(core): hide scheduled releases in copy version to menu

### DIFF
--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
@@ -51,9 +51,7 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: {
   const {t} = useTranslation()
   const {mode} = useReleasesUpsell()
   const isPublished = isPublishedId(documentId) && !isVersion
-  const optionsReleaseList = releases.map((release) => ({
-    value: release,
-  }))
+  const optionsReleaseList = releases.filter((release) => !isReleaseScheduledOrScheduling(release))
 
   const {checkWithPermissionGuard} = useReleasePermissions()
   const {createRelease} = useReleaseOperations()
@@ -109,17 +107,15 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: {
           }}
         >
           <ReleasesList key={fromRelease} space={1}>
-            {optionsReleaseList.map((option) => {
-              const isReleaseScheduled = isReleaseScheduledOrScheduling(option.value)
+            {optionsReleaseList.map((release) => {
               return (
                 <MenuItem
                   as="a"
-                  key={option.value._id}
-                  onClick={() => onCreateVersion(option.value._id)}
-                  renderMenuItem={() => <VersionContextMenuItem release={option.value} />}
-                  disabled={disabled || isReleaseScheduled}
+                  key={release._id}
+                  onClick={() => onCreateVersion(release._id)}
+                  renderMenuItem={() => <VersionContextMenuItem release={release} />}
+                  disabled={disabled}
                   tooltipProps={{
-                    disabled: isReleaseScheduled,
                     content: t('release.tooltip.locked'),
                   }}
                 />


### PR DESCRIPTION
### Description
Hides "locked" scheduled releases in copy version to menu


| Before | After |
|--------|--------|
|<img width="499" alt="Screenshot 2025-03-14 at 10 04 57" src="https://github.com/user-attachments/assets/07f7a32a-42f2-4987-98b0-fb9893caeae3" />|<img width="472" alt="Screenshot 2025-03-14 at 10 05 19" src="https://github.com/user-attachments/assets/975fe134-8a5c-4cce-9248-d03b424fc264" />| 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Not much
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Hides "locked" scheduled releases in copy version to menu

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
