### PR TITLE
chore(ci): improve check for release pr or commit

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -45,19 +45,18 @@ jobs:
       # Note: we can't skip, because this is a required status check, but exit 0 will report success
       - name: Skip for release PR or commit
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]] && \
-             [[ "${{ toJson(github.event.pull_request.labels.*.name) }}" == *"autorelease: pending"* ]]; then
-            echo "✅ Skipping test on release PR"
-            exit 0
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            if [[ "${{ github.event.pull_request.title }}" == chore:\ release* ]]; then
+              echo "✅ Skipping test on release PR"
+              exit 0
+            fi
           fi
-
-          if [[ "${{ github.event_name }}" == "push" ]] && \
-             [[ "${{ github.event.head_commit.message }}" == chore:\ release* ]]; then
-            echo "✅ Skipping test on release commit"
-            exit 0
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            if [[ "${{ github.event.head_commit.message }}" == chore:\ release* ]]; then
+              echo "✅ Skipping test on release commit"
+              exit 0
+            fi
           fi
-
-          echo "🔧 Continuing with full test flow"
       - name: Install project dependencies
         run: pnpm install
 


### PR DESCRIPTION
### Description

The change in #9262 produced invalid shell script (thanks ChatGPT! 🙄):

```sh
if [[ "pull_request" == "pull_request" ]] && \
   [[ "[
  "autorelease: pending"
]" == *"autorelease: pending"* ]]; then
  echo "✅ Skipping test on release PR"
  exit 0
fi
```

This PR updates the check to use a similar check for PR title as we use for the commit. Third time is the charm, eh?
