### PR TITLE
fix(structure): update release banners

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/AddToReleaseBanner.tsx
@@ -1,4 +1,4 @@
-import {Flex, Text, useToast} from '@sanity/ui'
+import {Text, useToast} from '@sanity/ui'
 import {useCallback, useEffect, useState} from 'react'
 import {
   getReleaseIdFromReleaseDocumentId,
@@ -11,7 +11,6 @@ import {
   useVersionOperations,
 } from 'sanity'
 
-import {Button} from '../../../../../ui-components'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {useConditionalToast} from '../documentViews/useConditionalToast'
 import {Banner} from './Banner'
@@ -84,32 +83,28 @@ export function AddToReleaseBanner({
   return (
     <Banner
       tone={tone}
-      paddingY={0}
       content={
-        <Flex align="center" justify="space-between" gap={1} flex={1}>
-          <Text size={1}>
-            <Translate
-              i18nKey="banners.release.not-in-release"
-              t={t}
-              values={{
-                title:
-                  currentRelease?.metadata?.title || tCore('release.placeholder-untitled-release'),
-              }}
-              components={{
-                VersionBadge: getVersionInlineBadge(currentRelease),
-              }}
-            />
-          </Text>
-          <Flex gap={2} align="center" justify="center">
-            <Button
-              text={t('banners.release.action.add-to-release')}
-              tone={tone}
-              disabled={Boolean(versionCreateState)}
-              onClick={handleAddToRelease}
-            />
-          </Flex>
-        </Flex>
+        <Text size={1}>
+          <Translate
+            i18nKey="banners.release.not-in-release"
+            t={t}
+            values={{
+              title:
+                currentRelease?.metadata?.title || tCore('release.placeholder-untitled-release'),
+            }}
+            components={{
+              VersionBadge: getVersionInlineBadge(currentRelease),
+            }}
+          />
+        </Text>
       }
+      action={{
+        text: t('banners.release.action.add-to-release'),
+        tone: tone,
+        disabled: Boolean(versionCreateState),
+        onClick: handleAddToRelease,
+        mode: 'default',
+      }}
     />
   )
 }

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ArchivedReleaseDocumentBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ArchivedReleaseDocumentBanner.tsx
@@ -1,4 +1,4 @@
-import {Flex, Text} from '@sanity/ui'
+import {Text} from '@sanity/ui'
 import {useMemo} from 'react'
 import {
   getReleaseIdFromReleaseDocumentId,
@@ -43,22 +43,19 @@ export function ArchivedReleaseDocumentBanner(): React.JSX.Element {
   return (
     <Banner
       tone="caution"
-      paddingY={2}
       content={
-        <Flex align="center" justify="space-between" gap={1} flex={1}>
-          <Text size={1}>
-            <Translate
-              t={t}
-              i18nKey={description}
-              values={{
-                title,
-              }}
-              components={{
-                VersionBadge: getVersionInlineBadge(release),
-              }}
-            />
-          </Text>
-        </Flex>
+        <Text size={1}>
+          <Translate
+            t={t}
+            i18nKey={description}
+            values={{
+              title,
+            }}
+            components={{
+              VersionBadge: getVersionInlineBadge(release),
+            }}
+          />
+        </Text>
       }
       action={
         params?.archivedRelease

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ScheduledReleaseBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ScheduledReleaseBanner.tsx
@@ -1,5 +1,5 @@
 import {LockIcon} from '@sanity/icons'
-import {Flex, Text} from '@sanity/ui'
+import {Text} from '@sanity/ui'
 import {
   formatRelativeLocalePublishDate,
   getReleaseTone,
@@ -23,22 +23,17 @@ export function ScheduledReleaseBanner({
   return (
     <Banner
       tone={tone}
-      paddingY={0}
+      icon={LockIcon}
       content={
-        <Flex align="center" justify="space-between" gap={1} flex={1}>
-          <Text size={1}>
-            <Flex align="center" justify="center" gap={2}>
-              <LockIcon />{' '}
-              <Translate
-                t={tCore}
-                i18nKey="release.banner.scheduled-for-publishing-on"
-                values={{
-                  date: formatRelativeLocalePublishDate(currentRelease),
-                }}
-              />
-            </Flex>
-          </Text>
-        </Flex>
+        <Text size={1}>
+          <Translate
+            t={tCore}
+            i18nKey="release.banner.scheduled-for-publishing-on"
+            values={{
+              date: formatRelativeLocalePublishDate(currentRelease),
+            }}
+          />
+        </Text>
       }
     />
   )


### PR DESCRIPTION
### Description

Updates the padding for the **Document in Scheduled release banner** and refactors the `AddToReleaseBanner` and `ArchivedReleaseDocumentBanner` to use the Banners default values instead of defining it's own spacing and padding.

[ScheduledReleaseBanner](https://test-studio-git-sapp-2496.sanity.dev/test/structure/book;555c9aec-9563-43a1-8368-fe622d828208?perspective=rlgC25MaP)
<img width="800" alt="Screenshot 2025-03-28 at 09 49 20" src="https://github.com/user-attachments/assets/e9d93fb2-b093-42fb-a220-f149599adccf" />

[AddDocumentToReleaseBanner](https://test-studio-git-sapp-2496.sanity.dev/test/structure/author;19648fe9-1b20-47a1-a235-2f746c1ea11f?perspective=rowtBLG0B)
<img width="800" alt="Screenshot 2025-03-28 at 09 49 44" src="https://github.com/user-attachments/assets/42d999de-62d3-4258-b38d-4a22b294e55a" />

[ArchivedReleaseBanner](https://test-studio-git-sapp-2496.sanity.dev/test/structure/book;5c80b890-badc-482b-a656-3adcc2ed75f7%2Crev%3D%2540lastEdited%2Cinspect%3Dsanity%252Fstructure%252Fhistory%2ChistoryEvent%3DuiACJ6LTu4zD9hQbAcQSpB%2ChistoryVersion%3DrKEX64Tz4%2CarchivedRelease%3Dtrue)
<img width="800" alt="Screenshot 2025-03-28 at 09 51 38" src="https://github.com/user-attachments/assets/9aef4675-5df8-4ee7-a142-96b0953ab85a" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
