### PR TITLE
fix(core): catch error on getOrganizationId

### DIFF
--- a/packages/sanity/src/core/canvas/actions/LinkToCanvas/LinkToCanvasAction.tsx
+++ b/packages/sanity/src/core/canvas/actions/LinkToCanvas/LinkToCanvasAction.tsx
@@ -11,6 +11,7 @@ import {useSchema} from '../../../hooks/useSchema'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {usePerspective} from '../../../perspective/usePerspective'
 import {isReleaseDocument} from '../../../releases/store/types'
+import {useProjectOrganizationId} from '../../../store/_legacy/project/useProjectOrganizationId'
 import {useRenderingContext} from '../../../store/renderingContext/useRenderingContext'
 import {getDraftId, getPublishedId} from '../../../util/draftUtils'
 import {canvasLocaleNamespace} from '../../i18n'
@@ -31,6 +32,7 @@ export const LinkToCanvasAction: DocumentActionComponent = (props: DocumentActio
   const {isLinked, loading} = useCanvasCompanionDoc(
     props.liveEditSchemaType ? getPublishedId(props.id) : getDraftId(props.id),
   )
+  const {value: organizationId} = useProjectOrganizationId()
   const {linkCtaClicked} = useCanvasTelemetry()
 
   const isExcludedType = useIsExcludedType(props.type)
@@ -53,6 +55,9 @@ export const LinkToCanvasAction: DocumentActionComponent = (props: DocumentActio
   }, [getFormValue, props.liveEditSchemaType, linkCtaClicked])
 
   const disabled = useMemo(() => {
+    if (!organizationId) {
+      return {disabled: true, reason: t('action.link-document-disabled.missing-permissions')}
+    }
     if (!isInDashboard) {
       return {disabled: true, reason: t('action.link-document-disabled.not-in-dashboard')}
     }
@@ -64,7 +69,7 @@ export const LinkToCanvasAction: DocumentActionComponent = (props: DocumentActio
     }
 
     return {disabled: false, reason: undefined}
-  }, [isVersionDocument, t, props.initialValueResolved, isInDashboard])
+  }, [isVersionDocument, t, props.initialValueResolved, isInDashboard, organizationId])
 
   useEffect(() => {
     if (isLinked) {

--- a/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
+++ b/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
@@ -145,6 +145,10 @@ export function useLinkToCanvas({document}: {document: SanityDocument | undefine
 
       return projectStore.getOrganizationId().pipe(
         map((organizationId) => {
+          if (!organizationId) {
+            // Users should not land at this stage, it is caught first in the action by disabling it
+            return () => {}
+          }
           const isStaging = client.config().apiHost === 'https://api.sanity.work'
 
           const canvasLinkUrl = `https://www.sanity.${isStaging ? 'work' : 'io'}/@${organizationId}/canvas/${path}`

--- a/packages/sanity/src/core/canvas/i18n/resources.ts
+++ b/packages/sanity/src/core/canvas/i18n/resources.ts
@@ -12,6 +12,9 @@ const canvasLocaleStrings = defineLocalesResources('canvas', {
   /** The text for the "Link to Canvas" action when the document is not in the dashboard. */
   'action.link-document-disabled.not-in-dashboard':
     'Open this document in Dashboard to link to Canvas',
+  /** The text for the "Link to Canvas" action when the user doesn't have permissions to link the document to Canvas. */
+  'action.link-document-disabled.missing-permissions':
+    "You don't have permissions to link this document to Canvas",
   /** The text for the "Link to Canvas" action when the document is a version document. */
   'action.link-document-disabled.version-document':
     'Version documents are not yet supported in Canvas',
@@ -64,6 +67,8 @@ const canvasLocaleStrings = defineLocalesResources('canvas', {
   'dialog.unlink-from-canvas.success': 'Unlinked from Canvas',
   /** The text for the "Unlink from Canvas" dialog error message. */
   'dialog.unlink-from-canvas.error': 'Failed to unlink from Canvas',
+  /** The text for the "Navigate to Canvas" dialog error message. */
+  'navigate-to-canvas-doc.error.missing-permissions': 'Missing permissions to navigate to Canvas',
 })
 
 /**

--- a/packages/sanity/src/core/store/_legacy/project/projectStore.ts
+++ b/packages/sanity/src/core/store/_legacy/project/projectStore.ts
@@ -1,5 +1,5 @@
 import {type SanityClient} from '@sanity/client'
-import {map, type Observable, repeat, shareReplay} from 'rxjs'
+import {catchError, map, type Observable, of, repeat, shareReplay} from 'rxjs'
 
 import {memoize} from '../document/utils/createMemoizer'
 import {type ProjectData, type ProjectStore} from './types'
@@ -26,6 +26,9 @@ const getOrganizationId = memoize(
         map((res) => res.organizationId),
         repeat({delay: REFETCH_INTERVAL}),
         shareReplay(1),
+        catchError(() => {
+          return of(null)
+        }),
       )
   },
   (client) => `${client.config().projectId}-${client.config().dataset}`,

--- a/packages/sanity/src/core/store/_legacy/project/types.ts
+++ b/packages/sanity/src/core/store/_legacy/project/types.ts
@@ -61,5 +61,5 @@ export interface ProjectDatasetData {
 export interface ProjectStore {
   get: () => Observable<ProjectData>
   getDatasets: () => Observable<ProjectDatasetData[]>
-  getOrganizationId: () => Observable<string>
+  getOrganizationId: () => Observable<string | null>
 }


### PR DESCRIPTION
### Description
In some cases users could not have permissions to fetch the organization id endpoint. In this cases we will catch the error and handle the `null` response in the consumers.

For canvas, the link action will be disabled.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in where some users couldn't open documents in the studio due to missing permissions to get the org id 
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
