### PR TITLE
fix(core): increase the window interfac for when the sidebar for the task is hovering

### DIFF
--- a/packages/sanity/src/core/tasks/plugin/TasksStudioActiveToolLayout.tsx
+++ b/packages/sanity/src/core/tasks/plugin/TasksStudioActiveToolLayout.tsx
@@ -14,7 +14,7 @@ const VARIANTS: Variants = {
 const TRANSITION: Transition = {duration: 0.2}
 
 const FULLSCREEN_MEDIA_INDEX = 1
-const POSITION_ABSOLUTE_MEDIA_INDEX = 2
+const POSITION_ABSOLUTE_MEDIA_INDEX = 3
 
 const RootFlex = styled(Flex)(({theme}) => {
   const media = theme.sanity.media


### PR DESCRIPTION
### Description

Withe the releases update, responsive wise it looks like the "triggering" for the hovering taskbar sidebar to becoming floating comes too late. With this update, instead of making it floating by the 900px breakpoint, it will make it by 1200px. 

This will impact all areas of the studio, instead of just the releases page, however, I think this is an acceptable thing given that the task sidebar should likely not take as important a real-estate as the "main" opened things in the studio

| Month    | Savings |
| -------- | ------- |
| <img width="998" alt="image" src="https://github.com/user-attachments/assets/64a04b6f-e99d-4626-a6d0-a490064d1c63" />  |  <img width="998" alt="image" src="https://github.com/user-attachments/assets/5809256c-b066-4dd4-a782-34623062019c" />   |

### What to review

Is there a better way of going about this?

### Testing

N/A

### Notes for release

N/A
