### PR TITLE
fix(cli): fixes issue where cli would error if version is missing

### DIFF
--- a/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
+++ b/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
@@ -4,7 +4,7 @@ import {generateHelpUrl} from '@sanity/generate-help-url'
 import resolveFrom from 'resolve-from'
 import semver, {type SemVer} from 'semver'
 
-import {readPackageManifest} from './readPackageManifest'
+import {readPackageJson, readPackageManifest} from './readPackageManifest'
 
 interface PackageInfo {
   name: string
@@ -26,7 +26,7 @@ const PACKAGES = [
 ]
 
 export async function checkStudioDependencyVersions(workDir: string): Promise<void> {
-  const manifest = await readPackageManifest(path.join(workDir, 'package.json'))
+  const manifest = await readPackageJson(path.join(workDir, 'package.json'))
   const dependencies = {...manifest.dependencies, ...manifest.devDependencies}
 
   const packageInfo = PACKAGES.map(async (pkg): Promise<PackageInfo | false> => {

--- a/packages/sanity/src/_internal/cli/util/readPackageManifest.ts
+++ b/packages/sanity/src/_internal/cli/util/readPackageManifest.ts
@@ -27,8 +27,12 @@ function isPackageManifest(item: unknown): item is PartialPackageManifest {
  * @param filePath - Path to package.json to read
  * @returns The parsed package.json
  */
-async function readPackageJson(filePath: string): Promise<PackageJson> {
-  return JSON.parse(await readFile(filePath, 'utf8'))
+export async function readPackageJson(filePath: string): Promise<PackageJson> {
+  try {
+    return JSON.parse(await readFile(filePath, 'utf8'))
+  } catch (err) {
+    throw new Error(`Failed to read "${filePath}": ${err.message}`)
+  }
 }
 /**
  * Read the `package.json` file at the given path and return an object that guarantees


### PR DESCRIPTION
### Description

Exported the `readPackageJson` function from `readPackageManifest.ts` and added error handling to provide more context when reading a package.json file fails. Updated `checkStudioDependencyVersions.ts` to use the newly exported function.

### What to review

- The error handling in `readPackageJson` now includes the file path in the error message
- The function is now properly exported for reuse
- The usage of this function in `checkStudioDependencyVersions.ts`

### Testing

The changes have been tested by verifying that:
- The function correctly reads package.json files
- Error messages now include the file path for better debugging
- The exported function works correctly when imported in other files

### Notes for release

Fixes issue where build command would fail if there is no version in package.json 