### PR TITLE
fix(cli): fix import for SanityApp and add fallback prop

### DIFF
--- a/packages/@sanity/cli/templates/core-app/src/App.css
+++ b/packages/@sanity/cli/templates/core-app/src/App.css
@@ -3,7 +3,9 @@
   max-width: 1200px;
   margin: 0 auto;
   padding: 2rem;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans',
+    'Helvetica Neue', sans-serif;
 }
 
 /* Basic reset */
@@ -15,4 +17,103 @@ body {
   margin: 0;
   padding: 0;
   background-color: #f9f9f9;
+}
+
+/* Sanity Login Styles */
+.container-inline {
+  container-type: inline-size;
+}
+
+.sc-login {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.sc-login-layout__card {
+  width: 320px;
+  margin: auto;
+  border-radius: 0.25rem;
+  box-shadow: 0 0 0 1px #e3e4e8;
+  padding: 1.5rem;
+}
+
+.sc-login__title {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.sc-login-providers {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  width: 100%;
+}
+
+.sc-login-providers a {
+  display: block;
+  padding: 0.5rem 1rem;
+  background-color: #f6f6f8;
+  border-radius: 3px;
+  box-shadow: inset 0 0 0 1px #d1d5db;
+  margin-bottom: 0.5rem;
+  text-decoration: none;
+  text-align: center;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  color: #000;
+}
+
+.sc-login-providers a:hover {
+  background-color: #f6f6f8;
+  box-shadow: inset 0 0 0 1px #d1d5db;
+}
+
+.sc-login-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem 0;
+}
+
+.sc-login-footer__logo {
+  width: auto;
+  height: 1.5rem;
+}
+
+.sc-login-footer__links {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.sc-login-footer__link {
+  display: flex;
+  align-items: center;
+  font-size: 0.875rem;
+}
+
+.sc-login-footer__link:not(:last-child)::after {
+  content: '•';
+  margin-left: 0.5rem;
+  color: inherit;
+}
+
+.sc-login-footer__link a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.sc-login-footer__link a:hover {
+  color: inherit;
+  text-decoration: underline;
 }

--- a/packages/@sanity/cli/templates/core-app/src/App.tsx
+++ b/packages/@sanity/cli/templates/core-app/src/App.tsx
@@ -1,5 +1,5 @@
 import {type SanityConfig} from '@sanity/sdk'
-import {SanityApp} from '@sanity/sdk-react/components'
+import {SanityApp} from '@sanity/sdk-react'
 import {ExampleComponent} from './ExampleComponent'
 import './App.css'
 
@@ -9,12 +9,12 @@ export function App() {
     {
       projectId: 'project-id',
       dataset: 'dataset-name',
-    }
+    },
   ]
 
   return (
     <div className="app-container">
-      <SanityApp sanityConfigs={sanityConfigs}>
+      <SanityApp sanityConfigs={sanityConfigs} fallback={<div>Loading...</div>}>
         {/* add your own components here! */}
         <ExampleComponent />
       </SanityApp>


### PR DESCRIPTION
### Description

This fixes a a broken import of `SanityApp` in the "core-app" template

<img width="1048" alt="Screenshot 2025-03-14 at 22 50 33" src="https://github.com/user-attachments/assets/ed574a34-7702-426c-a031-26b486743f59" />


It also adds the required `fallback` prop when using the `<SanityApp>` component.

I also added in some styles to improve the look of the login screen.  See image below with the left screen being the before

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/c0d9ab0d-089c-4d71-af6b-db77ae079dd4" />


### What to review

`SanityApp` appears to be exported here https://github.com/sanity-io/sdk/blob/main/packages/react/src/_exports/index.ts , not directly from `src/components`.  

### Testing

The template can be initiated and ran with:
```
pnpx sanity@latest init --template core-app
cd my-content-os-app
npm run dev
```

You can create a test project/template and copy/paste in my code updates pretty easily to test

### Notes for release

