### PR TITLE
chore(ci): link all versions

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,24 +7,43 @@
   "always-update": true,
   "include-component-in-tag": false,
   "packages": {
-    "packages/@repo/package.bundle": {},
-    "packages/@sanity/cli": {},
-    "packages/@sanity/codegen": {},
-    "packages/@sanity/diff": {},
-    "packages/@sanity/migrate": {},
-    "packages/@sanity/mutator": {},
-    "packages/@sanity/schema": {},
-    "packages/@sanity/types": {},
-    "packages/@sanity/util": {},
-    "packages/@sanity/vision": {},
-    "packages/create-sanity": {},
-    "packages/groq": {},
-    "packages/sanity": {}
+    "packages/@repo/package.bundle": {"component": "package.bundle"},
+    "packages/@sanity/cli": {"component": "cli"},
+    "packages/@sanity/codegen": {"component": "codegen"},
+    "packages/@sanity/diff": {"component": "diff"},
+    "packages/@sanity/migrate": {"component": "migrate"},
+    "packages/@sanity/mutator": {"component": "mutator"},
+    "packages/@sanity/schema": {"component": "schema"},
+    "packages/@sanity/types": {"component": "types"},
+    "packages/@sanity/util": {"component": "util"},
+    "packages/@sanity/vision": {"component": "vision"},
+    "packages/create-sanity": {"component": "create-sanity"},
+    "packages/groq": {"component": "groq"},
+    "packages/sanity": {"component": "sanity"}
   },
   "plugins": [
     {
       "type": "node-workspace",
-      "updateAllPackages": true
+      "merge": false
+    },
+    {
+      "type": "linked-versions",
+      "groupName": "Studio packages",
+      "components": [
+        "package.bundle",
+        "cli",
+        "codegen",
+        "diff",
+        "migrate",
+        "mutator",
+        "schema",
+        "types",
+        "util",
+        "vision",
+        "create-sanity",
+        "groq",
+        "sanity"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds the linked-packages plugin so that all packages are versioned together, based on the highest version number in the group, as per docs:

> When any component in the specified group is
updated, we pick the highest version amongst the components and update all
group components to the same version (keeping them in sync).


I initially thought that `updateAllPackages` would do this, but seems like that just guarantees that all packages are _bumped_, so that could leave us with e.g. `@sanity/types` being patch-bumped to `3.87.1` and, `sanity` minor-bumped to `3.88.0`
