### PR TITLE
fix(test): update flaky navbar test

### DIFF
--- a/packages/sanity/src/core/tasks/plugin/TasksStudioNavbar.tsx
+++ b/packages/sanity/src/core/tasks/plugin/TasksStudioNavbar.tsx
@@ -21,6 +21,7 @@ const TasksToolbar = ({onClick, isOpen}: {onClick: () => void; isOpen: boolean})
       mode="bleed"
       onClick={onClick}
       selected={isOpen}
+      data-testid="tasks-toolbar"
     />
   )
 }

--- a/test/e2e/tests/default-layout/navbar.spec.ts
+++ b/test/e2e/tests/default-layout/navbar.spec.ts
@@ -5,9 +5,11 @@ test.describe('@sanity/default-layout: Navbar', () => {
     await page.goto(baseURL ?? '')
   })
 
-  test('should show Help & Resource Menu', async ({page, browserName}) => {
-    // For now, only test in Chromium due to flakiness in Firefox and WebKit
-    test.skip(browserName !== 'chromium')
+  test('should show Help & Resource Menu', async ({page}) => {
+    await expect(page.getByTestId('studio-navbar')).toBeVisible()
+
+    // Wait for tasks toolbar to be visible, when this is rendered it re renders the navbar. Causing flakiness in the next assertion
+    await expect(page.getByTestId('tasks-toolbar')).toBeVisible()
 
     await expect(page.getByLabel('Help and resources')).toBeVisible()
 
@@ -16,9 +18,5 @@ test.describe('@sanity/default-layout: Navbar', () => {
     await page.getByLabel('Help and resources').click()
 
     await expect(page.getByTestId('menu-button-resources')).toBeVisible()
-  })
-
-  test('render ActionModal on top of pane headers in structure tool', async ({page}) => {
-    await expect(page.locator('data-testid=studio-navbar')).toBeVisible()
   })
 })


### PR DESCRIPTION
### Description
By inspecting the video in the flaky navbar test I think the issue is caused because the navbar is recreated when tasks plugin is injected.
Tasks do an async check to verify if it is enabled or not, using the `useFeatureEnabled('sanityTasks')` check.
This needs some time to resolve, my theory is the following:

- The studio renders.
- The navbar is shown and the test clicks on the button to show the help resources popover.
- **useFeatureEnabled** resolves and says tasks are enabled.
- The navbar is recreated because now we need to inject the tasks button. ([see this](https://github.com/sanity-io/sanity/blob/fix-flaky-navbar-spec/packages/sanity/src/core/tasks/plugin/TasksStudioNavbar.tsx#L77-L85))
- The popover is now closed because the navbar was recreated

This is visible on this video, in the first seconds after the studio loads the popover shows for a microsecond and then it disappears.
| Renders popover | Taks is added, popover disappears |
|--------|--------|
|<img width="600" alt="Screenshot 2025-03-19 at 12 40 24" src="https://github.com/user-attachments/assets/a6186fa0-eecf-4bf6-b4e6-b1cbb824acab" /> | <img width="600" alt="Screenshot 2025-03-19 at 12 40 30" src="https://github.com/user-attachments/assets/6c4f5812-f846-449a-8f4c-cec627e53307" />| 


**Video:**
[bf757adebb91ad63aadced8e9d58cd453620b5e4.webm](https://github.com/user-attachments/assets/081215ec-451b-4912-95f6-247c41ccac0e)

This also removes a test that was just checking for the navbar to exist and moves it to the navbar test.
 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Do tests pass on first pass?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
