### PR TITLE
fix(core): update document status indicator colors

### DIFF
--- a/packages/sanity/src/core/components/documentStatusIndicator/DocumentStatusIndicator.tsx
+++ b/packages/sanity/src/core/components/documentStatusIndicator/DocumentStatusIndicator.tsx
@@ -19,25 +19,24 @@ const Dot = styled.div<{$index: number}>`
   border-radius: 999px;
   box-shadow: 0 0 0 1px var(--card-bg-color);
   z-index: ${({$index}) => $index};
-  &[data-status='not-published'] {
-    --card-icon-color: var(--card-badge-default-dot-color);
-    opacity: 0.5 !important;
+  &[data-status='published'] {
+    --card-icon-color: var(--card-badge-positive-dot-color);
   }
   &[data-status='draft'] {
     --card-icon-color: var(--card-badge-caution-dot-color);
   }
   &[data-status='asap'] {
-    --card-icon-color: var(--card-badge-critical-dot-color);
+    --card-icon-color: var(--card-badge-caution-dot-color);
   }
   &[data-status='undecided'] {
-    --card-icon-color: var(--card-badge-suggest-dot-color);
+    --card-icon-color: var(--card-badge-neutral-dot-color);
   }
   &[data-status='scheduled'] {
-    --card-icon-color: var(--card-badge-primary-dot-color);
+    --card-icon-color: var(--card-badge-suggest-dot-color);
   }
 `
 
-type Status = 'not-published' | 'draft' | 'asap' | 'scheduled' | 'undecided'
+type Status = 'published' | 'draft' | 'asap' | 'scheduled' | 'undecided'
 
 /**
  * Renders a dot indicating the current document status.
@@ -67,7 +66,11 @@ export function DocumentStatusIndicator({draft, published, versions}: DocumentSt
     show: boolean
   }[] = [
     {
-      status: draft && !published ? 'not-published' : 'draft',
+      status: 'published',
+      show: Boolean(published),
+    },
+    {
+      status: 'draft',
       show: Boolean(draft),
     },
     {


### PR DESCRIPTION
### Description

Adds a new green dot that will show when a document is published 
Updates the published + draft view from only 1 orange dot to a green and orange dot.
Drafts will show always the orange dot.
Versions colors are updated to match the new colors introduced last week for releases.

![Screenshot 2025-03-24 at 11 18 28](https://github.com/user-attachments/assets/c23de7b5-909c-4bbd-b004-86a6d63ad4c7)


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Updates the status dots for the documents previews, showing a green color for the published, a orange for drafts and overlaying the green + orange when the document is both a published and a draft. 

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
