### PR TITLE
feat: i18n for release tool presence tooltips

### DIFF
--- a/packages/sanity/src/core/presence/DocumentPreviewPresence.tsx
+++ b/packages/sanity/src/core/presence/DocumentPreviewPresence.tsx
@@ -7,7 +7,9 @@ import {css, styled} from 'styled-components'
 
 import {Tooltip, type TooltipProps} from '../../ui-components'
 import {UserAvatar} from '../components'
+import {useTranslation} from '../i18n/hooks/useTranslation'
 import {getReleaseIdFromReleaseDocumentId, useActiveReleases} from '../releases'
+import {releasesLocaleNamespace} from '../releases/i18n'
 import {type DocumentPresence} from '../store'
 import {getVersionFromId, isNonNullable} from '../util'
 
@@ -31,6 +33,7 @@ const AvatarStackBox = styled.div((props) => {
 /** @internal */
 export function DocumentPreviewPresence(props: DocumentPreviewPresenceProps) {
   const {presence} = props
+  const {t} = useTranslation(releasesLocaleNamespace)
 
   const {data: releases} = useActiveReleases()
 
@@ -54,15 +57,18 @@ export function DocumentPreviewPresence(props: DocumentPreviewPresenceProps) {
           )
         : undefined
       const releaseTitle = release?.metadata?.title
-      return `${firstPresence.user.displayName} is editing this document${releaseTitle ? ` in the release "${releaseTitle}" right now` : 'in an untitled release right now'}`
+      return t('presence.tooltip.one', {
+        displayName: firstPresence.user.displayName,
+        releaseTitle: releaseTitle || t('release-placeholder.title'),
+      })
     }
 
     if (uniquePresence.length > 1) {
-      return `${uniquePresence.length} people are editing this document right now`
+      return t('presence.tooltip.other', {count: uniquePresence.length})
     }
 
     return undefined
-  }, [uniquePresence, releases])
+  }, [releases, t, uniquePresence])
 
   return (
     <Tooltip content={tooltipContent} {...PRESENCE_MENU_POPOVER_PROPS}>

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -216,6 +216,12 @@ const releasesLocaleStrings = {
   /** Tooltip label when the user doesn't have permission to unarchive release */
   'permissions.error.unarchive': 'You do not have permission to unarchive this release',
 
+  /** Tooltip text for when one user is editing a document in a release */
+  'presence.tooltip.one':
+    '{{displayName}} is editing this document in the "{{releaseTitle}}" release right now',
+  /** Tooltip text for when multiple users are editing a document in a release */
+  'presence.tooltip.other': '{{count}} people are editing this document right now',
+
   /** Tooltip text for publish release action when there are no documents */
   'publish-action.validation.no-documents': 'There are no documents to publish',
   /** Title for the dialog confirming the publish of a release */


### PR DESCRIPTION
### Description
Before:
<img width="487" alt="Screenshot 2025-04-29 at 09 46 37" src="https://github.com/user-attachments/assets/422da112-fa79-45d5-bab7-d9adee454a47" />

After:
<img width="513" alt="Screenshot 2025-04-29 at 09 47 14" src="https://github.com/user-attachments/assets/25674a80-6692-471a-8c27-a3c01674839f" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
