### PR TITLE
feat(struture): add title and translate aspects

### DIFF
--- a/dev/test-studio/locales/index.ts
+++ b/dev/test-studio/locales/index.ts
@@ -37,14 +37,16 @@ const nbNO = defineLocaleResourceBundle({
     // Used by `fieldGroupsWithI18n` debug schema type
     'field-groups.group-1': '🇳🇴 Gruppe 1',
     'field-groups.group-2': '🇳🇴 Gruppe 2',
+    'text-divider-title': 'Norsk overraskelse 🇳🇴',
   },
 })
 
-const nbNOBStructureOverrides = defineLocaleResourceBundle({
+export const nbNOBStructureOverrides = defineLocaleResourceBundle({
   locale: 'nb-NO',
   namespace: 'structure',
   resources: {
     'default-definition.content-title': 'Innhold 🇳🇴',
+    'text-divider-title': 'Norsk overraskelse 🇳🇴',
   },
 })
 

--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -15,7 +15,12 @@ import {uuid} from '@sanity/uuid'
 import {type Observable, timer} from 'rxjs'
 import {map} from 'rxjs/operators'
 import {type DocumentStore, type SanityDocument, type Schema} from 'sanity'
-import {type ItemChild, type StructureBuilder, type StructureResolver} from 'sanity/structure'
+import {
+  type ItemChild,
+  type StructureBuilder,
+  structureLocaleNamespace,
+  type StructureResolver,
+} from 'sanity/structure'
 
 import {DebugPane} from '../components/panes/debug'
 import {JsonDocumentDump} from '../components/panes/JsonDocumentDump'
@@ -90,7 +95,9 @@ export const structure: StructureResolver = (S, {schema, documentStore, i18n}) =
         ],
       }),
 
