### PR TITLE
fix: non sticky params are not preserved during navigation

### DIFF
--- a/packages/sanity/src/router/RouterProvider.tsx
+++ b/packages/sanity/src/router/RouterProvider.tsx
@@ -139,7 +139,7 @@ export function RouterProvider(props: RouterProviderProps): React.JSX.Element {
       validateStickyParams(nextStickyParams)
 
       const nextParams = baseState._searchParams || []
-      const mergedParams = mergeStickyParams([...currentParams, ...nextParams], nextStickyParams)
+      const mergedParams = mergeStickyParams(nextParams, nextStickyParams)
 
       onNavigate({
         path: resolvePathFromState({...baseState, _searchParams: mergedParams}),

--- a/packages/sanity/src/router/__test__/RouterProvider.test.tsx
+++ b/packages/sanity/src/router/__test__/RouterProvider.test.tsx
@@ -391,5 +391,44 @@ describe('RouterProvider', () => {
         replace: true,
       })
     })
+
+    it('should not preserve non-sticky params when navigating to a new state', () => {
+      const {result} = renderHook(() => useRouter(), {
+        wrapper: ({children}) => (
+          <RouterProvider
+            onNavigate={mockOnNavigate}
+            router={mockRouter}
+            state={{
+              existingKey: 'existingValue',
+              _searchParams: [
+                ['stickyFirstParam', 'stickyFirstParamValue'],
+                ['nonStickyParam', 'nonStickyValue'],
+              ],
+            }}
+          >
+            {children}
+          </RouterProvider>
+        ),
+      })
+
+      act(() => {
+        result.current.navigate({
+          state: {
+            newKey: 'newValue',
+            _searchParams: [['anotherNonSticky', 'anotherValue']],
+          },
+        })
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          newKey: 'newValue',
+          _searchParams: [
+            ['anotherNonSticky', 'anotherValue'],
+            ['stickyFirstParam', 'stickyFirstParamValue'],
+          ],
+        },
+      })
+    })
   })
 })


### PR DESCRIPTION
### Description
Fixes a bug that was introduced in https://github.com/sanity-io/sanity/pull/8620 where non-sticky search params would be preserved across navigation events.

This was surfaced in the viewport toggle in Presentation:

| Before | After |
|--------|--------|
| ![nonStickyBEFORE](https://github.com/user-attachments/assets/189fbcad-9896-4903-990d-4b0edf61669d) | ![nonStickyAFTER](https://github.com/user-attachments/assets/37e00cf0-a682-46da-8be7-aab676dcc589) | 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Added a new test case on `RouterProvider` to capture this exact scenario
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A - covered in 8620
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
