### PR TITLE
feat(studio): add version info/about dialog

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -10,6 +10,32 @@ import {type LocaleResourceBundle} from '../types'
  * @hidden
  */
 export const studioLocaleStrings = defineLocalesResources('studio', {
+  /** "Disabled" status for auto-updates in About-dialog */
+  'about-dialog.version-info.auto-updates.disabled': 'Disabled',
+  /** "Enabled" status for auto-updates in About-dialog */
+  'about-dialog.version-info.auto-updates.enabled': 'Enabled',
+  /** "Auto Updates" status header in About-dialog */
+  'about-dialog.version-info.auto-updates.header': 'Auto Updates',
+  /** "How to enable" next to Disabled state for Auto updates in about dialog */
+  'about-dialog.version-info.auto-updates.how-to-enable': 'How to enable',
+  /** Text displayed on the "Copy to clipboard"-button after clicked */
+  'about-dialog.version-info.copy-to-clipboard-button.copied-text':
+    'Copied to Clipboard. Happy pasting!',
+  /** "Copy to Clipboard" button text for copying version details from About-dialog */
+  'about-dialog.version-info.copy-to-clipboard-button.text': 'Copy to Clipboard',
+  /** "Current version" header in about dialog  */
+  'about-dialog.version-info.current-version.header': 'Current version',
+  /** "How to upgrade" link text */
+  'about-dialog.version-info.how-to-upgrade': 'How to upgrade',
+  /** "Latest version" header in about dialog */
+  'about-dialog.version-info.latest-version.header': 'Latest version',
+  /** "Latest version" header in about dialog */
+  'about-dialog.version-info.latest-version.text': 'Latest version is {{latestStudioVersion}}',
+  /** "Up to date" status in About-dialog */
+  'about-dialog.version-info.up-to-date': '(Up to date)',
+  /** "User agent" header in About-dialog */
+  'about-dialog.version-info.user-agent.header': 'User agent',
+
   /** The text used in the tooltip shown in the dialog close button */
   'announcement.dialog.close': 'Close',
   /** Aria label to be used in the dialog close button */
@@ -479,16 +505,24 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
    * These are titles for fallback links in the event the help & resources endpoint isn't able to be fetched
    */
   'help-resources.action.contact-sales': 'Contact sales',
+
   /**
    * Label for "help and support" call to action
    * These are titles for fallback links in the event the help & resources endpoint isn't able to be fetched
    */
   'help-resources.action.help-and-support': 'Help and support',
+
   /**
    * Label for "join our community" call to action
    * These are titles for fallback links in the event the help & resources endpoint isn't able to be fetched
    */
   'help-resources.action.join-our-community': 'Join our community',
+
+  /**
+   * Label for version info menu tooltip
+   */
+  'help-resources.action.version-menu-tooltip': 'More details',
+
   /** Information for what the latest sanity version is */
   'help-resources.latest-sanity-version': 'Latest version is {{latestVersion}}',
   /** Information for what studio version the current studio is running */

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
@@ -1,9 +1,12 @@
-import {HelpCircleIcon} from '@sanity/icons'
-import {Menu} from '@sanity/ui'
+import {CheckmarkCircleIcon, CopyIcon, HelpCircleIcon} from '@sanity/icons'
+import {Menu, Stack, Text, useToast} from '@sanity/ui'
+import {useCallback, useEffect, useId, useState} from 'react'
 import {styled} from 'styled-components'
 
-import {Button, MenuButton} from '../../../../../ui-components'
-import {useTranslation} from '../../../../i18n'
+import {Button, Dialog, MenuButton} from '../../../../../ui-components'
+import {hasSanityPackageInImportMap} from '../../../../environment/hasSanityPackageInImportMap'
+import {Translate, useTranslation} from '../../../../i18n'
+import {SANITY_VERSION} from '../../../../version'
 import {useGetHelpResources} from './helper-functions/hooks'
 import {ResourcesMenuItems} from './ResourcesMenuItems'
 
@@ -16,24 +19,158 @@ export function ResourcesButton() {
   const {t} = useTranslation()
 
   const {value, error, isLoading} = useGetHelpResources()
+  const [aboutDialogOpen, setAboutDialogOpen] = useState(false)
+
+  const latestStudioVersion = value?.latestVersion
+  const handleAboutDialogClose = useCallback(() => {
+    setAboutDialogOpen(false)
+  }, [])
+  const handleAboutDialogOpen = useCallback(() => {
+    setAboutDialogOpen(true)
+  }, [])
+  const aboutDialogId = useId()
+  const [copySuccess, setCopySuccess] = useState(false)
+
+  const {push} = useToast()
+  const isAutoUpdating = hasSanityPackageInImportMap()
+
+  const text = `## Current version
+${SANITY_VERSION}
+
+## Latest version
+${latestStudioVersion}
+
+## Auto updates
+${isAutoUpdating ? 'Enabled' : 'Disabled'}
+
+## Page URL
+${document.location.href}
+
+## User agent
+${navigator.userAgent}
+`
+
+  const handleCopyDetails = useCallback(() => {
+    navigator.clipboard.writeText(text).then(
+      () => {
+        setCopySuccess(true)
+      },
+      (err: unknown) => {
+        push({
+          status: 'warning',
+          title: `Unable to write to clipboard: ${(err && typeof err === 'object' && 'message' in err && err.message) || 'unknown error'}`,
+        })
+      },
+    )
+  }, [push, text])
+
+  useEffect(() => {
+    const timer = setTimeout(() => setCopySuccess(false), 3000)
+    return () => clearTimeout(timer)
+  }, [copySuccess])
 
   return (
-    <MenuButton
-      button={
-        <Button
-          aria-label={t('help-resources.title')}
-          icon={HelpCircleIcon}
-          mode="bleed"
-          tooltipProps={{content: t('help-resources.title')}}
-        />
-      }
-      id="menu-button-resources"
-      menu={
-        <StyledMenu data-testid="menu-button-resources">
-          <ResourcesMenuItems error={error} isLoading={isLoading} value={value} />
-        </StyledMenu>
-      }
-      popover={{constrainSize: true, tone: 'default'}}
-    />
+    <>
+      {aboutDialogOpen && (
+        <Dialog
+          header={'About'}
+          width={1}
+          onClickOutside={handleAboutDialogClose}
+          onClose={handleAboutDialogClose}
+          id={aboutDialogId}
+        >
+          <Stack space={4}>
+            <Stack space={3}>
+              <Text as="h2" size={1} weight="medium">
+                {t('about-dialog.version-info.current-version.header')}
+              </Text>
+              <Text muted size={1}>
+                {SANITY_VERSION}
+              </Text>
+            </Stack>
+            <Stack space={3}>
+              <Text as="h2" size={1} weight="medium">
+                {t('about-dialog.version-info.current-version.header')}
+              </Text>
+              <Text muted size={1}>
+                <Translate t={t} i18nKey="" components={{}} />
+                {t('about-dialog.version-info.latest-version.text', {latestStudioVersion})}
+                {latestStudioVersion === SANITY_VERSION ? (
+                  <>({t('about-dialog.version-info.up-to-date')})</>
+                ) : (
+                  <>
+                    {' '}
+                    (
+                    <a href="https://www.sanity.io/docs/upgrade">
+                      {t('about-dialog.version-info.how-to-upgrade')}
+                    </a>
+                    )
+                  </>
+                )}
+              </Text>
+            </Stack>
+            <Stack space={3}>
+              <Text as="h2" size={1} weight="medium">
+                {t('about-dialog.version-info.auto-updates.header')}
+              </Text>
+              {isAutoUpdating ? (
+                <Text muted size={1}>
+                  {t('about-dialog.version-info.auto-updates.enabled')}
+                </Text>
+              ) : (
+                <Text muted size={1}>
+                  {t('about-dialog.version-info.auto-updates.disabled')} (
+                  <a href="https://www.sanity.io/docs/auto-updating-studios">
+                    {t('about-dialog.version-info.auto-updates.how-to-enable')}
+                  </a>
+                  )
+                </Text>
+              )}
+            </Stack>
+            <Stack space={3}>
+              <Text as="h2" size={1} weight="medium">
+                {t('about-dialog.version-info.user-agent.header')}
+              </Text>
+              <Text muted size={1}>
+                {navigator.userAgent}
+              </Text>
+            </Stack>
+            <Button
+              icon={copySuccess ? CheckmarkCircleIcon : CopyIcon}
+              mode="bleed"
+              text={
+                copySuccess
+                  ? t('about-dialog.version-info.copy-to-clipboard-button.copied-text')
+                  : t('about-dialog.version-info.copy-to-clipboard-button.text')
+              }
+              paddingY={3}
+              onClick={handleCopyDetails}
+            />
+          </Stack>
+        </Dialog>
+      )}
+      <MenuButton
+        button={
+          <Button
+            aria-label={t('help-resources.title')}
+            icon={HelpCircleIcon}
+            mode="bleed"
+            tooltipProps={{content: t('help-resources.title')}}
+          />
+        }
+        id="menu-button-resources"
+        menu={
+          <StyledMenu data-testid="menu-button-resources">
+            <ResourcesMenuItems
+              error={error}
+              isLoading={isLoading}
+              value={value}
+              onAboutDialogOpen={handleAboutDialogOpen}
+            />
+          </StyledMenu>
+        }
+        popover={{constrainSize: true, tone: 'default'}}
+      />
+    </>
   )
 }

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
@@ -1,6 +1,6 @@
-import {Box, MenuDivider, Text} from '@sanity/ui'
+import {Box, MenuDivider, Stack, Text} from '@sanity/ui'
 
-import {MenuItem} from '../../../../../ui-components'
+import {Button, MenuItem} from '../../../../../ui-components'
 import {LoadingBlock} from '../../../../components/loadingBlock'
 import {hasSanityPackageInImportMap} from '../../../../environment/hasSanityPackageInImportMap'
 import {useTranslation} from '../../../../i18n'
@@ -12,9 +12,15 @@ interface ResourcesMenuItemProps {
   error: Error | null
   isLoading: boolean
   value?: ResourcesResponse
+  onAboutDialogOpen: () => void
 }
 
-export function ResourcesMenuItems({error, isLoading, value}: ResourcesMenuItemProps) {
+export function ResourcesMenuItems({
+  error,
+  isLoading,
+  value,
+  onAboutDialogOpen,
+}: ResourcesMenuItemProps) {
   const sections = value?.resources?.sectionArray
   const latestStudioVersion = value?.latestVersion
   const isAutoUpdating = hasSanityPackageInImportMap()
@@ -60,20 +66,28 @@ export function ResourcesMenuItems({error, isLoading, value}: ResourcesMenuItemP
         })}
 
       {/* Studio version information */}
-      <Box padding={3}>
-        <Text size={1} muted weight="medium" textOverflow="ellipsis">
-          {t('help-resources.studio-version', {studioVersion: SANITY_VERSION})}
-        </Text>
-        {!error && latestStudioVersion && !isAutoUpdating && (
-          <Box paddingTop={2}>
-            <Text size={1} muted textOverflow="ellipsis">
-              {t('help-resources.latest-sanity-version', {
-                latestVersion: latestStudioVersion,
-              })}
-            </Text>
-          </Box>
-        )}
-      </Box>
+      <Button
+        onClick={onAboutDialogOpen}
+        mode="bleed"
+        tooltipProps={{
+          content: <Text size={1}>{t('help-resources.action.version-menu-tooltip')}</Text>,
+        }}
+      >
+        <Stack space={1}>
+          <Text size={1} muted weight="medium" textOverflow="ellipsis">
+            {t('help-resources.studio-version', {studioVersion: SANITY_VERSION})}
+          </Text>
+          {!error && latestStudioVersion && !isAutoUpdating && (
+            <Box paddingTop={2}>
+              <Text size={1} muted textOverflow="ellipsis">
+                {t('help-resources.latest-sanity-version', {
+                  latestVersion: latestStudioVersion,
+                })}
+              </Text>
+            </Box>
+          )}
+        </Stack>
+      </Button>
     </>
   )
 }


### PR DESCRIPTION
### Description

If installing the Studio from a tagged release or using pkg.pr.new, version numbers often gets too long to fit in the version menu. For example:
<img width="330" alt="image" src="https://github.com/user-attachments/assets/0150781d-9ac0-4f8a-ab9e-d37c966f7dec" />

This information is too useful to cut off like this, so when looking into a fix, I figured why not make the version menu item pop a dialog with a bit of additional info with an easy way to copy it to the clipboard. So now, when you click the version info you'll now see this:
<img width="680" alt="image" src="https://github.com/user-attachments/assets/b61afcf9-4a19-4859-80e3-df9ebd1e46f6" />


### What to review
- Does it make sense?
- Is it a good start?
- What other information can we consider adding here?

### Testing
Check out the preview build here: https://test-studio-git-more-version-details.sanity.dev/

### Notes for release
- Now opens a version info dialog when clicking the "Current version"-menu item in the help resources from the Studio navigation bar
