### PR TITLE
feat(core): pte plugins middleware components

### DIFF
--- a/dev/test-studio/plugins/input/auto-close-brackets-plugin.tsx
+++ b/dev/test-studio/plugins/input/auto-close-brackets-plugin.tsx
@@ -3,7 +3,7 @@ import {useEditor} from '@portabletext/editor'
 import {defineBehavior, execute} from '@portabletext/editor/behaviors'
 import {useEffect} from 'react'
 import {definePlugin, isArrayOfBlocksSchemaType} from 'sanity'
-
+import {Text} from '@sanity/ui'
 /**
  * This Studio Plugin shows how to:
  *
@@ -76,7 +76,7 @@ function AutoCloseBracketsBehaviorPlugin() {
     }
   }, [editor])
 
-  return null
+  return <Text size={0}>Auto close brackets</Text>
 }
 
 /**
@@ -97,7 +97,7 @@ export const autoCloseBrackets = definePlugin({
           renderPlugins: (pluginProps) => {
             return (
               <>
-                {pluginProps.renderDefault(pluginProps)}
+                {props.renderPlugins?.(pluginProps)}
                 <AutoCloseBracketsBehaviorPlugin />
               </>
             )

--- a/dev/test-studio/plugins/input/auto-close-brackets-plugin.tsx
+++ b/dev/test-studio/plugins/input/auto-close-brackets-plugin.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-negated-condition */
 import {useEditor} from '@portabletext/editor'
 import {defineBehavior, execute} from '@portabletext/editor/behaviors'
-import {Text} from '@sanity/ui'
 import {useEffect} from 'react'
 import {definePlugin} from 'sanity'
 /**
@@ -76,7 +75,7 @@ function AutoCloseBracketsBehaviorPlugin() {
     }
   }, [editor])
 
-  return <Text size={0}>Auto close brackets</Text>
+  return null
 }
 
 /**

--- a/dev/test-studio/plugins/input/auto-close-brackets-plugin.tsx
+++ b/dev/test-studio/plugins/input/auto-close-brackets-plugin.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable no-negated-condition */
 import {useEditor} from '@portabletext/editor'
 import {defineBehavior, execute} from '@portabletext/editor/behaviors'
-import {useEffect} from 'react'
-import {definePlugin, isArrayOfBlocksSchemaType} from 'sanity'
 import {Text} from '@sanity/ui'
+import {useEffect} from 'react'
+import {definePlugin} from 'sanity'
 /**
  * This Studio Plugin shows how to:
  *
@@ -87,22 +87,15 @@ export const autoCloseBrackets = definePlugin({
   name: 'auto-close brackets',
   form: {
     components: {
-      input: (props) => {
-        if (!isArrayOfBlocksSchemaType(props.schemaType)) {
-          return props.renderDefault(props)
-        }
-
-        return props.renderDefault({
-          ...props,
-          renderPlugins: (pluginProps) => {
-            return (
-              <>
-                {props.renderPlugins?.(pluginProps)}
-                <AutoCloseBracketsBehaviorPlugin />
-              </>
-            )
-          },
-        })
+      pte: {
+        plugins: (props) => {
+          return (
+            <>
+              {props.renderDefault(props)}
+              <AutoCloseBracketsBehaviorPlugin />
+            </>
+          )
+        },
       },
     },
   },

--- a/dev/test-studio/plugins/input/wave-plugin.tsx
+++ b/dev/test-studio/plugins/input/wave-plugin.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable no-negated-condition */
 import {useEditor} from '@portabletext/editor'
 import {defineBehavior, execute} from '@portabletext/editor/behaviors'
-import {useEffect} from 'react'
-import {definePlugin, isArrayOfBlocksSchemaType} from 'sanity'
 import {Text} from '@sanity/ui'
