### PR TITLE
fix(test): updates flaky imageArrayDraft pte test

### DIFF
--- a/test/e2e/tests/pte/ImageArrayDrag.spec.ts
+++ b/test/e2e/tests/pte/ImageArrayDrag.spec.ts
@@ -1,47 +1,72 @@
+import {createReadStream} from 'node:fs'
+import path from 'node:path'
+
 import {expect} from '@playwright/test'
+import {type SanityImageAssetDocument} from '@sanity/client'
 import {test} from '@sanity/test'
 
-test('Portable Text Input - Array Input of images dragging an image will not trigger range out of bounds (toast)', async ({
-  page,
-  createDraftDocument,
-}) => {
-  await createDraftDocument('/test/content/input-standard;portable-text;pt_allTheBellsAndWhistles')
-
-  // set up the portable text editor
-  await page.getByTestId('field-body').focus()
-  await page.getByTestId('field-body').click()
-
-  page.on('dialog', async () => {
-    await expect(page.getByTestId('insert-menu-auto-collapse-menu')).toBeVisible()
+test.describe('Portable Text Input - ImageArrayDraft', () => {
+  let uploadedAsset: SanityImageAssetDocument
+  test.beforeAll(async ({sanityClient}) => {
+    const asset = await sanityClient.assets.upload(
+      'image',
+      createReadStream(path.join(__dirname, '..', '..', 'resources', 'capybara.jpg')),
+      {
+        filename: 'image-array-drag.jpg',
+        title: 'image-array-drag',
+      },
+    )
+    uploadedAsset = asset
   })
 
-  // open the insert menu
-  await page
-    .getByTestId('insert-menu-auto-collapse-menu')
-    .getByRole('button', {name: 'Insert Image slideshow (block)'})
-    .click()
+  test.afterAll(async ({sanityClient}) => {
+    await sanityClient.delete(uploadedAsset._id)
+  })
 
-  // set up for the PTE block
-  await page.getByRole('button', {name: 'Add item'}).click()
-  await page.getByTestId('file-input-multi-browse-button').click()
-  await page.getByTestId('file-input-browse-button-sanity-default').click()
+  test('Portable Text Input - Array Input of images dragging an image will not trigger range out of bounds (toast)', async ({
+    page,
+    createDraftDocument,
+  }) => {
+    await createDraftDocument(
+      '/test/content/input-standard;portable-text;pt_allTheBellsAndWhistles',
+    )
 
-  // grab an image
-  await page.getByRole('button', {name: 'capybara.jpg'}).click()
-  await page.getByLabel('Edit Image With Caption').getByLabel('Close dialog').click()
+    // set up the portable text editor
+    await page.getByTestId('field-body').focus()
+    await page.getByTestId('field-body').click()
 
-  // grab drag element in array element
-  await page.locator("[data-sanity-icon='drag-handle']").hover()
+    page.on('dialog', async () => {
+      await expect(page.getByTestId('insert-menu-auto-collapse-menu')).toBeVisible()
+    })
 
-  // drag and drop element
-  await page.mouse.down()
-  await page.getByRole('button', {name: 'Add item'}).hover()
-  await page.mouse.up()
+    // open the insert menu
+    await page
+      .getByTestId('insert-menu-auto-collapse-menu')
+      .getByRole('button', {name: 'Insert Image slideshow (block)'})
+      .click()
 
-  await page.locator(
-    `:has-text("Failed to execute 'getRangeAt' on 'Selection': 0 is not a valid index.']`,
-  )
+    // set up for the PTE block
+    await page.getByRole('button', {name: 'Add item'}).click()
+    await page.getByTestId('file-input-multi-browse-button').click()
+    await page.getByTestId('file-input-browse-button-sanity-default').click()
 
-  // check that the alert is not visible
-  await expect(await page.getByRole('alert').locator('div').nth(1)).not.toBeVisible()
+    // grab an image
+    await page.getByRole('button', {name: uploadedAsset.originalFilename}).click()
+    await page.getByLabel('Edit Image With Caption').getByLabel('Close dialog').click()
+
+    // grab drag element in array element
+    await page.locator("[data-sanity-icon='drag-handle']").hover()
+
+    // drag and drop element
+    await page.mouse.down()
+    await page.getByRole('button', {name: 'Add item'}).hover()
+    await page.mouse.up()
+
+    await page.locator(
+      `:has-text("Failed to execute 'getRangeAt' on 'Selection': 0 is not a valid index.']`,
+    )
+
+    // check that the alert is not visible
+    await expect(await page.getByRole('alert').locator('div').nth(1)).not.toBeVisible()
+  })
 })


### PR DESCRIPTION
### Description
The PTE image array test [tries to use a file ](https://github.com/sanity-io/sanity/blob/next/test/e2e/tests/pte/ImageArrayDrag.spec.ts#L30)that is added by another [test](https://github.com/sanity-io/sanity/blob/next/test/e2e/tests/inputs/array.spec.ts#L9), and it always fails on the first pass. 

With this changes, the test is responsible for adding the file, so it can run in isolation, without reusing files added by other tests, which could exist or not at the time this test runs.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
