### PR TITLE
chore(github): dataset create per push + dataset deletion on close/merge

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -130,7 +130,8 @@ jobs:
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_STAGING }}
           SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
-          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
+          # the id is based on the PR number and the workflow run id
+          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}-${{ github.run_id }}
         run: pnpm e2e:setup && pnpm e2e:build
 
   playwright-test:
@@ -194,8 +195,10 @@ jobs:
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_STAGING }}
-          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
-          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
+          SANITY_E2E_PROJECT_ID:
+            ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
+            # the id is based on the PR number and the workflow run id
+          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}-${{ github.run_id }}
         # As e2e:build ran in the `install` job, turbopack restores it from cache here
         run: pnpm e2e:build && pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -131,7 +131,7 @@ jobs:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_STAGING }}
           SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
           # the id is based on the PR number and the workflow run id
-          SANITY_E2E_DATASET: pr-${{ github.event.number }}-${{ matrix.project }}-${{ github.run_id }}
+          SANITY_E2E_DATASET: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}-{2}', github.event.number, matrix.project, github.run_id) || vars.SANITY_E2E_DATASET_STAGING }}
         run: pnpm e2e:setup && pnpm e2e:build
 
   playwright-test:
@@ -195,10 +195,9 @@ jobs:
           # Change the below to `secrets.SANITY_E2E_SESSION_TOKEN`
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_STAGING }}
-          SANITY_E2E_PROJECT_ID:
-            ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
-            # the id is based on the PR number and the workflow run id
-          SANITY_E2E_DATASET: pr-${{ github.event.number }}-${{ matrix.project }}-${{ github.run_id }}
+          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
+          # the id is based on the PR number and the workflow run id
+          SANITY_E2E_DATASET: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}-{2}', github.event.number, matrix.project, github.run_id) || vars.SANITY_E2E_DATASET_STAGING }}
         # As e2e:build ran in the `install` job, turbopack restores it from cache here
         run: pnpm e2e:build && pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -131,7 +131,7 @@ jobs:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_STAGING }}
           SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
           # the id is based on the PR number and the workflow run id
-          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}-${{ github.run_id }}
+          SANITY_E2E_DATASET: pr-${{ github.event.number }}-${{ matrix.project }}-${{ github.run_id }}
         run: pnpm e2e:setup && pnpm e2e:build
 
   playwright-test:
@@ -198,7 +198,7 @@ jobs:
           SANITY_E2E_PROJECT_ID:
             ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
             # the id is based on the PR number and the workflow run id
-          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}-${{ github.run_id }}
+          SANITY_E2E_DATASET: pr-${{ github.event.number }}-${{ matrix.project }}-${{ github.run_id }}
         # As e2e:build ran in the `install` job, turbopack restores it from cache here
         run: pnpm e2e:build && pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,8 +4,8 @@ permissions:
   pull-requests: write # for comment
 
 env:
-  CHROMIUM_DATASET: pr-chromium-${{ github.event.number }}
-  FIREFOX_DATASET: pr-firefox-${{ github.event.number }}
+  CHROMIUM_DATASET: pr-chromium-${{ github.event.number }}-${{ github.run_id }}
+  FIREFOX_DATASET: pr-firefox-${{ github.event.number }}-${{ github.run_id }}
 
 on:
   # Build on pushes branches that have a PR (including drafts)
@@ -86,7 +86,6 @@ jobs:
         run: pnpm build:cli --output-logs=full --log-order=grouped
 
       - name: dataset setup on PR (chromium)
-        if: ${{ github.event_name == 'pull_request' }}
         env:
           SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_STAGING }}
@@ -96,7 +95,6 @@ jobs:
           pnpm e2e:setup
 
       - name: dataset setup on PR (firefox)
-        if: ${{ github.event_name == 'pull_request' }}
         env:
           SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_STAGING }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,8 +4,8 @@ permissions:
   pull-requests: write # for comment
 
 env:
-  CHROMIUM_DATASET: pr-chromium-${{ github.event.number }}-${{ github.run_id }}
-  FIREFOX_DATASET: pr-firefox-${{ github.event.number }}-${{ github.run_id }}
+  CHROMIUM_DATASET: pr-${{ github.event.number }}-chromium-${{ github.run_id }}
+  FIREFOX_DATASET: pr-${{ github.event.number }}-firefox-${{ github.run_id }}
 
 on:
   # Build on pushes branches that have a PR (including drafts)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,8 +4,8 @@ permissions:
   pull-requests: write # for comment
 
 env:
-  CHROMIUM_DATASET: pr-${{ github.event.number }}-chromium-${{ github.run_id }}
-  FIREFOX_DATASET: pr-${{ github.event.number }}-firefox-${{ github.run_id }}
+  CHROMIUM_DATASET: ${{ github.event_name == 'pull_request' && format('pr-{0}-chromium-{1}', github.event.number, github.run_id) || vars.SANITY_E2E_DATASET_STAGING }}
+  FIREFOX_DATASET: ${{ github.event_name == 'pull_request' && format('pr-{0}-firefox-{1}', github.event.number, github.run_id) || vars.SANITY_E2E_DATASET_STAGING }}
 
 on:
   # Build on pushes branches that have a PR (including drafts)
