### PR TITLE
fix: excluding query params from pathname check when routing to tool

### DIFF
--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
@@ -70,12 +70,11 @@ function useRouterFromWorkspaceHistory(
     // matches where the pathname is a false subset of the current pathname.
     const routerBasePathRegex = new RegExp(`^${escapeRegExp(routerBasePath)}(\\/|$)`, 'i')
     const shouldHandle = (pathname: string) => {
-      // Short-circuit for root path
-      if (routerBasePath === '/') return true
-
       // For non-root paths, extract the path part (before any query string)
-      const pathPart = pathname.split('?')[0]
-      return routerBasePathRegex.test(pathPart)
+      const [pathPart] = pathname.split('?')
+
+      // this is necessary to prevent emissions intended for other workspaces.
+      return routerBasePath === '/' ? true : routerBasePathRegex.test(pathPart)
     }
 
     return {

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
@@ -66,16 +66,12 @@ function useRouterFromWorkspaceHistory(
   // If we don't, we risk hot reload seeing stale workspace configs as the user is editing them.
   const store = useMemo(() => {
     const routerBasePath = router.getBasePath()
-    // this regex ends with a `(\\/|$)` (forward slash or end) to prevent false
-    // matches where the pathname is a false subset of the current pathname.
-    const routerBasePathRegex = new RegExp(`^${escapeRegExp(routerBasePath)}(\\/|$)`, 'i')
-    const shouldHandle = (pathname: string) => {
-      // For non-root paths, extract the path part (before any query string)
-      const [pathPart] = pathname.split('?')
-
+    // this regex ends with patterns that match end of path, query params, or trailing slash
+    // to prevent false matches where the pathname is a false subset of the current pathname.
+    const routerBasePathRegex = new RegExp(`^${escapeRegExp(routerBasePath)}(\\/|\\?|$)`, 'i')
+    const shouldHandle = (pathname: string) =>
       // this is necessary to prevent emissions intended for other workspaces.
-      return routerBasePath === '/' ? true : routerBasePathRegex.test(pathPart)
-    }
+      routerBasePath === '/' ? true : routerBasePathRegex.test(pathname)
 
     return {
       subscribe: (onStoreChange: () => void) => history.listen(onStoreChange),

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
@@ -69,9 +69,15 @@ function useRouterFromWorkspaceHistory(
     // this regex ends with a `(\\/|$)` (forward slash or end) to prevent false
     // matches where the pathname is a false subset of the current pathname.
     const routerBasePathRegex = new RegExp(`^${escapeRegExp(routerBasePath)}(\\/|$)`, 'i')
-    const shouldHandle = (pathname: string) =>
-      // this is necessary to prevent emissions intended for other workspaces.
-      routerBasePath === '/' ? true : routerBasePathRegex.test(pathname)
+    const shouldHandle = (pathname: string) => {
+      // Short-circuit for root path
+      if (routerBasePath === '/') return true
+
+      // For non-root paths, extract the path part (before any query string)
+      const pathPart = pathname.split('?')[0]
+      return routerBasePathRegex.test(pathPart)
+    }
+
     return {
       subscribe: (onStoreChange: () => void) => history.listen(onStoreChange),
       getSnapshot: () => `${history.location.pathname}${history.location.search || ''}`,


### PR DESCRIPTION
### Description
When using query params, a trailing slash was always required after the URL route, before the `?`, otherwise the default tool and workspace would not load.

Now the trailing slash is not required, and query params are persisted during the routing
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manually tested, but there are some existing unit tests around this to verify no regressions
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue that stops the studio loading when the URL does not include a trailing slash immediately preceding  a query string.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
