### PR TITLE
feat: set background based on `prefers-color-scheme`

### DIFF
--- a/packages/sanity/src/_internal/cli/server/components/DefaultDocument.tsx
+++ b/packages/sanity/src/_internal/cli/server/components/DefaultDocument.tsx
@@ -90,7 +90,12 @@ const globalStyles = `
     src: url("https://studio-static.sanity.io/Inter-BlackItalic.woff2") format("woff2");
   }
   html {
-    background-color: #f1f3f6;
+    @media (prefers-color-scheme: dark) {
+      background-color: #13141b;
+    }
+    @media (prefers-color-scheme: light) {
+      background-color: #ffffff;
+    }
   }
   html,
   body,


### PR DESCRIPTION
### Description

This pull request fixes a minor issue where the initial background of the Studio does not respect the user's color scheme preferences. The main issue it solves is that, if a user prefers a dark color scheme, the app flashes white while loading before switching to the appropriate dark background color.

The `#13141b` color matches the default dark background in Sanity UI. While it may not exactly match custom Studio themes, it's probably generally a better fallback than white and will likely align more closely with most potential custom dark mode styles.

**Before:**  

https://github.com/user-attachments/assets/93d77270-57f9-46a4-82fd-e57b6037e896

**After:**  

https://github.com/user-attachments/assets/8e71ce60-a230-4305-89a0-fd093e423788


### What to review

- Does this makes sense?

### Notes for release

Fixes an issue where the user's color scheme preference was not respected during Studio loading.
