### PR TITLE
refactor(e2e): move to use staging env instead of production for client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,9 @@
 
 # This is a write token that allows playwright to interact with the studio as an authenticated user
 # You can generate your own token by heading over to the tokens-section of
-# https://www.sanity.io/manage/, or by using your CLI user token (`sanity debug --secrets`)
+# https://www.sanity.work/manage/, or by using your CLI user token (`sanity debug --secrets`)
 SANITY_E2E_SESSION_TOKEN=
-SANITY_E2E_PROJECT_ID=kin4wkua
+SANITY_E2E_PROJECT_ID=e9khh71e
 SANITY_E2E_DATASET=
 SANITY_E2E_BASE_URL=http://localhost:3339
 

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -128,8 +128,8 @@ jobs:
           # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
-          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
-          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID }}
+          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_RITA }}
+          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_RITA }}
           SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
         run: pnpm e2e:setup && pnpm e2e:build
 
@@ -193,7 +193,7 @@ jobs:
           # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
-          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
+          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_RITA }}
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
           SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
         # As e2e:build ran in the `install` job, turbopack restores it from cache here

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,9 +86,9 @@ jobs:
           # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
-          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
-          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID }}
-          SANITY_E2E_DATASET: ${{ vars.SANITY_E2E_DATASET }}
+          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_RITA }}
+          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_RITA }}
+          SANITY_E2E_DATASET: ${{ vars.SANITY_E2E_DATASET_RITA }}
         run: pnpm e2e:setup && pnpm e2e:build
 
       - name: Cache E2E test studio on PR
@@ -97,8 +97,8 @@ jobs:
           # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
-          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
-          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID }}
+          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_RITA }}
+          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_RITA }}
           SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
         run: pnpm e2e:setup && pnpm e2e:build
 
@@ -155,9 +155,9 @@ jobs:
           # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
-          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
-          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID }}
-          SANITY_E2E_DATASET: ${{ vars.SANITY_E2E_DATASET }}
+          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_RITA }}
+          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_RITA }}
+          SANITY_E2E_DATASET: ${{ vars.SANITY_E2E_DATASET_RITA }}
         # As e2e:build ran in the `install` job, turbopack restores it from cache here
         run: pnpm e2e:build && pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
@@ -169,9 +169,9 @@ jobs:
           PWTEST_BLOB_REPORT_NAME: ${{ matrix.project }}
           # Update the SANITY_E2E_SESSION_TOKEN on github to the new value once this is merged to next
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
-          # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
-          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
-          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID }}
+          # Delete `SANITY_E2E_SESSION_TOKEN_RITA` from github
+          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_RITA }}
+          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_RITA }}
           SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
         # As e2e:build ran in the `install` job, turbopack restores it from cache here
         run: pnpm e2e:build && pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Remove E2E datasets for closed PRs
         env:
-          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
+          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_RITA }}
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
           SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
         run: pnpm e2e:cleanup

--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
   dataset: process.env.SANITY_E2E_DATASET!,
 
   basePath: '/test',
+  apiHost: 'https://api.sanity.work',
 
   schema: {
     types: schemaTypes,

--- a/scripts/e2e/e2eClient.ts
+++ b/scripts/e2e/e2eClient.ts
@@ -15,5 +15,6 @@ export function createE2EClient(dataset: string): SanityClient {
     token: readEnv<KnownEnvVar>('SANITY_E2E_SESSION_TOKEN'),
     apiVersion: '2023-02-03',
     useCdn: false,
+    apiHost: 'https://api.sanity.work',
   })
 }

--- a/test/e2e/helpers/sanityClient.ts
+++ b/test/e2e/helpers/sanityClient.ts
@@ -32,6 +32,7 @@ const testSanityClient = createClient({
   token: SANITY_E2E_SESSION_TOKEN,
   useCdn: false,
   apiVersion: '2021-08-31',
+  apiHost: 'https://api.sanity.work',
 })
 
 /* eslint-disable callback-return*/


### PR DESCRIPTION
### Description

Move dataset and project to be used locally to be a staging project

- Edit: I need to change the vars for the CI to run as expected with the new project. I haven't made that change yet, instead I'm testing out with new envs and secrets.

### What to review

Did I miss anything else, can you run the e2e tests locally?

### Testing

Running the e2e tests locally should work as intended

### Notes for release

N/A