### PR TITLE
refactor(ci): prepare for renaming next-branch to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,11 @@ workflows:
     jobs:
       - build:
           filters:
+            tags:
+              only: /^v.*/
             branches:
-              only:
-                - current
-
+              # Jobs will run each commit unless explicitly told to ignore branches
+              ignore: /.*/
 jobs:
   build:
     docker:

--- a/.github/workflows/are-we-compiled-yet.yml
+++ b/.github/workflows/are-we-compiled-yet.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   # Build on commits pushed to branches without a PR if it's in the allowlist
   push:
-    branches: [next]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   # Build on commits pushed to branches without a PR if it's in the allowlist
   push:
-    branches: [next]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -50,5 +50,5 @@ jobs:
         id: test
         run: pnpm test:vitest --retry 4 --silent --project=@sanity/cli
         env:
-          # Update token in github and change below to ${{ secrets.SANITY_CI_CLI_AUTH_TOKEN }} after merge to next
+          # Update token in github and change below to ${{ secrets.SANITY_CI_CLI_AUTH_TOKEN }} after merge to main
           SANITY_CI_CLI_AUTH_TOKEN_STAGING: ${{ secrets.SANITY_CI_CLI_AUTH_TOKEN_STAGING }}

--- a/.github/workflows/docReport.yml
+++ b/.github/workflows/docReport.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   # Build on commits pushed to branches without a PR if it's in the allowlist
   push:
-    branches: [current, next]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -34,11 +34,11 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=8192
 
-      - name: Create Docs Report on current or next
-        if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/current' || github.ref == 'refs/heads/next') }}
+      - name: Create Docs Report on main
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         env:
           DOCS_REPORT_TOKEN: ${{ secrets.DOCS_REPORT_DATASET_TOKEN }}
-          DOCS_REPORT_DATASET: ${{ github.ref == 'refs/heads/current' && 'production' || 'next'}}
+          DOCS_REPORT_DATASET: 'production'
         run: pnpm docs:report:create
 
       - name: Create Docs Report on PR

--- a/.github/workflows/docReport.yml
+++ b/.github/workflows/docReport.yml
@@ -1,11 +1,12 @@
 name: Create Documentation Report
 
 on:
-  # Build on pushes branches that have a PR (including drafts)
-  pull_request:
-  # Build on commits pushed to branches without a PR if it's in the allowlist
+  # Build on version tags
   push:
-    branches: [main]
+    tags:
+      - "v*"
+
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -34,11 +35,11 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=8192
 
-      - name: Create Docs Report on main
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - name: Create Docs Report on version tag
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
         env:
           DOCS_REPORT_TOKEN: ${{ secrets.DOCS_REPORT_DATASET_TOKEN }}
-          DOCS_REPORT_DATASET: 'production'
+          DOCS_REPORT_DATASET: "production"
         run: pnpm docs:report:create
 
       - name: Create Docs Report on PR

--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   # Build on commits pushed to branches without a PR if it's in the allowlist
   push:
-    branches: [next]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -125,7 +125,7 @@ jobs:
         # Always run with PRs logic, to ensure tests run by the UI repo doesn't conflict with tests run by the sanity repo
         # if: ${{ github.event_name == 'pull_request' }}
         env:
-          # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
+          # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to main
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
@@ -190,7 +190,7 @@ jobs:
           # Missing in docs but in use
           # here https://github.com/microsoft/playwright/blob/main/packages/playwright/src/reporters/blob.ts#L108
           PWTEST_BLOB_REPORT_NAME: ${{ matrix.project }}
-          # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
+          # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to main
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   # Build on commits pushed to branches without a PR if it's in the allowlist
   push:
-    branches: [next]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -80,10 +80,10 @@ jobs:
         # This should take only a few seconds as it'll restore the remote cache that got primed in the `install` job
         run: pnpm build:cli --output-logs=full --log-order=grouped
 
-      - name: Cache E2E test studio on next
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+      - name: Cache E2E test studio on main
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         env:
-          # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
+          # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to main
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
@@ -94,7 +94,7 @@ jobs:
       - name: Cache E2E test studio on PR
         if: ${{ github.event_name == 'pull_request' }}
         env:
