### PR TITLE
fix(cli): Support unattended init within nextjs

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -315,12 +315,15 @@ export default async function initSanity(
   let initNext = false
   const isNextJs = detectedFramework?.slug === 'nextjs'
   if (isNextJs) {
-    initNext = await prompt.single({
-      type: 'confirm',
-      message:
-        'Would you like to add configuration files for a Sanity project in this Next.js folder?',
-      default: true,
-    })
+    initNext =
+      unattended ||
+      (await prompt.single({
+        type: 'confirm',
+        message:
+          'Would you like to add configuration files for a Sanity project in this Next.js folder?',
+        default: true,
+      }))
+
     trace.log({
       step: 'useDetectedFramework',
       selectedOption: initNext ? 'yes' : 'no',

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -290,6 +290,8 @@ export default async function initSanity(
     print('')
   }
 
+  const isNextJs = detectedFramework?.slug === 'nextjs'
+
   const flags = await prepareFlags()
 
   // We're authenticated, now lets select or create a project (for studios) or org (for core apps)
@@ -313,7 +315,6 @@ export default async function initSanity(
   }
 
   let initNext = false
-  const isNextJs = detectedFramework?.slug === 'nextjs'
   if (isNextJs) {
     initNext =
       unattended ||
@@ -1226,12 +1227,15 @@ export default async function initSanity(
 
     if (unattended) {
       debug('Unattended mode, validating required options')
-      const requiredForUnattended = ['dataset', 'output-path'] as const
-      requiredForUnattended.forEach((flag) => {
-        if (!cliFlags[flag]) {
-          throw new Error(`\`--${flag}\` must be specified in unattended mode`)
-        }
-      })
+
+      if (!cliFlags['dataset' as const]) {
+        throw new Error(`\`--dataset\` must be specified in unattended mode`)
+      }
+
+      // output-path is not used in unattended mode within nextjs
+      if (!isNextJs && !cliFlags['output-path' as const]) {
+        throw new Error(`\`--output-path\` must be specified in unattended mode`)
+      }
 
       if (!cliFlags.project && !createProjectName) {
         throw new Error(


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

I discovered that the init command incorrectly prompts for user input even when running in unattended mode within Next.js. This PR addresses that issue by adding correct handling for unattended mode specifically within Next.js contexts.

Additionally, I noticed that the command currently exits with an error if the --output-path flag is omitted in unattended mode. However, the --output-path value isn't actually utilized when initializing within Next.js. Therefore, this PR also removes the requirement for the --output-path flag when running in unattended mode inside Next.js.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

This change affects unattended `sanity init` when ran in a nextjs project. See Testing for more details.


### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

That you can initialize unattended within a nextjs project. Before this change you would be prompted

> Would you like to add configuration files for a Sanity project in this Next.js folder?

in unattended mode. 

Additionally, you would have gotten an error if you did not specify `--output-path`. If you specified it, you would find that your Studio was not generated in that folder, but in src/, and your output-path folder would be blank except for a .env file with projectId and dataset. After this change the variables should be correctly added to the root env file instead.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

Support unattended `sanity init` within nextjs projects
