### PR TITLE
refactor(ci): prepare for renaming next-branch to main

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -30,7 +30,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** "Latest version" header in about dialog */
   'about-dialog.version-info.latest-version.header': 'Latest version',
   /** "Latest version" header in about dialog */
-  'about-dialog.version-info.latest-version.text': 'Latest version is {{latestStudioVersion}}',
+  'about-dialog.version-info.latest-version.text': 'Latest version is {{latestVersion}}',
   /** "Up to date" status in About-dialog */
   'about-dialog.version-info.up-to-date': '(Up to date)',
   /** "User agent" header in About-dialog */
@@ -517,11 +517,6 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
    * These are titles for fallback links in the event the help & resources endpoint isn't able to be fetched
    */
   'help-resources.action.join-our-community': 'Join our community',
-
-  /**
-   * Label for version info menu tooltip
-   */
-  'help-resources.action.version-menu-tooltip': 'More details',
 
   /** Information for what the latest sanity version is */
   'help-resources.latest-sanity-version': 'Latest version is {{latestVersion}}',

--- a/packages/sanity/src/core/studio/components/navbar/resources/AboutDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/AboutDialog.tsx
@@ -1,0 +1,137 @@
+import {CheckmarkCircleIcon, CopyIcon} from '@sanity/icons'
+import {Stack, Text, useToast} from '@sanity/ui'
+import {useCallback, useEffect, useId, useState} from 'react'
+
+import {Button, Dialog} from '../../../../../ui-components'
+import {hasSanityPackageInImportMap} from '../../../../environment/hasSanityPackageInImportMap'
+import {Translate, useTranslation} from '../../../../i18n'
+
+interface AboutDialogProps {
+  latestVersion: string
+  currentVersion?: string
+  onClose: () => void
+}
+export function AboutDialog(props: AboutDialogProps) {
+  const {t} = useTranslation()
+
+  const {latestVersion, onClose, currentVersion} = props
+  const aboutDialogId = useId()
+  const [copySuccess, setCopySuccess] = useState(false)
+
+  const {push} = useToast()
+  const isAutoUpdating = hasSanityPackageInImportMap()
+
+  const text = `## Current version
+${currentVersion}
+
+## Latest version
+${latestVersion}
+
+## Auto updates
+${isAutoUpdating ? 'Enabled' : 'Disabled'}
+
+## Page URL
+${document.location.href}
+
+## User agent
+${navigator.userAgent}
+`
+
+  const handleCopyDetails = useCallback(() => {
+    navigator.clipboard.writeText(text).then(
+      () => {
+        setCopySuccess(true)
+      },
+      (err: unknown) => {
+        push({
+          status: 'warning',
+          title: `Unable to write to clipboard: ${(err && typeof err === 'object' && 'message' in err && err.message) || 'unknown error'}`,
+        })
+      },
+    )
+  }, [push, text])
+
+  useEffect(() => {
+    const timer = setTimeout(() => setCopySuccess(false), 3000)
+    return () => clearTimeout(timer)
+  }, [copySuccess])
+
+  return (
+    <Dialog
+      header={'About'}
+      width={1}
+      onClickOutside={onClose}
+      onClose={onClose}
+      id={aboutDialogId}
+    >
+      <Stack space={4}>
+        <Stack space={3}>
+          <Text as="h2" size={1} weight="medium">
+            {t('about-dialog.version-info.current-version.header')}
+          </Text>
+          <Text muted size={1}>
+            {currentVersion}
+          </Text>
+        </Stack>
+        <Stack space={3}>
+          <Text as="h2" size={1} weight="medium">
+            {t('about-dialog.version-info.current-version.header')}
+          </Text>
+          <Text muted size={1}>
+            <Translate t={t} i18nKey="" components={{}} />
+            {t('about-dialog.version-info.latest-version.text', {latestVersion})}
+            {latestVersion === currentVersion ? (
+              <>({t('about-dialog.version-info.up-to-date')})</>
+            ) : (
+              <>
+                {' '}
+                (
+                <a href="https://www.sanity.io/docs/upgrade">
+                  {t('about-dialog.version-info.how-to-upgrade')}
+                </a>
+                )
+              </>
+            )}
+          </Text>
+        </Stack>
+        <Stack space={3}>
+          <Text as="h2" size={1} weight="medium">
+            {t('about-dialog.version-info.auto-updates.header')}
+          </Text>
+          {isAutoUpdating ? (
+            <Text muted size={1}>
+              {t('about-dialog.version-info.auto-updates.enabled')}
+            </Text>
+          ) : (
+            <Text muted size={1}>
+              {t('about-dialog.version-info.auto-updates.disabled')} (
+              <a href="https://www.sanity.io/docs/auto-updating-studios">
+                {t('about-dialog.version-info.auto-updates.how-to-enable')}
+              </a>
+              )
+            </Text>
+          )}
+        </Stack>
+        <Stack space={3}>
+          <Text as="h2" size={1} weight="medium">
+            {t('about-dialog.version-info.user-agent.header')}
+          </Text>
+          <Text muted size={1}>
+            {navigator.userAgent}
+          </Text>
+        </Stack>
+        <Button
+          icon={copySuccess ? CheckmarkCircleIcon : CopyIcon}
+          mode="bleed"
+          text={
+            copySuccess
+              ? t('about-dialog.version-info.copy-to-clipboard-button.copied-text')
+              : t('about-dialog.version-info.copy-to-clipboard-button.text')
+          }
+          paddingY={3}
+          onClick={handleCopyDetails}
+        />
+      </Stack>
+    </Dialog>
+  )
+}

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
@@ -1,12 +1,12 @@
-import {CheckmarkCircleIcon, CopyIcon, HelpCircleIcon} from '@sanity/icons'
-import {Menu, Stack, Text, useToast} from '@sanity/ui'
-import {useCallback, useEffect, useId, useState} from 'react'
+import {HelpCircleIcon} from '@sanity/icons'
+import {Menu} from '@sanity/ui'
+import {useCallback, useState} from 'react'
 import {styled} from 'styled-components'
 
