### PR TITLE
fix: remove circular references

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/utils/TestWrapper.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/utils/TestWrapper.tsx
@@ -17,12 +17,12 @@ import {
   type WorkspaceOptions,
   WorkspaceProvider,
 } from 'sanity'
-import {Pane, PaneContent, PaneLayout} from 'sanity/structure'
 import {styled} from 'styled-components'
 
 import {PerspectiveProvider} from '../../../../src/core/perspective/PerspectiveProvider'
 import {route} from '../../../../src/router'
 import {RouterProvider} from '../../../../src/router/RouterProvider'
+import {Pane, PaneContent, PaneLayout} from '../../../../src/structure/components/pane'
 import {createMockSanityClient} from '../../../../test/mocks/mockSanityClient'
 import {getMockWorkspace} from '../../../../test/testUtils/getMockWorkspaceFromConfig'
 

--- a/packages/sanity/src/presentation/editor/DocumentPanel.tsx
+++ b/packages/sanity/src/presentation/editor/DocumentPanel.tsx
@@ -1,6 +1,6 @@
 import {type Path} from 'sanity'
-import {StructureToolProvider} from 'sanity/structure'
 
+import {StructureToolProvider} from '../../structure/StructureToolProvider'
 import {type PresentationSearchParams, type StructureDocumentPaneParams} from '../types'
 import {DocumentPane} from './DocumentPane'
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
@@ -10,9 +10,9 @@ import {
   useTranslation,
   useVersionOperations,
 } from 'sanity'
-import {structureLocaleNamespace} from 'sanity/structure'
 
 import {Button} from '../../../../../ui-components'
+import {structureLocaleNamespace} from '../../../../i18n'
 import {useConditionalToast} from '../documentViews/useConditionalToast'
 import {Banner} from './Banner'
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ArchivedReleaseDocumentBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ArchivedReleaseDocumentBanner.tsx
@@ -7,8 +7,9 @@ import {
   useArchivedReleases,
   useTranslation,
 } from 'sanity'
-import {structureLocaleNamespace, usePaneRouter} from 'sanity/structure'
 
