### PR TITLE
fix(releases): optimize document availability subscription

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -28,7 +28,6 @@ import {type LocaleSource} from '../../../i18n/types'
 import {type DocumentPreviewStore, prepareForPreview} from '../../../preview'
 import {useDocumentPreviewStore} from '../../../store/_legacy/datastores'
 import {useSource} from '../../../studio'
-import {getPublishedId} from '../../../util/draftUtils'
 import {validateDocumentWithReferences, type ValidationStatus} from '../../../validation'
 import {type ReleaseDocument} from '../../store/types'
 import {useReleasesStore} from '../../store/useReleasesStore'
@@ -69,9 +68,6 @@ const getActiveReleaseDocumentsObservable = ({
   getClient: ReturnType<typeof useSource>['getClient']
   releaseId: string
 }): ReleaseDocumentsObservableResult => {
-  const client = getClient(RELEASES_STUDIO_CLIENT_OPTIONS)
-  const observableClient = client.observable
-
   const groqFilter = `_id in path("versions.${releaseId}.**")`
 
   return documentPreviewStore
@@ -96,22 +92,14 @@ const getActiveReleaseDocumentsObservable = ({
           })
           .pipe(
             filter(Boolean),
-            switchMap((doc) =>
-              observableClient
-                .fetch(
-                  `*[_id in path("${getPublishedId(doc._id)}")]{_id}`,
-                  {},
-                  {tag: 'release-documents.check-existing'},
-                )
-                .pipe(
-                  switchMap((publishedDocumentExists) =>
-                    of({
-                      ...doc,
-                      publishedDocumentExists: !!publishedDocumentExists.length,
-                    }),
-                  ),
-                ),
-            ),
+            switchMap((doc) => {
+              return documentPreviewStore.unstable_observeDocumentPairAvailability(id).pipe(
+                map((availability) => ({
+                  ...doc,
+                  publishedDocumentExists: availability.published.available,
+                })),
+              )
+            }),
           )
         const validation$ = validateDocumentWithReferences(ctx, document$).pipe(
           map((validationStatus) => ({


### PR DESCRIPTION
### Description

Optimizes how we check whether a published document currently exists for the releases overview page

Instead of using the client directly, it calls `observeDocumentPairAvailability()` from the preview store, which is optimized for sharing across multiple subscribers etc.

### What to review

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
