### PR TITLE
chore: add simple e2e presentation test

### DIFF
--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -3,6 +3,7 @@ import {googleMapsInput} from '@sanity/google-maps-input'
 import {BookIcon} from '@sanity/icons'
 import {visionTool} from '@sanity/vision'
 import {defineConfig} from 'sanity'
+import {presentationTool} from 'sanity/presentation'
 import {structureTool} from 'sanity/structure'
 import {markdownSchema} from 'sanity-plugin-markdown'
 import {media} from 'sanity-plugin-media'
@@ -68,6 +69,14 @@ export default defineConfig({
       title: 'Content',
       structure,
       defaultDocumentNode,
+    }),
+    presentationTool({
+      name: 'presentation',
+      title: 'Presentation',
+      previewUrl: {
+        origin: 'https://test-studio.sanity.dev',
+        preview: '/preview/index.html',
+      },
     }),
     languageFilter({
       defaultLanguages: ['nb'],

--- a/packages/sanity/src/presentation/PresentationTool.tsx
+++ b/packages/sanity/src/presentation/PresentationTool.tsx
@@ -499,7 +499,7 @@ export default function PresentationTool(props: {
         <PresentationNavigateProvider navigate={navigate}>
           <PresentationParamsProvider params={params}>
             <SharedStateProvider comlink={visualEditingComlink}>
-              <Container height="fill">
+              <Container data-testid="presentation-root" height="fill">
                 <Panels>
                   <PresentationNavigator />
                   <Panel

--- a/test/e2e/tests/presentation/presentation.spec.ts
+++ b/test/e2e/tests/presentation/presentation.spec.ts
@@ -1,0 +1,15 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+import {getPresentationRegions, openPresentationTool} from './utils'
+
+test.describe('Presentation', () => {
+  test('should be able to load a simple preview', async ({page}) => {
+    await openPresentationTool(page)
+
+    const {previewIframeContents} = await getPresentationRegions(page)
+
+    // Checks that the preview iframe has loaded visual editing
+    await expect(previewIframeContents.locator('sanity-visual-editing')).toBeAttached()
+  })
+})

--- a/test/e2e/tests/presentation/utils.ts
+++ b/test/e2e/tests/presentation/utils.ts
@@ -1,0 +1,14 @@
+import {expect, type Page} from '@playwright/test'
+
+export async function openPresentationTool(page: Page): Promise<void> {
+  await page.goto('/test/presentation')
+  // Wait for presentation to be visible
+  await expect(page.getByTestId('presentation-root')).toBeVisible()
+}
+
+export async function getPresentationRegions(page: Page) {
+  const root = page.getByTestId('presentation-root')
+  const previewIframe = root.locator('iframe')
+  const previewIframeContents = previewIframe.first().contentFrame()
+  return {root, previewIframe, previewIframeContents}
+}


### PR DESCRIPTION
### Description

After merging #8299 the Presentation [test workspace](https://test-studio-jw4ozwi1o.sanity.dev/presentation/presentation) started crashing. [The build just prior works fine.](https://test-studio-5h0wzd5p4.sanity.dev/presentation/presentation)
Turns out the root cause is `@sanity/assist`, fixed here: https://github.com/sanity-io/assist/pull/64
To avoid breaking the test workspace in the future I'm adding a very simple E2E test. I'll be expanding the test suite over time, this is just to catch simple crash cases like this.
This PR should have a failing test until #8983 is merged, which upgrades `@sanity/assist` with the required fix.

### What to review

Does it make sense? I followed the same pattern as the new Vision Tool tests ✨ 

### Testing

If it passes it works (after #8983, before that it should fail consistently).

### Notes for release

N/A