### PR TITLE
fix(core): slugs validation

### DIFF
--- a/packages/sanity/src/core/validation/validators/slugValidator.ts
+++ b/packages/sanity/src/core/validation/validators/slugValidator.ts
@@ -10,6 +10,7 @@ import {
 } from '@sanity/types'
 import {memoize} from 'lodash'
 
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {getDraftId, getPublishedId, VERSION_FOLDER} from '../../util/draftUtils'
 
 const memoizedWarnOnArraySlug = memoize(warnOnArraySlug)
@@ -59,17 +60,19 @@ const defaultIsUnique: SlugIsUniqueValidator = (slug, context) => {
     `${atPath} == $slug`,
   ].join(' && ')
 
-  return getClient({apiVersion: '2023-11-13'}).fetch<boolean>(
-    `!defined(*[${constraints}][0]._id)`,
-    {
-      docType,
-      draft,
-      published,
-      versionPath,
-      slug,
-    },
-    {tag: 'validation.slug-is-unique'},
-  )
+  return getClient({apiVersion: DEFAULT_STUDIO_CLIENT_OPTIONS.apiVersion})
+    .withConfig({perspective: 'raw'})
+    .fetch<boolean>(
+      `!defined(*[${constraints}][0]._id)`,
+      {
+        docType,
+        draft,
+        published,
+        versionPath,
+        slug,
+      },
+      {tag: 'validation.slug-is-unique'},
+    )
 }
 
 function warnOnArraySlug(serializedPath: string) {

--- a/packages/sanity/test/validation/infer.test.ts
+++ b/packages/sanity/test/validation/infer.test.ts
@@ -146,12 +146,10 @@ describe('schema validation inference', () => {
 
       expect(client.fetch).toHaveBeenCalledTimes(1)
       expect(client.fetch.mock.calls[0]).toEqual([
-        '!defined(*[_type == $docType && !(_id in [$draft, $published, path($versionPath)]) && slugField.current == $slug][0]._id)',
+        '!defined(*[_type == $docType && !sanity::versionOf($published) && slugField.current == $slug][0]._id)',
         {
           docType: 'documentWithSlug',
-          draft: 'drafts.mockDocument',
           published: 'mockDocument',
-          versionPath: 'versions.**.mockDocument',
           slug: 'example-value',
         },
         {
@@ -186,12 +184,10 @@ describe('schema validation inference', () => {
 
       expect(client.fetch).toHaveBeenCalledTimes(1)
       expect(client.fetch.mock.calls[0]).toEqual([
-        '!defined(*[_type == $docType && !(_id in [$draft, $published, path($versionPath)]) && slugField.current == $slug][0]._id)',
+        '!defined(*[_type == $docType && !sanity::versionOf($published) && slugField.current == $slug][0]._id)',
         {
           docType: 'documentWithSlug',
-          draft: 'drafts.mockDocument',
           published: 'mockDocument',
-          versionPath: 'versions.**.mockDocument',
           slug: 'example-value',
         },
         {

--- a/packages/sanity/test/validation/infer.test.ts
+++ b/packages/sanity/test/validation/infer.test.ts
@@ -146,11 +146,12 @@ describe('schema validation inference', () => {
 
       expect(client.fetch).toHaveBeenCalledTimes(1)
       expect(client.fetch.mock.calls[0]).toEqual([
-        '!defined(*[_type == $docType && !(_id in [$draft, $published]) && !(_id in path("versions.**.mockDocument")) && slugField.current == $slug][0]._id)',
+        '!defined(*[_type == $docType && !(_id in [$draft, $published, path($versionPath)]) && slugField.current == $slug][0]._id)',
         {
           docType: 'documentWithSlug',
           draft: 'drafts.mockDocument',
           published: 'mockDocument',
+          versionPath: 'versions.**.mockDocument',
           slug: 'example-value',
         },
         {
@@ -185,11 +186,12 @@ describe('schema validation inference', () => {
 
       expect(client.fetch).toHaveBeenCalledTimes(1)
       expect(client.fetch.mock.calls[0]).toEqual([
-        '!defined(*[_type == $docType && !(_id in [$draft, $published]) && !(_id in path("versions.**.mockDocument")) && slugField.current == $slug][0]._id)',
+        '!defined(*[_type == $docType && !(_id in [$draft, $published, path($versionPath)]) && slugField.current == $slug][0]._id)',
         {
           docType: 'documentWithSlug',
           draft: 'drafts.mockDocument',
           published: 'mockDocument',
+          versionPath: 'versions.**.mockDocument',
           slug: 'example-value',
         },
         {


### PR DESCRIPTION
### Description
Fixes: https://github.com/sanity-io/sanity/issues/8724

With releases feature a bug was introduced in how the slugs are validated, allowing for repeated slugs across documents.
This PR fixes this by updating the query used to validate this making use of the [versionOf](https://www.sanity.io/docs/content-releases-cheat-sheet#d774f2dfc40f) function



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Are the changes correct?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Existing tests are updated.
Manual tests:
Created some documents with slug validations to verify:
 - **San francisco** is published, has a repeated slug in a draft document, it should error.
    - [Next](https://test-studio.sanity.dev/test/structure/input-standard;slugsTest;63be9484-35c6-40fa-8ee5-874c5c80ff8b)  No error shown, this is incorrect ❌ 
    - [Branch](https://test-studio-git-fix-slug-validation.sanity.dev/test/structure/input-standard;slugsTest;63be9484-35c6-40fa-8ee5-874c5c80ff8b) Shows error, correct ✅ 
    -  <img width="600" alt="Screenshot 2025-03-17 at 09 36 16" src="https://github.com/user-attachments/assets/8753f0d4-29cb-4700-bbee-423073e4418d" />


 - **Barcelona** two drafts with repeated slug, it should error.
   -  [Next](https://test-studio.sanity.dev/test/structure/input-standard;slugsTest;afb62743-565b-4689-98ea-6051f9a4dfbb) No error shown, this is incorrect ❌ 
   - [Branch](https://test-studio-git-fix-slug-validation.sanity.dev/test/structure/input-standard;slugsTest;afb62743-565b-4689-98ea-6051f9a4dfbb)  Shows error, correct ✅ 
   - <img width="600" alt="Screenshot 2025-03-17 at 09 36 41" src="https://github.com/user-attachments/assets/ca4daef7-4b21-4a4e-9939-bcbb5e7443de" />

- **Stockholm**, draft and [other version document with same slug](https://test-studio-git-fix-slug-validation.sanity.dev/test/structure/input-standard;slugsTest;d995c77e-10db-450d-8ec3-85872b55d3a1?perspective=rjOthGRpu), it should show the error.
   -  [Next](https://test-studio.sanity.dev/test/structure/input-standard;slugsTest;d995c77e-10db-450d-8ec3-85872b55d3a1) No error shown, this is incorrect ❌ 
   - [Branch](https://test-studio-git-fix-slug-validation.sanity.dev/test/structure/input-standard;slugsTest;d995c77e-10db-450d-8ec3-85872b55d3a1)  Shows error, correct ✅ 
   - <img width="1728" alt="Screenshot 2025-03-17 at 09 57 06" src="https://github.com/user-attachments/assets/25137386-33ef-4872-b1ab-424ceace194a" />


 - **Oslo** same base document in different versions, it should not error.
    - [Next](https://test-studio.sanity.dev/test/structure/input-standard;slugsTest;b2716605-7340-4c1c-9840-50680da90de4) Doesn't show error, correct ✅ 
    -  [Branch](https://test-studio-git-fix-slug-validation.sanity.dev/test/structure/input-standard;slugsTest;b2716605-7340-4c1c-9840-50680da90de4)   Doesn't show error, correct ✅ 
    - <img width="600" alt="Screenshot 2025-03-17 at 09 36 54" src="https://github.com/user-attachments/assets/47b86829-80fb-4ce4-813d-88c9c7235ac7" />


<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an error for slugs validation in where repeated slugs where not showing the validation error if no version document existed.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
