### PR TITLE
chore: manually bump internal packages

### DIFF
--- a/dev/depcheck-test/package.json
+++ b/dev/depcheck-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "depcheck-test",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>"

--- a/dev/design-studio/package.json
+++ b/dev/design-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-studio",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "description": "Sanity Design Studio",
   "keywords": [

--- a/dev/embedded-studio/package.json
+++ b/dev/embedded-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embedded-studio",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "scripts": {
     "build": "tsc && vite build && sanity manifest extract",

--- a/dev/media-library-aspects-studio/package.json
+++ b/dev/media-library-aspects-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "media-library-aspects-studio",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "description": "",
   "keywords": [],

--- a/dev/page-building-studio/package.json
+++ b/dev/page-building-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-page-building-studio",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",

--- a/dev/starter-studio/package.json
+++ b/dev/starter-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-starter-studio",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",

--- a/dev/strict-studio/package.json
+++ b/dev/strict-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-strict-studio",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",

--- a/dev/studio-e2e-testing/package.json
+++ b/dev/studio-e2e-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio-e2e-testing",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "keywords": [
     "sanity"

--- a/dev/test-create-integration-studio/package.json
+++ b/dev/test-create-integration-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-create-integration-studio",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-test-studio",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",

--- a/examples/blog-studio/package.json
+++ b/examples/blog-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blog-studio",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "description": "Content studio running with schema from the blog init template",
   "keywords": [

--- a/examples/clean-studio/package.json
+++ b/examples/clean-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clean-studio",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "description": "Content studio running with schema from the clean template",
   "keywords": [

--- a/examples/ecommerce-studio/package.json
+++ b/examples/ecommerce-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecommerce-studio",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "description": "",
   "keywords": [

--- a/examples/movies-studio/package.json
+++ b/examples/movies-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movies-studio",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "description": "Content studio running with schema from the moviedb init template",
   "keywords": [

--- a/lerna.json
+++ b/lerna.json
@@ -12,5 +12,5 @@
     "packages/groq",
     "packages/sanity"
   ],
-  "version": "3.85.1"
+  "version": "3.86.0"
 }

--- a/packages/@repo/dev-aliases/package.json
+++ b/packages/@repo/dev-aliases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/dev-aliases",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "description": "Dev aliases for the sanity monorepo",
   "type": "module",

--- a/packages/@repo/package.bundle/package.json
+++ b/packages/@repo/package.bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/package.bundle",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "description": "Shared package bundle configuration",
   "main": "./src/package.bundle.ts",

--- a/packages/@repo/package.config/package.json
+++ b/packages/@repo/package.config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/package.config",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "description": "Shared @sanity/pkg-utils configuration",
   "main": "./src/package.config.ts",

--- a/packages/@repo/test-config/package.json
+++ b/packages/@repo/test-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/test-config",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "description": "Test (as in unit test) config shared across packages in the sanity monorepo",
   "type": "module",

--- a/packages/@repo/test-exports/package.json
+++ b/packages/@repo/test-exports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/test-exports",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "description": "Ensures that all the monorepo packages that are published works in native node ESM and CJS runtimes",
   "exports": {

--- a/packages/@repo/tsconfig/package.json
+++ b/packages/@repo/tsconfig/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@repo/tsconfig",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true
 }

--- a/perf/studio/package.json
+++ b/perf/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perf-studio",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "description": "Sanity Studio with various test cases for tracking performance",
   "license": "MIT",

--- a/perf/tests/package.json
+++ b/perf/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-perf-tests",
-  "version": "3.85.1",
+  "version": "3.86.0",
   "private": true,
   "description": "Sanity Studio perf tests",
   "license": "MIT",


### PR DESCRIPTION
### Description
We need to configure release-please to bump every package (ideally also the version in lerna.json), but for now, this manually bumps internal packages up to v3.86.0

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
n/a – internal