### PR TITLE
fix(core): update since logic for useEventsStore

### DIFF
--- a/packages/sanity/src/core/store/events/useEventsStore.ts
+++ b/packages/sanity/src/core/store/events/useEventsStore.ts
@@ -14,6 +14,7 @@ import {getDocumentAtRevision} from './getDocumentAtRevision'
 import {
   type DocumentGroupEvent,
   type EventsStore,
+  isCreateDocumentVersionEvent,
   isEditDocumentVersionEvent,
   isPublishDocumentVersionEvent,
 } from './types'
@@ -109,7 +110,6 @@ export function useEventsStore({
     [client, documentId, revisionId],
   )
   const revision = useObservable(revision$, null)
-
   const sinceId = useMemo(() => {
     if (since && since !== '@lastPublished') return since
     if (!events) return null
@@ -118,6 +118,10 @@ export function useEventsStore({
       // Skip the first published, the since and rev cannot be the same.
       const lastPublishedId = events.slice(1).find(isPublishDocumentVersionEvent)?.id
       if (lastPublishedId) return lastPublishedId
+
+      // If it doesn't have a published event used the creation event as the since.
+      const creationEvent = events.find(isCreateDocumentVersionEvent)
+      if (creationEvent) return creationEvent.id
     }
 
     // rev has not been selected, the is seeing the last version of the document, select the event that comes after


### PR DESCRIPTION
### Description
In the events store we were assuming that a Published event will exist and if that was not the case we were using the `events[1]`, this could lead to an incorrect view of the diff shown in history, because in some cases a published doesn't exist but a `Created` does.
This PR updates the logic to check also for the `Created` event if a `Published` event was not found when searching for the `@lastPublished` event.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Documents with no published events, but multiple edits, should show the correct diff.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in where the revision tab would show incorrect events if a published event was not found and no document to compare was manually selected.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
