### PR TITLE
fix(core): add chevron to file browse sources button

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
@@ -2,7 +2,7 @@
 
 import {isFileSource} from '@sanity/asset-utils'
 import {type SanityClient} from '@sanity/client'
-import {ImageIcon, SearchIcon} from '@sanity/icons'
+import {ChevronDownIcon, ImageIcon, SearchIcon} from '@sanity/icons'
 import {
   type AssetFromSource,
   type AssetSource,
@@ -503,6 +503,7 @@ export class BaseFileInput extends PureComponent<BaseFileInputProps, BaseFileInp
               text={t('inputs.file.multi-browse-button.text')}
               data-testid="file-input-multi-browse-button"
               icon={SearchIcon}
+              iconRight={ChevronDownIcon}
             />
           }
           data-testid="input-select-button"


### PR DESCRIPTION
### Description

There's a discrepancy between the File og Image Input:

![image](https://github.com/user-attachments/assets/b1bf9c12-3e1e-4ccb-9433-effd18a03380)

File Input's "Select"-button doesn't have a chevron, while ImageInput does.

Added the chevron to File Input to have consistency in the design.

After:

![image](https://github.com/user-attachments/assets/eaf783ef-743c-463f-89d9-971777d02eb4)


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Too small to be mentioned?

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
