### PR TITLE
refactor(core): set MediaLibrary as the first (default) asset source

### DIFF
--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -636,7 +636,7 @@ function resolveSource({
           config,
           context,
           initialValue: mediaLibraryAssetSources.fileSource
-            ? [defaultAssetSources.fileSource, mediaLibraryAssetSources.fileSource]
+            ? [mediaLibraryAssetSources.fileSource, defaultAssetSources.fileSource]
             : [defaultAssetSources.fileSource],
           propertyName: 'formBuilder.file.assetSources',
           reducer: fileAssetSourceResolver,
@@ -648,7 +648,7 @@ function resolveSource({
           config,
           context,
           initialValue: mediaLibraryAssetSources.imageSource
-            ? [defaultAssetSources.imageSource, mediaLibraryAssetSources.imageSource]
+            ? [mediaLibraryAssetSources.imageSource, defaultAssetSources.imageSource]
             : [defaultAssetSources.imageSource],
           propertyName: 'formBuilder.image.assetSources',
           reducer: imageAssetSourceResolver,

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileAsset.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileAsset.tsx
@@ -79,7 +79,7 @@ export function FileAsset(props: FileAssetProps) {
       const rejectedFilesCount = fileInfo.length - acceptedFiles.length
 
       if (fileInfo.length > 0) {
-        if (rejectedFilesCount > 0 || !directUploads) {
+        if (rejectedFilesCount > 0 || directUploads === false) {
           canUpload = false
         }
       }
@@ -121,7 +121,7 @@ export function FileAsset(props: FileAssetProps) {
     const rejectedFilesCount = hoveringFiles.length - acceptedFiles.length
 
     if (hoveringFiles.length > 0) {
-      if (rejectedFilesCount > 0 || !directUploads) {
+      if (rejectedFilesCount > 0 || directUploads === false) {
         return 'critical'
       }
     }
@@ -162,7 +162,7 @@ export function FileAsset(props: FileAssetProps) {
       const acceptedFiles = files.filter((file) => resolveUploader?.(schemaType, file))
       const rejectedFilesCount = files.length - acceptedFiles.length
 
-      if (rejectedFilesCount > 0 || !directUploads) {
+      if (rejectedFilesCount > 0 || directUploads === false) {
         return
       }
 

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FilePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FilePreview.tsx
@@ -121,7 +121,7 @@ export function FilePreview(props: FileAssetProps) {
             data-asset-source-name={assetSourcesWithUpload[0].name}
             text={t('inputs.files.common.actions-menu.upload.label')}
             data-testid={`file-input-upload-button-${assetSourcesWithUpload[0].name}`}
-            disabled={readOnly || !directUploads}
+            disabled={readOnly || directUploads === false}
           />
         )
       default:

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -79,7 +79,7 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
     const rejectedFilesCount = hoveringFiles.length - acceptedFiles.length
 
     if (hoveringFiles.length > 0) {
-      if (rejectedFilesCount > 0 || !directUploads) {
+      if (rejectedFilesCount > 0 || directUploads === false) {
         return 'critical'
       }
     }

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -348,6 +348,7 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
     return (
       <ImageInputAssetMenu
         assetSources={assetSources}
+        directUploads={directUploads}
         handleOpenDialog={handleOpenDialog}
         handleRemoveButtonClick={handleRemoveButtonClick}
         onSelectFiles={handleSelectFilesToUpload}
@@ -366,6 +367,7 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
     )
   }, [
     assetSources,
+    directUploads,
     handleOpenDialog,
     handleRemoveButtonClick,
     handleSelectFilesToUpload,
@@ -378,6 +380,7 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
     schemaType,
     value,
   ])
+
   const renderBrowser = useCallback(() => {
     return (
       <ImageInputBrowser

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAsset.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAsset.tsx
@@ -84,7 +84,7 @@ function ImageInputAssetComponent(props: {
       const rejectedFilesCount = fileInfo.length - acceptedFiles.length
 
       if (fileInfo.length > 0) {
-        if (rejectedFilesCount > 0 || !directUploads) {
+        if (rejectedFilesCount > 0 || directUploads === false) {
           canUpload = false
         }
       }
@@ -105,7 +105,7 @@ function ImageInputAssetComponent(props: {
       const acceptedFiles = files.filter((file) => resolveUploader?.(schemaType, file))
       const rejectedFilesCount = files.length - acceptedFiles.length
 
-      if (rejectedFilesCount > 0 || !directUploads) {
+      if (rejectedFilesCount > 0 || directUploads === false) {
         return
       }
 

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAsset.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAsset.tsx
@@ -105,7 +105,7 @@ function ImageInputAssetComponent(props: {
       const acceptedFiles = files.filter((file) => resolveUploader?.(schemaType, file))
       const rejectedFilesCount = files.length - acceptedFiles.length
 
-      if (rejectedFilesCount > 0 || directUploads === false) {
+      if (rejectedFilesCount > 0) {
         return
       }
 

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
@@ -17,7 +17,13 @@ import {type BaseImageInputProps} from './types'
 function ImageInputAssetMenuComponent(
   props: Pick<
     BaseImageInputProps,
-    'assetSources' | 'imageUrlBuilder' | 'observeAsset' | 'readOnly' | 'schemaType' | 'value'
+    | 'assetSources'
+    | 'directUploads'
+    | 'imageUrlBuilder'
+    | 'observeAsset'
+    | 'readOnly'
+    | 'schemaType'
+    | 'value'
   > & {
     handleOpenDialog: () => void
     handleRemoveButtonClick: () => void
@@ -32,6 +38,7 @@ function ImageInputAssetMenuComponent(
 ) {
   const {
     assetSources,
+    directUploads,
     handleOpenDialog,
     handleRemoveButtonClick,
     onSelectFiles,
@@ -99,6 +106,7 @@ function ImageInputAssetMenuComponent(
       accept={accept}
       assetSources={assetSources}
       browseMenuItem={browseMenuItem}
+      directUploads={directUploads}
       handleOpenDialog={handleOpenDialog}
       handleRemoveButtonClick={handleRemoveButtonClick}
       onSelectFiles={onSelectFiles}

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
@@ -208,7 +208,7 @@ function ImageInputAssetMenuWithReferenceAssetComponent(
           data-asset-source-name={assetSourcesWithUpload[0].name}
           text={t('inputs.files.common.actions-menu.upload.label')}
           data-testid="file-input-upload-button"
-          disabled={readOnly || !directUploads}
+          disabled={readOnly || directUploads === false}
         />
       )
       break

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputPreview.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputPreview.tsx
@@ -80,7 +80,7 @@ function RenderImageInputPreview(props: {
     <ImagePreview
       alt={t('inputs.image.preview-uploaded-image')}
       drag={!value?._upload && hoveringFiles.length > 0}
-      isRejected={rejectedFilesCount > 0 || !directUploads}
+      isRejected={rejectedFilesCount > 0 || directUploads === false}
       onDoubleClick={handleOpenDialog}
       readOnly={readOnly}
       src={url}

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.tsx
@@ -79,10 +79,10 @@ function getHoverTextTranslationKey({
   readOnly?: boolean
 }) {
   if (isRejected) {
-    return 'inputs.image.drag-overlay.this-field-is-read-only'
+    return 'inputs.image.drag-overlay.cannot-upload-here'
   }
   return readOnly
-    ? 'inputs.image.drag-overlay.cannot-upload-here'
+    ? 'inputs.image.drag-overlay.this-field-is-read-only'
     : 'inputs.image.drag-overlay.drop-to-upload-image'
 }
 

--- a/packages/sanity/src/core/form/inputs/files/common/PlaceholderText.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/PlaceholderText.tsx
@@ -30,7 +30,7 @@ export function PlaceholderText(props: Props) {
       return <ReadOnlyIcon />
     }
 
-    if ((hoveringFiles && rejectedFilesCount > 0) || !directUploads) {
+    if ((hoveringFiles && rejectedFilesCount > 0) || directUploads === false) {
       return <AccessDeniedIcon />
     }
 
@@ -38,7 +38,7 @@ export function PlaceholderText(props: Props) {
   }, [directUploads, hoveringFiles, isFileType, readOnly, rejectedFilesCount])
 
   const messageText = useMemo(() => {
-    if (!directUploads) {
+    if (directUploads === false) {
       return t('inputs.files.common.placeholder.upload-not-supported')
     }
 

--- a/packages/sanity/src/core/form/inputs/files/common/UploadPlaceholder.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/UploadPlaceholder.tsx
@@ -85,7 +85,7 @@ function UploadPlaceholderComponent(props: UploadPlaceholderProps) {
           <FileInputButton
             accept={accept}
             data-testid={`file-input-upload-button-${assetSourcesWithUpload[0].name}`}
-            disabled={readOnly || !directUploads}
+            disabled={readOnly || directUploads === false}
             icon={UploadIcon}
             mode="bleed"
             // eslint-disable-next-line react/jsx-no-bind


### PR DESCRIPTION
### Description

If the Media Library is enabled in the workspace, set it as the first (and default) asset source.

Also, fix a couple of bugs related to the asset sources config.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