-      S.divider(),
+      S.divider()
+        .title('Divider title')
+        .i18n({title: {key: 'text-divider-title', ns: structureLocaleNamespace}}),
 
       _buildTypeGroup(S, schema, {
         id: 'input-standard',

--- a/packages/sanity/src/structure/panes/list/ListPaneContent.tsx
+++ b/packages/sanity/src/structure/panes/list/ListPaneContent.tsx
@@ -1,10 +1,11 @@
-import {Box} from '@sanity/ui'
+import {Box, Text} from '@sanity/ui'
 import {useCallback} from 'react'
 import {
   CommandList,
   type CommandListItemContext,
   type GeneralPreviewLayoutKey,
   useGetI18nText,
+  useI18nText,
 } from 'sanity'
 import {styled} from 'styled-components'
 
@@ -20,12 +21,43 @@ interface ListPaneContentProps {
   title: string
 }
 
+const DividerContainer = styled(Box)`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin: 0.75rem 0 0.25rem 0;
+`
+
 const Divider = styled.hr`
+  flex: 1;
   background-color: var(--card-border-color);
   height: 1px;
   margin: 0;
   border: none;
 `
+
+const DividerTitle = styled(Text)`
+  padding-bottom: 0.75rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+`
+
+interface DividerItemProps {
+  item: PaneListItemDivider
+}
+
+function DividerItem({item}: DividerItemProps) {
+  const {title: dividerTitle} = useI18nText(item)
+  return (
+    <DividerContainer>
+      <DividerTitle weight="semibold" muted size={1}>
+        {dividerTitle}
+      </DividerTitle>
+
+      <Divider />
+    </DividerContainer>
+  )
+}
 
 /**
  * @internal
@@ -67,9 +99,8 @@ export function ListPaneContent(props: ListPaneContentProps) {
 
       if (item.type === 'divider') {
         return (
-          // eslint-disable-next-line react/no-array-index-key
           <Box key={`divider-${itemIndex}`} marginBottom={1}>
-            <Divider />
+            {item.title ? <DividerItem item={item} /> : <Divider />}
           </Box>
         )
       }

--- a/packages/sanity/src/structure/structureBuilder/Divider.ts
+++ b/packages/sanity/src/structure/structureBuilder/Divider.ts
@@ -1,0 +1,67 @@
+import {uniqueId} from 'lodash'
+import {type I18nTextRecord} from 'sanity'
+
+import {type Divider, type Serializable} from './StructureNodes'
+
+export class DividerBuilder implements Serializable<Divider> {
+  protected spec: Divider
+
+  constructor(spec?: Divider) {
+    this.spec = {
+      id: uniqueId('__divider__'),
+      type: 'divider',
+      ...spec,
+    }
+  }
+
+  /** Set the title of the divider
+   * @param title - the title of the divider
+   * @returns divider builder based on title provided
+   */
+  title(title: string): DividerBuilder {
+    return this.clone({
+      title,
+    })
+  }
+
+  /** Get the title of the divider
+   * @returns the title of the divider
+   */
+  getTitle(): Divider['title'] {
+    return this.spec.title
+  }
+
+  /** Set the i18n key and namespace used to populate the localized title.
+   * @param i18n - the key and namespaced used to populate the localized title.
+   * @returns divider builder based on i18n key and ns provided
+   */
+  i18n(i18n: I18nTextRecord<'title'>): DividerBuilder {
+    return this.clone({
+      i18n,
+    })
+  }
+
+  /** Get i18n key and namespace used to populate the localized title
+   * @returns the i18n key and namespace used to populate the localized title
+   */
+  getI18n(): I18nTextRecord<'title'> | undefined {
+    return this.spec.i18n
+  }
+
+  /** Serialize the divider
+   * @returns the serialized divider
+   */
+  serialize(): Divider {
+    return {...this.spec}
+  }
+
+  /** Clone divider builder (allows for options overriding)
+   * @param withSpec - divider builder options
+   * @returns cloned builder
+   */
+  clone(withSpec?: Partial<Divider>): DividerBuilder {
+    const builder = new DividerBuilder()
+    builder.spec = {...this.spec, ...(withSpec || {})}
+    return builder
+  }
+}

--- a/packages/sanity/src/structure/structureBuilder/List.ts
+++ b/packages/sanity/src/structure/structureBuilder/List.ts
@@ -2,6 +2,7 @@ import {find} from 'lodash'
 import {isRecord} from 'sanity'
 
 import {type ChildResolver, type ChildResolverOptions} from './ChildResolver'
+import {DividerBuilder} from './Divider'
 import {isDocumentListItem} from './DocumentListItem'
 import {
   type BuildableGenericList,
@@ -56,12 +57,16 @@ const resolveChildForItem: ChildResolver = (itemId: string, options: ChildResolv
 }
 
 function maybeSerializeListItem(
-  item: ListItem | ListItemBuilder | Divider,
+  item: ListItem | ListItemBuilder | Divider | DividerBuilder,
   index: number,
   path: SerializePath,
 ): ListItem | Divider {
   if (item instanceof ListItemBuilder) {
     return item.serialize({path, index})
+  }
+
+  if (item instanceof DividerBuilder) {
+    return item.serialize()
   }
 
   const listItem = item as ListItem
@@ -104,7 +109,7 @@ export interface List extends GenericList {
  */
 export interface ListInput extends GenericListInput {
   /** List input items array. See {@link ListItem}, {@link ListItemBuilder} and {@link Divider} */
-  items?: (ListItem | ListItemBuilder | Divider)[]
+  items?: (ListItem | ListItemBuilder | Divider | DividerBuilder)[]
 }
 
 /**
@@ -114,7 +119,7 @@ export interface ListInput extends GenericListInput {
  */
 export interface BuildableList extends BuildableGenericList {
   /** List items. See {@link ListItem}, {@link ListItemBuilder} and {@link Divider} */
-  items?: (ListItem | ListItemBuilder | Divider)[]
+  items?: (ListItem | ListItemBuilder | Divider | DividerBuilder)[]
 }
 
 /**
@@ -142,7 +147,7 @@ export class ListBuilder extends GenericListBuilder<BuildableList, ListBuilder> 
    * @param items - list items. See {@link ListItemBuilder}, {@link ListItem} and {@link Divider}
    * @returns list builder based on items provided. See {@link ListBuilder}
    */
-  items(items: (ListItemBuilder | ListItem | Divider)[]): ListBuilder {
+  items(items: (ListItemBuilder | ListItem | Divider | DividerBuilder)[]): ListBuilder {
     return this.clone({items})
   }
 

--- a/packages/sanity/src/structure/structureBuilder/StructureNodes.ts
+++ b/packages/sanity/src/structure/structureBuilder/StructureNodes.ts
@@ -87,6 +87,14 @@ export interface Divider {
    */
   id: string
   type: 'divider'
+  /**
+   * The divider's title
+   */
+  title?: string
+  /**
+   * The i18n key and namespace used to populate the localized title
+   */
+  i18n?: I18nTextRecord<'title'>
 }
 
 /**

--- a/packages/sanity/src/structure/structureBuilder/createStructureBuilder.ts
+++ b/packages/sanity/src/structure/structureBuilder/createStructureBuilder.ts
@@ -1,10 +1,10 @@
 import {type SchemaType} from '@sanity/types'
-import {uniqueId} from 'lodash'
 import {isValidElementType} from 'react-is'
 import {getConfigContextFromSource, getPublishedId, type Source} from 'sanity'
 
 import {structureLocaleNamespace} from '../i18n'
 import {ComponentBuilder, type ComponentInput} from './Component'
+import {DividerBuilder} from './Divider'
 import {DocumentBuilder, documentFromEditor, documentFromEditorWithInitialValue} from './Document'
 import {DocumentListBuilder} from './DocumentList'
 import {DocumentListItemBuilder} from './DocumentListItem'
@@ -126,7 +126,7 @@ export function createStructureBuilder({
         : new ComponentBuilder(spec as ComponentInput)
     },
 
-    divider: (): Divider => ({id: uniqueId('__divider__'), type: 'divider'}),
+    divider: (spec?: Divider) => new DividerBuilder(spec),
 
     view: views,
     context,

--- a/packages/sanity/src/structure/structureBuilder/types.ts
+++ b/packages/sanity/src/structure/structureBuilder/types.ts
@@ -2,6 +2,7 @@ import {type SanityDocument, type SchemaType, type SortOrdering} from '@sanity/t
 import {type ConfigContext, type InitialValueTemplateItem, type Source} from 'sanity'
 
 import {type ComponentBuilder, type ComponentInput} from './Component'
+import {type DividerBuilder} from './Divider'
 import {type DocumentBuilder, type PartialDocumentNode} from './Document'
 import {type DocumentListBuilder, type DocumentListInput} from './DocumentList'
 import {type DocumentListItemBuilder, type DocumentListItemInput} from './DocumentListItem'
@@ -150,9 +151,9 @@ export interface StructureBuilder {
    */
   defaults: () => ListBuilder
   /** Get a structure Divider
-   * @returns a Divider. See {@link Divider}
+   * @returns a DividerBuilder. See {@link DividerBuilder}
    */
-  divider: () => Divider
+  divider: (spec?: Divider) => DividerBuilder
   /** By giving a partial Document Node receive the respective Document Builder
    * @param spec - a partial document node. See {@link PartialDocumentNode}
    * @returns a Document builder. See {@link DocumentBuilder}

--- a/packages/sanity/src/structure/types.ts
+++ b/packages/sanity/src/structure/types.ts
@@ -333,6 +333,14 @@ export interface PaneListItem<TParams = unknown> {
 /** @internal */
 export interface PaneListItemDivider {
   type: 'divider'
+  /**
+   * The title of the divider.
+   */
+  title?: string
+  /**
+   * The i18n key and namespace used to populate the localized title
+   */
+  i18n?: I18nTextRecord<'title'>
 }
 
 /** @internal */


### PR DESCRIPTION
### Description

> [!NOTE]  
> This PR has consciously left out .icons() and .component() methods as to keep it in shorter scope
> There are implications to both in the UI and UX that we don't have time to tackle right now but have been added in a separate story

Add a `.title()` and `.i18n()` methods to the `.divider()` 

<img width="350" alt="image" src="https://github.com/user-attachments/assets/33bb9e16-6a3c-4e1a-a49b-77af3a1b9f72" />

### What to review

Does this make sense? Did I miss anything?

### Testing

You can manually test the translation by following the next steps:

https://github.com/user-attachments/assets/047a3bcd-7fb7-494c-a502-31c11c695ba9

￼- In resolveStructure do
``` 
S.divider()
        .title('Divider title what what')
        .i18n({title: {key: 'text-divider-title', ns: structureLocaleNamespace}}),
```
- You can activate the translate of the studio by going to `userMenu/LocaleMenu` and removing the return nulls
- In the sanity.config.ts for the test studio add `…localPlugins` in the `sharedsettings`plugin 
- Add a key ‘text-divider-title’ to the structure resource

### Notes for release

You can now add a title and translations to the .divider() in the structure builder
