### PR TITLE
fix: releases used wrong key on duplicate action

### DIFF
--- a/packages/sanity/src/core/releases/plugin/documentActions/index.ts
+++ b/packages/sanity/src/core/releases/plugin/documentActions/index.ts
@@ -9,7 +9,7 @@ export default function resolveDocumentActions(
   existingActions: Action[],
   context: DocumentActionsContext,
 ): Action[] {
-  const duplicateAction = existingActions.filter(({name}) => name === 'DuplicateAction')
+  const duplicateAction = existingActions.filter(({action}) => action === 'duplicate')
 
   if (context.versionType === 'version') {
     return duplicateAction.concat(DiscardVersionAction, UnpublishVersionAction)


### PR DESCRIPTION
### Description
In minified bundles `name` may be minified, since I believe this is the `name` of the component. It is safer to use `action`.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Testing with additional studios and verified it works
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixing an issue where content releases would incorrectly hide the duplicate document action
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
