### PR TITLE
fix(presentation): fix multiple resolver document location state

### DIFF
--- a/packages/sanity/src/presentation/document/LocationsBanner.tsx
+++ b/packages/sanity/src/presentation/document/LocationsBanner.tsx
@@ -47,30 +47,31 @@ export function LocationsBanner(props: {
 
   const isResolving = status === 'resolving'
 
-  const len = state.locations?.length || 0
+  const {locations, message, tone} = state
+  const locationsCount = locations?.length || 0
 
   const {t} = useTranslation(presentationLocaleNamespace)
   const presentation = useContext(PresentationContext)
   const presentationName = presentation?.name
   const [expanded, setExpanded] = useState(false)
   const toggle = useCallback(() => {
-    if (!len) return
+    if (!locationsCount) return
     setExpanded((v) => !v)
-  }, [len])
+  }, [locationsCount])
 
   const title = isResolving
     ? t('locations-banner.resolving.text')
-    : state.message || t('locations-banner.locations-count', {count: len})
+    : message || t('locations-banner.locations-count', {count: locationsCount})
 
-  const ToneIcon = state.tone ? TONE_ICONS[state.tone] : undefined
+  const ToneIcon = tone ? TONE_ICONS[tone] : undefined
 
   if (!resolvers) return null
   return (
-    <Card padding={1} radius={2} border tone={state.tone}>
+    <Card padding={1} radius={2} border tone={tone}>
       <div style={{margin: -1}}>
-        {!state.locations && (
+        {!locations && (
           <Flex align="flex-start" gap={3} padding={3}>
-            {state.tone && ToneIcon && (
+            {tone && ToneIcon && (
               <Box flex="none">
                 <Text size={1}>
                   <ToneIcon />
@@ -85,10 +86,10 @@ export function LocationsBanner(props: {
             </Box>
           </Flex>
         )}
-        {state.locations && (
+        {locations && (
           <>
             <Card
-              as={len ? 'button' : undefined}
+              as={locationsCount ? 'button' : undefined}
               onClick={toggle}
               padding={3}
               radius={1}
@@ -100,7 +101,7 @@ export function LocationsBanner(props: {
                     <Spinner size={1} />
                   ) : (
                     <Text size={1}>
-                      {len === 0 ? (
+                      {locationsCount === 0 ? (
                         <InfoOutlineIcon />
                       ) : (
                         <ChevronRightIcon
@@ -122,7 +123,7 @@ export function LocationsBanner(props: {
               </Flex>
             </Card>
             <Stack hidden={!expanded} marginTop={1} space={1}>
-              {state.locations.map((l) => {
+              {locations.map((l) => {
                 let active = false
                 if (
                   (options.name || DEFAULT_TOOL_NAME) === presentationName &&

--- a/packages/sanity/src/presentation/document/PresentationDocumentHeader.tsx
+++ b/packages/sanity/src/presentation/document/PresentationDocumentHeader.tsx
@@ -5,7 +5,6 @@ import {PresentationDocumentContext} from 'sanity/_singletons'
 import {styled} from 'styled-components'
 
 import {type PresentationPluginOptions} from '../types'
-import {useDocumentLocations} from '../useDocumentLocations'
 import {LocationsBanner} from './LocationsBanner'
 
 const LocationStack = styled(Stack)`
@@ -24,39 +23,29 @@ export function PresentationDocumentHeader(props: {
 }): ReactNode {
   const {documentId, options, schemaType, version} = props
   const context = useContext(PresentationDocumentContext)
-  const {state, status} = useDocumentLocations({
-    id: documentId,
-    version,
-    resolvers: options.resolve?.locations || options.locate,
-    type: schemaType.name,
-  })
-
-  if ((context && context.options[0] !== options) || status === 'empty') {
-    return null
-  }
 
   const contextOptions = context?.options || []
+  const resolvers = contextOptions.map((o) => o.resolve?.locations || o.locate)
+  const hasResolvers = resolvers.some(Boolean)
+
+  if ((context && context.options[0] !== options) || !hasResolvers) {
+    return null
+  }
 
   return (
     <LocationStack marginBottom={5} space={5}>
       <Stack space={2}>
-        {contextOptions.map(
-          (
-            // eslint-disable-next-line @typescript-eslint/no-shadow
-            options,
-            idx,
-          ) => (
-            <LocationsBanner
-              documentId={documentId}
-              isResolving={status === 'resolving'}
-              key={idx}
-              options={options}
-              schemaType={schemaType}
-              showPresentationTitle={contextOptions.length > 1}
-              state={state}
-            />
-          ),
-        )}
+        {contextOptions.map((_options, idx) => (
+          <LocationsBanner
+            key={idx}
+            documentId={documentId}
+            options={_options}
+            resolvers={resolvers[idx]}
+            schemaType={schemaType}
+            showPresentationTitle={contextOptions.length > 1}
+            version={version}
+          />
+        ))}
       </Stack>
     </LocationStack>
   )


### PR DESCRIPTION
### Description

This PR fixes an issue ([reported in the community Slack](https://sanity-io-land.slack.com/archives/C9Z7RC3V1/p1747127158130599)) where document locations state was being incorrectly resolved when multiple instances of a Presentation tool were resolving locations for the same document type. In those situations, location state would be duplicated from that returned from the first resolver across any subsequent location state representations in the UI.

In the screenshot below, `First Instance: Page Title` is incorrectly shown in the resolved locations for the second instance of the Presentation tool.

<img width="663" alt="Screenshot 2025-05-14 at 14 05 35" src="https://github.com/user-attachments/assets/1700c15b-31a6-4a1c-a062-60179a316ac7" />

After this change, the location would show correctly as below:

<img width="691" alt="Screenshot 2025-05-14 at 14 08 25" src="https://github.com/user-attachments/assets/04768f85-2994-42f0-a719-aaad8b3d3263" />


The `useDocumentLocations` hook has also been refactored and simplified to use the document preview store. It now uses the store's `observeForPreview` method and passes a `type` object with an overriden `preview` property instead of using custom logic for recursively listening to documents.

### What to review

Locations state should resolve as expected when multiple Presentation tool instances exist that provide a resolver for a given document type.

### Testing

Duplicate or add another Presentation tool instance in `sanity.config.ts`. Alter some location resolver or state in the duplicated instance for a given document type (e.g. in the test studio, update the `simpleBlock` resolver to return a different title). In Presentation or Structure, the document pane should display two document location panes/dropdowns. On `main`, you should notice that the state returned for the second instance is incorrect. With this branch checked out, the state defined in the config should be reflected accurately.

### Notes for release

Fixes issue where a document location resolver state was incorrectly duplicated across Presentation instances.