### PR TITLE
feat: use sanity client to resolve GDR references

### DIFF
--- a/packages/sanity/src/core/form/studio/inputs/globalDocumentReference/StudioGlobalDocumentReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/globalDocumentReference/StudioGlobalDocumentReferenceInput.tsx
@@ -81,7 +81,7 @@ export function StudioGlobalDocumentReferenceInput(
   const {path, schemaType} = props
   const source = useSource()
   const client = source.getClient({
-    apiVersion: '2023-11-13',
+    apiVersion: '2025-02-19',
   })
   const getClient = source.getClient
   const {strategy: searchStrategy} = source.search

--- a/packages/sanity/src/core/form/studio/inputs/globalDocumentReference/datastores/getReferenceClient.ts
+++ b/packages/sanity/src/core/form/studio/inputs/globalDocumentReference/datastores/getReferenceClient.ts
@@ -1,212 +1,28 @@
-import {
-  type Any,
-  type ClientReturn,
-  connectEventSource,
-  type QueryWithoutParams,
-  type SanityClient,
-  type SanityDocument,
-  type ServerSentEvent,
-} from '@sanity/client'
+import {type SanityClient} from '@sanity/client'
 import {type GlobalDocumentReferenceSchemaType} from '@sanity/types'
-import {map, type Observable} from 'rxjs'
-
-import {
-  globalDatasetApiVersion,
-  globalDocumentReferenceApiVersion as apiVersion,
-} from '../constants'
-
-export type ReferenceClient = {
-  getDocument<R extends Record<string, Any>>(
-    id: string,
-    searchParams?: URLSearchParams,
-  ): Observable<SanityDocument<R> | null>
-  getDocuments<R extends Record<string, Any>>(
-    ids: string[],
-    searchParams?: URLSearchParams,
-  ): Observable<{
-    documents: SanityDocument<R>[]
-    omitted: {id: string; reason: 'existence' | 'permission'}[]
-  }>
-  query<
-    R = Any,
-    Q extends Record<string, unknown> | undefined = QueryWithoutParams,
-    G extends string = string,
-  >(
-    query: G,
-    params?: Q | QueryWithoutParams,
-  ): Observable<ClientReturn<G, R>>
-  listen<
-    Q extends Record<string, string> | undefined = QueryWithoutParams,
-    G extends string = string,
-  >(
-    query: G,
-    params?: Q | QueryWithoutParams,
-    opts?: {includeResult?: boolean},
-  ): Observable<ServerSentEvent<'mutation' | 'welcome'>>
-}
 
 export function getReferenceClient(
   client: SanityClient,
   schemaType: GlobalDocumentReferenceSchemaType,
-): ReferenceClient {
+): SanityClient {
   if (schemaType.resourceType === 'dataset') {
     const [projectId, datasetName] = schemaType.resourceId.split('.', 2)
-    return {
-      getDocument<R extends Record<string, Any>>(
-        id: string,
-        searchParams?: URLSearchParams,
-      ): Observable<SanityDocument<R> | null> {
-        const tag = searchParams?.get('tag') || undefined
-        searchParams?.delete('tag')
-        return client
-          .withConfig({
-            useProjectHostname: false,
-            apiVersion: globalDatasetApiVersion,
-          })
-          .observable.request({
-            useGlobalApi: true,
-            uri: `/projects/${projectId}/datasets/${datasetName}/doc/${id}?${searchParams?.toString() || ''}`,
-            method: 'GET',
-            tag,
-          })
-          .pipe(map((res) => res.documents[0]))
+    return client.withConfig({
+      'apiVersion': 'X',
+      '~experimental_resource': {
+        type: 'dataset',
+        id: `${projectId}.${datasetName}`,
       },
-      getDocuments<R extends Record<string, Any>>(
-        ids: string[],
-        searchParams?: URLSearchParams,
-      ): Observable<{
-        documents: SanityDocument<R>[]
-        omitted: {id: string; reason: 'existence' | 'permission'}[]
-      }> {
-        const tag = searchParams?.get('tag') || undefined
-        searchParams?.delete('tag')
-        return client
-          .withConfig({
-            useProjectHostname: false,
-            apiVersion: globalDatasetApiVersion,
-          })
-          .observable.request({
-            useGlobalApi: true,
-            uri: `/projects/${projectId}/datasets/${datasetName}/doc/${ids.join(',')}?${searchParams?.toString() || ''}`,
-            method: 'GET',
-            tag,
-          })
-      },
-      query<
-        R = Any,
-        Q extends Record<string, unknown> | undefined = QueryWithoutParams,
-        G extends string = string,
-      >(query: G, params: Q) {
-        return client.observable
-          .withConfig({
-            useProjectHostname: false,
-            apiVersion: globalDatasetApiVersion,
-          })
-          .request<{result: ClientReturn<G, R>}>({
-            url: `/projects/${projectId}/datasets/${datasetName}/query`,
-            useGlobalApi: true,
-            method: 'POST',
-            body: {query, params},
-            tag: 'sanity.studio.gdr.query',
-          })
-          .pipe(map((res) => res.result))
-      },
-      listen<
-        Q extends Record<string, string> | undefined = QueryWithoutParams,
-        G extends string = string,
-      >(query: G, params: Q, opts: {includeResult?: boolean} = {}) {
-        // add $ as a prefix to all keys in the params
-        const queryParams = Object.keys(params || {}).reduce<Record<string, string>>((acc, key) => {
-          acc[`$${key}`] = `"${params![key]}"`
-          return acc
-        }, {})
-        const allParams = {...queryParams, tag: 'sanity.studio.listen.gdr', query} as Record<
-          string,
-          string
-        >
-        if (opts.includeResult) {
-          allParams.includeResult = 'true'
-        }
-        const paramsString = new URLSearchParams(allParams).toString()
-        const uri = `${client.config().apiHost}/${globalDatasetApiVersion}/projects/${projectId}/datasets/${datasetName}/listen?${paramsString}`
-        return connectEventSource(
-          () => new EventSource(uri, {withCredentials: true}),
-          ['welcome', 'mutation'],
-        )
-      },
-    } satisfies ReferenceClient
+    })
   }
-  if (schemaType.resourceType === 'media-library') {
-    return {
-      getDocument<R extends Record<string, Any>>(
-        id: string,
-        searchParams?: URLSearchParams,
-      ): Observable<SanityDocument<R> | null> {
-        const tag = searchParams?.get('tag') || undefined
-        searchParams?.delete('tag')
-        return client
-          .withConfig({
-            useProjectHostname: false,
-            apiVersion,
-          })
-          .observable.request({
-            useGlobalApi: true,
-            uri: `/media-libraries/${schemaType.resourceId}/doc/${id}?${searchParams?.toString() || ''}`,
-            method: 'GET',
-            tag,
-          })
-          .pipe(map((res) => res.documents[0]))
+  if (schemaType.resourceType === 'media-library' || schemaType.resourceType === 'canvas') {
+    return client.withConfig({
+      'apiVersion': '2025-02-19',
+      '~experimental_resource': {
+        type: schemaType.resourceType,
+        id: schemaType.resourceId,
       },
-      getDocuments<R extends Record<string, Any>>(
-        ids: string[],
-        searchParams?: URLSearchParams,
-      ): Observable<{
-        documents: SanityDocument<R>[]
-        omitted: {id: string; reason: 'existence' | 'permission'}[]
-      }> {
-        const tag = searchParams?.get('tag') || undefined
-        searchParams?.delete('tag')
-        return client
-          .withConfig({
-            useProjectHostname: false,
-            apiVersion,
-          })
-          .observable.request({
-            useGlobalApi: true,
-            uri: `/${apiVersion}/media-libraries/${schemaType.resourceId}/doc/${ids.join(',')}?${searchParams?.toString() || ''}`,
-            method: 'GET',
-            tag,
-          })
-      },
-      query<
-        R = Any,
-        Q extends Record<string, unknown> | undefined = QueryWithoutParams,
-        G extends string = string,
-      >(query: G, params: Q) {
-        return client
-          .withConfig({
-            useProjectHostname: false,
-            apiVersion,
-          })
-          .observable.request<{result: ClientReturn<G, R>}>({
-            useGlobalApi: true,
-            uri: `/media-libraries/${schemaType.resourceId}/query`,
-            method: 'POST',
-            body: {query, params},
-            tag: 'gdr.query',
-          })
-          .pipe(map((res) => res.result))
-      },
-      listen<
-        Q extends Record<string, string> | undefined = QueryWithoutParams,
-        G extends string = string,
-      >(query: G, params: Q) {
-        const allParams = {...params, tag: 'listen', query}
-        const paramsString = new URLSearchParams(allParams).toString()
-        const uri = `${client.config().apiHost}/${apiVersion}/media-libraries/${schemaType.resourceId}/listen?${paramsString}`
-        return connectEventSource(() => new EventSource(uri, {}), ['welcome', 'mutation'])
-      },
-    } satisfies ReferenceClient
+    })
   }
   throw new Error(`Invalid resource type "${schemaType.resourceType}"`)
 }

--- a/packages/sanity/src/core/form/studio/inputs/globalDocumentReference/datastores/search.ts
+++ b/packages/sanity/src/core/form/studio/inputs/globalDocumentReference/datastores/search.ts
@@ -1,3 +1,4 @@
+import {type SanityClient} from '@sanity/client'
 import {
   type GlobalDocumentReferenceSchemaType,
   type GlobalDocumentReferenceType,
@@ -12,7 +13,6 @@ import {createSearchQuery} from '../../../../../search/groq2024/createSearchQuer
 import {getNextCursor} from '../../../../../search/groq2024/getNextCursor'
 import {type SearchParams} from '../../../../../search/weighted/createSearchQuery'
 import {collate} from '../../../../../util'
-import {type ReferenceClient} from './getReferenceClient'
 
 interface SearchHit {
   id: string
@@ -23,7 +23,7 @@ interface SearchHit {
 const limit = 10
 
 function doSearch(
-  client: ReferenceClient,
+  client: SanityClient,
   searchTerm: string,
   types: GlobalDocumentReferenceType[],
   searchOptions: ReferenceFilterSearchOptions,
@@ -34,7 +34,7 @@ function doSearch(
     searchOptions,
   )
 
-  return client.query<SanityDocumentLike[], SearchParams>(query, params).pipe(
+  return client.observable.fetch<SanityDocumentLike[], SearchParams>(query, params).pipe(
     map((hits) => {
       const hasNextPage = typeof limit !== 'undefined' && hits.length > limit
 
@@ -54,7 +54,7 @@ function doSearch(
 }
 
 export function search(
-  client: ReferenceClient,
+  client: SanityClient,
   textTerm: string,
   type: GlobalDocumentReferenceSchemaType,
   options: ReferenceFilterSearchOptions,


### PR DESCRIPTION
### Description

We were using a "fake" resource client to resolve GDR referenced documents. Now that we have resource support in the sanity client we can use the client to resolve these.

### What to review

Correctness

### Testing

Since this is more of a refactor, the functionality should stay the same, so no tests should be added or removed.

### Notes for release

N/A : No notes needed, more an internal improvements for future maintainability 