### PR TITLE
fix: resolving issue where string state is passed as a route parameter to router.navigate

### DIFF
--- a/packages/sanity/src/router/__test__/RouterScope.test.tsx
+++ b/packages/sanity/src/router/__test__/RouterScope.test.tsx
@@ -427,4 +427,54 @@ describe('RouteScope', () => {
       },
     })
   })
+
+  describe('navigate with string state', () => {
+    it('should handle navigation with string state in options', () => {
+      const wrapper = createWrapper()
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate({
+          state: 'stringState',
+        })
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [['stickyParam', 'stickyValue']],
+          tool: 'desk',
+          testScope: {
+            state: 'stringState',
+          },
+        },
+      })
+    })
+
+    it('should handle navigation with string state and replace option', () => {
+      const wrapper = createWrapper()
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate(
+          {
+            state: 'stringState',
+          },
+          {
+            replace: true,
+          },
+        )
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [['stickyParam', 'stickyValue']],
+          tool: 'desk',
+          testScope: {
+            state: 'stringState',
+          },
+        },
+        replace: true,
+      })
+    })
+  })
 })

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -346,7 +346,7 @@ export const isNavigateOptions = (
   !Array.isArray(maybeNavigateOptions) &&
   ('replace' in maybeNavigateOptions ||
     'stickyParams' in maybeNavigateOptions ||
-    'state' in maybeNavigateOptions)
+    ('state' in maybeNavigateOptions && typeof maybeNavigateOptions.state === 'object'))
 
 /**
  * Type representing either a new router state or navigation options with an optional state.

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -340,13 +340,33 @@ export type RouterState = Record<string, unknown> & {_searchParams?: SearchParam
 
 export const isNavigateOptions = (
   maybeNavigateOptions: unknown,
-): maybeNavigateOptions is NavigateOptions & {state?: RouterState | null} =>
-  typeof maybeNavigateOptions === 'object' &&
-  maybeNavigateOptions !== null &&
-  !Array.isArray(maybeNavigateOptions) &&
-  ('replace' in maybeNavigateOptions ||
+): maybeNavigateOptions is NavigateOptions & {state?: RouterState | null} => {
+  if (
+    typeof maybeNavigateOptions !== 'object' ||
+    maybeNavigateOptions === null ||
+    Array.isArray(maybeNavigateOptions)
+  ) {
+    return false
+  }
+
+  const hasNavigationProps =
+    'replace' in maybeNavigateOptions ||
     'stickyParams' in maybeNavigateOptions ||
-    ('state' in maybeNavigateOptions && typeof maybeNavigateOptions.state === 'object'))
+    'state' in maybeNavigateOptions
+
+  if (!hasNavigationProps) {
+    return false
+  }
+
+  // if state exists then it should be of RouterState type
+  if ('state' in maybeNavigateOptions) {
+    const {state} = maybeNavigateOptions as {state: unknown}
+    // allow null or undefined or RouterState (including empty object)
+    return state === null || state === undefined || typeof state === 'object'
+  }
+
+  return true
+}
 
 /**
  * Type representing either a new router state or navigation options with an optional state.


### PR DESCRIPTION
### Description
in cases where `router.navigate({state: 'stateRouteValue'})` is called, this was wrongly matching on the type guard `isNavigateOptions` for thinking this was the newer `navigate` signature (where `state` and other options are provided together as a single parameter).

Updating the guard to verify that `state` must be an object (to match `type RouterState = Record<string, unknown> & {_searchParams?: SearchParam[]}`) resolves the issue by correctly identifying `{state: 'stateRouteValue'}` as being the older `navigate(state, options)` signature


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Improvements to the type guard `isNavigateOptions`
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Added multiple tests specifically for these scenarios
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
* Fixes issue where Scheduled Publishing would not be accessible from the Studio tools bar
* [DEV] Fixes a regression in `router.navigate` where a `RouterState` with a `state` key/value pair would not perform expected navigation
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
