### PR TITLE
test(e2e): add skip tests e2e

### DIFF
--- a/test/e2e/tests/releases/displayDocument/DisplayedDocument.spec.ts
+++ b/test/e2e/tests/releases/displayDocument/DisplayedDocument.spec.ts
@@ -27,6 +27,9 @@ import {
 test.describe.configure({mode: 'serial'})
 
 test.describe('displayedDocument', () => {
+  // skipping to deal with issues in the CI
+  test.skip()
+
   /** documents */
   let publishedDocument: SanityDocument
   let publishedDocumentDupe: SanityDocument

--- a/test/e2e/tests/releases/revert/revertASAP.spec.ts
+++ b/test/e2e/tests/releases/revert/revertASAP.spec.ts
@@ -20,6 +20,8 @@ import {
 } from '../utils/release-detail-ui-methods'
 
 test.describe('Revert ASAP', () => {
+  // skipping to deal with issues in the CI
+  test.skip()
   const asapReleaseIdTestOne: string = getRandomReleaseId()
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {

--- a/test/e2e/tests/releases/revert/revertSchedule.spec.ts
+++ b/test/e2e/tests/releases/revert/revertSchedule.spec.ts
@@ -18,6 +18,8 @@ import {
 } from '../utils/release-detail-ui-methods'
 
 test.describe('Revert Scheduled', () => {
+  // skipping to deal with issues in the CI
+  test.skip()
   const scheduledReleaseIdTestOne: string = getRandomReleaseId()
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {

--- a/test/e2e/tests/releases/revert/revertUndecided.spec.ts
+++ b/test/e2e/tests/releases/revert/revertUndecided.spec.ts
@@ -18,6 +18,8 @@ import {
 } from '../utils/release-detail-ui-methods'
 
 test.describe('Revert Undecided', () => {
+  // skipping to deal with issues in the CI
+  test.skip()
   const undecidedReleaseIdTestOne: string = getRandomReleaseId()
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {


### PR DESCRIPTION
### Description

skipping e2e tests for the releases and displayed items, need to update these tests to use HAR files since it's causing issues with the dataset in the next branch

![image](https://github.com/user-attachments/assets/e6c4cde1-ba62-451c-a02f-9a3794e3e39b)


### What to review

N/A

### Testing

N/A

### Notes for release

N/A