### PR TITLE
fix(test): don't export `isNavigateOptions` 

### DIFF
--- a/packages/sanity/src/router/index.ts
+++ b/packages/sanity/src/router/index.ts
@@ -5,7 +5,28 @@ export * from './RouterProvider'
 export * from './RouteScope'
 export * from './StateLink'
 export * from './stickyParams'
-export * from './types'
+export type {
+  BaseIntentParams,
+  IntentJsonParams,
+  IntentParameters,
+  InternalSearchParam,
+  MatchError,
+  MatchOk,
+  MatchResult,
+  NavigateBaseOptions,
+  NavigateOptions,
+  NavigateOptionsWithState,
+  NextStateOrOptions,
+  Route,
+  RouteChildren,
+  Router,
+  RouterContextValue,
+  RouterNode,
+  RouterState,
+  RouteSegment,
+  RouteTransform,
+  SearchParam,
+} from './types'
 export * from './useIntentLink'
 export * from './useLink'
 export * from './useRouter'

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -338,10 +338,6 @@ export type SearchParam = [key: string, value: string]
  */
 export type RouterState = Record<string, unknown> & {_searchParams?: SearchParam[]}
 
-/**
- * Guard to check if an argument is NavigateOptions with optional state
- * @internal
- */
 export const isNavigateOptions = (
   maybeNavigateOptions: unknown,
 ): maybeNavigateOptions is NavigateOptions & {state?: RouterState | null} =>


### PR DESCRIPTION
### Description
After merging https://github.com/sanity-io/sanity/pull/9006 a new exports snapshot test was added.
this PR https://github.com/sanity-io/sanity/pull/8620 is exporting a new function, given it didn't have the tests on that branch, it was not notified about the new test and the snapshot was not updated.

This PR updates the snapshot to include this new function
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