-          # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
+          # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to main
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
@@ -146,13 +146,13 @@ jobs:
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
-      - name: Run E2E tests on next
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+      - name: Run E2E tests on main
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         env:
           # Missing in docs but in use
           # here https://github.com/microsoft/playwright/blob/main/packages/playwright/src/reporters/blob.ts#L108
           PWTEST_BLOB_REPORT_NAME: ${{ matrix.project }}
-          # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
+          # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to main
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
@@ -167,7 +167,7 @@ jobs:
           # Missing in docs but in use
           # here https://github.com/microsoft/playwright/blob/main/packages/playwright/src/reporters/blob.ts#L108
           PWTEST_BLOB_REPORT_NAME: ${{ matrix.project }}
-          # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
+          # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to main
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}

--- a/.github/workflows/formatCheck.yml
+++ b/.github/workflows/formatCheck.yml
@@ -1,7 +1,7 @@
 name: Format check
 on:
   push:
-    branches: [next]
+    branches: [main]
   pull_request:
 
 concurrency:

--- a/.github/workflows/lint-fix-if-needed.yml
+++ b/.github/workflows/lint-fix-if-needed.yml
@@ -3,7 +3,7 @@ name: ESLint --fix
 
 on:
   push:
-    branches: [next]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -18,7 +18,7 @@ jobs:
     name: Should the linter fix? 🤔
     runs-on: ubuntu-latest
     # workflow_dispatch always lets you select the branch ref, even though in this case we only ever want to run the action on `main` thus we need an if check
