### PR TITLE
feat(core): allow pulling metadata as configured on image type for ML assets

### DIFF
--- a/packages/@sanity/types/src/assets/types.ts
+++ b/packages/@sanity/types/src/assets/types.ts
@@ -2,7 +2,7 @@ import {type ComponentType} from 'react'
 
 import {type SanityDocument} from '../documents'
 import {type Reference} from '../reference'
-import {type SchemaType} from '../schema'
+import {type FileSchemaType, type ImageSchemaType, type SchemaType} from '../schema'
 
 /** @public */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -154,6 +154,7 @@ export interface AssetSourceComponentProps {
   selectedAssets: Asset[]
   onClose: () => void
   onSelect: (assetFromSource: AssetFromSource[]) => void
+  schemaType?: ImageSchemaType | FileSchemaType
 }
 
 /** @public */

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -489,7 +489,7 @@ export interface FileSchemaType extends Omit<ObjectSchemaType, 'options'> {
   options?: FileOptions
 }
 
-/** @internal */
+/** @public */
 export interface ImageSchemaType extends Omit<ObjectSchemaType, 'options'> {
   options?: ImageOptions
 }

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
@@ -29,7 +29,7 @@ import {type ObjectInputProps} from '../../../types'
 import {handleSelectAssetFromSource as handleSelectAssetFromSourceShared} from '../common/assetSource'
 import {type FileInfo} from '../common/styles'
 import {FileAsset as FileAssetComponent} from './FileAsset'
-import {FileAssetSource} from './FileAssetSource'
+import {FileAssetSource} from './FileInputAssetSource'
 
 /**
  * @hidden

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileInputAssetSource.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileInputAssetSource.tsx
@@ -55,15 +55,16 @@ export function FileAssetSource(props: FileAssetProps) {
   }
   return (
     <Component
+      accept={accept}
       action={isUploading ? 'upload' : 'select'}
       assetSource={selectedAssetSource}
-      selectedAssets={[]}
-      selectionType="single"
       assetType="file"
-      accept={accept}
       dialogHeaderTitle={t('inputs.file.dialog.title')}
       onClose={handleAssetSourceClosed}
       onSelect={onSelectAssets}
+      schemaType={schemaType}
+      selectedAssets={[]}
+      selectionType="single"
     />
   )
 }

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileInputAssetSource.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileInputAssetSource.tsx
@@ -39,15 +39,16 @@ export function FileAssetSource(props: FileAssetProps) {
       >
         {(fileAsset) => (
           <Component
+            accept={accept}
             action={isUploading ? 'upload' : 'select'}
             assetSource={selectedAssetSource}
-            selectedAssets={[fileAsset]}
-            selectionType="single"
             assetType="file"
-            accept={accept}
             dialogHeaderTitle={t('inputs.file.dialog.title')}
             onClose={handleAssetSourceClosed}
             onSelect={onSelectAssets}
+            schemaType={schemaType}
+            selectedAssets={[fileAsset]}
+            selectionType="single"
           />
         )}
       </WithReferencedAsset>

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetSource.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetSource.tsx
@@ -48,14 +48,15 @@ function ImageInputAssetSourceComponent(
   }
   return (
     <Component
+      accept={accept}
       action={isUploading ? 'upload' : 'select'}
       assetSource={selectedAssetSource}
-      selectedAssets={[]}
-      selectionType="single"
       assetType="image"
-      accept={accept}
       onClose={handleAssetSourceClosed}
       onSelect={handleSelectAssetFromSource}
+      schemaType={schemaType}
+      selectedAssets={[]}
+      selectionType="single"
     />
   )
 }

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetSource.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetSource.tsx
@@ -33,14 +33,15 @@ function ImageInputAssetSourceComponent(
       <WithReferencedAsset observeAsset={observeAsset} reference={value.asset}>
         {(imageAsset) => (
           <Component
+            accept={accept}
             action={isUploading ? 'upload' : 'select'}
             assetSource={selectedAssetSource}
-            selectedAssets={[imageAsset]}
             assetType="image"
-            accept={accept}
-            selectionType="single"
             onClose={handleAssetSourceClosed}
             onSelect={handleSelectAssetFromSource}
+            schemaType={schemaType}
+            selectedAssets={[imageAsset]}
+            selectionType="single"
           />
         )}
       </WithReferencedAsset>

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/MediaLibraryAssetSource.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/MediaLibraryAssetSource.tsx
@@ -80,17 +80,8 @@ const MediaLibraryAssetSourceComponent = function MediaLibraryAssetSourceCompone
       try {
         const result = await client.request({
           method: 'POST',
-          url: `/assets/media-library-link/${client.config().dataset}`,
+          url: `/assets/media-library-link/${client.config().dataset}?${metadataPropsFromSchema?.map((prop) => `meta[]=${prop}`).join('&') || ''}`,
           withCredentials: true,
-          // Allow metadata as configured in the schema
-          query: metadataPropsFromSchema
-            ? Object.fromEntries(
-                metadataPropsFromSchema.reduce((acc, meta) => {
-                  acc.append('meta', meta)
-                  return acc
-                }, new URLSearchParams()),
-              )
-            : undefined,
           body: {
             mediaLibraryId: resolvedLibraryId,
             assetInstanceId: asset.assetInstanceId,


### PR DESCRIPTION
### Description

This will add the allowed metadata as configured on an Image schema type to be put on the local asset document from the Media Library.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
