### PR TITLE
chore: add intl array test

### DIFF
--- a/dev/test-studio/preview/FieldGroups.tsx
+++ b/dev/test-studio/preview/FieldGroups.tsx
@@ -1,4 +1,4 @@
-import {Box, Card, Stack, Text} from '@sanity/ui'
+import {Box, Card, Flex, Spinner, Stack, Text} from '@sanity/ui'
 
 import {useQuery} from './loader'
 
@@ -28,7 +28,17 @@ export function FieldGroups(): React.JSX.Element {
   }
 
   if (loading) {
-    return <p>Loading...</p>
+    return (
+      <Flex
+        align="center"
+        direction="column"
+        height="fill"
+        justify="center"
+        style={{width: '100%'}}
+      >
+        <Spinner />
+      </Flex>
+    )
   }
 
   return (

--- a/dev/test-studio/preview/InternationalizedArrayTest.tsx
+++ b/dev/test-studio/preview/InternationalizedArrayTest.tsx
@@ -1,0 +1,78 @@
+import {Flex, Spinner} from '@sanity/ui'
+import {createDataAttribute} from '@sanity/visual-editing/create-data-attribute'
+import {Fragment} from 'react'
+
+import {useQuery} from './loader'
+
+export function InternationalizedArrayTest(): React.JSX.Element {
+  const {data, loading, error} = useQuery<
+    {
+      _id: string
+      title: string | null
+      titles: {_key: string; value: string}[] | null
+    }[]
+  >(
+    /* groq */ `*[_type == "internationalizedArrayTest"]{_id,"title":title[_key == "en"].value,"titles": title[_key != "en" && defined(value)]{_key,value}}`,
+  )
+
+  if (error) {
+    throw error
+  }
+
+  if (loading) {
+    return (
+      <Flex
+        align="center"
+        direction="column"
+        height="fill"
+        justify="center"
+        style={{width: '100%'}}
+      >
+        <Spinner />
+      </Flex>
+    )
+  }
+
+  const collator = new Intl.Collator('en')
+  const sortedData = data?.sort((a, b) => collator.compare(a.title || '', b.title || ''))
+
+  return (
+    <>
+      {sortedData?.map((item) => {
+        const dataAttribute = createDataAttribute({
+          type: 'internationalizedArrayTest',
+          id: item._id,
+        })
+        return (
+          <article
+            key={item._id}
+            style={{
+              margin: '10px 20px',
+              background: 'ghostwhite',
+              borderRadius: '8px',
+              border: '1px solid lightgray',
+              padding: '10px 20px',
+            }}
+          >
+            <h1>{item.title || 'Untitled'}</h1>
+            <dl>
+              {item.titles?.map(({_key, value}) => (
+                <Fragment key={_key}>
+                  <dt
+                    data-sanity={dataAttribute.scope(['title', {_key}]).toString()}
+                    data-sanity-drag-group={item._id}
+                  >
+                    {displayNames.of(_key)}
+                  </dt>
+                  <dd>{value}</dd>
+                </Fragment>
+              ))}
+            </dl>
+          </article>
+        )
+      })}
+    </>
+  )
+}
+
+const displayNames = new Intl.DisplayNames(['en'], {type: 'language'})

--- a/dev/test-studio/preview/SimpleBlockPortableText.tsx
+++ b/dev/test-studio/preview/SimpleBlockPortableText.tsx
@@ -1,5 +1,6 @@
 import {PortableText, type PortableTextComponents} from '@portabletext/react'
 import {stegaClean} from '@sanity/client/stega'
+import {Flex, Spinner} from '@sanity/ui'
 import {createDataAttribute} from '@sanity/visual-editing/create-data-attribute'
 import {type PortableTextBlock} from 'sanity'
 
@@ -42,7 +43,17 @@ export function SimpleBlockPortableText(): React.JSX.Element {
   }
 
   if (loading) {
-    return <p>Loading...</p>
+    return (
+      <Flex
+        align="center"
+        direction="column"
+        height="fill"
+        justify="center"
+        style={{width: '100%'}}
+      >
+        <Spinner />
+      </Flex>
+    )
   }
 
   return (

--- a/dev/test-studio/preview/main.tsx
+++ b/dev/test-studio/preview/main.tsx
@@ -5,15 +5,16 @@ import {createRoot} from 'react-dom/client'
 
 import {FieldGroups} from './FieldGroups'
 import {InitialValues} from './InitialValues'
+import {InternationalizedArrayTest} from './InternationalizedArrayTest'
 import {useLiveMode} from './loader'
 import {LongList} from './LongList'
 import {Markdown} from './Markdown'
 import {SimpleBlockPortableText} from './SimpleBlockPortableText'
 
 function Main() {
-  const [id, setId] = useState<'simple' | 'nested' | 'markdown' | 'longlist' | 'initialvalues'>(
-    'simple',
-  )
+  const [id, setId] = useState<
+    'simple' | 'nested' | 'markdown' | 'longlist' | 'initialvalues' | 'intl-array'
+  >('simple')
   return (
     <>
       <ThemeProvider theme={studioTheme}>
@@ -55,6 +56,13 @@ function Main() {
                 onClick={() => setId('initialvalues')}
                 selected={id === 'initialvalues'}
               />
+              <Tab
+                aria-controls="intl-array-panel"
+                id="intl-array-tab"
+                label="InternationalizedArrayTest"
+                onClick={() => setId('intl-array')}
+                selected={id === 'intl-array'}
+              />
             </TabList>
           </Box>
 
@@ -83,6 +91,11 @@ function Main() {
           {id === 'initialvalues' && (
             <TabPanel aria-labelledby="initialvalues-tab" id="initialvalues-panel">
               <InitialValues />
+            </TabPanel>
+          )}
+          {id === 'intl-array' && (
+            <TabPanel aria-labelledby="intl-array-tab" id="intl-array-panel">
+              <InternationalizedArrayTest />
             </TabPanel>
           )}
         </Flex>

--- a/dev/test-studio/schema/externalPlugins/internationalizedArray.ts
+++ b/dev/test-studio/schema/externalPlugins/internationalizedArray.ts
@@ -1,0 +1,41 @@
+import {defineType} from 'sanity'
+
+export default defineType({
+  type: 'document',
+  name: 'internationalizedArrayTest',
+  title: 'Internationalized Array Test',
+  fields: [
+    {
+      type: 'internationalizedArrayString',
+      name: 'title',
+      title: 'Title',
+    },
+  ],
+  preview: {
+    select: {
+      title: 'title',
+    },
+    prepare(selection) {
+      return {
+        title: selection.title?.find(({_key}: any) => _key === 'en')?.value || 'Untitled',
+        subtitle: selection.title?.some(({_key, value}: any) => _key !== 'en' && value?.trim())
+          ? formatLanguages(
+              selection.title
+                ?.filter(({_key, value}: any) => _key !== 'en' && value?.trim())
+                .map(({_key}: any) => _key),
+            )
+          : undefined,
+      }
+    },
+  },
+})
+
+function formatLanguages(langs: string[]) {
+  const displayNames = new Intl.DisplayNames(['en'], {type: 'language'})
+  const formattedLangs = langs.map((lang) => displayNames.of(lang))
+
+  return `${
+    // @ts-expect-error - ListFormat types are incomplete in older TS versions
+    new Intl.ListFormat('en', {style: 'short', type: 'conjunction'}).format(formattedLangs)
+  } available`
+}

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -83,6 +83,7 @@ import validation, {validationArraySuperType} from './debug/validation'
 import {virtualizationDebug} from './debug/virtualizationDebug'
 import {virtualizationInObject} from './debug/virtualizationInObject'
 import {v3docs} from './docs/v3'
+import internationalizedArray from './externalPlugins/internationalizedArray'
 import markdown from './externalPlugins/markdown'
 import mux from './externalPlugins/mux'
 import house from './house'
@@ -290,7 +291,7 @@ export function createSchemaTypes(projectId: string) {
     // Test documents with 3rd party plugin inputs
     markdown,
     mux,
-
+    internationalizedArray,
     // Other documents
     author,
     book,

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -110,4 +110,8 @@ export const DEBUG_FIELD_GROUP_TYPES = [
   'fieldGroupsWithFieldsetsHidden',
 ]
 
-export const EXTERNAL_PLUGIN_INPUT_TYPES = ['markdownTest', 'muxVideoPost']
+export const EXTERNAL_PLUGIN_INPUT_TYPES = [
+  'markdownTest',
+  'muxVideoPost',
+  'internationalizedArrayTest',
+]


### PR DESCRIPTION
### Description

Adds a test for `sanity-plugin-internationalized-array` in the `Presentation` tool, in the test studio. The way it handles intl is sensitive to how Presentation handles union references lookups when it handles drag and drop logic. We had issues with this in the past so adding this makes it easier to prevent regressions.

### What to review

It makes sense?

### Testing

I'll add an e2e test for this in a follow up PR ❤ 

### Notes for release

N/A