### PR TITLE
fix(presentation): previewUrl is required

### DIFF
--- a/packages/sanity/src/presentation/types.ts
+++ b/packages/sanity/src/presentation/types.ts
@@ -168,7 +168,7 @@ export interface PresentationPluginOptions {
     mainDocuments?: DocumentResolver[]
     locations?: DocumentLocationResolvers | DocumentLocationResolver
   }
-  previewUrl?: PreviewUrlOption
+  previewUrl: PreviewUrlOption
   components?: {
     unstable_header?: HeaderOptions
     unstable_navigator?: NavigatorOptions


### PR DESCRIPTION
### Description

The `previewUrl` option is actually required, but the `presentationTool` typings mark it as optional.

### Notes for release

The `previewUrl` option is now marked as required in the `presentationTool` typings, matching the fact that it's required at runtime.