### PR TITLE
feat(cli): add Media Library CLI

### DIFF
--- a/dev/media-library-aspects-studio/aspects/colourDetails.ts
+++ b/dev/media-library-aspects-studio/aspects/colourDetails.ts
@@ -1,0 +1,14 @@
+import {defineAssetAspect, defineField} from 'sanity'
+
+export default defineAssetAspect({
+  name: 'colourDetails',
+  title: 'Colour Details',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'colourName',
+      title: 'Colour Name',
+      type: 'string',
+    }),
+  ],
+})

--- a/dev/media-library-aspects-studio/aspects/productDetails.ts
+++ b/dev/media-library-aspects-studio/aspects/productDetails.ts
@@ -1,0 +1,19 @@
+import {defineAssetAspect, defineField} from 'sanity'
+
+export default defineAssetAspect({
+  name: 'productDetails',
+  title: 'Product Details',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'price',
+      title: 'Price',
+      type: 'number',
+    }),
+    defineField({
+      name: 'inventory',
+      title: 'Inventory',
+      type: 'number',
+    }),
+  ],
+})

--- a/dev/media-library-aspects-studio/package.json
+++ b/dev/media-library-aspects-studio/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "media-library-aspects-studio",
+  "version": "1.0.0",
+  "description": "",
+  "keywords": [],
+  "license": "ISC",
+  "author": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "sanity": "workspace:^"
+  }
+}

--- a/dev/media-library-aspects-studio/sanity.cli.ts
+++ b/dev/media-library-aspects-studio/sanity.cli.ts
@@ -1,0 +1,11 @@
+import {defineCliConfig} from 'sanity/cli'
+
+export default defineCliConfig({
+  api: {
+    projectId: 'ppsg7ml5',
+    dataset: 'test',
+  },
+  mediaLibrary: {
+    aspectsPath: 'aspects',
+  },
+})

--- a/dev/media-library-aspects-studio/sanity.config.ts
+++ b/dev/media-library-aspects-studio/sanity.config.ts
@@ -1,0 +1,6 @@
+import {defineConfig} from 'sanity'
+
+export default defineConfig({
+  projectId: 'ppsg7ml5',
+  dataset: 'test',
+})

--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -360,6 +360,17 @@ export interface CliConfig {
    * Signals to `sanity` commands that this is not a studio.
    */
   app?: AppConfig
+
+  /**
+   * Configuration for Sanity media libraries.
+   */
+  mediaLibrary?: {
+    /**
+     * The path to the Media Library aspects directory. When using the CLI to manage aspects, this
+     * is the directory they will be read from and written to.
+     */
+    aspectsPath: string
+  }
 }
 
 export type UserViteConfig =

--- a/packages/@sanity/schema/src/_exports/_internal.ts
+++ b/packages/@sanity/schema/src/_exports/_internal.ts
@@ -16,4 +16,5 @@ export {
   type TypeWithProblems,
   type SchemaValidationResult as ValidationResult,
 } from '../sanity/typedefs'
+export {validateMediaLibraryAssetAspect} from '../sanity/validateMediaLibraryAssetAspect'
 export {validateSchema} from '../sanity/validateSchema'

--- a/packages/@sanity/schema/src/sanity/validateMediaLibraryAssetAspect.ts
+++ b/packages/@sanity/schema/src/sanity/validateMediaLibraryAssetAspect.ts
@@ -1,0 +1,47 @@
+import {type SchemaValidationProblem} from '@sanity/types'
+
+import {groupProblems} from './groupProblems'
+import {validateSchema} from './validateSchema'
+
+function unsupportedTypeValidator(typeLabel: string) {
+  return function () {
+    return {
+      _problems: [
+        {
+          severity: 'error',
+          message: `Type unsupported in Media Library aspects: ${typeLabel}.`,
+        },
+      ],
+    }
+  }
+}
+
+/**
+ * Ensure that the provided value is a valid Media Library asset aspect that can be safely deployed.
+ *
+ * @internal
+ */
+export function validateMediaLibraryAssetAspect(
+  maybeAspect: unknown,
+): [isValidMediaLibraryAspect: boolean, validationErrors: SchemaValidationProblem[][]] {
+  const input = [maybeAspect]
+
+  const validated = validateSchema(input, {
+    transformTypeVisitors: (typeVisitors) => ({
+      ...typeVisitors,
+      document: unsupportedTypeValidator('document'),
+      image: unsupportedTypeValidator('image'),
+      file: unsupportedTypeValidator('file'),
+      reference: unsupportedTypeValidator('reference'),
+      crossDatasetReference: unsupportedTypeValidator('cross dataset reference'),
+    }),
+  })
+
+  const validation = groupProblems(validated.getTypes())
+
+  const errors = validation
+    .map((group) => group.problems.filter(({severity}) => severity === 'error'))
+    .filter((problems) => problems.length)
+
+  return [errors.length === 0, errors]
+}

