### PR TITLE
fix(sanity): reference strengthening upon version creation

### DIFF
--- a/packages/sanity/src/core/releases/util/prepareVersionReferences.ts
+++ b/packages/sanity/src/core/releases/util/prepareVersionReferences.ts
@@ -21,10 +21,13 @@ import {omit} from 'lodash'
  */
 export function prepareVersionReferences<T = any>(obj: T): T {
   if (isReference(obj)) {
+    const isStrengthenOnPublish = typeof obj._strengthenOnPublish !== 'undefined'
     const isSchemaMandatedWeakReference = obj._strengthenOnPublish?.weak === true
-    if (!isSchemaMandatedWeakReference) {
+
+    if (isStrengthenOnPublish && !isSchemaMandatedWeakReference) {
       return omit(obj, ['_weak']) as T
     }
+
     return obj
   }
   if (typeof obj !== 'object' || !obj) return obj


### PR DESCRIPTION
### Description

Upon version creation, Studio must not strengthen weak references unless the referenced document was created in place **and** is not mandated as weak in the schema.

Prior to this commit, the `prepareVersionReferences` function erroneously strengthened all weak references that were not created in place.

The correct behaviour is described in a code comment:

> Therefore, when creating a version of a document, the `_weak` property must be removed from any existing reference **that is set to strengthen on publish**.

However, the code was not checking whether the reference was set to strengthen on publish.

### What to review

- [x] Add a weak reference to a document. Upon creating a version of this document, the reference field in the created version should remain weak.
- [x] Create a reference document in place **for a weak reference**. Upon creating a version of this document, the reference field in the created version should remain weak.
- [x] Create a reference document in place **for a strong reference**. Upon creating a version of this document, the reference field in the created version should become strong.

### Testing

Manually tested each of the scenarios.

### Notes for release

Fixes a bug causing weak references to erroneously  be strengthened when creating a version of a document.