### PR TITLE
feat(core): add image schema options for hotspot tool configuration

### DIFF
--- a/dev/test-studio/schema/standard/images.ts
+++ b/dev/test-studio/schema/standard/images.ts
@@ -204,7 +204,6 @@ export default defineType({
       description: 'Should have custom hotspot preview aspect ratios',
       options: {
         hotspot: {
-          enabled: true,
           previews: [
             {title: '2:1', aspectRatio: 2 / 1},
             {title: '4:5', aspectRatio: 4 / 5},

--- a/dev/test-studio/schema/standard/images.ts
+++ b/dev/test-studio/schema/standard/images.ts
@@ -197,5 +197,21 @@ export default defineType({
       title: 'No asset source',
       options: {sources: []},
     },
+    {
+      name: 'hotspotImage',
+      title: 'Hotspot image',
+      type: 'image',
+      description: 'Should have custom hotspot preview aspect ratios',
+      options: {
+        hotspot: {
+          enabled: true,
+          previews: [
+            {title: '2:1', aspectRatio: 2 / 1},
+            {title: '4:5', aspectRatio: 4 / 5},
+            {title: '9:16', aspectRatio: 9 / 16},
+          ],
+        },
+      },
+    },
   ],
 })

--- a/packages/@sanity/types/src/schema/definition/type/image.ts
+++ b/packages/@sanity/types/src/schema/definition/type/image.ts
@@ -9,14 +9,14 @@ import {type ObjectDefinition} from './object'
 export type ImageMetadataType = 'blurhash' | 'lqip' | 'palette' | 'exif' | 'image' | 'location'
 
 /** @public */
-export interface HotspotImagePreview {
+export interface HotspotPreview {
   title: string
   aspectRatio: number
 }
 
 /** @public */
 export interface HotspotOptions {
-  previews?: HotspotImagePreview[]
+  previews?: HotspotPreview[]
 }
 
 /** @public */

--- a/packages/@sanity/types/src/schema/definition/type/image.ts
+++ b/packages/@sanity/types/src/schema/definition/type/image.ts
@@ -9,9 +9,20 @@ import {type ObjectDefinition} from './object'
 export type ImageMetadataType = 'blurhash' | 'lqip' | 'palette' | 'exif' | 'image' | 'location'
 
 /** @public */
+export interface HotspotImagePreview {
+  title: string
+  aspectRatio: number
+}
+
+/** @public */
+export interface HotspotOptions {
+  previews?: HotspotImagePreview[]
+}
+
+/** @public */
 export interface ImageOptions extends FileOptions {
   metadata?: ImageMetadataType[]
-  hotspot?: boolean
+  hotspot?: boolean | HotspotOptions
 }
 
 /** @public */

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -95,10 +95,10 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
     value?._upload,
     value?.asset,
   ])
-  const isImageToolEnabled = useCallback(
-    () => get(schemaType, 'options.hotspot') === true,
-    [schemaType],
-  )
+  const isImageToolEnabled = useCallback(() => {
+    const hotspotOptions = get(schemaType, 'options.hotspot')
+    return typeof hotspotOptions === 'object' || hotspotOptions === true
+  }, [schemaType])
   const valueIsArrayElement = useCallback(() => {
     const parentPathSegment = path.slice(-1)[0]
 

--- a/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
@@ -1,4 +1,4 @@
-import {type Image, type ImageSchemaType} from '@sanity/types'
+import {type HotspotImagePreview, type Image, type ImageSchemaType} from '@sanity/types'
 import {Box, Card, Flex, Grid, Heading, Stack, Text} from '@sanity/ui'
 import {type ReactNode, useCallback, useEffect, useMemo, useState} from 'react'
 import {styled} from 'styled-components'
@@ -23,11 +23,11 @@ export interface ImageToolInputProps
 
 const HOTSPOT_PATH = ['hotspot']
 
-const PREVIEW_ASPECT_RATIOS = [
-  ['3:4', 3 / 4],
-  ['Square', 1 / 1],
-  ['16:9', 16 / 9],
-  ['Panorama', 4 / 1],
+const DEFAULT_PREVIEWS: HotspotImagePreview[] = [
+  {title: '3:4', aspectRatio: 3 / 4},
+  {title: 'Square', aspectRatio: 1 / 1},
+  {title: '16:9', aspectRatio: 16 / 9},
+  {title: 'Panorama', aspectRatio: 4 / 1},
 ] as const
 
 const DEFAULT_VALUE: Partial<Image> = {
@@ -76,6 +76,10 @@ export function ImageToolInput(props: ImageToolInputProps) {
   }, [value])
 
   const hasFocus = focusPath[0] === 'hotspot'
+
+  const hotspotPreviews =
+    (typeof schemaType.options?.hotspot === 'object' && schemaType.options.hotspot.previews) ||
+    DEFAULT_PREVIEWS
 
   useDidUpdate(hasFocus, (hadFocus) => {
     if (!hadFocus && hasFocus) {
@@ -197,34 +201,37 @@ export function ImageToolInput(props: ImageToolInputProps) {
             </RatioBox>
           </ChangeIndicator>
         </Card>
-        <Box marginTop={3}>
-          <Grid columns={PREVIEW_ASPECT_RATIOS.length} gap={1}>
-            {PREVIEW_ASPECT_RATIOS.map(([title, ratio]) => (
-              <div key={ratio}>
-                <Heading as="h4" size={0}>
-                  {title}
-                </Heading>
-                <Box marginTop={2}>
-                  <RatioBox ratio={ratio}>
-                    <Card __unstable_checkered>
-                      {!isImageLoading && image ? (
-                        <HotspotImage
-                          aspectRatio={ratio}
-                          src={image.src}
-                          srcAspectRatio={image.width / image.height}
-                          hotspot={localValue.hotspot || DEFAULT_HOTSPOT}
-                          crop={localValue.crop || DEFAULT_CROP}
-                        />
-                      ) : (
-                        <Placeholder />
-                      )}
-                    </Card>
-                  </RatioBox>
-                </Box>
-              </div>
-            ))}
-          </Grid>
-        </Box>
+
+        {hotspotPreviews.length > 0 ? (
+          <Box marginTop={3}>
+            <Grid columns={4} gap={1}>
+              {hotspotPreviews.map(({title, aspectRatio}) => (
+                <div key={title}>
+                  <Heading as="h4" size={0}>
+                    {title}
+                  </Heading>
+                  <Box marginTop={2}>
+                    <RatioBox ratio={aspectRatio}>
+                      <Card __unstable_checkered border>
+                        {!isImageLoading && image ? (
+                          <HotspotImage
+                            aspectRatio={aspectRatio}
+                            src={image.src}
+                            srcAspectRatio={image.width / image.height}
+                            hotspot={localValue.hotspot || DEFAULT_HOTSPOT}
+                            crop={localValue.crop || DEFAULT_CROP}
+                          />
+                        ) : (
+                          <Placeholder />
+                        )}
+                      </Card>
+                    </RatioBox>
+                  </Box>
+                </div>
+              ))}
+            </Grid>
+          </Box>
+        ) : null}
       </div>
     </FormField>
   )

--- a/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
@@ -1,4 +1,4 @@
-import {type HotspotImagePreview, type Image, type ImageSchemaType} from '@sanity/types'
+import {type HotspotPreview, type Image, type ImageSchemaType} from '@sanity/types'
 import {Box, Card, Flex, Grid, Heading, Stack, Text} from '@sanity/ui'
 import {type ReactNode, useCallback, useEffect, useMemo, useState} from 'react'
 import {styled} from 'styled-components'
@@ -23,7 +23,7 @@ export interface ImageToolInputProps
 
 const HOTSPOT_PATH = ['hotspot']
 
-const DEFAULT_PREVIEWS: HotspotImagePreview[] = [
+const DEFAULT_PREVIEWS: HotspotPreview[] = [
   {title: '3:4', aspectRatio: 3 / 4},
   {title: 'Square', aspectRatio: 1 / 1},
   {title: '16:9', aspectRatio: 16 / 9},

--- a/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
@@ -203,10 +203,10 @@ export function ImageToolInput(props: ImageToolInputProps) {
         </Card>
 
         {hotspotPreviews.length > 0 ? (
-          <Box marginTop={3}>
+          <Box marginTop={2}>
             <Grid columns={4} gap={1}>
               {hotspotPreviews.map(({title, aspectRatio}) => (
-                <div key={title}>
+                <Box marginTop={2} key={title}>
                   <Heading as="h4" size={0}>
                     {title}
                   </Heading>
@@ -227,7 +227,7 @@ export function ImageToolInput(props: ImageToolInputProps) {
                       </Card>
                     </RatioBox>
                   </Box>
-                </div>
+                </Box>
               ))}
             </Grid>
           </Box>


### PR DESCRIPTION
### Description

This PR introduces an image schema option: the `hotspot` object to enable and configure the hotspot tool, this pattern is being mindful of future options for both the hotspot tool and previews.

Mentioned in #957 

### What to review

  - Currently, setting this object in schema options will enable the hotspot tool.
  - **Should we instead have a required `enabled` boolean inside this new options object?**

### Testing

I have verified image fields in the Test Studio:
- [x] The default preview aspect ratios are used if `previews` option is not set.
- [x] Hotspot boolean/undefined option still works as expected.
- [x] When setting an empty `previews` array, the tool does not show any previews.
- [x] A four column layout for previews is enforced to prevent unusually large previews.

### Notes for release

The `image` schema options now supports a `hotspot` object for configuring the image hotspot tool. This now enables custom aspect ratios for the crop previews to be configured:
```js
{
  name: 'hotspotImage',
  title: 'Hotspot image',
  type: 'image',
  options: {
    hotspot: {
      previews: [
        {title: '2:1', aspectRatio: 2 / 1},
        {title: '4:5', aspectRatio: 4 / 5},
        {title: '9:16', aspectRatio: 9 / 16},
      ],
    },
  },
},
```
This `hotspot` option still supports the boolean value to the enable/disable hotspot tool. The image hotspot tool will use default configuration if enabled with a boolean:
```js
{
  name: 'hotspotImage',
  title: 'Hotspot image',
  type: 'image',
  options: {
    hotspot: false
  },
},
```
```js
{
  name: 'hotspotImage',
  title: 'Hotspot image',
  type: 'image',
  options: {
    hotspot: true
  },
},
```

These are additive changes that require an update to the [image schema options spec docs](https://www.sanity.io/docs/image-type#options)
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
