### PR TITLE
fix(tests): add documentStatusAssertions util

### DIFF
--- a/test/e2e/helpers/documentStatusAssertions.ts
+++ b/test/e2e/helpers/documentStatusAssertions.ts
@@ -1,0 +1,63 @@
+import {expect, type Locator} from '@playwright/test'
+
+/**
+ * Regular expressions for matching document status text
+ * It matches the text "just now" or "secs. ago"
+ */
+const documentStatusPatterns = {
+  published: /^Published (just now|\d+ sec\. ago)/i,
+  created: /^Created (just now|\d+ sec\. ago)/i,
+  unpublished: /^Unpublished (just now|\d+ sec\. ago)/i,
+} as const
+
+/**
+ * Options for document status assertions
+ */
+interface DocumentStatusOptions {
+  timeout?: number
+  useInnerText?: boolean
+}
+
+const DEFAULT_OPTIONS: DocumentStatusOptions = {
+  timeout: 60_000,
+  useInnerText: true,
+}
+
+/**
+ * Assert that a document status element shows a published state
+ */
+export async function expectPublishedStatus(
+  statusElement: Locator,
+  options: DocumentStatusOptions = DEFAULT_OPTIONS,
+) {
+  await expect(statusElement).toContainText(documentStatusPatterns.published, {
+    useInnerText: options.useInnerText,
+    timeout: options.timeout,
+  })
+}
+
+/**
+ * Assert that a document status element shows a created state
+ */
+export async function expectCreatedStatus(
+  statusElement: Locator,
+  options: DocumentStatusOptions = DEFAULT_OPTIONS,
+) {
+  await expect(statusElement).toContainText(documentStatusPatterns.created, {
+    useInnerText: options.useInnerText,
+    timeout: options.timeout,
+  })
+}
+
+/**
+ * Assert that a document status element shows an unpublished state
+ */
+export async function expectUnpublishedStatus(
+  statusElement: Locator,
+  options: DocumentStatusOptions = DEFAULT_OPTIONS,
+) {
+  await expect(statusElement).toContainText(documentStatusPatterns.unpublished, {
+    useInnerText: options.useInnerText,
+    timeout: options.timeout,
+  })
+}

--- a/test/e2e/tests/document-actions/delete.spec.ts
+++ b/test/e2e/tests/document-actions/delete.spec.ts
@@ -1,6 +1,8 @@
 import {expect} from '@playwright/test'
 import {test} from '@sanity/test'
 
