### PR TITLE
fix(core): reset remote transactions when a draft is published

### DIFF
--- a/packages/sanity/src/core/store/events/getRemoteTransactionsSubscription.ts
+++ b/packages/sanity/src/core/store/events/getRemoteTransactionsSubscription.ts
@@ -55,6 +55,7 @@ export function getRemoteTransactionsSubscription({
     })
     if (effectState === 'created' || effectState === 'deleted') {
       onRefetch()
+      remoteTransactions$.next([])
       return
     }
     remoteTransactions$.next([

--- a/packages/sanity/src/core/store/events/types.ts
+++ b/packages/sanity/src/core/store/events/types.ts
@@ -453,7 +453,11 @@ export interface EventsStore {
   findRangeForRevision: (nextRev: string) => [string | null, string | null]
   findRangeForSince: (nextSince: string) => [string | null, string | null]
   loadMoreEvents: () => void
-  getChangesList: () => Observable<{diff: ObjectDiff | null; loading: boolean}>
+  getChangesList: () => Observable<{
+    diff: ObjectDiff | null
+    loading: boolean
+    error: Error | null
+  }>
   expandEvent: (event: DocumentGroupEvent) => Promise<void>
 }
 

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/EventsInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/EventsInspector.tsx
@@ -45,6 +45,7 @@ const SpinnerContainer = styled(Flex)`
 const DIFF_INITIAL_VALUE = {
   diff: null,
   loading: true,
+  error: null,
 }
 export function EventsInspector({showChanges}: {showChanges: boolean}): ReactElement {
   const {documentId, schemaType, timelineError, value, formState} = useDocumentPane()
@@ -54,7 +55,11 @@ export function EventsInspector({showChanges}: {showChanges: boolean}): ReactEle
 
   const isComparingCurrent = !revision?.revisionId
   const changesList$ = useMemo(() => getChangesList(), [getChangesList])
-  const {diff, loading: diffLoading} = useObservable(changesList$, DIFF_INITIAL_VALUE)
+  const {
+    diff,
+    loading: diffLoading,
+    error: diffError,
+  } = useObservable(changesList$, DIFF_INITIAL_VALUE)
 
   const {t} = useTranslation('studio')
 
@@ -136,7 +141,7 @@ export function EventsInspector({showChanges}: {showChanges: boolean}): ReactEle
               {showChanges && (
                 <Content
                   documentContext={documentContext}
-                  error={timelineError}
+                  error={timelineError || diffError}
                   loading={revision?.loading || sinceRevision?.loading || false}
                   schemaType={schemaType}
                 />


### PR DESCRIPTION
### Description

We use the remote transactions which are transactions received after the user has already loaded the document and the initial transactions, to render the review changes screen.
In the events store we have a listener to catch all of this transactions and apply the changes to the review screen in a "live" mode, every new transaction received will be shown.

When a draft document is published we receive a `delete` event, because the draft document is removed, but we were keeping around the remote transactions, and that causes an issue because now the transactions cannot be reconciled in a correct way, to fix this, when a `delete` or `publish` event is received and we trigger a new `onRefetch` action for the remote transactions we need to also declare the remote transactions as a new empty array.

This also adds a `catchError` to the observable so in case anything goes wrong we don't crash the studio and instead we show the error in the review changes screen.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
- create new document
- edit a field
- open history - review changes screen
- publish document
- edit a field

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in the review changes screen when draft documents were published and the user continues editing it, while the review changes screen is open.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
