### PR TITLE
fix(presentation): use `perspectiveStack` when resolving main document

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -12,7 +12,7 @@ import {debugSecrets} from '@sanity/preview-url-secret/sanity-plugin-debug-secre
 import {tsdoc} from '@sanity/tsdoc/studio'
 import {visionTool} from '@sanity/vision'
 import {defineConfig, definePlugin, type WorkspaceOptions} from 'sanity'
-import {defineLocations, presentationTool} from 'sanity/presentation'
+import {defineDocuments, defineLocations, presentationTool} from 'sanity/presentation'
 import {structureTool} from 'sanity/structure'
 import {imageHotspotArrayPlugin} from 'sanity-plugin-hotspot-array'
 import {markdownSchema} from 'sanity-plugin-markdown'
@@ -112,6 +112,12 @@ const sharedSettings = definePlugin({
     presentationTool({
       previewUrl: {preview: '/preview/index.html'},
       resolve: {
+        mainDocuments: defineDocuments([
+          {
+            route: '/preview/index.html',
+            filter: `_type == "simpleBlock" && isMain`,
+          },
+        ]),
         locations: {simpleBlock: defineLocations({locations: [{title: 'Home', href: '/'}]})},
       },
     }),

--- a/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
+++ b/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
@@ -41,6 +41,10 @@ export default defineType({
       type: 'string',
     },
     {
+      name: 'isMain',
+      type: 'boolean',
+    },
+    {
       name: 'body',
       title: 'Body',
       type: 'array',

--- a/packages/sanity/src/presentation/editor/usePreviewState.ts
+++ b/packages/sanity/src/presentation/editor/usePreviewState.ts
@@ -5,6 +5,7 @@ import {
   type PreviewValue,
   type SanityDocument,
   useDocumentPreviewStore,
+  usePerspective,
 } from 'sanity'
 
 interface PreviewState {
@@ -15,7 +16,7 @@ interface PreviewState {
 export default function usePreviewState(documentId: string, schemaType?: SchemaType): PreviewState {
   const documentPreviewStore = useDocumentPreviewStore()
   const [preview, setPreview] = useState<PreviewState>({})
-
+  const {perspectiveStack} = usePerspective()
   useEffect(() => {
     if (!schemaType) {
       return undefined
@@ -24,6 +25,7 @@ export default function usePreviewState(documentId: string, schemaType?: SchemaT
       documentPreviewStore,
       schemaType,
       documentId,
+      perspectiveStack,
     ).subscribe((state) => {
       setPreview(state)
     })
@@ -31,7 +33,7 @@ export default function usePreviewState(documentId: string, schemaType?: SchemaT
     return () => {
       subscription?.unsubscribe()
     }
-  }, [documentPreviewStore, schemaType, documentId])
+  }, [documentPreviewStore, schemaType, documentId, perspectiveStack])
 
   return preview
 }


### PR DESCRIPTION
### Description
Fixes https://github.com/sanity-io/sanity/issues/8986

This PR adds the `perspectiveStack` to the `useMainDocument` get function, allowing presentation to get the correct document when using a perspective.
If not, if the document doesn't exist as a draft it won't be shown as the main document.

It also fixes an issue with the preview for the main document shown in the presentation list to also respect the perspective.

See video for example:

https://github.com/user-attachments/assets/8e858b9c-2ecf-4e84-9904-2ab6934f7bd4


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Are the changes correct?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open our presentation studio, a main document should load.
If you add a main document to another release, then it should be respected when visiting the page.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in where main documents won't be accurately displayed if they only exist as part of a release.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
