### PR TITLE
fix(preview): don't apply preview fallback for documents in archived release

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -27,11 +27,7 @@ import {mergeMapArray} from 'rxjs-mergemap-array'
 
 import {useSchema} from '../../../hooks'
 import {type LocaleSource} from '../../../i18n/types'
-import {
-  type DocumentPreviewStore,
-  getPreviewValueWithFallback,
-  prepareForPreview,
-} from '../../../preview'
+import {type DocumentPreviewStore, prepareForPreview} from '../../../preview'
 import {useDocumentPreviewStore} from '../../../store/_legacy/datastores'
 import {useSource} from '../../../studio'
 import {getPublishedId} from '../../../util/draftUtils'
@@ -228,10 +224,7 @@ const getPublishedArchivedReleaseDocumentsObservable = ({
             take(1),
             map(({snapshot}) => ({
               isLoading: false,
-              values: prepareForPreview(
-                getPreviewValueWithFallback({snapshot, fallback: document}),
-                schemaType,
-              ),
+              values: prepareForPreview(snapshot || document, schemaType),
             })),
             startWith({isLoading: true, values: {}}),
             filter(({isLoading}) => !isLoading),


### PR DESCRIPTION
### Description
After #8904 we ended up passing the fallback value to `prepareForPreview` which caused an error because react isn't valid as preview attributes. 

### What to review
The document previews for archived releases should display the right values

### Notes for release
n/a - fixes an earlier unreleased bug