### PR TITLE
fix(structure): some touches to version chips

### DIFF
--- a/packages/sanity/src/core/releases/components/ReleaseAvatar.tsx
+++ b/packages/sanity/src/core/releases/components/ReleaseAvatar.tsx
@@ -2,6 +2,19 @@ import {DotIcon} from '@sanity/icons'
 import {type BadgeTone, Box, Text} from '@sanity/ui'
 import {type CSSProperties} from 'react'
 
+export const ReleaseAvatarIcon = ({tone}: {tone: BadgeTone}) => {
+  return (
+    <DotIcon
+      data-testid={`release-avatar-${tone}`}
+      style={
+        {
+          '--card-icon-color': `var(--card-badge-${tone}-icon-color)`,
+        } as CSSProperties
+      }
+    />
+  )
+}
+
 /** @internal */
 export function ReleaseAvatar({
   fontSize = 1,
@@ -15,14 +28,7 @@ export function ReleaseAvatar({
   return (
     <Box flex="none" padding={padding} style={{borderRadius: 3}}>
       <Text size={fontSize}>
-        <DotIcon
-          data-testid={`release-avatar-${tone}`}
-          style={
-            {
-              '--card-icon-color': `var(--card-badge-${tone}-icon-color)`,
-            } as CSSProperties
-          }
-        />
+        <ReleaseAvatarIcon tone={tone} />
       </Text>
     </Box>
   )

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -1,10 +1,7 @@
 import {LockIcon} from '@sanity/icons'
 import {
   type BadgeTone,
-  Box,
   Button, // eslint-disable-line no-restricted-imports
-  Flex,
-  Text,
   useClickOutsideEvent,
   useGlobalKeyDown,
 } from '@sanity/ui'
@@ -28,34 +25,25 @@ import {useVersionOperations} from '../../hooks/useVersionOperations'
 import {type ReleaseDocument, type ReleaseState} from '../../store/types'
 import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
 import {DiscardVersionDialog} from '../dialog/DiscardVersionDialog'
-import {ReleaseAvatar} from '../ReleaseAvatar'
+import {ReleaseAvatarIcon} from '../ReleaseAvatar'
 import {VersionContextMenu} from './contextMenu/VersionContextMenu'
 import {CopyToNewReleaseDialog} from './dialog/CopyToNewReleaseDialog'
 
-interface ChipStyleProps {
-  $isArchived?: boolean
-}
+const ChipButtonContainer = styled.span`
+  display: inline-flex;
+  --border-color: var(--card-border-color);
+`
 
-const ChipButton = styled(Button)<ChipStyleProps>(({$isArchived}) => {
+const ChipButton = styled(Button)(() => {
   return css`
     flex: none;
     transition: none;
     cursor: pointer;
-
-    // target enabled state
-    &:not([data-disabled='true']) {
-      --card-border-color: var(--card-badge-default-bg-color);
-    }
+    --card-border-color: var(--border-color);
 
     &[data-disabled='true'] {
-      color: var(--card-muted-fg-color);
       cursor: default;
-
-      // archived will be disabled but should have bg color
-      ${$isArchived &&
-      css`
-        background-color: var(--card-badge-default-bg-color);
-      `}
+      box-shadow: inset 0 0 0 1px var(--border-color);
     }
   `
 })
@@ -194,7 +182,7 @@ export const VersionChip = memo(function VersionChip(props: {
     <>
       <Tooltip content={tooltipContent} fallbackPlacements={[]} portal placement="bottom">
         {/* This span is needed to make the tooltip work in disabled buttons */}
-        <span style={{display: 'inline-flex'}}>
+        <ChipButtonContainer>
           <ChipButton
             data-testid={`document-header-${text.replaceAll(' ', '-')}-chip`}
             ref={chipRef}
@@ -204,25 +192,16 @@ export const VersionChip = memo(function VersionChip(props: {
             selected={selected}
             tone={tone}
             onContextMenu={contextMenuHandler}
-            padding={2}
+            paddingY={2}
+            paddingLeft={2}
             paddingRight={3}
+            space={2}
             radius="full"
-            $isArchived={releaseState === 'archived'}
-            text={
-              <Flex align="center" gap={1}>
-                <ReleaseAvatar padding={1} tone={tone} />
-                <Box flex="none" padding={1}>
-                  <Text size={1}>{text}</Text>
-                </Box>
-                {locked && (
-                  <Box paddingRight={1}>
-                    <LockIcon />
-                  </Box>
-                )}
-              </Flex>
-            }
+            icon={<ReleaseAvatarIcon tone={tone} />}
+            iconRight={locked && <LockIcon />}
+            text={text}
           />
-        </span>
+        </ChipButtonContainer>
       </Tooltip>
 
       <Popover

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -5,7 +5,6 @@ import {
   useClickOutsideEvent,
   useGlobalKeyDown,
 } from '@sanity/ui'
-// eslint-disable-next-line camelcase
 import {
   memo,
   type MouseEvent,
@@ -16,7 +15,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import {css, styled} from 'styled-components'
+import {styled} from 'styled-components'
 
 import {Popover, Tooltip} from '../../../../ui-components'
 import {getVersionId} from '../../../util/draftUtils'
@@ -34,19 +33,12 @@ const ChipButtonContainer = styled.span`
   --border-color: var(--card-border-color);
 `
 
-const ChipButton = styled(Button)(() => {
-  return css`
-    flex: none;
-    transition: none;
-    cursor: pointer;
-    --card-border-color: var(--border-color);
-
-    &[data-disabled='true'] {
-      cursor: default;
-      box-shadow: inset 0 0 0 1px var(--border-color);
-    }
-  `
-})
+const ChipButton = styled(Button)`
+  flex: none;
+  transition: none;
+  cursor: pointer;
+  --card-border-color: var(--border-color);
+`
 
 /**
  * @internal
@@ -187,7 +179,7 @@ export const VersionChip = memo(function VersionChip(props: {
             data-testid={`document-header-${text.replaceAll(' ', '-')}-chip`}
             ref={chipRef}
             disabled={disabled}
-            mode="bleed"
+            mode={disabled ? 'ghost' : 'bleed'}
             onClick={onClick}
             selected={selected}
             tone={tone}


### PR DESCRIPTION
### Description
Changes the borders for the version chips.
Removes the background for disabled chips and instead uses muted colors.

Last updates:
<img width="831" alt="Screenshot 2025-03-14 at 13 33 13" src="https://github.com/user-attachments/assets/2928f67a-1721-4526-9484-23f51be14490" />
![Screenshot 2025-03-14 at 13 37 31](https://github.com/user-attachments/assets/904fb180-19b1-4ea7-beb2-c385c6053bbc)





<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
