### PR TITLE
chore(core): reduce new releases and timezone buttons size

### DIFF
--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -413,7 +413,6 @@ export function ReleasesOverview() {
                       icon={EarthGlobeIcon}
                       iconRight={ChevronDownIcon}
                       mode="bleed"
-                      size="large"
                       text={`${timeZone.abbreviation} (${timeZone.namePretty})`}
                       onClick={dialogTimeZoneShow}
                     />


### PR DESCRIPTION
### Description
Updates the padding and spacing for new releases and timezone button.

| Before | After |
|--------|--------|
| <img width="381" alt="Screenshot 2025-03-14 at 10 21 57" src="https://github.com/user-attachments/assets/36886e68-d3b6-4439-beae-afe038847fce" /> | <img width="344" alt="Screenshot 2025-03-14 at 10 22 09" src="https://github.com/user-attachments/assets/5047272b-524a-432f-b584-7ef386461ed1" />| 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Does it looks good?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
