### PR TITLE
feat(cli): ask to auto update on sanity dev, build and deploy

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -191,6 +191,7 @@
     "@types/speakingurl": "^13.0.3",
     "@types/tar-stream": "^3.1.3",
     "@types/use-sync-external-store": "^1.5.0",
+    "@types/which": "^3.0.4",
     "@vitejs/plugin-react": "^4.3.4",
     "@xstate/react": "^5.0.3",
     "archiver": "^7.0.0",
@@ -240,6 +241,7 @@
     "pirates": "^4.0.0",
     "pluralize-esm": "^9.0.2",
     "polished": "^4.2.2",
+    "preferred-pm": "^4.1.1",
     "pretty-ms": "^7.0.1",
     "quick-lru": "^5.1.1",
     "raf": "^3.4.1",
@@ -272,6 +274,7 @@
     "use-sync-external-store": "^1.5.0",
     "uuid": "^11.0.5",
     "vite": "^6.0.11",
+    "which": "^5.0.0",
     "xstate": "^5.19.2",
     "yargs": "^17.3.0"
   },

--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -73,34 +73,30 @@ export default async function buildSanityStudio(
     output.print(`${info} Building with auto-updates enabled`)
 
     // Check the versions
-    try {
-      const result = await compareDependencyVersions(autoUpdatesImports, workDir)
+    const result = await compareDependencyVersions(autoUpdatesImports, workDir)
 
-      // If it is in unattended mode, we don't want to prompt
-      if (result?.length && !unattendedMode) {
-        const shouldUpgrade = await prompt.single({
-          type: 'confirm',
-          message: chalk.yellow(
-            `The following local package versions are different from the versions currently served at runtime.\n` +
-              `When using auto updates, we recommend that you test locally with the same versions before deploying. \n\n` +
-              `${result.map((mod) => ` - ${mod.pkg} (local version: ${mod.installed}, runtime version: ${mod.remote})`).join('\n')} \n\n` +
-              `Do you want to upgrade local versions instead?`,
-          ),
-          default: false,
-        })
+    // If it is in unattended mode, we don't want to prompt
+    if (result?.length && !unattendedMode) {
+      const shouldUpgrade = await prompt.single({
+        type: 'confirm',
+        message: chalk.yellow(
+          `The following local package versions are different from the versions currently served at runtime.\n` +
+            `When using auto updates, we recommend that you test locally with the same versions before deploying. \n\n` +
+            `${result.map((mod) => ` - ${mod.pkg} (local version: ${mod.installed}, runtime version: ${mod.remote})`).join('\n')} \n\n` +
+            `Do you want to upgrade local versions instead?`,
+        ),
+        default: false,
+      })
 
-        if (shouldUpgrade) {
-          await upgradePackages(
-            {
-              packageManager: (await getPackageManagerChoice(workDir, {interactive: false})).chosen,
-              packages: result.map((res) => [res.pkg, res.remote]),
-            },
-            context,
-          )
-        }
+      if (shouldUpgrade) {
+        await upgradePackages(
+          {
+            packageManager: (await getPackageManagerChoice(workDir, {interactive: false})).chosen,
+            packages: result.map((res) => [res.pkg, res.remote]),
+          },
+          context,
+        )
       }
-    } catch (err) {
-      throw err
     }
   }
 

--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -17,6 +17,8 @@ import {compareDependencyVersions} from '../../util/compareDependencyVersions'
 import {getStudioAutoUpdateImportMap} from '../../util/getAutoUpdatesImportMap'
 import {shouldAutoUpdate} from '../../util/shouldAutoUpdate'
 import {formatModuleSizes, sortModulesBySize} from '../../util/moduleFormatUtils'
+import {upgradePackages} from '../../util/packageManager/upgradePackages'
+import {getPackageManagerChoice} from '../../util/packageManager/packageManagerChoice'
 
 export interface BuildSanityStudioCommandFlags {
   'yes'?: boolean
@@ -76,19 +78,25 @@ export default async function buildSanityStudio(
 
       // If it is in unattended mode, we don't want to prompt
       if (result?.length && !unattendedMode) {
-        const shouldContinue = await prompt.single({
+        const shouldUpgrade = await prompt.single({
           type: 'confirm',
           message: chalk.yellow(
             `The following local package versions are different from the versions currently served at runtime.\n` +
               `When using auto updates, we recommend that you test locally with the same versions before deploying. \n\n` +
               `${result.map((mod) => ` - ${mod.pkg} (local version: ${mod.installed}, runtime version: ${mod.remote})`).join('\n')} \n\n` +
-              `Continue anyway?`,
+              `Do you want to upgrade local versions instead?`,
           ),
           default: false,
         })
 
-        if (!shouldContinue) {
-          return process.exit(0)
+        if (shouldUpgrade) {
+          await upgradePackages(
+            {
+              packageManager: (await getPackageManagerChoice(workDir, {interactive: false})).chosen,
+              packages: result.map((res) => [res.pkg, res.remote]),
+            },
+            context,
+          )
         }
       }
     } catch (err) {

--- a/packages/sanity/src/_internal/cli/util/packageManager/getUpgradeCommand.ts
+++ b/packages/sanity/src/_internal/cli/util/packageManager/getUpgradeCommand.ts
@@ -1,0 +1,25 @@
+import {type PackageManager} from './packageManagerChoice'
+
+export function getUpgradeCommand(options: {
+  packageManager: PackageManager
+  packages: [name: string, version: string][]
+}): string {
+  const {packageManager, packages} = options
+  const upgradePackageArgs = packages.map((pkg) => pkg.join('@')).join(' ')
+
+  // Define commands for known package managers
+  switch (packageManager) {
+    case 'yarn':
+      return `yarn upgrade ${upgradePackageArgs}`
+    case 'pnpm':
+      return `pnpm update ${upgradePackageArgs}`
+    case 'bun':
+      return `bun update ${upgradePackageArgs}` // Fixed the command for bun
+    case 'npm':
+      return `npm install ${upgradePackageArgs}`
+    case 'manual':
+      return `Manually upgrade the following packages using your preferred package manager: ${upgradePackageArgs}`
+    default:
+  }
+  return `Unsupported package manager ${packageManager}, manually upgrade the following packages using your preferred package manager, e.g. "${packageManager} upgrade ${upgradePackageArgs}"`
+}

--- a/packages/sanity/src/_internal/cli/util/packageManager/upgradePackages.ts
+++ b/packages/sanity/src/_internal/cli/util/packageManager/upgradePackages.ts
@@ -34,7 +34,7 @@ export async function upgradePackages(
     output.print(`Running 'pnpm ${pnpmArgs.join(' ')}'`)
     result = await execa('pnpm', pnpmArgs, execOptions)
   } else if (packageManager === 'bun') {
-    const bunArgs = ['upgrade', ...upgradePackageArgs]
+    const bunArgs = ['update', ...upgradePackageArgs]
     output.print(`Running 'bun ${bunArgs.join(' ')}'`)
     result = await execa('bun', bunArgs, execOptions)
   } else if (packageManager === 'manual') {

--- a/packages/sanity/src/_internal/cli/util/packageManager/upgradePackages.ts
+++ b/packages/sanity/src/_internal/cli/util/packageManager/upgradePackages.ts
@@ -1,0 +1,49 @@
+import execa, {type CommonOptions, type ExecaReturnValue} from 'execa'
+
+import {getPartialEnvWithNpmPath, type PackageManager} from './packageManagerChoice'
+
+export interface InstallOptions {
+  packageManager: PackageManager
+  packages: [name: string, version: string][]
+}
+
+export async function upgradePackages(
+  options: InstallOptions,
+  context: {output: {print: (output: string) => void}; workDir: string},
+): Promise<void> {
+  const {packageManager, packages} = options
+  const {output, workDir} = context
+  const execOptions: CommonOptions<'utf8'> = {
+    encoding: 'utf8',
+    env: getPartialEnvWithNpmPath(workDir),
+    cwd: workDir,
+    stdio: 'inherit',
+  }
+  const upgradePackageArgs = packages.map((pkg) => pkg.join('@'))
+  const npmArgs = ['upgrade', '--legacy-peer-deps', ...upgradePackageArgs]
+  let result: ExecaReturnValue<string> | undefined
+  if (packageManager === 'npm') {
+    output.print(`Running 'npm upgrade ${npmArgs.join(' ')}'`)
+    result = await execa('npm', npmArgs, execOptions)
+  } else if (packageManager === 'yarn') {
+    const yarnArgs = ['upgrade ', ...upgradePackageArgs]
+    output.print(`Running 'yarn ${yarnArgs.join(' ')}'`)
+    result = await execa('yarn', yarnArgs, execOptions)
+  } else if (packageManager === 'pnpm') {
+    const pnpmArgs = ['upgrade', ...upgradePackageArgs]
+    output.print(`Running 'pnpm ${pnpmArgs.join(' ')}'`)
+    result = await execa('pnpm', pnpmArgs, execOptions)
+  } else if (packageManager === 'bun') {
+    const bunArgs = ['upgrade', ...upgradePackageArgs]
+    output.print(`Running 'bun ${bunArgs.join(' ')}'`)
+    result = await execa('bun', bunArgs, execOptions)
+  } else if (packageManager === 'manual') {
+    output.print(
+      `Manual installation selected - run 'npm upgrade ${upgradePackageArgs.join(' ')}' or equivalent`,
+    )
+  }
+
+  if (result?.exitCode || result?.failed) {
+    throw new Error('Package upgrade failed')
+  }
+}

--- a/packages/sanity/src/_internal/cli/util/shouldAutoUpdate.ts
+++ b/packages/sanity/src/_internal/cli/util/shouldAutoUpdate.ts
@@ -1,9 +1,7 @@
 import {type CliConfig} from '@sanity/cli'
 
-import {type BuildSanityStudioCommandFlags} from '../actions/build/buildAction'
-
 interface AutoUpdateSources {
-  flags: BuildSanityStudioCommandFlags
+  flags: {['auto-updates']?: boolean}
   cliConfig?: CliConfig
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1493,6 +1493,9 @@ importers:
       '@types/use-sync-external-store':
         specifier: ^1.5.0
         version: 1.5.0
+      '@types/which':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.2.4(@types/node@22.13.1)(terser@5.38.2)(yaml@2.7.0))
@@ -1640,6 +1643,9 @@ importers:
       polished:
         specifier: ^4.2.2
         version: 4.3.1
+      preferred-pm:
+        specifier: ^4.1.1
+        version: 4.1.1
       pretty-ms:
         specifier: ^7.0.1
         version: 7.0.1
@@ -1736,6 +1742,9 @@ importers:
       vite:
         specifier: ^6.2.4
         version: 6.2.4(@types/node@22.13.1)(terser@5.38.2)(yaml@2.7.0)
+      which:
+        specifier: ^5.0.0
+        version: 5.0.0
       xstate:
         specifier: ^5.19.2
         version: 5.19.2
@@ -5523,6 +5532,9 @@ packages:
 
   '@types/which@2.0.2':
     resolution: {integrity: sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==}
+
+  '@types/which@3.0.4':
+    resolution: {integrity: sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==}
 
   '@types/wicg-task-scheduling@2024.1.0':
     resolution: {integrity: sha512-9g5QVDU8Na3P6rPMbyYx5pS8UpGDfzys8T7Xq5HMTbI7elSq/YioGbBVAh2u67JGNTThZ3o9PK0/qBvaVOYPYQ==}
@@ -10191,6 +10203,10 @@ packages:
     resolution: {integrity: sha512-lEHd+yEm22jXdCphDrkvIJQU66EuLojPPtvZkpKIkiD+l0DMThF/niqZKJSoU8Vl7iuvtmzyMhir9LdVy5WMnA==}
     engines: {node: '>=10'}
 
+  preferred-pm@4.1.1:
+    resolution: {integrity: sha512-rU+ZAv1Ur9jAUZtGPebQVQPzdGhNzaEiQ7VL9+cjsAWPHFYOccNXPNiev1CCDSOg/2j7UujM7ojNhpkuILEVNQ==}
+    engines: {node: '>=18.12'}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -12259,6 +12275,10 @@ packages:
     resolution: {integrity: sha512-MOiaDbA5ZZgUjkeMWM5EkJp4loW5ZRoa5bc3/aeMox/PJelMhE6t7S/mLuiY43DBupyxH+S0U1bTui9kWUlmsw==}
     engines: {node: '>=8.15'}
 
+  which-pm@3.0.1:
+    resolution: {integrity: sha512-v2JrMq0waAI4ju1xU5x3blsxBBMgdgZve580iYMN5frDaLGjbA24fok7wKCsya8KLVO19Ju4XDc5+zTZCJkQfg==}
+    engines: {node: '>=18.12'}
+
   which-typed-array@1.1.18:
     resolution: {integrity: sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==}
     engines: {node: '>= 0.4'}
@@ -12280,6 +12300,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  which@5.0.0:
+    resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
   why-is-node-running@2.3.0:
@@ -16936,6 +16961,8 @@ snapshots:
   '@types/validate-npm-package-name@3.0.3': {}
 
   '@types/which@2.0.2': {}
+
+  '@types/which@3.0.4': {}
 
   '@types/wicg-task-scheduling@2024.1.0': {}
 
@@ -22394,6 +22421,12 @@ snapshots:
       path-exists: 4.0.0
       which-pm: 2.2.0
 
+  preferred-pm@4.1.1:
+    dependencies:
+      find-up-simple: 1.0.0
+      find-yarn-workspace-root2: 1.2.16
+      which-pm: 3.0.1
+
   prelude-ls@1.2.1: {}
 
   preserve@0.2.0: {}
@@ -24815,6 +24848,10 @@ snapshots:
       load-yaml-file: 0.2.0
       path-exists: 4.0.0
 
+  which-pm@3.0.1:
+    dependencies:
+      load-yaml-file: 0.2.0
+
   which-typed-array@1.1.18:
     dependencies:
       available-typed-arrays: 1.0.7
@@ -24837,6 +24874,10 @@ snapshots:
       isexe: 2.0.0
 
   which@4.0.0:
+    dependencies:
+      isexe: 3.1.1
+
+  which@5.0.0:
     dependencies:
       isexe: 3.1.1
 


### PR DESCRIPTION
### Description

Currently it's easy to miss it if you have auto-updates enabled and are running `sanity dev` with outdated local dependencies compared to what's currently served at runtime for your deployed studio. This can lead to situations where you get different behavior locally than after deployment (i.e. you get hit by a bug during dev that's fixed for your deployed studio). It might also be surprising that your local versions aren't updated, since you've opted into auto-updates after all.

As of this PR, when `sanity dev` is invoked, we'll check if auto-updates are enabled, and if it is, and you have outdated local dependencies, we'll ask you if you'd like to upgrade.

Example:
```
npx sanity dev
? The following local package versions are different from the versions currently served at runtime.
When using auto updates, we recommend that you test locally with the same versions before deploying. 

 - sanity (local version: 3.82.0, runtime version: 3.86.1)
 - @sanity/vision (local version: 3.82.0, runtime version: 3.86.1) 

Do you want to upgrade local versions? (Y/n)
```

For `build` and `deploy` you can chose betwee 3 options, since it's likely that the developer would want to do a round of testing before continuing with the deploy:
```
? Select existing studio hostname bjoerge-aus-debug
ℹ Building with auto-updates enabled
? The following local package versions are different from the versions currently served at runtime.
When using auto updates, we recommend that you test locally with the same versions before deploying. 

 - @sanity/vision (local version: 3.83.0, runtime version: 3.86.1) 

Do you want to upgrade local versions before deploying? (Use arrow keys)
❯ Upgrade and proceed with deploy 
  Upgrade only. You will need to run the deploy command again 
  Cancel 
```

Note that this goes both ways: Although rarely, it might happen that you have a have higher version locally than what's currently served at runtime. If this happens, you should still be prompted and asked if you want to sync local deps.

### What to review
We already had a set of utils for executing `<packageManager> install` in the global `@sanity/cli`-package, but those are not easily accessible from the project CLI code in the `sanity`-package. It didn't feel right to expose them via the context that's passed to the project cli, so I opted for copying the relevant code over to the project CLI instead. This isn't ideal, but I've tried to keep the divergence at a minimum so it shouldn't be that big of a deal to combine them at a later point (if one day we merge global and project CLI code)

I did consider running the upgrade without prompting, but it felt very heavy-handled, and it's probably something we rather want to support as a configuration option, e.g. instead of `autoUpdates: true`, `autoUpdates: {enabled: true, autoSyncLocalDeps}` (or something).

Note: I've also implemented the same prompt in `sanity build` (and as a consequence `sanity deploy`, however, here the default will be `false`.

### Testing

How to test:
- Initialize a new Studio
- Enable auto-updates (if not already enabled)
- Deploy the studio
- Install the branch preview build: `npm i https://pkg.pr.new/sanity-io/sanity@9153`
- Downgrade to older sanity packages locally (i.e. `@sanity/vision`)
- Run `npx sanity dev` or `npx sanity deploy` or `npx sanity build`
- You should now be prompted and asked if you'd like to upgrade outdated packages.

### Notes for release
- If enabling Auto-Updates and running `sanity dev` or `sanity deploy` with outdated dependencies locally, you will now be asked if you'd like to upgrade local versions.
