### PR TITLE
refactor: createReleaseOperationsStore uses action client for version creation when reverting release

### DIFF
--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -1,5 +1,6 @@
 import {
   type BaseActionOptions,
+  type CreateVersionAction,
   type EditableReleaseDocument,
   type IdentifiedSanityDocumentStub,
   type ReleaseDocument,
@@ -197,15 +198,15 @@ export function createReleaseOperationsStore(options: {
         releaseType: 'asap',
       },
     })
-    await Promise.allSettled(
-      releaseDocuments.map((document) =>
-        handleCreateVersion(
-          getReleaseIdFromReleaseDocumentId(revertReleaseId),
-          document._id,
-          document,
-        ),
-      ),
+    const versionId = getReleaseIdFromReleaseDocumentId(revertReleaseId)
+    const newVersionDocumentActions: CreateVersionAction[] = releaseDocuments.map(
+      (releaseDocument) => ({
+        actionType: 'sanity.action.document.version.create',
+        document: {...releaseDocument, _id: getVersionId(releaseDocument._id, versionId)},
+        publishedId: getPublishedId(releaseDocument._id),
+      }),
     )
+    await client.action(newVersionDocumentActions)
 
     if (revertType === 'immediate') {
       await handlePublishRelease(revertReleaseId)


### PR DESCRIPTION
### Description
Moves the revert handler from creating individual requests to create a new version for each document, to a single API call with an array of `sanity.action.document.version.create` actions
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Updated the existing tests
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
