### PR TITLE
feat(sanity): add `Scheduler` polyfill

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -259,6 +259,7 @@
     "rxjs": "^7.8.0",
     "rxjs-exhaustmap-with-trailing": "^2.1.1",
     "rxjs-mergemap-array": "^0.1.0",
+    "scheduler-polyfill": "^1.3.0",
     "scroll-into-view-if-needed": "^3.0.3",
     "scrollmirror": "^1.2.0",
     "semver": "^7.3.5",

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line import/no-unassigned-import
+import 'scheduler-polyfill'
+
 export * from './changeIndicators'
 export * from './comments'
 export * from './components'

--- a/packages/sanity/src/core/templates/resolve.ts
+++ b/packages/sanity/src/core/templates/resolve.ts
@@ -307,3 +307,20 @@ export async function resolveInitialObjectValue<Params extends Record<string, un
 
   return merged
 }
+
+/**
+ * Schedule the provided callback using `scheduler.postTask`, if it's available.
+ * Otherwise, call it immediately.
+ *
+ * This is necessary because `scheduler-polyfill` does not work correctly in node, which is where
+ * Studio unit tests run currently.
+ */
+function postTask<Result>(
+  callback: () => Result,
+  options?: Parameters<typeof scheduler.postTask>[1],
+): Result | Promise<Result> {
+  if (!('scheduler' in globalThis)) {
+    return callback()
+  }
+  return scheduler.postTask(callback, options)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,9 +7,9 @@ settings:
 overrides:
   '@npmcli/arborist': ^7.5.4
   '@sanity/ui@2': ^2.15.7
+  '@types/node': ^22.10.0
   '@typescript-eslint/eslint-plugin': ^7.18.0
   '@typescript-eslint/parser': ^7.18.0
-  '@types/node': ^22.10.0
   '@vitest/coverage-v8': 3.0.9
   '@vitest/expect': 3.0.9
   eslint-plugin-react-hooks: 0.0.0-experimental-d55cc79b-20250228
@@ -1676,6 +1676,9 @@ importers:
       rxjs-mergemap-array:
         specifier: ^0.1.0
         version: 0.1.0(rxjs@7.8.2)
+      scheduler-polyfill:
+        specifier: ^1.3.0
+        version: 1.3.0
       scroll-into-view-if-needed:
         specifier: ^3.0.3
         version: 3.1.0
@@ -10646,6 +10649,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler-polyfill@1.3.0:
+    resolution: {integrity: sha512-bIjhi/KJqo08wrq+K2rlB6HNPh871KgREPpVti4zv0mSY1dCi3qr0rRCw+SGHc8/gtKceev29sN//lf6KiYa/g==}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -22391,6 +22397,8 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler-polyfill@1.3.0: {}
 
   scheduler@0.23.2:
     dependencies:


### PR DESCRIPTION
### Description

~This branch [adds a polyfill](https://github.com/GoogleChromeLabs/scheduler-polyfill) that uses various techniques to implement task scheduling when necessary.~

~I had some difficulty getting the polyfill to work correctly in node, which is where our unit tests run at the moment (a good reason to adopt Vitest Browser Mode, in my opinion!). I created a small `postTask` helper function that executes the provided callback immediately if neither the Prioritized Task Scheduling API or its polyfill is available. The only impact of this is that it allows our tests to run in node.~

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
