### PR TITLE
chore: marking use of useClient() with no options as deprecated

### DIFF
--- a/packages/sanity/src/core/hooks/useClient.ts
+++ b/packages/sanity/src/core/hooks/useClient.ts
@@ -43,7 +43,7 @@ export function useClient(): SanityClient
  * }
  * ```
  */
-export function useClient(clientOptions?: SourceClientOptions): SanityClient
+export function useClient(clientOptions: SourceClientOptions): SanityClient
 export function useClient(clientOptions?: SourceClientOptions): SanityClient {
   const source = useSource()
   if (!clientOptions) {

--- a/packages/sanity/src/core/hooks/useClient.ts
+++ b/packages/sanity/src/core/hooks/useClient.ts
@@ -5,7 +5,7 @@ import {useSource} from '../studio'
 
 /**
  *
- * @deprecated Calling `useClient()` without specifying an API version is deprecated and will stop working in the next major version - please specify a date, e.g. `useClient({apiVersion: "2025-02-07"})`.
+ * @deprecated Calling `useClient()` without specifying an API version is deprecated - specify a date to prevent breaking changes, e.g. `useClient({apiVersion: "2025-02-07"})`.
  *
  * React hook that returns a configured Sanity client instance based on the given configuration.
  * Automatically uses the correct project and dataset based on the current active workspace.

--- a/packages/sanity/src/core/hooks/useClient.ts
+++ b/packages/sanity/src/core/hooks/useClient.ts
@@ -4,6 +4,27 @@ import {type SourceClientOptions} from '../config'
 import {useSource} from '../studio'
 
 /**
+ *
+ * @deprecated Calling `useClient()` without specifying an API version is deprecated and will stop working in the next major version - please specify a date, e.g. `useClient({apiVersion: "2025-02-07"})`.
+ *
+ * React hook that returns a configured Sanity client instance based on the given configuration.
+ * Automatically uses the correct project and dataset based on the current active workspace.
+ *
+ * @public
+ * @returns A configured Sanity client instance
+ * @remarks The client instance is automatically memoized based on API version
+ * @remarks The client will fallback to `v2025-02-07` of the API
+ * @example Instantiating a client
+ * ```ts
+ * function MyComponent() {
+ *   const client = useClient({apiVersion: '2021-06-07'})
+ *   // ... do something with client instance ...
+ * }
+ * ```
+ */
+export function useClient(): SanityClient
+
+/**
  * React hook that returns a configured Sanity client instance based on the given configuration.
  * Automatically uses the correct project and dataset based on the current active workspace.
  *
@@ -22,6 +43,7 @@ import {useSource} from '../studio'
  * }
  * ```
  */
+export function useClient(clientOptions?: SourceClientOptions): SanityClient
 export function useClient(clientOptions?: SourceClientOptions): SanityClient {
   const source = useSource()
   if (!clientOptions) {


### PR DESCRIPTION
### Description
Currently calling `useClient()` will trigger a console warning. We have let this slip through a few times and retrospectively caught it in the monorepo, but this can also occur in client plugins.

Requiring `clientOptions` would be a breaking change, so instead if we overload `useClient` and mark `undefined` `clientOptions` signature as `deprecated` then we can give clear DX signal not to use this approach, whilst still supporting it.

<img width="439" alt="Screenshot 2025-05-14 at 11 55 46" src="https://github.com/user-attachments/assets/de2ac668-4472-4540-b5d5-5724342ae643" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* Does this imply that `useClient` might be deprecated entirely?
* Is there an alternative approach?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
N/A
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Using `useClient` without a defined `apiVersion` is now marked as deprecated.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
