### PR TITLE
fix(cli): remove projectId and dataset strings from app templates

### DIFF
--- a/packages/@sanity/cli/templates/app-quickstart/src/App.tsx
+++ b/packages/@sanity/cli/templates/app-quickstart/src/App.tsx
@@ -7,8 +7,8 @@ export function App() {
   // apps can access many different projects or other sources of data
   const sanityConfigs: SanityConfig[] = [
     {
-      projectId: 'project-id',
-      dataset: 'dataset-name',
+      projectId: '',
+      dataset: '',
     }
   ]
 

--- a/packages/@sanity/cli/templates/app-sanity-ui/src/App.tsx
+++ b/packages/@sanity/cli/templates/app-sanity-ui/src/App.tsx
@@ -10,8 +10,8 @@ export function App() {
   // apps can access many different projects or other sources of data
   const sanityConfigs: SanityConfig[] = [
     {
-      projectId: 'project-id',
-      dataset: 'dataset-name',
+      projectId: '',
+      dataset: '',
     }
   ]
 


### PR DESCRIPTION
### Description
The "example" strings with projectId and dataset were added before certain changes to the template and the SDK. In its current state, it tries to get permissions from a project and dataset that do not exist, meaning the first experience a user has with a template is an error.

The only hook in the template can work without a projectId or dataset, so the initial load does not present the user with an error.

### What to review
Does this make sense to a new user? Is there a better way to approach this?

### Testing
Probably the best way to test this is to use our existing init command (`pnpx sanity@latest init --template app-quickstart`), remove the projectId and dataset, and see the result. It should be an error-free app.

### Notes for release
Removes the default projectId and dataset from the App SDK templates.