### PR TITLE
refactor: update colour consts

### DIFF
--- a/packages/sanity/src/core/components/documentStatusIndicator/DocumentStatusIndicator.tsx
+++ b/packages/sanity/src/core/components/documentStatusIndicator/DocumentStatusIndicator.tsx
@@ -1,8 +1,8 @@
 import {Flex} from '@sanity/ui'
 import {useMemo} from 'react'
-import {styled} from 'styled-components'
+import {css, styled} from 'styled-components'
 
-import {type VersionInfoDocumentStub} from '../../releases'
+import {RELEASE_TYPES_TONES, type VersionInfoDocumentStub} from '../../releases'
 import {useActiveReleases} from '../../releases/store/useActiveReleases'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
 
@@ -12,29 +12,38 @@ interface DocumentStatusProps {
   versions?: Record<string, VersionInfoDocumentStub | undefined>
 }
 
-const Dot = styled.div<{$index: number}>`
-  width: 5px;
-  height: 5px;
-  background-color: var(--card-icon-color);
-  border-radius: 999px;
-  box-shadow: 0 0 0 1px var(--card-bg-color);
-  z-index: ${({$index}) => $index};
-  &[data-status='published'] {
-    --card-icon-color: var(--card-badge-positive-dot-color);
+const Dot = styled.div<{$index: number}>((props) => {
+  const {$index} = props
+  const tone = {
+    asap: RELEASE_TYPES_TONES.asap.tone,
+    scheduled: RELEASE_TYPES_TONES.scheduled.tone,
+    undecided: RELEASE_TYPES_TONES.undecided.tone,
   }
-  &[data-status='draft'] {
-    --card-icon-color: var(--card-badge-caution-dot-color);
-  }
-  &[data-status='asap'] {
-    --card-icon-color: var(--card-badge-caution-dot-color);
-  }
-  &[data-status='undecided'] {
-    --card-icon-color: var(--card-badge-neutral-dot-color);
-  }
-  &[data-status='scheduled'] {
-    --card-icon-color: var(--card-badge-suggest-dot-color);
-  }
-`
+
+  return css`
+    width: 5px;
+    height: 5px;
+    background-color: var(--card-icon-color);
+    border-radius: 999px;
+    box-shadow: 0 0 0 1px var(--card-bg-color);
+    z-index: ${$index};
+    &[data-status='published'] {
+      --card-icon-color: var(--card-badge-positive-dot-color);
+    }
+    &[data-status='draft'] {
+      --card-icon-color: var(--card-badge-caution-dot-color);
+    }
+    &[data-status='asap'] {
+      --card-icon-color: var(--card-badge-${tone.asap}-dot-color);
+    }
+    &[data-status='undecided'] {
+      --card-icon-color: var(--card-badge-${tone.undecided}-dot-color);
+    }
+    &[data-status='scheduled'] {
+      --card-icon-color: var(--card-badge-${tone.scheduled}-dot-color);
+    }
+  `
+})
 
 type Status = 'published' | 'draft' | 'asap' | 'scheduled' | 'undecided'
 

--- a/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
@@ -25,21 +25,10 @@ import {MenuButton, Tooltip} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
 import useTimeZone from '../../../scheduledPublishing/hooks/useTimeZone'
 import {type EditableReleaseDocument, isReleaseType, type ReleaseType} from '../../store/types'
+import {RELEASE_TYPES_TONES} from '../../util/const'
 import {ReleaseAvatar} from '../ReleaseAvatar'
 import {ScheduleDatePicker} from '../ScheduleDatePicker'
 import {TitleDescriptionForm} from './TitleDescriptionForm'
-
-const RELEASE_TYPES: Record<ReleaseType, {tone: BadgeTone}> = {
-  asap: {
-    tone: 'critical',
-  },
-  scheduled: {
-    tone: 'primary',
-  },
-  undecided: {
-    tone: 'suggest',
-  },
-}
 
 /** @internal */
 export function ReleaseForm(props: {
@@ -159,7 +148,7 @@ export function ReleaseForm(props: {
                 <Flex justify="space-between" align="center">
                   <ReleaseTypeOption
                     text={t(`release.type.${buttonReleaseType}`)}
-                    tone={RELEASE_TYPES[buttonReleaseType].tone}
+                    tone={RELEASE_TYPES_TONES[buttonReleaseType].tone}
                   />
                   <Text size={1}>
                     <ChevronDownIcon />
@@ -174,7 +163,7 @@ export function ReleaseForm(props: {
             }}
             menu={
               <Menu>
-                {Object.entries(RELEASE_TYPES).map(([type, {tone}]) => (
+                {Object.entries(RELEASE_TYPES_TONES).map(([type, {tone}]) => (
                   <MenuItem key={type} data-value={type} onClick={handleButtonReleaseTypeChange}>
                     <ReleaseTypeOption text={t(`release.type.${type}`)} tone={tone} />
                   </MenuItem>

--- a/packages/sanity/src/core/releases/util/const.ts
+++ b/packages/sanity/src/core/releases/util/const.ts
@@ -1,3 +1,7 @@
+import {type BadgeTone} from '@sanity/ui'
+
+import {type ReleaseType} from '../store/types'
+
 /**
  * @internal
  */
@@ -10,3 +14,15 @@ export const PUBLISHED = 'published' as const
 export const DEFAULT_RELEASE_TYPE = 'asap'
 
 export const ARCHIVED_RELEASE_STATES = ['archived', 'published']
+
+export const RELEASE_TYPES_TONES: Record<ReleaseType, {tone: BadgeTone}> = {
+  asap: {
+    tone: 'caution',
+  },
+  scheduled: {
+    tone: 'suggest',
+  },
+  undecided: {
+    tone: 'neutral',
+  },
+}

--- a/packages/sanity/src/core/releases/util/getReleaseTone.ts
+++ b/packages/sanity/src/core/releases/util/getReleaseTone.ts
@@ -2,6 +2,7 @@ import {type BadgeTone} from '@sanity/ui'
 
 import {type SelectedPerspective} from '../../perspective/types'
 import {isReleaseDocument} from '../store/types'
+import {RELEASE_TYPES_TONES} from './const'
 import {isDraftPerspective, isPublishedPerspective} from './util'
 
 /** @internal */
@@ -15,15 +16,15 @@ export function getReleaseTone(release: SelectedPerspective): BadgeTone {
     }
 
     if (release?.metadata?.releaseType === 'asap') {
-      return 'caution'
+      return RELEASE_TYPES_TONES.asap.tone
     }
 
     if (release?.metadata?.releaseType === 'undecided') {
-      return 'neutral'
+      return RELEASE_TYPES_TONES.undecided.tone
     }
 
     if (release?.metadata?.releaseType === 'scheduled') {
-      return 'suggest'
+      return RELEASE_TYPES_TONES.scheduled.tone
     }
   }
 


### PR DESCRIPTION
### Description

For the releases we had multiple spread across sections that had to be updated when the colours were updated. Moved code to have a single source of truth based on consts 

### What to review

Did I miss somewhere?

### Testing

Tests should have been updated

### Notes for release

N/A
