### PR TITLE
fix(cli): update copy for app undeploy

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/app/deployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/deployAction.ts
@@ -123,7 +123,7 @@ export default async function deployAppAction(
   const base = path.basename(sourceDir)
   const tarball = tar.pack(parentDir, {entries: [base]}).pipe(zlib.createGzip())
 
-  spinner = output.spinner('Deploying to Core...').start()
+  spinner = output.spinner('Deploying...').start()
   try {
     await createDeployment({
       client,

--- a/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts
@@ -51,7 +51,7 @@ export default async function undeployAppAction(
     type: 'confirm',
     default: false,
     message:
-      `This will undeploy ${chalk.yellow(userApplication.appHost)} and make it unavailable for your users.
+      `This will undeploy ${chalk.yellow(userApplication.id)} and make it unavailable for your users.
   The hostname will be available for anyone to claim.
   Are you ${chalk.red('sure')} you want to undeploy?`.trim(),
   })


### PR DESCRIPTION
### Description

This PR updates the messaging in the app deployment and undeployment processes:

1. Changes the deployment spinner message from "Deploying to Core..." to simply "Deploying..."
2. Updates the undeployment confirmation message to show the application ID instead of the application host

### What to review

- Check the deployment spinner message in `deployAction.ts`
- Verify the undeployment confirmation message in `undeployAction.ts` now shows the application ID

### Testing

Tested by running the deploy and undeploy commands and verifying the updated messages appear correctly.

### Notes for release

N/A