### PR TITLE
fix(deps): update dependency @sanity/runtime-cli to ^2.5.0

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -60,7 +60,7 @@
     "@babel/traverse": "^7.23.5",
     "@sanity/client": "^6.28.4",
     "@sanity/codegen": "3.83.0",
-    "@sanity/runtime-cli": "^1.1.1",
+    "@sanity/runtime-cli": "^2.4.0",
     "@sanity/telemetry": "^0.8.0",
     "@sanity/template-validator": "^2.4.3",
     "@sanity/util": "3.83.0",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -60,7 +60,7 @@
     "@babel/traverse": "^7.23.5",
     "@sanity/client": "^6.28.4",
     "@sanity/codegen": "3.83.0",
-    "@sanity/runtime-cli": "^2.4.0",
+    "@sanity/runtime-cli": "^2.5.0",
     "@sanity/telemetry": "^0.8.0",
     "@sanity/template-validator": "^2.4.3",
     "@sanity/util": "3.83.0",

--- a/packages/@sanity/cli/src/commands/functions/devFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/devFunctionsCommand.ts
@@ -30,9 +30,8 @@ const devFunctionsCommand: CliCommandDefinition = {
     const {print} = output
     const flags = {...defaultFlags, ...args.extOptions}
 
-    const {devAction} = await import('@sanity/runtime-cli')
-
-    devAction(flags.port)
+    const {functionsActions} = await import('@sanity/runtime-cli')
+    functionsActions.dev.dev(flags.port)
 
     print(`Server is running on port ${flags.port}\n`)
     open(`http://localhost:${flags.port}`)

--- a/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
@@ -11,6 +11,7 @@ Examples
 
 const defaultFlags = {
   id: undefined,
+  limit: 50,
 }
 
 const logsFunctionsCommand: CliCommandDefinition = {
@@ -32,10 +33,19 @@ const logsFunctionsCommand: CliCommandDefinition = {
 
     if (flags.id) {
       const token = client.config().token
-      if (token) {
-        const {logsAction} = await import('@sanity/runtime-cli')
-        const result = await logsAction(flags.id, token)
+      const {blueprintsActions} = await import('@sanity/runtime-cli')
+      const blueprintConfig = blueprintsActions.blueprint.readConfigFile()
+
+      if (token && blueprintConfig?.projectId) {
+        const {functionsActions} = await import('@sanity/runtime-cli')
+        const result = await functionsActions.logs.logs(
+          flags.id,
+          {limit: flags.limit},
+          {token, projectId: blueprintConfig.projectId},
+        )
         print(JSON.stringify(result, null, 2))
+      } else {
+        print('You must run this command from a blueprints project')
       }
     } else {
       print('You must provide a function ID')

--- a/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
@@ -2,16 +2,17 @@ import {type CliCommandDefinition} from '../../types'
 
 const helpText = `
 Options
-  --id <id> The ID of the function to retrieve logs for
+  --name <name> The name of the function to retrieve logs for
 
 Examples
   # Retrieve logs for Sanity Function abcd1234
-  sanity functions logs --id abcd1234
+  sanity functions logs --name echo
 `
 
 const defaultFlags = {
-  id: undefined,
+  name: '',
   limit: 50,
+  json: false,
 }
 
 const logsFunctionsCommand: CliCommandDefinition = {
@@ -31,24 +32,69 @@ const logsFunctionsCommand: CliCommandDefinition = {
       requireProject: false,
     })
 
-    if (flags.id) {
-      const token = client.config().token
-      const {blueprintsActions} = await import('@sanity/runtime-cli')
-      const blueprintConfig = blueprintsActions.blueprint.readConfigFile()
+    if (flags.name === '') {
+      print('You must provide a function name')
+      return
+    }
 
-      if (token && blueprintConfig?.projectId) {
-        const {functionsActions} = await import('@sanity/runtime-cli')
-        const result = await functionsActions.logs.logs(
-          flags.id,
-          {limit: flags.limit},
-          {token, projectId: blueprintConfig.projectId},
-        )
-        print(JSON.stringify(result, null, 2))
+    const token = client.config().token
+    const {blueprintsActions} = await import('@sanity/runtime-cli')
+
+    const {deployedStack} = await blueprintsActions.blueprint.readBlueprintOnDisk({
+      getStack: true,
+      token,
+    })
+
+    if (!deployedStack) print('Stack not found') // returns
+
+    const blueprintConfig = blueprintsActions.blueprint.readConfigFile()
+    const projectId = blueprintConfig?.projectId
+
+    const func = deployedStack?.resources?.find(
+      (r) => r?.type?.startsWith('sanity.function.') && r.name === flags.name,
+    )
+
+    if (!func) throw Error(`Unable to find function ${flags.name}`)
+
+    if (token && projectId) {
+      const {functionsActions} = await import('@sanity/runtime-cli')
+      const {ok, error, logs, total} = await functionsActions.logs.logs(
+        func.externalId,
+        {limit: flags.limit},
+        {token, projectId},
+      )
+
+      if (!ok) {
+        print(`Error: ${error || 'Unknown error'}`)
+        return
+      }
+
+      const filteredLogs = logs.filter(
+        (entry: {level: string; message: string}) => entry.level && entry.message,
+      )
+
+      if (filteredLogs.length === 0) {
+        print(`No logs found for function ${flags.name}`)
+        return
+      }
+
+      if (flags.json) {
+        print(JSON.stringify(filteredLogs, null, 2))
       } else {
-        print('You must run this command from a blueprints project')
+        print(`Found ${total} log entries for function ${flags.name}`)
+        if (logs.length < total) {
+          print(`Here are the last ${filteredLogs.length} entries`)
+        }
+        print('\n')
+
+        for (const log of filteredLogs) {
+          const {time, level, message} = log
+          const date = new Date(time)
+          print(`${date.toLocaleDateString()} ${date.toLocaleTimeString()} ${level} ${message}`)
+        }
       }
     } else {
-      print('You must provide a function ID')
+      print('You must run this command from a blueprints project')
     }
   },
 }

--- a/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/logsFunctionsCommand.ts
@@ -5,10 +5,18 @@ import {type CliCommandDefinition} from '../../types'
 const helpText = `
 Options
   --name <name> The name of the function to retrieve logs for
+  --limit <limit> The number of log entries to retrieve
+  --json If set return json
 
 Examples
   # Retrieve logs for Sanity Function abcd1234
   sanity functions logs --name echo
+
+  # Retrieve the last two log entries for Sanity Function abcd1234
+  sanity functions logs --name echo --limit 2
+
+  # Retrieve logs for Sanity Function abcd1234 in json format
+  sanity functions logs --name echo --json
 `
 
 const defaultFlags = {

--- a/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
@@ -4,24 +4,24 @@ const helpText = `
 Options
   --data <data> Data to send to the function
   --file <file> Read data from file and send to the function
-  --path <path> Path to your Sanity Function code
+  --name <name> The name of your Sanity Function
   --timeout <timeout> Execution timeout value in seconds
 
 Examples
   # Test function passing event data on command line
-  sanity functions test --path ./test.ts --data '{ "id": 1 }'
+  sanity functions test --name echo --data '{ "id": 1 }'
 
   # Test function passing event data via a file
-  sanity functions test -path ./test.js --file 'payload.json'
+  sanity functions test -name echo --file 'payload.json'
 
   # Test function passing event data on command line and cap execution time to 60 seconds
-  sanity functions test -path ./test.ts --data '{ "id": 1 }' --timeout 60
+  sanity functions test -name echo --data '{ "id": 1 }' --timeout 60
 `
 
 const defaultFlags = {
   data: undefined,
   file: undefined,
-  path: undefined,
+  name: '',
   timeout: 5, // seconds
 }
 
@@ -37,24 +37,35 @@ const testFunctionsCommand: CliCommandDefinition = {
     const {print} = output
     const flags = {...defaultFlags, ...args.extOptions}
 
-    if (flags.path) {
-      const {functionsActions} = await import('@sanity/runtime-cli')
-      const {json, logs, error} = await functionsActions.test.testAction(flags.path, {
-        data: flags.data,
-        file: flags.file,
-        timeout: flags.timeout,
-      })
+    if (flags.name === '') {
+      print('You must provide a function name')
+      return
+    }
 
-      if (error) {
-        print(error.toString())
-      } else {
-        print('Logs:')
-        print(logs)
-        print('Response:')
-        print(JSON.stringify(json, null, 2))
-      }
+    const {blueprintsActions, functionsActions, utils} = await import('@sanity/runtime-cli')
+
+    const {parsedBlueprint} = await blueprintsActions.blueprint.readBlueprintOnDisk({
+      getStack: false,
+    })
+
+    const src = utils.findFunctions.getFunctionSource(parsedBlueprint, flags.name)
+    if (!src) {
+      print(`Error: Function ${flags.name} has no source code`)
+    }
+
+    const {json, logs, error} = await functionsActions.test.testAction(src, {
+      data: flags.data,
+      file: flags.file,
+      timeout: flags.timeout,
+    })
+
+    if (error) {
+      print(error.toString())
     } else {
-      print('You must provide a path to the Sanity Function code')
+      print('Logs:')
+      print(logs)
+      print('Response:')
+      print(JSON.stringify(json, null, 2))
     }
   },
 }

--- a/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
@@ -38,8 +38,8 @@ const testFunctionsCommand: CliCommandDefinition = {
     const flags = {...defaultFlags, ...args.extOptions}
 
     if (flags.path) {
-      const {testAction} = await import('@sanity/runtime-cli')
-      const {json, logs, error} = await testAction(flags.path, {
+      const {functionsActions} = await import('@sanity/runtime-cli')
+      const {json, logs, error} = await functionsActions.test.testAction(flags.path, {
         data: flags.data,
         file: flags.file,
         timeout: flags.timeout,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,8 +723,8 @@ importers:
         specifier: 3.83.0
         version: link:../codegen
       '@sanity/runtime-cli':
-        specifier: ^2.4.0
-        version: 2.4.0(@types/node@22.13.1)
+        specifier: ^2.5.0
+        version: 2.5.0(@types/node@22.13.1)
       '@sanity/telemetry':
         specifier: ^0.8.0
         version: 0.8.1(react@19.1.0)
@@ -4826,8 +4826,8 @@ packages:
     peerDependencies:
       react: ^18.3 || >=19.0.0-rc
 
-  '@sanity/runtime-cli@2.4.0':
-    resolution: {integrity: sha512-upmZqqnFwpmK6/7SVDetm7k+dhNwLEB3JBMgG4URgjOFM9FEygR6WuCzN7/83ScJ1xx9JEM+A+QxsFG93i2teA==}
+  '@sanity/runtime-cli@2.5.0':
+    resolution: {integrity: sha512-wyapz5TKMd1LTMmTPStp/XxARPLq14eEzZ7mNn51uQ7m//w+rc9qEhSqEWDbUzBVrxOTsWsJr+SlmiGmtEKS8A==}
     engines: {node: '>=18.20.0'}
     hasBin: true
 
@@ -15638,7 +15638,7 @@ snapshots:
       - '@sanity/types'
       - debug
 
-  '@sanity/runtime-cli@2.4.0(@types/node@22.13.1)':
+  '@sanity/runtime-cli@2.5.0(@types/node@22.13.1)':
     dependencies:
       '@oclif/core': 4.2.10
       '@oclif/plugin-help': 6.2.27

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,8 +723,8 @@ importers:
         specifier: 3.83.0
         version: link:../codegen
       '@sanity/runtime-cli':
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^2.4.0
+        version: 2.4.0(@types/node@22.13.1)
       '@sanity/telemetry':
         specifier: ^0.8.0
         version: 0.8.1(react@19.1.0)
@@ -3648,6 +3648,127 @@ packages:
     peerDependencies:
       react: '*'
 
+  '@inquirer/checkbox@4.1.5':
+    resolution: {integrity: sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.10.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.9':
+    resolution: {integrity: sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.10.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.1.10':
+    resolution: {integrity: sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.10.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.10':
+    resolution: {integrity: sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.10.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.12':
+    resolution: {integrity: sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.10.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.11':
+    resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.1.9':
+    resolution: {integrity: sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.10.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.12':
+    resolution: {integrity: sha512-7HRFHxbPCA4e4jMxTQglHJwP+v/kpFsCf2szzfBHy98Wlc3L08HL76UDiA87TOdX5fwj2HMOLWqRWv9Pnn+Z5Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.10.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.12':
+    resolution: {integrity: sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.10.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.4.1':
+    resolution: {integrity: sha512-UlmM5FVOZF0gpoe1PT/jN4vk8JmpIWBlMvTL8M+hlvPmzN89K6z03+IFmyeu/oFCenwdwHDr2gky7nIGSEVvlA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.10.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.0.12':
+    resolution: {integrity: sha512-wNPJZy8Oc7RyGISPxp9/MpTOqX8lr0r+lCCWm7hQra+MDtYRgINv1hxw7R+vKP71Bu/3LszabxOodfV/uTfsaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.10.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.0.12':
+    resolution: {integrity: sha512-H/kDJA3kNlnNIjB8YsaXoQI0Qccgf0Na14K1h8ExWhNmUg2E941dyFPrZeugihEa9AZNW5NdsD/NcvUME83OPQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.10.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.1.1':
+    resolution: {integrity: sha512-IUXzzTKVdiVNMA+2yUvPxWsSgOG4kfX93jOM4Zb5FgujeInotv5SPIJVeXQ+fO4xu7tW8VowFhdG5JRmmCyQ1Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.10.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.6':
+    resolution: {integrity: sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.10.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -4042,16 +4163,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oclif/core@4.2.8':
-    resolution: {integrity: sha512-OWv4Va6bERxIhrYcnUGzyhGRqktc64lJO6cZ3UwkzJDpfR8ZrbCxRfKRBBah1i8kzUlOAeAXnpbMBMah3skKwA==}
+  '@oclif/core@4.2.10':
+    resolution: {integrity: sha512-fAqcXgqkUm4v5FYy7qWP4w1HaOlVSVJveah+yVTo5Nm5kTiXhmD5mQQ7+knGeBaStyrtQy6WardoC2xSic9rlQ==}
     engines: {node: '>=18.0.0'}
 
-  '@oclif/plugin-help@6.2.26':
-    resolution: {integrity: sha512-5KdldxEizbV3RsHOddN4oMxrX/HL6z79S94tbxEHVZ/dJKDWzfyCpgC9axNYqwmBF2pFZkozl/l7t3hCGOdalw==}
-    engines: {node: '>=18.0.0'}
-
-  '@oclif/plugin-plugins@5.4.34':
-    resolution: {integrity: sha512-19sX+tHyR6M24GHbnedqqtk6w9QBgFZoa1y4zPmHf6VYaBeBmMBaq2dsLsdG0zv8LnWxaqguocICoxZTrV9f6A==}
+  '@oclif/plugin-help@6.2.27':
+    resolution: {integrity: sha512-RWSWtCFVObRmCwgxVOye3lsYbPHTnB7G4He5LEAg2tf600Sil5yXEOL/ULx1TqL/XOQxKqRvmLn/rLQOMT85YA==}
     engines: {node: '>=18.0.0'}
 
   '@octokit/action@6.1.0':
@@ -4709,9 +4826,9 @@ packages:
     peerDependencies:
       react: ^18.3 || >=19.0.0-rc
 
-  '@sanity/runtime-cli@1.1.1':
-    resolution: {integrity: sha512-8iScG1ZFz/hAIa4yRJmSleUsCj+Ej8GSNKL6xXJnAQFMhw7RWlKO0GQq3fkiCVbmqELSG76v7CH9uHNZ9nu+DQ==}
-    engines: {node: '>=20.11.0'}
+  '@sanity/runtime-cli@2.4.0':
+    resolution: {integrity: sha512-upmZqqnFwpmK6/7SVDetm7k+dhNwLEB3JBMgG4URgjOFM9FEygR6WuCzN7/83ScJ1xx9JEM+A+QxsFG93i2teA==}
+    engines: {node: '>=18.20.0'}
     hasBin: true
 
   '@sanity/telemetry@0.8.1':
@@ -5524,6 +5641,10 @@ packages:
   add-stream@1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
 
+  adm-zip@0.5.16:
+    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
+    engines: {node: '>=12.0'}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -5608,8 +5729,8 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
-  ansis@3.16.0:
-    resolution: {integrity: sha512-sU7d/tfZiYrsIAXbdL/CNZld5bCkruzwT5KmqmadCJYxuLxHAOBjidxD5+iLmN/6xEfjcQq1l7OpsiCBlc4LzA==}
+  ansis@3.17.0:
+    resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
     engines: {node: '>=14'}
 
   anymatch@1.3.2:
@@ -5679,6 +5800,9 @@ packages:
   array-includes@3.1.8:
     resolution: {integrity: sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==}
     engines: {node: '>= 0.4'}
+
+  array-treeify@0.1.3:
+    resolution: {integrity: sha512-uUB7ngRUZe535QtK7VJeBIWcci58BFjT7O2of3Fkga/NPwr5vBeabMv83h1gMQVYVEyirXpp0kjqMGQftMTuiQ==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -6162,6 +6286,10 @@ packages:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -6203,6 +6331,10 @@ packages:
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
+
+  color-json@3.0.5:
+    resolution: {integrity: sha512-DG4zae1GmHDBNsYTUe+GJiDnuKutxs2vVSkPRQqbeA6oEGBRQyRixV+HmIByasCfyf9L0CwHo8vOoiHqe7Lzng==}
+    engines: {node: '>=12'}
 
   color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
@@ -7218,9 +7350,17 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.1:
+    resolution: {integrity: sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==}
+    engines: {node: '>=18.0.0'}
+
   eventsource@2.0.2:
     resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
     engines: {node: '>=12.0.0'}
+
+  eventsource@3.0.6:
+    resolution: {integrity: sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==}
+    engines: {node: '>=18.0.0'}
 
   execa@2.1.0:
     resolution: {integrity: sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==}
@@ -8070,6 +8210,15 @@ packages:
   init-package-json@6.0.3:
     resolution: {integrity: sha512-Zfeb5ol+H+eqJWHTaGca9BovufyGeIfr4zaaBorPmJBMrJ+KBnN+kQx2ZtXdsotUTgldHmHQV44xvUWOUA7E2w==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  inquirer@12.5.2:
+    resolution: {integrity: sha512-qoDk/vdSTIaXNXAoNnlg7ubexpJfUo7t8GT2vylxvE49BrLhToFuPPdMViidG2boHV7+AcP1TCkJs/+PPoF2QQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.10.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   inquirer@6.5.2:
     resolution: {integrity: sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==}
@@ -8964,12 +9113,20 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.18:
     resolution: {integrity: sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==}
     engines: {node: '>= 0.6'}
 
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.1:
+    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
   mime@1.6.0:
@@ -9165,6 +9322,10 @@ packages:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   mux-embed@5.2.1:
     resolution: {integrity: sha512-NukHw91xeEVDBeXVDBpi2BvXNix7gSuvdtyvOph5yR/ROn1hHbTlcYWoKQyCyJX9frsF00UROEul+S8wPzU3aQ==}
 
@@ -9313,84 +9474,6 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
-  npm-run-path@5.3.0:
-    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  npm@10.9.2:
-    resolution: {integrity: sha512-iriPEPIkoMYUy3F6f3wwSZAU93E0Eg6cHwIR6jzzOXWSy+SD/rOODEs74cVONHKSx2obXtuUoyidVEhISrisgQ==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-    hasBin: true
-    bundledDependencies:
-      - '@isaacs/string-locale-compare'
-      - '@npmcli/arborist'
-      - '@npmcli/config'
-      - '@npmcli/fs'
-      - '@npmcli/map-workspaces'
-      - '@npmcli/package-json'
-      - '@npmcli/promise-spawn'
-      - '@npmcli/redact'
-      - '@npmcli/run-script'
-      - '@sigstore/tuf'
-      - abbrev
-      - archy
-      - cacache
-      - chalk
-      - ci-info
-      - cli-columns
-      - fastest-levenshtein
-      - fs-minipass
-      - glob
-      - graceful-fs
-      - hosted-git-info
-      - ini
-      - init-package-json
-      - is-cidr
-      - json-parse-even-better-errors
-      - libnpmaccess
-      - libnpmdiff
-      - libnpmexec
-      - libnpmfund
-      - libnpmhook
-      - libnpmorg
-      - libnpmpack
-      - libnpmpublish
-      - libnpmsearch
-      - libnpmteam
-      - libnpmversion
-      - make-fetch-happen
-      - minimatch
-      - minipass
-      - minipass-pipeline
-      - ms
-      - node-gyp
-      - nopt
-      - normalize-package-data
-      - npm-audit-report
-      - npm-install-checks
-      - npm-package-arg
-      - npm-pick-manifest
-      - npm-profile
-      - npm-registry-fetch
-      - npm-user-validate
-      - p-map
-      - pacote
-      - parse-conflict-json
-      - proc-log
-      - qrcode-terminal
-      - read
-      - semver
-      - spdx-expression-parse
-      - ssri
-      - supports-color
-      - tar
-      - text-table
-      - tiny-relative-date
-      - treeverse
-      - validate-npm-package-name
-      - which
-      - write-file-atomic
-
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
@@ -9421,10 +9504,6 @@ packages:
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
-
-  object-treeify@4.0.1:
-    resolution: {integrity: sha512-Y6tg5rHfsefSkfKujv2SwHulInROy/rCL5F4w0QOWxut8AnxYxf0YmNhTh95Zfyxpsudo66uqkux0ACFnyMSgQ==}
-    engines: {node: '>= 16'}
 
   object-visit@1.0.1:
     resolution: {integrity: sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==}
@@ -9722,10 +9801,6 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-
-  path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -10600,6 +10675,10 @@ packages:
 
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
+    engines: {node: '>=0.12.0'}
+
+  run-async@3.0.0:
+    resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
     engines: {node: '>=0.12.0'}
 
   run-parallel@1.2.0:
@@ -12123,11 +12202,6 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yarn@1.22.22:
-    resolution: {integrity: sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==}
-    engines: {node: '>=4.0.0'}
-    hasBin: true
-
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
@@ -12138,6 +12212,18 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-spinner@0.2.1:
+    resolution: {integrity: sha512-lHHxjh0bXaLgdJy3cNnVb/F9myx3CkhrvSOEVTkaUgNMXnYFa2xYPVhtGnqhh3jErY2gParBOHallCbc7NrlZQ==}
+    engines: {node: '>=18.19'}
+
+  yoctocolors-cjs@2.1.2:
+    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
+    engines: {node: '>=18'}
+
+  yoctocolors@2.1.1:
+    resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
+    engines: {node: '>=18'}
 
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
@@ -13775,6 +13861,122 @@ snapshots:
     dependencies:
       react: 19.1.0
 
+  '@inquirer/checkbox@4.1.5(@types/node@22.13.1)':
+    dependencies:
+      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.6(@types/node@22.13.1)
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 22.13.1
+
+  '@inquirer/confirm@5.1.9(@types/node@22.13.1)':
+    dependencies:
+      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/type': 3.0.6(@types/node@22.13.1)
+    optionalDependencies:
+      '@types/node': 22.13.1
+
+  '@inquirer/core@10.1.10(@types/node@22.13.1)':
+    dependencies:
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.6(@types/node@22.13.1)
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 22.13.1
+
+  '@inquirer/editor@4.2.10(@types/node@22.13.1)':
+    dependencies:
+      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/type': 3.0.6(@types/node@22.13.1)
+      external-editor: 3.1.0
+    optionalDependencies:
+      '@types/node': 22.13.1
+
+  '@inquirer/expand@4.0.12(@types/node@22.13.1)':
+    dependencies:
+      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/type': 3.0.6(@types/node@22.13.1)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 22.13.1
+
+  '@inquirer/figures@1.0.11': {}
+
+  '@inquirer/input@4.1.9(@types/node@22.13.1)':
+    dependencies:
+      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/type': 3.0.6(@types/node@22.13.1)
+    optionalDependencies:
+      '@types/node': 22.13.1
+
+  '@inquirer/number@3.0.12(@types/node@22.13.1)':
+    dependencies:
+      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/type': 3.0.6(@types/node@22.13.1)
+    optionalDependencies:
+      '@types/node': 22.13.1
+
+  '@inquirer/password@4.0.12(@types/node@22.13.1)':
+    dependencies:
+      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/type': 3.0.6(@types/node@22.13.1)
+      ansi-escapes: 4.3.2
+    optionalDependencies:
+      '@types/node': 22.13.1
+
+  '@inquirer/prompts@7.4.1(@types/node@22.13.1)':
+    dependencies:
+      '@inquirer/checkbox': 4.1.5(@types/node@22.13.1)
+      '@inquirer/confirm': 5.1.9(@types/node@22.13.1)
+      '@inquirer/editor': 4.2.10(@types/node@22.13.1)
+      '@inquirer/expand': 4.0.12(@types/node@22.13.1)
+      '@inquirer/input': 4.1.9(@types/node@22.13.1)
+      '@inquirer/number': 3.0.12(@types/node@22.13.1)
+      '@inquirer/password': 4.0.12(@types/node@22.13.1)
+      '@inquirer/rawlist': 4.0.12(@types/node@22.13.1)
+      '@inquirer/search': 3.0.12(@types/node@22.13.1)
+      '@inquirer/select': 4.1.1(@types/node@22.13.1)
+    optionalDependencies:
+      '@types/node': 22.13.1
+
+  '@inquirer/rawlist@4.0.12(@types/node@22.13.1)':
+    dependencies:
+      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/type': 3.0.6(@types/node@22.13.1)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 22.13.1
+
+  '@inquirer/search@3.0.12(@types/node@22.13.1)':
+    dependencies:
+      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.6(@types/node@22.13.1)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 22.13.1
+
+  '@inquirer/select@4.1.1(@types/node@22.13.1)':
+    dependencies:
+      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.6(@types/node@22.13.1)
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 22.13.1
+
+  '@inquirer/type@3.0.6(@types/node@22.13.1)':
+    optionalDependencies:
+      '@types/node': 22.13.1
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -14395,10 +14597,10 @@ snapshots:
   '@nx/nx-win32-x64-msvc@20.4.2':
     optional: true
 
-  '@oclif/core@4.2.8':
+  '@oclif/core@4.2.10':
     dependencies:
       ansi-escapes: 4.3.2
-      ansis: 3.16.0
+      ansis: 3.17.0
       clean-stack: 3.0.1
       cli-spinners: 2.9.2
       debug: 4.4.0(supports-color@8.1.1)
@@ -14416,25 +14618,9 @@ snapshots:
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
 
-  '@oclif/plugin-help@6.2.26':
+  '@oclif/plugin-help@6.2.27':
     dependencies:
-      '@oclif/core': 4.2.8
-
-  '@oclif/plugin-plugins@5.4.34':
-    dependencies:
-      '@oclif/core': 4.2.8
-      ansis: 3.16.0
-      debug: 4.4.0(supports-color@9.4.0)
-      npm: 10.9.2
-      npm-package-arg: 11.0.3
-      npm-run-path: 5.3.0
-      object-treeify: 4.0.1
-      semver: 7.7.1
-      validate-npm-package-name: 5.0.1
-      which: 4.0.0
-      yarn: 1.22.22
-    transitivePeerDependencies:
-      - supports-color
+      '@oclif/core': 4.2.10
 
   '@octokit/action@6.1.0':
     dependencies:
@@ -15452,16 +15638,20 @@ snapshots:
       - '@sanity/types'
       - debug
 
-  '@sanity/runtime-cli@1.1.1':
+  '@sanity/runtime-cli@2.4.0(@types/node@22.13.1)':
     dependencies:
-      '@hono/node-server': 1.13.8(hono@4.7.2)
-      '@oclif/core': 4.2.8
-      '@oclif/plugin-help': 6.2.26
-      '@oclif/plugin-plugins': 5.4.34
-      hono: 4.7.2
+      '@oclif/core': 4.2.10
+      '@oclif/plugin-help': 6.2.27
+      adm-zip: 0.5.16
+      array-treeify: 0.1.3
+      color-json: 3.0.5
+      eventsource: 3.0.6
+      inquirer: 12.5.2(@types/node@22.13.1)
+      mime-types: 3.0.1
       xdg-basedir: 5.1.0
+      yocto-spinner: 0.2.1
     transitivePeerDependencies:
-      - supports-color
+      - '@types/node'
 
   '@sanity/telemetry@0.8.1(react@18.3.1)':
     dependencies:
@@ -16607,6 +16797,8 @@ snapshots:
 
   add-stream@1.0.0: {}
 
+  adm-zip@0.5.16: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.0(supports-color@9.4.0)
@@ -16681,7 +16873,7 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
-  ansis@3.16.0: {}
+  ansis@3.17.0: {}
 
   anymatch@1.3.2:
     dependencies:
@@ -16758,6 +16950,8 @@ snapshots:
       es-object-atoms: 1.1.1
       get-intrinsic: 1.2.7
       is-string: 1.1.1
+
+  array-treeify@0.1.3: {}
 
   array-union@2.1.0: {}
 
@@ -17327,6 +17521,8 @@ snapshots:
 
   cli-width@3.0.0: {}
 
+  cli-width@4.1.0: {}
+
   client-only@0.0.1: {}
 
   cliui@7.0.4:
@@ -17379,6 +17575,8 @@ snapshots:
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
+
+  color-json@3.0.5: {}
 
   color-name@1.1.3: {}
 
@@ -18661,7 +18859,13 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.1: {}
+
   eventsource@2.0.2: {}
+
+  eventsource@3.0.6:
+    dependencies:
+      eventsource-parser: 3.0.1
 
   execa@2.1.0:
     dependencies:
@@ -19677,6 +19881,18 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
 
+  inquirer@12.5.2(@types/node@22.13.1):
+    dependencies:
+      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/prompts': 7.4.1(@types/node@22.13.1)
+      '@inquirer/type': 3.0.6(@types/node@22.13.1)
+      ansi-escapes: 4.3.2
+      mute-stream: 2.0.0
+      run-async: 3.0.0
+      rxjs: 7.8.2
+    optionalDependencies:
+      '@types/node': 22.13.1
+
   inquirer@6.5.2:
     dependencies:
       ansi-escapes: 3.2.0
@@ -20688,6 +20904,8 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.18:
     dependencies:
       mime-db: 1.33.0
@@ -20695,6 +20913,10 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.1:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -20872,6 +21094,8 @@ snapshots:
   mute-stream@0.0.8: {}
 
   mute-stream@1.0.0: {}
+
+  mute-stream@2.0.0: {}
 
   mux-embed@5.2.1: {}
 
@@ -21060,12 +21284,6 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  npm-run-path@5.3.0:
-    dependencies:
-      path-key: 4.0.0
-
-  npm@10.9.2: {}
-
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
@@ -21133,8 +21351,6 @@ snapshots:
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
-
-  object-treeify@4.0.1: {}
 
   object-visit@1.0.1:
     dependencies:
@@ -21484,8 +21700,6 @@ snapshots:
   path-is-inside@1.0.2: {}
 
   path-key@3.1.1: {}
-
-  path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -22435,6 +22649,8 @@ snapshots:
       rrweb-snapshot: 2.0.0-alpha.4
 
   run-async@2.4.1: {}
+
+  run-async@3.0.0: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -24187,8 +24403,6 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yarn@1.22.22: {}
-
   yauzl@2.10.0:
     dependencies:
       buffer-crc32: 0.2.13
@@ -24197,6 +24411,14 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-spinner@0.2.1:
+    dependencies:
+      yoctocolors: 2.1.1
+
+  yoctocolors-cjs@2.1.2: {}
+
+  yoctocolors@2.1.1: {}
 
   zip-stream@6.0.1:
     dependencies:


### PR DESCRIPTION
### Description

The `@sanity/runtime-cli` package has release a new major. This update picks up the new release and modifies the commands to use the new method signatures introduced in the ^2.x.x release.

### What to review

This effects the `@sanity/cli` package. It updates the `sanity function` commands. 

### Testing

Automated testing is run in `@sanity/runtime-cli`. Local testing has been done as well. 

### Notes for release

Not required
