### PR TITLE
fix: supporting passing an auth token via URL hash

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -30,6 +30,21 @@ const getStorageKey = (projectId: string) => {
   return `__studio_auth_token_${projectId}`
 }
 
+const getTokenFromHash = (projectId: string): string | null => {
+  if (typeof window === 'undefined' || typeof window.location !== 'object') {
+    return null
+  }
+
+  const tokenPattern = /token=([^&]{32,})&?/
+  const [, tokenParam] = window.location.hash.match(tokenPattern) || []
+  if (!tokenParam) {
+    return null
+  }
+
+  saveToken({token: tokenParam, projectId})
+  return tokenParam
+}
+
 const getToken = (projectId: string): string | null => {
   try {
     const item = storage.getItem(getStorageKey(projectId))
@@ -42,7 +57,7 @@ const getToken = (projectId: string): string | null => {
   } catch (err) {
     console.error(err)
   }
-  return null
+  return getTokenFromHash(projectId) || null
 }
 
 const clearToken = (projectId: string): void => {


### PR DESCRIPTION
### Description
Before:
Currently studio has only one way of storing an auth token -> it takes an SID from an auth provider and uses a backend auth endpoint to convert this to an unstamped token. This token is then stored in local storage and possibly as a cookie.

After:
Now the studio will bypass the exchange from SID to token when a token is provided via the URL hash. This has 2 benefits. 1, it reduces a server round trip, which should speedup initial load times of studios running in these environments. Secondly, this resolves issues with running local studios within these environments.

Demo:
This is best demonstrated in terms of running a local studio within a wrapping environment.

| Before | After |
|--------|--------|
| ![dashboardAuthTokenBEFORE](https://github.com/user-attachments/assets/ff0e5d91-3f11-4131-9fee-242808f20971) | ![dashboardAuthTokenAFTER](https://github.com/user-attachments/assets/17f20efe-9cc7-4f27-8d3c-aa6f2295fc1e) | 

This shows how, in some browsers, when an SID is not provided then auth login is not successful. When the studio is running in an iframe it isn't possible to receive an SID given the differing origin the request is coming from. As such, the studio ends in a login screen loop.

After this change, when a token is provided via URL hash, the entire SID process is short circuited and that token is immediately stored and used.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
