### PR TITLE
fix(form): workaround for mutate-on-wheel-issue for number inputs

### DIFF
--- a/packages/sanity/src/core/form/inputs/NumberInput.tsx
+++ b/packages/sanity/src/core/form/inputs/NumberInput.tsx
@@ -1,8 +1,56 @@
 import {TextInput} from '@sanity/ui'
+import {useEffect} from 'react'
 
 import {type NumberInputProps} from '../types'
 import {getValidationRule} from '../utils/getValidationRule'
 
+function getScrollableParent(node: EventTarget) {
+  if (!node || !(node instanceof Element)) return null
+
+  let parent = node.parentElement
+
+  while (parent) {
+    const style = window.getComputedStyle(parent)
+    const overflowY = style.overflowY
+    const isScrollable = overflowY === 'auto' || overflowY === 'scroll'
+    if (isScrollable && parent.scrollHeight > parent.clientHeight) {
+      return parent
+    }
+    parent = parent.parentElement
+  }
+
+  return window
+}
+
+// Workaround for wheel-events causing number inputs to mutate
+//
+// The mere presence of an event listener for the wheel event causes number inputs to mutate on wheel.
+// This is terrible UX and can lead to accidental modifications of values that can go unnoticed.
+// The below event handler provides a workaround for Chromium-based browsers.
+// Firefox has removed mutate-on-wheel behavior
+// Safari has removed it as of current Technology Preview, but this workaround, however, does not fix
+// the issue for current Safari versions
+// See https://github.com/facebook/react/issues/32156
+function preventWheel(event: WheelEvent) {
+  if (event.currentTarget && document.activeElement === event.currentTarget) {
+    event.preventDefault()
+    const scrollContainer = getScrollableParent(event.currentTarget)
+    if (scrollContainer) {
+      // The above preventDefault also prevents scrolling, but we still want the wheel event to actually scroll
+      // so we'll instead explicitly call scrollBy on the nearest scroll container
+      // ## Note about Safari
+      // Testing in Safari 18.1.1 reveals that this call to .scrollBy actually brings back the mutate-on-scroll
+      // behavior and triggers an onChange on the input ending up voiding the workaround here, meaning
+      // mutate-on-wheel behavior will still be an issue in Safari. It's unclear to me why this happens.
+      // However, since WebKit has removed mutate-on-wheel behavior, this will cease to be an issue in a future release of Safari.
+      scrollContainer.scrollBy({
+        top: event.deltaY,
+        left: event.deltaX,
+        behavior: 'instant',
+      })
+    }
+  }
+}
 /**
  *
  * @hidden
@@ -20,6 +68,16 @@ export function NumberInput(props: NumberInputProps) {
 
   // eslint-disable-next-line no-nested-ternary
   const inputMode = onlyPositiveNumber ? (onlyIntegers ? 'numeric' : 'decimal') : 'text'
+
+  const inputElementRef = elementProps.ref
+
+  useEffect(() => {
+    const element = inputElementRef.current
+    element.addEventListener('wheel', preventWheel)
+    return () => {
+      element.removeEventListener('wheel', preventWheel)
+    }
+  }, [inputElementRef])
 
   return (
     <TextInput


### PR DESCRIPTION
### Description
Fixes the issue where number inputs gets modified if scroll wheel is used while hovering over while having focus.

Modifying the input value based on scroll wheel movement is the native browser behavior _when and only when_ a [`wheel`](https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event) event listener is added to any element on the page, and because React eagerly adds listeners for all events to the root container, this opts-in to the mutate-on-wheel behavior.

The issue is currently present in latest Chrome and Safari. Firefox has disabled the mutate-on-wheel behavior entirely as of v130, and Safari has disabled it in the latest Technology Preview.

Unfortunately, the workaround in this PR only applies to Chromium based browsers and the issue remains in Safari until they ship a version that includes the removal of the mutate-on-scroll behavior, but hopefully it won't be too long until that happens.

### What to review

This was the least intrusive workaround I could find. I'd love to hear it if you have better ideas about how it can be fixed.

Other workarounds I've seen and considered was:
- calling `event.preventDefault()` and leave it at that. This is bad, because the user expectation is to still be able to scroll the page/container while hovering over the input.
- calling `event.currentTarget.blur()` when scrolling. This is bad because it loses focus and impairs accessibility.

I've tested that this doesn't introduce any unintended side effects in latest Firefox, Chrome and Safari.

### Testing
Existing tests should be enough. Hard to test for this particular issue.

### Notes for release
- Fixes the issue where number inputs gets modified if scroll wheel is used while hovering over while having focus. Note: the issue remains in Firefox