+import {useEffect} from 'react'
+import {definePlugin} from 'sanity'
 
 /**
  * This Studio Plugin shows how to:
@@ -63,22 +63,15 @@ export const wave = definePlugin({
   name: 'wave',
   form: {
     components: {
-      input: (props) => {
-        if (!isArrayOfBlocksSchemaType(props.schemaType)) {
-          return props.renderDefault(props)
-        }
-
-        return props.renderDefault({
-          ...props,
-          renderPlugins: (pluginProps) => {
-            return (
-              <>
-                {props.renderPlugins?.(pluginProps)}
-                <WaveBehaviorPlugin />
-              </>
-            )
-          },
-        })
+      pte: {
+        plugins: (props) => {
+          return (
+            <>
+              {props.renderDefault(props)}
+              <WaveBehaviorPlugin />
+            </>
+          )
+        },
       },
     },
   },

--- a/dev/test-studio/plugins/input/wave-plugin.tsx
+++ b/dev/test-studio/plugins/input/wave-plugin.tsx
@@ -3,6 +3,7 @@ import {useEditor} from '@portabletext/editor'
 import {defineBehavior, execute} from '@portabletext/editor/behaviors'
 import {useEffect} from 'react'
 import {definePlugin, isArrayOfBlocksSchemaType} from 'sanity'
+import {Text} from '@sanity/ui'
 
 /**
  * This Studio Plugin shows how to:
@@ -52,7 +53,7 @@ function WaveBehaviorPlugin() {
     }
   }, [editor])
 
-  return null
+  return <Text size={0}>Wave plugin</Text>
 }
 
 /**
@@ -72,7 +73,7 @@ export const wave = definePlugin({
           renderPlugins: (pluginProps) => {
             return (
               <>
-                {pluginProps.renderDefault(pluginProps)}
+                {props.renderPlugins?.(pluginProps)}
                 <WaveBehaviorPlugin />
               </>
             )

--- a/dev/test-studio/plugins/input/wave-plugin.tsx
+++ b/dev/test-studio/plugins/input/wave-plugin.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-negated-condition */
 import {useEditor} from '@portabletext/editor'
 import {defineBehavior, execute} from '@portabletext/editor/behaviors'
-import {Text} from '@sanity/ui'
 import {useEffect} from 'react'
 import {definePlugin} from 'sanity'
 
@@ -53,7 +52,7 @@ function WaveBehaviorPlugin() {
     }
   }, [editor])
 
-  return <Text size={0}>Wave plugin</Text>
+  return null
 }
 
 /**

--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-no-bind */
 import {defineBehavior, effect, forward} from '@portabletext/editor/behaviors'
 import {BehaviorPlugin, DecoratorShortcutPlugin, OneLinePlugin} from '@portabletext/editor/plugins'
