### PR TITLE
fix(core): clear perspective when archiving or deleting a release

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
@@ -6,11 +6,14 @@ import {useRouter} from 'sanity/router'
 
 import {Button, Dialog, MenuButton} from '../../../../../ui-components'
 import {Translate, useTranslation} from '../../../../i18n'
+import {usePerspective} from '../../../../perspective/usePerspective'
+import {useSetPerspective} from '../../../../perspective/useSetPerspective'
 import {useReleasesUpsell} from '../../../contexts/upsell/useReleasesUpsell'
 import {releasesLocaleNamespace} from '../../../i18n'
 import {isReleaseLimitError} from '../../../store/isReleaseLimitError'
 import {type ReleaseDocument} from '../../../store/types'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
+import {getReleaseIdFromReleaseDocumentId} from '../../../util/getReleaseIdFromReleaseDocumentId'
 import {RELEASE_ACTION_MAP, type ReleaseAction} from './releaseActions'
 import {ReleaseMenu} from './ReleaseMenu'
 import {ReleasePreviewCard} from './ReleasePreviewCard'
@@ -32,6 +35,8 @@ export const ReleaseMenuButton = ({ignoreCTA, release, documentsCount}: ReleaseM
 
   const [isPerformingOperation, setIsPerformingOperation] = useState(false)
   const [selectedAction, setSelectedAction] = useState<ReleaseAction>()
+  const {selectedReleaseId} = usePerspective()
+  const setPerspective = useSetPerspective()
 
   const releaseMenuDisabled = !release
   const {t} = useTranslation(releasesLocaleNamespace)
@@ -64,6 +69,14 @@ export const ReleaseMenuButton = ({ignoreCTA, release, documentsCount}: ReleaseM
       const actionValues = RELEASE_ACTION_MAP[action]
 
       try {
+        if (
+          (action === 'archive' || action === 'delete') &&
+          selectedReleaseId === getReleaseIdFromReleaseDocumentId(release._id)
+        ) {
+          // Reset the perspective to drafts when the release is archived or deleted
+          // To avoid showing the release archived / deleted toast.
+          setPerspective('drafts')
+        }
         setIsPerformingOperation(true)
         await actionLookup[action](release._id)
 
@@ -118,6 +131,8 @@ export const ReleaseMenuButton = ({ignoreCTA, release, documentsCount}: ReleaseM
       toast,
       t,
       releaseTitle,
+      selectedReleaseId,
+      setPerspective,
     ],
   )
 


### PR DESCRIPTION
### Description
Clears the release perspective when archiving or deleting a release if that release is the pinned one.
This is to avoid showing the **release archived** or **release deleted**  toast when archiving or deleting a release.


https://github.com/user-attachments/assets/c943f70b-2a59-49c4-bf9e-a05933af92a9


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