-import {Button, Dialog, MenuButton} from '../../../../../ui-components'
-import {hasSanityPackageInImportMap} from '../../../../environment/hasSanityPackageInImportMap'
-import {Translate, useTranslation} from '../../../../i18n'
+import {Button, MenuButton} from '../../../../../ui-components'
+import {useTranslation} from '../../../../i18n'
 import {SANITY_VERSION} from '../../../../version'
+import {AboutDialog} from './AboutDialog'
 import {useGetHelpResources} from './helper-functions/hooks'
 import {ResourcesMenuItems} from './ResourcesMenuItems'
 
@@ -20,134 +20,22 @@ export function ResourcesButton() {
 
   const {value, error, isLoading} = useGetHelpResources()
   const [aboutDialogOpen, setAboutDialogOpen] = useState(false)
-
-  const latestStudioVersion = value?.latestVersion
   const handleAboutDialogClose = useCallback(() => {
     setAboutDialogOpen(false)
   }, [])
+
   const handleAboutDialogOpen = useCallback(() => {
     setAboutDialogOpen(true)
   }, [])
-  const aboutDialogId = useId()
-  const [copySuccess, setCopySuccess] = useState(false)
-
-  const {push} = useToast()
-  const isAutoUpdating = hasSanityPackageInImportMap()
-
-  const text = `## Current version
-${SANITY_VERSION}
-
-## Latest version
-${latestStudioVersion}
-
-## Auto updates
-${isAutoUpdating ? 'Enabled' : 'Disabled'}
-
-## Page URL
-${document.location.href}
-
-## User agent
-${navigator.userAgent}
-`
-
-  const handleCopyDetails = useCallback(() => {
-    navigator.clipboard.writeText(text).then(
-      () => {
-        setCopySuccess(true)
-      },
-      (err: unknown) => {
-        push({
-          status: 'warning',
-          title: `Unable to write to clipboard: ${(err && typeof err === 'object' && 'message' in err && err.message) || 'unknown error'}`,
-        })
-      },
-    )
-  }, [push, text])
-
-  useEffect(() => {
-    const timer = setTimeout(() => setCopySuccess(false), 3000)
-    return () => clearTimeout(timer)
-  }, [copySuccess])
 
   return (
     <>
       {aboutDialogOpen && (
-        <Dialog
-          header={'About'}
-          width={1}
-          onClickOutside={handleAboutDialogClose}
+        <AboutDialog
+          currentVersion={SANITY_VERSION}
+          latestVersion={value?.latestVersion || 'unknown'}
           onClose={handleAboutDialogClose}
-          id={aboutDialogId}
-        >
-          <Stack space={4}>
-            <Stack space={3}>
-              <Text as="h2" size={1} weight="medium">
-                {t('about-dialog.version-info.current-version.header')}
-              </Text>
-              <Text muted size={1}>
-                {SANITY_VERSION}
-              </Text>
-            </Stack>
-            <Stack space={3}>
-              <Text as="h2" size={1} weight="medium">
-                {t('about-dialog.version-info.current-version.header')}
-              </Text>
-              <Text muted size={1}>
-                <Translate t={t} i18nKey="" components={{}} />
-                {t('about-dialog.version-info.latest-version.text', {latestStudioVersion})}
-                {latestStudioVersion === SANITY_VERSION ? (
-                  <>({t('about-dialog.version-info.up-to-date')})</>
-                ) : (
-                  <>
-                    {' '}
-                    (
-                    <a href="https://www.sanity.io/docs/upgrade">
-                      {t('about-dialog.version-info.how-to-upgrade')}
-                    </a>
-                    )
-                  </>
-                )}
-              </Text>
-            </Stack>
-            <Stack space={3}>
-              <Text as="h2" size={1} weight="medium">
-                {t('about-dialog.version-info.auto-updates.header')}
-              </Text>
-              {isAutoUpdating ? (
-                <Text muted size={1}>
-                  {t('about-dialog.version-info.auto-updates.enabled')}
-                </Text>
-              ) : (
-                <Text muted size={1}>
-                  {t('about-dialog.version-info.auto-updates.disabled')} (
-                  <a href="https://www.sanity.io/docs/auto-updating-studios">
-                    {t('about-dialog.version-info.auto-updates.how-to-enable')}
-                  </a>
-                  )
-                </Text>
-              )}
-            </Stack>
-            <Stack space={3}>
-              <Text as="h2" size={1} weight="medium">
-                {t('about-dialog.version-info.user-agent.header')}
-              </Text>
-              <Text muted size={1}>
-                {navigator.userAgent}
-              </Text>
-            </Stack>
-            <Button
-              icon={copySuccess ? CheckmarkCircleIcon : CopyIcon}
-              mode="bleed"
-              text={
-                copySuccess
-                  ? t('about-dialog.version-info.copy-to-clipboard-button.copied-text')
-                  : t('about-dialog.version-info.copy-to-clipboard-button.text')
-              }
-              paddingY={3}
-              onClick={handleCopyDetails}
-            />
-          </Stack>
-        </Dialog>
+        />
       )}
       <MenuButton
         button={

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
@@ -1,6 +1,13 @@
-import {Box, MenuDivider, Stack, Text} from '@sanity/ui'
+import {
+  Box,
+  MenuDivider,
+  // eslint-disable-next-line no-restricted-imports
+  MenuItem as UIMenuItem,
+  Stack,
+  Text,
+} from '@sanity/ui'
 
-import {Button, MenuItem} from '../../../../../ui-components'
+import {MenuItem} from '../../../../../ui-components'
 import {LoadingBlock} from '../../../../components/loadingBlock'
 import {hasSanityPackageInImportMap} from '../../../../environment/hasSanityPackageInImportMap'
 import {useTranslation} from '../../../../i18n'
@@ -22,7 +29,7 @@ export function ResourcesMenuItems({
   onAboutDialogOpen,
 }: ResourcesMenuItemProps) {
   const sections = value?.resources?.sectionArray
-  const latestStudioVersion = value?.latestVersion
+  const latestVersion = value?.latestVersion
   const isAutoUpdating = hasSanityPackageInImportMap()
   const {t} = useTranslation()
 
@@ -66,28 +73,22 @@ export function ResourcesMenuItems({
         })}
 
       {/* Studio version information */}
-      <Button
-        onClick={onAboutDialogOpen}
-        mode="bleed"
-        tooltipProps={{
-          content: <Text size={1}>{t('help-resources.action.version-menu-tooltip')}</Text>,
-        }}
-      >
+      <UIMenuItem onClick={onAboutDialogOpen}>
         <Stack space={1}>
-          <Text size={1} muted weight="medium" textOverflow="ellipsis">
+          <Text size={1} weight="medium" textOverflow="ellipsis">
             {t('help-resources.studio-version', {studioVersion: SANITY_VERSION})}
           </Text>
-          {!error && latestStudioVersion && !isAutoUpdating && (
+          {!error && latestVersion && !isAutoUpdating && (
             <Box paddingTop={2}>
-              <Text size={1} muted textOverflow="ellipsis">
+              <Text size={1} textOverflow="ellipsis">
                 {t('help-resources.latest-sanity-version', {
-                  latestVersion: latestStudioVersion,
+                  latestVersion,
                 })}
               </Text>
             </Box>
           )}
         </Stack>
-      </Button>
+      </UIMenuItem>
     </>
   )
 }


### PR DESCRIPTION
### Description
Just a couple of tiny tweaks to the version menu that landed in #9131

- Making the menu item look like a menu item and removes muted text to make it more clear that you can click it
- Removing the tooltip
- Refactors the About dialog and extracts it into a separate file

### What to review
- Check that it makes sense

### Testing
Try it out in the preview build

### Notes for release
n/a 