### PR TITLE
fix: bump peer deps for `styled-components`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,6 +58,7 @@
         "@sanity/template-validator",
         "@sanity/ui",
         "@sanity/visual-editing-csm",
+        "framer-motion",
         "get-it",
         "groq-js",
         "react-rx"

--- a/dev/design-studio/package.json
+++ b/dev/design-studio/package.json
@@ -36,6 +36,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",
-    "styled-components": "^6.1.0"
+    "styled-components": "^6.1.15"
   }
 }

--- a/dev/embedded-studio/package.json
+++ b/dev/embedded-studio/package.json
@@ -12,7 +12,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",
-    "styled-components": "^6.1.0"
+    "styled-components": "^6.1.15"
   },
   "devDependencies": {
     "@types/react": "^19.0.10",

--- a/dev/page-building-studio/package.json
+++ b/dev/page-building-studio/package.json
@@ -19,6 +19,6 @@
     "react-dom": "^18.2.0",
     "react-icons": "^5.2.1",
     "sanity": "workspace:*",
-    "styled-components": "^6.1.8"
+    "styled-components": "^6.1.15"
   }
 }

--- a/dev/starter-studio/package.json
+++ b/dev/starter-studio/package.json
@@ -17,6 +17,6 @@
     "react-compiler-runtime": "19.0.0-beta-e1e972c-20250221",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",
-    "styled-components": "^6.1.0"
+    "styled-components": "^6.1.15"
   }
 }

--- a/dev/strict-studio/package.json
+++ b/dev/strict-studio/package.json
@@ -15,6 +15,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",
-    "styled-components": "^6.1.0"
+    "styled-components": "^6.1.15"
   }
 }

--- a/dev/studio-e2e-testing/package.json
+++ b/dev/studio-e2e-testing/package.json
@@ -28,6 +28,6 @@
     "sanity-plugin-media": "^2.3.1",
     "sanity-plugin-mux-input": "^2.5.0",
     "sanity-test-studio": "workspace:*",
-    "styled-components": "^6.1.0"
+    "styled-components": "^6.1.15"
   }
 }

--- a/dev/test-create-integration-studio/package.json
+++ b/dev/test-create-integration-studio/package.json
@@ -17,6 +17,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",
-    "styled-components": "^6.1.0"
+    "styled-components": "^6.1.15"
   }
 }

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -61,7 +61,7 @@
     "sanity-plugin-markdown": "^5.0.0",
     "sanity-plugin-media": "^2.3.1",
     "sanity-plugin-mux-input": "^2.5.0",
-    "styled-components": "^6.1.11"
+    "styled-components": "^6.1.15"
   },
   "devDependencies": {
     "@million/lint": "1.0.14",

--- a/examples/blog-studio/package.json
+++ b/examples/blog-studio/package.json
@@ -31,6 +31,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",
-    "styled-components": "^6.1.0"
+    "styled-components": "^6.1.15"
   }
 }

--- a/examples/clean-studio/package.json
+++ b/examples/clean-studio/package.json
@@ -31,6 +31,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",
-    "styled-components": "^6.1.0"
+    "styled-components": "^6.1.15"
   }
 }

--- a/examples/ecommerce-studio/package.json
+++ b/examples/ecommerce-studio/package.json
@@ -35,6 +35,6 @@
     "react-barcode": "^1.4.1",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",
-    "styled-components": "^6.1.0"
+    "styled-components": "^6.1.15"
   }
 }

--- a/examples/movies-studio/package.json
+++ b/examples/movies-studio/package.json
@@ -33,6 +33,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sanity": "workspace:*",
-    "styled-components": "^6.1.0"
+    "styled-components": "^6.1.15"
   }
 }

--- a/packages/@sanity/cli/test/__fixtures__/v3/package.json
+++ b/packages/@sanity/cli/test/__fixtures__/v3/package.json
@@ -17,6 +17,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sanity": "^3.0.0",
-    "styled-components": "^6.1.0"
+    "styled-components": "^6.1.15"
   }
 }

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -92,6 +92,6 @@
   },
   "peerDependencies": {
     "react": "^18 || ^19.0.0",
-    "styled-components": "^6.1"
+    "styled-components": "^6.1.15"
   }
 }

--- a/packages/sanity/fixtures/examples/prj-with-react-18/package.json
+++ b/packages/sanity/fixtures/examples/prj-with-react-18/package.json
@@ -4,6 +4,6 @@
   "dependencies": {
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
-    "styled-components": "^6.1.0"
+    "styled-components": "^6.1.15"
   }
 }

--- a/packages/sanity/fixtures/examples/prj-with-react-19/package.json
+++ b/packages/sanity/fixtures/examples/prj-with-react-19/package.json
@@ -4,6 +4,6 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "styled-components": "^6.1.0"
+    "styled-components": "^6.1.15"
   }
 }

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -212,7 +212,7 @@
     "exif-component": "^1.0.1",
     "fast-deep-equal": "3.1.3",
     "form-data": "^4.0.0",
