### PR TITLE
chore(tests): add vision e2e tests

### DIFF
--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -736,6 +736,7 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
         ref={this._visionRoot}
         sizing="border"
         overflow="hidden"
+        data-testid="vision-root"
       >
         <Header paddingX={3} paddingY={2}>
           <Grid columns={[1, 4, 8, 12]}>
@@ -896,7 +897,11 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
                 maxSize={paneSizeOptions.maxSize}
                 primary="first"
               >
-                <InputContainer display="flex" ref={this._queryEditorContainer}>
+                <InputContainer
+                  display="flex"
+                  ref={this._queryEditorContainer}
+                  data-testid="vision-query-editor"
+                >
                   <Box flex={1}>
                     <InputBackgroundContainerLeft>
                       <Flex>
@@ -911,7 +916,11 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
                   </Box>
                 </InputContainer>
                 <InputContainer display="flex" ref={this._paramsEditorContainer}>
-                  <Card flex={1} tone={hasValidParams ? 'default' : 'critical'}>
+                  <Card
+                    flex={1}
+                    tone={hasValidParams ? 'default' : 'critical'}
+                    data-testid="params-editor"
+                  >
                     <InputBackgroundContainerLeft>
                       <Flex>
                         <StyledLabel muted>{t('params.label')}</StyledLabel>
