### PR TITLE
chore(ci): skip cli tests on release PR and push

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -13,6 +13,17 @@ concurrency:
 
 jobs:
   cli-test:
+    # Do not run cli tests on release PRs or when the release PR is merged because
+    # the CLI tests will attempt to install the not-yet-released packages from npm
+    if: |
+      !(
+        github.event_name == 'pull_request' &&
+        contains(join(github.event.pull_request.labels.*.name, ','), 'autorelease: pending')
+      ) &&
+      !(
+        github.event_name == 'push' &&
+        startsWith(github.event.head_commit.message, 'chore: release')
+      )
     timeout-minutes: 60
     name: CLI Tests (${{ matrix.os }} / node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Description
Currently, the CLI tests tries to install the current version from npm as part of running the tests (these versions are later replaced with the local version). However, with our new release automation, a PR will be opened with version bumps _before_ they get published to npm, which means the CLI tests will fail on that PR and the subsequent merge of that PR (after merge the packages will be published, so after a while the tests will succeed, but I'd prefer not to have to hit retry after they fail initially)

### Testing
Once merged, we should see that the CLI tests are skipped on [this release PR](https://github.com/sanity-io/sanity/pull/9246), and the following merge of it.

### Notes for release
n/a