### PR TITLE
fix(presentation): resolve to publishedId when using publishedPerspective

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -127,7 +127,23 @@ const sharedSettings = ({projectId}: {projectId: string}) => {
               filter: `_type == "simpleBlock" && isMain`,
             },
           ]),
-          locations: {simpleBlock: defineLocations({locations: [{title: 'Home', href: '/'}]})},
+          locations: {
+            simpleBlock: defineLocations({
+              select: {
+                title: 'name',
+              },
+              resolve: (doc) => {
+                return {
+                  locations: [
+                    {
+                      title: doc?.title || 'Untitled',
+                      href: `/${doc?.title}`,
+                    },
+                  ],
+                }
+              },
+            }),
+          },
         },
       }),
       languageFilter({

--- a/packages/sanity/src/presentation/useDocumentLocations.ts
+++ b/packages/sanity/src/presentation/useDocumentLocations.ts
@@ -65,6 +65,7 @@ function listen(
     id,
     versions: perspectiveStack
       .map((p) => {
+        if (p === 'published') return getPublishedId(id)
         if (p === 'drafts') return getDraftId(id)
         return getVersionId(getPublishedId(id), p)
       })


### PR DESCRIPTION
### Description

Fixes an issue in where if users had configured a presentation resolver the studio the document will crash when trying to resolve the published id, this fixes this by not using "published" when trying to get the version id.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in where the presentation resolver would crash when using published perspective
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
