### PR TITLE
fix(core): update `resolveTypeForDocument` to work with version docs

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/hooks/__tests__/useDocumentType.test.tsx
+++ b/packages/sanity/src/core/store/_legacy/document/hooks/__tests__/useDocumentType.test.tsx
@@ -79,7 +79,7 @@ test('should return correct document type on document ID transition', async () =
   const responseGot = defer(() => of(['book']).pipe(observeOn(asyncScheduler)))
 
   client.observable.fetch = (_query, params) =>
-    params.documentId === 'grrm' ? responseGrrm : responseGot
+    params.publishedId === 'grrm' ? responseGrrm : responseGot
 
   let documentId = 'grrm'
   const {result, rerender} = renderHook(() => useDocumentType(documentId, undefined), {

--- a/packages/sanity/src/core/store/_legacy/document/resolveTypeForDocument.ts
+++ b/packages/sanity/src/core/store/_legacy/document/resolveTypeForDocument.ts
@@ -2,7 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {type Observable, of} from 'rxjs'
 import {map} from 'rxjs/operators'
 
-import {getDraftId, getPublishedId} from '../../../util'
+import {getPublishedId} from '../../../util'
 
 export function resolveTypeForDocument(
   client: SanityClient,
@@ -14,9 +14,15 @@ export function resolveTypeForDocument(
     return of(specifiedType)
   }
 
-  const query = '*[_id in [$documentId, $draftId]]._type'
-  const documentId = getPublishedId(id)
-  const draftId = getDraftId(documentId)
+  const query = '*[sanity::versionOf($publishedId)]._type'
 
-  return client.observable.fetch(query, {documentId, draftId}).pipe(map((types) => types[0]))
+  return client.observable
+    .fetch(
+      query,
+      {publishedId: getPublishedId(id)},
+      {
+        tag: 'document.resolve-type',
+      },
+    )
+    .pipe(map((types) => types[0]))
 }

--- a/packages/sanity/src/structure/structureBuilder/util/resolveTypeForDocument.ts
+++ b/packages/sanity/src/structure/structureBuilder/util/resolveTypeForDocument.ts
@@ -1,22 +1,15 @@
 import {type SanityClient} from '@sanity/client'
-import {
-  DEFAULT_STUDIO_CLIENT_OPTIONS,
-  getDraftId,
-  getPublishedId,
-  type SourceClientOptions,
-} from 'sanity'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS, getPublishedId, type SourceClientOptions} from 'sanity'
 
 export async function resolveTypeForDocument(
   getClient: (options: SourceClientOptions) => SanityClient,
   id: string,
 ): Promise<string | undefined> {
-  const query = '*[_id in [$documentId, $draftId]]._type'
-  const documentId = getPublishedId(id)
-  const draftId = getDraftId(id)
+  const query = '*[sanity::versionOf($publishedId)]._type'
 
   const types = await getClient(DEFAULT_STUDIO_CLIENT_OPTIONS).fetch(
     query,
-    {documentId, draftId},
+    {publishedId: getPublishedId(id)},
     {tag: 'structure.resolve-type'},
   )
 


### PR DESCRIPTION
### Description
Fixes https://github.com/sanity-io/sanity/issues/8761

This PR fixes an issue with `resolveTypeForDocument` if the document only exists as a version document the return value of this getters will be undefined, it won't find the document so the studio will crash.
As seen here https://test-studio.sanity.dev/test/structure/custom;anythingWithATitle;5e5cb18e-0559-4319-95bd-3fb225fcb1a6?perspective=rlaZGnKM3

<img width="800" alt="Screenshot 2025-03-17 at 15 03 32" src="https://github.com/user-attachments/assets/053938bc-2742-490d-9963-c2cf67b301cb" />

This PR, as suggested by @mariusGundersen updates the two `resolveTypeForDocument` functions we have to use the `versionOf` groq function.

Now, if you visit  https://test-studio-git-sgh-272.sanity.dev/test/structure/custom;anythingWithATitle;5e5cb18e-0559-4319-95bd-3fb225fcb1a6?perspective=rlaZGnKM3 it will pass

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Are this changes correct?
How could we identify all the other places this type of change is needed
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open this [link](https://test-studio-git-sgh-272.sanity.dev/test/structure/custom;anythingWithATitle;5e5cb18e-0559-4319-95bd-3fb225fcb1a6?perspective=rlaZGnKM3) , it should render the book.
Or, create a new document only as part of a release and open that document from a list which doesn't specifies the type and instead uses a custom filter option.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in where document lists were not able to resolve the document type when a document only existed as part of a release 
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
