### PR TITLE
chore: add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4564 @@
+# [0.0.0](https://github.com/sanity-io/sanity/compare/v3.84.0...v0.0.0) (2025-04-11)
+
+
+
+# [3.84.0](https://github.com/sanity-io/sanity/compare/v3.83.0...v3.84.0) (2025-04-11)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @portabletext/block-tools to ^1.1.17 ([#9162](https://github.com/sanity-io/sanity/issues/9162)) ([1ee46a7](https://github.com/sanity-io/sanity/commit/1ee46a7e91ca345045e567277ce6bba15c63c693))
+* **deps:** update dependency @portabletext/editor to ^1.46.0 ([#9155](https://github.com/sanity-io/sanity/issues/9155)) ([65ed182](https://github.com/sanity-io/sanity/commit/65ed1826e92899c0adb4ee4565fad0a2c2f6190b))
+* **deps:** update dependency @sanity/insert-menu to v1.1.9 ([#9177](https://github.com/sanity-io/sanity/issues/9177)) ([1ee5d8b](https://github.com/sanity-io/sanity/commit/1ee5d8bdf9fc72082ca899a803c731306723a5ed))
+* **deps:** update dependency @sanity/presentation-comlink to ^1.0.15 ([#9178](https://github.com/sanity-io/sanity/issues/9178)) ([c013294](https://github.com/sanity-io/sanity/commit/c0132943dfa3e9a91c0cf2dd98b66ca4c5421806))
+* **deps:** update dependency @sanity/ui to ^2.15.13 ([#9165](https://github.com/sanity-io/sanity/issues/9165)) ([fe553db](https://github.com/sanity-io/sanity/commit/fe553db3519fcf8f367e4b98d25edfdfdef775f4))
+* **deps:** Update dev-non-major ([#9183](https://github.com/sanity-io/sanity/issues/9183)) ([cda5bb5](https://github.com/sanity-io/sanity/commit/cda5bb52b32ca93c65882564f5bc5bde5483b9d2))
+* **i18n:** remove extra parens ([#9163](https://github.com/sanity-io/sanity/issues/9163)) ([957dfec](https://github.com/sanity-io/sanity/commit/957dfec266d7c0b758411b77c8a0c1f3f9434d5b))
+* **presentation:** resolve to publishedId when using publishedPerspective ([#9184](https://github.com/sanity-io/sanity/issues/9184)) ([0ccc1db](https://github.com/sanity-io/sanity/commit/0ccc1dbc7085e08dce57364a7457a8b331266347))
+* **typegen:** Use typeMap to resolve all inline types ([57ea3b5](https://github.com/sanity-io/sanity/commit/57ea3b5dea52aa5d2f319c3c9809d62de1b493af))
+
+
+### Features
+
+* set background based on `prefers-color-scheme` ([#9175](https://github.com/sanity-io/sanity/issues/9175)) ([c9b0abd](https://github.com/sanity-io/sanity/commit/c9b0abdce0adc94ecf2f5dcd0db62a0928000ce2))
+* specific published toast when remote release is published ([#9159](https://github.com/sanity-io/sanity/issues/9159)) ([b929837](https://github.com/sanity-io/sanity/commit/b92983700cac696eaa4c54bf7a261367b4f9e4c8))
+* **structure:** add schema description to document form header if it exists ([#9156](https://github.com/sanity-io/sanity/issues/9156)) ([99aa9f0](https://github.com/sanity-io/sanity/commit/99aa9f0c7d8bc8ff5c3451f1498d9045662568d7))
+* **typegen:** preiterate schema to ensure all schema types are generated for references/inline lookups ([35d1fe1](https://github.com/sanity-io/sanity/commit/35d1fe1d35ac1c6c3b3032be96001f918bb41b2f))
+
+
+
+# [3.83.0](https://github.com/sanity-io/sanity/compare/v3.82.0...v3.83.0) (2025-04-08)
+
+
+### Bug Fixes
+
+* **cli:** bump version of styled-components used by sanity init ([#9137](https://github.com/sanity-io/sanity/issues/9137)) ([c5fdcd5](https://github.com/sanity-io/sanity/commit/c5fdcd5fc30540440490f863e4ec9c7dca81e9f4))
+* **core:** make PTE active by default ([8cf7d02](https://github.com/sanity-io/sanity/commit/8cf7d02768731b1213374e893e962e30ddfb4ce7))
+* **core:** restore intended func. for 'directUploads' config param ([#9109](https://github.com/sanity-io/sanity/issues/9109)) ([d42025b](https://github.com/sanity-io/sanity/commit/d42025baa2d48bcf71676be53195e22cb32b667e))
+* **deps:** update dependency @portabletext/editor to ^1.44.10 ([#9108](https://github.com/sanity-io/sanity/issues/9108)) ([1ca2803](https://github.com/sanity-io/sanity/commit/1ca280335cc5d667bf2e1cec8c3b1935b0fde200))
+* **deps:** update dependency @portabletext/editor to ^1.44.11 ([#9135](https://github.com/sanity-io/sanity/issues/9135)) ([c11681e](https://github.com/sanity-io/sanity/commit/c11681eeb983b50af9c433b2ddac4e5c3dfb24cf))
+* **deps:** update dependency @portabletext/editor to ^1.44.16 ([#9143](https://github.com/sanity-io/sanity/issues/9143)) ([9343a59](https://github.com/sanity-io/sanity/commit/9343a59c0dfcc39c181f4fc65a99056f3ed7f82e))
+* **deps:** update dependency @sanity/import to ^3.38.2 ([#9104](https://github.com/sanity-io/sanity/issues/9104)) ([db23c55](https://github.com/sanity-io/sanity/commit/db23c553020a16d999f58bcb7b4cc0a9085e6f93))
+* **deps:** update dependency @sanity/insert-menu to v1.1.8 ([#9111](https://github.com/sanity-io/sanity/issues/9111)) ([89a239e](https://github.com/sanity-io/sanity/commit/89a239eeeafd51b8debfad1a5a2355cfcd014796))
+* **deps:** update dependency @sanity/presentation-comlink to ^1.0.14 ([#9116](https://github.com/sanity-io/sanity/issues/9116)) ([11b0ce5](https://github.com/sanity-io/sanity/commit/11b0ce5ceebd38738ff8a144d3ba375e5d9667cf))
+* **deps:** update dependency @sanity/preview-url-secret to ^2.1.7 ([#9117](https://github.com/sanity-io/sanity/issues/9117)) ([167cc75](https://github.com/sanity-io/sanity/commit/167cc7538d22a986b87573e396a205a0368d491b))
+* **deps:** update dependency @sanity/ui to ^2.15.11 ([#9106](https://github.com/sanity-io/sanity/issues/9106)) ([ff06350](https://github.com/sanity-io/sanity/commit/ff063507e6697e8db6e7758b7d292f191ae31b72))
+* **deps:** update dependency @sanity/ui to ^2.15.12 ([#9121](https://github.com/sanity-io/sanity/issues/9121)) ([c5ba17f](https://github.com/sanity-io/sanity/commit/c5ba17f2b0bb77ec7bdf5b1162b9338a104600d3))
+* **deps:** update dependency framer-motion to ^12.6.3 ([#9122](https://github.com/sanity-io/sanity/issues/9122)) ([65495bc](https://github.com/sanity-io/sanity/commit/65495bcb59a3e97d0c0a9d7f1f31dba561633e38))
+* **deps:** update dependency react-rx to ^4.1.27 ([#9118](https://github.com/sanity-io/sanity/issues/9118)) ([3fb02c8](https://github.com/sanity-io/sanity/commit/3fb02c87f420d5595d85529df85011c184302d85))
+* **deps:** Update dev-non-major ([#9115](https://github.com/sanity-io/sanity/issues/9115)) ([6038a8e](https://github.com/sanity-io/sanity/commit/6038a8e31b8051a88dd6ca0ebb4a5d6ad7880d46))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#9152](https://github.com/sanity-io/sanity/issues/9152)) ([50cad36](https://github.com/sanity-io/sanity/commit/50cad362745972ca774032a03654b3e167b6bf28))
+* **deps:** upgrade `use-sync-external-store` ([#9112](https://github.com/sanity-io/sanity/issues/9112)) ([11e0bd4](https://github.com/sanity-io/sanity/commit/11e0bd42db72380a04e23c457bfcdec4903646e7))
+* **presentation:** use perspectiveStack for useDocumentLocations listen ([#9107](https://github.com/sanity-io/sanity/issues/9107)) ([1dcf324](https://github.com/sanity-io/sanity/commit/1dcf3240be78055425d286b32f26abdf00074649))
+* **studio:** improve how presence works with releases ([#9151](https://github.com/sanity-io/sanity/issues/9151)) ([fd3a38c](https://github.com/sanity-io/sanity/commit/fd3a38c216eed8dd7b5d25e1670afef3733bddc4))
+* **test:** make test for sanity init w/template fetch from main branch instead of next ([#9139](https://github.com/sanity-io/sanity/issues/9139)) ([00dcdc9](https://github.com/sanity-io/sanity/commit/00dcdc91e1efb2ccf8f412886dd812ba914e2407))
+
+
+### Features
+
+* **cli:** add app-sanity-ui app template ([#9145](https://github.com/sanity-io/sanity/issues/9145)) ([a863b57](https://github.com/sanity-io/sanity/commit/a863b5725dcdc3a7bd55db83ea40abe4a1d8ad3d))
+* **cli:** use useCurrentUser hook in app-quickstart template ([#9094](https://github.com/sanity-io/sanity/issues/9094)) ([fc28b05](https://github.com/sanity-io/sanity/commit/fc28b05a3319733bb24e487891125867c37788e1))
+* **core:** rewrite imagetool with SVG rendering, improved interactions and accessibility ([#9134](https://github.com/sanity-io/sanity/issues/9134)) ([dab3ed6](https://github.com/sanity-io/sanity/commit/dab3ed697236c41e5782520d2e3f2d54207ee820))
+* **studio:** add version info/about dialog ([#9131](https://github.com/sanity-io/sanity/issues/9131)) ([eb5a259](https://github.com/sanity-io/sanity/commit/eb5a259c4fa8c23bc244457981feedfcb9f1bbb9))
+
+
+
+# [3.82.0](https://github.com/sanity-io/sanity/compare/v3.81.0...v3.82.0) (2025-04-01)
+
+
+### Bug Fixes
+
+* **cli:** call API to fetch dashboard url ([#9091](https://github.com/sanity-io/sanity/issues/9091)) ([dd49a51](https://github.com/sanity-io/sanity/commit/dd49a5191b07d390bbbb3aa9349eaa34bd72aa68))
+* **cli:** fixes issue where apps required styled-components ([#9097](https://github.com/sanity-io/sanity/issues/9097)) ([9c8cce8](https://github.com/sanity-io/sanity/commit/9c8cce8da1582b68853e9d64b863f9ab19d6e7f4))
+* **codegen:** Support .astro files by default ([#8947](https://github.com/sanity-io/sanity/issues/8947)) ([a4022af](https://github.com/sanity-io/sanity/commit/a4022af17112e0d3dc3d5696431779d73fa3ccc7))
+* **core:** add chevron to file browse sources button ([#9105](https://github.com/sanity-io/sanity/issues/9105)) ([32e90ed](https://github.com/sanity-io/sanity/commit/32e90ed0896bf7607db6728740d386a4fe13da8a))
+* **core:** reset remote transactions when a draft is published ([#9089](https://github.com/sanity-io/sanity/issues/9089)) ([0d18587](https://github.com/sanity-io/sanity/commit/0d185877e91df9891b9d1de791fe281eca15b355))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.15 ([#9048](https://github.com/sanity-io/sanity/issues/9048)) ([150f24a](https://github.com/sanity-io/sanity/commit/150f24ab59d3c1ae8b297a947f2247cfd55058f5))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.16 ([#9102](https://github.com/sanity-io/sanity/issues/9102)) ([f9b6470](https://github.com/sanity-io/sanity/commit/f9b6470a762575f471918b7fcd4e37ed6b9ac670))
+* **deps:** update dependency @portabletext/editor to ^1.43.1 ([#9049](https://github.com/sanity-io/sanity/issues/9049)) ([7799be4](https://github.com/sanity-io/sanity/commit/7799be47850f13593ac8f204814d4c4464ba605c))
+* **deps:** update dependency @portabletext/editor to ^1.44.0 ([#9055](https://github.com/sanity-io/sanity/issues/9055)) ([dfd13e6](https://github.com/sanity-io/sanity/commit/dfd13e66bb40b2216ee91f30fa28740011fc2ad1))
+* **deps:** update dependency @portabletext/editor to ^1.44.2 ([#9066](https://github.com/sanity-io/sanity/issues/9066)) ([b6c8a90](https://github.com/sanity-io/sanity/commit/b6c8a90e16bafb313962e2ca7ceceb982b37af74))
+* **deps:** update dependency @portabletext/editor to ^1.44.4 ([#9103](https://github.com/sanity-io/sanity/issues/9103)) ([281cfad](https://github.com/sanity-io/sanity/commit/281cfad5443caa6fb3e1ab3e7fe458a3679f5f4f))
+* **deps:** update dependency @sanity/client to ^6.28.4 ([#9068](https://github.com/sanity-io/sanity/issues/9068)) ([37cbcc7](https://github.com/sanity-io/sanity/commit/37cbcc74e71d7ce04c193394dae55f26ad61fd4c))
+* **deps:** update dependency @sanity/mutate to ^0.12.4 ([#9026](https://github.com/sanity-io/sanity/issues/9026)) ([fc3169e](https://github.com/sanity-io/sanity/commit/fc3169e011fc6a56ff5542f2b612e27a76eaf271))
+* **deps:** update dependency @sanity/ui to ^2.15.10 ([#9083](https://github.com/sanity-io/sanity/issues/9083)) ([f366ab9](https://github.com/sanity-io/sanity/commit/f366ab9f7cf2ca4688ef5c1ef3827e45d89c618f))
+* **deps:** update dependency framer-motion to ^12.6.2 ([#9092](https://github.com/sanity-io/sanity/issues/9092)) ([69d842b](https://github.com/sanity-io/sanity/commit/69d842bc6161e1aaef67bfb96a8d7cf71a79c857))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#9082](https://github.com/sanity-io/sanity/issues/9082)) ([d9dc27c](https://github.com/sanity-io/sanity/commit/d9dc27cdd34fbdd91c652e62978322cfd29acd23))
+* **form:** workaround for mutate-on-wheel-issue for number inputs ([#9064](https://github.com/sanity-io/sanity/issues/9064)) ([9928f2a](https://github.com/sanity-io/sanity/commit/9928f2aa14aaf455b1322f1661c74140dec91a12))
+* GraphQL deploy runs regardless of dry run argument ([#9075](https://github.com/sanity-io/sanity/issues/9075)) ([6e460d6](https://github.com/sanity-io/sanity/commit/6e460d6e78eea58fce3c8377a780b15bc3f3e486))
+* remove circular references ([#9056](https://github.com/sanity-io/sanity/issues/9056)) ([fd75db8](https://github.com/sanity-io/sanity/commit/fd75db800934a5f4c77f91c8566d44dd7c00dd2d))
+* renames unreleased schema cli command from store to deploy ([#9100](https://github.com/sanity-io/sanity/issues/9100)) ([fe1d436](https://github.com/sanity-io/sanity/commit/fe1d43678f365fbe03e1016c2b7d2d6e250c4c87))
+* resolving issue where string state is passed as a route parameter to router.navigate ([#9067](https://github.com/sanity-io/sanity/issues/9067)) ([0e36bda](https://github.com/sanity-io/sanity/commit/0e36bdadfad36789ce74499d28dae44ee6b6eee8))
+* **sanity:** reference strengthening upon version creation ([517c419](https://github.com/sanity-io/sanity/commit/517c419cb93afaab39ce12d96069b8217369ebc7))
+* **sentry:** report errors happening before init ([#9061](https://github.com/sanity-io/sanity/issues/9061)) ([8b31da7](https://github.com/sanity-io/sanity/commit/8b31da78d9c830c9e6eb0b7502930d9968b5c32f))
+* **structure:** update release banners ([#9070](https://github.com/sanity-io/sanity/issues/9070)) ([62a3674](https://github.com/sanity-io/sanity/commit/62a367491b9fb0a00354e2366c04743ca8d7eb76))
+* **tests:** add documentStatusAssertions util ([#9101](https://github.com/sanity-io/sanity/issues/9101)) ([5561ed5](https://github.com/sanity-io/sanity/commit/5561ed597bdc9e08d3a00de171e78b149b740be1))
+* **validation:** allow self-referencing drafts ([#9079](https://github.com/sanity-io/sanity/issues/9079)) ([93191e1](https://github.com/sanity-io/sanity/commit/93191e1dc68f064661fa7229674eedbbc382288c))
+
+
+### Features
+
+* **core:** Media Library Asset Source ([#8703](https://github.com/sanity-io/sanity/issues/8703)) ([61e32dc](https://github.com/sanity-io/sanity/commit/61e32dc15bd7a1feb791e07538752c08ac6e8ea9))
+* **core:** use project scoped media-libraries endpoint ([#9065](https://github.com/sanity-io/sanity/issues/9065)) ([b51a890](https://github.com/sanity-io/sanity/commit/b51a89056287c06133770802c05c6b9b5ddad591))
+* **dev:** shared settings with configurable options ([#9071](https://github.com/sanity-io/sanity/issues/9071)) ([b73c47b](https://github.com/sanity-io/sanity/commit/b73c47b1aaff30d5d5774976d4e3a54619c2e4bf))
+* **sanity:** make document editor read-only while initial value template resolves ([#9007](https://github.com/sanity-io/sanity/issues/9007)) ([4425e55](https://github.com/sanity-io/sanity/commit/4425e5538471e3b906324ff64836a62efe37e65f))
+* **sanity:** make initial value template resolution interruptible ([#9007](https://github.com/sanity-io/sanity/issues/9007)) ([06d63cf](https://github.com/sanity-io/sanity/commit/06d63cfb0e4bda3a790d991ad300de43eae7b57d))
+* **telemetry:** track INP performance from the field ([#8963](https://github.com/sanity-io/sanity/issues/8963)) ([15b5376](https://github.com/sanity-io/sanity/commit/15b5376c527cf86ab79ce2a1775ebbeb8e8aa709))
+
+
+
+# [3.81.0](https://github.com/sanity-io/sanity/compare/v3.80.1...v3.81.0) (2025-03-25)
+
+
+### Bug Fixes
+
+* archived releases table has default sort and defined sort working ([#9010](https://github.com/sanity-io/sanity/issues/9010)) ([0b7097b](https://github.com/sanity-io/sanity/commit/0b7097b7ac6313b686b658b5efb38a5523adf5a3))
+* **cli:** fixes issue where apps required styled-components dependency ([#9008](https://github.com/sanity-io/sanity/issues/9008)) ([779f4b0](https://github.com/sanity-io/sanity/commit/779f4b08339b7b5ebf2ae65b92662ac7e6e02cd6))
+* **cli:** use outpath as package name for apps ([#9003](https://github.com/sanity-io/sanity/issues/9003)) ([f29e10f](https://github.com/sanity-io/sanity/commit/f29e10f32651c1f6c6fac963948af30fdce7a13b))
+* **core:** drop explicit `withCredentials` on requests ([#8996](https://github.com/sanity-io/sanity/issues/8996)) ([bf6d8c7](https://github.com/sanity-io/sanity/commit/bf6d8c7068f91e1b1ee9c2274a997ffcd13a2a88))
+* **core:** hide discard changes action when published ([#9009](https://github.com/sanity-io/sanity/issues/9009)) ([db8a36b](https://github.com/sanity-io/sanity/commit/db8a36b2e1676e00c9ebe051ca1c7292d5398845))
+* **core:** increase the window interfac for when the sidebar for the task is hovering ([#9018](https://github.com/sanity-io/sanity/issues/9018)) ([8f4e32c](https://github.com/sanity-io/sanity/commit/8f4e32cf62cc8c6f270eb011db19e268cd491e6e))
+* **core:** stickyParams for `__unsafe_disableScopedSearchParams` ([#8987](https://github.com/sanity-io/sanity/issues/8987)) ([ed0264c](https://github.com/sanity-io/sanity/commit/ed0264c7e2e223645913988c69cb2feb0ba10996))
+* **core:** update document status indicator colors ([#9020](https://github.com/sanity-io/sanity/issues/9020)) ([cbb2ac8](https://github.com/sanity-io/sanity/commit/cbb2ac81883c55e5e46f9c90c635aed4478ddcdd))
+* **core:** use publishedId for search intent links ([#8980](https://github.com/sanity-io/sanity/issues/8980)) ([341b300](https://github.com/sanity-io/sanity/commit/341b300b26ae62fbf04468073eaa47cafa54c5b3))
+* creating new release immediately pins as perspective ([#8620](https://github.com/sanity-io/sanity/issues/8620)) ([a0b3243](https://github.com/sanity-io/sanity/commit/a0b32432711af20bee39b5023a5d88fe6b6bac8a))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.14 ([#8991](https://github.com/sanity-io/sanity/issues/8991)) ([d8217b1](https://github.com/sanity-io/sanity/commit/d8217b119024512573d990feeeb42ffdfb6308a9))
+* **deps:** update dependency @portabletext/editor to ^1.40.3 ([#8992](https://github.com/sanity-io/sanity/issues/8992)) ([faf0a3c](https://github.com/sanity-io/sanity/commit/faf0a3c6faa84ea7e04cfcdac56bed801e1fd264))
+* **deps:** update dependency @portabletext/editor to ^1.41.4 ([#9000](https://github.com/sanity-io/sanity/issues/9000)) ([36b7e1b](https://github.com/sanity-io/sanity/commit/36b7e1b7188db8846315280c08fe4463dfd5b52f))
+* **deps:** update dependency @portabletext/editor to ^1.42.0 ([#9042](https://github.com/sanity-io/sanity/issues/9042)) ([4d55990](https://github.com/sanity-io/sanity/commit/4d55990ce3f2ab0b27db0583c6bd22913d035f6f))
+* **deps:** update dependency @portabletext/editor to ^1.42.1 ([#9044](https://github.com/sanity-io/sanity/issues/9044)) ([c73c3b7](https://github.com/sanity-io/sanity/commit/c73c3b792febefc34d9f418e5c55a43ee414bfd4))
+* **deps:** update dependency @sanity/insert-menu to v1.1.7 ([#9025](https://github.com/sanity-io/sanity/issues/9025)) ([339618f](https://github.com/sanity-io/sanity/commit/339618f6338fe927cb9bd68e85fdfc71ed40830f))
+* **deps:** update dependency @sanity/presentation-comlink to ^1.0.13 ([#9027](https://github.com/sanity-io/sanity/issues/9027)) ([759238f](https://github.com/sanity-io/sanity/commit/759238f287b0a0f9634b1e7294cc87629d823298))
+* **deps:** update dependency @sanity/ui to ^2.15.8 ([#9028](https://github.com/sanity-io/sanity/issues/9028)) ([7c747bb](https://github.com/sanity-io/sanity/commit/7c747bbca130b066b58985fe469d3237376d1c27))
+* **deps:** update dependency react-rx to ^4.1.26 ([#9029](https://github.com/sanity-io/sanity/issues/9029)) ([512a6aa](https://github.com/sanity-io/sanity/commit/512a6aa17c91ba86b55fba1e912c93b475b00ccb))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#9030](https://github.com/sanity-io/sanity/issues/9030)) ([75f38f8](https://github.com/sanity-io/sanity/commit/75f38f8367adb738b627135291b5612f3624f7c7))
+* filters out @sanity/assist plugin if it is older than 3.2.2 ([#9047](https://github.com/sanity-io/sanity/issues/9047)) ([7b830f6](https://github.com/sanity-io/sanity/commit/7b830f6ee2326f8d3b97bd37928e7bafa445a8d3))
+* no releases screen shows the create release dialog ([#8988](https://github.com/sanity-io/sanity/issues/8988)) ([27d0820](https://github.com/sanity-io/sanity/commit/27d0820f6c2a290ab1624621009971d3c0b27f13))
+* non sticky params are not preserved during navigation ([#9032](https://github.com/sanity-io/sanity/issues/9032)) ([cf7eba0](https://github.com/sanity-io/sanity/commit/cf7eba019cfca12fe5eeb4e366b6f41e41e1f8d0))
+* **presentation:** add `sanity-preview-perspective`  to open preview link ([#9013](https://github.com/sanity-io/sanity/issues/9013)) ([fd161b1](https://github.com/sanity-io/sanity/commit/fd161b148afd1e3c08a907a2095ae3220a8386a0))
+* **presentation:** previewUrl is required ([#8995](https://github.com/sanity-io/sanity/issues/8995)) ([132154e](https://github.com/sanity-io/sanity/commit/132154e02a2e0828ec37839bbc9d221a37807b17))
+* **presentation:** use `perspectiveStack` when resolving main document ([#9005](https://github.com/sanity-io/sanity/issues/9005)) ([d3ae2ea](https://github.com/sanity-io/sanity/commit/d3ae2ea8db04d02de92c72da0b625f1b74f73e68))
+* **preview:** fix issue with document version indicators not syncing ([#9040](https://github.com/sanity-io/sanity/issues/9040)) ([e15f83a](https://github.com/sanity-io/sanity/commit/e15f83ada4af892e51c5cebb9ce28111c075c869))
+* releases used wrong key on duplicate action ([#9041](https://github.com/sanity-io/sanity/issues/9041)) ([16a89e7](https://github.com/sanity-io/sanity/commit/16a89e7dbd9b68327dcd584a95deb03772e5fd2d))
+* **sanity:** treat releases as inactive if releases tool not present ([#9001](https://github.com/sanity-io/sanity/issues/9001)) ([f02a360](https://github.com/sanity-io/sanity/commit/f02a36004bad9253c8079edbf848bf57b0e671f3))
+* **test:** don't export `isNavigateOptions`  ([#9015](https://github.com/sanity-io/sanity/issues/9015)) ([edb5303](https://github.com/sanity-io/sanity/commit/edb5303e76c33f208306b471dfbde5fea8f753a5))
+* **test:** update flaky navbar test ([#8984](https://github.com/sanity-io/sanity/issues/8984)) ([6e19713](https://github.com/sanity-io/sanity/commit/6e197132f60c0feae748a3079062e5c66b40a912))
+* **vision:** update code-mirror dependency, fix EditorSelection error ([#8998](https://github.com/sanity-io/sanity/issues/8998)) ([41e3846](https://github.com/sanity-io/sanity/commit/41e384621d13e209e9523946a0bbf4744fcf769a))
+
+
+### Features
+
+* **cli:** workspace schemas in dataset (behind env feature toggle) ([#8966](https://github.com/sanity-io/sanity/issues/8966)) ([89de4fe](https://github.com/sanity-io/sanity/commit/89de4fe312314e2e8dd784968693ed1562cf1889))
+* **core:** add version to documents when creating with a release pinned ([#8974](https://github.com/sanity-io/sanity/issues/8974)) ([04c4a10](https://github.com/sanity-io/sanity/commit/04c4a10157003f1964cfeff522594137e0280724))
+* releases tool tables show skeletons when loading rather than spinner ([#8989](https://github.com/sanity-io/sanity/issues/8989)) ([fad8013](https://github.com/sanity-io/sanity/commit/fad8013dc9a9c2ab266d038d9f8b8f5bb8b53298))
+* **vision:** transforms vision GUI into a functional component  ([#8879](https://github.com/sanity-io/sanity/issues/8879)) ([4ca0841](https://github.com/sanity-io/sanity/commit/4ca0841d20dbafd3448c700293dee9fe14087c64))
+
+
+
+## [3.80.1](https://github.com/sanity-io/sanity/compare/v3.80.0...v3.80.1) (2025-03-19)
+
+
+### Bug Fixes
+
+* **cli:** respect cli config for http host/port ([#8978](https://github.com/sanity-io/sanity/issues/8978)) ([a063981](https://github.com/sanity-io/sanity/commit/a063981e9352e69c58dcd87c00cac68dd15484b3))
+
+
+
+# [3.80.0](https://github.com/sanity-io/sanity/compare/v3.79.0...v3.80.0) (2025-03-18)
+
+
+### Bug Fixes
+
+* bump peer deps for `styled-components` ([#8940](https://github.com/sanity-io/sanity/issues/8940)) ([5347793](https://github.com/sanity-io/sanity/commit/5347793feb48204bf70a0d3bdb6c0b06753c4db3))
+* **cli:** fix the path of app-quickstart template ([#8976](https://github.com/sanity-io/sanity/issues/8976)) ([56c6cd2](https://github.com/sanity-io/sanity/commit/56c6cd2fe3cf59f12b14ce7dfbfc5d25ecdea12f))
+* **core:** arrays of references support disableActions ([#8877](https://github.com/sanity-io/sanity/issues/8877)) ([03c2f60](https://github.com/sanity-io/sanity/commit/03c2f605cb699307d3de1bb57dba1020734fa1a7))
+* **core:** clear perspective when archiving or deleting a release ([#8934](https://github.com/sanity-io/sanity/issues/8934)) ([4c455ec](https://github.com/sanity-io/sanity/commit/4c455ec7a04a016ea6a148e4a2ce1b58f9e8f9ab))
+* **core:** releases screen should not crash if schema type is unknown ([#8942](https://github.com/sanity-io/sanity/issues/8942)) ([578a368](https://github.com/sanity-io/sanity/commit/578a368a95cbb8f332fe82faa679f1f2ae468236))
+* **core:** slugs validation ([#8951](https://github.com/sanity-io/sanity/issues/8951)) ([05524ff](https://github.com/sanity-io/sanity/commit/05524ff836a3019b36ddc06d6374de5bab772e67))
+* **core:** update `resolveTypeForDocument` query ([#8969](https://github.com/sanity-io/sanity/issues/8969)) ([c1080f4](https://github.com/sanity-io/sanity/commit/c1080f41828907791d7f7d452a90c4af54f606d3))
+* **core:** update `resolveTypeForDocument` to work with version docs ([#8962](https://github.com/sanity-io/sanity/issues/8962)) ([7613d72](https://github.com/sanity-io/sanity/commit/7613d7248bbf5ddb9f810ff9b4235426e37993f9))
+* **core:** update releases navbar menu spacing and click area ([#8928](https://github.com/sanity-io/sanity/issues/8928)) ([df4d79a](https://github.com/sanity-io/sanity/commit/df4d79aa01e711dae3110fe68e2201eb727aa493))
+* **core:** updating document version actions to match deviated API ([#8913](https://github.com/sanity-io/sanity/issues/8913)) ([1a064d4](https://github.com/sanity-io/sanity/commit/1a064d4c1d559b6eb25f18384c7061273bb6e89c))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.12 ([#8853](https://github.com/sanity-io/sanity/issues/8853)) ([a385b49](https://github.com/sanity-io/sanity/commit/a385b49f28741d5d13e5af881b6d60894742a665))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.13 ([#8898](https://github.com/sanity-io/sanity/issues/8898)) ([1f9627d](https://github.com/sanity-io/sanity/commit/1f9627db35a4bd346837467400d53c2e1a69060c))
+* **deps:** update dependency @portabletext/editor to ^1.37.0 ([#8854](https://github.com/sanity-io/sanity/issues/8854)) ([2601018](https://github.com/sanity-io/sanity/commit/26010183fa365d9b422a01e98579168f2a253be0))
+* **deps:** update dependency @portabletext/editor to ^1.39.1 ([#8899](https://github.com/sanity-io/sanity/issues/8899)) ([6cffca3](https://github.com/sanity-io/sanity/commit/6cffca313646957b705dc58c92910b3660c4ba49))
+* **deps:** update dependency @portabletext/editor to ^1.40.2 ([#8965](https://github.com/sanity-io/sanity/issues/8965)) ([7f07747](https://github.com/sanity-io/sanity/commit/7f077471e68c9914ca288ae2f6bb2ecbff10fd63))
+* **deps:** update dependency @sanity/client to ^6.28.3 ([#8839](https://github.com/sanity-io/sanity/issues/8839)) ([0a6309d](https://github.com/sanity-io/sanity/commit/0a6309d86665ba9f2355cbb16ca4b2d5e63b58c3))
+* **deps:** update dependency @sanity/insert-menu to v1.1.5 ([#8910](https://github.com/sanity-io/sanity/issues/8910)) ([fdfdd3d](https://github.com/sanity-io/sanity/commit/fdfdd3d62bac88fd424a2ce44aca1a5281893cf7))
+* **deps:** update dependency @sanity/insert-menu to v1.1.6 ([#8955](https://github.com/sanity-io/sanity/issues/8955)) ([1d528be](https://github.com/sanity-io/sanity/commit/1d528be8ff7b3abc46b7d09f9fc7f3ec18b305c0))
+* **deps:** update dependency @sanity/mutate to ^0.12.3 ([#8905](https://github.com/sanity-io/sanity/issues/8905)) ([6ea3719](https://github.com/sanity-io/sanity/commit/6ea371944ca16bba1fbebe5690e90c2c22e117df))
+* **deps:** update dependency @sanity/presentation-comlink to ^1.0.10 ([#8911](https://github.com/sanity-io/sanity/issues/8911)) ([6b77ea9](https://github.com/sanity-io/sanity/commit/6b77ea95e4020103e34c7c34dbc7cc6ee7b95dbf))
+* **deps:** update dependency @sanity/presentation-comlink to ^1.0.11 ([#8935](https://github.com/sanity-io/sanity/issues/8935)) ([0067897](https://github.com/sanity-io/sanity/commit/0067897b53163771c845577e9073594696bfd856))
+* **deps:** update dependency @sanity/presentation-comlink to ^1.0.12 ([#8957](https://github.com/sanity-io/sanity/issues/8957)) ([1ba88ed](https://github.com/sanity-io/sanity/commit/1ba88ed5da13c2d5215e3e0d39a40730b02f5dcd))
+* **deps:** update dependency @sanity/preview-url-secret to ^2.1.6 ([#8912](https://github.com/sanity-io/sanity/issues/8912)) ([79c62d0](https://github.com/sanity-io/sanity/commit/79c62d00e2333112a85b125bd96feb5917153df8))
+* **deps:** update dependency @sanity/template-validator to ^2.4.3 ([#8972](https://github.com/sanity-io/sanity/issues/8972)) ([3bf6557](https://github.com/sanity-io/sanity/commit/3bf65570ac27f818adc311771aacbcc4283e2b65))
+* **deps:** update dependency @sanity/ui to ^2.15.5 ([#8872](https://github.com/sanity-io/sanity/issues/8872)) ([c580ffc](https://github.com/sanity-io/sanity/commit/c580ffc80f9c49fa5e9f3ab94550a54d9571d7c4))
+* **deps:** update dependency @sanity/ui to ^2.15.6 ([#8915](https://github.com/sanity-io/sanity/issues/8915)) ([1a7aaa2](https://github.com/sanity-io/sanity/commit/1a7aaa291b0b7434eaed75907ca000c57d356e89))
+* **deps:** update dependency @sanity/ui to ^2.15.7 ([#8959](https://github.com/sanity-io/sanity/issues/8959)) ([3313f53](https://github.com/sanity-io/sanity/commit/3313f538fed735aab3bcb344910e5c892d17a3dd))
+* **deps:** update dependency react-rx to ^4.1.24 ([#8871](https://github.com/sanity-io/sanity/issues/8871)) ([1c82d9a](https://github.com/sanity-io/sanity/commit/1c82d9a209258faf522fe08a76f1b06f67c2e07f))
+* **deps:** update dependency react-rx to ^4.1.25 ([#8958](https://github.com/sanity-io/sanity/issues/8958)) ([dd55c89](https://github.com/sanity-io/sanity/commit/dd55c89af2cd9cc844f79c7c4337a4505cc96b26))
+* **deps:** Update dev-non-major ([#8956](https://github.com/sanity-io/sanity/issues/8956)) ([60b8456](https://github.com/sanity-io/sanity/commit/60b84564f6f742781e3da140072f68660932e3c3))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#8873](https://github.com/sanity-io/sanity/issues/8873)) ([2ad5d53](https://github.com/sanity-io/sanity/commit/2ad5d53360754f0f9c517ab6e0176c64d4e34f45))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#8952](https://github.com/sanity-io/sanity/issues/8952)) ([618c52d](https://github.com/sanity-io/sanity/commit/618c52d059e3a8286c641a2f485b07bb97757e6f))
+* **i18n:** remove whitespace from tag ([#8901](https://github.com/sanity-io/sanity/issues/8901)) ([72b933f](https://github.com/sanity-io/sanity/commit/72b933f39c97292879491360e5bd20fd73fb177f))
+* **preview:** don't apply preview fallback for documents in archived release ([#8932](https://github.com/sanity-io/sanity/issues/8932)) ([5ee38ad](https://github.com/sanity-io/sanity/commit/5ee38ad75f944e242013eb84e0f50be46c26d3af))
+* published perspective shows correct tooltip for create buttons ([#8923](https://github.com/sanity-io/sanity/issues/8923)) ([c27c518](https://github.com/sanity-io/sanity/commit/c27c51871578ebd9ae1af19825c63111b3b7bf41))
+* release document actions disabled tooltips only shown when relevant ([#8884](https://github.com/sanity-io/sanity/issues/8884)) ([1637cee](https://github.com/sanity-io/sanity/commit/1637cee02d5ce8bbee82ed080b9fa63b106ed2f2))
+* **sanity:** use minimum supported API version for dataset import ([#8945](https://github.com/sanity-io/sanity/issues/8945)) ([605be41](https://github.com/sanity-io/sanity/commit/605be4129d56c014ca9fe3886a5c6ac4219e2963))
+* **structure:** click on published chip should take you back to document ([#8919](https://github.com/sanity-io/sanity/issues/8919)) ([f4ea15b](https://github.com/sanity-io/sanity/commit/f4ea15b85a6594d69493ad4129f0fcf9f9a85875))
+* **structure:** some touches to version chips ([#8933](https://github.com/sanity-io/sanity/issues/8933)) ([6ef4bfe](https://github.com/sanity-io/sanity/commit/6ef4bfe1e7cd749862a081eacc0460eb79958e9c))
+* **structure:** update archived and published docs in release links ([#8925](https://github.com/sanity-io/sanity/issues/8925)) ([8271a3b](https://github.com/sanity-io/sanity/commit/8271a3b6485b54c8d8690cc5202f65710ec7d802))
+* **studio:** handle document-level copy/paste reference mismatches ([#8895](https://github.com/sanity-io/sanity/issues/8895)) ([4034689](https://github.com/sanity-io/sanity/commit/40346890b1c3fe43229afe96d8d1d823ab7bfdc8))
+* **studio:** use correct logo in dark mode ([#8961](https://github.com/sanity-io/sanity/issues/8961)) ([8b68490](https://github.com/sanity-io/sanity/commit/8b68490b55c62b51de3a1f1c1d15987e41951808))
+* **test:** updates flaky imageArrayDraft pte test ([#8975](https://github.com/sanity-io/sanity/issues/8975)) ([56b0e71](https://github.com/sanity-io/sanity/commit/56b0e71579617d3cdccea68a2db781485f283093))
+* version operations error toast ([#8920](https://github.com/sanity-io/sanity/issues/8920)) ([2a155d9](https://github.com/sanity-io/sanity/commit/2a155d9a41219c08ededb0991fd821180e31baab))
+
+
+### Features
+
+* **cli:** allow opening apps and studios in dashboard ([#8858](https://github.com/sanity-io/sanity/issues/8858)) ([3204418](https://github.com/sanity-io/sanity/commit/3204418508763b7cd6e8cfbadd4fa5f23e7d7857))
+* **core:** Global Document References support ([#8299](https://github.com/sanity-io/sanity/issues/8299)) ([9c0566b](https://github.com/sanity-io/sanity/commit/9c0566b87ffcbdc32506fa67baf30bc0f0a68a0a))
+* **presentation:** include perspectiveStack and version in resolvers ([#8891](https://github.com/sanity-io/sanity/issues/8891)) ([17365d8](https://github.com/sanity-io/sanity/commit/17365d8b67d6a311016422c888efd5488106d0db))
+* **sanity:** add `isReleaseType` type guard ([#8875](https://github.com/sanity-io/sanity/issues/8875)) ([db83d84](https://github.com/sanity-io/sanity/commit/db83d84070e69c84a3397465804717dedb45b756))
+* **sanity:** add `TimeInput` component ([#8921](https://github.com/sanity-io/sanity/issues/8921)) ([88dbdb0](https://github.com/sanity-io/sanity/commit/88dbdb0592b8bb4de78ea84747a63e63cb0b8b28))
+* **sanity:** refine `TitleDescriptionForm` block spacing ([#8875](https://github.com/sanity-io/sanity/issues/8875)) ([0ec5daf](https://github.com/sanity-io/sanity/commit/0ec5daf1926448812d8ae5c7440696d610459b6e))
+* **sanity:** refine phrasing of `scheduled-for-publishing-on` string ([#8922](https://github.com/sanity-io/sanity/issues/8922)) ([bbd4cc3](https://github.com/sanity-io/sanity/commit/bbd4cc3817af9d994839a2ed16652b4478c232da))
+* **sanity:** refine release creation dialogue ([#8875](https://github.com/sanity-io/sanity/issues/8875)) ([a4f4af3](https://github.com/sanity-io/sanity/commit/a4f4af3bb427cf099f532c5bfe2b69539d5f4de2))
+* **sanity:** refine release toasts ([#8902](https://github.com/sanity-io/sanity/issues/8902)) ([2fd1579](https://github.com/sanity-io/sanity/commit/2fd15792f84aa43c4845e148579e5213f27fc319))
+* **sanity:** use time input in calendar ([#8921](https://github.com/sanity-io/sanity/issues/8921)) ([ddc9acf](https://github.com/sanity-io/sanity/commit/ddc9acf16b9ad8c40fec225fcd24188860bb8d96))
+* **studio:** detect and report high listener roundtrip latency ([#8943](https://github.com/sanity-io/sanity/issues/8943)) ([224cdb5](https://github.com/sanity-io/sanity/commit/224cdb547d6d9e8311c47bf76a52811e8c571db2))
+* **studio:** refine releases overview toolbar layout ([#8881](https://github.com/sanity-io/sanity/issues/8881)) ([16919e6](https://github.com/sanity-io/sanity/commit/16919e6e5fcc984bbeeb8494940f445db967c1cb))
+
+
+
+# [3.79.0](https://github.com/sanity-io/sanity/compare/v3.78.1...v3.79.0) (2025-03-11)
+
+
+### Bug Fixes
+
+* **cli:** add undeploy command back for apps ([#8857](https://github.com/sanity-io/sanity/issues/8857)) ([e7afbc0](https://github.com/sanity-io/sanity/commit/e7afbc073ae12f6737bda194c8a6a92ef6a69fe9))
+* **cli:** use `api.sanity.local` for CLI dev environment ([#8860](https://github.com/sanity-io/sanity/issues/8860)) ([cb2ad6e](https://github.com/sanity-io/sanity/commit/cb2ad6ea2e6db946c8f307ccec02d0510c22275b))
+* **deps:** update dependency @sanity/import to ^3.38.0 ([#8883](https://github.com/sanity-io/sanity/issues/8883)) ([d060f5d](https://github.com/sanity-io/sanity/commit/d060f5dd9469c6b9057d6ab4c36c8f7328e8efff))
+* **deps:** update dependency groq-js to ^1.16.0 ([#8856](https://github.com/sanity-io/sanity/issues/8856)) ([1f6b66a](https://github.com/sanity-io/sanity/commit/1f6b66a20582dcb707bcb63c7cb6be051d81c84a))
+* **preview:** pass filter only to liveDocumentIdSet listener ([#8863](https://github.com/sanity-io/sanity/issues/8863)) ([fb05db5](https://github.com/sanity-io/sanity/commit/fb05db5f90fd1a266a0f5ae28a1fdadd1e14fcbd))
+* **sanity:** allow discovery of all document versions using `groq2024` search ([#8775](https://github.com/sanity-io/sanity/issues/8775)) ([ab7c0f4](https://github.com/sanity-io/sanity/commit/ab7c0f47dfb612df87c9e8fd963f8e85d44119d1))
+* **sanity:** collate versions separately to draft ([#8775](https://github.com/sanity-io/sanity/issues/8775)) ([a115c35](https://github.com/sanity-io/sanity/commit/a115c35c4b51d3bd819beeec60eeb6199e58ce2f))
+* **typeEvaluation:** Significantly speeds up type generation on larger schemas when evaluating certain queries (groq-js@^1.16.1) ([#8870](https://github.com/sanity-io/sanity/issues/8870)) ([879f6f2](https://github.com/sanity-io/sanity/commit/879f6f2b242ef592ead930cb5451b00b114ea4a9))
+* **vision:** scroll jump - transform vision code mirror to uncontrolled ([#8878](https://github.com/sanity-io/sanity/issues/8878)) ([6ed87ce](https://github.com/sanity-io/sanity/commit/6ed87ce4a7b9a5dff08b075be0761ef00296f6fc))
+
+
+### Features
+
+* **sanity:** improve "pin release" button accessibility ([#8867](https://github.com/sanity-io/sanity/issues/8867)) ([c3f649b](https://github.com/sanity-io/sanity/commit/c3f649b7a82898bf9ff7c84cc707030fa77eeb8e))
+* **sanity:** include drafts perspective in overlay visualisation ([#8864](https://github.com/sanity-io/sanity/issues/8864)) ([392c81f](https://github.com/sanity-io/sanity/commit/392c81fe1853bba675509cf8eb056e84044a4b96))
+* **structure:** document panel UI updates ([#8622](https://github.com/sanity-io/sanity/issues/8622)) ([8e45b39](https://github.com/sanity-io/sanity/commit/8e45b391d4b98aaf8ce31133cdb6bcaab0472384))
+
+
+
+## [3.78.1](https://github.com/sanity-io/sanity/compare/v3.78.0...v3.78.1) (2025-03-06)
+
+
+### Bug Fixes
+
+* **cli:** require projects to be part of an organization ([#8723](https://github.com/sanity-io/sanity/issues/8723)) ([940c198](https://github.com/sanity-io/sanity/commit/940c1986fc3ab13b9f0b01aaa18c228ca8242157))
+* **core:** get previews for documents in archived releases ([#8855](https://github.com/sanity-io/sanity/issues/8855)) ([75b9bc4](https://github.com/sanity-io/sanity/commit/75b9bc47809f99c1f9431697ba79071ef2342c74))
+* **core:** reconnection title was missing ([#8840](https://github.com/sanity-io/sanity/issues/8840)) ([0af4ffb](https://github.com/sanity-io/sanity/commit/0af4ffb964ef10b63e8b42724f00b3958faf6729))
+* **core:** update perspectiveStack, use it as the client perspective ([#8845](https://github.com/sanity-io/sanity/issues/8845)) ([b23c238](https://github.com/sanity-io/sanity/commit/b23c2387f98a4fbc48c142be1bf91f6a754180f4))
+* **releases:** fix issue with missing draft/publish status tooltips ([#8844](https://github.com/sanity-io/sanity/issues/8844)) ([8c097fa](https://github.com/sanity-io/sanity/commit/8c097fa6315b65a90c5f4ebbca183d8d43a1ea42))
+* **releases:** specify apiVersion in useClient calls ([#8846](https://github.com/sanity-io/sanity/issues/8846)) ([ff629f6](https://github.com/sanity-io/sanity/commit/ff629f675f09cac1b9d0aebe29d7c0f006d62784))
+* resolve PTE popover scroll issue ([#8849](https://github.com/sanity-io/sanity/issues/8849)) ([14a896b](https://github.com/sanity-io/sanity/commit/14a896be5cdaa70bdad8c58f4b6505411cc09673))
+* **sanity:** ambient types for custom Vitest matchers ([#8837](https://github.com/sanity-io/sanity/issues/8837)) ([9e8a1e5](https://github.com/sanity-io/sanity/commit/9e8a1e5198f69b068613e452b5c6eb2b98b8bdd4))
+* **sanity:** use recursive wildcards for release document listings ([#8847](https://github.com/sanity-io/sanity/issues/8847)) ([580607f](https://github.com/sanity-io/sanity/commit/580607ff848ce718fbf6e87a6acd1d66aff19645))
+* silence context warnings in jsdom environments ([#8752](https://github.com/sanity-io/sanity/issues/8752)) ([aebfbc7](https://github.com/sanity-io/sanity/commit/aebfbc79ada6625c2381c72cb1579bc1541d5361))
+* **structure:** navigate to version when document only has versions ([#8759](https://github.com/sanity-io/sanity/issues/8759)) ([d9ddb8d](https://github.com/sanity-io/sanity/commit/d9ddb8d5b2d72366319598e242d498d519bd71c8))
+
+
+### Features
+
+* **cli:** add runtime functions command group ([#8780](https://github.com/sanity-io/sanity/issues/8780)) ([cf8d12d](https://github.com/sanity-io/sanity/commit/cf8d12d7f4f31a0f0049f36483d1ac3e8a2a4d53))
+* **cli:** add unattended mode flag to `sanity undeploy` ([#8130](https://github.com/sanity-io/sanity/issues/8130)) ([ab116ea](https://github.com/sanity-io/sanity/commit/ab116ea5e64796e8eeaffbb9437baf1fd6ae0af1))
+* **sanity:** add `CapabilityGate` component ([5b06c42](https://github.com/sanity-io/sanity/commit/5b06c426d8329a23aecf9ee6e713e54242c27a1a))
+* **sanity:** add Rendering Context Store ([b0c005a](https://github.com/sanity-io/sanity/commit/b0c005a46648391eae4191949c804019aa5a7b4b))
+* **sanity:** hide global user menu inside Core UI Rendering Context ([#8591](https://github.com/sanity-io/sanity/issues/8591)) ([db834ef](https://github.com/sanity-io/sanity/commit/db834ef4eefb03498487a4748910dbb9cf6ca97c))
+* **sanity:** hide workspace switcher inside Core UI rendering context ([6ae5097](https://github.com/sanity-io/sanity/commit/6ae509721fdb315afd7b034cb62a6c5c55a08c28))
+* **sanity:** use document layout middleware chain when rendering `DiffViewPane` ([#8843](https://github.com/sanity-io/sanity/issues/8843)) ([96d98fc](https://github.com/sanity-io/sanity/commit/96d98fc4e1be5ec612b777265bebc077957a1a29))
+
+
+
+# [3.78.0](https://github.com/sanity-io/sanity/compare/v3.77.2...v3.78.0) (2025-03-04)
+
+
+### Bug Fixes
+
+* **comments:** set up listener with filter-only query ([#8793](https://github.com/sanity-io/sanity/issues/8793)) ([3495c4a](https://github.com/sanity-io/sanity/commit/3495c4a4b09626a530fbfbd801c29de8dfeb8865))
+* **core:** add `isReleaseLocked` or `willBeUnpublished` to `useDocumentForm` ([#8822](https://github.com/sanity-io/sanity/issues/8822)) ([50a65ba](https://github.com/sanity-io/sanity/commit/50a65ba57b41a74a23a5e246183d991faecb32ff))
+* **core:** batch requests for archived releases view ([#8779](https://github.com/sanity-io/sanity/issues/8779)) ([54af2dd](https://github.com/sanity-io/sanity/commit/54af2dd01d670367ace54f34d0f479af4b2b28db))
+* **core:** memoize scheduledPublishing calls, trigger only once ([#8819](https://github.com/sanity-io/sanity/issues/8819)) ([34674d5](https://github.com/sanity-io/sanity/commit/34674d5757333a54694e5431238290a9667d18b6))
+* **core:** rename internal `deepEquals` to `deepEqualsIgnoreKey` ([#8790](https://github.com/sanity-io/sanity/issues/8790)) ([c44a858](https://github.com/sanity-io/sanity/commit/c44a8583efbe00f8aca4a8e86e16b97d7c9e31d2))
+* **core:** useDocumentForm update type ([#8791](https://github.com/sanity-io/sanity/issues/8791)) ([902e2db](https://github.com/sanity-io/sanity/commit/902e2db98501190dac9f0fa5316922f2c7db8f50))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.11 ([#8799](https://github.com/sanity-io/sanity/issues/8799)) ([762b0e3](https://github.com/sanity-io/sanity/commit/762b0e3bf476df62bca3a044cfe38f2c1aac98c7))
+* **deps:** update dependency @portabletext/editor to ^1.36.5 ([#8800](https://github.com/sanity-io/sanity/issues/8800)) ([c0c0fc1](https://github.com/sanity-io/sanity/commit/c0c0fc132e9f0149d26fdaf9f0e0bea6b4e1c5e7))
+* **deps:** update dependency @portabletext/editor to ^1.36.6 ([#8821](https://github.com/sanity-io/sanity/issues/8821)) ([6ff3fe2](https://github.com/sanity-io/sanity/commit/6ff3fe23446df7a92e2bf7bd580ad49ba28a4955))
+* **deps:** update dependency @sanity/client to ^6.28.2 ([#8806](https://github.com/sanity-io/sanity/issues/8806)) ([a21164f](https://github.com/sanity-io/sanity/commit/a21164fd7582d8e12ee172856dac6d9ba95b6578))
+* **deps:** update dependency @sanity/icons to ^3.7.0 ([#8789](https://github.com/sanity-io/sanity/issues/8789)) ([3d3aa2e](https://github.com/sanity-io/sanity/commit/3d3aa2e1b1b1b197347f96286eea818047f878a7))
+* **deps:** update dependency @sanity/insert-menu to v1.1.4 ([#8810](https://github.com/sanity-io/sanity/issues/8810)) ([8c94856](https://github.com/sanity-io/sanity/commit/8c948562ddf5033c0a993030fdcbbd08953250a4))
+* **deps:** update dependency @sanity/presentation-comlink to ^1.0.9 ([#8811](https://github.com/sanity-io/sanity/issues/8811)) ([017880a](https://github.com/sanity-io/sanity/commit/017880a8b39355662d286a5e73a68cb2a3512b5d))
+* **deps:** update dependency @sanity/preview-url-secret to ^2.1.5 ([#8812](https://github.com/sanity-io/sanity/issues/8812)) ([4a8950c](https://github.com/sanity-io/sanity/commit/4a8950c825e19b2c1e3aba55fbb5462755ddf74e))
+* **deps:** update dependency @sanity/ui to ^2.14.4 ([#8802](https://github.com/sanity-io/sanity/issues/8802)) ([6859ed5](https://github.com/sanity-io/sanity/commit/6859ed5bc16242f36d11631a9aee5b90512d575e))
+* **deps:** update dependency @sanity/ui to ^2.14.5 ([#8813](https://github.com/sanity-io/sanity/issues/8813)) ([144c065](https://github.com/sanity-io/sanity/commit/144c06566f6d7236bc324a7ec0137f83407f8a3b))
+* **deps:** update dependency @sanity/ui to ^2.15.0 ([#8823](https://github.com/sanity-io/sanity/issues/8823)) ([82489b9](https://github.com/sanity-io/sanity/commit/82489b90587d9f89a017c3759335883d26262848))
+* **deps:** update dependency @sanity/ui to ^2.15.2 ([#8824](https://github.com/sanity-io/sanity/issues/8824)) ([ac53a11](https://github.com/sanity-io/sanity/commit/ac53a11ad65d5783b481cbe5085a4c1dd5b9bc50))
+* **deps:** update dependency react-rx to ^4.1.22 ([#8814](https://github.com/sanity-io/sanity/issues/8814)) ([5cf1a5b](https://github.com/sanity-io/sanity/commit/5cf1a5b435ed7b9c3bc2a1e98fc06c24095ffea8))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#8807](https://github.com/sanity-io/sanity/issues/8807)) ([c15510c](https://github.com/sanity-io/sanity/commit/c15510c26f162ea8aeadf03996e0ea7ece5e35de))
+* handle motion.create warning ([#8805](https://github.com/sanity-io/sanity/issues/8805)) ([e50b1cc](https://github.com/sanity-io/sanity/commit/e50b1cc27dbc2b4fef98d4a00745e706536137de))
+* **presentation:** don't remount header when props change ([#8786](https://github.com/sanity-io/sanity/issues/8786)) ([6d99e26](https://github.com/sanity-io/sanity/commit/6d99e261b4e34d0470dcd4cff9b269198be142fa))
+* prevent over-fetching in free trial provider ([#8783](https://github.com/sanity-io/sanity/issues/8783)) ([8f65af3](https://github.com/sanity-io/sanity/commit/8f65af34925c58d431f2bd1eebc3d531fb4c0a41))
+* **preview:** prefer snapshot over original when previewing ([#8792](https://github.com/sanity-io/sanity/issues/8792)) ([9c6b207](https://github.com/sanity-io/sanity/commit/9c6b207b8febb81b88278b0cf901d56726bcfe26))
+* publish action hidden on published documents ([#8747](https://github.com/sanity-io/sanity/issues/8747)) ([f50cf9f](https://github.com/sanity-io/sanity/commit/f50cf9f42a249bac8e8a354c0219e861b3d13971))
+* **sanity:** error message typo ([#7907](https://github.com/sanity-io/sanity/issues/7907)) ([1d655c2](https://github.com/sanity-io/sanity/commit/1d655c299383b8c156d6a64e53747b092bbe4575))
+* **structure:** exclude documents outside of selected perspective from document lists ([#8798](https://github.com/sanity-io/sanity/issues/8798)) ([4945f0a](https://github.com/sanity-io/sanity/commit/4945f0ad8a07a916d717cc4024179362edf73118))
+* **structure:** fix issue with locked icon ([#8771](https://github.com/sanity-io/sanity/issues/8771)) ([709a5b4](https://github.com/sanity-io/sanity/commit/709a5b46ccb6f9ee372f41a41467dfc8a508c71b))
+* **structure:** preload should use published id ([#8796](https://github.com/sanity-io/sanity/issues/8796)) ([6eafe16](https://github.com/sanity-io/sanity/commit/6eafe16225a1566d623bb52694bf161c64feab77))
+* **structure:** provide feedback as document is added to release ([#8804](https://github.com/sanity-io/sanity/issues/8804)) ([d43553e](https://github.com/sanity-io/sanity/commit/d43553e9146d63b81bd71d2ce3cd38ffc0f4f2e1))
+
+
+### Features
+
+* **cli:** add app undeploy command ([ba663e3](https://github.com/sanity-io/sanity/commit/ba663e3b7626c9433274455543f611ebbd961000))
+* **core:** add `useDocumentForm` hook ([#8557](https://github.com/sanity-io/sanity/issues/8557)) ([1e1a417](https://github.com/sanity-io/sanity/commit/1e1a4172aa12d70f7edb8659627dc1c2da6c184b))
+* **core:** add default `code` and `strike-through` markdown shortcuts to PTE ([#8777](https://github.com/sanity-io/sanity/issues/8777)) ([5c9f705](https://github.com/sanity-io/sanity/commit/5c9f7053603debf39877841c7a83c40a479d13ba))
+* **migrate:** add support for `--api-version` flag ([#8781](https://github.com/sanity-io/sanity/issues/8781)) ([82c360f](https://github.com/sanity-io/sanity/commit/82c360fc285e8a18c7af120c3482d3acdd8cc1b8))
+* **sanity:** accept `disableNew` option in `ReferenceInputOptionsContext` ([#7907](https://github.com/sanity-io/sanity/issues/7907)) ([64a75ef](https://github.com/sanity-io/sanity/commit/64a75efcf794fbef96d48b53a76875052b6945b9))
+* **sanity:** add `isInteractive` prop to `ConnectorContext` ([#7907](https://github.com/sanity-io/sanity/issues/7907)) ([4d24fb4](https://github.com/sanity-io/sanity/commit/4d24fb428f50b03be791dacfbd3f63b3fe590856))
+* **sanity:** add `ReleaseAvatar` export ([#7907](https://github.com/sanity-io/sanity/issues/7907)) ([a3defc3](https://github.com/sanity-io/sanity/commit/a3defc34688c7d08b3811fae8e9da5717f1de345))
+* **sanity:** add `tone` prop to `Chip` component ([#7907](https://github.com/sanity-io/sanity/issues/7907)) ([b7087f8](https://github.com/sanity-io/sanity/commit/b7087f881165529e8dc3d829b8c746dc2234405d))
+* **sanity:** add `useDocumentIdStack` hook ([#7907](https://github.com/sanity-io/sanity/issues/7907)) ([43d4287](https://github.com/sanity-io/sanity/commit/43d4287e0291629f83ac86a51556fb0e8740a9fa))
+* **sanity:** add document comparison tool ([#7907](https://github.com/sanity-io/sanity/issues/7907)) ([7a4fb1b](https://github.com/sanity-io/sanity/commit/7a4fb1be4f3a7482ba6c32f541ae525f2e1cb81e))
+* **sanity:** improve system bundle handling ([#7907](https://github.com/sanity-io/sanity/issues/7907)) ([6a9d4c1](https://github.com/sanity-io/sanity/commit/6a9d4c14948d357518ab4af641f5ff6f8783180c))
+* set bridge script based on ENV & add data-attribute ([#8830](https://github.com/sanity-io/sanity/issues/8830)) ([c932020](https://github.com/sanity-io/sanity/commit/c93202080c7e0fadc1837370398a96824a01556e))
+
+
+
+## [3.77.2](https://github.com/sanity-io/sanity/compare/v3.77.1...v3.77.2) (2025-02-25)
+
+
+### Bug Fixes
+
+* **cli:** correct the default port for Astro app ([#8699](https://github.com/sanity-io/sanity/issues/8699)) ([6964961](https://github.com/sanity-io/sanity/commit/69649617df7a1d0298558293b33f757fe2126f58))
+* **cli:** update core app template ([#8722](https://github.com/sanity-io/sanity/issues/8722)) ([e3ab986](https://github.com/sanity-io/sanity/commit/e3ab9867396b7235b0f498c910e16e486afdad24))
+* **core:** abort file target drag events for portable text items ([#8760](https://github.com/sanity-io/sanity/issues/8760)) ([bdb695b](https://github.com/sanity-io/sanity/commit/bdb695b9686d4da8dce7692e72b541a6843fcc25))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.10 ([#8766](https://github.com/sanity-io/sanity/issues/8766)) ([44c357b](https://github.com/sanity-io/sanity/commit/44c357bf0ab98927fbfb245a8a272e77b97e2bba))
+* **deps:** update dependency @portabletext/editor to ^1.36.1 ([#8767](https://github.com/sanity-io/sanity/issues/8767)) ([33e54a6](https://github.com/sanity-io/sanity/commit/33e54a62ba965f6995ae68548223e00adc59a200))
+* Scheduled publishing badge issue ([#8755](https://github.com/sanity-io/sanity/issues/8755)) ([8161946](https://github.com/sanity-io/sanity/commit/8161946e9b659f00713b40697516d8582e0851b9))
+
+
+
+## [3.77.1](https://github.com/sanity-io/sanity/compare/v3.77.0...v3.77.1) (2025-02-24)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @portabletext/editor to ^1.35.4 ([#8742](https://github.com/sanity-io/sanity/issues/8742)) ([80840fc](https://github.com/sanity-io/sanity/commit/80840fc2eba22230ba78cf7fe968893275fc7228))
+* **deps:** update dependency @sanity/client to ^6.28.1 ([#8750](https://github.com/sanity-io/sanity/issues/8750)) ([7d2a8e3](https://github.com/sanity-io/sanity/commit/7d2a8e38eeddbc297fbeb11cf374cfb104b4c2df))
+* **deps:** update dependency @sanity/insert-menu to v1.1.3 ([#8740](https://github.com/sanity-io/sanity/issues/8740)) ([b8f9231](https://github.com/sanity-io/sanity/commit/b8f92312ab3050fb2c1021d4542dc15fa4cefb21))
+* **deps:** update dependency @sanity/presentation-comlink to ^1.0.8 ([#8741](https://github.com/sanity-io/sanity/issues/8741)) ([038e78b](https://github.com/sanity-io/sanity/commit/038e78ba4aad528ace8c1f9d0d3157b0a5206c58))
+* **deps:** update dependency @sanity/ui to ^2.14.3 ([#8743](https://github.com/sanity-io/sanity/issues/8743)) ([80a828f](https://github.com/sanity-io/sanity/commit/80a828fcf65018b10bd83da6d8dbd422d43181be))
+* **deps:** update dependency react-rx to ^4.1.21 ([#8745](https://github.com/sanity-io/sanity/issues/8745)) ([1d64a24](https://github.com/sanity-io/sanity/commit/1d64a24ae832d4181782cdbc69bccc082f2c38cb))
+* use raw perspective by default for search ([#8757](https://github.com/sanity-io/sanity/issues/8757)) ([b23459d](https://github.com/sanity-io/sanity/commit/b23459d41231e738afb2c31c835bde8b01676fab))
+
+
+
+# [3.77.0](https://github.com/sanity-io/sanity/compare/v3.76.3...v3.77.0) (2025-02-24)
+
+
+### Bug Fixes
+
+* add correct link to content releases banner ([#8744](https://github.com/sanity-io/sanity/issues/8744)) ([7735b59](https://github.com/sanity-io/sanity/commit/7735b59b6aec72cf6e8c65f8f989d326abfa68c9))
+* **core:** flag `application/x-portable-text` as portable text ([504d582](https://github.com/sanity-io/sanity/commit/504d5825557743b309a0f61b35161cff304ee5ff))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.9 ([#8717](https://github.com/sanity-io/sanity/issues/8717)) ([3e58e23](https://github.com/sanity-io/sanity/commit/3e58e237ffa83dc2c698ebf35f911c47e4f84030))
+* **deps:** update dependency @portabletext/editor to ^1.35.1 ([#8693](https://github.com/sanity-io/sanity/issues/8693)) ([9cfd2d9](https://github.com/sanity-io/sanity/commit/9cfd2d9bf249da1c42a6ea841f7194a6b9ab9441))
+* **deps:** update dependency @portabletext/editor to ^1.35.3 ([#8731](https://github.com/sanity-io/sanity/issues/8731)) ([745bcf0](https://github.com/sanity-io/sanity/commit/745bcf08858a99b42bafc600927bdbab2baa84c9))
+* **deps:** update dependency @sanity/ui to ^2.14.1 ([#8720](https://github.com/sanity-io/sanity/issues/8720)) ([8b20bd7](https://github.com/sanity-io/sanity/commit/8b20bd775156d5df44276b172494ccfd9d3547ae))
+* **deps:** update dependency @sanity/ui to ^2.14.2 ([#8734](https://github.com/sanity-io/sanity/issues/8734)) ([d00ae6d](https://github.com/sanity-io/sanity/commit/d00ae6d730b65e83c874cbfb7228da4ac7a99489))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#8732](https://github.com/sanity-io/sanity/issues/8732)) ([b1599ed](https://github.com/sanity-io/sanity/commit/b1599ed2e6992c322c248800878f6b42f25943b9))
+* generating new release ID each time defaults are used; only checking update release perms when release is active ([#8736](https://github.com/sanity-io/sanity/issues/8736)) ([764d3d1](https://github.com/sanity-io/sanity/commit/764d3d1d942ca2779b48920c49bad24e6cca54f6))
+* object object in error ([#8714](https://github.com/sanity-io/sanity/issues/8714)) ([dc9fbcf](https://github.com/sanity-io/sanity/commit/dc9fbcfd7d0c51d209b29068fca38020dd70e90c))
+* **sanity:** add missing `useInsertionEffect` hook dependency `isCreateLinked` ([#8715](https://github.com/sanity-io/sanity/issues/8715)) ([4be8f70](https://github.com/sanity-io/sanity/commit/4be8f70f52fbced4646ee38ab0b10bded7d0a517))
+* **sanity:** merge version events into `memoizedPair` ([#8735](https://github.com/sanity-io/sanity/issues/8735)) ([ed763df](https://github.com/sanity-io/sanity/commit/ed763df8aaca0f2baf5766d0cd2d9fc76f433fdd))
+* showing add doc toast once document is received in the subscription ([#8618](https://github.com/sanity-io/sanity/issues/8618)) ([61f7b1c](https://github.com/sanity-io/sanity/commit/61f7b1c300a953d19b9932ada4244cf02bd82ad7))
+
+
+### Features
+
+* make content releases opt out ([#8739](https://github.com/sanity-io/sanity/issues/8739)) ([5e0debd](https://github.com/sanity-io/sanity/commit/5e0debd8db416c6d1f25e9d7ce2ae1541e2f68b4))
+* org release limits ([#8682](https://github.com/sanity-io/sanity/issues/8682)) ([09c79f9](https://github.com/sanity-io/sanity/commit/09c79f9184fb4e0cf1675468d38988d0c5b1aa37))
+* reduce redundant success toast messages ([#8612](https://github.com/sanity-io/sanity/issues/8612)) ([5bf7d22](https://github.com/sanity-io/sanity/commit/5bf7d22d9958ffd580cd59b44accfa3b0afaa658))
+* **vision:** add API version 2025-02-19 ([#8707](https://github.com/sanity-io/sanity/issues/8707)) ([7195b11](https://github.com/sanity-io/sanity/commit/7195b110fe2a5b668c4acf15be68616fc6011994))
+
+
+
+## [3.76.3](https://github.com/sanity-io/sanity/compare/v3.76.2...v3.76.3) (2025-02-20)
+
+
+### Bug Fixes
+
+* add fallback context value for scheduled publish enablement ([#8713](https://github.com/sanity-io/sanity/issues/8713)) ([4237bcc](https://github.com/sanity-io/sanity/commit/4237bcc77bc49ff74effb4b37c80308472a04701))
+
+
+
+## [3.76.2](https://github.com/sanity-io/sanity/compare/v3.76.1...v3.76.2) (2025-02-20)
+
+
+### Bug Fixes
+
+* **core:** add api version config to `observeDocuments` ([#8697](https://github.com/sanity-io/sanity/issues/8697)) ([7c8b849](https://github.com/sanity-io/sanity/commit/7c8b8495f98c7fa1abda1438aff62c48d0dc4667))
+* **core:** archive and delete release dialogs revised ([#8694](https://github.com/sanity-io/sanity/issues/8694)) ([86a2586](https://github.com/sanity-io/sanity/commit/86a2586a6789b378d90ad799856dbaff5fe9806e))
+* **core:** handling cases where no dependencies are passed to a resourceCache value set ([#8702](https://github.com/sanity-io/sanity/issues/8702)) ([a3825bf](https://github.com/sanity-io/sanity/commit/a3825bf3ec091eb6a5cd2611acd5bb264391af9c))
+* **core:** hide schedule publishing if not used and not enabled by users ([#8594](https://github.com/sanity-io/sanity/issues/8594)) ([2e31cdc](https://github.com/sanity-io/sanity/commit/2e31cdcdf0c4f7942c73046dc2c74dd57d72dc82))
+* **core:** update responsive design on navbar ([#8708](https://github.com/sanity-io/sanity/issues/8708)) ([400cebd](https://github.com/sanity-io/sanity/commit/400cebd83a327ed050cddbbe415a40d03ee6d997))
+* **deps:** update dependency @sanity/ui to ^2.14.0 ([#8706](https://github.com/sanity-io/sanity/issues/8706)) ([3fe9584](https://github.com/sanity-io/sanity/commit/3fe9584655aee848d44631613711a43a237d8753))
+* **sanity:** discard draft permission check ([#8711](https://github.com/sanity-io/sanity/issues/8711)) ([e226ca4](https://github.com/sanity-io/sanity/commit/e226ca41b321e119a96cef6bc5c5006a023db254))
+* **sanity:** prevent unexpected release type picker mutation ([#8701](https://github.com/sanity-io/sanity/issues/8701)) ([2693a76](https://github.com/sanity-io/sanity/commit/2693a76192de147b434d0652088a1e10d7977418))
+* switch to dated api version for releases ([#8676](https://github.com/sanity-io/sanity/issues/8676)) ([c704980](https://github.com/sanity-io/sanity/commit/c7049802297c5106c142741e9187f73197aee82b))
+
+
+### Features
+
+* **cli:** add deploy command for non-studio applications ([#8592](https://github.com/sanity-io/sanity/issues/8592)) ([d315921](https://github.com/sanity-io/sanity/commit/d315921fca822ab866bfdb225c4effc38bdc3344))
+* **core:** updates archived releases overview ([#8677](https://github.com/sanity-io/sanity/issues/8677)) ([2220cc0](https://github.com/sanity-io/sanity/commit/2220cc02c4230b911a7cc175b138c2aee57187dd))
+* **sanity:** allow releases to be created using past publication time ([#8678](https://github.com/sanity-io/sanity/issues/8678)) ([f9168b9](https://github.com/sanity-io/sanity/commit/f9168b9497fa845ea466ce5a0e0d6f1e17235f1e))
+* **structure:** add unpublish document as part of a release banner ([#8681](https://github.com/sanity-io/sanity/issues/8681)) ([de8b517](https://github.com/sanity-io/sanity/commit/de8b51778557bd0180a74ae6befac2a7aa1d3c4f))
+
+
+
+## [3.76.1](https://github.com/sanity-io/sanity/compare/v3.76.0...v3.76.1) (2025-02-18)
+
+
+### Bug Fixes
+
+* **core:** revise wording for releases schedule actions ([#8692](https://github.com/sanity-io/sanity/issues/8692)) ([0ecb3d6](https://github.com/sanity-io/sanity/commit/0ecb3d6f846edf28dd10050043f6b1b530fd3e31))
+
+
+### Reverts
+
+* Revert "feat(typegen): `sanity typegen` Whitespace Handling in Query Output (#8648)" ([0f960d1](https://github.com/sanity-io/sanity/commit/0f960d144d54a8a2014b893eb6426f850642c684)), closes [#8648](https://github.com/sanity-io/sanity/issues/8648)
+
+
+
+# [3.76.0](https://github.com/sanity-io/sanity/compare/v3.75.1...v3.76.0) (2025-02-18)
+
+
+### Bug Fixes
+
+* **core:** add permission limitation for adding new version in the release details search ([#8637](https://github.com/sanity-io/sanity/issues/8637)) ([4ec1bc8](https://github.com/sanity-io/sanity/commit/4ec1bc8b67f299e01a8b98f0bc515a48b60a9529))
+* **core:** add permission limitation for create release ([#8623](https://github.com/sanity-io/sanity/issues/8623)) ([e4188c3](https://github.com/sanity-io/sanity/commit/e4188c3ce64fffd8d90098e4b5a992bcafefdf4e))
+* **core:** add permissions limitation to document actions in releases ([#8603](https://github.com/sanity-io/sanity/issues/8603)) ([4750d9c](https://github.com/sanity-io/sanity/commit/4750d9c0fbeb9cd94647d3865e96e2e5146947c7))
+* **core:** change publish now release action wording ([#8636](https://github.com/sanity-io/sanity/issues/8636)) ([df45eef](https://github.com/sanity-io/sanity/commit/df45eef913676cb3c85fe310fbb3784a934067bb))
+* **core:** clarify 'discard version' message for better understanding ([#8683](https://github.com/sanity-io/sanity/issues/8683)) ([bc9ec77](https://github.com/sanity-io/sanity/commit/bc9ec777b3799bbd950b7e4a858446aa0d7206c0))
+* **core:** create new doc button tooltip updated for when perspective is published and not a release ([#8616](https://github.com/sanity-io/sanity/issues/8616)) ([de19f20](https://github.com/sanity-io/sanity/commit/de19f202c2eea677ff000e3b5f7635215c95ecb6))
+* **core:** fix resolveLiveEdit name ([#8658](https://github.com/sanity-io/sanity/issues/8658)) ([d34dca8](https://github.com/sanity-io/sanity/commit/d34dca8046850aa8048000721318bd8f36764c9e))
+* **core:** in release documents rows only show errors count ([#8628](https://github.com/sanity-io/sanity/issues/8628)) ([d2cd442](https://github.com/sanity-io/sanity/commit/d2cd442c4d4d3f56ef9d4c0e830db936977387e8))
+* **core:** infer archive, unarchive and publish from release translog ([#8679](https://github.com/sanity-io/sanity/issues/8679)) ([01047a9](https://github.com/sanity-io/sanity/commit/01047a9a9cac326b4ea3f003728488fd670129b0))
+* **core:** releases edit events error when calculating differences ([#8632](https://github.com/sanity-io/sanity/issues/8632)) ([926b8ba](https://github.com/sanity-io/sanity/commit/926b8ba98713d56c3b168c4f29c627a6296ae761))
+* **core:** remove activity panel borders ([#8680](https://github.com/sanity-io/sanity/issues/8680)) ([82c995d](https://github.com/sanity-io/sanity/commit/82c995d5ada7f3a1c1df4688c414affc96ac63e8))
+* **core:** simplify pin release  button on release detail screen ([#8635](https://github.com/sanity-io/sanity/issues/8635)) ([5054ee3](https://github.com/sanity-io/sanity/commit/5054ee36ac01ecc04e10b0abb6747632e0a66a55))
+* **core:** update permissions on release actions ([#8607](https://github.com/sanity-io/sanity/issues/8607)) ([d435926](https://github.com/sanity-io/sanity/commit/d43592679b186c16ad76c03328068eda378738e1))
+* **core:** update releases permissions for main release action ([#8588](https://github.com/sanity-io/sanity/issues/8588)) ([b64c8aa](https://github.com/sanity-io/sanity/commit/b64c8aa6bed12ba44f7729851225686c2978c6b4))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.7 ([#8604](https://github.com/sanity-io/sanity/issues/8604)) ([2d4b11d](https://github.com/sanity-io/sanity/commit/2d4b11d834e1f21c7a42516538e971dd89977313))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.8 ([#8670](https://github.com/sanity-io/sanity/issues/8670)) ([b3b9e51](https://github.com/sanity-io/sanity/commit/b3b9e511a38814fe2d9819358121c38f2605bad5))
+* **deps:** update dependency @portabletext/editor to ^1.33.0 ([#8596](https://github.com/sanity-io/sanity/issues/8596)) ([54700f1](https://github.com/sanity-io/sanity/commit/54700f1ad3187fcd2d2f6bf4eff765d4e2e15891))
+* **deps:** update dependency @portabletext/editor to ^1.33.1 ([#8606](https://github.com/sanity-io/sanity/issues/8606)) ([ec0932a](https://github.com/sanity-io/sanity/commit/ec0932ad61c778d096535fcca7a18303cbb7b3c4))
+* **deps:** update dependency @portabletext/editor to ^1.33.2 ([#8615](https://github.com/sanity-io/sanity/issues/8615)) ([c89d581](https://github.com/sanity-io/sanity/commit/c89d58128b934a1bd3294e01331c3367e21f4891))
+* **deps:** update dependency @portabletext/editor to ^1.33.3 ([#8627](https://github.com/sanity-io/sanity/issues/8627)) ([d523304](https://github.com/sanity-io/sanity/commit/d5233043aa39f6162c6dc0037d03a3188b9f2952))
+* **deps:** update dependency @portabletext/editor to ^1.33.4 ([#8642](https://github.com/sanity-io/sanity/issues/8642)) ([9d70e1e](https://github.com/sanity-io/sanity/commit/9d70e1e36ae087f90d9745af815f5b484c840ba9))
+* **deps:** update dependency @portabletext/editor to ^1.33.5 ([#8660](https://github.com/sanity-io/sanity/issues/8660)) ([6d82661](https://github.com/sanity-io/sanity/commit/6d8266128e3f7bab3fda70b785fc5db8ddab9bd9))
+* **deps:** update dependency @portabletext/editor to ^1.33.6 ([#8671](https://github.com/sanity-io/sanity/issues/8671)) ([e28eacb](https://github.com/sanity-io/sanity/commit/e28eacb83ee2a40645ecf75a0e471ea0e1cee02d))
+* **deps:** update dependency @portabletext/editor to ^1.34.0 ([#8687](https://github.com/sanity-io/sanity/issues/8687)) ([6d008a7](https://github.com/sanity-io/sanity/commit/6d008a7120a698d01118ec739fcd8aecbabd02cb))
+* **deps:** update dependency @sanity/client to ^6.28.0 ([#8599](https://github.com/sanity-io/sanity/issues/8599)) ([36bd70d](https://github.com/sanity-io/sanity/commit/36bd70de04e19ea9be8c17ad115fb21e9aef908e))
+* **deps:** update dependency @sanity/client to ^6.28.0 ([#8653](https://github.com/sanity-io/sanity/issues/8653)) ([8dc9171](https://github.com/sanity-io/sanity/commit/8dc91716f350cc73bd4ece13d50e355b8e690cb6))
+* **deps:** update dependency @sanity/icons to ^3.6.0 ([#8634](https://github.com/sanity-io/sanity/issues/8634)) ([b6e9d4c](https://github.com/sanity-io/sanity/commit/b6e9d4c11e24a29ce9538386795a1ba68caa6812))
+* **deps:** update dependency @sanity/insert-menu to v1.1.2 ([#8668](https://github.com/sanity-io/sanity/issues/8668)) ([809d262](https://github.com/sanity-io/sanity/commit/809d2620757e901cfef07943b1cc0994b6e60e1b))
+* **deps:** update dependency @sanity/presentation-comlink to ^1.0.7 ([#8669](https://github.com/sanity-io/sanity/issues/8669)) ([d2127d2](https://github.com/sanity-io/sanity/commit/d2127d2a4075d2c8779674ea0d57ac8e4b949269))
+* **deps:** update dependency @sanity/ui to ^2.13.3 ([#8631](https://github.com/sanity-io/sanity/issues/8631)) ([635149b](https://github.com/sanity-io/sanity/commit/635149b340ff6eb0d56c7f69023a6ccdc8a7ec57))
+* **deps:** update dependency @sanity/ui to ^2.13.4 ([#8672](https://github.com/sanity-io/sanity/issues/8672)) ([d57a94f](https://github.com/sanity-io/sanity/commit/d57a94f9ccf407883dad7faab620cce58774de46))
+* **deps:** update dependency @sanity/ui to ^2.13.5 ([#8690](https://github.com/sanity-io/sanity/issues/8690)) ([4869aba](https://github.com/sanity-io/sanity/commit/4869aba5870177185263ab3586830aabc383822c))
+* **deps:** update dependency react-rx to ^4.1.20 ([#8662](https://github.com/sanity-io/sanity/issues/8662)) ([9340db1](https://github.com/sanity-io/sanity/commit/9340db1bb1058b71ad57b1f4fafc85cf15cff1b9))
+* **deps:** Update dev-non-major ([#8582](https://github.com/sanity-io/sanity/issues/8582)) ([dc897c0](https://github.com/sanity-io/sanity/commit/dc897c0075f5c26f78e9fdbfed6081a7f52cc30d))
+* **deps:** Update dev-non-major ([#8608](https://github.com/sanity-io/sanity/issues/8608)) ([4fd8960](https://github.com/sanity-io/sanity/commit/4fd8960a655fb2a7fd2c27a8ebe2987c31bce143))
+* **deps:** Update dev-non-major ([#8667](https://github.com/sanity-io/sanity/issues/8667)) ([5b0f4c2](https://github.com/sanity-io/sanity/commit/5b0f4c22880d6eca8835a4602d278624aedb0ba1))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#8657](https://github.com/sanity-io/sanity/issues/8657)) ([1067214](https://github.com/sanity-io/sanity/commit/1067214d8c97b6393c3ff5ba91884e4247aede19))
+* **docs:** replace `previewDrafts` with `drafts` ([#8601](https://github.com/sanity-io/sanity/issues/8601)) ([240b210](https://github.com/sanity-io/sanity/commit/240b21039a2ad8abb9e7482921e7c1f8bbb264a3))
+* release action dialog fixes; release overview style  ([#8619](https://github.com/sanity-io/sanity/issues/8619)) ([6070f1b](https://github.com/sanity-io/sanity/commit/6070f1b7806b70bd193fd8633ba716c91513f2f8))
+* **releases:** handling cases where no create release permissions whilst at limit of release in project ([#8644](https://github.com/sanity-io/sanity/issues/8644)) ([37846d5](https://github.com/sanity-io/sanity/commit/37846d50c26a074f8903075b62e717cb841f50ed))
+* **releases:** improvements to archive release detail ([#8597](https://github.com/sanity-io/sanity/issues/8597)) ([3a9727b](https://github.com/sanity-io/sanity/commit/3a9727b32326e200cbb1811b112bbeae3d5358a3))
+* **sanity:** allow patching via `handleChange` in Create-linked documents ([#8691](https://github.com/sanity-io/sanity/issues/8691)) ([716b2ea](https://github.com/sanity-io/sanity/commit/716b2ea4ed97bc0fc6dab9957ebb8f441c1ae062))
+* **sanity:** apply recursion fix to `deriveSearchWeightsFromType2024` ([21010c6](https://github.com/sanity-io/sanity/commit/21010c6af1be83e9bc0e34d27806d4b9d522187b))
+* **structure:** avoid spreading `key` into props, pass explicitly ([#8580](https://github.com/sanity-io/sanity/issues/8580)) ([8ad369b](https://github.com/sanity-io/sanity/commit/8ad369b81790485cafe5fe1fa1c786cfb5abf6f8))
+* **structure:** don't modify EMPTY_PARAMS object ([#8605](https://github.com/sanity-io/sanity/issues/8605)) ([9454c46](https://github.com/sanity-io/sanity/commit/9454c464af70e484fb838a720155b2bbe7af8182))
+
+
+### Features
+
+* **cli:** select org and add to sanity.cli.ts on initialization ([#8573](https://github.com/sanity-io/sanity/issues/8573)) ([12743ad](https://github.com/sanity-io/sanity/commit/12743ad805ec3c992e86a8994bb1da2706ab44fa))
+* **core:** add default bold/italic markdown shortcuts to PTE ([#8602](https://github.com/sanity-io/sanity/issues/8602)) ([b360e18](https://github.com/sanity-io/sanity/commit/b360e1821c9c82f4fe86970a5b32b24603cf5ce4))
+* **sanity:** add granular release error icons to global switcher ([#8661](https://github.com/sanity-io/sanity/issues/8661)) ([3789c98](https://github.com/sanity-io/sanity/commit/3789c98eb28915ab4481fbd71c7e90287f720637))
+* **sanity:** remove strengthen-on-publish fields when creating a version of a document ([fb9df5d](https://github.com/sanity-io/sanity/commit/fb9df5d0b59249951af1eacb17a2931fa7961749))
+* **sanity:** skip strengthen-on-publish process for documents inside a release ([5608954](https://github.com/sanity-io/sanity/commit/5608954e11ac8727e3dc46430518d65de18399d1))
+* **typegen:** `sanity typegen` Whitespace Handling in Query Output ([#8648](https://github.com/sanity-io/sanity/issues/8648)) ([df7bf58](https://github.com/sanity-io/sanity/commit/df7bf5841309e94ae5037a69bd17004d5c14ce3d))
+* **typegen:** glob for files synchronously for deterministic result ([2cacc01](https://github.com/sanity-io/sanity/commit/2cacc0163df54fa47ebcf7f5046640e056722fed))
+* updating document count for release overview cells ([#8576](https://github.com/sanity-io/sanity/issues/8576)) ([2862dec](https://github.com/sanity-io/sanity/commit/2862deca63fb6b11ca3c95688f513ce32746e89b))
+
+
+
+## [3.75.1](https://github.com/sanity-io/sanity/compare/v3.75.0...v3.75.1) (2025-02-15)
+
+
+### Bug Fixes
+
+* bump sanity ui ([#8649](https://github.com/sanity-io/sanity/issues/8649)) ([74a25dd](https://github.com/sanity-io/sanity/commit/74a25dd8622cba639fbcb97d5722f568e35d8d98))
+
+
+
+# [3.75.0](https://github.com/sanity-io/sanity/compare/v3.74.1...v3.75.0) (2025-02-11)
+
+
+### Bug Fixes
+
+* add missing tags for listen queries ([#8595](https://github.com/sanity-io/sanity/issues/8595)) ([e9d9b1f](https://github.com/sanity-io/sanity/commit/e9d9b1f80a4b8e1929fa51998ddead077c74d586))
+* **CI:** update playwright cache on CI consistently ([#8559](https://github.com/sanity-io/sanity/issues/8559)) ([f660657](https://github.com/sanity-io/sanity/commit/f66065723a73b87a4bda548b1eec68225e7eab70))
+* **core:** add breathing space for release create button in picker ([#8546](https://github.com/sanity-io/sanity/issues/8546)) ([310c523](https://github.com/sanity-io/sanity/commit/310c523e25601e1c52c48e46290ff961839525ea))
+* **core:** adds proper check for vite dev server stop ([#8584](https://github.com/sanity-io/sanity/issues/8584)) ([b229295](https://github.com/sanity-io/sanity/commit/b229295f259d28e2e99227bb745a2e3645add324))
+* **core:** incorrect status indicator color for undecided releases ([#8571](https://github.com/sanity-io/sanity/issues/8571)) ([19d1bc3](https://github.com/sanity-io/sanity/commit/19d1bc30da2f335c0bedf43b983aeec03b6f5413))
+* **core:** removes deprecated `textSearch` strategy ([#8524](https://github.com/sanity-io/sanity/issues/8524)) ([bcef9d7](https://github.com/sanity-io/sanity/commit/bcef9d788d21d1cd20ee56efddaa85c8147debcd))
+* **core:** reset all releaseDetail states when switching the release ([#8530](https://github.com/sanity-io/sanity/issues/8530)) ([8e033dc](https://github.com/sanity-io/sanity/commit/8e033dca81f65de4ec3927689fbb86423acf37e7))
+* **core:** use `MarkdownPlugin` instead of `behaviors={[...]}` ([#8473](https://github.com/sanity-io/sanity/issues/8473)) ([a91c165](https://github.com/sanity-io/sanity/commit/a91c1657cf82d700c706fd9abb79e144b3473854))
+* **core:** use `vX` for `observeFields` when querying for version docs ([#8509](https://github.com/sanity-io/sanity/issues/8509)) ([d582716](https://github.com/sanity-io/sanity/commit/d582716dae5bb05ca17064c5b3f717b45c7178a4))
+* **core:** use preview value title when unpublishing or discarding a document ([#8544](https://github.com/sanity-io/sanity/issues/8544)) ([d64c159](https://github.com/sanity-io/sanity/commit/d64c15924853d983942bf0662d3afbf083d5e1e2))
+* **deps:** swap `sanity-diff-patch` with `@sanity/diff-patch` ([#8503](https://github.com/sanity-io/sanity/issues/8503)) ([9c937d1](https://github.com/sanity-io/sanity/commit/9c937d19ba2cd5eaf800862737f0e914c85279c0))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.6 ([#8507](https://github.com/sanity-io/sanity/issues/8507)) ([0e1afe6](https://github.com/sanity-io/sanity/commit/0e1afe61a89635b1aafb35625da53da4a523e0ce))
+* **deps:** update dependency @portabletext/editor to ^1.30.3 ([#8508](https://github.com/sanity-io/sanity/issues/8508)) ([a6bd3af](https://github.com/sanity-io/sanity/commit/a6bd3afeb3ae3a4322afc7d243ad954795bcfcab))
+* **deps:** update dependency @portabletext/editor to ^1.30.4 ([#8512](https://github.com/sanity-io/sanity/issues/8512)) ([4e263d4](https://github.com/sanity-io/sanity/commit/4e263d4d5f6a40098ed1c3adbfc0eab915a606b0))
+* **deps:** update dependency @portabletext/editor to ^1.30.6 ([#8526](https://github.com/sanity-io/sanity/issues/8526)) ([8de1591](https://github.com/sanity-io/sanity/commit/8de1591a7576174750243cdd8ce1ecd8b788781f))
+* **deps:** update dependency @portabletext/editor to ^1.31.0 ([#8540](https://github.com/sanity-io/sanity/issues/8540)) ([1ffa00a](https://github.com/sanity-io/sanity/commit/1ffa00a8576eec2db71ce81134fb3c8261acda7f))
+* **deps:** update dependency @portabletext/editor to ^1.31.2 ([#8556](https://github.com/sanity-io/sanity/issues/8556)) ([927ee85](https://github.com/sanity-io/sanity/commit/927ee85044bfcd91b4fb23a56333e661003e9aee))
+* **deps:** update dependency @portabletext/editor to ^1.32.0 ([#8575](https://github.com/sanity-io/sanity/issues/8575)) ([d517632](https://github.com/sanity-io/sanity/commit/d517632e747ed3bec3c6d21a52f50b275ae37099))
+* **deps:** update dependency @sanity/insert-menu to v1.1.0 ([#8538](https://github.com/sanity-io/sanity/issues/8538)) ([4fb557b](https://github.com/sanity-io/sanity/commit/4fb557bd83eb73a19c43156b861eaa86d4416c08))
+* **deps:** update dependency @sanity/insert-menu to v1.1.1 ([#8560](https://github.com/sanity-io/sanity/issues/8560)) ([b87e110](https://github.com/sanity-io/sanity/commit/b87e1103060baf47c2ed0b208984fd07236268d5))
+* **deps:** update dependency @sanity/presentation-comlink to ^1.0.5 ([#8541](https://github.com/sanity-io/sanity/issues/8541)) ([8f00881](https://github.com/sanity-io/sanity/commit/8f008812dcd315dcf6eefe8e0c897fce2b8dbd4c))
+* **deps:** update dependency @sanity/presentation-comlink to ^1.0.6 ([#8561](https://github.com/sanity-io/sanity/issues/8561)) ([2908687](https://github.com/sanity-io/sanity/commit/29086875a7aaa6d5f15598c24d637b0af8c3a472))
+* **deps:** update dependency @sanity/ui to ^2.12.1 ([#8529](https://github.com/sanity-io/sanity/issues/8529)) ([2634e16](https://github.com/sanity-io/sanity/commit/2634e1676cc492dc8c9ee2cd6a8287e0d41e76c4))
+* **deps:** update dependency @sanity/ui to ^2.12.2 ([#8542](https://github.com/sanity-io/sanity/issues/8542)) ([b68186a](https://github.com/sanity-io/sanity/commit/b68186a12c7e667ee1061441f7fe1cb77a1f2a04))
+* **deps:** update dependency @sanity/ui to ^2.12.3 ([#8565](https://github.com/sanity-io/sanity/issues/8565)) ([7ee74d6](https://github.com/sanity-io/sanity/commit/7ee74d621fb400342727384270f45d540e36d460))
+* **deps:** update dependency react-rx to ^4.1.19 ([#8566](https://github.com/sanity-io/sanity/issues/8566)) ([3ab2271](https://github.com/sanity-io/sanity/commit/3ab2271e4fed1e76246423fde6f2dd5332ce0514))
+* **deps:** Update dev-non-major ([#8563](https://github.com/sanity-io/sanity/issues/8563)) ([b1b5d75](https://github.com/sanity-io/sanity/commit/b1b5d75f55d9f3193173714be57520b7083bfc8a))
+* **deps:** update plugin-mux dependency in test and studio-e2-testing ([#8520](https://github.com/sanity-io/sanity/issues/8520)) ([b3a95e2](https://github.com/sanity-io/sanity/commit/b3a95e2b46ceb6d6fde8d732237d4e0b4cd3afa0))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#8562](https://github.com/sanity-io/sanity/issues/8562)) ([7fd0330](https://github.com/sanity-io/sanity/commit/7fd0330389d052079620fcc356eeea253bb13265))
+* ensures comments permission check only requests project memberships once ([#8513](https://github.com/sanity-io/sanity/issues/8513)) ([966e97a](https://github.com/sanity-io/sanity/commit/966e97a5f2405e8c9e9bceeb64b2249151d7a35b))
+* handle `motion()` deprecation warning ([#8536](https://github.com/sanity-io/sanity/issues/8536)) ([7ea2eb3](https://github.com/sanity-io/sanity/commit/7ea2eb36d7137918bcdcc1feb82fdf874d95995d))
+* **releases:** change usage of versionsOf to versionOf ([#8522](https://github.com/sanity-io/sanity/issues/8522)) ([fc50316](https://github.com/sanity-io/sanity/commit/fc5031651d2a2e8ea3dc6d58c90eaf08c10b366a))
+* **releases:** timezone fixes in content releases ([#8514](https://github.com/sanity-io/sanity/issues/8514)) ([79312c7](https://github.com/sanity-io/sanity/commit/79312c74160f8359b8ae663801d4553ee31914cf))
+* **sanity:** don't show Live edit badge for versions ([#8593](https://github.com/sanity-io/sanity/issues/8593)) ([df6bcdb](https://github.com/sanity-io/sanity/commit/df6bcdb40d743d7657e825d898941557baa6fdfe))
+* **sanity:** use raw as default perspective ([#8586](https://github.com/sanity-io/sanity/issues/8586)) ([4371559](https://github.com/sanity-io/sanity/commit/43715598eff08f27b8f56e1f5cc7fad7f0884e29))
+
+
+### Features
+
+* **cli:** add non-studio app template ([#8394](https://github.com/sanity-io/sanity/issues/8394)) ([0d4e40d](https://github.com/sanity-io/sanity/commit/0d4e40d94a14c109067f82161867be98fa1d7717))
+* creating new scheduled release defaults time to start of next hour ([#8577](https://github.com/sanity-io/sanity/issues/8577)) ([224a4e5](https://github.com/sanity-io/sanity/commit/224a4e5a1987aa6c2728c31bbef6c6605918637c))
+* **releases:** using publishedAt to present publish time for past releases ([#8553](https://github.com/sanity-io/sanity/issues/8553)) ([595b8b8](https://github.com/sanity-io/sanity/commit/595b8b845b03d4b68216aad5b72f5ba6c181ddb4))
+* **sanity:** add Core UI bridge script ([#8523](https://github.com/sanity-io/sanity/issues/8523)) ([8e1ed89](https://github.com/sanity-io/sanity/commit/8e1ed89aef01f79709939e44f8c274cca6b093d6))
+* **sanity:** add error count to releases store ([7ee17ee](https://github.com/sanity-io/sanity/commit/7ee17ee1afaf24cceae7b544171b116de73f082e))
+* **sanity:** add release error details to `ReleaseDashboardDetails` ([e728372](https://github.com/sanity-io/sanity/commit/e7283723cf8d49692f0a4811467f54861ae3a5ca))
+* **sanity:** add release error indicators to `ReleasesOverview` ([a346f6d](https://github.com/sanity-io/sanity/commit/a346f6da69ef75d2b10cd9337207db7d2878ee5c))
+* **sanity:** add release tool error indicator ([2fa184c](https://github.com/sanity-io/sanity/commit/2fa184cf2c29812ff9061a207bbf0d86d6c418ab))
+* **sanity:** load release document `error` field ([d9c341e](https://github.com/sanity-io/sanity/commit/d9c341e20dde0231f683a523cf593284ac95b4d7))
+
+
+
+## [3.74.1](https://github.com/sanity-io/sanity/compare/v3.74.0...v3.74.1) (2025-02-05)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @portabletext/editor to ^1.30.3 ([#8508](https://github.com/sanity-io/sanity/issues/8508)) ([b92ed54](https://github.com/sanity-io/sanity/commit/b92ed54ad6e87198d4e89e28eee3c4f338d6e66c))
+
+
+
+# [3.74.0](https://github.com/sanity-io/sanity/compare/v3.73.0...v3.74.0) (2025-02-04)
+
+
+### Bug Fixes
+
+* **core:** show accurate history for live-edit documents ([#8497](https://github.com/sanity-io/sanity/issues/8497)) ([ccb2a4f](https://github.com/sanity-io/sanity/commit/ccb2a4f9b3c94cb59247b586c0b1be15909e911f))
+
+
+### Features
+
+* content releases ([#8454](https://github.com/sanity-io/sanity/issues/8454)) ([e485525](https://github.com/sanity-io/sanity/commit/e485525cbc800c1ea0fa7de2b38c1feec6d95a83))
+
+
+
+# [3.73.0](https://github.com/sanity-io/sanity/compare/v3.72.1...v3.73.0) (2025-02-04)
+
+
+### Bug Fixes
+
+* **cli:** apply write token ([#8450](https://github.com/sanity-io/sanity/issues/8450)) ([11dff40](https://github.com/sanity-io/sanity/commit/11dff40c067a61a35b174ca060619346e17e8ef4))
+* **cli:** fix issue where core sanity types were appearing in the validation for schemas and documents ([#8445](https://github.com/sanity-io/sanity/issues/8445)) ([81a3bc6](https://github.com/sanity-io/sanity/commit/81a3bc6c167d92e376d48b274531e44eef5c7bf0))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.4 ([#8446](https://github.com/sanity-io/sanity/issues/8446)) ([29a712c](https://github.com/sanity-io/sanity/commit/29a712c9bce63985f2bcd46db7eecea95691535f))
+* **deps:** update dependency @portabletext/editor to ^1.28.0 ([#8448](https://github.com/sanity-io/sanity/issues/8448)) ([8e7c346](https://github.com/sanity-io/sanity/commit/8e7c346edb2e914a1123a1a7e0532e323fe0b7ca))
+* **deps:** update dependency @portabletext/editor to ^1.30.1 ([#8479](https://github.com/sanity-io/sanity/issues/8479)) ([b6ebfb7](https://github.com/sanity-io/sanity/commit/b6ebfb70e0792ae2dd04b506b864f18b1bd645a0))
+* **deps:** update dependency @portabletext/editor to ^1.30.2 ([#8485](https://github.com/sanity-io/sanity/issues/8485)) ([f4600d7](https://github.com/sanity-io/sanity/commit/f4600d760bdcb71497fb91de736437b734762395))
+* **deps:** update dependency @sanity/ui to ^2.11.7 ([#8434](https://github.com/sanity-io/sanity/issues/8434)) ([ac0f20c](https://github.com/sanity-io/sanity/commit/ac0f20c64583569d5475cd2a1a9907bf512ed39e))
+* **deps:** update dependency @sanity/ui to ^2.11.8 ([#8488](https://github.com/sanity-io/sanity/issues/8488)) ([5cf7afc](https://github.com/sanity-io/sanity/commit/5cf7afcee721733d2a4da59e89010fc6aa1632e7))
+* **deps:** update dependency groq-js to ^1.15.0 ([#8481](https://github.com/sanity-io/sanity/issues/8481)) ([763561c](https://github.com/sanity-io/sanity/commit/763561cab44dc2be604382fc7fa7cd734aa54a09))
+* **deps:** update dependency react-rx to ^4.1.18 ([#8487](https://github.com/sanity-io/sanity/issues/8487)) ([0e51cbe](https://github.com/sanity-io/sanity/commit/0e51cbe9aeb277e99f5cbd88864c9f7944414688))
+* **deps:** Update dev-non-major ([#8461](https://github.com/sanity-io/sanity/issues/8461)) ([53b8009](https://github.com/sanity-io/sanity/commit/53b80094c6dbf961910f72070cc2d3337e8adddf))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#8477](https://github.com/sanity-io/sanity/issues/8477)) ([e5c8951](https://github.com/sanity-io/sanity/commit/e5c895180159f6ad5091abb24d68dc7e3b834f7e))
+* **migrate:** always use raw perspective for migrations ([#8467](https://github.com/sanity-io/sanity/issues/8467)) ([c317461](https://github.com/sanity-io/sanity/commit/c317461db3210a06054ad794b83f74ad347975f2))
+* **presentation:** use live content API for loaders ([#8429](https://github.com/sanity-io/sanity/issues/8429)) ([86e5af8](https://github.com/sanity-io/sanity/commit/86e5af88b09ec2d2f671948c2f10459aab313ec0))
+* set strictRequires to auto when building auto updating studios ([#8367](https://github.com/sanity-io/sanity/issues/8367)) ([01a9cd9](https://github.com/sanity-io/sanity/commit/01a9cd91ab15a1fdf1a8284da8a3969492afc68f))
+
+
+
+## [3.72.1](https://github.com/sanity-io/sanity/compare/v3.72.0...v3.72.1) (2025-01-28)
+
+
+### Bug Fixes
+
+* remove references array from GraphQL union references generation ([#8436](https://github.com/sanity-io/sanity/issues/8436)) ([62fcc43](https://github.com/sanity-io/sanity/commit/62fcc431ad61d77fb7d9321006a36c9726797b10))
+
+
+
+# [3.72.0](https://github.com/sanity-io/sanity/compare/v3.71.2...v3.72.0) (2025-01-28)
+
+
+### Bug Fixes
+
+* **@sanity/schema:** allow Cross Dataset References in Portable Text blocks ([23b2b6a](https://github.com/sanity-io/sanity/commit/23b2b6aab540acbe675ff2170a9d3ded6c2fdaa2))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.2 ([#8360](https://github.com/sanity-io/sanity/issues/8360)) ([d924950](https://github.com/sanity-io/sanity/commit/d924950a28599b85f238f6ac0b95aa4b53d32d62))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.3 ([#8399](https://github.com/sanity-io/sanity/issues/8399)) ([6780bcb](https://github.com/sanity-io/sanity/commit/6780bcb45a8a4bbe05f9c48d353b52de5372c0e5))
+* **deps:** update dependency @portabletext/editor to ^1.24.0 ([#8337](https://github.com/sanity-io/sanity/issues/8337)) ([4a9a29a](https://github.com/sanity-io/sanity/commit/4a9a29a8f1e9b36fd111c996b9bc2c73632fe82e))
+* **deps:** update dependency @portabletext/editor to ^1.25.0 ([#8368](https://github.com/sanity-io/sanity/issues/8368)) ([c367854](https://github.com/sanity-io/sanity/commit/c367854f80d6e14c4090f2d0eccfa616f96f9ada))
+* **deps:** update dependency @portabletext/editor to ^1.26.0 ([#8386](https://github.com/sanity-io/sanity/issues/8386)) ([be47ff9](https://github.com/sanity-io/sanity/commit/be47ff9a748848e411d0bc56404603ea5c8d2892))
+* **deps:** update dependency @portabletext/editor to ^1.26.2 ([#8400](https://github.com/sanity-io/sanity/issues/8400)) ([287dfa4](https://github.com/sanity-io/sanity/commit/287dfa4c4e48f99dfe8ba32b378af4a2c973517b))
+* **deps:** update dependency @portabletext/editor to ^1.26.3 ([#8423](https://github.com/sanity-io/sanity/issues/8423)) ([0fe8d70](https://github.com/sanity-io/sanity/commit/0fe8d70af5ba85a55af51f5bca6a9c4cd3496791))
+* **deps:** update dependency @sanity/client to ^6.27.0 ([#8357](https://github.com/sanity-io/sanity/issues/8357)) ([7f934e5](https://github.com/sanity-io/sanity/commit/7f934e5315c156386f0fa971312194dc31e0bb50))
+* **deps:** update dependency @sanity/client to ^6.27.1 ([#8376](https://github.com/sanity-io/sanity/issues/8376)) ([7eebb60](https://github.com/sanity-io/sanity/commit/7eebb60baf542aaacb8ea3571656a3352ba21f42))
+* **deps:** update dependency @sanity/client to ^6.27.2 ([#8426](https://github.com/sanity-io/sanity/issues/8426)) ([a2df043](https://github.com/sanity-io/sanity/commit/a2df0435892ed89a7c5ecb919e416c14f7168d25))
+* **deps:** update dependency @sanity/insert-menu to v1.0.20 ([#8353](https://github.com/sanity-io/sanity/issues/8353)) ([7418d2e](https://github.com/sanity-io/sanity/commit/7418d2eaefc2d6588b72e195dc5bfbfaa55e6d54))
+* **deps:** update dependency @sanity/presentation-comlink to ^1.0.2 ([#8354](https://github.com/sanity-io/sanity/issues/8354)) ([1828497](https://github.com/sanity-io/sanity/commit/18284977545b61d6f66ad3233e8b58dcfe25273b))
+* **deps:** update dependency @sanity/presentation-comlink to ^1.0.3 ([#8377](https://github.com/sanity-io/sanity/issues/8377)) ([3dc4058](https://github.com/sanity-io/sanity/commit/3dc4058567c022262ea2d1667c6b2a48230a11b7))
+* **deps:** update dependency @sanity/presentation-comlink to ^1.0.4 ([#8428](https://github.com/sanity-io/sanity/issues/8428)) ([24a74e9](https://github.com/sanity-io/sanity/commit/24a74e994d50167de3126594ab52406c7ec214e6))
+* **deps:** update dependency @sanity/preview-url-secret to ^2.1.1 ([#8356](https://github.com/sanity-io/sanity/issues/8356)) ([eb13847](https://github.com/sanity-io/sanity/commit/eb13847c9e21d4af4310884d2c80794ee4258fe3))
+* **deps:** update dependency @sanity/preview-url-secret to ^2.1.2 ([#8378](https://github.com/sanity-io/sanity/issues/8378)) ([6019bb7](https://github.com/sanity-io/sanity/commit/6019bb7f47b7c8beac0ff3d84a450a5bfe7868c9))
+* **deps:** update dependency @sanity/preview-url-secret to ^2.1.3 ([#8385](https://github.com/sanity-io/sanity/issues/8385)) ([ef41c78](https://github.com/sanity-io/sanity/commit/ef41c786668f475f3b74c88e22a7542b5326aa55))
+* **deps:** update dependency @sanity/preview-url-secret to ^2.1.4 ([#8431](https://github.com/sanity-io/sanity/issues/8431)) ([b8497c3](https://github.com/sanity-io/sanity/commit/b8497c330ad98accf527e3a04e2fd3a19cbc00af))
+* **deps:** update dependency @sanity/template-validator to ^2.4.0 ([#8390](https://github.com/sanity-io/sanity/issues/8390)) ([645db7b](https://github.com/sanity-io/sanity/commit/645db7b6ac1f7b730ca33839dead43162312188f))
+* **deps:** update dependency @sanity/ui to ^2.11.4 ([#8334](https://github.com/sanity-io/sanity/issues/8334)) ([576bf44](https://github.com/sanity-io/sanity/commit/576bf440e608396207cbf7c30ab04f24885c9d95))
+* **deps:** update dependency @sanity/ui to ^2.11.5 ([#8417](https://github.com/sanity-io/sanity/issues/8417)) ([2d28402](https://github.com/sanity-io/sanity/commit/2d28402727d1a43deaa3879da6ab6b1d5ca6eb81))
+* **deps:** update dependency @sanity/ui to ^2.11.6 ([#8420](https://github.com/sanity-io/sanity/issues/8420)) ([1ebb974](https://github.com/sanity-io/sanity/commit/1ebb9740f1e2b5e5cc532ac40f6476f9996a8bc2))
+* **deps:** update dependency get-it to ^8.6.7 ([#8424](https://github.com/sanity-io/sanity/issues/8424)) ([1f0777e](https://github.com/sanity-io/sanity/commit/1f0777e00325b392932cc00fb54c8162a9641cd1))
+* **deps:** update dependency react-rx to ^4.1.17 ([#8416](https://github.com/sanity-io/sanity/issues/8416)) ([17911eb](https://github.com/sanity-io/sanity/commit/17911eba52725a18bbff4248b5ea99d162a169ab))
+* **deps:** Update dev-non-major ([#8430](https://github.com/sanity-io/sanity/issues/8430)) ([2092b7e](https://github.com/sanity-io/sanity/commit/2092b7e5c9ce37edf72bf384c64329aa3579aaf6))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#8414](https://github.com/sanity-io/sanity/issues/8414)) ([bd53c3a](https://github.com/sanity-io/sanity/commit/bd53c3a399dc360b2b02169be08d0659cf5205c6))
+* **graphql:** add custom logic for reference unions ([#8350](https://github.com/sanity-io/sanity/issues/8350)) ([cdeeae6](https://github.com/sanity-io/sanity/commit/cdeeae693aa73dba5f5f42dc928d8b16414f78ff))
+* **presentation:** support `pt::text` in live queries ([#8380](https://github.com/sanity-io/sanity/issues/8380)) ([691aad1](https://github.com/sanity-io/sanity/commit/691aad1ee71480f7b70854b3a579741977c9efa0))
+* remove `process.env.SANITY_STUDIO_PRESENTATION_ENABLE_LIVE_DRAFT_EVENTS` ([#8401](https://github.com/sanity-io/sanity/issues/8401)) ([68b7fa3](https://github.com/sanity-io/sanity/commit/68b7fa37d35f21fb7fd7e8c121a358c5237373bc))
+* **structure:** do not set history inspector height to 0 ([#8421](https://github.com/sanity-io/sanity/issues/8421)) ([abb0b2e](https://github.com/sanity-io/sanity/commit/abb0b2e09824cb7081a6d7b5d02f14cedc9cb513))
+
+
+### Features
+
+* **core:** add unstable `useObserveDocument` hook ([#8407](https://github.com/sanity-io/sanity/issues/8407)) ([b693819](https://github.com/sanity-io/sanity/commit/b693819afeeeea3d2d5c3d633562a7604d0843c8))
+* support for sticky params and intent operations ([#8256](https://github.com/sanity-io/sanity/issues/8256)) ([1269760](https://github.com/sanity-io/sanity/commit/12697602c9a0849076c2bb6867c1e07e5ec50b5c))
+* **test-studio:** add Cross Dataset Reference error replication ([4eb7fa1](https://github.com/sanity-io/sanity/commit/4eb7fa17ba200590e2be2363755c99d508c86c12))
+
+
+
+## [3.71.2](https://github.com/sanity-io/sanity/compare/v3.71.1...v3.71.2) (2025-01-23)
+
+
+### Bug Fixes
+
+* **presentation:** perspective switching regression ([#8383](https://github.com/sanity-io/sanity/issues/8383)) ([a8bbb89](https://github.com/sanity-io/sanity/commit/a8bbb89828ecb95dc2d3679459be4e5941311651))
+
+
+
+## [3.71.1](https://github.com/sanity-io/sanity/compare/v3.71.0...v3.71.1) (2025-01-22)
+
+
+### Bug Fixes
+
+* revert back to vite v5 ([#8362](https://github.com/sanity-io/sanity/issues/8362)) ([44e6dd5](https://github.com/sanity-io/sanity/commit/44e6dd532b815dbf5128d93f4b631b4e217d6c90))
+
+
+
+# [3.71.0](https://github.com/sanity-io/sanity/compare/v3.70.0...v3.71.0) (2025-01-21)
+
+
+### Bug Fixes
+
+* add defineField helper to alt field ([#8333](https://github.com/sanity-io/sanity/issues/8333)) ([fc456ea](https://github.com/sanity-io/sanity/commit/fc456ea339c3b337970020ead3cd6b7844d85edd))
+* **core/form/inputs:** fix issue with tabbing to popover toolbar buttons in PT-input ([#5057](https://github.com/sanity-io/sanity/issues/5057)) ([6c61c9c](https://github.com/sanity-io/sanity/commit/6c61c9cff2531465752b810fca589c02b98f529c))
+* **core:** cannot find namespace 'vi' ([#8282](https://github.com/sanity-io/sanity/issues/8282)) ([3a3cc58](https://github.com/sanity-io/sanity/commit/3a3cc585f4f6a02d3e7632c559c3d029f3da1d99))
+* **core:** replace `@sanity/block-tools` with `@portabletext/block-tools` ([#8260](https://github.com/sanity-io/sanity/issues/8260)) ([0ff7c7f](https://github.com/sanity-io/sanity/commit/0ff7c7fb45a56b458d1f3b5b4e4a32e789268ca0))
+* **deps:** update dependency @portabletext/block-tools to ^1.1.0 ([#8285](https://github.com/sanity-io/sanity/issues/8285)) ([ba61226](https://github.com/sanity-io/sanity/commit/ba61226dcae4b5d5e06b5acca80f41d23bf27b3c))
+* **deps:** update dependency @portabletext/editor to ^1.22.0 ([#8252](https://github.com/sanity-io/sanity/issues/8252)) ([5379e4f](https://github.com/sanity-io/sanity/commit/5379e4f3c16c092056d2b30cb5b4ab8fc5eb89e3))
+* **deps:** update dependency @sanity/client to ^6.24.4 ([#8307](https://github.com/sanity-io/sanity/issues/8307)) ([ee29383](https://github.com/sanity-io/sanity/commit/ee29383351500bd99bcc5981339e1ed827ff37f2))
+* **deps:** update dependency @sanity/client to ^6.25.0 ([#8315](https://github.com/sanity-io/sanity/issues/8315)) ([d4175f9](https://github.com/sanity-io/sanity/commit/d4175f99c2d2a056320110079d950c5c01bc84f9))
+* **deps:** update dependency @sanity/mutate to ^0.12.1 ([#8239](https://github.com/sanity-io/sanity/issues/8239)) ([b53b164](https://github.com/sanity-io/sanity/commit/b53b1644bd79db4b25b228ff6f9db44d06e02350))
+* **deps:** update dependency @sanity/presentation to v1.22.0 ([#8295](https://github.com/sanity-io/sanity/issues/8295)) ([847f30e](https://github.com/sanity-io/sanity/commit/847f30ef49b1dcd239ded8e02de837ac90ac4535))
+* **deps:** update dependency @sanity/presentation to v1.22.1 ([#8308](https://github.com/sanity-io/sanity/issues/8308)) ([3a49a11](https://github.com/sanity-io/sanity/commit/3a49a1177aab90d9ee8da212bf27a280a6c35daa))
+* **deps:** update dependency @sanity/preview-url-secret to ^2.1.0 ([#8316](https://github.com/sanity-io/sanity/issues/8316)) ([e8faa3a](https://github.com/sanity-io/sanity/commit/e8faa3a600635933d87909b12c8d0425eb18ed4d))
+* **deps:** update dependency @sanity/ui to ^2.11.3 ([#8330](https://github.com/sanity-io/sanity/issues/8330)) ([148c1ec](https://github.com/sanity-io/sanity/commit/148c1ecff726beb03aa26f1ae2562902e51db8b6))
+* **deps:** update dependency react-rx to ^4.1.16 ([#8329](https://github.com/sanity-io/sanity/issues/8329)) ([76609d2](https://github.com/sanity-io/sanity/commit/76609d2d3b7818741a804341c094893cb17f24c0))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#8327](https://github.com/sanity-io/sanity/issues/8327)) ([2e1f58e](https://github.com/sanity-io/sanity/commit/2e1f58e8c2597e0027da02f717260324ab7f803f))
+* **deps:** upgrade `vite` to v6 ([532eb63](https://github.com/sanity-io/sanity/commit/532eb637cd0a1d07927bb5e21c105087469a5f70))
+* patching a readOnly document is blocked ([#8292](https://github.com/sanity-io/sanity/issues/8292)) ([49cc66f](https://github.com/sanity-io/sanity/commit/49cc66fb237d0fef6769a1ea0b65c30ea4088b0c))
+* **presentation:** always show all documents in use ([#8320](https://github.com/sanity-io/sanity/issues/8320)) ([cbbebd5](https://github.com/sanity-io/sanity/commit/cbbebd58d1aad40802a55e98625e69fbaa9638ca))
+* **presentation:** avoid duplicate key warning ([#8319](https://github.com/sanity-io/sanity/issues/8319)) ([48f3e68](https://github.com/sanity-io/sanity/commit/48f3e68ba5e996a8efbb77b576cdf4073fad3090))
+* readOnly pane overrides patch ([#8313](https://github.com/sanity-io/sanity/issues/8313)) ([ad3fd48](https://github.com/sanity-io/sanity/commit/ad3fd48dd52ee9c654275af1415fabd6c94ebdfd))
+* **types:** make `ObjectSchemaType['__experimental_search']` optional ([#8289](https://github.com/sanity-io/sanity/issues/8289)) ([7f5c037](https://github.com/sanity-io/sanity/commit/7f5c03712910f19cf4848001a89d888b23517187))
+
+
+### Features
+
+* **cli:** remote template bootstrapper to support write token ([#8277](https://github.com/sanity-io/sanity/issues/8277)) ([b5e5e9d](https://github.com/sanity-io/sanity/commit/b5e5e9d08e94f017deebfc75ad93fa19a210aa89))
+* **form:** add support for disabling array input capabilities ([#7615](https://github.com/sanity-io/sanity/issues/7615)) ([9ce399c](https://github.com/sanity-io/sanity/commit/9ce399c4a4d5df4692a4d816c2be6dbbc2d0d781))
+* **preview:** add experimental support for live document id sets ([#7398](https://github.com/sanity-io/sanity/issues/7398)) ([d1dc5b5](https://github.com/sanity-io/sanity/commit/d1dc5b5d13f7cc106f51617678b87b5af5380d9b))
+* **preview:** add experimental support for observing full documents ([#7397](https://github.com/sanity-io/sanity/issues/7397)) ([56bcd0a](https://github.com/sanity-io/sanity/commit/56bcd0ace66d6b84c319a138345db7aa2ab6801c))
+* Updated Navbar link for Tasks tool ([#8257](https://github.com/sanity-io/sanity/issues/8257)) ([498b05e](https://github.com/sanity-io/sanity/commit/498b05ecb5f5292d038e08308aac41dee0cb5e38))
+
+
+
+# [3.70.0](https://github.com/sanity-io/sanity/compare/v3.69.0...v3.70.0) (2025-01-14)
+
+
+### Bug Fixes
+
+* **block-tools:** "soft" deprecate in favour of @portabletext/block-tools ([#8254](https://github.com/sanity-io/sanity/issues/8254)) ([885cfe0](https://github.com/sanity-io/sanity/commit/885cfe0b815062b7300f865de83e5eb0b4c14910))
+* **ci:** pin ubuntu version for e2e component tests to 22.04 ([#8245](https://github.com/sanity-io/sanity/issues/8245)) ([b3cce81](https://github.com/sanity-io/sanity/commit/b3cce815b9dcf488c7cd49682339f5cf1fca010c))
+* **cli:** explicitly exit workers when they're done ([#8226](https://github.com/sanity-io/sanity/issues/8226)) ([104b74c](https://github.com/sanity-io/sanity/commit/104b74cebc4495c38b1742dd15b000ddbbe265a3))
+* **core:** export EditPortal as beta ([#8270](https://github.com/sanity-io/sanity/issues/8270)) ([c65b13c](https://github.com/sanity-io/sanity/commit/c65b13c150e494f7344326e48954d918fdaab45f))
+* **core:** support serverDocumentActions flag in plugins ([#8247](https://github.com/sanity-io/sanity/issues/8247)) ([78318f3](https://github.com/sanity-io/sanity/commit/78318f3d52022e2cf64b82eacbc842fee49f2bac))
+* **deps:** update dependency @portabletext/editor to ^1.21.0 ([#8227](https://github.com/sanity-io/sanity/issues/8227)) ([5c28f4f](https://github.com/sanity-io/sanity/commit/5c28f4f0004b7bed88f25082e43215aa921134cb))
+* **deps:** update dependency @portabletext/editor to ^1.21.1 ([#8234](https://github.com/sanity-io/sanity/issues/8234)) ([26b64c7](https://github.com/sanity-io/sanity/commit/26b64c7b93f16058ec677a36c36515eaab2c2f03))
+* **deps:** update dependency @portabletext/editor to ^1.21.5 ([#8264](https://github.com/sanity-io/sanity/issues/8264)) ([1938999](https://github.com/sanity-io/sanity/commit/1938999fdd8c5cd0bc22e3a0826e4bdca0665959))
+* **deps:** update dependency @sanity/client to ^6.24.3 ([#8213](https://github.com/sanity-io/sanity/issues/8213)) ([47577ea](https://github.com/sanity-io/sanity/commit/47577ea3768dd72874da42b0e5edbe3739b09b9c))
+* **deps:** update dependency @sanity/insert-menu to v1.0.19 ([#8222](https://github.com/sanity-io/sanity/issues/8222)) ([07651a5](https://github.com/sanity-io/sanity/commit/07651a5a16f844d63e42504802de957042ba4ca9))
+* **deps:** update dependency @sanity/presentation to v1.20.2 ([#8219](https://github.com/sanity-io/sanity/issues/8219)) ([5ddfe63](https://github.com/sanity-io/sanity/commit/5ddfe632d710800ac099b17dbb43e731c7044de2))
+* **deps:** update dependency @sanity/presentation to v1.20.3 ([#8223](https://github.com/sanity-io/sanity/issues/8223)) ([a363bba](https://github.com/sanity-io/sanity/commit/a363bba335439165b8814353e9165efcf5dfbe9e))
+* **deps:** update dependency @sanity/presentation to v1.21.1 ([#8230](https://github.com/sanity-io/sanity/issues/8230)) ([9e624fa](https://github.com/sanity-io/sanity/commit/9e624faf24cc36f613ec260b1586b956f2dccf7a))
+* **deps:** update dependency @sanity/presentation to v1.21.2 ([#8253](https://github.com/sanity-io/sanity/issues/8253)) ([39f8900](https://github.com/sanity-io/sanity/commit/39f8900365a69d30451c64973c04bd69f3f0545a))
+* **deps:** update dependency @sanity/presentation to v1.21.3 ([#8265](https://github.com/sanity-io/sanity/issues/8265)) ([df392a4](https://github.com/sanity-io/sanity/commit/df392a4b6da36cdbe05c6db9d210943aff339a93))
+* **deps:** update dependency @sanity/ui to ^2.11.2 ([#8248](https://github.com/sanity-io/sanity/issues/8248)) ([f3151c3](https://github.com/sanity-io/sanity/commit/f3151c395ff9160dff392f8eff31f1f42fc641b3))
+* **deps:** update dependency get-it to ^8.6.6 ([#8221](https://github.com/sanity-io/sanity/issues/8221)) ([17e10ca](https://github.com/sanity-io/sanity/commit/17e10caee562b7d2480be145a818c9b8ad183a3b))
+* **deps:** update dependency react-rx to ^4.1.14 ([#8246](https://github.com/sanity-io/sanity/issues/8246)) ([2664f0f](https://github.com/sanity-io/sanity/commit/2664f0fd34c3f5cbdef29aa9cf940a7c6a3a367d))
+* **deps:** update dependency react-rx to ^4.1.15 ([#8259](https://github.com/sanity-io/sanity/issues/8259)) ([9d362e1](https://github.com/sanity-io/sanity/commit/9d362e140f6bd2b0d24be88dfd02618aec480c5c))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#8244](https://github.com/sanity-io/sanity/issues/8244)) ([256ffac](https://github.com/sanity-io/sanity/commit/256ffac12b6d9e21765d5afc18945ac3882733a8))
+* ensures singleworkspace falls back to the name 'default' as expected in all contexts ([#8228](https://github.com/sanity-io/sanity/issues/8228)) ([fe708e8](https://github.com/sanity-io/sanity/commit/fe708e8a2133e8cd54530f41e5f00c570db7658f))
+* **vision:** debounce type setState to fix cursor jump ([#8238](https://github.com/sanity-io/sanity/issues/8238)) ([15cba9a](https://github.com/sanity-io/sanity/commit/15cba9ad537dbdf09f3201c5c2a0aeee5ea8042e))
+
+
+### Features
+
+* **cli:** skip directories without .env.example when bootstrapping remote template ([#8216](https://github.com/sanity-io/sanity/issues/8216)) ([86c6ab1](https://github.com/sanity-io/sanity/commit/86c6ab198591371b77b6bf306891d66136bf4bf5))
+* **cli:** slim down remote test template ([#8224](https://github.com/sanity-io/sanity/issues/8224)) ([41580c4](https://github.com/sanity-io/sanity/commit/41580c40eedcb5744c5237e6cdbbcfa8686eef4f))
+* **sanity:** include `_id` field in `groq2024` searches ([#8237](https://github.com/sanity-io/sanity/issues/8237)) ([e0a2b6d](https://github.com/sanity-io/sanity/commit/e0a2b6d2ea9a0dadf2846d114b868b6611b1f7a5))
+
+
+
+# [3.69.0](https://github.com/sanity-io/sanity/compare/v3.68.3...v3.69.0) (2025-01-08)
+
+
+### Bug Fixes
+
+* `WebSocket is closed before the connection is established` warning ([#8042](https://github.com/sanity-io/sanity/issues/8042)) ([57150e7](https://github.com/sanity-io/sanity/commit/57150e7116eb47065912d274c85d023585f61627))
+* **core:** merge in listenerEvents in _keepalive stream ([#8122](https://github.com/sanity-io/sanity/issues/8122)) ([babdfe4](https://github.com/sanity-io/sanity/commit/babdfe4692b63cdd517f1f76cc58104f199cf534))
+* **core:** re-subscribes to shared pair listener opens a new connection ([#8120](https://github.com/sanity-io/sanity/issues/8120)) ([8f61ce3](https://github.com/sanity-io/sanity/commit/8f61ce3e80148d44debee5217433a41741e70ac8))
+* **deps:** update dependency @portabletext/editor to ^1.18.1 ([#8088](https://github.com/sanity-io/sanity/issues/8088)) ([1d23092](https://github.com/sanity-io/sanity/commit/1d2309261586168473aa5219855a82313e00bd90))
+* **deps:** update dependency @portabletext/editor to ^1.18.2 ([#8113](https://github.com/sanity-io/sanity/issues/8113)) ([d3d1540](https://github.com/sanity-io/sanity/commit/d3d1540d2c8d0160e582ba7e207ba15fb7f4b3cf))
+* **deps:** update dependency @portabletext/editor to ^1.18.3 ([#8117](https://github.com/sanity-io/sanity/issues/8117)) ([cd989d1](https://github.com/sanity-io/sanity/commit/cd989d1eaa159d9d8594000e026172ba7861edd8))
+* **deps:** update dependency @portabletext/editor to ^1.18.5 ([#8124](https://github.com/sanity-io/sanity/issues/8124)) ([8c61a7e](https://github.com/sanity-io/sanity/commit/8c61a7e203943eb0a234d0eab24ff2d5d28fcf69))
+* **deps:** update dependency @portabletext/editor to ^1.18.6 ([#8136](https://github.com/sanity-io/sanity/issues/8136)) ([42b4320](https://github.com/sanity-io/sanity/commit/42b4320c4cca216e27549e975f92868c559df869))
+* **deps:** update dependency @portabletext/editor to ^1.18.7 ([#8148](https://github.com/sanity-io/sanity/issues/8148)) ([59b143e](https://github.com/sanity-io/sanity/commit/59b143e87491496dc2a243c6951546ebdb94d2ad))
+* **deps:** update dependency @portabletext/editor to ^1.19.0 ([#8167](https://github.com/sanity-io/sanity/issues/8167)) ([6c6fc0c](https://github.com/sanity-io/sanity/commit/6c6fc0c6f0e93d90e4842596e38e46d4b5a9c978))
+* **deps:** update dependency @portabletext/editor to ^1.20.0 ([#8208](https://github.com/sanity-io/sanity/issues/8208)) ([1e12bc9](https://github.com/sanity-io/sanity/commit/1e12bc9e3f2b87e695e7bc9d07e2f04e8e6fdce0))
+* **deps:** update dependency @sanity/export to ^3.42.0 ([#8111](https://github.com/sanity-io/sanity/issues/8111)) ([d6aa711](https://github.com/sanity-io/sanity/commit/d6aa711a0f6fc09949351ce0f085e331784b2be5))
+* **deps:** update dependency @sanity/export to ^3.42.1 ([#8153](https://github.com/sanity-io/sanity/issues/8153)) ([9722e5f](https://github.com/sanity-io/sanity/commit/9722e5f5dfc88bcdc5d45f18522e40c1514fbd18))
+* **deps:** update dependency @sanity/export to ^3.42.2 ([#8179](https://github.com/sanity-io/sanity/issues/8179)) ([4e60fe9](https://github.com/sanity-io/sanity/commit/4e60fe9721873633d872722af0e8b3a4453e410b))
+* **deps:** update dependency @sanity/icons to ^3.5.5 ([#8105](https://github.com/sanity-io/sanity/issues/8105)) ([9b7ee0b](https://github.com/sanity-io/sanity/commit/9b7ee0bed5b8fd0236a6ad1bf4b3eff4236d424f))
+* **deps:** update dependency @sanity/icons to ^3.5.5 ([#8106](https://github.com/sanity-io/sanity/issues/8106)) ([93ea8af](https://github.com/sanity-io/sanity/commit/93ea8af34c81166c67cc3a5d709987e4783363d5))
+* **deps:** update dependency @sanity/icons to ^3.5.6 ([#8129](https://github.com/sanity-io/sanity/issues/8129)) ([797a381](https://github.com/sanity-io/sanity/commit/797a381d7583ea3bbad292090e9930fb8005653a))
+* **deps:** update dependency @sanity/icons to ^3.5.7 ([#8155](https://github.com/sanity-io/sanity/issues/8155)) ([e113dff](https://github.com/sanity-io/sanity/commit/e113dffb1dea223c569dbe64542178be34398360))
+* **deps:** update dependency @sanity/insert-menu to v1.0.17 ([#8126](https://github.com/sanity-io/sanity/issues/8126)) ([4935373](https://github.com/sanity-io/sanity/commit/4935373aa353726dd2de732a2668003dcfb0365b))
+* **deps:** update dependency @sanity/insert-menu to v1.0.18 ([#8132](https://github.com/sanity-io/sanity/issues/8132)) ([30f3945](https://github.com/sanity-io/sanity/commit/30f394503817fdb87fd64f36283402dd9baeea58))
+* **deps:** update dependency @sanity/presentation to v1.19.14 ([#8127](https://github.com/sanity-io/sanity/issues/8127)) ([ac2be36](https://github.com/sanity-io/sanity/commit/ac2be369efd3d4e11cdc690d94d96943a1622827))
+* **deps:** update dependency @sanity/presentation to v1.19.16 ([#8133](https://github.com/sanity-io/sanity/issues/8133)) ([6d18640](https://github.com/sanity-io/sanity/commit/6d186403351f60af30d0caef50ea6a9d054d9e18))
+* **deps:** update dependency @sanity/presentation to v1.19.17 ([#8195](https://github.com/sanity-io/sanity/issues/8195)) ([c44e5b0](https://github.com/sanity-io/sanity/commit/c44e5b0c4e6793819fcc200ba7598c72bf490b33))
+* **deps:** update dependency @sanity/presentation to v1.20.1 ([#8206](https://github.com/sanity-io/sanity/issues/8206)) ([a354c03](https://github.com/sanity-io/sanity/commit/a354c035367d8f64776acd193b78aa639ab1fa21))
+* **deps:** update dependency @sanity/ui to ^2.10.12 ([#8108](https://github.com/sanity-io/sanity/issues/8108)) ([a20bcf7](https://github.com/sanity-io/sanity/commit/a20bcf79623c4b4068b1f7d819173e3c71ee962d))
+* **deps:** update dependency @sanity/ui to ^2.10.14 ([#8150](https://github.com/sanity-io/sanity/issues/8150)) ([751a5f5](https://github.com/sanity-io/sanity/commit/751a5f5dacada296ab9366d177dde84b03d36185))
+* **deps:** update dependency @sanity/ui to ^2.10.15 ([#8172](https://github.com/sanity-io/sanity/issues/8172)) ([5010c37](https://github.com/sanity-io/sanity/commit/5010c374b49e33319096c36ea572762e424bd9d9))
+* **deps:** update dependency @sanity/ui to ^2.10.16 ([#8175](https://github.com/sanity-io/sanity/issues/8175)) ([3a972e9](https://github.com/sanity-io/sanity/commit/3a972e9c0a40157a7d2f31da4e8fd4db436a5131))
+* **deps:** update dependency @sanity/ui to ^2.10.17 ([#8177](https://github.com/sanity-io/sanity/issues/8177)) ([9d68dad](https://github.com/sanity-io/sanity/commit/9d68dade21aedda5f43eb93c4edb781e31e84862))
+* **deps:** update dependency @sanity/ui to ^2.10.18 ([#8185](https://github.com/sanity-io/sanity/issues/8185)) ([d9c959a](https://github.com/sanity-io/sanity/commit/d9c959ac4a0b186d09d833b07693ffb3231447ef))
+* **deps:** update dependency @sanity/ui to ^2.11.0 ([#8190](https://github.com/sanity-io/sanity/issues/8190)) ([5211c0d](https://github.com/sanity-io/sanity/commit/5211c0de04558d5a9c1885c079f07de769899555))
+* **deps:** update dependency @sanity/ui to ^2.11.1 ([#8203](https://github.com/sanity-io/sanity/issues/8203)) ([e98cf47](https://github.com/sanity-io/sanity/commit/e98cf47f6c2ebc7364d0e67cba3991268731e996))
+* **deps:** update dependency react-rx to ^4.1.10 ([#8109](https://github.com/sanity-io/sanity/issues/8109)) ([87f783d](https://github.com/sanity-io/sanity/commit/87f783d3fdf04a1993de3d6d304cec06478a5507))
+* **deps:** update dependency react-rx to ^4.1.11 ([#8151](https://github.com/sanity-io/sanity/issues/8151)) ([1546ea7](https://github.com/sanity-io/sanity/commit/1546ea759617b15fb31154aa28efa5539c8c17d5))
+* **deps:** update dependency react-rx to ^4.1.12 ([#8189](https://github.com/sanity-io/sanity/issues/8189)) ([107435b](https://github.com/sanity-io/sanity/commit/107435b2466fee68d7781f2107560b7a7f105c69))
+* **deps:** Update dev-non-major ([#8100](https://github.com/sanity-io/sanity/issues/8100)) ([9897dbc](https://github.com/sanity-io/sanity/commit/9897dbcdadbb17242661ad86296d1baa5e1e5a24))
+* **deps:** Update dev-non-major ([#8174](https://github.com/sanity-io/sanity/issues/8174)) ([60cede8](https://github.com/sanity-io/sanity/commit/60cede8359d823f97503dc33e66411c87608d6d3))
+* **deps:** Update dev-non-major ([#8183](https://github.com/sanity-io/sanity/issues/8183)) ([504337e](https://github.com/sanity-io/sanity/commit/504337e669338d5a6a8198db459af72711073b3f))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#8134](https://github.com/sanity-io/sanity/issues/8134)) ([994598c](https://github.com/sanity-io/sanity/commit/994598c3a6d55b71d32cfcc78d03fd7221c359ea))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#8187](https://github.com/sanity-io/sanity/issues/8187)) ([fd30cb3](https://github.com/sanity-io/sanity/commit/fd30cb38d21dd016504692a48306b991ca307727))
+* fixes schema extraction with nested union refs ([#8096](https://github.com/sanity-io/sanity/issues/8096)) ([ac62487](https://github.com/sanity-io/sanity/commit/ac624879d66f8d8ca1b17e9e256cd50010250bc2))
+* make header new and error text customisable ([#8162](https://github.com/sanity-io/sanity/issues/8162)) ([30cd307](https://github.com/sanity-io/sanity/commit/30cd307bc5cbae620ae64bb87c71549b3ef1a6a6))
+* preload documents on hover ([#8110](https://github.com/sanity-io/sanity/issues/8110)) ([303841d](https://github.com/sanity-io/sanity/commit/303841dab5d4f87cacde679d00967d2a96d3b9ac))
+* React 19 typings (finally) ([#8171](https://github.com/sanity-io/sanity/issues/8171)) ([68f244b](https://github.com/sanity-io/sanity/commit/68f244b286dd93acc942eae1f76cc9ac1e38fa15))
+* remove react-hooks linter suppression ([#8051](https://github.com/sanity-io/sanity/issues/8051)) ([1d25b3c](https://github.com/sanity-io/sanity/commit/1d25b3cc05293ac4cff5858ab73d797dee6e93a3))
+* **sanity:** fix race condition introduced by [#8120](https://github.com/sanity-io/sanity/issues/8120) ([#8211](https://github.com/sanity-io/sanity/issues/8211)) ([27feda0](https://github.com/sanity-io/sanity/commit/27feda0445df33cb1ae23a148013ee4b79ea2d12))
+* **sanity:** throw a better error if onChange called during initial render  ([#8165](https://github.com/sanity-io/sanity/issues/8165)) ([3285312](https://github.com/sanity-io/sanity/commit/32853122cb612d635e214b52d43068a267063a91))
+* **structure:** set patchRef in an insertion effect instead of regular useEffect ([#8194](https://github.com/sanity-io/sanity/issues/8194)) ([facd3fb](https://github.com/sanity-io/sanity/commit/facd3fbb4d5494a149157e499cf3c0dc3c5ad49c))
+* unset should unset readOnly date field from custom input component ([#8192](https://github.com/sanity-io/sanity/issues/8192)) ([e4f7164](https://github.com/sanity-io/sanity/commit/e4f71645e216494a608fd41664f2da733883608c))
+
+
+### Features
+
+* **cli:** allow credentials when adding CORS entry ([#8191](https://github.com/sanity-io/sanity/issues/8191)) ([b57cb26](https://github.com/sanity-io/sanity/commit/b57cb264113d806ec3e158b122c79beb3365eae9))
+* **cli:** copy additions for remote project bootstrapper ([#8141](https://github.com/sanity-io/sanity/issues/8141)) ([f453cbc](https://github.com/sanity-io/sanity/commit/f453cbcccc2fb62e7e76b49c2db3aab97c749674))
+* **core:** add default markdown behaviors to PTE ([#8168](https://github.com/sanity-io/sanity/issues/8168)) ([17aa32c](https://github.com/sanity-io/sanity/commit/17aa32ce78b6d4d9210b06c207ac3f303110504a))
+* **typegen:** add support for astro ([#8098](https://github.com/sanity-io/sanity/issues/8098)) ([92dfc9f](https://github.com/sanity-io/sanity/commit/92dfc9fa8f95df94144c6662ac50f7e086d830e5))
+
+
+
+## [3.68.3](https://github.com/sanity-io/sanity/compare/v3.68.2...v3.68.3) (2024-12-20)
+
+
+### Bug Fixes
+
+* support react 19 type definitions ([#8121](https://github.com/sanity-io/sanity/issues/8121)) ([ac26a4f](https://github.com/sanity-io/sanity/commit/ac26a4f3ece9877669258b64e112ad520c72d9d0))
+
+
+
+## [3.68.2](https://github.com/sanity-io/sanity/compare/v3.68.1...v3.68.2) (2024-12-20)
+
+
+### Features
+
+* **cli:** remove patching of tsconfig.json and thus silver-fleece dependency ([#8114](https://github.com/sanity-io/sanity/issues/8114)) ([c146d76](https://github.com/sanity-io/sanity/commit/c146d7695c5daba74334ac982b473ce4455928c5))
+
+
+
+## [3.68.1](https://github.com/sanity-io/sanity/compare/v3.68.0...v3.68.1) (2024-12-18)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @sanity/presentation to v1.19.13 ([#8102](https://github.com/sanity-io/sanity/issues/8102)) ([cfaa69b](https://github.com/sanity-io/sanity/commit/cfaa69b07b2fcd6dc0be835020429de66bcda132))
+
+
+
+# [3.68.0](https://github.com/sanity-io/sanity/compare/v3.67.1...v3.68.0) (2024-12-18)
+
+
+### Bug Fixes
+
+* allow `useRelativeTime` to be auto-memoized ([#8089](https://github.com/sanity-io/sanity/issues/8089)) ([e2a9fff](https://github.com/sanity-io/sanity/commit/e2a9ffff421b249be9a92ab41eb58a59ee88296f))
+* **cli:** outputters should respect %s ([#8037](https://github.com/sanity-io/sanity/issues/8037)) ([85de530](https://github.com/sanity-io/sanity/commit/85de530630371e71dc20920e5791788bf036a3b9))
+* **core:** fix issue with different Webkit tab order in forms ([#8022](https://github.com/sanity-io/sanity/issues/8022)) ([b1307d9](https://github.com/sanity-io/sanity/commit/b1307d905927e266c7c024d8fa8c457f6eb47c7d))
+* **core:** fix issues with PT-Input PopoverModal ([#8021](https://github.com/sanity-io/sanity/issues/8021)) ([ded659e](https://github.com/sanity-io/sanity/commit/ded659e787e5bf5a814ac13cdd25072be43eabc2))
+* **core:** make PTE read-only until it's `'ready'` ([#8033](https://github.com/sanity-io/sanity/issues/8033)) ([07d80a7](https://github.com/sanity-io/sanity/commit/07d80a7bfa7f0abc5028838727d862635196c574))
+* delays rendering the Start in Create banner until document is ready ([#8020](https://github.com/sanity-io/sanity/issues/8020)) ([fa403da](https://github.com/sanity-io/sanity/commit/fa403dacd95f7cdc0529888a2b0620cc411270f3))
+* **deps:** align arrify versions, drop types package ([#8019](https://github.com/sanity-io/sanity/issues/8019)) ([fc55e3e](https://github.com/sanity-io/sanity/commit/fc55e3e39519fea8feb0465efdcdabbaebea81c2))
+* **deps:** drop `react-copy-to-clipboard` dependency ([#8041](https://github.com/sanity-io/sanity/issues/8041)) ([37b3065](https://github.com/sanity-io/sanity/commit/37b30650ef67c7caca9b4ed4c20e2993a853ad10))
+* **deps:** update dependency @portabletext/editor to ^1.16.3 ([#8031](https://github.com/sanity-io/sanity/issues/8031)) ([cb1647b](https://github.com/sanity-io/sanity/commit/cb1647bb9963f222bdfa87c07d082217f5bba6d5))
+* **deps:** update dependency @sanity/icons to ^3.5.3 ([#8071](https://github.com/sanity-io/sanity/issues/8071)) ([2886839](https://github.com/sanity-io/sanity/commit/2886839c83a56e3635fb7967423820dd9c43cad9))
+* **deps:** update dependency @sanity/presentation to v1.19.10 ([#8065](https://github.com/sanity-io/sanity/issues/8065)) ([27958af](https://github.com/sanity-io/sanity/commit/27958af054cd5b03408768fe66bca7d475540dfe))
+* **deps:** update dependency @sanity/presentation to v1.19.11 ([#8073](https://github.com/sanity-io/sanity/issues/8073)) ([1819bc8](https://github.com/sanity-io/sanity/commit/1819bc8d0916be1e62b8d5ad23a33005c67fb9d8))
+* **deps:** update dependency @sanity/presentation to v1.19.12 ([#8082](https://github.com/sanity-io/sanity/issues/8082)) ([a5a217a](https://github.com/sanity-io/sanity/commit/a5a217ad7f15bcca66e2d3eb9ebbac3726d302c6))
+* **deps:** update dependency @sanity/ui to ^2.10.10 ([#8074](https://github.com/sanity-io/sanity/issues/8074)) ([d280578](https://github.com/sanity-io/sanity/commit/d280578557211d08d648b196eab9f0df0c378795))
+* **deps:** update dependency @sanity/ui to ^2.10.11 ([#8083](https://github.com/sanity-io/sanity/issues/8083)) ([9dc200e](https://github.com/sanity-io/sanity/commit/9dc200e9075adfdcdb4bb3bb9b633f5cd017faa2))
+* **deps:** update dependency @sanity/ui to ^2.10.9 ([#8009](https://github.com/sanity-io/sanity/issues/8009)) ([bb8ae86](https://github.com/sanity-io/sanity/commit/bb8ae865234b75ceb99d0967980c8e380366b597))
+* **deps:** update dependency react-rx to ^4.1.9 ([#8075](https://github.com/sanity-io/sanity/issues/8075)) ([6f16545](https://github.com/sanity-io/sanity/commit/6f16545192c6ab4abcb8445048bf1c421c0f1b9c))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#8069](https://github.com/sanity-io/sanity/issues/8069)) ([e4009f1](https://github.com/sanity-io/sanity/commit/e4009f1e2b17dbc902df2443530fae1e8f76a8e6))
+* **deps:** upgrade `@tanstack/react-virtual` to v3.11.2 ([#8062](https://github.com/sanity-io/sanity/issues/8062)) ([04303f7](https://github.com/sanity-io/sanity/commit/04303f7a06d5bf7fca4246f6769f8f83bde14d9e))
+* **deps:** upgrade dependency react-focus-lock to v2.13.5 ([#8081](https://github.com/sanity-io/sanity/issues/8081)) ([04d5aa2](https://github.com/sanity-io/sanity/commit/04d5aa256ba3f42bdb0291b22a8ad097b0049a69))
+* **deps:** upgrade react-json-inspector ([#8017](https://github.com/sanity-io/sanity/issues/8017)) ([cf7afaf](https://github.com/sanity-io/sanity/commit/cf7afaf445700bdc39e9048313b9ab98e0d7181c))
+* don't read/write ref during render ([#8077](https://github.com/sanity-io/sanity/issues/8077)) ([b1f183d](https://github.com/sanity-io/sanity/commit/b1f183db1c4f206aa96d8cf5a196f10d8b2f03a6))
+* fixes unknown event handler error in CommentsOnboardingPopover ([#8087](https://github.com/sanity-io/sanity/issues/8087)) ([1fa5db6](https://github.com/sanity-io/sanity/commit/1fa5db6659e896b573e226b137d09e7f19bb8cd7))
+* improve `SanityDefaultPreview` memoization ([#8049](https://github.com/sanity-io/sanity/issues/8049)) ([a6d5320](https://github.com/sanity-io/sanity/commit/a6d5320e1fb6f94e467b306d2e4dc466595012e5))
+* improve color scheme store perf ([#8059](https://github.com/sanity-io/sanity/issues/8059)) ([ed3551b](https://github.com/sanity-io/sanity/commit/ed3551bf64f853947137dc672dbbbe469d85117a))
+* improve command list performance ([#8046](https://github.com/sanity-io/sanity/issues/8046)) ([80965bf](https://github.com/sanity-io/sanity/commit/80965bfee40ac7d75cda45732444167ccc217847))
+* improve presence menu performance ([#8039](https://github.com/sanity-io/sanity/issues/8039)) ([43f1b52](https://github.com/sanity-io/sanity/commit/43f1b521c8d3e86e2a026a0b8cfa1a7c5f0c4cf5))
+* **preview:** fix issue sometimes causing hotspot menu to stay a gray box after uploading ([#8076](https://github.com/sanity-io/sanity/issues/8076)) ([3d5f1d3](https://github.com/sanity-io/sanity/commit/3d5f1d3ff6d5a36840aaf2ab1af5c08c2e991126))
+* replace `React.createElement` with jsx runtime ([#8043](https://github.com/sanity-io/sanity/issues/8043)) ([3ef8280](https://github.com/sanity-io/sanity/commit/3ef8280e85ea15b4a53949500614382e9d44a60f))
+* replace unsafe `useMemo` with `useState` ([#8047](https://github.com/sanity-io/sanity/issues/8047)) ([05c9e74](https://github.com/sanity-io/sanity/commit/05c9e746e0eece6aba566a40f978a4abf306054a))
+* replace useMemo with useState ([#8095](https://github.com/sanity-io/sanity/issues/8095)) ([399a7be](https://github.com/sanity-io/sanity/commit/399a7be6cd6d517b0eef01740fc5afa92a72e761))
+* **sanity:** relative dates incorrectly appearing to be in the future ([#8034](https://github.com/sanity-io/sanity/issues/8034)) ([3869ede](https://github.com/sanity-io/sanity/commit/3869ede554ab8c7c1b00e116d7b80a197cfc746a))
+* search modal stays open with metaKey ([#8090](https://github.com/sanity-io/sanity/issues/8090)) ([f95a3d1](https://github.com/sanity-io/sanity/commit/f95a3d10592b75b2c6d69d07627859160ca9ce17))
+* speed up hovered field provider ([#8044](https://github.com/sanity-io/sanity/issues/8044)) ([e177ace](https://github.com/sanity-io/sanity/commit/e177ace62a468dece94ebbfb468eb12b96ca9ea3))
+* tooltip position in announcements popup ([#8092](https://github.com/sanity-io/sanity/issues/8092)) ([21c9fab](https://github.com/sanity-io/sanity/commit/21c9fab2d0adf98942dbebedd1b019c55639cb7e))
+* use consistent `framer-motion` semver range ([#8094](https://github.com/sanity-io/sanity/issues/8094)) ([78529d6](https://github.com/sanity-io/sanity/commit/78529d6b536b7222b950302beb521d9cde2afb15))
+* **vision:** upgrade react-split-pane to v1.0.0 ([#8061](https://github.com/sanity-io/sanity/issues/8061)) ([8996689](https://github.com/sanity-io/sanity/commit/89966896a3315bc28238ed175fca128a474119c6))
+
+
+### Features
+
+* **cli:** add cors entry automatically for template package ([#8035](https://github.com/sanity-io/sanity/issues/8035)) ([637d345](https://github.com/sanity-io/sanity/commit/637d345955a956b69c30b39579c676651b0ad3a2))
+* **cli:** misc copy changes ([#8003](https://github.com/sanity-io/sanity/issues/8003)) ([a61c4ee](https://github.com/sanity-io/sanity/commit/a61c4eece5875005a498fd001322523ff0af40c5))
+* **cli:** remove .github dirs when initializing with a remote template ([#8036](https://github.com/sanity-io/sanity/issues/8036)) ([2222e9e](https://github.com/sanity-io/sanity/commit/2222e9e8161be6e87cbcab07cef72b4f3802676a))
+* **cli:** remove is-builtin-module ([#6579](https://github.com/sanity-io/sanity/issues/6579)) ([2982082](https://github.com/sanity-io/sanity/commit/2982082b236508c88a7969cdf739a901fa6958b8))
+* **cli:** use `@sanity/template-validator` package ([#8014](https://github.com/sanity-io/sanity/issues/8014)) ([27fa7e5](https://github.com/sanity-io/sanity/commit/27fa7e589851f4bcce7b39bd1a89c90056724592))
+* **manifest:** add icons, tools & projectId ([#7980](https://github.com/sanity-io/sanity/issues/7980)) ([8d5fb58](https://github.com/sanity-io/sanity/commit/8d5fb58e79e58e924bdc2b3ab39382b3b4a55620))
+* **sanity:** export useReferringDocuments and mark as beta ([#8091](https://github.com/sanity-io/sanity/issues/8091)) ([e5cf80a](https://github.com/sanity-io/sanity/commit/e5cf80a54d546de3abb46eede716dc031e5e40f0))
+
+
+### Reverts
+
+* **cli:** use default ora options in spinner method ([#8038](https://github.com/sanity-io/sanity/issues/8038)) ([a54f8ef](https://github.com/sanity-io/sanity/commit/a54f8ef2e14761100521307c1fd8e86bc61a78e8))
+
+
+
+## [3.67.1](https://github.com/sanity-io/sanity/compare/v3.67.0...v3.67.1) (2024-12-11)
+
+
+### Bug Fixes
+
+* **core:** tasks UpdatedTimeAgo should be a hook ([#8011](https://github.com/sanity-io/sanity/issues/8011)) ([789f3b2](https://github.com/sanity-io/sanity/commit/789f3b278841bd3c5a2e3bfdef74fe215223b607))
+
+
+
+# [3.67.0](https://github.com/sanity-io/sanity/compare/v3.66.1...v3.67.0) (2024-12-10)
+
+
+### Bug Fixes
+
+* **deps:** deprecation warnings due to `glob` dependency ([#7977](https://github.com/sanity-io/sanity/issues/7977)) ([5e3b8c1](https://github.com/sanity-io/sanity/commit/5e3b8c13b7f8a4ffc73fad677c9b65cf769ce27d))
+* **deps:** update dependency @portabletext/editor to ^1.15.0 ([#7971](https://github.com/sanity-io/sanity/issues/7971)) ([6eacd33](https://github.com/sanity-io/sanity/commit/6eacd33d3a0e16932085cd39acf663bf65ee932c))
+* **deps:** update dependency @portabletext/editor to ^1.15.3 ([#7979](https://github.com/sanity-io/sanity/issues/7979)) ([ae98a1d](https://github.com/sanity-io/sanity/commit/ae98a1dfb9572cceccfa506a56b1ad201ce0bd35))
+* **deps:** update dependency @sanity/icons to ^3.5.1 ([#7989](https://github.com/sanity-io/sanity/issues/7989)) ([30d18d6](https://github.com/sanity-io/sanity/commit/30d18d6bac9b5300bd0776fe4919e7e9ae7cdee6))
+* **deps:** update dependency @sanity/icons to ^3.5.2 ([#7991](https://github.com/sanity-io/sanity/issues/7991)) ([1b6117f](https://github.com/sanity-io/sanity/commit/1b6117f055015599f4c6ee43c5652d52908de3c3))
+* **deps:** update dependency @sanity/presentation to v1.19.8 ([#7984](https://github.com/sanity-io/sanity/issues/7984)) ([ba996b7](https://github.com/sanity-io/sanity/commit/ba996b715eed3d3360b90a2299dcd0ea2002fbfa))
+* **deps:** update dependency @sanity/ui to ^2.10.1 ([#7975](https://github.com/sanity-io/sanity/issues/7975)) ([d23b3f0](https://github.com/sanity-io/sanity/commit/d23b3f0800635494a10589d135ace68930288e03))
+* **deps:** update dependency @sanity/ui to ^2.10.3 ([#7986](https://github.com/sanity-io/sanity/issues/7986)) ([22c9708](https://github.com/sanity-io/sanity/commit/22c970825ba06fa11383a8338884219de7414043))
+* **deps:** update dependency @sanity/ui to ^2.10.4 ([#7993](https://github.com/sanity-io/sanity/issues/7993)) ([9d3343c](https://github.com/sanity-io/sanity/commit/9d3343c0d603d4c8b7c3bc991ba0f0a3de727a21))
+* **deps:** update dependency @sanity/ui to ^2.10.7 ([#7998](https://github.com/sanity-io/sanity/issues/7998)) ([eb5739b](https://github.com/sanity-io/sanity/commit/eb5739b00315423eec37ed3ce74132df6e8247ed))
+* **deps:** update dependency @sanity/ui to ^2.10.7 ([#8005](https://github.com/sanity-io/sanity/issues/8005)) ([2f135f6](https://github.com/sanity-io/sanity/commit/2f135f6c7495b7cdaadd29c18e0275be9ada6c3b))
+* **deps:** update dependency groq-js to ^1.14.2 ([#7985](https://github.com/sanity-io/sanity/issues/7985)) ([5d5bac0](https://github.com/sanity-io/sanity/commit/5d5bac01da740424208464a03a47dce18ae1ef78))
+* **deps:** update dependency react-rx to ^4.1.8 ([#7983](https://github.com/sanity-io/sanity/issues/7983)) ([197fc3d](https://github.com/sanity-io/sanity/commit/197fc3db23ecb40db649a2a87b2a81999f2547fc))
+* **deps:** Update dev-non-major ([#7997](https://github.com/sanity-io/sanity/issues/7997)) ([305a143](https://github.com/sanity-io/sanity/commit/305a143a311d02b957cb886564c162a67c4239e5))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#7982](https://github.com/sanity-io/sanity/issues/7982)) ([bf67535](https://github.com/sanity-io/sanity/commit/bf67535636b57a9274e8e33e32960f9ebbcd1421))
+* **deps:** upgrade `vite` to v5 ([#5285](https://github.com/sanity-io/sanity/issues/5285)) ([6817f2e](https://github.com/sanity-io/sanity/commit/6817f2e6fc28bfebb943b3f9416b5ae9bb4ebd77))
+* **i18n:** allow weeks to start on Saturday ([#7965](https://github.com/sanity-io/sanity/issues/7965)) ([59deb00](https://github.com/sanity-io/sanity/commit/59deb001a54289e98639756d3ce7c28c15e70318))
+* **sanity:** do not perform incremental search for exact tokens ([#7972](https://github.com/sanity-io/sanity/issues/7972)) ([9fba9b7](https://github.com/sanity-io/sanity/commit/9fba9b7e9d22de259431870bffd52896f83ebed5))
+* **sanity:** optimise getLeafWeights to not stack overflow ([#7999](https://github.com/sanity-io/sanity/issues/7999)) ([ac2ab18](https://github.com/sanity-io/sanity/commit/ac2ab181b22bd0c386e14c78ffaff7dad0ed06dc))
+
+
+### Features
+
+* add `groq2024` search strategy ([13f2e48](https://github.com/sanity-io/sanity/commit/13f2e48fe32dd804f97b57ad5cd3be23b1c72c07))
+* add disableArrayWarning option to SlugOptions ([#7174](https://github.com/sanity-io/sanity/issues/7174)) ([1b5fd00](https://github.com/sanity-io/sanity/commit/1b5fd000ec4ac2dc40954101a20f8caf0e007079))
+* **cli:** use `@vercel/frameworks` in `bootstrapRemoteTemplate` ([#8001](https://github.com/sanity-io/sanity/issues/8001)) ([60537c8](https://github.com/sanity-io/sanity/commit/60537c85754978fda074611d17add9295e511576))
+* enable start in Create banner for new documents and include development mode information ([#7955](https://github.com/sanity-io/sanity/issues/7955)) ([656d4c8](https://github.com/sanity-io/sanity/commit/656d4c8866ce6d5ac8884e43cd0318481ba62aae))
+* **sanity:** do not fade out global search results while fetching more ([a303002](https://github.com/sanity-io/sanity/commit/a3030021d1dcbec0cd520a4b597acf7a0abd014e))
+* switch create integration to opt-out flow ([#8002](https://github.com/sanity-io/sanity/issues/8002)) ([6b322cb](https://github.com/sanity-io/sanity/commit/6b322cbfc4aaebd9e709dc98e7eef0f7310475f8))
+* **test-studio:** enable `groq2024` search strategy ([8c4e248](https://github.com/sanity-io/sanity/commit/8c4e248b623fea681505aafb3f8ab5621aab5e9e))
+* use eslint 9 for new studios ([#7978](https://github.com/sanity-io/sanity/issues/7978)) ([30d8f7e](https://github.com/sanity-io/sanity/commit/30d8f7e2b6fb62f3ed0c2e9cd69ec9300dd5dd03))
+
+
+
+## [3.66.1](https://github.com/sanity-io/sanity/compare/v3.66.0...v3.66.1) (2024-12-06)
+
+
+### Bug Fixes
+
+* **core:** guard against missing process variable ([#7967](https://github.com/sanity-io/sanity/issues/7967)) ([bab0e19](https://github.com/sanity-io/sanity/commit/bab0e1903db3da2a77f024319799aee3f1783197))
+* **deps:** allow react v19 as peer dependency ([#7962](https://github.com/sanity-io/sanity/issues/7962)) ([9722cd6](https://github.com/sanity-io/sanity/commit/9722cd677975e423f64cf479e074af89dffb3dd0))
+* **deps:** update dependency @sanity/presentation to v1.19.7 ([#7966](https://github.com/sanity-io/sanity/issues/7966)) ([c82d44c](https://github.com/sanity-io/sanity/commit/c82d44caf6d1a2b02bd95fc5d2d6eec4621ac3d6))
+* **sanity:** reset search cursor state when any parameter changes ([#7889](https://github.com/sanity-io/sanity/issues/7889)) ([4d7ae8d](https://github.com/sanity-io/sanity/commit/4d7ae8d00f8b6a06ef230c63e114422af22f8124))
+
+
+
+# [3.66.0](https://github.com/sanity-io/sanity/compare/v3.65.1...v3.66.0) (2024-12-05)
+
+
+### Bug Fixes
+
+* add svg hotspot+crop warning to image tool dialog ([#7917](https://github.com/sanity-io/sanity/issues/7917)) ([3bd79af](https://github.com/sanity-io/sanity/commit/3bd79af2017a88bec3c9dd3f76e518fb884831da))
+* **cli:** remove v2 commands ([#5750](https://github.com/sanity-io/sanity/issues/5750)) ([d98873c](https://github.com/sanity-io/sanity/commit/d98873c53f0c77f900f34d00ec2d78386d11ae36))
+* **core:** add telemetry debug/noop logger ([#7958](https://github.com/sanity-io/sanity/issues/7958)) ([4767ac7](https://github.com/sanity-io/sanity/commit/4767ac7e379eec6dea1460e54a2b64eb3b52d277))
+* **core:** disable scheduledPublishing and tasks if `/features` returns error ([#7517](https://github.com/sanity-io/sanity/issues/7517)) ([a20fb8f](https://github.com/sanity-io/sanity/commit/a20fb8f8f5c96197d0e48e12b449841378dc32a6))
+* **core:** only open one annotation object edit modal at a time ([#7898](https://github.com/sanity-io/sanity/issues/7898)) ([fbecbc8](https://github.com/sanity-io/sanity/commit/fbecbc8ac2b645763563ba973b25228c406db27f))
+* **core:** portable text annotations slow to show ([#7588](https://github.com/sanity-io/sanity/issues/7588)) ([ef50844](https://github.com/sanity-io/sanity/commit/ef50844e2b8737e31a8561f2d2683a383c36050a))
+* **deps:** bump sentry/react to 8.33 ([#7932](https://github.com/sanity-io/sanity/issues/7932)) ([e855a41](https://github.com/sanity-io/sanity/commit/e855a41a70128a7617b26ed71baaf8c0138a7b09))
+* **deps:** update dependency @portabletext/editor to ^1.12.0 ([#7883](https://github.com/sanity-io/sanity/issues/7883)) ([1dc2a68](https://github.com/sanity-io/sanity/commit/1dc2a68741c842204a4a5d1510af6f1e88bcc7df))
+* **deps:** update dependency @portabletext/editor to ^1.12.2 ([#7909](https://github.com/sanity-io/sanity/issues/7909)) ([b2f1ff2](https://github.com/sanity-io/sanity/commit/b2f1ff263cbd211fa80d5fd69e39a1ec97450ba6))
+* **deps:** update dependency @portabletext/editor to ^1.12.3 ([#7921](https://github.com/sanity-io/sanity/issues/7921)) ([1e6a839](https://github.com/sanity-io/sanity/commit/1e6a839bbc08e3bb5e66b1169ee0e36aa8612a95))
+* **deps:** update dependency @portabletext/editor to ^1.13.0 ([#7939](https://github.com/sanity-io/sanity/issues/7939)) ([ad43939](https://github.com/sanity-io/sanity/commit/ad43939ab46c02958966c8a960acaf191be8ab0f))
+* **deps:** update dependency @sanity/client to ^6.23.0 ([#7931](https://github.com/sanity-io/sanity/issues/7931)) ([90f884d](https://github.com/sanity-io/sanity/commit/90f884dccf0a1511cb84cc3ce7073a9f526c2a0f))
+* **deps:** update dependency @sanity/client to ^6.24.0 ([#7935](https://github.com/sanity-io/sanity/issues/7935)) ([5bce66e](https://github.com/sanity-io/sanity/commit/5bce66ec7efadc6bdc4a93a6e7a0cd6c77816c0d))
+* **deps:** update dependency @sanity/client to ^6.24.1 ([#7938](https://github.com/sanity-io/sanity/issues/7938)) ([4bc55d6](https://github.com/sanity-io/sanity/commit/4bc55d6dc5816ffd62560cffd799067987bc2a4b))
+* **deps:** update dependency @sanity/icons to ^3.5.0 ([#7900](https://github.com/sanity-io/sanity/issues/7900)) ([1ed427e](https://github.com/sanity-io/sanity/commit/1ed427eebdb7eec98b8d47ade638d308daece4e2))
+* **deps:** update dependency @sanity/icons to ^3.5.0 ([#7929](https://github.com/sanity-io/sanity/issues/7929)) ([8ee3384](https://github.com/sanity-io/sanity/commit/8ee3384a7c734b777aa89320d4a247778eb2f5b1))
+* **deps:** update dependency @sanity/insert-menu to v1.0.15 ([#7913](https://github.com/sanity-io/sanity/issues/7913)) ([d91efd9](https://github.com/sanity-io/sanity/commit/d91efd9bd0d1820c0a5fa68272306e516c2e0e39))
+* **deps:** update dependency @sanity/insert-menu to v1.0.16 ([#7942](https://github.com/sanity-io/sanity/issues/7942)) ([2aac70c](https://github.com/sanity-io/sanity/commit/2aac70c808e132d8fcb0ee6a1f36347413c54bfb))
+* **deps:** update dependency @sanity/mutate to ^0.11.1 ([#7903](https://github.com/sanity-io/sanity/issues/7903)) ([08d3686](https://github.com/sanity-io/sanity/commit/08d36861ebe185d3c3d414be03cc56c72c1a4073))
+* **deps:** update dependency @sanity/presentation to v1.19.2 ([#7899](https://github.com/sanity-io/sanity/issues/7899)) ([e432e37](https://github.com/sanity-io/sanity/commit/e432e37f4ed7f38249d3f9de3f22e4787cc11197))
+* **deps:** update dependency @sanity/presentation to v1.19.3 ([#7914](https://github.com/sanity-io/sanity/issues/7914)) ([e609391](https://github.com/sanity-io/sanity/commit/e609391e0069bfb1a198947ff666ac8bd807cddf))
+* **deps:** update dependency @sanity/presentation to v1.19.4 ([#7930](https://github.com/sanity-io/sanity/issues/7930)) ([ee5f3b6](https://github.com/sanity-io/sanity/commit/ee5f3b60a020339a2eb22064066c0afef55f9a01))
+* **deps:** update dependency @sanity/presentation to v1.19.5 ([#7957](https://github.com/sanity-io/sanity/issues/7957)) ([7c5a231](https://github.com/sanity-io/sanity/commit/7c5a231b453c27937962b9738f22ca615e19b6c6))
+* **deps:** update dependency @sanity/ui to ^2.8.26 ([#7906](https://github.com/sanity-io/sanity/issues/7906)) ([5b58ced](https://github.com/sanity-io/sanity/commit/5b58ced7dbdd248365a85fcb7c7d29522926ab0b))
+* **deps:** update dependency @sanity/ui to ^2.9.0 ([#7918](https://github.com/sanity-io/sanity/issues/7918)) ([d3a4a1f](https://github.com/sanity-io/sanity/commit/d3a4a1f5806dd0ee39b0788e8c3328b30cb16e0a))
+* **deps:** update dependency @sanity/ui to ^2.9.0 ([#7919](https://github.com/sanity-io/sanity/issues/7919)) ([b28b160](https://github.com/sanity-io/sanity/commit/b28b1601156dfbd65264fc737ed5c3d034b576be))
+* **deps:** update dependency @sanity/ui to ^2.9.1 ([#7948](https://github.com/sanity-io/sanity/issues/7948)) ([561e7fc](https://github.com/sanity-io/sanity/commit/561e7fc9b8728188e2bf0ccf2b36c7e3d700797d))
+* **deps:** update dependency groq-js to ^1.14.1 ([#7910](https://github.com/sanity-io/sanity/issues/7910)) ([037a2f4](https://github.com/sanity-io/sanity/commit/037a2f4f17cd1bcb1ddb67614be9e11e60ae276a))
+* **deps:** Update dev-non-major ([#7893](https://github.com/sanity-io/sanity/issues/7893)) ([3f7892e](https://github.com/sanity-io/sanity/commit/3f7892ef6b00ead5ae084dc4d454c0b7ab0e01f5))
+* **deps:** Update dev-non-major ([#7902](https://github.com/sanity-io/sanity/issues/7902)) ([56ed6cb](https://github.com/sanity-io/sanity/commit/56ed6cb53d613f5ba3613a005f726143640bd932))
+* **deps:** Update dev-non-major ([#7905](https://github.com/sanity-io/sanity/issues/7905)) ([b4c157c](https://github.com/sanity-io/sanity/commit/b4c157c9ac65515c086971fda09712cb36beeed4))
+* **deps:** Update dev-non-major ([#7920](https://github.com/sanity-io/sanity/issues/7920)) ([5b25212](https://github.com/sanity-io/sanity/commit/5b2521247c3633e3c76be9b39c688f4292b1110a))
+* **deps:** Update dev-non-major ([#7946](https://github.com/sanity-io/sanity/issues/7946)) ([59ebd9b](https://github.com/sanity-io/sanity/commit/59ebd9beba8ee707c807d0990f120501deda9d26))
+* **deps:** Update dev-non-major ([#7959](https://github.com/sanity-io/sanity/issues/7959)) ([c06deef](https://github.com/sanity-io/sanity/commit/c06deef1df917bb4b79c9eb3093c614f7f7b1a47))
+* reword warning about vector images not support crop/hotspot ([#7960](https://github.com/sanity-io/sanity/issues/7960)) ([eecd0c5](https://github.com/sanity-io/sanity/commit/eecd0c553f909856cf8d3e6415192a96e3711cc1))
+* **sanity:** support future UI tones ([#7916](https://github.com/sanity-io/sanity/issues/7916)) ([f5e85ae](https://github.com/sanity-io/sanity/commit/f5e85ae1a4de1f6551bf2a1c701b50e2ad9a6576))
+* support react compiler for auto updating studios ([#7897](https://github.com/sanity-io/sanity/issues/7897)) ([e40d5b6](https://github.com/sanity-io/sanity/commit/e40d5b6c246df18412b2501e1d3307a97a725d21))
+* vertically center pane header when no tabs ([#7912](https://github.com/sanity-io/sanity/issues/7912)) ([481febd](https://github.com/sanity-io/sanity/commit/481febdf135d16ce7b60fd85ee6330fe5b1ca441))
+* **vision:** add a warning about unsupported perspective when pasting ([#7937](https://github.com/sanity-io/sanity/issues/7937)) ([bd2b3cf](https://github.com/sanity-io/sanity/commit/bd2b3cf0236273c2ce2d02fc4c97a27e02d18e8e))
+
+
+### Features
+
+* add CI specific token label ([#7934](https://github.com/sanity-io/sanity/issues/7934)) ([4b64fbb](https://github.com/sanity-io/sanity/commit/4b64fbbb5cff5a3a847af165be5b6058532352ec))
+* **cli:** add support for remote templates with `--template`  ([#7867](https://github.com/sanity-io/sanity/issues/7867)) ([1f59825](https://github.com/sanity-io/sanity/commit/1f59825f8c3cf8092510b5a00e6b2bfeb2d4d6cf))
+* **cli:** add test-template for testing `--template` flag ([#7877](https://github.com/sanity-io/sanity/issues/7877)) ([52ab8b2](https://github.com/sanity-io/sanity/commit/52ab8b2d66a3b18680111768d65c1fdbb6106d16))
+* **cli:** generate read token conditionally for remote template ([#7953](https://github.com/sanity-io/sanity/issues/7953)) ([ff90128](https://github.com/sanity-io/sanity/commit/ff90128be83f9762f23e30158dc0e3b6418873d1))
+* **cli:** remove v2 init messaging ([#7887](https://github.com/sanity-io/sanity/issues/7887)) ([2333027](https://github.com/sanity-io/sanity/commit/23330277c309f2ac13a4ab4aacfd7c7f1eb69581))
+* Start in Create button is now enabled by default ([#7884](https://github.com/sanity-io/sanity/issues/7884)) ([723f7fe](https://github.com/sanity-io/sanity/commit/723f7feae571d56759214a9d525a795e94da2f93))
+* support search weight configuration for slug fields ([022c910](https://github.com/sanity-io/sanity/commit/022c9101bfd3e3c0e924d5967fd8faf7abb3fe9b))
+* **vision:** link to edit documents on `_id`, `_ref` attributes ([#6124](https://github.com/sanity-io/sanity/issues/6124)) ([2379f2b](https://github.com/sanity-io/sanity/commit/2379f2b372d180e576473093694d9055d216d285))
+
+
+### Reverts
+
+* Revert "feat: Start in Create button is now enabled by default (#7884)" ([e515f9e](https://github.com/sanity-io/sanity/commit/e515f9e5020caf94936612e147f7caa92a98fa9a)), closes [#7884](https://github.com/sanity-io/sanity/issues/7884)
+
+
+
+## [3.65.1](https://github.com/sanity-io/sanity/compare/v3.65.0...v3.65.1) (2024-11-28)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @sanity/insert-menu to v1.0.14 ([#7895](https://github.com/sanity-io/sanity/issues/7895)) ([74c18cc](https://github.com/sanity-io/sanity/commit/74c18cc45497a22c193b3792c30b208f16082ff4))
+* **deps:** update dependency @sanity/presentation to v1.19.1 ([#7894](https://github.com/sanity-io/sanity/issues/7894)) ([359f155](https://github.com/sanity-io/sanity/commit/359f155b1bc78119c74dd862ee1187d6c8a44019))
+* opt-out `@tanstack/react-virtual` from React Compiler ([#7891](https://github.com/sanity-io/sanity/issues/7891)) ([88d5ab3](https://github.com/sanity-io/sanity/commit/88d5ab3acb6b31ae7c4afbc16a9c9c73e72943cf))
+* Start in Create type exclusion now recursively checks for sanityCreate.exclude options ([#7890](https://github.com/sanity-io/sanity/issues/7890)) ([265030c](https://github.com/sanity-io/sanity/commit/265030c90f20dec2e177fd1f10377a0f55dc88bd))
+
+
+
+# [3.65.0](https://github.com/sanity-io/sanity/compare/v3.64.3...v3.65.0) (2024-11-26)
+
+
+### Bug Fixes
+
+* **core:** discard announcements dialog onClickOutside ([#7863](https://github.com/sanity-io/sanity/issues/7863)) ([7888272](https://github.com/sanity-io/sanity/commit/78882724e2711674c12f4e4c5afc0997278d80ea))
+* **deps:** update dependency @portabletext/editor to ^1.11.3 ([#7865](https://github.com/sanity-io/sanity/issues/7865)) ([a43bf85](https://github.com/sanity-io/sanity/commit/a43bf851d7e7f30aabaa56c65ac5a799fa914e6a))
+* **deps:** update dependency @sanity/insert-menu to v1.0.13 ([#7880](https://github.com/sanity-io/sanity/issues/7880)) ([71a5524](https://github.com/sanity-io/sanity/commit/71a552445ecedacbce781fa7daaf7cb53bb6e153))
+* **deps:** update dependency @sanity/presentation to v1.18.5 ([#7881](https://github.com/sanity-io/sanity/issues/7881)) ([00cc366](https://github.com/sanity-io/sanity/commit/00cc3660c2d99c9dd2c1c4e780ce1ac4ec0f8d60))
+* **deps:** update dependency @sanity/ui to ^2.8.25 ([#7876](https://github.com/sanity-io/sanity/issues/7876)) ([ecce434](https://github.com/sanity-io/sanity/commit/ecce43414536bd4ec03bf7e9c3fb05889e6f94a9))
+* **deps:** update dependency react-rx to ^4.1.7 ([#7874](https://github.com/sanity-io/sanity/issues/7874)) ([456187c](https://github.com/sanity-io/sanity/commit/456187c4731130e60adde2de109243c4d6431cd5))
+* **deps:** Update dev-non-major ([#7875](https://github.com/sanity-io/sanity/issues/7875)) ([4baafb1](https://github.com/sanity-io/sanity/commit/4baafb1b1c2b4fa4723e8cd12f18585dee4d0563))
+* **deps:** update React Compiler dependencies 🤖 ✨ ([#7872](https://github.com/sanity-io/sanity/issues/7872)) ([6fbae0b](https://github.com/sanity-io/sanity/commit/6fbae0bc1ba5e9b818ada73950a74bc8b5a068e8))
+* **telemetry:** log (well known) workspace and dataset names ([#7859](https://github.com/sanity-io/sanity/issues/7859)) ([b97d4aa](https://github.com/sanity-io/sanity/commit/b97d4aa17639721230e48eeeab51bbf6b1a2b374))
+
+
+### Features
+
+* add support for React Compiler beta ([#7702](https://github.com/sanity-io/sanity/issues/7702)) ([8aace40](https://github.com/sanity-io/sanity/commit/8aace40dea8d4a4e18969c29b2548c8fb87ddde4))
+* **structure:** History UI updates ([#7462](https://github.com/sanity-io/sanity/issues/7462)) ([16532a8](https://github.com/sanity-io/sanity/commit/16532a8b725caaaa6ab873d9694d54529d395965))
+
+
+
+## [3.64.3](https://github.com/sanity-io/sanity/compare/v3.64.2...v3.64.3) (2024-11-22)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @portabletext/editor to ^1.11.1 ([#7861](https://github.com/sanity-io/sanity/issues/7861)) ([ded3cbd](https://github.com/sanity-io/sanity/commit/ded3cbd523c215797e93adc6ede7a71906060809))
+
+
+
+## [3.64.2](https://github.com/sanity-io/sanity/compare/v3.64.1...v3.64.2) (2024-11-19)
+
+
+### Bug Fixes
+
+* **core:** add opt out option to studioAnnouncements  ([#7820](https://github.com/sanity-io/sanity/issues/7820)) ([3efc59d](https://github.com/sanity-io/sanity/commit/3efc59d4f738446b36666b45a7841a325699e5a6))
+* **deps:** update dependency @portabletext/editor to ^1.10.0 ([#7823](https://github.com/sanity-io/sanity/issues/7823)) ([a573d22](https://github.com/sanity-io/sanity/commit/a573d22512f62f4613e1b578f3c0367ffb0d2036))
+* **deps:** update dependency @portabletext/editor to ^1.10.2 ([#7829](https://github.com/sanity-io/sanity/issues/7829)) ([b3407b8](https://github.com/sanity-io/sanity/commit/b3407b80f273562829d74996bc583740ac0ed5a6))
+* **deps:** update dependency @portabletext/editor to ^1.8.0 ([#7810](https://github.com/sanity-io/sanity/issues/7810)) ([8730bb0](https://github.com/sanity-io/sanity/commit/8730bb089133ff6c133235792a4b154c77c5b131))
+* **deps:** update dependency @sanity/client to ^6.22.5 ([#7837](https://github.com/sanity-io/sanity/issues/7837)) ([2798bc9](https://github.com/sanity-io/sanity/commit/2798bc9e5cedf8b92d46cd247c34fa5f07cfd651))
+* **deps:** update dependency @sanity/insert-menu to v1.0.12 ([#7825](https://github.com/sanity-io/sanity/issues/7825)) ([974d18b](https://github.com/sanity-io/sanity/commit/974d18b2e36e3c349f219fbb63f6bb4d110be69f))
+* **deps:** update dependency @sanity/presentation to v1.18.3 ([#7821](https://github.com/sanity-io/sanity/issues/7821)) ([9b55123](https://github.com/sanity-io/sanity/commit/9b55123bd8144d18f1d71ed6ba52dd63b559f844))
+* **deps:** update dependency @sanity/presentation to v1.18.4 ([#7839](https://github.com/sanity-io/sanity/issues/7839)) ([95e3cc0](https://github.com/sanity-io/sanity/commit/95e3cc026e8939ad7201306987209e9e4db607cc))
+* **deps:** update dependency @sanity/ui to ^2.8.24 ([#7832](https://github.com/sanity-io/sanity/issues/7832)) ([fffa658](https://github.com/sanity-io/sanity/commit/fffa6582ec63446ff66ee928f76a573d8ac16223))
+* **deps:** update dependency react-rx to ^4.1.6 ([#7833](https://github.com/sanity-io/sanity/issues/7833)) ([3be6e81](https://github.com/sanity-io/sanity/commit/3be6e81f711360fe7325fc762ccce10b3bcd1892))
+* **deps:** Update dev-non-major ([#7809](https://github.com/sanity-io/sanity/issues/7809)) ([dff7a6c](https://github.com/sanity-io/sanity/commit/dff7a6c688ab35947f2c2d2079a2ef7cf24330dd))
+* **deps:** Update dev-non-major ([#7826](https://github.com/sanity-io/sanity/issues/7826)) ([9e59750](https://github.com/sanity-io/sanity/commit/9e5975041ff596ab510e0f2eb2f7e7a32e67a2d1))
+* **deps:** Update dev-non-major ([#7841](https://github.com/sanity-io/sanity/issues/7841)) ([22d28bc](https://github.com/sanity-io/sanity/commit/22d28bc5e673d6019cca8da1465c87a90d055f43))
+* explicitly list allowed image types for upload ([#7819](https://github.com/sanity-io/sanity/issues/7819)) ([0b0a6fa](https://github.com/sanity-io/sanity/commit/0b0a6fa53a1e1fb321d023fee3333e1941412ca0))
+* update create integration copy, use correct chevron icons ([#7842](https://github.com/sanity-io/sanity/issues/7842)) ([1d5d171](https://github.com/sanity-io/sanity/commit/1d5d17101126582d19ab0b0075eebe69a479ca5d))
+
+
+
+## [3.64.1](https://github.com/sanity-io/sanity/compare/v3.64.0...v3.64.1) (2024-11-13)
+
+
+### Bug Fixes
+
+* add --legacy-peer-deps to next-sanity pacakge install ([#7806](https://github.com/sanity-io/sanity/issues/7806)) ([cb3739b](https://github.com/sanity-io/sanity/commit/cb3739b6d155df82990b6bc61bc781f35b205187))
+* **deps:** update dependency @portabletext/editor to ^1.7.1 ([#7807](https://github.com/sanity-io/sanity/issues/7807)) ([3ca838e](https://github.com/sanity-io/sanity/commit/3ca838e1cefe64417ce4140a0be8a05301c8af63))
+* **deps:** update dependency @sanity/insert-menu to v1.0.11 ([#7802](https://github.com/sanity-io/sanity/issues/7802)) ([f770631](https://github.com/sanity-io/sanity/commit/f7706314e5378a4f3bf4e2211e2f50657752b469))
+* **deps:** update dependency @sanity/presentation to v1.18.1 ([#7803](https://github.com/sanity-io/sanity/issues/7803)) ([bcc9b2d](https://github.com/sanity-io/sanity/commit/bcc9b2d53c19c2d8967b598b5e9d521b021a58d4))
+* **deps:** update dependency @sanity/presentation to v1.18.2 ([#7808](https://github.com/sanity-io/sanity/issues/7808)) ([07d5996](https://github.com/sanity-io/sanity/commit/07d5996b1c29b4e133a19718a66354b41b90bd1a))
+* **deps:** Update dev-non-major ([#7804](https://github.com/sanity-io/sanity/issues/7804)) ([dc87ef6](https://github.com/sanity-io/sanity/commit/dc87ef61bcd9c5ef9d3108ac23f058e0451debf2))
+
+
+
+# [3.64.0](https://github.com/sanity-io/sanity/compare/v3.63.0...v3.64.0) (2024-11-12)
+
+
+### Bug Fixes
+
+* **core:** explicitly pass `randomKey(12)` as the PTE `keyGenerator` ([#7759](https://github.com/sanity-io/sanity/issues/7759)) ([0005825](https://github.com/sanity-io/sanity/commit/00058255bffd2e2f54525dc5aee8fb44dc9679c1))
+* **core:** update upsell description list items ([#7793](https://github.com/sanity-io/sanity/issues/7793)) ([1a48572](https://github.com/sanity-io/sanity/commit/1a48572b0f554994666deeb1ed182ac8f30da3fc))
+* create integration copy + layout updates ([#7787](https://github.com/sanity-io/sanity/issues/7787)) ([4807d52](https://github.com/sanity-io/sanity/commit/4807d52626b800e8b65bfab92f08a05383558a35))
+* **deps:** update dependency @portabletext/editor to ^1.5.5 ([#7763](https://github.com/sanity-io/sanity/issues/7763)) ([bbcbab8](https://github.com/sanity-io/sanity/commit/bbcbab820e6cccc31a6a4f02d8cfb81b3631fa68))
+* **deps:** update dependency @portabletext/editor to ^1.6.1 ([#7778](https://github.com/sanity-io/sanity/issues/7778)) ([3248f96](https://github.com/sanity-io/sanity/commit/3248f96fe43208b0d7d2909f9e211b841841b5f0))
+* **deps:** update dependency @portabletext/editor to ^1.7.0 ([#7799](https://github.com/sanity-io/sanity/issues/7799)) ([5d85b3c](https://github.com/sanity-io/sanity/commit/5d85b3cb6df3728814f5374fb4398fafa2074d36))
+* **deps:** update dependency @portabletext/editor to ^1.7.0 ([#7800](https://github.com/sanity-io/sanity/issues/7800)) ([d0194fc](https://github.com/sanity-io/sanity/commit/d0194fc97ce0b25afca6a1c2fd1cda444f7715fc))
+* **deps:** update dependency @sanity/client to ^6.22.3 ([#7766](https://github.com/sanity-io/sanity/issues/7766)) ([65bae66](https://github.com/sanity-io/sanity/commit/65bae6670de31aa5f3c4127b67a6abe93184fc76))
+* **deps:** update dependency @sanity/client to ^6.22.4 ([#7785](https://github.com/sanity-io/sanity/issues/7785)) ([335e74c](https://github.com/sanity-io/sanity/commit/335e74c8e9aed3c6c70e4b543c92f2cb6ce299cb))
+* **deps:** update dependency @sanity/mutate to ^0.10.2 ([#7781](https://github.com/sanity-io/sanity/issues/7781)) ([23fbba6](https://github.com/sanity-io/sanity/commit/23fbba62473fcb4a0492f7ccde769381d86683e9))
+* **deps:** update dependency @sanity/presentation to v1.17.10 ([#7767](https://github.com/sanity-io/sanity/issues/7767)) ([a89e00c](https://github.com/sanity-io/sanity/commit/a89e00cef67ff003c718f54c5824bba229237203))
+* **deps:** update dependency @sanity/presentation to v1.18.0 ([#7794](https://github.com/sanity-io/sanity/issues/7794)) ([ac4c8b4](https://github.com/sanity-io/sanity/commit/ac4c8b4cfe40597589550588e7e6cd02098374b3))
+* **deps:** update dependency @sanity/ui to ^2.8.21 ([#7779](https://github.com/sanity-io/sanity/issues/7779)) ([1714bb8](https://github.com/sanity-io/sanity/commit/1714bb87e505aa7c3084493a7bb1258a220eb526))
+* **deps:** update dependency @sanity/ui to ^2.8.23 ([#7790](https://github.com/sanity-io/sanity/issues/7790)) ([b10d030](https://github.com/sanity-io/sanity/commit/b10d030bf4b1e30f71318b0a83b9a5b874a56539))
+* **deps:** update dependency react-rx to ^4.1.4 ([#7768](https://github.com/sanity-io/sanity/issues/7768)) ([47dba32](https://github.com/sanity-io/sanity/commit/47dba32d178215882d8067dbd305080305f7ec21))
+* **deps:** update dependency react-rx to ^4.1.5 ([#7792](https://github.com/sanity-io/sanity/issues/7792)) ([95301c2](https://github.com/sanity-io/sanity/commit/95301c2f4019fe81c7c18f32edf32d06176b6714))
+* **deps:** Update dev-non-major ([#7770](https://github.com/sanity-io/sanity/issues/7770)) ([47b50a5](https://github.com/sanity-io/sanity/commit/47b50a5d7c08a2d2cf645b02fe50fc346a2e7fab))
+* **deps:** Update dev-non-major ([#7784](https://github.com/sanity-io/sanity/issues/7784)) ([92cfeb2](https://github.com/sanity-io/sanity/commit/92cfeb25089338a7d773128dca8e0f94520dceef))
+* **deps:** Update dev-non-major ([#7796](https://github.com/sanity-io/sanity/issues/7796)) ([e52ea6a](https://github.com/sanity-io/sanity/commit/e52ea6a6dba369441795184376399a193bf402fc))
+* **deps:** upgrade `@sanity/ui` to `2.8.22` ([#7783](https://github.com/sanity-io/sanity/issues/7783)) ([23ca786](https://github.com/sanity-io/sanity/commit/23ca78679103b0d895c6aa5a57d4c5e5d7e95260))
+
+
+### Features
+
+* **codegen:** add support for export all ([c68e298](https://github.com/sanity-io/sanity/commit/c68e2982ec291cae455b4accd2fde85ed4807335))
+* **codegen:** fix literal function arguments and add default values ([c518591](https://github.com/sanity-io/sanity/commit/c518591250575a8a9aa5e045c4cb589ad796e5aa))
+* simplify search strategy configuration ([#7765](https://github.com/sanity-io/sanity/issues/7765)) ([4d8193f](https://github.com/sanity-io/sanity/commit/4d8193f84e70b600f2fdb29cac1c977e174d5785))
+
+
+
+# [3.63.0](https://github.com/sanity-io/sanity/compare/v3.62.3...v3.63.0) (2024-11-05)
+
+
+### Bug Fixes
+
+* **core:** export BetaFeatures and ScheduledPublishing types ([#7659](https://github.com/sanity-io/sanity/issues/7659)) ([f2b1566](https://github.com/sanity-io/sanity/commit/f2b15664504b1a8a2c96d1a316a8875d62da6b1d))
+* **core:** export BetaFeatures and ScheduledPublishing types ([#7659](https://github.com/sanity-io/sanity/issues/7659)) ([9fbebab](https://github.com/sanity-io/sanity/commit/9fbebab14cee1ca3c4c35afcf71b3be109765488))
+* **deps:** Update babel monorepo ([#7719](https://github.com/sanity-io/sanity/issues/7719)) ([24a2686](https://github.com/sanity-io/sanity/commit/24a2686eed831848e8d8256808f801796c2ec7c3))
+* **deps:** Update babel monorepo ([#7719](https://github.com/sanity-io/sanity/issues/7719)) ([3b20ff6](https://github.com/sanity-io/sanity/commit/3b20ff672de8b720956c1dddd4f70453fc3ae851))
+* **deps:** update dependency @portabletext/editor to ^1.1.11 ([#7667](https://github.com/sanity-io/sanity/issues/7667)) ([b2be211](https://github.com/sanity-io/sanity/commit/b2be2116d61c30c6413a1dac7067bddf3c2bd60f))
+* **deps:** update dependency @portabletext/editor to ^1.1.11 ([#7667](https://github.com/sanity-io/sanity/issues/7667)) ([6479290](https://github.com/sanity-io/sanity/commit/647929063ede264b48dba574e9a86529109edaa1))
+* **deps:** update dependency @portabletext/editor to ^1.2.0 ([#7709](https://github.com/sanity-io/sanity/issues/7709)) ([b01cb63](https://github.com/sanity-io/sanity/commit/b01cb6372f7edf73631195766e6c80647225d2ac))
+* **deps:** update dependency @portabletext/editor to ^1.2.0 ([#7709](https://github.com/sanity-io/sanity/issues/7709)) ([d1a35d5](https://github.com/sanity-io/sanity/commit/d1a35d5ab0f1d84dedb6684a774db8841cdf807d))
+* **deps:** update dependency @portabletext/editor to ^1.3.0 ([#7727](https://github.com/sanity-io/sanity/issues/7727)) ([05efa3c](https://github.com/sanity-io/sanity/commit/05efa3c8ea1b12ba60f590f4768cc5185929afca))
+* **deps:** update dependency @portabletext/editor to ^1.3.0 ([#7727](https://github.com/sanity-io/sanity/issues/7727)) ([2f42394](https://github.com/sanity-io/sanity/commit/2f42394d362036c8d3a91bc138e4f5e8712d80b2))
+* **deps:** update dependency @portabletext/editor to ^1.4.0 ([#7729](https://github.com/sanity-io/sanity/issues/7729)) ([cee29d9](https://github.com/sanity-io/sanity/commit/cee29d97fd7fe0f7b1f1cba2f6233b7e7fc6cc3d))
+* **deps:** update dependency @portabletext/editor to ^1.4.0 ([#7729](https://github.com/sanity-io/sanity/issues/7729)) ([5c1a81a](https://github.com/sanity-io/sanity/commit/5c1a81a169b7b3542828e4fed22d59f6edf53145))
+* **deps:** update dependency @portabletext/editor to ^1.4.1 ([#7735](https://github.com/sanity-io/sanity/issues/7735)) ([2165044](https://github.com/sanity-io/sanity/commit/216504493d1b1dbb7028162b07c9396c79bf818c))
+* **deps:** update dependency @portabletext/editor to ^1.4.1 ([#7735](https://github.com/sanity-io/sanity/issues/7735)) ([953501d](https://github.com/sanity-io/sanity/commit/953501dd895529967ee95f465457811e1731bfc1))
+* **deps:** update dependency @portabletext/editor to ^1.5.4 ([#7737](https://github.com/sanity-io/sanity/issues/7737)) ([7c54252](https://github.com/sanity-io/sanity/commit/7c542528267f48cf3c848c041065af59bf61233a))
+* **deps:** update dependency @portabletext/editor to ^1.5.4 ([#7737](https://github.com/sanity-io/sanity/issues/7737)) ([c0bd3c2](https://github.com/sanity-io/sanity/commit/c0bd3c23f185b3bb244d46f525d417023fc540ab))
+* **deps:** update dependency @sanity/presentation to v1.17.8 ([#7743](https://github.com/sanity-io/sanity/issues/7743)) ([ab58bfe](https://github.com/sanity-io/sanity/commit/ab58bfe64f65fd9c6e9cdbaa527314b2993d9820))
+* **deps:** update dependency @sanity/presentation to v1.17.8 ([#7743](https://github.com/sanity-io/sanity/issues/7743)) ([e631b2d](https://github.com/sanity-io/sanity/commit/e631b2da18667f762b68dfeaf00c32379f8a3c67))
+* **deps:** update dependency @sanity/ui to ^2.8.13 ([#7694](https://github.com/sanity-io/sanity/issues/7694)) ([51d65c2](https://github.com/sanity-io/sanity/commit/51d65c26747a3d8237919312e5bac24e62465e85))
+* **deps:** update dependency @sanity/ui to ^2.8.13 ([#7694](https://github.com/sanity-io/sanity/issues/7694)) ([3e1cad6](https://github.com/sanity-io/sanity/commit/3e1cad6cd412e71aada6677542c957b80816f6a2))
+* **deps:** update dependency @sanity/ui to ^2.8.14 ([#7713](https://github.com/sanity-io/sanity/issues/7713)) ([c5ad94e](https://github.com/sanity-io/sanity/commit/c5ad94e05d096698ee8eaec5523ec7340208aa1f))
+* **deps:** update dependency @sanity/ui to ^2.8.14 ([#7713](https://github.com/sanity-io/sanity/issues/7713)) ([ef649b8](https://github.com/sanity-io/sanity/commit/ef649b852ce2e69116c462cca86d3666e47d56e1))
+* **deps:** update dependency @sanity/ui to ^2.8.15 ([#7717](https://github.com/sanity-io/sanity/issues/7717)) ([6a0e742](https://github.com/sanity-io/sanity/commit/6a0e7422519f9f56bef8a307bf3f8c8e0d097934))
+* **deps:** update dependency @sanity/ui to ^2.8.15 ([#7717](https://github.com/sanity-io/sanity/issues/7717)) ([0f7ee17](https://github.com/sanity-io/sanity/commit/0f7ee17a318988eda830f498cd132cd63551a0fb))
+* **deps:** update dependency @sanity/ui to ^2.8.15 ([#7718](https://github.com/sanity-io/sanity/issues/7718)) ([752069a](https://github.com/sanity-io/sanity/commit/752069a423881d0c2bc36347efd3a00258b5f006))
+* **deps:** update dependency @sanity/ui to ^2.8.15 ([#7718](https://github.com/sanity-io/sanity/issues/7718)) ([1fadac5](https://github.com/sanity-io/sanity/commit/1fadac51b7fd7c9189fbc72a7e072117dcc9243a))
+* **deps:** update dependency @sanity/ui to ^2.8.16 ([#7722](https://github.com/sanity-io/sanity/issues/7722)) ([1e10512](https://github.com/sanity-io/sanity/commit/1e10512d1ad4a729354e9620d89890adf5cab8ca))
+* **deps:** update dependency @sanity/ui to ^2.8.16 ([#7722](https://github.com/sanity-io/sanity/issues/7722)) ([4757af6](https://github.com/sanity-io/sanity/commit/4757af693eb918dc3930d42a62c7e05d40227abb))
+* **deps:** update dependency @sanity/ui to ^2.8.16 ([#7723](https://github.com/sanity-io/sanity/issues/7723)) ([965a8ba](https://github.com/sanity-io/sanity/commit/965a8ba113fc59367ebb679c2461eddbba16df8e))
+* **deps:** update dependency @sanity/ui to ^2.8.16 ([#7723](https://github.com/sanity-io/sanity/issues/7723)) ([3048630](https://github.com/sanity-io/sanity/commit/304863040d57c5457f613d81d4f12925a2f1140d))
+* **deps:** update dependency @sanity/ui to ^2.8.17 ([#7725](https://github.com/sanity-io/sanity/issues/7725)) ([d5a1b63](https://github.com/sanity-io/sanity/commit/d5a1b637ad19f7a6c28fa0182f75b6b458b6f44e))
+* **deps:** update dependency @sanity/ui to ^2.8.17 ([#7725](https://github.com/sanity-io/sanity/issues/7725)) ([4864eaa](https://github.com/sanity-io/sanity/commit/4864eaa4967e5829b02cf99f038d62a93041c2f6))
+* **deps:** update dependency @sanity/ui to ^2.8.18 ([#7730](https://github.com/sanity-io/sanity/issues/7730)) ([982ff9b](https://github.com/sanity-io/sanity/commit/982ff9bc4904e98100f8d4a93936c47c57689bad))
+* **deps:** update dependency @sanity/ui to ^2.8.18 ([#7730](https://github.com/sanity-io/sanity/issues/7730)) ([81cb734](https://github.com/sanity-io/sanity/commit/81cb734974090755dc61453183338b7c6b86c24b))
+* **deps:** update dependency @sanity/ui to ^2.8.19 ([#7742](https://github.com/sanity-io/sanity/issues/7742)) ([2c4ed6e](https://github.com/sanity-io/sanity/commit/2c4ed6e8cceefd00a8121e931517222d31fb8b4f))
+* **deps:** update dependency @sanity/ui to ^2.8.19 ([#7742](https://github.com/sanity-io/sanity/issues/7742)) ([60ece5f](https://github.com/sanity-io/sanity/commit/60ece5f196302ef6ac8bd06798a6e8dc72472b30))
+* **deps:** update dependency groq-js to ^1.14.0 ([#7738](https://github.com/sanity-io/sanity/issues/7738)) ([b1d7c12](https://github.com/sanity-io/sanity/commit/b1d7c12b9a1b32e3f69c56ce3db8e6764cb84c6d))
+* **deps:** update dependency groq-js to ^1.14.0 ([#7738](https://github.com/sanity-io/sanity/issues/7738)) ([c580ebf](https://github.com/sanity-io/sanity/commit/c580ebf7c8c2aeaa2f436ef36b313b150dc2811f))
+* **deps:** update dependency react-rx to ^4.0.1 ([#7712](https://github.com/sanity-io/sanity/issues/7712)) ([cd2e8c8](https://github.com/sanity-io/sanity/commit/cd2e8c8a860bf527d26cf3d7c11050108636c297))
+* **deps:** update dependency react-rx to ^4.0.1 ([#7712](https://github.com/sanity-io/sanity/issues/7712)) ([46982a3](https://github.com/sanity-io/sanity/commit/46982a3ab4aa1e57ece19ae990583edee1b34488))
+* **deps:** update dependency react-rx to ^4.1.0 ([#7714](https://github.com/sanity-io/sanity/issues/7714)) ([a9e9aaa](https://github.com/sanity-io/sanity/commit/a9e9aaa7f1ee6d67e878f66973a7e9b6fa2d648e))
+* **deps:** update dependency react-rx to ^4.1.0 ([#7714](https://github.com/sanity-io/sanity/issues/7714)) ([fa5cfe7](https://github.com/sanity-io/sanity/commit/fa5cfe7143ae946039adeb7866050cdc38696826))
+* **deps:** update dependency react-rx to ^4.1.1 ([#7739](https://github.com/sanity-io/sanity/issues/7739)) ([13bf574](https://github.com/sanity-io/sanity/commit/13bf574b3cd8323970e27708e8431a996e814db8))
+* **deps:** update dependency react-rx to ^4.1.1 ([#7739](https://github.com/sanity-io/sanity/issues/7739)) ([c4d4abb](https://github.com/sanity-io/sanity/commit/c4d4abb91373856261a857d5e72b3db550c2e199))
+* **deps:** update dependency react-rx to ^4.1.3 ([#7744](https://github.com/sanity-io/sanity/issues/7744)) ([a4e17b8](https://github.com/sanity-io/sanity/commit/a4e17b895848fcdfb1352f361077819467807cdf))
+* **deps:** update dependency react-rx to ^4.1.3 ([#7744](https://github.com/sanity-io/sanity/issues/7744)) ([4a3157d](https://github.com/sanity-io/sanity/commit/4a3157d102539b0da7db4a48eeb854a11ea01293))
+* **deps:** Update dev-non-major ([#7693](https://github.com/sanity-io/sanity/issues/7693)) ([d96504b](https://github.com/sanity-io/sanity/commit/d96504b07a8b9a878faa490c78cc64b4370dd3c5))
+* **deps:** Update dev-non-major ([#7693](https://github.com/sanity-io/sanity/issues/7693)) ([f03396f](https://github.com/sanity-io/sanity/commit/f03396fefc2742d5a198de81b749d66b63b3d5f5))
+* **deps:** Update dev-non-major ([#7708](https://github.com/sanity-io/sanity/issues/7708)) ([f1fb479](https://github.com/sanity-io/sanity/commit/f1fb479af533847d302cd970203d0060b7d20138))
+* **deps:** Update dev-non-major ([#7708](https://github.com/sanity-io/sanity/issues/7708)) ([ab24df2](https://github.com/sanity-io/sanity/commit/ab24df25a1f519425d6290581fb31e408405a143))
+* **deps:** Update dev-non-major ([#7724](https://github.com/sanity-io/sanity/issues/7724)) ([34a2900](https://github.com/sanity-io/sanity/commit/34a2900580b1bf222c78729b310033e50ab00a5e))
+* **deps:** Update dev-non-major ([#7724](https://github.com/sanity-io/sanity/issues/7724)) ([0e2888c](https://github.com/sanity-io/sanity/commit/0e2888cd8bf3159399f72144e74ffa1ee17d4e63))
+* **deps:** Update dev-non-major ([#7736](https://github.com/sanity-io/sanity/issues/7736)) ([888d4f0](https://github.com/sanity-io/sanity/commit/888d4f0e67a373adb0a47be22b712e4389d8036f))
+* **deps:** Update dev-non-major ([#7736](https://github.com/sanity-io/sanity/issues/7736)) ([eebf6c4](https://github.com/sanity-io/sanity/commit/eebf6c4cc2579e09df0f306fe701bf2eeaf60846))
+* invalid locale namespace specified for create ([#7732](https://github.com/sanity-io/sanity/issues/7732)) ([aacd548](https://github.com/sanity-io/sanity/commit/aacd54814e1471689405eb9b7d170984b35b56ad))
+* invalid locale namespace specified for create ([#7732](https://github.com/sanity-io/sanity/issues/7732)) ([9b2a6f7](https://github.com/sanity-io/sanity/commit/9b2a6f7b78ac41a2f78c1fec800580debad2a926))
+* scheduled pub scroll list issue ([#7658](https://github.com/sanity-io/sanity/issues/7658)) ([2bdccbd](https://github.com/sanity-io/sanity/commit/2bdccbd5ee45fb2ef20b2fa1342c2e140231819b))
+* scheduled pub scroll list issue ([#7658](https://github.com/sanity-io/sanity/issues/7658)) ([4e05b3a](https://github.com/sanity-io/sanity/commit/4e05b3a5d0a23ac08ab43438492787ad5d2c95ef))
+
+
+### Features
+
+* **cli:** prepare nextjs starter template for live mode ([#7633](https://github.com/sanity-io/sanity/issues/7633)) ([a1c1775](https://github.com/sanity-io/sanity/commit/a1c177517657929c09232178a188a6e4f261f60f))
+* **cli:** prepare nextjs starter template for live mode ([#7633](https://github.com/sanity-io/sanity/issues/7633)) ([d018a71](https://github.com/sanity-io/sanity/commit/d018a7117e65e3a65c8fba9b88d931ce45e728d9))
+
+
+
+## [3.62.3](https://github.com/sanity-io/sanity/compare/v3.62.2...v3.62.3) (2024-10-29)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @portabletext/editor to ^1.1.10 ([#7692](https://github.com/sanity-io/sanity/issues/7692)) ([7a564a6](https://github.com/sanity-io/sanity/commit/7a564a653b0167ec10c44bdff5cc9098aee8c484))
+* **deps:** update dependency @sanity/insert-menu to v1.0.10 ([#7668](https://github.com/sanity-io/sanity/issues/7668)) ([4ede77b](https://github.com/sanity-io/sanity/commit/4ede77b443d1900a4b89bab8e0e78dc4213fb689))
+* **deps:** update dependency @sanity/presentation to v1.17.6 ([#7669](https://github.com/sanity-io/sanity/issues/7669)) ([bd83ebb](https://github.com/sanity-io/sanity/commit/bd83ebbdc09de2a05dc69557511cf2d666a41dd0))
+* **deps:** update dependency @sanity/presentation to v1.17.7 ([#7683](https://github.com/sanity-io/sanity/issues/7683)) ([6c1febc](https://github.com/sanity-io/sanity/commit/6c1febcdd9baf45e53345b7c8d53caf37c4150d1))
+* **deps:** Update dev-non-major ([#7671](https://github.com/sanity-io/sanity/issues/7671)) ([1ebedd2](https://github.com/sanity-io/sanity/commit/1ebedd2614ab10491b1e9eeac61d8e7f30af063a))
+* **deps:** Update dev-non-major ([#7679](https://github.com/sanity-io/sanity/issues/7679)) ([070b33c](https://github.com/sanity-io/sanity/commit/070b33c66703d651965f15eee9fbc4aafcd62790))
+
+
+### Features
+
+* adds support for Create-Studio integration ([#7635](https://github.com/sanity-io/sanity/issues/7635)) ([12cb46b](https://github.com/sanity-io/sanity/commit/12cb46b0b7352370db9e66c83b1939737fe82fec))
+
+
+### Performance Improvements
+
+* **core:** memoize resolveInitialValueForType ([#7674](https://github.com/sanity-io/sanity/issues/7674)) ([3602d67](https://github.com/sanity-io/sanity/commit/3602d673d08d08f2777ece1a62abff0982413cb6))
+
+
+
+## [3.62.2](https://github.com/sanity-io/sanity/compare/v3.62.1...v3.62.2) (2024-10-24)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @sanity/presentation to v1.17.4 ([#7662](https://github.com/sanity-io/sanity/issues/7662)) ([35fdd4d](https://github.com/sanity-io/sanity/commit/35fdd4d5f29700c8cc29230faa81a3746b69fafd))
+* **deps:** Update dev-non-major ([#7661](https://github.com/sanity-io/sanity/issues/7661)) ([21988da](https://github.com/sanity-io/sanity/commit/21988da17e934e71f3d5cf2962043b1cbb86e704))
+* **deps:** Update dev-non-major ([#7663](https://github.com/sanity-io/sanity/issues/7663)) ([aa41c29](https://github.com/sanity-io/sanity/commit/aa41c29765177b37ef5f04ca8563f424a341d742))
+
+
+
+## [3.62.1](https://github.com/sanity-io/sanity/compare/v3.62.0...v3.62.1) (2024-10-24)
+
+
+### Features
+
+* **cli:** add warning and docs for react-19 and Next.Js combined ([#7660](https://github.com/sanity-io/sanity/issues/7660)) ([3e87891](https://github.com/sanity-io/sanity/commit/3e878913a6261aa56e1257214cbe9bbdf7140782))
+
+
+
+# [3.62.0](https://github.com/sanity-io/sanity/compare/v3.61.0...v3.62.0) (2024-10-22)
+
+
+### Bug Fixes
+
+* **core:** boolean value in search shows actual value ([#7623](https://github.com/sanity-io/sanity/issues/7623)) ([4ffa079](https://github.com/sanity-io/sanity/commit/4ffa0799876f4793d425e84d5d0417f4944b8bd6))
+* **core:** inherit readOnly state from ancestors in copyPaste function ([#7643](https://github.com/sanity-io/sanity/issues/7643)) ([4298fe0](https://github.com/sanity-io/sanity/commit/4298fe0ba2a8fed0288255993fcfd383d8185760))
+* **deps:** update dependency @portabletext/editor to ^1.1.5 ([#7638](https://github.com/sanity-io/sanity/issues/7638)) ([07c48a0](https://github.com/sanity-io/sanity/commit/07c48a0fbe64722aa074c7ac105b2e7a42138dda))
+* **deps:** update dependency @sanity/client to ^6.22.2 ([#7625](https://github.com/sanity-io/sanity/issues/7625)) ([2e150f1](https://github.com/sanity-io/sanity/commit/2e150f1d595f7e6815cce66ad31028ed77750a09))
+* **deps:** update dependency @sanity/mutate to ^0.10.1 ([#7650](https://github.com/sanity-io/sanity/issues/7650)) ([c9b574d](https://github.com/sanity-io/sanity/commit/c9b574d67456de9e717f784263580deac42c5040))
+* **deps:** update dependency @sanity/presentation to v1.17.0 ([#7640](https://github.com/sanity-io/sanity/issues/7640)) ([4973abc](https://github.com/sanity-io/sanity/commit/4973abc51f83b6a0fee14f8f27f8f8b0839fbe5f))
+* **deps:** update dependency @sanity/presentation to v1.17.1 ([#7645](https://github.com/sanity-io/sanity/issues/7645)) ([3698fd3](https://github.com/sanity-io/sanity/commit/3698fd3003893af001a8824fcd6d048398778f71))
+* **deps:** update dependency @sanity/presentation to v1.17.2 ([#7647](https://github.com/sanity-io/sanity/issues/7647)) ([93a1114](https://github.com/sanity-io/sanity/commit/93a111420201c7e927776d918eda13c1684f7de4))
+* **deps:** update dependency @sanity/presentation to v1.17.3 ([#7648](https://github.com/sanity-io/sanity/issues/7648)) ([2bc49be](https://github.com/sanity-io/sanity/commit/2bc49bec6dd646cdb93f7f8b81024a4e82d781be))
+* **deps:** update dependency @sanity/ui to ^2.8.10 ([#7652](https://github.com/sanity-io/sanity/issues/7652)) ([5452e3d](https://github.com/sanity-io/sanity/commit/5452e3db53fc5d66104a4db1f4f6c9342448ea48))
+* **deps:** update dependency @sanity/ui to ^2.8.10 ([#7653](https://github.com/sanity-io/sanity/issues/7653)) ([b6df802](https://github.com/sanity-io/sanity/commit/b6df802a5133ea076b388a55295aea418d33fb37))
+* **deps:** Update dev-non-major ([#7639](https://github.com/sanity-io/sanity/issues/7639)) ([97f1db0](https://github.com/sanity-io/sanity/commit/97f1db0f0afda06f3e286cf5c5a30074df944563))
+* **deps:** Update dev-non-major ([#7646](https://github.com/sanity-io/sanity/issues/7646)) ([5a8965e](https://github.com/sanity-io/sanity/commit/5a8965e0cc21057b82cd1c1a3c2f5447d01cee8c))
+* **deps:** Update dev-non-major ([#7649](https://github.com/sanity-io/sanity/issues/7649)) ([65d7e7e](https://github.com/sanity-io/sanity/commit/65d7e7eaee8fb83d5101818960559d301678083b))
+* restore support for defaultOrdering. ([#7626](https://github.com/sanity-io/sanity/issues/7626)) ([02da757](https://github.com/sanity-io/sanity/commit/02da757d0368767f12d85b07ebb0396dc17a727e))
+* warnings on React 19 ([#7654](https://github.com/sanity-io/sanity/issues/7654)) ([9c72c74](https://github.com/sanity-io/sanity/commit/9c72c74b1bf525357da5cc81923179c98673e578))
+
+
+### Features
+
+* validate PR title against conventional commits ([#7580](https://github.com/sanity-io/sanity/issues/7580)) ([a9525c8](https://github.com/sanity-io/sanity/commit/a9525c8bfb57960654922832a1c48e7f78245bc4))
+
+
+
+# [3.61.0](https://github.com/sanity-io/sanity/compare/v3.60.0...v3.61.0) (2024-10-15)
+
+
+### Bug Fixes
+
+* prevent excessive requests to access endpoint  ([#7597](https://github.com/sanity-io/sanity/issues/7597)) ([45a74fc](https://github.com/sanity-io/sanity/commit/45a74fc16e96394dd731d1a8521d0924bd5d5ca6))
+* use absolute urls for published sourcemap urls ([#7599](https://github.com/sanity-io/sanity/issues/7599)) ([1f94234](https://github.com/sanity-io/sanity/commit/1f9423465521b449783c0a9ca097014c1528366c))
+
+
+### Features
+
+* add CLI command to open Sanity Learn ([#7409](https://github.com/sanity-io/sanity/issues/7409)) ([1504511](https://github.com/sanity-io/sanity/commit/150451108e4278e90b83ebf129c099409ae43065))
+* **core:** document store loader - swr in edit state ([#7552](https://github.com/sanity-io/sanity/issues/7552)) ([e3cc6d5](https://github.com/sanity-io/sanity/commit/e3cc6d5fd680230e425402ef8899be2d639d2906))
+
+
+
+# [3.60.0](https://github.com/sanity-io/sanity/compare/v3.59.1...v3.60.0) (2024-10-08)
+
+
+### Bug Fixes
+
+* **cli:** do not throw during migrate if project ID is passed through flag ([#7594](https://github.com/sanity-io/sanity/issues/7594)) ([caced3b](https://github.com/sanity-io/sanity/commit/caced3b7b27fb3cfb587b89e4138d5253f181309))
+* **cli:** use studioHost from CLI config for intent link ([#7570](https://github.com/sanity-io/sanity/issues/7570)) ([818e151](https://github.com/sanity-io/sanity/commit/818e151cb7901af5d5b362283070a1b1a69d63a9))
+* **core:** add detection and recovery for missing mutation events ([#7576](https://github.com/sanity-io/sanity/issues/7576)) ([8195c96](https://github.com/sanity-io/sanity/commit/8195c96b829cf0d4e760a9352358b2d8af63d197))
+* **core:** add missing `listenerName` property on welcome event ([#7577](https://github.com/sanity-io/sanity/issues/7577)) ([13f0563](https://github.com/sanity-io/sanity/commit/13f0563e1a949644c7b190528c8f37f7427329fe))
+* **core:** fix reference preview flickering and improve loading ([#7563](https://github.com/sanity-io/sanity/issues/7563)) ([1e31c35](https://github.com/sanity-io/sanity/commit/1e31c359a356a5e38a8f57f7176f104fa19042ea))
+* **deps:** update dependency @portabletext/editor to ^1.1.3 ([#7575](https://github.com/sanity-io/sanity/issues/7575)) ([99fcc1f](https://github.com/sanity-io/sanity/commit/99fcc1f292f0ddaddfb2f6557dbb1f7421847892))
+* **deps:** update dependency @portabletext/editor to ^1.1.4 ([#7590](https://github.com/sanity-io/sanity/issues/7590)) ([b655562](https://github.com/sanity-io/sanity/commit/b6555624d07f39d8feb1eb8b1b52076e84e8992b))
+* **deps:** update dependency @sanity/client to ^6.22.1 ([#7585](https://github.com/sanity-io/sanity/issues/7585)) ([cd07e93](https://github.com/sanity-io/sanity/commit/cd07e93dd561869d835511a88c00378cd3e16f1d))
+* **sanity:** allow global search "contains" filter to match inside words ([#7572](https://github.com/sanity-io/sanity/issues/7572)) ([0cdfdce](https://github.com/sanity-io/sanity/commit/0cdfdce755ee602a72d45f235b57c2f4575d4798))
+* **structure:** improve and clean up form ready state ([#7600](https://github.com/sanity-io/sanity/issues/7600)) ([21d848d](https://github.com/sanity-io/sanity/commit/21d848d7b78c2a171dce132589ecf7b07e67cf58))
+* **structure:** memoize search query results ([#7555](https://github.com/sanity-io/sanity/issues/7555)) ([d4e4e44](https://github.com/sanity-io/sanity/commit/d4e4e44b4da3ec50025bf721bbef5832381d65f7))
+
+
+### Features
+
+* propagate `PairListenerOptions`; add telemetry for `OutOfSyncError` ([#7595](https://github.com/sanity-io/sanity/issues/7595)) ([d96f890](https://github.com/sanity-io/sanity/commit/d96f8900473ab94665526e6ea7f4b366c47de3b9)), closes [#7576](https://github.com/sanity-io/sanity/issues/7576) [#7576](https://github.com/sanity-io/sanity/issues/7576)
+* **sanity:** add config for onUncaughtError ([#7553](https://github.com/sanity-io/sanity/issues/7553)) ([e3cf177](https://github.com/sanity-io/sanity/commit/e3cf17766bbc3b173a748405028634a6836cbf19))
+* **sanity:** studio manifests cont ([#7403](https://github.com/sanity-io/sanity/issues/7403)) ([a098753](https://github.com/sanity-io/sanity/commit/a09875391fce2b6747e6fd26ed873ae22550c489))
+
+
+
+## [3.59.1](https://github.com/sanity-io/sanity/compare/v3.59.0...v3.59.1) (2024-10-04)
+
+
+### Bug Fixes
+
+* protect against falsy `selectedGroup` ([#7593](https://github.com/sanity-io/sanity/issues/7593)) ([98f4eb9](https://github.com/sanity-io/sanity/commit/98f4eb91710905a557b18e94d1e86baefde6a39b))
+
+
+
+# [3.59.0](https://github.com/sanity-io/sanity/compare/v3.58.0...v3.59.0) (2024-10-01)
+
+
+### Bug Fixes
+
+* **block-tools:** remove references to implicit globals `document` and `Text` ([#7532](https://github.com/sanity-io/sanity/issues/7532)) ([306a671](https://github.com/sanity-io/sanity/commit/306a6717cc7aa39c328b59c38522ed25f7c0b268))
+* **core:** emit setting from localStorage immediately upon subscription ([#7560](https://github.com/sanity-io/sanity/issues/7560)) ([1e79797](https://github.com/sanity-io/sanity/commit/1e797970541b3646fcd2b4997b32282ab52bd887))
+* **core:** fixes an issue with pasting in conditional readonly field ([#7564](https://github.com/sanity-io/sanity/issues/7564)) ([2e47715](https://github.com/sanity-io/sanity/commit/2e47715c1d2546ed1a8bd73fce24be61ebcf7bb7))
+* **deps:** update dependency @portabletext/editor to ^1.1.2 ([#7566](https://github.com/sanity-io/sanity/issues/7566)) ([a762c62](https://github.com/sanity-io/sanity/commit/a762c62d08d5259eac8e8a3c5e0ea1cda2d24149))
+* **deps:** update dependency @sanity/client to ^6.22.0 ([#7522](https://github.com/sanity-io/sanity/issues/7522)) ([7c01a95](https://github.com/sanity-io/sanity/commit/7c01a95220b1c9b9e9d6ae619382f16e761b55e8))
+* **preview:** allow `null` as valid cache/memo value for preview fields ([#7551](https://github.com/sanity-io/sanity/issues/7551)) ([7b9b556](https://github.com/sanity-io/sanity/commit/7b9b556598b21eacde942f985bf51b3ca32dd224))
+* **sanity:** prevent layout shifts in image input ([6b8a76f](https://github.com/sanity-io/sanity/commit/6b8a76fe6e8cf288caceb27daec35c5d2c93603f))
+* **sanity:** use correct color scheme in image input overlay ([df0e18a](https://github.com/sanity-io/sanity/commit/df0e18a9e6ece03083372b86ef1133a3506f63c5))
+* set `cliInitializedAt` even if project bootstrap fails ([#7558](https://github.com/sanity-io/sanity/issues/7558)) ([ea186d8](https://github.com/sanity-io/sanity/commit/ea186d8bdd5847e7ca3e5f9123bc2d88248bb36d))
+
+
+### Features
+
+* add ability to request edit access from viewer role ([#7546](https://github.com/sanity-io/sanity/issues/7546)) ([59f4fda](https://github.com/sanity-io/sanity/commit/59f4fdaa131608d3102c58062697e2681dac85fb))
+* **core:** specific error when dev server is stopped ([#7476](https://github.com/sanity-io/sanity/issues/7476)) ([7fcf22a](https://github.com/sanity-io/sanity/commit/7fcf22a948a1806c7c7409355df5d0b8617c576e))
+* **sanity:** allow image input block size to extend to `30vh` ([14ebf2c](https://github.com/sanity-io/sanity/commit/14ebf2cd95bb09af937a848a17ef602aea3d6ae8))
+
+
+
+# [3.58.0](https://github.com/sanity-io/sanity/compare/v3.57.4...v3.58.0) (2024-09-24)
+
+
+### Bug Fixes
+
+* **core:** clean up portable text input's selection change handling ([#7525](https://github.com/sanity-io/sanity/issues/7525)) ([714b3e1](https://github.com/sanity-io/sanity/commit/714b3e1e5d8a7cb9f761a62db728738fbe67e2c8))
+* **core:** document store cache memo not working ([#7530](https://github.com/sanity-io/sanity/issues/7530)) ([8c677c2](https://github.com/sanity-io/sanity/commit/8c677c29cd84c14a93620a9bf0b9f9504da15e1d))
+* **core:** hide `versions.*` documents from search, update `getPublishedId` to account for versions ([#7470](https://github.com/sanity-io/sanity/issues/7470)) ([7c814a8](https://github.com/sanity-io/sanity/commit/7c814a88e4d0629650b57d4705892ade2b7d1220))
+* **core:** skip updating focusPath state if unchanged ([#7524](https://github.com/sanity-io/sanity/issues/7524)) ([7183b24](https://github.com/sanity-io/sanity/commit/7183b2448e2fe5fbcfd6eecd55533bfd518a7469))
+* **structure:** live edit on draft documents ([#7526](https://github.com/sanity-io/sanity/issues/7526)) ([7bf9995](https://github.com/sanity-io/sanity/commit/7bf9995f4d4ed3f822b02b3278915d3033209d27))
+
+
+### Features
+
+* **core:** Studio announcements ([#7515](https://github.com/sanity-io/sanity/issues/7515)) ([3593bf5](https://github.com/sanity-io/sanity/commit/3593bf56a47b8041fc37d3ad9a0e8e8dcd332fc7))
+* **perf:** add new eFPS benchmark suite ([#7407](https://github.com/sanity-io/sanity/issues/7407)) ([2de06de](https://github.com/sanity-io/sanity/commit/2de06de0ea03b5ff9775db8b256199d217723cfb))
+* **sanity:** add "Copy error details" button to document list error UI ([a218c88](https://github.com/sanity-io/sanity/commit/a218c88030030ad243a85a61e807e84db630ece2))
+* **sanity:** add `ErrorActions` component ([7809762](https://github.com/sanity-io/sanity/commit/7809762b794c6b8eb6233e0292febe84ed03ac2a))
+* **sanity:** refine `StudioErrorBoundary` component UI ([d11efce](https://github.com/sanity-io/sanity/commit/d11efce41082f6b17816ba60cf7ea5b652ebf636))
+
+
+
+## [3.57.4](https://github.com/sanity-io/sanity/compare/v3.57.3...v3.57.4) (2024-09-17)
+
+
+### Bug Fixes
+
+* add padding above the "Push to reload" button instead of below ([#7464](https://github.com/sanity-io/sanity/issues/7464)) ([1a33125](https://github.com/sanity-io/sanity/commit/1a33125c502e6362b9abd54323abb36075ef563b))
+* **core:** correctly reset PTE list counts after non-numbered lists and in sublists ([#7506](https://github.com/sanity-io/sanity/issues/7506)) ([4918a9e](https://github.com/sanity-io/sanity/commit/4918a9e5fa7fdc4857ffbbfa7999ef7ab70065c6))
+* **core:** drafts not using server actions always generate a created at ([#7503](https://github.com/sanity-io/sanity/issues/7503)) ([728311e](https://github.com/sanity-io/sanity/commit/728311e4a273dc16666913702de511970b2bab2a))
+* **deps:** update dependency @portabletext/editor to ^1.1.0 ([#7501](https://github.com/sanity-io/sanity/issues/7501)) ([a6e0389](https://github.com/sanity-io/sanity/commit/a6e038941abeb07503e0ee409a40c450e58abf67))
+* **deps:** update dependency @portabletext/editor to ^1.1.1 ([#7514](https://github.com/sanity-io/sanity/issues/7514)) ([daf4ffa](https://github.com/sanity-io/sanity/commit/daf4ffad04c6a5d5c4966225f52d4fd7c833df92))
+* **deps:** Update dev-non-major ([#7510](https://github.com/sanity-io/sanity/issues/7510)) ([fe75e37](https://github.com/sanity-io/sanity/commit/fe75e376172d08a3bcfad8d625f006ee812ebe67))
+* forward received onItemPrepend/onItemAppend to ArrayFunctions ([#7516](https://github.com/sanity-io/sanity/issues/7516)) ([4a50023](https://github.com/sanity-io/sanity/commit/4a50023cc7083da42da895f1ae9297fad6438f0b))
+* **sanity:** prevent empty patches being created ([#7499](https://github.com/sanity-io/sanity/issues/7499)) ([99f1bb6](https://github.com/sanity-io/sanity/commit/99f1bb6163fac1aa61218b6c2a3cfd1a34cadc71))
+
+
+### Performance Improvements
+
+* **core:** memoize `prepareFormState` ([#7498](https://github.com/sanity-io/sanity/issues/7498)) ([3bf7096](https://github.com/sanity-io/sanity/commit/3bf70962b4f2eb052311a0c66dc376498cae2954))
+
+
+
+## [3.57.3](https://github.com/sanity-io/sanity/compare/v3.57.2...v3.57.3) (2024-09-12)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @sanity/insert-menu to v1.0.9 ([#7492](https://github.com/sanity-io/sanity/issues/7492)) ([e4afd03](https://github.com/sanity-io/sanity/commit/e4afd03a351500da9702175625f5a723d68f1281))
+* **deps:** update dependency @sanity/presentation to v1.16.5 ([#7493](https://github.com/sanity-io/sanity/issues/7493)) ([f9d354f](https://github.com/sanity-io/sanity/commit/f9d354ffec5c74cabd3c95b0e471005c6386670e))
+* **deps:** Update dev-non-major ([#7488](https://github.com/sanity-io/sanity/issues/7488)) ([fd37976](https://github.com/sanity-io/sanity/commit/fd379762bbcc60da6cefd6625da69ca086421995))
+
+
+### Features
+
+* **cli:** use auto-updates flag in init ([#7401](https://github.com/sanity-io/sanity/issues/7401)) ([17c02f9](https://github.com/sanity-io/sanity/commit/17c02f99a2c332134080eb1cf66849133ddb154f))
+
+
+
+## [3.57.2](https://github.com/sanity-io/sanity/compare/v3.57.1...v3.57.2) (2024-09-10)
+
+
+### Bug Fixes
+
+* **core:** Fix Title in "Untitled was published" toast ([#7473](https://github.com/sanity-io/sanity/issues/7473)) ([f44786c](https://github.com/sanity-io/sanity/commit/f44786c1bc2a156279f72712686b044a03173f4b))
+* **deps:** update dependency @sanity/client to ^6.21.3 ([#7373](https://github.com/sanity-io/sanity/issues/7373)) ([2002add](https://github.com/sanity-io/sanity/commit/2002add60bfc5d577c84f391e6c65c410c34f7ff))
+* **deps:** update dependency @sanity/mutate to ^0.10.0 ([#7451](https://github.com/sanity-io/sanity/issues/7451)) ([ea3a79a](https://github.com/sanity-io/sanity/commit/ea3a79ae50d0ed6df6292ad7ce3bd07b4dfd601d))
+* **deps:** update dependency @sanity/ui to ^2.8.9 ([#7436](https://github.com/sanity-io/sanity/issues/7436)) ([048068e](https://github.com/sanity-io/sanity/commit/048068e41c4853a44fe223fd83588c6e23459fbd))
+* **deps:** Update dev-non-major ([#7477](https://github.com/sanity-io/sanity/issues/7477)) ([dce41fb](https://github.com/sanity-io/sanity/commit/dce41fb7a277d5cdb7b0d5503a720d7a75a1bda5))
+
+
+### Features
+
+* **sanity:** add telemetry when creating a draft ([#7459](https://github.com/sanity-io/sanity/issues/7459)) ([e6b0614](https://github.com/sanity-io/sanity/commit/e6b0614c0b65ceafbcdf97ee92ef7006aaf4e19d))
+
+
+### Reverts
+
+* Revert "chore: support for sticky params in URL and intent ops (#7429)" (#7489) ([5cb335b](https://github.com/sanity-io/sanity/commit/5cb335b1a2dcdf5cc967e88e22d2e8c082bb9c2e)), closes [#7429](https://github.com/sanity-io/sanity/issues/7429) [#7489](https://github.com/sanity-io/sanity/issues/7489)
+
+
+
+## [3.57.1](https://github.com/sanity-io/sanity/compare/v3.57.0...v3.57.1) (2024-09-06)
+
+
+### Bug Fixes
+
+* **core:** ensure all keys are reconciled ([6393df8](https://github.com/sanity-io/sanity/commit/6393df81923f302709b24ec33ee9da119d7d70c5))
+
+
+
+# [3.57.0](https://github.com/sanity-io/sanity/compare/v3.56.0...v3.57.0) (2024-09-03)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @portabletext/editor to ^1.0.19 ([#7405](https://github.com/sanity-io/sanity/issues/7405)) ([5ebff0d](https://github.com/sanity-io/sanity/commit/5ebff0df710dcfc8854cfee2411896ebded0d164))
+* significantly speed up styled-components in dev mode ([#7440](https://github.com/sanity-io/sanity/issues/7440)) ([c259119](https://github.com/sanity-io/sanity/commit/c2591194efb4ebcd64b46ac13a061c99dd9046b8))
+* **structure:** passing from operation context to label for success toast ([#7437](https://github.com/sanity-io/sanity/issues/7437)) ([f4e414c](https://github.com/sanity-io/sanity/commit/f4e414cfb81bff5509a6e9120e2b227e3ee0314e))
+
+
+### Features
+
+* **cli:** allow setting `--max-fetch-concurrency` to prevent stalled validators ([#7450](https://github.com/sanity-io/sanity/issues/7450)) ([85b0538](https://github.com/sanity-io/sanity/commit/85b0538de46db258faa61594ed6fe757755d75ef))
+
+
+
+# [3.56.0](https://github.com/sanity-io/sanity/compare/v3.55.0...v3.56.0) (2024-08-27)
+
+
+### Bug Fixes
+
+* **core:** avoid unnecessary re-renders in useDocumentPresence ([#7365](https://github.com/sanity-io/sanity/issues/7365)) ([379620e](https://github.com/sanity-io/sanity/commit/379620e0a96b91a6f36871a098ab72285b334610))
+* **deps:** update dependency @sanity/icons to ^3.4.0 ([#7417](https://github.com/sanity-io/sanity/issues/7417)) ([6bd4f8c](https://github.com/sanity-io/sanity/commit/6bd4f8cd2099fa7e9bb5b2345c11d7af1e739db1))
+* **deps:** update dependency groq-js to ^1.13.0 ([#7424](https://github.com/sanity-io/sanity/issues/7424)) ([14530aa](https://github.com/sanity-io/sanity/commit/14530aa3b0072c70b8c9cf4a5182af78ec975f81))
+* **sanity:** add prop for constraintSize ([#7421](https://github.com/sanity-io/sanity/issues/7421)) ([17a7b1d](https://github.com/sanity-io/sanity/commit/17a7b1d9f88bba37367ca8db5ce114fe5c661192))
+* **structure:** make sync document toast dismisable ([#7209](https://github.com/sanity-io/sanity/issues/7209)) ([dc40f6e](https://github.com/sanity-io/sanity/commit/dc40f6ee94d3c5e5fd2c9b5ad377340d16ea8f7b))
+
+
+### Features
+
+* **cli:** respect `--no-auto-updates flag` in CLI config ([#7396](https://github.com/sanity-io/sanity/issues/7396)) ([c83021e](https://github.com/sanity-io/sanity/commit/c83021ebaf0f5eb6cd87b3ece8320c67b51a0712))
+* **sanity:** add always present document action to copy url to clipboard ([#7416](https://github.com/sanity-io/sanity/issues/7416)) ([7afcdb4](https://github.com/sanity-io/sanity/commit/7afcdb408c250a934a5efc93b90c5a7f3c3b38b3))
+* **sanity:** Update presence menu button for inviting new collaborators ([#7406](https://github.com/sanity-io/sanity/issues/7406)) ([064519a](https://github.com/sanity-io/sanity/commit/064519a2aa9bd867c6f129d928b3d2560acdf72a))
+
+
+
+# [3.55.0](https://github.com/sanity-io/sanity/compare/v3.54.0...v3.55.0) (2024-08-20)
+
+
+### Bug Fixes
+
+* **core:** fix copy related issues ([#7394](https://github.com/sanity-io/sanity/issues/7394)) ([49083dd](https://github.com/sanity-io/sanity/commit/49083ddc865dd9a6343bd6b70f6bd04e16b220f1)), closes [#7265](https://github.com/sanity-io/sanity/issues/7265)
+* **deps:** update dependency @portabletext/editor to ^1.0.15 ([#7377](https://github.com/sanity-io/sanity/issues/7377)) ([f273249](https://github.com/sanity-io/sanity/commit/f2732495d688584f149d113116f4e48d4224c7d5))
+* **deps:** update dependency get-it to ^8.6.5 ([#7376](https://github.com/sanity-io/sanity/issues/7376)) ([b5d7418](https://github.com/sanity-io/sanity/commit/b5d7418d609eae587538f186a77eb06d199638eb))
+* do not show latest version if auto-updating ([#7388](https://github.com/sanity-io/sanity/issues/7388)) ([1872388](https://github.com/sanity-io/sanity/commit/1872388e2b5e5bc916f4339fa546fa69e2b08499))
+* **form:** fix issue where FormInput was not rendering field when passed 'includeField' ([#7350](https://github.com/sanity-io/sanity/issues/7350)) ([e6185ef](https://github.com/sanity-io/sanity/commit/e6185ef8d72d481dcfd6119c121ed59186373bec))
+* **typegen:** find queries imported with defineQuery from next-sanity ([#7391](https://github.com/sanity-io/sanity/issues/7391)) ([b86e3d0](https://github.com/sanity-io/sanity/commit/b86e3d0cf4f382e351d187a6fd19a6321096e0af))
+
+
+### Features
+
+* **sanity:** request access flow ([#7248](https://github.com/sanity-io/sanity/issues/7248)) ([5ab35a5](https://github.com/sanity-io/sanity/commit/5ab35a54f3df729cb95d9d7e063a6a23f2919339))
+* **typegen:** set overload client methods to default to true ([#7390](https://github.com/sanity-io/sanity/issues/7390)) ([c11e51f](https://github.com/sanity-io/sanity/commit/c11e51fdb20169282f6fdcdd51905096ecb98cac))
+
+
+
+# [3.54.0](https://github.com/sanity-io/sanity/compare/v3.53.0...v3.54.0) (2024-08-14)
+
+
+### Bug Fixes
+
+* **core:** update eslintrc config to show no-restricted-imports rules ([#7367](https://github.com/sanity-io/sanity/issues/7367)) ([22e717e](https://github.com/sanity-io/sanity/commit/22e717e1a69ff65de42fa4cf868145da0b567a0f))
+* **deps:** `@bjoerge/mutiny` is now `@sanity/mutate` ([#7344](https://github.com/sanity-io/sanity/issues/7344)) ([4aeb5b6](https://github.com/sanity-io/sanity/commit/4aeb5b6f0df6bfd74a6a88131d380cad3bd12417))
+* **deps:** update and pin react-i18next to 14.0.2 ([#7364](https://github.com/sanity-io/sanity/issues/7364)) ([3cecfdd](https://github.com/sanity-io/sanity/commit/3cecfdd8c1182c9e6ea484e45ee5e02cdc902031))
+* **deps:** update dependency @portabletext/editor to ^1.0.12 ([#7352](https://github.com/sanity-io/sanity/issues/7352)) ([ecde097](https://github.com/sanity-io/sanity/commit/ecde097776597e97be384b891602673df4348401))
+* **deps:** update dependency @portabletext/editor to ^1.0.13 ([#7370](https://github.com/sanity-io/sanity/issues/7370)) ([a361063](https://github.com/sanity-io/sanity/commit/a36106315bf38b162b6d77c0246cc87eb5958a12))
+* **deps:** update dependency @sanity/client to ^6.21.2 ([#7354](https://github.com/sanity-io/sanity/issues/7354)) ([db6741b](https://github.com/sanity-io/sanity/commit/db6741b1920e9dd2abf075c7592bb39e73fe00e7))
+* **deps:** update dependency @sanity/insert-menu to v1.0.8 ([#7343](https://github.com/sanity-io/sanity/issues/7343)) ([088139d](https://github.com/sanity-io/sanity/commit/088139dac3453cc803e5489ab2c523a0eb19d2ff))
+* **deps:** update dependency @sanity/presentation to v1.16.4 ([#7359](https://github.com/sanity-io/sanity/issues/7359)) ([441d7e5](https://github.com/sanity-io/sanity/commit/441d7e576d5c37bd97db3b0bd29efa804ca7521f))
+* **deps:** update dependency get-it to ^8.6.4 ([#7353](https://github.com/sanity-io/sanity/issues/7353)) ([f6b6378](https://github.com/sanity-io/sanity/commit/f6b6378052e511639feef48e766c979327ae356e))
+* **deps:** Update dev-non-major ([#7345](https://github.com/sanity-io/sanity/issues/7345)) ([eefb5ea](https://github.com/sanity-io/sanity/commit/eefb5ea138444e669ee1701baef9ef7f0f034d74))
+* **sanity:** prevent empty actions being executed ([c2e4eb3](https://github.com/sanity-io/sanity/commit/c2e4eb3255ef0ac69b7f22d55346a21be9eb9d2e))
+* **typegen:** dont treat all document type refs as references ([#7366](https://github.com/sanity-io/sanity/issues/7366)) ([32958d3](https://github.com/sanity-io/sanity/commit/32958d3e759e8569d390d7ae4b0e016cdec6edfe))
+
+
+### Features
+
+* **cli:** update CLI to use new deploy endpoint ([#7244](https://github.com/sanity-io/sanity/issues/7244)) ([14ae5cb](https://github.com/sanity-io/sanity/commit/14ae5cb8310fdac21255640782e8bdda7273df27)), closes [#7349](https://github.com/sanity-io/sanity/issues/7349)
+* **core:** support pasting object into array + copying individual array items ([#7292](https://github.com/sanity-io/sanity/issues/7292)) ([ea55826](https://github.com/sanity-io/sanity/commit/ea558269fc44b0b5e41ff7e9b03eda7a04f8a627))
+* **test-studio:** add noop custom publish action example ([7860c8e](https://github.com/sanity-io/sanity/commit/7860c8e58bb9f219dc244898f2b09f436d0b76d0))
+
+
+
+# [3.53.0](https://github.com/sanity-io/sanity/compare/v3.52.4...v3.53.0) (2024-08-06)
+
+
+### Bug Fixes
+
+* **cli:** dedupe `styled-components` in vite config ([#7310](https://github.com/sanity-io/sanity/issues/7310)) ([e82e815](https://github.com/sanity-io/sanity/commit/e82e8157db40b230a087fd881f380ae4b5a161fe))
+* **cli:** don't prepend message about .env.local if creating .env.local ([#7288](https://github.com/sanity-io/sanity/issues/7288)) ([ec27de0](https://github.com/sanity-io/sanity/commit/ec27de0f8d75ec20af7bebde59a51c858b014d81))
+* **core:** correctly reset PTE list counts ([#7286](https://github.com/sanity-io/sanity/issues/7286)) ([acbc351](https://github.com/sanity-io/sanity/commit/acbc3518beb9217f865961f05db5d2f666392bc9))
+* **deps:** update dependency @portabletext/editor to ^1.0.10 ([#7290](https://github.com/sanity-io/sanity/issues/7290)) ([e5e2c89](https://github.com/sanity-io/sanity/commit/e5e2c899f809ec3429395a30c6b0c9de6681a7ca))
+* **deps:** update dependency @portabletext/editor to ^1.0.11 ([#7316](https://github.com/sanity-io/sanity/issues/7316)) ([cec7b12](https://github.com/sanity-io/sanity/commit/cec7b12249633f887a6bc84101a78538506b052d))
+* **deps:** update dependency @portabletext/editor to ^1.0.11 ([#7317](https://github.com/sanity-io/sanity/issues/7317)) ([de01242](https://github.com/sanity-io/sanity/commit/de01242bb93430c077017622fbf740f694689b17))
+* **deps:** update dependency @sanity/presentation to v1.16.3 ([#7302](https://github.com/sanity-io/sanity/issues/7302)) ([cc744df](https://github.com/sanity-io/sanity/commit/cc744df230a38a563c791af09b01cbde4e794f8a))
+* **deps:** update dependency react-rx to v4 ([#7266](https://github.com/sanity-io/sanity/issues/7266)) ([a9b9feb](https://github.com/sanity-io/sanity/commit/a9b9febc313a040352c6cfb7fbd8c3f163bcd496))
+* **deps:** Update dev-non-major ([#7294](https://github.com/sanity-io/sanity/issues/7294)) ([8d47f3e](https://github.com/sanity-io/sanity/commit/8d47f3e37594c3be0502dd5335d7716709d1e0b6))
+* **deps:** Update dev-non-major ([#7307](https://github.com/sanity-io/sanity/issues/7307)) ([fe40caf](https://github.com/sanity-io/sanity/commit/fe40cafb41389106696e0a1afcb02a9ba47b2e36))
+* ensure search context provider value is memoized ([#7200](https://github.com/sanity-io/sanity/issues/7200)) ([edf7560](https://github.com/sanity-io/sanity/commit/edf7560eb7f437d6c8c985ae3e8c6a6e200b38bd))
+* **migrate:** properly decode chunks of multibyte unicode strings ([#7321](https://github.com/sanity-io/sanity/issues/7321)) ([ba4d4a8](https://github.com/sanity-io/sanity/commit/ba4d4a86aca97439e71e25f15cdcf93a5f552f9e))
+* remove react hooks linter suppressions in PT hooks ([#7222](https://github.com/sanity-io/sanity/issues/7222)) ([f5cac7b](https://github.com/sanity-io/sanity/commit/f5cac7b335a7fea67ee1bff8b986a1340eeb2308))
+* support field presence avatars on react 19 ([#7308](https://github.com/sanity-io/sanity/issues/7308)) ([8d003e8](https://github.com/sanity-io/sanity/commit/8d003e83ee4e1a06f3633c6e2ff55b9fe6df78a2))
+
+
+### Features
+
+* **codegen:** generate SanityQueries interface in @sanity/codegen ([#6997](https://github.com/sanity-io/sanity/issues/6997)) ([#7304](https://github.com/sanity-io/sanity/issues/7304)) ([886ab25](https://github.com/sanity-io/sanity/commit/886ab25c467ffcae6582fcdfda9ae958b0315e2f)), closes [#7215](https://github.com/sanity-io/sanity/issues/7215)
+* embellish nextjs blog starter ([#7258](https://github.com/sanity-io/sanity/issues/7258)) ([0fc8216](https://github.com/sanity-io/sanity/commit/0fc8216ee60900ea7d50640d4e3e3a19509d70b5))
+* **typegen:** add location of discovered query ([#7327](https://github.com/sanity-io/sanity/issues/7327)) ([d77e3ad](https://github.com/sanity-io/sanity/commit/d77e3ad07ecbd3667b19f2f369fd3dfd6516b3d6))
+
+
+
+## [3.52.4](https://github.com/sanity-io/sanity/compare/v3.52.3...v3.52.4) (2024-07-30)
+
+
+### Bug Fixes
+
+* **core:** early return if paste target is a file/image ([#7269](https://github.com/sanity-io/sanity/issues/7269)) ([6fc602c](https://github.com/sanity-io/sanity/commit/6fc602c6e28a09e83cc2ad57def9b3d61217b016))
+* **deps:** bump `@sanity/pkg-utils` to `v6.10.7` ([#7277](https://github.com/sanity-io/sanity/issues/7277)) ([56d9e16](https://github.com/sanity-io/sanity/commit/56d9e16c4c795ef53826977ac9ab77a870a67105))
+
+
+
+## [3.52.3](https://github.com/sanity-io/sanity/compare/v3.52.2...v3.52.3) (2024-07-30)
+
+
+### Bug Fixes
+
+* add back `FieldPresenceWithOverlay` export ([#7263](https://github.com/sanity-io/sanity/issues/7263)) ([b9785f0](https://github.com/sanity-io/sanity/commit/b9785f04ef540bf5f2d35e7512e41a7e269a0dfe))
+* **chore:** add aria label to datepicker button ([#6952](https://github.com/sanity-io/sanity/issues/6952)) ([a5c05d9](https://github.com/sanity-io/sanity/commit/a5c05d900c6440cec4850d294cf9eb81d4b67e25))
+* **cli:** remove `conditions` to prevent CJS interop errors ([#7267](https://github.com/sanity-io/sanity/issues/7267)) ([5031cef](https://github.com/sanity-io/sanity/commit/5031cef0f0dd622b735231e965d466dc52d3c220))
+* **deps:** update dependency @portabletext/editor to ^1.0.9 ([#7250](https://github.com/sanity-io/sanity/issues/7250)) ([10fa5cb](https://github.com/sanity-io/sanity/commit/10fa5cbbd0f40e08034a856f39af98358e8614c8))
+* **deps:** update dependency groq-js to ^1.11.1 ([#7247](https://github.com/sanity-io/sanity/issues/7247)) ([0d6c67e](https://github.com/sanity-io/sanity/commit/0d6c67e2e1a414422f5f142127bfd1f6f55ea515))
+* **deps:** update dependency groq-js to ^1.12.0 ([#7252](https://github.com/sanity-io/sanity/issues/7252)) ([ef01b92](https://github.com/sanity-io/sanity/commit/ef01b921c96e0ee67219ae3e971a9e8c796a341a))
+* **deps:** Update dev-non-major ([#7273](https://github.com/sanity-io/sanity/issues/7273)) ([95e4ce0](https://github.com/sanity-io/sanity/commit/95e4ce03173dbcd18832f66669baad8fc673e73e))
+
+
+
+## [3.52.2](https://github.com/sanity-io/sanity/compare/v3.52.1...v3.52.2) (2024-07-24)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @sanity/client to ^6.21.1 ([#7215](https://github.com/sanity-io/sanity/issues/7215)) ([08658f2](https://github.com/sanity-io/sanity/commit/08658f2049539c7b8c6fe5d65bf96cbf76349128))
+* **deps:** update dependency @sanity/export to ^3.41.0 ([#7223](https://github.com/sanity-io/sanity/issues/7223)) ([0332d38](https://github.com/sanity-io/sanity/commit/0332d38776d539bce56c29212d78bc9b2e36dc97))
+* **deps:** update dependency groq-js to ^1.11.0 ([#7229](https://github.com/sanity-io/sanity/issues/7229)) ([8b92196](https://github.com/sanity-io/sanity/commit/8b92196875c06638a1077133cb7a2dd1b11a6b72))
+* hard link between datasets, for now ([#7228](https://github.com/sanity-io/sanity/issues/7228)) ([2e77986](https://github.com/sanity-io/sanity/commit/2e77986f2478083054067a16f5607a2f60c5b74f))
+* improve hook collection state performance ([#7218](https://github.com/sanity-io/sanity/issues/7218)) ([bebeac5](https://github.com/sanity-io/sanity/commit/bebeac52eb0b529747617cea2a6f32c7fbb2438d))
+* remove "a key prop is spread into JSX" warning ([#7224](https://github.com/sanity-io/sanity/issues/7224)) ([615c3c8](https://github.com/sanity-io/sanity/commit/615c3c8b319be71384475d084173a52d63806f6a))
+* **WorkspacesProvider:** run `prepareConfig` in a passive effect ([#7226](https://github.com/sanity-io/sanity/issues/7226)) ([2c35087](https://github.com/sanity-io/sanity/commit/2c35087448807b9370a9d91fa6de6722d55ee67d))
+
+
+### Features
+
+* refactor `createTrackerScope` internals to be more efficient ([#6946](https://github.com/sanity-io/sanity/issues/6946)) ([c4f9a1f](https://github.com/sanity-io/sanity/commit/c4f9a1f2bf84728c1e458a67dd1437681c3416f0))
+
+
+
+## [3.52.1](https://github.com/sanity-io/sanity/compare/v3.52.0...v3.52.1) (2024-07-23)
+
+
+### Bug Fixes
+
+* **deps:** Update dev-non-major ([#7216](https://github.com/sanity-io/sanity/issues/7216)) ([f6bb311](https://github.com/sanity-io/sanity/commit/f6bb3117fed60e3fbb98295926e6bda054d1e518))
+* ensure context provider values are memoized ([#7199](https://github.com/sanity-io/sanity/issues/7199)) ([ff49411](https://github.com/sanity-io/sanity/commit/ff49411d4ea9acd40dcd4ed80d0cc893e0277096))
+* **sanity/cli:** issue with plugins would crash ([3682286](https://github.com/sanity-io/sanity/commit/3682286db2b844a001bf2dddffc0f27bc8628dc1))
+
+
+
+# [3.52.0](https://github.com/sanity-io/sanity/compare/v3.51.0...v3.52.0) (2024-07-19)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @sanity/icons to ^3.3.1 ([#7204](https://github.com/sanity-io/sanity/issues/7204)) ([bf9ca0b](https://github.com/sanity-io/sanity/commit/bf9ca0b622f0e46843dd9381bc2c72595c4e1928))
+* **deps:** update dependency @sanity/ui to ^2.7.0 ([#7168](https://github.com/sanity-io/sanity/issues/7168)) ([b60195b](https://github.com/sanity-io/sanity/commit/b60195b08f782062b645a8d7f2b875caf50cde07))
+* **deps:** update dependency @sanity/ui to ^2.8.2 ([#7185](https://github.com/sanity-io/sanity/issues/7185)) ([6535562](https://github.com/sanity-io/sanity/commit/6535562ebca550b3d1692aeaca8e3ebe28c5d2b1))
+* **deps:** update dependency @sanity/ui to ^2.8.2 ([#7188](https://github.com/sanity-io/sanity/issues/7188)) ([ef0d937](https://github.com/sanity-io/sanity/commit/ef0d9373e9c425665fd47f5875007d105d992b73))
+* **deps:** update dependency @sanity/ui to ^2.8.5 ([#7191](https://github.com/sanity-io/sanity/issues/7191)) ([8a9730c](https://github.com/sanity-io/sanity/commit/8a9730c0f1b4356414536e76c1b0ef0d66892f7d))
+* **deps:** update dependency @sanity/ui to ^2.8.5 ([#7192](https://github.com/sanity-io/sanity/issues/7192)) ([1515df1](https://github.com/sanity-io/sanity/commit/1515df1fbf29e1907b097d21f3275dcca1f32fd3))
+* **deps:** update dependency @sanity/ui to ^2.8.6 ([#7196](https://github.com/sanity-io/sanity/issues/7196)) ([7771ee0](https://github.com/sanity-io/sanity/commit/7771ee0ee14eed6cb359d2c8e44e606a66c6eefd))
+* **deps:** update dependency @sanity/ui to ^2.8.7 ([#7197](https://github.com/sanity-io/sanity/issues/7197)) ([fe8efa0](https://github.com/sanity-io/sanity/commit/fe8efa0c1b2c3b3fd4318db9efb192b077c63569))
+* **deps:** update dependency @sanity/ui to ^2.8.8 ([#7210](https://github.com/sanity-io/sanity/issues/7210)) ([944d392](https://github.com/sanity-io/sanity/commit/944d392a07b8873c154412d70b2b20d4cbc1d951))
+* **deps:** Update dev-non-major ([#7184](https://github.com/sanity-io/sanity/issues/7184)) ([706a86b](https://github.com/sanity-io/sanity/commit/706a86b59b6a6bb3cd1d33483cce9b592de4c2ba))
+* **deps:** Update dev-non-major ([#7203](https://github.com/sanity-io/sanity/issues/7203)) ([f0d5f82](https://github.com/sanity-io/sanity/commit/f0d5f82fc51b63727d798a389acd4676c7223c96))
+* **deps:** Update dev-non-major ([#7212](https://github.com/sanity-io/sanity/issues/7212)) ([a20e9b1](https://github.com/sanity-io/sanity/commit/a20e9b12568b8393a2e96e8a117fb6e987bb8f98))
+* detect duplicate context errors ([#7160](https://github.com/sanity-io/sanity/issues/7160)) ([7f3a881](https://github.com/sanity-io/sanity/commit/7f3a8814e94a69330957374165a3a5c5aa51b2b5))
+* **sanity:** ensure Actions API client uses adequate API version ([#7166](https://github.com/sanity-io/sanity/issues/7166)) ([25a983b](https://github.com/sanity-io/sanity/commit/25a983bc7cdc4c22c847e129df7400943a2ae487))
+* unify externals in auto-updating builds ([#7187](https://github.com/sanity-io/sanity/issues/7187)) ([a6def04](https://github.com/sanity-io/sanity/commit/a6def041b6a5c91c2623b7c09cd0a5bc06616bde))
+
+
+### Features
+
+* **core:** add aliases to mitigate context issues ([#7172](https://github.com/sanity-io/sanity/issues/7172)) ([776f16b](https://github.com/sanity-io/sanity/commit/776f16b8034f8d00e0dd8c0662d5cd7c2aa2b653))
+
+
+
+# [3.51.0](https://github.com/sanity-io/sanity/compare/v3.50.0...v3.51.0) (2024-07-16)
+
+
+### Bug Fixes
+
+* **core:** restore platform-aware keyboard shortcuts ([#6819](https://github.com/sanity-io/sanity/issues/6819)) ([512965c](https://github.com/sanity-io/sanity/commit/512965c1b2b5de17b55c7a0e197f2e894bcedd74))
+* **deps:** update dependency @sanity/ui to ^2.6.8 ([#7144](https://github.com/sanity-io/sanity/issues/7144)) ([3fca2ef](https://github.com/sanity-io/sanity/commit/3fca2ef7ac9994e6844e5de42e102c8d4d9d5842))
+* **deps:** Update dev-non-major ([#7149](https://github.com/sanity-io/sanity/issues/7149)) ([3ae92a5](https://github.com/sanity-io/sanity/commit/3ae92a50e0769fa405280a028909d1170291cc34))
+* **deps:** Update dev-non-major ([#7164](https://github.com/sanity-io/sanity/issues/7164)) ([41a3039](https://github.com/sanity-io/sanity/commit/41a3039b208675b72c92abbe9d297437ecd9ef1a))
+* force arborist ^7.5.4 ([49f278a](https://github.com/sanity-io/sanity/commit/49f278adb11869e91b7582e80cba0c548444d7be))
+* **sanity:** open correct groups and fieldsets on `setOpenPath` ([#7154](https://github.com/sanity-io/sanity/issues/7154)) ([b278800](https://github.com/sanity-io/sanity/commit/b278800dead9c39cb101d6e5fac1d7c5f0741abc))
+
+
+### Features
+
+* **core:** clickable links in comment message ([#7093](https://github.com/sanity-io/sanity/issues/7093)) ([6fad0c5](https://github.com/sanity-io/sanity/commit/6fad0c53e71da2b571b5d9c8b48a3f99ce63b82e))
+* update schema types formatting and init to include src ([#7094](https://github.com/sanity-io/sanity/issues/7094)) ([d42da14](https://github.com/sanity-io/sanity/commit/d42da143a75e0e61181084e0fda934cccf71d578))
+
+
+
+# [3.50.0](https://github.com/sanity-io/sanity/compare/v3.49.0...v3.50.0) (2024-07-11)
+
+
+### Bug Fixes
+
+* **cli:** allow styled-component as dev dependency ([#7132](https://github.com/sanity-io/sanity/issues/7132)) ([ff31556](https://github.com/sanity-io/sanity/commit/ff31556cc6ee4677e23020977db2e91a48369218))
+* **cli:** mock `document.execCommand` when emulating browser env ([#7062](https://github.com/sanity-io/sanity/issues/7062)) ([e54ae8a](https://github.com/sanity-io/sanity/commit/e54ae8a3391a18e6d0b8c698b8ee58a2f4094284))
+* **core:** error reporting consent tweaks ([#7131](https://github.com/sanity-io/sanity/issues/7131)) ([1552e20](https://github.com/sanity-io/sanity/commit/1552e20d26fdac857a3616979a3d72667254d378))
+* **core:** fixes url for checking studio version ([#7060](https://github.com/sanity-io/sanity/issues/7060)) ([a44fd5b](https://github.com/sanity-io/sanity/commit/a44fd5b3a7e534e93ee0dfa95c6c382e952dafac))
+* **core:** handle array fields within nested objects in array items ([#7069](https://github.com/sanity-io/sanity/issues/7069)) ([3c057a8](https://github.com/sanity-io/sanity/commit/3c057a86ad315eb32b68857cd498bbd9b581f14c))
+* **core:** minor typo fix in i18n comment ([#7115](https://github.com/sanity-io/sanity/issues/7115)) ([04c374a](https://github.com/sanity-io/sanity/commit/04c374aa02af492583468470d70671625fb6a58a))
+* **deps:** bump @sanity/ui ^2.6.7 ([#7143](https://github.com/sanity-io/sanity/issues/7143)) ([b58b0f8](https://github.com/sanity-io/sanity/commit/b58b0f8ed19284e63c859e6f19fd0290d91441ce))
+* **deps:** update dependency @portabletext/editor to ^1.0.8 ([#7101](https://github.com/sanity-io/sanity/issues/7101)) ([07771ed](https://github.com/sanity-io/sanity/commit/07771edc2fcbfcb7c9759ffa43f38e101b4371bb))
+* **deps:** update dependency @sanity/bifur-client to ^0.4.1 ([#7102](https://github.com/sanity-io/sanity/issues/7102)) ([048b4fb](https://github.com/sanity-io/sanity/commit/048b4fb8073d8f3de1f92d82cdc95ccf5a57609a))
+* **deps:** update dependency @sanity/client to ^6.20.1 ([#7088](https://github.com/sanity-io/sanity/issues/7088)) ([baa20cb](https://github.com/sanity-io/sanity/commit/baa20cbe7b148fe1a36fbeeaa92c31c450092eed))
+* **deps:** update dependency @sanity/client to ^6.20.2 ([#7110](https://github.com/sanity-io/sanity/issues/7110)) ([2e1c86a](https://github.com/sanity-io/sanity/commit/2e1c86a64e85b12a9f3fcbc0881137a6939cc633))
+* **deps:** update dependency @sanity/client to ^6.20.2 ([#7111](https://github.com/sanity-io/sanity/issues/7111)) ([8ec952e](https://github.com/sanity-io/sanity/commit/8ec952ef5283a969fb8a7f2bbe7e817a04f17b47))
+* **deps:** update dependency @sanity/client to ^6.21.0 ([#7137](https://github.com/sanity-io/sanity/issues/7137)) ([a23b2a5](https://github.com/sanity-io/sanity/commit/a23b2a5d6e6914517bb6fdc6b282d48ae2511734))
+* **deps:** update dependency @sanity/icons to ^3.3.0 ([#7098](https://github.com/sanity-io/sanity/issues/7098)) ([451e841](https://github.com/sanity-io/sanity/commit/451e841023cd70f44fe2d6f0c210410721cce990))
+* **deps:** update dependency @sanity/presentation to v1.16.2 ([#7078](https://github.com/sanity-io/sanity/issues/7078)) ([7aa5732](https://github.com/sanity-io/sanity/commit/7aa57323a9989d4ac0d0b873295b9eafccece44f))
+* **deps:** update dependency @sanity/ui to ^2.6.3 ([#7104](https://github.com/sanity-io/sanity/issues/7104)) ([8cba533](https://github.com/sanity-io/sanity/commit/8cba533c19d609d44002fca812aaeb569c876482))
+* **deps:** update dependency @sanity/ui to ^2.6.6 ([#7136](https://github.com/sanity-io/sanity/issues/7136)) ([2548de6](https://github.com/sanity-io/sanity/commit/2548de6925af7282503cd2f05e76b928fe3e3e77))
+* **deps:** update dependency get-it to ^8.6.3 ([#7108](https://github.com/sanity-io/sanity/issues/7108)) ([32024fe](https://github.com/sanity-io/sanity/commit/32024fe3401fa0356cb3b47da5f9cb607054b8e6))
+* **deps:** update dependency react-rx to ^3.1.1 ([#7113](https://github.com/sanity-io/sanity/issues/7113)) ([0d4c8e6](https://github.com/sanity-io/sanity/commit/0d4c8e60e1393801e336cb4bfa9bf37489654e31))
+* **deps:** update dependency react-rx to ^3.1.2 ([#7123](https://github.com/sanity-io/sanity/issues/7123)) ([3030181](https://github.com/sanity-io/sanity/commit/3030181d5ac1caa9dd5d8fa8308f135318a7f4d8))
+* **deps:** update dependency react-rx to ^3.1.3 ([#7138](https://github.com/sanity-io/sanity/issues/7138)) ([137bf75](https://github.com/sanity-io/sanity/commit/137bf758b273d12f08a90e6b4ae60fb8216b6e44))
+* **deps:** Update dev-non-major ([#7086](https://github.com/sanity-io/sanity/issues/7086)) ([554d579](https://github.com/sanity-io/sanity/commit/554d5791d7bb5574bb06ed85c142e0a4390d62e4))
+* **deps:** Update dev-non-major ([#7100](https://github.com/sanity-io/sanity/issues/7100)) ([b9d98bf](https://github.com/sanity-io/sanity/commit/b9d98bf25efc4503bb8177bc0a125547c9f53a5d))
+* **deps:** Update dev-non-major ([#7139](https://github.com/sanity-io/sanity/issues/7139)) ([5606d85](https://github.com/sanity-io/sanity/commit/5606d857fe9d432b33e6441797f8488d0185e665))
+* **deps:** Update dev-non-major ([#7140](https://github.com/sanity-io/sanity/issues/7140)) ([b95094c](https://github.com/sanity-io/sanity/commit/b95094c8f2ff730b54dfa1786613f32cfbe8c552))
+* **i18n:** allow locale plugins to translate "All fields" field group ([#7117](https://github.com/sanity-io/sanity/issues/7117)) ([24f9936](https://github.com/sanity-io/sanity/commit/24f99367c997e2ad873271fc39b64da25b544baa))
+
+
+### Features
+
+* **cli:** Add support for exporting dataset with cursor ([#7068](https://github.com/sanity-io/sanity/issues/7068)) ([d019845](https://github.com/sanity-io/sanity/commit/d0198454bc894c273bfca1af463b321283ecc5ec))
+* **core:** focus root array item when closing tree editing dialog ([#7049](https://github.com/sanity-io/sanity/issues/7049)) ([8e80b14](https://github.com/sanity-io/sanity/commit/8e80b146e978ab74b2714724fdbff0133c5d83bf))
+* **core:** global copy paste ([#6856](https://github.com/sanity-io/sanity/issues/6856)) ([53aa46b](https://github.com/sanity-io/sanity/commit/53aa46b0b87bda5f167c9523de8e83206dc67d81)), closes [#6878](https://github.com/sanity-io/sanity/issues/6878) [#6931](https://github.com/sanity-io/sanity/issues/6931)
+* **router:** update router to support query params in intent links ([#7095](https://github.com/sanity-io/sanity/issues/7095)) ([793b2b0](https://github.com/sanity-io/sanity/commit/793b2b0759c8b50ad91dbf931cb8773398c3963b))
+* **sanity:** allow Actions API enablement based on Studio version semver constraint ([47a160b](https://github.com/sanity-io/sanity/commit/47a160bee08e755463efa7597677b8c1f49178f4))
+
+
+
+# [3.49.0](https://github.com/sanity-io/sanity/compare/v3.48.1...v3.49.0) (2024-07-02)
+
+
+### Bug Fixes
+
+* **core:**  open PTE dialogs in tree editing dialog with `openPath` ([#7046](https://github.com/sanity-io/sanity/issues/7046)) ([d0b9ab0](https://github.com/sanity-io/sanity/commit/d0b9ab01435745eee825217d2a612e3dc7910c86))
+* **core:** change padding to fix tab box ([#7000](https://github.com/sanity-io/sanity/issues/7000)) ([7ed682e](https://github.com/sanity-io/sanity/commit/7ed682e36af7e20d0bddce82ef79f2a4f281ae97))
+* **core:** handle fieldset members in `FormInput` ([#7045](https://github.com/sanity-io/sanity/issues/7045)) ([b932de6](https://github.com/sanity-io/sanity/commit/b932de61fbfb53beb88db2a55eb5cd251ea9c16b))
+* **deps:** update dependency @sanity/export to ^3.40.0 ([#7056](https://github.com/sanity-io/sanity/issues/7056)) ([c44c405](https://github.com/sanity-io/sanity/commit/c44c405d672c40a383497a68bdc02b74b382e2f8))
+* **deps:** update dependency get-it to ^8.6.2 ([#7052](https://github.com/sanity-io/sanity/issues/7052)) ([b73b68c](https://github.com/sanity-io/sanity/commit/b73b68c2987b8be7eb4350953d1ebb9febecc31b))
+* **deps:** update dependency groq-js to ^1.10.0 ([#7053](https://github.com/sanity-io/sanity/issues/7053)) ([628cb76](https://github.com/sanity-io/sanity/commit/628cb76f4050e2682d3c36afcb2cb8225dd87c42))
+
+
+
+## [3.48.1](https://github.com/sanity-io/sanity/compare/v3.48.0...v3.48.1) (2024-06-27)
+
+
+### Bug Fixes
+
+* check for telemetry consent before error reporting ([#7019](https://github.com/sanity-io/sanity/issues/7019)) ([83e1111](https://github.com/sanity-io/sanity/commit/83e11116e13fba7345b8deafb4e89e9aac3aa5ea))
+* **cli:** allow no-confirm no-dry-run migrations ([#7031](https://github.com/sanity-io/sanity/issues/7031)) ([b06d143](https://github.com/sanity-io/sanity/commit/b06d14356c2de57bc41398b01ceb304485287831))
+* **core:** put back select button for single-asset source ([#7030](https://github.com/sanity-io/sanity/issues/7030)) ([4af12eb](https://github.com/sanity-io/sanity/commit/4af12eb0b01febdaa0e82452c98ee75e6192c53b))
+* **core:** update url for notify endpoint ([#7022](https://github.com/sanity-io/sanity/issues/7022)) ([6e2ad73](https://github.com/sanity-io/sanity/commit/6e2ad738b4f301c0c3767f6b1a7138ab51df19b0))
+
+
+
+# [3.48.0](https://github.com/sanity-io/sanity/compare/v3.47.1...v3.48.0) (2024-06-25)
+
+
+### Bug Fixes
+
+* **core:** tree editing dialog open issue ([#7013](https://github.com/sanity-io/sanity/issues/7013)) ([fcb09f9](https://github.com/sanity-io/sanity/commit/fcb09f98472de758bedc23da45696b72ae8b0b1c))
+* deprecate @sanity/portable-text-editor ([#7020](https://github.com/sanity-io/sanity/issues/7020)) ([f2ddfa7](https://github.com/sanity-io/sanity/commit/f2ddfa7d4f4c5124adb0a4b1cf7c8e96babd0051))
+* **deps:** update dependency @sanity/export to ^3.38.2 ([#7015](https://github.com/sanity-io/sanity/issues/7015)) ([d09cc9b](https://github.com/sanity-io/sanity/commit/d09cc9b6582969f27fab42930ce33548aa90ef56))
+* remove trailing commas when sanitizing ([#7007](https://github.com/sanity-io/sanity/issues/7007)) ([6b9f910](https://github.com/sanity-io/sanity/commit/6b9f91029200e93a0acb8037b48e7e8596239422))
+
+
+### Features
+
+* **core:** array editing improvements  ([#6682](https://github.com/sanity-io/sanity/issues/6682)) ([6fbfcdc](https://github.com/sanity-io/sanity/commit/6fbfcdc70bd19ccffb0fb71c7854d647d961d73b)), closes [#6677](https://github.com/sanity-io/sanity/issues/6677) [#6697](https://github.com/sanity-io/sanity/issues/6697) [#6725](https://github.com/sanity-io/sanity/issues/6725) [#6677](https://github.com/sanity-io/sanity/issues/6677) [#6697](https://github.com/sanity-io/sanity/issues/6697)
+* **core:** support insert menu options in array item context menus ([#6921](https://github.com/sanity-io/sanity/issues/6921)) ([784cfd3](https://github.com/sanity-io/sanity/commit/784cfd3f4a4ac75438628114238034162667fe46))
+* include hashes in vendor builds ([#7018](https://github.com/sanity-io/sanity/issues/7018)) ([4bbe337](https://github.com/sanity-io/sanity/commit/4bbe337ce69ea40eb3293dd9419cee9bb58e8001))
+* utilize timestamps in build and renderDocument for AUS ([#6964](https://github.com/sanity-io/sanity/issues/6964)) ([a1da8cc](https://github.com/sanity-io/sanity/commit/a1da8ccdb93bfe611183f7976a641cccc2934b6a))
+
+
+
+## [3.47.1](https://github.com/sanity-io/sanity/compare/v3.47.0...v3.47.1) (2024-06-19)
+
+
+### Bug Fixes
+
+* **cli:** correct noop return value on esbuild-register in dev ([#6990](https://github.com/sanity-io/sanity/issues/6990)) ([51ecce0](https://github.com/sanity-io/sanity/commit/51ecce044a5c5828320f4fe5665d20552d9d0ef2))
+* **core:** make version check not depend on `process.env` ([#6991](https://github.com/sanity-io/sanity/issues/6991)) ([7c00b8f](https://github.com/sanity-io/sanity/commit/7c00b8f65e3df5bb1af853fdcaf479acc878916d))
+* **migrate:** fixes error message to be more helpful ([#6986](https://github.com/sanity-io/sanity/issues/6986)) ([df89f88](https://github.com/sanity-io/sanity/commit/df89f884287da39e800117a67fa005560935e7cf))
+
+
+
+# [3.47.0](https://github.com/sanity-io/sanity/compare/v3.46.1...v3.47.0) (2024-06-18)
+
+
+### Bug Fixes
+
+* change `useListFormat` to no longer violate the rule of hooks ([#6876](https://github.com/sanity-io/sanity/issues/6876)) ([cae047f](https://github.com/sanity-io/sanity/commit/cae047f1c1996122f3320a0239c2c4ff3e5037af))
+* **ci:** importmap path on windows ([#6948](https://github.com/sanity-io/sanity/issues/6948)) ([6bbf609](https://github.com/sanity-io/sanity/commit/6bbf609f676df697fe7307d5e82aeaf6c8c49b37))
+* **cli:** account for base path in the importmap ([#6919](https://github.com/sanity-io/sanity/issues/6919)) ([8f28054](https://github.com/sanity-io/sanity/commit/8f280547b5161ec211da0450494b36b3574dc60e))
+* **core:** fix issue with pasting mixed content (files and text) for pt-input ([#6924](https://github.com/sanity-io/sanity/issues/6924)) ([fda9387](https://github.com/sanity-io/sanity/commit/fda9387eefb0af6765fe621de34e27b0f7b19ca8))
+* **core:** make array insert menu full width if grid view is configured ([#6969](https://github.com/sanity-io/sanity/issues/6969)) ([47d204c](https://github.com/sanity-io/sanity/commit/47d204c27dd88fc7a994fcd43449610ef4892b46))
+* **deps:** update dependency @sanity/presentation to v1.16.0 ([#6942](https://github.com/sanity-io/sanity/issues/6942)) ([abe562b](https://github.com/sanity-io/sanity/commit/abe562bd2e68d072087ca3a8c79c58915873082b))
+* **deps:** update dependency @sanity/ui to ^2.3.6 ([#6943](https://github.com/sanity-io/sanity/issues/6943)) ([c1869b9](https://github.com/sanity-io/sanity/commit/c1869b928f59c2ed172c2fb8d0d759dd16b9d81d))
+* **deps:** update dependency @sanity/ui to ^2.4.0 ([#6959](https://github.com/sanity-io/sanity/issues/6959)) ([5a38691](https://github.com/sanity-io/sanity/commit/5a38691682b8e96bb0f861409db7aaca337b9d95))
+* **deps:** Update dev-non-major ([#6915](https://github.com/sanity-io/sanity/issues/6915)) ([f00ca7e](https://github.com/sanity-io/sanity/commit/f00ca7ecbb21d1163da17835a4a4c36991dca96e))
+* **deps:** Update dev-non-major ([#6941](https://github.com/sanity-io/sanity/issues/6941)) ([3300904](https://github.com/sanity-io/sanity/commit/330090487256930c8c7a0d34e54942267d3c6db3))
+* **deps:** Update dev-non-major ([#6958](https://github.com/sanity-io/sanity/issues/6958)) ([d89acea](https://github.com/sanity-io/sanity/commit/d89acea8e46df8f93d65315a2151782481aa5dc8))
+* **form:** activate PTE input when dragging files ([#6929](https://github.com/sanity-io/sanity/issues/6929)) ([a2be16c](https://github.com/sanity-io/sanity/commit/a2be16c4104e83ede1eac41fd34aa6f41214fa8f))
+* improve perf of <Resize> by creating the canvas in a side effect ([#6874](https://github.com/sanity-io/sanity/issues/6874)) ([5d8031b](https://github.com/sanity-io/sanity/commit/5d8031b38f40723cb1ad3800b2a4a62f13668dc8))
+* layout shift when uploading images ([#6930](https://github.com/sanity-io/sanity/issues/6930)) ([ae142d4](https://github.com/sanity-io/sanity/commit/ae142d4571076da4de5b8b4fb91eefde0ecf940d))
+* **router:** pass options on scoped router navigation ([#6923](https://github.com/sanity-io/sanity/issues/6923)) ([2fabc2e](https://github.com/sanity-io/sanity/commit/2fabc2eeb6ec39dab5704538ff4ebd3922f05c22))
+* **sanity:** only include create action when restoring a deleted document ([#6937](https://github.com/sanity-io/sanity/issues/6937)) ([2736835](https://github.com/sanity-io/sanity/commit/273683562eb46674c70017d8f1ce239f9b2d18ec))
+* **sanity:** remove `ifDraftRevisionId` optimistic lock usage when publishing documents ([3064705](https://github.com/sanity-io/sanity/commit/306470520c442189d63612f20654f47b29e606d2))
+* **schema:** use base type for title if no subtype title or name is given ([#6947](https://github.com/sanity-io/sanity/issues/6947)) ([bbe7ac0](https://github.com/sanity-io/sanity/commit/bbe7ac0ec0be90d13907d5ed72e10b967c348b91))
+* **structure:** don't replace url when navigating back to list after document deletion ([#6953](https://github.com/sanity-io/sanity/issues/6953)) ([f662ae2](https://github.com/sanity-io/sanity/commit/f662ae2525bf561d2fbd3f6d081be8d3547ff392))
+* **vision:** center loading spinner ([#6900](https://github.com/sanity-io/sanity/issues/6900)) ([5943d4f](https://github.com/sanity-io/sanity/commit/5943d4f0aaa66ed2d8cdaf47df318c9285e4c7c5))
+
+
+### Features
+
+* **core:** implement basic error reporting ([#6914](https://github.com/sanity-io/sanity/issues/6914)) ([02dab2a](https://github.com/sanity-io/sanity/commit/02dab2a876e679d4e4a955542e03b75939d9aca4))
+* **core:** new insert menu for arrays with filtering, type preview support ([#6853](https://github.com/sanity-io/sanity/issues/6853)) ([203f135](https://github.com/sanity-io/sanity/commit/203f1358f05446d4500173d6bf8d3871a6bf3942))
+* **deps:** upgrade react-rx to v3 ([#6883](https://github.com/sanity-io/sanity/issues/6883)) ([c0fe9f6](https://github.com/sanity-io/sanity/commit/c0fe9f6dfdd027aab69198769d4eae99456874fd))
+* notify AUS studio users of new studio versions ([#6893](https://github.com/sanity-io/sanity/issues/6893)) ([e9b16c8](https://github.com/sanity-io/sanity/commit/e9b16c89f1d24da42fcb48ac95d5a0966d51a99e))
+* **typegen:** add all schema types exported union ([#6962](https://github.com/sanity-io/sanity/issues/6962)) ([fa459a4](https://github.com/sanity-io/sanity/commit/fa459a428ce46469a1ec9108524a41c9d5cae591))
+
+
+
+## [3.46.1](https://github.com/sanity-io/sanity/compare/v3.46.0...v3.46.1) (2024-06-13)
+
+
+### Bug Fixes
+
+* **sanity:** ignore sticky overlay regions with a falsey DOM node ([#6910](https://github.com/sanity-io/sanity/issues/6910)) ([d47e176](https://github.com/sanity-io/sanity/commit/d47e176974a38cddf5cb0177e07b5a82872c480d))
+
+
+
+# [3.46.0](https://github.com/sanity-io/sanity/compare/v3.45.0...v3.46.0) (2024-06-12)
+
+
+### Bug Fixes
+
+* **cli:** allow using auto-updates in unattended mode ([#6897](https://github.com/sanity-io/sanity/issues/6897)) ([61f1f8c](https://github.com/sanity-io/sanity/commit/61f1f8cad81f11fb811dcb2163adecc8ffad11be))
+* **core:** chunk user loading into batches of max 400 items ([#6858](https://github.com/sanity-io/sanity/issues/6858)) ([4531750](https://github.com/sanity-io/sanity/commit/4531750501c117246c7530c5c97f704e57dddef3))
+* **core:** fix dragging existing blocks in pte ([#6867](https://github.com/sanity-io/sanity/issues/6867)) ([0d92883](https://github.com/sanity-io/sanity/commit/0d9288362ee1768bd4203ae8339645e322a81d06))
+* **deps:** Update babel monorepo ([#6861](https://github.com/sanity-io/sanity/issues/6861)) ([4fa813d](https://github.com/sanity-io/sanity/commit/4fa813d74d260fc0aea95c778d6ba5be77c45879))
+* **deps:** update dependency @sanity/client to ^6.20.0 ([#6886](https://github.com/sanity-io/sanity/issues/6886)) ([124dc22](https://github.com/sanity-io/sanity/commit/124dc2238ecb6a0c9738f0482900b287afcd5f8d))
+* **deps:** update dependency @sanity/ui to ^2.3.1 ([#6851](https://github.com/sanity-io/sanity/issues/6851)) ([74d4e67](https://github.com/sanity-io/sanity/commit/74d4e67f0e322fae9e5f1f1b365d70cbfc54ad6c))
+* **deps:** update dependency get-it to ^8.6.0 ([#6884](https://github.com/sanity-io/sanity/issues/6884)) ([9f5e29f](https://github.com/sanity-io/sanity/commit/9f5e29facec2eb427c3494e68be1a3badec2b493))
+* **deps:** Update dev-non-major ([#6862](https://github.com/sanity-io/sanity/issues/6862)) ([74f8080](https://github.com/sanity-io/sanity/commit/74f80803f6641a01fcebf20c0946843e9d76e904))
+* **form:** avoid spreading key prop ([#6887](https://github.com/sanity-io/sanity/issues/6887)) ([51eb56a](https://github.com/sanity-io/sanity/commit/51eb56a3cb9e706fa9884ff8676db3058a679b0a))
+* portable text editor crash on React 19 ([#6870](https://github.com/sanity-io/sanity/issues/6870)) ([293e7d1](https://github.com/sanity-io/sanity/commit/293e7d11daa7c466a4f605ba678a66a797bc683e))
+* regression causing ESM build errors ([#6909](https://github.com/sanity-io/sanity/issues/6909)) ([0b92a8e](https://github.com/sanity-io/sanity/commit/0b92a8e4132e950e79ca58e1658d508cda45f9c2))
+* **scheduled-publishing:** export EditScheduleForm from core ([#6872](https://github.com/sanity-io/sanity/issues/6872)) ([43711d7](https://github.com/sanity-io/sanity/commit/43711d78a2f5d97dfcfe647a4961567b8a60270b))
+* **search:** include `text` type fields in search queries ([#6895](https://github.com/sanity-io/sanity/issues/6895)) ([5e505ac](https://github.com/sanity-io/sanity/commit/5e505ace02d473f343a8ba11fce91b6d8f759a66))
+* **structure:** fixing issue with shift mutli select of documents ([#6857](https://github.com/sanity-io/sanity/issues/6857)) ([15861f4](https://github.com/sanity-io/sanity/commit/15861f4fbcfe0526c1ec7209d3ac45c8daa359a6))
+
+
+### Features
+
+* add CLI options to enable auto-updating studios ([#6514](https://github.com/sanity-io/sanity/issues/6514)) ([5077c8b](https://github.com/sanity-io/sanity/commit/5077c8b336f8a00eba81fc6cd3b4c8074eb24736)), closes [#6742](https://github.com/sanity-io/sanity/issues/6742) [#6784](https://github.com/sanity-io/sanity/issues/6784)
+* add error boundary for form input components ([#6869](https://github.com/sanity-io/sanity/issues/6869)) ([23c42ae](https://github.com/sanity-io/sanity/commit/23c42ae523617642a6adb886c352b7cf3323669b))
+* add hasSanityPackageInImportMap ([#6832](https://github.com/sanity-io/sanity/issues/6832)) ([8ea7d8f](https://github.com/sanity-io/sanity/commit/8ea7d8fe9a60594476621bca1f52368b69a7ee15))
+* add integration when creating a new project through cli ([#6639](https://github.com/sanity-io/sanity/issues/6639)) ([ac214b8](https://github.com/sanity-io/sanity/commit/ac214b8e2edc82a2e7780144a6cc81b52260571d))
+* **cli:** show prompt if local version doesn't match remote ([#6707](https://github.com/sanity-io/sanity/issues/6707)) ([50f1e54](https://github.com/sanity-io/sanity/commit/50f1e543e41323b1e64e6a110bc3b4d8c085b43c))
+
+
+
+# [3.45.0](https://github.com/sanity-io/sanity/compare/v3.44.0...v3.45.0) (2024-06-04)
+
+
+### Bug Fixes
+
+* call dynamic hooks in a way that can be compiled ([#6814](https://github.com/sanity-io/sanity/issues/6814)) ([6e65eed](https://github.com/sanity-io/sanity/commit/6e65eedce696ab5c7b780399709254eb0352824f))
+* **deps:** update dependency @sanity/presentation to v1.15.13 ([#6823](https://github.com/sanity-io/sanity/issues/6823)) ([d0e5e95](https://github.com/sanity-io/sanity/commit/d0e5e95a6096c19522faba621edc8968b2adc41a))
+* **deps:** Update dev-non-major ([#6809](https://github.com/sanity-io/sanity/issues/6809)) ([a9662ec](https://github.com/sanity-io/sanity/commit/a9662ecddf6ea3fe0b9a5041de6a6d31d5544faa))
+* **deps:** Update dev-non-major ([#6841](https://github.com/sanity-io/sanity/issues/6841)) ([48022c1](https://github.com/sanity-io/sanity/commit/48022c11f27257f0da79c39d35ca326db0197cb5))
+* handle circular import issue in a compiler friendly way ([#6812](https://github.com/sanity-io/sanity/issues/6812)) ([8ac809f](https://github.com/sanity-io/sanity/commit/8ac809f4384ac5e882163623d55cd8fd0b14d147))
+* regression in [#6813](https://github.com/sanity-io/sanity/issues/6813) ([#6827](https://github.com/sanity-io/sanity/issues/6827)) ([8ac0812](https://github.com/sanity-io/sanity/commit/8ac0812f395b4aec7f4a15b3a51755eb7ea37bf1))
+* **sanity:** align Actions API usage with correct types ([f07d7ae](https://github.com/sanity-io/sanity/commit/f07d7aeec3c9907d62ab45a5346632a4a49e4a25))
+* **structure:** allow searching/listing ignored types when explicitly requested ([#6771](https://github.com/sanity-io/sanity/issues/6771)) ([5b66664](https://github.com/sanity-io/sanity/commit/5b666649a9f4fc9b86e41e13dafe0e3eea3aef73))
+* **types:** correct `ArrayOptions` ([#6737](https://github.com/sanity-io/sanity/issues/6737)) ([39da169](https://github.com/sanity-io/sanity/commit/39da169babebb1d2ca5bcb34d712517a1685fd9c))
+* use `useImperativeHandle` instead of mutating a parent ref ([#6813](https://github.com/sanity-io/sanity/issues/6813)) ([13158e9](https://github.com/sanity-io/sanity/commit/13158e939dab63084a1e127afb8c931da572494b))
+
+
+### Features
+
+* **cli:** allow the ability to specify package manager in init command ([#6820](https://github.com/sanity-io/sanity/issues/6820)) ([f1ef0a6](https://github.com/sanity-io/sanity/commit/f1ef0a65b5e2f4c0a33f2edc2539132afafaa31a))
+* **migrate:** add `dryRun` to context ([#6816](https://github.com/sanity-io/sanity/issues/6816)) ([104162a](https://github.com/sanity-io/sanity/commit/104162a4df27597e0c354afd188ee95580825d48))
+* move up call to PATCH metadata after bootstrapping template files ([#6828](https://github.com/sanity-io/sanity/issues/6828)) ([7d47a51](https://github.com/sanity-io/sanity/commit/7d47a518e5d6e4a8d3ba1d6ad7ba8334e16a5dab))
+* **structure:**  sheet list table columns selectors style edx-1435 ([#6839](https://github.com/sanity-io/sanity/issues/6839)) ([6d53c4c](https://github.com/sanity-io/sanity/commit/6d53c4c989f279e1fb980c8a7c50c9da4d03d827))
+
+
+
+# [3.44.0](https://github.com/sanity-io/sanity/compare/v3.43.0...v3.44.0) (2024-05-29)
+
+
+### Bug Fixes
+
+* **cli:** graphql api flag is respected during validation ([#6615](https://github.com/sanity-io/sanity/issues/6615)) ([c739eea](https://github.com/sanity-io/sanity/commit/c739eea81e787e003cded2b8d24ce0590f61dc9d))
+* **core/form:** prohibit focus and unset on root input ([#6706](https://github.com/sanity-io/sanity/issues/6706)) ([4a2f141](https://github.com/sanity-io/sanity/commit/4a2f14119c39515e25036c1ddf7d8d74f3de01d4))
+* **core:** add retry to image observer and loading state ([#6709](https://github.com/sanity-io/sanity/issues/6709)) ([0f51f9d](https://github.com/sanity-io/sanity/commit/0f51f9dad914fc332ccb78f81af763abf06fa3dc))
+* **core:** avoid attribute names being scanned as symbols ([23f6c67](https://github.com/sanity-io/sanity/commit/23f6c67199d633a0f2a7f2d71c16e5188123876e)), closes [#5673](https://github.com/sanity-io/sanity/issues/5673)
+* **core:** fix issue with nested preview fields not being included in legacy text search ([#6767](https://github.com/sanity-io/sanity/issues/6767)) ([044ac39](https://github.com/sanity-io/sanity/commit/044ac39a2f8bfc282429b4d94e3da97c8f792315))
+* **core:** reactions menu open issue ([#6765](https://github.com/sanity-io/sanity/issues/6765)) ([3f52b83](https://github.com/sanity-io/sanity/commit/3f52b83caa0a11fd02763951736df45f944b2ffb))
+* **core:** remove id from patch when using server actions ([#6751](https://github.com/sanity-io/sanity/issues/6751)) ([7b90cad](https://github.com/sanity-io/sanity/commit/7b90cad2d5ead6855866f7ebc911e44c3f428bfc))
+* **core:** unable to open block style select when in nested PTEs in fullscreen ([#6738](https://github.com/sanity-io/sanity/issues/6738)) ([9f7ab8b](https://github.com/sanity-io/sanity/commit/9f7ab8b22b0c87a19ffb2e45ce20838a93ebf9cc))
+* **deps:** update dependency @sanity/client to ^6.18.3 ([#6762](https://github.com/sanity-io/sanity/issues/6762)) ([3e1bc3e](https://github.com/sanity-io/sanity/commit/3e1bc3e50b0c9d312846a2065a900e413ec968e4))
+* **deps:** update dependency @sanity/client to ^6.19.0 ([#6781](https://github.com/sanity-io/sanity/issues/6781)) ([1961904](https://github.com/sanity-io/sanity/commit/19619042e4a6a4a3c42a593a57c1bf41edcc32a7))
+* **deps:** update dependency @sanity/presentation to v1.15.10 ([#6786](https://github.com/sanity-io/sanity/issues/6786)) ([517a1a9](https://github.com/sanity-io/sanity/commit/517a1a977ed82c7ec30e62ac3ac28fba31963ffa))
+* **deps:** update dependency @sanity/presentation to v1.15.11 ([#6799](https://github.com/sanity-io/sanity/issues/6799)) ([42fd4bf](https://github.com/sanity-io/sanity/commit/42fd4bff54b0472176602f17229b8eddade96d2b))
+* **deps:** update dependency @sanity/ui to ^2.1.12 ([#6757](https://github.com/sanity-io/sanity/issues/6757)) ([9025619](https://github.com/sanity-io/sanity/commit/9025619e5c3150dd9e3586b10b8f7923d9193639))
+* **deps:** update dependency @sanity/ui to ^2.1.13 ([#6787](https://github.com/sanity-io/sanity/issues/6787)) ([43f1766](https://github.com/sanity-io/sanity/commit/43f17664c117669d0d9a82d3f4ea389464db1b3b))
+* **deps:** update dependency @sanity/ui to ^2.1.14 ([#6800](https://github.com/sanity-io/sanity/issues/6800)) ([faa5bcf](https://github.com/sanity-io/sanity/commit/faa5bcfc8d8f7b6720e0980f7057d81b467f41c9))
+* **deps:** update dependency get-it to ^8.5.0 ([#6758](https://github.com/sanity-io/sanity/issues/6758)) ([6b98663](https://github.com/sanity-io/sanity/commit/6b98663fb19ef0639d109af45bf4b8f2fb0809ac))
+* **deps:** Update dev-non-major ([#6719](https://github.com/sanity-io/sanity/issues/6719)) ([dadfcfa](https://github.com/sanity-io/sanity/commit/dadfcfafd1131749f4f4f1ddb0f1061fb038eb67))
+* **deps:** Update dev-non-major ([#6745](https://github.com/sanity-io/sanity/issues/6745)) ([7c44121](https://github.com/sanity-io/sanity/commit/7c4412159c0a3a634afeb6fb8d54b27f62f7fdd2))
+* **deps:** Update dev-non-major ([#6759](https://github.com/sanity-io/sanity/issues/6759)) ([5893609](https://github.com/sanity-io/sanity/commit/58936096c60522a0256504ca0bb3c62b5f6c27b8))
+* **deps:** Update dev-non-major ([#6789](https://github.com/sanity-io/sanity/issues/6789)) ([772d464](https://github.com/sanity-io/sanity/commit/772d464d3a03590650bebdac83b356f123bb04f8))
+* **deps:** Update dev-non-major ([#6798](https://github.com/sanity-io/sanity/issues/6798)) ([6640ad4](https://github.com/sanity-io/sanity/commit/6640ad41d9dd9015038dcbccfab71bbed573dd2c))
+* EXIF data on Image asset not included when uploading multiple images to array type, or via drag-and-drop ([#6708](https://github.com/sanity-io/sanity/issues/6708)) ([222418a](https://github.com/sanity-io/sanity/commit/222418acec6f57bb3a973aa203ab9609cb89020b))
+* **form:** avoid spreading key prop ([#6776](https://github.com/sanity-io/sanity/issues/6776)) ([eeba7f2](https://github.com/sanity-io/sanity/commit/eeba7f272e79b627bfd9ee15cfefe1e883fa58fe))
+* **form:** fix issue making circular structures sometimes causing infinite loop ([#6699](https://github.com/sanity-io/sanity/issues/6699)) ([7efdeeb](https://github.com/sanity-io/sanity/commit/7efdeebdbaa255aaccb7e616a930e3ec47d4e903)), closes [#6646](https://github.com/sanity-io/sanity/issues/6646)
+* **form:** properly support passing `undefined` as title to `renderDefault()` for array and object fields ([#6774](https://github.com/sanity-io/sanity/issues/6774)) ([f341c2d](https://github.com/sanity-io/sanity/commit/f341c2d7ea8573b9013817277754e149f671d63c))
+* handle React Compiler errors ([#6750](https://github.com/sanity-io/sanity/issues/6750)) ([403f485](https://github.com/sanity-io/sanity/commit/403f485bfa7dd1f369a8f61f6ad30a43bc754b13))
+* **portable-text-editor:** add autoresolving validations and fix normalization issues ([#6770](https://github.com/sanity-io/sanity/issues/6770)) ([c458289](https://github.com/sanity-io/sanity/commit/c45828947ba20c71335d0410cd36a13b2c29eb2b))
+* **pte:** improve text selection in fullscreen inputs ([#6642](https://github.com/sanity-io/sanity/issues/6642)) ([6163d96](https://github.com/sanity-io/sanity/commit/6163d961fe30af405b3d78c2dcead878f6e4b718))
+* resolve type error by inlining DocumentComponents definition ([#6703](https://github.com/sanity-io/sanity/issues/6703)) ([10e1bc3](https://github.com/sanity-io/sanity/commit/10e1bc370314f0a2c39d5695e7345d81af78ccde))
+* **sanity:** respect Studio configuration when rendering "restore" document action ([#6637](https://github.com/sanity-io/sanity/issues/6637)) ([6ba71f2](https://github.com/sanity-io/sanity/commit/6ba71f2588ab23b7a59682210674551c5fd52f3c))
+
+
+### Features
+
+* **sanity:** add timeline test ids ([038a1a2](https://github.com/sanity-io/sanity/commit/038a1a2b9cc0813a6998f4f71a848a31fa48b764))
+* **sanity:** use Actions API when restoring drafts ([47e5420](https://github.com/sanity-io/sanity/commit/47e54209faedabe5a618f896ffa8a5c3d0b59bb5))
+* **sanity:** use optimistic locking when publishing documents ([#6711](https://github.com/sanity-io/sanity/issues/6711)) ([6fe8c69](https://github.com/sanity-io/sanity/commit/6fe8c698cf19f090754858d7f83a6d2ea5d3e2c9))
+* store all versions in the manifest ([#6769](https://github.com/sanity-io/sanity/issues/6769)) ([1fcc0f2](https://github.com/sanity-io/sanity/commit/1fcc0f2e8416e73fb8702211ff0e9b45fbfd7401))
+* **structure:** sheet list prototype ([#6741](https://github.com/sanity-io/sanity/issues/6741)) ([f0670bf](https://github.com/sanity-io/sanity/commit/f0670bf20dbbca49f15e06175fa8c2beab1d67fb))
+
+
+
+# [3.43.0](https://github.com/sanity-io/sanity/compare/v3.42.1...v3.43.0) (2024-05-21)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @sanity/client to ^6.18.2 ([#6674](https://github.com/sanity-io/sanity/issues/6674)) ([4da4ae5](https://github.com/sanity-io/sanity/commit/4da4ae58075744d346315fa3c427c46da3934bb1))
+* **deps:** update dependency @sanity/presentation to v1.15.3 ([#6667](https://github.com/sanity-io/sanity/issues/6667)) ([71e6319](https://github.com/sanity-io/sanity/commit/71e6319643160bd0a9aa2332d134cb57e51fb7c5))
+* **deps:** update dependency @sanity/presentation to v1.15.4 ([#6681](https://github.com/sanity-io/sanity/issues/6681)) ([f97c348](https://github.com/sanity-io/sanity/commit/f97c3484ef7779192f4c96558c7f2fe8f213648d))
+* **deps:** update dependency @sanity/presentation to v1.15.5 ([#6687](https://github.com/sanity-io/sanity/issues/6687)) ([a61a679](https://github.com/sanity-io/sanity/commit/a61a6799d6af44c2fdd76b2beebf6a85127919b6))
+* **deps:** update dependency @sanity/presentation to v1.15.8 ([#6724](https://github.com/sanity-io/sanity/issues/6724)) ([17ca815](https://github.com/sanity-io/sanity/commit/17ca81527162332f9a46acb1bb87b3af32b74444))
+* **deps:** update dependency @sanity/ui to ^2.1.10 ([#6701](https://github.com/sanity-io/sanity/issues/6701)) ([af0eee4](https://github.com/sanity-io/sanity/commit/af0eee486ea44855c466c4e8d682ad3603905923))
+* **deps:** update dependency @sanity/ui to ^2.1.11 ([#6720](https://github.com/sanity-io/sanity/issues/6720)) ([61cc315](https://github.com/sanity-io/sanity/commit/61cc315859f9b3fd7baf8ff22471733a2e94e8bd))
+* **deps:** update dependency @sanity/ui to ^2.1.8 ([#6675](https://github.com/sanity-io/sanity/issues/6675)) ([e8a40e2](https://github.com/sanity-io/sanity/commit/e8a40e2fc7fd4e668fe1bf62598196bc90e361fb))
+* **deps:** update dependency @sanity/ui to ^2.1.9 ([#6691](https://github.com/sanity-io/sanity/issues/6691)) ([3aa444f](https://github.com/sanity-io/sanity/commit/3aa444f0c969f396c601d6788de9cf458518a79e))
+* **deps:** update dependency get-it to ^8.4.30 ([#6676](https://github.com/sanity-io/sanity/issues/6676)) ([0715793](https://github.com/sanity-io/sanity/commit/0715793f3ed968a1d6a362d24d48a8f3edeeda29))
+* **deps:** update dependency groq-js to ^1.9.0 ([#6655](https://github.com/sanity-io/sanity/issues/6655)) ([71a0758](https://github.com/sanity-io/sanity/commit/71a07586be795c8cdb2df41e99c6a8e88abaca48))
+* **deps:** Update dev-non-major ([#6659](https://github.com/sanity-io/sanity/issues/6659)) ([ab0f97d](https://github.com/sanity-io/sanity/commit/ab0f97d2276f09af0f5041656c2e1d37f6337f61))
+* **deps:** Update dev-non-major ([#6673](https://github.com/sanity-io/sanity/issues/6673)) ([409d7df](https://github.com/sanity-io/sanity/commit/409d7dfec097d101c8a71ce9da35bb56d443dc01))
+* **deps:** Update dev-non-major ([#6680](https://github.com/sanity-io/sanity/issues/6680)) ([ab4a9e8](https://github.com/sanity-io/sanity/commit/ab4a9e80066ebf29664d2ec5a8baeb5f7ac015e5))
+* **deps:** Update dev-non-major ([#6690](https://github.com/sanity-io/sanity/issues/6690)) ([ec179d0](https://github.com/sanity-io/sanity/commit/ec179d0a9a98eb52be94ae9feeea789e097c8b20))
+* **deps:** Update dev-non-major ([#6700](https://github.com/sanity-io/sanity/issues/6700)) ([77785ff](https://github.com/sanity-io/sanity/commit/77785ffba4d290863d56be3a0fd6178e7c00b9f0))
+* **i18n:** remove extraneous curly brace ([#6726](https://github.com/sanity-io/sanity/issues/6726)) ([74f2fd5](https://github.com/sanity-io/sanity/commit/74f2fd5b81b0eb2da24dad7c21901241855a9b33))
+* pin framer-motion to an earlier version ([#6717](https://github.com/sanity-io/sanity/issues/6717)) ([6c2aea2](https://github.com/sanity-io/sanity/commit/6c2aea29f31791d99aaa9d68941fa43ad0dcdc21))
+* remove circular reference to `usePaneRouter` ([#6664](https://github.com/sanity-io/sanity/issues/6664)) ([d66def2](https://github.com/sanity-io/sanity/commit/d66def2a58c79cb43927d0229a32439bc19314a3))
+* **schedule-publishing:** avoid polling in upsell mode ([#6670](https://github.com/sanity-io/sanity/issues/6670)) ([87889d1](https://github.com/sanity-io/sanity/commit/87889d19ff8e74c26c987e78d3c8acde97d3753a))
+* **scheduled-publishing:** don't include it if it's the only plugin available ([#6530](https://github.com/sanity-io/sanity/issues/6530)) ([b2fa80b](https://github.com/sanity-io/sanity/commit/b2fa80b5b41d2c8655cd7817a453d459aac5564e))
+* **structure:** fixing incorrect way of setting col visibility ([#6716](https://github.com/sanity-io/sanity/issues/6716)) ([06f7902](https://github.com/sanity-io/sanity/commit/06f79025c6014976f5eb13ff576646e9049dd553))
+* **tasks:** hide footer button until the active document is set ([#6695](https://github.com/sanity-io/sanity/issues/6695)) ([93c7d66](https://github.com/sanity-io/sanity/commit/93c7d663d2a3ed84129094699b75c026c134e6ec))
+* **tasks:** reduce tasks sidebar zoffset ([#6718](https://github.com/sanity-io/sanity/issues/6718)) ([5ab0819](https://github.com/sanity-io/sanity/commit/5ab08194561ac8f42ba1bd99755b6584751b5647))
+* update `@sanity/presentation` and remove deprecated internal exports no longer in use ([#6694](https://github.com/sanity-io/sanity/issues/6694)) ([69246c1](https://github.com/sanity-io/sanity/commit/69246c1d527a5b1b41390736542a3696a8fd9a82))
+
+
+### Features
+
+* fetch feature toggle to enable serverside document actions ([#6418](https://github.com/sanity-io/sanity/issues/6418)) ([8610fc6](https://github.com/sanity-io/sanity/commit/8610fc6a3af6fd9ba12cfac665f294c62235e168)), closes [#6582](https://github.com/sanity-io/sanity/issues/6582) [#6634](https://github.com/sanity-io/sanity/issues/6634)
+* **pte:** add `initialActive` prop to `PortableTextInput` ([#6638](https://github.com/sanity-io/sanity/issues/6638)) ([5add977](https://github.com/sanity-io/sanity/commit/5add977533b6c1f911d47e04e50b5d2afc41cccb))
+* **sanity:** add test ids to confirm dialog buttons ([73d51cb](https://github.com/sanity-io/sanity/commit/73d51cb72f379ed5e88a5207c94a98d35d9874cc))
+* **sanity:** memoize initial value resolver ([#6614](https://github.com/sanity-io/sanity/issues/6614)) ([39bab8a](https://github.com/sanity-io/sanity/commit/39bab8abf725239a7ec7e03ef1e95e284180f900))
+* **sanity:** use actions API when discarding drafts ([c1755d1](https://github.com/sanity-io/sanity/commit/c1755d1f24272b27a049d3554a931a5b107fb460))
+* **structure:** add sheet list table view. ([#6647](https://github.com/sanity-io/sanity/issues/6647)) ([c5916d4](https://github.com/sanity-io/sanity/commit/c5916d4b5b4f83a88b753dec0c3ce785489c32e3))
+* **structure:** Sheet View columns ([#6661](https://github.com/sanity-io/sanity/issues/6661)) ([d8a37a8](https://github.com/sanity-io/sanity/commit/d8a37a862bd2c4fc5bf40c1fffcc09f49ac63c2f)), closes [#6580](https://github.com/sanity-io/sanity/issues/6580) [#6607](https://github.com/sanity-io/sanity/issues/6607) [#6516](https://github.com/sanity-io/sanity/issues/6516)
+* **typegen:** add optout for prettier formatting ([#6702](https://github.com/sanity-io/sanity/issues/6702)) ([ac5103a](https://github.com/sanity-io/sanity/commit/ac5103a5dea761928cf65d6e77d77166cf2650b0))
+* upgrade `sanity init` for Next.js to next-sanity v9 ([#6644](https://github.com/sanity-io/sanity/issues/6644)) ([f48e38b](https://github.com/sanity-io/sanity/commit/f48e38b5f63b605eb7fdeb8ac527873e26e20f7d))
+
+
+
+## [3.42.1](https://github.com/sanity-io/sanity/compare/v3.42.0...v3.42.1) (2024-05-15)
+
+
+### Bug Fixes
+
+* regression crashing the document list pane in presentation ([#6684](https://github.com/sanity-io/sanity/issues/6684)) ([22980c2](https://github.com/sanity-io/sanity/commit/22980c263b689b5846d51ecb594f706bcaefaacb))
+
+
+
+# [3.42.0](https://github.com/sanity-io/sanity/compare/v3.41.2...v3.42.0) (2024-05-14)
+
+
+### Bug Fixes
+
+* **core/form:** prevent onFocus for root object paths being called by editing form ([#6610](https://github.com/sanity-io/sanity/issues/6610)) ([516ada5](https://github.com/sanity-io/sanity/commit/516ada5d2362ba57a200e359d0d19c610cb3fa6a))
+* **core:** fixes issue with history loading indefinitely ([#6539](https://github.com/sanity-io/sanity/issues/6539)) ([52a5308](https://github.com/sanity-io/sanity/commit/52a5308211848d0384fc0e6c5cad69979f9b7af1))
+* **core:** update test snapshots ([#6629](https://github.com/sanity-io/sanity/issues/6629)) ([20b66b1](https://github.com/sanity-io/sanity/commit/20b66b1292eef6352bf73426a4703d64dcd2c74b))
+* **deps:** update dependency @sanity/client to ^6.18.0 ([#6604](https://github.com/sanity-io/sanity/issues/6604)) ([c2b143e](https://github.com/sanity-io/sanity/commit/c2b143eb5f9beebd1860914edac911de79523b03))
+* **deps:** update dependency @sanity/client to ^6.18.1 ([#6653](https://github.com/sanity-io/sanity/issues/6653)) ([083960f](https://github.com/sanity-io/sanity/commit/083960f5e39e40dd771780b63a175470e8aa7e03))
+* **deps:** update dependency @sanity/ui to ^2.1.7 ([#6633](https://github.com/sanity-io/sanity/issues/6633)) ([34b4754](https://github.com/sanity-io/sanity/commit/34b4754a53a7c2a2d998ffa303f9e57dda42bca1))
+* **deps:** update dependency get-it to ^8.4.29 ([#6603](https://github.com/sanity-io/sanity/issues/6603)) ([cc08614](https://github.com/sanity-io/sanity/commit/cc08614d4e119fbe1a4a56ac71b4a217aaf5d9fd))
+* **e2e:** support headless/headful env var toggle ([#6558](https://github.com/sanity-io/sanity/issues/6558)) ([92260a4](https://github.com/sanity-io/sanity/commit/92260a423df5cdb8d4a1eb3a205bcfc1bca76bbb))
+* **pte:** cursor presence causes pte error ([#6622](https://github.com/sanity-io/sanity/issues/6622)) ([b13fff4](https://github.com/sanity-io/sanity/commit/b13fff49697d16489d997d88fa646b8489ba6903))
+* **pte:** don't render the PTE block extras container when not in use, disable pointer events on highlights ([#6620](https://github.com/sanity-io/sanity/issues/6620)) ([4c73ded](https://github.com/sanity-io/sanity/commit/4c73ded0a580f092d383185ddcbc7257a5402dde))
+* **structure:** use case insensitive search for inspect dialog ([#6588](https://github.com/sanity-io/sanity/issues/6588)) ([1dca6db](https://github.com/sanity-io/sanity/commit/1dca6db3fe409219e39a899f9fa793e976d695ba))
+* **studio:** adding tooltip to read-only bool inputs ([#6580](https://github.com/sanity-io/sanity/issues/6580)) ([55153ac](https://github.com/sanity-io/sanity/commit/55153acc39f915c895e6066df3b26aa39d08ae24))
+* **typegen:** move type new line separator into formatter ([#6649](https://github.com/sanity-io/sanity/issues/6649)) ([109a180](https://github.com/sanity-io/sanity/commit/109a1805d1170b65dcaa747c730ebbb884c97f9d))
+
+
+### Features
+
+* add canHandleIntent to Structure Builder component ([#6516](https://github.com/sanity-io/sanity/issues/6516)) ([d3d0c04](https://github.com/sanity-io/sanity/commit/d3d0c0460b7ded19810b5b9ae399ab8f73fef486))
+* add icon to BlockStyleDefinition ([#6613](https://github.com/sanity-io/sanity/issues/6613)) ([2e69eee](https://github.com/sanity-io/sanity/commit/2e69eeed1c337b271b075c9c237c8f069fbe4f9c))
+* **pte:** add `hideToolbar` and `fullscreen` props to `PortableTextInput` ([#6621](https://github.com/sanity-io/sanity/issues/6621)) ([800149f](https://github.com/sanity-io/sanity/commit/800149f60a79f3a7469fec8c877ccad282d8ce40))
+* **pte:** expose data-attributes on PTE Text + Object blocks ([#6641](https://github.com/sanity-io/sanity/issues/6641)) ([fceff23](https://github.com/sanity-io/sanity/commit/fceff236c6e6106ea779f753e612a5c8dc761ae9))
+* **pte:** initial support for `renderEditable` in portable text inputs ([#6627](https://github.com/sanity-io/sanity/issues/6627)) ([1d0fd3e](https://github.com/sanity-io/sanity/commit/1d0fd3e929487f7369ca674d12e55f151e9ba33d))
+* **vision:** add "save result as json/csv" buttons ([#6158](https://github.com/sanity-io/sanity/issues/6158)) ([14be9b6](https://github.com/sanity-io/sanity/commit/14be9b6e795ed9d262bb1e5eadc0b9d0437bff1f)), closes [#6213](https://github.com/sanity-io/sanity/issues/6213)
+
+
+
+## [3.41.2](https://github.com/sanity-io/sanity/compare/v3.41.1...v3.41.2) (2024-05-14)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @sanity/presentation to v1.15.2 ([#6632](https://github.com/sanity-io/sanity/issues/6632)) ([43823f6](https://github.com/sanity-io/sanity/commit/43823f6a5e456fb49ac41a6020f1900b75367b77))
+
+
+
+## [3.41.1](https://github.com/sanity-io/sanity/compare/v3.41.0...v3.41.1) (2024-05-08)
+
+
+### Bug Fixes
+
+* **presentation:** regression causing a crash when in an embedded studio ([#6606](https://github.com/sanity-io/sanity/issues/6606)) ([99dfb60](https://github.com/sanity-io/sanity/commit/99dfb601051c32ebd7e38b16aac51d828d4e9d26))
+
+
+
+# [3.41.0](https://github.com/sanity-io/sanity/compare/v3.40.0...v3.41.0) (2024-05-07)
+
+
+### Bug Fixes
+
+* **core:** collapsed range decorations ([#6568](https://github.com/sanity-io/sanity/issues/6568)) ([70ab283](https://github.com/sanity-io/sanity/commit/70ab283686e6629b7f87c10c79aab207d566a0df))
+* **deps:** replace hashlru with quicklru ([#6557](https://github.com/sanity-io/sanity/issues/6557)) ([d634727](https://github.com/sanity-io/sanity/commit/d634727876bf8818a15a4fe09fc3b3aedfc69cd5))
+* **deps:** update dependency @sanity/client to ^6.16.0 ([#6548](https://github.com/sanity-io/sanity/issues/6548)) ([35b19c2](https://github.com/sanity-io/sanity/commit/35b19c21173dd12f2b5a86b8ff2c86876589d680))
+* **deps:** update dependency @sanity/client to ^6.17.2 ([#6567](https://github.com/sanity-io/sanity/issues/6567)) ([154d90b](https://github.com/sanity-io/sanity/commit/154d90ba10a6fb8cfe57f57a54b02a3a4a6d28f2))
+* **deps:** update dependency @sanity/presentation to v1.14.0 ([#6577](https://github.com/sanity-io/sanity/issues/6577)) ([0812390](https://github.com/sanity-io/sanity/commit/081239070e3cc0c783897fbb8838b0513b0c2c1a))
+* **deps:** update dependency @sanity/presentation to v1.15.0 ([#6591](https://github.com/sanity-io/sanity/issues/6591)) ([1d88df6](https://github.com/sanity-io/sanity/commit/1d88df6a7d61ab5ad9f9454b7b8fcdb9c22d2aec))
+* **deps:** update dependency @sanity/ui to ^2.1.6 ([#6575](https://github.com/sanity-io/sanity/issues/6575)) ([48321e6](https://github.com/sanity-io/sanity/commit/48321e638d5962fd5185b5fb31e6706f73a65501))
+* **deps:** update dependency get-it to ^8.4.28 ([#6576](https://github.com/sanity-io/sanity/issues/6576)) ([47ef785](https://github.com/sanity-io/sanity/commit/47ef785957501077276b1679ab8528da3751f9f8))
+* inline `swr`, `date-fns-tz` and `@vvo/tzdb` to restore embedded studios ([#6553](https://github.com/sanity-io/sanity/issues/6553)) ([9a50252](https://github.com/sanity-io/sanity/commit/9a50252a9716ec79ad0aa0cc9a66b5d2422a96ea))
+* **pte:** insert empty text block after removing void block  ([#6552](https://github.com/sanity-io/sanity/issues/6552)) ([379510f](https://github.com/sanity-io/sanity/commit/379510f1d41e866501cca125e580c533e5a165b2))
+* **pte:** preserve block key when pressing enter at start of block ([#6521](https://github.com/sanity-io/sanity/issues/6521)) ([7df5396](https://github.com/sanity-io/sanity/commit/7df53960d8e49928445d9174919f1fe8ed14563f))
+* **pte:** tools are active only when all blocks use the tool ([#6524](https://github.com/sanity-io/sanity/issues/6524)) ([169e5fd](https://github.com/sanity-io/sanity/commit/169e5fd18f9d5c00bf50b1e25b6067e028516ddb)), closes [#6328](https://github.com/sanity-io/sanity/issues/6328) [#6310](https://github.com/sanity-io/sanity/issues/6310)
+* remove `cleanStegaUnicode` helper ([#6564](https://github.com/sanity-io/sanity/issues/6564)) ([2e224d4](https://github.com/sanity-io/sanity/commit/2e224d4fc1d09a123e9be4f926c9e62ab1eedb7a))
+* remove unconditional external from vite build ([#6554](https://github.com/sanity-io/sanity/issues/6554)) ([f1e9546](https://github.com/sanity-io/sanity/commit/f1e9546c630242f491e7caab47a473b2dd6fee85))
+* **sanity:** do not order by `_updatedAt` when relevance ordering is used with Text Search API search strategy ([#6537](https://github.com/sanity-io/sanity/issues/6537)) ([0ede4cf](https://github.com/sanity-io/sanity/commit/0ede4cf3f877d49400e1ca75c237c8897e2888a0))
+* **schedule-publishing:** update flag used to check scheduledPublishing ([#6543](https://github.com/sanity-io/sanity/issues/6543)) ([57fcbac](https://github.com/sanity-io/sanity/commit/57fcbac404cc15cdfbb716f5021639f81437a73a))
+* **tasks:** close the form only after the task is created ([#6450](https://github.com/sanity-io/sanity/issues/6450)) ([e089eb7](https://github.com/sanity-io/sanity/commit/e089eb7c093c6cf5d2c3ac8e72b9302ca5f97aa8))
+* **tasks:** update tasks panel z index ([#6571](https://github.com/sanity-io/sanity/issues/6571)) ([3b3125c](https://github.com/sanity-io/sanity/commit/3b3125c456ff90a66ebcb912c44fa3411459b3a9))
+* **typegen:** pass resolved path instead of the imported path ([#6540](https://github.com/sanity-io/sanity/issues/6540)) ([e7ffe93](https://github.com/sanity-io/sanity/commit/e7ffe9332c3c6e386edc200a6bff5eab514fc389))
+* use `vercelStegaClean` util from `@vercel/stega` ([#6544](https://github.com/sanity-io/sanity/issues/6544)) ([790bc8f](https://github.com/sanity-io/sanity/commit/790bc8f07e2f4458646e84dfa44e61cf87ad7888))
+* use discard when doc is not published ([#6535](https://github.com/sanity-io/sanity/issues/6535)) ([9c86166](https://github.com/sanity-io/sanity/commit/9c86166ee63064d3a2c714d8a89a380ed668f9bc))
+
+
+### Features
+
+* add cliInitializedAt field to project metadata ([#6538](https://github.com/sanity-io/sanity/issues/6538)) ([15486f7](https://github.com/sanity-io/sanity/commit/15486f7f46eb3ff4b73e77b7520a7ca43008deb8))
+* **comments:** add telemetry ([#6541](https://github.com/sanity-io/sanity/issues/6541)) ([2d35256](https://github.com/sanity-io/sanity/commit/2d35256a2296e91e153a70edb8781c3fe4efd168))
+* **form/inputs:** add support for image drop+paste in PTE input ([#6534](https://github.com/sanity-io/sanity/issues/6534)) ([e964b1e](https://github.com/sanity-io/sanity/commit/e964b1e9c212790fd9905efbb71f40e018ff9362))
+* **pte:** create new text blocks if needed ([#6560](https://github.com/sanity-io/sanity/issues/6560)) ([cadd496](https://github.com/sanity-io/sanity/commit/cadd496f2a311303aaae773ffea607ce7f9b0883))
+
+
+
+# [3.40.0](https://github.com/sanity-io/sanity/compare/v3.39.1...v3.40.0) (2024-04-30)
+
+
+### Bug Fixes
+
+* **@sanity:** issue where hidden unicode characters were bloating document in PTE ([#6440](https://github.com/sanity-io/sanity/issues/6440)) ([ffa68ec](https://github.com/sanity-io/sanity/commit/ffa68ec009c45e4fc14559cb04410bdcea376da0))
+* build after pkg-utils@5 upgrade ([c3b756b](https://github.com/sanity-io/sanity/commit/c3b756b527904463777e4bc1c2b5bd0b1a1313ed))
+* **build:** add missing legacy exports and types information ([2053b1f](https://github.com/sanity-io/sanity/commit/2053b1fd00ec4e12ed8ace9279d143a1136ea14b))
+* **cli:** mock matchMedia window function ([#6472](https://github.com/sanity-io/sanity/issues/6472)) ([ea715e8](https://github.com/sanity-io/sanity/commit/ea715e8fd88cdeaf34bba651d7feb489f947607f))
+* **comments:** inline comment creation issue in Safari ([#6510](https://github.com/sanity-io/sanity/issues/6510)) ([3b4a7e6](https://github.com/sanity-io/sanity/commit/3b4a7e65237ebd95d70722b066b87422c748e736))
+* **core:** change scrollintoview block to be nearest ([#6328](https://github.com/sanity-io/sanity/issues/6328)) ([509757c](https://github.com/sanity-io/sanity/commit/509757c6540c8923c9022c2aecbd9fa5e059415d))
+* **core:** export AddonDataSetContext from singletons ([970cf7d](https://github.com/sanity-io/sanity/commit/970cf7d79462dc4baf8c459f21056610dca992a0))
+* **core:** set scroll boundary to nearest ([#6310](https://github.com/sanity-io/sanity/issues/6310)) ([0dae0da](https://github.com/sanity-io/sanity/commit/0dae0da8d1baeab0a3e6b75e720d191e4c6ac5a5))
+* **core:** skip reset presence selection on PTE blur ([#6511](https://github.com/sanity-io/sanity/issues/6511)) ([f0c94f1](https://github.com/sanity-io/sanity/commit/f0c94f1e6ea0c224703006db483a8d581aea1908))
+* **deps:** update dependency @sanity/presentation to v1.12.10 ([#6501](https://github.com/sanity-io/sanity/issues/6501)) ([06ef31d](https://github.com/sanity-io/sanity/commit/06ef31d64f4364bd6327fb182a98bb25a03652fa))
+* **deps:** update dependency @sanity/presentation to v1.12.8 ([#6485](https://github.com/sanity-io/sanity/issues/6485)) ([05aad5c](https://github.com/sanity-io/sanity/commit/05aad5c0b79d11911e3dd2519a57b772abcee11a))
+* **deps:** Update react monorepo ([#6502](https://github.com/sanity-io/sanity/issues/6502)) ([fa9d145](https://github.com/sanity-io/sanity/commit/fa9d145dd4fa4e0fa994f7730e17fea177f8c8cf))
+* fix linting and type errors after rebase ([c093246](https://github.com/sanity-io/sanity/commit/c0932461b064b201a97c7e96931b868a58990d49))
+* next studio build ([52bcbda](https://github.com/sanity-io/sanity/commit/52bcbda69a03b061a07c06be95e3f7fed668dbbb))
+* **portable-text-editor:** fix issue where decoration on inline object would cause freeze ([#6531](https://github.com/sanity-io/sanity/issues/6531)) ([f03f6eb](https://github.com/sanity-io/sanity/commit/f03f6ebd62157055535bfe32ef52964fac140dc2))
+* **portable-text-editor:** fix issue where decoration would not target correctly ([#6532](https://github.com/sanity-io/sanity/issues/6532)) ([251d592](https://github.com/sanity-io/sanity/commit/251d592265efe31d8a4f2cd1655bc9bede03e66f))
+* prevent looping requests to keyvalue in recent searches ([#6480](https://github.com/sanity-io/sanity/issues/6480)) ([232385e](https://github.com/sanity-io/sanity/commit/232385ecf577e09b16c842c7866b5eb2c7de52fb))
+* **router:** expose RouterContext from sanity/router ([7eeda3b](https://github.com/sanity-io/sanity/commit/7eeda3bf0160a1df13577efd43329082f98f8f59))
+* **scheduled-publishing:** deprecated error toast shows multiple times ([#6513](https://github.com/sanity-io/sanity/issues/6513)) ([21d5b32](https://github.com/sanity-io/sanity/commit/21d5b322619ccbcb337f1dfacf61e7369bb1f368))
+* **singletons:** fix build issues and move CalendarContext interface back ([b3de008](https://github.com/sanity-io/sanity/commit/b3de008a426626169c29a9be5545e9a07c321494))
+* **singletons:** use relative path for StructureToolContextValue type ([30204c7](https://github.com/sanity-io/sanity/commit/30204c7c3137d2dc9caaf47d40fc776e7bfcde55))
+* statusButton requires provided aria-label ([#6430](https://github.com/sanity-io/sanity/issues/6430)) ([06c67fc](https://github.com/sanity-io/sanity/commit/06c67fc6cdbd7a60c23f51f9a94972ba1d790755)), closes [#6463](https://github.com/sanity-io/sanity/issues/6463) [#6460](https://github.com/sanity-io/sanity/issues/6460) [#6472](https://github.com/sanity-io/sanity/issues/6472) [#6427](https://github.com/sanity-io/sanity/issues/6427) [#6457](https://github.com/sanity-io/sanity/issues/6457) [#6464](https://github.com/sanity-io/sanity/issues/6464) [#6475](https://github.com/sanity-io/sanity/issues/6475) [#6474](https://github.com/sanity-io/sanity/issues/6474) [#6476](https://github.com/sanity-io/sanity/issues/6476) [#6465](https://github.com/sanity-io/sanity/issues/6465) [#6466](https://github.com/sanity-io/sanity/issues/6466) [#6467](https://github.com/sanity-io/sanity/issues/6467) [#6468](https://github.com/sanity-io/sanity/issues/6468) [#6470](https://github.com/sanity-io/sanity/issues/6470) [#6469](https://github.com/sanity-io/sanity/issues/6469) [#6471](https://github.com/sanity-io/sanity/issues/6471) [#6482](https://github.com/sanity-io/sanity/issues/6482) [#6484](https://github.com/sanity-io/sanity/issues/6484) [#6483](https://github.com/sanity-io/sanity/issues/6483) [#6485](https://github.com/sanity-io/sanity/issues/6485) [#6490](https://github.com/sanity-io/sanity/issues/6490) [#6491](https://github.com/sanity-io/sanity/issues/6491) [#6487](https://github.com/sanity-io/sanity/issues/6487) [#6494](https://github.com/sanity-io/sanity/issues/6494) [#6493](https://github.com/sanity-io/sanity/issues/6493) [#6068](https://github.com/sanity-io/sanity/issues/6068) [#6496](https://github.com/sanity-io/sanity/issues/6496) [#6497](https://github.com/sanity-io/sanity/issues/6497) [#6498](https://github.com/sanity-io/sanity/issues/6498) [#6499](https://github.com/sanity-io/sanity/issues/6499) [#6488](https://github.com/sanity-io/sanity/issues/6488) [#6503](https://github.com/sanity-io/sanity/issues/6503) [#6463](https://github.com/sanity-io/sanity/issues/6463) [#6460](https://github.com/sanity-io/sanity/issues/6460) [#6427](https://github.com/sanity-io/sanity/issues/6427) [#6464](https://github.com/sanity-io/sanity/issues/6464) [#6474](https://github.com/sanity-io/sanity/issues/6474) [#6476](https://github.com/sanity-io/sanity/issues/6476) [#6466](https://github.com/sanity-io/sanity/issues/6466) [#6468](https://github.com/sanity-io/sanity/issues/6468) [#6470](https://github.com/sanity-io/sanity/issues/6470) [#6469](https://github.com/sanity-io/sanity/issues/6469) [#6471](https://github.com/sanity-io/sanity/issues/6471) [#6482](https://github.com/sanity-io/sanity/issues/6482) [#6484](https://github.com/sanity-io/sanity/issues/6484) [#6483](https://github.com/sanity-io/sanity/issues/6483) [#6485](https://github.com/sanity-io/sanity/issues/6485) [#6490](https://github.com/sanity-io/sanity/issues/6490) [#6487](https://github.com/sanity-io/sanity/issues/6487) [#6493](https://github.com/sanity-io/sanity/issues/6493) [#6496](https://github.com/sanity-io/sanity/issues/6496) [#6498](https://github.com/sanity-io/sanity/issues/6498) [#6499](https://github.com/sanity-io/sanity/issues/6499) [#6500](https://github.com/sanity-io/sanity/issues/6500) [#6501](https://github.com/sanity-io/sanity/issues/6501) [#6081](https://github.com/sanity-io/sanity/issues/6081)
+* **structure:** add string for duplicate event ([#6523](https://github.com/sanity-io/sanity/issues/6523)) ([f51b157](https://github.com/sanity-io/sanity/commit/f51b1577c7722c4cc6cfc19911a2bdb06481d671))
+* **structure:** expose PaneRouterContext from structure ([ab835d9](https://github.com/sanity-io/sanity/commit/ab835d9fd21d42b3a4ad1eb3ccbb02a339c4dd05))
+* **structure:** uncaught error while swapping images in array in PTE ([#6399](https://github.com/sanity-io/sanity/issues/6399)) ([c9bfc31](https://github.com/sanity-io/sanity/commit/c9bfc3127f7ac923d6e0efed296233d0898a4edc))
+* **test:** remove hydrateroot warning test ([#6494](https://github.com/sanity-io/sanity/issues/6494)) ([d50a0f1](https://github.com/sanity-io/sanity/commit/d50a0f19dbe0f8798d0521adc5ba60bdcc2f0874))
+* **typegen:** fixes a bug where we imported the wrong relative path ([#6457](https://github.com/sanity-io/sanity/issues/6457)) ([e1bd1f0](https://github.com/sanity-io/sanity/commit/e1bd1f0de203b9f42efec9ecd46a5bd111512a56))
+
+
+### Features
+
+* **core:** implement presence cursors ([#6081](https://github.com/sanity-io/sanity/issues/6081)) ([1522806](https://github.com/sanity-io/sanity/commit/1522806aa331ede86a50ceadcaa85227574f9da4))
+* set print width to 40 ([#6068](https://github.com/sanity-io/sanity/issues/6068)) ([2e24fcd](https://github.com/sanity-io/sanity/commit/2e24fcdfa7e2ef466c51815e3ff0f249728cda6b))
+* **singletons:** add a singleton package exports ([884fca1](https://github.com/sanity-io/sanity/commit/884fca1bd6b8dd18b9cad570902c59e4fc78fd9b))
+* **singletons:** add eslint rule for boundaries ([bfd9a30](https://github.com/sanity-io/sanity/commit/bfd9a30ecf166e374759a62e8c6687aae8bfb93b))
+* **typegen:** also search for queries in app and sanity folders ([#6475](https://github.com/sanity-io/sanity/issues/6475)) ([03cbb12](https://github.com/sanity-io/sanity/commit/03cbb12cf81519a982f4aba6ae88e5c86f4f5f3d))
+* use prefersLatestPublished parameter in DocumentPaneProvider ([#6486](https://github.com/sanity-io/sanity/issues/6486)) ([3da55ae](https://github.com/sanity-io/sanity/commit/3da55ae5329ffe0d418c19321457cd99b92a1428))
+
+
+
+## [3.39.1](https://github.com/sanity-io/sanity/compare/v3.39.0...v3.39.1) (2024-04-26)
+
+
+### Bug Fixes
+
+* **cli:** remove comments from moviedb template, hide location field ([#6488](https://github.com/sanity-io/sanity/issues/6488)) ([10f19a1](https://github.com/sanity-io/sanity/commit/10f19a144544bdb592bb76fd0b6a3a991a5cc5db))
+* **search:** revert to old search API for now ([#6503](https://github.com/sanity-io/sanity/issues/6503)) ([a512167](https://github.com/sanity-io/sanity/commit/a5121675ae74158b914a066269d3b3836af16a36))
+
+
+
+# [3.39.0](https://github.com/sanity-io/sanity/compare/v3.38.0...v3.39.0) (2024-04-23)
+
+
+### Bug Fixes
+
+* **codeowners:** update codeowners for tasks and comments ([#6414](https://github.com/sanity-io/sanity/issues/6414)) ([d286050](https://github.com/sanity-io/sanity/commit/d286050dda5550b1575b94681468cffaabbfa274))
+* **comments:** conditional rendering of `CommentsProvider` ([#6412](https://github.com/sanity-io/sanity/issues/6412)) ([379396e](https://github.com/sanity-io/sanity/commit/379396e63e05487aebe0056f3f42cff9cdb8c635))
+* **core:** prevent transformation of negation tokens into wildcard prefix tokens ([#6396](https://github.com/sanity-io/sanity/issues/6396)) ([f28ef7e](https://github.com/sanity-io/sanity/commit/f28ef7e0947a6dbe967b22478170c54edff1c058))
+* **deps:** update dependency @sanity/client to ^6.15.17 ([#6406](https://github.com/sanity-io/sanity/issues/6406)) ([82e505f](https://github.com/sanity-io/sanity/commit/82e505fc8c1f1019e40cd7657cb7ddb182086e75))
+* **deps:** update dependency @sanity/client to ^6.15.19 ([#6433](https://github.com/sanity-io/sanity/issues/6433)) ([4e32715](https://github.com/sanity-io/sanity/commit/4e32715c399c8005a9f9cc649b65902afd16c8e5))
+* **deps:** update dependency @sanity/client to ^6.15.20 ([#6461](https://github.com/sanity-io/sanity/issues/6461)) ([d7f1067](https://github.com/sanity-io/sanity/commit/d7f1067718725d6ddb07a9f27f9c7004ca86c05f))
+* **deps:** update dependency @sanity/presentation to v1.12.5 ([#6407](https://github.com/sanity-io/sanity/issues/6407)) ([98bb233](https://github.com/sanity-io/sanity/commit/98bb2338b04021e9b2d6599a1d8d4aa49c724df8))
+* **deps:** update dependency @sanity/presentation to v1.12.6 ([#6437](https://github.com/sanity-io/sanity/issues/6437)) ([3eb44db](https://github.com/sanity-io/sanity/commit/3eb44db1a4e7b40716abfbf6035e332578a5175b))
+* **deps:** update dependency @sanity/presentation to v1.12.7 ([#6448](https://github.com/sanity-io/sanity/issues/6448)) ([f9634f4](https://github.com/sanity-io/sanity/commit/f9634f42c1cecef02b488d8f8bba8941e56b6aab))
+* **deps:** update dependency @sanity/ui to ^2.1.4 ([#6408](https://github.com/sanity-io/sanity/issues/6408)) ([59cad0b](https://github.com/sanity-io/sanity/commit/59cad0b9239b0012b03a51fa2e2d903e0640f9d5))
+* **deps:** update dependency get-it to ^8.4.26 ([#6409](https://github.com/sanity-io/sanity/issues/6409)) ([159f542](https://github.com/sanity-io/sanity/commit/159f5428e5d0927bcccebf36869ca31f7ec37015))
+* **deps:** update dependency get-it to ^8.4.27 ([#6434](https://github.com/sanity-io/sanity/issues/6434)) ([5fb7ddf](https://github.com/sanity-io/sanity/commit/5fb7ddf1b535e91e1255c92148f177ae2043fd79))
+* **migrate:** forward possible API error response to error thrown for non 2xx ([#6387](https://github.com/sanity-io/sanity/issues/6387)) ([9316475](https://github.com/sanity-io/sanity/commit/9316475346a7404abcae3166695b1033487cb67e))
+* **portable-text-editor:** support collapsed range decorations ([#6428](https://github.com/sanity-io/sanity/issues/6428)) ([2d02d62](https://github.com/sanity-io/sanity/commit/2d02d625996a673149db5d01541fe63956d06a3e))
+* refactor checkoutPair to allow mutations for liveEdit documents ([#6393](https://github.com/sanity-io/sanity/issues/6393)) ([f6ae402](https://github.com/sanity-io/sanity/commit/f6ae4028b4bbe54fef4c800b275bea92310a423f))
+* **structure:** resolve static types in document list filters ([#6439](https://github.com/sanity-io/sanity/issues/6439)) ([048ce0b](https://github.com/sanity-io/sanity/commit/048ce0b98b4b38b09a3100866976d6846444e484))
+* **structure:** update to not crash validation panel if unable to get path title ([#6417](https://github.com/sanity-io/sanity/issues/6417)) ([d5f8fb6](https://github.com/sanity-io/sanity/commit/d5f8fb6799dcabb361b1ca6859152b27f11d57d0))
+* **tasks:** update tasks upsell provider client version ([#6413](https://github.com/sanity-io/sanity/issues/6413)) ([61a887c](https://github.com/sanity-io/sanity/commit/61a887c0186a280f146edbf8ee6bdd13e867eb64))
+* **tasks:** update taskURL for notification target ([#6395](https://github.com/sanity-io/sanity/issues/6395)) ([7c8cebf](https://github.com/sanity-io/sanity/commit/7c8cebf37d19e0736e1a14292ef7d3243700a0b1))
+* TS import paths importing index.ts twice incorrectly ([#6415](https://github.com/sanity-io/sanity/issues/6415)) ([6066e92](https://github.com/sanity-io/sanity/commit/6066e9287e64d5e22b8b7102c98adacb2c27208a))
+* **typegen:** fixes a case where we track ratio as NaN ([#6309](https://github.com/sanity-io/sanity/issues/6309)) ([b0f405e](https://github.com/sanity-io/sanity/commit/b0f405e29237d90ab8478aa74637f81d2f911f38))
+
+
+### Features
+
+* **scheduled-publishing:** move scheduled publishing into core. ([#6416](https://github.com/sanity-io/sanity/issues/6416)) ([a6fc5af](https://github.com/sanity-io/sanity/commit/a6fc5af0d27a2a1e846edbf47798bfd0d7405187)), closes [#6455](https://github.com/sanity-io/sanity/issues/6455)
+
+
+### Performance Improvements
+
+* **portable-text-editor:** improve range deocration render perf ([#6441](https://github.com/sanity-io/sanity/issues/6441)) ([c9b1ebb](https://github.com/sanity-io/sanity/commit/c9b1ebb461d7bdc4388cec648a36a1afe159fe76))
+
+
+
+# [3.38.0](https://github.com/sanity-io/sanity/compare/v3.37.2...v3.38.0) (2024-04-16)
+
+
+### Bug Fixes
+
+* **block-tools:** removal of strikethrough in links when copying from gdocs to PTE ([#6382](https://github.com/sanity-io/sanity/issues/6382)) ([52cf1c7](https://github.com/sanity-io/sanity/commit/52cf1c7d4a39d95c1c8d9e8522509d6466bb1496))
+* **bug:** update to not add annotation in PTE if all fields are null ([#6346](https://github.com/sanity-io/sanity/issues/6346)) ([e10fd87](https://github.com/sanity-io/sanity/commit/e10fd872c6ae2ca0223eec6dd2e1c95dfdfba167))
+* **cli:** add `migration` to list of core commands, remove `migrate` ([#6377](https://github.com/sanity-io/sanity/issues/6377)) ([100048a](https://github.com/sanity-io/sanity/commit/100048ab5a3f7fd3308ff33fbbcb721c8f446e93))
+* **cli:** add note about webhooks in migration run command ([#6112](https://github.com/sanity-io/sanity/issues/6112)) ([9baf406](https://github.com/sanity-io/sanity/commit/9baf4069b64618fbe15d77de5f58c6d6831bdd70))
+* **cli:** upgrade and unpin import & export modules ([#6347](https://github.com/sanity-io/sanity/issues/6347)) ([905d469](https://github.com/sanity-io/sanity/commit/905d469667d22b3be13fea6d5c468d4047114b6b))
+* **core/inputs:** fix issues with focus handling ([#6370](https://github.com/sanity-io/sanity/issues/6370)) ([eca960e](https://github.com/sanity-io/sanity/commit/eca960e37be3307cbc7f4bbca15c69877001d44e)), closes [#6129](https://github.com/sanity-io/sanity/issues/6129)
+* **core:** hidden caret on code formatted text ([#6307](https://github.com/sanity-io/sanity/issues/6307)) ([1c8cff0](https://github.com/sanity-io/sanity/commit/1c8cff0281b28f59ba95595c45866c998fc9631e))
+* **core:** ignore locally applied createIfNotExists mutations when using server actions ([#6334](https://github.com/sanity-io/sanity/issues/6334)) ([c204a7a](https://github.com/sanity-io/sanity/commit/c204a7ae0af93fd3798c7dae76ff46656bcbc9fc))
+* **core:** reset global search results when SEARCH_REQUEST_COMPLETE occurs after any action causing search parameters to change ([#6224](https://github.com/sanity-io/sanity/issues/6224)) ([00a5d91](https://github.com/sanity-io/sanity/commit/00a5d91ffca5987bf5c93ca404699adf9f21b412))
+* crash in hotspot and cropping on Next.js ([#6380](https://github.com/sanity-io/sanity/issues/6380)) ([0dade62](https://github.com/sanity-io/sanity/commit/0dade6273fe4ee55c82099353268f58a6c80b597))
+* **deps:** update dependency @sanity/client to ^6.15.13 ([#6331](https://github.com/sanity-io/sanity/issues/6331)) ([2c4671a](https://github.com/sanity-io/sanity/commit/2c4671a37fae3b089573cdf4b13d7a9500b3503b))
+* **deps:** update dependency @sanity/client to ^6.15.14 ([#6367](https://github.com/sanity-io/sanity/issues/6367)) ([aaaf585](https://github.com/sanity-io/sanity/commit/aaaf5851df02142dc3d21c029a3da1b689335c00))
+* **deps:** update dependency @sanity/presentation to v1.12.4 ([#6386](https://github.com/sanity-io/sanity/issues/6386)) ([fb78d57](https://github.com/sanity-io/sanity/commit/fb78d57c987bd7a234e883a87b9dcadb75c093f4))
+* **deps:** update dependency @sanity/ui to ^2.1.3 ([#6344](https://github.com/sanity-io/sanity/issues/6344)) ([e5c763a](https://github.com/sanity-io/sanity/commit/e5c763aa5a1e2c7b267a7c55cd2f6efad84bbe55))
+* **deps:** update dependency get-it to ^8.4.19 ([#6325](https://github.com/sanity-io/sanity/issues/6325)) ([a7755ac](https://github.com/sanity-io/sanity/commit/a7755ac805c9896247bc2500efe0e8ff8a137d14))
+* **deps:** update dependency get-it to ^8.4.21 ([#6332](https://github.com/sanity-io/sanity/issues/6332)) ([98626ec](https://github.com/sanity-io/sanity/commit/98626ec21485dc33ccfcd60dd8e9ac42995316a8))
+* **deps:** update dependency get-it to ^8.4.23 ([#6362](https://github.com/sanity-io/sanity/issues/6362)) ([f08cf40](https://github.com/sanity-io/sanity/commit/f08cf40721c7c42b8df9e5370da7f138d5fbb39c))
+* **form/inputs:** Remove obsolete code for restoring selection after editing Annotation ([#6389](https://github.com/sanity-io/sanity/issues/6389)) ([b7961fd](https://github.com/sanity-io/sanity/commit/b7961fdb5985b48c0446c8636f0a0ca2124e0641))
+* **pte:** fix an issue where when PTE throws exception after resize ([#6152](https://github.com/sanity-io/sanity/issues/6152)) ([cf75a0b](https://github.com/sanity-io/sanity/commit/cf75a0b7fcebaf6d0b335bdd3006da9ee79c016c))
+* regression hiding tool buttons when embedded on Next.js ([#6338](https://github.com/sanity-io/sanity/issues/6338)) ([d30cfd9](https://github.com/sanity-io/sanity/commit/d30cfd9509a0817c400cf2d74ee5cf7e854f52bd))
+* resolve PTE inconsistency by passing serverActionsEnabled to documentEvents ([#6299](https://github.com/sanity-io/sanity/issues/6299)) ([4123260](https://github.com/sanity-io/sanity/commit/4123260b10368206e84bd5c528000c4112555300))
+* **structure:** remove 'ago' suffix when published time was yesterday ([#6137](https://github.com/sanity-io/sanity/issues/6137)) ([66495e5](https://github.com/sanity-io/sanity/commit/66495e5a4f4541248bfa1894ac34bca902dfa66e))
+* **structure:** remove padding prop in contextMenuButton ([#6097](https://github.com/sanity-io/sanity/issues/6097)) ([b3860ed](https://github.com/sanity-io/sanity/commit/b3860edbb9af4029ded769353f34018f181a252e))
+* **tasks:** padding when comment input is focused ([#6372](https://github.com/sanity-io/sanity/issues/6372)) ([f6c46cc](https://github.com/sanity-io/sanity/commit/f6c46cc60826ea0bba0ba8c595c73338d8d53f3f))
+* update TelemetryUserProperties to use machinePlatform instead of platform ([#6312](https://github.com/sanity-io/sanity/issues/6312)) ([bc6be95](https://github.com/sanity-io/sanity/commit/bc6be952b70e52b908342776d26a0c9e65a6e88f))
+* update unit tests to account for new create behavior ([#6391](https://github.com/sanity-io/sanity/issues/6391)) ([55cacc6](https://github.com/sanity-io/sanity/commit/55cacc6e5f9268aaa659b1257d69910eebfd7512))
+* use pane key in settings for document lists that do not have types available ([#6335](https://github.com/sanity-io/sanity/issues/6335)) ([57749e5](https://github.com/sanity-io/sanity/commit/57749e5e3c773b324f8fb30d946370440bf41920))
+
+
+### Features
+
+* **core:** add prefix search support ([#6010](https://github.com/sanity-io/sanity/issues/6010)) ([3849b53](https://github.com/sanity-io/sanity/commit/3849b5370c4c11a0cb20f97c05c68f6a1adff511))
+* **core:** display custom styles in PTE style selector ([#6275](https://github.com/sanity-io/sanity/issues/6275)) ([ee31fb1](https://github.com/sanity-io/sanity/commit/ee31fb1d05467658291ba4d42202f2e0e80ae413))
+* **core:** enable Text Search API search strategy by default ([#6373](https://github.com/sanity-io/sanity/issues/6373)) ([679a788](https://github.com/sanity-io/sanity/commit/679a788850d7430e29cb0dbad3d749b93bfe4407))
+* **core:** make PTE resizable ([#6255](https://github.com/sanity-io/sanity/issues/6255)) ([d92eea3](https://github.com/sanity-io/sanity/commit/d92eea390fb6be33f47202c5e475ee75873a8882))
+
+
+
+## [3.37.2](https://github.com/sanity-io/sanity/compare/v3.37.1...v3.37.2) (2024-04-09)
+
+
+### Bug Fixes
+
+* **cli:** ensure output path for types exist before writing ([#6300](https://github.com/sanity-io/sanity/issues/6300)) ([e75bffe](https://github.com/sanity-io/sanity/commit/e75bffe56f6c8fc58e05bc8b0058721b58960a0f))
+* **codegen:** prevent crash due to incorrect babel config path ([#6298](https://github.com/sanity-io/sanity/issues/6298)) ([fc784d1](https://github.com/sanity-io/sanity/commit/fc784d1d574fd24d38fe2859c18c00d4d3107c8a))
+* **deps:** update dependency @sanity/ui to ^2.1.2 ([#6301](https://github.com/sanity-io/sanity/issues/6301)) ([9ebe73d](https://github.com/sanity-io/sanity/commit/9ebe73d3eb070e091ffdb36bc16be2e440fbe4c4))
+
+
+
+## [3.37.1](https://github.com/sanity-io/sanity/compare/v3.37.0...v3.37.1) (2024-04-09)
+
+
+### Bug Fixes
+
+* bump `styled-components` used by `npm create sanity` ([#6281](https://github.com/sanity-io/sanity/issues/6281)) ([61dbbe2](https://github.com/sanity-io/sanity/commit/61dbbe28b6c05e943c4caf660457f82583e7ba5f))
+* **deps:** update dependency @sanity/ui to ^2.1.1 ([#6283](https://github.com/sanity-io/sanity/issues/6283)) ([90c7c57](https://github.com/sanity-io/sanity/commit/90c7c57219d411f4626d2a8fcb195d37ea0bb98f))
+* disable server actions in test studio ([#6270](https://github.com/sanity-io/sanity/issues/6270)) ([f1451a9](https://github.com/sanity-io/sanity/commit/f1451a9959bcc1c32202b379e4e70b06bca9dfb3))
+* restore node ESM strict mode support ([#6287](https://github.com/sanity-io/sanity/issues/6287)) ([46563c8](https://github.com/sanity-io/sanity/commit/46563c8910cd17ef7ee2842088de35bd66815ffa))
+
+
+
+# [3.37.0](https://github.com/sanity-io/sanity/compare/v3.36.4...v3.37.0) (2024-04-09)
+
+
+### Bug Fixes
+
+* **cli:** do not suggest v2 cli commands on "no such command" error ([#6211](https://github.com/sanity-io/sanity/issues/6211)) ([69ff7ff](https://github.com/sanity-io/sanity/commit/69ff7ff2c18992ffbca82289c07678038ad9a01c))
+* **cli:** formalize requirement of styled-components@6 and @sanity/ui@2 ([#6234](https://github.com/sanity-io/sanity/issues/6234)) ([5fe2d47](https://github.com/sanity-io/sanity/commit/5fe2d47f499c8183737380b025b4c640808119ba))
+* **cli:** improve error handling on missing extracted schema ([#6204](https://github.com/sanity-io/sanity/issues/6204)) ([4fb0e66](https://github.com/sanity-io/sanity/commit/4fb0e66a64cd71060b9ce88fcb7afe002800cd9e))
+* **cli:** use stub file loader for scss, sass extensions ([#6215](https://github.com/sanity-io/sanity/issues/6215)) ([80f4f22](https://github.com/sanity-io/sanity/commit/80f4f220f1c71e47f0ce706e1d7f7f37799f3cb1))
+* **comments:** weaken references in content snapshot ([#6131](https://github.com/sanity-io/sanity/issues/6131)) ([d1f1a4c](https://github.com/sanity-io/sanity/commit/d1f1a4cd40419d4748d94c7dbaadea063386a20c))
+* **core:** add readOnly prop to dragHandle ([#6190](https://github.com/sanity-io/sanity/issues/6190)) ([234d009](https://github.com/sanity-io/sanity/commit/234d00982693f6dc98ac79caa26cc7f09502a574))
+* **deps:** narrow accepted peer dependency range of style-components ([#6271](https://github.com/sanity-io/sanity/issues/6271)) ([1ac127b](https://github.com/sanity-io/sanity/commit/1ac127b33ca010e7b6603a22091e8fff4de2a8fc))
+* **deps:** pin framer-motion to the same version used by `@sanity/ui` ([#6183](https://github.com/sanity-io/sanity/issues/6183)) ([7120aa8](https://github.com/sanity-io/sanity/commit/7120aa8ce6eced79c90dd2c61901138d11f76795))
+* **deps:** update dependency @sanity/client to ^6.15.10 ([#6228](https://github.com/sanity-io/sanity/issues/6228)) ([ba323ae](https://github.com/sanity-io/sanity/commit/ba323ae8763d852f95c69ba6f9aae21547882813))
+* **deps:** update dependency @sanity/client to ^6.15.11 ([#6253](https://github.com/sanity-io/sanity/issues/6253)) ([a3b7458](https://github.com/sanity-io/sanity/commit/a3b7458352debee14811d9594101ca9b301934be))
+* **deps:** update dependency @sanity/client to ^6.15.9 ([#6177](https://github.com/sanity-io/sanity/issues/6177)) ([fbeb6fb](https://github.com/sanity-io/sanity/commit/fbeb6fbabd0bbabc3ab12881c9b1403779404519))
+* **deps:** update dependency @sanity/presentation to v1.12.2 ([#6235](https://github.com/sanity-io/sanity/issues/6235)) ([acbb08a](https://github.com/sanity-io/sanity/commit/acbb08a9d38bd58b0f9d2415ff9c5977b8cdc319))
+* **deps:** update dependency @sanity/presentation to v1.12.3 ([#6251](https://github.com/sanity-io/sanity/issues/6251)) ([0959294](https://github.com/sanity-io/sanity/commit/0959294ef6592519976681390b97ac6e65792e1f))
+* **deps:** update dependency @sanity/ui to ^2.0.13 ([#6178](https://github.com/sanity-io/sanity/issues/6178)) ([4f1b36d](https://github.com/sanity-io/sanity/commit/4f1b36d245651426f75d3b098f8f229936afa8eb))
+* **deps:** update dependency @sanity/ui to ^2.0.14 ([#6209](https://github.com/sanity-io/sanity/issues/6209)) ([f4d2e7e](https://github.com/sanity-io/sanity/commit/f4d2e7ebc45c46718f0c3e0b9d6feda06b840489))
+* **deps:** update dependency @sanity/ui to ^2.0.15 ([#6229](https://github.com/sanity-io/sanity/issues/6229)) ([a6eb947](https://github.com/sanity-io/sanity/commit/a6eb947793b36400eb4a92e4ce30511b9adf928b))
+* **deps:** update dependency @sanity/ui to ^2.0.16 ([#6241](https://github.com/sanity-io/sanity/issues/6241)) ([58c319a](https://github.com/sanity-io/sanity/commit/58c319a82dc3691861e78deb4c0e2438d7749bac))
+* **deps:** update dependency @sanity/ui to ^2.1.0 ([#6254](https://github.com/sanity-io/sanity/issues/6254)) ([6b2abb9](https://github.com/sanity-io/sanity/commit/6b2abb996d5562c4731245f275095c25b3ad0e81))
+* **deps:** update dependency get-it to ^8.4.17 ([#6179](https://github.com/sanity-io/sanity/issues/6179)) ([ee16280](https://github.com/sanity-io/sanity/commit/ee162803e918949e177fd287ca72299a21bdc942))
+* **deps:** update dependency get-it to ^8.4.18 ([#6222](https://github.com/sanity-io/sanity/issues/6222)) ([70f0963](https://github.com/sanity-io/sanity/commit/70f0963337402104f6ba6d985a2b290703b702e9))
+* **deps:** Update react monorepo ([#6176](https://github.com/sanity-io/sanity/issues/6176)) ([c4f24d2](https://github.com/sanity-io/sanity/commit/c4f24d2a668db0cffba69079131d0c8b73416518))
+* replace the JSON5 parser with JSON ([#6149](https://github.com/sanity-io/sanity/issues/6149)) ([fe11588](https://github.com/sanity-io/sanity/commit/fe11588c74b435efbacb132de3ffe1d9ea311fa4))
+* **schema:** make `current` field for slugs required ([#6205](https://github.com/sanity-io/sanity/issues/6205)) ([e420b6f](https://github.com/sanity-io/sanity/commit/e420b6f11a63b6ef57f94c4ea115d99b1298eb2f))
+* **structure:** prevent duplication of search filters when `listenSearchQuery` is used (e.g. in document lists) ([#6247](https://github.com/sanity-io/sanity/issues/6247)) ([fce97c7](https://github.com/sanity-io/sanity/commit/fce97c78985b4118ecfc800b4c0fafdf8b3f6636))
+* **tasks:** change tasks button in nav to be toggle ([#6236](https://github.com/sanity-io/sanity/issues/6236)) ([8e40ecb](https://github.com/sanity-io/sanity/commit/8e40ecb08623566abb664d908cd5234874240be3))
+* **tasks:** disable autocomplete on 'assign to' input ([#6193](https://github.com/sanity-io/sanity/issues/6193)) ([da49af0](https://github.com/sanity-io/sanity/commit/da49af083556833987d0378efc4d4bdcfcc64e0f))
+* **tasks:** tasks UI updates. ([#6136](https://github.com/sanity-io/sanity/issues/6136)) ([d45b210](https://github.com/sanity-io/sanity/commit/d45b210dcb7bed8441b03d2d55b0443dc6da0d22))
+* upgrade to `@sanity/pkg-utils` v5 and use updated ESM best practices ([#5983](https://github.com/sanity-io/sanity/issues/5983)) ([62a6810](https://github.com/sanity-io/sanity/commit/62a6810bf8217a9b33a1c030666c5e6d98ab2169))
+* use named `styled` import for better ESM runtime compat ([#6185](https://github.com/sanity-io/sanity/issues/6185)) ([b544abb](https://github.com/sanity-io/sanity/commit/b544abb372600300d7bb5e11acda6172a24aa4bd)), closes [#6188](https://github.com/sanity-io/sanity/issues/6188)
+
+
+### Features
+
+* **core:** add serverActions flag to config ([#6212](https://github.com/sanity-io/sanity/issues/6212)) ([1b94d40](https://github.com/sanity-io/sanity/commit/1b94d404f4268f1559147ecdd963f154e20af29d))
+* **core:** adopt Actions API ([#6257](https://github.com/sanity-io/sanity/issues/6257)) ([4d45224](https://github.com/sanity-io/sanity/commit/4d4522400d43054e1d7ebac21bbcda2de8fc3a55)), closes [#6094](https://github.com/sanity-io/sanity/issues/6094) [#6115](https://github.com/sanity-io/sanity/issues/6115)
+* **tasks:** add feedback link to tasks ([#6256](https://github.com/sanity-io/sanity/issues/6256)) ([8668f48](https://github.com/sanity-io/sanity/commit/8668f48965385ae8ba8a5d7676340b0c8e551d37))
+* **tasks:** add tasks upsell ui ([#6216](https://github.com/sanity-io/sanity/issues/6216)) ([658262e](https://github.com/sanity-io/sanity/commit/658262e7204dee799644bb40cd9db230c0f76671))
+* **tasks:** add telemetry events to tasks ([#6246](https://github.com/sanity-io/sanity/issues/6246)) ([346600c](https://github.com/sanity-io/sanity/commit/346600cc7ad3043f54a0e08cc9cd0f1b5c45c266))
+
+
+### Reverts
+
+* Revert "chore(deps): update dependency use-hot-module-reload to v2 (#6180)" (#6182) ([3b8c28c](https://github.com/sanity-io/sanity/commit/3b8c28ce1179447cacb183a3005e04d9e4ea0ac9)), closes [#6180](https://github.com/sanity-io/sanity/issues/6180) [#6182](https://github.com/sanity-io/sanity/issues/6182)
+
+
+
+## [3.36.4](https://github.com/sanity-io/sanity/compare/v3.36.3...v3.36.4) (2024-04-03)
+
+
+### Bug Fixes
+
+* **core:** remove custom options in comments upsell request ([#6201](https://github.com/sanity-io/sanity/issues/6201)) ([1d85e9f](https://github.com/sanity-io/sanity/commit/1d85e9fa23a5e02b979622dc22775ba943d58dea))
+* **structure:** annotations not opening in portable text editor ([#6198](https://github.com/sanity-io/sanity/issues/6198)) ([eb927b6](https://github.com/sanity-io/sanity/commit/eb927b671a191855560b4c38ab7242a12ac9feca))
+
+
+
+## [3.36.3](https://github.com/sanity-io/sanity/compare/v3.36.2...v3.36.3) (2024-04-02)
+
+
+### Bug Fixes
+
+* **pte:** update default height of PTE in Form ([#6119](https://github.com/sanity-io/sanity/issues/6119)) ([5756753](https://github.com/sanity-io/sanity/commit/5756753c49c3bebce8818ab416819ac7ddeb3c75))
+* **schema-extraction:** check for _required field in validation rules ([#6151](https://github.com/sanity-io/sanity/issues/6151)) ([5ba26a5](https://github.com/sanity-io/sanity/commit/5ba26a5746579a32df5687d9aa3c5e79c909d1d8))
+* **structure:** improve document pane path handling ([#6129](https://github.com/sanity-io/sanity/issues/6129)) ([9b4d105](https://github.com/sanity-io/sanity/commit/9b4d1059dd4a493fa6201a954abd89a8bb0740a1))
+* **tasks:** don't open tasks search on hotkey + enter ([#6165](https://github.com/sanity-io/sanity/issues/6165)) ([d387316](https://github.com/sanity-io/sanity/commit/d3873165eb9d70e852a065e02124e7c47a77556e))
+
+
+### Features
+
+* **schema:** handle assetRequired when extracting schema with enforceRequiredFields ([#6157](https://github.com/sanity-io/sanity/issues/6157)) ([cd52979](https://github.com/sanity-io/sanity/commit/cd529795a394963f38589cedadb281d7cef79a55))
+
+
+
+## [3.36.2](https://github.com/sanity-io/sanity/compare/v3.36.1...v3.36.2) (2024-03-28)
+
+
+### Bug Fixes
+
+* add default listFormat locale where LocaleProvider may not be available ([#6147](https://github.com/sanity-io/sanity/issues/6147)) ([3c4d4cf](https://github.com/sanity-io/sanity/commit/3c4d4cf1d4833718c10a140416f5c37f40006dd9))
+* **tasks:** don't lowercase users when searching in the assignee menu ([#6138](https://github.com/sanity-io/sanity/issues/6138)) ([27643c8](https://github.com/sanity-io/sanity/commit/27643c8a37d8980a24e5b959bb3420fab3ac8d53))
+
+
+
+## [3.36.1](https://github.com/sanity-io/sanity/compare/v3.36.0...v3.36.1) (2024-03-27)
+
+
+### Bug Fixes
+
+* **core:** remove duplicateds tasks plugins ([#6134](https://github.com/sanity-io/sanity/issues/6134)) ([a0fce46](https://github.com/sanity-io/sanity/commit/a0fce46d1c7921535e9427b57eafc9b8faf2fa6c))
+* **i18n:** allow list formatter without arguments in `Translate` component ([#6135](https://github.com/sanity-io/sanity/issues/6135)) ([3e5b8d6](https://github.com/sanity-io/sanity/commit/3e5b8d60f3f3b91dcd1d97b29e7f14b9f4004c13))
+* **tasks:** group changes done to the same field ([#6132](https://github.com/sanity-io/sanity/issues/6132)) ([61c7ef8](https://github.com/sanity-io/sanity/commit/61c7ef8fcc8917e481c5ffd59e4fdefc5408ee95))
+* **typegen:** add placeholder group to allow typegen to show in help ([#6133](https://github.com/sanity-io/sanity/issues/6133)) ([45f0406](https://github.com/sanity-io/sanity/commit/45f04067339bf1c1ed3ac1b5e6953b04bbb56838))
+
+
+
+# [3.36.0](https://github.com/sanity-io/sanity/compare/v3.35.2...v3.36.0) (2024-03-26)
+
+
+### Bug Fixes
+
+* **comments:** update close icon to be consistent ([#6096](https://github.com/sanity-io/sanity/issues/6096)) ([89fd7ec](https://github.com/sanity-io/sanity/commit/89fd7ecbdb2a868846a896b39131170dd4c61689))
+* **deps:** update dependency @sanity/client to ^6.15.7 ([#6106](https://github.com/sanity-io/sanity/issues/6106)) ([69a5d6d](https://github.com/sanity-io/sanity/commit/69a5d6d60c1429bd38cb01b6709cea518a70d70d))
+* **deps:** update dependency @sanity/presentation to v1.12.1 ([#6109](https://github.com/sanity-io/sanity/issues/6109)) ([2014ef5](https://github.com/sanity-io/sanity/commit/2014ef56cc405dce24b087880c7407dd577fdbeb))
+* **deps:** update dependency @sanity/ui to ^2.0.12 ([#6107](https://github.com/sanity-io/sanity/issues/6107)) ([4886b00](https://github.com/sanity-io/sanity/commit/4886b00b17a77b24033f770b07dad443e3714dba))
+* move typegen cli into @sanity/cli ([#6111](https://github.com/sanity-io/sanity/issues/6111)) ([3f37c21](https://github.com/sanity-io/sanity/commit/3f37c218ee750be782b3648c4341f35b9b214979))
+* **pte:** PTE inline block object modal closing on validation state changes ([#6113](https://github.com/sanity-io/sanity/issues/6113)) ([a272c71](https://github.com/sanity-io/sanity/commit/a272c71ee856f5d919d2bb979516acde56129a27))
+* **schema:** correctly assert optional fields with enforce required fields ([#6121](https://github.com/sanity-io/sanity/issues/6121)) ([f568e14](https://github.com/sanity-io/sanity/commit/f568e14fd79bcedf258946ad9f4e09d44d3b5366))
+* **schemaExtract:** guard for list options not being an array ([#6128](https://github.com/sanity-io/sanity/issues/6128)) ([e4f28e5](https://github.com/sanity-io/sanity/commit/e4f28e5e953c6bb7b2a1006bae0b2c4b21c6c5d5))
+* **tasks:** update description input to create blocks edx-1206 ([#6126](https://github.com/sanity-io/sanity/issues/6126)) ([852bfca](https://github.com/sanity-io/sanity/commit/852bfca3a643ed770c029f91ced1bc753fe89bc3))
+* **vision:** fixes bug where codemirror would insert a new line on cmd-return ([#6123](https://github.com/sanity-io/sanity/issues/6123)) ([971ba9f](https://github.com/sanity-io/sanity/commit/971ba9f65b5e2a1b78f46a4612dc56f2a02bdff5))
+
+
+### Features
+
+* **codegen:** attempt to parse groq queries with parameter in slices ([#6117](https://github.com/sanity-io/sanity/issues/6117)) ([97c0b0c](https://github.com/sanity-io/sanity/commit/97c0b0cff76795021ea462468ff0da15b9f6e7a0))
+* indicate in metadata that the quickstart option was used in project creation ([#6065](https://github.com/sanity-io/sanity/issues/6065)) ([468e76c](https://github.com/sanity-io/sanity/commit/468e76c8ccca91e848046fc24c3a3d99c4dd5f84))
+* **tasks:** add tasks empty states ([#6130](https://github.com/sanity-io/sanity/issues/6130)) ([22afbb4](https://github.com/sanity-io/sanity/commit/22afbb4fdb3031068485dba058e851cb72405f97))
+
+
+
+## [3.35.2](https://github.com/sanity-io/sanity/compare/v3.35.1...v3.35.2) (2024-03-21)
+
+
+### Bug Fixes
+
+* **comments:** drop permission check ([#6110](https://github.com/sanity-io/sanity/issues/6110)) ([d6a3891](https://github.com/sanity-io/sanity/commit/d6a3891f4b930354abcc6e7dc9c3409e1aa60e8a))
+* **deps:** update dependency get-it to ^8.4.16 ([#6108](https://github.com/sanity-io/sanity/issues/6108)) ([eca9c30](https://github.com/sanity-io/sanity/commit/eca9c3097e1728797577c26ad80041fb1d66373b))
+
+
+
+## [3.35.1](https://github.com/sanity-io/sanity/compare/v3.35.0...v3.35.1) (2024-03-20)
+
+
+### Bug Fixes
+
+* **codegen:** include babel.config.json in the published package ([#6075](https://github.com/sanity-io/sanity/issues/6075)) ([2e06b84](https://github.com/sanity-io/sanity/commit/2e06b84c43f96b03f038275f08a6a6353bb02049))
+* **codegen:** uppercase query type names ([#6080](https://github.com/sanity-io/sanity/issues/6080)) ([7402093](https://github.com/sanity-io/sanity/commit/74020938c9cbea29f9ef20ff70b4a27ad2e420a9))
+* **codegen:** use relative path when globbing for files ([#6083](https://github.com/sanity-io/sanity/issues/6083)) ([5bc629f](https://github.com/sanity-io/sanity/commit/5bc629fd2397644fefb880f937ba5d9a23746b41))
+* **comments:** hide resolve action if no handler is provided ([#6084](https://github.com/sanity-io/sanity/issues/6084)) ([4767b32](https://github.com/sanity-io/sanity/commit/4767b3248105dce59087ebeaa3101748ae076040))
+* **comments:** permission check ([#6057](https://github.com/sanity-io/sanity/issues/6057)) ([2163ff0](https://github.com/sanity-io/sanity/commit/2163ff0002d02bed91001017eda77089b127e681))
+* **core:** increase default width of PT inline popovers ([#5878](https://github.com/sanity-io/sanity/issues/5878)) ([f809fe3](https://github.com/sanity-io/sanity/commit/f809fe37147d2219a07d616f87d74844759fd960))
+* **structure:** use correct loading messages while resolving panes ([#6093](https://github.com/sanity-io/sanity/issues/6093)) ([d784f82](https://github.com/sanity-io/sanity/commit/d784f825e4afb6a8859167f7b7c04647e0dd63ed))
+* **tasks:** add new sanityTasks flag ([#6089](https://github.com/sanity-io/sanity/issues/6089)) ([ae89244](https://github.com/sanity-io/sanity/commit/ae89244f28a159939545d4fe3fb0427f67b63b37))
+* **tasks:** copy changes for Tasks feature ([#6085](https://github.com/sanity-io/sanity/issues/6085)) ([3ab20ef](https://github.com/sanity-io/sanity/commit/3ab20ef81af00f890449627a7fa52bf01ea5211b))
+* **tasks:** ui adjustments ([#6086](https://github.com/sanity-io/sanity/issues/6086)) ([f89111c](https://github.com/sanity-io/sanity/commit/f89111c01ce2faf0e0892b9ee7907bfe1ac91e10))
+* **tasks:** update how addonDatasetProvider ready state is set ([#6076](https://github.com/sanity-io/sanity/issues/6076)) ([a08a82f](https://github.com/sanity-io/sanity/commit/a08a82f2f3e2f48cb22fa09c1f8b2ade96815d7f))
+* **tasks:** update info passed to the tasks comments notification context ([#6087](https://github.com/sanity-io/sanity/issues/6087)) ([6635d72](https://github.com/sanity-io/sanity/commit/6635d7200d3b108c0458e268d2e295f932195de8))
+* use workspace protocol for all workspace dependencies ([#6088](https://github.com/sanity-io/sanity/issues/6088)) ([0653134](https://github.com/sanity-io/sanity/commit/06531345b184746e2d3cd12becc913397fefa59b))
+
+
+### Reverts
+
+* Revert "fix: use workspace protocol for all workspace dependencies (#6088)" (#6092) ([abfc5d2](https://github.com/sanity-io/sanity/commit/abfc5d23decfa59965d52b6c2423c5274ac9f8b9)), closes [#6088](https://github.com/sanity-io/sanity/issues/6088) [#6092](https://github.com/sanity-io/sanity/issues/6092)
+
+
+
+# [3.35.0](https://github.com/sanity-io/sanity/compare/v3.34.0...v3.35.0) (2024-03-19)
+
+
+### Bug Fixes
+
+* **codegen:** update help text and generated comments copy ([#6059](https://github.com/sanity-io/sanity/issues/6059)) ([2afbc3b](https://github.com/sanity-io/sanity/commit/2afbc3bfddb428e76dc8cc8e89946c4f302fb38a))
+* **comments:** hide context menu actions if handler is undefined ([#6011](https://github.com/sanity-io/sanity/issues/6011)) ([cb55bc5](https://github.com/sanity-io/sanity/commit/cb55bc5e87beef32a80ecdbbe445f15160f9f508))
+* **core:** include request tag in Text Search API requests ([#5988](https://github.com/sanity-io/sanity/issues/5988)) ([471854e](https://github.com/sanity-io/sanity/commit/471854e455dd84752a06df9c7655ac76c0d5d801))
+* **deps:** update dependency @sanity/client to ^6.15.5 ([#6012](https://github.com/sanity-io/sanity/issues/6012)) ([01dec12](https://github.com/sanity-io/sanity/commit/01dec12e2de2776fcccbb14523d6b71d121ee0a0))
+* **deps:** update dependency @sanity/client to ^6.15.6 ([#6052](https://github.com/sanity-io/sanity/issues/6052)) ([ac206c2](https://github.com/sanity-io/sanity/commit/ac206c2e8d95e9521064773d0f269cc32577b2d1))
+* **deps:** update dependency @sanity/presentation to v1.11.7 ([#6007](https://github.com/sanity-io/sanity/issues/6007)) ([1041460](https://github.com/sanity-io/sanity/commit/10414601ad3ff370117016e4609a07174f8e344b))
+* **deps:** update dependency @sanity/presentation to v1.11.8 ([#6048](https://github.com/sanity-io/sanity/issues/6048)) ([bd44216](https://github.com/sanity-io/sanity/commit/bd4421669e11305eb81131f6af1e70aa4da2222d))
+* **deps:** update dependency get-it to ^8.4.13 ([#6013](https://github.com/sanity-io/sanity/issues/6013)) ([1da1feb](https://github.com/sanity-io/sanity/commit/1da1feb417af33f058c22919302cb2c35f545678))
+* **deps:** update dependency get-it to ^8.4.14 ([#6049](https://github.com/sanity-io/sanity/issues/6049)) ([01866ed](https://github.com/sanity-io/sanity/commit/01866ed7e03ec878eafc30263c81ad7dca2517e3))
+* ensure that useStructureToolSetting updates only when necessary ([#6004](https://github.com/sanity-io/sanity/issues/6004)) ([a4d8d2d](https://github.com/sanity-io/sanity/commit/a4d8d2d3e4e6f82649429bdecdad973e569d08ee))
+* schema extraction object type name ([#6014](https://github.com/sanity-io/sanity/issues/6014)) ([dcd5537](https://github.com/sanity-io/sanity/commit/dcd55378b81b0b37c0b0dda5e2b747ee2e69dc7a))
+* **tasks:** hide safari details marker ([#6020](https://github.com/sanity-io/sanity/issues/6020)) ([f70cf04](https://github.com/sanity-io/sanity/commit/f70cf04d173175bc38e0a887cf80a1c85c4a9e4d))
+* **tasks:** only display tasks with edits in the drafts menu ([#6053](https://github.com/sanity-io/sanity/issues/6053)) ([050f452](https://github.com/sanity-io/sanity/commit/050f45206c7eefe2f06d3815efa70dcdb75b2dbe))
+* use more reliable comparison in deduping search results ([#6034](https://github.com/sanity-io/sanity/issues/6034)) ([1dd2ccc](https://github.com/sanity-io/sanity/commit/1dd2cccad87ca267ea85d183b04f3db65a08e27c))
+* **util:** safely stringify path segments named as GROQ data types (e.g. `null`) ([#5986](https://github.com/sanity-io/sanity/issues/5986)) ([561ee14](https://github.com/sanity-io/sanity/commit/561ee14fe320d3bde50901eebe01d08059abe2e5))
+
+
+### Features
+
+* **codegen:** add CLI to generate types given a codegen config ([#5982](https://github.com/sanity-io/sanity/issues/5982)) ([3742b3f](https://github.com/sanity-io/sanity/commit/3742b3f5a2240555f7a13d0287adec8fffc80cf3))
+* **codegen:** add codegen skeleton package ([#5979](https://github.com/sanity-io/sanity/issues/5979)) ([e94c02f](https://github.com/sanity-io/sanity/commit/e94c02f58d6f4585e5e6c15bd4231d312a62a895))
+* **codegen:** add groq finder methods. ([#5980](https://github.com/sanity-io/sanity/issues/5980)) ([7addeef](https://github.com/sanity-io/sanity/commit/7addeefdac1d5702d3d971272dca1eede570fce2))
+* **codegen:** add typegen methods to codegen package ([#5981](https://github.com/sanity-io/sanity/issues/5981)) ([baf7cf0](https://github.com/sanity-io/sanity/commit/baf7cf0445a0b9fe7e4ade6d58329bbb0b8b12b6))
+* **codegen:** expose referenced type as hidden symbol ([#6008](https://github.com/sanity-io/sanity/issues/6008)) ([2826c46](https://github.com/sanity-io/sanity/commit/2826c4630032460664ed87527df0dcb4553a484a))
+* **core:** integrate with Text Search API ordering ([#6001](https://github.com/sanity-io/sanity/issues/6001)) ([a59f4bc](https://github.com/sanity-io/sanity/commit/a59f4bc620aaab685e72d670f35f02f2db1bd773))
+* **tasks:** add comment delete confirm dialog ([#6009](https://github.com/sanity-io/sanity/issues/6009)) ([c105115](https://github.com/sanity-io/sanity/commit/c10511552412848fa9f8bc3bbae200d8cf439c2b))
+* **tasks:** Localize Task feature ([#6017](https://github.com/sanity-io/sanity/issues/6017)) ([06d812c](https://github.com/sanity-io/sanity/commit/06d812c001d2ec15d31d0e36b738123a773260e8))
+* **tasks:** ui improvements  ([#5990](https://github.com/sanity-io/sanity/issues/5990)) ([a58b596](https://github.com/sanity-io/sanity/commit/a58b596462b615dcbe23c693bf25a3f9c2573def))
+
+
+
+# [3.34.0](https://github.com/sanity-io/sanity/compare/v3.33.0...v3.34.0) (2024-03-14)
+
+
+### Bug Fixes
+
+* **cli:** use inferred project root when creating migrations from subdirectory ([#5905](https://github.com/sanity-io/sanity/issues/5905)) ([1d2775c](https://github.com/sanity-io/sanity/commit/1d2775cf13d0959906433dbb445ea2463dfa7bc9))
+* **core:** handle no userId in getUser ([#5992](https://github.com/sanity-io/sanity/issues/5992)) ([c9ceac0](https://github.com/sanity-io/sanity/commit/c9ceac00389fe04f3e599d9f331aeff0dbf279a8))
+* **deps:** update dependency @sanity/presentation to v1.11.6 ([#5999](https://github.com/sanity-io/sanity/issues/5999)) ([51d3bbd](https://github.com/sanity-io/sanity/commit/51d3bbd5a15c8f685cd33346fc977b6a66eda165))
+* **portable-text-editor:** fix and test issue with merge block operation ([#5996](https://github.com/sanity-io/sanity/issues/5996)) ([96bc72b](https://github.com/sanity-io/sanity/commit/96bc72be1b798a28ffc43766b5f7092e998ecc8a))
+
+
+### Features
+
+* **cli:** improve migration runner output ([#5904](https://github.com/sanity-io/sanity/issues/5904)) ([11d15ce](https://github.com/sanity-io/sanity/commit/11d15ce65b90f82c32b5c6ba06cb1306e0f00484))
+* **core:** store and fetch user settings from backend ([#5939](https://github.com/sanity-io/sanity/issues/5939)) ([ecb3495](https://github.com/sanity-io/sanity/commit/ecb349553b5b2adf01aea50d0289b2d0b7904624)), closes [#5901](https://github.com/sanity-io/sanity/issues/5901) [#5940](https://github.com/sanity-io/sanity/issues/5940) [#5938](https://github.com/sanity-io/sanity/issues/5938) [#5993](https://github.com/sanity-io/sanity/issues/5993) [#5997](https://github.com/sanity-io/sanity/issues/5997) [#6000](https://github.com/sanity-io/sanity/issues/6000)
+* **tasks:** add notification data for tasks document and tasks comments ([#5998](https://github.com/sanity-io/sanity/issues/5998)) ([8e63552](https://github.com/sanity-io/sanity/commit/8e63552f24625332f18e34c9ae2ef7174d03639d))
+
+
+
+# [3.33.0](https://github.com/sanity-io/sanity/compare/v3.32.0...v3.33.0) (2024-03-12)
+
+
+### Bug Fixes
+
+* **ci:** align pnpm install across all workflows ([#5920](https://github.com/sanity-io/sanity/issues/5920)) ([f103967](https://github.com/sanity-io/sanity/commit/f10396750bd21e2416ce2dbc9b98167ea6bb0f2e))
+* **comments:** enable check ([#5918](https://github.com/sanity-io/sanity/issues/5918)) ([c230bb5](https://github.com/sanity-io/sanity/commit/c230bb50709a6efdbef830aac2839dea97d8e5c2))
+* **comments:** handle lack of access to inline comments ([#5925](https://github.com/sanity-io/sanity/issues/5925)) ([2d4f60c](https://github.com/sanity-io/sanity/commit/2d4f60c16ba6f9cf79eed806b9ec95140a1fe064))
+* **comments:** lost comment message while document is reconnecting ([#5928](https://github.com/sanity-io/sanity/issues/5928)) ([ec4da46](https://github.com/sanity-io/sanity/commit/ec4da462b50899102ca45cc1e7ca1b8aff031570))
+* **comments:** use `_weak` instead of `weak` ([#5936](https://github.com/sanity-io/sanity/issues/5936)) ([642224f](https://github.com/sanity-io/sanity/commit/642224f1ac0c92d8397b582a13a3c71118108ed6))
+* **core:** add onDoubleClick to open image crop ([#5815](https://github.com/sanity-io/sanity/issues/5815)) ([e3bfee0](https://github.com/sanity-io/sanity/commit/e3bfee0e5268058fb20c0d7cc7ac679dfd2a46e5))
+* **core:** allow `_projectId` and `_strengthOnPublish` in templates ([#5942](https://github.com/sanity-io/sanity/issues/5942)) ([5adca88](https://github.com/sanity-io/sanity/commit/5adca888ffd63f21f6297b869b978ff538843c01))
+* **core:** remove prev and next month buttons in calendar input ([#5931](https://github.com/sanity-io/sanity/issues/5931)) ([01f7df2](https://github.com/sanity-io/sanity/commit/01f7df21b6588c10619c9d332958ac6957d8abc8))
+* **core:** upgrade and fix types for typescript 5.4 ([#5943](https://github.com/sanity-io/sanity/issues/5943)) ([4e72b80](https://github.com/sanity-io/sanity/commit/4e72b80dc91e4691c7c1cfb8b611a4c277f36886))
+* **deps:** update @sanity/icons  ([#5956](https://github.com/sanity-io/sanity/issues/5956)) ([15f53bd](https://github.com/sanity-io/sanity/commit/15f53bd87f69b6bf98b4f4d0641eaa482de72f26))
+* **deps:** update dependency @sanity/client to ^6.15.3 ([#5953](https://github.com/sanity-io/sanity/issues/5953)) ([fc22e9f](https://github.com/sanity-io/sanity/commit/fc22e9fdc540b6e6f56399456bb21fa977d819c9))
+* **deps:** update dependency @sanity/client to ^6.15.4 ([#5975](https://github.com/sanity-io/sanity/issues/5975)) ([a701e1c](https://github.com/sanity-io/sanity/commit/a701e1cb4ba49d7212ae3f7e6a5c3e0cb85243c7))
+* **deps:** update dependency @sanity/presentation to v1.11.4 ([#5954](https://github.com/sanity-io/sanity/issues/5954)) ([a5a1a5d](https://github.com/sanity-io/sanity/commit/a5a1a5d52b0e8e63e9eccac41158f751c1ba289f))
+* **deps:** update dependency @sanity/presentation to v1.11.5 ([#5973](https://github.com/sanity-io/sanity/issues/5973)) ([9254565](https://github.com/sanity-io/sanity/commit/9254565bd3cec17639ba50cc735a78c1fb8943ec))
+* **deps:** update dependency @sanity/ui to ^2.0.10 ([#5976](https://github.com/sanity-io/sanity/issues/5976)) ([b7bcc2d](https://github.com/sanity-io/sanity/commit/b7bcc2df41e8a7b4225b15bd3ee076a4049ec3e7))
+* **deps:** update dependency @sanity/ui to ^2.0.8 ([#5966](https://github.com/sanity-io/sanity/issues/5966)) ([a1237d6](https://github.com/sanity-io/sanity/commit/a1237d6fc873b12b48d51067e648af1d8dcdfbc2))
+* **deps:** update dependency @sanity/ui to ^2.0.9 ([#5972](https://github.com/sanity-io/sanity/issues/5972)) ([218d09c](https://github.com/sanity-io/sanity/commit/218d09c464519c48e6e4f36bc66f81d2dcdf7642))
+* **deps:** update dependency get-it to ^8.4.11 ([#5967](https://github.com/sanity-io/sanity/issues/5967)) ([25dce83](https://github.com/sanity-io/sanity/commit/25dce83ea3a63bc6db120244b58cbc1444ec41ef))
+* **pte:** updates zoffset for PopoverEditDialog to not be on top of InspectDialog ([#5882](https://github.com/sanity-io/sanity/issues/5882)) ([69b3552](https://github.com/sanity-io/sanity/commit/69b35528976712b89a5dd2340713222ae3023c61))
+* **tasks:** show pending tasks in document footer ([#5894](https://github.com/sanity-io/sanity/issues/5894)) ([177bc79](https://github.com/sanity-io/sanity/commit/177bc79763a5567a028c1ead33794ea9445d171a))
+
+
+### Features
+
+* add cmd to generate a JSON representation of schema ([#5919](https://github.com/sanity-io/sanity/issues/5919)) ([c1e4f2a](https://github.com/sanity-io/sanity/commit/c1e4f2aac2431fc2c5a6a4d8ea3e0e074cacdb59))
+* **comments:** support task comments ([#5934](https://github.com/sanity-io/sanity/issues/5934)) ([75273af](https://github.com/sanity-io/sanity/commit/75273afb9f2737e654fb3e901b6ff7b9b2d9581a))
+* **core:** add groups to document actions, introduce paneActions group ([#5933](https://github.com/sanity-io/sanity/issues/5933)) ([4e95e09](https://github.com/sanity-io/sanity/commit/4e95e092b4c08442cb6171a22a4c88747072a14b))
+* **core:** add navbar actions (`[@internal](https://github.com/internal)`) ([#5968](https://github.com/sanity-io/sanity/issues/5968)) ([8336c9f](https://github.com/sanity-io/sanity/commit/8336c9f585d56447ebadc0c99dd697b730bd9975))
+* **core:** add new search config API ([#5948](https://github.com/sanity-io/sanity/issues/5948)) ([3c458c8](https://github.com/sanity-io/sanity/commit/3c458c89a96257658b7aed8322183eb286ae3bd5))
+* **core:** redirect to previous path after login ([#5932](https://github.com/sanity-io/sanity/issues/5932)) ([96cd0b6](https://github.com/sanity-io/sanity/commit/96cd0b636d2d8d49b5d7fdf5d16666f007858935))
+* **tasks:** bootstrap tasks plugin ([#5704](https://github.com/sanity-io/sanity/issues/5704)) ([dd0794a](https://github.com/sanity-io/sanity/commit/dd0794a36f9f54a0b4774f9c35921a8da9ae79c1)), closes [#5935](https://github.com/sanity-io/sanity/issues/5935)
+* **tasks:** track activity changes with document history. ([#5965](https://github.com/sanity-io/sanity/issues/5965)) ([0a76390](https://github.com/sanity-io/sanity/commit/0a763903dfe7af4e33e2a2c12572511498aced9c))
+* **tasks:** use FormBuilder to create and edit tasks. ([#5897](https://github.com/sanity-io/sanity/issues/5897)) ([908577e](https://github.com/sanity-io/sanity/commit/908577e989f949ca8f6ee01541fef913e989a473)), closes [#5929](https://github.com/sanity-io/sanity/issues/5929)
+
+
+
+# [3.32.0](https://github.com/sanity-io/sanity/compare/v3.31.0...v3.32.0) (2024-03-06)
+
+
+### Bug Fixes
+
+* **core:** clean up edit state listeners ([#5911](https://github.com/sanity-io/sanity/issues/5911)) ([4acc11e](https://github.com/sanity-io/sanity/commit/4acc11e6cdb194a087b742db041ef6dde26977b9))
+* **core:** update placeholder text to be more clear and accessible ([#5910](https://github.com/sanity-io/sanity/issues/5910)) ([9978095](https://github.com/sanity-io/sanity/commit/997809589495e5edcf2297aa1eb5586acec01585))
+* **deps:** update dependency @sanity/client to ^6.15.1 ([#5913](https://github.com/sanity-io/sanity/issues/5913)) ([3b741a1](https://github.com/sanity-io/sanity/commit/3b741a18225caa9effd4e5891c447217722bd3f5))
+* **deps:** update dependency @sanity/presentation to v1.11.3 ([#5914](https://github.com/sanity-io/sanity/issues/5914)) ([2bebf24](https://github.com/sanity-io/sanity/commit/2bebf2477dc9f2b600f53e8c488e59d760076e83))
+
+
+
+# [3.31.0](https://github.com/sanity-io/sanity/compare/v3.30.1...v3.31.0) (2024-03-05)
+
+
+### Bug Fixes
+
+* **comments:** allow ranges to be collapsed ([#5892](https://github.com/sanity-io/sanity/issues/5892)) ([eb5cd50](https://github.com/sanity-io/sanity/commit/eb5cd5020d8e83026f7357221d780d221bb5ba58))
+* **comments:** loading state ([#5908](https://github.com/sanity-io/sanity/issues/5908)) ([e0f6669](https://github.com/sanity-io/sanity/commit/e0f6669a3f8e783c581c9a38ddbf2d0cbe7b5b09))
+* **core:** allow `_dataset` for cross-dataset references in templates ([#5889](https://github.com/sanity-io/sanity/issues/5889)) ([9fc34a2](https://github.com/sanity-io/sanity/commit/9fc34a25ea010ed7d86eaa191726f6012623fe5c))
+* **core:** change modalWidth of inlineObjects to 1 by default ([#5839](https://github.com/sanity-io/sanity/issues/5839)) ([6e551b0](https://github.com/sanity-io/sanity/commit/6e551b09d388a7d21a4906e65bb9f07a5beed55e))
+* **core:** check if previous state is null for unmounted component ([#5724](https://github.com/sanity-io/sanity/issues/5724)) ([9ed5cca](https://github.com/sanity-io/sanity/commit/9ed5cca51ba8f8c1919108daa15c1a56f8876497))
+* **core:** updates to not show "cannot upload" on hover when using extension based accepts settings ([#5881](https://github.com/sanity-io/sanity/issues/5881)) ([023e7e6](https://github.com/sanity-io/sanity/commit/023e7e646abba3471bea48792e889aebe2ca5275))
+* **form:** prevent drop event propagating outside of EditPortal component ([#5813](https://github.com/sanity-io/sanity/issues/5813)) ([fc73437](https://github.com/sanity-io/sanity/commit/fc73437ae055b6a013f36575cb51788fd83bca53))
+* **portable-text-editor:** all paths must be checked ([#5891](https://github.com/sanity-io/sanity/issues/5891)) ([4ae88a0](https://github.com/sanity-io/sanity/commit/4ae88a028b965127ead53e00519303f49e7086e5))
+* **portable-text-editor:** check that path is lengthy  ([#5875](https://github.com/sanity-io/sanity/issues/5875)) ([2deebb1](https://github.com/sanity-io/sanity/commit/2deebb18943971b4922c636a70ec80d4013e9db2))
+* **sanity:** preserve form (as readOnly) when reconnecting ([#5884](https://github.com/sanity-io/sanity/issues/5884)) ([ed87e2a](https://github.com/sanity-io/sanity/commit/ed87e2a40f55fca89987c05dc3af979997efe808))
+* **structure:** provide better error handling if orderings contain invalid field ([#5709](https://github.com/sanity-io/sanity/issues/5709)) ([4926b78](https://github.com/sanity-io/sanity/commit/4926b78e49393739e0e42ac15dd3275dd5cd39d7))
+
+
+### Features
+
+* **ci:** cache release dependencies ([#5834](https://github.com/sanity-io/sanity/issues/5834)) ([75ac3cf](https://github.com/sanity-io/sanity/commit/75ac3cfb19dcf18bbc7dc1df6f8cc2c44123d7e7))
+* **cli:** --quickstart flag for ejecting server schemas ([#5797](https://github.com/sanity-io/sanity/issues/5797)) ([174a616](https://github.com/sanity-io/sanity/commit/174a61641312734ca29d57803119ca3dfad0b78e))
+* **comments:** introduce inline commenting ([#5606](https://github.com/sanity-io/sanity/issues/5606)) ([7ed2b0f](https://github.com/sanity-io/sanity/commit/7ed2b0f65a5a3aec9b3a569e4aea864219b9ed89)), closes [#5760](https://github.com/sanity-io/sanity/issues/5760)
+* **core:** add `onFullScreenChange ` to Portable Text Input  ([#5879](https://github.com/sanity-io/sanity/issues/5879)) ([84a0c90](https://github.com/sanity-io/sanity/commit/84a0c902813a1387f8f782489c9ee4b567bd190c))
+* **core:** add Text Search API search strategy ([#5785](https://github.com/sanity-io/sanity/issues/5785)) ([49fa240](https://github.com/sanity-io/sanity/commit/49fa2404c253698ebc848cf3d365a7a1b8455f11))
+* **core:** export useWorkspaceLoader from core ([#5898](https://github.com/sanity-io/sanity/issues/5898)) ([3670459](https://github.com/sanity-io/sanity/commit/36704596348801ab4a63540fd62afbf5b3197365))
+* **portable-text-editor:** implement `isSelectionOverlapping` method ([#5870](https://github.com/sanity-io/sanity/issues/5870)) ([1d41af7](https://github.com/sanity-io/sanity/commit/1d41af7c81ce72fdff5aff2fdef1d17c17d58a8b))
+* **portable-text-editor:** preserve keys on undo/redo ([#5805](https://github.com/sanity-io/sanity/issues/5805)) ([f83e8e4](https://github.com/sanity-io/sanity/commit/f83e8e401da4d34c05a4fab444c964056cb746ae))
+* **portable-text-editor:** range decorations ([#5871](https://github.com/sanity-io/sanity/issues/5871)) ([fa330a0](https://github.com/sanity-io/sanity/commit/fa330a0bafd1073fe41df298b1d9392c8f4b4286))
+* **structure:** support closing first collapsed `DocumentPanel` ([#5867](https://github.com/sanity-io/sanity/issues/5867)) ([6d61e94](https://github.com/sanity-io/sanity/commit/6d61e940241e64112ac80d24137f5625c847fd82))
+
+
+
+## [3.30.1](https://github.com/sanity-io/sanity/compare/v3.30.0...v3.30.1) (2024-02-27)
+
+
+### Bug Fixes
+
+* **cli:** handle API Error and update text output when backups are enabled ([#5861](https://github.com/sanity-io/sanity/issues/5861)) ([11d3ceb](https://github.com/sanity-io/sanity/commit/11d3cebcbf8782b938c608d86bf8fb6bf5aecff8))
+* **core:** add aria label to action button pte toolbar ([#5653](https://github.com/sanity-io/sanity/issues/5653)) ([0794d72](https://github.com/sanity-io/sanity/commit/0794d72069360e281b0cb90c394e7598e3aa0dc4))
+* **core:** add missing aria-labels to navbar icons ([#5810](https://github.com/sanity-io/sanity/issues/5810)) ([ea8f97a](https://github.com/sanity-io/sanity/commit/ea8f97a4a0c3c64d044412077f7c542910ef6557))
+* **core:** change telemetry event names ([#5832](https://github.com/sanity-io/sanity/issues/5832)) ([242e2ca](https://github.com/sanity-io/sanity/commit/242e2ca057b5c2c3f76e58f94cdc312ff3d771f9))
+* **core:** free trial shows twice ([#5837](https://github.com/sanity-io/sanity/issues/5837)) ([e774ce1](https://github.com/sanity-io/sanity/commit/e774ce11f3a40428fe4d2ea483f84ad43485fc54))
+* **deps:** update dependency @sanity/client to ^6.14.2 ([#5830](https://github.com/sanity-io/sanity/issues/5830)) ([447dfba](https://github.com/sanity-io/sanity/commit/447dfba03f572085c4bba4a8c2797541854902aa))
+* **deps:** update dependency @sanity/client to ^6.14.4 ([#5840](https://github.com/sanity-io/sanity/issues/5840)) ([8aec841](https://github.com/sanity-io/sanity/commit/8aec8413c9091d83078fba6e5e08841d82956073))
+* **deps:** update dependency @sanity/client to ^6.15.0 ([#5857](https://github.com/sanity-io/sanity/issues/5857)) ([9ddde9a](https://github.com/sanity-io/sanity/commit/9ddde9a1585ce4d5fbd04682f11c6dce0440ca3b))
+* **deps:** update dependency @sanity/presentation to v1.11.0 ([#5842](https://github.com/sanity-io/sanity/issues/5842)) ([78bc713](https://github.com/sanity-io/sanity/commit/78bc713856d70778d0f2a0aabdada2389a7d7ccb))
+* **deps:** update dependency @sanity/presentation to v1.11.1 ([#5853](https://github.com/sanity-io/sanity/issues/5853)) ([d467be4](https://github.com/sanity-io/sanity/commit/d467be4c8de1e091004efd0d92a5fce7798e36f7))
+* **deps:** update dependency @sanity/presentation to v1.11.2 ([#5860](https://github.com/sanity-io/sanity/issues/5860)) ([24cf9e0](https://github.com/sanity-io/sanity/commit/24cf9e0682b677d4ff59042f6d86e121d3b63671))
+* **deps:** update dependency get-it to ^8.4.10 ([#5841](https://github.com/sanity-io/sanity/issues/5841)) ([09970ef](https://github.com/sanity-io/sanity/commit/09970ef1720dc968ca41ba952ede731505e40a24))
+* **deps:** update dependency get-it to ^8.4.9 ([#5827](https://github.com/sanity-io/sanity/issues/5827)) ([06968cd](https://github.com/sanity-io/sanity/commit/06968cd87da76d77c976f2d86902c934a9faa90e))
+* **docs:** complete apidocs for migrations ([#5679](https://github.com/sanity-io/sanity/issues/5679)) ([32569be](https://github.com/sanity-io/sanity/commit/32569beaf73812720805cba3b142a12a77178b49))
+* **i18n:** add successful document restoration string ([#5821](https://github.com/sanity-io/sanity/issues/5821)) ([21677cd](https://github.com/sanity-io/sanity/commit/21677cd6793ce7ae386277cb88b5841e9075a80d))
+* **i18n:** escape interpolated values inside of <Translate> ([#5804](https://github.com/sanity-io/sanity/issues/5804)) ([78ffbaf](https://github.com/sanity-io/sanity/commit/78ffbaf428137e83ab6cd66b47ad8fffa385e487))
+* **pte:** add telemetry to invalidvalue error ([#5809](https://github.com/sanity-io/sanity/issues/5809)) ([f3fd972](https://github.com/sanity-io/sanity/commit/f3fd972a42b48a7a9de4915a680dcbb2014c2908))
+* **pte:** update pte placeholder color ([#5756](https://github.com/sanity-io/sanity/issues/5756)) ([2ec0605](https://github.com/sanity-io/sanity/commit/2ec06057f21f2fd177d9885228004c2cd297f07a))
+* **test:** fix breaking annotation popover test ([#5838](https://github.com/sanity-io/sanity/issues/5838)) ([042cd34](https://github.com/sanity-io/sanity/commit/042cd3452b21522bf76f76af3db8ecc221503853))
+* wait for all streams to close when writing backups ([#5835](https://github.com/sanity-io/sanity/issues/5835)) ([0363599](https://github.com/sanity-io/sanity/commit/03635996c148bde6f959e6be93c8a5bf7fff759f))
+
+
+### Features
+
+* **core/inputs:** support custom editor change callback ([#5803](https://github.com/sanity-io/sanity/issues/5803)) ([1a36a74](https://github.com/sanity-io/sanity/commit/1a36a740130d52e70ac500570621cd0e0a66de0d))
+* **form/inputs:** control PortableTextEditor instance via ref ([#5793](https://github.com/sanity-io/sanity/issues/5793)) ([f655b5c](https://github.com/sanity-io/sanity/commit/f655b5cec7c724631538bbc582a2e1c75099bba0))
+* **portable-text-editor:** determine if selection is made backward ([#5807](https://github.com/sanity-io/sanity/issues/5807)) ([db8fd66](https://github.com/sanity-io/sanity/commit/db8fd66190a2c7307eff9329e941d7be057ce99d))
+* **portable-text-editor:** new API method getFragment ([#5806](https://github.com/sanity-io/sanity/issues/5806)) ([f210112](https://github.com/sanity-io/sanity/commit/f210112e349c7fb9024ef1384510d3a62f0e1fe2))
+* update indexing endpoint for new name ([#5725](https://github.com/sanity-io/sanity/issues/5725)) ([477b60c](https://github.com/sanity-io/sanity/commit/477b60cb616e99c1b852c9dd892fb14cfc676338))
+
+
+
+# [3.30.0](https://github.com/sanity-io/sanity/compare/v3.29.1...v3.30.0) (2024-02-20)
+
+
+### Bug Fixes
+
+* **chore:** fix lint script ([#5739](https://github.com/sanity-io/sanity/issues/5739)) ([d1fc36d](https://github.com/sanity-io/sanity/commit/d1fc36da9c25391928803a75390e5b40856c15d0))
+* **ci:** fix subargs issue w/pte e2e tests ([f0fad4c](https://github.com/sanity-io/sanity/commit/f0fad4c017f1218e43f9e7f0a0069ffaf90f408c))
+* **ci:** remove pnpm reference from setup-node step ([#5801](https://github.com/sanity-io/sanity/issues/5801)) ([19c0e86](https://github.com/sanity-io/sanity/commit/19c0e86f26b72bf612aa2dacf034049cfc5810b3))
+* **ci:** run e2e-pte tests in the correct folder ([e2f26c4](https://github.com/sanity-io/sanity/commit/e2f26c424c66b4058d19d4f1e8947d3ad4edb9ed))
+* **ci:** setup pnpm ([#5800](https://github.com/sanity-io/sanity/issues/5800)) ([83630cf](https://github.com/sanity-io/sanity/commit/83630cfb607763b4dac7a1e053e306e4787989b0))
+* **ci:** use pnpm for package releases ([#5746](https://github.com/sanity-io/sanity/issues/5746)) ([4dedf3b](https://github.com/sanity-io/sanity/commit/4dedf3b499d5412bfc3b1cebbc0fb82004af1880))
+* **cli:** minor whitespace tuning for migration error output ([#5727](https://github.com/sanity-io/sanity/issues/5727)) ([b20f121](https://github.com/sanity-io/sanity/commit/b20f121afe54d75cd0b94ec282c953f91eb367c8))
+* **cli:** project root resolution ([#5712](https://github.com/sanity-io/sanity/issues/5712)) ([e30f45f](https://github.com/sanity-io/sanity/commit/e30f45f3568a9986fc9150d3942a1a17bdfd30d1))
+* **core/inputs:** fix issues with calling onPathFocus for PT-input ([#5794](https://github.com/sanity-io/sanity/issues/5794)) ([0f114b1](https://github.com/sanity-io/sanity/commit/0f114b1fe9e3737c7e406d2a99772612bd8592c9))
+* **core:** add `@types/lodash` ([#5753](https://github.com/sanity-io/sanity/issues/5753)) ([59f8afd](https://github.com/sanity-io/sanity/commit/59f8afd95202509c9a288246bb7ad29123105ff5))
+* **core:** bring back subtitle in workspace list view ([#5788](https://github.com/sanity-io/sanity/issues/5788)) ([2202e3c](https://github.com/sanity-io/sanity/commit/2202e3c6ec5db321d42a6b222051fbec90cfaadb))
+* **core:** update featuresEnabled when switching projects ([#5787](https://github.com/sanity-io/sanity/issues/5787)) ([32d79a2](https://github.com/sanity-io/sanity/commit/32d79a23a699b02524d66b41a492a984b41648fa))
+* **deps:** update dependency @sanity/client to ^6.13.3 ([#5772](https://github.com/sanity-io/sanity/issues/5772)) ([79ef8c3](https://github.com/sanity-io/sanity/commit/79ef8c39c17838f3728060455156658759f8dde7))
+* **deps:** update dependency @sanity/presentation to v1.9.1 ([#5773](https://github.com/sanity-io/sanity/issues/5773)) ([b7a3f13](https://github.com/sanity-io/sanity/commit/b7a3f13628ac40ddfd86e32584abfb2f7a264cee))
+* **github:** enable pnpm before installing dependencies ([0b572f1](https://github.com/sanity-io/sanity/commit/0b572f1751fa2af022575cd207e20d58001f4a11))
+* **github:** fix workflow file ([5a215ca](https://github.com/sanity-io/sanity/commit/5a215ca29416d853eea5d7998e862fff69e23193))
+* **migrate:** throw if attempting to iterate over documents producer ([#5758](https://github.com/sanity-io/sanity/issues/5758)) ([928f04d](https://github.com/sanity-io/sanity/commit/928f04d3abbc7e917871426d3bcb5a1c35c4605b))
+* **monorepo:** add missing dev dependency ([b5359d3](https://github.com/sanity-io/sanity/commit/b5359d341058e72dcefbe9661e6b5b4afd8ed51c))
+* **mutator:** fix type export issue ([c7ed0c9](https://github.com/sanity-io/sanity/commit/c7ed0c9df8e2cfe01ed657078a87fb21af17b60d))
+* **pte:** PTE modal seems to re-render on validation state change due to tooltip disabled change ([#5766](https://github.com/sanity-io/sanity/issues/5766)) ([c24e4d9](https://github.com/sanity-io/sanity/commit/c24e4d9a9689c24f709a999038762ef54310ba71))
+* remove no private ([#5726](https://github.com/sanity-io/sanity/issues/5726)) ([a3998c3](https://github.com/sanity-io/sanity/commit/a3998c38477d70a8d9e834b1fdaf967a313f8471))
+* run prettier ([e24a458](https://github.com/sanity-io/sanity/commit/e24a458ea7e097d42f3e7e0a1025869466654b3f))
+* **sanity:** update test snapshots ([70bcf6f](https://github.com/sanity-io/sanity/commit/70bcf6fb7446412ff4f3e511408b3a9ebf1a7d71))
+* **structure:** allow sanity.previewUrlSecret in document lists ([#5733](https://github.com/sanity-io/sanity/issues/5733)) ([8fd55c4](https://github.com/sanity-io/sanity/commit/8fd55c4c808b7fc89e353b00dbd032099e379943))
+* **structure:** intent menu item nodes not rendering ([#5728](https://github.com/sanity-io/sanity/issues/5728)) ([613e1dd](https://github.com/sanity-io/sanity/commit/613e1dd8c44c9f5d4e449dad3f259cc74e82534e))
+* **test:** remove unused files ([4317541](https://github.com/sanity-io/sanity/commit/4317541db96180aac5becf24fe6c0cd2a5983a32))
+* **test:** remove usage of jest-dom/extend-expect ([8a80150](https://github.com/sanity-io/sanity/commit/8a801504a1cd4c3572980e5fef54954b70aa2af3))
+* update ndjson specification url ([#5780](https://github.com/sanity-io/sanity/issues/5780)) ([15b9e79](https://github.com/sanity-io/sanity/commit/15b9e79bfa5d01e2e7100e0e64485794ad42f2e3))
+* **vision:** add missing type dependency ([6e91aef](https://github.com/sanity-io/sanity/commit/6e91aef484fdde0134f263d79f278c411e643161))
+
+
+### Features
+
+* **core:** add studioActiveToolLayout and navbar rightSectionNode prop ([#5749](https://github.com/sanity-io/sanity/issues/5749)) ([c708671](https://github.com/sanity-io/sanity/commit/c7086717acf12928f2ae838197fa878fedf3cbd4))
+* **core:** rename useMentionOptions to useUserListWithPermission and move to core ([#5778](https://github.com/sanity-io/sanity/issues/5778)) ([5da8891](https://github.com/sanity-io/sanity/commit/5da88914803e8ae9a39aa003addb94e183379b0f))
+
+
+
+## [3.29.1](https://github.com/sanity-io/sanity/compare/v3.29.0...v3.29.1) (2024-02-14)
+
+
+### Bug Fixes
+
+* pin get-random-values-esm to 1.0.0 ([8b09226](https://github.com/sanity-io/sanity/commit/8b092266db20bc413f2b0ccc0c6505ccc2b6b667))
+
+
+
+# [3.29.0](https://github.com/sanity-io/sanity/compare/v3.28.0...v3.29.0) (2024-02-13)
+
+
+### Bug Fixes
+
+* **comments:** catch and suppress errors from comments upsell ([#5700](https://github.com/sanity-io/sanity/issues/5700)) ([fbaffd2](https://github.com/sanity-io/sanity/commit/fbaffd2215a94046c5413b1bfb3ccf7f7c706d29))
+* **core:** update PortableTextInput doc reference ([#5688](https://github.com/sanity-io/sanity/issues/5688)) ([2664990](https://github.com/sanity-io/sanity/commit/2664990650edcb013aac4132b0b79b76337d591f))
+* **deps:** update dependency @sanity/client to ^6.12.4 ([#5701](https://github.com/sanity-io/sanity/issues/5701)) ([f85396f](https://github.com/sanity-io/sanity/commit/f85396f438d7b3638f9ba3b429b289c52e2fc1a4))
+* **deps:** update dependency @sanity/presentation to v1.8.0 ([#5694](https://github.com/sanity-io/sanity/issues/5694)) ([e725a3c](https://github.com/sanity-io/sanity/commit/e725a3c1f0f83d1a6bf2ce5944050832b9a12fbc))
+* **deps:** update dependency @sanity/presentation to v1.8.1 ([#5699](https://github.com/sanity-io/sanity/issues/5699)) ([d645d37](https://github.com/sanity-io/sanity/commit/d645d37c0ccd8462b8a4a2d04365750b88ce64b2))
+* **deps:** update dependency @sanity/presentation to v1.8.2 ([#5702](https://github.com/sanity-io/sanity/issues/5702)) ([c23ccb4](https://github.com/sanity-io/sanity/commit/c23ccb4cc4ab1a2cd418073a8d95bcfa3a5c0404))
+* **eslint:** add rules to enforce consistent type imports and import sort orders ([1ec2c39](https://github.com/sanity-io/sanity/commit/1ec2c3929ea4756897640fd6200a11168a50e077))
+* **structure:** add workaround for circular import issue causing resolveIntent tests to fail ([c2e6017](https://github.com/sanity-io/sanity/commit/c2e60176a8cd11c91193deda2804f1584038ce7d))
+* **structure:** use useDocumentTitle hook for toast message ([#5719](https://github.com/sanity-io/sanity/issues/5719)) ([51ed18d](https://github.com/sanity-io/sanity/commit/51ed18d28f14dfeabae2b100a8111693bb4a821c))
+
+
+### Features
+
+* **backup:** add new command dataset backup for server-side backups ([#5571](https://github.com/sanity-io/sanity/issues/5571)) ([f04c76e](https://github.com/sanity-io/sanity/commit/f04c76eb7d1ebece102d99ef2c2e5e515da7707e))
+* **CLI:** in sanity dataset import cmd, add --allow-system-documents to explicitly permit system document import, which should be ignore otherwise ([#5689](https://github.com/sanity-io/sanity/issues/5689)) ([fa9f924](https://github.com/sanity-io/sanity/commit/fa9f924f306032d565272ffa37b96f8b999f650b))
+* **comments:** add optional intent link to comments ([#5576](https://github.com/sanity-io/sanity/issues/5576)) ([27bf5f9](https://github.com/sanity-io/sanity/commit/27bf5f98d44b53b09e4c91ea045d3ced7ea6bc44))
+* **telemetry:** add telemetry for Trial Dialogs ([#5643](https://github.com/sanity-io/sanity/issues/5643)) ([ad971f8](https://github.com/sanity-io/sanity/commit/ad971f8ae849942977af89fd7b5d1a911e1bfa41))
+
+
+
+# [3.28.0](https://github.com/sanity-io/sanity/compare/v3.27.1...v3.28.0) (2024-02-06)
+
+
+### Bug Fixes
+
+* add icon display as default to documentTypeList ([#5644](https://github.com/sanity-io/sanity/issues/5644)) ([40b3d50](https://github.com/sanity-io/sanity/commit/40b3d5035a62aef550c741c5a4bcc36a988d5521))
+* **cli:** respect unattended mode ([#5659](https://github.com/sanity-io/sanity/issues/5659)) ([0e0fd1f](https://github.com/sanity-io/sanity/commit/0e0fd1fab69feb47b09501a8ccc2830708407331))
+* **cli:** update migration run usage text ([#5637](https://github.com/sanity-io/sanity/issues/5637)) ([0bae465](https://github.com/sanity-io/sanity/commit/0bae465a44cb77393ade2a89b2d396de00ce52e7))
+* **comments:** improve text wrapping logic inside of user list ([6317b49](https://github.com/sanity-io/sanity/commit/6317b49d23de69cc4025f47267dc084fb08a7ca6))
+* **comments:** remove stray `t` prop in cloning causing warnings ([a89f5d3](https://github.com/sanity-io/sanity/commit/a89f5d327defb9115c66151b9f6b8113030b70f5))
+* **comments:** translate input placeholder ([e93633c](https://github.com/sanity-io/sanity/commit/e93633c17b6246a9b3df5fc44d7492ac0cbea98c))
+* **comments:** use correct apostroph in onboarding popover ([07e0317](https://github.com/sanity-io/sanity/commit/07e03172e23c463eb9cd7a938d6b34fd367d66ba))
+* **comments:** use locale-aware date formatting ([d7fbcd8](https://github.com/sanity-io/sanity/commit/d7fbcd8912429c3c13b32ede692c8b808c642ace))
+* **core:** adding accessibility labels to pte objects ([#5652](https://github.com/sanity-io/sanity/issues/5652)) ([3d6ed07](https://github.com/sanity-io/sanity/commit/3d6ed071a0b6332c490c7ffa9d4b4d87cf4eb47a))
+* **core:** fix aligning of columnar objects/fieldsets ([#5627](https://github.com/sanity-io/sanity/issues/5627)) ([851b62d](https://github.com/sanity-io/sanity/commit/851b62d0abdb0c02443d1446d22df73336c1b4f5))
+* **deps:** update dependency @sanity/client to ^6.12.3 ([#5623](https://github.com/sanity-io/sanity/issues/5623)) ([5116ee0](https://github.com/sanity-io/sanity/commit/5116ee003e72ce5fda2e207c62bb7e95d0c8138e))
+* **deps:** update dependency @sanity/presentation to v1.7.3 ([#5622](https://github.com/sanity-io/sanity/issues/5622)) ([c04afbc](https://github.com/sanity-io/sanity/commit/c04afbc0551e7a7d0c240f64eea125727b3e447f))
+* **deps:** update dependency @sanity/presentation to v1.7.4 ([#5671](https://github.com/sanity-io/sanity/issues/5671)) ([55a54b5](https://github.com/sanity-io/sanity/commit/55a54b542018ffcfed2a5747e5d201af0be73864))
+* **deps:** update dependency @sanity/presentation to v1.7.6 ([#5682](https://github.com/sanity-io/sanity/issues/5682)) ([8f0e911](https://github.com/sanity-io/sanity/commit/8f0e9114ecdb7ec3d3b2d3bce3fc394141b728a6))
+* **form:** preserve intrinsic block size of field labels ([#5639](https://github.com/sanity-io/sanity/issues/5639)) ([08f6694](https://github.com/sanity-io/sanity/commit/08f669449cb79683b21cc4636b58843b72a78a31))
+* **migrate:** submit mutations with visibility=async ([#5675](https://github.com/sanity-io/sanity/issues/5675)) ([0eda4a7](https://github.com/sanity-io/sanity/commit/0eda4a7e5608909ec62b7c3e5a447d970fe6a263))
+* **migration:** fixes an issue where migration command would error sometimes ([#5678](https://github.com/sanity-io/sanity/issues/5678)) ([805745f](https://github.com/sanity-io/sanity/commit/805745f9e1f6fd9de153fdcf7fd289af227ffbff))
+* **migration:** make `sanity migration list` also include file-only migrations ([c6745ab](https://github.com/sanity-io/sanity/commit/c6745ab292005bfd330d001ee51e8ea4357fd550))
+* **migration:** shows better error message when running migration list ([#5625](https://github.com/sanity-io/sanity/issues/5625)) ([9c2db95](https://github.com/sanity-io/sanity/commit/9c2db955f8000ccc80fa8c711f71d62e1cff3884))
+* only fully collapse PTE toolbars in 'root' FormBuilder instances ([#5547](https://github.com/sanity-io/sanity/issues/5547)) ([e219e2a](https://github.com/sanity-io/sanity/commit/e219e2a6893f3019a8e6e19980ab95554b0fe12b))
+* **perf:** fixes build and deploy issues with perf studio ([#5646](https://github.com/sanity-io/sanity/issues/5646)) ([d17f722](https://github.com/sanity-io/sanity/commit/d17f722fd94161978abe4afe93a4ca2388cec582))
+* regression caused by [#5440](https://github.com/sanity-io/sanity/issues/5440) ([#5657](https://github.com/sanity-io/sanity/issues/5657)) ([0af205c](https://github.com/sanity-io/sanity/commit/0af205cbc37c6a0d49ea93be98ef3e5b2cadbc7c))
+* remove `__unstable_focusRing` unknown forwarded prop warning ([#5621](https://github.com/sanity-io/sanity/issues/5621)) ([6c87bea](https://github.com/sanity-io/sanity/commit/6c87bea0c976b3c0e056fc620f8bb315548e79c4))
+* **src:** add document title to publosh/unpublish success message in toast ([#5605](https://github.com/sanity-io/sanity/issues/5605)) ([0cf3772](https://github.com/sanity-io/sanity/commit/0cf377270ea8410b96f6504d402fbecc022f73a0))
+* **studio:** center studio nav ([#5608](https://github.com/sanity-io/sanity/issues/5608)) ([d1aecb5](https://github.com/sanity-io/sanity/commit/d1aecb56837d94086279db4a563afaea7ecf73f1))
+* **vision:** ensure query/params from localStorage are strings ([d1dd537](https://github.com/sanity-io/sanity/commit/d1dd5379fd2060524ed6c2299fd07b683684a8ae))
+* **vision:** explicitly allow `v1` as valid API version ([175ece0](https://github.com/sanity-io/sanity/commit/175ece0d0c73aee44b4f46d242b2555f28ab1d8c))
+* **vision:** persist raw (string) value of params to localStorage ([c13868a](https://github.com/sanity-io/sanity/commit/c13868a007567047e38a1c9b8064d1b9bbec3e19))
+* **vision:** provide error boundary with cache clear on error ([3a8a987](https://github.com/sanity-io/sanity/commit/3a8a987b0b5683690659374ddb0976e6f67193ce))
+
+
+### Features
+
+* apply text balance to document titles ([#5641](https://github.com/sanity-io/sanity/issues/5641)) ([4e2507b](https://github.com/sanity-io/sanity/commit/4e2507b078e912d9f9b6d6de1cd615bdaf772a58))
+* **cli:** improve reporting when dry running from export ([#5609](https://github.com/sanity-io/sanity/issues/5609)) ([b8eefc6](https://github.com/sanity-io/sanity/commit/b8eefc6c68b50e5f8f9db21537bb213af3378e62))
+* **cli:** prompt to use default plan when wrong coupon or plan ([8e202c7](https://github.com/sanity-io/sanity/commit/8e202c74be8f12cfaf7aac2eb468652d91547ddd))
+* **comments:** adds read-only state to comments. ([#5570](https://github.com/sanity-io/sanity/issues/5570)) ([fab7cec](https://github.com/sanity-io/sanity/commit/fab7cecedb6e7c6ce5880c17945156fdbc6668d5)), closes [#5622](https://github.com/sanity-io/sanity/issues/5622) [#5629](https://github.com/sanity-io/sanity/issues/5629)
+* **migrate:** use autoGenerateKeys=true when submitting mutations ([#5685](https://github.com/sanity-io/sanity/issues/5685)) ([5ec6a22](https://github.com/sanity-io/sanity/commit/5ec6a22726800e704cfea89a1fbe670314c97a27))
+* **migration:** (re)introduce --from-export ([#5672](https://github.com/sanity-io/sanity/issues/5672)) ([7332a9f](https://github.com/sanity-io/sanity/commit/7332a9f8593e8a313242db98242bb5b97fa5bbbf))
+
+
+
+## [3.27.1](https://github.com/sanity-io/sanity/compare/v3.27.0...v3.27.1) (2024-02-01)
+
+
+### Bug Fixes
+
+* **migration:** fixes issues where patch would happen twice ([#5638](https://github.com/sanity-io/sanity/issues/5638)) ([343765d](https://github.com/sanity-io/sanity/commit/343765d7c9ddd492bdc4cb3ca2b467a03e8930f0))
+
+
+
+# [3.27.0](https://github.com/sanity-io/sanity/compare/v3.26.1...v3.27.0) (2024-01-30)
+
+
+### Bug Fixes
+
+* **cli:** add support for `import.meta.env` ([#5617](https://github.com/sanity-io/sanity/issues/5617)) ([083ff16](https://github.com/sanity-io/sanity/commit/083ff16e3dd6fcc17b5d4f5a88a631d6fc6d106a))
+* **cli:** use dryRun from @sanity/migrate ([4c2cab9](https://github.com/sanity-io/sanity/commit/4c2cab9e0196c4be622f0b22da81501f8dae278b))
+* **comments:** localize all strings ([#5578](https://github.com/sanity-io/sanity/issues/5578)) ([a7086f2](https://github.com/sanity-io/sanity/commit/a7086f2a623b7f09a56e0f449d41b8d241911702))
+* **core:** wait for duplicate success before navigating ([#5556](https://github.com/sanity-io/sanity/issues/5556)) ([088830d](https://github.com/sanity-io/sanity/commit/088830d2e6ccc8f3a86c4be38e70070452170cb6))
+* **deps:** update dependency @sanity/client to ^6.12.3 ([#5593](https://github.com/sanity-io/sanity/issues/5593)) ([e6cad2e](https://github.com/sanity-io/sanity/commit/e6cad2e0dcda87250dbd96681562028eccda64d8))
+* **deps:** update dependency @sanity/presentation to v1.7.2 ([#5596](https://github.com/sanity-io/sanity/issues/5596)) ([3650fb2](https://github.com/sanity-io/sanity/commit/3650fb24174258db86bee099845e0cc305eb8d0a))
+* **deps:** update dependency `@sanity/presentation` to `v1.6.1` ([68e6b07](https://github.com/sanity-io/sanity/commit/68e6b072cdd014353ac6798a2eaab83b6842c59b))
+* **dev:** fix example migration script imports ([5381f34](https://github.com/sanity-io/sanity/commit/5381f3480d252ec531a9af7d5956d664ec3719cc))
+* **i18n:** spelling mistake in asset source string ([#5575](https://github.com/sanity-io/sanity/issues/5575)) ([3a81d6b](https://github.com/sanity-io/sanity/commit/3a81d6b181ee3c83571e2b040a9cf3ea1089b2f6))
+* **migrate:** add request tags and user agent ([f22aa0c](https://github.com/sanity-io/sanity/commit/f22aa0cc03f2b6d2693699fda9b4913987ef761f))
+* **migrate:** buffer exports through file ([dd47e2b](https://github.com/sanity-io/sanity/commit/dd47e2beeceacaf7d9b1476b310b462a3b8f3cb2))
+* **migrate:** cleanup buffer file after read ([#5618](https://github.com/sanity-io/sanity/issues/5618)) ([387945c](https://github.com/sanity-io/sanity/commit/387945cde1e16e1181f9bb3d29b9c5f143474924))
+* **migrate:** fix error asserting transaction ([df310cf](https://github.com/sanity-io/sanity/commit/df310cf5f3ab3a854bcf150097ab3234bb11f4f1))
+* **migrate:** inline functions from uint8array-extras for now ([f379f40](https://github.com/sanity-io/sanity/commit/f379f407b3c17b971f646564edbc7e770118443f))
+* **migrate:** limit client methods during migration ([13de5a2](https://github.com/sanity-io/sanity/commit/13de5a273b853ca7491f6e7d4d13de3c3275f6f9))
+* **migrate:** minor typing issue ([663da91](https://github.com/sanity-io/sanity/commit/663da91a84c33f6c74be16841d77c054b73baa8a))
+* **migrate:** remove mkdirp in favor of node:fs ([#5619](https://github.com/sanity-io/sanity/issues/5619)) ([338bf26](https://github.com/sanity-io/sanity/commit/338bf269c95aa9926ba8cd349714c9b5e7e5f0ae))
+* **migrate:** run migration against all documents if documentTypes is omitted ([e80bbdf](https://github.com/sanity-io/sanity/commit/e80bbdf9a106f0c3d5d080a7769f711935288d88))
+* **migrate:** scope node path to the current node ([#5620](https://github.com/sanity-io/sanity/issues/5620)) ([93f82d2](https://github.com/sanity-io/sanity/commit/93f82d2dcb567586f037d8ae331a11ad0e0d906f))
+* **migrate:** simplify bufferThroughFile ([990fb50](https://github.com/sanity-io/sanity/commit/990fb5058c093648c59c742437ef5780c40fd77c))
+* **migrate:** use transactionId instead of id on mutation payload ([a82df02](https://github.com/sanity-io/sanity/commit/a82df02b54ada62a2f9475a6a6e507f7dce444b4))
+* **migrate:** various naming consistency fixes ([dbb7048](https://github.com/sanity-io/sanity/commit/dbb70480e26fc6dea7aa20e918cb2a7bee973f41))
+* **migrate:** workaround issue with p-map and ESM ([7aaa5ed](https://github.com/sanity-io/sanity/commit/7aaa5ed6af9edb2357a911b6913a0bf2650de9a2))
+* **migration:** fixes dry run not showing any information ([2568666](https://github.com/sanity-io/sanity/commit/256866675210027627cdc91e4df1547ab0c55bd1))
+* **migration:** parse cli arguments so the types are proper ([#5616](https://github.com/sanity-io/sanity/issues/5616)) ([7751df1](https://github.com/sanity-io/sanity/commit/7751df17174e8841ed3bce922700c26d60c804eb))
+* **migration:** show proper error message when the file has code issues ([7256f85](https://github.com/sanity-io/sanity/commit/7256f85a3df54af30a0b37b7f5422be6223fd694))
+* **sanity:** add --no-progress flag ([24bc18f](https://github.com/sanity-io/sanity/commit/24bc18f99b8d94dd950db1571e8762f0486ad7c0))
+* **sanity:** add a few examples to help text for 'sanity migration create' ([8290bae](https://github.com/sanity-io/sanity/commit/8290baecee2e9590ea0651b047e1d19a26f734f0))
+* **sanity:** fix quoting of documentTypes in migration templates ([8a5f67b](https://github.com/sanity-io/sanity/commit/8a5f67bf420fdbec5b40693dc91ae977d94d35ff))
+* **sanity:** improve error handling on 'sanity migration run' without id ([5d9a556](https://github.com/sanity-io/sanity/commit/5d9a556f9d680323b7f32a210553cf7784770446))
+* **sanity:** improve minimal example ([2e77de7](https://github.com/sanity-io/sanity/commit/2e77de7b7a62e0928a8115e2b28bc36bfd4ab79e))
+* **sanity:** polish cli and migration templates ([027ad47](https://github.com/sanity-io/sanity/commit/027ad476c3d8f8ea4f75ab1df7b0b969910256a8))
+* **sanity:** rename migration name => title ([27b0088](https://github.com/sanity-io/sanity/commit/27b00884984941c0fd4913de810ecaded48d004b))
+* **sanity:** use --no-dry instead of --dry=false ([ba905dc](https://github.com/sanity-io/sanity/commit/ba905dc41d3fd81547d7fd5ddd0843d1760e0705))
+* **src:** add textskeleton to loading state of mentions ([#5587](https://github.com/sanity-io/sanity/issues/5587)) ([26cbae7](https://github.com/sanity-io/sanity/commit/26cbae78eaf0f9a4c465a924dab75171f9dc3457))
+* **studio:** fallback to <unnamed> when logging installed plugins ([#5602](https://github.com/sanity-io/sanity/issues/5602)) ([6df6ee5](https://github.com/sanity-io/sanity/commit/6df6ee5c03356dedd54b95d7ac8b848797efef2a))
+* **util:** fix package.json formatting ([17e8130](https://github.com/sanity-io/sanity/commit/17e8130770a45126ccf24567c7fcdd69c6966d2c))
+* **validation:** filter system documents when running validation ([#5590](https://github.com/sanity-io/sanity/issues/5590)) ([d8c4a3f](https://github.com/sanity-io/sanity/commit/d8c4a3f2d9ccaa30fd7a8dff40984ea3fd0dcf87))
+* **validation:** update min and max to include string for dates ([#5555](https://github.com/sanity-io/sanity/issues/5555)) ([881a991](https://github.com/sanity-io/sanity/commit/881a9910d27e622a3e61c6f415bc43d48b8591a4))
+
+
+### Features
+
+* basic `migrations list` command ([ead9f3e](https://github.com/sanity-io/sanity/commit/ead9f3ed194e016ef8a384c4904b6bf11a06ac40))
+* basic migration cli support ([8304afc](https://github.com/sanity-io/sanity/commit/8304afc76d5b00c24e766be51ce3001af6842d12))
+* **cli:** add `intentUrl` to `json` and `ndjson` reporters ([#5610](https://github.com/sanity-io/sanity/issues/5610)) ([71f9aed](https://github.com/sanity-io/sanity/commit/71f9aedc21249628423ada34db56c9c6c97fff2e))
+* **cli:** add new `sanity schema validate` command ([#5583](https://github.com/sanity-io/sanity/issues/5583)) ([09cdb5f](https://github.com/sanity-io/sanity/commit/09cdb5fc541e85696c746f7a5acdf76fbc3c23c3))
+* **cli:** add pretty mutation formatting to migration runner ([#5573](https://github.com/sanity-io/sanity/issues/5573)) ([2dba206](https://github.com/sanity-io/sanity/commit/2dba20698361e74e1bd67b390e42384d26ee4a85))
+* **cli:** allow user provided concurrency ([2579159](https://github.com/sanity-io/sanity/commit/25791599697e72b8a11b3e86ce51887e248d7e81))
+* **cli:** scaffold create/run migration cli commands ([9495db7](https://github.com/sanity-io/sanity/commit/9495db75411ffc7a8c97c7aa3e3b86b32a9f0641))
+* **cli:** support `--file` in `sanity documents validate` ([#5580](https://github.com/sanity-io/sanity/issues/5580)) ([5cb4ea6](https://github.com/sanity-io/sanity/commit/5cb4ea63cce14a2c64e1f29bd098747ec5d30582))
+* **migrate:** add asyncIterableToStream util ([0563e7b](https://github.com/sanity-io/sanity/commit/0563e7b3c1845154db67d08fe6771d1eeef32876))
+* **migrate:** add bufferThroughFile utility ([ed7c904](https://github.com/sanity-io/sanity/commit/ed7c904247d6226e763f96ec9a60017ca6785223))
+* **migrate:** add customisable parser and iterator type to `parseJSON` ([5e8e666](https://github.com/sanity-io/sanity/commit/5e8e66677e8235baf1b4fab0ef9579cdd9c7bb65))
+* **migrate:** add JSON parser that can handle chunks interrupted by an error object ([74db2df](https://github.com/sanity-io/sanity/commit/74db2df76c84178f0f5535f69772f0342e634ed2))
+* **migrate:** add support for yielding transactions ([0a58fa3](https://github.com/sanity-io/sanity/commit/0a58fa3d9743a763839183589b614cf637c6c834))
+* **migrate:** implement mutation batcher and use when submitting against mutate endpoint ([1822dc2](https://github.com/sanity-io/sanity/commit/1822dc2e8f0e286cc942c7906b306643fdaa1427))
+* **migrate:** limit request concurrency ([a9bfef9](https://github.com/sanity-io/sanity/commit/a9bfef9f09cb8e123e9d7b6f0162122cc6283ebd))
+* **migrate:** move into monorepo from poc ([fa86d63](https://github.com/sanity-io/sanity/commit/fa86d633e8684f704051249521f30bcc533b06c2))
+* **migrate:** unify contexts, add support for document lookup and query during a migration ([3a54e20](https://github.com/sanity-io/sanity/commit/3a54e207873ef4b86c2a76d66c439ca8d93369b1))
+* **migrate:** use safe JSON parser when streaming from Export HTTP API ([#5542](https://github.com/sanity-io/sanity/issues/5542)) ([a1c0faf](https://github.com/sanity-io/sanity/commit/a1c0faf191d86d9fdfca9a63ec7f90b402dab64a))
+* migration create command w/templates ([0a596e4](https://github.com/sanity-io/sanity/commit/0a596e4505877d302889a682ba0bf96323ba816f))
+* **migration:** add a prompt before runing a real migration ([#5552](https://github.com/sanity-io/sanity/issues/5552)) ([4ab2ac2](https://github.com/sanity-io/sanity/commit/4ab2ac27ed7ae3a3617e2de83c289eae625df514))
+* **migration:** improve progress as migration is running ([#5550](https://github.com/sanity-io/sanity/issues/5550)) ([67aa5a9](https://github.com/sanity-io/sanity/commit/67aa5a9983e6f5f3310e5465cd70e123399acdcb))
+* **migration:** support async hooks in migration nodes ([#5564](https://github.com/sanity-io/sanity/issues/5564)) ([cc6b2f3](https://github.com/sanity-io/sanity/commit/cc6b2f33a1229032dcc7bedd2d2565f26eb5b401))
+* **migration:** support passing an array of documentTypes to migration ([#5566](https://github.com/sanity-io/sanity/issues/5566)) ([458ac49](https://github.com/sanity-io/sanity/commit/458ac49adbef82abec8da2e7a86492b0190ddf12))
+* **sanity:** add exports for sanity/migrate + sanity/migrate/mutations ([c4b19a4](https://github.com/sanity-io/sanity/commit/c4b19a422b795fe4fed4b5d1b9883825a7572897))
+
+
+
+## [3.26.1](https://github.com/sanity-io/sanity/compare/v3.26.0...v3.26.1) (2024-01-26)
+
+
+### Bug Fixes
+
+* **comments:** addon dataset creation ([#5577](https://github.com/sanity-io/sanity/issues/5577)) ([c8f1da3](https://github.com/sanity-io/sanity/commit/c8f1da3c14e719fdb525a5d66a908b8150851bf4))
+
+
+
+# [3.26.0](https://github.com/sanity-io/sanity/compare/v3.25.0...v3.26.0) (2024-01-23)
+
+
+### Bug Fixes
+
+* **cli:** always treat arguments without options as strings ([#5500](https://github.com/sanity-io/sanity/issues/5500)) ([9ca1cd0](https://github.com/sanity-io/sanity/commit/9ca1cd0cef43d1ca870748608b8d08aa45b2b9c7))
+* **cli:** misc sanity documents validate fixes ([#5521](https://github.com/sanity-io/sanity/issues/5521)) ([475981d](https://github.com/sanity-io/sanity/commit/475981d6de5dec0ad888c8c1f64c79a37e6232fc))
+* **cli:** upgrade templates to use @sanity/ui@2 ([#5528](https://github.com/sanity-io/sanity/issues/5528)) ([8c3d46a](https://github.com/sanity-io/sanity/commit/8c3d46a1e58f8ec3370baedd06b7834f098d1452))
+* **core:** `token` login method session restoration ([#5497](https://github.com/sanity-io/sanity/issues/5497)) ([ae44bc7](https://github.com/sanity-io/sanity/commit/ae44bc7fbe0df3648ae9a6b43edfbce0847f5aef))
+* **core:** error handling in `useFeatureEnabled` ([#5538](https://github.com/sanity-io/sanity/issues/5538)) ([08eb76c](https://github.com/sanity-io/sanity/commit/08eb76c39c51c9ead43ca724acc67416e03f1ac1))
+* **deps:** update dependency `@sanity/presentation` to `v1.6.1` ([#5526](https://github.com/sanity-io/sanity/issues/5526)) ([6dbacea](https://github.com/sanity-io/sanity/commit/6dbaceaf4f32c99bf6dd24de9af4c2296e359cd8))
+* **deps:** update dependency `@sanity/presentation` to `v1.7.0` ([#5537](https://github.com/sanity-io/sanity/issues/5537)) ([88ab3ad](https://github.com/sanity-io/sanity/commit/88ab3adaf120cb016ccabf73683f366c44166284))
+* **desk:** correct import from `@sanity/structure` to `sanity/structure` ([e644633](https://github.com/sanity-io/sanity/commit/e64463350e72907069cea13b95caade71c66ffaa))
+* **i18n:** missing translation on document inspector close button ([#5520](https://github.com/sanity-io/sanity/issues/5520)) ([39babbf](https://github.com/sanity-io/sanity/commit/39babbfade472486d29a6a9d4baca75dffac05be))
+* increase space between published date and last updated date ([#5548](https://github.com/sanity-io/sanity/issues/5548)) ([1d0bac9](https://github.com/sanity-io/sanity/commit/1d0bac9602c21b917eb0393394c8afae3e1ed0d7))
+* **performance:** add back `useMemo` on `DocumentPaneContext` value ([#5458](https://github.com/sanity-io/sanity/issues/5458)) ([bd141cd](https://github.com/sanity-io/sanity/commit/bd141cdacafca63dad6e132e637758904ac61494))
+* **structure:** fix unintended import from `@sanity/ui-workshop` ([#5545](https://github.com/sanity-io/sanity/issues/5545)) ([0e18aa9](https://github.com/sanity-io/sanity/commit/0e18aa9ad604a9abd4e2f9c21ce3ee644ade3a5b))
+* **ui-components:** add TooltipDelayGroupProvider to ui-components ([#5514](https://github.com/sanity-io/sanity/issues/5514)) ([030780a](https://github.com/sanity-io/sanity/commit/030780a8e1aa67f75cb8525f46ec58468d73f927))
+
+
+### Features
+
+* **comments:** implement reactions ([#5409](https://github.com/sanity-io/sanity/issues/5409)) ([8c140be](https://github.com/sanity-io/sanity/commit/8c140beab7eb6e15208607019eab48bd45756970)), closes [#5524](https://github.com/sanity-io/sanity/issues/5524)
+* **core:** add telemetry scaffolding to Studio ([#5503](https://github.com/sanity-io/sanity/issues/5503)) ([66b88f7](https://github.com/sanity-io/sanity/commit/66b88f7ebed603eb02854e573d99841aa106b55a))
+* **core:** schema and field deprecation ([#5489](https://github.com/sanity-io/sanity/issues/5489)) ([f7c2417](https://github.com/sanity-io/sanity/commit/f7c2417879e40b02f89aefc761fec0a8fcf2c788)), closes [#5470](https://github.com/sanity-io/sanity/issues/5470) [#5484](https://github.com/sanity-io/sanity/issues/5484) [#5516](https://github.com/sanity-io/sanity/issues/5516)
+* **i18n:** add i18n resources for browser document title ([#5477](https://github.com/sanity-io/sanity/issues/5477)) ([fb4eb68](https://github.com/sanity-io/sanity/commit/fb4eb6813d33c789cd9b02463cd2a24c6052227f))
+
+
+
+# [3.25.0](https://github.com/sanity-io/sanity/compare/v3.24.1...v3.25.0) (2024-01-16)
+
+
+### Bug Fixes
+
+* **block-tools:** more robust formatting detection on copy paste in Safari ([#5485](https://github.com/sanity-io/sanity/issues/5485)) ([0cec72b](https://github.com/sanity-io/sanity/commit/0cec72badbcca5fff86d81fb872e0d0a46975350))
+* **cli:** telemetry: only log first 10 elements in args array ([#5471](https://github.com/sanity-io/sanity/issues/5471)) ([5281b42](https://github.com/sanity-io/sanity/commit/5281b42fa2ecfdc71f1d00db0fe04f2578629cca))
+* **core:** add missing inter fontface for weights 800+900 ([#5490](https://github.com/sanity-io/sanity/issues/5490)) ([ec84a42](https://github.com/sanity-io/sanity/commit/ec84a42935b9dfcb1006abea2c98d59431c81169))
+* **core:** include cookieless auth token in logout request if it exists ([#5491](https://github.com/sanity-io/sanity/issues/5491)) ([ee9f89f](https://github.com/sanity-io/sanity/commit/ee9f89f1be391b02ccdd88e7598dc44b47e91737))
+* **deps:** update @sanity/ui to 2.0.0 and @sanity/color to 3.0.0 ([#5507](https://github.com/sanity-io/sanity/issues/5507)) ([cc27cb8](https://github.com/sanity-io/sanity/commit/cc27cb842a503e2d2ceaf1c6ce518adc24dfe8a9))
+* **deps:** update dependency @sanity/client to ^6.11.1 ([#5488](https://github.com/sanity-io/sanity/issues/5488)) ([0f51ba9](https://github.com/sanity-io/sanity/commit/0f51ba97c898b010f5e4e55a3f3546bcd43932d0))
+* **deps:** update dependency @sanity/presentation to v1.5.3 ([#5486](https://github.com/sanity-io/sanity/issues/5486)) ([4a25ee9](https://github.com/sanity-io/sanity/commit/4a25ee9fe909ab6a89fcc0ec3fedbf5fe2ee25d5))
+* **deps:** update dependency `@sanity/presentation` to `v1.6.0` ([#5508](https://github.com/sanity-io/sanity/issues/5508)) ([ddece4c](https://github.com/sanity-io/sanity/commit/ddece4c553d47e1c761370505b4fad8bf693c7a8))
+* ensure list array card focusRing isn't cropped and renders with correct radii ([#5505](https://github.com/sanity-io/sanity/issues/5505)) ([ffb6268](https://github.com/sanity-io/sanity/commit/ffb6268931251b5ccb65bdfcac102aa957e76b78))
+* **form/inputs:** include text blocks in PT-members when theya are focused ([#5502](https://github.com/sanity-io/sanity/issues/5502)) ([f2a228f](https://github.com/sanity-io/sanity/commit/f2a228fb71f4532e1ece7abdf8a51c009166a9d7))
+* mark builds as completed/errored and indicate empty cli runs ([#5469](https://github.com/sanity-io/sanity/issues/5469)) ([a581d8d](https://github.com/sanity-io/sanity/commit/a581d8dfba2cc63112d0838aec3b47f3f5b4cee2))
+* **test:** use `"runtime": "automatic"` for `"@babel/preset-react"` ([#5492](https://github.com/sanity-io/sanity/issues/5492)) ([8023c33](https://github.com/sanity-io/sanity/commit/8023c330511aa25f3ed1405fa5c6708897f257a2))
+* use help icon for help + resources button ([#5506](https://github.com/sanity-io/sanity/issues/5506)) ([9105ec7](https://github.com/sanity-io/sanity/commit/9105ec7674e582856049ebe1bdc378dc962cca10))
+* various navbar improvements ([#5504](https://github.com/sanity-io/sanity/issues/5504)) ([6c8dce9](https://github.com/sanity-io/sanity/commit/6c8dce9aadb0964ed92fd89e55b81551b9392270))
+
+
+### Features
+
+* **block-tools:** add special notion handling for single block decorators ([#5411](https://github.com/sanity-io/sanity/issues/5411)) ([a281061](https://github.com/sanity-io/sanity/commit/a281061607dcee23c7de2abfd04ea76e280e6084))
+* **cli:** new documents validate command ([#5475](https://github.com/sanity-io/sanity/issues/5475)) ([8369061](https://github.com/sanity-io/sanity/commit/836906142431f31068cf1fc9d6db3c54baf4286a))
+
+
+
+## [3.24.1](https://github.com/sanity-io/sanity/compare/v3.24.0...v3.24.1) (2024-01-10)
+
+
+
+# [3.24.0](https://github.com/sanity-io/sanity/compare/v3.23.4...v3.24.0) (2024-01-10)
+
+
+### Bug Fixes
+
+* add custom resize handle icon ([#5462](https://github.com/sanity-io/sanity/issues/5462)) ([38f951c](https://github.com/sanity-io/sanity/commit/38f951c5bea1d3889a668c43129c44ff55601776))
+* **block-tools:** keep strike-through formatting when pasting from gdocs ([#5443](https://github.com/sanity-io/sanity/issues/5443)) ([779a114](https://github.com/sanity-io/sanity/commit/779a114e1a27b3fc32802c244939d35e614ed189))
+* **cli:** bootstrap new studios with structure import ([7516d0f](https://github.com/sanity-io/sanity/commit/7516d0f78a6d6fb534968a0bd6ee058c754ffda8))
+* **cli:** uniquify temp directory used during dataset import ([#5400](https://github.com/sanity-io/sanity/issues/5400)) ([a84cfeb](https://github.com/sanity-io/sanity/commit/a84cfeb845564d0c2ee6b8686e58613840c1fad1))
+* **cli:** update esbuild options for better compat ([#5461](https://github.com/sanity-io/sanity/issues/5461)) ([fc45930](https://github.com/sanity-io/sanity/commit/fc45930ee7fe71b4b00b850c6714c1b993f9f54e))
+* **core:** add aria-label to expand PTE button ([#5459](https://github.com/sanity-io/sanity/issues/5459)) ([d709112](https://github.com/sanity-io/sanity/commit/d7091127ba725935431fb19c5cdc545db8a155ba))
+* **core:** add scroll event listener for AnnotationToolbarPopover referenceBoundary ([#5410](https://github.com/sanity-io/sanity/issues/5410)) ([5719a09](https://github.com/sanity-io/sanity/commit/5719a092d29d90aa317e795cda4253d51427da20))
+* **core:** add useClickOutside function to filter buttons ([afdb3f9](https://github.com/sanity-io/sanity/commit/afdb3f9694101c3ac77b96df9c7accad1db16d80))
+* **core:** correct typesVersions path for structure export ([b018193](https://github.com/sanity-io/sanity/commit/b01819332da22d5927dae06bb3926c92e35d1d84))
+* **core:** form fieldset border ([#5468](https://github.com/sanity-io/sanity/issues/5468)) ([8ff0308](https://github.com/sanity-io/sanity/commit/8ff030823bc711bda67d8f7d653af99e4d51d17f))
+* **core:** left align button text in PTE ([#5422](https://github.com/sanity-io/sanity/issues/5422)) ([a21656e](https://github.com/sanity-io/sanity/commit/a21656efe6bddd5f11d3a2082a1aca77bab5913d))
+* **core:** remove variable fonts in global styles ([#5456](https://github.com/sanity-io/sanity/issues/5456)) ([47d84a2](https://github.com/sanity-io/sanity/commit/47d84a2134a70829eaba59c853eab0403e390869))
+* **deps:** update dependency @sanity/presentation to v1.4.2 ([7972ff4](https://github.com/sanity-io/sanity/commit/7972ff48b4e4094e3b2bcd5ea4ce13789f3669b3))
+* **deps:** update dependency @sanity/presentation to v1.4.3 ([5479069](https://github.com/sanity-io/sanity/commit/5479069646ba6714f1e1f2edaec437be73f5d6dd))
+* **deps:** update dependency @sanity/presentation to v1.5.0 ([75b052c](https://github.com/sanity-io/sanity/commit/75b052c96c6958ef995e6c54d4baef958374c462))
+* **desk:** utranslate when form title is missing ([#5439](https://github.com/sanity-io/sanity/issues/5439)) ([8c52faa](https://github.com/sanity-io/sanity/commit/8c52faa15a7069ef350e995236f6cc95e9fd90dc))
+* **i18n:** pass Code component to document list pane error ([#5434](https://github.com/sanity-io/sanity/issues/5434)) ([30f9bef](https://github.com/sanity-io/sanity/commit/30f9bef0b701725438d5cbb0954116df9215bed8))
+* **i18n:** use correct locale string for document restore confirmation ([#5453](https://github.com/sanity-io/sanity/issues/5453)) ([2d817cb](https://github.com/sanity-io/sanity/commit/2d817cb7e8cd7ac27cddcfa788aa047ef8e9203d))
+* **legacy-theme:** update buildLegacyTheme to support custom colors ([#5437](https://github.com/sanity-io/sanity/issues/5437)) ([b4fb5b6](https://github.com/sanity-io/sanity/commit/b4fb5b67f59274bd114814a5a0daddef79e3349a))
+* opt-out of internal studio ui-components for user facing custom document action dialogs ([#5444](https://github.com/sanity-io/sanity/issues/5444)) ([5a9d1f8](https://github.com/sanity-io/sanity/commit/5a9d1f8fac5b0bf5b4d2640add512abe568f999e))
+* position search button in the LHS navbar ([#5479](https://github.com/sanity-io/sanity/issues/5479)) ([8b3aa07](https://github.com/sanity-io/sanity/commit/8b3aa07e0959f3c19b23d7ce41aabce7578148da))
+* prevent props that are unknown html attributes from passing through ([#5481](https://github.com/sanity-io/sanity/issues/5481)) ([ddf605f](https://github.com/sanity-io/sanity/commit/ddf605ff7525faa30586a797c0d74492c84da548))
+* **structure:** fix typo in renamed structure tool context ([00496ab](https://github.com/sanity-io/sanity/commit/00496ab8f6b9f60f5c8c1510a90def52448b4a8f))
+* **theme:** update studio theming, support only color and fonts customisation. ([#5442](https://github.com/sanity-io/sanity/issues/5442)) ([078574b](https://github.com/sanity-io/sanity/commit/078574bde24bedc144fba49e1bc69a5c14fee1d0))
+* update reverse trial button styles, add tooltips to nav button and localize ([#5478](https://github.com/sanity-io/sanity/issues/5478)) ([8e8c474](https://github.com/sanity-io/sanity/commit/8e8c474ed6db3531ba26099f5601aa3e6209b021))
+* **vision:** use untranslated value for "other" api version ([#5433](https://github.com/sanity-io/sanity/issues/5433)) ([f3181ba](https://github.com/sanity-io/sanity/commit/f3181ba94e0a7898e1564a44253dbb15cfadfc9f))
+
+
+### Features
+
+* **cli:** add desk rename codemod ([749444d](https://github.com/sanity-io/sanity/commit/749444d19b3908c89a160760e131349a38f6d8ed))
+* **comments:** enable by default ([#5467](https://github.com/sanity-io/sanity/issues/5467)) ([c09a26d](https://github.com/sanity-io/sanity/commit/c09a26d7cc4dea44cde9b24cb8d9683416f46afd))
+* conditionally set maximum search depth in studio search ([#5440](https://github.com/sanity-io/sanity/issues/5440)) ([261b05e](https://github.com/sanity-io/sanity/commit/261b05efc0ce2bd7b6d54e85e4c1a058dc9cb990))
+* **desk:** add __experimental_formPreviewTitle to documents ([#5452](https://github.com/sanity-io/sanity/issues/5452)) ([90c24c8](https://github.com/sanity-io/sanity/commit/90c24c8956539a68263763db08bdbfb9b1aa29da))
+* **graphql:** add experimental mode to optimize/cache schema union definitions ([52e4369](https://github.com/sanity-io/sanity/commit/52e436973e1fb9db6314e615bd90a31dcc28dca4))
+* **validation:** `validateDocument` ([#5465](https://github.com/sanity-io/sanity/issues/5465)) ([3c5421e](https://github.com/sanity-io/sanity/commit/3c5421efb936ade67831d51dfdf785b6f7852096))
+
+
+
+## [3.23.4](https://github.com/sanity-io/sanity/compare/v3.23.3...v3.23.4) (2023-12-22)
+
+
+### Bug Fixes
+
+* **core:** icon size in previews with custom icon ([#5425](https://github.com/sanity-io/sanity/issues/5425)) ([c6becc9](https://github.com/sanity-io/sanity/commit/c6becc9a2cfe214c2d3940664e73adbade02f94f))
+* **core:** wait until the ref is available before showing trial popover ([#5424](https://github.com/sanity-io/sanity/issues/5424)) ([26d08fe](https://github.com/sanity-io/sanity/commit/26d08fe4358a4d91badfe1e89a6e036b930f35c9))
+
+
+
+## [3.23.3](https://github.com/sanity-io/sanity/compare/v3.23.2...v3.23.3) (2023-12-22)
+
+
+
+## [3.23.2](https://github.com/sanity-io/sanity/compare/v3.23.1...v3.23.2) (2023-12-21)
+
+
+### Bug Fixes
+
+* **block-tools:** fix broken unit tests ([87895f1](https://github.com/sanity-io/sanity/commit/87895f13b004964a76ed3275e1d8228c09722538))
+* **cli:** provide more detailed info if consent status change fails ([#5416](https://github.com/sanity-io/sanity/issues/5416)) ([8eaea18](https://github.com/sanity-io/sanity/commit/8eaea189f99b5e2b62190ea3ac53c4d9b8115e0d))
+* **core:** add missing deprecated tag to workspace logo ([#5413](https://github.com/sanity-io/sanity/issues/5413)) ([cc53cca](https://github.com/sanity-io/sanity/commit/cc53cca45752a3bf4f17ac55cfff5f6998f9a11f))
+* **core:** adds consistent padding to document footer ([#5415](https://github.com/sanity-io/sanity/issues/5415)) ([dfe1039](https://github.com/sanity-io/sanity/commit/dfe10391f5baba6da67185e2edcc487d82a8fc53))
+* **core:** box sizing content box in preview elements, free trial popover position ([#5418](https://github.com/sanity-io/sanity/issues/5418)) ([37d9c28](https://github.com/sanity-io/sanity/commit/37d9c2818696927ef5b015265c5891b1af650bcf))
+* **desk:** add bleed mode to field action button ([#5414](https://github.com/sanity-io/sanity/issues/5414)) ([790a71a](https://github.com/sanity-io/sanity/commit/790a71addfa2c14b2700825a75ea489ba0191210))
+* **form:** fix missing subtitles in array previews ([#5412](https://github.com/sanity-io/sanity/issues/5412)) ([963b778](https://github.com/sanity-io/sanity/commit/963b77843a677af4734c40f64be44f1d814798c9))
+* **portable-text-editor:** copy paste improvements ([#5274](https://github.com/sanity-io/sanity/issues/5274)) ([a5901b0](https://github.com/sanity-io/sanity/commit/a5901b013556d3a8de5a65da9ee945b43e79a34a))
+* **sanity:** guard against telemetry not provided from older global CLI versions ([#5420](https://github.com/sanity-io/sanity/issues/5420)) ([7e435e4](https://github.com/sanity-io/sanity/commit/7e435e47e64241d518e65c90abe6c69176ce9de9))
+* temporarily disable locale selection in nav drawer menu ([#5406](https://github.com/sanity-io/sanity/issues/5406)) ([67aac92](https://github.com/sanity-io/sanity/commit/67aac929e05ef4371875e6250dc15b68cef2e275))
+
+
+### Reverts
+
+* Revert "test(e2e): disable dataset creation per PR (#5210)" (#5402) ([30de036](https://github.com/sanity-io/sanity/commit/30de036accbe0d00b376f07c2f1857a647ea2355)), closes [#5210](https://github.com/sanity-io/sanity/issues/5210) [#5402](https://github.com/sanity-io/sanity/issues/5402)
+
+
+
+## [3.23.1](https://github.com/sanity-io/sanity/compare/v3.23.0...v3.23.1) (2023-12-19)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @sanity/presentation to v1.4.0 ([#5405](https://github.com/sanity-io/sanity/issues/5405)) ([3365bb6](https://github.com/sanity-io/sanity/commit/3365bb6ee7497455b2ee492f3b00231fe1f57f1a))
+* **i18n:** use short instead of narrow formatting for relative time ([4e753ff](https://github.com/sanity-io/sanity/commit/4e753ffeb9a3b48ec54201b3685b4a3fa985399d))
+
+
+
+# [3.23.0](https://github.com/sanity-io/sanity/compare/v3.22.1...v3.23.0) (2023-12-19)
+
+
+### Bug Fixes
+
+* add clarifying comments on container query support, reverse header font size selection (fixes edx-860) ([069a622](https://github.com/sanity-io/sanity/commit/069a622042eea6958b3d2357b332f89e0bd96596))
+* add localized text for common loader component ([544eaf1](https://github.com/sanity-io/sanity/commit/544eaf17c2c37550252ab79a8542c322ca79e7f0))
+* add localized text for config issue tooltip button (fixes edx-859) ([e8acd4e](https://github.com/sanity-io/sanity/commit/e8acd4e83c176cbdd78809ae5f2e98027852ae44))
+* add localized text for review change button tooltips ([9734ed1](https://github.com/sanity-io/sanity/commit/9734ed1906819e2fa629bdcd35e52baca77da361))
+* add localized text for shared dialog component ([a23aa6e](https://github.com/sanity-io/sanity/commit/a23aa6e814d3e03b46bdb5d7aec9bb217ea8b51b))
+* add padding to workspace auth page, tweak mobile nav drawer ([3d445b6](https://github.com/sanity-io/sanity/commit/3d445b6c422ec5fc67831d58824a800f99e88cf8))
+* **cli:** upgrade templates to use @sanity/ui@beta ([#5401](https://github.com/sanity-io/sanity/issues/5401)) ([92fdc06](https://github.com/sanity-io/sanity/commit/92fdc06d437f655954d6643167a6d31bc4c0377f))
+* **comments:** update spacing for SpacerAvatar ([dd3a249](https://github.com/sanity-io/sanity/commit/dd3a249149ed23bf12e32717ae9241f26e95cc74))
+* **core/tests:** fix failed tests ([#5376](https://github.com/sanity-io/sanity/issues/5376)) ([0fd3ad1](https://github.com/sanity-io/sanity/commit/0fd3ad1fa44f890febda9c5b7040ad7f4c5ec2aa))
+* **core:** fields actions position shift ([#5348](https://github.com/sanity-io/sanity/issues/5348)) ([132cf0c](https://github.com/sanity-io/sanity/commit/132cf0c6caaee56e277a56266b0af56f1ca2ec78))
+* **core:** newDocumentButton filter not working in mobile ([f597584](https://github.com/sanity-io/sanity/commit/f5975848500a32bf6836c3a66dfe1360f2e41849))
+* **core:** update changes inspector revert confirmation popovers ([#5398](https://github.com/sanity-io/sanity/issues/5398)) ([95144df](https://github.com/sanity-io/sanity/commit/95144dff87ff7c83a96d671561555aa5f7b5df98))
+* **core:** update corsOriginErroScreen ([16f7fc5](https://github.com/sanity-io/sanity/commit/16f7fc5a5b7400b372bbe66d18b7b5f7f16cb54e))
+* **core:** updates after rebase ([fda5cdd](https://github.com/sanity-io/sanity/commit/fda5cdd0fb566251778a104510c55269226c9b5f))
+* **deps:** update @sanity/ui ([8aac0c9](https://github.com/sanity-io/sanity/commit/8aac0c998f19ad1ada9ef234ced358199b0b50d8))
+* **deps:** update `@sanity/icons` ([174d209](https://github.com/sanity-io/sanity/commit/174d209d3c8359842452accc6f656d7f8a637fab))
+* **deps:** update `@sanity/ui` ([6d180e3](https://github.com/sanity-io/sanity/commit/6d180e3fa284b4ffed8290383f92cb72830b6cd5))
+* **deps:** update `@sanity/ui` ([ad87f0e](https://github.com/sanity-io/sanity/commit/ad87f0e65ba0011950b8a6df9802df8edd625190))
+* **deps:** update `@sanity/ui` ([4688224](https://github.com/sanity-io/sanity/commit/46882244c26b69b36957dffc56a9504392dbf0e2))
+* **deps:** update `@sanity/ui` ([d241553](https://github.com/sanity-io/sanity/commit/d2415539ebfb39506b4ca73873bd1f185ee8500e))
+* **deps:** update `@sanity/ui` ([d276475](https://github.com/sanity-io/sanity/commit/d276475b84138ffcef3380e1a9dd981bd578218a))
+* **deps:** update `@sanity/ui` ([9c5de6a](https://github.com/sanity-io/sanity/commit/9c5de6ad3ac029bf81257e7898a758881ac155b7))
+* **deps:** update `@sanity/ui` ([8da8961](https://github.com/sanity-io/sanity/commit/8da8961bfc0cc4943e5ddc5dbebdfc07e85c814b))
+* **deps:** update dependencies ([b80ba29](https://github.com/sanity-io/sanity/commit/b80ba292a71c9d1361157db8b823f469c1b06e21))
+* **deps:** upgrade `@sanity/color` ([e8a8047](https://github.com/sanity-io/sanity/commit/e8a8047f587e34c909a5f2d39dd4d6de7d7d608f))
+* **desk:** add tooltip on menuitem when disabled only ([#5375](https://github.com/sanity-io/sanity/issues/5375)) ([0127ba7](https://github.com/sanity-io/sanity/commit/0127ba72c22fbad831cecb20b33168a4d547cdf5))
+* **desk:** align comment feature feedback ([8658e93](https://github.com/sanity-io/sanity/commit/8658e9387907911082642e4cd1c3e0e238e0d7e1))
+* **desk:** align document actions ([dbab681](https://github.com/sanity-io/sanity/commit/dbab681f15d302e83f49d4e2ffa23a67bd3661ce))
+* **desk:** align document status bar ([60b17fa](https://github.com/sanity-io/sanity/commit/60b17faeb9f400fd31d79c07bc557d7b475e6023))
+* **desk:** align id container ([463646b](https://github.com/sanity-io/sanity/commit/463646bfa37c39cea57282e49897194b82e546b7))
+* **desk:** align pane header ([5794688](https://github.com/sanity-io/sanity/commit/5794688a6c21e5be4020fc487d87d70f1b01dba3))
+* **desk:** always use icon for publish action ([a7b54d7](https://github.com/sanity-io/sanity/commit/a7b54d7ec20d5d9094043cc1424a4acb8631760e))
+* **desk:** simplify copy ([9e15e9e](https://github.com/sanity-io/sanity/commit/9e15e9ea34edb1e55bacac1d37c4490c935f4be2))
+* **desk:** update DeskRename popover ([e2c28d2](https://github.com/sanity-io/sanity/commit/e2c28d2c460b5fb4fc0398bf8d3c3c8a1cbecc53))
+* **desk:** update inspect dialog ([ae499a4](https://github.com/sanity-io/sanity/commit/ae499a44525a1d6977902dbf70f7f936df3926dc))
+* **desk:** use json icon ([a7f792b](https://github.com/sanity-io/sanity/commit/a7f792bfa94d8b1072f5be4c6c27a93e1f0a0c88))
+* ensure field names correctly truncate in search filter tooltips ([1ea1ed0](https://github.com/sanity-io/sanity/commit/1ea1ed0ebd96ba6c1ed795134d2c18c6e8bdf8c1))
+* ensure focus is returned when closing search (defer focus handling to `<FocusLock>`) ([1c6a62c](https://github.com/sanity-io/sanity/commit/1c6a62c9753259bc3056057385618231d0ab232e))
+* ensure media border styles are only applied on the targeted element only ([4ed01ff](https://github.com/sanity-io/sanity/commit/4ed01ffb4b73b32a75d9bb54b05cac2da870d6da))
+* expose document status indicator and tooltip in global search results ([4c049a7](https://github.com/sanity-io/sanity/commit/4c049a7bc17be1f5393a2298ea7db093634e1919))
+* **facelift:** remove duplicated const after rebase ([3d28b0b](https://github.com/sanity-io/sanity/commit/3d28b0b888d6b00f9933831b00926f69f2814082))
+* **facelift:** self serve Inter font ([#5374](https://github.com/sanity-io/sanity/issues/5374)) ([e41ffca](https://github.com/sanity-io/sanity/commit/e41ffcad94a15ed3f4d1eff894f03a5c9c772ec3))
+* **facelift:** update focus ring offset in WithFocusRing cards ([ac8b995](https://github.com/sanity-io/sanity/commit/ac8b995e72232141e8b3af75454e1f609b7a8233))
+* **facelift:** update free trial to match facelift ([9b04d87](https://github.com/sanity-io/sanity/commit/9b04d8769591093a8b5acab3f23fa1c422a9186c))
+* **facelift:** update i18n ignore rules ([879aee1](https://github.com/sanity-io/sanity/commit/879aee1091cac441099fd1431b311b08584c3dda))
+* **facelift:** update i18n imports after rebase ([320f695](https://github.com/sanity-io/sanity/commit/320f6959bd1310b07753ea265b4c865922818e28))
+* fix back button alignment on smaller breakpoints, tweak search styles ([d680d5f](https://github.com/sanity-io/sanity/commit/d680d5fd4c23514cf793f57ef064ade5cce1bdc4))
+* force useRelativeTime to always render idiomatic dates with weeks in full ([af3056c](https://github.com/sanity-io/sanity/commit/af3056cee9a8e71750b1323fdb9716f074c53081))
+* **form:** align elements ([cd54159](https://github.com/sanity-io/sanity/commit/cd541591b507d82c7904f795d8412a721050464e))
+* **form:** align form field header ([1ba30f5](https://github.com/sanity-io/sanity/commit/1ba30f5cb4a290d1108409697f57865d362909bf))
+* **form:** simplify and set status color using theme v2 ([d83c705](https://github.com/sanity-io/sanity/commit/d83c70526e0fc5afd843362c289e0660a27954c3))
+* **form:** update border radius ([86e8519](https://github.com/sanity-io/sanity/commit/86e85198d5bac15e0fefb13f06638e3a6d2d84db))
+* **form:** update date input and picker ([603d01f](https://github.com/sanity-io/sanity/commit/603d01f051d2d0186097a42ff5f736872811d340))
+* **form:** update pte styles ([b6a852c](https://github.com/sanity-io/sanity/commit/b6a852c43715484c1635103d986266d508ece909))
+* **form:** use border instead of shadow for file input ([c8e241c](https://github.com/sanity-io/sanity/commit/c8e241c79b74f56c98a71fb4dcbd672d47a46378))
+* **form:** use border instead of shadow for reference input ([3374503](https://github.com/sanity-io/sanity/commit/3374503b79f24ab9b16043c6f3282b01d4a6a252))
+* hide document status dot for published documents with no edits ([f208707](https://github.com/sanity-io/sanity/commit/f20870735217088ae7631d0f0d864d631f6b4bc6))
+* hide loading text in generic loader by default, tweak timings, update test snapshots ([d09822e](https://github.com/sanity-io/sanity/commit/d09822e4f4381966266e1fde54a343b08bb074cf))
+* **i18n:** init with all namespaces, optimize later ([00c424a](https://github.com/sanity-io/sanity/commit/00c424a9f36c7adb91061ecc0d973ddafc519728))
+* **i18n:** regression in reference create button text ([e0976c2](https://github.com/sanity-io/sanity/commit/e0976c23369d3005df096ba1b239ddd8abb9e823))
+* **i18n:** simplify copy ([ea3e77e](https://github.com/sanity-io/sanity/commit/ea3e77e466db875fc55183df2b49be2dc9dfbea2))
+* **i18n:** translate DocumentStatus ([12642b6](https://github.com/sanity-io/sanity/commit/12642b615825d6d5d80a0417af7d65be05fda2b8))
+* large button size for remove field button ([d88fa79](https://github.com/sanity-io/sanity/commit/d88fa79dad406cca47dfa28a45bc37e54ab1cd11))
+* localize create new button tooltip in document pane headers ([b8197d6](https://github.com/sanity-io/sanity/commit/b8197d6860ef5081e0c47a162eaad244bf147af0))
+* localize create new document button ([b720e4a](https://github.com/sanity-io/sanity/commit/b720e4a236b7e65d5c79bc74b6dd4fa6fc9ce89c))
+* localize document actions button tooltip, update ContextMenuButton signature ([32efb69](https://github.com/sanity-io/sanity/commit/32efb69dffd5e268e2fa50f80f2110ca86410282))
+* localize drag handle button, use correct delay values ([f9c2ec8](https://github.com/sanity-io/sanity/commit/f9c2ec86c99e6160e57b11075f2be573d2cd2c60))
+* localize pane header back button tooltip ([dac416c](https://github.com/sanity-io/sanity/commit/dac416c6d7903770e474925fa6b521d610fa6253))
+* localize search button tooltip text ([1b7e658](https://github.com/sanity-io/sanity/commit/1b7e65813a411ba3cafbf42073b126cf692672dd))
+* localize untitled text in compact preview ([d038b7d](https://github.com/sanity-io/sanity/commit/d038b7d4033d9105a2a30aea993c9675ff06054d))
+* minor regression with menu item spacing ([41caf72](https://github.com/sanity-io/sanity/commit/41caf721736b8a738b2ba8034526400d9e8e333a))
+* new presence menu item avatar sizes ([a6fd7f6](https://github.com/sanity-io/sanity/commit/a6fd7f6c2632e0fd89db62659bff793cefdc4a8e))
+* **preview:** use icon color ([a827f29](https://github.com/sanity-io/sanity/commit/a827f294941864b6e43e787e06dd33a182f6658a))
+* re-enable buildLegacyTheme (fixes edx-857) ([142b44f](https://github.com/sanity-io/sanity/commit/142b44fe959b993f0c9021720d0d05503f2c8de7))
+* re-use StatusButton component in mobile search header, localize tooltip text ([24ed95b](https://github.com/sanity-io/sanity/commit/24ed95b91270da13a375dd9e7c1ed5a6b0312db5))
+* remove extraneous padding on manage members menu item ([5d6ec16](https://github.com/sanity-io/sanity/commit/5d6ec16defa6470e8f8a06dbf552ff5ca6aa6f55))
+* remove responsive styles from global search filters ([91a361f](https://github.com/sanity-io/sanity/commit/91a361fb823b614e7db04fef0a5bd47232022567))
+* remove subtitle support from studio UI menu items, update layout, update search string list inputs ([a08d1e9](https://github.com/sanity-io/sanity/commit/a08d1e9c1724875f2b2a559335b17641e9f25558))
+* **sanity:** set `maximum-scale` viewport property ([0b2935e](https://github.com/sanity-io/sanity/commit/0b2935e4787ef956dece0934d065267382474dc3))
+* show checkmark on selected locale in locale menu ([162f9d6](https://github.com/sanity-io/sanity/commit/162f9d646b2907ea351c13abdd791076232fc6a9))
+* **studio:** adjust avatar size in user menu ([e525b02](https://github.com/sanity-io/sanity/commit/e525b02ac49787a9e6944bed64a24715df755d16))
+* **studio:** align navbar menus ([fbf9671](https://github.com/sanity-io/sanity/commit/fbf967127d1b08b086e9505e6880391ca0b9b364))
+* **studio:** decrease heading size in config issues dialog ([4a5349f](https://github.com/sanity-io/sanity/commit/4a5349f9a270bac2b30dd5d1fab337b220551666))
+* **studio:** do not use experimental avatar status ([f237032](https://github.com/sanity-io/sanity/commit/f237032dcac005034823508a9ca6b13b065d7fe5))
+* **studio:** increase button size in mobile search overlay ([c9fc186](https://github.com/sanity-io/sanity/commit/c9fc18610ea18b293c1d05560d2c213a0c8d83b5))
+* **studio:** render smaller avatars in document previews ([48c9642](https://github.com/sanity-io/sanity/commit/48c9642b4f988b653aa57010f8925488454ad963))
+* **studio:** set global selection color ([3acc6f6](https://github.com/sanity-io/sanity/commit/3acc6f6aa7911cd3ad5d45c6f05430b6801775bb))
+* **studio:** simplify `TextWithTone` component ([928ca2a](https://github.com/sanity-io/sanity/commit/928ca2adf69c8def3f52536e060beb9875123e7d))
+* **studio:** update beta badge ([a6d93fa](https://github.com/sanity-io/sanity/commit/a6d93fa378c229d1d5ee9a2ee6f829b42540a700))
+* **studio:** update change indicator ([22d6867](https://github.com/sanity-io/sanity/commit/22d686756636b17fa00361a3a21e00c341a4426e))
+* **studio:** update default studio theme ([a01e31a](https://github.com/sanity-io/sanity/commit/a01e31aeef4bde0ace87f8c874aefebce984c507))
+* **studio:** update global styles ([1a837bf](https://github.com/sanity-io/sanity/commit/1a837bf9fdd7d9b4276bb801519e70b7331bef2e))
+* **studio:** update navbar spacing ([38787a5](https://github.com/sanity-io/sanity/commit/38787a5b996da28e043c66c3bd1102bc75573361))
+* **studio:** update preview components ([e8ac660](https://github.com/sanity-io/sanity/commit/e8ac66098f3e60526720e985c98de406e3eb660f))
+* **studio:** update scrollbar style ([8a42dcd](https://github.com/sanity-io/sanity/commit/8a42dcd4e2813ec537333c9a91b8f0bd9ca630c0))
+* **test-studio:** remove i18n.loadNamespaces function ([d775fe6](https://github.com/sanity-io/sanity/commit/d775fe6517921ed0b6e8842612522cdda5d2e228))
+* **tests:** add react reference to fix broken test ([ebad2de](https://github.com/sanity-io/sanity/commit/ebad2de6adf7b4a32167298830097449e68a48b5))
+* **tests:** fix studio.spec test ([45b2cde](https://github.com/sanity-io/sanity/commit/45b2cdeb4e19d3e75611454a36869f549d4769ba))
+* **tests:** remove studio.components.logo test ([88b326f](https://github.com/sanity-io/sanity/commit/88b326f06460f8a2e52cf7ff57b6366bf18a803e))
+* **tooltip:** use regular font weight ([d9f319e](https://github.com/sanity-io/sanity/commit/d9f319e0a9aa7bb44a5b50e0c4b22c783dc986c9))
+* tweak navbar padding, minor cleanup ([1afcc29](https://github.com/sanity-io/sanity/commit/1afcc29f3574b6408044fe81e0701fd8822c8b1a))
+* tweak placement for workspace + presence menu tooltips ([ccf45df](https://github.com/sanity-io/sanity/commit/ccf45dfeea28be0ab54499bd16897f099e91aeab))
+* **ui:** align document status ([93bc894](https://github.com/sanity-io/sanity/commit/93bc89425852345b2d37e65328158366bceee462))
+* **ui:** align tooltip ([4fdca80](https://github.com/sanity-io/sanity/commit/4fdca80e547fecc4e619b4547e2fe9d623cefe69))
+* **ui:** change copy from 'Updated' to 'Edited' ([fc15d0d](https://github.com/sanity-io/sanity/commit/fc15d0d283e497dc59d60eaa9f518208c8547919))
+* **ui:** do not show dot on hover ([9813368](https://github.com/sanity-io/sanity/commit/9813368087a63209e6d8648d9c7e8635e6e960b3))
+* **ui:** fade preview when menu item is disabled ([d753974](https://github.com/sanity-io/sanity/commit/d75397475d599a83a9222d1876de5ef39888850d))
+* **ui:** include `paddingY` property ([415240c](https://github.com/sanity-io/sanity/commit/415240ce57d56afb68d82a25dd4e5eb901adde97))
+* **ui:** update document status components ([14e9d4d](https://github.com/sanity-io/sanity/commit/14e9d4dfb9e22a1503d94b5218e0e892a31eb830))
+* update create new button localized text ([c2d27bf](https://github.com/sanity-io/sanity/commit/c2d27bfebaa364ba201307a8535c3ab15533ea07))
+* update global search date picker styles, remove unused LazyTextInput component ([c4b4187](https://github.com/sanity-io/sanity/commit/c4b4187c07675bfaaed421aa601fccb776a6453b))
+* update global search result item padding ([0cf060e](https://github.com/sanity-io/sanity/commit/0cf060e0de5d463210f61f904ca7630e766da086))
+* use correct document status indicator colors, update document status tooltip spacing ([ee5b543](https://github.com/sanity-io/sanity/commit/ee5b543aba3c53f663f2dc7d19441b28bb5bd3d8))
+* use correct focus ring offset + width for list panes + comment pte input ([995fb0a](https://github.com/sanity-io/sanity/commit/995fb0af3068ae8fb269e4b5a5def80d47849aee))
+* use correct tooltip styling for search datetime errors, simplify + remove Translate usage ([9935997](https://github.com/sanity-io/sanity/commit/993599753e154e9d6d12039329c7130f0eb6b46d))
+* use localized relative time hook ([1061d86](https://github.com/sanity-io/sanity/commit/1061d864251b522a468d397fd38eeb0b92cf6667))
+* use relative paths for core imports ([a71bd8d](https://github.com/sanity-io/sanity/commit/a71bd8de30ec96fb9471af58ac921a77f14ebf60))
+* use single pixel border for document banners ([78dde3c](https://github.com/sanity-io/sanity/commit/78dde3c87accd1440544b0b0e53e0ba7fb9393d1))
+* use updated background color for global search popover ([02a70fc](https://github.com/sanity-io/sanity/commit/02a70fc3a5b90e2ce098845eda34594e53800e7b))
+
+
+### Features
+
+* add absolute tooltip dates to document statusbar, don't render statusbar until ready, minor cleanup ([9a811da](https://github.com/sanity-io/sanity/commit/9a811da9a3e40af97b4d85b126a9032f265995b2))
+* add common localized context menu button component ([96462cc](https://github.com/sanity-io/sanity/commit/96462cce03e9342eac3e624cd653e61d20eedd04))
+* add customized Popover and MenuItem components and enable animation, update comments ([daa0de5](https://github.com/sanity-io/sanity/commit/daa0de504e308c6f7fdbb53a2bc2ceb5bbede2c7))
+* align search popover overlay background with dialog ([83e3163](https://github.com/sanity-io/sanity/commit/83e31637309cd664b291c5288e44e4cc2eb98f4a))
+* animate search popover ([74d513f](https://github.com/sanity-io/sanity/commit/74d513f8aae1f8cddca8f93d5bc359b36a2e3beb))
+* **core:** add locale switcher in navdrawer, update layout ([83b47b8](https://github.com/sanity-io/sanity/commit/83b47b8d0c0679a613a097d0547ff21f57ff3f41))
+* **desk:** add responsive layout to document status bar ([c885024](https://github.com/sanity-io/sanity/commit/c885024f2ab00595cd079f2086aa7adb68c46eee))
+* detach global search position from header ([9fed9cd](https://github.com/sanity-io/sanity/commit/9fed9cd49fcff811824ec3a82bc9d0aa17a34edd))
+* DRY document banners and update styles, create dedicated spacer button ([2a6aed2](https://github.com/sanity-io/sanity/commit/2a6aed24ec07bccff5c600bb9bc3ebca492f056e))
+* new document status indicator, lockup and tooltips ([bad7091](https://github.com/sanity-io/sanity/commit/bad7091fd36cfa91ff33e8d13fd2eefb1233ccec))
+* studio facelift ([8a9d18f](https://github.com/sanity-io/sanity/commit/8a9d18fb4cb4b8405574251ea6465ede5522bf91))
+* update comments discard dialog styles ([23c3ba7](https://github.com/sanity-io/sanity/commit/23c3ba7a86b4e9a72bfe0beb371f1d4096f0a3ea))
+* update delete confirm dialog styles, use compact cards ([e981dcb](https://github.com/sanity-io/sanity/commit/e981dcb223896bbca3a493af27fff27f0d4482ab))
+* update file and image input + placeholder styles ([511b291](https://github.com/sanity-io/sanity/commit/511b29167514254560992bef496ea9fd0ad3c1ea))
+* update font styles for no search results + insufficient permissions messages ([6324dd1](https://github.com/sanity-io/sanity/commit/6324dd1b09b819abb87e04dc36796f8a73edd6d2))
+* update image + file asset source styling ([12c1b77](https://github.com/sanity-io/sanity/commit/12c1b773596248718770df5dd47067043bc8b10f))
+* update user menu and presence menu items with new avatar sizes ([e41e7d7](https://github.com/sanity-io/sanity/commit/e41e7d75ee904e3fff62b732d84fec9fca24d4e3))
+* use smaller font size for hotkey + badge text in menu items and tooltips ([f8343ed](https://github.com/sanity-io/sanity/commit/f8343ed5599542a5b0ee564b16a0542e8d2c74b9))
+
+
+
+## [3.22.1](https://github.com/sanity-io/sanity/compare/v3.22.0...v3.22.1) (2023-12-19)
+
+
+### Bug Fixes
+
+* **cli:** include command context in all trace event logs ([#5397](https://github.com/sanity-io/sanity/issues/5397)) ([0ed9a81](https://github.com/sanity-io/sanity/commit/0ed9a81fc6eadb59626166840c2dfe830fcc460f))
+
+
+
+# [3.22.0](https://github.com/sanity-io/sanity/compare/v3.21.3...v3.22.0) (2023-12-19)
+
+
+### Bug Fixes
+
+* **cli:** add (experimental) support for bun as package manager ([#5356](https://github.com/sanity-io/sanity/issues/5356)) ([0c6a32e](https://github.com/sanity-io/sanity/commit/0c6a32ee43b6ed1a77fc9dfdc9c43dcf519e431d))
+* **cli:** improve telemetry exit flushing ([#5392](https://github.com/sanity-io/sanity/issues/5392)) ([53232c7](https://github.com/sanity-io/sanity/commit/53232c7392d9c940ea4b5efef4cad9740d3e71d8))
+* **core:** add timestamps to all preview components ([#5352](https://github.com/sanity-io/sanity/issues/5352)) ([2083fd3](https://github.com/sanity-io/sanity/commit/2083fd31d2ea0e32fd5047ab4c012604d58faa7c))
+* **core:** prevent annotation popover from jumping when opening ([#5280](https://github.com/sanity-io/sanity/issues/5280)) ([8c77a10](https://github.com/sanity-io/sanity/commit/8c77a105822acbe8220abb5fbd3871ab179739c9))
+* **core:** simplify code for getting preview paths ([#5360](https://github.com/sanity-io/sanity/issues/5360)) ([423c1b4](https://github.com/sanity-io/sanity/commit/423c1b4c63b7260e278813c809ce2fc74f795f8f))
+* **core:** update getPreviewPaths function ([#5362](https://github.com/sanity-io/sanity/issues/5362)) ([a70bf39](https://github.com/sanity-io/sanity/commit/a70bf39f85ad3554ac2c576e34b0412b02e8ee80))
+* **deps:** update dependency @sanity/presentation to v1.2.1 ([#5364](https://github.com/sanity-io/sanity/issues/5364)) ([d0a43f6](https://github.com/sanity-io/sanity/commit/d0a43f6128f5ee39a8d212fceffcfe88ef7392d0))
+* **free-trial:** add apiVersion stamp to free trial request ([#5385](https://github.com/sanity-io/sanity/issues/5385)) ([785d87c](https://github.com/sanity-io/sanity/commit/785d87caf6cf8cb9a1265d855021e5bdfa4296d4))
+* **i18n:** add missing string for cancelling uploads ([#5388](https://github.com/sanity-io/sanity/issues/5388)) ([2a7aff1](https://github.com/sanity-io/sanity/commit/2a7aff1e5ce513ff5dba6413d2dcf71a71c23f7d))
+* **i18n:** correct "create new" button translation labels ([4790958](https://github.com/sanity-io/sanity/commit/4790958e19d0a332a7dd4e06428396171e29b94a))
+* **i18n:** fix incorrect menu items; localize default group titles ([#5370](https://github.com/sanity-io/sanity/issues/5370)) ([bd87ffc](https://github.com/sanity-io/sanity/commit/bd87ffc4b756630b300bfd37c0a9656fcdea895f))
+* **i18n:** give default root structure node an i18n title ([2b16afb](https://github.com/sanity-io/sanity/commit/2b16afb4741262e837300b73eb01f144d2fa867a))
+* **i18n:** translate placeholder text for tags input ([3dae10b](https://github.com/sanity-io/sanity/commit/3dae10b491fc3fda1bbeba1c55b0e79624795a5d))
+* **i18n:** translate structure tool loading pane ([7f517d2](https://github.com/sanity-io/sanity/commit/7f517d2e35d1ecfeb7eac23d2512291bce238498))
+* **portable-text-editor:** return unless range count ([#5391](https://github.com/sanity-io/sanity/issues/5391)) ([5b3492b](https://github.com/sanity-io/sanity/commit/5b3492b6e3f543773948bb6dab0fab12e64dc47e))
+* **pte:** add transalation to disabled tooltip text ([#5366](https://github.com/sanity-io/sanity/issues/5366)) ([da54a28](https://github.com/sanity-io/sanity/commit/da54a288bf97baab15b76b9032ae8583b6af42a9))
+* **pte:** clear unused markdefs when removing annotations ([#5254](https://github.com/sanity-io/sanity/issues/5254)) ([41552c3](https://github.com/sanity-io/sanity/commit/41552c305c8a86ba8a22b2ac0085fd4ee4caa6a4))
+* **pte:** disable multiple blocks annotations ([#5257](https://github.com/sanity-io/sanity/issues/5257)) ([7452848](https://github.com/sanity-io/sanity/commit/74528480a8c0e93f841f6f0dfb962576383011c0))
+* **pte:** removes empty text block when inserting a new block in that position ([#5271](https://github.com/sanity-io/sanity/issues/5271)) ([b6ef7dc](https://github.com/sanity-io/sanity/commit/b6ef7dc366255de1e3a5c1927bd14f7ff4e3cbdb))
+* **pte:** update removing annotations function ([#5267](https://github.com/sanity-io/sanity/issues/5267)) ([d4e5409](https://github.com/sanity-io/sanity/commit/d4e5409ea213102980d667b3ef9a7ce5eaa0968a))
+* **vision:** fixes an issue where selection other would crash ([#5377](https://github.com/sanity-io/sanity/issues/5377)) ([87e5493](https://github.com/sanity-io/sanity/commit/87e5493fbb310cc0982f0f7896557b61ea919072))
+
+
+### Features
+
+* **cli:** add env var for logging telemetry events to file ([#5347](https://github.com/sanity-io/sanity/issues/5347)) ([44008f4](https://github.com/sanity-io/sanity/commit/44008f4a1592e7fe6a1472a38df2e6719626c226))
+* **cli:** add telemetry cli commands ([#5322](https://github.com/sanity-io/sanity/issues/5322)) ([02f4cf2](https://github.com/sanity-io/sanity/commit/02f4cf25eb9739106373fea52fa509d149596594))
+* **cli:** instrument cli with telemetry events ([#5320](https://github.com/sanity-io/sanity/issues/5320)) ([75e4555](https://github.com/sanity-io/sanity/commit/75e4555de51519e1f24088a53433e97d390c9d05))
+* **core:** document layout ([#5340](https://github.com/sanity-io/sanity/issues/5340)) ([adaae0e](https://github.com/sanity-io/sanity/commit/adaae0e7eb89e5126064b67936e8869998c53a6e))
+* **free-trial:** adds free trial button, popover and modal. ([#5345](https://github.com/sanity-io/sanity/issues/5345)) ([16a8b58](https://github.com/sanity-io/sanity/commit/16a8b58d3b5537b5519c656271ef377f6c2625a7))
+* **graphql:** add support for customizing the filter suffix for graphql types ([#5372](https://github.com/sanity-io/sanity/issues/5372)) ([67dee78](https://github.com/sanity-io/sanity/commit/67dee782a5ee94735f893be8802bd2015c8842e5))
+* **i18n:** use last registered locale as default ([#5381](https://github.com/sanity-io/sanity/issues/5381)) ([30cbe31](https://github.com/sanity-io/sanity/commit/30cbe315abef737ccc1eb5d828b12f4be91ffb2b))
+
+
+
+## [3.21.3](https://github.com/sanity-io/sanity/compare/v3.21.2...v3.21.3) (2023-12-12)
+
+
+### Bug Fixes
+
+* **core:** export `LocaleWeekInfo` type ([759c476](https://github.com/sanity-io/sanity/commit/759c476f35320ffc6b963fcb00b4d266e4cb00f2))
+
+
+
+## [3.21.2](https://github.com/sanity-io/sanity/compare/v3.21.1...v3.21.2) (2023-12-12)
+
+
+### Bug Fixes
+
+* **core:** close PTE fullscreen when changing tab ([#5251](https://github.com/sanity-io/sanity/issues/5251)) ([4d62fbb](https://github.com/sanity-io/sanity/commit/4d62fbb016f46507672dfebc999d5f5da5cd7e63))
+* **core:** incorrect week day names for calendar ([#5342](https://github.com/sanity-io/sanity/issues/5342)) ([f5c1927](https://github.com/sanity-io/sanity/commit/f5c1927799947239150eb87a12541370b252e279))
+* **deps:** update dependency @sanity/client to ^6.10.0 ([#5357](https://github.com/sanity-io/sanity/issues/5357)) ([260387a](https://github.com/sanity-io/sanity/commit/260387af49ad91f3435d7c931c5af5714cf426fe))
+* **deps:** update dependency @sanity/presentation to v1.1.5 ([#5341](https://github.com/sanity-io/sanity/issues/5341)) ([95ccd44](https://github.com/sanity-io/sanity/commit/95ccd44b6dca5d705bb7539aa7b90fb3155430de))
+* **deps:** update dependency @sanity/presentation to v1.1.6 ([#5346](https://github.com/sanity-io/sanity/issues/5346)) ([a7eb2f8](https://github.com/sanity-io/sanity/commit/a7eb2f8e48b2f6e8163bbe566806bbe3b217c1cb))
+* **deps:** update dependency @sanity/presentation to v1.2.0 ([#5358](https://github.com/sanity-io/sanity/issues/5358)) ([7248a04](https://github.com/sanity-io/sanity/commit/7248a04feedc24a21f588db83cd62e9762c84818))
+* **form:** recalculate virtualized descendants when selected group changes ([#5314](https://github.com/sanity-io/sanity/issues/5314)) ([ed72687](https://github.com/sanity-io/sanity/commit/ed726878ff2124d6913e493c6a3381e62ed71f72))
+* prefer narrow relative time formatting in useRelativeTime ([#5338](https://github.com/sanity-io/sanity/issues/5338)) ([6e76d89](https://github.com/sanity-io/sanity/commit/6e76d89c32fa63cefaf45be7b8bc8ebadfab985f))
+
+
+### Features
+
+* **core:** make calendars aware of locale week start day ([dc50df9](https://github.com/sanity-io/sanity/commit/dc50df99fa42190fe0aa1ffc07cafb641e8fd184))
+* expose all locale info from `useCurrentLocale` hook ([#5343](https://github.com/sanity-io/sanity/issues/5343)) ([6ad0e3f](https://github.com/sanity-io/sanity/commit/6ad0e3f2ecdaf525071e347d138e276fdd36e868))
+* **i18n:** add `weekInfo` to locale definition ([facf708](https://github.com/sanity-io/sanity/commit/facf70850915a299bc2fd61375f11d2e4d05a3ad))
+* **i18n:** localize menu items ([#5308](https://github.com/sanity-io/sanity/issues/5308)) ([d08ce66](https://github.com/sanity-io/sanity/commit/d08ce6674165a127d21b463443015edadeec239a))
+
+
+
+## [3.21.1](https://github.com/sanity-io/sanity/compare/v3.21.0...v3.21.1) (2023-12-07)
+
+
+### Bug Fixes
+
+* **core:** fixes issue where studio crashes when embedded w/ vite ([#5337](https://github.com/sanity-io/sanity/issues/5337)) ([7dd3f25](https://github.com/sanity-io/sanity/commit/7dd3f250ce81d0fe04df0516aa467cfc5b6edfb1))
+* **deps:** update dependency @sanity/client to ^6.9.3 ([#5336](https://github.com/sanity-io/sanity/issues/5336)) ([5a7bde1](https://github.com/sanity-io/sanity/commit/5a7bde14b88f9090090fc66cb4a255b87f0e464a))
+* **deps:** update dependency @sanity/presentation to v1.1.3 ([#5335](https://github.com/sanity-io/sanity/issues/5335)) ([98f46f1](https://github.com/sanity-io/sanity/commit/98f46f18a791e90f63f0a8ebb4ae07cffc57c5fd))
+
+
+
+# [3.21.0](https://github.com/sanity-io/sanity/compare/v3.20.2...v3.21.0) (2023-12-05)
+
+
+### Bug Fixes
+
+* **cli:** improve help output of `dataset import` command ([#5318](https://github.com/sanity-io/sanity/issues/5318)) ([5018ea0](https://github.com/sanity-io/sanity/commit/5018ea0bdc4a630ffb34180992c3b093fc411287))
+* **cli:** make dataset import `--skip-cross-dataset-references` flag work ([#5297](https://github.com/sanity-io/sanity/issues/5297)) ([c9877a7](https://github.com/sanity-io/sanity/commit/c9877a75a3358b27519f6f053bee9cb64d97d003))
+* **cli:** next template image url builder not returning a url ([#5293](https://github.com/sanity-io/sanity/issues/5293)) ([0bfc989](https://github.com/sanity-io/sanity/commit/0bfc98997637b52a00856bbcb14cab9bf20e48d6))
+* **comments:** experimental API warning for dataset profile request ([#5329](https://github.com/sanity-io/sanity/issues/5329)) ([55edc2e](https://github.com/sanity-io/sanity/commit/55edc2ef03d111c154a1b7a4795f4abcec6accef))
+* **core:** add 'action' subgroup to core (change panel) ([c7b443d](https://github.com/sanity-io/sanity/commit/c7b443db2de3c40ba773441256e97b63c8df3ab6))
+* **core:** add 'action' subgroup to desk (change panel) ([61ecda0](https://github.com/sanity-io/sanity/commit/61ecda0f63f5865af80058ccfca5045a5f6f7caf))
+* **core:** add missing `assetRequired` type to image and file rule ([#5303](https://github.com/sanity-io/sanity/issues/5303)) ([1916c31](https://github.com/sanity-io/sanity/commit/1916c31d26d9b0a3a797db72125493ecd92537fd))
+* **core:** adjust mismatched tsdoc visibility ([f855ec8](https://github.com/sanity-io/sanity/commit/f855ec8c21240485a11c059ac499600012106d6e))
+* **core:** field actions hidden state ([#5317](https://github.com/sanity-io/sanity/issues/5317)) ([92f35f1](https://github.com/sanity-io/sanity/commit/92f35f180e83e0d8aa238a22c751051ee4352290))
+* **core:** fix namespace generic for TFunction ([b16807c](https://github.com/sanity-io/sanity/commit/b16807c1cb27d24a3e39d93c12b25af07bdc2c4c))
+* **core:** inconsistent navbar prefix ([5338da4](https://github.com/sanity-io/sanity/commit/5338da40e0331855ff1f2055f04b752754c9fbad))
+* **core:** presence menu ui ([#5298](https://github.com/sanity-io/sanity/issues/5298)) ([f2f6f40](https://github.com/sanity-io/sanity/commit/f2f6f40a160814cd1d0f9bebf3009e65738f58d3))
+* **core:** re-export `ValidationContext` from `sanity` module ([b473973](https://github.com/sanity-io/sanity/commit/b4739732e5ce7283ca256d2ba3b0717a87c078d3))
+* **core:** remove unused css selector ([18152ec](https://github.com/sanity-io/sanity/commit/18152ec6a48535b770f68695f19b7e24a36f2e33))
+* **core:** workplace -> workspace ([fe85683](https://github.com/sanity-io/sanity/commit/fe85683207f87f208c23437cff7eb77ba9b0f7c7))
+* delete unused focus managers internals ([#5283](https://github.com/sanity-io/sanity/issues/5283)) ([5d3e825](https://github.com/sanity-io/sanity/commit/5d3e825837b9dc5a7ed00b25b8df379c3b20c999))
+* **deps:** update dependency @sanity/presentation to v1.0.13 ([#5312](https://github.com/sanity-io/sanity/issues/5312)) ([31ff42a](https://github.com/sanity-io/sanity/commit/31ff42a242c0874bcc30b9f85d12b95b6a5515c4))
+* **deps:** update dependency @sanity/presentation to v1.1.1 ([#5331](https://github.com/sanity-io/sanity/issues/5331)) ([3bd2fe3](https://github.com/sanity-io/sanity/commit/3bd2fe34d997caff2b0fe605361315099ad871d4))
+* **desk:** show all validation errors for a given path ([f6e3980](https://github.com/sanity-io/sanity/commit/f6e39806e345fffdc737ec7b3af5b5fc095692d6))
+* **dialog:** drag events in edit portal are applied to underlying elements ([#5282](https://github.com/sanity-io/sanity/issues/5282)) ([a7e0ec8](https://github.com/sanity-io/sanity/commit/a7e0ec8babd964160a9c7f6e8b235a78f108800a))
+* ensure image tool drag handles work when both coarse + fine pointers are present ([#5277](https://github.com/sanity-io/sanity/issues/5277)) ([69ed0fc](https://github.com/sanity-io/sanity/commit/69ed0fcd6fe3e4eee5c26310a826ac7208e0aa5c))
+* **form:** include group name in group tab test id ([#5278](https://github.com/sanity-io/sanity/issues/5278)) ([6890b10](https://github.com/sanity-io/sanity/commit/6890b1008208e0cf7e5c69b8e0ce54affd3fc1bd))
+* **i18n:** add missing calendar labels ([#5011](https://github.com/sanity-io/sanity/issues/5011)) ([ef71aab](https://github.com/sanity-io/sanity/commit/ef71aabb3744ea62b95644ab13c2af299a84297a))
+* **i18n:** allow `<` and `>` before/after tags in resource strings ([ccf2323](https://github.com/sanity-io/sanity/commit/ccf2323fd99a168e0f00744ab5de8965a43f47f1))
+* **i18n:** allow more types as values for Translate component ([f1f88b4](https://github.com/sanity-io/sanity/commit/f1f88b4d892554141131078c104e304fd57fd721))
+* **i18n:** annotate alpha/beta items with `[@hidden](https://github.com/hidden)` ([3a1e589](https://github.com/sanity-io/sanity/commit/3a1e589232393ed42f1763edfa35b0ca8804f7f7))
+* **i18n:** camelCase to kebab-case for resource ids ([#4994](https://github.com/sanity-io/sanity/issues/4994)) ([71ec6ad](https://github.com/sanity-io/sanity/commit/71ec6ad84b192d8ba91dc893efaad6fc039efef1))
+* **i18n:** change tsdoc visibility tag for `LocaleSource` ([2cbb3c1](https://github.com/sanity-io/sanity/commit/2cbb3c14b383229f3044cfc72c71389b4e6e094c))
+* **i18n:** correct permission check banner interpolation ([#5326](https://github.com/sanity-io/sanity/issues/5326)) ([7b83ad5](https://github.com/sanity-io/sanity/commit/7b83ad58d7d5369e493c0a3c88509e67ee0e9048))
+* **i18n:** correct return type for undefined locale resource helper ([0f3eae0](https://github.com/sanity-io/sanity/commit/0f3eae07ef96ae6a2e62ea6d7b9d0c993b3f53b3))
+* **i18n:** correct title text for pane context menu button ([52a0faf](https://github.com/sanity-io/sanity/commit/52a0faf804587c6479f1a816b5232175debdeb20))
+* **i18n:** drop microsecond, nanosecond from unit formatter ([e3d8760](https://github.com/sanity-io/sanity/commit/e3d8760fa66df25b1ae0e3603a29429981ae5bd5))
+* **i18n:** drop use of flags for languages ([2a8b5a7](https://github.com/sanity-io/sanity/commit/2a8b5a7c12b5493addff9b43d98c5e38bb009661))
+* **i18n:** error in minimal seconds/minutes localization string ([0c00667](https://github.com/sanity-io/sanity/commit/0c0066720805a2a035e51b0cb844ea1dd9ed3866))
+* **i18n:** fallback when no localStorage is available ([d1dee31](https://github.com/sanity-io/sanity/commit/d1dee316c42eca2e303163e5c9ad3f2833d0922e))
+* **i18n:** fix incorrect key being used for create button ([2e57c5b](https://github.com/sanity-io/sanity/commit/2e57c5b1ef98744080809d0f20338bec193a3e1b))
+* **i18n:** hide internal helper method, use explicit exports ([760a2f9](https://github.com/sanity-io/sanity/commit/760a2f9e4c61ca7656b439dd1e1241d5394b25a3))
+* **i18n:** improve error message on whitespace in translation components ([0af303b](https://github.com/sanity-io/sanity/commit/0af303b500f1e68d4a4b85338d73af141d82da81))
+* **i18n:** inconsistent name for document inspector item ([26b795b](https://github.com/sanity-io/sanity/commit/26b795b0d610484408765b14356e7f24fb41d41f))
+* **i18n:** invalid key for cdr "copy id to clipboard" button tooltip ([#5324](https://github.com/sanity-io/sanity/issues/5324)) ([86a09fd](https://github.com/sanity-io/sanity/commit/86a09fddc1f0c8d67f39ae2270c11563da40af25))
+* **i18n:** key being used instead of translated value ([#5323](https://github.com/sanity-io/sanity/issues/5323)) ([d2b7ec6](https://github.com/sanity-io/sanity/commit/d2b7ec6ac8d83591e9f0e4a4e3c29c13b3fcc054))
+* **i18n:** move quotes to resource string ([6c77039](https://github.com/sanity-io/sanity/commit/6c7703929eb898ea1d789d7721dba9469139e4a6))
+* **i18n:** pass through the `count` parameter to replacement values ([#5138](https://github.com/sanity-io/sanity/issues/5138)) ([bb65da9](https://github.com/sanity-io/sanity/commit/bb65da9d26164130ac982b5a41f970b53c577194))
+* **i18n:** rework translation keys for form/inputs/files ([#5134](https://github.com/sanity-io/sanity/issues/5134)) ([9680513](https://github.com/sanity-io/sanity/commit/968051311a30691499a43c251c78aec72080ac75))
+* **i18n:** use correct keys for file asset source headings and accepted types ([#5328](https://github.com/sanity-io/sanity/issues/5328)) ([dddcdc1](https://github.com/sanity-io/sanity/commit/dddcdc15e6a766b15a2c3505006a590d59deb7d3))
+* **i18n:** use static titles for workspace links ([a7239ea](https://github.com/sanity-io/sanity/commit/a7239ea7aadfe4984c843a2bf49d00648ee9f66d))
+* **i18n:** use translated strings for primitive array item row actions ([8da638f](https://github.com/sanity-io/sanity/commit/8da638f3ab0868db789ace9fb742939e390eed2d))
+* prevent props that are unknown html attributes from passing through ([#5284](https://github.com/sanity-io/sanity/issues/5284)) ([edf2709](https://github.com/sanity-io/sanity/commit/edf2709c2d8ba3f03a24e64520fbc20c2113cf3f))
+* remove circular dependency between `useGlobalPresence` and `usePresenceStore` ([#5286](https://github.com/sanity-io/sanity/issues/5286)) ([5aa6c74](https://github.com/sanity-io/sanity/commit/5aa6c74c27065e6bcdee3cfd0a28c4387da91e52))
+* update `rollup` and `esbuild` tooling ([#5243](https://github.com/sanity-io/sanity/issues/5243)) ([962c11c](https://github.com/sanity-io/sanity/commit/962c11cb28f29cb1e9961cc7d355836b26b78127))
+* **vision:** add missing 't' param to tryParseParams in ParamsEditor ([b6ab762](https://github.com/sanity-io/sanity/commit/b6ab76264ac4b851d4cca9c0d847edc3a9939afb))
+
+
+### Features
+
+* **core:** add `sliceString`/`truncateString` unicode utility functions ([6343939](https://github.com/sanity-io/sanity/commit/6343939fb5cf4925784a60d0085255616aecb1c1))
+* **core:** add i18n primitives to AddFilterButton ([7c85b25](https://github.com/sanity-io/sanity/commit/7c85b259698fb597c39e0df11e4f2d5be7a3f3a0))
+* **core:** add i18n primitives to AddFilterPopoverContent + add plural for "filters" + generic no search found ([ff37beb](https://github.com/sanity-io/sanity/commit/ff37beb2e7d85ef8fb711fe30d499868453adb54))
+* **core:** add i18n primitives to ArrayOfObjectsFunctions + ArrayOfPrimitivesFunctions ([524a664](https://github.com/sanity-io/sanity/commit/524a664e2d85bb019dcfaa9c7e924b437facb46d))
+* **core:** add i18n primitives to ArrayOfObjectsItem ([e0f2c69](https://github.com/sanity-io/sanity/commit/e0f2c6902af909ffd8695bfa1f53f9391ae0bb71))
+* **core:** add i18n primitives to Asset ([aec0156](https://github.com/sanity-io/sanity/commit/aec0156e70156eefd797c0d10241d08bdf21fe98))
+* **core:** add i18n primitives to AssetSourceError ([d8b9866](https://github.com/sanity-io/sanity/commit/d8b9866586c8ec451af95d2746b39c9fed1716b8))
+* **core:** add i18n primitives to Boolean ([1cbbad9](https://github.com/sanity-io/sanity/commit/1cbbad92e3f9996532bcbbdcdefdc86075a8036a))
+* **core:** add i18n primitives to ButtonValue ([43e4610](https://github.com/sanity-io/sanity/commit/43e4610a2a48b1d5bdb44bd62d5bcadb002aff5d))
+* **core:** add i18n primitives to ConfigIssuesButton ([60801be](https://github.com/sanity-io/sanity/commit/60801beed0ce80754bbca34da804ab214d64f454))
+* **core:** add i18n primitives to createFilterMenuItems ([4489693](https://github.com/sanity-io/sanity/commit/4489693c97d46901aacd82ef408d903cc9cf53f7))
+* **core:** add i18n primitives to documentTypesTruncated ([5e20a23](https://github.com/sanity-io/sanity/commit/5e20a23f0a76c8814345dc3bfe9a3b70892775e3))
+* **core:** add i18n primitives to FilterButton ([74a4c65](https://github.com/sanity-io/sanity/commit/74a4c65be84abe48dbc5a6634d0e0a8cc1d48269))
+* **core:** add i18n primitives to FilterError ([2677178](https://github.com/sanity-io/sanity/commit/2677178f869b74cc72553613be664b18de9ba59b))
+* **core:** add i18n primitives to FilterPopoverContentHeader + DocumentTypesPopoverContent ([782c12b](https://github.com/sanity-io/sanity/commit/782c12ba2eefc3dfcf1a998a1b76c34b4a7e634e))
+* **core:** add i18n primitives to Filters ([fbfb5f3](https://github.com/sanity-io/sanity/commit/fbfb5f303c87fb024ba85fe2e6892e8de3266ecb))
+* **core:** add i18n primitives to FilterTooltip ([109dca7](https://github.com/sanity-io/sanity/commit/109dca749d53c29200c2e5f31273c6dc840f2517))
+* **core:** add i18n primitives to Grid/ErrorItem + List/ErrorItem ([123b06d](https://github.com/sanity-io/sanity/commit/123b06dbc422bd681547d425157a3fd992183c73))
+* **core:** add i18n primitives to GridArrayInput + ListArrayInput ([13162e1](https://github.com/sanity-io/sanity/commit/13162e14521f3b3820e24ba2ebc38d09ba2d355c))
+* **core:** add i18n primitives to GridItem + PreviewItem ([0945e09](https://github.com/sanity-io/sanity/commit/0945e0947cf1db100506cdc212bef6461a78f934))
+* **core:** add i18n primitives to IncompatibleItemType (array, grid, list) ([8e563d5](https://github.com/sanity-io/sanity/commit/8e563d504f8a96e3a6fdfd92d9caf704711ddc9c))
+* **core:** add i18n primitives to Instructions ([c8827e1](https://github.com/sanity-io/sanity/commit/c8827e141a801feb271f8511f3b1b39887c4c698))
+* **core:** add i18n primitives to Layout (in WorkspaceAuth) ([60b1586](https://github.com/sanity-io/sanity/commit/60b158675d27938f2445a5cfe03b4acda8650ed7))
+* **core:** add i18n primitives to LocaleMenu ([d89f467](https://github.com/sanity-io/sanity/commit/d89f4670a9f910f83eb72e666d021e0ce5ef0fc3))
+* **core:** add i18n primitives to NavDrawer ([65bd1da](https://github.com/sanity-io/sanity/commit/65bd1da117bded0082b26561bc1a3902c0155cad))
+* **core:** add i18n primitives to NewDocumentButton ([22f3e40](https://github.com/sanity-io/sanity/commit/22f3e401ba16db7362e7af516f3db2c17b6d8dee))
+* **core:** add i18n primitives to NewDocumentList ([21a477f](https://github.com/sanity-io/sanity/commit/21a477fa9148323df85430b932e8a3e673c02712))
+* **core:** add i18n primitives to NewDocumentListOption ([b7a932d](https://github.com/sanity-io/sanity/commit/b7a932db9a96b4da09c38ecc26bcdfa1c1caa0e1))
+* **core:** add i18n primitives to NoResults ([45c88e9](https://github.com/sanity-io/sanity/commit/45c88e97e0a3e908e683a5bb5a1c78f187d7abeb))
+* **core:** add i18n primitives to Number ([142aaa3](https://github.com/sanity-io/sanity/commit/142aaa34c6f238ee3efef3af064a186fb2853418))
+* **core:** add i18n primitives to NumberRange ([a292a85](https://github.com/sanity-io/sanity/commit/a292a859a3f004e60c94f8d90ee8be7311f324b7))
+* **core:** add i18n primitives to PresenceMenu ([126c5b8](https://github.com/sanity-io/sanity/commit/126c5b882955ed668798bd49dba8a9faafade7c1))
+* **core:** add i18n primitives to PresenceMenuItem ([548dac9](https://github.com/sanity-io/sanity/commit/548dac95d9a73e84f10459f98210a89bd221befd))
+* **core:** add i18n primitives to RecentSearches ([defe3bd](https://github.com/sanity-io/sanity/commit/defe3bd0be14198bd7f9e8dae8442937fc918b30))
+* **core:** add i18n primitives to Reference ([47138ff](https://github.com/sanity-io/sanity/commit/47138ff3201cfbc585462624397e7cf6f40bc16f))
+* **core:** add i18n primitives to ReferenceAutocomplete ([1059d17](https://github.com/sanity-io/sanity/commit/1059d175cf452c0bd262af0de4ace40cab52d552))
+* **core:** add i18n primitives to ResourcesButton ([44705ba](https://github.com/sanity-io/sanity/commit/44705baf92e8d1bbb9990b1388d062814af87b7d))
+* **core:** add i18n primitives to ResourcesMenuItems ([43f9db2](https://github.com/sanity-io/sanity/commit/43f9db29bbb6b87eac34b8deecac6c4430fd40e7))
+* **core:** add i18n primitives to SchemaProblemGroups ([847cb1b](https://github.com/sanity-io/sanity/commit/847cb1b696838215d91199c63c2928b780aa28cf))
+* **core:** add i18n primitives to SearchDialog ([a0c84fa](https://github.com/sanity-io/sanity/commit/a0c84fad55f0598d7cbc0f8b54a7ef69393b065e))
+* **core:** add i18n primitives to SearchError ([d9b9aee](https://github.com/sanity-io/sanity/commit/d9b9aee9df1606ead8dd46463d678d10f490e543))
+* **core:** add i18n primitives to SearchHeader ([5d8e790](https://github.com/sanity-io/sanity/commit/5d8e790408cae5f22e318e50f756e0f6347b9511))
+* **core:** add i18n primitives to SearchPopover ([224e142](https://github.com/sanity-io/sanity/commit/224e142a21dfe6e12427571c0a31691834251c85))
+* **core:** add i18n primitives to SearchResults ([a86f88f](https://github.com/sanity-io/sanity/commit/a86f88fb5db1f423e1a8ea02778a500c031de596))
+* **core:** add i18n primitives to SlugInput ([86d3373](https://github.com/sanity-io/sanity/commit/86d33731137fb1ee26bfb6bdb77090f7abb2ab9c))
+* **core:** add i18n primitives to String ([f4db5f9](https://github.com/sanity-io/sanity/commit/f4db5f93bd7e7282cacaac365f73d151e86d6a14))
+* **core:** add i18n primitives to StringList ([7a3841c](https://github.com/sanity-io/sanity/commit/7a3841c7d2ba4fcdb7b8e9d401c6bf9a6011ed77))
+* **core:** add i18n primitives to StudioNavBar ([3e8872f](https://github.com/sanity-io/sanity/commit/3e8872f8f750d7d46ef4839db33893f9f4755e09))
+* **core:** add i18n primitives to uploadTarget in array inputs ([7b1c2b8](https://github.com/sanity-io/sanity/commit/7b1c2b8c887d57aff40c945e0f26039bd4651e67))
+* **core:** add i18n primitives to UserMenu + AppearanceMenu ([0cd9e3b](https://github.com/sanity-io/sanity/commit/0cd9e3bfac5eefad8c5530e764dbeae221703401))
+* **core:** add i18n primitives to useSearchState ([11b3330](https://github.com/sanity-io/sanity/commit/11b3330e6ba49e497f031500256771bff4188839))
+* **core:** add i18n primitives to WorkspaceAuth ([19a804e](https://github.com/sanity-io/sanity/commit/19a804e8f69a582c8f6c43ed6c670db9682b55db))
+* **core:** add i18n primitives to WorkspaceMenuButton ([8b3ee10](https://github.com/sanity-io/sanity/commit/8b3ee10c773fa64a2e900234246f9a99795b891c))
+* **desk:** add i18n primitives to ChangeList - Change all button ([1aae71b](https://github.com/sanity-io/sanity/commit/1aae71b5961c44e474dc1149fcd19e67f8f8f904))
+* **desk:** add i18n primitives to ChangesInspector ([b3036a0](https://github.com/sanity-io/sanity/commit/b3036a07d044a71faf1f8f98691d8050fb749fc3))
+* **desk:** add i18n primitives to DiffTooltip ([e9f5b42](https://github.com/sanity-io/sanity/commit/e9f5b42e4e5ff61d90f20139f1455cabe9a942c5))
+* **desk:** add i18n primitives to FieldChange ([6d6010e](https://github.com/sanity-io/sanity/commit/6d6010e73593a38f1e901230c197e749d09f0aac))
+* **desk:** add i18n primitives to GroupChange ([8331556](https://github.com/sanity-io/sanity/commit/83315561275bf5baad14d3539cca9ad29b444ded))
+* **desk:** add i18n primitives to LoadingContent ([02c99cc](https://github.com/sanity-io/sanity/commit/02c99cc2d95d0ed229309816e1ccff9ab1ca48cc))
+* **desk:** add i18n primitives to NoChanges ([a45ae42](https://github.com/sanity-io/sanity/commit/a45ae42265cecdef4dd2304e792d69cf3401fe24))
+* **desk:** add i18n primitives to timeline ([db821b8](https://github.com/sanity-io/sanity/commit/db821b8a72a033238653d656d125ffd9b87a8ea6))
+* **desk:** add i18n primitives to TimelineError ([a7f553b](https://github.com/sanity-io/sanity/commit/a7f553b4203ecf93ff804bec4575dc06c6d12b05))
+* **desk:** add i18n primitives to timelineItem + removal of unused consts ([162e5dc](https://github.com/sanity-io/sanity/commit/162e5dc28e08cd69df7ee8b0060864b24654906d))
+* **desk:** add i18n primitives to timelineMenu ([ac2c3fc](https://github.com/sanity-io/sanity/commit/ac2c3fc21f86be7974d47f474d329fa915944d19))
+* **desk:** localize desk tool components ([0e91a72](https://github.com/sanity-io/sanity/commit/0e91a727f45e0970b28398dec608ec3a228fee2a))
+* **desk:** use localized date time format for timeline ([49c3b94](https://github.com/sanity-io/sanity/commit/49c3b9440cf1df99b2882c44e579da91ec631ed5))
+* **i18n:** add `loadNamespaces` method to i18n source ([f0cb6e3](https://github.com/sanity-io/sanity/commit/f0cb6e3edf17c130506a4c927fc7ae37faca31c8))
+* **i18n:** add `useIntlDateTimeFormat` hook ([0a28b22](https://github.com/sanity-io/sanity/commit/0a28b224717e36cf48d5e1cd8c22bdd6e1752d18))
+* **i18n:** add `useIntlListFormat` hook ([259e901](https://github.com/sanity-io/sanity/commit/259e901583bf4608540ddae40fccbaa7b2e86378))
+* **i18n:** add `useUnitFormatter` hook ([206428d](https://github.com/sanity-io/sanity/commit/206428d1408c6f28376406907ca4e3af286cac10))
+* **i18n:** add a few missing translations for aria labels ([7de94df](https://github.com/sanity-io/sanity/commit/7de94dfa36f946de0c7b9b6bf5c169e9d67e8e82))
+* **i18n:** add flag for debugging i18n ([#5010](https://github.com/sanity-io/sanity/issues/5010)) ([b5e328c](https://github.com/sanity-io/sanity/commit/b5e328ca56e2742053ad947c7cffeebb1eb81e0c))
+* **i18n:** add helper to remove undefined locale resources from object ([60176a3](https://github.com/sanity-io/sanity/commit/60176a3959ce6023b489587eda0b2064af9a3940))
+* **i18n:** add internal `intlCache` for instances ([9540581](https://github.com/sanity-io/sanity/commit/95405816db3ee1bf7cefa22308b31da1ac8972c6))
+* **i18n:** add localization for UnknownPaneType ([#5019](https://github.com/sanity-io/sanity/issues/5019)) ([c15012c](https://github.com/sanity-io/sanity/commit/c15012cdd8bbb436ab8e15f8aaab429bc09c243c))
+* **i18n:** adds missing translation for a few random files ([d4939da](https://github.com/sanity-io/sanity/commit/d4939da2b5847feb2d58f97cea1f41a5e9f69d47))
+* **i18n:** adds translation for desk panes ([#5085](https://github.com/sanity-io/sanity/issues/5085)) ([669ef64](https://github.com/sanity-io/sanity/commit/669ef6488df286572800b25515c944ab4697e26d))
+* **i18n:** allow certain simple HTML tags when using Translate component ([#5114](https://github.com/sanity-io/sanity/issues/5114)) ([7c192c8](https://github.com/sanity-io/sanity/commit/7c192c82d8ca9792c9a7ae8f4289af4eb74f081a))
+* **i18n:** allow debug mode that only logs ([6a544b0](https://github.com/sanity-io/sanity/commit/6a544b020a4f3354050e7e0180aaf512292bed86))
+* **i18n:** allow debugging i18n by using right-to-left modifier ([d6860bf](https://github.com/sanity-io/sanity/commit/d6860bfcde444176bdccf4a6ec7a11dbe17864a1))
+* **i18n:** allow specifying object of localized validation messages ([e97f606](https://github.com/sanity-io/sanity/commit/e97f60693e32a6e7c658a62e254a585ef189b710))
+* **i18n:** convert date/datetime input strings to use i18n primitives ([#4973](https://github.com/sanity-io/sanity/issues/4973)) ([8ecf93a](https://github.com/sanity-io/sanity/commit/8ecf93a303b39396a668817da924c9798625a8a6))
+* **i18n:** convert document actions strings to use i18n primitives ([#4968](https://github.com/sanity-io/sanity/issues/4968)) ([caf69d4](https://github.com/sanity-io/sanity/commit/caf69d4a2e5d12dcf1c840cfba1021c7767d958d))
+* **i18n:** convert file, image and imagetool input strings to use i18n primitives ([#4984](https://github.com/sanity-io/sanity/issues/4984)) ([23b9658](https://github.com/sanity-io/sanity/commit/23b96581b621b814c25bd7689faae13aa7381fc3))
+* **i18n:** convert review changes button to use i18n primitives ([#4993](https://github.com/sanity-io/sanity/issues/4993)) ([4b769b5](https://github.com/sanity-io/sanity/commit/4b769b53a0a576536107d3f0b9e91e2f5ccc48a5))
+* **i18n:** expose `useIntlDateTimeFormat` hook ([00df522](https://github.com/sanity-io/sanity/commit/00df52277f079b139f94381bcd26c2a5154ff2ae))
+* **i18n:** fix confirm delete dialog ([#5139](https://github.com/sanity-io/sanity/issues/5139)) ([5a538b2](https://github.com/sanity-io/sanity/commit/5a538b2ee8acc2c482979d2ad70fb39b973abe54))
+* **i18n:** implement relative time/timeAgo using i18n primitives ([4984d54](https://github.com/sanity-io/sanity/commit/4984d548c36b7e27e6a2c867e36f22e3f523dfc9))
+* **i18n:** implement simplified `Translate` component ([#4921](https://github.com/sanity-io/sanity/issues/4921)) ([c42d65b](https://github.com/sanity-io/sanity/commit/c42d65b5f29bc08f8b3b176e399b1d4690566fe3))
+* **i18n:** localize datetime input placeholder ([#5304](https://github.com/sanity-io/sanity/issues/5304)) ([c91c16f](https://github.com/sanity-io/sanity/commit/c91c16fa8cdaa5bbce7ba4f81a45e65bc10c00d6))
+* **i18n:** localize default asset source ([89791c5](https://github.com/sanity-io/sanity/commit/89791c51394ecfc95990492a3f50048326d5b424))
+* **i18n:** localize default validation messages ([7ac27f6](https://github.com/sanity-io/sanity/commit/7ac27f6fe1df202f67b91ae960a9d2ef6f24e332))
+* **i18n:** localize global search filters and results ([461a268](https://github.com/sanity-io/sanity/commit/461a2680771c925aa23c93db3196980708b4ab97))
+* **i18n:** localize PTE activation message ([#5305](https://github.com/sanity-io/sanity/issues/5305)) ([f0b042e](https://github.com/sanity-io/sanity/commit/f0b042ee1a16c97699ecf74ef568198284a7b581))
+* **i18n:** localize reference input ([6289e54](https://github.com/sanity-io/sanity/commit/6289e546cdf452937885a757414fca21f9bbb5ad))
+* **i18n:** localize reference preview ([8e0b035](https://github.com/sanity-io/sanity/commit/8e0b035a5f1ff208aef3d20a697c744770ca8c78))
+* **i18n:** make backend retry on failure to load bundles ([32c2dc2](https://github.com/sanity-io/sanity/commit/32c2dc26a7a15ad832edfccaf2add96c13c9d188))
+* **i18n:** proof of concept i18n framework ([daa3fa8](https://github.com/sanity-io/sanity/commit/daa3fa802009998c826556739ea895f42e65c535))
+* **i18n:** provide formatted duration hook (`useFormattedDuration`) ([#5014](https://github.com/sanity-io/sanity/issues/5014)) ([9ef27b8](https://github.com/sanity-io/sanity/commit/9ef27b8de90f7673f1cd8c04bc4542a528e2cc04))
+* **i18n:** translate form field components ([#5137](https://github.com/sanity-io/sanity/issues/5137)) ([e69303e](https://github.com/sanity-io/sanity/commit/e69303e3b149ce116f0479c90c270455cec4c54c))
+* **i18n:** translate insert block/inline object actions for PTE ([cc2e970](https://github.com/sanity-io/sanity/commit/cc2e9706b0cb35d30e9a8a2b5ccac9517f018e84))
+* **i18n:** translate portable text editor ([#5225](https://github.com/sanity-io/sanity/issues/5225)) ([532569e](https://github.com/sanity-io/sanity/commit/532569e58a17ec0c991607c049c19289fa5a8fcd))
+* **i18n:** translate preview components ([#5159](https://github.com/sanity-io/sanity/issues/5159)) ([023f4f7](https://github.com/sanity-io/sanity/commit/023f4f7bf63d6c1d1111d6c05348194721ec352a))
+* **i18n:** translate vision to norwegian ([53da0a9](https://github.com/sanity-io/sanity/commit/53da0a9e09f8dd2fe077764dd9157611a0244cfd))
+* **i18n:** translate/localize diff components ([#5129](https://github.com/sanity-io/sanity/issues/5129)) ([036bcc4](https://github.com/sanity-io/sanity/commit/036bcc4bbbe6dbc37324f6023f3ebc7fb539fd3a))
+* **i18n:** translate/localize references, cross-dataset references ([75e6198](https://github.com/sanity-io/sanity/commit/75e619821c6409c2a938c500492db9238fce4cd4))
+* **i18n:** updates translation for object form inputs ([#5135](https://github.com/sanity-io/sanity/issues/5135)) ([b61a804](https://github.com/sanity-io/sanity/commit/b61a8042b5c6afaa29f9fcb03a078f812bc6402d))
+* **i18n:** use i18n primitives for document changes, validation panels ([f891949](https://github.com/sanity-io/sanity/commit/f8919499b42e89cc2cf672fb05078e56a41d9622))
+* **i18n:** use i18n primitives for inspect dialog, document pane menu items ([6910c6d](https://github.com/sanity-io/sanity/commit/6910c6d684f14b894508a65648f9f8ae5327a9f3))
+* **i18n:** use i18n primitives for publish status button ([96b6862](https://github.com/sanity-io/sanity/commit/96b6862fecebde5e3d40d8adef60ffb73cb0e630))
+* **i18n:** weave locale source into validation context ([b34301e](https://github.com/sanity-io/sanity/commit/b34301e1c9eeea394d2492670e03e584d657968e))
+* **vision:** add i18n primitives to PerspectivePopover ([02ab218](https://github.com/sanity-io/sanity/commit/02ab21838c369af544479a18c3ed0e1e20666d87))
+* **vision:** add i18n primitives to perspectives dropdown (adjust consts) ([199751f](https://github.com/sanity-io/sanity/commit/199751f633952b900118f1a7f617286f6f45e452))
+* **vision:** add i18n primitives to QueryErrorDetails ([8f12e07](https://github.com/sanity-io/sanity/commit/8f12e0711cb63b03951ca437979032b8fefccafa))
+* **vision:** add i18n primitives to tryParseParams ([c2d0817](https://github.com/sanity-io/sanity/commit/c2d08172a344810bb49b0d851f9b86506c8a6e22))
+* **vision:** add i18n primitives to VisionGui ([375df2e](https://github.com/sanity-io/sanity/commit/375df2e19531d15a38719bc29e716a179741dc80))
+* **vision:** add translation bundle + "dataset" translate key ([0cc3a19](https://github.com/sanity-io/sanity/commit/0cc3a198ea60525422cbce7679595fc9d95aab29))
+
+
+
+## [3.20.2](https://github.com/sanity-io/sanity/compare/v3.20.1...v3.20.2) (2023-11-28)
+
+
+### Bug Fixes
+
+* add `node.module` export condition ([#4798](https://github.com/sanity-io/sanity/issues/4798)) ([50ee66e](https://github.com/sanity-io/sanity/commit/50ee66e7723918db324f0e2f37e7b46c5b2ea6a9))
+* **comments:** performance issue in `CommentField` ([#5275](https://github.com/sanity-io/sanity/issues/5275)) ([b305a8f](https://github.com/sanity-io/sanity/commit/b305a8f63430a52ffdf870c9646b2ecf573bbcc2))
+* **core:** ensure that `StudioLayout` utilizes the components API ([#5264](https://github.com/sanity-io/sanity/issues/5264)) ([a417dce](https://github.com/sanity-io/sanity/commit/a417dced3fc278be2d24caccaffbf5dda22bce8f))
+* **deps:** downgrade lerna to v4 ([#5287](https://github.com/sanity-io/sanity/issues/5287)) ([c38a0a9](https://github.com/sanity-io/sanity/commit/c38a0a9569de7a80b022ddfa38dbc3d0bb58451a))
+* **deps:** update dependency @sanity/presentation to v1.0.8 ([#5279](https://github.com/sanity-io/sanity/issues/5279)) ([d2132b3](https://github.com/sanity-io/sanity/commit/d2132b3c69ab6f18ede0f7e9d164c12b11769a6d))
+* **form/inputs:** optimize rendering of member inputs ([#5205](https://github.com/sanity-io/sanity/issues/5205)) ([53359c8](https://github.com/sanity-io/sanity/commit/53359c846a139496b685c8d6fd468479073c6033))
+* **form:** pte activate overlay ([#5266](https://github.com/sanity-io/sanity/issues/5266)) ([9bc643e](https://github.com/sanity-io/sanity/commit/9bc643ec0e4bf7901c8c2bd7e6d2dcb3e0934c66))
+* **form:** various typing speed improvements ([#5270](https://github.com/sanity-io/sanity/issues/5270)) ([0d0c7d1](https://github.com/sanity-io/sanity/commit/0d0c7d1121b4498f1b5038974b40c341b62a674f)), closes [#5258](https://github.com/sanity-io/sanity/issues/5258)
+* **portable-text-editor:** improve backspace handling on text blocks ([#5252](https://github.com/sanity-io/sanity/issues/5252)) ([1f7dc76](https://github.com/sanity-io/sanity/commit/1f7dc76abb96d99c343bcd8910661e46e028e3f3))
+* **portable-text-editor:** values util: ensure children value ([#5253](https://github.com/sanity-io/sanity/issues/5253)) ([99244d8](https://github.com/sanity-io/sanity/commit/99244d8985e8e3eb3ed9ab16f0cf05f5a080a1ac))
+
+
+### Features
+
+* **perf:** add cli flag for excluding patch releases ([#5268](https://github.com/sanity-io/sanity/issues/5268)) ([df6b45d](https://github.com/sanity-io/sanity/commit/df6b45de8ac816d568a6c779fc1883320d3b0646))
+
+
+### Performance Improvements
+
+* **form:** improve form state reconciliation ([#5269](https://github.com/sanity-io/sanity/issues/5269)) ([a0f93cb](https://github.com/sanity-io/sanity/commit/a0f93cba7430a4584d01256a55e078d52a05c459))
+
+
+
+## [3.20.1](https://github.com/sanity-io/sanity/compare/v3.20.0...v3.20.1) (2023-11-21)
+
+
+### Bug Fixes
+
+* **comments:** context menu layer issue ([#5203](https://github.com/sanity-io/sanity/issues/5203)) ([465ad45](https://github.com/sanity-io/sanity/commit/465ad452381dc8d676d5aba1ec68b65283efbc8b))
+* **comments:** discard dialog z-offset ([#5238](https://github.com/sanity-io/sanity/issues/5238)) ([2796ec7](https://github.com/sanity-io/sanity/commit/2796ec78dcc917b4d52ee27495f0e4c74b89dec8))
+* **comments:** reply input focus issue ([#5232](https://github.com/sanity-io/sanity/issues/5232)) ([d4d51d8](https://github.com/sanity-io/sanity/commit/d4d51d8a9df9dac292fb0a8263e3f2eff69d3493))
+* **deps:** update dependency @sanity/presentation to v1.0.7 ([#5240](https://github.com/sanity-io/sanity/issues/5240)) ([ec5520f](https://github.com/sanity-io/sanity/commit/ec5520f46ffcf28a5fac03a9273608177c538a3f))
+* **form:** only allow one PTE toolbar menu to be open ([#5249](https://github.com/sanity-io/sanity/issues/5249)) ([47c865d](https://github.com/sanity-io/sanity/commit/47c865d4909e3718b63f28ef1c73d1409dbdeea8))
+* globally replace compose icon with add icon ([#5244](https://github.com/sanity-io/sanity/issues/5244)) ([b1def57](https://github.com/sanity-io/sanity/commit/b1def57f2c16f55b26ea72c38a92d6b3ca04694b))
+* **router:** use base64url for encoding parameter payloads ([#5221](https://github.com/sanity-io/sanity/issues/5221)) ([457d3da](https://github.com/sanity-io/sanity/commit/457d3daa44567a4e213dd16e2ce0be602a4c5af2))
+
+
+
+# [3.20.0](https://github.com/sanity-io/sanity/compare/v3.19.3...v3.20.0) (2023-11-16)
+
+
+### Bug Fixes
+
+* **comments:** feedback footer font size and copy ([#5215](https://github.com/sanity-io/sanity/issues/5215)) ([80e243e](https://github.com/sanity-io/sanity/commit/80e243ef934c5d54528bf883daf1fec5ca986ebf))
+* **core:** field actions hidden issue ([#5212](https://github.com/sanity-io/sanity/issues/5212)) ([e3a39e6](https://github.com/sanity-io/sanity/commit/e3a39e66d15e918aad770651c3d36ba621c4f7cf))
+* **deps:** Update react monorepo ([#5089](https://github.com/sanity-io/sanity/issues/5089)) ([0c851c6](https://github.com/sanity-io/sanity/commit/0c851c6e4c5fb0fc1fd5ccfb6aca7b73bd0d8c4f))
+* **deps:** upgrade @sanity/client and @sanity/presentation ([#5219](https://github.com/sanity-io/sanity/issues/5219)) ([ef4de9a](https://github.com/sanity-io/sanity/commit/ef4de9a65cad9a3c55fecc6986633b74d4c3142e))
+* **desk:** change link to help article about the Desk - Structure rename ([#5217](https://github.com/sanity-io/sanity/issues/5217)) ([51190b0](https://github.com/sanity-io/sanity/commit/51190b0dea41328cd3b75909ecd607099505cdc4))
+
+
+### Features
+
+* **desk:** rename Desk to Structure in public facing UI ([#5181](https://github.com/sanity-io/sanity/issues/5181)) ([f238440](https://github.com/sanity-io/sanity/commit/f2384402bfb801c705d8fec47497cbd6429e3fa4))
+* re-export `@sanity/presentation` as `sanity/presentation` ([#5200](https://github.com/sanity-io/sanity/issues/5200)) ([02736d5](https://github.com/sanity-io/sanity/commit/02736d599ef01db53162f0e8b411d8bea4234403))
+
+
+
+## [3.19.3](https://github.com/sanity-io/sanity/compare/v3.19.2...v3.19.3) (2023-11-14)
+
+
+### Bug Fixes
+
+* **comments:** addon dataset client api version ([#5177](https://github.com/sanity-io/sanity/issues/5177)) ([86f8f9a](https://github.com/sanity-io/sanity/commit/86f8f9a772656399a1d0fc6a0d978490ab87184b))
+* **comments:** consider comment status when scrolling from URL ([#5164](https://github.com/sanity-io/sanity/issues/5164)) ([65eb8c2](https://github.com/sanity-io/sanity/commit/65eb8c2bfbca78bc1ed5443e55dd629b1f233c00))
+* **comments:** default placement of comment popover ([#5165](https://github.com/sanity-io/sanity/issues/5165)) ([6eeb797](https://github.com/sanity-io/sanity/commit/6eeb797fe374c1c03f0f0588ca276ac024846bbb))
+* **comments:** improve scroll behavior ([#5179](https://github.com/sanity-io/sanity/issues/5179)) ([533af73](https://github.com/sanity-io/sanity/commit/533af73ff494589ac124f2861dd591ae8e92f57a))
+* **comments:** prevent pasted links being rendered as DefaultAnnotations at author time ([#5162](https://github.com/sanity-io/sanity/issues/5162)) ([e9c7e79](https://github.com/sanity-io/sanity/commit/e9c7e794137b82ae32ce867e5c942cb71debc03c))
+* **comments:** truncate long field names in placeholder ([#5153](https://github.com/sanity-io/sanity/issues/5153)) ([c5e2194](https://github.com/sanity-io/sanity/commit/c5e2194c4a826ddba697ad96a0e3f4c08c40a754))
+* **core:** disable pointer events when field actions are hidden ([#5180](https://github.com/sanity-io/sanity/issues/5180)) ([c4aec5d](https://github.com/sanity-io/sanity/commit/c4aec5d0158369ff8639467eceeb8986a8486de2))
+* **deps:** update dependency @sanity/client to ^6.8.5 ([#5169](https://github.com/sanity-io/sanity/issues/5169)) ([8c674ac](https://github.com/sanity-io/sanity/commit/8c674ac6066310a823aaad67841366f0ecf662be))
+* **form:** forward original portal element ([c941b6b](https://github.com/sanity-io/sanity/commit/c941b6b651975e0c1c358644fb37058eda9a00d8))
+* **form:** open hotspot editor using `focusPath` ([#5160](https://github.com/sanity-io/sanity/issues/5160)) ([5673f2a](https://github.com/sanity-io/sanity/commit/5673f2a959df73678b8df24b93606db737500e24))
+* **navbar:** reset url state when navigating to other tools ([#5171](https://github.com/sanity-io/sanity/issues/5171)) ([e607be8](https://github.com/sanity-io/sanity/commit/e607be828dec1c7903731faed601a848ac545335))
+* **portable-text-editor:** selection validation and perf. improvement ([#5136](https://github.com/sanity-io/sanity/issues/5136)) ([fd05eba](https://github.com/sanity-io/sanity/commit/fd05ebae6120972f5934db1b2fbb47c358b28ed4))
+* **router:** improve search params encoding ([#5173](https://github.com/sanity-io/sanity/issues/5173)) ([d4d8a9f](https://github.com/sanity-io/sanity/commit/d4d8a9f5de2f1454641182fdbac22ddf99c78064))
+* **router:** memoize `navigate` callback ([#5149](https://github.com/sanity-io/sanity/issues/5149)) ([fa7625d](https://github.com/sanity-io/sanity/commit/fa7625d00fb4afacd800ca59798c07a6e9b6e047))
+
+
+### Features
+
+* **cli:** adds information about projectId and datasets on import and export dataset commands ([#5128](https://github.com/sanity-io/sanity/issues/5128)) ([72ae08f](https://github.com/sanity-io/sanity/commit/72ae08ffb8700d013bfb5cb6d6fe00a409e5252c))
+* **core:** make field actions keyboard accessible ([#5163](https://github.com/sanity-io/sanity/issues/5163)) ([5709800](https://github.com/sanity-io/sanity/commit/5709800c0274012d83bfab8f513339b077c13fce))
+* **core:** support weighted `template`, `mode` intent parameters ([#5157](https://github.com/sanity-io/sanity/issues/5157)) ([ebbef52](https://github.com/sanity-io/sanity/commit/ebbef52d0f3fa68775a01407779e314176633726))
+* **desk:** add `onFocusPath` callback property ([#5150](https://github.com/sanity-io/sanity/issues/5150)) ([3188ab4](https://github.com/sanity-io/sanity/commit/3188ab46269ab92868ba39d7445568c32bf33981))
+* **router:** add support for tools to bypass search param scoping ([#5172](https://github.com/sanity-io/sanity/issues/5172)) ([3c7d79b](https://github.com/sanity-io/sanity/commit/3c7d79b6e3e040490b24ef24a7ce42c7c349dd55))
+
+
+
+## [3.19.2](https://github.com/sanity-io/sanity/compare/v3.19.1...v3.19.2) (2023-11-08)
+
+
+### Bug Fixes
+
+* avoid forwarding as-props/link props to reference link card ([#5124](https://github.com/sanity-io/sanity/issues/5124)) ([48cd888](https://github.com/sanity-io/sanity/commit/48cd8885eb7c3eb87884db54f7ee0b01935a2482))
+* **core:** field actions vertical alignment ([#5131](https://github.com/sanity-io/sanity/issues/5131)) ([69b6838](https://github.com/sanity-io/sanity/commit/69b683865af7719d3f09d287b23ca94b38d830d3))
+* **desk/comments:** insert space after mention insert ([#5126](https://github.com/sanity-io/sanity/issues/5126)) ([bdaecfb](https://github.com/sanity-io/sanity/commit/bdaecfb55c9f04115854c8ec83a4b6927db8b7a1))
+* **desk:** comment mention list issue when using the '@' button ([#5121](https://github.com/sanity-io/sanity/issues/5121)) ([213569b](https://github.com/sanity-io/sanity/commit/213569b42db2439b39457bd844cfa0c4aaf564a7))
+* **desk:** comments on anonymous objects  ([#5101](https://github.com/sanity-io/sanity/issues/5101)) ([78f17e3](https://github.com/sanity-io/sanity/commit/78f17e3813a62117dfea510f7d78d22530630705))
+* **desk:** various comments UX papercuts ([#5130](https://github.com/sanity-io/sanity/issues/5130)) ([4735262](https://github.com/sanity-io/sanity/commit/47352620603d2295ed835bed57905a5bf1b68ae3))
+* **portable-text-editor:** fix various ([#5123](https://github.com/sanity-io/sanity/issues/5123)) ([206b7d5](https://github.com/sanity-io/sanity/commit/206b7d53ab2b84e7b7503065b3207ded56ee4de5))
+* **schema/types:** fix issues with block schema's internal structure ([#5152](https://github.com/sanity-io/sanity/issues/5152)) ([aca6e81](https://github.com/sanity-io/sanity/commit/aca6e81e2d425e3c27a2c4844ea42e97c8a63376)), closes [#5079](https://github.com/sanity-io/sanity/issues/5079)
+
+
+### Features
+
+* **comments:** add feedback footer in the inspector ([#5154](https://github.com/sanity-io/sanity/issues/5154)) ([c7e3f3e](https://github.com/sanity-io/sanity/commit/c7e3f3e98b53942bd6e142a9ee7deb194158ff64))
+* **core:** add `BetaBadge` component ([#5125](https://github.com/sanity-io/sanity/issues/5125)) ([1d48d23](https://github.com/sanity-io/sanity/commit/1d48d23a10ecd60ec7c1e7d551c5313810a9faa1))
+* **desk:** delay comments onboarding popover visibility ([#5133](https://github.com/sanity-io/sanity/issues/5133)) ([0d590de](https://github.com/sanity-io/sanity/commit/0d590deb29d7e7c1fdb337b194b778c4bca81209))
+* **desk:** export DocumentPane and DocumentListPane ([#5103](https://github.com/sanity-io/sanity/issues/5103)) ([79de34f](https://github.com/sanity-io/sanity/commit/79de34f29bfd19b1d2f9a5b03ff77bc3bdd7d6fc))
+* **desk:** improve comments mention list filtering ([#5132](https://github.com/sanity-io/sanity/issues/5132)) ([4c1c29b](https://github.com/sanity-io/sanity/commit/4c1c29b0fc4f20b744df2992c7b7ae62ef59438c))
+* **router:** add support for search params ([#5094](https://github.com/sanity-io/sanity/issues/5094)) ([4f37f78](https://github.com/sanity-io/sanity/commit/4f37f781b7a547e0da3034dd64c9bd630240b4c3))
+
+
+
+## [3.19.1](https://github.com/sanity-io/sanity/compare/v3.19.0...v3.19.1) (2023-11-03)
+
+
+### Bug Fixes
+
+* **core:** reference links not opening correct pane ([#5116](https://github.com/sanity-io/sanity/issues/5116)) ([ba7a558](https://github.com/sanity-io/sanity/commit/ba7a5583edecc0c52abb7bc7253b9915ec7e910f))
+* **form/inputs:** fix bug with onRemove cb for TextBlock ([#5061](https://github.com/sanity-io/sanity/issues/5061)) ([c64d0e2](https://github.com/sanity-io/sanity/commit/c64d0e29eb9e47a2291baaac5ca90a9c3b781ff9))
+* **portable-text-editor:** fix issues for .delete fn and add tests ([#5060](https://github.com/sanity-io/sanity/issues/5060)) ([77a60d2](https://github.com/sanity-io/sanity/commit/77a60d2285e96086621050b3cbf31707f9e6ae51))
+
+
+### Features
+
+* **core:** use platform-aware hotkeys ([#5065](https://github.com/sanity-io/sanity/issues/5065)) ([6e1518c](https://github.com/sanity-io/sanity/commit/6e1518cbc7dde745726e7d24d4583953c4bbf7ba))
+* **vision:** add v2022-03-07 to list of API versions ([#5102](https://github.com/sanity-io/sanity/issues/5102)) ([ddd25cd](https://github.com/sanity-io/sanity/commit/ddd25cd7c9d6807b3a8d4446c962b26fd5c47f1b))
+
+
+
+# [3.19.0](https://github.com/sanity-io/sanity/compare/v3.18.1...v3.19.0) (2023-10-31)
+
+
+### Bug Fixes
+
+* **block-tools:** enforce list support in schema ([#4985](https://github.com/sanity-io/sanity/issues/4985)) ([318efe4](https://github.com/sanity-io/sanity/commit/318efe47ec4af5b280f3350dd8a4edad805b852e))
+* **block-tools:** fix Windows issue with gdocs preprocessor rule ([f30b869](https://github.com/sanity-io/sanity/commit/f30b86929e9a0e95d6afc3e596f7d61b9c95328f))
+* **core/form/inputs:** fix scrolling of annotation toolbar popover ([3c64bec](https://github.com/sanity-io/sanity/commit/3c64bec20b8202e700ea90caace3870d291389c8))
+* **core/form/inputs:** use useLayoutEffect over useEffect for focusPath tracking hook ([601b187](https://github.com/sanity-io/sanity/commit/601b187fc43b86424be191aa7fe0dda2282802e0))
+* **core/inputs:** always scroll to member, but don't re-apply same selection ([22ba618](https://github.com/sanity-io/sanity/commit/22ba618d8399db8f4e6834ed2c5d241396354a7a))
+* **core/inputs:** fix issue with toolbar popover visibility toggling ([8ea5cff](https://github.com/sanity-io/sanity/commit/8ea5cff706f81b0096c9cbd63bb80869a3d97875))
+* **core/inputs:** support setting initial PTE selection ([95d290d](https://github.com/sanity-io/sanity/commit/95d290dbdd95c9f487f12bb5e46a62065c44cb5c))
+* **deps:** bump @sanity/ui to latest ([#5056](https://github.com/sanity-io/sanity/issues/5056)) ([935601b](https://github.com/sanity-io/sanity/commit/935601bf255e1612f743a6a6deb427afada2bb46))
+* **deps:** support `styled-components` v6 ([#4917](https://github.com/sanity-io/sanity/issues/4917)) ([eb86f8a](https://github.com/sanity-io/sanity/commit/eb86f8aaa8c4398a5e364bac684e7e3e7961d6a8))
+* **deps:** update dependency @sanity/client to ^6.7.0 ([#5032](https://github.com/sanity-io/sanity/issues/5032)) ([36a33d4](https://github.com/sanity-io/sanity/commit/36a33d49ab89019e6aa3160f9665cd49126bea3a))
+* **deps:** update dependency get-it to ^8.4.4 ([#5071](https://github.com/sanity-io/sanity/issues/5071)) ([01e3eef](https://github.com/sanity-io/sanity/commit/01e3eef2ebdf0e175f506bbbd48db4f71dcd4b03))
+* **desk:** edit logic for published- and edit status message in document list  ([#5067](https://github.com/sanity-io/sanity/issues/5067)) ([2013203](https://github.com/sanity-io/sanity/commit/2013203d084e4767442380339d3508afc7c786a0))
+* **form/inputs:** Track focusPath for a span's .text prop + harden test condition ([85d83fb](https://github.com/sanity-io/sanity/commit/85d83fb3c5f70e4a33a0c24e34948a49fe717333))
+* **login:** fix issue where logo is not shown on custom auth providers ([#5002](https://github.com/sanity-io/sanity/issues/5002)) ([744bfdf](https://github.com/sanity-io/sanity/commit/744bfdfd69ad855ba68f3549e9cc0afdb1bd1242)), closes [#4674](https://github.com/sanity-io/sanity/issues/4674)
+* **mutator:** apply `setIfMissing` prior to `set` ([#5062](https://github.com/sanity-io/sanity/issues/5062)) ([8b4ec5d](https://github.com/sanity-io/sanity/commit/8b4ec5d7353cb0c727d5a6a7967b808f0980a994))
+* **mutator:** match deep set/setIfMissing behavior ([#5048](https://github.com/sanity-io/sanity/issues/5048)) ([28884c6](https://github.com/sanity-io/sanity/commit/28884c65b90e59bc094365c8fc996a5ff165f1c0))
+* **mutator:** restore greater than/less than in jsonmatch constraints ([#5063](https://github.com/sanity-io/sanity/issues/5063)) ([fd7db60](https://github.com/sanity-io/sanity/commit/fd7db60cb1e6046dda3d8680ab85987a7b4320eb)), closes [#2474](https://github.com/sanity-io/sanity/issues/2474)
+* **portable-text-editor:** allow user event handlers on Editable component ([#5058](https://github.com/sanity-io/sanity/issues/5058)) ([441f637](https://github.com/sanity-io/sanity/commit/441f637ef0e4631950d894b51254920b10648dc8))
+
+
+### Features
+
+* **desk:** implement comments (beta) ([#4886](https://github.com/sanity-io/sanity/issues/4886)) ([0803464](https://github.com/sanity-io/sanity/commit/08034640c32cabf418260a03d7eeba87335d369c)), closes [#4935](https://github.com/sanity-io/sanity/issues/4935) [#4929](https://github.com/sanity-io/sanity/issues/4929) [#4992](https://github.com/sanity-io/sanity/issues/4992) [#5004](https://github.com/sanity-io/sanity/issues/5004) [#5012](https://github.com/sanity-io/sanity/issues/5012) [#5021](https://github.com/sanity-io/sanity/issues/5021) [#5041](https://github.com/sanity-io/sanity/issues/5041)
+
+
+### Reverts
+
+* Revert "chore(deps): update dependency @tanstack/react-virtual to v3.0.0-beta.68 (#5028)" ([1728fa6](https://github.com/sanity-io/sanity/commit/1728fa6d03591aac2725d2cc84048b63f0b76fcb)), closes [#5028](https://github.com/sanity-io/sanity/issues/5028)
+
+
+
+## [3.18.1](https://github.com/sanity-io/sanity/compare/v3.18.0...v3.18.1) (2023-10-17)
+
+
+### Bug Fixes
+
+* **core:** fixes issue with overlapping text in error message ([#4970](https://github.com/sanity-io/sanity/issues/4970)) ([2001ced](https://github.com/sanity-io/sanity/commit/2001ced41a95960e87a022c0da42b6c3e586c5e5))
+
+
+### Features
+
+* **cli:** add CDR metadata to GraphQL json schema ([#4975](https://github.com/sanity-io/sanity/issues/4975)) ([d8cbf10](https://github.com/sanity-io/sanity/commit/d8cbf10ae9a2f72fd62301bff000db777e7c0034))
+
+
+
+# [3.18.0](https://github.com/sanity-io/sanity/compare/v3.17.0...v3.18.0) (2023-10-10)
+
+
+### Bug Fixes
+
+* **desk:** fixes type for canHandleIntent in documentList ([#4969](https://github.com/sanity-io/sanity/issues/4969)) ([ad3cf4f](https://github.com/sanity-io/sanity/commit/ad3cf4f1f627a8854cf0927f4268898fde085ae6))
+* **desk:** pass intent in MenuNodes resolver ([#4892](https://github.com/sanity-io/sanity/issues/4892)) ([4151f2e](https://github.com/sanity-io/sanity/commit/4151f2e640c6a1577d22b8c57d9b3015e60a8288))
+* **form:** set fallback placement for type-select popover in array inputs ([#4979](https://github.com/sanity-io/sanity/issues/4979)) ([0068787](https://github.com/sanity-io/sanity/commit/0068787598effc3f08a768eaba4d4952e7e75820))
+
+
+### Features
+
+* **vision:** make panes responsive for minimal breakpoint ([#4893](https://github.com/sanity-io/sanity/issues/4893)) ([4b3a183](https://github.com/sanity-io/sanity/commit/4b3a183ca451a955dbc05644bf4465497a68c863))
+
+
+
+# [3.17.0](https://github.com/sanity-io/sanity/compare/v3.16.7...v3.17.0) (2023-10-03)
+
+
+### Bug Fixes
+
+* **core:** accessibility improvements on document lists ([#4958](https://github.com/sanity-io/sanity/issues/4958)) ([0fa5e70](https://github.com/sanity-io/sanity/commit/0fa5e7083d8427c606831070effecbb7399b0e7f))
+* **core:** fix array items not showing in field groups ([#4930](https://github.com/sanity-io/sanity/issues/4930)) ([f55b7d8](https://github.com/sanity-io/sanity/commit/f55b7d8ae52e8d75baeeec469f2852f12ee37615))
+* **core:** make sure to re-emit current edit state when re-subscribing to document validation ([#4954](https://github.com/sanity-io/sanity/issues/4954)) ([17300c8](https://github.com/sanity-io/sanity/commit/17300c8e2b679e58e7c4c3f6e741a930a67186b6))
+* **core:** re-use previously prepared workspace configs ([#4867](https://github.com/sanity-io/sanity/issues/4867)) ([8387122](https://github.com/sanity-io/sanity/commit/8387122095b2245e7de399ecccbbb2a9eb35149e))
+* **core:** set default placements for certain studio popovers ([#4963](https://github.com/sanity-io/sanity/issues/4963)) ([aab85f9](https://github.com/sanity-io/sanity/commit/aab85f9d6d38df691984004bbf8768bf9ee52d3a))
+* **core:** unset changes in reverse order in patch operation ([#4957](https://github.com/sanity-io/sanity/issues/4957)) ([0715a15](https://github.com/sanity-io/sanity/commit/0715a15dad3493addb6af618a3db475dc7052317))
+* syntax issues in next.js JS blog template ([#4952](https://github.com/sanity-io/sanity/issues/4952)) ([c672253](https://github.com/sanity-io/sanity/commit/c6722539c2af18bd7bdaa6c0a1420b7b30db5cec))
+
+
+### Features
+
+* support perspectives in `listenQuery` ([#4878](https://github.com/sanity-io/sanity/issues/4878)) ([6020a46](https://github.com/sanity-io/sanity/commit/6020a46588ffd324e233b45eaf526a58652c62f2))
+
+
+
+## [3.16.7](https://github.com/sanity-io/sanity/compare/v3.16.6...v3.16.7) (2023-09-14)
+
+
+
+## [3.16.6](https://github.com/sanity-io/sanity/compare/v3.16.5...v3.16.6) (2023-09-14)
+
+
+
+## [3.16.5](https://github.com/sanity-io/sanity/compare/v3.16.4...v3.16.5) (2023-09-14)
+
+
+### Bug Fixes
+
+* **core:** add aria-label to reference publish icons ([#4899](https://github.com/sanity-io/sanity/issues/4899)) ([3153954](https://github.com/sanity-io/sanity/commit/31539543b0df74df2e1ab542f80cf5d42d82e4d4))
+* **core:** add maxLength to breadcrumb and change symbol ([#4880](https://github.com/sanity-io/sanity/issues/4880)) ([5c75b2c](https://github.com/sanity-io/sanity/commit/5c75b2c04943e340b0f739dc210c51463e656a68))
+* **core:** fixes issue with restoring document in nested panes ([#4915](https://github.com/sanity-io/sanity/issues/4915)) ([47f3be9](https://github.com/sanity-io/sanity/commit/47f3be9dc1b069a844f6bdf545826f82c8bdf3f3))
+* **desk:** use correct dialog positioning at smaller breakpoints ([#4894](https://github.com/sanity-io/sanity/issues/4894)) ([e62906f](https://github.com/sanity-io/sanity/commit/e62906f32bd8fafbbf61665c8705621246589707))
+* **desk:** use index as key instead of path ([#4890](https://github.com/sanity-io/sanity/issues/4890)) ([645aedd](https://github.com/sanity-io/sanity/commit/645aeddae8086ef8e42816545a647c368ad14339))
+* **import:** increase concurrency of patching, document creation ([#4900](https://github.com/sanity-io/sanity/issues/4900)) ([0f52cfc](https://github.com/sanity-io/sanity/commit/0f52cfc544030437d5f71c7a01a1cf7445f66fe6))
+* **schema:** add 'span' to core types ([4e02847](https://github.com/sanity-io/sanity/commit/4e0284789a8338f5c66005930f3cf141a33efe54))
+
+
+### Features
+
+* **titles:** Update titles inside desk tool ([#4887](https://github.com/sanity-io/sanity/issues/4887)) ([2ace4f1](https://github.com/sanity-io/sanity/commit/2ace4f1f6d83866046d95ac8f48b692afa935430)), closes [#4898](https://github.com/sanity-io/sanity/issues/4898)
+* **WCAG:** Associate field descriptions to inputs ([#4896](https://github.com/sanity-io/sanity/issues/4896)) ([e7a8e32](https://github.com/sanity-io/sanity/commit/e7a8e327f31c3dbafa32d2ea0c18232dfe98c614))
+
+
+
+## [3.16.4](https://github.com/sanity-io/sanity/compare/v3.16.3...v3.16.4) (2023-09-05)
+
+
+### Bug Fixes
+
+* **core:** use primitiveField for slug schema type ([#4861](https://github.com/sanity-io/sanity/issues/4861)) ([ba879cb](https://github.com/sanity-io/sanity/commit/ba879cb3bb2cd104282190756cd6a13b73794586))
+* **portable-text-editor:** emit new selection on mark toggle ([#4881](https://github.com/sanity-io/sanity/issues/4881)) ([886b9cd](https://github.com/sanity-io/sanity/commit/886b9cdc1060b03bc2163bf9cbc3b9f4ef73f710))
+
+
+
+## [3.16.3](https://github.com/sanity-io/sanity/compare/v3.16.2...v3.16.3) (2023-09-05)
+
+
+
+## [3.16.2](https://github.com/sanity-io/sanity/compare/v3.16.1...v3.16.2) (2023-08-31)
+
+
+### Bug Fixes
+
+* **core:** preserve earlier document availability status ([#4888](https://github.com/sanity-io/sanity/issues/4888)) ([a262c7d](https://github.com/sanity-io/sanity/commit/a262c7d0ad44d6e1980b74d8bd7b15aa6b2072f4))
+
+
+
+## [3.16.1](https://github.com/sanity-io/sanity/compare/v3.16.0...v3.16.1) (2023-08-30)
+
+
+### Bug Fixes
+
+* **desk:** remove simple filter check/v1 fallback ([#4882](https://github.com/sanity-io/sanity/issues/4882)) ([e3e004f](https://github.com/sanity-io/sanity/commit/e3e004f199f8a7fd9060daff90319236471b8050))
+
+
+
+# [3.16.0](https://github.com/sanity-io/sanity/compare/v3.15.1...v3.16.0) (2023-08-29)
+
+
+### Bug Fixes
+
+* allow exceeding indices when applying DMP patches ([80f1bdb](https://github.com/sanity-io/sanity/commit/80f1bdb615a15dae417e65fabea08334c5129db0))
+* allow exceeding indices when applying DMP patches ([716788c](https://github.com/sanity-io/sanity/commit/716788c959baf20925d5c055ee5c5c4f102a857d))
+* **core/form/inouts:** PT-input - remove default outline style of the PTE ([2bafd32](https://github.com/sanity-io/sanity/commit/2bafd325631dcbd0a44b5f46d3b5e7914c38b6ad))
+* **core/form/inputs:** keep selection intact when toggling block styles (PT-input) ([79959c9](https://github.com/sanity-io/sanity/commit/79959c9c66958322e70c8d08e35e67e25aa2ba87))
+* **core:** add check for cdr schematype and use PrimitiveField ([#4859](https://github.com/sanity-io/sanity/issues/4859)) ([3ad324b](https://github.com/sanity-io/sanity/commit/3ad324b3eac7bbeea88e73e5a1e29a8902f00485))
+* **core:** close navbar tooltips when menubutton is open ([#4826](https://github.com/sanity-io/sanity/issues/4826)) ([c5bfa12](https://github.com/sanity-io/sanity/commit/c5bfa12f8f5e8caffe717287b81cc5d0a43e231e))
+* **core:** remove padding on ReferenceField ([#4842](https://github.com/sanity-io/sanity/issues/4842)) ([0a2438c](https://github.com/sanity-io/sanity/commit/0a2438cde252e63b25b63d1ef5f1e3eb0ba2b38c))
+* **core:** svg preview issue in safari ([#4838](https://github.com/sanity-io/sanity/issues/4838)) ([6a041b3](https://github.com/sanity-io/sanity/commit/6a041b35c47023c7fa7cd83808427ed50a86b99d))
+* **core:** wait for availability status to arrive before passing on document existence status ([#4860](https://github.com/sanity-io/sanity/issues/4860)) ([201cfcc](https://github.com/sanity-io/sanity/commit/201cfcc9f7b353dbe20071f59ae9eaef2f7c0740))
+* **deps:** update dependency @sanity/client to ^6.4.9 ([#4851](https://github.com/sanity-io/sanity/issues/4851)) ([7b3e1f2](https://github.com/sanity-io/sanity/commit/7b3e1f27513353227712983040bf916cf5540785))
+* **deps:** update dependency esbuild to ^0.19.0 ([#4810](https://github.com/sanity-io/sanity/issues/4810)) ([97b3363](https://github.com/sanity-io/sanity/commit/97b3363d8c734bad7daf418a9c784138013d5878))
+* **deps:** update dependency get-it to ^8.4.3 ([#4852](https://github.com/sanity-io/sanity/issues/4852)) ([1514a69](https://github.com/sanity-io/sanity/commit/1514a696e28cfbf9a34b48fe9c753d0dbdbc3261))
+* **desk:** center align pane header action icons ([#4854](https://github.com/sanity-io/sanity/issues/4854)) ([d36c174](https://github.com/sanity-io/sanity/commit/d36c17453f2c73881d9d176ad0c86267d93feca3))
+* **desk:** close document panes when document is deleted ([#4563](https://github.com/sanity-io/sanity/issues/4563)) ([5b3a415](https://github.com/sanity-io/sanity/commit/5b3a4153e1c55afaa38fc14045ca68ab6574bfcb)), closes [#4813](https://github.com/sanity-io/sanity/issues/4813) [#4818](https://github.com/sanity-io/sanity/issues/4818)
+* **desk:** use configured api version when fetching document lists ([#4749](https://github.com/sanity-io/sanity/issues/4749)) ([9d90fb0](https://github.com/sanity-io/sanity/commit/9d90fb04f9f25dfc3151dac31ce6cd7cdbd0ddfd))
+* **portable-text-editor:** fix bug in offset calculation for undo/redo remove text ([aeff824](https://github.com/sanity-io/sanity/commit/aeff8240907f7538ee4716d33040bb27a34aa366))
+* **portable-text-editor:** fix empty placeholder placement for webkit ([757b7b5](https://github.com/sanity-io/sanity/commit/757b7b5238deecb2d7a57b520cd4b65b2258e78b))
+* **portable-text-editor:** fix issue with fast toggling of decorators ([25867d6](https://github.com/sanity-io/sanity/commit/25867d6f1e6bc49761feba5db0216e8337813678))
+* **portable-text-editor:** remove invalid return value ([99355d8](https://github.com/sanity-io/sanity/commit/99355d8bc144a9f4ddb4dfcf63d078e53df5cd4a))
+
+
+### Features
+
+* **core:** field actions improvements ([#4824](https://github.com/sanity-io/sanity/issues/4824)) ([e47e251](https://github.com/sanity-io/sanity/commit/e47e251d2e8095508f97c8dec880ea3ae327b8c5))
+
+
+
+## [3.15.1](https://github.com/sanity-io/sanity/compare/v3.15.0...v3.15.1) (2023-08-10)
+
+
+### Bug Fixes
+
+* **core:** parenthesis around GROQ-filters crashing ACL checks ([#4820](https://github.com/sanity-io/sanity/issues/4820)) ([281ac7a](https://github.com/sanity-io/sanity/commit/281ac7a25aaced209b082aded13b3d74bf53a697)), closes [#4817](https://github.com/sanity-io/sanity/issues/4817)
+* **core:** timeouts randomly being cancelled ([#4815](https://github.com/sanity-io/sanity/issues/4815)) ([390c8e5](https://github.com/sanity-io/sanity/commit/390c8e5d25ce3adc0f8b46fdfa60e5a755bfaf0b))
+* delay refetching for listener events arriving with visibility != query ([#4795](https://github.com/sanity-io/sanity/issues/4795)) ([d06b0e0](https://github.com/sanity-io/sanity/commit/d06b0e0a6dd32cbfd2c5c629df17468c74c9183c))
+* ensure `@sanity/client` pulls in the right `get-it` version ([#4811](https://github.com/sanity-io/sanity/issues/4811)) ([41662a3](https://github.com/sanity-io/sanity/commit/41662a3cc044a049da8b322f9d0d92fc74d52fcc))
+
+
+
+# [3.15.0](https://github.com/sanity-io/sanity/compare/v3.14.5...v3.15.0) (2023-08-08)
+
+
+### Bug Fixes
+
+* **cli:** correct URL for the `sanity manage` command ([#4783](https://github.com/sanity-io/sanity/issues/4783)) ([12af996](https://github.com/sanity-io/sanity/commit/12af996b8583ada669c7d842bc1042bf71424272))
+* **cli:** improve performance of projects list ([c0a7911](https://github.com/sanity-io/sanity/commit/c0a791182724843f78fa006ae77a860b599e3597))
+* **core:** fix issue with change indicator and path lines ([#4685](https://github.com/sanity-io/sanity/issues/4685)) ([70f635e](https://github.com/sanity-io/sanity/commit/70f635ea420bf28ef22712a4fd66a10e6a1a4374))
+* **deps:** update dependency esbuild to v0.18.17 ([#4766](https://github.com/sanity-io/sanity/issues/4766)) ([d39a4a3](https://github.com/sanity-io/sanity/commit/d39a4a3fc374569b058d8f23dec3140918bc2b4c))
+* **deps:** Update dependency mendoza to v3 ([#4802](https://github.com/sanity-io/sanity/issues/4802)) ([e2fd12a](https://github.com/sanity-io/sanity/commit/e2fd12a032073c996b933b35983b3b41963eedfe))
+* **form:** improve message when reference points to undeclared document type ([#4768](https://github.com/sanity-io/sanity/issues/4768)) ([366a9f1](https://github.com/sanity-io/sanity/commit/366a9f1d86b774b1429c70a5e67b4a97a5d4c426))
+* **form:** improve microcopy of reference strength mismatch warning ([#4768](https://github.com/sanity-io/sanity/issues/4768)) ([b1c0856](https://github.com/sanity-io/sanity/commit/b1c0856e54d3469b46786b72f4515a615a0e75bc))
+* **form:** move availability checks to reference value preview ([#4768](https://github.com/sanity-io/sanity/issues/4768)) ([f48430c](https://github.com/sanity-io/sanity/commit/f48430ccce3e7bcf6d07319fa2f75336d5779b2f))
+* **validation:** reset regex state between validation checks ([#4777](https://github.com/sanity-io/sanity/issues/4777)) ([4b7d80c](https://github.com/sanity-io/sanity/commit/4b7d80cf99c4423f5fd7aec42fe1030f1b156751))
+
+
+### Features
+
+* **auth:** allow specifying options without createAuthStore() ([#4773](https://github.com/sanity-io/sanity/issues/4773)) ([d9a88a5](https://github.com/sanity-io/sanity/commit/d9a88a5521f006a11666bfe3d24490bef071a3b2))
+* **auth:** allow using explicit `token` mode for authentication ([#4772](https://github.com/sanity-io/sanity/issues/4772)) ([ccfe3e7](https://github.com/sanity-io/sanity/commit/ccfe3e76b1654b76a62b44554bfdd89fe1101fb7))
+* **graphql:** adds is_defined filter ([#4767](https://github.com/sanity-io/sanity/issues/4767)) ([1b23692](https://github.com/sanity-io/sanity/commit/1b236922df279bf4984ac324e519024f722e0969))
+
+
+
+## [3.14.5](https://github.com/sanity-io/sanity/compare/v3.14.4...v3.14.5) (2023-08-02)
+
+
+### Bug Fixes
+
+* **core:** allow `null` and `role`-less user in `userHasRole` fn ([#4740](https://github.com/sanity-io/sanity/issues/4740)) ([a735461](https://github.com/sanity-io/sanity/commit/a735461ff39cb34626ac7053049520e6d3af48c2))
+* **core:** change cdr tooltip text ([#4750](https://github.com/sanity-io/sanity/issues/4750)) ([c78f9bd](https://github.com/sanity-io/sanity/commit/c78f9bdf0a01ae724061327553c79f829d06d21d))
+* **core:** fix auto scrolling issue on collapsed fieldset w/ array ([#4738](https://github.com/sanity-io/sanity/issues/4738)) ([0cb1a0e](https://github.com/sanity-io/sanity/commit/0cb1a0ed5ab879a49ff5706370c3b5a67589f5d1))
+* **core:** fixes issues with virtualized list when wrapped in an element ([#4739](https://github.com/sanity-io/sanity/issues/4739)) ([8779740](https://github.com/sanity-io/sanity/commit/8779740e12fb165df341c99c4ce4be3b12169d63))
+* **core:** optimize wheel event on CommandList virtual element ([#4722](https://github.com/sanity-io/sanity/issues/4722)) ([3dffb11](https://github.com/sanity-io/sanity/commit/3dffb111b81143d2c499eb0e5942bd3abc655753))
+* **deps:** update dependency @vercel/frameworks to v1.5.0 ([#4752](https://github.com/sanity-io/sanity/issues/4752)) ([d9dcc3c](https://github.com/sanity-io/sanity/commit/d9dcc3c64ac56358c03ef35c1f87aa045a3f33b0))
+* **deps:** update dependency @vercel/fs-detectors to v4.1.1 ([#4764](https://github.com/sanity-io/sanity/issues/4764)) ([bae83ad](https://github.com/sanity-io/sanity/commit/bae83ad35ce6186a7af9f247c2053f6841b8a2fb))
+* **desk:** prevent duplicate validation/change inspectors ([#4748](https://github.com/sanity-io/sanity/issues/4748)) ([3c1a0e5](https://github.com/sanity-io/sanity/commit/3c1a0e5b20330d6e943c068a2182737bd922a9d6))
+* **form:** make recently introduced props for ArrayOfObjectInputMembers optional ([#4776](https://github.com/sanity-io/sanity/issues/4776)) ([aa778d1](https://github.com/sanity-io/sanity/commit/aa778d1dfb51b49053fb34b049c2cfc4fb5684d0))
+
+
+### Features
+
+* **types:** add `isSlug` asserter method ([#4746](https://github.com/sanity-io/sanity/issues/4746)) ([31cee8f](https://github.com/sanity-io/sanity/commit/31cee8ff9b37c0da26b6719a7bb40239a58612f9))
+
+
+
+## [3.14.4](https://github.com/sanity-io/sanity/compare/v3.14.3...v3.14.4) (2023-07-25)
+
+
+### Bug Fixes
+
+* **core:** add a11y labels to presence indicators ([5182529](https://github.com/sanity-io/sanity/commit/51825295552567d5f7666d350fc2b4f7aac29c06))
+* **core:** add logic to focusFirst in customised popover ([#4667](https://github.com/sanity-io/sanity/issues/4667)) ([1313dd4](https://github.com/sanity-io/sanity/commit/1313dd4f9bd2d78af10436d6967c58db0a530485))
+* **core:** add missing validation at input level validation (boolean) ([#4719](https://github.com/sanity-io/sanity/issues/4719)) ([cb64607](https://github.com/sanity-io/sanity/commit/cb646078bab8f63b29d436937ba7cc1fcaa2b4de))
+* **core:** deprecate `projectId` in cross-dataset reference definitions ([103d99d](https://github.com/sanity-io/sanity/commit/103d99d652a0ab1f0e82bfa633bf7f85cda503aa))
+* **deps:** update dependency @sanity/client to v6.1.7 ([#4737](https://github.com/sanity-io/sanity/issues/4737)) ([dacb164](https://github.com/sanity-io/sanity/commit/dacb164fba5a19b9d9c008a26b0398c98cee235d))
+* **deps:** update dependency @sanity/ui to v1.7.3 ([#4728](https://github.com/sanity-io/sanity/issues/4728)) ([8176fba](https://github.com/sanity-io/sanity/commit/8176fba58a15271b9dcb6ca70fdb6d6e4a60b2c4))
+* **deps:** update dependency @sanity/uuid to v3.0.2 ([#4729](https://github.com/sanity-io/sanity/issues/4729)) ([5f65434](https://github.com/sanity-io/sanity/commit/5f65434a97883f171e8cf2165bcf25f9f54d4475))
+* **deps:** update dependency @vitejs/plugin-react to v4.0.3 ([#4730](https://github.com/sanity-io/sanity/issues/4730)) ([ba4e659](https://github.com/sanity-io/sanity/commit/ba4e6596787dd2761a3d894912b05e51b61ff16b))
+* **deps:** update dependency esbuild to v0.18.16 ([#4731](https://github.com/sanity-io/sanity/issues/4731)) ([9437194](https://github.com/sanity-io/sanity/commit/9437194b0eb1bd567806b4167a9e046cbe73531d))
+* **deps:** update dependency framer-motion to v10.13.1 ([#4735](https://github.com/sanity-io/sanity/issues/4735)) ([4af3c69](https://github.com/sanity-io/sanity/commit/4af3c6961ad57dbb8e39cca5f33293d7af04fad9))
+* **deps:** update dependency get-it to v8.3.0 ([#4736](https://github.com/sanity-io/sanity/issues/4736)) ([52d7eb7](https://github.com/sanity-io/sanity/commit/52d7eb787691a732a5a8337ee545c962f209c291))
+* **deps:** update dependency react-focus-lock to v2.9.5 ([#4732](https://github.com/sanity-io/sanity/issues/4732)) ([0c6f3a2](https://github.com/sanity-io/sanity/commit/0c6f3a23a7bdc4711ec55015550cc434f1895b3c))
+* **deps:** update dependency vite to v4.4.7 ([#4733](https://github.com/sanity-io/sanity/issues/4733)) ([1f83fce](https://github.com/sanity-io/sanity/commit/1f83fcec77ed20c71c6a0db5f081bef008d02199))
+* **desk:** add accessible label to publish icon ([fd6c2e9](https://github.com/sanity-io/sanity/commit/fd6c2e9204e4a2c71b444650935b247fb39c6289))
+* **desk:** add accessible labels to publish status ([dcb1fc7](https://github.com/sanity-io/sanity/commit/dcb1fc70537987fa7a1644bd7a7ca65e3fa4ac84))
+* **desk:** add accessible labels to review changes button ([736437b](https://github.com/sanity-io/sanity/commit/736437babc86fc2e09d6018f069791719967e737))
+* **desk:** minor style change of references in delete/unpublish dialog ([#4705](https://github.com/sanity-io/sanity/issues/4705)) ([a8e7c24](https://github.com/sanity-io/sanity/commit/a8e7c2474c2fd0592e8fff66f7c14d75b65ea9af))
+* **import:** rewrite cross-dataset references, add option to skip ([ad10b38](https://github.com/sanity-io/sanity/commit/ad10b38f5e49ddcfab5fe9580b8be744dc6a2ee9))
+* **import:** skip datasets lookup if no CDRs are found ([ed34949](https://github.com/sanity-io/sanity/commit/ed34949e61619749fe128d88b88d76337bd14f92))
+* **types:** add missing `group` property on fieldset definitions ([87d642a](https://github.com/sanity-io/sanity/commit/87d642a0a3f6a1872c64271fdb7f230b8d0ebdaf))
+* **types:** adjust `icon` property for field group (can only be component) ([cf968aa](https://github.com/sanity-io/sanity/commit/cf968aa8bb795ef0f0f4a5fb14ada466f91acbfe))
+* **types:** deprecate experimental search for CDRs ([ea075f0](https://github.com/sanity-io/sanity/commit/ea075f071ad98661f093e1372f43640aca6ab382))
+
+
+### Features
+
+* **cli:** add `--skip-cross-dataset-references` flag to `dataset import` ([c9cac66](https://github.com/sanity-io/sanity/commit/c9cac6630be77b8db2e950f40397f7ac70440f0a))
+* **core:** implement document creation context in `document.newDocumentOptions` ([#4680](https://github.com/sanity-io/sanity/issues/4680)) ([b9298e8](https://github.com/sanity-io/sanity/commit/b9298e8ca27c4329e9f31a9197b2c0b8d31ef8d5))
+* **import:** check for missing datasets prior to importing ([8e8242d](https://github.com/sanity-io/sanity/commit/8e8242dcec5e959953e5a66ec4734ff345e8a453))
+* **schema:** automatically create titles for field groups without one ([ffb8339](https://github.com/sanity-io/sanity/commit/ffb83395d091a36b560e11821f3fa7e1c5ce6579))
+* **schema:** automatically create titles for fieldsets without one ([6f201e0](https://github.com/sanity-io/sanity/commit/6f201e0495be04356e3e83ab1f0eb2ba5b59247d))
+* **schema:** do not warn on missing title for schema type ([6164d24](https://github.com/sanity-io/sanity/commit/6164d242343dc6d903eb955e269c8d16649f6a46))
+
+
+
+## [3.14.3](https://github.com/sanity-io/sanity/compare/v3.14.2...v3.14.3) (2023-07-18)
+
+
+### Bug Fixes
+
+* **cli:** warn about putting secrets in `.env` ([#4683](https://github.com/sanity-io/sanity/issues/4683)) ([69083ce](https://github.com/sanity-io/sanity/commit/69083cefa607372e8109805dcb858dabd58686a6))
+* **core/desk:** remove muted prop in tooltip content ([#4703](https://github.com/sanity-io/sanity/issues/4703)) ([5d58280](https://github.com/sanity-io/sanity/commit/5d58280acce60aeb22c24a63039e04dd37b61df4))
+* **core:** add scrolling to workspace login screen  ([#4697](https://github.com/sanity-io/sanity/issues/4697)) ([d2c85b4](https://github.com/sanity-io/sanity/commit/d2c85b43a1bf40faec151f3f86eacb339ef14819))
+* **deps:** update dependency @vercel/frameworks to v1.4.3 ([#4669](https://github.com/sanity-io/sanity/issues/4669)) ([f49db76](https://github.com/sanity-io/sanity/commit/f49db76710af165270ebef84ce3f76cdbce7eba4))
+* **deps:** update dependency @vercel/fs-detectors to v4 ([#4634](https://github.com/sanity-io/sanity/issues/4634)) ([ada8367](https://github.com/sanity-io/sanity/commit/ada836738439ae202b4f5d7990c4577b57836366))
+* **deps:** update dependency @vitejs/plugin-react to v4 ([#4635](https://github.com/sanity-io/sanity/issues/4635)) ([de75d69](https://github.com/sanity-io/sanity/commit/de75d697636078bd3dc2d59b88977a0b5f65d7c2))
+* **deps:** update dependency esbuild to ^0.18.0 ([#4630](https://github.com/sanity-io/sanity/issues/4630)) ([bae43bf](https://github.com/sanity-io/sanity/commit/bae43bfd42d97e9f31cb0dcd10f4352f51d4bb59))
+* **deps:** update dependency vite to v4.4.4 ([#4673](https://github.com/sanity-io/sanity/issues/4673)) ([6c37226](https://github.com/sanity-io/sanity/commit/6c37226ccd93bdae86ea523915e5bac14977cf30))
+
+
+
+## [3.14.2](https://github.com/sanity-io/sanity/compare/v3.14.1...v3.14.2) (2023-07-11)
+
+
+### Bug Fixes
+
+* add missing styled component dependency ([#4681](https://github.com/sanity-io/sanity/issues/4681)) ([cafa41b](https://github.com/sanity-io/sanity/commit/cafa41bcdf733a673e884628e3b12e2cd4068b75))
+* **cli:** typing update for request/response client errors ([d548dbd](https://github.com/sanity-io/sanity/commit/d548dbdf8fad01c70f0ad0039f19a4d949f1531e))
+* **core:** restore not working on nested panes ([#4668](https://github.com/sanity-io/sanity/issues/4668)) ([b7886ec](https://github.com/sanity-io/sanity/commit/b7886ecfb6e89af26c72e891643fe02c2ab24b0f))
+* **deps:** update dependency @sanity/client to v6.1.6 ([#4628](https://github.com/sanity-io/sanity/issues/4628)) ([27bfeae](https://github.com/sanity-io/sanity/commit/27bfeae2dbb447d74f1f1b9fd48e249d5b2b756c))
+* **deps:** update dependency @sanity/ui to v1.7.1 ([#4670](https://github.com/sanity-io/sanity/issues/4670)) ([4802d7c](https://github.com/sanity-io/sanity/commit/4802d7ca6f3120533d4286a557c1452486798ede))
+* **deps:** update dependency @vercel/fs-detectors to v3.9.3 ([#4642](https://github.com/sanity-io/sanity/issues/4642)) ([946ec16](https://github.com/sanity-io/sanity/commit/946ec16a13435cf6747eae1c47d4b2316795872f))
+* **deps:** update dependency get-it to v8.2.0 ([72ce4ef](https://github.com/sanity-io/sanity/commit/72ce4ef8df5e70ff33b3197fd40854fc93abe7b2))
+* **desk:** prevent fallback editor node from getting 'Editor' as title ([#4688](https://github.com/sanity-io/sanity/issues/4688)) ([9952de9](https://github.com/sanity-io/sanity/commit/9952de95585c6d383852f06b7c2dbf3a08b4eece))
+
+
+
+## [3.14.1](https://github.com/sanity-io/sanity/compare/v3.14.0...v3.14.1) (2023-06-30)
+
+
+### Bug Fixes
+
+* **core:** add aria-label to resources button ([#4659](https://github.com/sanity-io/sanity/issues/4659)) ([e0ae4bf](https://github.com/sanity-io/sanity/commit/e0ae4bf9e6f63467ab5be268c1ac55feae531ac8))
+* **core:** increase button hit area of collapsible fieldset ([#4646](https://github.com/sanity-io/sanity/issues/4646)) ([7d9086b](https://github.com/sanity-io/sanity/commit/7d9086b2ff34ab45f5a01e476a4e41e2ac595473))
+* **deps:** update dependency framer-motion to v10.12.17 ([#4643](https://github.com/sanity-io/sanity/issues/4643)) ([f82b718](https://github.com/sanity-io/sanity/commit/f82b718537adb038dae18d08f6350d86366ac8af))
+* upgrade `next-sanity` in `init` to `v5` ([#4658](https://github.com/sanity-io/sanity/issues/4658)) ([cdf810c](https://github.com/sanity-io/sanity/commit/cdf810ca44221b8cd2a5a4ae0a33badf1fe2cb11))
+
+
+
+# [3.14.0](https://github.com/sanity-io/sanity/compare/v3.13.0...v3.14.0) (2023-06-29)
+
+
+### Bug Fixes
+
+* **core:** add Help&Resources button to navbar ([#4545](https://github.com/sanity-io/sanity/issues/4545)) ([a4cb4a7](https://github.com/sanity-io/sanity/commit/a4cb4a7ccdbb8ebcf9737e0327baf6158811667e))
+* **deps:** update dependency @portabletext/react to v3.0.4 ([#4647](https://github.com/sanity-io/sanity/issues/4647)) ([ae38208](https://github.com/sanity-io/sanity/commit/ae38208d5a5d64489bf5eeb5cef4881e4ff3a52d))
+
+
+### Features
+
+* **vision:** add perspective support ([2f9cbc7](https://github.com/sanity-io/sanity/commit/2f9cbc701de90ffefa7c2c8056615244899608bd))
+
+
+
+# [3.13.0](https://github.com/sanity-io/sanity/compare/v3.12.2...v3.13.0) (2023-06-27)
+
+
+### Bug Fixes
+
+* **core:** improve PTE popover behavior ([#4606](https://github.com/sanity-io/sanity/issues/4606)) ([c17929e](https://github.com/sanity-io/sanity/commit/c17929efa13c56aeba94b3a5dbbc88da079c2cd8))
+* **deps:** update `@sanity/icons` ([0b2c40e](https://github.com/sanity-io/sanity/commit/0b2c40e9697f2712d541ab4f05c99e25b4094940))
+* **deps:** update dependency @portabletext/react to v3 ([#4625](https://github.com/sanity-io/sanity/issues/4625)) ([e3c3223](https://github.com/sanity-io/sanity/commit/e3c32230fb71d9dd868ef4f8f4ef1aec89379ab3))
+* **deps:** update dependency @portabletext/types to v2.0.5 ([#4627](https://github.com/sanity-io/sanity/issues/4627)) ([0b01660](https://github.com/sanity-io/sanity/commit/0b01660b843ef3e1e1150a6cacd5be86825b2e1f))
+* **deps:** update dependency get-it to v8.1.3 ([#4644](https://github.com/sanity-io/sanity/issues/4644)) ([d461bb6](https://github.com/sanity-io/sanity/commit/d461bb606e7f0d87627585bec5e5f215d11235b2))
+* **deps:** update dependency styled-components to v5.3.11 ([#4629](https://github.com/sanity-io/sanity/issues/4629)) ([76df1cf](https://github.com/sanity-io/sanity/commit/76df1cf52ef8dd56bbf062f582e8fee2d77e277d))
+* **deps:** update three packages ([#4631](https://github.com/sanity-io/sanity/issues/4631)) ([ef36686](https://github.com/sanity-io/sanity/commit/ef36686c148e472105565835bf6e34940cfb86f6))
+
+
+### Features
+
+* add etl layer ([#4584](https://github.com/sanity-io/sanity/issues/4584)) ([aff1e63](https://github.com/sanity-io/sanity/commit/aff1e63fcb68e6130026ff9ee794c747ed9fa41e))
+* **cli:** print all current user roles in debug output ([#4609](https://github.com/sanity-io/sanity/issues/4609)) ([ea322f2](https://github.com/sanity-io/sanity/commit/ea322f2416dc08ac67b629a2af49b87a1a2411b5))
+* **core:** `fieldActions` config property ([18c5894](https://github.com/sanity-io/sanity/commit/18c5894cdbf78376bef31b915c9fb4efc4453b74))
+* **core:** add `StatusButton` hotkey property ([f1b154a](https://github.com/sanity-io/sanity/commit/f1b154a67d907730c62b42aa05017c95a6110eff))
+* **core:** add `TooltipOfDisabled` component ([b58e238](https://github.com/sanity-io/sanity/commit/b58e2380981aaa66fdd874e310a5c13683be1a44))
+* **core:** render field actions ([3c0ea55](https://github.com/sanity-io/sanity/commit/3c0ea55aa4cb5722f1abffeb003311d16e0a88ac))
+* **core:** take `StatusButton` disabled reason ([38c6e93](https://github.com/sanity-io/sanity/commit/38c6e93000bbc5c1123ec4e6e2e2bf461281fe51))
+* **core:** take `StatusButton` mode property ([ba1092d](https://github.com/sanity-io/sanity/commit/ba1092d64247271d9b57967c2a44de23b54b7c02))
+* **desk:** document inspectors (`[@beta](https://github.com/beta)`) ([#4252](https://github.com/sanity-io/sanity/issues/4252)) ([e9c068a](https://github.com/sanity-io/sanity/commit/e9c068ac828c0e73464d16995230160649880579))
+* **desk:** render document field actions ([cc9edc7](https://github.com/sanity-io/sanity/commit/cc9edc7547e96947a7c29dc248b57de980635705))
+* **desk:** resolve field actions ([4086ddd](https://github.com/sanity-io/sanity/commit/4086dddfd4e3a518d6c6317801801711e7f48ec5))
+
+
+### Performance Improvements
+
+* add field actions to perf studio ([a1a4182](https://github.com/sanity-io/sanity/commit/a1a418209628a73c1178e456738f1ee2caed5a67))
+
+
+
+## [3.12.2](https://github.com/sanity-io/sanity/compare/v3.12.1...v3.12.2) (2023-06-20)
+
+
+### Bug Fixes
+
+* add missing tags ([#4607](https://github.com/sanity-io/sanity/issues/4607)) ([0de3b08](https://github.com/sanity-io/sanity/commit/0de3b081b85d64d7f1b562e0a469a425194a0cec))
+* **cli:** shopify studio intent fixes ([#4592](https://github.com/sanity-io/sanity/issues/4592)) ([1c301d4](https://github.com/sanity-io/sanity/commit/1c301d484d9506607f0ec5a8850b72892374194b))
+* **core:** a11y issue in command list ([#4600](https://github.com/sanity-io/sanity/issues/4600)) ([bf59af0](https://github.com/sanity-io/sanity/commit/bf59af062fd6c1bc392355275a0cfb18ac106d79))
+* **core:** align @types/react-is module version ([#4594](https://github.com/sanity-io/sanity/issues/4594)) ([ae39220](https://github.com/sanity-io/sanity/commit/ae39220166375e51f1ad71654f11c45565739927))
+* **core:** include request tag prefix for websocket ([#4590](https://github.com/sanity-io/sanity/issues/4590)) ([ccedf6e](https://github.com/sanity-io/sanity/commit/ccedf6e5c74ad74a4a5ed7c01b16eefcf24083e2))
+* **core:** re-add missing DocumentActionCustomDialogComponentProps ([d093e31](https://github.com/sanity-io/sanity/commit/d093e312c48344f681d37067a2775be64b743f92))
+* **core:** use portal prop on validation tooltip, remove muted text ([#4582](https://github.com/sanity-io/sanity/issues/4582)) ([7d6dc90](https://github.com/sanity-io/sanity/commit/7d6dc90260fc85cfebcd87efc46015d7eaf25cc1))
+* **deps:** update `@sanity/ui` ([b056494](https://github.com/sanity-io/sanity/commit/b0564946bb8ef00d8360b965f773222bc55037e3))
+
+
+### Features
+
+* add @sanity/tsdoc [sc-31040] ([17a5ec3](https://github.com/sanity-io/sanity/commit/17a5ec3199727aae2d9ae8e47c4511dfe3b6757e))
+* **sanity:** add hidden tag for tsdoc ([a94d548](https://github.com/sanity-io/sanity/commit/a94d5489f807ebfd812c1f4fcd7ea395577426e8))
+
+
+
+## [3.12.1](https://github.com/sanity-io/sanity/compare/v3.12.0...v3.12.1) (2023-06-14)
+
+
+### Bug Fixes
+
+* **cli:** prevent empty references for graphql unions ([#4583](https://github.com/sanity-io/sanity/issues/4583)) ([940dbb4](https://github.com/sanity-io/sanity/commit/940dbb447f3c914183464f44965a1e6e13858c2b))
+* **deps:** update dependency vite to v4.3.9 ([#4548](https://github.com/sanity-io/sanity/issues/4548)) ([b8337fb](https://github.com/sanity-io/sanity/commit/b8337fb756d590899225ab8946a96629c2ddb1e9))
+* **desk:** fix readOnly document state while document is syncing ([#4564](https://github.com/sanity-io/sanity/issues/4564)) ([305fe16](https://github.com/sanity-io/sanity/commit/305fe16043087fbf366f5cdc4bf4e911eef00bea))
+* **desk:** pane item selected ui ([#4569](https://github.com/sanity-io/sanity/issues/4569)) ([9d355f8](https://github.com/sanity-io/sanity/commit/9d355f80a917eb6966c7f126c78feb2b6aaf1984))
+
+
+### Features
+
+* **mutator:** export `extract` method ([#4461](https://github.com/sanity-io/sanity/issues/4461)) ([e4779a6](https://github.com/sanity-io/sanity/commit/e4779a6b84de7ad7b2c05e5cd0ad9c0c562a2013))
+
+
+
+# [3.12.0](https://github.com/sanity-io/sanity/compare/v3.11.5...v3.12.0) (2023-06-06)
+
+
+### Bug Fixes
+
+* **block-tools:** preserve whitespace in preprocess for certain html tags ([#4540](https://github.com/sanity-io/sanity/issues/4540)) ([4848781](https://github.com/sanity-io/sanity/commit/4848781bb04b8bf921012a16403a65d415f31da9))
+* **form:** check for shallow emptyness instead of deep when determining whether a patch should unset the value ([f2e16ff](https://github.com/sanity-io/sanity/commit/f2e16ff56060bcd716f7bdbc9a09a0a7d40c1ed6))
+* **form:** fix bug making fields not inherit document level readOnly state ([#4558](https://github.com/sanity-io/sanity/issues/4558)) ([6f5578d](https://github.com/sanity-io/sanity/commit/6f5578d5da83453a7c1e7f05d816a7e822678e5d))
+* **form:** pass the correct data to conditional fields contained inside fieldsets ([#4556](https://github.com/sanity-io/sanity/issues/4556)) ([a08334f](https://github.com/sanity-io/sanity/commit/a08334fdf0f8ff3156f72eaaf27f282bfad0838f))
+* **perf:** add flag to list known test ids ([#4553](https://github.com/sanity-io/sanity/issues/4553)) ([981b99f](https://github.com/sanity-io/sanity/commit/981b99f9c25e8b466344bb08ba49fd6e7474e147))
+
+
+
+## [3.11.5](https://github.com/sanity-io/sanity/compare/v3.11.4...v3.11.5) (2023-05-31)
+
+
+
+## [3.11.4](https://github.com/sanity-io/sanity/compare/v3.11.3...v3.11.4) (2023-05-31)
+
+
+### Bug Fixes
+
+* **core/form/inputs:** clean up rebase leftovers (next branch) ([3923b6c](https://github.com/sanity-io/sanity/commit/3923b6c2219bc859195d96ef3a777f04ed68e9f7))
+* **core/form/inputs:** fix issue with re-focusing the editor after toggling fullscreen ([02feb8d](https://github.com/sanity-io/sanity/commit/02feb8dc1d86303a9896453ee19bce183adaaf48))
+* **core/form/inputs:** rename autofocus > autoFocus ([fb88521](https://github.com/sanity-io/sanity/commit/fb88521d05fda94e43f883fe26753c1445acfdb7))
+* **core/form/inputs:** use isImage asserter to determine image preview ([#4532](https://github.com/sanity-io/sanity/issues/4532)) ([c2f98ba](https://github.com/sanity-io/sanity/commit/c2f98ba88cb56121cf4d5ff0ab020a6cac700631))
+* **core/form/inputs:** value should be passed here, not schematype ([854e37a](https://github.com/sanity-io/sanity/commit/854e37a2821852605c6b9b41eb2b7cc8c7f93bd2))
+* **core:** add change indicators to boolean fields ([#4538](https://github.com/sanity-io/sanity/issues/4538)) ([94e1c7a](https://github.com/sanity-io/sanity/commit/94e1c7a4e015545cb884fec10088829022794a2b))
+* **deps:** update dependency @portabletext/types to v2 ([#4379](https://github.com/sanity-io/sanity/issues/4379)) ([83711a4](https://github.com/sanity-io/sanity/commit/83711a45e1225bb92d5122775b7c4b120e4990f8))
+* **deps:** update dependency groq-js to v1 ([#4384](https://github.com/sanity-io/sanity/issues/4384)) ([cf002fb](https://github.com/sanity-io/sanity/commit/cf002fb977853456ad5d3adf832a2a23f640772f))
+* whitelist all standard text decorators in block-tools ([#4526](https://github.com/sanity-io/sanity/issues/4526)) ([47be700](https://github.com/sanity-io/sanity/commit/47be70099399633b71741cac57bbfa1319765c35))
+
+
+### Features
+
+* **core:** add document action custom dialog component ([#4529](https://github.com/sanity-io/sanity/issues/4529)) ([d6a841b](https://github.com/sanity-io/sanity/commit/d6a841bf7a777a6b374199d47fa6c61b2754fbc7))
+
+
+
+## [3.11.3](https://github.com/sanity-io/sanity/compare/v3.11.2...v3.11.3) (2023-05-25)
+
+
+### Bug Fixes
+
+* **core/form/inputs:** fix rendering regression for PT-input ([#4530](https://github.com/sanity-io/sanity/issues/4530)) ([fba12cf](https://github.com/sanity-io/sanity/commit/fba12cf73cb0bbcd17a077a5acd8e3a79051d9d0))
+* **core:** add `PortableTextInputProps` to `InputProps` union ([#4522](https://github.com/sanity-io/sanity/issues/4522)) ([4031d3c](https://github.com/sanity-io/sanity/commit/4031d3c0682bd31084e25f5e3f8165b7ef28312c))
+* **deps:** update dependency @tanstack/react-virtual to v3.0.0-beta.54 ([#4478](https://github.com/sanity-io/sanity/issues/4478)) ([4bef600](https://github.com/sanity-io/sanity/commit/4bef6000e27d7c15371872ee7ed022b64b91dd2e))
+
+
+
+## [3.11.2](https://github.com/sanity-io/sanity/compare/v3.11.1...v3.11.2) (2023-05-24)
+
+
+### Bug Fixes
+
+* **core:** editing reference input in PTE does not show value ([#4499](https://github.com/sanity-io/sanity/issues/4499)) ([7a4275e](https://github.com/sanity-io/sanity/commit/7a4275e2ba654cd059014adaa8e896f0b5d7927b))
+* **core:** fix image and file upload ([#4518](https://github.com/sanity-io/sanity/issues/4518)) ([8861dfa](https://github.com/sanity-io/sanity/commit/8861dfafa92549eeca844eeee0635d500f1ac473))
+* **core:** fix PT reference autocomplete being cut off ([#4519](https://github.com/sanity-io/sanity/issues/4519)) ([6581afd](https://github.com/sanity-io/sanity/commit/6581afddb0685ae2f5ca2c40790f3abb47ba3367))
+* **deps:** update dependency @sanity/client to 6.1.1 ([05b29b7](https://github.com/sanity-io/sanity/commit/05b29b7670261c0def25d71e704f1b80f2a90515))
+* **form/inputs:** ensure same empty presence object for PT-input components ([6c7c4e4](https://github.com/sanity-io/sanity/commit/6c7c4e43ce15d0ca2f1687306c27482ad0f00384))
+* **form/inputs:** fix re-rendering issue with PT-input block object ([75dfb9c](https://github.com/sanity-io/sanity/commit/75dfb9ca1bbb6bc21cad9c8139e4a9d87f9522ad))
+* **form/inputs:** use ref to value as dependency ([4c83b91](https://github.com/sanity-io/sanity/commit/4c83b91d2d0ea63670e2a8deab567918cd508598))
+
+
+
+## [3.11.1](https://github.com/sanity-io/sanity/compare/v3.11.0...v3.11.1) (2023-05-16)
+
+
+
+# [3.11.0](https://github.com/sanity-io/sanity/compare/v3.10.3...v3.11.0) (2023-05-15)
+
+
+### Bug Fixes
+
+* avoid scroll on `overflow: hidden` ([#4458](https://github.com/sanity-io/sanity/issues/4458)) ([47302b5](https://github.com/sanity-io/sanity/commit/47302b5fa4ce52e973489b52bb834b702186ebfa))
+* **core:**  unset objects when no values in patch when empty value ([#4495](https://github.com/sanity-io/sanity/issues/4495)) ([ba760f3](https://github.com/sanity-io/sanity/commit/ba760f3c9153622100ec91909081165ff5c1d928))
+* **deps:** update dependency @sanity/client to v6 ([#4454](https://github.com/sanity-io/sanity/issues/4454)) ([e092721](https://github.com/sanity-io/sanity/commit/e092721ff056eeb471e04df262c1206abba76ae6))
+* **deps:** update dependency @vercel/frameworks to v1.4.2 ([97b923e](https://github.com/sanity-io/sanity/commit/97b923ec4823c331c3691b9d2ccf1f198c9a64ee))
+* **deps:** update dependency @vercel/fs-detectors to v3.9.2 ([56c81ff](https://github.com/sanity-io/sanity/commit/56c81ff3ed5e4bab4a728e2e00569cafa0189718))
+* **deps:** update dependency framer-motion to v10.12.10 ([9602964](https://github.com/sanity-io/sanity/commit/96029646e01ad5b1aab801120beed27df39bba73))
+* **desk:** remove path param from url after initially read ([#4469](https://github.com/sanity-io/sanity/issues/4469)) ([eee026d](https://github.com/sanity-io/sanity/commit/eee026d4365eaa9a821cc4b5251e88e069e0c118))
+* **form/inputs:** improve tracking of formState focusPath for PT-input ([#4466](https://github.com/sanity-io/sanity/issues/4466)) ([bdcea25](https://github.com/sanity-io/sanity/commit/bdcea252f319af7c3e71d8c975183671bb287d01))
+* **form:** show fields without groups only when 'All fields' is selected ([#4472](https://github.com/sanity-io/sanity/issues/4472)) ([b246b81](https://github.com/sanity-io/sanity/commit/b246b818df40c19731cb2955ea2c3f9c171b175f))
+* **portable-text-editor:** fix sync issue with text spans ([#4467](https://github.com/sanity-io/sanity/issues/4467)) ([036e68a](https://github.com/sanity-io/sanity/commit/036e68ab7c8656a85285ca2bb287e3d9b0a23e33))
+
+
+### Features
+
+* document list search ([#4436](https://github.com/sanity-io/sanity/issues/4436)) ([c6a729f](https://github.com/sanity-io/sanity/commit/c6a729fbf964642bfd3c9370cb0abe98b49a9b16)), closes [#4441](https://github.com/sanity-io/sanity/issues/4441)
+
+
+
+## [3.10.3](https://github.com/sanity-io/sanity/compare/v3.10.1...v3.10.3) (2023-05-12)
+
+
+
+## [3.10.1](https://github.com/sanity-io/sanity/compare/v3.10.0...v3.10.1) (2023-05-09)
+
+
+### Bug Fixes
+
+* **core:** ensure the create new button dialog is functional on smaller breakpoints ([#4450](https://github.com/sanity-io/sanity/issues/4450)) ([f1dc5ec](https://github.com/sanity-io/sanity/commit/f1dc5ec2ebde28bd1a99f3d0154ab3ef27e87dbe))
+* **core:** prevent number primitive fields from triggering change callbacks when numbers are out of range ([#4456](https://github.com/sanity-io/sanity/issues/4456)) ([aa2dd6e](https://github.com/sanity-io/sanity/commit/aa2dd6efffe8d49f7989add3a32d30e9b606be72))
+
+
+
+# [3.10.0](https://github.com/sanity-io/sanity/compare/v3.9.1...v3.10.0) (2023-05-03)
+
+
+### Bug Fixes
+
+* **cli:** add missing dependencies for shopify template ([8af0512](https://github.com/sanity-io/sanity/commit/8af0512a2240dea00e35329789a4a1a625e5db5f))
+* **cli:** prefer package manager that is currently executing ([#4426](https://github.com/sanity-io/sanity/issues/4426)) ([4523046](https://github.com/sanity-io/sanity/commit/4523046efd4627a8c2479b96397be56b67bb3d48))
+* **cli:** resolve and install latest sanity+vision dependencies ([#4424](https://github.com/sanity-io/sanity/issues/4424)) ([25303f9](https://github.com/sanity-io/sanity/commit/25303f97027a2959adf008525549aaf92938ac27))
+* **cli:** shopify template docs typos ([46bcf81](https://github.com/sanity-io/sanity/commit/46bcf812c4c1a021d2ef7e86e7dd14d5c376b111))
+* **cli:** skip v3 init prompt in unattended mode ([#4425](https://github.com/sanity-io/sanity/issues/4425)) ([7c17124](https://github.com/sanity-io/sanity/commit/7c17124e1c84748ad70821d9be7c47c2af35001f))
+* **cli:** sync shopify template updates ([8047e5d](https://github.com/sanity-io/sanity/commit/8047e5de9b3aa891e366a6a76841d916606310f5))
+* **cli:** update shopify template dependency ranges ([d159107](https://github.com/sanity-io/sanity/commit/d159107ef0ea20e2d651a2008b8d6861614093f1))
+* **core:** add fieldset within field to expandOperation ([488676a](https://github.com/sanity-io/sanity/commit/488676a0cb52178b98a6a387f03d0639e345861e))
+* **core:** focus first descendant in FormView when empty initial focus path is given ([350b567](https://github.com/sanity-io/sanity/commit/350b5678074696a705c41ec5e0883bf5d8b0b0be))
+* **core:** scroll PTE input into view when receiving focus ([627640d](https://github.com/sanity-io/sanity/commit/627640df4372baebe87b3d85fd7d828dfd9dd633))
+* **deps:** update codemirror ([#4377](https://github.com/sanity-io/sanity/issues/4377)) ([989dd81](https://github.com/sanity-io/sanity/commit/989dd812adb92583e8ae24269cffbb66568c2e81))
+* **desk:** set collapsed/fieldgroup/open path based on router path ([b1f1eb4](https://github.com/sanity-io/sanity/commit/b1f1eb4b739d127133c24affe0ff6b06bfd0adc6))
+* **desk:** use resolveKeyedPath to set initial open/focus path from url ([dc04b49](https://github.com/sanity-io/sanity/commit/dc04b49883022c5096966b417aa9863745d8adea))
+* **form:** fix focus issue with reference fields ([#4429](https://github.com/sanity-io/sanity/issues/4429)) ([912ce0d](https://github.com/sanity-io/sanity/commit/912ce0d40208f5e25dbb6cc10b8dbcd121bbbd88))
+* **form:** improve focus handling for image and file inputs ([#4451](https://github.com/sanity-io/sanity/issues/4451)) ([dd8e424](https://github.com/sanity-io/sanity/commit/dd8e424c0180aed262161f7223d1122e93e15e2e))
+* **form:** make sure getExpandOperations recursively expands objects and fieldsets ([8d50b9e](https://github.com/sanity-io/sanity/commit/8d50b9ea1bb0dafead3af2cdb044368086b06495))
+* **form:** prevent autofocus on array dialogs where focus is on a deeper value ([8cb0642](https://github.com/sanity-io/sanity/commit/8cb064261d31cf90c8c678de4c598f09f6db40c2))
+* **form:** skip autofocus on field groups as it's handled by either focusPath or focusFirstDescendant ([51c9483](https://github.com/sanity-io/sanity/commit/51c94836ac1c2fe370ee648408f8185d9c3df830))
+* **form:** sync local focus state when focused/focusPath props change ([89adbd8](https://github.com/sanity-io/sanity/commit/89adbd86ccd52b50249f0cd91cf5c2367f909d8a))
+
+
+### Features
+
+* **cli:** `sanity init` for Next.js apps ([#4439](https://github.com/sanity-io/sanity/issues/4439)) ([6effcfe](https://github.com/sanity-io/sanity/commit/6effcfec7a2f67f1c5c813f1dcb0c09b4f6bfae7))
+* **cli:** skip dataset name validation in unattended mode when provided through options ([#4422](https://github.com/sanity-io/sanity/issues/4422)) ([605d62b](https://github.com/sanity-io/sanity/commit/605d62bc75720d9eca7b5cbe0d681daddcac233c))
+* **util:** add resolveKeyedPath ([ec31040](https://github.com/sanity-io/sanity/commit/ec310409df37a96fd0147bc48495b560b6023b42))
+
+
+
+## [3.9.1](https://github.com/sanity-io/sanity/compare/v3.9.0...v3.9.1) (2023-04-26)
+
+
+### Bug Fixes
+
+* **cli:** remove broken custom document component link ([71f0d45](https://github.com/sanity-io/sanity/commit/71f0d4566db0f29eaf4ef12ea9de8d25382e6f79))
+* **cli:** use more recent version ranges for new projects ([#4393](https://github.com/sanity-io/sanity/issues/4393)) ([b382120](https://github.com/sanity-io/sanity/commit/b3821203d716af3b9ace85cb0fee8bc8d1074d62))
+* **core:** add max height to popover ([#4414](https://github.com/sanity-io/sanity/issues/4414)) ([6742eda](https://github.com/sanity-io/sanity/commit/6742eda1f969a3ba329b49d5f14f180585afe9fc))
+* **core:** allow for skipping visibility in preview element (fix flickering issue) ([#4408](https://github.com/sanity-io/sanity/issues/4408)) ([2aa071b](https://github.com/sanity-io/sanity/commit/2aa071b5fa866171550defa723d7b7d06edd5cc2))
+* **core:** array item not showing when using `modal: 'popover'` ([#4423](https://github.com/sanity-io/sanity/issues/4423)) ([8106688](https://github.com/sanity-io/sanity/commit/8106688dddcff056012c5d9a6e90f40bdd759b96))
+* **core:** fix focus issues when a new reference field is added ([#4400](https://github.com/sanity-io/sanity/issues/4400)) ([c575bcb](https://github.com/sanity-io/sanity/commit/c575bcb6f7b12435c307d00046dc913f3d3d9003))
+* **core:** fix scrolling issue with documents ([35c0ba9](https://github.com/sanity-io/sanity/commit/35c0ba90b0b048c6669ea30a7df3dc1b445dbe57))
+* **core:** list virtualization is broken inside modals ([#4410](https://github.com/sanity-io/sanity/issues/4410)) ([a00f0b9](https://github.com/sanity-io/sanity/commit/a00f0b97e4b2ef903b4241d51f9b0dfe095d0385))
+* **deps:** update dependency framer-motion to v10 ([#4380](https://github.com/sanity-io/sanity/issues/4380)) ([09d7f7c](https://github.com/sanity-io/sanity/commit/09d7f7c30433c9d5d824bc4c6729d3ca72bb111b))
+* **desk:** Change message shown after successfully deleting document ([#4398](https://github.com/sanity-io/sanity/issues/4398)) ([14f7f6d](https://github.com/sanity-io/sanity/commit/14f7f6dcf216bd6ddb9633f40b77dcc9c7ee1ee4))
+* **desk:** document timeline performance improvements ([#4347](https://github.com/sanity-io/sanity/issues/4347)) ([4d56352](https://github.com/sanity-io/sanity/commit/4d56352eb759aaf3d848cf62d8cb685c231a7255))
+* exhaustive dependency arrays ([#4368](https://github.com/sanity-io/sanity/issues/4368)) ([2d7fe78](https://github.com/sanity-io/sanity/commit/2d7fe784c41b455db5e3f0812d52568ec314da72))
+* **form:** force-select "all fields" group and disable all others when changes panel is open ([755c337](https://github.com/sanity-io/sanity/commit/755c337ee73f032bd7b42811515566aa137f132b))
+* **form:** hide field groups where all fields are hidden ([fcfe3a8](https://github.com/sanity-io/sanity/commit/fcfe3a8e63645c686a21c7bf39abc4bd863413cc))
+* **form:** wrap members in an intermediate structure and hide field groups with no fields ([e6bafe0](https://github.com/sanity-io/sanity/commit/e6bafe00ebb0a64352c4d11c7d9dff9b1c15113c))
+* **portable-text-editor:** fix issue with PTE merge operation not producing unset patch ([#4416](https://github.com/sanity-io/sanity/issues/4416)) ([3f2b278](https://github.com/sanity-io/sanity/commit/3f2b278bb00dcae96df88dd819bc2d60b4535314))
+* **portable-text-editor:** ignore void edits inside markDefs ([#4419](https://github.com/sanity-io/sanity/issues/4419)) ([1800fe5](https://github.com/sanity-io/sanity/commit/1800fe5cf47ed6d73f9d76e1cd5e5173825079c1))
+* **portable-text-editor:** keep selection when emtied remotely ([d30d93c](https://github.com/sanity-io/sanity/commit/d30d93cd49772551fb422cf82d22ca880d26fa2f))
+* **validation:** Remove recursive validation check for annotations in pte ([#4397](https://github.com/sanity-io/sanity/issues/4397)) ([5e47c39](https://github.com/sanity-io/sanity/commit/5e47c398d4df9df4c2407f4f67633e5d5f088da7))
+
+
+### Features
+
+* **cli:** support serving custom favicons ([#4394](https://github.com/sanity-io/sanity/issues/4394)) ([14be444](https://github.com/sanity-io/sanity/commit/14be444877463674a34fe7204d501dd24c158c28))
+
+
+
+# [3.9.0](https://github.com/sanity-io/sanity/compare/v3.8.3...v3.9.0) (2023-04-18)
+
+
+### Bug Fixes
+
+* **cli:** apply user vite config in `preview` ([9432959](https://github.com/sanity-io/sanity/commit/94329592b1d922af8964fdd2183284942f4456cb))
+* **cli:** fix basePath not assigned to css files ([#4354](https://github.com/sanity-io/sanity/issues/4354)) ([7126000](https://github.com/sanity-io/sanity/commit/71260003e9fd0fea1133c1ac8a8eb065911fa98c))
+* **core:** add ellipsis textOverflow to type in file picker list ([#4348](https://github.com/sanity-io/sanity/issues/4348)) ([fcbea4b](https://github.com/sanity-io/sanity/commit/fcbea4b634cc934cebc9b5e391ba53380c1e57ac))
+* **core:** add virtualization to array of objects and references ([#4299](https://github.com/sanity-io/sanity/issues/4299)) ([09afa59](https://github.com/sanity-io/sanity/commit/09afa59ad69870da94a096d3d466e504d5a919c0))
+* **core:** capitalize type name if item type lacks title in pte ([#4385](https://github.com/sanity-io/sanity/issues/4385)) ([df16d46](https://github.com/sanity-io/sanity/commit/df16d464cf9ae6ebabdbc5883f60c5e036e13d98))
+* **core:** clear unused references in an array when clicked outside ([#4361](https://github.com/sanity-io/sanity/issues/4361)) ([cb9ef3a](https://github.com/sanity-io/sanity/commit/cb9ef3ab3890655594b2c9ee300d9471f2b9b387))
+* **core:** fix permissions when initialValue is empty object ([#4360](https://github.com/sanity-io/sanity/issues/4360)) ([937421a](https://github.com/sanity-io/sanity/commit/937421a0a93bc9716667257b79485f7c277f7fe3))
+* **core:** fix typos in config reducer error messages ([72b37a5](https://github.com/sanity-io/sanity/commit/72b37a5ef6551c2359c3f2ff56f1b4effa8149bc))
+* **deps:** update `@sanity/icons` ([2f0ec12](https://github.com/sanity-io/sanity/commit/2f0ec122a64771965ab0ee35cc4e13746564ab16))
+* **deps:** update dependency @types/three to ^0.150.0 ([#4382](https://github.com/sanity-io/sanity/issues/4382)) ([629acf4](https://github.com/sanity-io/sanity/commit/629acf4a543e1ffe7c88e16cbc171523deabb3d3))
+* **deps:** update dependency scroll-into-view-if-needed to v3.0.10 ([#4328](https://github.com/sanity-io/sanity/issues/4328)) ([0e598ba](https://github.com/sanity-io/sanity/commit/0e598baaec1b4849fc1c27235b54a304a6816cf7))
+* **deps:** update dependency three to ^0.151.0 ([#4383](https://github.com/sanity-io/sanity/issues/4383)) ([f6f9b8c](https://github.com/sanity-io/sanity/commit/f6f9b8ced780179aa16dc124ab78792d3b573118))
+* **desk:** compare selected on  sortOrderRaw instead of sortOrder ([#4345](https://github.com/sanity-io/sanity/issues/4345)) ([16cf235](https://github.com/sanity-io/sanity/commit/16cf23550bc33f7f34ecc6e1d7febce85b7eb7e4))
+* log inability to fetch user for avatars, revent studio crash ([#4367](https://github.com/sanity-io/sanity/issues/4367)) ([bcc240d](https://github.com/sanity-io/sanity/commit/bcc240dee3324e159954679d969aac43a294559e))
+* **perf-runner:** add support for running tests against recent tags only ([#4386](https://github.com/sanity-io/sanity/issues/4386)) ([036c029](https://github.com/sanity-io/sanity/commit/036c0298347dd289867c69a3b939a3c8f762c6e9))
+* **portable-text-editor:** invalid Portable Text value causing crash ([#4364](https://github.com/sanity-io/sanity/issues/4364)) ([2a15433](https://github.com/sanity-io/sanity/commit/2a154336ff4e4e00eb291ebb766e04c66d34ee21))
+* refactor desk tool intent resolver to reduce remounts ([#4363](https://github.com/sanity-io/sanity/issues/4363)) ([e888f51](https://github.com/sanity-io/sanity/commit/e888f513b5a450476f0833f3646f664c4131f258))
+* **schema:** validate that object has no standalone block fields ([#4199](https://github.com/sanity-io/sanity/issues/4199)) ([c131116](https://github.com/sanity-io/sanity/commit/c1311164a99610776a5ecd7991fc1bc6c32664bc)), closes [#4152](https://github.com/sanity-io/sanity/issues/4152)
+
+
+### Features
+
+* **cli:** add `--bare` and `--env` flags to `sanity init` ([#4290](https://github.com/sanity-io/sanity/issues/4290)) ([345d319](https://github.com/sanity-io/sanity/commit/345d319ee1308b23f29f94b3748ac9b7b02b09f7))
+* **cli:** align with vite config fn behavior ([437a1b4](https://github.com/sanity-io/sanity/commit/437a1b45895d2fcefe53e9e53d8bd847d1657f57))
+* **cli:** merge user vite config object ([53f7808](https://github.com/sanity-io/sanity/commit/53f780826544dee8ffa02bf2aac6e288c3e4ea58))
+
+
+
+## [3.8.3](https://github.com/sanity-io/sanity/compare/v3.8.2...v3.8.3) (2023-04-04)
+
+
+### Bug Fixes
+
+* **core:** fix document title not working ([#4325](https://github.com/sanity-io/sanity/issues/4325)) ([76992d6](https://github.com/sanity-io/sanity/commit/76992d69e11e7c6304f8347a4a8fcbbb7c02b02f)), closes [#4319](https://github.com/sanity-io/sanity/issues/4319) [#4324](https://github.com/sanity-io/sanity/issues/4324)
+* **form:** fix issue with immutableReconcile producing new identities for siblings of changed items ([19e2a13](https://github.com/sanity-io/sanity/commit/19e2a1387f30d6f92c61112cea010d8ddef8cc6b))
+* **perf-runner:** handle test errors and store on performanceTestRun documents ([#4332](https://github.com/sanity-io/sanity/issues/4332)) ([0e1e717](https://github.com/sanity-io/sanity/commit/0e1e71798c2007b6709adcc4f866b57a3e5e090c))
+* **perf:** make sure form callbacks are stable ([9a03202](https://github.com/sanity-io/sanity/commit/9a03202c9e3c17c9274f9144b9fb460ca0705eb1))
+* **perf:** memoize list of ids passed to Sortable ([81d6551](https://github.com/sanity-io/sanity/commit/81d6551121150c32c0e8f220ce16dd8fc30e20ad))
+* **router:** resolve intent resolver regression since `v3.7.1` ([#4344](https://github.com/sanity-io/sanity/issues/4344)) ([8a2a52d](https://github.com/sanity-io/sanity/commit/8a2a52d329989aae518146ea6c7d7ae0916d92e8))
+
+
+
+## [3.8.2](https://github.com/sanity-io/sanity/compare/v3.8.1...v3.8.2) (2023-03-31)
+
+
+### Bug Fixes
+
+* **portable-text-editor:** fix wrong path being created for markDefs ([#4341](https://github.com/sanity-io/sanity/issues/4341)) ([016efc7](https://github.com/sanity-io/sanity/commit/016efc7cefdb4ee0fbcd5de8f1d34cbfc1346388))
+
+
+
+## [3.8.1](https://github.com/sanity-io/sanity/compare/v3.8.0...v3.8.1) (2023-03-29)
+
+
+### Bug Fixes
+
+* **form/inputs:** fix Safari issue with annotation edit popovers being hidden ([6d2a7b3](https://github.com/sanity-io/sanity/commit/6d2a7b3a298a852f3e285611ea37f0f1b2a13f31))
+* **portable-text-editor:** fix issue when pasting mulitple empty blocks ([469a262](https://github.com/sanity-io/sanity/commit/469a262171c0aec8480f23fe44e449ecdff45369))
+
+
+
+# [3.8.0](https://github.com/sanity-io/sanity/compare/v3.7.1...v3.8.0) (2023-03-28)
+
+
+### Bug Fixes
+
+* **form/inputs:** fix invalid CSS value ([0f42777](https://github.com/sanity-io/sanity/commit/0f42777bb4a5b9bf55fbfd72dfe343c505ebb073))
+* **form/inputs:** fix popover open/close state issue with PT-input ([921319c](https://github.com/sanity-io/sanity/commit/921319cccdc00f6aead63b34dd3c2f4d3f9e3cde))
+* **form/inputs:** fix wrong mode for delete inline object call ([c92586f](https://github.com/sanity-io/sanity/commit/c92586f18ee22fa1493e39c2ef64cb0dac9109ee))
+* **form/inputs:** mark as not contentEditable ([0d79679](https://github.com/sanity-io/sanity/commit/0d796790c2f16dbc3adf202b53a941d99de498ed))
+* **form/inputs:** test for length of focusPath before creating initial selection ([c571694](https://github.com/sanity-io/sanity/commit/c5716949c9a6a803420602c71df9b6feb744df6b))
+* **portable-text-editor:** ensure that changed inlineBlocks gets correct _key ([aea3b23](https://github.com/sanity-io/sanity/commit/aea3b23bc8ff388519c1f542eac434244b5c4249))
+* **portable-text-editor:** fix incorrect path matching with diffMatchPatches ([3e121d4](https://github.com/sanity-io/sanity/commit/3e121d4fb81b7689ac3e2d2a9221cb03ce69dde5))
+* **portable-text-editor:** fix issue with focused and selected prop for leaves ([1766c63](https://github.com/sanity-io/sanity/commit/1766c63c2073990d52bc8e0df82c55abaeab3ac0))
+* **portable-text-editor:** fix issue with setIfMissing and insert patches on empty editor ([3aee080](https://github.com/sanity-io/sanity/commit/3aee080704116511a8e30f22cf5b360424cfe1f3))
+* **portable-text-editor:** fix useMemo deps gone wrong ([2b3004b](https://github.com/sanity-io/sanity/commit/2b3004bef6e50c5686a19edcfa4cf4548ad21848))
+* **portable-text-editor:** make deprecated property non-enumerable ([b9f0b5f](https://github.com/sanity-io/sanity/commit/b9f0b5fad21ac8d55227588149b729f3525e44ab))
+* **portable-text-editor:** remove redundant and incorrect hook ([485e18b](https://github.com/sanity-io/sanity/commit/485e18b68def08dec5f01520fdce2b22a0e97895))
+* **portable-text-editor:** remove unused props left behind ([fc6326f](https://github.com/sanity-io/sanity/commit/fc6326ff6e7ea786b3b54d150a0c5a6faca057b2))
+* upgrade `@sanity/eventsource` ([#4303](https://github.com/sanity-io/sanity/issues/4303)) ([55c4f31](https://github.com/sanity-io/sanity/commit/55c4f31b6315c40a171ba766f99b10f63e69e561))
+* **vision:** fix results getting cut off in vision ([#4287](https://github.com/sanity-io/sanity/issues/4287)) ([63753c2](https://github.com/sanity-io/sanity/commit/63753c24291558a870166480a4553234d9c8d411))
+
+
+### Features
+
+* **core:** improve global create menu ([#4288](https://github.com/sanity-io/sanity/issues/4288)) ([ea69cf4](https://github.com/sanity-io/sanity/commit/ea69cf4c8dbde31d29a1dce2700ce482f2fad5e3))
+
+
+
+## [3.7.1](https://github.com/sanity-io/sanity/compare/v3.7.0...v3.7.1) (2023-03-21)
+
+
+### Bug Fixes
+
+* **core:** handle 403 responses when calling `userStore.getUser()` ([#4281](https://github.com/sanity-io/sanity/issues/4281)) ([06fc26e](https://github.com/sanity-io/sanity/commit/06fc26e12306c6fab51b96703f88fc8c50100460))
+* **core:** remove array from document when it's only item is unset ([#4285](https://github.com/sanity-io/sanity/issues/4285)) ([8a2b8ad](https://github.com/sanity-io/sanity/commit/8a2b8adeb154c6514b6009e8586aa1d3b47c0f5f))
+* **core:** typo ([2155050](https://github.com/sanity-io/sanity/commit/2155050b379b4198ba2d79989d845d99366e6792))
+* preserve preview panes on small screens ([#4276](https://github.com/sanity-io/sanity/issues/4276)) ([c5ca9b6](https://github.com/sanity-io/sanity/commit/c5ca9b6b7ea535a445ff1b367cbb9a52a0cb7fa5))
+* **SSR:** handle `scheme` & `onSchemeChange` props edge cases ([#4283](https://github.com/sanity-io/sanity/issues/4283)) ([0082be5](https://github.com/sanity-io/sanity/commit/0082be56225633a2c3c6cd2e4fa1a910c9b4e70f))
+* **types:** add `hidden` to `FieldGroupDefinition` ([#4208](https://github.com/sanity-io/sanity/issues/4208)) ([0fcb439](https://github.com/sanity-io/sanity/commit/0fcb43956c89283cfc64cbcbf5ffe530efc2efdd))
+* upgrade `history` to v5 ([#4282](https://github.com/sanity-io/sanity/issues/4282)) ([1adf7f9](https://github.com/sanity-io/sanity/commit/1adf7f90908c69e206a9ec94538477c6fcf23d08))
+
+
+
+# [3.7.0](https://github.com/sanity-io/sanity/compare/v3.6.0...v3.7.0) (2023-03-15)
+
+
+### Bug Fixes
+
+* **core:** fix deleting invalid reference items in array ([#4256](https://github.com/sanity-io/sanity/issues/4256)) ([a81119e](https://github.com/sanity-io/sanity/commit/a81119e2b2ca68fa21dc472ecb53fda89e819d02))
+* **core:** fix typings to reflect that the second argument to patch.execute is optional ([#4274](https://github.com/sanity-io/sanity/issues/4274)) ([401192c](https://github.com/sanity-io/sanity/commit/401192ca9dbfc3026211c714ec90db1cb46a9db2))
+* **core:** remove button to convert to reference for arrays ([#4275](https://github.com/sanity-io/sanity/issues/4275)) ([5d3de49](https://github.com/sanity-io/sanity/commit/5d3de498094889f6eb186c1371928dbf8fd2f778))
+* **validation:** show validation error for missing _ref ([#4264](https://github.com/sanity-io/sanity/issues/4264)) ([5634746](https://github.com/sanity-io/sanity/commit/56347466f2292637dca23cb77545c9cb5e53397b))
+
+
+### Features
+
+* **core:** provide `getClient()` method to reference filter context ([#4267](https://github.com/sanity-io/sanity/issues/4267)) ([28f2f6a](https://github.com/sanity-io/sanity/commit/28f2f6a3110c5a86de2e5b022f31ca744772e0a8))
+
+
+
+# [3.6.0](https://github.com/sanity-io/sanity/compare/v3.5.1...v3.6.0) (2023-03-08)
+
+
+### Bug Fixes
+
+* **auth:** use configured api hostname for auth checks ([#4234](https://github.com/sanity-io/sanity/issues/4234)) ([5e7faeb](https://github.com/sanity-io/sanity/commit/5e7faeb52cd08653b4f6e9f4cd550c58945eb9fe))
+* **ci:** enable perf test workflow for "next"-branch ([921a0c6](https://github.com/sanity-io/sanity/commit/921a0c669928236594a0110b198e15095ee7a98b))
+* **ci:** set a 60 minute timeout on the test workflow ([b9d666f](https://github.com/sanity-io/sanity/commit/b9d666fa30d6f3aaf28d8c1248492c76d23bbbda))
+* **core:** changing workspace with same document id causes error ([#4223](https://github.com/sanity-io/sanity/issues/4223)) ([2db15e9](https://github.com/sanity-io/sanity/commit/2db15e99fca2a08ec7e987ec6ad26e540277e503))
+* **core:** ensure filter function on reference field is always fired when menu is opened ([#4241](https://github.com/sanity-io/sanity/issues/4241)) ([e32302b](https://github.com/sanity-io/sanity/commit/e32302b6e2d273571c408793de0d46b04711f6f3))
+* **core:** fix crash when history does not include valid user information ([#4248](https://github.com/sanity-io/sanity/issues/4248)) ([3825976](https://github.com/sanity-io/sanity/commit/3825976ef09175fcef524101ea5fde15158b4ec2))
+* **core:** focus issue in nav drawer ([#4232](https://github.com/sanity-io/sanity/issues/4232)) ([2e6e59a](https://github.com/sanity-io/sanity/commit/2e6e59a176286e49e954d1f393e52aaa1e5d7b63))
+* **core:** icons not showing in array fields ([#4242](https://github.com/sanity-io/sanity/issues/4242)) ([1465a1a](https://github.com/sanity-io/sanity/commit/1465a1afb9bbe401111e1a838cefeef0b293ab93))
+* **core:** restore "open in new tab" function for reference arrays ([#4243](https://github.com/sanity-io/sanity/issues/4243)) ([115dd23](https://github.com/sanity-io/sanity/commit/115dd234745f6bb25a656d5343cf6e81c19777ab))
+* **core:** search performance improvements ([#4216](https://github.com/sanity-io/sanity/issues/4216)) ([824b5fd](https://github.com/sanity-io/sanity/commit/824b5fd03b0fd0d83852fb29f5b6d9ca98ba4778))
+* **deps:** upgrade playwright to latest ([3926ba3](https://github.com/sanity-io/sanity/commit/3926ba3bb1cbfc8f796a27502ca23a36da2f1007))
+* **desk:** attempt to resolve missing document type automatically ([#4244](https://github.com/sanity-io/sanity/issues/4244)) ([a038ecf](https://github.com/sanity-io/sanity/commit/a038ecff7631f81a3705bb17ffb4da36a125be45))
+* **desk:** cyrillic characters in deskStructure crashing sanity ([#4224](https://github.com/sanity-io/sanity/issues/4224)) ([98f716b](https://github.com/sanity-io/sanity/commit/98f716bfcd5289ba9e2b944b8812d62f4ffc9240))
+* **form:** allow fractional part of a number to have leading zeros ([#4206](https://github.com/sanity-io/sanity/issues/4206)) ([1930213](https://github.com/sanity-io/sanity/commit/19302131c329e5176d04bdf70e432e771630af11)), closes [#4192](https://github.com/sanity-io/sanity/issues/4192) [#4192](https://github.com/sanity-io/sanity/issues/4192)
+
+
+### Features
+
+* **cli:** use local callback server for auth instead of listener ([#4222](https://github.com/sanity-io/sanity/issues/4222)) ([8ba697c](https://github.com/sanity-io/sanity/commit/8ba697cae6d9e66f34558d90d4d079f496d72685))
+* **cli:** use strict mode schemas for shopify online template ([#4229](https://github.com/sanity-io/sanity/issues/4229)) ([5edcce8](https://github.com/sanity-io/sanity/commit/5edcce8ea759ca540182e9a26c138a2244f22be3))
+
+
+
+## [3.5.1](https://github.com/sanity-io/sanity/compare/v3.5.0...v3.5.1) (2023-03-01)
+
+
+### Bug Fixes
+
+* **build:** add an empty perf/studio folder so that the vercel build can be skipped ([fa968be](https://github.com/sanity-io/sanity/commit/fa968bed00cd99ec21fd60b9affab16930a71efd))
+* **cli:** add `@types/styled-components` dependency to new projects ([#4202](https://github.com/sanity-io/sanity/issues/4202)) ([5282654](https://github.com/sanity-io/sanity/commit/52826542bf6700602a855497bebd013315e6fc02)), closes [#4198](https://github.com/sanity-io/sanity/issues/4198)
+* **cli:** correct noop return value for renderDocument ([f2053ee](https://github.com/sanity-io/sanity/commit/f2053ee8af8c2b1cc09c12b11c5ccf406b4c4429))
+* **cli:** patch missing `SYSTEMROOT` env var on windows ([#4221](https://github.com/sanity-io/sanity/issues/4221)) ([2b9beaf](https://github.com/sanity-io/sanity/commit/2b9beaff95ae4572463d7fe7ab4c458bfd940905))
+* **core:** date and datime review changes ui ([#4217](https://github.com/sanity-io/sanity/issues/4217)) ([fd870df](https://github.com/sanity-io/sanity/commit/fd870df311e69c0cb1cb89fb54c658a079a99c2f))
+* **core:** focus handling and dialog behavior ([#4139](https://github.com/sanity-io/sanity/issues/4139)) ([460bbaf](https://github.com/sanity-io/sanity/commit/460bbaf4511642e512fe1270d3129a1daeaeb638))
+* **core:** invalid reference link ([#4201](https://github.com/sanity-io/sanity/issues/4201)) ([afbe551](https://github.com/sanity-io/sanity/commit/afbe551297857e86fea825d86b975286876255e7))
+* **core:** move theme logic to component and use in both navbars ([#4183](https://github.com/sanity-io/sanity/issues/4183)) ([e2eb622](https://github.com/sanity-io/sanity/commit/e2eb622d3c1b1ff2a6877ec7f00d51d7b27b87bb))
+* **core:** non valid file types for image and file inputs will be greyed out ([#4127](https://github.com/sanity-io/sanity/issues/4127)) ([8ad9eb8](https://github.com/sanity-io/sanity/commit/8ad9eb8837c1f366230f74ebcdf297e8ecde9837))
+* **core:** select default group (If exists) on expand ([#4173](https://github.com/sanity-io/sanity/issues/4173)) ([09e6b08](https://github.com/sanity-io/sanity/commit/09e6b08874903484a9436d2e814485038793f8de))
+* **desk:** document list menu items selected state ([#4207](https://github.com/sanity-io/sanity/issues/4207)) ([2123f93](https://github.com/sanity-io/sanity/commit/2123f93268075dbcf25547c828470315d88e6860))
+* **desk:** focusFirst in document and dialog behavior ([#4156](https://github.com/sanity-io/sanity/issues/4156)) ([a210ee7](https://github.com/sanity-io/sanity/commit/a210ee752184c05d6fbe117f30699e002e35559d))
+* **desk:** update tools and schema help links ([#4205](https://github.com/sanity-io/sanity/issues/4205)) ([113f46c](https://github.com/sanity-io/sanity/commit/113f46c062671a79f897eefdd746ebd984a68903))
+* **portable-text-editor:** fix some issues with syncing the value ([663336e](https://github.com/sanity-io/sanity/commit/663336e2596cfea49a12475e62cbbaa399ad6f57))
+* **portable-text-editor:** fix state toggle issue in withPreserveKeys ([1fafb02](https://github.com/sanity-io/sanity/commit/1fafb02b04ff753fefb120cb93e186012681241e))
+* **portable-text-editor:** only preserveKeys when strictly needed ([776c1b8](https://github.com/sanity-io/sanity/commit/776c1b83cc02933cb0778b07658b10e03fc1f285))
+
+
+### Features
+
+* **cli:** add back get-started template ([#4225](https://github.com/sanity-io/sanity/issues/4225)) ([fbbbfeb](https://github.com/sanity-io/sanity/commit/fbbbfeb13ceab4ab0a5f801cb3297ed9e0e87193))
+
+
+
+# [3.5.0](https://github.com/sanity-io/sanity/compare/v3.4.0...v3.5.0) (2023-02-21)
+
+
+### Bug Fixes
+
+* **cli:** add .local files to .gitignore for new projects ([b8229be](https://github.com/sanity-io/sanity/commit/b8229beec1d5a0380c369587c0d4b894e2468e9e))
+* **cli:** explicitly pass down env from parent to workers ([20a4366](https://github.com/sanity-io/sanity/commit/20a4366803eee778be815112425ec50194f71131))
+* **cli:** maintain old pluralization behavior on graphql gen1 schemas ([eeaf26c](https://github.com/sanity-io/sanity/commit/eeaf26cc4fc8b2cecf1b57a510dc0abe764492c7))
+
+
+### Features
+
+* **cli:** ensure `process.env.MODE` is always defined ([cc44f04](https://github.com/sanity-io/sanity/commit/cc44f0415388f55867c87afbad5e6ce2c179b84a))
+* **cli:** expose `getStudioEnvironmentVariables` method, add dotenv handling ([c03ef40](https://github.com/sanity-io/sanity/commit/c03ef40ae4271f18f2f1fa1f6b116cc49e9cc77a))
+
+
+
+# [3.4.0](https://github.com/sanity-io/sanity/compare/v3.3.1...v3.4.0) (2023-02-15)
+
+
+### Bug Fixes
+
+* **form/inputs:** add missing hook deps and types ([0ac5085](https://github.com/sanity-io/sanity/commit/0ac5085938a2a40aec30d37c0c55c70a00c16a25))
+* **portable-text-editor:** add condition (no listItem) to equalToEmptyEditor test fn ([d66f967](https://github.com/sanity-io/sanity/commit/d66f9677f27714320089c3e539d730176ce4a65c))
+* **portable-text-editor:** fail proof unset patchToOperation ([61823ad](https://github.com/sanity-io/sanity/commit/61823ade2d4550387c19627b8935f8e13a967661))
+* **portable-text-editor:** fix a bug where content wasn't unset correctly ([9ed28c0](https://github.com/sanity-io/sanity/commit/9ed28c0cab96c9d91c0838bc39a621151fbf8251))
+* **portable-text-editor:** remove export that no longer exist ([0840377](https://github.com/sanity-io/sanity/commit/0840377a1307eb90ea46b40665b114693bd2249c))
+* revert client getUrl and getDataUrl usage ([#4174](https://github.com/sanity-io/sanity/issues/4174)) ([dc6f1cc](https://github.com/sanity-io/sanity/commit/dc6f1cc71b1102f572e7c8049cf575808eadc9e1))
+* **types:** add forgotten component schema extension (inlineBlock) ([57c850c](https://github.com/sanity-io/sanity/commit/57c850c234c84377aaa243fe64289c2e4902a4db))
+
+
+
+## [3.3.1](https://github.com/sanity-io/sanity/compare/v3.3.0...v3.3.1) (2023-02-08)
+
+
+### Features
+
+* **cli:** add new shopify online template ([b0a0876](https://github.com/sanity-io/sanity/commit/b0a08766e08ae521e87b0dad9ff39dd600ccb200))
+* **cli:** allow templates to flag themselves as typescript-only ([5a8afd3](https://github.com/sanity-io/sanity/commit/5a8afd30d4722aaa5aedc8af28408282cd1f7534))
+
+
+
+# [3.3.0](https://github.com/sanity-io/sanity/compare/v3.2.6...v3.3.0) (2023-02-08)
+
+
+### Bug Fixes
+
+* **ci:** change test studio build command to 'build:test-studio' ([937ef83](https://github.com/sanity-io/sanity/commit/937ef83850cd6ba4c4548d9aadafde7034fa92c7))
+* **core:** add readOnly prop to sortable array items ([#4161](https://github.com/sanity-io/sanity/issues/4161)) ([0deee1f](https://github.com/sanity-io/sanity/commit/0deee1fb2d4ba76a2b677a838dff52f38518c823))
+* **core:** change design for clickable present users in dropdown ([#4154](https://github.com/sanity-io/sanity/issues/4154)) ([81c9d4c](https://github.com/sanity-io/sanity/commit/81c9d4c7c4500d1780a4667748705555c18e49db))
+* **core:** improve tags input read only visibility ([ab61f15](https://github.com/sanity-io/sanity/commit/ab61f154094d18649f9b492433cca73cd820ddc0))
+* **core:** only notify subscribers if the the current user object has changed ([b3b26fb](https://github.com/sanity-io/sanity/commit/b3b26fbcc5a7fc4ed53f9fb579ebc248ca3a753a))
+* **desk:** field validation - scroll to field ([#4149](https://github.com/sanity-io/sanity/issues/4149)) ([3b611f0](https://github.com/sanity-io/sanity/commit/3b611f088f8c8a7d3548c87734531511b83c76a3))
+
+
+### Features
+
+* **cli:** provide (unresolved) cross-dataset references for graphql APIs ([#4137](https://github.com/sanity-io/sanity/issues/4137)) ([5de629b](https://github.com/sanity-io/sanity/commit/5de629b9beec75260ac21af3fddf5cadaacc4a47))
+* **config:** allow specifying `apiHost` for source ([#4142](https://github.com/sanity-io/sanity/issues/4142)) ([57d72f9](https://github.com/sanity-io/sanity/commit/57d72f9d677eb3a507b46a9edb0f3f73caed29ac))
+
+
+
+## [3.2.6](https://github.com/sanity-io/sanity/compare/v3.2.5...v3.2.6) (2023-01-31)
+
+
+### Bug Fixes
+
+* **core:** clear reference fields when replacing links + fix open in new tab links ([#4105](https://github.com/sanity-io/sanity/issues/4105)) ([a8a5031](https://github.com/sanity-io/sanity/commit/a8a50316a6815b9e827c83ba670ae496656a04bf))
+* **core:** improve `PopoverDialog` ([a6707da](https://github.com/sanity-io/sanity/commit/a6707da04540feaa927b603dc6ee80ecad68597c))
+* **core:** reset document actions state when changing document ([7fc1c29](https://github.com/sanity-io/sanity/commit/7fc1c29786242ca348a355cb3c5ea11b7a61f1e4))
+* **deps:** upgrade rxjs-exhaustmap-with-trailing to latest ([#4134](https://github.com/sanity-io/sanity/issues/4134)) ([a370e3e](https://github.com/sanity-io/sanity/commit/a370e3ed70950b6d4ab0e0725fedee7e78c175f6))
+* **form:** make sure fields inside fieldsets actually get their readOnly state ([#4129](https://github.com/sanity-io/sanity/issues/4129)) ([64e9715](https://github.com/sanity-io/sanity/commit/64e97151edb43bfc3a82bc7000e9dad925951efd))
+* **tests:** make sure cli tests don't crash if no token specified ([#4136](https://github.com/sanity-io/sanity/issues/4136)) ([4e5eb6b](https://github.com/sanity-io/sanity/commit/4e5eb6b75f219d5bfc8ac2f77b16cf2bf2afbaf1))
+
+
+
+## [3.2.5](https://github.com/sanity-io/sanity/compare/v3.2.4...v3.2.5) (2023-01-24)
+
+
+### Bug Fixes
+
+* **cli:** exit if user does not confirm v3 init continuation ([8a51feb](https://github.com/sanity-io/sanity/commit/8a51feb5eb56de15713348226c1715fa7125f9c2))
+* **core:** add readonly prop to RefenceInput ([#4123](https://github.com/sanity-io/sanity/issues/4123)) ([29e2513](https://github.com/sanity-io/sanity/commit/29e251378398a493cf658918d9565fd108f9d804))
+* **core:** remove uploaded image from hoveringFiles ([#4112](https://github.com/sanity-io/sanity/issues/4112)) ([c5607cd](https://github.com/sanity-io/sanity/commit/c5607cd99e73a94b9599c51993ba36bef39187e1))
+* **desk:** add full timestamp tooltip to timeline items ([#4100](https://github.com/sanity-io/sanity/issues/4100)) ([555de75](https://github.com/sanity-io/sanity/commit/555de75177abe6155bae53ab89a520320ebebdc5))
+* **desk:** Change hardcoded delete word in action dialog to the correct action ([#4118](https://github.com/sanity-io/sanity/issues/4118)) ([7744143](https://github.com/sanity-io/sanity/commit/774414390fe513d791d4468d78305b0cd78e3ea8))
+* set `htmlFor` on `<label>`s ([#4115](https://github.com/sanity-io/sanity/issues/4115)) ([641b38a](https://github.com/sanity-io/sanity/commit/641b38ac4f26080ac9ba9591d421806200a76f4f))
+
+
+
+## [3.2.4](https://github.com/sanity-io/sanity/compare/v3.2.3...v3.2.4) (2023-01-17)
+
+
+### Bug Fixes
+
+* allow global studio base path ([#3996](https://github.com/sanity-io/sanity/issues/3996)) ([71932dc](https://github.com/sanity-io/sanity/commit/71932dc9a116cabd1ba62bb6b577cf23c0f43406))
+* **core:** make sure that the validation block is behind the text node ([32e80c3](https://github.com/sanity-io/sanity/commit/32e80c39af1784d0ac6ebf52bd8033d3dc94e796))
+* **core:** popover wrap button to allow replacing uploaded image ([#4094](https://github.com/sanity-io/sanity/issues/4094)) ([918d8bd](https://github.com/sanity-io/sanity/commit/918d8bd9719b226b77990b86176706edcc8540ec))
+* **form/inputs:** don't wrap custom style comps. in Text ([d43e1cc](https://github.com/sanity-io/sanity/commit/d43e1cc1903031f679fd11c4096ab3314e6743b3))
+* require node 14.18 or higher ([8470761](https://github.com/sanity-io/sanity/commit/84707614b3cee6ca41b671bf703a926725f8b6be))
+* **schema:** set correct fallback title for image and file fields ([#4093](https://github.com/sanity-io/sanity/issues/4093)) ([f9eb765](https://github.com/sanity-io/sanity/commit/f9eb765c5c207cece81fc823da8392deeee0c760))
+
+
+### Features
+
+* **core:** global search date range support + minor fixes ([#4055](https://github.com/sanity-io/sanity/issues/4055)) ([8db713e](https://github.com/sanity-io/sanity/commit/8db713e511c08f06ac60011c2b4728e2b5461db4))
+* **server:** support studio env vars through `process.env` ([0e733a6](https://github.com/sanity-io/sanity/commit/0e733a6a76d7864b1a25ce72ef2826121436f8d6))
+
+
+
+## [3.2.3](https://github.com/sanity-io/sanity/compare/v3.2.2...v3.2.3) (2023-01-12)
+
+
+### Bug Fixes
+
+* actually fix the `groq` bug and include tests that prove it ([#4088](https://github.com/sanity-io/sanity/issues/4088)) ([060084c](https://github.com/sanity-io/sanity/commit/060084c5ca2b10a4ebf7ac5993264c88ba260f84))
+
+
+
+## [3.2.2](https://github.com/sanity-io/sanity/compare/v3.2.1...v3.2.2) (2023-01-12)
+
+
+### Bug Fixes
+
+* add the node folder to the npm publish allowlist ([#4086](https://github.com/sanity-io/sanity/issues/4086)) ([f4b9146](https://github.com/sanity-io/sanity/commit/f4b91469fb49c624bd250ac22718a77ba71a7449))
+* **portable-text-editor:** add missing hook dep. ([7eaf2bf](https://github.com/sanity-io/sanity/commit/7eaf2bfff712404a779c694e1714cd9a463a31b8))
+* **portable-text-editor:** fix issue with equality test ([92a8f16](https://github.com/sanity-io/sanity/commit/92a8f168dfc70f54ed323b2eb46513c41ba81e9f))
+* **portable-text-editor:** fix missing default to 0 for array insert pos ([d175ecf](https://github.com/sanity-io/sanity/commit/d175ecf808a75b2fa785160e2006cb1e21f3c5ab))
+* **portable-text-editor:** fix prop propagation issue ([7ba165e](https://github.com/sanity-io/sanity/commit/7ba165efe080e18d7e44c92088048f9a2a8ef6a4))
+* **portable-text-editor:** fix selection issue with placeholder block ([ecf07c2](https://github.com/sanity-io/sanity/commit/ecf07c2c9ac2d019f4dde3c688f3e4801c5fde2d))
+* **portable-text-editor:** move selection from state to ref ([7742991](https://github.com/sanity-io/sanity/commit/7742991fa6965a98d68a884e6cc5e23eaa4c126f))
+* **portable-text-editor:** set placeholder directly ([14bca9e](https://github.com/sanity-io/sanity/commit/14bca9e25e624264358b8a568f5eacbd0e7f0dcd))
+
+
+
+## [3.2.1](https://github.com/sanity-io/sanity/compare/v3.2.0...v3.2.1) (2023-01-12)
+
+
+### Bug Fixes
+
+* add missing default export to `groq` for the `node` ESM wrapper ([#4085](https://github.com/sanity-io/sanity/issues/4085)) ([8dd6b26](https://github.com/sanity-io/sanity/commit/8dd6b269d2414d55333f879024d9f6e4801c7e91))
+
+
+
+# [3.2.0](https://github.com/sanity-io/sanity/compare/v3.1.4...v3.2.0) (2023-01-11)
+
+
+### Bug Fixes
+
+* add esbuild to depcheck ignore (esbuild-register peer dependency) ([6c04052](https://github.com/sanity-io/sanity/commit/6c04052040063c2ec125fb3454a76091a91695d0))
+* **cli:** improve error when failing to encode CLI configuration ([70de8eb](https://github.com/sanity-io/sanity/commit/70de8ebb1907fe59a6bcab8b273b5881522976da))
+* **cli:** make project ID optional in cli config when deploying graphql API ([9c68553](https://github.com/sanity-io/sanity/commit/9c685533ef2921d3e2c4035c6af6acfbea328196))
+* **cli:** prevent crash when deploying graphql API without a cli config ([570958f](https://github.com/sanity-io/sanity/commit/570958faf2b92a86fcd13257ab4236e5a681501e))
+* **cli:** reintroduce deprecated graphql deployment flags ([93d3080](https://github.com/sanity-io/sanity/commit/93d30808bda8b877b015b0b65da4543aec768d8b))
+* **core:**  lagging one iteration behind ([3eebac3](https://github.com/sanity-io/sanity/commit/3eebac376d03462698a019db97c53a2178c1cd4e))
+* **core:** add default icon to new document dialog ([bba4c71](https://github.com/sanity-io/sanity/commit/bba4c7104e7d53d7558e554128227e196d007725))
+* **core:** add missing hook dependencies ([6b9ae90](https://github.com/sanity-io/sanity/commit/6b9ae908ce8f547b0c14d64d09f43687e591fcd6))
+* **core:** improve boolean read only ui ([e449ad6](https://github.com/sanity-io/sanity/commit/e449ad627563a4a392de401f6c348f17ec2cfed1))
+* **core:** uploaded images popover display ([#4048](https://github.com/sanity-io/sanity/issues/4048)) ([b9d335b](https://github.com/sanity-io/sanity/commit/b9d335b6581c6cb35f834a28a41c55c401844e36))
+* **create-sanity:** resolve cli module without `module.resolve` ([ad98901](https://github.com/sanity-io/sanity/commit/ad9890119c82414d065679b46769f010ef9ee0d0))
+* **deps:** upgrade to `@sanity/pkg-utils@2` ([#4012](https://github.com/sanity-io/sanity/issues/4012)) ([7f5f8fc](https://github.com/sanity-io/sanity/commit/7f5f8fc0a1459330cbad02fcc8f7f0a5bbe22bfd))
+* **desk-tool:** prevent form-state being re-used when switching between documents of different types ([f02b5dd](https://github.com/sanity-io/sanity/commit/f02b5dd5368a3d9010eba7453aee416956e2003d))
+* **desk:** improve saving indicator ([3009836](https://github.com/sanity-io/sanity/commit/30098361f663403fdab539321e127b0ed7fe2059))
+* **desk:** set the form to read-only when reconnecting ([e1b94d3](https://github.com/sanity-io/sanity/commit/e1b94d310535937645de02aa47e873b184a6af5f))
+* rename various scripts publish => release ([ca49582](https://github.com/sanity-io/sanity/commit/ca495827479966eefe64b63373c47da7249920c0))
+* **schema:** Disallows fieldnames that are already defined ([#4057](https://github.com/sanity-io/sanity/issues/4057)) ([020e24f](https://github.com/sanity-io/sanity/commit/020e24f782e7599555f22e8454f35b4a694f8679))
+* **server:** make build entries plugin compatible with vite 4 ([e3aa8fd](https://github.com/sanity-io/sanity/commit/e3aa8fd0059a34f4465ca4aff6be205373964e40))
+* type fix for legacy experimental actions declaration ([d0bd029](https://github.com/sanity-io/sanity/commit/d0bd029e209d951ba700c4ab22bd6fdb90e1317c))
+* **types:** add missing asset source extension properties ([a1f1ed7](https://github.com/sanity-io/sanity/commit/a1f1ed7cac8123a4cc1adda5cb9fdf84655d533b))
+* **types:** allow use of `Rule.valueOfField` inside `defineField` ([827a88f](https://github.com/sanity-io/sanity/commit/827a88f187d8e67ddcd8e81dbdde7e1acb308572))
+* use `esbuild-register` only once in each thread ([2005960](https://github.com/sanity-io/sanity/commit/20059606509326fed4418c2a4537586226f7e649))
+
+
+
+## [3.1.4](https://github.com/sanity-io/sanity/compare/v3.1.3...v3.1.4) (2023-01-03)
+
+
+
+## [3.1.3](https://github.com/sanity-io/sanity/compare/v3.1.2...v3.1.3) (2023-01-03)
+
+
+### Bug Fixes
+
+* **base:** wait for all chunked requests to arrive before continuing ([#4017](https://github.com/sanity-io/sanity/issues/4017)) ([2134b27](https://github.com/sanity-io/sanity/commit/2134b275609decc3048f03e6cc17f3e40047b2af))
+* **core:** add transition effect when sorting array of primitives ([71e3212](https://github.com/sanity-io/sanity/commit/71e3212fa7834bf1af69516a1c57bc98706503a3))
+* **core:** file/image input layout in narrow widths ([125dc41](https://github.com/sanity-io/sanity/commit/125dc416e30babb2167f3812c2c89e658fddf8be))
+* **desk:** remove restore action when revision is latest version ([2846eec](https://github.com/sanity-io/sanity/commit/2846eec88128bf1ad97db4eb34ac30e146031d76))
+* **vision:** render error tooltip in a portal ([fe96da1](https://github.com/sanity-io/sanity/commit/fe96da15bbf8d303228aaf7728898012da52979c))
+
+
+
+## [3.1.2](https://github.com/sanity-io/sanity/compare/v3.1.1...v3.1.2) (2022-12-22)
+
+
+### Bug Fixes
+
+* **core/form:** fix forgotten optional extension ([24805ae](https://github.com/sanity-io/sanity/commit/24805ae664b3b81f5e83aa110fb593777abac80e))
+* **form/inputs:** fix component fallback behaviour ([e892c62](https://github.com/sanity-io/sanity/commit/e892c62bc77d05e7632a3d0a88634329ddcda1cc))
+* **schema:** fix validator text typo ([5e4c562](https://github.com/sanity-io/sanity/commit/5e4c5624300ce2324d63f967df49a6c9e53aa71f))
+
+
+
+## [3.1.1](https://github.com/sanity-io/sanity/compare/v3.1.0...v3.1.1) (2022-12-21)
+
+
+### Bug Fixes
+
+* `clientFactory` should be optional ([d894d56](https://github.com/sanity-io/sanity/commit/d894d564693c2a3300d4430c7fbb224a703c2edf))
+* apply `config.form.image.directUploads` ([cf52ee7](https://github.com/sanity-io/sanity/commit/cf52ee7a4503f8b763ff613ef79aa4e8fc3aa5d2))
+* ensure lodash is optimized in every monorepo package ([8494ac0](https://github.com/sanity-io/sanity/commit/8494ac0d19e233a91c13024f711a42604d8b23fc))
+* **groq:** provide tsdoc for groq template literal function ([f9520b2](https://github.com/sanity-io/sanity/commit/f9520b2e978c9e355a3367249bd28a5f1e4f8dc2))
+
+
+
+# [3.1.0](https://github.com/sanity-io/sanity/compare/v3.0.6...v3.1.0) (2022-12-21)
+
+
+### Bug Fixes
+
+* **block-tools:** ignore blocks inside list items ([#3492](https://github.com/sanity-io/sanity/issues/3492)) ([5e51831](https://github.com/sanity-io/sanity/commit/5e51831296fdc79acf1c7df0f387c404913c658f))
+* **cli:** only require workspace name if more than 1 workspace ([743244b](https://github.com/sanity-io/sanity/commit/743244b9aee8c6f4bcaf8f98886f18eedf0409e6))
+* **config:** respect `unstable_clientFactory` ([bcd4854](https://github.com/sanity-io/sanity/commit/bcd4854e3746435002e5866f087e04ef491002bf))
+* **config:** throw error early if tools/template resolution fails ([2f2e467](https://github.com/sanity-io/sanity/commit/2f2e4678aadb4ef46f2d12f8c288b6ba73f5e98b))
+* **core:** components API execution order ([299ac06](https://github.com/sanity-io/sanity/commit/299ac066fbdf4e730ff4db3ce5e4b2871a00794e))
+* **core:** update workspace preview design ([543a0f3](https://github.com/sanity-io/sanity/commit/543a0f39b69c4d709fb92d666a03f33c6c20ef79))
+* **desk:** always use default ordering on first rendering if any and update order on sort ([663cc67](https://github.com/sanity-io/sanity/commit/663cc67e4ffbfa88a26b90d607848b006d6dd73c))
+* **desk:** recompute default sort order on desk structure change ([4f9a353](https://github.com/sanity-io/sanity/commit/4f9a35327c291eb39a2f854176e5b83f77a98f98))
+* **desk:** use last updated at as default sort order ([d5166e5](https://github.com/sanity-io/sanity/commit/d5166e52d1669170036adb98b8f88804c7e2c337))
+* **form:** fix issue with zero being rendered as empty string in number input ([7be7511](https://github.com/sanity-io/sanity/commit/7be751176d5e2452bdbbd9a519bbcbd17d5916b3)), closes [#3940](https://github.com/sanity-io/sanity/issues/3940)
+* optimize lodash imports ([#3974](https://github.com/sanity-io/sanity/issues/3974)) ([6c7d48d](https://github.com/sanity-io/sanity/commit/6c7d48dbf2686f2ec794befaffde23f34a5d9b1c))
+* pass `readOnly` to select element ([#3900](https://github.com/sanity-io/sanity/issues/3900)) ([f70736f](https://github.com/sanity-io/sanity/commit/f70736f2de07d08bf303d83429b28d44bb451fc9))
+* **schema:** add help id to blockeditor schema warnings ([8d74ace](https://github.com/sanity-io/sanity/commit/8d74ace917651a307acd61198f09b5050289f55f))
+
+
+### Features
+
+* **core:** add `userHasRole` utility method ([cd0819f](https://github.com/sanity-io/sanity/commit/cd0819f11d8d43866f239987e09240b4a2fbc143))
+* **core:** add new `documentIdEquals` utility method ([f7eb4b3](https://github.com/sanity-io/sanity/commit/f7eb4b3a653702d07cd1263b732ba9d0757cd285))
+* **core:** move padding from `LogoButton` to `StudioLogo` ([d774bc6](https://github.com/sanity-io/sanity/commit/d774bc64d61c0e343bce94165cdc5acc78ed5086))
+* **core:** store selected color scheme i local storage ([9ce0108](https://github.com/sanity-io/sanity/commit/9ce010870c52ffe267aaa5e2a97525127abaae1d))
+* **core:** update user menu with color schemes ([788d23b](https://github.com/sanity-io/sanity/commit/788d23bde7cca9ec16d1c9c12a9b18fa863ce346))
+
+
+
+## [3.0.6](https://github.com/sanity-io/sanity/compare/v3.0.5...v3.0.6) (2022-12-08)
+
+
+### Bug Fixes
+
+* **core:** update upgrade command in changelog dialog ([5abfecc](https://github.com/sanity-io/sanity/commit/5abfeccd0e7d861c4a52eb7e6103d9b3cd710b11))
+
+
+
+## [3.0.5](https://github.com/sanity-io/sanity/compare/v3.0.4...v3.0.5) (2022-12-08)
+
+
+
+## [3.0.4](https://github.com/sanity-io/sanity/compare/v3.0.2...v3.0.4) (2022-12-08)
+
+
+### Bug Fixes
+
+* **create-sanity:** fix Windows issue ([2759e93](https://github.com/sanity-io/sanity/commit/2759e932e3a2a24bb6cfc2feaba5ff6cf312f7ee))
+
+
+
+## [3.0.2](https://github.com/sanity-io/sanity/compare/v3.0.0...v3.0.2) (2022-12-07)
+
+
+### Bug Fixes
+
+* bump `scroll-into-view-if-needed` for better ESM support ([#3919](https://github.com/sanity-io/sanity/issues/3919)) ([2609b3b](https://github.com/sanity-io/sanity/commit/2609b3bfaa25ba3c0076658f651c73c911312574))
+* **cli,create-sanity:** don't show v2 prompt when init is run from create-sanity ([948efc8](https://github.com/sanity-io/sanity/commit/948efc8ca4e9f3b082ea5d026f95ca468cb17d3e))
+* **core:** show block style select when there is more than one option ([9238447](https://github.com/sanity-io/sanity/commit/923844707de437800f425cd93c4ef49b545b5951))
+* **core:** user menu popover position ([62717b7](https://github.com/sanity-io/sanity/commit/62717b7c7c8f21c6b3d8ca3f9144d41b08bfd2cf))
+* **form:** fix issue with PTE-preview using legacy code ([d253d2b](https://github.com/sanity-io/sanity/commit/d253d2b841cfb15da0bd3178f28f4000459672fc))
+
+
+### Features
+
+* **cli:** add vision as default plugin to templates ([e886f2c](https://github.com/sanity-io/sanity/commit/e886f2cc74bb3a06c16ee6d1cb0da458ceba88a5))
+* **core:** add warnings when using deprecated schema config ([0725449](https://github.com/sanity-io/sanity/commit/0725449c79c85fd3b5d8b4a1922f1937bf6cdff3))
+* **studio:** filtered search ([#3928](https://github.com/sanity-io/sanity/issues/3928)) ([1237e4d](https://github.com/sanity-io/sanity/commit/1237e4d3a44b0c6426a96a5f8404e4bf1d2314e2))
+
+
+
+# [3.0.0](https://github.com/sanity-io/sanity/compare/v3.0.0-rc.3...v3.0.0) (2022-11-25)
+
+
+


### PR DESCRIPTION
### Description

Retroactively adds a changelog. This is autogenerated from the first v3.0.0 commit using the command
```npx conventional-changelog --preset angular --release-count 196 --outfile ./CHANGELOG.md```

### What to review
- Is the format/preset ok? (note: it's easy to regenerate later)
I figured there's not much point in going further back than v3.0.0

### Testing
n/a

### Notes for release

n/a