### PR TITLE
fix(studio): improve how presence works with releases

### DIFF
--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -227,9 +227,11 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
 
   const [presence, setPresence] = useState<DocumentPresence[]>([])
   useEffect(() => {
-    const subscription = presenceStore.documentPresence(value._id).subscribe((nextPresence) => {
-      setPresence(nextPresence)
-    })
+    const subscription = presenceStore
+      .documentPresence(value._id, {excludeVersions: true})
+      .subscribe((nextPresence) => {
+        setPresence(nextPresence)
+      })
     return () => {
       subscription.unsubscribe()
     }

--- a/packages/sanity/src/core/presence/DocumentPreviewPresence.tsx
+++ b/packages/sanity/src/core/presence/DocumentPreviewPresence.tsx
@@ -7,8 +7,9 @@ import {css, styled} from 'styled-components'
 
 import {Tooltip, type TooltipProps} from '../../ui-components'
 import {UserAvatar} from '../components'
+import {getReleaseIdFromReleaseDocumentId, useActiveReleases} from '../releases'
 import {type DocumentPresence} from '../store'
-import {isNonNullable} from '../util'
+import {getVersionFromId, isNonNullable} from '../util'
 
 /** @internal */
 export interface DocumentPreviewPresenceProps {
@@ -27,23 +28,13 @@ const AvatarStackBox = styled.div((props) => {
   `
 })
 
-const getTooltipText = (presence: Omit<DocumentPresence, 'path'>[]) => {
-  if (presence.length === 1) {
-    return `${presence[0].user.displayName} is editing this document`
-  }
-
-  if (presence.length > 1) {
-    return `${presence.length} people are editing this document right now`
-  }
-
-  return undefined
-}
-
 /** @internal */
 export function DocumentPreviewPresence(props: DocumentPreviewPresenceProps) {
   const {presence} = props
 
-  const uniqueUsers = useMemo(
+  const {data: releases} = useActiveReleases()
+
+  const uniquePresence = useMemo(
     () =>
       Array.from(new Set(presence.map((a) => a.user.id)))
         .map((id) => {
@@ -53,13 +44,31 @@ export function DocumentPreviewPresence(props: DocumentPreviewPresenceProps) {
     [presence],
   )
 
-  const tooltipContent = useMemo(() => getTooltipText(uniqueUsers), [uniqueUsers])
+  const tooltipContent = useMemo(() => {
+    if (uniquePresence.length === 1) {
+      const firstPresence = uniquePresence[0]
+      const documentId = firstPresence?.documentId
+      const release = documentId
+        ? releases.find(
+            (r) => getReleaseIdFromReleaseDocumentId(r._id) === getVersionFromId(documentId),
+          )
+        : undefined
+      const releaseTitle = release?.metadata?.title
+      return `${firstPresence.user.displayName} is editing this document${releaseTitle ? ` in the release "${releaseTitle}" right now` : 'in an untitled release right now'}`
+    }
+
+    if (uniquePresence.length > 1) {
+      return `${uniquePresence.length} people are editing this document right now`
+    }
+
+    return undefined
+  }, [uniquePresence, releases])
 
   return (
     <Tooltip content={tooltipContent} {...PRESENCE_MENU_POPOVER_PROPS}>
       <AvatarStackBox>
-        <AvatarStack maxLength={2} aria-label={getTooltipText(uniqueUsers)} size={0}>
-          {uniqueUsers.map((item) => (
+        <AvatarStack maxLength={2} aria-label={tooltipContent} size={0}>
+          {uniquePresence.map((item) => (
             <UserAvatar key={item.user.id} size={0} user={item.user} />
           ))}
         </AvatarStack>

--- a/packages/sanity/src/core/store/_legacy/presence/types.ts
+++ b/packages/sanity/src/core/store/_legacy/presence/types.ts
@@ -36,6 +36,11 @@ export interface DocumentPresence {
   user: User
   path: Path
   sessionId: string
+  /**
+   * this is the specific id of the document that the user is in
+   * e.g. if the user is in the draft, this will be the draft id, if the user is in a version, it will be the version id
+   * */
+  documentId?: string
   lastActiveAt: string // iso date
 }
 

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenuItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenuItem.tsx
@@ -7,6 +7,7 @@ import {MenuItem} from '../../../../../ui-components'
 import {UserAvatar} from '../../../../components'
 import {useTranslation} from '../../../../i18n'
 import {type GlobalPresence} from '../../../../store'
+import {getPublishedId, getVersionFromId} from '../../../../util'
 
 interface PresenceListRowProps {
   focused: boolean
@@ -45,15 +46,17 @@ export const PresenceMenuItem = memo(function PresenceMenuItem(props: PresenceLi
   const hasLink = Boolean(lastActiveLocation?.documentId)
 
   if (lastActiveLocation) {
+    const perspective = getVersionFromId(lastActiveLocation.documentId)
     return (
       <MenuItem
         as={IntentLink}
         // @ts-expect-error - `intent` is valid when using `IntentLink`
         intent="edit"
         params={{
-          id: lastActiveLocation.documentId,
+          id: getPublishedId(lastActiveLocation.documentId),
           path: PathUtils.toString(lastActiveLocation.path),
         }}
+        searchParams={perspective ? [['perspective', perspective]] : []}
         // Shared props
         data-as="a"
         onFocus={handleFocus}


### PR DESCRIPTION
### Description
This fixes a couple of issues with presence and content releases:

- Document lists did not display avatars of users working in versions of documents
- Clicking on an avatar for a user in the global presence menu always took you to the draft, not the actual version the user was in. This is now fixed by adding the version of the document as `perspective` param to the link. This also means that clicking a presence avatar from the global presence menu changes your studio perspective.

Note: Field presence is still scoped to version. I.e. field presence won't display users working in the same field in other versions of the document. I personally think this is the most sensible since the purpose of presence here is first and foremost to tell who are concurrently editing the exact field. We could consider visually indicating different versions here though.

### Testing
This would be good to have some tests for, I'll look into adding test cases for these.

### What to review
Does this make sense UX wise?

### Notes for release
- Improved how presence works with Content Releases