### PR TITLE
chore(core): adds `canvasApp` options to schema types 

### DIFF
--- a/dev/test-create-integration-studio/schema.ts
+++ b/dev/test-create-integration-studio/schema.ts
@@ -24,6 +24,7 @@ export const schemaTypes = [
     ],
     options: {
       sanityCreate: {exclude: true},
+      canvasApp: {exclude: true},
     },
   }),
   defineType({
@@ -34,6 +35,7 @@ export const schemaTypes = [
         name: 'title',
         title: 'Documents with initial values are disabled for Create',
         type: 'string',
+        options: {canvasApp: {exclude: true}},
         initialValue: () =>
           new Promise<string>((resolve) => {
             setTimeout(() => {

--- a/packages/@sanity/types/src/schema/definition/type/common.ts
+++ b/packages/@sanity/types/src/schema/definition/type/common.ts
@@ -41,6 +41,22 @@ export interface SanityCreateOptions {
 }
 
 /**
+ * Options for configuring how Canvas app interfaces with the type or field.
+ *
+ * @public
+ */
+export interface CanvasAppOptions {
+  /** Set to true to exclude a type or field from appearing in Canvas */
+  exclude?: boolean
+
+  /**
+   * A short description of what the type or field is used for.
+   * Purpose can be used to improve how and when content mapping uses the field.
+   * */
+  purpose?: string
+}
+
+/**
  * `BaseOptions` applies to all type options.
  *
  *  It can be extended by interface declaration merging in plugins to provide generic options to all types and fields.
@@ -49,6 +65,7 @@ export interface SanityCreateOptions {
  *  */
 export interface BaseSchemaTypeOptions {
   sanityCreate?: SanityCreateOptions
+  canvasApp?: CanvasAppOptions
 }
 
 /** @public */

--- a/packages/@sanity/types/test/options.test-d.ts
+++ b/packages/@sanity/types/test/options.test-d.ts
@@ -1,0 +1,38 @@
+import {assertType, describe, test} from 'vitest'
+
+import {type BaseSchemaTypeOptions} from '../src/schema/definition/type/common'
+import {type DocumentDefinition} from '../src/schema/definition/type/document'
+
+describe('SchemaType', () => {
+  test('should  take canvas options in BaseSchemaTypeOptions', () => {
+    assertType<BaseSchemaTypeOptions>({
+      canvasApp: {
+        exclude: false,
+        purpose: 'this is a test',
+      },
+    })
+  })
+  test('should  take canvas options in document and fields', () => {
+    assertType<DocumentDefinition>({
+      name: 'test',
+      type: 'document',
+      fields: [
+        {
+          type: 'string',
+          name: 'test',
+          options: {
+            canvasApp: {
+              exclude: true,
+            },
+          },
+        },
+      ],
+      options: {
+        canvasApp: {
+          exclude: false,
+          purpose: 'this is a test',
+        },
+      },
+    })
+  })
+})

--- a/packages/@sanity/types/test/url.test.ts
+++ b/packages/@sanity/types/test/url.test.ts
@@ -33,11 +33,6 @@ describe('url types', () => {
         ],
         hidden: () => false,
         readOnly: () => false,
-        options: {
-          layout: 'radio',
-          direction: 'horizontal',
-          list: [{value: 'A', title: 'An entry'}],
-        },
       })
 
       const assignableToUrl: UrlDefinition = urlDef

--- a/packages/@sanity/types/vitest.config.mts
+++ b/packages/@sanity/types/vitest.config.mts
@@ -2,5 +2,11 @@ import {defineConfig} from '@repo/test-config/vitest'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  test: {
+    typecheck: {
+      enabled: true,
+      ignoreSourceErrors: false,
+    },
+  },
   plugins: [react({babel: {plugins: [['babel-plugin-react-compiler', {target: '18'}]]}})],
 })


### PR DESCRIPTION
### Description
[WIP]
Adds canvas app options to the schema types allowing users to configure how the fields or the schema type will behave inside canvas. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
