### PR TITLE
feat(core): add studio - canvas telemetry

### DIFF
--- a/packages/sanity/src/core/canvas/__telemetry__/canvas.telemetry.ts
+++ b/packages/sanity/src/core/canvas/__telemetry__/canvas.telemetry.ts
@@ -14,7 +14,7 @@ export const CanvasLinkRedirected = defineEvent<{
   origin: CanvasLinkOrigin
   diffs?: DiffTypesCount
 }>({
-  name: 'Canvas Link Redirect',
+  name: 'Canvas Link Redirected',
   version: 1,
   description: 'The user is redirected to the canvas studio-import page',
 })
@@ -47,7 +47,7 @@ export const CanvasUnlinkApproved = defineEvent({
 
 export type OpenCanvasOrigin = 'action' | 'banner'
 export const CanvasOpened = defineEvent<{origin: OpenCanvasOrigin}>({
-  name: 'Canvas Opened',
+  name: 'Canvas Opened from studio',
   version: 1,
   description: 'User clicked "Edit in Canvas"',
 })

--- a/packages/sanity/src/core/canvas/__telemetry__/canvas.telemetry.ts
+++ b/packages/sanity/src/core/canvas/__telemetry__/canvas.telemetry.ts
@@ -1,13 +1,20 @@
 import {defineEvent} from '@sanity/telemetry'
 
+import {type CanvasDiff} from '../types'
+
 export const CanvasLinkCtaClicked = defineEvent({
   name: 'Canvas Link CTA Clicked',
   version: 1,
   description: 'The "Link to Canvas" button is clicked.',
 })
 
-export type CanvasLinkRedirectOrigin = 'diff-dialog' | 'redirect'
-export const CanvasLinkRedirected = defineEvent<{origin: CanvasLinkRedirectOrigin}>({
+export type CanvasLinkRedirectOptions =
+  | {origin: 'redirect'}
+  | {
+      origin: 'diff-dialog'
+      diffs: CanvasDiff[]
+    }
+export const CanvasLinkRedirected = defineEvent<CanvasLinkRedirectOptions>({
   name: 'Canvas Link Redirect',
   version: 1,
   description: 'The user is redirected to the canvas studio-import page',
@@ -19,7 +26,9 @@ export const CanvasLinkDialogDiffsShown = defineEvent({
   description: 'The diffs dialog is shown',
 })
 
-export const CanvasLinkDialogRejected = defineEvent({
+export const CanvasLinkDialogRejected = defineEvent<{
+  diffs: CanvasDiff[]
+}>({
   name: 'Canvas Link Dialog Rejected',
   version: 1,
   description: 'The user rejects the diffs shown in the dialog',

--- a/packages/sanity/src/core/canvas/__telemetry__/canvas.telemetry.ts
+++ b/packages/sanity/src/core/canvas/__telemetry__/canvas.telemetry.ts
@@ -31,13 +31,13 @@ export const CanvasLinkDialogRejected = defineEvent<{
 }>({
   name: 'Canvas Link Dialog Rejected',
   version: 1,
-  description: 'The user rejects the diffs shown in the dialog',
+  description: 'User clicked "Cancel" in the "Link to Canvas" dialog after seeing the diffs',
 })
 
 export const CanvasUnlinkCtaClicked = defineEvent({
   name: 'Canvas Unlink CTA Clicked',
   version: 1,
-  description: 'The Unlink action was clicked',
+  description: 'User clicked "Unlink" action',
 })
 
 export const CanvasUnlinkApproved = defineEvent({

--- a/packages/sanity/src/core/canvas/__telemetry__/canvas.telemetry.ts
+++ b/packages/sanity/src/core/canvas/__telemetry__/canvas.telemetry.ts
@@ -1,6 +1,6 @@
 import {defineEvent} from '@sanity/telemetry'
 
-import {type CanvasDiff} from '../types'
+export type DiffTypesCount = Record<string, number>
 
 export const CanvasLinkCtaClicked = defineEvent({
   name: 'Canvas Link CTA Clicked',
@@ -8,13 +8,12 @@ export const CanvasLinkCtaClicked = defineEvent({
   description: 'The "Link to Canvas" button is clicked.',
 })
 
-export type CanvasLinkRedirectOptions =
-  | {origin: 'redirect'}
-  | {
-      origin: 'diff-dialog'
-      diffs: CanvasDiff[]
-    }
-export const CanvasLinkRedirected = defineEvent<CanvasLinkRedirectOptions>({
+export type CanvasLinkOrigin = 'redirect' | 'diff-dialog'
+
+export const CanvasLinkRedirected = defineEvent<{
+  origin: CanvasLinkOrigin
+  diffs?: DiffTypesCount
+}>({
   name: 'Canvas Link Redirect',
   version: 1,
   description: 'The user is redirected to the canvas studio-import page',
@@ -27,7 +26,7 @@ export const CanvasLinkDialogDiffsShown = defineEvent({
 })
 
 export const CanvasLinkDialogRejected = defineEvent<{
-  diffs: CanvasDiff[]
+  diffs: DiffTypesCount
 }>({
   name: 'Canvas Link Dialog Rejected',
   version: 1,

--- a/packages/sanity/src/core/canvas/__telemetry__/canvas.telemetry.ts
+++ b/packages/sanity/src/core/canvas/__telemetry__/canvas.telemetry.ts
@@ -1,0 +1,45 @@
+import {defineEvent} from '@sanity/telemetry'
+
+export const CanvasLinkCtaClicked = defineEvent({
+  name: 'Canvas Link CTA Clicked',
+  version: 1,
+  description: 'The "Link to Canvas" button is clicked.',
+})
+
+export type CanvasLinkRedirectOrigin = 'diff-dialog' | 'redirect'
+export const CanvasLinkRedirected = defineEvent<{origin: CanvasLinkRedirectOrigin}>({
+  name: 'Canvas Link Redirect',
+  version: 1,
+  description: 'The user is redirected to the canvas studio-import page',
+})
+
+export const CanvasLinkDialogDiffsShown = defineEvent({
+  name: 'Canvas Link Dialog Diffs Shown',
+  version: 1,
+  description: 'The diffs dialog is shown',
+})
+
+export const CanvasLinkDialogRejected = defineEvent({
+  name: 'Canvas Link Dialog Rejected',
+  version: 1,
+  description: 'The user rejects the diffs shown in the dialog',
+})
+
+export const CanvasUnlinkCtaClicked = defineEvent({
+  name: 'Canvas Unlink CTA Clicked',
+  version: 1,
+  description: 'The Unlink action was clicked',
+})
+
+export const CanvasUnlinkApproved = defineEvent({
+  name: 'Canvas Unlink Approved',
+  version: 1,
+  description: 'User confirmed that they want the Studio document unlinked',
+})
+
+export type OpenCanvasOrigin = 'action' | 'banner'
+export const CanvasOpened = defineEvent<{origin: OpenCanvasOrigin}>({
+  name: 'Canvas Opened',
+  version: 1,
+  description: 'User clicked "Edit in Canvas"',
+})

--- a/packages/sanity/src/core/canvas/actions/EditInCanvas/EditInCanvasAction.tsx
+++ b/packages/sanity/src/core/canvas/actions/EditInCanvas/EditInCanvasAction.tsx
@@ -15,7 +15,7 @@ export const EditInCanvasAction: DocumentActionComponent = (props: DocumentActio
   const {isLinked, companionDoc, loading} = useCanvasCompanionDoc(
     props.liveEditSchemaType ? getPublishedId(props.id) : getDraftId(props.id),
   )
-  const navigateToCanvas = useNavigateToCanvasDoc(companionDoc?.canvasDocumentId)
+  const navigateToCanvas = useNavigateToCanvasDoc(companionDoc?.canvasDocumentId, 'action')
 
   if (!isLinked || loading) return null
 

--- a/packages/sanity/src/core/canvas/actions/LinkToCanvas/LinkToCanvasAction.tsx
+++ b/packages/sanity/src/core/canvas/actions/LinkToCanvas/LinkToCanvasAction.tsx
@@ -14,6 +14,7 @@ import {isReleaseDocument} from '../../../releases/store/types'
 import {useRenderingContext} from '../../../store/renderingContext/useRenderingContext'
 import {getDraftId, getPublishedId} from '../../../util/draftUtils'
 import {canvasLocaleNamespace} from '../../i18n'
+import {useCanvasTelemetry} from '../../useCanvasTelemetry'
 import {useCanvasCompanionDoc} from '../useCanvasCompanionDoc'
 import {LinkToCanvasDialog} from './LinkToCanvasDialog'
 
@@ -30,6 +31,7 @@ export const LinkToCanvasAction: DocumentActionComponent = (props: DocumentActio
   const {isLinked, loading} = useCanvasCompanionDoc(
     props.liveEditSchemaType ? getPublishedId(props.id) : getDraftId(props.id),
   )
+  const {linkCtaClicked} = useCanvasTelemetry()
 
   const isExcludedType = useIsExcludedType(props.type)
 
@@ -41,13 +43,14 @@ export const LinkToCanvasAction: DocumentActionComponent = (props: DocumentActio
   const [formValue, setFormValue] = useState<SanityDocument | undefined>()
 
   const handleOpenDialog = useCallback(() => {
+    linkCtaClicked()
     const value = getFormValue([]) as SanityDocument
     setFormValue({
       ...value,
       _id: props.liveEditSchemaType ? getPublishedId(value._id) : getDraftId(value._id),
     })
     setIsDialogOpen(true)
-  }, [getFormValue, props.liveEditSchemaType])
+  }, [getFormValue, props.liveEditSchemaType, linkCtaClicked])
 
   const disabled = useMemo(() => {
     if (!isInDashboard) {

--- a/packages/sanity/src/core/canvas/actions/LinkToCanvas/LinkToCanvasDialog.tsx
+++ b/packages/sanity/src/core/canvas/actions/LinkToCanvas/LinkToCanvasDialog.tsx
@@ -2,12 +2,13 @@ import {type SanityDocument} from '@sanity/client'
 import {ComposeSparklesIcon} from '@sanity/icons'
 import {Box, Card, Text} from '@sanity/ui'
 import {motion} from 'framer-motion'
-import {useId} from 'react'
+import {useCallback, useId} from 'react'
 
 import {Dialog} from '../../../../ui-components'
 import {LoadingBlock} from '../../../components/loadingBlock/LoadingBlock'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {canvasLocaleNamespace} from '../../i18n'
+import {useCanvasTelemetry} from '../../useCanvasTelemetry'
 import {LinkToCanvasDiff} from './LinkToCanvasDiff'
 import {useLinkToCanvas} from './useLinkToCanvas'
 
@@ -21,12 +22,20 @@ export const LinkToCanvasDialog = ({
   const {t} = useTranslation(canvasLocaleNamespace)
   const id = useId()
   const {status, error, navigateToCanvas, response} = useLinkToCanvas({document})
+  const {linkDialogRejected} = useCanvasTelemetry()
+
+  const handleClose = useCallback(() => {
+    onClose()
+    if (status === 'diff') {
+      linkDialogRejected()
+    }
+  }, [onClose, linkDialogRejected, status])
 
   return (
     <Dialog
       id={`dialog-link-to-canvas-${id}`}
       header={t('dialog.link-to-canvas.title')}
-      onClose={onClose}
+      onClose={handleClose}
       width={1}
       bodyHeight="stretch"
       padding={false}

--- a/packages/sanity/src/core/canvas/actions/LinkToCanvas/LinkToCanvasDialog.tsx
+++ b/packages/sanity/src/core/canvas/actions/LinkToCanvas/LinkToCanvasDialog.tsx
@@ -27,9 +27,9 @@ export const LinkToCanvasDialog = ({
   const handleClose = useCallback(() => {
     onClose()
     if (status === 'diff') {
-      linkDialogRejected()
+      linkDialogRejected(response?.diff || [])
     }
-  }, [onClose, linkDialogRejected, status])
+  }, [onClose, linkDialogRejected, status, response?.diff])
 
   return (
     <Dialog

--- a/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
+++ b/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
@@ -11,6 +11,7 @@ import {useWorkspaceSchemaId} from '../../../hooks/useWorkspaceSchemaId'
 import {useComlinkStore, useProjectStore} from '../../../store/_legacy/datastores'
 import {useRenderingContext} from '../../../store/renderingContext/useRenderingContext'
 import {useWorkspace} from '../../../studio/workspace'
+import {type CanvasDiff} from '../../types'
 import {useCanvasTelemetry} from '../../useCanvasTelemetry'
 
 const localeSettings = Intl.DateTimeFormat().resolvedOptions()
@@ -20,12 +21,7 @@ interface CanvasResponse {
   originalDocument?: SanityDocument
   mappedDocument?: SanityDocument
   canvasContent?: unknown
-  diff?: {
-    indexedPath: string[]
-    prevValue: unknown
-    value: unknown
-    type: string
-  }[]
+  diff?: CanvasDiff[]
 }
 
 type StudioToCanvasRequestBody = ({documentId: string} | {document: SanityDocument}) & {
@@ -169,7 +165,11 @@ export function useLinkToCanvas({document}: {document: SanityDocument | undefine
             error: null,
             response: preflight,
             navigateToCanvas: () => {
-              linkRedirected(status === 'diff' ? 'diff-dialog' : 'redirect')
+              linkRedirected(
+                status === 'diff'
+                  ? {origin: 'diff-dialog', diffs: preflight.diff || []}
+                  : {origin: 'redirect'},
+              )
               navigateToCanvas()
             },
           }

--- a/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
+++ b/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
@@ -160,16 +160,13 @@ export function useLinkToCanvas({document}: {document: SanityDocument | undefine
       map(([preflight, navigateToCanvas]) => {
         if (!preflight.error) {
           const status = preflight.diff?.length ? ('diff' as const) : ('redirecting' as const)
+
           return {
             status: status,
             error: null,
             response: preflight,
             navigateToCanvas: () => {
-              linkRedirected(
-                status === 'diff'
-                  ? {origin: 'diff-dialog', diffs: preflight.diff || []}
-                  : {origin: 'redirect'},
-              )
+              linkRedirected(status === 'diff' ? 'diff-dialog' : 'redirect', preflight.diff)
               navigateToCanvas()
             },
           }

--- a/packages/sanity/src/core/canvas/actions/UnlinkFromCanvas/UnlinkFromCanvasAction.tsx
+++ b/packages/sanity/src/core/canvas/actions/UnlinkFromCanvas/UnlinkFromCanvasAction.tsx
@@ -11,6 +11,7 @@ import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
 import {getDraftId, getPublishedId} from '../../../util/draftUtils'
 import {canvasLocaleNamespace} from '../../i18n'
+import {useCanvasTelemetry} from '../../useCanvasTelemetry'
 import {useCanvasCompanionDoc} from '../useCanvasCompanionDoc'
 import {UnlinkFromCanvasDialog} from './UnlinkFromCanvasDialog'
 
@@ -19,16 +20,23 @@ export const UnlinkFromCanvasAction: DocumentActionComponent = (props: DocumentA
   const {isLinked, companionDoc, loading} = useCanvasCompanionDoc(
     props.liveEditSchemaType ? getPublishedId(props.id) : getDraftId(props.id),
   )
-  const [isDialogOpen, setIsDialogOpen] = useState(false)
-  const handleCloseDialog = useCallback(() => setIsDialogOpen(false), [])
-  const handleOpenDialog = useCallback(() => setIsDialogOpen(true), [])
-  const [status, setStatus] = useState<'loading' | 'error' | 'idle'>('idle')
-  const toast = useToast()
-  const [error, setError] = useState<string | null>(null)
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  const {unlinkCtaClicked, unlinkApproved} = useCanvasTelemetry()
+  const toast = useToast()
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [status, setStatus] = useState<'loading' | 'error' | 'success' | 'idle'>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleCloseDialog = useCallback(() => setIsDialogOpen(false), [])
+  const handleOpenDialog = useCallback(() => {
+    unlinkCtaClicked()
+    setIsDialogOpen(true)
+  }, [unlinkCtaClicked])
+
   const handleUnlink = useCallback(async () => {
     try {
       setStatus('loading')
+      unlinkApproved()
       if (!companionDoc?._id) {
         throw new Error('Companion doc not found')
       }
@@ -44,7 +52,7 @@ export const UnlinkFromCanvasAction: DocumentActionComponent = (props: DocumentA
       setError(e.message)
       setStatus('error')
     }
-  }, [client, companionDoc?._id, handleCloseDialog, t, toast])
+  }, [client, companionDoc?._id, handleCloseDialog, unlinkApproved, toast, t])
 
   const document = props.version || props.draft || props.published
   if (!document) return null

--- a/packages/sanity/src/core/canvas/types.ts
+++ b/packages/sanity/src/core/canvas/types.ts
@@ -3,3 +3,10 @@ export interface CompanionDoc {
   canvasDocumentId: string
   studioDocumentId: string
 }
+
+export interface CanvasDiff {
+  indexedPath: string[]
+  prevValue: unknown
+  value: unknown
+  type: string
+}

--- a/packages/sanity/src/core/canvas/useCanvasTelemetry.ts
+++ b/packages/sanity/src/core/canvas/useCanvasTelemetry.ts
@@ -1,0 +1,42 @@
+import {useTelemetry} from '@sanity/telemetry/react'
+import {useMemo} from 'react'
+
+import {
+  CanvasLinkCtaClicked,
+  CanvasLinkDialogDiffsShown,
+  CanvasLinkDialogRejected,
+  CanvasLinkRedirected,
+  type CanvasLinkRedirectOrigin,
+  CanvasOpened,
+  CanvasUnlinkApproved,
+  CanvasUnlinkCtaClicked,
+  type OpenCanvasOrigin,
+} from './__telemetry__/canvas.telemetry'
+
+interface CanvasTelemetryHookValue {
+  linkCtaClicked: () => void
+  linkRedirected: (origin: CanvasLinkRedirectOrigin) => void
+  linkDialogDiffsShown: () => void
+  linkDialogRejected: () => void
+  unlinkCtaClicked: () => void
+  unlinkApproved: () => void
+  canvasOpened: (origin: OpenCanvasOrigin) => void
+}
+
+/** @internal */
+export function useCanvasTelemetry(): CanvasTelemetryHookValue {
+  const telemetry = useTelemetry()
+
+  return useMemo(
+    (): CanvasTelemetryHookValue => ({
+      linkCtaClicked: () => telemetry.log(CanvasLinkCtaClicked),
+      linkRedirected: (origin) => telemetry.log(CanvasLinkRedirected, {origin}),
+      linkDialogDiffsShown: () => telemetry.log(CanvasLinkDialogDiffsShown),
+      linkDialogRejected: () => telemetry.log(CanvasLinkDialogRejected),
+      unlinkCtaClicked: () => telemetry.log(CanvasUnlinkCtaClicked),
+      unlinkApproved: () => telemetry.log(CanvasUnlinkApproved),
+      canvasOpened: (origin) => telemetry.log(CanvasOpened, {origin}),
+    }),
+    [telemetry],
+  )
+}

--- a/packages/sanity/src/core/canvas/useCanvasTelemetry.ts
+++ b/packages/sanity/src/core/canvas/useCanvasTelemetry.ts
@@ -6,18 +6,19 @@ import {
   CanvasLinkDialogDiffsShown,
   CanvasLinkDialogRejected,
   CanvasLinkRedirected,
-  type CanvasLinkRedirectOrigin,
+  type CanvasLinkRedirectOptions,
   CanvasOpened,
   CanvasUnlinkApproved,
   CanvasUnlinkCtaClicked,
   type OpenCanvasOrigin,
 } from './__telemetry__/canvas.telemetry'
+import {type CanvasDiff} from './types'
 
 interface CanvasTelemetryHookValue {
   linkCtaClicked: () => void
-  linkRedirected: (origin: CanvasLinkRedirectOrigin) => void
+  linkRedirected: (options: CanvasLinkRedirectOptions) => void
   linkDialogDiffsShown: () => void
-  linkDialogRejected: () => void
+  linkDialogRejected: (diffs: CanvasDiff[]) => void
   unlinkCtaClicked: () => void
   unlinkApproved: () => void
   canvasOpened: (origin: OpenCanvasOrigin) => void
@@ -30,9 +31,9 @@ export function useCanvasTelemetry(): CanvasTelemetryHookValue {
   return useMemo(
     (): CanvasTelemetryHookValue => ({
       linkCtaClicked: () => telemetry.log(CanvasLinkCtaClicked),
-      linkRedirected: (origin) => telemetry.log(CanvasLinkRedirected, {origin}),
+      linkRedirected: (options) => telemetry.log(CanvasLinkRedirected, options),
       linkDialogDiffsShown: () => telemetry.log(CanvasLinkDialogDiffsShown),
-      linkDialogRejected: () => telemetry.log(CanvasLinkDialogRejected),
+      linkDialogRejected: (diffs: CanvasDiff[]) => telemetry.log(CanvasLinkDialogRejected, {diffs}),
       unlinkCtaClicked: () => telemetry.log(CanvasUnlinkCtaClicked),
       unlinkApproved: () => telemetry.log(CanvasUnlinkApproved),
       canvasOpened: (origin) => telemetry.log(CanvasOpened, {origin}),

--- a/packages/sanity/src/core/canvas/useCanvasTelemetry.ts
+++ b/packages/sanity/src/core/canvas/useCanvasTelemetry.ts
@@ -5,25 +5,31 @@ import {
   CanvasLinkCtaClicked,
   CanvasLinkDialogDiffsShown,
   CanvasLinkDialogRejected,
+  type CanvasLinkOrigin,
   CanvasLinkRedirected,
-  type CanvasLinkRedirectOptions,
   CanvasOpened,
   CanvasUnlinkApproved,
   CanvasUnlinkCtaClicked,
+  type DiffTypesCount,
   type OpenCanvasOrigin,
 } from './__telemetry__/canvas.telemetry'
 import {type CanvasDiff} from './types'
 
 interface CanvasTelemetryHookValue {
   linkCtaClicked: () => void
-  linkRedirected: (options: CanvasLinkRedirectOptions) => void
+  linkRedirected: (origin: CanvasLinkOrigin, diffs?: CanvasDiff[]) => void
   linkDialogDiffsShown: () => void
   linkDialogRejected: (diffs: CanvasDiff[]) => void
   unlinkCtaClicked: () => void
   unlinkApproved: () => void
   canvasOpened: (origin: OpenCanvasOrigin) => void
 }
-
+const getDiffTypesCount = (diffs: CanvasDiff[]): DiffTypesCount => {
+  return diffs.reduce((acc, diff) => {
+    acc[diff.type] = (acc[diff.type] || 0) + 1
+    return acc
+  }, {} as DiffTypesCount)
+}
 /** @internal */
 export function useCanvasTelemetry(): CanvasTelemetryHookValue {
   const telemetry = useTelemetry()
@@ -31,9 +37,14 @@ export function useCanvasTelemetry(): CanvasTelemetryHookValue {
   return useMemo(
     (): CanvasTelemetryHookValue => ({
       linkCtaClicked: () => telemetry.log(CanvasLinkCtaClicked),
-      linkRedirected: (options) => telemetry.log(CanvasLinkRedirected, options),
+      linkRedirected: (origin, diffs) =>
+        telemetry.log(CanvasLinkRedirected, {
+          origin,
+          diffs: diffs ? getDiffTypesCount(diffs) : undefined,
+        }),
       linkDialogDiffsShown: () => telemetry.log(CanvasLinkDialogDiffsShown),
-      linkDialogRejected: (diffs: CanvasDiff[]) => telemetry.log(CanvasLinkDialogRejected, {diffs}),
+      linkDialogRejected: (diffs) =>
+        telemetry.log(CanvasLinkDialogRejected, {diffs: getDiffTypesCount(diffs)}),
       unlinkCtaClicked: () => telemetry.log(CanvasUnlinkCtaClicked),
       unlinkApproved: () => telemetry.log(CanvasUnlinkApproved),
       canvasOpened: (origin) => telemetry.log(CanvasOpened, {origin}),

--- a/packages/sanity/src/core/canvas/useNavigateToCanvasDoc.ts
+++ b/packages/sanity/src/core/canvas/useNavigateToCanvasDoc.ts
@@ -6,23 +6,30 @@ import {useComlinkStore} from '../store/_legacy/datastores'
 import {useProjectOrganizationId} from '../store/_legacy/project/useProjectOrganizationId'
 import {useRenderingContext} from '../store/renderingContext/useRenderingContext'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../studioClient'
+import {type OpenCanvasOrigin} from './__telemetry__/canvas.telemetry'
+import {useCanvasTelemetry} from './useCanvasTelemetry'
 
 /**
  *
  * @hidden
  * @internal
  */
-export const useNavigateToCanvasDoc = (canvasDocId: string | undefined) => {
+export const useNavigateToCanvasDoc = (
+  canvasDocId: string | undefined,
+  origin: OpenCanvasOrigin,
+) => {
   const {value: organizationId} = useProjectOrganizationId()
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const {node} = useComlinkStore()
   const renderingContext = useRenderingContext()
   const isInDashboard = renderingContext?.name === 'coreUi'
+  const {canvasOpened} = useCanvasTelemetry()
 
   const navigateToCanvas = useCallback(() => {
     if (!organizationId || !canvasDocId) {
       return
     }
+    canvasOpened(origin)
     // If comlink is connected send the message, otherwise open the url in a new tab
     if (isInDashboard && node) {
       const message: Bridge.Navigation.NavigateToResourceMessage = {
@@ -43,7 +50,7 @@ export const useNavigateToCanvasDoc = (canvasDocId: string | undefined) => {
         '_blank',
       )
     }
-  }, [organizationId, canvasDocId, node, client, isInDashboard])
+  }, [organizationId, canvasDocId, node, client, isInDashboard, canvasOpened, origin])
 
   return navigateToCanvas
 }

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/CanvasLinkedBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/CanvasLinkedBanner.tsx
@@ -110,7 +110,7 @@ export function CanvasLinkedBanner() {
   const {t} = useTranslation(structureLocaleNamespace)
   const id = displayed?._id || documentId
   const {companionDoc} = useCanvasCompanionDoc(id)
-  const navigateToCanvas = useNavigateToCanvasDoc(companionDoc?.canvasDocumentId)
+  const navigateToCanvas = useNavigateToCanvasDoc(companionDoc?.canvasDocumentId, 'banner')
 
   if (!companionDoc) return null
 


### PR DESCRIPTION
### Description
Adds studio canvas telemetry.
It will track the following actions:
1) link to canvas (event)
     - no diffs - auto-accept (event)
     - has diffs
         -   show diffs dialog (event)
             -   Accepts diffs (event)
             -   Rejects diffs (event)
2) Unlink from canvas (event)
     - accept - unlink (event)
     - reject - do nothing
3) Open canvas (event)
     - origin: action
     - origin: banner

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is there any other event to track?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a 
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
