### PR TITLE
refactor(cli): rename app config keys and properties

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapLocalTemplate.ts
@@ -143,7 +143,7 @@ export async function bootstrapLocalTemplate(
   // ...and a CLI config (`sanity.cli.[ts|js]`)
   const cliConfig = isAppTemplate
     ? createAppCliConfig({
-        appLocation: template.appLocation!,
+        entry: template.entry!,
         organizationId: variables.organizationId,
       })
     : createCliConfig({

--- a/packages/@sanity/cli/src/actions/init-project/createAppCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init-project/createAppCliConfig.ts
@@ -4,16 +4,16 @@ const defaultAppTemplate = `
 import {defineCliConfig} from 'sanity/cli'
 
 export default defineCliConfig({
-  __experimental_appConfiguration: {
+  app: {
     organizationId: '%organizationId%',
-    appLocation: '%appLocation%',
+    entry: '%entry%',
   },
 })
 `
 
 export interface GenerateCliConfigOptions {
   organizationId?: string
-  appLocation: string
+  entry: string
 }
 
 export function createAppCliConfig(options: GenerateCliConfigOptions): string {

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -98,7 +98,7 @@ export interface ProjectTemplate {
   importPrompt?: string
   configTemplate?: string | ((variables: GenerateConfigOptions['variables']) => string)
   typescriptOnly?: boolean
-  appLocation?: string
+  entry?: string
   scripts?: Record<string, string>
 }
 

--- a/packages/@sanity/cli/src/actions/init-project/templates/appQuickstart.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/appQuickstart.ts
@@ -19,7 +19,7 @@ const appTemplate: ProjectTemplate = {
     'sanity': '^3',
     'typescript': '^5.1.6',
   },
-  appLocation: './src/App.tsx',
+  entry: './src/App.tsx',
   scripts: {
     dev: 'sanity dev',
     build: 'sanity build',

--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -311,6 +311,15 @@ export interface ReactCompilerConfig {
   compilationMode?: 'infer' | 'syntax' | 'annotation' | 'all'
 }
 
+interface AppConfig {
+  organizationId: string
+  /**
+   * Defaults to './src/App'
+   */
+  entry?: string
+  id?: string
+}
+
 export interface CliConfig {
   api?: CliApiConfig
 
@@ -349,13 +358,8 @@ export interface CliConfig {
   /**
    * Parameter used to configure other kinds of applications.
    * Signals to `sanity` commands that this is not a studio.
-   * @internal
    */
-  __experimental_appConfiguration?: {
-    organizationId: string
-    appLocation?: string
-    appId?: string
-  }
+  app?: AppConfig
 }
 
 export type UserViteConfig =

--- a/packages/sanity/src/_internal/cli/actions/app/__tests__/deployAction.test.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/__tests__/deployAction.test.ts
@@ -63,9 +63,8 @@ describe('deployAppAction', () => {
       },
       prompt: {single: vi.fn()},
       cliConfig: {
-        // eslint-disable-next-line camelcase
-        __experimental_appConfiguration: {
-          appLocation: 'app',
+        app: {
+          entry: 'app',
           organizationId: 'org-id',
         },
       },
@@ -129,8 +128,8 @@ describe('deployAppAction', () => {
     const mockSpinner = mockContext.output.spinner('')
     mockContext.cliConfig = {
       // eslint-disable-next-line camelcase
-      __experimental_appConfiguration: {
-        appId: 'configured-app-id',
+      app: {
+        id: 'configured-app-id',
         organizationId: 'org-id',
       },
     } as CliConfig
@@ -322,7 +321,7 @@ describe('deployAppAction', () => {
     // Create a context without appId in the config
     mockContext.cliConfig = {
       // eslint-disable-next-line camelcase
-      __experimental_appConfiguration: {
+      app: {
         organizationId: 'org-id',
       },
     } as CliConfig
@@ -351,11 +350,9 @@ describe('deployAppAction', () => {
 
     // Verify the hint to add appId to config is shown
     expect(mockContext.output.print).toHaveBeenCalledWith(
-      expect.stringContaining("Add appId: 'app-id'"),
+      expect.stringContaining("Add id: 'app-id'"),
     )
-    expect(mockContext.output.print).toHaveBeenCalledWith(
-      expect.stringContaining('to __experimental_appConfiguration'),
-    )
+    expect(mockContext.output.print).toHaveBeenCalledWith(expect.stringContaining('to `app`'))
     expect(mockContext.output.print).toHaveBeenCalledWith(
       expect.stringContaining('to avoid prompting on next deploy'),
     )

--- a/packages/sanity/src/_internal/cli/actions/app/__tests__/undeployAction.test.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/__tests__/undeployAction.test.ts
@@ -52,9 +52,8 @@ describe('undeployAppAction', () => {
       },
       prompt: {single: vi.fn()},
       cliConfig: {
-        // eslint-disable-next-line camelcase
-        __experimental_appConfiguration: {
-          appId: 'app-id',
+        app: {
+          id: 'app-id',
         },
       },
     } as unknown as CliCommandContext
@@ -68,7 +67,7 @@ describe('undeployAppAction', () => {
 
     expect(mockContext.output.print).toHaveBeenCalledWith('No application ID provided.')
     expect(mockContext.output.print).toHaveBeenCalledWith(
-      'Please set appId in `__experimental_appConfiguration` in sanity.cli.js or sanity.cli.ts.',
+      'Please set id in `app` in sanity.cli.js or sanity.cli.ts.',
     )
     expect(mockContext.output.print).toHaveBeenCalledWith('Nothing to undeploy.')
   })

--- a/packages/sanity/src/_internal/cli/actions/app/deployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/deployAction.ts
@@ -34,10 +34,7 @@ export default async function deployAppAction(
   const isAutoUpdating = shouldAutoUpdate({flags, cliConfig})
 
   const installedSanityVersion = await getInstalledSanityVersion()
-  const appId =
-    cliConfig &&
-    '__experimental_appConfiguration' in cliConfig &&
-    cliConfig.__experimental_appConfiguration?.appId
+  const appId = cliConfig && 'app' in cliConfig && cliConfig.app?.id
 
   const client = apiClient({
     requireUser: true,
@@ -143,8 +140,8 @@ export default async function deployAppAction(
     output.print(`\nSuccess! Application deployed`)
 
     if (!appId) {
-      output.print(`\nAdd ${chalk.cyan(`appId: '${userApplication.id}'`)}`)
-      output.print(`to __experimental_appConfiguration in sanity.cli.js or sanity.cli.ts`)
+      output.print(`\nAdd ${chalk.cyan(`id: '${userApplication.id}'`)}`)
+      output.print('to `app` in sanity.cli.js or sanity.cli.ts')
       output.print(`to avoid prompting on next deploy.`)
     }
   } catch (err) {

--- a/packages/sanity/src/_internal/cli/actions/app/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/devAction.ts
@@ -28,12 +28,8 @@ export default async function startAppDevServer(
   }
 
   let organizationId: string | undefined
-  if (
-    cliConfig &&
-    '__experimental_appConfiguration' in cliConfig &&
-    cliConfig.__experimental_appConfiguration?.organizationId
-  ) {
-    organizationId = cliConfig.__experimental_appConfiguration.organizationId
+  if (cliConfig && 'app' in cliConfig && cliConfig.app?.organizationId) {
+    organizationId = cliConfig.app.organizationId
   }
 
   if (!organizationId) {

--- a/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts
@@ -20,17 +20,12 @@ export default async function undeployAppAction(
   // Check that the project has an application ID
   let spinner = output.spinner('Checking application info').start()
 
-  const appId =
-    cliConfig && '__experimental_appConfiguration' in cliConfig
-      ? cliConfig.__experimental_appConfiguration?.appId
-      : undefined
+  const appId = cliConfig && 'app' in cliConfig ? cliConfig.app?.id : undefined
 
   if (!appId) {
     spinner.fail()
     output.print(`No application ID provided.`)
-    output.print(
-      'Please set appId in `__experimental_appConfiguration` in sanity.cli.js or sanity.cli.ts.',
-    )
+    output.print('Please set id in `app` in sanity.cli.js or sanity.cli.ts.')
     output.print('Nothing to undeploy.')
     return
   }

--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -177,10 +177,7 @@ export default async function buildSanityStudio(
       importMap,
       reactCompiler:
         cliConfig && 'reactCompiler' in cliConfig ? cliConfig.reactCompiler : undefined,
-      appLocation:
-        cliConfig && '__experimental_appConfiguration' in cliConfig
-          ? cliConfig.__experimental_appConfiguration?.appLocation
-          : undefined,
+      entry: cliConfig && 'app' in cliConfig ? cliConfig.app?.entry : undefined,
       isApp,
     })
 

--- a/packages/sanity/src/_internal/cli/actions/deploy/__tests__/helpers.test.ts
+++ b/packages/sanity/src/_internal/cli/actions/deploy/__tests__/helpers.test.ts
@@ -414,8 +414,7 @@ describe('getOrCreateApplication', () => {
     output: mockOutput,
     prompt: mockPrompt,
     cliConfig: {
-      // eslint-disable-next-line camelcase
-      __experimental_appConfiguration: {
+      app: {
         organizationId: 'test-org',
       },
     },

--- a/packages/sanity/src/_internal/cli/actions/deploy/helpers.ts
+++ b/packages/sanity/src/_internal/cli/actions/deploy/helpers.ts
@@ -274,10 +274,7 @@ export async function getOrCreateApplication({
   spinner,
 }: GetOrCreateUserApplicationOptions): Promise<UserApplication> {
   const {prompt, cliConfig} = context
-  const organizationId =
-    cliConfig &&
-    '__experimental_appConfiguration' in cliConfig &&
-    cliConfig.__experimental_appConfiguration?.organizationId
+  const organizationId = cliConfig && 'app' in cliConfig && cliConfig.app?.organizationId
 
   // Complete the spinner so prompt can properly work
   spinner.succeed()
@@ -415,10 +412,7 @@ async function getOrCreateAppFromConfig({
   appId,
 }: AppConfigOptions): Promise<UserApplication> {
   const {output, cliConfig} = context
-  const organizationId =
-    cliConfig &&
-    '__experimental_appConfiguration' in cliConfig &&
-    cliConfig.__experimental_appConfiguration?.organizationId
+  const organizationId = cliConfig && 'app' in cliConfig && cliConfig.app?.organizationId
   if (appId) {
     const existingUserApplication = await getUserApplication({
       client,
@@ -433,7 +427,7 @@ async function getOrCreateAppFromConfig({
   }
 
   // core apps cannot arbitrarily create ids or hosts, so send them to create option
-  output.print('The appId provided in your configuration is not recognized.')
+  output.print('The id provided in your configuration is not recognized.')
   output.print('Checking existing applications...')
   return getOrCreateApplication({client, context, spinner})
 }

--- a/packages/sanity/src/_internal/cli/server/buildStaticFiles.ts
+++ b/packages/sanity/src/_internal/cli/server/buildStaticFiles.ts
@@ -34,7 +34,7 @@ export interface StaticBuildOptions {
 
   vite?: UserViteConfig
   reactCompiler: ReactCompilerConfig | undefined
-  appLocation?: string
+  entry?: string
   isApp?: boolean
 }
 
@@ -50,7 +50,7 @@ export async function buildStaticFiles(
     vite: extendViteConfig,
     importMap,
     reactCompiler,
-    appLocation,
+    entry,
     isApp,
   } = options
 
@@ -60,7 +60,7 @@ export async function buildStaticFiles(
     reactStrictMode: false,
     watch: false,
     basePath,
-    appLocation,
+    entry,
     isApp,
   })
 

--- a/packages/sanity/src/_internal/cli/server/devServer.ts
+++ b/packages/sanity/src/_internal/cli/server/devServer.ts
@@ -17,7 +17,7 @@ export interface DevServerOptions {
   reactStrictMode: boolean
   reactCompiler: ReactCompilerConfig | undefined
   vite?: UserViteConfig
-  appLocation?: string
+  entry?: string
   isApp?: boolean
   skipStartLog?: boolean
 }
@@ -35,14 +35,14 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     reactStrictMode,
     vite: extendViteConfig,
     reactCompiler,
-    appLocation,
+    entry,
     isApp,
     skipStartLog,
   } = options
 
   const startTime = Date.now()
   debug('Writing Sanity runtime files')
-  await writeSanityRuntime({cwd, reactStrictMode, watch: true, basePath, appLocation, isApp})
+  await writeSanityRuntime({cwd, reactStrictMode, watch: true, basePath, entry, isApp})
 
   debug('Resolving vite config')
   const mode = 'development'

--- a/packages/sanity/src/_internal/cli/server/getEntryModule.ts
+++ b/packages/sanity/src/_internal/cli/server/getEntryModule.ts
@@ -30,7 +30,7 @@ const appEntryModule = `
 // Modifications to this file is automatically discarded
 import {createRoot} from 'react-dom/client'
 import {createElement} from 'react'
-import App from %APP_LOCATION%
+import App from %ENTRY%
 
 const root = createRoot(document.getElementById('root'))
 const element = createElement(App)
@@ -41,13 +41,13 @@ export function getEntryModule(options: {
   reactStrictMode: boolean
   relativeConfigLocation: string | null
   basePath?: string
-  appLocation?: string
+  entry?: string
   isApp?: boolean
 }): string {
-  const {reactStrictMode, relativeConfigLocation, basePath, appLocation, isApp} = options
+  const {reactStrictMode, relativeConfigLocation, basePath, entry, isApp} = options
 
   if (isApp) {
-    return appEntryModule.replace(/%APP_LOCATION%/, JSON.stringify(appLocation || './src/App'))
+    return appEntryModule.replace(/%ENTRY%/, JSON.stringify(entry || './src/App'))
   }
 
   const sourceModule = relativeConfigLocation ? entryModule : noConfigEntryModule

--- a/packages/sanity/src/_internal/cli/server/runtime.ts
+++ b/packages/sanity/src/_internal/cli/server/runtime.ts
@@ -21,7 +21,7 @@ export interface RuntimeOptions {
   reactStrictMode: boolean
   watch: boolean
   basePath?: string
-  appLocation?: string
+  entry?: string
   isApp?: boolean
 }
 
@@ -37,7 +37,7 @@ export async function writeSanityRuntime({
   reactStrictMode,
   watch,
   basePath,
-  appLocation,
+  entry,
   isApp,
 }: RuntimeOptions): Promise<void> {
   debug('Resolving Sanity monorepo information')
@@ -82,12 +82,12 @@ export async function writeSanityRuntime({
     relativeConfigLocation = studioConfigPath ? path.relative(runtimeDir, studioConfigPath) : null
   }
 
-  const relativeAppLocation = cwd ? path.resolve(cwd, appLocation || './src/App') : appLocation
+  const relativeEntry = cwd ? path.resolve(cwd, entry || './src/App') : entry
   const appJsContent = getEntryModule({
     reactStrictMode,
     relativeConfigLocation,
     basePath,
-    appLocation: relativeAppLocation,
+    entry: relativeEntry,
     isApp,
   })
   await fs.writeFile(path.join(runtimeDir, 'app.js'), appJsContent)

--- a/packages/sanity/src/_internal/cli/util/determineIsApp.ts
+++ b/packages/sanity/src/_internal/cli/util/determineIsApp.ts
@@ -1,5 +1,5 @@
 import {type CliConfig} from '@sanity/cli'
 
 export function determineIsApp(cliConfig?: CliConfig): boolean {
-  return Boolean(cliConfig && '__experimental_appConfiguration' in cliConfig)
+  return Boolean(cliConfig && 'app' in cliConfig)
 }

--- a/packages/sanity/src/_internal/cli/util/servers.ts
+++ b/packages/sanity/src/_internal/cli/util/servers.ts
@@ -48,7 +48,7 @@ export function getSharedServerConfig({
   httpHost: string
   basePath: string
   vite: CliConfig['vite']
-  appLocation?: string
+  entry?: string
   isApp?: boolean
 } {
   // Order of preference: CLI flags, environment variables, user build config, default config
@@ -66,8 +66,8 @@ export function getSharedServerConfig({
     env.SANITY_STUDIO_BASEPATH ?? (cliConfig?.project?.basePath || '/'),
   )
 
-  const isApp = cliConfig && '__experimental_appConfiguration' in cliConfig
-  const appLocation = cliConfig?.__experimental_appConfiguration?.appLocation
+  const isApp = cliConfig && 'app' in cliConfig
+  const entry = cliConfig?.app?.entry
 
   return {
     cwd: workDir,
@@ -75,7 +75,7 @@ export function getSharedServerConfig({
     httpHost,
     basePath,
     vite: cliConfig?.vite,
-    appLocation,
+    entry,
     isApp,
   }
 }


### PR DESCRIPTION
### Description

Renamed `__experimental_appConfiguration` to `app` in the CLI config, and renamed its properties for better clarity:
- `appLocation` → `entry`
- `appId` → `id`

This change improves the developer experience by moving from an experimental API to a stable one with more intuitive property names.

Before:
```js
export default defineCliConfig({
  __experimental_appConfiguration: {
    organizationId: 'your-org-id',
    appLocation: './src/App.tsx',
    appId: 'your-app-id',
  },
})
```

After:
```js
export default defineCliConfig({
  app: {
    organizationId: 'your-org-id',
    entry: './src/App.tsx',
    id: 'your-app-id',
  },
})
```

### What to review

- The renaming of configuration properties in the CLI config
- Updates to all references of these properties throughout the codebase
- Error messages and hints that reference these configuration options

### Testing

Run the following steps to test manually
1. run `pnpm build` at the root
2. cd to `dev` folder
3. run `npx sanity init --template app-quickstart`
4. See the new CLI changes 
5. Ensure, dev, build and deploy commands still work

### Notes for release
N/A