### PR TITLE
fix(core): drop explicit `withCredentials` on requests

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -71,7 +71,6 @@ const getCurrentUser = async (
   try {
     const user = await client.request({
       uri: '/users/me',
-      withCredentials: true,
       tag: 'users.get-current',
     })
 
@@ -159,8 +158,7 @@ export function _createAuthStore({
         dataset,
         apiVersion: '2021-06-07',
         useCdn: false,
-        ...(token && {token}),
-        withCredentials: true,
+        ...(token ? {token} : {withCredentials: true}),
         perspective: 'raw',
         requestTagPrefix: 'sanity.studio',
         ignoreBrowserTokenWarning: true,
@@ -238,12 +236,12 @@ export function _createAuthStore({
   }
 
   async function logout() {
+    const token = getToken(projectId)
     const requestClient = clientFactory({
       projectId,
       dataset,
       useCdn: true,
-      withCredentials: true,
-      token: getToken(projectId) ?? undefined,
+      ...(token ? {token} : {withCredentials: true}),
       apiVersion: '2021-06-07',
       requestTagPrefix: 'sanity.studio',
       ...hostOptions,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/utils/fetchFeatureToggle.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/utils/fetchFeatureToggle.ts
@@ -26,7 +26,6 @@ function createFeatureToggle(client: SanityClient) {
       client.observable
         .request({
           uri: `/data/actions/${dataset}`,
-          withCredentials: true,
         })
         .pipe(
           mapResponse(),

--- a/packages/sanity/src/core/store/_legacy/grants/__tests__/createGrantsStore.test.ts
+++ b/packages/sanity/src/core/store/_legacy/grants/__tests__/createGrantsStore.test.ts
@@ -20,7 +20,7 @@ function createMockClient(data: {requests?: Record<string, any>} = {}): SanityCl
   const mockClient = {
     config: () => mockConfig,
     withConfig: () => mockClient,
-    request: vi.fn((opts: {uri: string; tag?: string; withCredentials: boolean}) => {
+    request: vi.fn((opts: {uri: string; tag?: string; withCredentials?: boolean}) => {
       const path = opts.uri.slice(requestUriPrefix.length)
 
       if (data?.requests?.[path]) {
@@ -65,7 +65,6 @@ describe('checkDocumentPermission', () => {
         {
           tag: 'acl.get',
           uri: '/projects/mock-project-id/datasets/mock-data-set/acl',
-          withCredentials: true,
         },
       ],
     ])

--- a/packages/sanity/src/core/store/_legacy/grants/grantsStore.ts
+++ b/packages/sanity/src/core/store/_legacy/grants/grantsStore.ts
@@ -24,7 +24,6 @@ async function getDatasetGrants(
   const grants: Grant[] = await client.request({
     uri: `/projects/${projectId}/datasets/${dataset}/acl`,
     tag: 'acl.get',
-    withCredentials: true,
   })
 
   return grants

--- a/packages/sanity/src/core/store/_legacy/user/__tests__/userStore.test.ts
+++ b/packages/sanity/src/core/store/_legacy/user/__tests__/userStore.test.ts
@@ -114,7 +114,6 @@ describe('userStore', () => {
       expect(client.request).toHaveBeenLastCalledWith({
         uri: `/users/${lastBatch.join(',')}`,
         tag: 'users.get',
-        withCredentials: true,
       })
     })
   })

--- a/packages/sanity/src/core/store/_legacy/user/userStore.ts
+++ b/packages/sanity/src/core/store/_legacy/user/userStore.ts
@@ -40,7 +40,6 @@ export function createUserStore({client: _client, currentUser}: UserStoreOptions
     async (userIds) => {
       const value = await client.request<(User | null)[]>({
         uri: `/users/${userIds.join(',')}`,
-        withCredentials: true,
         tag: 'users.get',
       })
       const response = Array.isArray(value) ? value : [value]

--- a/packages/sanity/src/core/store/key-value/storage/serverStorage.ts
+++ b/packages/sanity/src/core/store/key-value/storage/serverStorage.ts
@@ -26,7 +26,6 @@ export function createServerStorage({client: _client}: ServerStorageOptions): Se
     const value = await client
       .request<KeyValuePair[]>({
         uri: `/users/me/keyvalue/${keys.join(',')}`,
-        withCredentials: true,
       })
       .catch((error) => {
         console.error('Error fetching data:', error)
@@ -56,7 +55,6 @@ export function createServerStorage({client: _client}: ServerStorageOptions): Se
         method: 'PUT',
         uri: `/users/me/keyvalue`,
         body: [{key, value: nextValue}],
-        withCredentials: true,
       })
       .then(
         (response) => {

--- a/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
+++ b/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
@@ -41,7 +41,6 @@ function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
         projectId,
         requestTagPrefix: 'sanity.studio',
         useCdn: false,
-        withCredentials: true,
       })
 
       return client

--- a/packages/sanity/test/mocks/mockSanityClient.ts
+++ b/packages/sanity/test/mocks/mockSanityClient.ts
@@ -103,7 +103,7 @@ export function createMockSanityClient(
 
     withConfig: () => mockClient,
 
-    request: (opts: {uri: string; tag?: string; withCredentials: boolean}) => {
+    request: (opts: {uri: string; tag?: string; withCredentials?: boolean}) => {
       $log.request.push(opts)
 
       if (opts.uri.startsWith(requestUriPrefix)) {
@@ -147,7 +147,7 @@ export function createMockSanityClient(
         return of({type: 'welcome'})
       },
 
-      request: (opts: {uri: string; tag?: string; withCredentials: boolean}) => {
+      request: (opts: {uri: string; tag?: string; withCredentials?: boolean}) => {
         // console.log('mockSanityClient.observable.request', opts)
 
         $log.observable.request.push(opts)

--- a/test/e2e/tests/desk/documentTypeListContextMenu.spec.ts
+++ b/test/e2e/tests/desk/documentTypeListContextMenu.spec.ts
@@ -18,7 +18,6 @@ test('clicking default sort order and direction sets value in storage', async ({
 
   const existingKeys = await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
     uri: `/users/me/keyvalue/${SORT_KEY}`,
-    withCredentials: true,
   })
 
   // If the value is not null there are existingKeys, delete them in that case
@@ -26,7 +25,6 @@ test('clicking default sort order and direction sets value in storage', async ({
     // Clear the sort order
     await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
       uri: `/users/me/keyvalue/${SORT_KEY}`,
-      withCredentials: true,
       method: 'DELETE',
     })
   }
@@ -74,7 +72,6 @@ test('clicking custom sort order and direction sets value in storage', async ({
 
   const existingKeys = await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
     uri: `/users/me/keyvalue/${CUSTOM_SORT_KEY}`,
-    withCredentials: true,
   })
 
   // If the value is not null there are existingKeys, delete them in that case
@@ -82,7 +79,6 @@ test('clicking custom sort order and direction sets value in storage', async ({
     // Clear the sort order
     await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
       uri: `/users/me/keyvalue/${CUSTOM_SORT_KEY}`,
-      withCredentials: true,
       method: 'DELETE',
     })
   }
@@ -112,7 +108,6 @@ test('clicking list view sets value in storage', async ({page, sanityClient}) =>
 
   const existingKeys = await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
     uri: `/users/me/keyvalue/${LAYOUT_KEY}`,
-    withCredentials: true,
   })
 
   // If the value is not null there are existingKeys, delete them in that case
@@ -120,7 +115,6 @@ test('clicking list view sets value in storage', async ({page, sanityClient}) =>
     // Clear the sort order
     await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
       uri: `/users/me/keyvalue/${LAYOUT_KEY}`,
-      withCredentials: true,
       method: 'DELETE',
     })
   }

--- a/test/e2e/tests/navbar/search.spec.ts
+++ b/test/e2e/tests/navbar/search.spec.ts
@@ -12,7 +12,6 @@ test('searching creates unique saved searches', async ({
 
   const existingKeys = await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
     uri: `/users/me/keyvalue/${SEARCH_KEY}.${dataset}`,
-    withCredentials: true,
   })
 
   // If the value is not null there are existingKeys, delete them in that case
@@ -20,7 +19,6 @@ test('searching creates unique saved searches', async ({
     // Clear the sort order
     await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
       uri: `/users/me/keyvalue/${SEARCH_KEY}.${dataset}`,
-      withCredentials: true,
       method: 'DELETE',
     })
   }


### PR DESCRIPTION
### Description

Two changes:
1. Only provide `withCredentials: true` to client constructor if we are not using a token. If we have a token, we don't _also_ want to send a cookie, as this is both unnecessary (it's likely not there, given we are using a token), and might include irrelevant cookies that were mistakenly attached to the `.sanity.io` domain. 
2. Providing `withCredentials: true` to the client's `.request()` _shouldn't_ be necessary unless the base client for the source does _not_ do so. While it traditionally hasn't been a problem, we want to discourage this pattern as it is confusing: what happens if both an auth cookie and an `authorization` header is provided? While the answer in our case is that the `authorization` header wins, this is not necessarily obvious, and can make things harder to debug.

By moving to an explicit "EITHER bearer token OR session cookie" implementation, things are made a bit clearer. Note that this also aligns with this [upcoming change](https://github.com/sanity-io/client/pull/1037) in the client and silences what will in the future be a warning being printed.

### What to review

All code paths modified still work as expected. I am relying on the previous authors to verify this, as I do not have the full context of why `withCredentials` was included in the first place.

### Testing

Sufficient testing should hopefully already be in place :) 

### Notes for release

None
