### PR TITLE
chore(eslint): switch off no-nested-ternary rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -158,6 +158,7 @@ const config = {
     'no-shadow': 'off',
     'no-unused-vars': 'off',
     'no-useless-catch': 'warn',
+    'no-nested-ternary': 'off',
     'no-async-promise-executor': 'warn',
     'unicorn/prefer-string-slice': 'error',
     'unicorn/prefer-node-protocol': 'error',


### PR DESCRIPTION
This rule frequently adds friction and provides very little value IMO. Yes, nested ternaries be definitely be overused and make code less readable, but I don't expect us to go wild with nested ternaries and we do have a low bar for requesting readability improvements in code reviews.

It's also not clear how to work around the rule in a way that makes things more readable. Extracting the logic into a separate function adds extra work and a level of indirection (often justified though!), IIFEs are weird, and combinations of `&&` and `||` ends up being harder to unpack in my experience.