### PR TITLE
feat(cli): add env prefix for apps

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/app/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/buildAction.ts
@@ -112,14 +112,14 @@ export default async function buildSanityApp(
 
   // Determine base path for built studio
   let basePath = '/'
-  const envBasePath = process.env.SANITY_STUDIO_BASEPATH
+  const envBasePath = process.env.SANITY_APP_BASEPATH
   const configBasePath = cliConfig?.project?.basePath
 
   // Allow `sanity deploy` to override base path
   if (overrides?.basePath) {
     basePath = overrides.basePath
   } else if (envBasePath) {
-    // Environment variable (SANITY_STUDIO_BASEPATH)
+    // Environment variable (SANITY_APP_BASEPATH)
     basePath = envBasePath
   } else if (configBasePath) {
     // `sanity.cli.ts`
@@ -202,5 +202,5 @@ export default async function buildSanityApp(
 
 // eslint-disable-next-line no-process-env
 function getSanityEnvVars(env: Record<string, string | undefined> = process.env): string[] {
-  return Object.keys(env).filter((key) => key.toUpperCase().startsWith('SANITY_STUDIO_'))
+  return Object.keys(env).filter((key) => key.toUpperCase().startsWith('SANITY_APP_'))
 }

--- a/packages/sanity/src/_internal/cli/server/getStudioEnvironmentVariables.ts
+++ b/packages/sanity/src/_internal/cli/server/getStudioEnvironmentVariables.ts
@@ -2,6 +2,7 @@
 import {loadEnv} from '@sanity/cli'
 
 const envPrefix = 'SANITY_STUDIO_'
+const appEnvPrefix = 'SANITY_APP_'
 
 /**
  * The params for the `getStudioEnvironmentVariables` function that gets Studio focused environment variables.
@@ -59,4 +60,32 @@ export function getStudioEnvironmentVariables(
     }
   }
   return studioEnv
+}
+
+/**
+ * Get environment variables prefixed with SANITY_APP_, as an object.
+ *
+ * @param options - Options for the environment variable loading
+ *  {@link StudioEnvVariablesOptions}
+ * @returns Object of app environment variables
+ *
+ * @internal
+ */
+export function getAppEnvironmentVariables(
+  options: StudioEnvVariablesOptions = {},
+): Record<string, string> {
+  const {prefix = '', envFile = false, jsonEncode = false} = options
+  const fullEnv = envFile
+    ? {...process.env, ...loadEnv(envFile.mode, envFile.envDir || process.cwd(), [envPrefix])}
+    : process.env
+
+  const appEnv: Record<string, string> = {}
+  for (const key in fullEnv) {
+    if (key.startsWith(appEnvPrefix)) {
+      appEnv[`${prefix}${key}`] = jsonEncode
+        ? JSON.stringify(fullEnv[key] || '')
+        : fullEnv[key] || ''
+    }
+  }
+  return appEnv
 }


### PR DESCRIPTION
### Description

This PR changes the environment variable prefix for Sanity apps from `SANITY_STUDIO_` to `SANITY_APP_`. This creates a clearer distinction between studio and app environments, making it easier to configure different settings for each context.

### What to review

- The changes to environment variable loading in the CLI
- The implementation of `getAppEnvironmentVariables` function
- The updated environment variable prefix in the Vite configuration for apps
- The order of operations in the CLI to ensure environment variables are loaded after the CLI config is determined

### Testing

Tested by verifying that:
- Apps correctly load environment variables with the `SANITY_APP_` prefix
- Studios continue to use the `SANITY_STUDIO_` prefix
- The basePath configuration works correctly with the new prefix

### Notes for release

N/A