-import {defineType, type PortableTextInputProps} from 'sanity'
+import {defineType} from 'sanity'
 
 export const customPlugins = defineType({
   name: 'customPlugins',
@@ -29,11 +29,6 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        annotation: (props: PortableTextInputProps) => {
-          return props.renderDefault({
-            ...props,
-          })
-        },
         pte: {
           plugins: (props) => {
             return (

--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -29,18 +29,18 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        input: (props: PortableTextInputProps) => {
+        annotation: (props: PortableTextInputProps) => {
           return props.renderDefault({
             ...props,
-            renderPlugins: (pluginProps) => {
-              return (
-                <>
-                  {pluginProps.renderDefault(pluginProps)}
-                  <OneLinePlugin />
-                </>
-              )
-            },
           })
+        },
+        ptePlugins: (props) => {
+          return (
+            <>
+              {props.renderDefault(props)}
+              <OneLinePlugin />
+            </>
+          )
         },
       },
     },
@@ -71,25 +71,15 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        input: (props: PortableTextInputProps) => {
+        ptePlugins: (props) => {
           return props.renderDefault({
             ...props,
-            renderPlugins: (pluginProps) => (
-              <>
-                {pluginProps.renderDefault({
-                  ...pluginProps,
-                  renderMarkdownPlugin: (markdownPluginProps) => {
-                    return markdownPluginProps.renderDefault({
-                      config: {
-                        ...markdownPluginProps.config,
-                        boldDecorator: ({schema}) =>
-                          schema.decorators.find((decorator) => decorator.value === 'bold')?.value,
-                      },
-                    })
-                  },
-                })}
-              </>
-            ),
+            markdownPluginProps: {
+              config: {
+                boldDecorator: ({schema}) =>
+                  schema.decorators.find((decorator) => decorator.value === 'bold')?.value,
+              },
+            },
           })
         },
       },
@@ -112,62 +102,57 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        input: (props: PortableTextInputProps) => {
-          return props.renderDefault({
-            ...props,
-            renderPlugins: (pluginProps) => (
-              <>
-                <DecoratorShortcutPlugin
-                  decorator={({schema}) =>
-                    schema.decorators.find((decorator) => decorator.name === 'strong')?.name
-                  }
-                  pair={{
-                    char: '👻',
-                    amount: 2,
-                  }}
-                />
-                <DecoratorShortcutPlugin
-                  decorator={({schema}) =>
-                    schema.decorators.find((decorator) => decorator.name === 'strong')?.name
-                  }
-                  pair={{
-                    char: '🕹️',
-                    amount: 2,
-                  }}
-                />
-                <DecoratorShortcutPlugin
-                  decorator={({schema}) =>
-                    schema.decorators.find((decorator) => decorator.name === 'em')?.name
-                  }
-                  pair={{
-                    char: '👻',
-                    amount: 1,
-                  }}
-                />
-                <DecoratorShortcutPlugin
-                  decorator={({schema}) =>
-                    schema.decorators.find((decorator) => decorator.name === 'em')?.name
-                  }
-                  pair={{
-                    char: '🕹️',
-                    amount: 1,
-                  }}
-                />
-                {pluginProps.renderDefault({
-                  ...pluginProps,
-                  renderMarkdownPlugin: (markdownPluginProps) => {
-                    return markdownPluginProps.renderDefault({
-                      config: {
-                        ...markdownPluginProps.config,
-                        boldDecorator: undefined,
-                        italicDecorator: undefined,
-                      },
-                    })
+        ptePlugins: (props) => {
+          return (
+            <>
+              {props.renderDefault({
+                ...props,
+                markdownPluginProps: {
+                  config: {
+                    ...props.markdownPluginProps.config,
+                    boldDecorator: undefined,
+                    italicDecorator: undefined,
                   },
-                })}
-              </>
-            ),
-          })
+                },
+              })}
+              <DecoratorShortcutPlugin
+                decorator={({schema}) =>
+                  schema.decorators.find((decorator) => decorator.name === 'strong')?.name
+                }
+                pair={{
+                  char: '👻',
+                  amount: 2,
+                }}
+              />
+              <DecoratorShortcutPlugin
+                decorator={({schema}) =>
+                  schema.decorators.find((decorator) => decorator.name === 'strong')?.name
+                }
+                pair={{
+                  char: '🕹️',
+                  amount: 2,
+                }}
+              />
+              <DecoratorShortcutPlugin
+                decorator={({schema}) =>
+                  schema.decorators.find((decorator) => decorator.name === 'em')?.name
+                }
+                pair={{
+                  char: '👻',
+                  amount: 1,
+                }}
+              />
+              <DecoratorShortcutPlugin
+                decorator={({schema}) =>
+                  schema.decorators.find((decorator) => decorator.name === 'em')?.name
+                }
+                pair={{
+                  char: '🕹️',
+                  amount: 1,
+                }}
+              />
+            </>
+          )
         },
       },
     },
@@ -188,11 +173,8 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        input: (props: PortableTextInputProps) => {
-          return props.renderDefault({
-            ...props,
-            renderPlugins: () => <></>,
-          })
+        ptePlugins: (props) => {
+          return null
         },
       },
     },
@@ -214,31 +196,28 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        input: (props: PortableTextInputProps) => {
-          return props.renderDefault({
-            ...props,
-            renderPlugins: (pluginProps) => (
-              <>
-                <BehaviorPlugin
-                  behaviors={[
-                    defineBehavior({
-                      on: 'insert.text',
-                      actions: [
-                        ({event}) => [
-                          effect(() => {
-                            // eslint-disable-next-line no-console
-                            console.log(event)
-                          }),
-                          forward(event),
-                        ],
+        ptePlugins: (props) => {
+          return (
+            <>
+              {props.renderDefault(props)}
+              <BehaviorPlugin
+                behaviors={[
+                  defineBehavior({
+                    on: 'insert.text',
+                    actions: [
+                      ({event}) => [
+                        effect(() => {
+                          // eslint-disable-next-line no-console
+                          console.log(event)
+                        }),
+                        forward(event),
                       ],
-                    }),
-                  ]}
-                />
-                {pluginProps.renderDefault(pluginProps)}
-              </>
-            ),
-          })
+                    ],
+                  }),
+                ]}
+              />
+            </>
+          )
         },
       },
     },

--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -34,13 +34,15 @@ export const customPlugins = defineType({
             ...props,
           })
         },
-        ptePlugins: (props) => {
-          return (
-            <>
-              {props.renderDefault(props)}
-              <OneLinePlugin />
-            </>
-          )
+        pte: {
+          plugins: (props) => {
+            return (
+              <>
+                {props.renderDefault(props)}
+                <OneLinePlugin />
+              </>
+            )
+          },
         },
       },
     },
@@ -71,16 +73,18 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        ptePlugins: (props) => {
-          return props.renderDefault({
-            ...props,
-            markdownPluginProps: {
-              config: {
-                boldDecorator: ({schema}) =>
-                  schema.decorators.find((decorator) => decorator.value === 'bold')?.value,
+        pte: {
+          plugins: (props) => {
+            return props.renderDefault({
+              ...props,
+              markdownPluginProps: {
+                config: {
+                  boldDecorator: ({schema}) =>
+                    schema.decorators.find((decorator) => decorator.value === 'bold')?.value,
+                },
               },
-            },
-          })
+            })
+          },
         },
       },
     },
@@ -102,57 +106,59 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        ptePlugins: (props) => {
-          return (
-            <>
-              {props.renderDefault({
-                ...props,
-                markdownPluginProps: {
-                  config: {
-                    ...props.markdownPluginProps.config,
-                    boldDecorator: undefined,
-                    italicDecorator: undefined,
+        pte: {
+          plugins: (props) => {
+            return (
+              <>
+                {props.renderDefault({
+                  ...props,
+                  markdownPluginProps: {
+                    config: {
+                      ...props.markdownPluginProps.config,
+                      boldDecorator: undefined,
+                      italicDecorator: undefined,
+                    },
                   },
-                },
-              })}
-              <DecoratorShortcutPlugin
-                decorator={({schema}) =>
-                  schema.decorators.find((decorator) => decorator.name === 'strong')?.name
-                }
-                pair={{
-                  char: '👻',
-                  amount: 2,
-                }}
-              />
-              <DecoratorShortcutPlugin
-                decorator={({schema}) =>
-                  schema.decorators.find((decorator) => decorator.name === 'strong')?.name
-                }
-                pair={{
-                  char: '🕹️',
-                  amount: 2,
-                }}
-              />
-              <DecoratorShortcutPlugin
-                decorator={({schema}) =>
-                  schema.decorators.find((decorator) => decorator.name === 'em')?.name
-                }
-                pair={{
-                  char: '👻',
-                  amount: 1,
-                }}
-              />
-              <DecoratorShortcutPlugin
-                decorator={({schema}) =>
-                  schema.decorators.find((decorator) => decorator.name === 'em')?.name
-                }
-                pair={{
-                  char: '🕹️',
-                  amount: 1,
-                }}
-              />
-            </>
-          )
+                })}
+                <DecoratorShortcutPlugin
+                  decorator={({schema}) =>
+                    schema.decorators.find((decorator) => decorator.name === 'strong')?.name
+                  }
+                  pair={{
+                    char: '👻',
+                    amount: 2,
+                  }}
+                />
+                <DecoratorShortcutPlugin
+                  decorator={({schema}) =>
+                    schema.decorators.find((decorator) => decorator.name === 'strong')?.name
+                  }
+                  pair={{
+                    char: '🕹️',
+                    amount: 2,
+                  }}
+                />
+                <DecoratorShortcutPlugin
+                  decorator={({schema}) =>
+                    schema.decorators.find((decorator) => decorator.name === 'em')?.name
+                  }
+                  pair={{
+                    char: '👻',
+                    amount: 1,
+                  }}
+                />
+                <DecoratorShortcutPlugin
+                  decorator={({schema}) =>
+                    schema.decorators.find((decorator) => decorator.name === 'em')?.name
+                  }
+                  pair={{
+                    char: '🕹️',
+                    amount: 1,
+                  }}
+                />
+              </>
+            )
+          },
         },
       },
     },
@@ -173,8 +179,10 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        ptePlugins: (props) => {
-          return null
+        pte: {
+          plugins: (props) => {
+            return null
+          },
         },
       },
     },
