### PR TITLE
test(e2e): update e2e reference test

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
@@ -54,6 +54,7 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
       contentRef: Ref<HTMLDivElement>,
     ) => (
       <StyledPopover
+        data-testid="autocomplete-popover"
         placement="bottom-start"
         fallbackPlacements={FALLBACK_PLACEMENTS}
         arrow={false}

--- a/test/e2e/tests/inputs/reference.spec.ts
+++ b/test/e2e/tests/inputs/reference.spec.ts
@@ -35,7 +35,7 @@ withDefaultClient((context) => {
     const paneFooter = page.getByTestId('pane-footer')
     const publishButton = page.getByTestId('action-publish')
     const authorListbox = page.locator('#author-listbox')
-    const popover = page.locator("[data-ui='Popover']")
+    const popover = page.getByTestId('autocomplete-popover')
 
     // Open the Author reference input.
     await referenceInput.getByLabel('Open').click()
@@ -54,6 +54,8 @@ withDefaultClient((context) => {
     await page.locator('#author-menuButton').click()
     await page.getByRole('menuitem').getByText('Replace').click()
     await referenceInput.getByLabel('Open').click()
+    // instead of opening with the dropdown button, open with the space key
+    await referenceInput.getByTestId('autocomplete').press(' ')
     await expect(popover).toBeVisible()
     await expect(authorListbox).toBeVisible()
 

--- a/test/e2e/tests/inputs/reference.spec.ts
+++ b/test/e2e/tests/inputs/reference.spec.ts
@@ -2,7 +2,7 @@ import {expect} from '@playwright/test'
 import {test} from '@sanity/test'
 
 import {withDefaultClient} from '../../helpers'
-import {expectPublishedStatus} from '../../helpers/documentStatusAssertions'
+import {expectEditedStatus, expectPublishedStatus} from '../../helpers/documentStatusAssertions'
 
 withDefaultClient((context) => {
   test(`value can be changed after the document has been published`, async ({
@@ -46,6 +46,9 @@ withDefaultClient((context) => {
     await page.keyboard.press('ArrowDown')
     await page.keyboard.press('Enter')
 
+    // wait for the edit to finish
+    await expectEditedStatus(paneFooter)
+
     // Wait for the document to be published.
     publishButton.click()
     await expectPublishedStatus(paneFooter)
@@ -53,9 +56,8 @@ withDefaultClient((context) => {
     // Open the Author reference input.
     await page.locator('#author-menuButton').click()
     await page.getByRole('menuitem').getByText('Replace').click()
-    await referenceInput.getByLabel('Open').click()
     // instead of opening with the dropdown button, open with the space key
-    await referenceInput.getByTestId('autocomplete').press(' ')
+    await referenceInput.getByTestId('autocomplete').press('Space')
     await expect(popover).toBeVisible()
     await expect(authorListbox).toBeVisible()
 
@@ -63,6 +65,9 @@ withDefaultClient((context) => {
     await page.keyboard.press('ArrowDown')
     await page.keyboard.press('Enter')
     await expect(paneFooter).toContainText('Saved', {timeout: 30_000})
+
+    // wait for the edit to finish
+    await expectEditedStatus(paneFooter)
 
     // Wait for the document to be published.
     publishButton.click()


### PR DESCRIPTION
### Description

For some reason when running the test the dropdown doesn't want to open when clicking the arrow down button. However, when testing manually there is no issue. It is also not a consistent bug / behaviour.
However, using the input to trigger the input to open the list seems to work consistently and since the button behaviour is not what we are checking I've just changed that.

### What to review

Does this make sense?

### Testing

It's all test

### Notes for release

N/A
