### PR TITLE
fix(cli): bump version of styled-components used by sanity init

### DIFF
--- a/packages/@sanity/cli/src/studioDependencies.ts
+++ b/packages/@sanity/cli/src/studioDependencies.ts
@@ -10,7 +10,7 @@ export const studioDependencies = {
     // Non-Sanity dependencies
     'react': '^18.2.0',
     'react-dom': '^18.2.0',
-    'styled-components': '^6.1.8',
+    'styled-components': '^6.1.15',
   },
 
   devDependencies: {


### PR DESCRIPTION
### Description
The peer-dependecy requirement for `styled-components` was bumped in #8940, but sanity init will still add `^6.1.8` to package.json for new projects, so this PR also updates that to be `^6.1.15`.

### What to review

### Testing
Probably best tested via the pkg.pr.new version that will be published after PR approval

### Notes for release
n/a