### PR TITLE
fix(cli): fixes issue where apps required styled-components

### DIFF
--- a/packages/sanity/src/_internal/cli/server/components/BasicDocument.tsx
+++ b/packages/sanity/src/_internal/cli/server/components/BasicDocument.tsx
@@ -1,11 +1,18 @@
+/**
+ * App HTML Document, this is in the _internal package
+ * to avoid importing styled-components from sanity pacakge
+ */
+
 /* eslint-disable i18next/no-literal-string  -- title is literal for now */
+import {type JSX} from 'react'
+
 import {Favicons} from './Favicons'
-import {GlobalErrorHandler} from './globalErrorHandler'
+import {GlobalErrorHandler} from './globalErrorHandler/GlobalErrorHandler'
 import {NoJavascript} from './NoJavascript'
 
 /**
- * @hidden
- * @beta */
+ * @internal
+ */
 export interface BasicDocumentProps {
   entryPath: string
   css?: string[]
@@ -18,9 +25,9 @@ const EMPTY_ARRAY: never[] = []
 
 /**
  * This is the equivalent of DefaultDocument for non-studio apps.
- * @hidden
- * @beta */
-export function BasicDocument(props: BasicDocumentProps): React.JSX.Element {
+ * @internal
+ */
+export function BasicDocument(props: BasicDocumentProps): JSX.Element {
   const {entryPath, css = EMPTY_ARRAY} = props
 
   return (

--- a/packages/sanity/src/_internal/cli/server/components/DefaultDocument.tsx
+++ b/packages/sanity/src/_internal/cli/server/components/DefaultDocument.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable i18next/no-literal-string */
 
 import {Favicons} from './Favicons'
-import {GlobalErrorHandler} from './globalErrorHandler'
+import {GlobalErrorHandler} from './globalErrorHandler/GlobalErrorHandler'
 import {NoJavascript} from './NoJavascript'
 
 const globalStyles = `
@@ -119,10 +119,7 @@ export interface DefaultDocumentProps {
 const EMPTY_ARRAY: never[] = []
 
 /**
- * @hidden
- * @beta
- *
- * @deprecated Moved to `_internal` package
+ * @internal
  */
 export function DefaultDocument(props: DefaultDocumentProps): React.JSX.Element {
   const {entryPath, css = EMPTY_ARRAY} = props

--- a/packages/sanity/src/_internal/cli/server/components/Favicons.tsx
+++ b/packages/sanity/src/_internal/cli/server/components/Favicons.tsx
@@ -1,0 +1,13 @@
+import {type JSX} from 'react'
+
+export function Favicons(): JSX.Element {
+  const base = '/static'
+  return (
+    <>
+      <link rel="icon" href={`${base}/favicon.ico`} sizes="any" />
+      <link rel="icon" href={`${base}/favicon.svg`} type="image/svg+xml" />
+      <link rel="apple-touch-icon" href={`${base}/apple-touch-icon.png`} />
+      <link rel="manifest" href={`${base}/manifest.webmanifest`} />
+    </>
+  )
+}

--- a/packages/sanity/src/_internal/cli/server/components/NoJavascript.tsx
+++ b/packages/sanity/src/_internal/cli/server/components/NoJavascript.tsx
@@ -1,0 +1,40 @@
+import {type JSX} from 'react'
+
+/* eslint-disable i18next/no-literal-string,@sanity/i18n/no-attribute-string-literals */
+const NoJsStyles = `
+.sanity-app-no-js__root {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
+  background: #fff;
+}
+
+.sanity-app-no-js__content {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  font-family: helvetica, arial, sans-serif;
+}
+`
+
+/** @internal */
+export function NoJavascript(): JSX.Element {
+  return (
+    <noscript>
+      <div className="sanity-app-no-js__root">
+        <div className="sanity-app-no-js__content">
+          <style type="text/css">{NoJsStyles}</style>
+          <h1>JavaScript disabled</h1>
+          <p>
+            Please <a href="https://www.enable-javascript.com/">enable JavaScript</a> in your
+            browser and reload the page to proceed.
+          </p>
+        </div>
+      </div>
+    </noscript>
+  )
+}

--- a/packages/sanity/src/_internal/cli/server/components/globalErrorHandler/GlobalErrorHandler.tsx
+++ b/packages/sanity/src/_internal/cli/server/components/globalErrorHandler/GlobalErrorHandler.tsx
@@ -1,0 +1,175 @@
+import {type JSX} from 'react'
+
+const errorHandlerScript = `
+;(function () {
+  var _caughtErrors = []
+
+  var errorChannel = (function () {
+    var subscribers = []
+
+    function publish(msg) {
+      for (var i = 0; i < subscribers.length; i += 1) {
+        subscribers[i](msg)
+      }
+    }
+
+    function subscribe(subscriber) {
+      subscribers.push(subscriber)
+
+      return function () {
+        var idx = subscribers.indexOf(subscriber)
+
+        if (idx > -1) {
+          subscribers.splice(idx, 1)
+        }
+      }
+    }
+
+    return {publish, subscribe, subscribers}
+  })()
+
+  // NOTE: Store the error channel instance in the global scope so that the application can
+  // access it and subscribe to errors.
+  window.__sanityErrorChannel = {
+    subscribe: errorChannel.subscribe,
+  }
+
+  function _nextTick(callback) {
+    setTimeout(callback, 0)
+  }
+
+  function _handleError(error, params) {
+    _nextTick(function () {
+      // - If there are error channel subscribers, then we notify them (no console error).
+      // - If there are no subscribers, then we log the error to the console and render the error overlay.
+      if (errorChannel.subscribers.length) {
+        errorChannel.publish({error, params})
+      } else {
+        console.error(error)
+
+        _renderErrorOverlay(error, params)
+      }
+    })
+  }
+
+  var ERROR_BOX_STYLE = [
+    'background: #fff',
+    'border-radius: 6px',
+    'box-sizing: border-box',
+    'color: #121923',
+    'flex: 1',
+    "font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue','Liberation Sans',Helvetica,Arial,system-ui,sans-serif",
+    'font-size: 16px',
+    'line-height: 21px',
+    'margin: 0 auto',
+    'max-width: 960px',
+    'overflow: auto',
+    'padding: 20px',
+    'width: 100%',
+  ].join(';')
+
+  var ERROR_CODE_STYLE = [
+    'color: #972E2A',
+    "font-family: -apple-system-ui-monospace, 'SF Mono', Menlo, Monaco, Consolas, monospace",
+    'font-size: 13px',
+    'line-height: 17px',
+    'margin: 0',
+  ].join(';')
+
+  function _renderErrorOverlay(error, params) {
+    var errorElement = document.querySelector('#__sanityError') || document.createElement('div')
+    var colno = params.event.colno
+    var lineno = params.event.lineno
+    var filename = params.event.filename
+
+    errorElement.id = '__sanityError'
+    errorElement.innerHTML = [
+      '<div style="' + ERROR_BOX_STYLE + '">',
+      '<div style="font-weight: 700;">Uncaught error: ' + error.message + '</div>',
+      '<div style="color: #515E72; font-size: 13px; line-height: 17px; margin: 10px 0;">' +
+        filename +
+        ':' +
+        lineno +
+        ':' +
+        colno +
+        '</div>',
+      '<pre style="' + ERROR_CODE_STYLE + '">' + error.stack + '</pre>',
+      '</div>',
+    ].join('')
+
+    errorElement.style.position = 'fixed'
+    errorElement.style.zIndex = 1000000
+    errorElement.style.top = 0
+    errorElement.style.left = 0
+    errorElement.style.right = 0
+    errorElement.style.bottom = 0
+    errorElement.style.padding = '20px'
+    errorElement.style.background = 'rgba(16,17,18,0.66)'
+    errorElement.style.display = 'flex'
+    errorElement.style.alignItems = 'center'
+    errorElement.style.justifyContent = 'center'
+
+    document.body.appendChild(errorElement)
+  }
+
+  // NOTE:
+  // Yes – we're attaching 2 error listeners below 👀
+  // This is because React makes the same error throw twice (in development mode).
+  // See: https://github.com/facebook/react/issues/10384
+
+  // Error listener #1
+  window.onerror = function (event, source, lineno, colno, error) {
+    _nextTick(function () {
+      if (_caughtErrors.indexOf(error) !== -1) return
+
+      _caughtErrors.push(error)
+
+      _handleError(error, {
+        event,
+        lineno,
+        colno,
+        source,
+      })
+
+      _nextTick(function () {
+        var idx = _caughtErrors.indexOf(error)
+
+        if (idx > -1) _caughtErrors.splice(idx, 1)
+      })
+    })
+
+    // IMPORTANT: this callback must return \`true\` to prevent the error from being rendered in
+    // the browser’s console.
+    return true
+  }
+
+  // Error listener #2
+  window.addEventListener('error', function (event) {
+    if (_caughtErrors.indexOf(event.error) !== -1) return true
+
+    _caughtErrors.push(event.error)
+
+    _handleError(event.error, {
+      event,
+      lineno: event.lineno,
+      colno: event.colno,
+    })
+
+    _nextTick(function () {
+      _nextTick(function () {
+        var idx = _caughtErrors.indexOf(event.error)
+
+        if (idx > -1) _caughtErrors.splice(idx, 1)
+      })
+    })
+
+    return true
+  })
+})()
+`
+
+/** @internal */
+export function GlobalErrorHandler(): JSX.Element {
+  // eslint-disable-next-line react/no-danger
+  return <script dangerouslySetInnerHTML={{__html: errorHandlerScript}} />
+}

--- a/packages/sanity/src/_internal/cli/server/components/globalErrorHandler/_script.js
+++ b/packages/sanity/src/_internal/cli/server/components/globalErrorHandler/_script.js
@@ -1,0 +1,169 @@
+/* eslint-disable no-var */
+/* eslint-disable prefer-arrow-callback */
+/* eslint-disable prefer-template */
+
+;(function () {
+  var _caughtErrors = []
+
+  var errorChannel = (function () {
+    var subscribers = []
+
+    function publish(msg) {
+      for (var i = 0; i < subscribers.length; i += 1) {
+        subscribers[i](msg)
+      }
+    }
+
+    function subscribe(subscriber) {
+      subscribers.push(subscriber)
+
+      return function () {
+        var idx = subscribers.indexOf(subscriber)
+
+        if (idx > -1) {
+          subscribers.splice(idx, 1)
+        }
+      }
+    }
+
+    return {publish, subscribe, subscribers}
+  })()
+
+  // NOTE: Store the error channel instance in the global scope so that the Studio application can
+  // access it and subscribe to errors.
+  window.__sanityErrorChannel = {
+    subscribe: errorChannel.subscribe,
+  }
+
+  function _nextTick(callback) {
+    setTimeout(callback, 0)
+  }
+
+  function _handleError(error, params) {
+    _nextTick(function () {
+      // - If there are error channel subscribers, then we notify them (no console error).
+      // - If there are no subscribers, then we log the error to the console and render the error overlay.
+      if (errorChannel.subscribers.length) {
+        errorChannel.publish({error, params})
+      } else {
+        console.error(error)
+
+        _renderErrorOverlay(error, params)
+      }
+    })
+  }
+
+  var ERROR_BOX_STYLE = [
+    'background: #fff',
+    'border-radius: 6px',
+    'box-sizing: border-box',
+    'color: #121923',
+    'flex: 1',
+    "font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue','Liberation Sans',Helvetica,Arial,system-ui,sans-serif",
+    'font-size: 16px',
+    'line-height: 21px',
+    'margin: 0 auto',
+    'max-width: 960px',
+    'overflow: auto',
+    'padding: 20px',
+    'width: 100%',
+  ].join(';')
+
+  var ERROR_CODE_STYLE = [
+    'color: #972E2A',
+    "font-family: -apple-system-ui-monospace, 'SF Mono', Menlo, Monaco, Consolas, monospace",
+    'font-size: 13px',
+    'line-height: 17px',
+    'margin: 0',
+  ].join(';')
+
+  function _renderErrorOverlay(error, params) {
+    var errorElement = document.querySelector('#__sanityError') || document.createElement('div')
+    var colno = params.event.colno
+    var lineno = params.event.lineno
+    var filename = params.event.filename
+
+    errorElement.id = '__sanityError'
+    errorElement.innerHTML = [
+      '<div style="' + ERROR_BOX_STYLE + '">',
+      '<div style="font-weight: 700;">Uncaught error: ' + error.message + '</div>',
+      '<div style="color: #515E72; font-size: 13px; line-height: 17px; margin: 10px 0;">' +
+        filename +
+        ':' +
+        lineno +
+        ':' +
+        colno +
+        '</div>',
+      '<pre style="' + ERROR_CODE_STYLE + '">' + error.stack + '</pre>',
+      '</div>',
+    ].join('')
+
+    errorElement.style.position = 'fixed'
+    errorElement.style.zIndex = 1000000
+    errorElement.style.top = 0
+    errorElement.style.left = 0
+    errorElement.style.right = 0
+    errorElement.style.bottom = 0
+    errorElement.style.padding = '20px'
+    errorElement.style.background = 'rgba(16,17,18,0.66)'
+    errorElement.style.display = 'flex'
+    errorElement.style.alignItems = 'center'
+    errorElement.style.justifyContent = 'center'
+
+    document.body.appendChild(errorElement)
+  }
+
+  // NOTE:
+  // Yes – we're attaching 2 error listeners below 👀
+  // This is because React makes the same error throw twice (in development mode).
+  // See: https://github.com/facebook/react/issues/10384
+
+  // Error listener #1
+  window.onerror = function (event, source, lineno, colno, error) {
+    _nextTick(function () {
+      if (_caughtErrors.indexOf(error) !== -1) return
+
+      _caughtErrors.push(error)
+
+      _handleError(error, {
+        event,
+        lineno,
+        colno,
+        source,
+      })
+
+      _nextTick(function () {
+        var idx = _caughtErrors.indexOf(error)
+
+        if (idx > -1) _caughtErrors.splice(idx, 1)
+      })
+    })
+
+    // IMPORTANT: this callback must return `true` to prevent the error from being rendered in
+    // the browser’s console.
+    return true
+  }
+
+  // Error listener #2
+  window.addEventListener('error', function (event) {
+    if (_caughtErrors.indexOf(event.error) !== -1) return true
+
+    _caughtErrors.push(event.error)
+
+    _handleError(event.error, {
+      event,
+      lineno: event.lineno,
+      colno: event.colno,
+    })
+
+    _nextTick(function () {
+      _nextTick(function () {
+        var idx = _caughtErrors.indexOf(event.error)
+
+        if (idx > -1) _caughtErrors.splice(idx, 1)
+      })
+    })
+
+    return true
+  })
+})()

--- a/packages/sanity/src/_internal/cli/server/components/globalErrorHandler/types.ts
+++ b/packages/sanity/src/_internal/cli/server/components/globalErrorHandler/types.ts
@@ -1,0 +1,22 @@
+/** @internal */
+export interface GlobalErrorMessage {
+  error: Error | null
+  params: {
+    colno: number
+    lineno: number
+    error: Error
+    event: ErrorEvent | string
+    source?: string
+  }
+}
+
+/** @internal */
+export type GlobalErrorSubscriber = (msg: GlobalErrorMessage) => void
+
+/** @internal */
+export type GlobalErrorUnsubscriber = () => void
+
+/** @internal */
+export interface GlobalErrorChannel {
+  subscribe: (subscriber: GlobalErrorSubscriber) => GlobalErrorUnsubscriber
+}

--- a/packages/sanity/src/_internal/cli/server/renderDocument.tsx
+++ b/packages/sanity/src/_internal/cli/server/renderDocument.tsx
@@ -15,6 +15,8 @@ import importFresh from 'import-fresh'
 import {parse as parseHtml} from 'node-html-parser'
 import {renderToStaticMarkup} from 'react-dom/server'
 
+import {BasicDocument} from './components/BasicDocument'
+import {DefaultDocument} from './components/DefaultDocument'
 import {TIMESTAMPED_IMPORTMAP_INJECTOR_SCRIPT} from './constants'
 import {debug as serverDebug} from './debug'
 import {getMonorepoAliases, type SanityMonorepo} from './sanityMonorepo'
@@ -228,7 +230,7 @@ async function renderDocumentFromWorkerData() {
         loader: 'jsx',
       })
 
-  const html = await getDocumentHtml(studioRootPath, props, importMap, isApp)
+  const html = getDocumentHtml(studioRootPath, props, importMap, isApp)
 
   parentPort.postMessage({type: 'result', html})
 
@@ -237,13 +239,13 @@ async function renderDocumentFromWorkerData() {
   unregisterJs()
 }
 
-async function getDocumentHtml(
+function getDocumentHtml(
   studioRootPath: string,
   props?: DocumentProps,
   importMap?: {imports?: Record<string, string>},
   isApp?: boolean,
-): Promise<string> {
-  const Document = await getDocumentComponent(studioRootPath, isApp)
+): string {
+  const Document = getDocumentComponent(studioRootPath, isApp)
 
   // NOTE: Validate the list of CSS paths so implementers of `_document.tsx` don't have to
   // - If the path is not a full URL, check if it starts with `/`
@@ -299,17 +301,8 @@ export function addTimestampedImportMapScriptToHtml(
   return root.outerHTML
 }
 
-async function getDocumentComponent(studioRootPath: string, isApp?: boolean) {
+function getDocumentComponent(studioRootPath: string, isApp?: boolean) {
   debug('Loading default document component from `sanity` module')
-
-  // When running in dev mode, we use require because it doesn't need extension
-  const {BasicDocument} = __DEV__
-    ? require('../../../core/components/BasicDocument')
-    : await import('sanity')
-
-  const {DefaultDocument} = __DEV__
-    ? require('../../../core/components/DefaultDocument')
-    : await import('sanity')
 
   const Document = isApp ? BasicDocument : DefaultDocument
 

--- a/packages/sanity/src/core/components/index.ts
+++ b/packages/sanity/src/core/components/index.ts
@@ -4,7 +4,6 @@
 // export * from './collapseMenu'
 // export * from './scroll'
 
-export * from './BasicDocument'
 export * from './BetaBadge'
 export * from './commandList'
 export * from './contextMenuButton'

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -18,7 +18,6 @@ exports[`exports snapshot 1`] = `
     "ArrayOfPrimitivesItem": "function",
     "AutoCollapseMenu": "object",
     "AvatarSkeleton": "object",
-    "BasicDocument": "function",
     "BetaBadge": "function",
     "BlockEditor": "function",
     "BlockImagePreview": "function",


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This is another attempt at fixing not requiring styled-components deps for non studio templates. #9008 did not work as import also import styled-components dependency from down the tree. In this iteration, it moves the documents from the core package to the internal package to avoid the boundaries and the marks the DefaultDocument as deprecated. It is kept to avoid breaking change and there is duplication right now which is unfortunate.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Changes makes sense

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

`3.81.1-sdk-295.36` - canary release

- `npx sanity@3.81.1-sdk-295.36 init --template app-quickstart` 
- Choose `npm` as package manager
- cd in folder and run `npm build`
- run `npm run build`, you should get an error
- replace the sanity version in package.json with `3.81.1-sdk-295.36`
- run `npm install --legacy-peer-deps` again
- run `npm run build`, error should go away

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

N/A