### PR TITLE
feat(structure): add actions.action value to actions states

### DIFF
--- a/dev/test-create-integration-studio/CustomAction.tsx
+++ b/dev/test-create-integration-studio/CustomAction.tsx
@@ -1,0 +1,8 @@
+import {type DocumentActionDescription} from 'sanity'
+
+export function CustomAction(): DocumentActionDescription {
+  return {
+    label: 'Custom Action',
+    onHandle: () => null,
+  }
+}

--- a/dev/test-create-integration-studio/sanity.config.ts
+++ b/dev/test-create-integration-studio/sanity.config.ts
@@ -3,10 +3,14 @@ import {codeInput} from '@sanity/code-input'
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 
+import {CustomAction} from './CustomAction'
 import {schemaTypes} from './schema'
 
 const baseConfig = defineConfig({
   plugins: [structureTool(), codeInput()],
+  document: {
+    actions: [CustomAction],
+  },
   projectId: 'ppsg7ml5',
   dataset: 'test',
   schema: {types: schemaTypes},

--- a/packages/sanity/src/core/components/hookCollection/defineHookStateComponent.tsx
+++ b/packages/sanity/src/core/components/hookCollection/defineHookStateComponent.tsx
@@ -31,7 +31,11 @@ export function defineHookStateComponent<Args, State>({
     })
 
     useEffect(() => {
-      handleNext(id, hookState)
+      if (hookState) {
+        handleNext(id, {...hookState, action: useHook.action})
+      } else {
+        handleNext(id, hookState)
+      }
       return () => {
         handleNext(id, null)
       }

--- a/packages/sanity/src/core/components/hookCollection/types.ts
+++ b/packages/sanity/src/core/components/hookCollection/types.ts
@@ -2,6 +2,7 @@
 export interface HookCollectionActionHook<Args, State> {
   (args: Args): State | null
   displayName?: string | undefined
+  action?: string
 }
 
 /** @public */

--- a/packages/sanity/src/structure/components/RenderActionCollectionState.tsx
+++ b/packages/sanity/src/structure/components/RenderActionCollectionState.tsx
@@ -1,10 +1,14 @@
-import {memo, type ReactNode} from 'react'
+import {memo, type ReactNode, useMemo} from 'react'
 import {
+  type DocumentActionComponent,
   type DocumentActionDescription,
   type DocumentActionGroup,
   type DocumentActionProps,
   GetHookCollectionState,
+  useTranslation,
 } from 'sanity'
+
+import {structureLocaleNamespace} from '../i18n'
 
 /** @internal */
 export interface Action<Args, Description> {
@@ -25,14 +29,68 @@ export const RenderActionCollectionState = memo((props: RenderActionCollectionPr
   const {actions, children, actionProps, onActionComplete, group} = props
 
   return (
-    <GetHookCollectionState<Omit<DocumentActionProps, 'onComplete'>, DocumentActionDescription>
+    <GetHookCollectionState<
+      Omit<DocumentActionProps, 'onComplete'>,
+      DocumentActionDescription & {action?: DocumentActionComponent['action']}
+    >
       onReset={onActionComplete}
       hooks={actions}
       args={actionProps}
       group={group}
     >
-      {children}
+      {({states}) => (
+        <ActionsGuardWrapper states={states} documentId={actionProps.id}>
+          {children}
+        </ActionsGuardWrapper>
+      )}
     </GetHookCollectionState>
   )
 })
 RenderActionCollectionState.displayName = 'Memo(RenderActionCollectionState)'
+
+/**
+ * This is a list of the actions that are supported when a document is linked to Canvas.
+ * Custom actions and actions that are not supported by Canvas will be disabled and will include a tooltip explaining that the action is not supported.
+ */
+const SUPPORTED_LINKED_TO_CANVAS_ACTIONS: DocumentActionComponent['action'][] = [
+  'delete',
+  'duplicate',
+  'publish',
+  'unpublish',
+]
+
+/**
+ * TODO: See PR https://github.com/sanity-io/sanity/pull/9289 for the removal of this
+ * This will be `const {isLinked} = useCanvasCompanionDoc(documentId)`
+ * Do not change this constant to true or all custom actions will be disabled.
+ */
+const TEMP_DISABLED_BY_CANVAS = false
+interface ActionsGuardWrapperProps {
+  states: Array<DocumentActionDescription & {action?: DocumentActionComponent['action']}>
+  documentId: string
+  children: (props: {states: DocumentActionDescription[]}) => ReactNode
+}
+
+const ActionsGuardWrapper = (props: ActionsGuardWrapperProps) => {
+  const {states, children, documentId} = props
+  const {t} = useTranslation(structureLocaleNamespace)
+  const result = useMemo(() => {
+    if (TEMP_DISABLED_BY_CANVAS) {
+      return children({
+        states: states.map((s) => {
+          if (!s.action || !SUPPORTED_LINKED_TO_CANVAS_ACTIONS.includes(s.action)) {
+            return {
+              ...s,
+              disabled: true,
+              title: t('action.disabled-by-canvas.tooltip'),
+            }
+          }
+          return s
+        }),
+      })
+    }
+    return children({states})
+  }, [children, states, t])
+
+  return result
+}

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -18,7 +18,9 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'action.delete.label': 'Delete',
   /** Label for the "Delete" document action while the document is being deleted */
   'action.delete.running.label': 'Deleting…',
-
+  /** Tooltip when action is disabled because the document is linked to Canvas */
+  'action.disabled-by-canvas.tooltip':
+    'Custom document actions are disabled for documents linked to Canvas',
   /** Message prompting the user to confirm discarding changes */
   'action.discard-changes.confirm-dialog.confirm-discard-changes':
     'Are you sure you want to discard all changes since last published?',


### PR DESCRIPTION
### Description
This PR consist of two changes:
1) Adds `action.action` value to the action states hooks return value. This are the value of the hooks returned by the document actions. We need this in order to help categorize an action as custom or not, and also to expose more action data down the tree.

2) Adds a placeholder to disable the actions that are not supported when a document is linked to canvas, see https://github.com/sanity-io/sanity/pull/9289/


This `TEMP_DISABLED_BY_CANVAS` will be removed in the PR mentioned above and will be replaced by the canvas companion doc validation.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Are this changes correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Actions should remain the same, nothing should change.
If you want to test the disabled actions locally go to `sanity/dev/test-create-integration-studio` and then `pnpm dev`, this will run the create testing studio.
After that, switch the `TEMP_DISABLED_BY_CANVAS` const to `true` 

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a internal
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
