### PR TITLE
chore(ci): simplify release-please setup

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  "packages/@repo/package.bundle": "3.86.0",
   "packages/@sanity/cli": "3.86.0",
   "packages/@sanity/codegen": "3.86.0",
   "packages/@sanity/diff": "3.86.0",

--- a/dev/depcheck-test/package.json
+++ b/dev/depcheck-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "depcheck-test",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>"

--- a/dev/design-studio/package.json
+++ b/dev/design-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-studio",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "description": "Sanity Design Studio",
   "keywords": [

--- a/dev/embedded-studio/package.json
+++ b/dev/embedded-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embedded-studio",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "build": "tsc && vite build && sanity manifest extract",

--- a/dev/media-library-aspects-studio/package.json
+++ b/dev/media-library-aspects-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "media-library-aspects-studio",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "description": "",
   "keywords": [],

--- a/dev/page-building-studio/package.json
+++ b/dev/page-building-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-page-building-studio",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",

--- a/dev/starter-studio/package.json
+++ b/dev/starter-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-starter-studio",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",

--- a/dev/studio-e2e-testing/package.json
+++ b/dev/studio-e2e-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studio-e2e-testing",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "keywords": [
     "sanity"

--- a/dev/test-create-integration-studio/package.json
+++ b/dev/test-create-integration-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-create-integration-studio",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-test-studio",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",

--- a/examples/blog-studio/package.json
+++ b/examples/blog-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blog-studio",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "description": "Content studio running with schema from the blog init template",
   "keywords": [

--- a/examples/clean-studio/package.json
+++ b/examples/clean-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clean-studio",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "description": "Content studio running with schema from the clean template",
   "keywords": [

--- a/examples/ecommerce-studio/package.json
+++ b/examples/ecommerce-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecommerce-studio",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "description": "",
   "keywords": [

--- a/examples/movies-studio/package.json
+++ b/examples/movies-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movies-studio",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "description": "Content studio running with schema from the moviedb init template",
   "keywords": [

--- a/packages/@repo/dev-aliases/package.json
+++ b/packages/@repo/dev-aliases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/dev-aliases",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "description": "Dev aliases for the sanity monorepo",
   "type": "module",

--- a/packages/@repo/package.config/package.json
+++ b/packages/@repo/package.config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/package.config",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "description": "Shared @sanity/pkg-utils configuration",
   "main": "./src/package.config.ts",

--- a/packages/@repo/test-config/package.json
+++ b/packages/@repo/test-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/test-config",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "description": "Test (as in unit test) config shared across packages in the sanity monorepo",
   "type": "module",

--- a/packages/@repo/test-exports/package.json
+++ b/packages/@repo/test-exports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/test-exports",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "description": "Ensures that all the monorepo packages that are published works in native node ESM and CJS runtimes",
   "exports": {

--- a/packages/@repo/tsconfig/package.json
+++ b/packages/@repo/tsconfig/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@repo/tsconfig",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true
 }

--- a/perf/efps/package.json
+++ b/perf/efps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "efps",
-  "version": "3.53.0",
+  "version": "0.0.0",
   "private": true,
   "description": "Sanity Studio eFPS perf suite",
   "keywords": [],

--- a/perf/studio/package.json
+++ b/perf/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perf-studio",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "description": "Sanity Studio with various test cases for tracking performance",
   "license": "MIT",

--- a/perf/tests/package.json
+++ b/perf/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-perf-tests",
-  "version": "3.86.0",
+  "version": "0.0.0",
   "private": true,
   "description": "Sanity Studio perf tests",
   "license": "MIT",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,40 +1,31 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "495035dad4e5391a180b0b0a02f9b5ba8fb2b728",
+  "release-type": "node",
+  "separate-pull-requests": false,
+  "draft-pull-request": true,
+  "skip-github-release": true,
+  "always-update": true,
+  "include-component-in-tag": false,
   "packages": {
-    "packages/@sanity/cli": {"component": "cli"},
-    "packages/@sanity/codegen": {"component": "codegen"},
-    "packages/@sanity/diff": {"component": "diff"},
-    "packages/@sanity/migrate": {"component": "migrate"},
-    "packages/@sanity/mutator": {"component": "mutator"},
-    "packages/@sanity/schema": {"component": "schema"},
-    "packages/@sanity/types": {"component": "types"},
-    "packages/@sanity/util": {"component": "util"},
-    "packages/@sanity/vision": {"component": "vision"},
-    "packages/create-sanity": {"component": "create-sanity"},
-    "packages/groq": {"component": "groq"},
-    "packages/sanity": {"component": "sanity"}
+    "packages/@repo/package.bundle": {},
+    "packages/@sanity/cli": {},
+    "packages/@sanity/codegen": {},
+    "packages/@sanity/diff": {},
+    "packages/@sanity/migrate": {},
+    "packages/@sanity/mutator": {},
+    "packages/@sanity/schema": {},
+    "packages/@sanity/types": {},
+    "packages/@sanity/util": {},
+    "packages/@sanity/vision": {},
+    "packages/create-sanity": {},
+    "packages/groq": {},
+    "packages/sanity": {}
   },
   "plugins": [
-    "node-workspace",
     {
-      "type": "linked-versions",
-      "groupName": "studio",
-      "components": [
-        "cli",
-        "codegen",
-        "diff",
-        "migrate",
-        "mutator",
-        "schema",
-        "types",
-        "util",
-        "vision",
-        "create-sanity",
-        "groq",
-        "sanity"
-      ]
+      "type": "node-workspace",
+      "updateAllPackages": true
     }
-  ],
-  "separate-pull-requests": false
+  ]
 }


### PR DESCRIPTION
### Description
Includes some tweaks and improvements to the release setup.

- bumps all packages as part of the release. This is a continuation of our already established convention.
- sets the version of internal packages to 0.0.0, these are never release anyway, so no reason to bump them as part of published packages.
- adds `packages/@repo/package.bundle` to the list of packages that will be bumped. This is the source of truth for "current version" used by Auto-Updating Studios.


### What to review

Example PR made by this config: https://github.com/sanity-io/sanity/pull/9256
Note: The description of that PR isn't great, ideally it should list the package name in the section summary, but think it's just merged as is from changelogs and found no way to easily configuring this.


### Notes for release
n/a