### PR TITLE
test(e2e): skip release tests for now

### DIFF
--- a/test/e2e/tests/releases/revert/revertASAP.spec.ts
+++ b/test/e2e/tests/releases/revert/revertASAP.spec.ts
@@ -20,6 +20,7 @@ import {
 } from '../utils/release-detail-ui-methods'
 
 test.describe('Revert ASAP', () => {
+  test.skip()
   const asapReleaseIdTestOne: string = getRandomReleaseId()
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {

--- a/test/e2e/tests/releases/revert/revertSchedule.spec.ts
+++ b/test/e2e/tests/releases/revert/revertSchedule.spec.ts
@@ -18,6 +18,8 @@ import {
 } from '../utils/release-detail-ui-methods'
 
 test.describe('Revert Scheduled', () => {
+  test.skip()
+
   const scheduledReleaseIdTestOne: string = getRandomReleaseId()
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {

--- a/test/e2e/tests/releases/revert/revertUndecided.spec.ts
+++ b/test/e2e/tests/releases/revert/revertUndecided.spec.ts
@@ -18,6 +18,8 @@ import {
 } from '../utils/release-detail-ui-methods'
 
 test.describe('Revert Undecided', () => {
+  test.skip()
+
   const undecidedReleaseIdTestOne: string = getRandomReleaseId()
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {

--- a/test/e2e/tests/releases/unarchive/unarchiveASAP.spec.ts
+++ b/test/e2e/tests/releases/unarchive/unarchiveASAP.spec.ts
@@ -18,6 +18,8 @@ import {
 } from '../utils/release-detail-ui-methods'
 
 test.describe('Unarchive ASAP', () => {
+  test.skip()
+
   const asapReleaseIdTestOne: string = getRandomReleaseId()
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {

--- a/test/e2e/tests/releases/unarchive/unarchiveScheduled.spec.ts
+++ b/test/e2e/tests/releases/unarchive/unarchiveScheduled.spec.ts
@@ -14,6 +14,8 @@ import {
 } from '../utils/methods'
 
 test.describe('Unarchive Scheduled', () => {
+  test.skip()
+
   const scheduledReleaseIdTestOne: string = getRandomReleaseId()
 
   test.beforeEach(async ({sanityClient, browserName}) => {

--- a/test/e2e/tests/releases/unarchive/unarchiveUndecided.spec.ts
+++ b/test/e2e/tests/releases/unarchive/unarchiveUndecided.spec.ts
@@ -18,6 +18,8 @@ import {
 } from '../utils/release-detail-ui-methods'
 
 test.describe('Unarchive Undecided', () => {
+  test.skip()
+
   const undecidedReleaseIdTestOne: string = getRandomReleaseId()
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {


### PR DESCRIPTION
### Description

Tests are failing again, we need to find a better way or lift the 10 releases limit
This will make main healthy again (hopefully)

### What to review

Did I miss anything? I think the displayDocument is safe to keep

### Testing

N/A

### Notes for release

N/A
