### PR TITLE
Revert "test(e2e): add skip tests e2e"

### DIFF
--- a/test/e2e/tests/releases/displayDocument/DisplayedDocument.spec.ts
+++ b/test/e2e/tests/releases/displayDocument/DisplayedDocument.spec.ts
@@ -27,9 +27,6 @@ import {
 test.describe.configure({mode: 'serial'})
 
 test.describe('displayedDocument', () => {
-  // skipping to deal with issues in the CI
-  test.skip()
-
   /** documents */
   let publishedDocument: SanityDocument
   let publishedDocumentDupe: SanityDocument

--- a/test/e2e/tests/releases/revert/revertASAP.spec.ts
+++ b/test/e2e/tests/releases/revert/revertASAP.spec.ts
@@ -20,8 +20,6 @@ import {
 } from '../utils/release-detail-ui-methods'
 
 test.describe('Revert ASAP', () => {
-  // skipping to deal with issues in the CI
-  test.skip()
   const asapReleaseIdTestOne: string = getRandomReleaseId()
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {

--- a/test/e2e/tests/releases/revert/revertSchedule.spec.ts
+++ b/test/e2e/tests/releases/revert/revertSchedule.spec.ts
@@ -18,8 +18,6 @@ import {
 } from '../utils/release-detail-ui-methods'
 
 test.describe('Revert Scheduled', () => {
-  // skipping to deal with issues in the CI
-  test.skip()
   const scheduledReleaseIdTestOne: string = getRandomReleaseId()
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {

--- a/test/e2e/tests/releases/revert/revertUndecided.spec.ts
+++ b/test/e2e/tests/releases/revert/revertUndecided.spec.ts
@@ -18,8 +18,6 @@ import {
 } from '../utils/release-detail-ui-methods'
 
 test.describe('Revert Undecided', () => {
-  // skipping to deal with issues in the CI
-  test.skip()
   const undecidedReleaseIdTestOne: string = getRandomReleaseId()
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {


### PR DESCRIPTION
### Description

This reverts commit 1784b5408de862fcb1a42d0174dae5c27cf25837.
Bjørge has updated the dataset so until we figure out HAR files / tiered branching, we should be able to make the tests run again without breaking due to limits

### What to review

N/A

### Testing

N/A

### Notes for release

N/A