### PR TITLE
fix(core): strip NULL-characters from exif string fields

### DIFF
--- a/packages/sanity/src/core/form/studio/uploads/image/readExif.ts
+++ b/packages/sanity/src/core/form/studio/uploads/image/readExif.ts
@@ -23,9 +23,43 @@ const SKIP_EXIF_ERROR_RE = /(invalid image format)|(No exif data)/i
 // 128k should be enough for exif data according to https://github.com/mattiasw/ExifReader#tips
 const EXIF_BUFFER_LENGTH = 128000
 
+/**
+ * Sanitizes string values in EXIF data to handle null-terminated strings
+ * from manufacturers like Fujifilm. This prevents Unicode validation errors
+ * when storing the data in Sanity.
+ */
+function sanitizeExifData(exifData: unknown): Record<string, unknown> {
+  // If exifData is null, undefined, or not an object, return an empty object
+  if (!exifData || typeof exifData !== 'object') {
+    return {}
+  }
+
+  const result: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(exifData as Record<string, unknown>)) {
+    if (typeof value === 'string') {
+      // Trim the string at the first null character (if any)
+      const nullTerminatorIndex = value.indexOf('\0')
+      if (nullTerminatorIndex === -1) {
+        result[key] = value
+      } else {
+        result[key] = value.slice(0, Math.max(0, nullTerminatorIndex))
+      }
+    } else if (value !== null && typeof value === 'object') {
+      // Recursively sanitize nested objects
+      result[key] = sanitizeExifData(value)
+    } else {
+      result[key] = value
+    }
+  }
+
+  return result
+}
+
 export function readExif(file: File) {
   return observableFrom(readFileAsArrayBuffer(file, EXIF_BUFFER_LENGTH)).pipe(
     map((buf) => exif(buf)),
+    map((exifData) => sanitizeExifData(exifData)), // Sanitize the EXIF data
     catchError((error) => {
       if (!SKIP_EXIF_ERROR_RE.test(error.message)) {
         // Exif read failed, we do not want to fail hard


### PR DESCRIPTION
### Description

This PR trims null characters from EXIF string fields (e.g., LensModel) returned by exif-component, which are causing validation errors with certain camera metadata (notably from Fujifilm). The solution wraps the parsed EXIF object and sanitizes all string values to remove `\u0000` characters before further use.  Fixes #9394 

### What to review

Upload the offending example image and confirm the error doesn't happen and that good looking exif data appears attached to the asset.

### Testing

I coudln't find any valid tests.

I don't know how to run a full test studio from my fork (is that embarassing?) I feel bad submitting it without actually running the code but I don't know how.

### Notes for release

* Fixes bug which will now allow images with unusual EXIF data to be uploaded to as assets when using optional exif setting