### PR TITLE
fix: reverting release translog handling

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates.ts
@@ -61,11 +61,8 @@ export const useDocumentRevertStates = (releaseDocuments: DocumentInRelease[]) =
       ),
     ).pipe(
       map((transactions) => {
-        if (transactions.length === 0) throw new Error('No transactions found.')
-
         const getDocumentTransaction = (docId: string) =>
-          // second element is the transaction before the release
-          transactions.filter(({documentIDs}) => documentIDs.includes(docId))[1]?.id
+          transactions.find(({documentIDs}) => documentIDs.includes(docId))?.id
 
         return publishedDocuments.map((document) => ({
           docId: document._id,


### PR DESCRIPTION
### Description
reverting document with only unpublish documents is handled correctly; fixes issue with reverting one transaction too far back
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in Releases+ where reverting a release would fail is only unpublish documents had been included in the release.
Fixes an issue in Releases+ where reverting a release would revert documents back 1 revision too far
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
