### PR TITLE
refactor(e2e): update text for craeting release

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1222,6 +1222,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.deleted-tooltip': 'This release has been deleted',
   /** Title for copying version to a new release dialog */
   'release.dialog.copy-to-release.title': 'Copy version to new release',
+  /** Title for action create a release */
+  'release.dialog.create.confirm': 'Create release',
   /** Title for creating releases dialog */
   'release.dialog.create.title': 'New release',
   /** Label for description in tooltip to explain release types */

--- a/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
@@ -1,4 +1,3 @@
-import {ArrowRightIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Box, Card, Flex, useToast} from '@sanity/ui'
 import {type FormEvent, useCallback, useState} from 'react'
@@ -81,6 +80,7 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
   }, [])
 
   const dialogTitle = t('release.dialog.create.title')
+  const dialogConfirm = t('release.dialog.create.confirm')
 
   return (
     <Dialog
@@ -100,9 +100,8 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
             <Button
               size="large"
               disabled={isSubmitting}
-              iconRight={ArrowRightIcon}
               type="submit"
-              text={dialogTitle}
+              text={dialogConfirm}
               loading={isSubmitting}
               data-testid="submit-release-button"
             />


### PR DESCRIPTION
### Description

As mentioned, update the text for the action button when creating a release to be "Create release" without an arrow following updates to design

### What to review

Double check that everything works as intended

### Testing

Existing tests should suffice

### Notes for release

N/A