### PR TITLE
chore(ci): enable updateAllPackages

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,7 +24,8 @@
   "plugins": [
     {
       "type": "node-workspace",
-      "merge": false
+      "merge": false,
+      "updateAllPackages": true
     },
     {
       "type": "linked-versions",


### PR DESCRIPTION
Looking at the generated [diff for the release PR](https://github.com/sanity-io/sanity/pull/9270/files) after merging #9275, not all packages were bumped, so looks like we _also_ want to keep `updateAllPackages` in combo with linked-versions.
