### PR TITLE
fix(structure): check that document is in scheduled release before showing banner

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -27,9 +27,9 @@ import {
   InsufficientPermissionBanner,
   ReferenceChangedBanner,
 } from './banners'
-import {AddToReleaseBanner} from './banners/AddToReleaseBanner'
 import {ArchivedReleaseDocumentBanner} from './banners/ArchivedReleaseDocumentBanner'
 import {CreateLinkedBanner} from './banners/CreateLinkedBanner'
+import {DocumentNotInReleaseBanner} from './banners/DocumentNotInReleaseBanner'
 import {DraftLiveEditBanner} from './banners/DraftLiveEditBanner'
 import {OpenReleaseToEditBanner} from './banners/OpenReleaseToEditBanner'
 import {ScheduledReleaseBanner} from './banners/ScheduledReleaseBanner'
@@ -167,9 +167,17 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     if (params?.historyVersion) {
       return <ArchivedReleaseDocumentBanner />
     }
+
     const isScheduledRelease =
       isReleaseDocument(selectedPerspective) && isReleaseScheduledOrScheduling(selectedPerspective)
-    if (isScheduledRelease) {
+
+    const documentInScheduledRelease = Boolean(
+      isScheduledRelease &&
+        displayed?._id &&
+        getVersionFromId(displayed?._id) === selectedReleaseId,
+    )
+
+    if (documentInScheduledRelease) {
       return <ScheduledReleaseBanner currentRelease={selectedPerspective as ReleaseDocument} />
     }
     const isPinnedDraftOrPublish = isSystemBundle(selectedPerspective)
@@ -181,10 +189,11 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
       !isPinnedDraftOrPublish
     ) {
       return (
-        <AddToReleaseBanner
+        <DocumentNotInReleaseBanner
           documentId={value._id}
           currentRelease={selectedPerspective as ReleaseDocument}
           value={displayed || undefined}
+          isScheduledRelease={isScheduledRelease}
         />
       )
     }

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DocumentNotInReleaseBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DocumentNotInReleaseBanner.tsx
@@ -23,14 +23,16 @@ type VersionCreateState = {
   lastUpdate: Date
 }
 
-export function AddToReleaseBanner({
+export function DocumentNotInReleaseBanner({
   documentId,
   currentRelease,
   value,
+  isScheduledRelease,
 }: {
   documentId: string
   currentRelease: ReleaseDocument
   value?: Record<string, unknown>
+  isScheduledRelease?: boolean
 }): React.JSX.Element {
   const tone = getReleaseTone(currentRelease ?? LATEST)
   const {t} = useTranslation(structureLocaleNamespace)
@@ -98,13 +100,18 @@ export function AddToReleaseBanner({
           />
         </Text>
       }
-      action={{
-        text: t('banners.release.action.add-to-release'),
-        tone: tone,
-        disabled: Boolean(versionCreateState),
-        onClick: handleAddToRelease,
-        mode: 'default',
-      }}
+      // Adding to a scheduled release is not allowed
+      action={
+        isScheduledRelease
+          ? undefined
+          : {
+              text: t('banners.release.action.add-to-release'),
+              tone: tone,
+              disabled: Boolean(versionCreateState),
+              onClick: handleAddToRelease,
+              mode: 'default',
+            }
+      }
     />
   )
 }


### PR DESCRIPTION
### Description
This PR fixes a bug where, when viewing the Studio with a pinned release that was scheduled, a "Scheduled to be released" banner would show on all documents.

We've refined the logic to check if the specific document you're viewing is part of the release.

### What to review
Just the additional logic condition. Any gotchas or places this will break?

Also, I believe it's intended that a user should _not_ be able to edit any document when viewing the Studio with a scheduled perspective, so I haven't made any additional changes to allow documents to be edited in this state, but please let me know if that's incorrect and I'll fix this too.

### Testing
I didn't see existing tests for this but feel free to point me in the right direction.

### Notes for release
Resolves an issue where a "Scheduled to be released" banner would show on all documents when viewing the studio with a scheduled pinned release.
