### PR TITLE
fix(core): useDocumentVersions should use stable initial value

### DIFF
--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -19,7 +19,11 @@ export interface DocumentPerspectiveState {
 }
 
 const swr = createSWR<{documentIds: string[]}>({maxSize: 100})
-
+const INITIAL_VALUE = {
+  data: [],
+  error: null,
+  loading: true,
+}
 /**
  * Fetches the document versions for a given document
  * @param props - document Id of the document (might include release id)
@@ -52,7 +56,7 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
       )
   }, [documentPreviewStore, publishedId])
 
-  const result = useObservable(observable, {data: [], error: null, loading: true})
+  const result = useObservable(observable, INITIAL_VALUE)
 
   return result
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
fixes an issue in where in some cases opening a document throws a set state error
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
