### PR TITLE
fix(test): use base url fallback value

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,14 +8,14 @@ import {
 } from '@playwright/test'
 
 import {loadEnvFiles} from './scripts/utils/loadEnvFiles'
-import {readBoolEnv, readEnv} from './test/e2e/helpers/envVars'
+import {findEnv, readBoolEnv, readEnv} from './test/e2e/helpers/envVars'
 
 loadEnvFiles()
 
 // Read environment variables
 const CI = readBoolEnv('CI', false)
 const HEADLESS = readBoolEnv('HEADLESS', true)
-const BASE_URL = readEnv('SANITY_E2E_BASE_URL') || 'http://localhost:3333'
+const BASE_URL = findEnv('SANITY_E2E_BASE_URL') || 'http://localhost:3339'
 const PROJECT_ID = readEnv('SANITY_E2E_PROJECT_ID')
 const TOKEN = readEnv('SANITY_E2E_SESSION_TOKEN')
 const E2E_DEBUG = readBoolEnv('SANITY_E2E_DEBUG', false)


### PR DESCRIPTION
### Description
Update BASE_URL, to instead of using `readEnv` which throws if the env var doesn't exist, use the `findEnv` so it supports having a fallback value, and update it to localhost:3339, which is the default port we use for testing.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
