### PR TITLE
fix(core): hide discard changes action when published

### DIFF
--- a/packages/sanity/src/core/scheduledPublishing/plugin/documentActions/schedule/index.ts
+++ b/packages/sanity/src/core/scheduledPublishing/plugin/documentActions/schedule/index.ts
@@ -1,9 +1,16 @@
-import {type DocumentActionComponent} from '../../../../config'
+import {type DocumentActionComponent, type DocumentActionsContext} from '../../../../config'
 import {ScheduleAction} from './ScheduleAction'
 
 type Action = DocumentActionComponent
 
-export default function resolveDocumentActions(existingActions: Action[]): Action[] {
+export default function resolveDocumentActions(
+  existingActions: Action[],
+  context: DocumentActionsContext,
+): Action[] {
+  if (context.versionType === 'published') {
+    return existingActions
+  }
+
   // Add schedule action after default publish action
   const index = existingActions.findIndex((a) => a.action === 'publish')
   if (index < 0) {

--- a/packages/sanity/src/core/scheduledPublishing/plugin/index.ts
+++ b/packages/sanity/src/core/scheduledPublishing/plugin/index.ts
@@ -26,7 +26,7 @@ export const scheduledPublishing = definePlugin({
   name: SCHEDULED_PUBLISHING_NAME,
 
   document: {
-    actions: (prev) => resolveDocumentActions(prev),
+    actions: (prev, context) => resolveDocumentActions(prev, context),
     badges: (prev) => resolveDocumentBadges(prev),
   },
 

--- a/packages/sanity/src/structure/documentActions/DiscardChangesAction.tsx
+++ b/packages/sanity/src/structure/documentActions/DiscardChangesAction.tsx
@@ -6,6 +6,7 @@ import {
   type DocumentActionComponent,
   type DocumentActionDialogProps,
   InsufficientPermissionsMessage,
+  isPublishedId,
   useCurrentUser,
   useDocumentOperation,
   useDocumentPairPermissions,
@@ -13,6 +14,7 @@ import {
 } from 'sanity'
 
 import {structureLocaleNamespace} from '../i18n'
+import {useDocumentPane} from '../panes/document/useDocumentPane'
 
 const DISABLED_REASON_KEY = {
   NO_CHANGES: 'action.discard-changes.disabled.no-change',
@@ -38,8 +40,10 @@ export const DiscardChangesAction: DocumentActionComponent = ({
     permission: 'discardDraft',
   })
   const currentUser = useCurrentUser()
+  const {displayed} = useDocumentPane()
 
   const {t} = useTranslation(structureLocaleNamespace)
+  const isPublished = displayed?._id && isPublishedId(displayed?._id)
 
   const handleConfirm = useCallback(() => {
     discardChanges.execute()
@@ -63,7 +67,7 @@ export const DiscardChangesAction: DocumentActionComponent = ({
   )
 
   return useMemo(() => {
-    if (!published || liveEdit) {
+    if (!published || liveEdit || isPublished) {
       return null
     }
 
@@ -94,6 +98,7 @@ export const DiscardChangesAction: DocumentActionComponent = ({
     discardChanges.disabled,
     handle,
     isPermissionsLoading,
+    isPublished,
     liveEdit,
     permissions?.granted,
     published,


### PR DESCRIPTION
### Description

- [x] Hide "Discard Changes" when Published is Displayed
- [x] Hide "Schedule" from ScheduledPlugin when Published is Displayed 

### What to review

Does this make sense?

### Testing

Currently we don't have tests for this

### Notes for release

Hide "Discard Changes" and "Schedule" actions from the document actions when the displayed document is the published