+import {usePaneRouter} from '../../../../components/paneRouter/usePaneRouter'
+import {structureLocaleNamespace} from '../../../../i18n'
 import {Banner} from './Banner'
 
 export function ArchivedReleaseDocumentBanner(): React.JSX.Element {

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/CreateLinkedBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/CreateLinkedBanner.tsx
@@ -1,6 +1,6 @@
 import {getSanityCreateLinkMetadata, useSanityCreateConfig} from 'sanity'
-import {useDocumentPane} from 'sanity/structure'
 
+import {useDocumentPane} from '../../useDocumentPane'
 import {Banner} from './Banner'
 
 export function CreateLinkedBanner() {

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/OpenReleaseToEditBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/OpenReleaseToEditBanner.tsx
@@ -13,9 +13,9 @@ import {
   useTranslation,
   VersionInlineBadge,
 } from 'sanity'
-import {structureLocaleNamespace} from 'sanity/structure'
 
 import {Button} from '../../../../../ui-components'
+import {structureLocaleNamespace} from '../../../../i18n'
 import {Banner} from './Banner'
 
 export function OpenReleaseToEditBanner({

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/DeletedDocumentBanners.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/DeletedDocumentBanners.test.tsx
@@ -6,11 +6,11 @@ import {
   usePerspective,
   useReleasesIds,
 } from 'sanity'
-import {useDocumentPane} from 'sanity/structure'
 import {describe, expect, it, type Mock, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
 import {structureUsEnglishLocaleBundle} from '../../../../../i18n'
+import {useDocumentPane} from '../../../useDocumentPane'
 import {DeletedDocumentBanners} from '../DeletedDocumentBanners'
 
 vi.mock('../../../useDocumentPane', () => ({

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -22,9 +22,9 @@ import {
   useTranslation,
   VersionChip,
 } from 'sanity'
-import {usePaneRouter} from 'sanity/structure'
 
 import {isLiveEditEnabled} from '../../../../../components/paneItem/helpers'
+import {usePaneRouter} from '../../../../../components/paneRouter/usePaneRouter'
 import {useFilteredReleases} from '../../../../../hooks/useFilteredReleases'
 import {useDocumentPane} from '../../../useDocumentPane'
 

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/EventsSelector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/EventsSelector.tsx
@@ -12,11 +12,11 @@ import {
   useEvents,
   useTranslation,
 } from 'sanity'
-import {useDocumentPane} from 'sanity/structure'
 import {styled} from 'styled-components'
 
 import {EventsTimeline} from '../../timeline/events/EventsTimeline'
 import {TimelineError} from '../../timeline/TimelineError'
+import {useDocumentPane} from '../../useDocumentPane'
 
 const Scroller = styled(ScrollContainer)`
   height: 100%;

--- a/packages/sanity/src/structure/panes/document/timeline/events/PublishedEventMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/events/PublishedEventMenu.tsx
@@ -20,9 +20,9 @@ import {
   VersionInlineBadge,
 } from 'sanity'
 import {IntentLink} from 'sanity/router'
-import {usePaneRouter} from 'sanity/structure'
 
 import {MenuButton} from '../../../../../ui-components'
+import {usePaneRouter} from '../../../../components/paneRouter/usePaneRouter'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {TIMELINE_MENU_PORTAL} from '../timelineMenu'
 

--- a/packages/sanity/src/structure/panes/documentList/__tests__/PaneContainer.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/PaneContainer.test.tsx
@@ -1,10 +1,10 @@
 import {act, render, screen, waitFor} from '@testing-library/react'
 import {defineConfig, type PerspectiveContextValue, useSearchState} from 'sanity'
-import {type DocumentListPaneNode, type StructureToolContextValue} from 'sanity/structure'
 import {describe, expect, it, type Mock, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {structureUsEnglishLocaleBundle} from '../../../i18n'
+import {type DocumentListPaneNode, type StructureToolContextValue} from '../../../types'
 import {useStructureToolSetting} from '../../../useStructureToolSetting'
 import {PaneContainer} from '../PaneContainer'
 

--- a/packages/sanity/src/structure/panes/documentList/sheetList/__tests__/DocumentSheetListPane.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/__tests__/DocumentSheetListPane.test.tsx
@@ -2,11 +2,11 @@ import {fireEvent, render, screen, within} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {act} from 'react'
 import {defineConfig} from 'sanity'
-import {type DocumentListPaneNode} from 'sanity/structure'
 import {describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
 import {structureUsEnglishLocaleBundle} from '../../../../i18n'
+import {type DocumentListPaneNode} from '../../../../types'
 import {DocumentSheetListPane} from '../DocumentSheetListPane'
 
 vi.mock('../useDocumentSheetList', () => ({


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

When running a build with my astro/vite application it logs a few warning messages

```sh
13:47:22 [WARN] [vite] Export "structureLocaleNamespace" of module "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/_chunks-es/pane.mjs" was reexported through module "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/_chunks-es/pane.mjs" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
13:47:22 [WARN] [vite] Export "useDocumentPane" of module "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/_chunks-es/pane.mjs" was reexported through module "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/_chunks-es/pane.mjs" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
13:47:22 [WARN] [vite] Export "usePaneRouter" of module "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/_chunks-es/pane.mjs" was reexported through module "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/_chunks-es/pane.mjs" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
13:47:22 [WARN] [vite] Export "StructureToolProvider" of module "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/_chunks-es/pane.mjs" was reexported through module "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/_chunks-es/PresentationToolGrantsCheck.mjs" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
13:47:22 [WARN] [vite] Export "PaneLayout" of module "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/_chunks-es/pane.mjs" was reexported through module "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/_chunks-es/PresentationToolGrantsCheck.mjs" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
13:47:22 [WARN] [vite] Export "DocumentPane" of module "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/_chunks-es/pane.mjs" was reexported through module "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/_chunks-es/PresentationToolGrantsCheck.mjs" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
13:47:22 [WARN] [vite] Export "PaneContainer" of module "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/_chunks-es/pane.mjs" was reexported through module "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/.pnpm/sanity@3.81.0_@emotion+is-prop-valid@1.2.2_@types+node@22.13.13_@types+react@19.0.12_ji_b540238d86544ced2c46ad0688fd4a8f/node_modules/sanity/lib/_chunks-es/PresentationToolGrantsCheck.mjs" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
```

which are apparently due to the fact that they were imported from `sanity/structure` instead of being imported directly

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Just making sure that the build and the package works as they normally do.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

No tests are required, the build passing and already existing tests are sufficient since there's no change made

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

Fixes circular imports inside to remove Rollup complaints
