### PR TITLE
test: improving robustness of unpublish.spec e2e

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -260,7 +260,13 @@ export const DocumentPanelHeader = memo(
           <Card hidden={collapsed} style={{lineHeight: 0}} borderBottom>
             <Flex gap={3} paddingY={3}>
               <HorizontalScroller>
-                <Flex flex={1} gap={1} overflow="auto" paddingX={3}>
+                <Flex
+                  flex={1}
+                  gap={1}
+                  overflow="auto"
+                  paddingX={3}
+                  data-testid="document-perspective-list"
+                >
                   <DocumentPerspectiveList />
                 </Flex>
               </HorizontalScroller>

--- a/test/e2e/tests/document-actions/unpublish.spec.ts
+++ b/test/e2e/tests/document-actions/unpublish.spec.ts
@@ -19,6 +19,7 @@ test(`should be able to unpublish a published document`, async ({page, createDra
 
   await createDraftDocument('/test/content/book')
   await titleInput.fill(titleA)
+
   // Wait for the document to finish saving
   await expect(documentStatus).toContainText(/created/i, {useInnerText: true, timeout: 30_000})
 
@@ -30,13 +31,13 @@ test(`should be able to unpublish a published document`, async ({page, createDra
   await expect(unpublishButton).toBeVisible()
   await unpublishButton.click()
 
-  await page.waitForTimeout(2_000)
-
-  await expect(unpublishModal).toBeVisible()
+  await expect(unpublishModal).toBeVisible({timeout: 4_000})
   await page.getByTestId('confirm-button').click()
 
-  // Check the published button is disabled that is the reference to determine the published document doesn't exist.
-  const button = await page.getByRole('button', {name: 'Published', exact: true})
+  const documentPerspectiveList = page.getByTestId('document-perspective-list')
+  const button = documentPerspectiveList.getByRole('button', {name: 'Published', exact: true})
+
+  // Check the published button is disabled
   await expect(button).toBeDisabled()
   await expect(documentStatus).toContainText('Unpublished just now')
 })

--- a/test/e2e/tests/document-actions/unpublish.spec.ts
+++ b/test/e2e/tests/document-actions/unpublish.spec.ts
@@ -19,7 +19,6 @@ test(`should be able to unpublish a published document`, async ({page, createDra
 
   await createDraftDocument('/test/content/book')
   await titleInput.fill(titleA)
-
   // Wait for the document to finish saving
   await expect(documentStatus).toContainText(/created/i, {useInnerText: true, timeout: 30_000})
 
@@ -37,7 +36,7 @@ test(`should be able to unpublish a published document`, async ({page, createDra
   const documentPerspectiveList = page.getByTestId('document-perspective-list')
   const button = documentPerspectiveList.getByRole('button', {name: 'Published', exact: true})
 
-  // Check the published button is disabled
+  // Check the published button is disabled that is the reference to determine the published document doesn't exist.
   await expect(button).toBeDisabled()
   await expect(documentStatus).toContainText('Unpublished just now')
 })


### PR DESCRIPTION
### Description
Sometimes there can be 2 'Published' elements available after unpublishing is run in `unpublish.spec` - this is because briefly the Publish document action button shows 'Published' as the document state is reconciled.

This PR places a `data-testid` around the document perspective list, and uses this to target the correct 'Published'
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Repeat running of this particular test (locally and in CI) shows improved robustness
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
