### PR TITLE
fix(core): use publishedId for search intent links

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
@@ -43,7 +43,11 @@ export function SearchResultItem({
   const schema = useSchema()
   const type = schema.get(documentType)
   const documentPresence = useDocumentPresence(documentId)
-  const params = useMemo(() => ({id: documentId, type: type?.name}), [documentId, type?.name])
+  const params = useMemo(
+    () => ({id: getPublishedId(documentId), type: type?.name}),
+    [documentId, type?.name],
+  )
+
   const {onClick: onIntentClick, href} = useIntentLink({
     intent: 'edit',
     params,


### PR DESCRIPTION
### Description
Use `publishedId` for search intent links, in some cases, using a draft id could lead to not finding the document.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
fixes an issue in where sometimes navigating to a draft document from the search dialog was not working

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
