### PR TITLE
docs: update sanity dataset export CLI help text

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/dataset/exportDatasetCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/exportDatasetCommand.ts
@@ -99,7 +99,8 @@ const exportDatasetCommand: CliCommandDefinition<ExportFlags> = {
   name: 'export',
   group: 'dataset',
   signature: '[NAME] [DESTINATION]',
-  description: 'Export dataset to local filesystem as a gzipped tarball',
+  description: `Export dataset to local filesystem as a gzipped tarball.
+      Assets failing with HTTP status codes 401, 403 and 404 upon download are ignored and excluded from export.`,
   helpText,
   action: async (args, context) => {
     const {apiClient, output, chalk, workDir, prompt} = context


### PR DESCRIPTION
### Description

This PR updates sanity dataset export CLI text to include how failing assets are handled.

Failing assets in certain conditions are ignored after [this](https://github.com/sanity-io/export/pull/19) release of export package, which was included in `v3.69.0` sanity CLI version. Sanity documentation update reflecting this change is already in draft, pending review.