### PR TITLE
fix(cli): fixes vision deps check for apps

### DIFF
--- a/packages/sanity/src/_internal/cli/util/getAutoUpdatesImportMap.ts
+++ b/packages/sanity/src/_internal/cli/util/getAutoUpdatesImportMap.ts
@@ -4,8 +4,8 @@
 export interface StudioAutoUpdatesImportMap {
   'sanity': string
   'sanity/': string
-  '@sanity/vision': string
-  '@sanity/vision/': string
+  '@sanity/vision'?: string
+  '@sanity/vision/'?: string
 }
 
 export interface SanityAppAutoUpdatesImportMap extends Partial<StudioAutoUpdatesImportMap> {
@@ -27,14 +27,23 @@ function getTimestamp(): string {
 /**
  * @internal
  */
-export function getStudioAutoUpdateImportMap(version: string): StudioAutoUpdatesImportMap {
+export function getStudioAutoUpdateImportMap(
+  version: string,
+  includeVision = true,
+): StudioAutoUpdatesImportMap {
   const timestamp = getTimestamp()
 
   const autoUpdatesImports = {
     'sanity': `${MODULES_HOST}/v1/modules/sanity/default/${version}/${timestamp}`,
     'sanity/': `${MODULES_HOST}/v1/modules/sanity/default/${version}/${timestamp}/`,
-    '@sanity/vision': `${MODULES_HOST}/v1/modules/@sanity__vision/default/${version}/${timestamp}`,
-    '@sanity/vision/': `${MODULES_HOST}/v1/modules/@sanity__vision/default/${version}/${timestamp}/`,
+  }
+
+  if (includeVision) {
+    return {
+      ...autoUpdatesImports,
+      '@sanity/vision': `${MODULES_HOST}/v1/modules/@sanity__vision/default/${version}/${timestamp}`,
+      '@sanity/vision/': `${MODULES_HOST}/v1/modules/@sanity__vision/default/${version}/${timestamp}/`,
+    }
   }
 
   return autoUpdatesImports
@@ -63,8 +72,7 @@ export function getAppAutoUpdateImportMap(
   }
 
   if (sanityVersion) {
-    const sanityImportMap = getStudioAutoUpdateImportMap(sanityVersion)
-
+    const sanityImportMap = getStudioAutoUpdateImportMap(sanityVersion, false)
     return {...autoUpdatesImports, ...sanityImportMap}
   }
 


### PR DESCRIPTION
### Description

This PR makes `@sanity/vision` imports optional in the auto-updates import map. It modifies the `getStudioAutoUpdateImportMap` function to accept a new `includeVision` parameter (defaulting to `true`), which controls whether Vision-related imports are included in the returned map. The `getAppAutoUpdateImportMap` function now explicitly passes `false` for this parameter when calling `getStudioAutoUpdateImportMap`.

### What to review

- The type changes to make `@sanity/vision` and `@sanity/vision/` optional in the `StudioAutoUpdatesImportMap` interface
- The refactoring of `getStudioAutoUpdateImportMap` to conditionally include Vision imports
- The updated call to `getStudioAutoUpdateImportMap` in `getAppAutoUpdateImportMap` with `includeVision` set to `false`

### Testing

Verify that:
- Studio auto-updates continue to include Vision imports by default
- App auto-updates correctly exclude Vision imports
- The type changes don't break existing code

### Notes for release

N/A