### PR TITLE
feat(sanity): make initial value template resolution interruptible

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -306,6 +306,7 @@
     "@types/resolve-from": "^4.0.0",
     "@types/semver": "^6.2.3",
     "@types/tar-fs": "^2.0.1",
+    "@types/wicg-task-scheduling": "^2024.1.0",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/expect": "^3.0.8",
     "@vvo/tzdb": "6.137.0",

--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -43,6 +43,7 @@ import {isPublishedPerspective, isReleaseScheduledOrScheduling} from '../release
 import {
   type DocumentPresence,
   type EditStateFor,
+  type InitialValueState,
   type PermissionCheckResult,
   useDocumentValuePermissions,
   usePresenceStore,
@@ -64,7 +65,7 @@ interface DocumentFormOptions {
   documentType: string
   documentId: string
   releaseId?: ReleaseId
-  initialValue?: SanityDocumentLike
+  initialValue?: InitialValueState
   initialFocusPath?: Path
   selectedPerspectiveName?: ReleaseId | 'published'
   readOnly?: boolean | ((editState: EditStateFor) => boolean)
@@ -192,7 +193,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
   }, [comparisonValueRaw, editState])
 
   const value: SanityDocumentLike = useMemo(() => {
-    const baseValue = initialValue || {_id: documentId, _type: documentType}
+    const baseValue = initialValue?.value || {_id: documentId, _type: documentType}
     if (releaseId) {
       return editState.version || editState.draft || editState.published || baseValue
     }
@@ -269,7 +270,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
   const isNonExistent = !value?._id
   const isCreateLinked = isSanityCreateLinkedDocument(value)
 
-  const ready = connectionState === 'connected' && editState.ready
+  const ready = connectionState === 'connected' && editState.ready && !initialValue?.loading
 
   const selectedPerspective = useMemo(() => {
     return getSelectedPerspective(selectedPerspectiveName, releases)
@@ -382,7 +383,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
           telemetry.log(CreatedDraft)
         }
 
-        patch.execute(toMutationPatches(event.patches), initialValue)
+        patch.execute(toMutationPatches(event.patches), initialValue?.value)
       }
     }
   }, [

--- a/packages/sanity/src/core/store/_legacy/document/initialValue/initialValue.ts
+++ b/packages/sanity/src/core/store/_legacy/document/initialValue/initialValue.ts
@@ -76,7 +76,7 @@ export function getInitialValueStream(
 
       if (!opts.templateName) {
         // @todo: Make sure this is the correct behavior
-        return of({isResolving: false, initialValue: undefined})
+        return of({isResolving: false, initialValue: undefined, type: 'success'})
       }
 
       const template = initialValueTemplates.find((t) => t.id === opts.templateName)
@@ -84,7 +84,7 @@ export function getInitialValueStream(
       if (!template) {
         // eslint-disable-next-line no-console
         console.warn('Template "%s" not defined, using empty initial value', opts.templateName)
-        return of({isResolving: false, initialValue: undefined})
+        return of({isResolving: false, initialValue: undefined, type: 'success'})
       }
 
       const initialValueWithParams$ = from(

--- a/packages/sanity/src/core/store/_legacy/document/useInitialValue.ts
+++ b/packages/sanity/src/core/store/_legacy/document/useInitialValue.ts
@@ -39,12 +39,6 @@ export function useInitialValue(props: {
 
   useEffect(() => {
     const initialValueOptions = {documentId, documentType, templateName, templateParams}
-
-    if (!templateName) {
-      setState({loading: true, error: null, value: defaultValue})
-      return undefined
-    }
-
     const initialValueMsg$ = documentStore.initialValue(initialValueOptions, context)
 
     const sub = initialValueMsg$.subscribe((msg) => {

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.tsx
@@ -62,7 +62,17 @@ const TasksFormBuilderInner = ({
     collapsedPaths,
     schemaType,
     value,
-  } = useDocumentForm({documentId, documentType: 'tasks.task', initialValue})
+  } = useDocumentForm({
+    documentId,
+    documentType: 'tasks.task',
+    initialValue: initialValue
+      ? {
+          loading: false,
+          value: initialValue,
+          error: null,
+        }
+      : undefined,
+  })
 
   const isLoading = formState === null || !ready
 

--- a/packages/sanity/src/core/templates/resolve.ts
+++ b/packages/sanity/src/core/templates/resolve.ts
@@ -229,11 +229,11 @@ export const resolveInitialValueForType = memoizeResolveInitialValueForType(
     }
 
     if (isObjectSchemaType(type)) {
-      return resolveInitialObjectValue(type, params, maxDepth, context, options)
+      return postTask(() => resolveInitialObjectValue(type, params, maxDepth, context, options))
     }
 
     if (isArraySchemaType(type)) {
-      return resolveInitialArrayValue(type, params, maxDepth, context, options)
+      return postTask(() => resolveInitialArrayValue(type, params, maxDepth, context, options))
     }
 
     return resolveValue(type.initialValue, params, context, options)
@@ -306,4 +306,18 @@ export async function resolveInitialObjectValue<Params extends Record<string, un
   }
 
   return merged
+}
+
+/**
+ * Schedule the provided callback using `scheduler.postTask`, if it's available.
+ * Otherwise, call it immediately.
+ */
+function postTask<Result>(
+  callback: () => Result,
+  options: PostTaskOptions = {},
+): Result | Promise<Result> {
+  if ('scheduler' in window && typeof window.scheduler?.postTask === 'function') {
+    return window.scheduler.postTask(callback, options)
+  }
+  return callback()
 }

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -201,7 +201,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   } = useDocumentForm({
     documentType,
     documentId,
-    initialValue: initialValue.value,
+    initialValue: initialValue,
     comparisonValue: getComparisonValue,
     releaseId: selectedReleaseId,
     selectedPerspectiveName,

--- a/packages/sanity/tsconfig.settings.json
+++ b/packages/sanity/tsconfig.settings.json
@@ -15,8 +15,13 @@
       "sanity/structure": ["./src/_exports/structure.ts"],
       "sanity": ["./src/_exports/index.ts"]
     },
-    // vite/client: For import.meta.env/import.meta.hot definition and similar
-    // @testing-library/jest-dom: @testing-library DOM matchers for vitest (toBeInTheDocument etc)
-    "types": ["vite/client", "@testing-library/jest-dom"]
+    "types": [
+      // vite/client: For import.meta.env/import.meta.hot definition and similar
+      "vite/client",
+      // @testing-library/jest-dom: @testing-library DOM matchers for vitest (toBeInTheDocument etc)
+      "@testing-library/jest-dom",
+      // For `Scheduler` API (can be removed if we adopt scheduler-polyfill, which comes with its own types)
+      "@types/wicg-task-scheduling"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1812,6 +1812,9 @@ importers:
       '@types/tar-fs':
         specifier: ^2.0.1
         version: 2.0.4
+      '@types/wicg-task-scheduling':
+        specifier: ^2024.1.0
+        version: 2024.1.0
       '@vitest/expect':
         specifier: 3.0.9
         version: 3.0.9
@@ -5270,6 +5273,9 @@ packages:
 
   '@types/which@2.0.2':
     resolution: {integrity: sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==}
+
+  '@types/wicg-task-scheduling@2024.1.0':
+    resolution: {integrity: sha512-9g5QVDU8Na3P6rPMbyYx5pS8UpGDfzys8T7Xq5HMTbI7elSq/YioGbBVAh2u67JGNTThZ3o9PK0/qBvaVOYPYQ==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -16108,6 +16114,8 @@ snapshots:
   '@types/validate-npm-package-name@3.0.3': {}
 
   '@types/which@2.0.2': {}
+
+  '@types/wicg-task-scheduling@2024.1.0': {}
 
   '@types/yargs-parser@21.0.3': {}
 

--- a/test/e2e/tests/comments/inline.spec.ts
+++ b/test/e2e/tests/comments/inline.spec.ts
@@ -27,9 +27,9 @@ async function inlineCommentCreationTest(props: InlineCommentCreationTestProps) 
   // 3. Select all text in the editor.
   await page.waitForSelector('[data-testid="pt-editor"]', WAIT_OPTIONS)
   const editor = page.locator('[data-testid="pt-editor"]')
-  await page.waitForSelector('div[role="textbox"]', WAIT_OPTIONS)
-  const textBox = editor.locator('div[role="textbox"]')
-  textBox.selectText()
+  await page.waitForSelector('div[role="textbox"][contenteditable=true]', WAIT_OPTIONS)
+  const textBox = editor.locator('div[role="textbox"][contenteditable=true]')
+  await textBox.selectText()
 
   // 4. Click on the floating comment button to start authoring a comment.
   await page.waitForSelector('[data-testid="inline-comment-button"]', {


### PR DESCRIPTION
### Description

When schemas have many initial value templates, or long initial value templates, the main thread may become blocked while these are resolved. When examining performance in a Studio affected by this issue, you will likely see the browser cumulatively spends a lot of time executing the `resolveInitialObjectValue` function.

This branch improves the situation by using [the Prioritized Task Scheduling API](https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) to break initial value template resolution into smaller tasks that the browser can coordinate without blocking the main thread.

Not only does this keep the UI responsive while initial value templates are being resolved, but it appears the browser is able to coordinate the work more efficiently. **Users who previously reported creating a new document to be unusably slow reported that this change resolved the issue.**

Note: it would be great to spend some time investigating whether we can speed the resolution process up, perhaps making this mitigation unnecessary.

#### Changes to document editor read-only state

This branch updates the document editor such that it's rendered in a read-only state while the document's initial value is resolved. I suspect it's an oversight that this wasn't already the case; what's the expected behaviour if the initial value resolves _after_ the user has modified the new document?

#### Prioritized Task Scheduling API polyfill

The Prioritized Task Scheduling API is not yet supported by all browsers. I created a small `postTask` helper function that executes the provided callback immediately if the Prioritized Task Scheduling API is not available. **We know that some of the users most severely affected by the issue are using web browsers that support Prioritized Task Scheduling**.

We will follow this change up by adding a polyfill or a fallback strategy. I have started work on including a polyfill in #9024.

### What to review

- Does the general approach seem sound?
- Do you have any concerns about the changes made in order for the document editor to be read-only while the initial value template resolves?

### Testing

- Initial value template resolution is already well-tested, and these existing tests continue to pass.
- Manually tested using a contrived large schema.
- Manually tested using a user-supplied real-world large schema.
- Manually tested by affected users.