@@ -86,6 +86,7 @@ jobs:
         run: pnpm build:cli --output-logs=full --log-order=grouped
 
       - name: dataset setup on PR (chromium)
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_STAGING }}
@@ -95,6 +96,7 @@ jobs:
           pnpm e2e:setup
 
       - name: dataset setup on PR (firefox)
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_STAGING }}

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Remove E2E datasets for closed PRs
         env:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_STAGING }}
-          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
-          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
+          SANITY_E2E_PROJECT_ID:
+            ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
+            # the id is based on the PR number and the workflow run id
+          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}-${{ github.run_id }}
         run: pnpm e2e:cleanup

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -34,9 +34,6 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-    strategy:
-      matrix:
-        project: [chromium, firefox]
 
     steps:
       - uses: actions/checkout@v4
@@ -52,8 +49,6 @@ jobs:
       - name: Remove E2E datasets for closed PRs
         env:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_STAGING }}
-          SANITY_E2E_PROJECT_ID:
-            ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
-            # the id is based on the PR number and the workflow run id
-          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}-${{ github.run_id }}
+          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
+          PR_NUMBER: ${{ github.event.number }}
         run: pnpm e2e:cleanup

--- a/scripts/e2e/cleanup.ts
+++ b/scripts/e2e/cleanup.ts
@@ -1,25 +1,42 @@
 import {readEnv} from '../utils/envVars'
-import {sanityIdify} from '../utils/sanityIdify'
 import {startTimer} from '../utils/startTimer'
 import {createE2EClient, type KnownEnvVar} from './e2eClient'
 
-const DATASET = readEnv<KnownEnvVar>('SANITY_E2E_DATASET')
-const studioE2EClient = createE2EClient(DATASET)
+const prNumber = readEnv<KnownEnvVar>('PR_NUMBER')
+const studioE2EClient = createE2EClient('production')
 
-const timer = startTimer(`Deleting dataset ${DATASET}`)
+async function cleanup() {
+  const datasets = await studioE2EClient.datasets.list()
+  // gets all the datasets that belong to the PR but not the ones associated with comments
+  // since those will be removed automatically
+  const prDatasets = datasets.filter(
+    (ds) => ds.name.startsWith(`pr-${prNumber}-`) && !ds.name.endsWith('-comments'),
+  )
 
-studioE2EClient.datasets
-  .delete(sanityIdify(DATASET))
-  .then((res) => {
-    if (res.deleted) {
-      console.log('Deleted dataset')
-    } else {
-      console.log('Dataset was not deleted')
-    }
-  })
-  .catch((err) => {
-    throw new Error(`Something went wrong! ${err?.response?.body?.message}`)
-  })
-  .finally(() => {
+  console.log(`Found ${prDatasets.length} datasets to clean up`)
+
+  for (const dataset of prDatasets) {
+    const timer = startTimer(`Deleting dataset ${dataset.name}`)
+    await studioE2EClient.datasets
+      .delete(dataset.name)
+      .then((res) => {
+        if (res.deleted) {
+          console.log('Deleted dataset')
+        } else {
+          console.log('Dataset was not deleted')
+        }
+      })
+      .catch((err) => {
+        throw new Error(`Something went wrong! ${err?.response?.body?.message}`)
+      })
+
     timer.end()
-  })
+  }
+
+  console.log('PR cleanup complete')
+}
+
+cleanup().catch((error) => {
+  console.error('Cleanup failed:', error)
+  process.exit(1)
+})

--- a/scripts/e2e/e2eClient.ts
+++ b/scripts/e2e/e2eClient.ts
@@ -7,6 +7,7 @@ export type KnownEnvVar =
   | 'SANITY_E2E_DATASET'
   | 'SANITY_E2E_PROJECT_ID'
   | 'SANITY_E2E_SESSION_TOKEN'
+  | 'PR_NUMBER'
 
 export function createE2EClient(dataset: string): SanityClient {
   return createClient({


### PR DESCRIPTION
### Description

- Changed the ids to rely not only on the PR id (example: 9295) but also on the workflow ID. I used the workflow instead of the SHA (commit) because sometimes we need to re-run works - and in those instances, what we want to rely on is the workflow ID - example (`pr-9295-chromium-14727017893`)
- The clean up will now find any dataset that starts with the right PR id and remove any and all datasets.
- Removed split between chrome and firefox in the cleanup, the cleanup for the datasets happens based on the PR id than necessarily focused on specific environments / projects

### What to review

Does this make sense?
Did we miss anything? My biggest concern is that this will be solely focused on the branches and PRs and that I feel that the main branch will remain untouched - which might be what we want - but it feels out of scope? I'm not sure.
  - Spoke with Pedro and we'll keep this focused on the branchs and PRs

### Testing

Closing this PR deletes and shows the errors, double checked on manage.

### Notes for release

N/A