### PR TITLE
feat(sanity): allow draft model to be switched off

### DIFF
--- a/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
@@ -11,6 +11,7 @@ import {
   useActiveReleases,
   type VersionInfoDocumentStub,
 } from '../../releases'
+import {useWorkspace} from '../../studio/workspace'
 
 interface DocumentStatusProps {
   draft?: PreviewValue | Partial<SanityDocument> | null
@@ -34,6 +35,12 @@ export function DocumentStatus({draft, published, versions, singleLine}: Documen
   const versionsList = useMemo(() => Object.entries(versions ?? {}), [versions])
   const {t} = useTranslation()
 
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
   return (
     <Flex
       align={singleLine ? 'center' : 'flex-start'}
@@ -49,7 +56,7 @@ export function DocumentStatus({draft, published, versions, singleLine}: Documen
           tone={'positive'}
         />
       )}
-      {draft && (
+      {isDraftModelEnabled && draft && (
         <VersionStatus
           title={t('release.chip.draft')}
           mode="draft"

--- a/packages/sanity/src/core/components/documentStatusIndicator/DocumentStatusIndicator.tsx
+++ b/packages/sanity/src/core/components/documentStatusIndicator/DocumentStatusIndicator.tsx
@@ -5,6 +5,7 @@ import {css, styled} from 'styled-components'
 import {RELEASE_TYPES_TONES, type VersionInfoDocumentStub} from '../../releases'
 import {useActiveReleases} from '../../releases/store/useActiveReleases'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
+import {useWorkspace} from '../../studio/workspace'
 
 interface DocumentStatusProps {
   draft?: VersionInfoDocumentStub | undefined
@@ -54,6 +55,13 @@ type Status = 'published' | 'draft' | 'asap' | 'scheduled' | 'undecided'
  */
 export function DocumentStatusIndicator({draft, published, versions}: DocumentStatusProps) {
   const {data: releases} = useActiveReleases()
+
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
   const versionsList = useMemo(
     () =>
       versions
@@ -79,8 +87,8 @@ export function DocumentStatusIndicator({draft, published, versions}: DocumentSt
       show: Boolean(published),
     },
     {
-      status: 'draft',
-      show: Boolean(draft),
+      status: 'draft' as const,
+      show: isDraftModelEnabled && Boolean(draft),
     },
     {
       status: 'asap',

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -521,6 +521,21 @@ export const legacySearchEnabledReducer: ConfigPropertyReducer<boolean, ConfigCo
   return prev
 }
 
+export const draftsEnabledReducer: ConfigPropertyReducer<boolean, ConfigContext> = (
+  prev,
+  {document},
+): boolean => {
+  if (typeof document?.drafts?.enabled === 'boolean') {
+    return document?.drafts?.enabled
+  }
+
+  if (typeof document?.drafts?.enabled !== 'undefined') {
+    throw new Error(`Expected boolean, but received ${getPrintableType(document?.drafts?.enabled)}`)
+  }
+
+  return prev
+}
+
 /**
  * Some projects may already be using the `enableLegacySearch` option. In order to gracefully
  * migrate to the `strategy` option, this reducer produces a value that respects any existing

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -34,6 +34,7 @@ import {
   documentCommentsEnabledReducer,
   documentInspectorsReducer,
   documentLanguageFilterReducer,
+  draftsEnabledReducer,
   eventsAPIReducer,
   fileAssetSourceResolver,
   imageAssetSourceResolver,
@@ -592,6 +593,15 @@ function resolveSource({
           propertyName: 'document.badges',
           reducer: documentBadgesReducer,
         }),
+      drafts: {
+        enabled: resolveConfigProperty({
+          config,
+          context,
+          reducer: draftsEnabledReducer,
+          propertyName: 'document.drafts.enabled',
+          initialValue: true,
+        }),
+      },
       unstable_fieldActions: (partialContext) =>
         resolveConfigProperty({
           config,

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -298,6 +298,18 @@ export interface DocumentPluginOptions {
   comments?: {
     enabled: boolean | ((context: DocumentCommentsEnabledContext) => boolean)
   }
+
+  drafts?: {
+    /**
+     * Whether the workspace provides the draft model for interacting with documents.
+     *
+     * When switched off, documents may only be edited:
+     *
+     *  - Inside a release.
+     *  - Outside a release if they support live-edit.
+     */
+    enabled?: boolean
+  }
 }
 
 /**
@@ -718,6 +730,18 @@ export interface Source {
      * @internal
      */
     components?: DocumentComponents
+
+    drafts: {
+      /**
+       * Whether the workspace provides the draft model for interacting with documents.
+       *
+       * When switched off, documents may only be edited:
+       *
+       *  - Inside a release.
+       *  - Outside a release if they support live-edit.
+       */
+      enabled: boolean
+    }
 
     /** @internal */
     unstable_fieldActions: (

--- a/packages/sanity/src/core/perspective/GlobalPerspectiveProvider.tsx
+++ b/packages/sanity/src/core/perspective/GlobalPerspectiveProvider.tsx
@@ -7,9 +7,10 @@ import {useTranslation} from '../i18n/hooks/useTranslation'
 import {Translate} from '../i18n/Translate'
 import {useActiveReleases} from '../releases/store/useActiveReleases'
 import {useArchivedReleases} from '../releases/store/useArchivedReleases'
-import {LATEST} from '../releases/util/const'
+import {LATEST, PUBLISHED} from '../releases/util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../releases/util/getReleaseIdFromReleaseDocumentId'
 import {isPublishedPerspective} from '../releases/util/util'
+import {useWorkspace} from '../studio/workspace'
 import {EMPTY_ARRAY} from '../util/empty'
 import {PerspectiveProvider} from './PerspectiveProvider'
 import {type ReleaseId} from './types'
@@ -102,10 +103,20 @@ const ResetPerspectiveHandler = () => {
 export function GlobalPerspectiveProvider({children}: {children: ReactNode}) {
   const router = useRouter()
 
-  const selectedPerspectiveName = router.stickyParams.perspective as
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
+  let selectedPerspectiveName = router.stickyParams.perspective as
     | 'published'
     | ReleaseId
     | undefined
+
+  if (!isDraftModelEnabled && typeof selectedPerspectiveName === 'undefined') {
+    selectedPerspectiveName = PUBLISHED
+  }
 
   const excludedPerspectives = useMemo(
     () => router.stickyParams.excludedPerspectives?.split(',') || EMPTY_ARRAY,

--- a/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
+++ b/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
@@ -3,6 +3,7 @@ import {PerspectiveContext} from 'sanity/_singletons'
 
 import {getReleasesPerspectiveStack} from '../releases/hooks/utils'
 import {useActiveReleases} from '../releases/store/useActiveReleases'
+import {useWorkspace} from '../studio/workspace'
 import {isSystemBundleName} from '../util/draftUtils'
 import {EMPTY_ARRAY} from '../util/empty'
 import {getSelectedPerspective} from './getSelectedPerspective'
@@ -22,6 +23,12 @@ export function PerspectiveProvider({
 }) {
   const {data: releases} = useActiveReleases()
 
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
   const selectedPerspective: SelectedPerspective = useMemo(
     () => getSelectedPerspective(selectedPerspectiveName, releases),
     [selectedPerspectiveName, releases],
@@ -33,8 +40,9 @@ export function PerspectiveProvider({
         releases,
         selectedPerspectiveName,
         excludedPerspectives,
+        isDraftModelEnabled,
       }),
-    [releases, selectedPerspectiveName, excludedPerspectives],
+    [releases, selectedPerspectiveName, excludedPerspectives, isDraftModelEnabled],
   )
 
   const value: PerspectiveContextValue = useMemo(

--- a/packages/sanity/src/core/perspective/isPerspectiveWriteable.ts
+++ b/packages/sanity/src/core/perspective/isPerspectiveWriteable.ts
@@ -1,7 +1,7 @@
 import {type ObjectSchemaType} from '@sanity/types'
 
 import {isReleaseDocument} from '../releases/store/types'
-import {isPublishedPerspective} from '../releases/util/util'
+import {isDraftPerspective, isPublishedPerspective} from '../releases/util/util'
 import {type SelectedPerspective} from './types'
 
 /**
@@ -11,6 +11,7 @@ export type PerspectiveNotWriteableReason =
   | 'INSUFFICIENT_DATA'
   | 'RELEASE_NOT_ACTIVE'
   | 'PUBLISHED_NOT_WRITEABLE'
+  | 'DRAFTS_NOT_WRITEABLE'
 
 /**
  * Check whether the provided schema type can be written to the provided perspective. This depends
@@ -22,9 +23,11 @@ export type PerspectiveNotWriteableReason =
  */
 export function isPerspectiveWriteable({
   selectedPerspective,
+  isDraftModelEnabled,
   schemaType,
 }: {
   selectedPerspective: SelectedPerspective
+  isDraftModelEnabled: boolean
   schemaType?: ObjectSchemaType
 }): {result: true} | {result: false; reason: PerspectiveNotWriteableReason} {
   if (typeof schemaType === 'undefined') {
@@ -45,6 +48,17 @@ export function isPerspectiveWriteable({
     return {
       result: false,
       reason: 'PUBLISHED_NOT_WRITEABLE',
+    }
+  }
+
+  if (
+    isDraftPerspective(selectedPerspective) &&
+    !isDraftModelEnabled &&
+    schemaType.liveEdit !== true
+  ) {
+    return {
+      result: false,
+      reason: 'DRAFTS_NOT_WRITEABLE',
     }
   }
 

--- a/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenuItem.tsx
+++ b/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenuItem.tsx
@@ -13,7 +13,7 @@ import {usePerspective} from '../../perspective/usePerspective'
 import {useSetPerspective} from '../../perspective/useSetPerspective'
 import {ReleaseAvatar} from '../../releases/components/ReleaseAvatar'
 import {isReleaseDocument} from '../../releases/store/types'
-import {type LATEST} from '../../releases/util/const'
+import {LATEST, PUBLISHED} from '../../releases/util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
 import {getReleaseTone} from '../../releases/util/getReleaseTone'
 import {
@@ -22,6 +22,7 @@ import {
   isPublishedPerspective,
   isReleaseScheduledOrScheduling,
 } from '../../releases/util/util'
+import {useWorkspace} from '../../studio/workspace'
 import {type ReleasesNavMenuItemPropsGetter} from '../types'
 import {GlobalPerspectiveMenuItemIndicator} from './PerspectiveLayerIndicator'
 
@@ -91,6 +92,14 @@ export const GlobalPerspectiveMenuItem = forwardRef<
   }
 >((props, ref) => {
   const {release, rangePosition} = props
+
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
+  const defaultPerspective = isDraftModelEnabled ? LATEST : PUBLISHED
   const {selectedPerspective, selectedPerspectiveName} = usePerspective()
   const setPerspective = useSetPerspective()
   const {toggleExcludedPerspective, isPerspectiveExcluded} = useExcludedPerspective()
@@ -100,7 +109,7 @@ export const GlobalPerspectiveMenuItem = forwardRef<
 
   const active = selectedPerspectiveName
     ? releaseId === selectedPerspectiveName
-    : isDraftPerspective(release)
+    : release === defaultPerspective
 
   const isReleasePerspectiveExcluded = isPerspectiveExcluded(releaseId)
 
@@ -135,7 +144,7 @@ export const GlobalPerspectiveMenuItem = forwardRef<
 
   return (
     <GlobalPerspectiveMenuItemIndicator
-      $isDraft={isDraftPerspective(release)}
+      $isDefaultPerspective={release === defaultPerspective}
       $first={rangePosition === 'first'}
       $last={rangePosition === 'last'}
       $inRange={Boolean(rangePosition)}

--- a/packages/sanity/src/core/perspective/navbar/PerspectiveLayerIndicator.tsx
+++ b/packages/sanity/src/core/perspective/navbar/PerspectiveLayerIndicator.tsx
@@ -10,9 +10,9 @@ export const GlobalPerspectiveMenuItemIndicator = styled.div<{
   $inRange: boolean
   $last: boolean
   $first: boolean
-  $isDraft: boolean
+  $isDefaultPerspective: boolean
 }>(
-  ({$inRange, $last, $first, $isDraft}) => css`
+  ({$inRange, $last, $first, $isDefaultPerspective}) => css`
     position: relative;
 
     --indicator-left: ${INDICATOR_LEFT_OFFSET}px;
@@ -32,7 +32,9 @@ export const GlobalPerspectiveMenuItemIndicator = styled.div<{
         left: var(--indicator-left);
         bottom: -var(--indicator-bottom);
         width: var(--indicator-width);
-        height: ${$isDraft ? 'calc(var(--indicator-bottom) + 12px)' : 'var(--indicator-bottom)'};
+        height: ${$isDefaultPerspective
+          ? 'calc(var(--indicator-bottom) + 12px)'
+          : 'var(--indicator-bottom)'};
         background-color: var(--card-border-color);
       }
     `}

--- a/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
@@ -6,7 +6,9 @@ import {css, styled} from 'styled-components'
 import {CreateReleaseMenuItem} from '../../releases/components/CreateReleaseMenuItem'
 import {useReleasesUpsell} from '../../releases/contexts/upsell/useReleasesUpsell'
 import {useActiveReleases} from '../../releases/store/useActiveReleases'
-import {LATEST} from '../../releases/util/const'
+import {useReleaseOperations} from '../../releases/store/useReleaseOperations'
+import {useReleasePermissions} from '../../releases/store/useReleasePermissions'
+import {LATEST, PUBLISHED} from '../../releases/util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
 import {type ReleasesNavMenuItemPropsGetter} from '../types'
 import {usePerspective} from '../usePerspective'
@@ -19,8 +21,6 @@ import {ReleaseTypeMenuSection} from './ReleaseTypeMenuSection'
 import {type ScrollElement} from './useScrollIndicatorVisibility'
 
 const orderedReleaseTypes: ReleaseType[] = ['asap', 'scheduled', 'undecided']
-
-const ASAP_RANGE_OFFSET = 2
 
 const StyledBox = styled(Box)`
   overflow: auto;
@@ -86,14 +86,13 @@ export function ReleasesList({
     const isDraftsPerspective = typeof selectedPerspectiveName === 'undefined'
     let lastIndex = isDraftsPerspective ? 1 : 0
 
+    const systemStack = [PUBLISHED, LATEST]
     const {asap, scheduled} = sortedReleaseTypeReleases
-    const countAsapReleases = asap.length
-    const countScheduledReleases = scheduled.length
 
     const offsets = {
-      asap: ASAP_RANGE_OFFSET,
-      scheduled: ASAP_RANGE_OFFSET + countAsapReleases,
-      undecided: ASAP_RANGE_OFFSET + countAsapReleases + countScheduledReleases,
+      asap: systemStack.length,
+      scheduled: systemStack.length + asap.length,
+      undecided: systemStack.length + asap.length + scheduled.length,
     }
 
     const adjustIndexForReleaseType = (type: ReleaseType) => {

--- a/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
@@ -6,10 +6,9 @@ import {css, styled} from 'styled-components'
 import {CreateReleaseMenuItem} from '../../releases/components/CreateReleaseMenuItem'
 import {useReleasesUpsell} from '../../releases/contexts/upsell/useReleasesUpsell'
 import {useActiveReleases} from '../../releases/store/useActiveReleases'
-import {useReleaseOperations} from '../../releases/store/useReleaseOperations'
-import {useReleasePermissions} from '../../releases/store/useReleasePermissions'
 import {LATEST, PUBLISHED} from '../../releases/util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
+import {useWorkspace} from '../../studio/workspace'
 import {type ReleasesNavMenuItemPropsGetter} from '../types'
 import {usePerspective} from '../usePerspective'
 import {
@@ -65,6 +64,12 @@ export function ReleasesList({
   const {loading, data: releases} = useActiveReleases()
   const {selectedPerspectiveName} = usePerspective()
 
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
   const handleCreateBundleClick = useCallback(
     () => guardWithReleaseLimitUpsell(() => setCreateBundleDialogOpen(true)),
     [guardWithReleaseLimitUpsell, setCreateBundleDialogOpen],
@@ -86,7 +91,7 @@ export function ReleasesList({
     const isDraftsPerspective = typeof selectedPerspectiveName === 'undefined'
     let lastIndex = isDraftsPerspective ? 1 : 0
 
-    const systemStack = [PUBLISHED, LATEST]
+    const systemStack = [PUBLISHED, isDraftModelEnabled ? LATEST : []].flat()
     const {asap, scheduled} = sortedReleaseTypeReleases
 
     const offsets = {
@@ -114,7 +119,7 @@ export function ReleasesList({
       lastIndex,
       offsets,
     }
-  }, [selectedPerspectiveName, selectedReleaseId, sortedReleaseTypeReleases])
+  }, [isDraftModelEnabled, selectedPerspectiveName, selectedReleaseId, sortedReleaseTypeReleases])
 
   if (loading) {
     return (
@@ -136,11 +141,13 @@ export function ReleasesList({
             release={'published'}
             menuItemProps={menuItemProps}
           />
-          <GlobalPerspectiveMenuItem
-            rangePosition={isRangeVisible ? getRangePosition(range, 1) : undefined}
-            release={LATEST}
-            menuItemProps={menuItemProps}
-          />
+          {isDraftModelEnabled && (
+            <GlobalPerspectiveMenuItem
+              rangePosition={isRangeVisible ? getRangePosition(range, 1) : undefined}
+              release={LATEST}
+              menuItemProps={menuItemProps}
+            />
+          )}
         </StyledPublishedBox>
         {areReleasesEnabled && (
           <>

--- a/packages/sanity/src/core/perspective/useSetPerspective.tsx
+++ b/packages/sanity/src/core/perspective/useSetPerspective.tsx
@@ -1,6 +1,8 @@
 import {useCallback} from 'react'
 import {useRouter} from 'sanity/router'
 
+import {LATEST, PUBLISHED} from '../releases/util/const'
+import {useWorkspace} from '../studio/workspace'
 import {type ReleaseId} from './types'
 
 /**
@@ -8,16 +10,25 @@ import {type ReleaseId} from './types'
  */
 export function useSetPerspective() {
   const router = useRouter()
+
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
+  const defaultPerspective = isDraftModelEnabled ? LATEST : PUBLISHED
+
   const setPerspective = useCallback(
     (releaseId: 'published' | 'drafts' | ReleaseId | undefined) => {
       router.navigate({
         stickyParams: {
           excludedPerspectives: null,
-          perspective: releaseId === 'drafts' ? '' : releaseId,
+          perspective: releaseId === defaultPerspective ? '' : releaseId,
         },
       })
     },
-    [router],
+    [defaultPerspective, router],
   )
   return setPerspective
 }

--- a/packages/sanity/src/core/releases/hooks/__tests__/utils.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/utils.test.ts
@@ -212,34 +212,90 @@ describe('getReleasesPerspectiveStack()', () => {
   const testCases: {
     selectedPerspectiveName: ReleaseId | 'published' | undefined
     excludedPerspectives: string[]
+    isDraftModelEnabled: boolean
     expected: string[]
   }[] = [
-    {selectedPerspectiveName: 'rasap1', excludedPerspectives: [], expected: ['rasap1', 'drafts']},
+    {
+      selectedPerspectiveName: 'rasap1',
+      isDraftModelEnabled: true,
+      excludedPerspectives: [],
+      expected: ['rasap1', 'drafts'],
+    },
+    {
+      selectedPerspectiveName: 'rasap1',
+      isDraftModelEnabled: false,
+      excludedPerspectives: [],
+      expected: ['rasap1', 'published'],
+    },
     {
       selectedPerspectiveName: 'rasap2',
+      isDraftModelEnabled: true,
       excludedPerspectives: [],
       expected: ['rasap2', 'rasap1', 'drafts'],
     },
     {
+      selectedPerspectiveName: 'rasap2',
+      isDraftModelEnabled: false,
+      excludedPerspectives: [],
+      expected: ['rasap2', 'rasap1', 'published'],
+    },
+    {
       selectedPerspectiveName: 'rundecided2',
+      isDraftModelEnabled: true,
       excludedPerspectives: [],
       expected: ['rundecided2', 'rfuture4', 'rfuture1', 'rasap2', 'rasap1', 'drafts'],
     },
     {
       selectedPerspectiveName: 'rundecided2',
+      isDraftModelEnabled: false,
+      excludedPerspectives: [],
+      expected: ['rundecided2', 'rfuture4', 'rfuture1', 'rasap2', 'rasap1', 'published'],
+    },
+    {
+      selectedPerspectiveName: 'rundecided2',
+      isDraftModelEnabled: true,
       excludedPerspectives: ['rfuture1', 'drafts'],
       expected: ['rundecided2', 'rfuture4', 'rasap2', 'rasap1'],
     },
-    {selectedPerspectiveName: 'published', excludedPerspectives: [], expected: ['published']},
-    {selectedPerspectiveName: undefined, excludedPerspectives: [], expected: ['drafts']},
+    {
+      selectedPerspectiveName: 'rundecided2',
+      isDraftModelEnabled: false,
+      excludedPerspectives: ['rfuture1', 'published'],
+      expected: ['rundecided2', 'rfuture4', 'rasap2', 'rasap1'],
+    },
+    {
+      selectedPerspectiveName: 'published',
+      isDraftModelEnabled: true,
+      excludedPerspectives: [],
+      expected: ['published'],
+    },
+    {
+      selectedPerspectiveName: 'published',
+      isDraftModelEnabled: false,
+      excludedPerspectives: [],
+      expected: ['published'],
+    },
+    {
+      selectedPerspectiveName: undefined,
+      isDraftModelEnabled: true,
+      excludedPerspectives: [],
+      expected: ['drafts'],
+    },
+    {
+      selectedPerspectiveName: undefined,
+      isDraftModelEnabled: false,
+      excludedPerspectives: [],
+      expected: ['published'],
+    },
   ]
   it.each(testCases)(
     'should return the correct release stack for %s',
-    ({selectedPerspectiveName, excludedPerspectives, expected}) => {
+    ({selectedPerspectiveName, isDraftModelEnabled, excludedPerspectives, expected}) => {
       const result = getReleasesPerspectiveStack({
         releases,
         selectedPerspectiveName,
         excludedPerspectives,
+        isDraftModelEnabled,
       })
       expect(result).toEqual(expected)
     },

--- a/packages/sanity/src/core/releases/hooks/utils.ts
+++ b/packages/sanity/src/core/releases/hooks/utils.ts
@@ -1,7 +1,6 @@
 import {type ClientPerspective, type ReleaseDocument} from '@sanity/client'
 
 import {type PerspectiveStack, type ReleaseId} from '../../perspective/types'
-import {DRAFTS_FOLDER} from '../../util/draftUtils'
 import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
 
 export function sortReleases(releases: ReleaseDocument[] = []): ReleaseDocument[] {
@@ -56,13 +55,16 @@ export function getReleasesPerspectiveStack({
   selectedPerspectiveName,
   releases,
   excludedPerspectives,
+  isDraftModelEnabled,
 }: {
   selectedPerspectiveName: ReleaseId | undefined | 'published'
   releases: ReleaseDocument[]
   excludedPerspectives: string[]
+  isDraftModelEnabled: boolean
 }): PerspectiveStack {
+  const defaultPerspective = isDraftModelEnabled ? DRAFTS : PUBLISHED
   if (!selectedPerspectiveName) {
-    return DRAFTS
+    return defaultPerspective
   }
   if (selectedPerspectiveName === 'published') {
     return PUBLISHED
@@ -76,6 +78,6 @@ export function getReleasesPerspectiveStack({
   }
   return sorted
     .slice(selectedIndex)
-    .concat(DRAFTS_FOLDER)
+    .concat(defaultPerspective)
     .filter((name) => !excludedPerspectives.includes(name))
 }

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -95,6 +95,9 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** Description for the archived release banner, rendered when viewing the history of a version document from the publihed view */
   'banners.archived-release.description':
     'This document version belongs to the archived <VersionBadge>{{title}}</VersionBadge> release',
+  /** The explanation displayed when a user attempts to create a new draft document, but the draft model is not switched on */
+  'banners.choose-new-document-destination.cannot-create-draft-document':
+    'Cannot create a draft document.',
   /** The explanation displayed when a user attempts to create a new published document, but the schema type doesn't support live-editing */
   'banners.choose-new-document-destination.cannot-create-published-document':
     'Cannot create a published document.',

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -22,6 +22,7 @@ import {
   useStudioUrl,
   useTranslation,
   useUnique,
+  useWorkspace,
 } from 'sanity'
 import {DocumentPaneContext} from 'sanity/_singletons'
 
@@ -91,6 +92,12 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const {buildStudioUrl} = useStudioUrl()
 
   const perspective = usePerspective()
+
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
 
   const {selectedReleaseId, selectedPerspectiveName} = useMemo(() => {
     // TODO: COREL - Remove this after updating sanity-assist to use <PerspectiveProvider>
@@ -169,11 +176,19 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
         isDeleted ||
         !isPerspectiveWriteable({
           selectedPerspective: perspective.selectedPerspective,
+          isDraftModelEnabled,
           schemaType,
         }).result
       )
     },
-    [getIsDeleted, isDeleting, params.rev, perspective.selectedPerspective, schemaType],
+    [
+      getIsDeleted,
+      isDeleting,
+      isDraftModelEnabled,
+      params.rev,
+      perspective.selectedPerspective,
+      schemaType,
+    ],
   )
 
   const getDisplayed = useCallback(

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -13,6 +13,7 @@ import {
   type ReleaseDocument,
   ScrollContainer,
   usePerspective,
+  useWorkspace,
   VirtualizerScrollInstanceProvider,
 } from 'sanity'
 import {css, styled} from 'styled-components'
@@ -103,6 +104,12 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
   const [documentScrollElement, setDocumentScrollElement] = useState<HTMLDivElement | null>(null)
   const formContainerElement = useRef<HTMLDivElement | null>(null)
 
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
   const requiredPermission = value._createdAt ? 'update' : 'create'
 
   const activeView = useMemo(
@@ -184,6 +191,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
 
     const isSelectedPerspectiveWriteable = isPerspectiveWriteable({
       selectedPerspective,
+      isDraftModelEnabled,
       schemaType,
     })
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ChooseNewDocumentDestinationBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ChooseNewDocumentDestinationBanner.tsx
@@ -12,6 +12,7 @@ import {
   type SelectedPerspective,
   Translate,
   useTranslation,
+  useWorkspace,
 } from 'sanity'
 
 import {structureLocaleNamespace} from '../../../../i18n'
@@ -37,14 +38,21 @@ export const ChooseNewDocumentDestinationBanner: ComponentType<Props> = ({
 }) => {
   const {t} = useTranslation(structureLocaleNamespace)
 
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
   const menuItemProps = useCallback<ReleasesNavMenuItemPropsGetter>(
     ({perspective}) => ({
       disabled: !isPerspectiveWriteable({
         selectedPerspective: perspective,
+        isDraftModelEnabled,
         schemaType,
       }).result,
     }),
-    [schemaType],
+    [isDraftModelEnabled, schemaType],
   )
 
   return (

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ChooseNewDocumentDestinationBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ChooseNewDocumentDestinationBanner.tsx
@@ -64,6 +64,8 @@ export const ChooseNewDocumentDestinationBanner: ComponentType<Props> = ({
           <Text size={1}>
             {reason === 'PUBLISHED_NOT_WRITEABLE' &&
               t('banners.choose-new-document-destination.cannot-create-published-document')}
+            {reason === 'DRAFTS_NOT_WRITEABLE' &&
+              t('banners.choose-new-document-destination.cannot-create-draft-document')}
             {reason === 'RELEASE_NOT_ACTIVE' && isReleaseDocument(selectedPerspective) && (
               <Translate
                 t={t}


### PR DESCRIPTION
### Description

This branch introduces the `document.drafts.enabled` configuration option for controlling whether the draft model is enabled. By default, this option is `true`.

[Walkthrough video](https://supercut.video/share/ash/RphOFMD1JFI_iVOc1vIMEH).

When the draft model is switched off:

- Studio will display the published perspective by default.
- The drafts (latest) perspective is removed from the global perspective switcher.
- The drafts chip is removed from the document version chips.
- Draft documents are not shown in the document comparison view.
- Draft documents will not be loaded in document lists.
- Draft document status indicators will not appear in document previews.

### What to review

1. Does the general approach seem sound?
2. Are there any issues caused by making the published perspective the default (and removing the drafts perspective)?
3. Have we missed any obvious surfaces on which drafts appear?
4. Should we warn that a draft exists when viewing a document with the drafts model switched off? e.g. like the live-edit banner that appears when viewing a live-edit document.

### Testing

Updated existing unit tests.

### Notes for release

The draft model can now be switched off by setting the `document.drafts.enabled` configuration option to `false`. When the draft model is switched off, drafts will not appear in Studio, and users may only create or edit documents inside a release (unless they are live-edit documents).

The draft model is enabled by default.