### PR TITLE
feat(gdr): allow sending base url to studioUrl for GDRs

### DIFF
--- a/dev/test-studio/schema/standard/globalDocumentReference.ts
+++ b/dev/test-studio/schema/standard/globalDocumentReference.ts
@@ -44,11 +44,6 @@ export default function createGDRType(projectId: string) {
         resourceType: 'dataset',
         resourceId: `${projectId}.blog`,
         weak: true,
-        studioUrl: ({id, type}) => {
-          return type
-            ? `${document.location.protocol}//${document.location.host}/playground/content/${type};${id}`
-            : null
-        },
         to: [
           {
             type: 'book',

--- a/dev/test-studio/schema/standard/globalDocumentReference.ts
+++ b/dev/test-studio/schema/standard/globalDocumentReference.ts
@@ -43,6 +43,7 @@ export default function createGDRType(projectId: string) {
         type: 'globalDocumentReference',
         resourceType: 'dataset',
         resourceId: `${projectId}.blog`,
+        weak: true,
         studioUrl: ({id, type}) => {
           return type
             ? `${document.location.protocol}//${document.location.host}/playground/content/${type};${id}`
@@ -76,11 +77,7 @@ export default function createGDRType(projectId: string) {
         resourceType: 'dataset',
         resourceId: `${projectId}.blog`,
         weak: true,
-        studioUrl: ({id, type}) => {
-          return type
-            ? `${document.location.protocol}//${document.location.host}/playground/content/${type};${id}`
-            : null
-        },
+        studioUrl: `${document.location.protocol}//${document.location.host}/staging`,
         to: [
           {
             type: 'book',

--- a/packages/@sanity/schema/src/sanity/validation/types/globalDocumentReference.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/globalDocumentReference.ts
@@ -115,10 +115,14 @@ export default (typeDef: any, visitorContext: any) => {
     )
   }
 
-  if (typeDef.studioUrl && typeof typeDef.studioUrl !== 'function') {
+  if (
+    typeDef.studioUrl &&
+    typeof typeDef.studioUrl !== 'function' &&
+    typeof typeDef.studioUrl !== 'string'
+  ) {
     problems.push(
       error(
-        'The "studioUrl" property on a global document reference must be a function taking "{id, type}" as argument and returning a studio url.',
+        'The "studioUrl" property on a global document reference must either be a function taking "{id, type}" as argument and returning a studio url, or a string being the base url pointing to a studio.',
         HELP_IDS.GLOBAL_DOCUMENT_REFERENCE_INVALID,
       ),
     )

--- a/packages/@sanity/types/src/globalDocumentReference/types.ts
+++ b/packages/@sanity/types/src/globalDocumentReference/types.ts
@@ -55,7 +55,7 @@ export interface GlobalDocumentReferenceSchemaType extends Omit<ObjectSchemaType
   to: GlobalDocumentReferenceType[]
   resourceType: string
   resourceId: string
-  studioUrl?: (document: {id: string; type?: string}) => string | null
+  studioUrl?: string | ((document: {id: string; type?: string}) => string | null)
   weak?: boolean
   options?: ReferenceFilterOptions
 }

--- a/packages/@sanity/types/src/schema/definition/type/globalDocumentReference.ts
+++ b/packages/@sanity/types/src/schema/definition/type/globalDocumentReference.ts
@@ -19,5 +19,5 @@ export interface GlobalDocumentReferenceDefinition extends BaseSchemaDefinition 
   resourceId: string
   options?: ReferenceOptions
 
-  studioUrl?: (document: {id: string; type?: string}) => string | null
+  studioUrl?: string | ((document: {id: string; type?: string}) => string | null)
 }

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/GlobalDocumentReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/GlobalDocumentReferenceInput.tsx
@@ -241,13 +241,29 @@ export function GlobalDocumentReferenceInput(props: GlobalDocumentReferenceInput
   const showWeakRefMismatch =
     !loadableReferenceInfo.isLoading && hasRef && actualStrength !== weakShouldBe
 
-  const studioUrl =
-    (value?._ref &&
-      schemaType.studioUrl?.({
-        id: value?._ref,
-        type: loadableReferenceInfo?.result?.type,
-      })) ||
-    null
+  const studioUrl: string | null = useMemo(() => {
+    if (!value?._ref) {
+      return null
+    }
+
+    if (!isGlobalDocumentReference(value)) {
+      return null
+    }
+    const [, , documentId] = value._ref.split(':')
+
+    if (!schemaType.studioUrl || !loadableReferenceInfo?.result?.type) {
+      return null
+    }
+
+    if (typeof schemaType.studioUrl === 'string') {
+      return `${schemaType.studioUrl}/desk/intent/edit/id=${documentId};type=${loadableReferenceInfo.result.type}/`
+    }
+
+    return schemaType.studioUrl({
+      id: documentId,
+      type: loadableReferenceInfo.result.type,
+    })
+  }, [value, schemaType, loadableReferenceInfo])
 
   const renderOption = useCallback(
     (option: FIXME) => {

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/GlobalDocumentReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/GlobalDocumentReferenceInput.tsx
@@ -3,6 +3,7 @@ import {ResetIcon as ClearIcon, SyncIcon as ReplaceIcon} from '@sanity/icons'
 import {
   type GlobalDocumentReferenceSchemaType,
   type GlobalDocumentReferenceValue,
+  isGlobalDocumentReference,
 } from '@sanity/types'
 import {Box, Card, Flex, Inline, Menu, Stack, useClickOutsideEvent, useToast} from '@sanity/ui'
 import {
@@ -363,7 +364,7 @@ export function GlobalDocumentReferenceInput(props: GlobalDocumentReferenceInput
                     value={value}
                     referenceInfo={loadableReferenceInfo}
                     showStudioUrlIcon
-                    hasStudioUrl={!!studioUrl}
+                    hasStudioUrl
                     type={schemaType}
                   />
                 </PreviewCard>
@@ -383,7 +384,6 @@ export function GlobalDocumentReferenceInput(props: GlobalDocumentReferenceInput
                   <PreviewReferenceValue
                     value={value}
                     referenceInfo={loadableReferenceInfo}
-                    showStudioUrlIcon
                     type={schemaType}
                   />
                 </PreviewCard>


### PR DESCRIPTION
### Description

* Instead of providing a function we can provide a studio base url. This allows us to serialize them in aspects, and it's also easier to construct.
* If no studio url is given, we hide the icon.

### What to review

Missed anything?

### Testing

* Added to the test studio and tested manually

### Notes for release

N/A - No release notes needed for this.