### PR TITLE
fix(core): remove `renderEditable` from PTE inputs again

### DIFF
--- a/dev/test-studio/schema/standard/portableText/customBlockEditors.tsx
+++ b/dev/test-studio/schema/standard/portableText/customBlockEditors.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/jsx-no-bind */
-import {Card} from '@sanity/ui'
 import {BlockEditor, defineType, type PortableTextInputProps} from 'sanity'
 
 export const ptCustomBlockEditors = defineType({
@@ -42,34 +40,6 @@ export const ptCustomBlockEditors = defineType({
       type: 'array',
       components: {
         input: (props: PortableTextInputProps) => <BlockEditor {...props} readOnly />,
-      },
-      of: [{type: 'block'}],
-    },
-    {
-      name: 'renderEditable',
-      title: 'Custom renderEditable',
-      description: 'Wrapped in card components with a custom placeholder',
-      type: 'array',
-      components: {
-        input: (props: PortableTextInputProps) => (
-          <BlockEditor
-            {...props}
-            renderEditable={(editableProps) => {
-              return (
-                <Card border padding={2} tone="critical">
-                  <Card border padding={2} tone="critical">
-                    {editableProps.renderDefault({
-                      ...editableProps,
-                      renderPlaceholder: () => (
-                        <span style={{opacity: 0.25}}>Nothing to see here</span>
-                      ),
-                    })}
-                  </Card>
-                </Card>
-              )
-            }}
-          />
-        ),
       },
       of: [{type: 'block'}],
     },

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -17,11 +17,7 @@ import {ChangeIndicator} from '../../../changeIndicators'
 import {EMPTY_ARRAY} from '../../../util'
 import {ActivateOnFocus} from '../../components/ActivateOnFocus/ActivateOnFocus'
 import {TreeEditingEnabledProvider} from '../../studio/tree-editing'
-import {
-  type ArrayOfObjectsInputProps,
-  type PortableTextInputProps,
-  type RenderCustomMarkers,
-} from '../../types'
+import {type ArrayOfObjectsInputProps, type RenderCustomMarkers} from '../../types'
 import {type RenderBlockActionsCallback} from '../../types/_transitional'
 import {UploadTargetCard} from '../arrays/common/UploadTargetCard'
 import {ExpandedLayer, Root} from './Compositor.styles'
@@ -50,7 +46,6 @@ interface InputProps extends ArrayOfObjectsInputProps<PortableTextBlock> {
   rangeDecorations?: RangeDecoration[]
   renderBlockActions?: RenderBlockActionsCallback
   renderCustomMarkers?: RenderCustomMarkers
-  renderEditable?: PortableTextInputProps['renderEditable']
 }
 
 /** @internal */
@@ -82,7 +77,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     renderBlock,
     renderBlockActions,
     renderCustomMarkers,
-    renderEditable,
     renderField,
     renderInlineBlock,
     renderInput,
@@ -432,7 +426,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
           renderAnnotation={editorRenderAnnotation}
           renderBlock={editorRenderBlock}
           renderChild={editorRenderChild}
-          renderEditable={renderEditable}
           setPortalElement={setPortalElement}
           scrollElement={scrollElement}
           setScrollElement={setScrollElement}
@@ -462,7 +455,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       resolveUploader,
       rangeDecorations,
       readOnly,
-      renderEditable,
       scrollElement,
     ],
   )

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -17,13 +17,11 @@ import {type Path} from '@sanity/types'
 import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
 // eslint-disable-next-line camelcase
 import {getTheme_v2} from '@sanity/ui/theme'
-import {omit} from 'lodash'
 import {type ReactNode, useCallback, useMemo} from 'react'
 import {css, styled} from 'styled-components'
 
 import {TooltipDelayGroupProvider} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
-import {type PortableTextInputProps} from '../../types/inputProps'
 import {useFormBuilder} from '../../useFormBuilder'
 import {EditableCard, EditableWrapper, Root, Scroller, ToolbarCard} from './Editor.styles'
 import {useScrollSelectionIntoView} from './hooks/useScrollSelectionIntoView'
@@ -63,7 +61,6 @@ interface EditorProps {
   renderAnnotation: RenderAnnotationFunction
   renderBlock: RenderBlockFunction
   renderChild: RenderChildFunction
-  renderEditable?: PortableTextInputProps['renderEditable']
   scrollElement: HTMLElement | null
   setPortalElement?: (portalElement: HTMLDivElement | null) => void
   setScrollElement: (scrollElement: HTMLElement | null) => void
@@ -102,7 +99,6 @@ export function Editor(props: EditorProps): ReactNode {
     renderAnnotation,
     renderBlock,
     renderChild,
-    renderEditable,
     scrollElement,
     setPortalElement,
     setScrollElement,
@@ -161,13 +157,8 @@ export function Editor(props: EditorProps): ReactNode {
       spellCheck,
       'style': noOutlineStyle,
     } satisfies PortableTextEditableProps
-    const defaultRender = (defaultRenderProps: PortableTextEditableProps) => (
-      <PortableTextEditable {...editableProps} {...omit(defaultRenderProps, ['renderDefault'])} />
-    )
-    if (renderEditable) {
-      return renderEditable({...editableProps, renderDefault: defaultRender})
-    }
-    return defaultRender(editableProps)
+
+    return <PortableTextEditable {...editableProps} />
   }, [
     ariaDescribedBy,
     elementRef,
@@ -179,7 +170,6 @@ export function Editor(props: EditorProps): ReactNode {
     renderAnnotation,
     renderBlock,
     renderChild,
-    renderEditable,
     renderPlaceholder,
     scrollSelectionIntoView,
     spellCheck,

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -6,10 +6,8 @@ import {
   type InvalidValue,
   type OnPasteFn,
   type Patch,
-  type PortableTextEditableProps,
   PortableTextEditor,
   type RangeDecoration,
-  type RenderEditableFunction,
   useEditor,
   usePortableTextEditor,
 } from '@portabletext/editor'
@@ -87,10 +85,6 @@ export interface PortableTextMemberItem {
   node: ObjectFormNode
   input?: ReactNode
 }
-/** @public */
-export interface RenderPortableTextInputEditableProps extends PortableTextEditableProps {
-  renderDefault: RenderEditableFunction
-}
 
 /**
  * Input component for editing block content
@@ -125,7 +119,6 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
     rangeDecorations: rangeDecorationsProp,
     renderBlockActions,
     renderCustomMarkers,
-    renderEditable,
     schemaType,
     value,
     resolveUploader,
@@ -435,7 +428,6 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
                 readOnly={readOnly || !ready}
                 renderBlockActions={renderBlockActions}
                 renderCustomMarkers={renderCustomMarkers}
-                renderEditable={renderEditable}
               />
             </EditorProvider>
           </PortableTextMemberItemsProvider>

--- a/packages/sanity/src/core/form/types/inputProps.ts
+++ b/packages/sanity/src/core/form/types/inputProps.ts
@@ -31,7 +31,6 @@ import {
   type ReactNode,
 } from 'react'
 
-import {type RenderPortableTextInputEditableProps} from '../inputs'
 import {type FormPatch, type PatchEvent} from '../patch'
 import {type FormFieldGroup} from '../store'
 import {
@@ -572,13 +571,6 @@ export interface PortableTextInputProps
    * Use the `renderBlock` interface instead.
    */
   renderCustomMarkers?: RenderCustomMarkers
-  /**
-   * Function to render the PortableTextInput's editable component.
-   * This is the actual contentEditable element that users type into.
-   * @hidden
-   * @beta
-   */
-  renderEditable?: (props: RenderPortableTextInputEditableProps) => React.JSX.Element
   /**
    * Array of {@link RangeDecoration} that can be used to decorate the content.
    */


### PR DESCRIPTION
### Description

`renderEditable` was added as a `@hidden` `@beta` feature in #6627 in order to provide Canvas (then Create) a way to configure PTE at the lowest level. However, Canvas has been using Standalone PTE for more than half a year now and as such, there is no need for this API anymore. In fact, the `renderEditable` API poses a problem to the Standalone PTE itself since it exposes the entire prop surface of the `<PortableTextEditable />` offered by this library. The more Standalone PTE APIs we expose directly through Studio, the harder it is going to be to move `@portabletext/editor` forward since breaking these APIs, in most cases, will be impossible (since that would introduce breaking changes in Studio).

On top of that, most of the use cases Canvas had for `renderEditable` (for example hooking into text insertions and altering their outcome) have been replaced with the Behavior API, which, in the near future, is going to be the recommended way to extend PTE through Studio as well.

To be on the safe side and to shield Standalone PTE from too much direct exposure through Studio, this commit removes `renderEditable` again.

### What to review

Is the API removal and reasoning sound to you?

### Testing

n/a

### Notes for release

n/a