-    "framer-motion": "^12.0.0",
+    "framer-motion": "^12.5.0",
     "get-it": "^8.6.7",
     "get-random-values-esm": "1.0.2",
     "groq-js": "^1.16.1",
@@ -320,9 +320,9 @@
     "vitest": "^3.0.8"
   },
   "peerDependencies": {
-    "react": "^18 || ^19.0.0",
-    "react-dom": "^18 || ^19.0.0",
-    "styled-components": "^6.1"
+    "react": "^18 || ^19",
+    "react-dom": "^18 || ^19",
+    "styled-components": "^6.1.15"
   },
   "engines": {
     "node": ">=18"

--- a/perf/studio/package.json
+++ b/perf/studio/package.json
@@ -18,6 +18,6 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "sanity": "workspace:*",
-    "styled-components": "^6.1.0"
+    "styled-components": "^6.1.15"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,7 +254,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sanity
       styled-components:
-        specifier: ^6.1.0
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   dev/embedded-studio:
@@ -272,7 +272,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sanity
       styled-components:
-        specifier: ^6.1.0
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@types/react':
@@ -315,7 +315,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sanity
       styled-components:
-        specifier: ^6.1.8
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   dev/starter-studio:
@@ -336,7 +336,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sanity
       styled-components:
-        specifier: ^6.1.0
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   dev/strict-studio:
@@ -351,7 +351,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sanity
       styled-components:
-        specifier: ^6.1.0
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   dev/studio-e2e-testing:
@@ -396,7 +396,7 @@ importers:
         specifier: workspace:*
         version: link:../test-studio
       styled-components:
-        specifier: ^6.1.0
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
   dev/test-create-integration-studio:
@@ -414,7 +414,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sanity
       styled-components:
-        specifier: ^6.1.0
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   dev/test-studio:
@@ -555,7 +555,7 @@ importers:
         specifier: ^2.5.0
         version: 2.7.0(@emotion/is-prop-valid@1.3.1)(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@packages+sanity)(styled-components@6.1.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       styled-components:
-        specifier: ^6.1.11
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@million/lint':
@@ -580,7 +580,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sanity
       styled-components:
-        specifier: ^6.1.0
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   examples/clean-studio:
@@ -595,7 +595,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sanity
       styled-components:
-        specifier: ^6.1.0
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   examples/ecommerce-studio:
@@ -619,7 +619,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sanity
       styled-components:
-        specifier: ^6.1.0
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   examples/movies-studio:
@@ -637,7 +637,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sanity
       styled-components:
-        specifier: ^6.1.0
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   packages/@repo/dev-aliases: {}
@@ -1525,7 +1525,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1
       framer-motion:
-        specifier: ^12.0.0
+        specifier: ^12.5.0
         version: 12.5.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       get-it:
         specifier: ^8.6.7
@@ -1844,7 +1844,7 @@ importers:
         specifier: ^18.3.0
         version: 18.3.1(react@18.3.1)
       styled-components:
-        specifier: ^6.1.0
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   packages/sanity/fixtures/examples/prj-with-react-19:
@@ -1856,7 +1856,7 @@ importers:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
       styled-components:
-        specifier: ^6.1.0
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
   packages/sanity/fixtures/examples/prj-with-styled-components-5:
@@ -1955,7 +1955,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sanity
       styled-components:
-        specifier: ^6.1.0
+        specifier: ^6.1.15
         version: 6.1.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
   perf/tests:


### PR DESCRIPTION
### Description

Hopefully fixes #8927, although I couldn't verify that it does given that it didn't contain a reproduction.
Before the crash this warning is seen:
```bash
•Warning: Function components cannot be given refs. Attempts to access this ref will chunk-PWQMGZHF.js?v=84711372:521 fail. Did you mean to use React. forwardRef()?
Check the render method of 'PopChild'.
at Toast (http://localhost:3333/node modules/.sanity/vite/deps/chunk-5ZLLAU7C.js?v=84711372:23998:51)
```
We don't send refs as a prop in our codebase. But `styled-components` had an issue in React 19 where it accidentally sent `ref={null}` if no ref were provided, it was fixed in [v6.1.14](https://styled-components.com/releases#styled-components@6.1.14). This PR bumps the requirement from v6.1 to v6.1.15 to hopefully make package managers bump styled-components in userland so they get this fix, among many other fixes.
While at it I'm also bumping `framer-motion` as `PopChild` is part of the `<AnimatePresence mode="popLayout">` that we use in `@sanity/ui`: https://github.com/sanity-io/ui/blob/84e8a2b3c9489d218bc5541c7dfd87a0c9dad8f9/src/core/components/toast/toastProvider.tsx#L91-L104
It's not clear if userland are on an older version of `framer-motion` and that being the root cause. In any case it's a good thing to make sure it's up to date.

### What to review

Does it make sense?

### Testing

If tests pass we're good.

### Notes for release

Increases the required version of `styled-components` to latest stable, ensuring important React 19 fixes are included.
