### PR TITLE
fix(validation): allow self-referencing drafts

### DIFF
--- a/packages/sanity/src/core/validation/validators/objectValidator.ts
+++ b/packages/sanity/src/core/validation/validators/objectValidator.ts
@@ -1,5 +1,6 @@
 import {isReference, type Validators} from '@sanity/types'
 
+import {getPublishedId} from '../../util'
 import {genericValidators} from './genericValidator'
 
 const metaKeys = ['_key', '_type', '_weak']
@@ -26,7 +27,7 @@ export const objectValidators: Validators = {
       return true
     }
 
-    const {type, getDocumentExists, i18n} = context
+    const {type, document, getDocumentExists, i18n} = context
 
     if (!isReference(value)) {
       return message || i18n.t('validation:object.not-reference')
@@ -44,6 +45,11 @@ export const objectValidators: Validators = {
       throw new Error(`\`getDocumentExists\` was not provided in validation context`)
     }
 
+    const documentId = document?._id
+    if (documentId && value._ref == getPublishedId(documentId)) {
+      // a document should be able to reference itself without first being published
+      return true
+    }
     const exists = await getDocumentExists({id: value._ref})
     if (!exists) {
       return i18n.t('validation:object.reference-not-published', {documentId: value._ref})


### PR DESCRIPTION
### Description
Currently, if you have an unpublished document with a reference field that references itself, you're not allowed to publish. This isn't a backend datastore restriction, but purely due to client side validation not considering whether a reference points at the current document when validating.

### What to review
Any unforeseen consequences of this? I can't think of any.

- Create a new draft, e.g here: https://test-studio.sanity.dev//test/structure/input-debug;simpleReferences
- Make a self reference
- Observe that you are allowed to publish

### Notes for release
- Fixes an issue preventing unpublished documents from referencing themselves.