### PR TITLE
refactor: using sanity::partOfRelease where appropriate

### DIFF
--- a/packages/sanity/src/core/releases/store/createReleaseMetadataAggregator.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseMetadataAggregator.ts
@@ -29,7 +29,7 @@ const getFetchQuery = (releaseIds: string[]) => {
       // get a version of the id that is safe to use as key in objects
       const safeId = getSafeKey(bundleId)
 
-      const subquery = `${accSubquery}"${safeId}": *[sanity::partOfRelease(${bundleId})]{_updatedAt, "docId": string::split(_id, ".")[2] } | order(_updatedAt desc),`
+      const subquery = `${accSubquery}"${safeId}": *[sanity::partOfRelease("${bundleId}")]{_updatedAt, "docId": string::split(_id, ".")[2] } | order(_updatedAt desc),`
 
       const projection = `${accProjection}"${releaseId}": {
               "updatedAt": ${safeId}[0]._updatedAt,
@@ -108,7 +108,7 @@ export const createReleaseMetadataAggregator = (client: SanityClient | null) => 
       .listen(
         `*[(${releaseIds.reduce(
           (accQuery, releaseId, index) =>
-            `${accQuery}${index === 0 ? '' : ' ||'} sanity::partOfRelease(${releaseId})`,
+            `${accQuery}${index === 0 ? '' : ' ||'} sanity::partOfRelease("${releaseId}")`,
           '',
         )})]`,
         {},

--- a/packages/sanity/src/core/releases/store/createReleaseMetadataAggregator.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseMetadataAggregator.ts
@@ -29,7 +29,7 @@ const getFetchQuery = (releaseIds: string[]) => {
       // get a version of the id that is safe to use as key in objects
       const safeId = getSafeKey(bundleId)
 
-      const subquery = `${accSubquery}"${safeId}": *[_id in path("versions.${bundleId}.*")]{_updatedAt, "docId": string::split(_id, ".")[2] } | order(_updatedAt desc),`
+      const subquery = `${accSubquery}"${safeId}": *[sanity::partOfRelease(${bundleId})]{_updatedAt, "docId": string::split(_id, ".")[2] } | order(_updatedAt desc),`
 
       const projection = `${accProjection}"${releaseId}": {
               "updatedAt": ${safeId}[0]._updatedAt,
@@ -108,7 +108,7 @@ export const createReleaseMetadataAggregator = (client: SanityClient | null) => 
       .listen(
         `*[(${releaseIds.reduce(
           (accQuery, releaseId, index) =>
-            `${accQuery}${index === 0 ? '' : ' ||'} _id in path("versions.${releaseId}.**")`,
+            `${accQuery}${index === 0 ? '' : ' ||'} sanity::partOfRelease(${releaseId})`,
           '',
         )})]`,
         {},

--- a/packages/sanity/src/core/releases/tool/detail/events/getReleaseEvents.ts
+++ b/packages/sanity/src/core/releases/tool/detail/events/getReleaseEvents.ts
@@ -76,14 +76,19 @@ export function getReleaseEvents({
     ? getReleaseActivityEvents({client, releaseId})
     : notEnabledActivityEvents
 
-  const groqFilter = `sanity::partOfRelease(${getReleaseIdFromReleaseDocumentId(releaseId)})`
+  const groqFilter = `sanity::partOfRelease($releaseId)`
+
   // Turn off document counts listener if eventsAPI is not enabled.
   const documentsCount$ = eventsAPIEnabled
     ? of(0)
     : documentPreviewStore
-        .unstable_observeDocumentIdSet(groqFilter, undefined, {
-          apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion,
-        })
+        .unstable_observeDocumentIdSet(
+          groqFilter,
+          {releaseId: getReleaseIdFromReleaseDocumentId(releaseId)},
+          {
+            apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion,
+          },
+        )
         .pipe(
           filter(({status}) => status === 'connected'),
           map(({documentIds}) => documentIds.length),

--- a/packages/sanity/src/core/releases/tool/detail/events/getReleaseEvents.ts
+++ b/packages/sanity/src/core/releases/tool/detail/events/getReleaseEvents.ts
@@ -76,7 +76,7 @@ export function getReleaseEvents({
     ? getReleaseActivityEvents({client, releaseId})
     : notEnabledActivityEvents
 
-  const groqFilter = `_id in path("versions.${getReleaseIdFromReleaseDocumentId(releaseId)}.*")`
+  const groqFilter = `sanity::partOfRelease(${getReleaseIdFromReleaseDocumentId(releaseId)})`
   // Turn off document counts listener if eventsAPI is not enabled.
   const documentsCount$ = eventsAPIEnabled
     ? of(0)

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -72,13 +72,16 @@ const getActiveReleaseDocumentsObservable = ({
   const client = getClient(RELEASES_STUDIO_CLIENT_OPTIONS)
   const observableClient = client.observable
 
-  // const groqFilter = `_id in path("versions.${releaseId}.**")`
-  const groqFilter = `sanity::partOfRelease(${releaseId})`
+  const groqFilter = `sanity::partOfRelease($releaseId)`
 
   return documentPreviewStore
-    .unstable_observeDocumentIdSet(groqFilter, undefined, {
-      apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion,
-    })
+    .unstable_observeDocumentIdSet(
+      groqFilter,
+      {releaseId},
+      {
+        apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion,
+      },
+    )
     .pipe(
       map((state) => (state.documentIds || []) as string[]),
       mergeMapArray((id: string) => {

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -72,7 +72,8 @@ const getActiveReleaseDocumentsObservable = ({
   const client = getClient(RELEASES_STUDIO_CLIENT_OPTIONS)
   const observableClient = client.observable
 
-  const groqFilter = `_id in path("versions.${releaseId}.**")`
+  // const groqFilter = `_id in path("versions.${releaseId}.**")`
+  const groqFilter = `sanity::partOfRelease(${releaseId})`
 
   return documentPreviewStore
     .unstable_observeDocumentIdSet(groqFilter, undefined, {


### PR DESCRIPTION
### Description
Minor refactor to use `partOfRelease` query rather than our own `_id in ...`
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Verified that the 3 places this touches still load as expected.
<img width="579" alt="Screenshot 2025-05-09 at 15 35 04" src="https://github.com/user-attachments/assets/fd977dc1-dc46-4c9d-9994-7a62dadf92f7" />
Release overview list still loads - tests `createReleaseMetadataAggregator`

<img width="900" alt="Screenshot 2025-05-09 at 15 35 27" src="https://github.com/user-attachments/assets/d4fb5d72-3110-4567-b1f6-db4e228e767f" />
Release detail list still loads - tests `useBundleDocuments`

`getReleaseEvents` is more tricky to visually show, but have verified that the correct subscription is being setup.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