+import {expectCreatedStatus, expectPublishedStatus} from '../../helpers/documentStatusAssertions'
+
 const name = 'Test Name'
 
 test(`unpublished documents can be deleted`, async ({page, createDraftDocument}) => {
@@ -9,7 +11,7 @@ test(`unpublished documents can be deleted`, async ({page, createDraftDocument})
   const paneFooter = page.getByTestId('pane-footer-document-status')
 
   // Wait for the document to save before deleting.
-  await expect(paneFooter).toContainText(/created/i, {useInnerText: true, timeout: 30_000})
+  await expectCreatedStatus(paneFooter)
 
   await page.getByTestId('action-menu-button').click()
   await page.getByTestId('action-Delete').click()
@@ -25,11 +27,11 @@ test(`published documents can be deleted`, async ({page, createDraftDocument}) =
   const publishButton = page.getByTestId('action-publish')
 
   // Wait for the document to save before publishing.
-  await expect(paneFooter).toContainText(/created/i, {useInnerText: true, timeout: 30_000})
+  await expectCreatedStatus(paneFooter)
 
   // Wait for the document to be published.
   await publishButton.click()
-  await expect(paneFooter).toContainText(/published/i, {useInnerText: true, timeout: 30_000})
+  await expectPublishedStatus(paneFooter)
 
   await page.getByTestId('action-menu-button').click()
   await page.getByTestId('action-Delete').click()

--- a/test/e2e/tests/document-actions/discardChanges.spec.ts
+++ b/test/e2e/tests/document-actions/discardChanges.spec.ts
@@ -1,6 +1,8 @@
 import {expect} from '@playwright/test'
 import {test} from '@sanity/test'
 
+import {expectPublishedStatus} from '../../helpers/documentStatusAssertions'
+
 test(`isn't possible to discard changes if a changed document has no published version`, async ({
   page,
   createDraftDocument,
@@ -30,6 +32,7 @@ test(`is possible to discard changes if a changed document has a published versi
   const actionMenuButton = page.getByTestId('action-menu-button')
   const discardChangesButton = page.getByTestId('action-Discardchanges')
   const paneFooterDocumentStatusPulse = page.getByTestId('pane-footer-document-status-pulse')
+  const paneFooterDocumentStatus = page.getByTestId('pane-footer-document-status')
 
   await titleInput.fill('This is a book')
   // Wait for the document to finish saving
@@ -39,10 +42,7 @@ test(`is possible to discard changes if a changed document has a published versi
   await expect(publishButton).toBeEnabled({timeout: 30_000})
   await publishButton.click()
   // Wait for the document to be published.
-  await expect(page.getByTestId('pane-footer-document-status')).toContainText(
-    'Published just now',
-    {useInnerText: true, timeout: 30_000},
-  )
+  await expectPublishedStatus(paneFooterDocumentStatus)
 
   await titleInput.fill('This is not a book')
 
@@ -72,10 +72,7 @@ test(`displays the published document state after discarding changes`, async ({
   await expect(publishButton).toBeEnabled()
   await publishButton.click()
   // Wait for the document to be published.
-  await expect(paneFooterDocumentStatus).toContainText('Published just now', {
-    useInnerText: true,
-    timeout: 30_000,
-  })
+  await expectPublishedStatus(paneFooterDocumentStatus)
 
   // Change the title.
   await titleInput.fill('This is not a book')

--- a/test/e2e/tests/document-actions/publish.spec.ts
+++ b/test/e2e/tests/document-actions/publish.spec.ts
@@ -1,6 +1,8 @@
 import {expect} from '@playwright/test'
 import {test} from '@sanity/test'
 
+import {expectCreatedStatus, expectPublishedStatus} from '../../helpers/documentStatusAssertions'
+
 test(`document panel displays correct title for published document`, async ({
   page,
   createDraftDocument,
@@ -29,7 +31,7 @@ test(`document panel displays correct title for published document`, async ({
 
   // Wait for the document to be published.
   page.getByTestId('action-publish').click()
-  await expect(page.getByText('Published just now')).toBeVisible({timeout: 30_000})
+  await expectPublishedStatus(page.getByTestId('pane-footer-document-status'))
 
   // Ensure the correct title is displayed after publishing.
   expect(page.getByTestId('document-panel-document-title')).toHaveText(title)
@@ -51,7 +53,7 @@ test(`custom publish action can patch document before publication`, async ({
   await titleInput.fill(title)
 
   // Wait for the document to save before publishing.
-  await expect(paneFooter).toContainText(/created/i, {useInnerText: true, timeout: 30_000})
+  await expectCreatedStatus(paneFooter)
 
   // Wait for the document to be published.
   //
@@ -59,7 +61,7 @@ test(`custom publish action can patch document before publication`, async ({
   // has been overridden for the `documentActionsTest` type, and is not visible without opening the
   // document actions menu.
   await publishKeypress()
-  await expect(documentStatus).toContainText('Published just now')
+  await expectPublishedStatus(documentStatus)
 
   // Ensure the custom publish action succeeded in setting the `publishedAt` field.
   await expect(publishedAtInput).toHaveValue(/.*/)

--- a/test/e2e/tests/document-actions/restore.spec.ts
+++ b/test/e2e/tests/document-actions/restore.spec.ts
@@ -1,6 +1,8 @@
 import {expect} from '@playwright/test'
 import {test} from '@sanity/test'
 
+import {expectCreatedStatus, expectPublishedStatus} from '../../helpers/documentStatusAssertions'
+
 test(`documents can be restored to an earlier revision`, async ({page, createDraftDocument}) => {
   test.slow()
   const titleA = 'Title A'
@@ -23,11 +25,11 @@ test(`documents can be restored to an earlier revision`, async ({page, createDra
   await createDraftDocument('/test/content/book')
   await titleInput.fill(titleA)
   // Wait for the document to finish saving
-  await expect(documentStatus).toContainText(/created/i, {useInnerText: true, timeout: 60_000})
+  await expectCreatedStatus(documentStatus)
 
   // Wait for the document to be published.
   await publishButton.click()
-  await expect(documentStatus).toContainText('Published just now')
+  await expectPublishedStatus(documentStatus)
 
   // Change the title.
   await titleInput.fill(titleB)
@@ -36,7 +38,7 @@ test(`documents can be restored to an earlier revision`, async ({page, createDra
   // Wait for the document to be published.
   await page.waitForTimeout(2_000)
   await publishButton.click()
-  await expect(documentStatus).toContainText('Published just now')
+  await expectPublishedStatus(documentStatus)
 
   // Pick the previous revision from the revision timeline.
   await contextMenuButton.click()
@@ -84,7 +86,7 @@ test(`respects overridden restore action`, async ({page, createDraftDocument}) =
 
   await titleInput.fill(titleA)
   // Wait for the document to finish saving
-  await expect(documentStatus).toContainText(/created/i, {useInnerText: true, timeout: 30_000})
+  await expectCreatedStatus(documentStatus)
 
   // Wait for the document to be published.
   //
@@ -92,7 +94,7 @@ test(`respects overridden restore action`, async ({page, createDraftDocument}) =
   // has been overridden for the `documentActionsTest` type, and is not visible without opening the
   // document actions menu.
   await publishKeypress()
-  await expect(documentStatus).toContainText('Published just now')
+  await expectPublishedStatus(documentStatus)
 
   // Change the title.
   await titleInput.fill(titleB)
@@ -101,7 +103,7 @@ test(`respects overridden restore action`, async ({page, createDraftDocument}) =
   // Wait for the document to be published.
   await page.waitForTimeout(2_000)
   await publishKeypress()
-  await expect(documentStatus).toContainText('Published just now')
+  await expectPublishedStatus(documentStatus)
 
   // Pick the previous revision from the revision timeline.
   await contextMenuButton.click()
@@ -152,11 +154,11 @@ test(`respects removed restore action`, async ({page, createDraftDocument}) => {
   await createDraftDocument('/test/content/input-debug;removeRestoreActionTest')
   await titleInput.fill(titleA)
   // Wait for the document to finish saving
-  await expect(documentStatus).toContainText(/created/i, {useInnerText: true, timeout: 30_000})
+  await expectCreatedStatus(documentStatus)
 
   // Wait for the document to be published.
   await publishButton.click()
-  await expect(documentStatus).toContainText('Published just now')
+  await expectPublishedStatus(documentStatus)
 
   // Change the title.
   await titleInput.fill(titleB)
@@ -165,7 +167,7 @@ test(`respects removed restore action`, async ({page, createDraftDocument}) => {
   // Wait for the document to be published.
   await page.waitForTimeout(2_000)
   await publishButton.click()
-  await expect(documentStatus).toContainText('Published just now')
+  await expectPublishedStatus(documentStatus)
 
   // Pick the previous revision from the revision timeline.
   await contextMenuButton.click()

--- a/test/e2e/tests/document-actions/unpublish.spec.ts
+++ b/test/e2e/tests/document-actions/unpublish.spec.ts
@@ -1,6 +1,12 @@
 import {expect} from '@playwright/test'
 import {test} from '@sanity/test'
 
+import {
+  expectCreatedStatus,
+  expectPublishedStatus,
+  expectUnpublishedStatus,
+} from '../../helpers/documentStatusAssertions'
+
 test(`should be able to unpublish a published document`, async ({page, createDraftDocument}) => {
   /** publish initial action */
   const titleA = 'Title A'
@@ -20,11 +26,11 @@ test(`should be able to unpublish a published document`, async ({page, createDra
   await createDraftDocument('/test/content/book')
   await titleInput.fill(titleA)
   // Wait for the document to finish saving
-  await expect(documentStatus).toContainText(/created/i, {useInnerText: true, timeout: 30_000})
+  await expectCreatedStatus(documentStatus)
 
   // Wait for the document to be published.
   await publishButton.click()
-  await expect(documentStatus).toContainText('Published just now')
+  await expectPublishedStatus(documentStatus)
 
   await contextFooterMenu.click()
   await expect(unpublishButton).toBeVisible()
@@ -38,5 +44,5 @@ test(`should be able to unpublish a published document`, async ({page, createDra
 
   // Check the published button is disabled that is the reference to determine the published document doesn't exist.
   await expect(button).toBeDisabled()
-  await expect(documentStatus).toContainText('Unpublished just now')
+  await expectUnpublishedStatus(documentStatus)
 })

--- a/test/e2e/tests/inputs/reference.spec.ts
+++ b/test/e2e/tests/inputs/reference.spec.ts
@@ -2,6 +2,7 @@ import {expect} from '@playwright/test'
 import {test} from '@sanity/test'
 
 import {withDefaultClient} from '../../helpers'
+import {expectPublishedStatus} from '../../helpers/documentStatusAssertions'
 
 withDefaultClient((context) => {
   test(`value can be changed after the document has been published`, async ({
@@ -47,7 +48,7 @@ withDefaultClient((context) => {
 
     // Wait for the document to be published.
     publishButton.click()
-    await expect(paneFooter).toContainText('Published just now', {timeout: 30_000})
+    await expectPublishedStatus(paneFooter)
 
     // Open the Author reference input.
     await page.locator('#author-menuButton').click()
@@ -63,7 +64,7 @@ withDefaultClient((context) => {
 
     // Wait for the document to be published.
     publishButton.click()
-    await expect(paneFooter).toContainText('Published just now', {timeout: 30_000})
+    await expectPublishedStatus(paneFooter)
   })
 
   test(`_strengthenOnPublish and _weak properties exist when adding reference to a draft document`, async ({
@@ -174,14 +175,14 @@ withDefaultClient((context) => {
       'Reference test',
     )
     page.getByTestId('action-publish').nth(1).click() // publish reference
-    await expect(documentStatus.nth(1)).toContainText('Published just now')
+    await expectPublishedStatus(documentStatus.nth(1))
 
     /** --- IN ORIGINAL DOC --- */
     page.locator('[data-testid="document-pane"]', {hasText: originalTitle}).click()
 
     page.getByTestId('action-publish').first().click() // publish reference
 
-    await expect(documentStatus.first()).toContainText('Published just now')
+    await expectPublishedStatus(documentStatus.first())
 
     // open the context menu
     page.getByTestId('pane-context-menu-button').first().click()
@@ -223,14 +224,14 @@ withDefaultClient((context) => {
       'Reference test',
     )
     page.getByTestId('action-publish').nth(1).click() // publish reference
-    await expect(documentStatus.nth(1)).toContainText('Published just now')
+    await expectPublishedStatus(documentStatus.nth(1))
 
     /** --- IN ORIGINAL DOC --- */
     page.locator('[data-testid="document-pane"]', {hasText: originalTitle}).click()
 
     page.getByTestId('action-publish').first().click() // publish reference
 
-    await expect(documentStatus.first()).toContainText('Published just now')
+    await expectPublishedStatus(documentStatus.first())
 
     // open the context menu
     page.getByTestId('pane-context-menu-button').first().click()

--- a/test/e2e/tests/inputs/text.spec.ts
+++ b/test/e2e/tests/inputs/text.spec.ts
@@ -6,6 +6,8 @@
 import {expect} from '@playwright/test'
 import {test} from '@sanity/test'
 
+import {expectCreatedStatus, expectPublishedStatus} from '../../helpers/documentStatusAssertions'
+
 const kanji = `
 速ヒマヤレ誌相ルなあね日諸せ変評ホ真攻同潔ク作先た員勝どそ際接レゅ自17浅ッ実情スヤ籍認ス重力務鳥の。8平はートご多乗12青國暮整ル通国うれけこ能新ロコラハ元横ミ休探ミソ梓批ざょにね薬展むい本隣ば禁抗ワアミ部真えくト提知週むすほ。査ル人形ルおじつ政謙減セヲモ読見れレぞえ録精てざ定第ぐゆとス務接産ヤ写馬エモス聞氏サヘマ有午ごね客岡ヘロ修彩枝雨父のけリド。
 
@@ -87,21 +89,21 @@ test.describe('inputs: text', () => {
 
     await titleInput.fill('Title A')
     // The creation is happening in the same transaction as the first edit, so this will show that the document was created just now.
-    await expect(paneFooter).toHaveText(/Created just now/i)
+    await expectCreatedStatus(paneFooter)
     await titleInput.fill('Title A updated')
     // A subsequent edit will show that the document was edited just now.
-    await expect(paneFooter).toHaveText(/Edited just now/i)
+    await expectCreatedStatus(paneFooter)
 
     // Wait for the document to be published.
     publishButton.click()
-    await expect(paneFooter).toHaveText(/published/i)
+    await expectPublishedStatus(paneFooter)
 
     // Change the title.
     await titleInput.fill('Title B')
-    await expect(paneFooter).toHaveText(/Created just now/i)
+    await expectCreatedStatus(paneFooter)
 
     // Wait for the document to be published.
     publishButton.click()
-    await expect(paneFooter).toHaveText(/published/i)
+    await expectPublishedStatus(paneFooter)
   })
 })


### PR DESCRIPTION
### Description
Adds new test util useful to match status texts, it will match the `<status> "just now"| "X secs. ago"`.
Replace all the uses of ` getByText('Published just now'))` for the new helpers.

```diff
-  await expect(paneFooter).toContainText(/"Published just now", {useInnerText: true, timeout: 30_000})
+   await expectPublishedStatus(paneFooter)
```

<img width="137" alt="Screenshot 2025-04-01 at 10 23 22" src="https://github.com/user-attachments/assets/b467e5c8-d1ad-48cc-9f9d-274d1f78008c" />
<img width="150" alt="Screenshot 2025-04-01 at 10 22 44" src="https://github.com/user-attachments/assets/e842afdc-cf90-4d7e-9c57-4b65384e53ae" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Tests should pass.
I have manually tested the new secs. ago assertion by forcing the time value to be some secs ago.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
