### PR TITLE
fix(test): make test for sanity init w/template fetch from main branch instead of next

### DIFF
--- a/packages/@sanity/cli/test/init.test.ts
+++ b/packages/@sanity/cli/test/init.test.ts
@@ -150,7 +150,7 @@ describeCliTest('CLI: `sanity init v3`', () => {
         '--dataset',
         testRunArgs.dataset,
         '--template',
-        'https://github.com/sanity-io/sanity/tree/next/packages/@sanity/cli/test/__fixtures__/remote-template',
+        'https://github.com/sanity-io/sanity/tree/main/packages/@sanity/cli/test/__fixtures__/remote-template',
         '--output-path',
         `${baseTestPath}/${outpath}`,
         '--package-manager',


### PR DESCRIPTION
### Description

Small fix for this test failure that we got after renaming `next` to `main`:
https://github.com/sanity-io/sanity/actions/runs/14246268611/job/39928363613?pr=9137#step:7:144