@@ -196,28 +204,30 @@ export const customPlugins = defineType({
         },
       ],
       components: {
-        ptePlugins: (props) => {
-          return (
-            <>
-              {props.renderDefault(props)}
-              <BehaviorPlugin
-                behaviors={[
-                  defineBehavior({
-                    on: 'insert.text',
-                    actions: [
-                      ({event}) => [
-                        effect(() => {
-                          // eslint-disable-next-line no-console
-                          console.log(event)
-                        }),
-                        forward(event),
+        pte: {
+          plugins: (props) => {
+            return (
+              <>
+                {props.renderDefault(props)}
+                <BehaviorPlugin
+                  behaviors={[
+                    defineBehavior({
+                      on: 'insert.text',
+                      actions: [
+                        ({event}) => [
+                          effect(() => {
+                            // eslint-disable-next-line no-console
+                            console.log(event)
+                          }),
+                          forward(event),
+                        ],
                       ],
-                    ],
-                  }),
-                ]}
-              />
-            </>
-          )
+                    }),
+                  ]}
+                />
+              </>
+            )
+          },
         },
       },
     },

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -227,6 +227,7 @@ export interface BaseSchemaType extends Partial<DeprecationConfiguration> {
     input?: ComponentType<any>
     item?: ComponentType<any>
     preview?: ComponentType<any>
+    ptePlugins?: ComponentType<any>
   }
 
   /**

--- a/packages/sanity/src/core/config/form/types.ts
+++ b/packages/sanity/src/core/config/form/types.ts
@@ -2,12 +2,12 @@ import {type ComponentType} from 'react'
 
 import {type PreviewProps} from '../../components'
 import {
-  PtePluginsProps,
   type BlockAnnotationProps,
   type BlockProps,
   type FieldProps,
   type InputProps,
   type ItemProps,
+  type PtePluginsProps,
 } from '../../form'
 
 /**
@@ -21,5 +21,7 @@ export interface FormComponents {
   input?: ComponentType<InputProps>
   item?: ComponentType<ItemProps>
   preview?: ComponentType<PreviewProps>
-  ptePlugins?: ComponentType<PtePluginsProps>
+  pte?: {
+    plugins?: ComponentType<PtePluginsProps>
+  }
 }

--- a/packages/sanity/src/core/config/form/types.ts
+++ b/packages/sanity/src/core/config/form/types.ts
@@ -2,6 +2,7 @@ import {type ComponentType} from 'react'
 
 import {type PreviewProps} from '../../components'
 import {
+  PtePluginsProps,
   type BlockAnnotationProps,
   type BlockProps,
   type FieldProps,
@@ -20,4 +21,5 @@ export interface FormComponents {
   input?: ComponentType<InputProps>
   item?: ComponentType<ItemProps>
   preview?: ComponentType<PreviewProps>
+  ptePlugins?: ComponentType<PtePluginsProps>
 }

--- a/packages/sanity/src/core/form/form-components-hooks/picks.ts
+++ b/packages/sanity/src/core/form/form-components-hooks/picks.ts
@@ -3,6 +3,7 @@ import {type ComponentType} from 'react'
 import {type PreviewProps} from '../../components/previews'
 import {type PluginOptions} from '../../config'
 import {
+  PtePluginsProps,
   type BlockAnnotationProps,
   type BlockProps,
   type FieldProps,
@@ -51,5 +52,13 @@ export function pickAnnotationComponent(
 ): ComponentType<Omit<BlockAnnotationProps, 'renderDefault'>> {
   return plugin.form?.components?.annotation as ComponentType<
     Omit<BlockAnnotationProps, 'renderDefault'>
+  >
+}
+
+export function pickPTEPluginsComponent(
+  plugin: PluginOptions,
+): ComponentType<Omit<PtePluginsProps, 'renderDefault'>> {
+  return plugin.form?.components?.ptePlugins as ComponentType<
+    Omit<PtePluginsProps, 'renderDefault'>
   >
 }

--- a/packages/sanity/src/core/form/form-components-hooks/picks.ts
+++ b/packages/sanity/src/core/form/form-components-hooks/picks.ts
@@ -3,12 +3,12 @@ import {type ComponentType} from 'react'
 import {type PreviewProps} from '../../components/previews'
 import {type PluginOptions} from '../../config'
 import {
-  PtePluginsProps,
   type BlockAnnotationProps,
   type BlockProps,
   type FieldProps,
   type InputProps,
   type ItemProps,
+  type PtePluginsProps,
 } from '../types'
 
 export function pickInputComponent(
@@ -58,7 +58,7 @@ export function pickAnnotationComponent(
 export function pickPTEPluginsComponent(
   plugin: PluginOptions,
 ): ComponentType<Omit<PtePluginsProps, 'renderDefault'>> {
-  return plugin.form?.components?.ptePlugins as ComponentType<
+  return plugin.form?.components?.pte?.plugins as ComponentType<
     Omit<PtePluginsProps, 'renderDefault'>
   >
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -46,13 +46,13 @@ import {PortableTextMarkersProvider} from './contexts/PortableTextMarkers'
 import {PortableTextMemberItemsProvider} from './contexts/PortableTextMembers'
 import {usePortableTextMemberItemsFromProps} from './hooks/usePortableTextMembers'
 import {InvalidValue as RespondToInvalidContent} from './InvalidValue'
+import {PTEPlugins} from './object/Plugins'
 import {
   type PresenceCursorDecorationsHookProps,
   usePresenceCursorDecorations,
 } from './presence-cursors'
 import {getUploadCandidates} from './upload/helpers'
 import {usePatches} from './usePatches'
-import {PTEPlugins} from './object/Plugins'
 
 interface UploadTask {
   file: File

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -11,11 +11,7 @@ import {
   useEditor,
   usePortableTextEditor,
 } from '@portabletext/editor'
-import {
-  EventListenerPlugin,
-  MarkdownPlugin,
-  type MarkdownPluginConfig,
-} from '@portabletext/editor/plugins'
+import {EventListenerPlugin} from '@portabletext/editor/plugins'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {isKeySegment, type Path, type PortableTextBlock} from '@sanity/types'
 import {Box, Flex, Text, useToast} from '@sanity/ui'
@@ -56,6 +52,7 @@ import {
 } from './presence-cursors'
 import {getUploadCandidates} from './upload/helpers'
 import {usePatches} from './usePatches'
+import {PTEPlugins} from './object/Plugins'
 
 interface UploadTask {
   file: File
@@ -91,19 +88,6 @@ export interface PortableTextMemberItem {
 }
 
 /**
- * @beta
- */
-export interface RenderPortableTextInputPluginsProps {
-  renderMarkdownPlugin: (props: {config: MarkdownPluginConfig}) => ReactNode
-  renderDefault: (props: {
-    renderMarkdownPlugin: (props: {
-      config: MarkdownPluginConfig
-      renderDefault: (props: {config: MarkdownPluginConfig}) => ReactNode
-    }) => ReactNode
-  }) => ReactNode
-}
-
-/**
  * Input component for editing block content
  * ({@link https://github.com/portabletext/portabletext | Portable Text}) in the Sanity Studio.
  *
@@ -136,7 +120,6 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
     rangeDecorations: rangeDecorationsProp,
     renderBlockActions,
     renderCustomMarkers,
-    renderPlugins,
     schemaType,
     value,
     resolveUploader,
@@ -406,7 +389,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
               <PatchesPlugin path={path} />
               <UpdateReadOnlyPlugin readOnly={readOnly || !ready} />
               <UpdateValuePlugin value={value} />
-              <RenderPlugins renderPlugins={renderPlugins} />
+              <PTEPlugins schemaType={schemaType} />
               <Compositor
                 {...props}
                 elementRef={elementRef}
@@ -431,41 +414,6 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
       )}
     </Box>
   )
-}
-
-const markdownConfig: MarkdownPluginConfig = {
-  boldDecorator: ({schema}) =>
-    schema.decorators.find((decorator) => decorator.name === 'strong')?.name,
-  codeDecorator: ({schema}) =>
-    schema.decorators.find((decorator) => decorator.name === 'code')?.name,
-  italicDecorator: ({schema}) =>
-    schema.decorators.find((decorator) => decorator.name === 'em')?.name,
-  strikeThroughDecorator: ({schema}) =>
-    schema.decorators.find((decorator) => decorator.name === 'strike-through')?.name,
-  defaultStyle: ({schema}) => schema.styles.find((style) => style.name === 'normal')?.name,
-  blockquoteStyle: ({schema}) => schema.styles.find((style) => style.name === 'blockquote')?.name,
-  headingStyle: ({schema, level}) =>
-    schema.styles.find((style) => style.name === `h${level}`)?.name,
-  orderedListStyle: ({schema}) => schema.lists.find((list) => list.name === 'number')?.name,
-  unorderedListStyle: ({schema}) => schema.lists.find((list) => list.name === 'bullet')?.name,
-}
-
-function RenderPlugins(props: {renderPlugins?: PortableTextInputProps['renderPlugins']}) {
-  if (!props.renderPlugins) {
-    return <MarkdownPlugin config={markdownConfig} />
-  }
-
-  return props.renderPlugins({
-    renderMarkdownPlugin: (markdownPluginProps) => <MarkdownPlugin {...markdownPluginProps} />,
-    renderDefault: (defaultProps) => (
-      <>
-        {defaultProps.renderMarkdownPlugin({
-          config: markdownConfig,
-          renderDefault: (markdownPluginProps) => <MarkdownPlugin {...markdownPluginProps} />,
-        })}
-      </>
-    ),
-  })
 }
 
 /**

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -1,0 +1,77 @@
+import {MarkdownPlugin, MarkdownPluginConfig} from '@portabletext/editor/plugins'
+import {ArraySchemaType, PortableTextBlock} from '@sanity/types'
+import {ComponentType, useMemo} from 'react'
+import {PtePluginsProps} from '../../../types/blockProps'
+import {Stack, Text} from '@sanity/ui'
+import {useMiddlewareComponents} from '../../../../config/components/useMiddlewareComponents'
+import {pickPTEPluginsComponent} from '../../../form-components-hooks/picks'
+
+const markdownConfig: MarkdownPluginConfig = {
+  boldDecorator: ({schema}) =>
+    schema.decorators.find((decorator) => decorator.name === 'strong')?.name,
+  codeDecorator: ({schema}) =>
+    schema.decorators.find((decorator) => decorator.name === 'code')?.name,
+  italicDecorator: ({schema}) =>
+    schema.decorators.find((decorator) => decorator.name === 'em')?.name,
+  strikeThroughDecorator: ({schema}) =>
+    schema.decorators.find((decorator) => decorator.name === 'strike-through')?.name,
+  defaultStyle: ({schema}) => schema.styles.find((style) => style.name === 'normal')?.name,
+  blockquoteStyle: ({schema}) => schema.styles.find((style) => style.name === 'blockquote')?.name,
+  headingStyle: ({schema, level}) =>
+    schema.styles.find((style) => style.name === `h${level}`)?.name,
+  orderedListStyle: ({schema}) => schema.lists.find((list) => list.name === 'number')?.name,
+  unorderedListStyle: ({schema}) => schema.lists.find((list) => list.name === 'bullet')?.name,
+}
+
+export const PTEPlugins = (props: {schemaType: ArraySchemaType<PortableTextBlock>}) => {
+  const componentProps = useMemo(
+    (): PtePluginsProps => ({
+      ...props,
+      markdownPluginProps: {config: markdownConfig},
+      renderDefault: RenderDefault,
+    }),
+    [props],
+  )
+
+  const CustomComponent = props.schemaType.components?.ptePlugins as
+    | ComponentType<PtePluginsProps>
+    | undefined
+
+  return CustomComponent ? (
+    <CustomComponent {...componentProps} />
+  ) : (
+    <RenderDefault {...componentProps} />
+  )
+}
+
+export const DefaultPTEPlugins = (props: Omit<PtePluginsProps, 'renderDefault'>) => {
+  return (
+    <>
+      <Text size={0}>Markdown plugin</Text>
+      <Text size={0}>Supported markdown:</Text>
+      <Text size={0}>
+        {JSON.stringify(
+          Object.entries(props.markdownPluginProps.config)
+            .filter(([key, value]) => value)
+            .map(([key]) => key),
+        )}
+      </Text>
+      <MarkdownPlugin config={props.markdownPluginProps.config} />
+    </>
+  )
+}
+
+export const RenderDefault = (props: Omit<PtePluginsProps, 'renderDefault'>) => {
+  const RenderPlugins = useMiddlewareComponents({
+    defaultComponent: DefaultPTEPlugins,
+    pick: pickPTEPluginsComponent,
+  })
+  return (
+    <Stack space={3} paddingBottom={3} style={{border: '1px solid red'}}>
+      <Text size={1} weight="medium">
+        Render default PTE plugins
+      </Text>
+      <RenderPlugins {...props} />
+    </Stack>
+  )
+}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -26,11 +26,10 @@ const markdownConfig: MarkdownPluginConfig = {
 export const PTEPlugins = (props: {schemaType: ArraySchemaType<PortableTextBlock>}) => {
   const componentProps = useMemo(
     (): PtePluginsProps => ({
-      ...props,
       markdownPluginProps: {config: markdownConfig},
       renderDefault: RenderDefault,
     }),
-    [props],
+    [],
   )
 
   const CustomComponent = props.schemaType.components?.ptePlugins as

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -1,10 +1,10 @@
-import {MarkdownPlugin, MarkdownPluginConfig} from '@portabletext/editor/plugins'
-import {ArraySchemaType, PortableTextBlock} from '@sanity/types'
-import {ComponentType, useMemo} from 'react'
-import {PtePluginsProps} from '../../../types/blockProps'
-import {Stack, Text} from '@sanity/ui'
+import {MarkdownPlugin, type MarkdownPluginConfig} from '@portabletext/editor/plugins'
+import {type ArraySchemaType, type PortableTextBlock} from '@sanity/types'
+import {type ComponentType, useMemo} from 'react'
+
 import {useMiddlewareComponents} from '../../../../config/components/useMiddlewareComponents'
 import {pickPTEPluginsComponent} from '../../../form-components-hooks/picks'
+import {type PtePluginsProps} from '../../../types/blockProps'
 
 const markdownConfig: MarkdownPluginConfig = {
   boldDecorator: ({schema}) =>
@@ -45,20 +45,7 @@ export const PTEPlugins = (props: {schemaType: ArraySchemaType<PortableTextBlock
 }
 
 export const DefaultPTEPlugins = (props: Omit<PtePluginsProps, 'renderDefault'>) => {
-  return (
-    <>
-      <Text size={0}>Markdown plugin</Text>
-      <Text size={0}>Supported markdown:</Text>
-      <Text size={0}>
-        {JSON.stringify(
-          Object.entries(props.markdownPluginProps.config)
-            .filter(([key, value]) => value)
-            .map(([key]) => key),
-        )}
-      </Text>
-      <MarkdownPlugin config={props.markdownPluginProps.config} />
-    </>
-  )
+  return <MarkdownPlugin config={props.markdownPluginProps.config} />
 }
 
 export const RenderDefault = (props: Omit<PtePluginsProps, 'renderDefault'>) => {
@@ -66,12 +53,5 @@ export const RenderDefault = (props: Omit<PtePluginsProps, 'renderDefault'>) => 
     defaultComponent: DefaultPTEPlugins,
     pick: pickPTEPluginsComponent,
   })
-  return (
-    <Stack space={3} paddingBottom={3} style={{border: '1px solid red'}}>
-      <Text size={1} weight="medium">
-        Render default PTE plugins
-      </Text>
-      <RenderPlugins {...props} />
-    </Stack>
-  )
+  return <RenderPlugins {...props} />
 }

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -23,6 +23,7 @@ import {
   type RenderInputCallback,
   type RenderPreviewCallback,
 } from './renderCallback'
+import {MarkdownPluginConfig} from '@portabletext/editor/plugins'
 
 /**
  * Props for rendering text decorations in Portable Text blocks.
@@ -434,4 +435,13 @@ export interface BlockProps {
    * Value of the block.
    */
   value: PortableTextBlock
+}
+
+export interface PtePluginsProps {
+  renderDefault: (props: PtePluginsProps) => React.JSX.Element
+  /**
+   * The schema type for the annotation object.
+   */
+  schemaType: ArraySchemaType<PortableTextBlock>
+  markdownPluginProps: {config: MarkdownPluginConfig}
 }

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -1,3 +1,4 @@
+import {type MarkdownPluginConfig} from '@portabletext/editor/plugins'
 import {
   type ArraySchemaType,
   type BlockDecoratorDefinition,
@@ -23,7 +24,6 @@ import {
   type RenderInputCallback,
   type RenderPreviewCallback,
 } from './renderCallback'
-import {MarkdownPluginConfig} from '@portabletext/editor/plugins'
 
 /**
  * Props for rendering text decorations in Portable Text blocks.
@@ -437,11 +437,12 @@ export interface BlockProps {
   value: PortableTextBlock
 }
 
+/**
+ * Props for rendering Portable Text plugins
+ *
+ * @beta
+ */
 export interface PtePluginsProps {
   renderDefault: (props: PtePluginsProps) => React.JSX.Element
-  /**
-   * The schema type for the annotation object.
-   */
-  schemaType: ArraySchemaType<PortableTextBlock>
   markdownPluginProps: {config: MarkdownPluginConfig}
 }

--- a/packages/sanity/src/core/form/types/definitionExtensions.ts
+++ b/packages/sanity/src/core/form/types/definitionExtensions.ts
@@ -11,6 +11,7 @@ import {type ComponentType} from 'react'
 import {type PreviewProps} from '../../components'
 import {type CrossDatasetReferenceInputProps, type ReferenceInputProps} from '../studio'
 import {
+  PtePluginsProps,
   type BlockAnnotationProps,
   type BlockDecoratorProps,
   type BlockListItemProps,
@@ -51,6 +52,7 @@ declare module '@sanity/types' {
     input?: ComponentType<ArrayOfObjectsInputProps>
     item?: ComponentType<ObjectItemProps>
     preview?: ComponentType<PreviewProps>
+    ptePlugins?: ComponentType<PtePluginsProps>
   }
 
   /**

--- a/packages/sanity/src/core/form/types/definitionExtensions.ts
+++ b/packages/sanity/src/core/form/types/definitionExtensions.ts
@@ -11,12 +11,12 @@ import {type ComponentType} from 'react'
 import {type PreviewProps} from '../../components'
 import {type CrossDatasetReferenceInputProps, type ReferenceInputProps} from '../studio'
 import {
-  PtePluginsProps,
   type BlockAnnotationProps,
   type BlockDecoratorProps,
   type BlockListItemProps,
   type BlockProps,
   type BlockStyleProps,
+  type PtePluginsProps,
 } from './blockProps'
 import {
   type ArrayFieldProps,
@@ -52,7 +52,7 @@ declare module '@sanity/types' {
     input?: ComponentType<ArrayOfObjectsInputProps>
     item?: ComponentType<ObjectItemProps>
     preview?: ComponentType<PreviewProps>
-    ptePlugins?: ComponentType<PtePluginsProps>
+    pte?: {plugins: ComponentType<PtePluginsProps>}
   }
 
   /**

--- a/packages/sanity/src/core/form/types/inputProps.ts
+++ b/packages/sanity/src/core/form/types/inputProps.ts
@@ -31,7 +31,6 @@ import {
   type ReactNode,
 } from 'react'
 
-import {type RenderPortableTextInputPluginsProps} from '../inputs'
 import {type FormPatch, type PatchEvent} from '../patch'
 import {type FormFieldGroup} from '../store'
 import {
@@ -576,10 +575,6 @@ export interface PortableTextInputProps
    * Array of {@link RangeDecoration} that can be used to decorate the content.
    */
   rangeDecorations?: RangeDecoration[]
-  /**
-   * @beta
-   */
-  renderPlugins?: (props: RenderPortableTextInputPluginsProps) => ReactNode
 }
 
 /**


### PR DESCRIPTION
### Description

Introduces `components.pte.plugins` property to the system, allowing users to define custom pte plugins.
They can be defined in a plugin or in schemas

When multiple plugins are defined, they will be all inserted as long as each new plugin keeps expanding on the rest by using the `props.renderDefault(props)` function.

```ts
  components: {
      pte: {
        plugins: (props) => {
          return (
            <>
              {props.renderDefault(props)}
              <AutoCloseBracketsBehaviorPlugin />
            </>
          )
        },

```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