-    if: ${{ github.ref_name == 'next' }}
+    if: ${{ github.ref_name == 'main' }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/lintPr.yml
+++ b/.github/workflows/lintPr.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   # Build on commits pushed to branches without a PR if it's in the allowlist
   push:
-    branches: [next]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./perf
         env:
           BRANCH_DEPLOYMENT_URL: ${{ github.event.deployment_status.target_url }}
-          PERF_TEST_BRANCH: "next"
+          PERF_TEST_BRANCH: "main"
           PERF_TEST_SANITY_TOKEN: ${{ secrets.PERF_TEST_SANITY_TOKEN }}
           PERF_TEST_METRICS_TOKEN: ${{ secrets.PERF_TEST_METRICS_TOKEN }}
         run: pnpm perf:test:ci

--- a/.github/workflows/pnpm-if-needed.yml
+++ b/.github/workflows/pnpm-if-needed.yml
@@ -3,7 +3,7 @@ name: Dedupe lockfile
 
 on:
   push:
-    branches: [next]
+    branches: [main]
     paths:
       - "pnpm-lock.yaml"
   workflow_dispatch:
@@ -20,7 +20,7 @@ jobs:
     name: Can pnpm-lock.yaml be deduped? 🤔
     runs-on: ubuntu-latest
     # workflow_dispatch always lets you select the branch ref, even though in this case we only ever want to run the action on `main` thus we need an if check
-    if: ${{ github.ref_name == 'next' }}
+    if: ${{ github.ref_name == 'main' }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/prettier-if-needed.yml
+++ b/.github/workflows/prettier-if-needed.yml
@@ -3,7 +3,7 @@ name: Prettier
 
 on:
   push:
-    branches: [next]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -18,7 +18,7 @@ jobs:
     name: Can the code be prettier? 🤔
     runs-on: ubuntu-latest
     # workflow_dispatch always lets you select the branch ref, even though in this case we only ever want to run the action on `main` thus we need an if check
-    if: ${{ github.ref_name == 'next' }}
+    if: ${{ github.ref_name == 'main' }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,12 +55,12 @@ jobs:
 
           # Fetch all branches (-u allows fetching the current branch)
           git fetch origin current:current -u
-          git fetch origin next:next -u
+          git fetch origin main:main -u
           git fetch origin ${{ github.ref }}:${{ github.ref }} -u
 
-          # Check for unexpected commits in 'next'
-          git log next..current --oneline | grep -q '.' && { \
-            echo "Error: 'current' has commits that 'next' does not. Aborting."; \
+          # Check for unexpected commits in 'main'
+          git log main..current --oneline | grep -q '.' && { \
+            echo "Error: 'current' has commits that 'main' does not. Aborting."; \
             exit 1; } || true
 
           # Check for unexpected commits in selected branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   # Build on commits pushed to branches without a PR if it's in the allowlist
   push:
-    branches: [next]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,12 +21,12 @@ pnpm dev
 # Release/workflow guidelines
 
 - `current` always points to the last released version
-- Anything in the `next` branch is scheduled for the next release and should always be ready to released
-- To work on something new, create a descriptively named branch off of `next` (ie: `feat/some-new-feature`)
+- Anything in the `main` branch is scheduled for the next release and should always be ready to released
+- To work on something new, create a descriptively named branch off of `main` (ie: `feat/some-new-feature`)
 - Commit to that branch locally and regularly push your work to the same named branch on the remote
-- Rebase your feature branch regularly against `next`. Make sure its even with `next` before merging
-- Once it's done, open a pull request targeting `next`
-- After at least two reviewers has approved the pull request, you can merge it into `next` when you feel ready (if you're on the Sanity team, obviously)
+- Rebase your feature branch regularly against `main`. Make sure its even with `main` before merging
+- Once it's done, open a pull request targeting `main`
+- After at least two reviewers has approved the pull request, you can merge it into `main` when you feel ready (if you're on the Sanity team, obviously)
 - Pull requests should be as ready as possible for merge. Unless stated otherwise, it should be safe to assume that:
 
   - The changes/feature are reviewed and tested by you
@@ -41,8 +41,8 @@ Prefer squash + merge. If it makes sense to keep individual commits (e.g. differ
 
 ## Branches
 
-- `current`: This contains all the features and fixes included in the latest official release.
-- `next`: This includes everything scheduled for the next, upcoming release.
+- `main`: The main branch, where official releases goes out from (i.e. on the `latest` npm tag). When a PR is merged to `main` it should be considered safe to release. Also development branches are typically made from here.
+- `stable`: Releases on the `stable` tag goes out from here. Commits in this branch is typically released every Tuesday and typically only includes changes that has been released from `main` and been out for a few days.
 
 # How to file an issue
 

--- a/scripts/doc-report/docReport.ts
+++ b/scripts/doc-report/docReport.ts
@@ -128,7 +128,7 @@ combineLatest([
     <table>
       <tr>
         <th>This branch</th>
-        <th>Next branch</th>
+        <th>Main branch</th>
       </tr>
       <tr>
         <td>${r.branchDocumented} documented</td>

--- a/scripts/printReleaseNotesTemplate.ts
+++ b/scripts/printReleaseNotesTemplate.ts
@@ -7,7 +7,7 @@ const flags = yargs(hideBin(process.argv)).argv as Record<string, any>
 const revParsed = execa.commandSync('git rev-parse --abbrev-ref HEAD', {shell: true}).stdout.trim()
 const isFromV3 = revParsed === 'v3' || revParsed === 'v3-current'
 
-const BASE_BRANCH = isFromV3 ? revParsed : 'next'
+const BASE_BRANCH = isFromV3 ? revParsed : 'main'
 const PREV_RELEASE =
   flags.from || execa.commandSync('git describe --abbrev=0', {shell: true}).stdout.trim()
 const CHANGELOG_COMMAND = `git log --pretty=format:'%aN | %s | %h' --abbrev-commit --reverse ${PREV_RELEASE}..origin/${BASE_BRANCH}`


### PR DESCRIPTION
### Description
This prepares for renaming `next` to `main`, mostly updates to workflow definitions and docs.

Once this is merged, I'll rename the main branch of this repo to uhm… `main`. This will hopefully not cause too much trouble, as GH should make sure open PRs get `main` as their new base automatically, and if I'm not mistaken GitHub will also set up redirects from urls pointing at `next` to `main`

### What to review


### Testing
Don't think this can (or should) be subject to automated testing. I'll do the required manual testing once the rename is done.

### Notes for release
n/a