### PR TITLE
chore(ci): prevent passing PR title to workflow script

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -39,16 +39,12 @@ jobs:
         id: check_release
         run: |
           SKIP="false"
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            if [[ "${{ github.event.pull_request.title }}" == chore:\ release* ]]; then
-              SKIP="true"
-            fi
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            if [[ "${{ github.event.head_commit.message }}" == chore:\ release* ]]; then
-              SKIP="true"
-            fi
+          if [[ "$MESSAGE" == chore:\ release* ]]; then
+            SKIP="true"
           fi
           echo "skip=$SKIP" >> $GITHUB_OUTPUT
+        env:
+          MESSAGE: ${{ (github.event_name == 'pull_request' && github.event.pull_request.title) ||  (github.event_name == 'push' && github.event.head_commit.message)  }}
 
       - uses: actions/checkout@v4
         if: steps.check_release.outputs.skip != 'true'


### PR DESCRIPTION
### Description
Sets the PR title as an env var instead of passing to bash.

### What to review
- Does it make sense?

### Testing
No way to easily test this, but the CLI tests still be skipped for release PRs after merging

### Notes for release
n/a