### PR TITLE
test: trying to make inline.spec more robust

### DIFF
--- a/test/e2e/tests/comments/inline.spec.ts
+++ b/test/e2e/tests/comments/inline.spec.ts
@@ -16,96 +16,133 @@ interface InlineCommentCreationTestProps {
 // The base test for creating an inline comment.
 async function inlineCommentCreationTest(props: InlineCommentCreationTestProps) {
   const {page, createDraftDocument} = props
+  test.slow()
 
   // 1. Create a new draft document
   await createDraftDocument('/test/content/input-ci;commentsCI')
 
+  // Wait for network to become idle to ensure document is fully loaded
+  await page.waitForLoadState('load', {timeout: WAIT_OPTIONS.timeout * 2})
+
   // 2. Click the overlay to active the editor.
-  await page.waitForSelector('[data-testid="activate-overlay"]', WAIT_OPTIONS)
+  await page.getByTestId('activate-overlay').waitFor(WAIT_OPTIONS)
   await page.click('[data-testid="activate-overlay"]')
 
+  // Wait for any network activity triggered by activating the editor to complete
+  await page.waitForLoadState('load', {timeout: WAIT_OPTIONS.timeout * 2})
+
   // 3. Select all text in the editor.
-  await page.waitForSelector('[data-testid="pt-editor"]', WAIT_OPTIONS)
-  const editor = page.locator('[data-testid="pt-editor"]')
-  await page.waitForSelector('div[role="textbox"][contenteditable=true]', WAIT_OPTIONS)
-  const textBox = editor.locator('div[role="textbox"][contenteditable=true]')
-  await textBox.selectText()
+  await page.getByTestId('pt-editor').waitFor(WAIT_OPTIONS)
+
+  const textbox = page
+    .locator('[data-testid="pt-editor"]')
+    .locator('div[role="textbox"][contenteditable=true]')
+
+  await textbox.waitFor({...WAIT_OPTIONS, state: 'visible'})
+
+  // Make sure the editor is fully loaded by waiting for the text content to be present
+  await expect(textbox).toContainText(PTE_CONTENT_TEXT, {timeout: 10000})
+
+  // First ensure we're not already focused on the editor by clicking elsewhere
+  await page.click('body', {force: true, position: {x: 0, y: 0}})
+  await page.waitForTimeout(300)
+
+  // Now focus on the editor and ensure it's ready for selection
+  await textbox.click({force: true})
+  await page.waitForTimeout(300)
+
+  // Try multiple selection strategies to ensure robustness
+  // Strategy 1: Triple-click to select paragraph
+  await textbox.click({clickCount: 3, force: true})
+  await page.waitForTimeout(500)
+
+  // Verify selection and try alternative strategy if needed
+  const isFullTextSelected = await page.evaluate((expectedText) => {
+    const selection = window.getSelection()?.toString() || ''
+    return selection.includes(expectedText)
+  }, PTE_CONTENT_TEXT)
+
+  // If triple-click didn't work, try keyboard selection
+  if (!isFullTextSelected) {
+    // Click at the beginning of the text
+    await textbox.click({position: {x: 0, y: 10}})
+    await page.keyboard.down('Shift')
+
+    // Press End to select to end of line
+    await page.keyboard.press('End')
+    await page.keyboard.up('Shift')
+    await page.waitForTimeout(300)
+  }
+
+  // Final verification that we have the correct text selected
+  await expect(async () => {
+    const selectedText = await page.evaluate(() => window.getSelection()?.toString() || '')
+    return selectedText.includes(PTE_CONTENT_TEXT)
+  }).toPass({timeout: 5000})
 
   // 4. Click on the floating comment button to start authoring a comment.
-  await page.waitForSelector('[data-testid="inline-comment-button"]', {
+  await page.getByTestId('inline-comment-button').waitFor({
     ...WAIT_OPTIONS,
     state: 'visible',
   })
 
-  const button = page.locator('[data-testid="inline-comment-button"]')
-  await expect(button).toBeVisible()
-  button.click({
+  const getCommentButton = () => page.locator('[data-testid="inline-comment-button"]')
+  await expect(getCommentButton()).toBeVisible()
+  getCommentButton().click({
     delay: 1000,
   })
 
   // 5. Ensure the comment input field is displayed and the selected text is visually marked for commenting.
-  await page.waitForSelector('[data-testid="comment-input"]', {
+  await page.getByTestId('comment-input').waitFor({
     ...WAIT_OPTIONS,
     state: 'visible',
   })
-  const commentInput = page.locator('[data-testid="comment-input"]')
-  await expect(commentInput).toBeVisible()
+  const getCommentInput = () => page.locator('[data-testid="comment-input"]')
+  await expect(getCommentInput()).toBeVisible()
 
-  await page.waitForSelector('[data-inline-comment-state="authoring"]', WAIT_OPTIONS)
-  const authoringDecorator = page.locator('[data-inline-comment-state="authoring"]')
-  await expect(authoringDecorator).toHaveText(PTE_CONTENT_TEXT)
+  const authoringDecorator = '[data-inline-comment-state="authoring"]'
+  await page.locator(authoringDecorator).waitFor(WAIT_OPTIONS)
+  await expect(page.locator(authoringDecorator)).toHaveText(PTE_CONTENT_TEXT)
 
   // 6. Author the comment and submit it by clicking the send button.
-  const commentInputTextBox = commentInput.locator('div[role="textbox"]')
-  await commentInputTextBox.fill('This is a comment')
-  const sendButton = commentInput.locator('[data-testid="comment-input-send-button"]')
-  await sendButton.click({
+  await getCommentInput().locator('div[role="textbox"]').fill('This is a comment')
+  await getCommentInput().locator('[data-testid="comment-input-send-button"]').click({
     delay: 1000,
   })
 
   // 7. Verify the comment has been successfully added by checking for the presence of the
   //    comment decorator with the correct content.
-  await page.waitForSelector('[data-inline-comment-state="added"]', WAIT_OPTIONS)
-  const addedDecorator = page.locator('[data-inline-comment-state="added"]')
-  await expect(addedDecorator).toHaveText(PTE_CONTENT_TEXT)
+  const addedDecorator = '[data-inline-comment-state="added"]'
+  await page.locator(addedDecorator).waitFor(WAIT_OPTIONS)
+  await expect(page.locator(addedDecorator)).toHaveText(PTE_CONTENT_TEXT)
 
   // 8. Verify that the comments list is visible after the comment has been added.
-  await page.waitForSelector('[data-testid="comments-list"]', WAIT_OPTIONS)
-  const commentsList = page.locator('[data-testid="comments-list"]')
-  await expect(commentsList).toBeVisible()
+  await page.getByTestId('comments-list').waitFor(WAIT_OPTIONS)
+  await expect(page.locator('[data-testid="comments-list"]')).toBeVisible()
 
   // 9. Verify that the comment appears within the list and correctly references the intended content.
-  await page.waitForSelector('[data-testid="comments-list-item"]', WAIT_OPTIONS)
-  const commentsListItem = page.locator('[data-testid="comments-list-item"]')
-  await expect(commentsListItem).toBeVisible()
-  const commentsListItemReferencedValue = page.locator(
-    '[data-testid="comments-list-item-referenced-value"]',
+  const commentsListItem = '[data-testid="comments-list-item"]'
+  await page.getByTestId('comments-list-item').waitFor(WAIT_OPTIONS)
+  await expect(page.locator(commentsListItem)).toBeVisible()
+  await expect(page.locator('[data-testid="comments-list-item-referenced-value"]')).toHaveText(
+    PTE_CONTENT_TEXT,
   )
-  await expect(commentsListItemReferencedValue).toHaveText(PTE_CONTENT_TEXT)
 }
 
 test.describe('Inline comments:', () => {
-  test('should create inline comment', async ({page, createDraftDocument, browserName}) => {
-    // For now, only test in Chromium due to flakiness in Firefox and WebKit
-    test.skip(browserName !== 'chromium')
-
+  test('should create inline comment', async ({page, createDraftDocument}) => {
     await inlineCommentCreationTest({page, createDraftDocument})
   })
 
-  test('should resolve inline comment', async ({page, createDraftDocument, browserName}) => {
-    // For now, only test in Chromium due to flakiness in Firefox and WebKit
-    test.skip(browserName !== 'chromium')
-
+  test('should resolve inline comment', async ({page, createDraftDocument}) => {
     // 1. Create a new inline comment
     await inlineCommentCreationTest({page, createDraftDocument})
 
     // 2. Resolve the comment by clicking the status button in the comments list item.
-    await page.waitForSelector('[data-testid="comments-list-item-status-button"]', WAIT_OPTIONS)
-    const statusButton = page.locator('[data-testid="comments-list-item-status-button"]')
-    await statusButton.click()
+    await page.getByTestId('comments-list-item-status-button').waitFor(WAIT_OPTIONS)
+    await page.locator('[data-testid="comments-list-item-status-button"]').click()
 
     // 3. Verify that the text is no longer highlighted in the editor.
-    const addedDecorator = page.locator('[data-inline-comment-state="added"]')
-    await expect(addedDecorator).not.toBeVisible()
+    await expect(page.locator('[data-inline-comment-state="added"]')).not.toBeVisible()
   })
 })


### PR DESCRIPTION
### Description
Lots of changes to the test:
* Turning on for webkit and firefox (since fingers crossed it seems robust enough to handle these)
* Using a triple click to highlight the text in the PTE
* Using a fallback of keyboard highlighting if the triple click didn't work
* Using network idle checks to ensure that test is ready to begin
* Marking as slow because firefox can be very slow at this test (and in general this is one of the most flakey tests)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
