### PR TITLE
fix(core): releases screen should not crash if schema type is unknown

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -379,6 +379,9 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Label to show in the document footer indicating the revision from date of the document */
   'document-status.revision-from': 'Revision from <em>{{date}}</em>',
 
+  /** Label to indicate that a document type was not found */
+  'document.type.not-found': 'Document type "{{type}}" not found',
+
   /** The value of the <code>_key</code> property must be a unique string. */
   'form.error.duplicate-keys-alert.details.additional-description':
     'The value of the <code>_key</code> property must be a unique string.',

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -55,7 +55,6 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
   const [pendingAddedDocument, setPendingAddedDocument] = useState<BundleDocumentRow[]>([])
 
   const {t} = useTranslation(releasesLocaleNamespace)
-  const {t: tCore} = useTranslation()
 
   const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
 
@@ -74,14 +73,9 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
       if (!isBundleDocumentRow(rowProps.datum)) return null
       if (rowProps.datum.isPending) return null
 
-      return (
-        <DocumentActions
-          document={rowProps.datum}
-          releaseTitle={release.metadata.title || tCore('release.placeholder-untitled-release')}
-        />
-      )
+      return <DocumentActions document={rowProps.datum} />
     },
-    [release.metadata.title, release.state, tCore],
+    [release.state],
   )
 
   const documentTableColumnDefs = useMemo(


### PR DESCRIPTION
### Description
Prevents crashing the releases view if a document type doesn't exist.
The `<DocumentActions>` is doing a check for document permissions, which throws an error if the schema type doesn't exist.

<img width="1175" alt="Screenshot 2025-03-14 at 14 55 14" src="https://github.com/user-attachments/assets/d9d4153e-356d-41d5-bf08-269f4d439bba" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Visit this [page](https://test-studio-git-sapp-2443.sanity.dev/test/releases/rjRelfUYt)
The studio should not crash

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
