### PR TITLE
fix(studio): use correct logo in dark mode

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/Layout.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/Layout.tsx
@@ -1,9 +1,7 @@
 import {SanityLogo} from '@sanity/logos'
-import {Box, Card, Flex, Heading, Stack, Text} from '@sanity/ui'
+import {Box, Card, Flex, Heading, Stack, Text, usePrefersDark} from '@sanity/ui'
 import {Fragment, type ReactNode} from 'react'
 import {styled} from 'styled-components'
-
-import {useTranslation} from '../../../../../i18n'
 
 const LINKS = [
   {
@@ -42,7 +40,7 @@ interface LayoutProps {
 
 export function Layout(props: LayoutProps) {
   const {children, footer, header} = props
-  const {t} = useTranslation()
+  const prefersDark = usePrefersDark()
 
   return (
     <Stack space={6}>
@@ -69,7 +67,7 @@ export function Layout(props: LayoutProps) {
 
       <Flex direction="column" gap={4} justify="center" align="center" paddingBottom={4}>
         <Text size={3}>
-          <SanityLogo />
+          <SanityLogo dark={prefersDark} />
         </Text>
 
         <Flex align="center" gap={2}>


### PR DESCRIPTION
### Description

- Fixing a long standing issue of our Logo being used wrong on the auth screen when theme is "dark"
- Removed unused hook import

#### This is wrong:

![image](https://github.com/user-attachments/assets/954af68e-f8f4-4864-a01b-131530aa9373)

#### Correct usage:

https://github.com/user-attachments/assets/902ccdac-71b2-487a-aa54-65235ffd944f

### Testing

Visit a studio and try flipping your system scheme. The logo should be red on light mode, white on dark mode.


### Notes for release

N/A