### PR TITLE
fix(core): remove duplicated call to useBundleDocuments

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/AddDocumentSearch.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/AddDocumentSearch.tsx
@@ -3,7 +3,6 @@ import {LayerProvider, PortalProvider} from '@sanity/ui'
 
 import {SearchPopover} from '../../../studio/components/navbar/search/components/SearchPopover'
 import {SearchProvider} from '../../../studio/components/navbar/search/contexts/search/SearchProvider'
-import {useBundleDocuments} from './useBundleDocuments'
 
 export type AddedDocument = Pick<SanityDocument, '_id' | '_type' | 'title'> &
   Partial<SanityDocument>
@@ -12,14 +11,13 @@ export function AddDocumentSearch({
   open,
   onClose,
   releaseId,
+  idsInRelease,
 }: {
   open: boolean
   onClose: (document?: AddedDocument) => void
   releaseId: string
+  idsInRelease: string[]
 }): React.JSX.Element {
-  const {results} = useBundleDocuments(releaseId)
-  const idsInRelease: string[] = results.map((doc) => doc.document._id)
-
   return (
     <LayerProvider zOffset={1}>
       <SearchProvider disabledDocumentIds={idsInRelease} canDisableAction>

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -205,6 +205,7 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
         open={openAddDocumentDialog}
         onClose={closeAddDialog}
         releaseId={releaseId}
+        idsInRelease={aggregatedData.map(({document}) => document._id)}
       />
     </Card>
   )


### PR DESCRIPTION
### Description
When reviewing releases with more than 1000 documents I found that we are doing a duplicated invocation of `useBundleDocuments`, this hook is the one that gets all the documents in the release, validates them and gets the preview for them.
By calling this hook in two components inside the `ReleasesDetail` view we are duplicating all of this logic, in small releases it's not a big problem, but in very large ones this could lead to thousands of queries being duplicated and eventually crashing.

As next steps we could think on moving this to a cached store so we can reuse the hook anywhere with no risks, but doing this now feels like an unnecessary risk.
We should also consider how we fetch and validate data in the releases overview screen given we are also calling this hook there in `ReleaseMenuButtonWrapper` 


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is search inside releases still working as before?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
