### PR TITLE
feat(structure): adds `initialValueResolved` to DocumentActionProps

### DIFF
--- a/packages/sanity/src/core/config/document/actions.ts
+++ b/packages/sanity/src/core/config/document/actions.ts
@@ -19,6 +19,10 @@ export interface ActionComponent<ActionProps> {
 export interface DocumentActionProps extends EditStateFor {
   revision?: string
   onComplete: () => void
+  /**
+   * Whether the initial value has been resolved.
+   */
+  initialValueResolved: boolean
 }
 
 /**

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -77,6 +77,7 @@ export const DocumentPanelHeader = memo(
       actions: allActions,
       editState,
       onMenuAction,
+      isInitialValueLoading,
       onPaneClose,
       onPaneSplit,
       menuItemGroups,
@@ -189,7 +190,7 @@ export const DocumentPanelHeader = memo(
           {editState && (
             <RenderActionCollectionState
               actions={actions}
-              actionProps={editState}
+              actionProps={{...editState, initialValueResolved: !isInitialValueLoading}}
               group="paneActions"
             >
               {renderPaneActions}
@@ -232,6 +233,7 @@ export const DocumentPanelHeader = memo(
         BackLink,
         actions,
         editState,
+        isInitialValueLoading,
         menuButtonNodes,
         onPaneClose,
         onPaneSplit,

--- a/packages/sanity/src/structure/panes/document/keyboardShortcuts/DocumentActionShortcuts.tsx
+++ b/packages/sanity/src/structure/panes/document/keyboardShortcuts/DocumentActionShortcuts.tsx
@@ -100,7 +100,7 @@ export interface DocumentActionShortcutsProps {
 export const DocumentActionShortcuts = memo(
   (props: DocumentActionShortcutsProps & Omit<HTMLProps<HTMLDivElement>, 'as'>) => {
     const {actionsBoxElement, as = 'div', children, ...rest} = props
-    const {actions, editState} = useDocumentPane()
+    const {actions, editState, isInitialValueLoading, revisionId} = useDocumentPane()
     const [activeIndex, setActiveIndex] = useState(-1)
 
     const onActionStart = useCallback((idx: number) => {
@@ -115,10 +115,10 @@ export const DocumentActionShortcuts = memo(
           // @todo: what to call here?
           onComplete: () => undefined,
 
-          // @todo: get revision string
-          revision: undefined,
+          revision: revisionId || undefined,
+          initialValueResolved: !isInitialValueLoading,
         },
-      [editState],
+      [editState, isInitialValueLoading, revisionId],
     )
 
     const renderDocumentActionShortcuts = useCallback<


### PR DESCRIPTION
### Description
Adds a boolean for the documentActionProps to indicate if a initial value is resolved or not.
This is necessary because in some cases we want to disable a custom action while the initial values are resolving, initial values can be async and there is nothing to indicate if this process has ended or not.

See [LinkToCanvasAction](https://github.com/sanity-io/sanity/pull/9289/commits/1becedb09a9425372ec434107811a72b8ef33525#diff-b6dc28109fa776de745fc0e66f56ea28dd32bb62ceda784e622d8a4705363055R57-R59) in  https://github.com/sanity-io/sanity/pull/9289 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Adds a new property to `DocumentActionProps` indicating if the document initial value is resolved.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
