### PR TITLE
feat(core): use project scoped media-libraries endpoint

### DIFF
--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/MediaLibrarySource.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/MediaLibrarySource.tsx
@@ -43,23 +43,16 @@ const MediaLibraryAssetSource = function MediaLibraryAssetSource(
     if (libraryIdProp || fetchedLibraryId) {
       return
     }
-    client.request({uri: `/projects/${projectId}`}).then((project) => {
-      const {organizationId} = project
-      client
-        .withConfig({
-          useProjectHostname: false,
-        })
-        .request({uri: `/media-libraries`, query: {organizationId}, useGlobalApi: true})
-        .then((result) => {
-          const libraryIdFromResult = result.data[0]?.id
-          if (libraryIdFromResult) {
-            // Add to cache for this project (organization)
-            if (projectId) {
-              fetchedLibraryIdCache.set(projectId, libraryIdFromResult)
-            }
-            setFetchedLibraryId(libraryIdFromResult)
-          }
-        })
+    if (!projectId) {
+      throw new Error('projectId is required to fetch Media Library ID')
+    }
+    client.request({uri: `/media-libraries`, query: {projectId}}).then((result) => {
+      const libraryIdFromResult = result.data[0]?.id
+      if (libraryIdFromResult) {
+        // Add to cache for this project (organization)
+        fetchedLibraryIdCache.set(projectId, libraryIdFromResult)
+        setFetchedLibraryId(libraryIdFromResult)
+      }
     })
   }, [client, fetchedLibraryId, libraryIdProp, projectId])
 


### PR DESCRIPTION
### Description

We have a new endpoint available under the project API host to fetch the projects media libraries. 

This will use the same auth and CORS settings as with everything else in the studio.

Also we get rid of one hop to fetch the organization id.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That it works.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Can be tested in the test-studio by selecting "Media Library". The test studio is configured without specifying `libraryId`.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

N/A - part of yet unannounced code.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
