### PR TITLE
fix(sanity): use minimum supported API version for dataset import

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/dataset/importDatasetCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/importDatasetCommand.ts
@@ -103,6 +103,9 @@ function parseFlags(rawFlags: ImportFlags): ParsedImportFlags {
   }
 }
 
+// The minimum supported API version, providing the ability to handle version documents.
+const MINIMUM_API_VERSION = '2025-02-19'
+
 const importDatasetCommand: CliCommandDefinition = {
   name: 'import',
   group: 'dataset',
@@ -161,7 +164,10 @@ const importDatasetCommand: CliCommandDefinition = {
       }
     }
 
-    const importClient = client.clone().config({dataset: targetDataset})
+    const importClient = client.clone().config({
+      apiVersion: MINIMUM_API_VERSION,
+      dataset: targetDataset,
+    })
 
     // Print information about what projectId and dataset it is being imported to
     const {projectId, dataset} = importClient.config()


### PR DESCRIPTION
### Description

This change is the smallest possible band-aid for fixing dataset import containing version documents. It explicitly sets the importer to use API version `2025-02-19`.

Prior to API version `2025-02-19`, `"versions."` is a reserved document id path. The API therefore prevents the importer creating such documents, erroring with:

```
Invalid document version ID "versions.<id>": "versions" is a reserved prefix
```

I think we should take a closer look at how CLI API versions are managed. For example, if you arrive at [this code](https://github.com/sanity-io/sanity/blob/f70fe46de682ad952b836ef81c279126e6e32875/packages/@sanity/cli/src/cliClient.ts#L25), you may end up thinking _`2022-06-06` is probably used_. But if you make it to [this code](https://github.com/sanity-io/sanity/blob/f70fe46de682ad952b836ef81c279126e6e32875/packages/@sanity/cli/src/util/clientWrapper.ts#L111), you'll see the API version is being set to `1`. If you take a look through the various CLI commands, you'll see the API version is frequently arbitrarily overwritten (e.g. [here](https://github.com/sanity-io/sanity/blob/f70fe46de682ad952b836ef81c279126e6e32875/packages/sanity/src/_internal/cli/actions/graphql/listApisAction.ts#L22), [here](https://github.com/sanity-io/sanity/blob/f70fe46de682ad952b836ef81c279126e6e32875/packages/sanity/src/_internal/cli/actions/app/deployAction.ts#L45), and [here](https://github.com/sanity-io/sanity/blob/f70fe46de682ad952b836ef81c279126e6e32875/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts#L18)). 

### What to review

Seem like a reasonable fix?

### Testing

I have manually tested this by exporting and importing a dataset containing a version, and verifying the version is successfully imported after I deleted it from my dataset.

### Notes for release

Fixes a bug causing dataset imports containing version documents to fail with error `Invalid document version ID "versions.<id>": "versions" is a reserved prefix`.