### PR TITLE
refactor: use release version actions client

### DIFF
--- a/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
+++ b/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
@@ -1,3 +1,4 @@
+import {type SingleActionResult} from '@sanity/client'
 import {useTelemetry} from '@sanity/telemetry/react'
 
 import {type ReleaseId} from '../../perspective/types'
@@ -12,8 +13,8 @@ export interface VersionOperationsValue {
     documentId: string,
     initialValue?: Record<string, unknown>,
   ) => Promise<void>
-  discardVersion: (releaseId: string, documentId: string) => Promise<void>
-  unpublishVersion: (documentId: string) => Promise<void>
+  discardVersion: (releaseId: string, documentId: string) => Promise<SingleActionResult>
+  unpublishVersion: (documentId: string) => Promise<SingleActionResult>
 }
 
 /** @internal */

--- a/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
@@ -1,8 +1,18 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
+import {
+  activeASAPRelease,
+  activeScheduledRelease,
+  archivedScheduledRelease,
+  publishedASAPRelease,
+  scheduledRelease,
+} from '../../__fixtures__/release.fixture'
 import {type RevertDocument} from '../../tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates'
-import {createReleaseOperationsStore} from '../createReleaseOperationStore'
+import {
+  createReleaseOperationsStore,
+  type ReleaseOperationsStore,
+} from '../createReleaseOperationStore'
 
 describe('createReleaseOperationsStore', () => {
   let mockClient: any
@@ -10,9 +20,20 @@ describe('createReleaseOperationsStore', () => {
   beforeEach(() => {
     mockClient = {
       config: vi.fn().mockReturnValue({dataset: 'test-dataset'}),
-      request: vi.fn().mockResolvedValue(undefined),
-      create: vi.fn().mockResolvedValue(undefined),
+      releases: {
+        create: vi.fn().mockResolvedValue(undefined),
+        edit: vi.fn().mockResolvedValue(undefined),
+        publish: vi.fn().mockResolvedValue(undefined),
+        schedule: vi.fn().mockResolvedValue(undefined),
+        unschedule: vi.fn().mockResolvedValue(undefined),
+        archive: vi.fn().mockResolvedValue(undefined),
+        unarchive: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+      },
       getDocument: vi.fn(),
+      createVersion: vi.fn().mockResolvedValue(undefined),
+      discardVersion: vi.fn().mockResolvedValue(undefined),
+      unpublishVersion: vi.fn().mockResolvedValue(undefined),
     }
   })
 
@@ -24,147 +45,99 @@ describe('createReleaseOperationsStore', () => {
 
   it('should create a release', async () => {
     const store = createStore()
-    const release = {_id: '_.releases.release-id', metadata: {title: 'Test Release'}}
+    const release = activeASAPRelease
     await store.createRelease(release)
-    expect(mockClient.request).toHaveBeenCalledWith({
-      uri: '/data/actions/test-dataset',
-      method: 'POST',
-      body: {
-        actions: [
-          {
-            actionType: 'sanity.action.release.create',
-            releaseId: 'release-id',
-            metadata: release.metadata,
-          },
-        ],
+    expect(mockClient.releases.create).toHaveBeenCalledWith(
+      {
+        releaseId: 'rASAP',
+        metadata: release.metadata,
       },
-    })
+      undefined,
+    )
   })
 
   it('should update a release', async () => {
     const store = createStore()
-    const release = {_id: '_.releases.release-id', metadata: {title: 'Updated Title'}}
+    const release = activeScheduledRelease
     await store.updateRelease(release)
-    expect(mockClient.request).toHaveBeenCalledWith({
-      uri: '/data/actions/test-dataset',
-      method: 'POST',
-      body: {
-        actions: [
-          {
-            actionType: 'sanity.action.release.edit',
-            releaseId: 'release-id',
-            patch: {
-              set: {metadata: release.metadata},
-              unset: [],
-            },
-          },
-        ],
+    expect(mockClient.releases.edit).toHaveBeenCalledWith(
+      {
+        releaseId: 'rActive',
+        patch: {
+          set: {metadata: release.metadata},
+          unset: [],
+        },
       },
-    })
+      undefined,
+    )
   })
 
   it('should publish a release using stable publish', async () => {
     const store = createStore()
-    await store.publishRelease('_.releases.release-id')
-    expect(mockClient.request).toHaveBeenCalledWith({
-      uri: '/data/actions/test-dataset',
-      method: 'POST',
-      body: {
-        actions: [
-          {
-            actionType: 'sanity.action.release.publish',
-            releaseId: 'release-id',
-          },
-        ],
+    await store.publishRelease(activeASAPRelease._id)
+    expect(mockClient.releases.publish).toHaveBeenCalledWith(
+      {
+        releaseId: 'rASAP',
       },
-    })
+      undefined,
+    )
   })
 
   it('should schedule a release', async () => {
     const store = createStore()
     const date = new Date('2024-01-01T00:00:00Z')
-    await store.schedule('_.releases.release-id', date)
-    expect(mockClient.request).toHaveBeenCalledWith({
-      uri: '/data/actions/test-dataset',
-      method: 'POST',
-      body: {
-        actions: [
-          {
-            actionType: 'sanity.action.release.schedule',
-            releaseId: 'release-id',
-            publishAt: date.toISOString(),
-          },
-        ],
+    await store.schedule(scheduledRelease._id, date)
+    expect(mockClient.releases.schedule).toHaveBeenCalledWith(
+      {
+        releaseId: 'rScheduled',
+        publishAt: date.toISOString(),
       },
-    })
+      undefined,
+    )
   })
 
   it('should unschedule a release', async () => {
     const store = createStore()
-    await store.unschedule('_.releases.release-id')
-    expect(mockClient.request).toHaveBeenCalledWith({
-      uri: '/data/actions/test-dataset',
-      method: 'POST',
-      body: {
-        actions: [
-          {
-            actionType: 'sanity.action.release.unschedule',
-            releaseId: 'release-id',
-          },
-        ],
+    await store.unschedule(scheduledRelease._id)
+    expect(mockClient.releases.unschedule).toHaveBeenCalledWith(
+      {
+        releaseId: 'rScheduled',
       },
-    })
+      undefined,
+    )
   })
 
   it('should archive a release', async () => {
     const store = createStore()
-    await store.archive('_.releases.release-id')
-    expect(mockClient.request).toHaveBeenCalledWith({
-      uri: '/data/actions/test-dataset',
-      method: 'POST',
-      body: {
-        actions: [
-          {
-            actionType: 'sanity.action.release.archive',
-            releaseId: 'release-id',
-          },
-        ],
+    await store.archive(activeScheduledRelease._id)
+    expect(mockClient.releases.archive).toHaveBeenCalledWith(
+      {
+        releaseId: 'rActive',
       },
-    })
+      undefined,
+    )
   })
 
   it('should unarchive a release', async () => {
     const store = createStore()
-    await store.unarchive('_.releases.release-id')
-    expect(mockClient.request).toHaveBeenCalledWith({
-      uri: '/data/actions/test-dataset',
-      method: 'POST',
-      body: {
-        actions: [
-          {
-            actionType: 'sanity.action.release.unarchive',
-            releaseId: 'release-id',
-          },
-        ],
+    await store.unarchive(archivedScheduledRelease._id)
+    expect(mockClient.releases.unarchive).toHaveBeenCalledWith(
+      {
+        releaseId: 'rArchived',
       },
-    })
+      undefined,
+    )
   })
 
   it('should delete a release', async () => {
     const store = createStore()
-    await store.deleteRelease('_.releases.release-id')
-    expect(mockClient.request).toHaveBeenCalledWith({
-      uri: '/data/actions/test-dataset',
-      method: 'POST',
-      body: {
-        actions: [
-          {
-            actionType: 'sanity.action.release.delete',
-            releaseId: 'release-id',
-          },
-        ],
+    await store.deleteRelease(publishedASAPRelease._id)
+    expect(mockClient.releases.delete).toHaveBeenCalledWith(
+      {
+        releaseId: 'rPublished',
       },
-    })
+      undefined,
+    )
   })
 
   describe('revertRelease', () => {
@@ -191,65 +164,31 @@ describe('createReleaseOperationsStore', () => {
         'immediate',
       )
 
-      expect(mockClient.request).toHaveBeenCalledWith({
-        uri: '/data/actions/test-dataset',
-        method: 'POST',
-        body: {
-          actions: [
-            {
-              actionType: 'sanity.action.release.create',
-              releaseId: revertReleaseId,
-              metadata: {...releaseMetadata, releaseType: 'asap'},
-            },
-          ],
+      expect(mockClient.releases.create).toHaveBeenCalledWith(
+        {
+          releaseId: revertReleaseId,
+          metadata: {...releaseMetadata, releaseType: 'asap'},
         },
-      })
+        undefined,
+      )
 
-      expect(mockClient.request).toHaveBeenNthCalledWith(1, {
-        body: {
-          actions: [
-            {
-              actionType: 'sanity.action.release.create',
-              metadata: {
-                description: 'A reverted release',
-                releaseType: 'asap',
-                title: 'Revert Release',
-              },
-              releaseId: 'revert-release-id',
-            },
-          ],
+      expect(mockClient.createVersion).toHaveBeenCalledWith(
+        {
+          document: {
+            _id: 'versions.revert-release-id.doc1',
+          },
+          publishedId: 'doc1',
+          releaseId: 'revert-release-id',
         },
-        method: 'POST',
-        uri: '/data/actions/test-dataset',
-      })
-      expect(mockClient.request).toHaveBeenNthCalledWith(2, {
-        body: {
-          actions: [
-            {
-              actionType: 'sanity.action.document.version.create',
-              document: {
-                _id: 'versions.revert-release-id.doc1',
-              },
-              publishedId: 'doc1',
-            },
-          ],
-        },
-        method: 'POST',
-        uri: '/data/actions/test-dataset',
-      })
+        undefined,
+      )
 
-      expect(mockClient.request).toHaveBeenCalledWith({
-        uri: '/data/actions/test-dataset',
-        method: 'POST',
-        body: {
-          actions: [
-            {
-              actionType: 'sanity.action.release.publish',
-              releaseId: 'revert-release-id',
-            },
-          ],
+      expect(mockClient.releases.publish).toHaveBeenCalledWith(
+        {
+          releaseId: 'revert-release-id',
         },
-      })
+        undefined,
+      )
     })
 
     it('should create a new release without publishing when revertType is "staged"', async () => {
@@ -260,25 +199,20 @@ describe('createReleaseOperationsStore', () => {
         'staged',
       )
 
-      expect(mockClient.request).toHaveBeenCalledWith({
-        uri: '/data/actions/test-dataset',
-        method: 'POST',
-        body: {
-          actions: [
-            {
-              actionType: 'sanity.action.release.create',
-              releaseId: revertReleaseId,
-              metadata: {...releaseMetadata, releaseType: 'asap'},
-            },
-          ],
+      expect(mockClient.releases.create).toHaveBeenCalledWith(
+        {
+          releaseId: revertReleaseId,
+          metadata: {...releaseMetadata, releaseType: 'asap'},
         },
-      })
+        undefined,
+      )
 
-      expect(mockClient.request).toHaveBeenCalledTimes(3)
+      expect(mockClient.createVersion).toHaveBeenCalledTimes(2)
+      expect(mockClient.releases.publish).not.toHaveBeenCalled()
     })
 
     it('should fail if a document does not exist and no initial value is provided', async () => {
-      mockClient.getDocument.mockResolvedValueOnce(null) // Simulate a missing document
+      mockClient.getDocument.mockResolvedValueOnce(null)
 
       await expect(
         store.revertRelease(
@@ -291,7 +225,7 @@ describe('createReleaseOperationsStore', () => {
     })
 
     it('should handle partial failure gracefully when creating versions', async () => {
-      mockClient.create.mockRejectedValueOnce(new Error('Failed to create version'))
+      mockClient.createVersion.mockRejectedValueOnce(new Error('Failed to create version'))
 
       const result = await store.revertRelease(
         revertReleaseDocumentId,
@@ -301,59 +235,12 @@ describe('createReleaseOperationsStore', () => {
       )
 
       expect(result).toBeUndefined()
-      expect(mockClient.request).toHaveBeenCalledTimes(3)
-      expect(mockClient.request).toHaveBeenNthCalledWith(1, {
-        body: {
-          actions: [
-            {
-              actionType: 'sanity.action.release.create',
-              metadata: {
-                description: 'A reverted release',
-                releaseType: 'asap',
-                title: 'Revert Release',
-              },
-              releaseId: 'revert-release-id',
-            },
-          ],
-        },
-        method: 'POST',
-        uri: '/data/actions/test-dataset',
-      })
-
-      expect(mockClient.request).toHaveBeenNthCalledWith(2, {
-        body: {
-          actions: [
-            {
-              actionType: 'sanity.action.document.version.create',
-              document: {
-                _id: 'versions.revert-release-id.doc1',
-              },
-              publishedId: 'doc1',
-            },
-          ],
-        },
-        method: 'POST',
-        uri: '/data/actions/test-dataset',
-      })
-      expect(mockClient.request).toHaveBeenNthCalledWith(3, {
-        body: {
-          actions: [
-            {
-              actionType: 'sanity.action.document.version.create',
-              document: {
-                _id: 'versions.revert-release-id.doc2',
-              },
-              publishedId: 'doc2',
-            },
-          ],
-        },
-        method: 'POST',
-        uri: '/data/actions/test-dataset',
-      })
+      expect(mockClient.releases.create).toHaveBeenCalledTimes(1)
+      expect(mockClient.createVersion).toHaveBeenCalledTimes(2)
     })
 
     it('should throw an error if creating the release fails', async () => {
-      mockClient.request.mockRejectedValueOnce(new Error('Failed to create release'))
+      mockClient.releases.create.mockRejectedValueOnce(new Error('Failed to create release'))
 
       await expect(
         store.revertRelease(revertReleaseDocumentId, releaseDocuments, releaseMetadata, 'staged'),
@@ -365,23 +252,18 @@ describe('createReleaseOperationsStore', () => {
     const store = createStore()
     mockClient.getDocument.mockResolvedValue({_id: 'doc-id', data: 'example'})
     await store.createVersion('release-id', 'doc-id', {newData: 'value'})
-    expect(mockClient.request).toHaveBeenCalledWith({
-      body: {
-        actions: [
-          {
-            actionType: 'sanity.action.document.version.create',
-            document: {
-              _id: `versions.release-id.doc-id`,
-              data: 'example',
-              newData: 'value',
-            },
-            publishedId: 'doc-id',
-          },
-        ],
+    expect(mockClient.createVersion).toHaveBeenCalledWith(
+      {
+        document: {
+          _id: `versions.release-id.doc-id`,
+          data: 'example',
+          newData: 'value',
+        },
+        publishedId: 'doc-id',
+        releaseId: 'release-id',
       },
-      method: 'POST',
-      uri: '/data/actions/test-dataset',
-    })
+      undefined,
+    )
   })
 
   it('should omit _weak from reference fields if _strengthenOnPublish is present when it creates a version of a document', async () => {
@@ -471,129 +353,211 @@ describe('createReleaseOperationsStore', () => {
 
     await store.createVersion('release-id', 'doc-id')
 
-    expect(mockClient.request).toHaveBeenCalledWith({
-      body: {
-        actions: [
-          {
-            actionType: 'sanity.action.document.version.create',
-            document: {
-              _id: `versions.release-id.doc-id`,
-              artist: {
-                _ref: 'some-artist-id',
-                _strengthenOnPublish: {
-                  template: {
-                    id: 'artist',
-                  },
-                  type: 'artist',
-                },
-                _type: 'reference',
+    expect(mockClient.createVersion).toHaveBeenCalledWith(
+      {
+        document: {
+          _id: `versions.release-id.doc-id`,
+          artist: {
+            _ref: 'some-artist-id',
+            _strengthenOnPublish: {
+              template: {
+                id: 'artist',
               },
-              expectedWeakReference: {
-                _ref: 'expected-weak-reference',
-                _type: 'reference',
-                _weak: true,
-                _strengthenOnPublish: {
-                  template: {
-                    id: 'some-document',
-                  },
-                  type: 'some-document',
-                  weak: true,
-                },
-              },
-              plants: [
-                {
-                  _ref: 'some-plant-id',
-                  _strengthenOnPublish: {
-                    template: {
-                      id: 'plant',
-                    },
-                    type: 'plant',
-                  },
-                  _type: 'reference',
-                },
-                {
-                  _ref: 'some-plant-id',
-                  _strengthenOnPublish: {
-                    template: {
-                      id: 'plant',
-                    },
-                    type: 'plant',
-                  },
-                  _type: 'reference',
-                },
-              ],
-              stores: [
-                {
-                  name: 'some-store',
-                  inventory: {
-                    products: [
-                      {
-                        _ref: 'some-product-id',
-                        _strengthenOnPublish: {
-                          template: {
-                            id: 'product',
-                          },
-                          type: 'product',
-                        },
-                        _type: 'reference',
-                      },
-                      {
-                        _ref: 'some-product-id',
-                        _strengthenOnPublish: {
-                          template: {
-                            id: 'product',
-                          },
-                          type: 'product',
-                        },
-                        _type: 'reference',
-                      },
-                    ],
-                  },
-                },
-              ],
+              type: 'artist',
             },
-            publishedId: 'doc-id',
+            _type: 'reference',
           },
-        ],
+          expectedWeakReference: {
+            _ref: 'expected-weak-reference',
+            _type: 'reference',
+            _weak: true,
+            _strengthenOnPublish: {
+              template: {
+                id: 'some-document',
+              },
+              type: 'some-document',
+              weak: true,
+            },
+          },
+          plants: [
+            {
+              _ref: 'some-plant-id',
+              _strengthenOnPublish: {
+                template: {
+                  id: 'plant',
+                },
+                type: 'plant',
+              },
+              _type: 'reference',
+            },
+            {
+              _ref: 'some-plant-id',
+              _strengthenOnPublish: {
+                template: {
+                  id: 'plant',
+                },
+                type: 'plant',
+              },
+              _type: 'reference',
+            },
+          ],
+          stores: [
+            {
+              name: 'some-store',
+              inventory: {
+                products: [
+                  {
+                    _ref: 'some-product-id',
+                    _strengthenOnPublish: {
+                      template: {
+                        id: 'product',
+                      },
+                      type: 'product',
+                    },
+                    _type: 'reference',
+                  },
+                  {
+                    _ref: 'some-product-id',
+                    _strengthenOnPublish: {
+                      template: {
+                        id: 'product',
+                      },
+                      type: 'product',
+                    },
+                    _type: 'reference',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        publishedId: 'doc-id',
+        releaseId: 'release-id',
       },
-      method: 'POST',
-      uri: '/data/actions/test-dataset',
-    })
+      undefined,
+    )
   })
 
   it('should discard a version of a document', async () => {
     const store = createStore()
     await store.discardVersion('release-id', 'doc-id')
-    expect(mockClient.request).toHaveBeenCalledWith({
-      uri: '/data/actions/test-dataset',
-      method: 'POST',
-      body: {
-        actions: [
-          {
-            actionType: 'sanity.action.document.version.discard',
-            versionId: 'versions.release-id.doc-id',
-            purge: false,
-          },
-        ],
+    expect(mockClient.discardVersion).toHaveBeenCalledWith(
+      {
+        releaseId: 'release-id',
+        publishedId: 'doc-id',
       },
-    })
+      false,
+      undefined,
+    )
   })
 
   it('should unpublish a version of a document', async () => {
     const store = createStore()
     await store.unpublishVersion('versions.release-id.doc-id')
-    expect(mockClient.request).toHaveBeenCalledWith({
-      uri: '/data/actions/test-dataset',
-      method: 'POST',
-      body: {
-        actions: [
-          {
-            actionType: 'sanity.action.document.version.unpublish',
-            versionId: 'versions.release-id.doc-id',
-            publishedId: `doc-id`,
-          },
-        ],
+    expect(mockClient.unpublishVersion).toHaveBeenCalledWith(
+      {
+        releaseId: 'release-id',
+        publishedId: 'doc-id',
       },
+      undefined,
+    )
+  })
+
+  it('should create a release with options', async () => {
+    const store = createStore()
+    const release = activeASAPRelease
+    const opts = {dryRun: true}
+    await store.createRelease(release, opts)
+    expect(mockClient.releases.create).toHaveBeenCalledWith(
+      {
+        releaseId: 'rASAP',
+        metadata: release.metadata,
+      },
+      opts,
+    )
+  })
+
+  it('should update a release with options', async () => {
+    const store = createStore()
+    const release = activeScheduledRelease
+    const opts = {dryRun: true}
+    await store.updateRelease(release, opts)
+    expect(mockClient.releases.edit).toHaveBeenCalledWith(
+      {
+        releaseId: 'rActive',
+        patch: {
+          set: {metadata: release.metadata},
+          unset: [],
+        },
+      },
+      opts,
+    )
+  })
+
+  it('should publish a release with dryRun', async () => {
+    const store = createStore()
+    const opts = {dryRun: true}
+    await store.publishRelease(activeASAPRelease._id, opts)
+    expect(mockClient.releases.publish).toHaveBeenCalledWith(
+      {
+        releaseId: 'rASAP',
+      },
+      opts,
+    )
+  })
+
+  describe('handleReleaseLimitError', () => {
+    type MethodTestCase<K extends keyof ReleaseOperationsStore> = {
+      name: K
+      method: string
+      runTest: (store: ReleaseOperationsStore) => Promise<unknown>
+    }
+
+    const methods: MethodTestCase<keyof ReleaseOperationsStore>[] = [
+      {
+        name: 'createRelease',
+        method: 'create',
+        runTest: (store) => store.createRelease(activeASAPRelease),
+      },
+      {
+        name: 'updateRelease',
+        method: 'edit',
+        runTest: (store) => store.updateRelease(activeScheduledRelease),
+      },
+      {
+        name: 'publishRelease',
+        method: 'publish',
+        runTest: (store) => store.publishRelease(activeASAPRelease._id),
+      },
+      {
+        name: 'schedule',
+        method: 'schedule',
+        runTest: (store) => store.schedule(scheduledRelease._id, new Date('2024-01-01T00:00:00Z')),
+      },
+      {
+        name: 'unarchive',
+        method: 'unarchive',
+        runTest: (store) => store.unarchive(archivedScheduledRelease._id),
+      },
+    ]
+
+    describe.each(methods)('$name', ({method, runTest}) => {
+      it('should call onReleaseLimitReached when release limit is reached', async () => {
+        const error = new Error('Release limit reached') as Error & {
+          details: {type: 'releaseLimitExceededError'; limit: number}
+        }
+        error.details = {type: 'releaseLimitExceededError', limit: 5}
+        mockClient.releases[method].mockRejectedValueOnce(error)
+
+        const onReleaseLimitReached = vi.fn()
+        const store = createReleaseOperationsStore({
+          client: mockClient,
+          onReleaseLimitReached,
+        })
+
+        await expect(runTest(store)).rejects.toThrow('Release limit reached')
+        expect(onReleaseLimitReached).toHaveBeenCalledWith(5)
+      })
     })
   })
 })

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -20,7 +20,10 @@ export interface ReleaseOperationsStore {
   unschedule: (releaseId: string, opts?: BaseActionOptions) => Promise<SingleActionResult>
   archive: (releaseId: string, opts?: BaseActionOptions) => Promise<SingleActionResult>
   unarchive: (releaseId: string, opts?: BaseActionOptions) => Promise<SingleActionResult>
-  updateRelease: (release: EditableReleaseDocument, opts?: BaseActionOptions) => Promise<void>
+  updateRelease: (
+    release: EditableReleaseDocument,
+    opts?: BaseActionOptions,
+  ) => Promise<SingleActionResult>
   createRelease: (
     release: EditableReleaseDocument,
     opts?: BaseActionOptions,
@@ -37,7 +40,7 @@ export interface ReleaseOperationsStore {
     documentId: string,
     initialValue?: Omit<EditableReleaseDocument, '_id' | '_type'>,
     opts?: BaseActionOptions,
-  ) => Promise<void>
+  ) => Promise<SingleActionResult>
   discardVersion: (
     releaseId: string,
     documentId: string,
@@ -86,7 +89,7 @@ export function createReleaseOperationsStore(options: {
       .filter(([_, value]) => value === undefined)
       .map(([key]) => `metadata.${key}`)
 
-    await handleReleaseLimitError(
+    return handleReleaseLimitError(
       client.releases.edit(
         {
           releaseId,
@@ -159,7 +162,7 @@ export function createReleaseOperationsStore(options: {
       _id: getVersionId(documentId, releaseId),
     }) as IdentifiedSanityDocumentStub
 
-    await client.createVersion(
+    return client.createVersion(
       {document: versionDocument, publishedId: getPublishedId(documentId), releaseId},
       opts,
     )

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -1,173 +1,147 @@
 import {
-  type Action,
+  type BaseActionOptions,
   type EditableReleaseDocument,
-  type EditAction,
   type IdentifiedSanityDocumentStub,
   type ReleaseDocument,
   type SanityClient,
+  type SingleActionResult,
 } from '@sanity/client'
 
-import {getPublishedId, getVersionId} from '../../util'
+import {getPublishedId, getVersionFromId, getVersionId} from '../../util'
 import {type ReleasesUpsellContextValue} from '../contexts/upsell/types'
 import {getReleaseIdFromReleaseDocumentId} from '../index'
 import {type RevertDocument} from '../tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates'
 import {prepareVersionReferences} from '../util/prepareVersionReferences'
 import {isReleaseLimitError} from './isReleaseLimitError'
 
-interface operationsOptions {
-  dryRun?: boolean
-  skipCrossDatasetValidation?: boolean
-}
 export interface ReleaseOperationsStore {
-  publishRelease: (releaseId: string, opts?: operationsOptions) => Promise<void>
-  schedule: (releaseId: string, date: Date, opts?: operationsOptions) => Promise<void>
-  //todo: reschedule: (releaseId: string, newDate: Date) => Promise<void>
-  unschedule: (releaseId: string, opts?: operationsOptions) => Promise<void>
-  archive: (releaseId: string, opts?: operationsOptions) => Promise<void>
-  unarchive: (releaseId: string, opts?: operationsOptions) => Promise<void>
-  updateRelease: (release: EditableReleaseDocument, opts?: operationsOptions) => Promise<void>
-  createRelease: (release: EditableReleaseDocument, opts?: operationsOptions) => Promise<void>
-  deleteRelease: (releaseId: string, opts?: operationsOptions) => Promise<void>
+  publishRelease: (releaseId: string, opts?: BaseActionOptions) => Promise<SingleActionResult>
+  schedule: (releaseId: string, date: Date, opts?: BaseActionOptions) => Promise<SingleActionResult>
+  unschedule: (releaseId: string, opts?: BaseActionOptions) => Promise<SingleActionResult>
+  archive: (releaseId: string, opts?: BaseActionOptions) => Promise<SingleActionResult>
+  unarchive: (releaseId: string, opts?: BaseActionOptions) => Promise<SingleActionResult>
+  updateRelease: (release: EditableReleaseDocument, opts?: BaseActionOptions) => Promise<void>
+  createRelease: (
+    release: EditableReleaseDocument,
+    opts?: BaseActionOptions,
+  ) => Promise<SingleActionResult>
+  deleteRelease: (releaseId: string, opts?: BaseActionOptions) => Promise<SingleActionResult>
   revertRelease: (
     revertReleaseId: string,
     documents: RevertDocument[],
     releaseMetadata: ReleaseDocument['metadata'],
     revertType: 'staged' | 'immediate',
-    opts?: operationsOptions,
   ) => Promise<void>
   createVersion: (
     releaseId: string,
     documentId: string,
-    initialvalue?: Record<string, unknown>,
-    opts?: operationsOptions,
+    initialValue?: Omit<EditableReleaseDocument, '_id' | '_type'>,
+    opts?: BaseActionOptions,
   ) => Promise<void>
-  discardVersion: (releaseId: string, documentId: string, opts?: operationsOptions) => Promise<void>
-  unpublishVersion: (documentId: string, opts?: operationsOptions) => Promise<void>
+  discardVersion: (
+    releaseId: string,
+    documentId: string,
+    opts?: BaseActionOptions,
+  ) => Promise<SingleActionResult>
+  unpublishVersion: (documentId: string, opts?: BaseActionOptions) => Promise<SingleActionResult>
 }
-
-const METADATA_PROPERTY_NAME = 'metadata'
 
 export function createReleaseOperationsStore(options: {
   client: SanityClient
   onReleaseLimitReached: ReleasesUpsellContextValue['onReleaseLimitReached']
 }): ReleaseOperationsStore {
-  const {client} = options
-  const requestAction = createRequestAction(options.onReleaseLimitReached)
+  const {client, onReleaseLimitReached} = options
 
-  const handleCreateRelease = (release: EditableReleaseDocument, opts?: operationsOptions) =>
-    requestAction(
-      client,
-      {
-        actionType: 'sanity.action.release.create',
-        releaseId: getReleaseIdFromReleaseDocumentId(release._id),
-        [METADATA_PROPERTY_NAME]: release.metadata,
-      },
+  const handleReleaseLimitError = (
+    action: Promise<SingleActionResult>,
+    opts?: {dryRun?: boolean},
+  ) =>
+    action.catch((error) => {
+      // if dryRunning then essentially this is a silent request
+      // so don't want to create disruptive upsell because of limit
+      if (!opts?.dryRun && isReleaseLimitError(error)) {
+        // free accounts do not return limit, 0 is implied
+        onReleaseLimitReached(error.details.limit || 0)
+      }
+
+      throw error
+    })
+
+  const handleCreateRelease = (release: EditableReleaseDocument, opts?: BaseActionOptions) =>
+    handleReleaseLimitError(
+      client.releases.create(
+        {releaseId: getReleaseIdFromReleaseDocumentId(release._id), metadata: release.metadata},
+        opts,
+      ),
       opts,
     )
 
   const handleUpdateRelease = async (
     release: EditableReleaseDocument,
-    opts?: operationsOptions,
+    opts?: BaseActionOptions,
   ) => {
-    const bundleId = getReleaseIdFromReleaseDocumentId(release._id)
+    const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
 
     const unsetKeys = Object.entries(release)
       .filter(([_, value]) => value === undefined)
-      .map(([key]) => `${METADATA_PROPERTY_NAME}.${key}`)
+      .map(([key]) => `metadata.${key}`)
 
-    await requestAction(
-      client,
-      {
-        actionType: 'sanity.action.release.edit',
-        releaseId: bundleId,
-        patch: {
-          // todo: consider more granular updates here
-          set: {[METADATA_PROPERTY_NAME]: release.metadata},
-          unset: unsetKeys,
+    await handleReleaseLimitError(
+      client.releases.edit(
+        {
+          releaseId,
+          patch: {
+            set: {metadata: release.metadata},
+            unset: unsetKeys,
+          },
         },
-      },
+        opts,
+      ),
       opts,
     )
   }
 
-  const handlePublishRelease = (releaseId: string, opts?: operationsOptions) =>
-    requestAction(
-      client,
-      [
-        {
-          actionType: 'sanity.action.release.publish',
-          releaseId: getReleaseIdFromReleaseDocumentId(releaseId),
-        },
-      ],
+  const handlePublishRelease = (releaseId: string, opts?: BaseActionOptions) =>
+    handleReleaseLimitError(
+      client.releases.publish({releaseId: getReleaseIdFromReleaseDocumentId(releaseId)}, opts),
       opts,
     )
 
-  const handleScheduleRelease = (releaseId: string, publishAt: Date, opts?: operationsOptions) =>
-    requestAction(
-      client,
-      [
+  const handleScheduleRelease = (releaseId: string, publishAt: Date, opts?: BaseActionOptions) =>
+    handleReleaseLimitError(
+      client.releases.schedule(
         {
-          actionType: 'sanity.action.release.schedule',
           releaseId: getReleaseIdFromReleaseDocumentId(releaseId),
           publishAt: publishAt.toISOString(),
         },
-      ],
+        opts,
+      ),
       opts,
     )
 
-  const handleUnscheduleRelease = (releaseId: string, opts?: operationsOptions) =>
-    requestAction(
-      client,
-      [
-        {
-          actionType: 'sanity.action.release.unschedule',
-          releaseId: getReleaseIdFromReleaseDocumentId(releaseId),
-        },
-      ],
+  const handleUnscheduleRelease = (releaseId: string, opts?: BaseActionOptions) =>
+    handleReleaseLimitError(
+      client.releases.unschedule({releaseId: getReleaseIdFromReleaseDocumentId(releaseId)}, opts),
       opts,
     )
 
-  const handleArchiveRelease = (releaseId: string, opts?: operationsOptions) =>
-    requestAction(
-      client,
-      [
-        {
-          actionType: 'sanity.action.release.archive',
-          releaseId: getReleaseIdFromReleaseDocumentId(releaseId),
-        },
-      ],
+  const handleArchiveRelease = (releaseId: string, opts?: BaseActionOptions) =>
+    client.releases.archive({releaseId: getReleaseIdFromReleaseDocumentId(releaseId)}, opts)
+
+  const handleUnarchiveRelease = (releaseId: string, opts?: BaseActionOptions) =>
+    handleReleaseLimitError(
+      client.releases.unarchive({releaseId: getReleaseIdFromReleaseDocumentId(releaseId)}, opts),
       opts,
     )
 
-  const handleUnarchiveRelease = (releaseId: string, opts?: operationsOptions) =>
-    requestAction(
-      client,
-      [
-        {
-          actionType: 'sanity.action.release.unarchive',
-          releaseId: getReleaseIdFromReleaseDocumentId(releaseId),
-        },
-      ],
-      opts,
-    )
-
-  const handleDeleteRelease = (releaseId: string, opts?: operationsOptions) =>
-    requestAction(
-      client,
-      [
-        {
-          actionType: 'sanity.action.release.delete',
-          releaseId: getReleaseIdFromReleaseDocumentId(releaseId),
-        },
-      ],
-      opts,
-    )
+  const handleDeleteRelease = (releaseId: string, opts?: BaseActionOptions) =>
+    client.releases.delete({releaseId: getReleaseIdFromReleaseDocumentId(releaseId)}, opts)
 
   const handleCreateVersion = async (
     releaseId: string,
     documentId: string,
-    initialValue?: Record<string, unknown>,
-    opts?: operationsOptions,
+    initialValue?: Omit<EditableReleaseDocument, '_id' | '_type'>,
+    opts?: BaseActionOptions,
   ) => {
     // the documentId will show you where the document is coming from and which
     // document should it copy from
@@ -185,40 +159,26 @@ export function createReleaseOperationsStore(options: {
       _id: getVersionId(documentId, releaseId),
     }) as IdentifiedSanityDocumentStub
 
-    await requestAction(
-      client,
-      [
-        {
-          actionType: 'sanity.action.document.version.create',
-          publishedId: getPublishedId(documentId),
-          document: versionDocument,
-        },
-      ],
+    await client.createVersion(
+      {document: versionDocument, publishedId: getPublishedId(documentId), releaseId},
       opts,
     )
   }
 
-  const handleDiscardVersion = (releaseId: string, documentId: string, opts?: operationsOptions) =>
-    requestAction(
-      client,
-      [
-        {
-          actionType: 'sanity.action.document.version.discard',
-          versionId: getVersionId(documentId, releaseId),
-          purge: false, // keep document history
-        },
-      ],
-      opts,
-    )
+  const handleDiscardVersion = (releaseId: string, documentId: string, opts?: BaseActionOptions) =>
+    client.discardVersion({releaseId, publishedId: getPublishedId(documentId)}, false, opts)
 
-  const handleUnpublishVersion = (documentId: string) =>
-    requestAction(client, [
-      {
-        actionType: 'sanity.action.document.version.unpublish',
-        versionId: documentId,
-        publishedId: getPublishedId(documentId),
-      },
-    ])
+  const handleUnpublishVersion = (documentId: string, opts?: BaseActionOptions) => {
+    const releaseId = getVersionFromId(documentId)
+    // in cases where the document is not part of a release, or document is `drafts.`
+    // the releaseId will be undefined
+    // cannot unpublish in this case
+    if (!releaseId) {
+      throw new Error(`Release ID not found for document ${documentId}`)
+    }
+
+    return client.unpublishVersion({releaseId, publishedId: getPublishedId(documentId)}, opts)
+  }
 
   const handleRevertRelease = async (
     revertReleaseId: string,
@@ -262,113 +222,5 @@ export function createReleaseOperationsStore(options: {
     createVersion: handleCreateVersion,
     discardVersion: handleDiscardVersion,
     unpublishVersion: handleUnpublishVersion,
-  }
-}
-
-interface ScheduleApiAction {
-  actionType: 'sanity.action.release.schedule'
-  releaseId: string
-  publishAt: string
-  dryRun?: boolean
-  skipCrossDatasetValidation?: boolean
-}
-
-interface PublishApiAction {
-  actionType: 'sanity.action.release.publish'
-  releaseId: string
-}
-
-interface ArchiveApiAction {
-  actionType: 'sanity.action.release.archive'
-  releaseId: string
-}
-
-interface UnarchiveApiAction {
-  actionType: 'sanity.action.release.unarchive'
-  releaseId: string
-}
-
-interface UnscheduleApiAction {
-  actionType: 'sanity.action.release.unschedule'
-  releaseId: string
-}
-
-interface CreateReleaseApiAction {
-  actionType: 'sanity.action.release.create'
-  releaseId: string
-  [METADATA_PROPERTY_NAME]?: Partial<ReleaseDocument['metadata']>
-}
-
-interface CreateVersionReleaseApiAction {
-  actionType: 'sanity.action.document.version.create'
-  publishedId: string
-  document: IdentifiedSanityDocumentStub
-}
-
-interface UnpublishVersionReleaseApiAction {
-  actionType: 'sanity.action.document.version.unpublish'
-  versionId: string
-  publishedId: string
-}
-
-interface DiscardVersionReleaseApiAction {
-  actionType: 'sanity.action.document.version.discard'
-  versionId: string
-  purge?: boolean
-}
-
-interface EditReleaseApiAction {
-  actionType: 'sanity.action.release.edit'
-  releaseId: string
-  patch: EditAction['patch']
-}
-
-interface DeleteApiAction {
-  actionType: 'sanity.action.release.delete'
-  releaseId: string
-}
-
-type ReleaseAction =
-  | Action
-  | ScheduleApiAction
-  | PublishApiAction
-  | CreateReleaseApiAction
-  | EditReleaseApiAction
-  | UnscheduleApiAction
-  | ArchiveApiAction
-  | UnarchiveApiAction
-  | DeleteApiAction
-  | CreateVersionReleaseApiAction
-  | UnpublishVersionReleaseApiAction
-  | DiscardVersionReleaseApiAction
-
-export function createRequestAction(
-  onReleaseLimitReached: ReleasesUpsellContextValue['onReleaseLimitReached'],
-) {
-  return async function requestAction(
-    client: SanityClient,
-    actions: ReleaseAction | ReleaseAction[],
-    options?: operationsOptions,
-  ): Promise<void> {
-    const {dataset} = client.config()
-    try {
-      return await client.request({
-        uri: `/data/actions/${dataset}`,
-        method: 'POST',
-        body: {
-          ...options,
-          actions: Array.isArray(actions) ? actions : [actions],
-        },
-      })
-    } catch (e) {
-      // if dryRunning then essentially this is a silent request
-      // so don't want to create disruptive upsell because of limit
-      if (!options?.dryRun && isReleaseLimitError(e)) {
-        // free accounts do not return limit, 0 is implied
-        onReleaseLimitReached(e.details.limit || 0)
-      }
-
-      throw e
-    }
   }
 }

--- a/packages/sanity/src/core/releases/store/createReleasePermissionsStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleasePermissionsStore.ts
@@ -37,7 +37,7 @@ export function createReleasePermissionsStore(
    * @returns true or false depending if the user can perform the action
    */
   const checkWithPermissionGuard = async <
-    T extends (...args: any[]) => Promise<void | SingleActionResult> | void,
+    T extends (...args: any[]) => Promise<void | SingleActionResult>,
   >(
     action: T,
     ...args: Parameters<T>

--- a/packages/sanity/src/core/releases/store/createReleasePermissionsStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleasePermissionsStore.ts
@@ -1,3 +1,5 @@
+import {type SingleActionResult} from '@sanity/client'
+
 import {isErrorWithDetails} from '../../error/types/isErrorWithDetails'
 import {type useReleasePermissionsValue} from './useReleasePermissions'
 
@@ -34,7 +36,9 @@ export function createReleasePermissionsStore(
    * @param args - the arguments to pass to the action (release id, etc)
    * @returns true or false depending if the user can perform the action
    */
-  const checkWithPermissionGuard = async <T extends (...args: any[]) => Promise<void> | void>(
+  const checkWithPermissionGuard = async <
+    T extends (...args: any[]) => Promise<void | SingleActionResult> | void,
+  >(
     action: T,
     ...args: Parameters<T>
   ): Promise<boolean> => {

--- a/packages/sanity/src/core/releases/store/useReleasePermissions.ts
+++ b/packages/sanity/src/core/releases/store/useReleasePermissions.ts
@@ -1,3 +1,4 @@
+import {type SingleActionResult} from '@sanity/client'
 import {useMemo} from 'react'
 
 import {useFeatureEnabled} from '../../hooks/useFeatureEnabled'
@@ -7,7 +8,9 @@ import {createReleasePermissionsStore} from './createReleasePermissionsStore'
 const RELEASE_PERMISSIONS_RESOURCE_CACHE_NAMESPACE = 'ReleasePermissions'
 
 export interface useReleasePermissionsValue {
-  checkWithPermissionGuard: <T extends (...args: any[]) => Promise<void> | void>(
+  checkWithPermissionGuard: <
+    T extends (...args: any[]) => Promise<void | SingleActionResult> | void,
+  >(
     action: T,
     ...args: Parameters<T>
   ) => Promise<boolean>

--- a/packages/sanity/src/core/releases/store/useReleasePermissions.ts
+++ b/packages/sanity/src/core/releases/store/useReleasePermissions.ts
@@ -8,9 +8,7 @@ import {createReleasePermissionsStore} from './createReleasePermissionsStore'
 const RELEASE_PERMISSIONS_RESOURCE_CACHE_NAMESPACE = 'ReleasePermissions'
 
 export interface useReleasePermissionsValue {
-  checkWithPermissionGuard: <
-    T extends (...args: any[]) => Promise<void | SingleActionResult> | void,
-  >(
+  checkWithPermissionGuard: <T extends (...args: any[]) => Promise<void | SingleActionResult>>(
     action: T,
     ...args: Parameters<T>
   ) => Promise<boolean>

--- a/packages/sanity/src/core/releases/util/const.ts
+++ b/packages/sanity/src/core/releases/util/const.ts
@@ -6,14 +6,24 @@ import {type BadgeTone} from '@sanity/ui'
  */
 export const LATEST = 'drafts' as const
 
+/**
+ * @internal
+ */
 export const PUBLISHED = 'published' as const
+
 /**
  * @internal
  */
 export const DEFAULT_RELEASE_TYPE = 'asap'
 
+/**
+ * @internal
+ */
 export const ARCHIVED_RELEASE_STATES = ['archived', 'published']
 
+/**
+ * @internal
+ */
 export const RELEASE_TYPES_TONES: Record<ReleaseType, {tone: BadgeTone}> = {
   asap: {
     tone: 'caution',


### PR DESCRIPTION
### Description
Moving `createReleaseOperationsStore` to use the new methods exported from `client`.

This involves a slight refactor of how the release limit error catching happens, but means a lot of the types for actions can be removed and replaced with uses from client.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Updated and adding in more test coverage to `createReleaseOperationsStore.test` to cover limit testing and test that the client is being called with the correct method and args.

The E2Es that test around creating releases still pass too.

Also manually tested the various release and version flows to ensure there are no regressions.
Would appreciate if when reviewing you could also give a whirl through a few flows to make sure there aren't any fails
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
