### PR TITLE
fix(core): restore intended func. for 'directUploads' config param

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -68,6 +68,9 @@ const sharedSettings = ({projectId}: {projectId: string}) => {
       image: {
         assetSources: [imageAssetSource],
       },
+      file: {
+        assetSources: [imageAssetSource],
+      },
     },
 
     i18n: {

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -228,6 +228,29 @@ export const fileAssetSourceResolver: ConfigPropertyReducer<AssetSource[], Confi
   )
 }
 
+export const directUploadsReducer = (opts: {
+  config: PluginOptions
+  schemaTypeName: 'file' | 'image'
+}): boolean => {
+  const {config, schemaTypeName} = opts
+  const flattenedConfig = flattenConfig(config, [])
+
+  const result = flattenedConfig.reduce((acc, {config: innerConfig}) => {
+    const resolver = innerConfig.form?.[schemaTypeName]?.directUploads
+
+    if (!resolver && typeof resolver !== 'boolean') return acc
+    if (typeof resolver === 'boolean') return resolver
+
+    throw new Error(
+      `Expected \`form.${schemaTypeName}.directUploads\` to be a boolean, but received ${getPrintableType(
+        resolver,
+      )}`,
+    )
+  }, true)
+
+  return result
+}
+
 export const imageAssetSourceResolver: ConfigPropertyReducer<AssetSource[], ConfigContext> = (
   prev,
   {form},

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -28,6 +28,7 @@ import {EMPTY_ARRAY, isNonNullable} from '../util'
 import {
   announcementsEnabledReducer,
   createFallbackOriginReducer,
+  directUploadsReducer,
   documentActionsReducer,
   documentBadgesReducer,
   documentCommentsEnabledReducer,
@@ -628,10 +629,7 @@ function resolveSource({
           propertyName: 'formBuilder.file.assetSources',
           reducer: fileAssetSourceResolver,
         }),
-        directUploads:
-          // TODO: consider refactoring this to `noDirectUploads` or similar
-          // default value for this is `true`
-          config.form?.file?.directUploads === undefined ? true : config.form.file.directUploads,
+        directUploads: directUploadsReducer({config, schemaTypeName: 'file'}),
       },
       image: {
         assetSources: resolveConfigProperty({
@@ -643,10 +641,7 @@ function resolveSource({
           propertyName: 'formBuilder.image.assetSources',
           reducer: imageAssetSourceResolver,
         }),
-        directUploads:
-          // TODO: consider refactoring this to `noDirectUploads` or similar
-          // default value for this is `true`
-          config.form?.image?.directUploads === undefined ? true : config.form.image.directUploads,
+        directUploads: directUploadsReducer({config, schemaTypeName: 'image'}),
       },
     },
 

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
@@ -465,7 +465,7 @@ export class BaseFileInput extends PureComponent<BaseFileInputProps, BaseFileInp
   }
 
   renderAssetMenu(tone: ThemeColorToneKey) {
-    const {schemaType, readOnly, directUploads, resolveUploader} = this.props
+    const {schemaType, readOnly, resolveUploader} = this.props
     const {hoveringFiles} = this.state
 
     const acceptedFiles = hoveringFiles.filter((file) => resolveUploader?.(schemaType, file))
@@ -479,7 +479,6 @@ export class BaseFileInput extends PureComponent<BaseFileInputProps, BaseFileInp
             hoveringFiles={hoveringFiles}
             acceptedFiles={acceptedFiles}
             rejectedFilesCount={rejectedFilesCount}
-            directUploads={directUploads}
             type="file"
           />
         </FlexContainer>
@@ -488,11 +487,11 @@ export class BaseFileInput extends PureComponent<BaseFileInputProps, BaseFileInp
   }
 
   renderBrowser() {
-    const {assetSources, readOnly, directUploads, id, t} = this.props
+    const {assetSources, readOnly, id, t} = this.props
 
     if (assetSources.length === 0) return null
 
-    if (assetSources.length > 1 && !readOnly && directUploads) {
+    if (assetSources.length > 1 && !readOnly) {
       return (
         <MenuButton
           id={`${id}_assetFileButton`}

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -305,7 +305,6 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
     return (
       <ImageInputAssetMenu
         assetSources={assetSources}
-        directUploads={directUploads}
         handleOpenDialog={handleOpenDialog}
         handleRemoveButtonClick={handleRemoveButtonClick}
         handleSelectFiles={handleSelectFiles}
@@ -324,7 +323,6 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
     )
   }, [
     assetSources,
-    directUploads,
     handleOpenDialog,
     handleRemoveButtonClick,
     handleSelectFiles,
@@ -342,13 +340,12 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
       <ImageInputBrowser
         assetSources={assetSources}
         readOnly={readOnly}
-        directUploads={directUploads}
         id={id}
         setMenuOpen={setMenuOpen}
         handleSelectImageFromAssetSource={handleSelectImageFromAssetSource}
       />
     )
-  }, [assetSources, directUploads, handleSelectImageFromAssetSource, id, readOnly])
+  }, [assetSources, handleSelectImageFromAssetSource, id, readOnly])
   const renderUploadPlaceholder = useCallback(() => {
     return (
       <ImageInputUploadPlaceholder

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
@@ -15,13 +15,7 @@ import {type BaseImageInputProps} from './types'
 function ImageInputAssetMenuComponent(
   props: Pick<
     BaseImageInputProps,
-    | 'assetSources'
-    | 'directUploads'
-    | 'imageUrlBuilder'
-    | 'observeAsset'
-    | 'readOnly'
-    | 'schemaType'
-    | 'value'
+    'assetSources' | 'imageUrlBuilder' | 'observeAsset' | 'readOnly' | 'schemaType' | 'value'
   > & {
     handleOpenDialog: () => void
     handleRemoveButtonClick: () => void
@@ -36,7 +30,6 @@ function ImageInputAssetMenuComponent(
 ) {
   const {
     assetSources,
-    directUploads,
     handleOpenDialog,
     handleRemoveButtonClick,
     handleSelectFiles,
@@ -103,7 +96,6 @@ function ImageInputAssetMenuComponent(
     <ImageInputAssetMenuWithReferenceAsset
       accept={accept}
       browseMenuItem={browseMenuItem}
-      directUploads={directUploads}
       handleOpenDialog={handleOpenDialog}
       handleRemoveButtonClick={handleRemoveButtonClick}
       handleSelectFiles={handleSelectFiles}

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputBrowser.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputBrowser.tsx
@@ -11,19 +11,18 @@ import {type BaseImageInputProps} from './types'
 const ASSET_IMAGE_MENU_POPOVER: MenuButtonProps['popover'] = {portal: true} as const
 
 function ImageInputBrowserComponent(
-  props: Pick<BaseImageInputProps, 'assetSources' | 'readOnly' | 'directUploads' | 'id'> & {
+  props: Pick<BaseImageInputProps, 'assetSources' | 'readOnly' | 'id'> & {
     setMenuOpen: (isOpen: boolean) => void
     handleSelectImageFromAssetSource: (source: AssetSource) => void
   },
   forwardedRef: ForwardedRef<HTMLButtonElement>,
 ) {
-  const {assetSources, readOnly, directUploads, id, setMenuOpen, handleSelectImageFromAssetSource} =
-    props
+  const {assetSources, readOnly, id, setMenuOpen, handleSelectImageFromAssetSource} = props
   const {t} = useTranslation()
 
   if (assetSources && assetSources.length === 0) return null
 
-  if (assetSources && assetSources.length > 1 && !readOnly && directUploads) {
+  if (assetSources && assetSources.length > 1 && !readOnly) {
     return (
       <MenuButton
         id={`${id}_assetImageButton`}

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -579,7 +579,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Acessibility label for button to open file options menu */
   'inputs.file.actions-menu.file-options.aria-label': 'Open file options menu',
   /** Browse */
-  'inputs.file.browse-button.text': 'Browse',
+  'inputs.file.browse-button.text': 'Select',
   /** Select file */
   'inputs.file.dialog.title': 'Select file',
   /** Unknown member kind: `{{kind}}` */


### PR DESCRIPTION
### Description

The `config.form.image.directUploads` and similar for `config.form.file.directUploads` was introduced when we created assetSources in v2. 

These config parameters were intended to prohibit local uploads and force editors to use existing assets from (external) asset sources.

Somewhere along the v3 journey, this option was misinterpreted and prohibited selecting from the external asset sources when set to true. It was only possible to select from the "Uploaded images":

![image](https://github.com/user-attachments/assets/22824065-fd33-4169-942a-80603ea83fc7)

This breaks the intention of the config parameter. I have restored it to how it should work:

![image](https://github.com/user-attachments/assets/8c1a2950-2c37-43a4-b12e-479c5877bff7)


I have also added a reducer function for the config parameters to set them appropriately through plugins (was only supported on workspace config level)


Also, this is how it looks when there's only one (the build in) asset source. It behaves like before, but I have streamlined the buttons so they both read "Select" instead of "Select" and "Browse" (they also read "Select" when there are multiple asset sources, so I think we should just keep this consistent).

![image](https://github.com/user-attachments/assets/1ae19bee-904d-4de9-9c46-473741f32728)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixed a bug where the config options for `directUploads=false` would disable browsing external assets sources.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
