### PR TITLE
fix(core): update `resolveTypeForDocument` query

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/resolveTypeForDocument.ts
+++ b/packages/sanity/src/core/store/_legacy/document/resolveTypeForDocument.ts
@@ -1,6 +1,5 @@
 import {type SanityClient} from '@sanity/client'
 import {type Observable, of} from 'rxjs'
-import {map} from 'rxjs/operators'
 
 import {getPublishedId} from '../../../util'
 
@@ -14,15 +13,13 @@ export function resolveTypeForDocument(
     return of(specifiedType)
   }
 
-  const query = '*[sanity::versionOf($publishedId)]._type'
+  const query = '*[sanity::versionOf($publishedId)][0]._type'
 
-  return client.observable
-    .fetch(
-      query,
-      {publishedId: getPublishedId(id)},
-      {
-        tag: 'document.resolve-type',
-      },
-    )
-    .pipe(map((types) => types[0]))
+  return client.observable.fetch(
+    query,
+    {publishedId: getPublishedId(id)},
+    {
+      tag: 'document.resolve-type',
+    },
+  )
 }

--- a/packages/sanity/src/structure/structureBuilder/util/resolveTypeForDocument.ts
+++ b/packages/sanity/src/structure/structureBuilder/util/resolveTypeForDocument.ts
@@ -5,13 +5,13 @@ export async function resolveTypeForDocument(
   getClient: (options: SourceClientOptions) => SanityClient,
   id: string,
 ): Promise<string | undefined> {
-  const query = '*[sanity::versionOf($publishedId)]._type'
+  const query = '*[sanity::versionOf($publishedId)][0]._type'
 
-  const types = await getClient(DEFAULT_STUDIO_CLIENT_OPTIONS).fetch(
+  const type = await getClient(DEFAULT_STUDIO_CLIENT_OPTIONS).fetch(
     query,
     {publishedId: getPublishedId(id)},
     {tag: 'structure.resolve-type'},
   )
 
-  return types[0]
+  return type
 }


### PR DESCRIPTION
### Description
Follow up from https://github.com/sanity-io/sanity/pull/8962, comments added here https://github.com/sanity-io/sanity/pull/8962#pullrequestreview-2691121032

Instead of using a query that returns an array with types, use groq to get only the first type instead of doing it client side.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
