### PR TITLE
chore(ci): don't skip github release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
   "release-type": "node",
   "separate-pull-requests": false,
   "draft-pull-request": true,
-  "skip-github-release": true,
   "always-update": true,
   "include-component-in-tag": false,
   "packages": {


### PR DESCRIPTION
### Description
looks like "skip-github-release": true, is not what we want as it looks like it will skip creating the tags and doing the release alltogether
