### PR TITLE
chore(cli): update runtime cli

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -60,7 +60,7 @@
     "@babel/traverse": "^7.23.5",
     "@sanity/client": "^7.2.1",
     "@sanity/codegen": "workspace:*",
-    "@sanity/runtime-cli": "^7.0.2",
+    "@sanity/runtime-cli": "^7.0.3",
     "@sanity/telemetry": "^0.8.0",
     "@sanity/template-validator": "^2.4.3",
     "@sanity/util": "workspace:3.88.2",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -60,7 +60,7 @@
     "@babel/traverse": "^7.23.5",
     "@sanity/client": "^7.2.1",
     "@sanity/codegen": "workspace:*",
-    "@sanity/runtime-cli": "^7.0.1",
+    "@sanity/runtime-cli": "^7.0.2",
     "@sanity/telemetry": "^0.8.0",
     "@sanity/template-validator": "^2.4.3",
     "@sanity/util": "workspace:3.88.2",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -60,7 +60,7 @@
     "@babel/traverse": "^7.23.5",
     "@sanity/client": "^7.2.1",
     "@sanity/codegen": "workspace:*",
-    "@sanity/runtime-cli": "^6.1.1",
+    "@sanity/runtime-cli": "^7.0.1",
     "@sanity/telemetry": "^0.8.0",
     "@sanity/template-validator": "^2.4.3",
     "@sanity/util": "workspace:3.88.2",

--- a/packages/@sanity/cli/src/commands/blueprints/addBlueprintsCommand.ts
+++ b/packages/@sanity/cli/src/commands/blueprints/addBlueprintsCommand.ts
@@ -5,10 +5,13 @@ Arguments
   <type>  Type of Resource to add (currently only 'function' is supported)
 
 Options
-  --name <name>                Name of the Resource
-  --fn-type <type>             Type of Function Resource to add (e.g. document-publish)
-  --fn-lang, --lang <ts|js>    Language of the Function Resource
-  --js, --javascript           Use JavaScript for the Function Resource
+  --name, -n <name>              Name of the Resource
+  --fn-type <type>               Type of Function Resource to add (e.g. document-publish)
+  --fn-language, --lang <ts|js>  Language of the Function Resource
+  --js, --javascript             Use JavaScript for the Function Resource
+  --fn-installer, --installer    <npm|pnpm|yarn> to use for Function helpers
+  --install, -i                  Shortcut for --fn-installer npm
+  --no-fn-helpers                Do not add helpers to the Function Resource
 
 Examples:
   # Add a Function Resource (TypeScript by default)
@@ -22,20 +25,41 @@ Examples:
 
   # Add a Function Resource in JavaScript
   sanity blueprints add function --name my-function --fn-type document-publish --js
