### PR TITLE
fix(i18n): remove extra parens

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -32,7 +32,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** "Latest version" header in about dialog */
   'about-dialog.version-info.latest-version.text': 'Latest version is {{latestVersion}}',
   /** "Up to date" status in About-dialog */
-  'about-dialog.version-info.up-to-date': '(Up to date)',
+  'about-dialog.version-info.up-to-date': 'Up to date',
   /** "User agent" header in About-dialog */
   'about-dialog.version-info.user-agent.header': 'User agent',
 

--- a/packages/sanity/src/core/studio/components/navbar/resources/AboutDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/AboutDialog.tsx
@@ -79,12 +79,11 @@ ${navigator.userAgent}
           </Text>
           <Text muted size={1}>
             <Translate t={t} i18nKey="" components={{}} />
-            {t('about-dialog.version-info.latest-version.text', {latestVersion})}
+            {t('about-dialog.version-info.latest-version.text', {latestVersion})}{' '}
             {latestVersion === currentVersion ? (
               <>({t('about-dialog.version-info.up-to-date')})</>
             ) : (
               <>
-                {' '}
                 (
                 <a href="https://www.sanity.io/docs/upgrade">
                   {t('about-dialog.version-info.how-to-upgrade')}


### PR DESCRIPTION
### Description
Fixes the whitespace issue and removes redundant parens from the version info dialog that currently looks like this:
<img width="319" alt="image" src="https://github.com/user-attachments/assets/794f1707-c8f7-4e04-9ef4-39a57f143c38" />