### PR TITLE
chore(renovate): remove ESBuild <=0.21 allowance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -106,11 +106,6 @@
       "schedule": ["every weekday"]
     },
     {
-      "description": "ESBuild 0.23 drops support for Windows 7 and 8, for now we don't want renovate to open PRs to bump them",
-      "allowedVersions": "<=0.21",
-      "matchPackageNames": ["esbuild"]
-    },
-    {
       "description": "Group TypeScript related deps in a single PR, as they often have to update together",
       "groupName": "typescript-tooling",
       "matchPackageNames": ["@sanity/pkg-utils", "@sanity/tsdoc", "typescript"]


### PR DESCRIPTION
### Description

[ESBuild <= 0.21 is allowed by our Renovate config](https://github.com/sanity-io/sanity/blob/de31066a46a4405380c3749031d65451f73f2734/.github/renovate.json#L108-L112), so we have no automation to keep the four ESBuild dependencies across the monorepo in sync. We added this exception because subsequent ESBuild releases removed support for Windows 7 & 8.

The result is that we have no automation for updating ESBuild security patches. Members of the community have kindly opened PRs to update ESBuild, however, we now have a combination of ESBuild versions in the monorepo. We should keep these versions consistent.

Important security fixes (e.g. [GHSA-67mh-4wv8-2f99](https://github.com/advisories/GHSA-67mh-4wv8-2f99)) have not been backported to older ESBuild versions. We have decided to remove the ESBuild exception from Renovate, and update to the latest version.

### What to review

- The Renovate configuration.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

We have updated to the latest version of ESBuild in order to include security fixes. This version of ESBuild drops support for Windows 7 & 8. Therefore, Sanity CLI no longer supports these platforms.