### PR TITLE
fix(structure): revert document view tabs placement and behavior

### DIFF
--- a/dev/test-studio/schema/debug/manyViews.tsx
+++ b/dev/test-studio/schema/debug/manyViews.tsx
@@ -1,0 +1,14 @@
+import {defineField, defineType} from 'sanity'
+
+export const manyViewsType = defineType({
+  type: 'document',
+  name: 'manyViews',
+  title: 'Many views',
+  fields: [
+    defineField({
+      type: 'string',
+      name: 'title',
+      title: 'Title',
+    }),
+  ],
+})

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -52,6 +52,7 @@ import {languageFilterDebugType} from './debug/languageFilter'
 import liveEdit from './debug/liveEdit'
 import localeString from './debug/localeString'
 import manyFieldsTest from './debug/manyFieldsTest'
+import {manyViewsType} from './debug/manyViews'
 import notitle from './debug/notitle'
 import {objectsDebug} from './debug/objectsDebug'
 import {patchOnMountDebug} from './debug/patchOnMount'
@@ -224,6 +225,7 @@ export function createSchemaTypes(projectId: string) {
     liveEdit,
     localeString,
     manyFieldsTest,
+    manyViewsType,
     myImage,
     myObject,
     namedDeprecatedObject,

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -63,6 +63,7 @@ export const DEBUG_INPUT_TYPES = [
   'invalidPreviews',
   'languageFilterDebug',
   'manyFieldsTest',
+  'manyViews',
   'noTitleField',
   'objectsDebug',
   'poppers',

--- a/dev/test-studio/structure/resolveStructureDocumentNode.ts
+++ b/dev/test-studio/structure/resolveStructureDocumentNode.ts
@@ -10,5 +10,21 @@ export const defaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}
     ])
   }
 
+  if (schemaType === 'manyViews') {
+    return S.document().views([
+      S.view.form(),
+      S.view.component(JSONPreviewDocumentView).title('JSON 1'),
+      S.view.component(JSONPreviewDocumentView).title('JSON 2'),
+      S.view.component(JSONPreviewDocumentView).title('JSON 3'),
+      S.view.component(JSONPreviewDocumentView).title('JSON 4'),
+      S.view.component(JSONPreviewDocumentView).title('JSON 5'),
+      S.view.component(JSONPreviewDocumentView).title('JSON 6'),
+      S.view.component(JSONPreviewDocumentView).title('JSON 7'),
+      S.view.component(JSONPreviewDocumentView).title('JSON 8'),
+      S.view.component(JSONPreviewDocumentView).title('JSON 9'),
+      S.view.component(JSONPreviewDocumentView).title('JSON 10'),
+    ])
+  }
+
   return null
 }

