### PR TITLE
feat(studio): detect and report high listener roundtrip latency

### DIFF
--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -29,6 +29,11 @@ import {useResourceCache} from './ResourceCacheProvider'
 import {createUserStore, type UserStore} from './user'
 
 /**
+ * Latencies below this value will not be logged
+ */
+const IGNORE_LATENCY_BELOW_MS = 1000
+
+/**
  * @hidden
  * @beta */
 export function useUserStore(): UserStore {
@@ -158,7 +163,7 @@ export function useDocumentStore(): DocumentStore {
 
   const handleReportLatency = useCallback(
     (event: LatencyReportEvent) => {
-      if (event.latencyMs > 1000) {
+      if (event.latencyMs > IGNORE_LATENCY_BELOW_MS) {
         telemetry.log(HighListenerLatencyOccurred, {
           latency: event.latencyMs,
           shard: event.shard,

--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -16,8 +16,9 @@ import {
   type ConnectionStatusStore,
   createConnectionStatusStore,
 } from './connection-status/connection-status-store'
-import {createDocumentStore, type DocumentStore} from './document'
+import {createDocumentStore, type DocumentStore, type LatencyReportEvent} from './document'
 import {DocumentDesynced} from './document/__telemetry__/documentOutOfSyncEvents.telemetry'
+import {HighListenerLatencyOccurred} from './document/__telemetry__/listenerLatency.telemetry'
 import {fetchFeatureToggle} from './document/document-pair/utils/fetchFeatureToggle'
 import {type OutOfSyncError} from './document/utils/sequentializeListenerEvents'
 import {createGrantsStore, type GrantsStore} from './grants'
@@ -155,6 +156,19 @@ export function useDocumentStore(): DocumentStore {
     [telemetry],
   )
 
+  const handleReportLatency = useCallback(
+    (event: LatencyReportEvent) => {
+      if (event.latencyMs > 1000) {
+        telemetry.log(HighListenerLatencyOccurred, {
+          latency: event.latencyMs,
+          shard: event.shard,
+          transactionId: event.transactionId,
+        })
+      }
+    },
+    [telemetry],
+  )
+
   return useMemo(() => {
     const documentStore =
       resourceCache.get<DocumentStore>({
@@ -169,7 +183,8 @@ export function useDocumentStore(): DocumentStore {
         schema,
         i18n,
         serverActionsEnabled,
-        pairListenerOptions: {
+        extraOptions: {
+          onReportLatency: handleReportLatency,
           onSyncErrorRecovery: handleSyncErrorRecovery,
         },
       })
@@ -191,6 +206,7 @@ export function useDocumentStore(): DocumentStore {
     workspace,
     templates,
     serverActionsEnabled,
+    handleReportLatency,
     handleSyncErrorRecovery,
   ])
 }

--- a/packages/sanity/src/core/store/_legacy/document/__telemetry__/listenerLatency.telemetry.ts
+++ b/packages/sanity/src/core/store/_legacy/document/__telemetry__/listenerLatency.telemetry.ts
@@ -6,7 +6,7 @@ type Samples = {
   shard?: string
 }
 export const HighListenerLatencyOccurred = defineEvent<Samples>({
-  name: 'High Listener Latency detected',
+  name: 'High Listener Latency Detected',
   version: 1,
   description: 'Emits when a high listener latency is detected',
 })

--- a/packages/sanity/src/core/store/_legacy/document/__telemetry__/listenerLatency.telemetry.ts
+++ b/packages/sanity/src/core/store/_legacy/document/__telemetry__/listenerLatency.telemetry.ts
@@ -1,0 +1,12 @@
+import {defineEvent} from '@sanity/telemetry'
+
+type Samples = {
+  latency: number
+  transactionId: string
+  shard?: string
+}
+export const HighListenerLatencyOccurred = defineEvent<Samples>({
+  name: 'High Listener Latency detected',
+  version: 1,
+  description: 'Emits when a high listener latency is detected',
+})

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/consistencyStatus.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/consistencyStatus.ts
@@ -2,7 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {combineLatest, type Observable} from 'rxjs'
 import {distinctUntilChanged, map, publishReplay, refCount, switchMap} from 'rxjs/operators'
 
-import {type PairListenerOptions} from '../getPairListener'
+import {type DocumentStoreExtraOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {memoizedPair} from './memoizedPair'
@@ -15,16 +15,16 @@ export const consistencyStatus: (
   idPair: IdPair,
   typeName: string,
   serverActionsEnabled: Observable<boolean>,
-  pairListenerOptions?: PairListenerOptions,
+  extraOptions?: DocumentStoreExtraOptions,
 ) => Observable<boolean> = memoize(
   (
     client: SanityClient,
     idPair: IdPair,
     typeName: string,
     serverActionsEnabled: Observable<boolean>,
-    pairListenerOptions?: PairListenerOptions,
+    extraOptions?: DocumentStoreExtraOptions,
   ) => {
-    return memoizedPair(client, idPair, typeName, serverActionsEnabled, pairListenerOptions).pipe(
+    return memoizedPair(client, idPair, typeName, serverActionsEnabled, extraOptions).pipe(
       switchMap(({draft, published}) =>
         combineLatest([draft.consistency$, published.consistency$]),
       ),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/documentEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/documentEvents.ts
@@ -2,7 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {merge, type Observable} from 'rxjs'
 import {switchMap} from 'rxjs/operators'
 
-import {type PairListenerOptions} from '../getPairListener'
+import {type DocumentStoreExtraOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {type DocumentVersionEvent} from './checkoutPair'
@@ -17,7 +17,7 @@ export const documentEvents = memoize(
     idPair: IdPair,
     typeName: string,
     serverActionsEnabled: Observable<boolean>,
-    pairListenerOptions?: PairListenerOptions,
+    pairListenerOptions?: DocumentStoreExtraOptions,
   ): Observable<DocumentVersionEvent> => {
     return memoizedPair(client, idPair, typeName, serverActionsEnabled, pairListenerOptions).pipe(
       switchMap(({draft, published}) => merge(draft.events, published.events)),

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editOperations.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editOperations.ts
@@ -4,7 +4,7 @@ import {concat, EMPTY, merge, type Observable, of} from 'rxjs'
 import {map, mergeMap, shareReplay} from 'rxjs/operators'
 
 import {type HistoryStore} from '../../history'
-import {type PairListenerOptions} from '../getPairListener'
+import {type DocumentStoreExtraOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {memoizeKeyGen} from './memoizeKeyGen'
@@ -20,7 +20,7 @@ export const editOperations = memoize(
       historyStore: HistoryStore
       schema: Schema
       serverActionsEnabled: Observable<boolean>
-      pairListenerOptions?: PairListenerOptions
+      pairListenerOptions?: DocumentStoreExtraOptions
     },
     idPair: IdPair,
     typeName: string,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
@@ -5,7 +5,7 @@ import {map, publishReplay, refCount, startWith, switchMap} from 'rxjs/operators
 
 import {getVersionFromId} from '../../../../util'
 import {createSWR} from '../../../../util/rxSwr'
-import {type PairListenerOptions} from '../getPairListener'
+import {type DocumentStoreExtraOptions} from '../getPairListener'
 import {type IdPair, type PendingMutationsEvent} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {memoizeKeyGen} from './memoizeKeyGen'
@@ -57,7 +57,7 @@ export const editState = memoize(
       client: SanityClient
       schema: Schema
       serverActionsEnabled: Observable<boolean>
-      pairListenerOptions?: PairListenerOptions
+      extraOptions?: DocumentStoreExtraOptions
     },
     idPair: IdPair,
     typeName: string,
@@ -70,7 +70,7 @@ export const editState = memoize(
       idPair,
       typeName,
       ctx.serverActionsEnabled,
-      ctx.pairListenerOptions,
+      ctx.extraOptions,
     ).pipe(
       switchMap((versions) =>
         combineLatest([

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
@@ -2,7 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {EMPTY, merge, Observable, of, ReplaySubject, share, timer} from 'rxjs'
 import {mergeMap} from 'rxjs/operators'
 
-import {type PairListenerOptions} from '../getPairListener'
+import {type DocumentStoreExtraOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {checkoutPair, type Pair} from './checkoutPair'
@@ -16,14 +16,14 @@ export const memoizedPair: (
   idPair: IdPair,
   typeName: string,
   serverActionsEnabled: Observable<boolean>,
-  pairListenerOptions?: PairListenerOptions,
+  extraOptions?: DocumentStoreExtraOptions,
 ) => Observable<Pair> = memoize(
   (
     client: SanityClient,
     idPair: IdPair,
     _typeName: string,
     serverActionsEnabled: Observable<boolean>,
-    pairListenerOptions?: PairListenerOptions,
+    pairListenerOptions?: DocumentStoreExtraOptions,
   ): Observable<Pair> => {
     return new Observable<Pair>((subscriber) => {
       const pair = checkoutPair(client, idPair, serverActionsEnabled, pairListenerOptions)

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
@@ -7,7 +7,7 @@ import {combineLatest, type Observable} from 'rxjs'
 import {map, publishReplay, refCount, switchMap} from 'rxjs/operators'
 
 import {type HistoryStore} from '../../history'
-import {type PairListenerOptions} from '../getPairListener'
+import {type DocumentStoreExtraOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {memoizeKeyGen} from './memoizeKeyGen'
@@ -21,7 +21,7 @@ export const operationArgs = memoize(
       historyStore: HistoryStore
       schema: Schema
       serverActionsEnabled: Observable<boolean>
-      pairListenerOptions?: PairListenerOptions
+      pairListenerOptions?: DocumentStoreExtraOptions
     },
     idPair: IdPair,
     typeName: string,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationEvents.ts
@@ -19,7 +19,7 @@ import {
 } from 'rxjs/operators'
 
 import {type HistoryStore} from '../../history'
-import {type PairListenerOptions} from '../getPairListener'
+import {type DocumentStoreExtraOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {consistencyStatus} from './consistencyStatus'
@@ -144,7 +144,7 @@ export const operationEvents = memoize(
     historyStore: HistoryStore
     schema: Schema
     serverActionsEnabled: Observable<boolean>
-    pairListenerOptions?: PairListenerOptions
+    extraOptions?: DocumentStoreExtraOptions
   }) => {
     const result$: Observable<IntermediarySuccess | IntermediaryError> = operationCalls$.pipe(
       groupBy((op) => op.idPair.publishedId),
@@ -167,7 +167,7 @@ export const operationEvents = memoize(
                   args.idPair,
                   args.typeName,
                   ctx.serverActionsEnabled,
-                  ctx.pairListenerOptions,
+                  ctx.extraOptions,
                 ).pipe(filter(Boolean))
                 const ready$ = requiresConsistency ? isConsistent$.pipe(take(1)) : of(true)
                 return ready$.pipe(

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/remoteSnapshots.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/remoteSnapshots.ts
@@ -2,7 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {EMPTY, merge, type Observable} from 'rxjs'
 import {switchMap} from 'rxjs/operators'
 
-import {type PairListenerOptions} from '../getPairListener'
+import {type DocumentStoreExtraOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {type RemoteSnapshotVersionEvent} from './checkoutPair'
@@ -16,7 +16,7 @@ export const remoteSnapshots = memoize(
     idPair: IdPair,
     typeName: string,
     serverActionsEnabled: Observable<boolean>,
-    pairListenerOptions?: PairListenerOptions,
+    pairListenerOptions?: DocumentStoreExtraOptions,
   ): Observable<RemoteSnapshotVersionEvent> => {
     return memoizedPair(client, idPair, typeName, serverActionsEnabled, pairListenerOptions).pipe(
       switchMap(({published, draft, version}) =>

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/snapshotPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/snapshotPair.ts
@@ -4,7 +4,7 @@ import {type Observable} from 'rxjs'
 import {filter, map, publishReplay, refCount} from 'rxjs/operators'
 
 import {type BufferedDocumentEvent, type MutationPayload, type SnapshotEvent} from '../buffered-doc'
-import {type PairListenerOptions} from '../getPairListener'
+import {type DocumentStoreExtraOptions} from '../getPairListener'
 import {type IdPair, type PendingMutationsEvent, type ReconnectEvent} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {type DocumentVersion} from './checkoutPair'
@@ -68,7 +68,7 @@ export const snapshotPair = memoize(
     idPair: IdPair,
     typeName: string,
     serverActionsEnabled: Observable<boolean>,
-    pairListenerOptions?: PairListenerOptions,
+    pairListenerOptions?: DocumentStoreExtraOptions,
   ): Observable<SnapshotPair> => {
     return memoizedPair(client, idPair, typeName, serverActionsEnabled, pairListenerOptions).pipe(
       map(({published, draft, version, transactionsPendingEvents$}): SnapshotPair => {

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
@@ -9,7 +9,7 @@ import {type SourceClientOptions} from '../../../../config'
 import {type LocaleSource} from '../../../../i18n'
 import {type DraftsModelDocumentAvailability} from '../../../../preview'
 import {validateDocumentWithReferences, type ValidationStatus} from '../../../../validation'
-import {type PairListenerOptions} from '../getPairListener'
+import {type DocumentStoreExtraOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {editState} from './editState'
@@ -32,7 +32,7 @@ export const validation = memoize(
       schema: Schema
       i18n: LocaleSource
       serverActionsEnabled: Observable<boolean>
-      pairListenerOptions?: PairListenerOptions
+      pairListenerOptions?: DocumentStoreExtraOptions
     },
     {draftId, publishedId, versionId}: IdPair,
     typeName: string,

--- a/packages/sanity/src/core/store/_legacy/document/getPairListener.ts
+++ b/packages/sanity/src/core/store/_legacy/document/getPairListener.ts
@@ -31,8 +31,17 @@ export interface InitialSnapshotEvent {
   document: SanityDocument | null
 }
 
+/**
+ * @internal
+ */
+export interface LatencyReportEvent {
+  shard?: string
+  latencyMs: number
+  transactionId: string
+}
+
 /** @internal */
-export interface PairListenerOptions {
+export interface DocumentStoreExtraOptions {
   tag?: string
 
   /**
@@ -41,6 +50,7 @@ export interface PairListenerOptions {
    * @param error - the {@link OutOfSyncError} recovered from
    */
   onSyncErrorRecovery?(error: OutOfSyncError): void
+  onReportLatency?: (event: LatencyReportEvent) => void
 }
 
 /** @internal */
@@ -75,7 +85,7 @@ function allPendingTransactionEventsReceived(listenerEvents: ListenerEvent[]) {
 export function getPairListener(
   _client: SanityClient,
   idPair: IdPair,
-  options: PairListenerOptions = {},
+  options: DocumentStoreExtraOptions = {},
 ): Observable<ListenerEvent> {
   const {publishedId, draftId, versionId} = idPair
   const client = idPair.versionId ? _client.withConfig(RELEASES_STUDIO_CLIENT_OPTIONS) : _client

--- a/packages/sanity/src/core/store/_legacy/grants/documentPairPermissions.ts
+++ b/packages/sanity/src/core/store/_legacy/grants/documentPairPermissions.ts
@@ -15,7 +15,7 @@ import {
   type PartialExcept,
 } from '../../../util'
 import {useGrantsStore} from '../datastores'
-import {type PairListenerOptions, snapshotPair} from '../document'
+import {type DocumentStoreExtraOptions, snapshotPair} from '../document'
 import {fetchFeatureToggle} from '../document/document-pair/utils/fetchFeatureToggle'
 import {type GrantsStore, type PermissionCheckResult} from './types'
 
@@ -183,7 +183,7 @@ export interface DocumentPairPermissionsOptions {
   version?: string
   permission: DocumentPermission
   serverActionsEnabled: Observable<boolean>
-  pairListenerOptions?: PairListenerOptions
+  pairListenerOptions?: DocumentStoreExtraOptions
 }
 
 /**


### PR DESCRIPTION
### Description
We want to track e2e listener latency, this reports a telemetry event every time we detect >1s latency from after an edit action request has completed until we receive an event with a corresponding transaction id back from the listener.

### What to review

I've tried to implement this as cleanly as possible to make it easy to delete the code path for tracking latency at some point in the future. The implementation follows the same pattern as the "document desynced" event in the document store takes a callback that will be called with latency, shard identifier and transaction id.

### Testing
To see that the the Studio sends the event, start with `SANITY_STUDIO_DEBUG_TELEMETRY=true pnpm dev` which will log the telemetry events to the console.

This, combined with network throttling should likely cause some "High Listener Latency Detected"-events to be reported


### Notes for release
n/a