### PR TITLE
chore: lowercase sanity.studio url

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/deploy/deployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/deploy/deployAction.ts
@@ -148,7 +148,7 @@ export default async function deployStudioAction(
   const base = path.basename(sourceDir)
   const tarball = tar.pack(parentDir, {entries: [base]}).pipe(zlib.createGzip())
 
-  spinner = output.spinner('Deploying to Sanity.Studio').start()
+  spinner = output.spinner('Deploying to sanity.studio').start()
   try {
     const {location} = await createDeployment({
       client,


### PR DESCRIPTION
### Description

When deploying `Sanity.Studio` looks weird as it uses Title Case in a domain name.