### PR TITLE
feat: notify user about Media Library was not found

### DIFF
--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibrary.test.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibrary.test.tsx
@@ -1,0 +1,145 @@
+import {type SanityClient} from '@sanity/client'
+import {type AssetSourceComponentProps} from '@sanity/types'
+import {render, screen, waitFor} from '@testing-library/react'
+import {noop} from 'lodash'
+import {describe, expect, test} from 'vitest'
+
+import {createMockSanityClient} from '../../../../../../test/mocks/mockSanityClient'
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {defineConfig} from '../../../../config'
+import {createSanityMediaLibraryFileSource} from '../createAssetSource'
+
+const fileAssetSource = createSanityMediaLibraryFileSource({
+  libraryId: null,
+})
+
+const projectId = 'mock-project-id'
+const organizationId = 'mock-organization-id'
+
+function createWrapperComponent(client: SanityClient) {
+  const config = defineConfig({
+    projectId,
+    dataset: 'test',
+  })
+
+  return createTestProvider({
+    client,
+    config,
+  })
+}
+const AssetSourceComponent = fileAssetSource.component
+const assetSourceComponentProps: AssetSourceComponentProps = {
+  accept: '*/*',
+  action: 'select',
+  assetSource: fileAssetSource,
+  assetType: 'file',
+  selectionType: 'single',
+  selectedAssets: [],
+  onClose: noop,
+  onSelect: noop,
+}
+
+const assetSourceComponent = <AssetSourceComponent {...assetSourceComponentProps} />
+
+describe('provisioning', () => {
+  test('renders error when organizationId is not found', async () => {
+    const client = createMockSanityClient({
+      requests: {
+        '/projects/mock-project-id': {
+          organizationId: undefined,
+        },
+      },
+    })
+    const TestProvider = await createWrapperComponent(client as any)
+
+    const {getByTestId} = render(<TestProvider>{assetSourceComponent}</TestProvider>)
+
+    await waitFor(() => {
+      expect(getByTestId('media-library-provision-error')).toBeInTheDocument()
+      expect(getByTestId('ERROR_NO_ORGANIZATION_FOUND')).toBeInTheDocument()
+    })
+  })
+
+  test('renders error when there are no Media Libraries result', async () => {
+    const client = createMockSanityClient({
+      requests: {
+        '/projects/mock-project-id': {
+          organizationId,
+        },
+      },
+    })
+    const TestProvider = await createWrapperComponent(client as any)
+
+    const {getByTestId} = render(<TestProvider>{assetSourceComponent}</TestProvider>)
+
+    await waitFor(() => {
+      expect(getByTestId('media-library-provision-error')).toBeInTheDocument()
+      expect(getByTestId('ERROR_NO_MEDIA_LIBRARIES_FOUND')).toBeInTheDocument()
+    })
+  })
+
+  test('provisions', async () => {
+    const client = createMockSanityClient({
+      requests: {
+        '/projects/mock-project-id': {
+          organizationId,
+        },
+        '/media-libraries?organizationId=mock-organization-id': {
+          data: [],
+        },
+        // POST request response to provision a Media Library with invalid response
+        '/media-libraries': {foo: 'bar'},
+      },
+    })
+    const TestProvider = await createWrapperComponent(client as any)
+    const {getByTestId} = render(<TestProvider>{assetSourceComponent}</TestProvider>)
+
+    await waitFor(() => {
+      expect(getByTestId('media-library-provision-error')).toBeInTheDocument()
+      expect(getByTestId('ERROR_FAILED_TO_CREATE_MEDIA_LIBRARY')).toBeInTheDocument()
+    })
+  })
+
+  test('provisions', async () => {
+    const client = createMockSanityClient({
+      requests: {
+        '/projects/mock-project-id': {
+          organizationId,
+        },
+        '/media-libraries?organizationId=mock-organization-id': {
+          data: [],
+        },
+        // POST request response to provision a Media Library
+        '/media-libraries': {
+          id: 'mock-library-id',
+          name: 'Mock Media Library',
+          organizationId,
+          status: 'provisioning',
+        },
+        '/media-libraries/mock-library-id': {
+          id: 'mock-library-id',
+          name: 'Mock Media Library',
+          organizationId,
+          status: 'active',
+        },
+      },
+    })
+    const TestProvider = await createWrapperComponent(client as any)
+    render(<TestProvider>{assetSourceComponent}</TestProvider>)
+
+    // Provisioning message should be shown
+    await waitFor(() => {
+      expect(screen.queryByTestId('media-library-provisioning-message')).toBeInTheDocument()
+    })
+
+    // Provisioning message should not be shown after the Media Library is provisioned
+    await waitFor(() => {
+      expect(screen.queryByTestId('media-library-provisioning-message')).not.toBeInTheDocument()
+    })
+
+    // Media Library dialog should be shown
+    await waitFor(() => {
+      expect(screen.queryByTestId('media-library-plugin-dialog-select-assets')).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/hooks/useProvision.ts
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/hooks/useProvision.ts
@@ -1,0 +1,212 @@
+/* eslint-disable max-nested-callbacks */
+import {type ObservableSanityClient} from '@sanity/client'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {
+  catchError,
+  concat,
+  concatMap,
+  interval,
+  type Observable,
+  of,
+  switchMap,
+  takeWhile,
+} from 'rxjs'
+
+import {useClient} from '../../../../hooks/useClient'
+import {type MediaLibrary} from '../types'
+
+export type ProvisionErrorCode =
+  | 'ERROR_NO_MEDIA_LIBRARIES_FOUND'
+  | 'ERROR_NO_ORGANIZATION_FOUND'
+  | 'ERROR_FAILED_TO_CREATE_MEDIA_LIBRARY'
+
+export class ProvisionError extends Error {
+  message: string
+  error: string
+  code: ProvisionErrorCode
+  // eslint-disable-next-line unicorn/custom-error-definition
+  constructor(message: string, error: string, code: ProvisionErrorCode) {
+    // eslint-disable-next-line unicorn/custom-error-definition
+    super(message)
+    this.message = message
+    this.error = error
+    this.code = code
+  }
+}
+
+type ProvisionResponse = {
+  id?: string
+  organizationId?: string
+  status: 'provisioning' | 'active' | 'loading'
+}
+
+function getMediaLibrariesForOrganization(
+  client: ObservableSanityClient,
+  organizationId: string,
+): Observable<MediaLibrary[]> {
+  return client
+    .request({
+      uri: `/media-libraries?organizationId=${organizationId}`,
+      method: 'GET',
+    })
+    .pipe(
+      concatMap((data) => {
+        if (data && Array.isArray(data.data)) {
+          return of(data.data)
+        }
+        throw new ProvisionError(
+          'No media libraries found',
+          'No media libraries found',
+          'ERROR_NO_MEDIA_LIBRARIES_FOUND',
+        )
+      }),
+    )
+}
+
+function getOrganizationIdFromProjectId(
+  client: ObservableSanityClient,
+  projectId: string,
+): Observable<string> {
+  return client
+    .request({
+      uri: `/projects/${projectId}`,
+      method: 'GET',
+    })
+    .pipe(
+      concatMap(async (data) => {
+        if (data.organizationId) {
+          return data.organizationId
+        }
+        throw new ProvisionError(
+          'Organization ID not found',
+          'Organization ID not found',
+          'ERROR_NO_ORGANIZATION_FOUND',
+        )
+      }),
+    )
+}
+
+function requestMediaLibraryStatus(
+  client: ObservableSanityClient,
+  libraryId: string,
+): Observable<ProvisionResponse> {
+  return client
+    .request({
+      uri: `/media-libraries/${libraryId}`,
+      method: 'GET',
+    })
+    .pipe(
+      concatMap((data) => {
+        if (data && data.id) {
+          return of({
+            id: data.id,
+            organizationId: data.organizationId,
+            status: data.status,
+          } satisfies ProvisionResponse)
+        }
+        throw new ProvisionError(
+          'Media library not found',
+          'Media library not found',
+          'ERROR_NO_MEDIA_LIBRARIES_FOUND',
+        )
+      }),
+    )
+}
+
+function createMediaLibrary(
+  client: ObservableSanityClient,
+  organizationId: string,
+): Observable<ProvisionResponse> {
+  return client.request({
+    uri: `/media-libraries`,
+    method: 'POST',
+    body: {organizationId},
+  })
+}
+
+export function useProvision(
+  projectId: string,
+  onProvisionError?: (error: ProvisionError) => Observable<ProvisionResponse>,
+  onLibraryId?: (libraryId: string) => void,
+): ProvisionResponse {
+  if (!projectId) {
+    throw new Error('projectId is required to fetch organizationId')
+  }
+  const client = useClient({apiVersion: 'vX'}).observable
+  const observable = useMemo(
+    () =>
+      getOrganizationIdFromProjectId(client, projectId).pipe(
+        switchMap((organizationId) => {
+          // console.log('Fetched Organization ID:', organizationId)
+          return getMediaLibrariesForOrganization(client, organizationId).pipe(
+            concatMap((mediaLibraryData) => {
+              if (mediaLibraryData.length > 0) {
+                const id = mediaLibraryData[0].id
+                if (onLibraryId) {
+                  onLibraryId(id)
+                }
+                return of({id, organizationId, status: 'active'} satisfies ProvisionResponse)
+              }
+              return createMediaLibrary(client, organizationId).pipe(
+                // eslint-disable-next-line max-nested-callbacks
+                concatMap((createdData) => {
+                  if (createdData && createdData.id) {
+                    return of({
+                      id: createdData.id,
+                      organizationId,
+                      status: 'provisioning',
+                    } satisfies ProvisionResponse)
+                  }
+                  throw new ProvisionError(
+                    'Failed to create Media Library',
+                    'Failed to create Media Library',
+                    'ERROR_FAILED_TO_CREATE_MEDIA_LIBRARY',
+                  )
+                }),
+                concatMap((libraryData) =>
+                  concat(
+                    of(libraryData), // Emit the initial response immediately
+                    interval(1000).pipe(
+                      concatMap(() => {
+                        // Poll for the media library status
+                        if (libraryData.id) {
+                          return requestMediaLibraryStatus(client, libraryData.id).pipe(
+                            concatMap((statusData) => {
+                              if (statusData.status === 'active') {
+                                if (onLibraryId) {
+                                  onLibraryId(statusData.id ?? '')
+                                }
+                              }
+                              return of(libraryData)
+                            }),
+                          )
+                        }
+                        return of(libraryData)
+                      }),
+                      takeWhile((pData) => pData?.status === 'provisioning', true),
+                    ),
+                  ),
+                ),
+              )
+            }),
+          )
+        }),
+        catchError((err) => {
+          if (err instanceof ProvisionError && onProvisionError !== undefined) {
+            return onProvisionError(err)
+          }
+          throw err
+        }),
+      ),
+    [client, projectId, onLibraryId, onProvisionError],
+  )
+
+  return (
+    useObservable(observable) ?? {
+      id: undefined,
+      organizationId: undefined,
+      status: 'loading',
+    }
+  )
+}

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/Provisioning.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/Provisioning.tsx
@@ -1,0 +1,89 @@
+import {ErrorOutlineIcon} from '@sanity/icons'
+import {Card, Flex, Spinner, Stack, Text} from '@sanity/ui'
+import {useCallback, useState} from 'react'
+
+import {ErrorBoundary} from '../../../../../ui-components/errorBoundary'
+import {useTranslation} from '../../../../i18n/hooks/useTranslation'
+import {ProvisionError, useProvision} from '../hooks/useProvision'
+
+const Provision = function Provision(props: {
+  projectId: string
+  onSetMediaLibraryId: (id: string) => void
+}) {
+  const {t} = useTranslation()
+  const {status} = useProvision(
+    props.projectId,
+    (err) => {
+      throw err
+    },
+    (libraryId) => {
+      props.onSetMediaLibraryId(libraryId)
+    },
+  )
+  if (status === 'provisioning') {
+    return (
+      <Card padding={4} radius={4} tone="caution">
+        <Flex gap={3}>
+          <Text size={1}>
+            <Spinner />
+          </Text>
+          <Stack space={4}>
+            <Text size={1} weight="semibold" data-testid="media-library-provisioning-message">
+              {t('asset-sources.media-library.info.provisioning')}
+            </Text>
+          </Stack>
+        </Flex>
+      </Card>
+    )
+  }
+  return null
+}
+
+export const Provisioning = function Provisioning(props: {
+  projectId: string
+  onSetMediaLibraryId: (id: string) => void
+}) {
+  const [provisionError, setProvisionError] = useState<{
+    error: Error
+    info: React.ErrorInfo
+  } | null>(null)
+
+  const {t} = useTranslation()
+
+  const handleProvisionError = useCallback(
+    ({error, info}: {error: Error; info: React.ErrorInfo}) => {
+      console.error(error, info)
+      setProvisionError({error, info})
+    },
+    [],
+  )
+
+  if (provisionError) {
+    let errorCodeTestId = 'ERROR_UNKNOWN'
+    if (provisionError.error instanceof ProvisionError) {
+      errorCodeTestId = provisionError.error.code
+    }
+    return (
+      <Card padding={4} radius={4} tone="critical" data-testid="media-library-provision-error">
+        <Flex gap={3}>
+          <Text size={1}>
+            <ErrorOutlineIcon />
+          </Text>
+          <Stack space={4} data-testid={errorCodeTestId}>
+            <Text size={1} weight="semibold">
+              {provisionError.error.message ||
+                t('asset-sources.media-library.error.library-not-found')}
+            </Text>
+          </Stack>
+        </Flex>
+      </Card>
+    )
+  }
+  return (
+    <>
+      <ErrorBoundary onCatch={handleProvisionError}>
+        <Provision projectId={props.projectId} onSetMediaLibraryId={props.onSetMediaLibraryId} />
+      </ErrorBoundary>
+    </>
+  )
+}

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
@@ -82,10 +82,11 @@ export function SelectAssetsDialog(props: SelectAssetsDialogProps): ReactNode {
     <AppDialog
       animate
       header={dialogHeaderTitle}
-      id="sanity-media-library-plugin-dialog-select-assets"
+      id="media-library-plugin-dialog-select-assets"
       onClose={handleClose}
       open
       ref={ref}
+      data-testid="media-library-plugin-dialog-select-assets"
       width={3}
       footer={
         <Flex width="full" gap={3} justify="flex-end" padding={2}>

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/types.ts
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/types.ts
@@ -1,6 +1,15 @@
 import {type SanityDocument} from '@sanity/types'
 
 /**
+ * @alpha
+ */
+export type MediaLibrary = {
+  id: string
+  organizationId: string
+  status: 'active' | 'provisioning'
+}
+
+/**
  * Config for the Media Library Asset Source
  * @alpha
  */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -168,12 +168,17 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'asset-sources.dataset.file.title': 'Workspace files',
   'asset-sources.dataset.image.title': 'Workspace images',
 
+  /** Error messages for the Media Library Asset Source  */
+  'asset-sources.media-library.error.library-not-found':
+    'No available Media Library was found for this project.',
+
   /** Menu Items for Media Library Asset Source */
   'asset-sources.media-library.file.title': 'Media Library',
   'asset-sources.media-library.image.title': 'Media Library',
 
-  /** Error messages for the Media Library Asset Source  */
-  'asset-sources.media-library.error.library-not-found': 'No available Media Library was found for this project.',
+  /** Info messages for the Media Library Asset Source  */
+  'asset-sources.media-library.info.provisioning':
+    'Please wait while we prepare your Media Library',
 
   /** Label when a release has been deleted by a different user */
   'banners.deleted-bundle-banner.text':

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -172,6 +172,9 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'asset-sources.media-library.file.title': 'Media Library',
   'asset-sources.media-library.image.title': 'Media Library',
 
+  /** Error messages for the Media Library Asset Source  */
+  'asset-sources.media-library.error.library-not-found': 'No available Media Library was found for this project.',
+
   /** Label when a release has been deleted by a different user */
   'banners.deleted-bundle-banner.text':
     "The '<strong>{{title}}</strong>' release has been deleted.",

--- a/packages/sanity/test/mocks/mockSanityClient.ts
+++ b/packages/sanity/test/mocks/mockSanityClient.ts
@@ -66,6 +66,7 @@ export function createMockSanityClient(
 
   const apiVersion = (options.apiVersion || '1').replace(/^v/, '')
   const mockConfig = {
+    apiHost: 'mock.api.sanity.io',
     useCdn: false,
     projectId: 'mock-project-id',
     dataset: 'mock-data-set',


### PR DESCRIPTION
### Description

This will seamlessly create a Media Library for the organization if it doesn't exist when the user is interacting with the Studio Asset Source for the Media Library.

Also wrote tests for this.


https://github.com/user-attachments/assets/23d11f8c-fdfe-4690-bbdb-9016831e3df7


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
