### PR TITLE
chore(test-studio): add vite-ignore to dynamic imports to silence warning

### DIFF
--- a/dev/test-studio/plugins/error-reporting-test/ErrorReportingTest.tsx
+++ b/dev/test-studio/plugins/error-reporting-test/ErrorReportingTest.tsx
@@ -7,7 +7,7 @@ function triggerCustomErrorOnEvent() {
 
 function triggerImportError() {
   const filename = '/does-not-exist.js'
-  import(filename)
+  import(/* @vite-ignore */ filename)
 }
 
 function triggerTypeErrorOnEvent(evt: any) {
@@ -116,7 +116,7 @@ export function ErrorReportingTest() {
 
 const ReactLazyError = lazy(() => {
   const name = '/does-not-exist.js'
-  return import(name)
+  return import(/* @vite-ignore */ name)
 })
 
 function WithRenderError({text}: any) {


### PR DESCRIPTION
### Description
Silences the following warning that was introduced by #9349
```
./test-studio/plugins/error-reporting-test/ErrorReportingTest.tsx
225|  const ReactLazyError = lazy(_c3 = () => {
226|    const name = "/does-not-exist.js";
227|    return import(name);
   |                  ^^^^
228|  });
229|  _c4 = ReactLazyError;
The above dynamic import cannot be analyzed by Vite.
See https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.

  Plugin: vite:import-analysis
  File: ./test-studio/plugins/error-reporting-test/ErrorReportingTest.tsx
```

### Notes for release
n/a
