### PR TITLE
fix(studio): add missing negative margin to global perspective menu

### DIFF
--- a/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
@@ -16,6 +16,7 @@ const ReleasesNavContainer = styled(Card)`
   align-items: center;
   gap: 2px;
   padding: 2px;
+  margin: -3px 0;
 
   // The children in button is rendered inside a span, we need to absolutely position the dot for the error.
   span:has(> [data-ui='error-status-icon']) {
@@ -31,6 +32,7 @@ const ReleasesNavContainer = styled(Card)`
     z-index: 2;
   }
 `
+
 export function ReleasesNav(): React.JSX.Element {
   const releasesToolAvailable = useReleasesToolAvailable()
   const {selectedPerspective, selectedReleaseId} = usePerspective()


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- Fixes a CSS issue that caused the studio navbar to take up 6px more vertical height than intended.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

- Make sure the navbar takes up 50px vertical height in all scenarios (any device width).

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
