### PR TITLE
chore: add presentation to regular workspace

### DIFF
--- a/dev/test-studio/preview/FieldGroups.tsx
+++ b/dev/test-studio/preview/FieldGroups.tsx
@@ -20,7 +20,7 @@ export function FieldGroups(): React.JSX.Element {
       } | null
     }[]
   >(
-    /* groq */ `*[_type == "fieldGroupsWithFieldsetsHidden"]{_id,field1,field2,nested{field3,field4,field5,nested{field6,field7,field8}}}`,
+    /* groq */ `*[_type == "fieldGroupsWithFieldsetsHidden"][0..10]{_id,field1,field2,nested{field3,field4,field5,nested{field6,field7,field8}}}`,
   )
 
   if (error) {

--- a/dev/test-studio/preview/SimpleBlockPortableText.tsx
+++ b/dev/test-studio/preview/SimpleBlockPortableText.tsx
@@ -28,7 +28,9 @@ export function SimpleBlockPortableText(): React.JSX.Element {
       body: PortableTextBlock[]
       notes: {_key: string; title?: string; minutes?: number; notes?: PortableTextBlock[]}[]
     }[]
-  >(/* groq */ `*[_type == "simpleBlock"]{_id,title,"bodyString":pt::text(body),body,notes}`)
+  >(
+    /* groq */ `*[_type == "simpleBlock"] | order(_updatedAt desc)[0..10]{_id,title,"bodyString":pt::text(body),body,notes}`,
+  )
 
   if (error) {
     throw error

--- a/dev/test-studio/preview/loader.tsx
+++ b/dev/test-studio/preview/loader.tsx
@@ -4,17 +4,10 @@ import {createQueryStore} from '@sanity/react-loader'
 
 const client = createClient({
   projectId: 'ppsg7ml5',
-  dataset: 'playground',
+  dataset: 'test',
   useCdn: true,
-  apiVersion: 'X',
-  stega: {
-    enabled: true,
-    studioUrl: '/presentation',
-    // logger: console,
-    filter: (props) => {
-      return props.filterDefault(props)
-    },
-  },
+  apiVersion: '2025-03-19',
+  stega: {enabled: true, studioUrl: '/presentation'},
 })
 
 export const {useQuery, useLiveMode} = createQueryStore({client})

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -108,6 +108,13 @@ const sharedSettings = definePlugin({
       structure,
       defaultDocumentNode,
     }),
+    debugSecrets(),
+    presentationTool({
+      previewUrl: {preview: '/preview/index.html'},
+      resolve: {
+        locations: {simpleBlock: defineLocations({locations: [{title: 'Home', href: '/'}]})},
+      },
+    }),
     languageFilter({
       defaultLanguages: ['nb'],
       supportedLanguages: [
@@ -363,31 +370,5 @@ export default defineConfig([
         input: StegaDebugger,
       },
     },
-  },
-  {
-    name: 'presentation',
-    title: 'Presentation Studio',
-    projectId: 'ppsg7ml5',
-    dataset: 'playground',
-    plugins: [
-      debugSecrets(),
-      presentationTool({
-        name: 'presentation',
-        title: 'Presentation',
-        previewUrl: {
-          preview: '/preview/index.html',
-        },
-        resolve: {
-          locations: {
-            simpleBlock: defineLocations({
-              locations: [{title: 'Home', href: '/'}],
-            }),
-          },
-        },
-      }),
-      assist(),
-      sharedSettings(),
-    ],
-    basePath: '/presentation',
   },
 ]) as WorkspaceOptions[]


### PR DESCRIPTION
### Description

Just adds the Presentation Tool to the regular workspace so it's a bit easier to work with and expand the complexity of the integration tests.

### What to review

Makes sense?

### Testing

Click around on http://localhost:3333/test/presentation and it should work like it did on http://localhost:3333/presentation/presentation

### Notes for release

N/A
