### PR TITLE
fix(cli): clean up mentions of 'core apps' -> 'custom apps'

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -294,7 +294,7 @@ export default async function initSanity(
 
   const flags = await prepareFlags()
 
-  // We're authenticated, now lets select or create a project (for studios) or org (for core apps)
+  // We're authenticated, now lets select or create a project (for studios) or org (for custom apps)
   const {projectId, displayName, isFirstProject, datasetName, schemaUrl, organizationId} =
     await getProjectDetails()
 

--- a/packages/@sanity/cli/test/dev.test.ts
+++ b/packages/@sanity/cli/test/dev.test.ts
@@ -105,7 +105,7 @@ describeCliTest('CLI: `sanity dev`', () => {
         basePath: '/app-base-path',
         args: ['--port', `${port}`],
         cwd: path.join(fixturesPath, 'app'),
-        expectedTitle: 'Sanity CORE App',
+        expectedTitle: 'Sanity Custom App',
       })
 
       // Verify that the dashboard URL is printed

--- a/packages/sanity/src/_internal/cli/actions/app/deployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/deployAction.ts
@@ -38,7 +38,7 @@ export default async function deployAppAction(
 
   const client = apiClient({
     requireUser: true,
-    requireProject: false, // core apps are not project-specific
+    requireProject: false, // custom apps are not project-specific
   }).withConfig({apiVersion: 'v2024-08-01'})
 
   if (customSourceDir) {

--- a/packages/sanity/src/_internal/cli/actions/deploy/helpers.ts
+++ b/packages/sanity/src/_internal/cli/actions/deploy/helpers.ts
@@ -426,7 +426,7 @@ async function getOrCreateAppFromConfig({
     }
   }
 
-  // core apps cannot arbitrarily create ids or hosts, so send them to create option
+  // custom apps cannot arbitrarily create ids or hosts, so send them to create option
   output.print('The id provided in your configuration is not recognized.')
   output.print('Checking existing applications...')
   return getOrCreateApplication({client, context, spinner})

--- a/packages/sanity/src/_internal/cli/server/components/BasicDocument.tsx
+++ b/packages/sanity/src/_internal/cli/server/components/BasicDocument.tsx
@@ -39,7 +39,7 @@ export function BasicDocument(props: BasicDocumentProps): JSX.Element {
         <meta name="referrer" content="same-origin" />
 
         <Favicons />
-        <title>Sanity CORE App</title>
+        <title>Sanity Custom App</title>
         <GlobalErrorHandler />
 
         {css.map((href) => (

--- a/packages/sanity/src/_internal/cli/util/checkRequiredDependencies.ts
+++ b/packages/sanity/src/_internal/cli/util/checkRequiredDependencies.ts
@@ -32,7 +32,7 @@ interface CheckResult {
  * Additionally, returns the version of the 'sanity' dependency from the package.json.
  */
 export async function checkRequiredDependencies(context: CliCommandContext): Promise<CheckResult> {
-  // currently there's no check needed for core apps,
+  // currently there's no check needed for custom apps,
   // but this should be removed once they are more mature
   const isApp = determineIsApp(context.cliConfig)
   if (isApp) {


### PR DESCRIPTION
### Description

Replaces mentions of 'core apps' with 'custom apps'. Most importantly, it replaces the mention in the `<title>` in custom apps' `index.html` files.

### What to review

- Any places you'd like these mentions to not be changed?

### Testing

Updated a test that checked for `document.title`

### Notes for release

None, internal
