### PR TITLE
feat(core): add version to documents when creating with a release pinned

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
@@ -6,6 +6,7 @@ import {useIntentLink} from 'sanity/router'
 import {Tooltip} from '../../../../../ui-components'
 import {InsufficientPermissionsMessage} from '../../../../components'
 import {useI18nText} from '../../../../i18n'
+import {usePerspective} from '../../../../perspective/usePerspective'
 import {type NewDocumentOption, type PreviewLayout} from './types'
 
 // This value is used to calculate the max-height of the popover and for the virtual list item size.
@@ -23,9 +24,10 @@ interface NewDocumentListOptionProps {
 
 export function NewDocumentListOption(props: NewDocumentListOptionProps) {
   const {option, currentUser, onClick, preview} = props
+  const {selectedReleaseId} = usePerspective()
   const params = useMemo(
-    () => ({template: option.templateId, type: option.schemaType}),
-    [option.schemaType, option.templateId],
+    () => ({template: option.templateId, type: option.schemaType, version: selectedReleaseId}),
+    [option.schemaType, option.templateId, selectedReleaseId],
   )
   const {onClick: onIntentClick, href} = useIntentLink({
     intent: 'create',


### PR DESCRIPTION
### Description
This Pr adds the `version` to the intent link generated when the user clicks to create a new document from the Studio Navbar **New document** button.

Now, if you have a release pinned, that release will follow you in the creation of the document.
We do this by assigning the `version` parameter to the link, in the same way as in **[PaneHeaderCreateButton](https://github.com/sanity-io/sanity/blob/next/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx#L43)**

https://github.com/user-attachments/assets/25f7c10d-48f0-4d53-8330-8a965151cc53


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->



### What to review


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Pin a release, click on **new document**, the document should be added as part of the release.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
If the user has a release pinned, when creating a new document from the studio navbar, the document will be created as part of the release.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
