### PR TITLE
feat(telemetry): track INP performance from the field

### DIFF
--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -29,8 +29,8 @@ import {
 import {type StudioProps} from './Studio'
 import {StudioAnnouncementsProvider} from './studioAnnouncements/StudioAnnouncementsProvider'
 import {StudioErrorBoundary} from './StudioErrorBoundary'
-import {StudioTelemetryProvider} from './StudioTelemetryProvider'
 import {StudioThemeProvider} from './StudioThemeProvider'
+import {StudioTelemetryProvider} from './telemetry/StudioTelemetryProvider'
 import {WorkspaceLoader} from './workspaceLoader'
 import {WorkspacesProvider} from './workspaces'
 

--- a/packages/sanity/src/core/studio/__telemetry__/performance.telemetry.ts
+++ b/packages/sanity/src/core/studio/__telemetry__/performance.telemetry.ts
@@ -1,0 +1,16 @@
+import {defineEvent} from '@sanity/telemetry'
+
+export interface PerformanceINPMeasuredData {
+  target: string | null
+  duration: number
+  interaction: string
+}
+
+export const PerformanceINPMeasured = defineEvent<PerformanceINPMeasuredData>({
+  name: 'Performance INP Measured',
+  //@ts-expect-error not yet supported, see https://github.com/sanity-io/telemetry/pull/6
+  // Do not sample more often than every 10s
+  maxSampleRate: 10_000,
+  version: 1,
+  description: 'Performance INP (Interaction to Next Paint) measurement happened',
+})

--- a/packages/sanity/src/core/studio/__telemetry__/performance.telemetry.ts
+++ b/packages/sanity/src/core/studio/__telemetry__/performance.telemetry.ts
@@ -8,9 +8,8 @@ export interface PerformanceINPMeasuredData {
 
 export const PerformanceINPMeasured = defineEvent<PerformanceINPMeasuredData>({
   name: 'Performance INP Measured',
-  //@ts-expect-error not yet supported, see https://github.com/sanity-io/telemetry/pull/6
-  // Do not sample more often than every 10s
-  maxSampleRate: 10_000,
+  // Sample at most every minute
+  maxSampleRate: 60_000,
   version: 1,
   description: 'Performance INP (Interaction to Next Paint) measurement happened',
 })

--- a/packages/sanity/src/core/studio/__telemetry__/performance.telemetry.ts
+++ b/packages/sanity/src/core/studio/__telemetry__/performance.telemetry.ts
@@ -2,6 +2,10 @@ import {defineEvent} from '@sanity/telemetry'
 
 export interface PerformanceINPMeasuredData {
   target: string | null
+  attrs?: {
+    ui?: string
+    testId?: string
+  }
   duration: number
   interaction: string
 }

--- a/packages/sanity/src/core/studio/telemetry/PerformanceTelemetry.ts
+++ b/packages/sanity/src/core/studio/telemetry/PerformanceTelemetry.ts
@@ -1,0 +1,12 @@
+// Tracks performance metrics from the field
+import {type PropsWithChildren} from 'react'
+
+import {useMeasurePerformanceTelemetry} from './useMeasurePerformanceTelemetry'
+
+/**
+ * @internal
+ */
+export function PerformanceTelemetryTracker(props: PropsWithChildren) {
+  useMeasurePerformanceTelemetry()
+  return props.children
+}

--- a/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
+++ b/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
@@ -7,9 +7,10 @@ import {TelemetryProvider} from '@sanity/telemetry/react'
 import arrify from 'arrify'
 import {type ReactNode, useEffect, useMemo} from 'react'
 
-import {type Config} from '../config'
-import {useClient} from '../hooks'
-import {SANITY_VERSION} from '../version'
+import {type Config} from '../../config'
+import {useClient} from '../../hooks'
+import {SANITY_VERSION} from '../../version'
+import {PerformanceTelemetryTracker} from './PerformanceTelemetry'
 
 const sessionId = createSessionId()
 
@@ -18,7 +19,7 @@ const DEBUG_TELEMETRY = !!(
 )
 
 /* eslint-disable no-console */
-export const debugLoggingStore: CreateBatchedStoreOptions = {
+const debugLoggingStore: CreateBatchedStoreOptions = {
   // submit any pending events every <n> ms
   flushInterval: 1000,
 
@@ -105,5 +106,9 @@ export function StudioTelemetryProvider(props: {children: ReactNode; config: Con
     })
   }, [props.config, store.logger])
 
-  return <TelemetryProvider store={store}>{props.children}</TelemetryProvider>
+  return (
+    <TelemetryProvider store={store}>
+      <PerformanceTelemetryTracker>{props.children}</PerformanceTelemetryTracker>
+    </TelemetryProvider>
+  )
 }

--- a/packages/sanity/src/core/studio/telemetry/useMeasurePerformanceTelemetry.ts
+++ b/packages/sanity/src/core/studio/telemetry/useMeasurePerformanceTelemetry.ts
@@ -3,6 +3,15 @@ import {useCallback, useEffect} from 'react'
 
 import {PerformanceINPMeasured} from '../__telemetry__/performance.telemetry'
 
+function getInterestingAttrs(node: Node | null): undefined | {ui?: string; testId?: string} {
+  if (!node || !(node instanceof Element)) {
+    return undefined
+  }
+  const ui = node.getAttribute('data-ui') || undefined
+  const testId = node.getAttribute('data-testid') || undefined
+  return ui || testId ? {ui, testId} : undefined
+}
+
 function getElementIdentifier(node: Node | null) {
   if (!node) {
     return null
@@ -45,6 +54,7 @@ export function useMeasurePerformanceTelemetry() {
       }
       telemetry.log(PerformanceINPMeasured, {
         target: getElementIdentifier(maxEntry.target),
+        attrs: getInterestingAttrs(maxEntry.target),
         interaction: maxEntry.name,
         duration: maxEntry.duration,
       })

--- a/packages/sanity/src/core/studio/telemetry/useMeasurePerformanceTelemetry.ts
+++ b/packages/sanity/src/core/studio/telemetry/useMeasurePerformanceTelemetry.ts
@@ -1,0 +1,61 @@
+import {useTelemetry} from '@sanity/telemetry/react'
+import {useCallback, useEffect} from 'react'
+
+import {PerformanceINPMeasured} from '../__telemetry__/performance.telemetry'
+
+function getElementIdentifier(node: Node | null) {
+  if (!node) {
+    return null
+  }
+  if (!(node instanceof Element)) {
+    return node.nodeName
+  }
+  // Note: Deliberately using classList instead of className here since className isn't always a string
+  // See https://developer.mozilla.org/en-US/docs/Web/API/Element/className#notes
+  const {nodeName, classList, id} = node
+  return (
+    nodeName.toLowerCase() +
+    (id ? `#${id}` : '') +
+    (classList ? `.${classList.value.replaceAll(' ', '.')}` : '')
+  )
+}
+
+function isPerformanceEventTiming(entry: PerformanceEntry): entry is PerformanceEventTiming {
+  return entry.entryType === 'event'
+}
+
+/**
+ * @internal
+ */
+export function useMeasurePerformanceTelemetry() {
+  const telemetry = useTelemetry()
+  const onEvent = useCallback(
+    (list: PerformanceObserverEntryList, observer: PerformanceObserver) => {
+      const entries = list.getEntries()
+
+      let maxEntry: PerformanceEventTiming | undefined = undefined
+      for (const entry of entries) {
+        if (!isPerformanceEventTiming(entry)) continue
+        if (entry.duration > (maxEntry?.duration || 0)) {
+          maxEntry = entry
+        }
+      }
+      if (!maxEntry) {
+        return
+      }
+      telemetry.log(PerformanceINPMeasured, {
+        target: getElementIdentifier(maxEntry.target),
+        interaction: maxEntry.name,
+        duration: maxEntry.duration,
+      })
+    },
+    [telemetry],
+  )
+  useEffect(() => {
+    const observer = new PerformanceObserver(onEvent)
+    observer.observe({type: 'event', buffered: true})
+    return () => {
+      observer.disconnect()
+    }
+  }, [onEvent])
+}

--- a/packages/sanity/src/core/studio/telemetry/useMeasurePerformanceTelemetry.ts
+++ b/packages/sanity/src/core/studio/telemetry/useMeasurePerformanceTelemetry.ts
@@ -52,8 +52,12 @@ export function useMeasurePerformanceTelemetry() {
     [telemetry],
   )
   useEffect(() => {
+    if (!('PerformanceObserver' in globalThis)) {
+      return
+    }
     const observer = new PerformanceObserver(onEvent)
     observer.observe({type: 'event', buffered: true})
+    // eslint-disable-next-line consistent-return
     return () => {
       observer.disconnect()
     }


### PR DESCRIPTION
### Description
Collects [INP](https://web.dev/articles/inp) (Interaction to Next Paint) telemetry from the field.

This adds a performance observer that samples INP at most every minute. In addition to the INP duration, we also log the interaction event target. Example payload:

```json
{
  "target": "input#myNumberField.Input-sc-h62wco-4.evDwFo",
  "attrs": {"testId":"number-input"},
  "interaction": "keydown",
  "duration": 160
}
```


### What to review
- Does the event definition look sane?
- Is the sample rate of 1 minute acceptable?

### Notes for release
n/a