### PR TITLE
fix: no releases screen shows the create release dialog

### DIFF
--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -445,10 +445,10 @@ export function ReleasesOverview() {
                 )}
               </Box>
             </Flex>
-            {renderCreateReleaseDialog()}
           </>
         )}
       </Flex>
+      {renderCreateReleaseDialog()}
     </Flex>
   )
 }


### PR DESCRIPTION
### Description
| Before | After |
|--------|--------|
| ![noReleaseBEFORE](https://github.com/user-attachments/assets/fddddeef-db89-44c2-b6ff-c517fc22e9d9) | ![noReleasesNEW](https://github.com/user-attachments/assets/76e9c556-a394-4c42-9df7-90e271999709) | 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes issue in Releases Tool so that creating first release shows the create release dialog
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