--- a/packages/sanity/src/structure/components/pane/PaneHeader.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneHeader.tsx
@@ -77,54 +77,58 @@ export const PaneHeader = forwardRef(function PaneHeader(
         <LegacyLayerProvider zOffset="paneHeader">
           <Card data-collapsed={collapsed ? '' : undefined} tone="inherit">
             <Layout
+              direction="column"
               gap={3}
               onClick={handleLayoutClick}
               padding={3}
               sizing="border"
               style={layoutStyle}
             >
-              {backButton && <Box flex="none">{backButton}</Box>}
+              <Flex align="flex-start" gap={3}>
+                {backButton && <Box flex="none">{backButton}</Box>}
 
-              <TitleCard
-                __unstable_focusRing
-                flex={1}
-                onClick={handleTitleClick}
-                paddingLeft={backButton ? 1 : 2}
-                padding={2}
-                tabIndex={tabIndex}
-              >
-                {loading && (
-                  <Box>
-                    <TitleTextSkeleton animated radius={1} size={1} />
+                <TitleCard
+                  __unstable_focusRing
+                  flex={1}
+                  onClick={handleTitleClick}
+                  paddingLeft={backButton ? 1 : 2}
+                  padding={2}
+                  tabIndex={tabIndex}
+                >
+                  {loading && (
+                    <Box>
+                      <TitleTextSkeleton animated radius={1} size={1} />
+                    </Box>
+                  )}
+                  {!loading && (
+                    <Flex align="center" gap={1}>
+                      <TitleText size={1} textOverflow="ellipsis" weight="semibold">
+                        {title}
+                      </TitleText>
+                      {appendTitle}
+                    </Flex>
+                  )}
+                </TitleCard>
+
+                {actions && (
+                  <Box hidden={collapsed}>
+                    <LegacyLayerProvider zOffset="paneHeader">{actions}</LegacyLayerProvider>
                   </Box>
                 )}
-                {!loading && (
-                  <Flex align="center" gap={1}>
-                    <TitleText size={1} textOverflow="ellipsis" weight="semibold">
-                      {title}
-                    </TitleText>
-                    {appendTitle}
-                  </Flex>
-                )}
-              </TitleCard>
+              </Flex>
 
-              {actions && (
-                <Box hidden={collapsed}>
-                  <LegacyLayerProvider zOffset="paneHeader">{actions}</LegacyLayerProvider>
-                </Box>
-              )}
               {showTabsOrSubActions && (
                 <Flex align="center" hidden={collapsed} overflow="auto">
                   <Box flex={1} marginRight={subActions ? 3 : 0}>
                     {tabs}
                   </Box>
 
-                  {subActions && subActions}
+                  {subActions}
                 </Flex>
               )}
             </Layout>
 
-            {!collapsed && contentAfter && contentAfter}
+            {!collapsed && contentAfter}
           </Card>
         </LegacyLayerProvider>
       </Root>

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTabs.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTabs.tsx
@@ -1,9 +1,8 @@
-import {CheckmarkIcon, ChevronDownIcon} from '@sanity/icons'
-import {Menu, TabList, useElementSize} from '@sanity/ui'
+import {TabList, useElementSize} from '@sanity/ui'
 import {motion} from 'framer-motion'
 import {type ComponentType, type ReactNode, useCallback, useState} from 'react'
 
-import {Button, MenuButton, MenuItem, Tab} from '../../../../../ui-components'
+import {Tab} from '../../../../../ui-components'
 import {usePaneRouter} from '../../../../components'
 import {useDocumentPane} from '../../useDocumentPane'
 
@@ -35,51 +34,16 @@ function DelayedDiv({children, show}: {show: boolean; children: ReactNode}) {
  * it will not change back to tabs, this is a limitation of the current implementation but an ok tradeoff to avoid mounting
  * ghost elements just to measure the width.
  */
-export function DocumentHeaderTabs({parentRef}: {parentRef: HTMLDivElement | null}) {
+export function DocumentHeaderTabs() {
   const {activeViewId, paneKey, views} = useDocumentPane()
 
   const [tabList, setTabList] = useState<HTMLDivElement | null>(null)
-  const parentSize = useElementSize(parentRef)
   const tabListSize = useElementSize(tabList)
 
-  const parentWidth = parentSize?.border?.width ?? 0
   const tabListWidth = tabListSize?.border?.width ?? 0
 
   const tabPanelId = `${paneKey}tabpanel`
-  const activeTab = views.find((view) => view.id === activeViewId)
 
-  if (parentWidth < 480 || tabListWidth > 200) {
-    return (
-      <DelayedDiv
-        // We immediately show the dropdown if the elements have been calculated
-        show={Boolean(parentWidth + tabListWidth)}
-      >
-        <MenuButton
-          id={`${paneKey}tab-menu`}
-          popover={{
-            placement: 'bottom-end',
-            portal: true,
-          }}
-          button={<Button iconRight={ChevronDownIcon} mode="bleed" text={activeTab?.title ?? ''} />}
-          menu={
-            <Menu>
-              {views.map((view, index) => (
-                <DocumentHeaderMenuItem
-                  icon={view.icon}
-                  id={`${paneKey}tab-${view.id}`}
-                  isActive={activeViewId === view.id}
-                  key={view.id}
-                  label={view.title}
-                  tabPanelId={tabPanelId}
-                  viewId={index === 0 ? null : (view.id ?? null)}
-                />
-              ))}
-            </Menu>
-          }
-        />
-      </DelayedDiv>
-    )
-  }
   return (
     <DelayedDiv show={Boolean(tabListWidth)}>
       <TabList space={1} ref={setTabList}>
@@ -96,34 +60,6 @@ export function DocumentHeaderTabs({parentRef}: {parentRef: HTMLDivElement | nul
         ))}
       </TabList>
     </DelayedDiv>
-  )
-}
-
-function DocumentHeaderMenuItem(props: {
-  icon?: ComponentType | ReactNode
-  id: string
-  isActive: boolean
-  label: string
-  tabPanelId: string
-  viewId: string | null
-}) {
-  const {icon, id, isActive, label, tabPanelId, viewId} = props
-  const {ready, editState} = useDocumentPane()
-  const {setView} = usePaneRouter()
-  const handleClick = useCallback(() => setView(viewId), [setView, viewId])
-
-  return (
-    <MenuItem
-      aria-controls={tabPanelId}
-      disabled={!ready && !editState?.draft && !editState?.published}
-      icon={icon}
-      id={id}
-      text={label}
-      onClick={handleClick}
-      selected={isActive}
-      pressed={isActive}
-      iconRight={isActive ? CheckmarkIcon : undefined}
-    />
   )
 }
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTabs.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTabs.tsx
@@ -6,23 +6,6 @@ import {Tab} from '../../../../../ui-components'
 import {usePaneRouter} from '../../../../components'
 import {useDocumentPane} from '../../useDocumentPane'
 
-function DelayedDiv({children, show}: {show: boolean; children: ReactNode}) {
-  return (
-    <motion.div
-      key={show ? 'show' : 'wait'}
-      initial={{opacity: show ? 1 : 0}}
-      animate={{opacity: 1}}
-      transition={
-        show
-          ? {duration: 0.2}
-          : // We delay the showing the element to avoid flickering
-            {delay: 1, duration: 0.2}
-      }
-    >
-      {children}
-    </motion.div>
-  )
-}
 
 /**
  * This component will render the tabs for the document pane, following this rules:
@@ -37,15 +20,9 @@ function DelayedDiv({children, show}: {show: boolean; children: ReactNode}) {
 export function DocumentHeaderTabs() {
   const {activeViewId, paneKey, views} = useDocumentPane()
 
-  const [tabList, setTabList] = useState<HTMLDivElement | null>(null)
-  const tabListSize = useElementSize(tabList)
-
-  const tabListWidth = tabListSize?.border?.width ?? 0
-
   const tabPanelId = `${paneKey}tabpanel`
 
   return (
-    <DelayedDiv show={Boolean(tabListWidth)}>
       <TabList space={1} ref={setTabList}>
         {views.map((view, index) => (
           <DocumentHeaderTab
@@ -59,7 +36,6 @@ export function DocumentHeaderTabs() {
           />
         ))}
       </TabList>
-    </DelayedDiv>
   )
 }
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTabs.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTabs.tsx
@@ -1,11 +1,9 @@
-import {TabList, useElementSize} from '@sanity/ui'
-import {motion} from 'framer-motion'
-import {type ComponentType, type ReactNode, useCallback, useState} from 'react'
+import {TabList} from '@sanity/ui'
+import {type ComponentType, type ReactNode, useCallback} from 'react'
 
 import {Tab} from '../../../../../ui-components'
 import {usePaneRouter} from '../../../../components'
 import {useDocumentPane} from '../../useDocumentPane'
-
 
 /**
  * This component will render the tabs for the document pane, following this rules:
@@ -23,19 +21,19 @@ export function DocumentHeaderTabs() {
   const tabPanelId = `${paneKey}tabpanel`
 
   return (
-      <TabList space={1} ref={setTabList}>
-        {views.map((view, index) => (
-          <DocumentHeaderTab
-            icon={view.icon}
-            id={`${paneKey}tab-${view.id}`}
-            isActive={activeViewId === view.id}
-            key={view.id}
-            label={view.title}
-            tabPanelId={tabPanelId}
-            viewId={index === 0 ? null : (view.id ?? null)}
-          />
-        ))}
-      </TabList>
+    <TabList space={1}>
+      {views.map((view, index) => (
+        <DocumentHeaderTab
+          icon={view.icon}
+          id={`${paneKey}tab-${view.id}`}
+          isActive={activeViewId === view.id}
+          key={view.id}
+          label={view.title}
+          tabPanelId={tabPanelId}
+          viewId={index === 0 ? null : (view.id ?? null)}
+        />
+      ))}
+    </TabList>
   )
 }
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelSubHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelSubHeader.tsx
@@ -1,5 +1,5 @@
 import {ArrowLeftIcon} from '@sanity/icons'
-import {memo, useMemo, useState} from 'react'
+import {memo, useMemo} from 'react'
 import {CapabilityGate, getPublishedId, useActiveWorkspace, useTranslation} from 'sanity'
 
 import {Button} from '../../../../../ui-components'
@@ -19,9 +19,9 @@ export const DocumentPanelSubHeader = memo(function DocumentPanelHeader() {
   const {editState, connectionState, views, documentId, displayed} = useDocumentPane()
   const {features} = useStructureTool()
   const {index, BackLink} = usePaneRouter()
-  const [parentRef, setParentRef] = useState<HTMLDivElement | null>(null)
   const {activeWorkspace} = useActiveWorkspace()
   const publishedDocId = getPublishedId(documentId)
+
   const showTabs = views.length > 1
 
   const {collapsed, isLast} = usePane()
@@ -35,10 +35,7 @@ export const DocumentPanelSubHeader = memo(function DocumentPanelHeader() {
   const {t} = useTranslation(structureLocaleNamespace)
 
   const title = useMemo(() => <DocumentHeaderTitle />, [])
-  const tabs = useMemo(
-    () => showTabs && <DocumentHeaderTabs parentRef={parentRef} />,
-    [showTabs, parentRef],
-  )
+  const tabs = useMemo(() => showTabs && <DocumentHeaderTabs />, [showTabs])
 
   const backButton = useMemo(
     () =>
@@ -75,7 +72,6 @@ export const DocumentPanelSubHeader = memo(function DocumentPanelHeader() {
 
   return (
     <PaneHeader
-      ref={setParentRef}
       loading={connectionState === 'connecting' && !editState?.draft && !editState?.published}
       title={title}
       tabs={tabs}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR reverts the UX changes to document view tabs that was done as part of the Releases launch.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

- Open document types without view tabs and make sure they behave as before.
- Open document types with view tabs and make sure they behave as prior to the Releases launch.
  - [Type with many views](https://test-studio-git-refactor-sapp-2658.sanity.dev/test/structure/input-debug;manyViews;45afd740-f949-4920-bc1d-58459a8a5638)
  - [Type with 1 view](https://test-studio-git-refactor-sapp-2658.sanity.dev/test/structure/author;e0e1b95d-6182-4198-a92d-4c0c63215681)

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
