### PR TITLE
fix: archived releases table has default sort and defined sort working

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -117,8 +117,10 @@ const TableInner = <TableData, AdditionalRowTableData>({
 
       const [aValue, bValue]: (number | string)[] = [a, b].map(
         (sortValue) =>
-          sortColumn?.sortTransform?.(sortValue as RowDatum<TableData, AdditionalRowTableData>) ??
-          get(sortValue, sort.column),
+          sortColumn?.sortTransform?.(
+            sortValue as RowDatum<TableData, AdditionalRowTableData>,
+            sort.direction,
+          ) ?? get(sortValue, sort.column),
       )
       if (
         typeof aValue === 'string' &&
@@ -175,7 +177,10 @@ const TableInner = <TableData, AdditionalRowTableData>({
   )
 
   const amalgamatedColumnDefs = useMemo(
-    () => (rowActions ? [...columnDefs, rowActionColumnDef] : columnDefs),
+    () =>
+      (rowActions ? [...columnDefs, rowActionColumnDef] : columnDefs).filter(
+        (column) => !column.hidden,
+      ),
     [columnDefs, rowActionColumnDef, rowActions],
   )
 

--- a/packages/sanity/src/core/releases/tool/components/Table/TableHeader.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/TableHeader.tsx
@@ -4,6 +4,7 @@ import {motion} from 'framer-motion'
 import {useMemo} from 'react'
 
 import {Button, type ButtonProps} from '../../../../../ui-components'
+import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {useTableContext} from './TableProvider'
 import {type HeaderProps, type TableHeaderProps} from './types'
 
@@ -52,6 +53,7 @@ const TableHeaderSearch = ({
   searchDisabled,
   placeholder,
 }: HeaderProps & {placeholder?: string}) => {
+  const {t} = useTranslation()
   const {setSearchTerm, searchTerm} = useTableContext()
 
   return (
@@ -60,7 +62,7 @@ const TableHeaderSearch = ({
         border={false}
         fontSize={1}
         icon={SearchIcon}
-        placeholder={placeholder || 'Search'}
+        placeholder={placeholder || t('search.placeholder')}
         radius={3}
         value={searchTerm || ''}
         disabled={searchDisabled}
@@ -88,18 +90,21 @@ export const TableHeader = ({headers, searchDisabled}: TableHeaderProps) => {
         )`,
         }}
       >
-        {headers.map(({header: Header, style, width, id, sorting}) => (
-          <Header
-            key={String(id)}
-            headerProps={{
-              as: 'th',
-              id: String(id),
-              style: {...style, width: width || undefined},
-            }}
-            header={{id, sorting}}
-            searchDisabled={searchDisabled}
-          />
-        ))}
+        {headers.map(
+          ({header: Header, style, width, id, sorting}) =>
+            !!Header && (
+              <Header
+                key={String(id)}
+                headerProps={{
+                  as: 'th',
+                  id: String(id),
+                  style: {...style, width: width || undefined},
+                }}
+                header={{id, sorting}}
+                searchDisabled={searchDisabled}
+              />
+            ),
+        )}
       </Flex>
     </Card>
   )

--- a/packages/sanity/src/core/releases/tool/components/Table/TableProvider.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/TableProvider.tsx
@@ -1,9 +1,11 @@
 import {type ComponentType, type PropsWithChildren, useCallback, useContext, useState} from 'react'
 import {TableContext} from 'sanity/_singletons'
 
+import {type SortDirection} from './types'
+
 export interface TableSort {
   column: string
-  direction: 'asc' | 'desc'
+  direction: SortDirection
 }
 
 /**

--- a/packages/sanity/src/core/releases/tool/components/Table/types.ts
+++ b/packages/sanity/src/core/releases/tool/components/Table/types.ts
@@ -6,19 +6,33 @@ export interface InjectedTableProps {
   style: {width?: number}
 }
 
-export interface Column<TableData = unknown> {
-  header: (props: HeaderProps) => React.JSX.Element
+export type SortDirection = 'asc' | 'desc'
+
+interface BaseColumn<TableData = unknown> {
+  id: keyof TableData | string
+  width: number | null
+  style?: CSSProperties
+  sorting?: boolean
+  sortTransform?: (value: TableData, sortDirection: SortDirection) => number | string
+}
+
+export interface HiddenColumn<TableData = unknown> extends BaseColumn<TableData> {
+  hidden: true
+  cell?: undefined
+  header?: undefined
+}
+
+export interface VisibleColumn<TableData = unknown> extends BaseColumn<TableData> {
+  hidden?: false
   cell: (props: {
     datum: TableData & {isLoading?: boolean}
     cellProps: InjectedTableProps
     sorting: boolean
   }) => React.ReactNode
-  id: keyof TableData | string
-  width: number | null
-  style?: CSSProperties
-  sorting?: boolean
-  sortTransform?: (value: TableData) => number | string
+  header: (props: HeaderProps) => React.JSX.Element
 }
+
+export type Column<TableData = unknown> = HiddenColumn<TableData> | VisibleColumn<TableData>
 
 export interface TableHeaderProps {
   headers: Omit<Column, 'cell'>[]

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -50,7 +50,7 @@ export interface TableRelease extends ReleaseDocument {
 
 const DEFAULT_RELEASES_OVERVIEW_SORT: TableSort = {column: 'publishAt', direction: 'asc'}
 const DEFAULT_ARCHIVED_RELEASES_OVERVIEW_SORT: TableSort = {
-  column: 'publishedAt',
+  column: 'lastActivity',
   direction: 'desc',
 }
 // eslint-disable-next-line max-statements

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -90,11 +90,32 @@ export const releasesOverviewColumnDefs: (
       },
       'active',
     ),
+    // This is a hidden column only used for sorting when
+    // no other sort column is selected (the default state)
+    checkColumnMode(
+      {
+        id: 'lastActivity',
+        hidden: true,
+        sorting: true,
+        width: 100,
+        sortTransform: ({publishedAt, _updatedAt}) => {
+          // the default sort is always descending, so -Infinity pushes missing values to end
+          const lastActivity = publishedAt ?? _updatedAt
+
+          return lastActivity ? new Date(lastActivity).getTime() : -Infinity
+        },
+      },
+      'archived',
+    ),
     checkColumnMode(
       {
         id: 'publishedAt',
         sorting: true,
-        sortTransform: (release) => {
+        sortTransform: (release, direction) => {
+          if (release.state !== 'published') {
+            if (direction === 'asc') return Infinity
+            return -Infinity
+          }
           if (!release.publishedAt) return release._updatedAt
           return new Date(release.publishedAt).getTime()
         },
@@ -125,8 +146,12 @@ export const releasesOverviewColumnDefs: (
       {
         id: '_updatedAt',
         sorting: true,
-        sortTransform: (release) => {
-          if (release.state !== 'archived') return Infinity
+        sortTransform: (release, direction) => {
+          if (release.state !== 'archived') {
+            if (direction === 'asc') return Infinity
+            return -Infinity
+          }
+
           return new Date(release._updatedAt).getTime()
         },
         width: 250,

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseName.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseName.tsx
@@ -15,10 +15,13 @@ import {releasesLocaleNamespace} from '../../../i18n'
 import {getReleaseIdFromReleaseDocumentId} from '../../../util/getReleaseIdFromReleaseDocumentId'
 import {getReleaseTone} from '../../../util/getReleaseTone'
 import {type TableRowProps} from '../../components/Table/Table'
-import {type Column} from '../../components/Table/types'
+import {type VisibleColumn} from '../../components/Table/types'
 import {type TableRelease} from '../ReleasesOverview'
 
-export const ReleaseNameCell: Column<TableRelease>['cell'] = ({cellProps, datum: release}) => {
+export const ReleaseNameCell: VisibleColumn<TableRelease>['cell'] = ({
+  cellProps,
+  datum: release,
+}) => {
   const router = useRouter()
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: tCore} = useTranslation()


### PR DESCRIPTION
### Description
* Default sorting on a hidden column - which sorts by either `_updatedAt` or `publishedAt` depending on which is available 
* When sorting by published, all archived releases are at the end of the list, when sorting by archived, all published releases are at the end of the list

| Scenario | Before | After |
|--------|--------|--------|
| Default sort | ![defaultSortOLD](https://github.com/user-attachments/assets/8f0fe13c-e816-4e08-bc05-c8b269e8c677) | ![defaultSortNEW](https://github.com/user-attachments/assets/154414e6-22ce-4ae5-8e5e-79e0aa26ee8b) |
| Published at sort | ![publishedSortOLD](https://github.com/user-attachments/assets/90696bd6-4340-4ad3-bd56-42c215d32715) | ![publishedSortNEW](https://github.com/user-attachments/assets/c41cf07f-c32d-4328-9d6a-039eda45d93e) |
| Archived at sort | ![archivedSortOLD](https://github.com/user-attachments/assets/23147940-aaa6-4382-a08a-2567e2a61d8e) | ![ArchivedSortNEW](https://github.com/user-attachments/assets/1a1b88d2-4891-4979-bcfc-36024f337b96) | 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Supporting `hidden` columns in the `Table` - this is a bit of a hack just to support this particular case (where we want the default sorting to be across multiple columns. An alternative abstraction would be to move a function for default sorting out to the `Table` prop surface, but given the `Table` is only used within releases in 2 locations, going to those extents doesn't seem appropriate.
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
No new tests added, as Table isn't currently covered by tests
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fix for incorrect ordering when sorting archived and published releases in the Content Releases tool
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
