### PR TITLE
fix(cli): use outpath as package name for apps

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapLocalTemplate.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import chalk from 'chalk'
+import {deburr} from 'lodash'
 
 import {debug} from '../../debug'
 import {studioDependencies} from '../../studioDependencies'
@@ -113,10 +114,21 @@ export async function bootstrapLocalTemplate(
     {} as Record<string, string>,
   )
 
+  let packageJsonName: string = packageName
+
+  /**
+   * Currently app init doesn't ask for a name, so we use the last part of the path
+   */
+  if (isAppTemplate) {
+    packageJsonName = deburr(path.basename(outputPath).toLowerCase())
+      .replace(/\s+/g, '-')
+      .replace(/[^a-z0-9-]/g, '')
+  }
+
   // Now create a package manifest (`package.json`) with the merged dependencies
   spinner = output.spinner('Creating default project files').start()
   const packageManifest = await createPackageManifest({
-    name: packageName,
+    name: packageJsonName,
     dependencies,
     devDependencies,
     scripts: template.scripts,


### PR DESCRIPTION
### Description

This PR fixes an issue with the app template initialization process. Currently, when using the app template, the CLI doesn't ask for a package name, resulting in potentially invalid package names in the generated `package.json` file.

The change adds logic to derive a valid package name from the output path when using an app template. It:
- Uses the last part of the output path as the base for the package name
- Removes diacritical marks using lodash's `deburr`
- Converts to lowercase
- Replaces spaces with hyphens
- Removes any characters that aren't lowercase letters, numbers, or hyphens

### What to review

- The new logic for generating package names for app templates
- Verify that the generated package names follow npm naming conventions
- Check that the original behavior for non-app templates remains unchanged

### Testing

Tested by initializing projects with app templates in directories with various naming patterns, including spaces, uppercase characters, and special characters. Verified that the resulting package names in the generated `package.json` files were valid according to npm naming conventions.

### Notes for release

N/A