+
+  # Add a Function Resource without helpers
+  sanity blueprints add function --no-fn-helpers
+
+  # Add a document-publish .js Function with helpers and install with npm
+  sanity blueprints add function -n roboto --fn-type document-publish --js -i
 `
 
 export interface BlueprintsAddFlags {
   'name'?: string
+  'n'?: string
+
   'fn-type'?: string
+
+  'fn-language'?: string
   'fn-lang'?: string
   'language'?: string
   'lang'?: string
+
   'js'?: boolean
   'javascript'?: boolean
+
+  'fn-helpers'?: boolean
+  'helpers'?: boolean
+
+  'fn-installer'?: string
+  'installer'?: string
+
+  'install'?: boolean
+  'i'?: boolean
 }
 
 const defaultFlags: BlueprintsAddFlags = {
-  //
+  'fn-language': 'ts',
+  // 'fn-helpers': true, // ask, for now
 }
 
 const addBlueprintsCommand: CliCommandDefinition<BlueprintsAddFlags> = {
@@ -47,8 +71,16 @@ const addBlueprintsCommand: CliCommandDefinition<BlueprintsAddFlags> = {
   description: 'Add a Resource to a Blueprint',
 
   async action(args, context) {
-    const {output} = context
+    const {output, apiClient} = context
     const flags = {...defaultFlags, ...args.extOptions}
+
+    const client = apiClient({
+      requireUser: true,
+      requireProject: false,
+    })
+    const {token} = client.config()
+
+    if (!token) throw new Error('No API token found. Please run `sanity login`.')
 
     const [resourceType] = args.argsWithoutOptions
 
@@ -57,16 +89,26 @@ const addBlueprintsCommand: CliCommandDefinition<BlueprintsAddFlags> = {
       return
     }
 
+    const {initBlueprintConfig} = await import('@sanity/runtime-cli/cores')
     const {blueprintAddCore} = await import('@sanity/runtime-cli/cores/blueprints')
+
+    const cmdConfig = await initBlueprintConfig('sanity', (msg: string) => output.print(msg), token)
+
+    if (!cmdConfig.ok) {
+      throw new Error(cmdConfig.error)
+    }
+
     const {success, error} = await blueprintAddCore({
-      bin: 'sanity',
-      log: (msg) => output.print(msg),
+      ...cmdConfig.value,
       args: {type: resourceType},
       flags: {
-        'name': flags.name,
+        'name': flags.n ?? flags.name,
         'fn-type': flags['fn-type'],
-        'language': flags['fn-lang'] ?? flags.language ?? flags.lang,
+        'language': flags.lang ?? flags.language ?? flags['fn-lang'] ?? flags['fn-language'],
         'javascript': flags.js || flags.javascript,
+        'fn-helpers': flags.helpers || flags['fn-helpers'],
+        'fn-installer': flags.installer ?? flags['fn-installer'],
+        'install': flags.i || flags.install,
       },
     })
 

--- a/packages/@sanity/cli/src/commands/blueprints/addBlueprintsCommand.ts
+++ b/packages/@sanity/cli/src/commands/blueprints/addBlueprintsCommand.ts
@@ -93,9 +93,11 @@ const addBlueprintsCommand: CliCommandDefinition<BlueprintsAddFlags> = {
     const {initBlueprintConfig} = await import('@sanity/runtime-cli/cores')
     const {blueprintAddCore} = await import('@sanity/runtime-cli/cores/blueprints')
 
-    const bin = 'sanity'
-    const log = (msg: string) => output.print(msg)
-    const cmdConfig = await initBlueprintConfig(bin, log, token)
+    const cmdConfig = await initBlueprintConfig({
+      bin: 'sanity',
+      log: (message) => output.print(message),
+      token,
+    })
 
     if (!cmdConfig.ok) throw new Error(cmdConfig.error)
 

--- a/packages/@sanity/cli/src/commands/blueprints/configBlueprintsCommand.ts
+++ b/packages/@sanity/cli/src/commands/blueprints/configBlueprintsCommand.ts
@@ -57,21 +57,19 @@ const configBlueprintsCommand: CliCommandDefinition<BlueprintsConfigFlags> = {
 
     if (!token) throw new Error('No API token found. Please run `sanity login`.')
 
+    const {initBlueprintConfig} = await import('@sanity/runtime-cli/cores')
     const {blueprintConfigCore} = await import('@sanity/runtime-cli/cores/blueprints')
-    const {getBlueprintAndStack} = await import('@sanity/runtime-cli/actions/blueprints')
-    const {display} = await import('@sanity/runtime-cli/utils')
 
-    const {localBlueprint, issues} = await getBlueprintAndStack({token})
-
-    if (issues) {
-      // print issues and continue
-      output.print(display.errors.presentBlueprintIssues(issues))
-    }
-
-    const {success, error} = await blueprintConfigCore({
+    const cmdConfig = await initBlueprintConfig({
       bin: 'sanity',
       log: (message) => output.print(message),
-      blueprint: localBlueprint,
+      token,
+    })
+
+    if (!cmdConfig.ok) throw new Error(cmdConfig.error)
+
+    const {success, error} = await blueprintConfigCore({
+      ...cmdConfig.value,
       token,
       flags: {
         'project-id': flags['project-id'] ?? flags.projectId ?? flags.project,

--- a/packages/@sanity/cli/src/commands/blueprints/destroyBlueprintsCommand.ts
+++ b/packages/@sanity/cli/src/commands/blueprints/destroyBlueprintsCommand.ts
@@ -50,16 +50,19 @@ const destroyBlueprintsCommand: CliCommandDefinition<BlueprintsDestroyFlags> = {
     const {token} = client.config()
     if (!token) throw new Error('No API token found. Please run `sanity login`.')
 
+    const {initBlueprintConfig} = await import('@sanity/runtime-cli/cores')
     const {blueprintDestroyCore} = await import('@sanity/runtime-cli/cores/blueprints')
-    const {getBlueprintAndStack} = await import('@sanity/runtime-cli/actions/blueprints')
 
-    const {localBlueprint} = await getBlueprintAndStack({token})
-
-    const {success, error} = await blueprintDestroyCore({
+    const cmdConfig = await initBlueprintConfig({
       bin: 'sanity',
       log: (message) => output.print(message),
       token,
-      blueprint: localBlueprint,
+    })
+
+    if (!cmdConfig.ok) throw new Error(cmdConfig.error)
+
+    const {success, error} = await blueprintDestroyCore({
+      ...cmdConfig.value,
       flags: {
         'no-wait': flags['no-wait'],
         'force': flags.force ?? flags.f,

--- a/packages/@sanity/cli/src/commands/blueprints/infoBlueprintsCommand.ts
+++ b/packages/@sanity/cli/src/commands/blueprints/infoBlueprintsCommand.ts
@@ -32,26 +32,19 @@ const infoBlueprintsCommand: CliCommandDefinition<BlueprintsInfoFlags> = {
     const {token} = client.config()
     if (!token) throw new Error('No API token found. Please run `sanity login`.')
 
+    const {initDeployedBlueprintConfig} = await import('@sanity/runtime-cli/cores')
     const {blueprintInfoCore} = await import('@sanity/runtime-cli/cores/blueprints')
-    const {getBlueprintAndStack} = await import('@sanity/runtime-cli/actions/blueprints')
-    const {display} = await import('@sanity/runtime-cli/utils')
 
-    const {localBlueprint, deployedStack, issues} = await getBlueprintAndStack({token})
-
-    if (issues) {
-      output.print(display.errors.presentBlueprintIssues(issues))
-      throw new Error('Unable to parse Blueprint file.')
-    }
-
-    const {projectId, stackId} = localBlueprint
-    const auth = {token, projectId}
-
-    const {success, error} = await blueprintInfoCore({
+    const cmdConfig = await initDeployedBlueprintConfig({
       bin: 'sanity',
       log: (message) => output.print(message),
-      auth,
-      stackId,
-      deployedStack,
+      token,
+    })
+
+    if (!cmdConfig.ok) throw new Error(cmdConfig.error)
+
+    const {success, error} = await blueprintInfoCore({
+      ...cmdConfig.value,
       flags,
     })
 

--- a/packages/@sanity/cli/src/commands/blueprints/planBlueprintsCommand.ts
+++ b/packages/@sanity/cli/src/commands/blueprints/planBlueprintsCommand.ts
@@ -29,21 +29,19 @@ const planBlueprintsCommand: CliCommandDefinition<BlueprintsPlanFlags> = {
     const {token} = client.config()
     if (!token) throw new Error('No API token found. Please run `sanity login`.')
 
+    const {initBlueprintConfig} = await import('@sanity/runtime-cli/cores')
     const {blueprintPlanCore} = await import('@sanity/runtime-cli/cores/blueprints')
-    const {getBlueprintAndStack} = await import('@sanity/runtime-cli/actions/blueprints')
-    const {display} = await import('@sanity/runtime-cli/utils')
 
-    const {localBlueprint, issues} = await getBlueprintAndStack({token})
-
-    if (issues) {
-      // print issues and continue
-      output.print(display.errors.presentBlueprintIssues(issues))
-    }
-
-    const {success, error} = await blueprintPlanCore({
+    const cmdConfig = await initBlueprintConfig({
       bin: 'sanity',
       log: (message) => output.print(message),
-      blueprint: localBlueprint,
+      token,
+    })
+
+    if (!cmdConfig.ok) throw new Error(cmdConfig.error)
+
+    const {success, error} = await blueprintPlanCore({
+      ...cmdConfig.value,
     })
 
     if (!success) throw new Error(error)

--- a/packages/@sanity/cli/src/commands/blueprints/stacksBlueprintsCommand.ts
+++ b/packages/@sanity/cli/src/commands/blueprints/stacksBlueprintsCommand.ts
@@ -41,22 +41,19 @@ const stacksBlueprintsCommand: CliCommandDefinition<BlueprintsStacksFlags> = {
     const {token} = client.config()
     if (!token) throw new Error('No API token found. Please run `sanity login`.')
 
+    const {initBlueprintConfig} = await import('@sanity/runtime-cli/cores')
     const {blueprintStacksCore} = await import('@sanity/runtime-cli/cores/blueprints')
-    const {getBlueprintAndStack} = await import('@sanity/runtime-cli/actions/blueprints')
-    const {display} = await import('@sanity/runtime-cli/utils')
 
-    const {localBlueprint, issues} = await getBlueprintAndStack({token})
-
-    if (issues) {
-      // print issues and continue
-      output.print(display.errors.presentBlueprintIssues(issues))
-    }
-
-    const {success, error} = await blueprintStacksCore({
+    const cmdConfig = await initBlueprintConfig({
       bin: 'sanity',
       log: (message) => output.print(message),
       token,
-      blueprint: localBlueprint,
+    })
+
+    if (!cmdConfig.ok) throw new Error(cmdConfig.error)
+
+    const {success, error} = await blueprintStacksCore({
+      ...cmdConfig.value,
       flags: {
         projectId: flags['project-id'] ?? flags.projectId ?? flags.project,
       },

--- a/packages/@sanity/cli/src/commands/functions/functionsGroup.ts
+++ b/packages/@sanity/cli/src/commands/functions/functionsGroup.ts
@@ -4,7 +4,7 @@ const functionsGroup: CliCommandGroupDefinition = {
   name: 'functions',
   signature: '[COMMAND]',
   isGroupRoot: true,
-  description: 'Test Sanity Functions locally, update environment variables and retrieve logs',
+  description: 'Manage, test, and observe Sanity Functions',
 }
 
 export default functionsGroup

--- a/packages/@sanity/cli/test/blueprints.test.ts
+++ b/packages/@sanity/cli/test/blueprints.test.ts
@@ -34,6 +34,15 @@ const localBlueprint = {
 vi.mock('@sanity/runtime-cli/actions/blueprints', () => ({
   getBlueprintAndStack: vi.fn().mockResolvedValue({localBlueprint}),
 }))
+vi.mock('@sanity/runtime-cli/cores', () => ({
+  initBlueprintConfig: vi.fn().mockResolvedValue({
+    ok: true,
+    value: {
+      bin: 'sanity',
+      log: vi.fn(),
+    },
+  }),
+}))
 
 describe('blueprints commands', () => {
   it('should be a set of commands', async () => {
@@ -80,6 +89,7 @@ describe('blueprints commands', () => {
           'name': 'test-function',
           'fn-type': 'document-publish',
           'lang': 'ts',
+          'no-fn-helpers': true,
         },
       }
 
@@ -95,6 +105,7 @@ describe('blueprints commands', () => {
           'fn-type': 'document-publish',
           'language': 'ts',
           'javascript': undefined,
+          'fn-helpers': false,
         },
       })
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -726,8 +726,8 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@sanity/runtime-cli':
-        specifier: ^7.0.1
-        version: 7.0.1(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.7.0)
+        specifier: ^7.0.2
+        version: 7.0.2(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.7.0)
       '@sanity/telemetry':
         specifier: ^0.8.0
         version: 0.8.1(react@19.1.0)
@@ -4747,8 +4747,8 @@ packages:
     peerDependencies:
       react: ^18.3 || >=19.0.0-rc
 
-  '@sanity/runtime-cli@7.0.1':
-    resolution: {integrity: sha512-W2c4Uum1eJedMtPXoNu+gfYMR7GLGPcFRDwZPj0cPyL4Gf4sXX54nQSIsItQrv6aEndWmArohwpNlZ2ExjtPsA==}
+  '@sanity/runtime-cli@7.0.2':
+    resolution: {integrity: sha512-7qGKqEk25RLyyZPqSRveMqQYkGPFD0//msQvxaB6mjCEH6OLx8D2EExZti88wtAISfJydKBl8N1O/2CBFDqkzw==}
     engines: {node: '>=18.20.0'}
     hasBin: true
 
@@ -7361,8 +7361,8 @@ packages:
     resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
     engines: {node: '>=12.0.0'}
 
-  eventsource@3.0.6:
-    resolution: {integrity: sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==}
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
   execa@2.1.0:
@@ -15676,7 +15676,7 @@ snapshots:
       - debug
       - typescript
 
-  '@sanity/runtime-cli@7.0.1(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.7.0)':
+  '@sanity/runtime-cli@7.0.2(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.7.0)':
     dependencies:
       '@oclif/core': 4.3.0
       '@oclif/plugin-help': 6.2.28
@@ -15684,7 +15684,7 @@ snapshots:
       array-treeify: 0.1.5
       chalk: 5.4.1
       color-json: 3.0.5
-      eventsource: 3.0.6
+      eventsource: 3.0.7
       find-up: 7.0.0
       inquirer: 12.6.1(@types/node@22.13.1)
       mime-types: 3.0.1
@@ -18979,7 +18979,7 @@ snapshots:
 
   eventsource@2.0.2: {}
 
-  eventsource@3.0.6:
+  eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -726,8 +726,8 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@sanity/runtime-cli':
-        specifier: ^6.1.1
-        version: 6.1.1(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.7.0)
+        specifier: ^7.0.1
+        version: 7.0.1(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.7.0)
       '@sanity/telemetry':
         specifier: ^0.8.0
         version: 0.8.1(react@19.1.0)
@@ -3549,8 +3549,8 @@ packages:
     peerDependencies:
       react: '*'
 
-  '@inquirer/checkbox@4.1.5':
-    resolution: {integrity: sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ==}
+  '@inquirer/checkbox@4.1.6':
+    resolution: {integrity: sha512-62u896rWCtKKE43soodq5e/QcRsA22I+7/4Ov7LESWnKRO6BVo2A1DFLDmXL9e28TB0CfHc3YtkbPm7iwajqkg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^22.10.0
@@ -3558,8 +3558,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/confirm@5.1.9':
-    resolution: {integrity: sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==}
+  '@inquirer/confirm@5.1.10':
+    resolution: {integrity: sha512-FxbQ9giWxUWKUk2O5XZ6PduVnH2CZ/fmMKMBkH71MHJvWr7WL5AHKevhzF1L5uYWB2P548o1RzVxrNd3dpmk6g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^22.10.0
@@ -3567,8 +3567,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/core@10.1.10':
-    resolution: {integrity: sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==}
+  '@inquirer/core@10.1.11':
+    resolution: {integrity: sha512-BXwI/MCqdtAhzNQlBEFE7CEflhPkl/BqvAuV/aK6lW3DClIfYVDWPP/kXuXHtBWC7/EEbNqd/1BGq2BGBBnuxw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^22.10.0
@@ -3576,8 +3576,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/editor@4.2.10':
-    resolution: {integrity: sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==}
+  '@inquirer/editor@4.2.11':
+    resolution: {integrity: sha512-YoZr0lBnnLFPpfPSNsQ8IZyKxU47zPyVi9NLjCWtna52//M/xuL0PGPAxHxxYhdOhnvY2oBafoM+BI5w/JK7jw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^22.10.0
@@ -3585,8 +3585,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/expand@4.0.12':
-    resolution: {integrity: sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw==}
+  '@inquirer/expand@4.0.13':
+    resolution: {integrity: sha512-HgYNWuZLHX6q5y4hqKhwyytqAghmx35xikOGY3TcgNiElqXGPas24+UzNPOwGUZa5Dn32y25xJqVeUcGlTv+QQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^22.10.0
@@ -3598,8 +3598,8 @@ packages:
     resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
     engines: {node: '>=18'}
 
-  '@inquirer/input@4.1.9':
-    resolution: {integrity: sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==}
+  '@inquirer/input@4.1.10':
+    resolution: {integrity: sha512-kV3BVne3wJ+j6reYQUZi/UN9NZGZLxgc/tfyjeK3mrx1QI7RXPxGp21IUTv+iVHcbP4ytZALF8vCHoxyNSC6qg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^22.10.0
@@ -3607,8 +3607,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/number@3.0.12':
-    resolution: {integrity: sha512-7HRFHxbPCA4e4jMxTQglHJwP+v/kpFsCf2szzfBHy98Wlc3L08HL76UDiA87TOdX5fwj2HMOLWqRWv9Pnn+Z5Q==}
+  '@inquirer/number@3.0.13':
+    resolution: {integrity: sha512-IrLezcg/GWKS8zpKDvnJ/YTflNJdG0qSFlUM/zNFsdi4UKW/CO+gaJpbMgQ20Q58vNKDJbEzC6IebdkprwL6ew==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^22.10.0
@@ -3616,8 +3616,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/password@4.0.12':
-    resolution: {integrity: sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g==}
+  '@inquirer/password@4.0.13':
+    resolution: {integrity: sha512-NN0S/SmdhakqOTJhDwOpeBEEr8VdcYsjmZHDb0rblSh2FcbXQOr+2IApP7JG4WE3sxIdKytDn4ed3XYwtHxmJQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^22.10.0
@@ -3625,8 +3625,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/prompts@7.4.1':
-    resolution: {integrity: sha512-UlmM5FVOZF0gpoe1PT/jN4vk8JmpIWBlMvTL8M+hlvPmzN89K6z03+IFmyeu/oFCenwdwHDr2gky7nIGSEVvlA==}
+  '@inquirer/prompts@7.5.1':
+    resolution: {integrity: sha512-5AOrZPf2/GxZ+SDRZ5WFplCA2TAQgK3OYrXCYmJL5NaTu4ECcoWFlfUZuw7Es++6Njv7iu/8vpYJhuzxUH76Vg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^22.10.0
@@ -3634,8 +3634,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/rawlist@4.0.12':
-    resolution: {integrity: sha512-wNPJZy8Oc7RyGISPxp9/MpTOqX8lr0r+lCCWm7hQra+MDtYRgINv1hxw7R+vKP71Bu/3LszabxOodfV/uTfsaA==}
+  '@inquirer/rawlist@4.1.1':
+    resolution: {integrity: sha512-VBUC0jPN2oaOq8+krwpo/mf3n/UryDUkKog3zi+oIi8/e5hykvdntgHUB9nhDM78RubiyR1ldIOfm5ue+2DeaQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^22.10.0
@@ -3643,8 +3643,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/search@3.0.12':
-    resolution: {integrity: sha512-H/kDJA3kNlnNIjB8YsaXoQI0Qccgf0Na14K1h8ExWhNmUg2E941dyFPrZeugihEa9AZNW5NdsD/NcvUME83OPQ==}
+  '@inquirer/search@3.0.13':
+    resolution: {integrity: sha512-9g89d2c5Izok/Gw/U7KPC3f9kfe5rA1AJ24xxNZG0st+vWekSk7tB9oE+dJv5JXd0ZSijomvW0KPMoBd8qbN4g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^22.10.0
@@ -3652,8 +3652,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/select@4.1.1':
-    resolution: {integrity: sha512-IUXzzTKVdiVNMA+2yUvPxWsSgOG4kfX93jOM4Zb5FgujeInotv5SPIJVeXQ+fO4xu7tW8VowFhdG5JRmmCyQ1Q==}
+  '@inquirer/select@4.2.1':
+    resolution: {integrity: sha512-gt1Kd5XZm+/ddemcT3m23IP8aD8rC9drRckWoP/1f7OL46Yy2FGi8DSmNjEjQKtPl6SV96Kmjbl6p713KXJ/Jg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^22.10.0
@@ -4058,12 +4058,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oclif/core@4.2.10':
-    resolution: {integrity: sha512-fAqcXgqkUm4v5FYy7qWP4w1HaOlVSVJveah+yVTo5Nm5kTiXhmD5mQQ7+knGeBaStyrtQy6WardoC2xSic9rlQ==}
+  '@oclif/core@4.3.0':
+    resolution: {integrity: sha512-lIzHY+JMP6evrS5E/sGijNnwrCoNtGy8703jWXcMuPOYKiFhWoAqnIm1BGgoRgmxczkbSfRsHUL/lwsSgh74Lw==}
     engines: {node: '>=18.0.0'}
 
-  '@oclif/plugin-help@6.2.27':
-    resolution: {integrity: sha512-RWSWtCFVObRmCwgxVOye3lsYbPHTnB7G4He5LEAg2tf600Sil5yXEOL/ULx1TqL/XOQxKqRvmLn/rLQOMT85YA==}
+  '@oclif/plugin-help@6.2.28':
+    resolution: {integrity: sha512-eFLP2yjiK+xMRGcv9k9jOWV08HB+/Cgg1ND91zS4Uwgp1krMoL39Is+hIqnZOKkmiEMtiv8k5EDqCVv+DTRywg==}
     engines: {node: '>=18.0.0'}
 
   '@octokit/action@6.1.0':
@@ -4747,8 +4747,8 @@ packages:
     peerDependencies:
       react: ^18.3 || >=19.0.0-rc
 
-  '@sanity/runtime-cli@6.1.1':
-    resolution: {integrity: sha512-cmDK545s29s8hfIHr/zftqnF+ygBHZWeY3rzap7dnLT/loWpEDRwtQ7CQsnZupbBEUdGb12D4PLmwY+WVo1spw==}
+  '@sanity/runtime-cli@7.0.1':
+    resolution: {integrity: sha512-W2c4Uum1eJedMtPXoNu+gfYMR7GLGPcFRDwZPj0cPyL4Gf4sXX54nQSIsItQrv6aEndWmArohwpNlZ2ExjtPsA==}
     engines: {node: '>=18.20.0'}
     hasBin: true
 
@@ -5813,8 +5813,8 @@ packages:
     resolution: {integrity: sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==}
     engines: {node: '>= 0.4'}
 
-  array-treeify@0.1.3:
-    resolution: {integrity: sha512-uUB7ngRUZe535QtK7VJeBIWcci58BFjT7O2of3Fkga/NPwr5vBeabMv83h1gMQVYVEyirXpp0kjqMGQftMTuiQ==}
+  array-treeify@0.1.5:
+    resolution: {integrity: sha512-Ag85dlQyM0wahhm62ZvsLDLU0TcGNXjonRWpEUvlmmaFBuJNuzoc19Gi51uMs9HXoT2zwSewk6JzxUUw8b412g==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -8218,8 +8218,8 @@ packages:
     resolution: {integrity: sha512-Zfeb5ol+H+eqJWHTaGca9BovufyGeIfr4zaaBorPmJBMrJ+KBnN+kQx2ZtXdsotUTgldHmHQV44xvUWOUA7E2w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  inquirer@12.5.2:
-    resolution: {integrity: sha512-qoDk/vdSTIaXNXAoNnlg7ubexpJfUo7t8GT2vylxvE49BrLhToFuPPdMViidG2boHV7+AcP1TCkJs/+PPoF2QQ==}
+  inquirer@12.6.1:
+    resolution: {integrity: sha512-MGFnzHVS3l3oM3cy+LWkyR7UUtVEn3D5U41CZbEY34szToWoJAvaVtCTz1mxsEzZFk/HXWyCArn0HDgloTXMDw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^22.10.0
@@ -12269,16 +12269,8 @@ packages:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
 
-  yocto-spinner@0.2.1:
-    resolution: {integrity: sha512-lHHxjh0bXaLgdJy3cNnVb/F9myx3CkhrvSOEVTkaUgNMXnYFa2xYPVhtGnqhh3jErY2gParBOHallCbc7NrlZQ==}
-    engines: {node: '>=18.19'}
-
   yoctocolors-cjs@2.1.2:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
-    engines: {node: '>=18'}
-
-  yoctocolors@2.1.1:
-    resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
   zip-stream@6.0.1:
@@ -13864,9 +13856,9 @@ snapshots:
     dependencies:
       react: 19.1.0
 
-  '@inquirer/checkbox@4.1.5(@types/node@22.13.1)':
+  '@inquirer/checkbox@4.1.6(@types/node@22.13.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/core': 10.1.11(@types/node@22.13.1)
       '@inquirer/figures': 1.0.11
       '@inquirer/type': 3.0.6(@types/node@22.13.1)
       ansi-escapes: 4.3.2
@@ -13874,14 +13866,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.1
 
-  '@inquirer/confirm@5.1.9(@types/node@22.13.1)':
+  '@inquirer/confirm@5.1.10(@types/node@22.13.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/core': 10.1.11(@types/node@22.13.1)
       '@inquirer/type': 3.0.6(@types/node@22.13.1)
     optionalDependencies:
       '@types/node': 22.13.1
 
-  '@inquirer/core@10.1.10(@types/node@22.13.1)':
+  '@inquirer/core@10.1.11(@types/node@22.13.1)':
     dependencies:
       '@inquirer/figures': 1.0.11
       '@inquirer/type': 3.0.6(@types/node@22.13.1)
@@ -13894,17 +13886,17 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.1
 
-  '@inquirer/editor@4.2.10(@types/node@22.13.1)':
+  '@inquirer/editor@4.2.11(@types/node@22.13.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/core': 10.1.11(@types/node@22.13.1)
       '@inquirer/type': 3.0.6(@types/node@22.13.1)
       external-editor: 3.1.0
     optionalDependencies:
       '@types/node': 22.13.1
 
-  '@inquirer/expand@4.0.12(@types/node@22.13.1)':
+  '@inquirer/expand@4.0.13(@types/node@22.13.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/core': 10.1.11(@types/node@22.13.1)
       '@inquirer/type': 3.0.6(@types/node@22.13.1)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
@@ -13912,63 +13904,63 @@ snapshots:
 
   '@inquirer/figures@1.0.11': {}
 
-  '@inquirer/input@4.1.9(@types/node@22.13.1)':
+  '@inquirer/input@4.1.10(@types/node@22.13.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/core': 10.1.11(@types/node@22.13.1)
       '@inquirer/type': 3.0.6(@types/node@22.13.1)
     optionalDependencies:
       '@types/node': 22.13.1
 
-  '@inquirer/number@3.0.12(@types/node@22.13.1)':
+  '@inquirer/number@3.0.13(@types/node@22.13.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/core': 10.1.11(@types/node@22.13.1)
       '@inquirer/type': 3.0.6(@types/node@22.13.1)
     optionalDependencies:
       '@types/node': 22.13.1
 
-  '@inquirer/password@4.0.12(@types/node@22.13.1)':
+  '@inquirer/password@4.0.13(@types/node@22.13.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/core': 10.1.11(@types/node@22.13.1)
       '@inquirer/type': 3.0.6(@types/node@22.13.1)
       ansi-escapes: 4.3.2
     optionalDependencies:
       '@types/node': 22.13.1
 
-  '@inquirer/prompts@7.4.1(@types/node@22.13.1)':
+  '@inquirer/prompts@7.5.1(@types/node@22.13.1)':
     dependencies:
-      '@inquirer/checkbox': 4.1.5(@types/node@22.13.1)
-      '@inquirer/confirm': 5.1.9(@types/node@22.13.1)
-      '@inquirer/editor': 4.2.10(@types/node@22.13.1)
-      '@inquirer/expand': 4.0.12(@types/node@22.13.1)
-      '@inquirer/input': 4.1.9(@types/node@22.13.1)
-      '@inquirer/number': 3.0.12(@types/node@22.13.1)
-      '@inquirer/password': 4.0.12(@types/node@22.13.1)
-      '@inquirer/rawlist': 4.0.12(@types/node@22.13.1)
-      '@inquirer/search': 3.0.12(@types/node@22.13.1)
-      '@inquirer/select': 4.1.1(@types/node@22.13.1)
+      '@inquirer/checkbox': 4.1.6(@types/node@22.13.1)
+      '@inquirer/confirm': 5.1.10(@types/node@22.13.1)
+      '@inquirer/editor': 4.2.11(@types/node@22.13.1)
+      '@inquirer/expand': 4.0.13(@types/node@22.13.1)
+      '@inquirer/input': 4.1.10(@types/node@22.13.1)
+      '@inquirer/number': 3.0.13(@types/node@22.13.1)
+      '@inquirer/password': 4.0.13(@types/node@22.13.1)
+      '@inquirer/rawlist': 4.1.1(@types/node@22.13.1)
+      '@inquirer/search': 3.0.13(@types/node@22.13.1)
+      '@inquirer/select': 4.2.1(@types/node@22.13.1)
     optionalDependencies:
       '@types/node': 22.13.1
 
-  '@inquirer/rawlist@4.0.12(@types/node@22.13.1)':
+  '@inquirer/rawlist@4.1.1(@types/node@22.13.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/core': 10.1.11(@types/node@22.13.1)
       '@inquirer/type': 3.0.6(@types/node@22.13.1)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 22.13.1
 
-  '@inquirer/search@3.0.12(@types/node@22.13.1)':
+  '@inquirer/search@3.0.13(@types/node@22.13.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/core': 10.1.11(@types/node@22.13.1)
       '@inquirer/figures': 1.0.11
       '@inquirer/type': 3.0.6(@types/node@22.13.1)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 22.13.1
 
-  '@inquirer/select@4.1.1(@types/node@22.13.1)':
+  '@inquirer/select@4.2.1(@types/node@22.13.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.13.1)
+      '@inquirer/core': 10.1.11(@types/node@22.13.1)
       '@inquirer/figures': 1.0.11
       '@inquirer/type': 3.0.6(@types/node@22.13.1)
       ansi-escapes: 4.3.2
@@ -14591,7 +14583,7 @@ snapshots:
   '@nx/nx-win32-x64-msvc@20.4.2':
     optional: true
 
-  '@oclif/core@4.2.10':
+  '@oclif/core@4.3.0':
     dependencies:
       ansi-escapes: 4.3.2
       ansis: 3.17.0
@@ -14612,9 +14604,9 @@ snapshots:
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
 
-  '@oclif/plugin-help@6.2.27':
+  '@oclif/plugin-help@6.2.28':
     dependencies:
-      '@oclif/core': 4.2.10
+      '@oclif/core': 4.3.0
 
   '@octokit/action@6.1.0':
     dependencies:
@@ -15684,22 +15676,22 @@ snapshots:
       - debug
       - typescript
 
-  '@sanity/runtime-cli@6.1.1(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.7.0)':
+  '@sanity/runtime-cli@7.0.1(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.7.0)':
     dependencies:
-      '@oclif/core': 4.2.10
-      '@oclif/plugin-help': 6.2.27
+      '@oclif/core': 4.3.0
+      '@oclif/plugin-help': 6.2.28
       adm-zip: 0.5.16
-      array-treeify: 0.1.3
+      array-treeify: 0.1.5
       chalk: 5.4.1
       color-json: 3.0.5
       eventsource: 3.0.6
       find-up: 7.0.0
-      inquirer: 12.5.2(@types/node@22.13.1)
+      inquirer: 12.6.1(@types/node@22.13.1)
       mime-types: 3.0.1
+      ora: 8.2.0
       vite: 6.2.4(@types/node@22.13.1)(terser@5.38.2)(yaml@2.7.0)
       vite-tsconfig-paths: 5.1.4(typescript@5.8.3)(vite@6.2.4(@types/node@22.13.1)(terser@5.38.2)(yaml@2.7.0))
       xdg-basedir: 5.1.0
-      yocto-spinner: 0.2.1
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -17107,7 +17099,7 @@ snapshots:
       get-intrinsic: 1.3.0
       is-string: 1.1.1
 
-  array-treeify@0.1.3: {}
+  array-treeify@0.1.5: {}
 
   array-union@2.1.0: {}
 
@@ -20010,10 +20002,10 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
 
-  inquirer@12.5.2(@types/node@22.13.1):
+  inquirer@12.6.1(@types/node@22.13.1):
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.13.1)
-      '@inquirer/prompts': 7.4.1(@types/node@22.13.1)
+      '@inquirer/core': 10.1.11(@types/node@22.13.1)
+      '@inquirer/prompts': 7.5.1(@types/node@22.13.1)
       '@inquirer/type': 3.0.6(@types/node@22.13.1)
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
@@ -24603,13 +24595,7 @@ snapshots:
 
   yocto-queue@1.2.1: {}
 
-  yocto-spinner@0.2.1:
-    dependencies:
-      yoctocolors: 2.1.1
-
   yoctocolors-cjs@2.1.2: {}
-
-  yoctocolors@2.1.1: {}
 
   zip-stream@6.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -726,8 +726,8 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@sanity/runtime-cli':
-        specifier: ^7.0.2
-        version: 7.0.2(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.7.0)
+        specifier: ^7.0.3
+        version: 7.0.3(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.7.0)
       '@sanity/telemetry':
         specifier: ^0.8.0
         version: 0.8.1(react@19.1.0)
@@ -4747,8 +4747,8 @@ packages:
     peerDependencies:
       react: ^18.3 || >=19.0.0-rc
 
-  '@sanity/runtime-cli@7.0.2':
-    resolution: {integrity: sha512-7qGKqEk25RLyyZPqSRveMqQYkGPFD0//msQvxaB6mjCEH6OLx8D2EExZti88wtAISfJydKBl8N1O/2CBFDqkzw==}
+  '@sanity/runtime-cli@7.0.3':
+    resolution: {integrity: sha512-YkBoO2FcTD9vR4f5zNvcynojSHpRuzlbtkhCg9VFWcByUzUr01pSQvUL5Mag/a+aexOtmbiNeeOl+2e+6vAMVQ==}
     engines: {node: '>=18.20.0'}
     hasBin: true
 
@@ -15676,7 +15676,7 @@ snapshots:
       - debug
       - typescript
 
-  '@sanity/runtime-cli@7.0.2(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.7.0)':
+  '@sanity/runtime-cli@7.0.3(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.7.0)':
     dependencies:
       '@oclif/core': 4.3.0
       '@oclif/plugin-help': 6.2.28


### PR DESCRIPTION
### Description

`runtime-cli` is now at v7+, adding some function name validation for `blueprints add`, bug fixes, new config initialization helpers, and options for installing `@sanity/functions` helpers 

### What to review

The `blueprints add` command has new flags. They are not required and if omitted, users will be prompted about adding and installing the functions helpers.

![blueprints-add-fn-helpers2](https://github.com/user-attachments/assets/023341cc-2c63-4376-be6f-de3787332664)

### Testing

I updated the blueprints command tests to mock the new initBlueprintConfig and initDeployedBlueprintConfig functions

### Notes for release

the main update is the addition and installation of `@sanity/functions` helpers when using `blueprints add function`