--- a/packages/@sanity/schema/src/sanity/validateSchema.ts
+++ b/packages/@sanity/schema/src/sanity/validateSchema.ts
@@ -47,13 +47,22 @@ function combine(...visitors: any) {
   }
 }
 
+interface Options {
+  transformTypeVisitors?: (visitors: typeof typeVisitors) => Partial<typeof typeVisitors>
+}
+
 /**
  * @internal
  */
-export function validateSchema(schemaTypes: _FIXME_) {
+export function validateSchema(
+  schemaTypes: _FIXME_,
+  {transformTypeVisitors = (visitors) => visitors}: Options = {},
+) {
   return traverseSanitySchema(schemaTypes, (schemaDef, visitorContext) => {
     const typeVisitor =
-      (schemaDef && schemaDef.type && (typeVisitors as any)[schemaDef.type]) ||
+      (schemaDef &&
+        schemaDef.type &&
+        (transformTypeVisitors(typeVisitors) as any)[schemaDef.type]) ||
       getNoopVisitor(visitorContext)
 
     if (visitorContext.isRoot) {

--- a/packages/@sanity/types/src/mediaLibrary/asserters.ts
+++ b/packages/@sanity/types/src/mediaLibrary/asserters.ts
@@ -5,6 +5,8 @@ import {MEDIA_LIBRARY_ASSET_ASPECT_TYPE_NAME, type MediaLibraryAssetAspectDocume
  *
  * Note: This function does not perform a comprehensive check.
  *
+ * @see validateMediaLibraryAssetAspect
+ *
  * @internal
  */
 export function isAssetAspect(

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -166,6 +166,7 @@
     "@sanity/eventsource": "^5.0.0",
     "@sanity/export": "^3.42.2",
     "@sanity/icons": "^3.7.0",
+    "@sanity/id-utils": "^1.0.0",
     "@sanity/image-url": "^1.0.2",
     "@sanity/import": "^3.38.2",
     "@sanity/insert-menu": "^1.1.9",

--- a/packages/sanity/src/_internal/cli/actions/media/constants.ts
+++ b/packages/sanity/src/_internal/cli/actions/media/constants.ts
@@ -1,0 +1,2 @@
+export const MINIMUM_API_VERSION = 'v2025-02-19'
+export const ASPECT_FILE_EXTENSIONS = ['.ts', '.js']

--- a/packages/sanity/src/_internal/cli/actions/media/createAspectAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/media/createAspectAction.ts
@@ -1,0 +1,82 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import {type CliCommandAction} from '@sanity/cli'
+import {createPublishedId} from '@sanity/id-utils'
+import {camelCase} from 'lodash'
+
+import {withMediaLibraryConfig} from './lib/withMediaLibraryConfig'
+
+const createAspectAction: CliCommandAction = async (args, context) => {
+  const {output, chalk, prompt, mediaLibrary} = withMediaLibraryConfig(context)
+
+  const title = await prompt.single({
+    message: 'Title',
+    type: 'input',
+  })
+
+  const name = await prompt.single({
+    message: 'Name',
+    type: 'input',
+    default: createPublishedId(camelCase(title)),
+  })
+
+  const safeName = createPublishedId(camelCase(name))
+  const destinationPath = path.resolve(mediaLibrary.aspectsPath, `${safeName}.ts`)
+  const relativeDestinationPath = path.relative(process.cwd(), destinationPath)
+
+  await fs.mkdir(path.resolve(mediaLibrary.aspectsPath), {
+    recursive: true,
+  })
+
+  const destinationPathExists = await fs
+    .stat(destinationPath)
+    .then(() => true)
+    .catch(() => false)
+
+  if (destinationPathExists) {
+    output.error(`A file already exists at ${chalk.bold(relativeDestinationPath)}`)
+    return
+  }
+
+  await fs.writeFile(
+    destinationPath,
+    template({
+      name: safeName,
+      title,
+    }),
+  )
+
+  output.success(`Aspect created! ${chalk.bold(relativeDestinationPath)}`)
+  output.print()
+  output.print('Next steps:')
+  output.print(
+    `Open ${chalk.bold(relativeDestinationPath)} in your code editor and customize the aspect.`,
+  )
+  output.print()
+  output.print('Deploy this aspect by running:')
+  output.print(chalk.bold(`sanity media deploy-aspect ${safeName}`))
+  output.print()
+  output.print('Deploy all aspects by running:')
+  output.print(chalk.bold(`sanity media deploy-aspect --all`))
+}
+
+export default createAspectAction
+
+function template({name, title}: {name: string; title: string}) {
+  return `import {defineAssetAspect, defineField} from 'sanity'
+
+export default defineAssetAspect({
+  name: '${name}',
+  title: '${title}',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'string',
+      title: 'Plain String',
+      type: 'string',
+    }),
+  ],
+})
+`
+}

--- a/packages/sanity/src/_internal/cli/actions/media/deleteAspectAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/media/deleteAspectAction.ts
@@ -1,0 +1,84 @@
+import {type CliCommandAction} from '@sanity/cli'
+import {MEDIA_LIBRARY_ASSET_ASPECT_TYPE_NAME} from '@sanity/types'
+import {tap} from 'rxjs'
+
+import {MINIMUM_API_VERSION} from './constants'
+import {determineTargetMediaLibrary} from './lib/determineTargetMediaLibrary'
+
+interface DeleteAspectFlags {
+  'media-library-id'?: string
+  'aspect-name'?: string
+}
+
+const deleteAspectAction: CliCommandAction<DeleteAspectFlags> = async (args, context) => {
+  const {output, chalk, apiClient, prompt} = context
+  const [aspectName] = args.argsWithoutOptions
+
+  if (typeof aspectName === 'undefined') {
+    output.error('Specify an aspect name.')
+    return
+  }
+
+  const mediaLibraryId =
+    args.extOptions['media-library-id'] ?? (await determineTargetMediaLibrary(context))
+
+  const confirmedDelete = await prompt.single({
+    type: 'confirm',
+    message: `Are you absolutely sure you want to undeploy the ${aspectName} aspect from the "${mediaLibraryId}" media library?`,
+    default: false,
+  })
+
+  if (!confirmedDelete) {
+    return
+  }
+
+  const client = apiClient().withConfig({apiVersion: MINIMUM_API_VERSION})
+
+  client.observable
+    .request({
+      method: 'POST',
+      uri: `/media-libraries/${mediaLibraryId}/mutate`,
+      body: {
+        mutations: [
+          {
+            delete: {
+              query: `*[_type == $type && _id == $id]`,
+              params: {
+                id: aspectName,
+                type: MEDIA_LIBRARY_ASSET_ASPECT_TYPE_NAME,
+              },
+            },
+          },
+        ],
+      },
+    })
+    .pipe(
+      tap({
+        error(error) {
+          output.print()
+          output.error(chalk.bold('Failed to delete aspect'))
+          output.print(`  - ${aspectName}`)
+          output.print()
+          output.print(chalk.red(error.message))
+        },
+        next(response) {
+          if (response.results.length === 0) {
+            output.print()
+            output.warn(chalk.bold(`There's no deployed aspect with that name`))
+            output.print(`  - ${aspectName}`)
+            return
+          }
+
+          output.print()
+          output.success(chalk.bold(`Deleted aspect`))
+          output.print(`  - ${aspectName}`)
+        },
+      }),
+    )
+    .subscribe()
+
+  // TODO: Find existing aspect definition files matching the undeployed aspect name and offer
+  // to delete them.
+}
+
+export default deleteAspectAction

--- a/packages/sanity/src/_internal/cli/actions/media/deployAspectAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/media/deployAspectAction.ts
@@ -1,0 +1,372 @@
+import fs from 'node:fs/promises'
+import {EOL} from 'node:os'
+import path from 'node:path'
+
+import {type CliCommandAction, type CliCommandContext, type SanityClient} from '@sanity/cli'
+import {validateMediaLibraryAssetAspect} from '@sanity/schema/_internal'
+import {
+  isAssetAspect,
+  type MediaLibraryAssetAspectDocument,
+  type MultipleMutationResult,
+  type SchemaValidationProblem,
+} from '@sanity/types'
+import {type Chalk} from 'chalk'
+import {register} from 'esbuild-register/dist/node'
+import pluralize from 'pluralize-esm'
+import {
+  catchError,
+  filter,
+  finalize,
+  from,
+  groupBy,
+  map,
+  mergeMap,
+  type MonoTypeOperatorFunction,
+  type Observable,
+  of,
+  type OperatorFunction,
+  pipe,
+  scan,
+  switchMap,
+  takeLast,
+  tap,
+  toArray,
+  zip,
+} from 'rxjs'
+
+import {ASPECT_FILE_EXTENSIONS, MINIMUM_API_VERSION} from './constants'
+import {determineTargetMediaLibrary} from './lib/determineTargetMediaLibrary'
+import {withMediaLibraryConfig} from './lib/withMediaLibraryConfig'
+
+interface DeployAspectFlags {
+  'media-library-id'?: string
+  'aspect-id'?: string
+  'all'?: boolean
+}
+
+type Result =
+  | {
+      status: 'failure'
+      reason: 'invalidAspect' | 'failedMutation'
+      aspects: AspectContainer[]
+      error?: unknown
+    }
+  | {
+      status: 'success'
+      aspects: AspectContainer[]
+    }
+
+type Status = 'valid' | 'invalid'
+
+type AspectsPair = [status: Status, aspects: AspectContainer[]]
+
+type AspectContainer = {
+  filename: string
+  validationErrors: SchemaValidationProblem[][]
+} & (
+  | {
+      status: Extract<Status, 'valid'>
+      aspect: MediaLibraryAssetAspectDocument
+    }
+  | {
+      status: Extract<Status, 'invalid'>
+      aspect: unknown
+    }
+)
+
+const deployAspectAction: CliCommandAction<DeployAspectFlags> = async (args, context) => {
+  const {output, apiClient, mediaLibrary} = withMediaLibraryConfig(context)
+  const [aspectId] = args.argsWithoutOptions
+  const all = args.extOptions.all ?? false
+
+  if (!all && typeof aspectId === 'undefined') {
+    output.error(
+      'Specify an aspect name, or use the `--all` option to deploy all aspect definitions.',
+    )
+    return
+  }
+
+  if (all && typeof aspectId !== 'undefined') {
+    output.error('Specified both an aspect name and `--all`.')
+    return
+  }
+
+  const mediaLibraryId =
+    args.extOptions['media-library-id'] ?? (await determineTargetMediaLibrary(context))
+
+  const client = apiClient().withConfig({
+    apiVersion: MINIMUM_API_VERSION,
+    requestTagPrefix: 'sanity.mediaLibraryCli',
+  })
+
+  importAspects({
+    aspectsPath: mediaLibrary.aspectsPath,
+    filterAspects: (entry) => {
+      if (all) {
+        return true
+      }
+
+      if (typeof entry === 'object' && entry !== null && '_id' in entry) {
+        return entry._id === aspectId
+      }
+
+      return false
+    },
+  })
+    .pipe(
+      mergeMap<AspectsPair, Observable<Result>>(([status, aspects]) => {
+        if (status === 'invalid') {
+          return of<Result>({
+            status: 'failure',
+            reason: 'invalidAspect',
+            aspects,
+          })
+        }
+
+        return of(aspects).pipe(
+          deployAspects({
+            client,
+            mediaLibraryId,
+            dryRun: false,
+          }),
+        )
+      }),
+      reportResult({context}),
+      reportUnfoundAspect({aspectId, context}),
+    )
+    .subscribe()
+}
+
+export default deployAspectAction
+
+function importAspects({
+  aspectsPath,
+  filterAspects = () => true,
+}: {
+  aspectsPath: string
+  filterAspects?: (aspect: unknown) => boolean
+}): Observable<AspectsPair> {
+  let unregister: (() => void) | undefined
+
+  const entries = fs.readdir(aspectsPath, {
+    withFileTypes: true,
+  })
+
+  return from(entries).pipe(
+    tap({
+      subscribe() {
+        if (!__DEV__) {
+          unregister = register({
+            target: `node${process.version.slice(1)}`,
+            supported: {'dynamic-import': true},
+          }).unregister
+        }
+      },
+    }),
+    mergeMap((entry) => from(entry)),
+    filter((file) => file.isFile()),
+    filter((file) => ASPECT_FILE_EXTENSIONS.includes(path.extname(file.name))),
+    switchMap((file) => importAspect({aspectsPath, filename: file.name})),
+    map(([filename, maybeAspect]) => {
+      if (!isAssetAspect(maybeAspect)) {
+        return {
+          status: 'invalid' as const,
+          aspect: maybeAspect,
+          validationErrors: [],
+          filename,
+        }
+      }
+
+      const [valid, errors] = validateMediaLibraryAssetAspect(maybeAspect.definition)
+
+      if (!valid) {
+        return {
+          status: 'invalid' as const,
+          aspect: maybeAspect,
+          validationErrors: errors,
+          filename,
+        }
+      }
+
+      return {
+        status: 'valid' as const,
+        aspect: maybeAspect,
+        validationErrors: [],
+        filename,
+      }
+    }),
+    groupBy<AspectContainer, 'valid' | 'invalid'>((maybeAspect) => maybeAspect.status),
+    mergeMap(
+      (group) =>
+        zip(
+          of(group.key),
+          group.pipe(
+            filter(({aspect}) => filterAspects(aspect)),
+            toArray(),
+          ),
+        ) as Observable<AspectsPair>,
+    ),
+    finalize(() => unregister?.()),
+  )
+}
+
+function importAspect({
+  aspectsPath,
+  filename,
+}: {
+  aspectsPath: string
+  filename: string
+}): Observable<[filename: string, aspect: MediaLibraryAssetAspectDocument]> {
+  // eslint-disable-next-line import/no-dynamic-require
+  return of([filename, require(path.resolve(aspectsPath, filename)).default])
+}
+
+function deployAspects({
+  client,
+  dryRun,
+  mediaLibraryId,
+}: {
+  client: SanityClient
+  dryRun: boolean
+  mediaLibraryId: string
+}): OperatorFunction<AspectContainer[], Result> {
+  return pipe(
+    filter((aspects) => aspects.length !== 0),
+    switchMap((aspects) => {
+      return client.observable
+        .request<MultipleMutationResult>({
+          method: 'POST',
+          uri: `/media-libraries/${mediaLibraryId}/mutate`,
+          tag: 'deployAspects',
+          query: {
+            dryRun: String(dryRun),
+          },
+          body: {
+            mutations: aspects.map(({aspect}) => ({
+              createOrReplace: aspect,
+            })),
+          },
+        })
+        .pipe(
+          mergeMap(() =>
+            of<Result>({
+              status: 'success',
+              aspects,
+            }),
+          ),
+          catchError((error) =>
+            of<Result>({
+              status: 'failure',
+              reason: 'failedMutation',
+              error: error.message,
+              aspects,
+            }),
+          ),
+        )
+    }),
+  )
+}
+
+function reportResult({context}: {context: CliCommandContext}): MonoTypeOperatorFunction<Result> {
+  return tap((result) => {
+    const {output, chalk} = context
+
+    const list = formatAspectList({
+      aspects: result.aspects,
+      chalk,
+    })
+
+    if (result.status === 'success' && result.aspects.length !== 0) {
+      output.print()
+      output.success(
+        chalk.bold(
+          `Deployed ${result.aspects.length} ${pluralize('aspect', result.aspects.length)}`,
+        ),
+      )
+      output.print(list)
+    }
+
+    if (
+      result.status === 'failure' &&
+      result.aspects.length !== 0 &&
+      result.reason === 'invalidAspect'
+    ) {
+      output.print()
+      output.warn(
+        chalk.bold(
+          `Skipped ${result.aspects.length} invalid ${pluralize('aspect', result.aspects.length)}`,
+        ),
+      )
+      output.print(list)
+    }
+
+    if (
+      result.status === 'failure' &&
+      result.aspects.length !== 0 &&
+      result.reason === 'failedMutation'
+    ) {
+      output.print()
+      output.error(
+        chalk.bold(
+          `Failed to deploy ${result.aspects.length} ${pluralize('aspect', result.aspects.length)}`,
+        ),
+      )
+      output.print(list)
+      output.print()
+      output.print(chalk.red(result.error))
+    }
+  })
+}
+
+function reportUnfoundAspect({
+  aspectId,
+  context,
+}: {
+  context: CliCommandContext
+  aspectId?: string
+}): OperatorFunction<Result, AspectContainer[]> {
+  const {output, chalk} = context
+
+  return pipe(
+    scan<Result, AspectContainer[]>((aspects, result) => aspects.concat(result.aspects), []),
+    takeLast(1),
+    tap((aspects) => {
+      const aspectNotFound = aspects.length === 0 && aspectId
+      if (aspectNotFound) {
+        output.print()
+        output.error(`Could not find aspect: ${chalk.bold(aspectId)}`)
+      }
+    }),
+  )
+}
+
+function formatAspectList({aspects, chalk}: {aspects: AspectContainer[]; chalk: Chalk}): string {
+  return aspects
+    .map(({aspect, filename, validationErrors}) => {
+      const label =
+        typeof aspect === 'object' &&
+        aspect !== null &&
+        '_id' in aspect &&
+        typeof aspect._id !== 'undefined'
+          ? aspect._id
+          : 'Unnamed aspect'
+
+      const simplifiedErrors = validationErrors.flatMap((group) =>
+        group.map(({message}) => message),
+      )
+
+      const errorLabel = simplifiedErrors.length === 0 ? '' : ` ${chalk.bgRed(simplifiedErrors[0])}`
+
+      const remainingErrorsCount = simplifiedErrors.length - 1
+
+      const remainingErrorsLabel =
+        remainingErrorsCount > 0
+          ? chalk.italic(
+              ` and ${simplifiedErrors.length - 1} other ${pluralize('error', remainingErrorsCount)}`,
+            )
+          : ''
+
+      return `  - ${label} ${chalk.dim(filename)}${errorLabel}${remainingErrorsLabel}`
+    })
+    .join(EOL)
+}

--- a/packages/sanity/src/_internal/cli/actions/media/lib/determineTargetMediaLibrary.ts
+++ b/packages/sanity/src/_internal/cli/actions/media/lib/determineTargetMediaLibrary.ts
@@ -1,0 +1,55 @@
+import {CliCommandContext} from '@sanity/cli'
+import {debug} from '../../../debug'
+import {filter, firstValueFrom, groupBy, mergeMap, of, toArray, zip} from 'rxjs'
+
+/**
+ * Fetch a list of available media libraries and present them to the user in a list prompt. The items
+ * in the list prompt are grouped by organization id.
+ */
+export async function determineTargetMediaLibrary({
+  apiClient,
+  output,
+  prompt,
+}: CliCommandContext): Promise<string> {
+  const client = apiClient().withConfig({apiVersion: 'vX'})
+  const {projectId} = client.config()
+
+  // Note: a more user-friendly error is displayed by CLI code that is executed before this code.
+  // This function should never be executed if a project id is not defined.
+  if (typeof projectId === 'undefined') {
+    throw new Error('Project id is required')
+  }
+
+  debug('Fetching available media libraries')
+  const spinner = output.spinner('Fetching available media libraries').start()
+
+  const mediaLibrariesByOrganization = await firstValueFrom(
+    client.observable
+      .request<{
+        data: {status: 'active'; id: string; organizationId: string}[]
+      }>({
+        uri: `/media-libraries`,
+        query: {
+          projectId,
+        },
+      })
+      .pipe(
+        mergeMap((response) => response.data),
+        filter(({status}) => status === 'active'),
+        groupBy(({organizationId}) => organizationId),
+        mergeMap((group) => zip(of(group.key), group.pipe(toArray()))),
+        toArray(),
+      ),
+  )
+
+  spinner.succeed('[100%] Fetching available media libraries')
+
+  return prompt.single({
+    message: 'Select media library',
+    type: 'list',
+    choices: mediaLibrariesByOrganization.flatMap(([organizationId, mediaLibraries]) => [
+      new prompt.Separator(`Organization: ${organizationId}`),
+      ...mediaLibraries.map(({id}) => ({value: id, name: id})),
+    ]),
+  })
+}

--- a/packages/sanity/src/_internal/cli/actions/media/lib/withMediaLibraryConfig.ts
+++ b/packages/sanity/src/_internal/cli/actions/media/lib/withMediaLibraryConfig.ts
@@ -1,0 +1,27 @@
+import type {CliCommandContext, CliConfig} from '@sanity/cli'
+import path from 'node:path'
+
+export function withMediaLibraryConfig(
+  context: CliCommandContext,
+): CliCommandContext & Required<Pick<CliConfig, 'mediaLibrary'>> {
+  const {cliConfig, cliConfigPath} = context
+
+  const mediaLibrary =
+    typeof cliConfig === 'object' && 'mediaLibrary' in cliConfig
+      ? cliConfig.mediaLibrary
+      : undefined
+
+  const relativeConfigPath = path.relative(process.cwd(), cliConfigPath ?? '')
+
+  if (typeof mediaLibrary?.aspectsPath === 'undefined') {
+    throw new Error(
+      `${relativeConfigPath} does not contain a media library aspects path ("mediaLibrary.aspectsPath"), ` +
+        'which is required for the Sanity CLI to manage aspects.',
+    )
+  }
+
+  return {
+    ...context,
+    mediaLibrary,
+  }
+}

--- a/packages/sanity/src/_internal/cli/commands/index.ts
+++ b/packages/sanity/src/_internal/cli/commands/index.ts
@@ -42,6 +42,10 @@ import listHooksCommand from './hook/listHooksCommand'
 import printHookAttemptCommand from './hook/printHookAttemptCommand'
 import extractManifestCommand from './manifest/extractManifestCommand'
 import manifestGroup from './manifest/manifestGroup'
+import createAspectCommand from './media/createAspectCommand'
+import deleteAspectCommand from './media/deleteAspectCommand'
+import deployAspectCommand from './media/deployAspectCommand'
+import mediaGroup from './media/mediaGroup'
 import createMigrationCommand from './migration/createMigrationCommand'
 import listMigrationsCommand from './migration/listMigrationsCommand'
 import migrationGroup from './migration/migrationGroup'
@@ -112,6 +116,10 @@ const baseCommands: (CliCommandDefinition | CliCommandGroupDefinition)[] = [
   execCommand,
   manifestGroup,
   extractManifestCommand,
+  mediaGroup,
+  createAspectCommand,
+  deleteAspectCommand,
+  deployAspectCommand,
 ]
 
 const featureToggledSchemaCommands = [fetchSchemaCommand, deploySchemaCommand, deleteSchemaCommand]

--- a/packages/sanity/src/_internal/cli/commands/media/createAspectCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/media/createAspectCommand.ts
@@ -1,0 +1,21 @@
+import {type CliCommandDefinition} from '@sanity/cli'
+
+const helpText = `
+Examples
+  # Create a new aspect definition file.
+  sanity media create-aspect
+`
+
+const createAspectCommand: CliCommandDefinition = {
+  name: 'create-aspect',
+  group: 'media',
+  signature: '',
+  description: 'Create a new aspect definition file.',
+  helpText,
+  action: async (args, context) => {
+    const mod = await import('../../actions/media/createAspectAction')
+    return mod.default(args, context)
+  },
+}
+
+export default createAspectCommand

--- a/packages/sanity/src/_internal/cli/commands/media/deleteAspectCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/media/deleteAspectCommand.ts
@@ -1,0 +1,24 @@
+import {type CliCommandDefinition} from '@sanity/cli'
+
+const helpText = `
+Options
+  --media-library-id The id of the target media library.
+
+Examples
+  # Delete the aspect named "someAspect".
+  sanity media delete-aspect someAspect
+`
+
+const deleteAspectCommand: CliCommandDefinition = {
+  name: 'delete-aspect',
+  group: 'media',
+  signature: '[ASPECT_NAME]',
+  description: 'Undeploy an aspect.',
+  helpText,
+  action: async (args, context) => {
+    const mod = await import('../../actions/media/deleteAspectAction')
+    return mod.default(args, context)
+  },
+}
+
+export default deleteAspectCommand

--- a/packages/sanity/src/_internal/cli/commands/media/deployAspectCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/media/deployAspectCommand.ts
@@ -1,0 +1,28 @@
+import {type CliCommandDefinition} from '@sanity/cli'
+
+const helpText = `
+Options
+  --media-library-id The id of the target media library.
+  --all              Deploy all aspects.
+
+Examples
+  # Deploy the aspect named "someAspect".
+  sanity media deploy-aspect someAspect
+
+  # Deploy all aspects.
+  sanity media deploy-aspect --all
+`
+
+const deployAspectCommand: CliCommandDefinition = {
+  name: 'deploy-aspect',
+  group: 'media',
+  signature: '[ASPECT_NAME]',
+  description: 'Deploy an aspect.',
+  helpText,
+  action: async (args, context) => {
+    const mod = await import('../../actions/media/deployAspectAction')
+    return mod.default(args, context)
+  },
+}
+
+export default deployAspectCommand

--- a/packages/sanity/src/_internal/cli/commands/media/mediaGroup.ts
+++ b/packages/sanity/src/_internal/cli/commands/media/mediaGroup.ts
@@ -1,0 +1,11 @@
+import {type CliCommandGroupDefinition} from '@sanity/cli'
+
+const mediaGroup: CliCommandGroupDefinition = {
+  name: 'media',
+  signature: '[COMMAND]',
+  description: 'Manage Media Library.',
+  isGroupRoot: true,
+  hideFromHelp: true,
+}
+
+export default mediaGroup

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1415,6 +1415,9 @@ importers:
       '@sanity/icons':
         specifier: ^3.7.0
         version: 3.7.0(react@18.3.1)
+      '@sanity/id-utils':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@sanity/image-url':
         specifier: ^1.0.2
         version: 1.1.0
@@ -4731,6 +4734,10 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: ^18.3 || ^19.0.0-0
+
+  '@sanity/id-utils@1.0.0':
+    resolution: {integrity: sha512-2sb7tbdMDuUuVyocJPKG0gZBiOML/ovCe+mJiLrv1j69ODOfa2LfUjDVR+dRw/A/+XuxoJSSP8ebG7NiwTOgIA==}
+    engines: {node: '>=18'}
 
   '@sanity/image-url@1.1.0':
     resolution: {integrity: sha512-JHumVRxzzaZAJyOimntdukA9TjjzsJiaiq/uUBdTknMLCNvtM6KQ5OCp6W5fIdY78uyFxtQjz+MPXwK8WBIxWg==}
@@ -11473,6 +11480,9 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
+  ts-brand@0.2.0:
+    resolution: {integrity: sha512-H5uo7OqMvd91D2EefFmltBP9oeNInNzWLAZUSt6coGDn8b814Eis6SnEtzyXORr9ccEb38PfzyiRVDacdkycSQ==}
+
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
@@ -15341,6 +15351,12 @@ snapshots:
   '@sanity/icons@3.7.0(react@19.1.0)':
     dependencies:
       react: 19.1.0
+
+  '@sanity/id-utils@1.0.0':
+    dependencies:
+      '@sanity/uuid': 3.0.2
+      lodash: 4.17.21
+      ts-brand: 0.2.0
 
   '@sanity/image-url@1.1.0': {}
 
@@ -23711,6 +23727,8 @@ snapshots:
   ts-api-utils@1.4.3(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
+
+  ts-brand@0.2.0: {}
 
   ts-node@10.9.2(@swc/core@1.10.15)(@types/node@22.13.1)(typescript@5.8.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,12 @@ importers:
         specifier: ^6.2.4
         version: 6.2.4(@types/node@22.13.1)(terser@5.38.2)(yaml@2.7.0)
 
+  dev/media-library-aspects-studio:
+    dependencies:
+      sanity:
+        specifier: workspace:^
+        version: link:../../packages/sanity
+
   dev/page-building-studio:
     dependencies:
       '@sanity/vision':


### PR DESCRIPTION
### Description

This branch adds Media Library CLI config and three commands for managing asset aspects.

All commands that require a media library id to be specified accept a `--media-library-id` option. If no `--media-library-id` is specified, the CLI will load available media libraries and present a list to the user.

#### CLI config

The `mediaLibrary.aspectsPath` option specifies the path in the project in which aspect definitions are stored. This must be specified for the CLI to be able to manage aspects.

> [!NOTE]
> These commands are currently hidden from the CLI's help text.

#### Command: `sanity media create-aspect`

Scaffold a new aspect definition in the path specified by the project's `mediaLibrary.aspectsPath` option.

#### Command: `sanity media delete-aspect`

Undeploy the aspect matching the provided name. This command does not clean up dangling aspect data, nor does it delete aspect definitions in the local project.

#### Command: `sanity media deploy-aspect`

Deploy a single aspect matching the provided name, or all aspects if the `--all` option is used.

#### Aspect validation

The existing schema tooling is used to validate schema definitions before deploying them. The following types are unsupported by Media Library, and will cause the validation to fail if they appear at any depth:

- `document`
- `image`
- `file`
- `reference`
- `crossDatasetReference`

When aspects fail validation, the CLI prints a warning:

<img width="923" alt="Screenshot 2025-04-13 at 15 32 45" src="https://github.com/user-attachments/assets/df391f7f-82e7-4bda-9f07-e870e55de5a1" />

### What to review

- The `media` group of CLI commands.
- The changes to `traverseSanitySchema` to enable type visitor extension.

### Testing

Tests to follow. This is preview functionality that we'd like to get into the hands of test users and then iterate on.

To manually test the commands:

1. Build the project (`pnpm build`).
2. Navigate to the test project (`cd dev/media-library-aspects-studio`).
3. Run the commands e.g. `pnpm exec sanity media create-aspect`.

To verify aspects are deployed and undeployed correctly, you can query the media library dataset:

```
curl https://api.sanity.io/v2025-03-24/media-libraries/al34RQcBfuD7/query?query=*%5B_type%3D%3D%22sanity.asset.aspect%22%5D
```

You can also verify the aspects are displayed in the web UI correctly by running the Huey project locally with `NEXT_PUBLIC_RUNTIME_ENV=production`.