### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,5 +25,8 @@
 /packages/@sanity/cli/src/commands/typegen @sanity-io/content-lake-dx
 /packages/@sanity/cli/src/workers/typegenGenerate.ts @sanity-io/content-lake-dx
 
+# Ignore package.json
+/packages/@sanity/codegen/package.json
+
 # Presentation Tool, which interfaces with Visual Editing libraries
 /packages/sanity/src/presentation/ @sanity-io/ecosystem

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 # areas to improve maintainablitly and availability
 
 # Releases
-/packages/sanity/src/core/releases @sanity-io/studio-app
+/packages/sanity/src/core/releases @sanity-io/studio
 
 # -- Others --
 


### PR DESCRIPTION
A couple of small modifications to codeowners:
- marking codegen/package.json as not owned by anyone
- fixing a reference to the wrong team (shoudl be `@sanity-io/studio`, not `@sanity-io/studio-app`


### Notes for release
n/a