### PR TITLE
chore(ci): update ETL workflow to trigger on release events

### DIFF
--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -5,9 +5,9 @@ on:
   workflow_dispatch:
   # Build on pushes branches that have a PR (including drafts)
   pull_request:
-  # Build on commits pushed to branches without a PR if it's in the allowlist
-  push:
-    branches: [current]
+  # Build on release publishes
+  release:
+    types: [published]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -38,7 +38,8 @@ jobs:
 
       - name: Extract API docs
         env:
-          EXTRACT_SANITY_PROJECT_ID: "${{((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/current') && vars.EXTRACT_SANITY_PROJECT_ID || vars.DEV_EXTRACT_SANITY_PROJECT_ID}}"
-          EXTRACT_SANITY_DATASET: "${{((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/current') && vars.EXTRACT_SANITY_DATASET || vars.DEV_EXTRACT_SANITY_DATASET}}"
-          EXTRACT_SANITY_API_TOKEN: "${{((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/current') && secrets.EXTRACT_SANITY_API_TOKEN || secrets.DEV_EXTRACT_SANITY_API_TOKEN}}"
+          # Use production environment only for release builds
+          EXTRACT_SANITY_PROJECT_ID: "${{ github.event_name == 'release' && vars.EXTRACT_SANITY_PROJECT_ID || vars.DEV_EXTRACT_SANITY_PROJECT_ID }}"
+          EXTRACT_SANITY_DATASET: "${{ github.event_name == 'release' && vars.EXTRACT_SANITY_DATASET || vars.DEV_EXTRACT_SANITY_DATASET }}"            
+          EXTRACT_SANITY_API_TOKEN: "${{ github.event_name == 'release' && secrets.EXTRACT_SANITY_API_TOKEN || secrets.DEV_EXTRACT_SANITY_API_TOKEN }}"
         run: pnpm etl sanity

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -40,6 +40,6 @@ jobs:
         env:
           # Use production environment only for release builds
           EXTRACT_SANITY_PROJECT_ID: "${{ github.event_name == 'release' && vars.EXTRACT_SANITY_PROJECT_ID || vars.DEV_EXTRACT_SANITY_PROJECT_ID }}"
-          EXTRACT_SANITY_DATASET: "${{ github.event_name == 'release' && vars.EXTRACT_SANITY_DATASET || vars.DEV_EXTRACT_SANITY_DATASET }}"            
+          EXTRACT_SANITY_DATASET: "${{ github.event_name == 'release' && vars.EXTRACT_SANITY_DATASET || vars.DEV_EXTRACT_SANITY_DATASET }}"
           EXTRACT_SANITY_API_TOKEN: "${{ github.event_name == 'release' && secrets.EXTRACT_SANITY_API_TOKEN || secrets.DEV_EXTRACT_SANITY_API_TOKEN }}"
         run: pnpm etl sanity


### PR DESCRIPTION
### Description
* triggers ETL on release events as well as other pushes
* Uses production secrets for pushing TSDocs when triggered by a release publish event
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
