### PR TITLE
chore(manifest): add media library config to extracted manifest

### DIFF
--- a/packages/sanity/.eslintrc.cjs
+++ b/packages/sanity/.eslintrc.cjs
@@ -22,7 +22,7 @@ module.exports = {
           },
           {
             from: 'sanity/_internal__contents',
-            allow: ['sanity', 'sanity/_internal__contents'],
+            allow: ['sanity', 'sanity/_internal__contents', 'sanity__contents'],
           },
           {
             // export

--- a/packages/sanity/.eslintrc.cjs
+++ b/packages/sanity/.eslintrc.cjs
@@ -22,7 +22,7 @@ module.exports = {
           },
           {
             from: 'sanity/_internal__contents',
-            allow: ['sanity', 'sanity/_internal__contents', 'sanity__contents'],
+            allow: ['sanity', 'sanity/_internal__contents'],
           },
           {
             // export

--- a/packages/sanity/src/_internal/manifest/extractWorkspaceManifest.tsx
+++ b/packages/sanity/src/_internal/manifest/extractWorkspaceManifest.tsx
@@ -90,6 +90,7 @@ export function extractCreateWorkspaceManifest(workspace: Workspace): CreateWork
       title: workspace.title,
       subtitle: workspace.subtitle,
     }),
+    mediaLibrary: workspace.mediaLibrary,
     schema: serializedSchema,
     tools: serializedTools,
   }

--- a/packages/sanity/src/_internal/manifest/manifestTypes.ts
+++ b/packages/sanity/src/_internal/manifest/manifestTypes.ts
@@ -1,4 +1,5 @@
 import {type SanityDocumentLike} from '@sanity/types'
+import {type MediaLibraryConfig} from '../../core/config'
 
 export const SANITY_WORKSPACE_SCHEMA_ID_PREFIX = '_.schemas'
 export const SANITY_WORKSPACE_SCHEMA_TYPE = 'system.schema'
@@ -29,6 +30,7 @@ export interface CreateWorkspaceManifest {
   basePath: string
   dataset: string
   projectId: string
+  mediaLibrary?: MediaLibraryConfig
   schema: ManifestSchemaType[]
   tools: ManifestTool[]
   /**

--- a/packages/sanity/src/_internal/manifest/manifestTypes.ts
+++ b/packages/sanity/src/_internal/manifest/manifestTypes.ts
@@ -1,5 +1,6 @@
 import {type SanityDocumentLike} from '@sanity/types'
-import {type MediaLibraryConfig} from '../../core/config'
+
+import {type MediaLibraryConfig} from '../../core/config/types'
 
 export const SANITY_WORKSPACE_SCHEMA_ID_PREFIX = '_.schemas'
 export const SANITY_WORKSPACE_SCHEMA_TYPE = 'system.schema'

--- a/packages/sanity/src/_internal/manifest/manifestTypes.ts
+++ b/packages/sanity/src/_internal/manifest/manifestTypes.ts
@@ -1,6 +1,5 @@
 import {type SanityDocumentLike} from '@sanity/types'
-
-import {type MediaLibraryConfig} from '../../core/config/types'
+import {type MediaLibraryConfig} from 'sanity'
 
 export const SANITY_WORKSPACE_SCHEMA_ID_PREFIX = '_.schemas'
 export const SANITY_WORKSPACE_SCHEMA_TYPE = 'system.schema'

--- a/packages/sanity/test/manifest/extractManifest.test.ts
+++ b/packages/sanity/test/manifest/extractManifest.test.ts
@@ -2,10 +2,37 @@
 import {defineArrayMember, defineField, defineType} from '@sanity/types'
 import {describe, expect, test} from 'vitest'
 
-import {extractManifestSchemaTypes} from '../../src/_internal/manifest/extractWorkspaceManifest'
-import {createSchema} from '../../src/core'
+import {
+  extractCreateWorkspaceManifest,
+  extractManifestSchemaTypes,
+} from '../../src/_internal/manifest/extractWorkspaceManifest'
+import {createSchema, createWorkspaceFromConfig} from '../../src/core'
 
 describe('Extract studio manifest', () => {
+  describe('extract workspace config', () => {
+    test('should extract workspace config', async () => {
+      const projectId = 'ppsg7ml5'
+      const dataset = 'production'
+
+      const workspaceConfig = await createWorkspaceFromConfig({
+        projectId,
+        dataset,
+        name: 'default',
+        mediaLibrary: {
+          enabled: true,
+          libraryId: undefined,
+        },
+      })
+
+      const extracted = extractCreateWorkspaceManifest(workspaceConfig)
+      expect(extracted).toMatchObject({
+        name: 'default',
+        projectId,
+        dataset,
+        mediaLibrary: {enabled: true, libraryId: undefined},
+      })
+    })
+  })
   describe('serialize schema for manifest', () => {
     test('extracted schema should only include user defined types (and no built-in types)', () => {
       const documentType = 'basic'
@@ -81,6 +108,7 @@ describe('Extract studio manifest', () => {
               reason: 'old',
             },
             options: {
+              // @ts-expect-error - this is a test
               custom: 'value',
             },
             initialValue: {title: 'Default'},


### PR DESCRIPTION
### Description

This exposes the `mediaLibrary` config from the workspace when extracting the studio manifest.

### What to review

We just pull the full `mediaLibrary` property from the workspace config into the manifest. I assume this is fine, it only include a `enabled` boolean for now but might include more information later.


### Testing

- Run the `sanity manifest extract` command
- Verify that `dist/static/create-manifest.json` includes the `mediaLibrary` property in the workspace config

### Notes for release

n/a