### PR TITLE
fix(core): add fix for useDocumentForm

### DIFF
--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -49,7 +49,15 @@ import {
   useDocumentValuePermissions,
   usePresenceStore,
 } from '../store'
-import {EMPTY_ARRAY, getDraftId, getPublishedId, getVersionFromId, useUnique} from '../util'
+import {
+  EMPTY_ARRAY,
+  getDraftId,
+  getPublishedId,
+  getVersionFromId,
+  isDraftId,
+  isPublishedId,
+  useUnique,
+} from '../util'
 import {
   type FormState,
   getExpandOperations,
@@ -259,12 +267,21 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
   )
 
   const requiredPermission = value._createdAt ? 'update' : 'create'
+  const getDocumentId = useCallback(
+    (docId: string) => {
+      if (liveEdit || isPublishedId(docId)) {
+        return getPublishedId(docId)
+      }
+      return isDraftId(docId) ? getDraftId(docId) : docId
+    },
+    [liveEdit],
+  )
   const docPermissionsInput = useMemo(() => {
     return {
       ...value,
-      _id: liveEdit ? getPublishedId(documentId) : getDraftId(documentId),
+      _id: getDocumentId(value._id),
     }
-  }, [liveEdit, value, documentId])
+  }, [value, getDocumentId])
 
   const [permissions, isPermissionsLoading] = useDocumentValuePermissions({
     document: docPermissionsInput,


### PR DESCRIPTION
### Description

Not ready yet

Fixes issue where a user without permissions to edit or create drafts but _did_ have permissions to create and edit versions wasn't being able to edit versions and was instead being given the banner that they didn't have permissions

before
<img width="836" alt="image" src="https://github.com/user-attachments/assets/38b17b12-fecc-44cd-afee-f79336718d61" />


### What to review

Does this make sense?

### Testing

Assign your user to the role, rita custom groq query role, you'll be able to edit and perform operations with versions as long as the pinned version matches (if you use the deployed version, if you use the main version you'll see the issue)

### Notes for release

Fixes issue where a user that should have permissions to edit version of documents, wasn't being able to.