### PR TITLE
fix(sanity): switch to `RouterContextValue` instance for performing Comlink-driven navigation

### DIFF
--- a/packages/sanity/src/core/studio/hooks/useComlinkRouteHandler.ts
+++ b/packages/sanity/src/core/studio/hooks/useComlinkRouteHandler.ts
@@ -1,8 +1,8 @@
 import {type PathChangeMessage} from '@sanity/message-protocol'
 import {useEffect} from 'react'
+import {useRouter} from 'sanity/router'
 
 import {useComlinkStore} from '../../store/_legacy/datastores'
-import {useRouterHistory} from '../router/RouterHistoryContext'
 
 /**
  * Perform a navigation when a Comlink `dashboard/v1/history/change-path` event is emitted.
@@ -11,22 +11,25 @@ import {useRouterHistory} from '../router/RouterHistoryContext'
  */
 export function useComlinkRouteHandler(): void {
   const {node} = useComlinkStore()
-  const history = useRouterHistory()
+  const {navigateUrl} = useRouter()
 
   useEffect(() => {
     return node?.on<PathChangeMessage['type'], PathChangeMessage>(
       'dashboard/v1/history/change-path',
       ({path}) => {
-        history.push(relativePath(path))
+        navigateUrl({
+          path: sanitizePath(path),
+          replace: false,
+        })
         return undefined
       },
     )
-  }, [history, node])
+  }, [navigateUrl, node])
 }
 
 /**
- * Remove all `/` characters that occur at the beginning of the provided string.
+ * Ensure no more than one `/` character occurs at the beginning of the provided string.
  */
-function relativePath(path: string): string {
-  return path.replace(/^\/+/, '')
+function sanitizePath(path: string): string {
+  return path.replace(/^\/+/, '/')
 }


### PR DESCRIPTION
### Description

Comlink-driven navigation currently relies on the history instance provided by `useRouterHistory`. This does not work correctly for intent resolution when multiple workspaces are present.

This branch fixes the problem by switching to the router instance provided by `useRouter`.

### What to review

- The router usage.

### Testing

- Tested by installing this tagged release in a Studio with multiple workspaces, deploying it to production, and using it in Dashboard. [You can access that Studio in Dashboard here](https://core.sanity.io/@oSyH1iET5/studio/zdd721swr6za1cgp5ot34hxf).
- Tested the same Studio with only a single workspace and verified routing continues to work correctly.
