### PR TITLE
fix: GraphQL deploy runs regardless of dry run argument

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/graphql/deployApiAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/deployApiAction.ts
@@ -143,6 +143,7 @@ export default async function deployGraphQLApiAction(
     output.warn(`Deploying only specified APIs: ${onlyApis.join(', ')}`)
   }
 
+  process.exitCode = 0
   let index = -1
   for (const apiDef of apiDefs) {
     if (onlyApis && (!apiDef.id || !onlyApis.includes(apiDef.id))) {
@@ -218,7 +219,7 @@ export default async function deployGraphQLApiAction(
 
       if (err instanceof SchemaError) {
         err.print(output)
-        process.exit(1) // eslint-disable-line no-process-exit
+        process.exitCode = 1
       }
 
       throw err
@@ -244,7 +245,8 @@ export default async function deployGraphQLApiAction(
       if (dryRun) {
         spinner.fail()
         renderBreakingChanges(valid, output)
-        process.exit(1)
+        process.exitCode = 1
+        continue
       }
 
       if (!isInteractive) {
@@ -272,7 +274,7 @@ export default async function deployGraphQLApiAction(
     } else if (dryRun) {
       spinner.succeed()
       output.print('GraphQL API is valid and has no breaking changes')
-      process.exit(0)
+      continue
     }
 
     deployTasks.push({
@@ -322,7 +324,8 @@ export default async function deployGraphQLApiAction(
   // Because of side effects when loading the schema, we can end up in situations where
   // the API has been successfully deployed, but some timer or other handle is keeping
   // the process from naturally exiting.
-  process.exit(0)
+
+  process.exit(process.exitCode)
 }
 
 async function shouldEnablePlayground({


### PR DESCRIPTION
### Description

When deploying a specific GraphQL API with the dry run flag if there are no breaking changes the API deploys even though dry run is set to true. This is happening because the `process.exit(0)` is not guaranteed to immediately stop execution. To address that I removed the process.exit(0) from that dryRun block and replaced it with a `continue`. Given the `api` flag can support multiple APIs it makes sense to test all of the requested APIs rather than stopping after the first one that matches. Given that `process.exit` can not be relied on I set the `process.exitCode` to **1** in any of the places where `process.exit(1)` was being called before.

### What to review

1. Create a sanity.cli.ts file with multiple GraphQL APIs (this shouldn't matter but could help illustrate the race condition)
2. Run the deploy command with the dry run flag and ensure none of the logging after `GraphQL API is valid and has no breaking changes` appears.

### Testing
I connected my Sanity project dependency to the local build after these changes and verified dry run works in the happy path and when there are breaking changes. I also tested the non dry run deployment workflow as well. 

