### PR TITLE
refactor(core): add release description to discard dialog

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -20,8 +20,9 @@ export function DiscardVersionDialog(props: {
   onClose: () => void
   documentId: string
   documentType: string
+  releaseName?: string
 }): React.JSX.Element {
-  const {onClose, documentId, documentType} = props
+  const {onClose, documentId, documentType, releaseName} = props
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: coreT} = useTranslation()
   const {discardChanges} = useDocumentOperation(getPublishedId(documentId), documentType)
@@ -64,7 +65,9 @@ export function DiscardVersionDialog(props: {
   return (
     <Dialog
       id={'discard-version-dialog'}
-      header={t('discard-version-dialog.header')}
+      header={t('discard-version-dialog.header', {
+        releaseTitle: releaseName,
+      })}
       onClose={onClose}
       width={0}
       padding={false}

--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -21,9 +21,9 @@ export function DiscardVersionDialog(props: {
   onClose: () => void
   documentId: string
   documentType: string
-  discardFromPerspective: string | SelectedPerspective
+  fromPerspective: string | SelectedPerspective
 }): React.JSX.Element {
-  const {onClose, documentId, documentType, discardFromPerspective} = props
+  const {onClose, documentId, documentType, fromPerspective} = props
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: coreT} = useTranslation()
   const {discardChanges} = useDocumentOperation(getPublishedId(documentId), documentType)
@@ -34,9 +34,7 @@ export function DiscardVersionDialog(props: {
   const [isDiscarding, setIsDiscarding] = useState(false)
   const discardType = isDraftId(documentId) ? 'draft' : 'release'
   const releaseName =
-    typeof discardFromPerspective === 'string'
-      ? discardFromPerspective
-      : discardFromPerspective.metadata.title
+    typeof fromPerspective === 'string' ? fromPerspective : fromPerspective.metadata.title
 
   const schemaType = schema.get(documentType)
 

--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -91,7 +91,7 @@ export function DiscardVersionDialog(props: {
         )}
         <Box paddingX={2}>
           <Text size={1} muted>
-            {t('discard-version-dialog.description')}
+            {t('discard-version-dialog.description', {releaseTitle: releaseName})}
           </Text>
         </Box>
       </Stack>

--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -4,7 +4,7 @@ import {useCallback, useState} from 'react'
 import {Dialog} from '../../../../ui-components'
 import {LoadingBlock} from '../../../components'
 import {useDocumentOperation, useSchema} from '../../../hooks'
-import {useTranslation} from '../../../i18n'
+import {Translate, useTranslation} from '../../../i18n'
 import {type SelectedPerspective} from '../../../perspective/types'
 import {usePerspective} from '../../../perspective/usePerspective'
 import {Preview} from '../../../preview'
@@ -71,9 +71,13 @@ export function DiscardVersionDialog(props: {
   return (
     <Dialog
       id={'discard-version-dialog'}
-      header={t(`discard-version-dialog.header-${discardType}`, {
-        releaseTitle: releaseName,
-      })}
+      header={
+        <Translate
+          t={t}
+          i18nKey={`discard-version-dialog.header-${discardType}`}
+          values={{releaseTitle: releaseName}}
+        />
+      }
       onClose={onClose}
       width={0}
       padding={false}
@@ -97,7 +101,11 @@ export function DiscardVersionDialog(props: {
         )}
         <Box paddingX={2}>
           <Text size={1} muted>
-            {t(`discard-version-dialog.description-${discardType}`, {releaseTitle: releaseName})}
+            <Translate
+              t={t}
+              i18nKey={`discard-version-dialog.description-${discardType}`}
+              values={{releaseTitle: releaseName}}
+            />
           </Text>
         </Box>
       </Stack>

--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -20,7 +20,7 @@ export function DiscardVersionDialog(props: {
   onClose: () => void
   documentId: string
   documentType: string
-  releaseName?: string
+  releaseName: string
 }): React.JSX.Element {
   const {onClose, documentId, documentType, releaseName} = props
   const {t} = useTranslation(releasesLocaleNamespace)

--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -5,6 +5,7 @@ import {Dialog} from '../../../../ui-components'
 import {LoadingBlock} from '../../../components'
 import {useDocumentOperation, useSchema} from '../../../hooks'
 import {useTranslation} from '../../../i18n'
+import {type SelectedPerspective} from '../../../perspective/types'
 import {usePerspective} from '../../../perspective/usePerspective'
 import {Preview} from '../../../preview'
 import {getPublishedId, getVersionFromId, isDraftId, isVersionId} from '../../../util/draftUtils'
@@ -20,9 +21,9 @@ export function DiscardVersionDialog(props: {
   onClose: () => void
   documentId: string
   documentType: string
-  releaseName: string
+  discardFromPerspective: string | SelectedPerspective
 }): React.JSX.Element {
-  const {onClose, documentId, documentType, releaseName} = props
+  const {onClose, documentId, documentType, discardFromPerspective} = props
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: coreT} = useTranslation()
   const {discardChanges} = useDocumentOperation(getPublishedId(documentId), documentType)
@@ -32,6 +33,10 @@ export function DiscardVersionDialog(props: {
   const toast = useToast()
   const [isDiscarding, setIsDiscarding] = useState(false)
   const discardType = isDraftId(documentId) ? 'draft' : 'release'
+  const releaseName =
+    typeof discardFromPerspective === 'string'
+      ? discardFromPerspective
+      : discardFromPerspective.metadata.title
 
   const schemaType = schema.get(documentType)
 

--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -7,7 +7,7 @@ import {useDocumentOperation, useSchema} from '../../../hooks'
 import {useTranslation} from '../../../i18n'
 import {usePerspective} from '../../../perspective/usePerspective'
 import {Preview} from '../../../preview'
-import {getPublishedId, getVersionFromId, isVersionId} from '../../../util/draftUtils'
+import {getPublishedId, getVersionFromId, isDraftId, isVersionId} from '../../../util/draftUtils'
 import {useVersionOperations} from '../../hooks'
 import {releasesLocaleNamespace} from '../../i18n'
 import {type ReleaseDocument} from '../../store'
@@ -31,6 +31,7 @@ export function DiscardVersionDialog(props: {
   const schema = useSchema()
   const toast = useToast()
   const [isDiscarding, setIsDiscarding] = useState(false)
+  const discardType = isDraftId(documentId) ? 'draft' : 'release'
 
   const schemaType = schema.get(documentType)
 
@@ -65,7 +66,7 @@ export function DiscardVersionDialog(props: {
   return (
     <Dialog
       id={'discard-version-dialog'}
-      header={t('discard-version-dialog.header', {
+      header={t(`discard-version-dialog.header-${discardType}`, {
         releaseTitle: releaseName,
       })}
       onClose={onClose}
@@ -77,7 +78,7 @@ export function DiscardVersionDialog(props: {
           onClick: onClose,
         },
         confirmButton: {
-          text: t('discard-version-dialog.title'),
+          text: t(`discard-version-dialog.title-${discardType}`),
           onClick: handleDiscardVersion,
           disabled: isDiscarding,
         },
@@ -91,7 +92,7 @@ export function DiscardVersionDialog(props: {
         )}
         <Box paddingX={2}>
           <Text size={1} muted>
-            {t('discard-version-dialog.description', {releaseTitle: releaseName})}
+            {t(`discard-version-dialog.description-${discardType}`, {releaseTitle: releaseName})}
           </Text>
         </Box>
       </Stack>

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -243,7 +243,7 @@ export const VersionChip = memo(function VersionChip(props: {
               ? getVersionId(documentId, getReleaseIdFromReleaseDocumentId(menuReleaseId))
               : documentId
           }
-          discardFromPerspective={text}
+          fromPerspective={text}
           documentType={documentType}
         />
       )}

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -243,7 +243,7 @@ export const VersionChip = memo(function VersionChip(props: {
               ? getVersionId(documentId, getReleaseIdFromReleaseDocumentId(menuReleaseId))
               : documentId
           }
-          releaseName={text}
+          discardFromPerspective={text}
           documentType={documentType}
         />
       )}

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -243,6 +243,7 @@ export const VersionChip = memo(function VersionChip(props: {
               ? getVersionId(documentId, getReleaseIdFromReleaseDocumentId(menuReleaseId))
               : documentId
           }
+          releaseName={text}
           documentType={documentType}
         />
       )}

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -123,8 +123,7 @@ const releasesLocaleStrings = {
   'discard-version-dialog.description':
     'This will also permanently remove the changes made to this document within this release.',
   /** Header for discarding a version of a document dialog */
-  'discard-version-dialog.header':
-    'Are you sure you want to remove this document from the release?',
+  'discard-version-dialog.header': 'Remove document from the {{releaseTitle}} release?',
   /** Title for dialog for discarding a version of a document */
   'discard-version-dialog.title': 'Yes, discard version',
 

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -119,13 +119,21 @@ const releasesLocaleStrings = {
   'diff.no-changes': 'No changes',
   /** Text for when there's no changes in a release diff */
   'diff.list-empty': 'Changes list is empty, see document',
+  /** Description for discarding a draft of a document dialog */
+  'discard-version-dialog.description-draft':
+    'This will permanently remove all changes made to this document. This action cannot be undone.',
   /** Description for discarding a version of a document dialog */
-  'discard-version-dialog.description':
+  'discard-version-dialog.description-release':
     'This will permanently remove all changes made to this document within the "{{releaseTitle}}" release. This action cannot be undone.',
-  /** Header for discarding a version of a document dialog */
-  'discard-version-dialog.header': 'Remove document from the "{{releaseTitle}}" release?',
+  /** Title for dialog for discarding a draft of a document */
+  'discard-version-dialog.header-draft': 'Discard draft?',
+  /** Header for discarding a version from a release of a document dialog */
+  'discard-version-dialog.header-release': 'Remove document from the "{{releaseTitle}}" release?',
+
+  /** Title for dialog for discarding a draft of a document */
+  'discard-version-dialog.title-draft': 'Discard draft',
   /** Title for dialog for discarding a version of a document */
-  'discard-version-dialog.title': 'Remove from release',
+  'discard-version-dialog.title-release': 'Remove from release',
 
   /** Label for when a document in a release has multiple validation warnings */
   'document-validation.error_other': '{{count}} validation errors',

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -124,11 +124,12 @@ const releasesLocaleStrings = {
     'This will permanently remove all changes made to this document. This action cannot be undone.',
   /** Description for discarding a version of a document dialog */
   'discard-version-dialog.description-release':
-    'This will permanently remove all changes made to this document within the "{{releaseTitle}}" release. This action cannot be undone.',
+    "This will permanently remove all changes made to this document within the '<strong>{{releaseTitle}}</strong>' release. This action cannot be undone.",
   /** Title for dialog for discarding a draft of a document */
   'discard-version-dialog.header-draft': 'Discard draft?',
   /** Header for discarding a version from a release of a document dialog */
-  'discard-version-dialog.header-release': 'Remove document from the "{{releaseTitle}}" release?',
+  'discard-version-dialog.header-release':
+    "Remove document from the '<strong>{{releaseTitle}}</strong>' release?",
 
   /** Title for dialog for discarding a draft of a document */
   'discard-version-dialog.title-draft': 'Discard draft',

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -121,11 +121,11 @@ const releasesLocaleStrings = {
   'diff.list-empty': 'Changes list is empty, see document',
   /** Description for discarding a version of a document dialog */
   'discard-version-dialog.description':
-    'This will also permanently remove the changes made to this document within this release.',
+    'This will permanently remove all changes made to this document within the {{releaseTitle}} release. This action cannot be undone.',
   /** Header for discarding a version of a document dialog */
   'discard-version-dialog.header': 'Remove document from the {{releaseTitle}} release?',
   /** Title for dialog for discarding a version of a document */
-  'discard-version-dialog.title': 'Yes, discard version',
+  'discard-version-dialog.title': 'Remove from release',
 
   /** Label for when a document in a release has multiple validation warnings */
   'document-validation.error_other': '{{count}} validation errors',

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -121,9 +121,9 @@ const releasesLocaleStrings = {
   'diff.list-empty': 'Changes list is empty, see document',
   /** Description for discarding a version of a document dialog */
   'discard-version-dialog.description':
-    'This will permanently remove all changes made to this document within the {{releaseTitle}} release. This action cannot be undone.',
+    'This will permanently remove all changes made to this document within the "{{releaseTitle}}" release. This action cannot be undone.',
   /** Header for discarding a version of a document dialog */
-  'discard-version-dialog.header': 'Remove document from the {{releaseTitle}} release?',
+  'discard-version-dialog.header': 'Remove document from the "{{releaseTitle}}" release?',
   /** Title for dialog for discarding a version of a document */
   'discard-version-dialog.title': 'Remove from release',
 

--- a/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
@@ -58,7 +58,7 @@ export const DiscardVersionAction = (
           documentId={version._id}
           documentType={type}
           onClose={() => setDialogOpen(false)}
-          discardFromPerspective={selectedPerspective}
+          fromPerspective={selectedPerspective}
         />
       ),
     },

--- a/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
@@ -7,6 +7,7 @@ import {
   type DocumentActionDescription,
   type DocumentActionProps,
 } from '../../../config/document/actions'
+import {usePerspective} from '../../../perspective/usePerspective'
 import {useDocumentPairPermissions} from '../../../store/_legacy/grants/documentPairPermissions'
 import {useCurrentUser} from '../../../store/user/hooks'
 import {DiscardVersionDialog} from '../../components/dialog/DiscardVersionDialog'
@@ -20,6 +21,11 @@ export const DiscardVersionAction = (
   const {id, type, release, version} = props
   const currentUser = useCurrentUser()
   const {t} = useTranslation()
+  const {selectedPerspective} = usePerspective()
+  const selectedName =
+    typeof selectedPerspective === 'string'
+      ? selectedPerspective
+      : selectedPerspective.metadata.title
 
   const [permissions, isPermissionsLoading] = useDocumentPairPermissions({
     id,
@@ -56,6 +62,7 @@ export const DiscardVersionAction = (
           documentId={version._id}
           documentType={type}
           onClose={() => setDialogOpen(false)}
+          releaseName={selectedName}
         />
       ),
     },

--- a/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
@@ -22,10 +22,6 @@ export const DiscardVersionAction = (
   const currentUser = useCurrentUser()
   const {t} = useTranslation()
   const {selectedPerspective} = usePerspective()
-  const selectedName =
-    typeof selectedPerspective === 'string'
-      ? selectedPerspective
-      : selectedPerspective.metadata.title
 
   const [permissions, isPermissionsLoading] = useDocumentPairPermissions({
     id,
@@ -62,7 +58,7 @@ export const DiscardVersionAction = (
           documentId={version._id}
           documentType={type}
           onClose={() => setDialogOpen(false)}
-          releaseName={selectedName}
+          discardFromPerspective={selectedPerspective}
         />
       ),
     },

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -74,7 +74,7 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
       if (!isBundleDocumentRow(rowProps.datum)) return null
       if (rowProps.datum.isPending) return null
 
-      return <DocumentActions document={rowProps.datum} releaseName={release.metadata.title} />
+      return <DocumentActions document={rowProps.datum} releaseTitle={release.metadata.title} />
     },
     [release.metadata.title, release.state],
   )

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -74,9 +74,9 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
       if (!isBundleDocumentRow(rowProps.datum)) return null
       if (rowProps.datum.isPending) return null
 
-      return <DocumentActions document={rowProps.datum} />
+      return <DocumentActions document={rowProps.datum} releaseName={release.metadata.title} />
     },
-    [release.state],
+    [release.metadata.title, release.state],
   )
 
   const documentTableColumnDefs = useMemo(

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -113,7 +113,7 @@ const DocumentActionsInner = memo(
             onClose={() => setShowDiscardDialog(false)}
             documentId={document.document._id}
             documentType={document.document._type}
-            releaseName={releaseName}
+            discardFromPerspective={releaseName}
           />
         )}
         {showUnpublishDialog && (

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -113,7 +113,7 @@ const DocumentActionsInner = memo(
             onClose={() => setShowDiscardDialog(false)}
             documentId={document.document._id}
             documentType={document.document._type}
-            discardFromPerspective={releaseName}
+            fromPerspective={releaseName}
           />
         )}
         {showUnpublishDialog && (

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -17,10 +17,10 @@ import {type BundleDocumentRow} from '../ReleaseSummary'
 const DocumentActionsInner = memo(
   function DocumentActionsInner({
     document,
-    releaseName,
+    releaseTitle,
   }: {
     document: BundleDocumentRow
-    releaseName: string
+    releaseTitle: string
   }) {
     const [showDiscardDialog, setShowDiscardDialog] = useState(false)
     const [showUnpublishDialog, setShowUnpublishDialog] = useState(false)
@@ -113,7 +113,7 @@ const DocumentActionsInner = memo(
             onClose={() => setShowDiscardDialog(false)}
             documentId={document.document._id}
             documentType={document.document._type}
-            fromPerspective={releaseName}
+            fromPerspective={releaseTitle}
           />
         )}
         {showUnpublishDialog && (
@@ -131,7 +131,7 @@ const DocumentActionsInner = memo(
 
 export const DocumentActions = memo(function GuardedDocumentActions(props: {
   document: BundleDocumentRow
-  releaseName: string
+  releaseTitle: string
 }) {
   const schema = useSchema()
   const type = schema.get(props.document.document._type)

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -15,7 +15,13 @@ import {isGoingToUnpublish} from '../../../util/isGoingToUnpublish'
 import {type BundleDocumentRow} from '../ReleaseSummary'
 
 const DocumentActionsInner = memo(
-  function DocumentActionsInner({document}: {document: BundleDocumentRow}) {
+  function DocumentActionsInner({
+    document,
+    releaseName,
+  }: {
+    document: BundleDocumentRow
+    releaseName: string
+  }) {
     const [showDiscardDialog, setShowDiscardDialog] = useState(false)
     const [showUnpublishDialog, setShowUnpublishDialog] = useState(false)
     const {t: coreT} = useTranslation()
@@ -107,6 +113,7 @@ const DocumentActionsInner = memo(
             onClose={() => setShowDiscardDialog(false)}
             documentId={document.document._id}
             documentType={document.document._type}
+            releaseName={releaseName}
           />
         )}
         {showUnpublishDialog && (
@@ -124,6 +131,7 @@ const DocumentActionsInner = memo(
 
 export const DocumentActions = memo(function GuardedDocumentActions(props: {
   document: BundleDocumentRow
+  releaseName: string
 }) {
   const schema = useSchema()
   const type = schema.get(props.document.document._type)


### PR DESCRIPTION
### Description

> [!Note]
> Waiting for a final ✅ from knut for the draft version but everything else should be good to go.

- Update copy for the discard module as feedback from Knut

| Discard a draft | Discard a version |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/2b9fd0fb-5c3b-4f39-8a73-87abe192a30b) | ![image](https://github.com/user-attachments/assets/9d09e30f-e9b1-430d-a591-9f2382456af7) |

### What to review

Does this make sense?

### Testing

N/A

### Notes for release

N/A
