### PR TITLE
fix(sanity): treat releases as inactive if releases tool not present

### DIFF
--- a/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
@@ -2,7 +2,7 @@ import {Card} from '@sanity/ui'
 import {styled} from 'styled-components'
 
 import {usePerspective} from '../../perspective/usePerspective'
-import {useWorkspace} from '../../studio'
+import {useReleasesToolAvailable} from '../../releases/hooks/useReleasesToolAvailable'
 import {ReleasesToolLink} from '../ReleasesToolLink'
 import {CurrentGlobalPerspectiveLabel} from './currentGlobalPerspectiveLabel'
 import {GlobalPerspectiveMenu} from './GlobalPerspectiveMenu'
@@ -32,17 +32,16 @@ const ReleasesNavContainer = styled(Card)`
   }
 `
 export function ReleasesNav(): React.JSX.Element {
-  const areReleasesEnabled = !!useWorkspace().releases?.enabled
-
+  const releasesToolAvailable = useReleasesToolAvailable()
   const {selectedPerspective, selectedReleaseId} = usePerspective()
 
   return (
     <ReleasesNavContainer flex="none" tone="inherit" radius="full" data-ui="ReleasesNav" border>
-      {areReleasesEnabled && <ReleasesToolLink />}
+      {releasesToolAvailable && <ReleasesToolLink />}
       <CurrentGlobalPerspectiveLabel selectedPerspective={selectedPerspective} />
       <GlobalPerspectiveMenu
         selectedReleaseId={selectedReleaseId}
-        areReleasesEnabled={areReleasesEnabled}
+        areReleasesEnabled={releasesToolAvailable}
       />
     </ReleasesNavContainer>
   )

--- a/packages/sanity/src/core/releases/hooks/useReleasesToolAvailable.ts
+++ b/packages/sanity/src/core/releases/hooks/useReleasesToolAvailable.ts
@@ -1,0 +1,18 @@
+import {useMemo} from 'react'
+
+import {useWorkspace} from '../../studio/workspace'
+import {releasesToolAvailable} from '../util/releasesToolAvailable'
+
+/**
+ * Determine whether the releases tool is available in the current workspace.
+ *
+ * This check is performed on the available tools, rather than the enabled status of the releases
+ * feature itself. This caters to scenarios in which releases are enabled for the workspace, but the
+ * release tool was later removed (e.g. using a workspace tool filter).
+ *
+ * @internal
+ */
+export function useReleasesToolAvailable(): boolean {
+  const workspace = useWorkspace()
+  return useMemo(() => releasesToolAvailable(workspace), [workspace])
+}

--- a/packages/sanity/src/core/releases/plugin/ReleasesStudioLayout.tsx
+++ b/packages/sanity/src/core/releases/plugin/ReleasesStudioLayout.tsx
@@ -1,12 +1,12 @@
 import {type LayoutProps} from '../../config'
-import {useWorkspace} from '../../studio'
 import {ReleasesMetadataProvider} from '../contexts/ReleasesMetadataProvider'
 import {ReleasesUpsellProvider} from '../contexts/upsell/ReleasesUpsellProvider'
+import {useReleasesToolAvailable} from '../hooks/useReleasesToolAvailable'
 
 export function ReleasesStudioLayout(props: LayoutProps) {
-  const isReleasesEnabled = !!useWorkspace().releases?.enabled
+  const releasesToolAvailable = useReleasesToolAvailable()
 
-  if (!isReleasesEnabled) {
+  if (!releasesToolAvailable) {
     return props.renderDefault(props)
   }
 

--- a/packages/sanity/src/core/releases/util/releasesToolAvailable.ts
+++ b/packages/sanity/src/core/releases/util/releasesToolAvailable.ts
@@ -1,0 +1,15 @@
+import {type Workspace} from '../../config/types'
+import {RELEASES_TOOL_NAME} from '../plugin'
+
+/**
+ * Determine whether the releases tool is available in the provided workspace.
+ *
+ * This check is performed on the available tools, rather than the enabled status of the releases
+ * feature itself. This caters to scenarios in which releases are enabled for a workspace, but the
+ * release tool was later removed (e.g. using a workspace tool filter).
+ *
+ * @internal
+ */
+export function releasesToolAvailable(workspace: Workspace): boolean {
+  return workspace.tools.some(({name}) => name === RELEASES_TOOL_NAME)
+}

--- a/packages/sanity/src/core/scheduledPublishing/tool/Tool.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/tool/Tool.tsx
@@ -5,6 +5,7 @@ import {type RouterContextValue, useRouter} from 'sanity/router'
 import {styled} from 'styled-components'
 
 import {LoadingBlock} from '../../components/loadingBlock/LoadingBlock'
+import {useReleasesToolAvailable} from '../../releases/hooks/useReleasesToolAvailable'
 import {useWorkspace} from '../../studio/workspace'
 import ErrorCallout from '../components/errorCallout/ErrorCallout'
 import InfoCallout from '../components/infoCallout/InfoCallout'
@@ -35,7 +36,7 @@ const DATE_SLUG_FORMAT = 'yyyy-MM-dd' // date-fns format
 export default function Tool() {
   const router = useRouter()
   const {scheduledPublishing, releases} = useWorkspace()
-  const isReleasesEnabled = Boolean(releases?.enabled)
+  const releasesToolAvailable = useReleasesToolAvailable()
 
   const {sanity: theme} = useTheme()
   const {error, isInitialLoading, schedules = NO_SCHEDULE} = usePollSchedules()
@@ -107,7 +108,7 @@ export default function Tool() {
 
   return (
     <SchedulesProvider value={schedulesContext}>
-      {isReleasesEnabled && scheduledPublishing.showReleasesBanner && <WarningBanner />}
+      {releasesToolAvailable && scheduledPublishing.showReleasesBanner && <WarningBanner />}
       <Flex direction="column" height="fill" flex={1} overflow="hidden">
         <Flex flex={1} height="fill">
           {/* LHS Column */}


### PR DESCRIPTION
### Description

There are various parts of the codebase that rely on `releases.enabled` from the workspace configuration to determine whether releases—and the releases tool—are available. This check fails when `releases.enabled` is `true`, but the releases tool is later removed (e.g. in the workspace tool filter).

In this scenario, Studio crashes because `ReleasesNav` attempts to generate a link to the nonexistent releases tool.

This branch fixes the problem by instead basing the availability of releases on the presence of the releases tool in the workspace.

### What to review

The parts of the UI that rely on this check correctly respond to the presence of the releases tool.

### Testing

Tested manually by adding the following `tool` filter to `defaultWorkspace` in Test Studio:

```ts
{
  tools: (prev) => prev.filter((tool) => tool.name !== 'releases'),
}
```

Also verified this works as expected when removing the tool filter and setting `releases.enabled` to `false`.

### Notes for release

Fixes a bug causing Studio to crash with error `Unable to find matching route for state` when the releases tool is not present (e.g. when the workspace tools filter removes it).