### PR TITLE
feat(core): add `useProjectOrganizationId` hook

### DIFF
--- a/packages/sanity/src/core/store/_legacy/project/projectStore.ts
+++ b/packages/sanity/src/core/store/_legacy/project/projectStore.ts
@@ -1,9 +1,15 @@
 import {type SanityClient} from '@sanity/client'
-import {map, type Observable, shareReplay} from 'rxjs'
+import {map, type Observable, repeat, shareReplay} from 'rxjs'
 
 import {memoize} from '../document/utils/createMemoizer'
 import {type ProjectData, type ProjectStore} from './types'
 
+const REFETCH_INTERVAL = 5 * 60 * 1000 // 5 minutes
+
+/**
+ * This value will be cached for 5 minutes, after that internal the cache will be refreshed.
+ * If you need to be 100% sure the organizationId is up to date, you can call the `/projects/${projectId}` endpoint directly.
+ */
 const getOrganizationId = memoize(
   (client: SanityClient) => {
     return client.observable
@@ -18,6 +24,7 @@ const getOrganizationId = memoize(
       })
       .pipe(
         map((res) => res.organizationId),
+        repeat({delay: REFETCH_INTERVAL}),
         shareReplay(1),
       )
   },

--- a/packages/sanity/src/core/store/_legacy/project/types.ts
+++ b/packages/sanity/src/core/store/_legacy/project/types.ts
@@ -61,4 +61,5 @@ export interface ProjectDatasetData {
 export interface ProjectStore {
   get: () => Observable<ProjectData>
   getDatasets: () => Observable<ProjectDatasetData[]>
+  getOrganizationId: () => Observable<string>
 }

--- a/packages/sanity/src/core/store/_legacy/project/useProjectOrganizationId.ts
+++ b/packages/sanity/src/core/store/_legacy/project/useProjectOrganizationId.ts
@@ -1,0 +1,28 @@
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {map, startWith} from 'rxjs'
+
+import {useProjectStore} from '../datastores'
+
+const INITIAL_STATE = {value: null, loading: true}
+
+/**
+ * @beta
+ * Returns the organization ID for the current project.
+ * */
+export function useProjectOrganizationId(): {value: string | null; loading: boolean} {
+  const projectStore = useProjectStore()
+
+  const obs$ = useMemo(
+    () =>
+      projectStore.getOrganizationId().pipe(
+        map((res) => {
+          return {value: res, loading: false}
+        }),
+        startWith({value: null, loading: true}),
+      ),
+    [projectStore],
+  )
+
+  return useObservable(obs$, INITIAL_STATE)
+}


### PR DESCRIPTION
### Description
Adds a new `getOrganizationId` function  in the `projectStore` to get the project organization id, this is useful in our move to dashboard as we will need to fetch the org id to navigate to the correct dashboard. 

It also includes a hook to simplify the usage of the new function.




<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Are this changes correct?


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
You can see how it is being used in the [`studio-canvas`](https://github.com/sanity-io/sanity/compare/studio-canvas/actions) integration.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
