### PR TITLE
fix: filters out @sanity/assist plugin if it is older than 3.2.2

### DIFF
--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -19,7 +19,7 @@
     "@portabletext/block-tools": "^1.1.14",
     "@portabletext/editor": "^1.42.1",
     "@portabletext/react": "^3.0.0",
-    "@sanity/assist": "^3.1.0",
+    "@sanity/assist": "^3.2.1",
     "@sanity/client": "^6.28.3",
     "@sanity/color": "^3.0.0",
     "@sanity/color-input": "^4.0.1",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -19,7 +19,7 @@
     "@portabletext/block-tools": "^1.1.14",
     "@portabletext/editor": "^1.42.1",
     "@portabletext/react": "^3.0.0",
-    "@sanity/assist": "^3.2.1",
+    "@sanity/assist": "^3.2.2",
     "@sanity/client": "^6.28.3",
     "@sanity/color": "^3.0.0",
     "@sanity/color-input": "^4.0.1",

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -127,7 +127,26 @@ export function prepareConfig(
     const sources = [rootSource as SourceOptions, ...nestedSources].map(({plugins, ...source}) => {
       return {
         ...source,
-        plugins: [...(plugins ?? []), ...getDefaultPlugins(defaultPluginsOptions, plugins)],
+        plugins: [...(plugins ?? []), ...getDefaultPlugins(defaultPluginsOptions, plugins)]
+          /*
+           * @FIXME: with the introduction of global references, @sanity/assist broke
+           * As a quickfix the plugins was released with a know property on the plugin definition.
+           * This checks for that property: if it is missing, the plugin is not compatible with this version of the studio.
+           * This ensurs auto updating studios can start, albeit without assist, it it is old.
+           */
+          .filter((plugin) => {
+            const validPlugin =
+              plugin.name !== '@sanity/assist' ||
+              (plugin as unknown as {handlesGDR?: boolean}).handlesGDR
+            if (!validPlugin) {
+              console.warn(
+                'Found an incompatible version of @sanity/assist plugin. It has been disabled.\n' +
+                  'To re-enable the plugin, please upgrade to https://github.com/sanity-io/assist/releases/tag/v3.2.2 or later.',
+              )
+            }
+
+            return validPlugin
+          }),
       }
     })
 

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -132,7 +132,7 @@ export function prepareConfig(
            * @FIXME: with the introduction of global references, @sanity/assist broke
            * As a quickfix the plugins was released with a know property on the plugin definition.
            * This checks for that property: if it is missing, the plugin is not compatible with this version of the studio.
-           * This ensurs auto updating studios can start, albeit without assist, it it is old.
+           * This ensures auto updating studios can start, albeit without assist, it it is old.
            */
           .filter((plugin) => {
             const validPlugin =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,8 +437,8 @@ importers:
         specifier: ^3.0.0
         version: 3.2.1(react@19.0.0)
       '@sanity/assist':
-        specifier: ^3.1.0
-        version: 3.2.1(@emotion/is-prop-valid@1.3.1)(@sanity/mutator@packages+@sanity+mutator)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@packages+sanity)(styled-components@6.1.16(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        specifier: ^3.2.2
+        version: 3.2.2(@emotion/is-prop-valid@1.3.1)(@sanity/mutator@packages+@sanity+mutator)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@packages+sanity)(styled-components@6.1.16(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@sanity/client':
         specifier: ^6.28.3
         version: 6.28.3(debug@4.4.0)
@@ -4499,8 +4499,8 @@ packages:
     resolution: {integrity: sha512-dBsZWH5X6ANcvclFRnQT9Y+NNvoWTJZIMKR5HT6hzoRpRb48p7+vWn+wi1V1wPvqgZg2ScsOQQcGXWXskbPbQQ==}
     engines: {node: '>=18'}
 
-  '@sanity/assist@3.2.1':
-    resolution: {integrity: sha512-IvAyxueKRFgSg3nVLr4lW0w0pdVwsst8xX/yj2vNb5GCIoEpsHmHBbwuMSA4k54OamRU7Y+0o5E8agNzoj6kIQ==}
+  '@sanity/assist@3.2.2':
+    resolution: {integrity: sha512-6RCVtI73Z/2if770p9yoD3tOfPvKiCZdxguyyuvmvS+f5NVklTUHsPYTZkObqZANxdqVeo0ouaRqQUowjFKu7w==}
     engines: {node: '>=14'}
     peerDependencies:
       '@sanity/mutator': ^3.36.4
@@ -14816,7 +14816,7 @@ snapshots:
 
   '@sanity/asset-utils@2.2.1': {}
 
-  '@sanity/assist@3.2.1(@emotion/is-prop-valid@1.3.1)(@sanity/mutator@packages+@sanity+mutator)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@packages+sanity)(styled-components@6.1.16(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@sanity/assist@3.2.2(@emotion/is-prop-valid@1.3.1)(@sanity/mutator@packages+@sanity+mutator)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@packages+sanity)(styled-components@6.1.16(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@sanity/icons': 3.7.0(react@19.0.0)
       '@sanity/incompatible-plugin': 1.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)


### PR DESCRIPTION
as part of a quick fix