### PR TITLE
fix(core): unlink dialog crash

### DIFF
--- a/packages/sanity/src/core/canvas/actions/UnlinkFromCanvas/UnlinkFromCanvasAction.tsx
+++ b/packages/sanity/src/core/canvas/actions/UnlinkFromCanvas/UnlinkFromCanvasAction.tsx
@@ -35,11 +35,11 @@ export const UnlinkFromCanvasAction: DocumentActionComponent = (props: DocumentA
 
   const handleUnlink = useCallback(async () => {
     try {
-      setStatus('loading')
-      unlinkApproved()
       if (!companionDoc?._id) {
         throw new Error('Companion doc not found')
       }
+      setStatus('loading')
+      unlinkApproved()
       await client.delete(companionDoc?._id)
       setStatus('idle')
       handleCloseDialog()
@@ -55,13 +55,7 @@ export const UnlinkFromCanvasAction: DocumentActionComponent = (props: DocumentA
   }, [client, companionDoc?._id, handleCloseDialog, unlinkApproved, toast, t])
 
   const document = props.version || props.draft || props.published
-  if (!document) return null
-  if (
-    // If we are deleting the document in this action, we don't want to remove the dialog
-    // until we show to the users that the document has been deleted
-    !isDialogOpen &&
-    (!isLinked || loading)
-  ) {
+  if (!document || !isLinked || loading) {
     return null
   }
   return {

--- a/packages/sanity/src/core/canvas/actions/UnlinkFromCanvas/UnlinkFromCanvasDialog.tsx
+++ b/packages/sanity/src/core/canvas/actions/UnlinkFromCanvas/UnlinkFromCanvasDialog.tsx
@@ -7,14 +7,14 @@ import {Dialog} from '../../../../ui-components'
 import {useSchema} from '../../../hooks/useSchema'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {Translate} from '../../../i18n/Translate'
-import {unstable_useValuePreview} from '../../../preview/useValuePreview'
+import {unstable_useValuePreview as useValuePreview} from '../../../preview/useValuePreview'
 import {canvasLocaleNamespace} from '../../i18n'
 
 const useDocumentTitle = ({document}: {document: SanityDocument}) => {
   const schema = useSchema()
   const schemaType = schema.get(document._type)
 
-  const {error, value} = unstable_useValuePreview({
+  const {error, value} = useValuePreview({
     enabled: Boolean(document),
     schemaType,
     value: document,


### PR DESCRIPTION
### Description

When using hooks the hook should start with  `use` or react will fail when unmounting the component in production mode.
This PR updates the use of `unstable_useValuePreview` to be `useValuePreview` 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
