### PR TITLE
fix(cli): respect cli config for http host/port

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/app/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/devAction.ts
@@ -10,8 +10,8 @@ import {getCoreAppURL, getDevServerConfig, type StartDevServerCommandFlags} from
 function parseCliFlags(args: {argv?: string[]}) {
   // Using slice(1) to remove the first argument, which is the command `dev` path to the CLI
   return yargs(hideBin(args.argv || process.argv).slice(1))
-    .options('host', {type: 'string', default: 'localhost'})
-    .options('port', {type: 'number', default: 3333})
+    .options('host', {type: 'string'})
+    .options('port', {type: 'number'})
     .options('load-in-dashboard', {type: 'boolean', default: true}).argv
 }
 

--- a/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
@@ -46,8 +46,8 @@ export const getCoreAppURL = ({
 function parseCliFlags(args: {argv?: string[]}) {
   // Using slice(1) to remove the first argument, which is the command `dev` path to the CLI
   return yargs(hideBin(args.argv || process.argv).slice(1))
-    .options('host', {type: 'string', default: 'localhost'})
-    .options('port', {type: 'number', default: 3333})
+    .options('host', {type: 'string'})
+    .options('port', {type: 'number'})
     .option('load-in-dashboard', {type: 'boolean', default: false}).argv
 }
 


### PR DESCRIPTION
### Description

Fixes a regression in 3.80.0 where the host/port CLI flags would get default values if not provided, but would be treated as explicitly set. The result is that they took precedent over both env vars and CLI config values, which they should do _if explicitly passed_, but not if they are the fallback values.

### What to review

- Using `http.port`/`http.host` in `sanity.cli.ts` still works.

### Testing

Would be ideal to get a test in here, but hotfixing for now

### Notes for release

- Fixes a regression in 3.80.0 causing http host/port configured in environment variables/CLI configuration not to be respected by the `dev` command