@@ -996,7 +1005,7 @@ export class VisionGui extends PureComponent<VisionGuiProps, VisionGuiState> {
                 </InputContainer>
               </SplitPane>
             </Box>
-            <ResultOuterContainer direction="column">
+            <ResultOuterContainer direction="column" data-testid="vision-result">
               <ResultInnerContainer flex={1}>
                 <ResultContainer
                   flex={1}

--- a/test/e2e/tests/vision/utils.ts
+++ b/test/e2e/tests/vision/utils.ts
@@ -1,4 +1,4 @@
-import {type Page} from '@playwright/test'
+import {expect, type Page} from '@playwright/test'
 
 export function encodeQueryString(
   query: string,
@@ -22,16 +22,14 @@ export function encodeQueryString(
 export const openVisionTool = async (page: Page) => {
   await page.goto('/test/vision')
   // Wait for vision to be visible
-  await page.waitForSelector('[data-testid="vision-root"]', {
-    timeout: 30_000,
-  })
+  await expect(page.getByTestId('vision-root')).toBeVisible()
 }
 
 export const getVisionRegions = async (page: Page) => {
-  const queryEditorRegion = page.locator('[data-testid="vision-query-editor"]')
+  const queryEditorRegion = page.getByTestId('vision-query-editor')
   const queryEditor = queryEditorRegion.locator('.cm-content')
-  const paramsRegion = page.locator('[data-testid="params-editor"]')
+  const paramsRegion = page.getByTestId('params-editor')
   const paramsEditor = paramsRegion.locator('.cm-content')
-  const resultRegion = page.locator('[data-testid="vision-result"]')
+  const resultRegion = page.getByTestId('vision-result')
   return {queryEditorRegion, queryEditor, paramsRegion, paramsEditor, resultRegion}
 }

--- a/test/e2e/tests/vision/utils.ts
+++ b/test/e2e/tests/vision/utils.ts
@@ -1,0 +1,37 @@
+import {type Page} from '@playwright/test'
+
+export function encodeQueryString(
+  query: string,
+  params: Record<string, unknown> = {},
+  options: Record<string, string | string[]> = {},
+): string {
+  const searchParams = new URLSearchParams()
+  searchParams.set('query', query)
+
+  for (const [key, value] of Object.entries(params)) {
+    searchParams.set(`$${key}`, JSON.stringify(value))
+  }
+
+  for (const [key, value] of Object.entries(options)) {
+    if (value) searchParams.set(key, `${value}`)
+  }
+
+  return `?${searchParams}`
+}
+
+export const openVisionTool = async (page: Page) => {
+  await page.goto('/test/vision')
+  // Wait for vision to be visible
+  await page.waitForSelector('[data-testid="vision-root"]', {
+    timeout: 30_000,
+  })
+}
+
+export const getVisionRegions = async (page: Page) => {
+  const queryEditorRegion = page.locator('[data-testid="vision-query-editor"]')
+  const queryEditor = queryEditorRegion.locator('.cm-content')
+  const paramsRegion = page.locator('[data-testid="params-editor"]')
+  const paramsEditor = paramsRegion.locator('.cm-content')
+  const resultRegion = page.locator('[data-testid="vision-result"]')
+  return {queryEditorRegion, queryEditor, paramsRegion, paramsEditor, resultRegion}
+}

--- a/test/e2e/tests/vision/vision.spec.ts
+++ b/test/e2e/tests/vision/vision.spec.ts
@@ -94,9 +94,7 @@ test.describe('Vision', () => {
     // The query executes automatically when a url is pasted, so it should have results
     // Assert that the results are visible
     // It should find the book document assert that by checking the title and the id
-    await expect(resultRegion.getByText(bookTitle)).toBeVisible({
-      timeout: 10_000,
-    })
+    await expect(resultRegion.getByText(bookTitle)).toBeVisible()
     await expect(resultRegion.getByText(bookDocument._id)).toBeVisible()
   })
 

--- a/test/e2e/tests/vision/vision.spec.ts
+++ b/test/e2e/tests/vision/vision.spec.ts
@@ -1,0 +1,143 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+import {encodeQueryString, getVisionRegions, openVisionTool} from './utils'
+
+test.describe('Vision', () => {
+  test('should be possible to type an execute a query', async ({page, sanityClient}) => {
+    const bookTitle = 'Test Book'
+    const bookDocument = await sanityClient.create({
+      _type: 'book',
+      title: bookTitle,
+    })
+
+    await openVisionTool(page)
+    // Clears local storage
+    await page.evaluate(() => localStorage.clear())
+
+    const {queryEditor, paramsEditor, paramsRegion, resultRegion} = await getVisionRegions(page)
+
+    // Click to focus the editor
+    await queryEditor.click()
+
+    // Type text into the CodeMirror editor
+    const inputText = '*[_type == "book" && _id == $id]{_id, title}'
+    await queryEditor.fill(inputText)
+
+    // Assert that the text was correctly inserted
+    await expect(queryEditor).toHaveText(inputText)
+
+    const paramsInputText = JSON.stringify({id: bookDocument._id})
+    // Type text into the params editor
+    await paramsEditor.fill(paramsInputText.slice(0, -2))
+    // Error icon should be visible
+    await expect(paramsRegion.locator('[data-sanity-icon="error-outline"]')).toBeVisible()
+
+    // Fill the params editor with the correct text
+    await paramsEditor.fill(paramsInputText)
+    // Error icon should not be visible
+    await expect(paramsRegion.locator('[data-sanity-icon="error-outline"]')).not.toBeVisible()
+    // Assert that the text was correctly inserted
+    await expect(paramsEditor).toHaveText(paramsInputText)
+
+    // Find the button with the text "Fetch" and click it.
+    await page.locator('button').filter({hasText: 'Fetch'}).click()
+
+    // Assert that the results are visible
+    // It should find the book document assert that by checking the title and the id
+    await expect(resultRegion.getByText(bookTitle)).toBeVisible()
+    await expect(resultRegion.getByText(bookDocument._id)).toBeVisible()
+  })
+
+  test('should be possible to paste and parse a query', async ({
+    page,
+    context,
+    sanityClient,
+    browserName,
+  }) => {
+    // Firefox doesn't support pasting from the clipboard
+    test.skip(browserName === 'firefox')
+
+    const bookTitle = 'Test Book'
+    const bookDocument = await sanityClient.create({
+      _type: 'book',
+      title: bookTitle,
+    })
+
+    // Grant clipboard permissions before opening the page
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+
+    await openVisionTool(page)
+    const query = `*[_type == "book" && _id == $id]{_id, title}`
+    const params = {id: bookDocument._id}
+    const url = sanityClient.getUrl(
+      sanityClient.getDataUrl('query', encodeQueryString(query, params)),
+    )
+    await page.evaluate((text) => {
+      navigator.clipboard.writeText(text)
+    }, url)
+
+    const {queryEditor, paramsEditor, resultRegion, queryEditorRegion} =
+      await getVisionRegions(page)
+    await queryEditorRegion.click()
+    await queryEditor.focus()
+    // Paste the url into the query editor
+    await page.keyboard.press('Meta+V')
+    // Assert that the text was correctly inserted
+    await expect(queryEditor).toHaveText(query)
+
+    const paramsText = await paramsEditor.textContent()
+    const parsedParams = JSON.parse(paramsText || '{}')
+    expect(parsedParams).toHaveProperty('id', bookDocument._id)
+
+    // The query executes automatically when a url is pasted, so it should have results
+    // Assert that the results are visible
+    // It should find the book document assert that by checking the title and the id
+    await expect(resultRegion.getByText(bookTitle)).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(resultRegion.getByText(bookDocument._id)).toBeVisible()
+  })
+
+  test('should be possible to listen to changes', async ({page, _testContext, sanityClient}) => {
+    const bookTitle = 'Test Book'
+    const bookDocumentId = _testContext.getUniqueDocumentId()
+    await openVisionTool(page)
+    // Clears local storage
+    await page.evaluate(() => localStorage.clear())
+
+    const {queryEditor, resultRegion} = await getVisionRegions(page)
+
+    // Click to focus the editor
+    await queryEditor.click()
+
+    // Type text into the CodeMirror editor
+    const inputText = `*[_type == "book" && _id == "${bookDocumentId}"]`
+    await queryEditor.fill(inputText)
+    // Assert that the text was correctly inserted
+    await expect(queryEditor).toHaveText(inputText)
+
+    // sleep for a bit so the text is part of the query, there is nothing in the ui to show that the text has been inserted
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    // Find the button with the text "Fetch" and click it.
+    await page.locator('button').filter({hasText: 'Listen'}).click()
+
+    // Wait until the listener is active
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    await sanityClient.create({
+      _type: 'book',
+      title: bookTitle,
+      _id: bookDocumentId,
+    })
+
+    // Assert that the results are visible
+    await expect(resultRegion.getByText(bookTitle)).toBeVisible()
+    await expect(resultRegion.getByText(`documentId:${bookDocumentId}`)).toBeVisible()
+
+    // Stop the listener
+    await page.locator('button').filter({hasText: 'Stop'}).click()
+    await expect(page.locator('button').filter({hasText: 'Listen'})).toBeVisible()
+  })
+})

--- a/test/e2e/tests/vision/vision.spec.ts
+++ b/test/e2e/tests/vision/vision.spec.ts
@@ -81,8 +81,9 @@ test.describe('Vision', () => {
       await getVisionRegions(page)
     await queryEditorRegion.click()
     await queryEditor.focus()
-    // Paste the url into the query editor
-    await page.keyboard.press('Meta+V')
+    // // Paste the url into the query editor
+    await page.keyboard.press('ControlOrMeta+V')
+
     // Assert that the text was correctly inserted
     await expect(queryEditor).toHaveText(query)
 


### PR DESCRIPTION
### Description
Adds e2e tests for vision.
This branch https://github.com/sanity-io/sanity/pull/8879 is changing vision to a functional component.
So having some e2e tests for the basics functionality before merging the refactor is a nice thing to do and get some extra security.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
