### PR TITLE
fix(cli): remove linting configs from app templates

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/bootstrapLocalTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapLocalTemplate.ts
@@ -132,6 +132,7 @@ export async function bootstrapLocalTemplate(
     dependencies,
     devDependencies,
     scripts: template.scripts,
+    isAppTemplate,
   })
 
   // ...and a studio config (`sanity.config.[ts|js]`)
@@ -163,10 +164,14 @@ export async function bootstrapLocalTemplate(
       ],
       writeFileIfNotExists(`sanity.cli.${codeExt}`, cliConfig),
       writeFileIfNotExists('package.json', packageManifest),
-      writeFileIfNotExists(
-        'eslint.config.mjs',
-        `import studio from '@sanity/eslint-config-studio'\n\nexport default [...studio]\n`,
-      ),
+      ...[
+        isAppTemplate
+          ? Promise.resolve(null)
+          : writeFileIfNotExists(
+              'eslint.config.mjs',
+              `import studio from '@sanity/eslint-config-studio'\n\nexport default [...studio]\n`,
+            ),
+      ],
     ].filter(Boolean),
   )
 

--- a/packages/@sanity/cli/src/actions/init-project/createPackageManifest.ts
+++ b/packages/@sanity/cli/src/actions/init-project/createPackageManifest.ts
@@ -17,12 +17,27 @@ const manifestPropOrder = [
 ]
 
 export function createPackageManifest(
-  data: Omit<PackageJson, 'version'> & {gitRemote?: string},
+  data: Omit<PackageJson, 'version'> & {gitRemote?: string} & {isAppTemplate?: boolean},
 ): string {
+  const {isAppTemplate} = data
+
   const dependencies = data.dependencies ? {dependencies: sortObject(data.dependencies)} : {}
+
   const devDependencies = data.devDependencies
     ? {devDependencies: sortObject(data.devDependencies)}
     : {}
+
+  // Don't write a prettier config for SDK apps; we want to allow developers to use their own
+  const prettierConfig = isAppTemplate
+    ? {}
+    : {
+        prettier: {
+          semi: false,
+          printWidth: 100,
+          bracketSpacing: false,
+          singleQuote: true,
+        },
+      }
 
   const pkg = {
     ...getCommonManifest(data),
@@ -39,13 +54,7 @@ export function createPackageManifest(
 
     ...dependencies,
     ...devDependencies,
-
-    prettier: {
-      semi: false,
-      printWidth: 100,
-      bracketSpacing: false,
-      singleQuote: true,
-    },
+    ...prettierConfig,
   }
 
   return serializeManifest(pkg)

--- a/packages/@sanity/cli/src/actions/init-project/templates/appQuickstart.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/appQuickstart.ts
@@ -8,14 +8,7 @@ const appTemplate: ProjectTemplate = {
     'react-dom': '^19',
   },
   devDependencies: {
-    /*
-     * this will be changed to eslint-config sanity,
-     *  eslint.config generation will be a fast follow
-     */
-    '@sanity/eslint-config-studio': '^5.0.1',
     '@types/react': '^18.0.25',
-    'eslint': '^9.9.0',
-    'prettier': '^3.0.2',
     'sanity': '^3',
     'typescript': '^5.1.6',
   },

--- a/packages/@sanity/cli/src/actions/init-project/templates/appSanityUi.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/appSanityUi.ts
@@ -10,14 +10,7 @@ const appSanityUiTemplate: ProjectTemplate = {
     'styled-components': '^6.1.17',
   },
   devDependencies: {
-    /*
-     * this will be changed to eslint-config sanity,
-     *  eslint.config generation will be a fast follow
-     */
-    '@sanity/eslint-config-studio': '^5.0.1',
     '@types/react': '^18.0.25',
-    'eslint': '^9.9.0',
-    'prettier': '^3.0.2',
     'sanity': '^3',
     'typescript': '^5.1.6',
   },


### PR DESCRIPTION
### Description

We want SDK app developers to be able to use their preferred linting/formatting configuration when working on custom apps. This commit bypasses adding the prettier config to package.json and writing the eslint config file when initializing a new app from either of the app templates.

### What to review

Is the control flow for choosing whether or not linting/formatting configs/files should be written appropriate? I've tried to mirror patterns I saw being used already, but super open if there's a better way to do this!

### Testing

Built the project and ran `npx sanity init --template app-quickstart` to verify the prettier config and eslint config were not written to the app project.

Then ran `npx sanity init` to ensure the prettier config and eslint config *were* written to the Studio project.

### Notes for release

- New SDK apps initialized with the `app-quickstart` and `app-sanity-ui` templates will no longer include configurations for Prettier and ESLint; this is to allow developers to use their preferred formatting and linting configurations when building custom apps.