### PR TITLE
fix(sanity): remove redundant background colour from perspective label child

### DIFF
--- a/packages/sanity/src/core/perspective/navbar/currentGlobalPerspectiveLabel.tsx
+++ b/packages/sanity/src/core/perspective/navbar/currentGlobalPerspectiveLabel.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports -- Bundle Button requires more fine-grained styling than studio button
-import {Button, Card, Text} from '@sanity/ui'
+import {Box, Button, Text} from '@sanity/ui'
 import {motion} from 'framer-motion'
 import {
   type ForwardedRef,
@@ -113,13 +113,13 @@ export function CurrentGlobalPerspectiveLabel({
       text={isReleaseDocument(selectedPerspective) ? selectedPerspective._id : selectedPerspective}
     >
       {isPublishedPerspective(selectedPerspective) || isDraftPerspective(selectedPerspective) ? (
-        <Card tone="inherit" padding={2} style={{userSelect: 'none', overflow: 'hidden'}}>
+        <Box padding={2} style={{userSelect: 'none', overflow: 'hidden'}}>
           <Text size={1} textOverflow="ellipsis" weight="medium">
             {isPublishedPerspective(selectedPerspective)
               ? t('release.chip.published')
               : t('release.chip.global.drafts')}
           </Text>
-        </Card>
+        </Box>
       ) : (
         <ReleasesLink selectedPerspective={selectedPerspective} />
       )}


### PR DESCRIPTION
### Description

This small visual regression was probably introduced when we adjusted the perspective menu's layout. It only manifests when the releases tool is unavailable.

It's fixed by switching the inner component from a `Card` with an inherited background colour, to a `Box` with no background colour at all.

| Before | After |
| --- | --- |
| <img width="124" alt="before" src="https://github.com/user-attachments/assets/f7d172c6-f5d8-4042-9293-f422d417f7bf" /> | <img width="124" alt="after" src="https://github.com/user-attachments/assets/5ecb9c04-1df6-4768-b490-506e4693def6" /> |

### What to review

- The perspective menu when the releases tool is unavailable.

### Testing

- Tested in browser.