### PR TITLE
feat(schema): place builtin types in a separate registry

### DIFF
--- a/packages/@sanity/schema/src/legacy/Schema.ts
+++ b/packages/@sanity/schema/src/legacy/Schema.ts
@@ -58,7 +58,7 @@ function compileRegistry(schemaDef: any) {
 export class Schema {
   _original: {name: string; types: any[]; parent?: Schema}
   _registry: {[typeName: string]: any}
-  _localTypeNames: string[]
+  #localTypeNames: string[]
 
   static compile(schemaDef: any): Schema {
     return new Schema(schemaDef)
@@ -69,7 +69,7 @@ export class Schema {
 
     const {registry, localTypeNames} = compileRegistry(schemaDef)
     this._registry = registry
-    this._localTypeNames = localTypeNames
+    this.#localTypeNames = localTypeNames
   }
 
   get name(): string {
@@ -96,7 +96,7 @@ export class Schema {
   }
 
   getLocalTypeNames(): string[] {
-    return this._localTypeNames
+    return this.#localTypeNames
   }
 }
 

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -97,6 +97,17 @@ export interface Schema {
   get: (name: string) => SchemaType | undefined
   has: (name: string) => boolean
   getTypeNames: () => string[]
+
+  /**
+   * Returns the types which were explicitly defined in this schema,
+   * as opposed to the types which were inherited from the parent.
+   */
+  getLocalTypeNames: () => string[]
+
+  /**
+   * Returns the parent schema.
+   */
+  parent?: Schema
 }
 
 /** @beta */

--- a/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
@@ -41,33 +41,34 @@ export const internal = Symbol('internal')
 function getBaseType(baseSchema: CompiledSchema, typeName: IntrinsicTypeName): SchemaType {
   if (typeName === 'crossDatasetReference') {
     return Schema.compile({
-      types: (baseSchema._original?.types || []).concat([
+      types: [
         {
           name: `__placeholder__`,
           type: 'crossDatasetReference',
           // Just needs _something_ to refer to, doesn't matter what
           to: [{type: 'sanity.imageAsset'}],
         },
-      ]),
+      ],
+      parent: baseSchema,
     }).get('__placeholder__')
   }
   if (typeName === 'globalDocumentReference') {
     return Schema.compile({
-      types: (baseSchema._original?.types || []).concat([
+      types: [
         {
           name: `__placeholder__`,
           type: 'globalDocumentReference',
           // Just needs _something_ to refer to, doesn't matter what
           to: [{type: 'sanity.imageAsset'}],
         },
-      ]),
+      ],
+      parent: baseSchema,
     }).get('__placeholder__')
   }
 
   return Schema.compile({
-    types: (baseSchema._original?.types || []).concat([
-      {name: `__placeholder__`, type: typeName, options: {hotspot: true}},
-    ]),
+    types: [{name: `__placeholder__`, type: typeName, options: {hotspot: true}}],
+    parent: baseSchema,
   }).get('__placeholder__')
 }
 

--- a/packages/sanity/src/core/schema/createSchema.ts
+++ b/packages/sanity/src/core/schema/createSchema.ts
@@ -6,6 +6,12 @@ import {inferFromSchema as inferValidation} from '../validation'
 
 const isError = (problem: SchemaValidationResult) => problem.severity === 'error'
 
+const builtinSchema = SchemaBuilder.compile({
+  name: 'studio',
+  types: builtinTypes,
+})
+inferValidation(builtinSchema)
+
 /**
  * @hidden
  * @beta */
@@ -16,7 +22,8 @@ export function createSchema(schemaDef: {name: string; types: any[]}): Schema {
 
   const compiled = SchemaBuilder.compile({
     name: schemaDef.name,
-    types: hasErrors ? [] : [...schemaDef.types, ...builtinTypes].filter(Boolean),
+    types: hasErrors ? [] : schemaDef.types.filter(Boolean),
+    parent: builtinSchema,
   })
 
   // ;(compiled as any)._source = schemaDef

--- a/packages/sanity/src/core/validation/inferFromSchema.ts
+++ b/packages/sanity/src/core/validation/inferFromSchema.ts
@@ -4,7 +4,7 @@ import {inferFromSchemaType} from './inferFromSchemaType'
 
 // Note: Mutates schema. Refactor when @sanity/schema supports middlewares
 export function inferFromSchema(schema: Schema): Schema {
-  const typeNames = schema.getTypeNames()
+  const typeNames = schema.getLocalTypeNames()
 
   typeNames.forEach((typeName) => {
     const schemaType = schema.get(typeName)


### PR DESCRIPTION
### Description

This changes the internal representation of `Schema` to also support a "parent schema". We're using this to build a schema containing the built-in types once, and then each workspace's schema has this schema as a parent. This has a bunch of nice properties:

- We end up only validating/parsing the built-in types once. We also end up reusing the type objects.
- It's now easy to determine the local types defined in a schema (`getLocalTypeNames()`) as opposed to ones that are built-in.

The main purpose of this is in the context of serialized schema. In this world we'd like to serialize the built-in schema separately from the custom schema. Without this work there's no clean way of 

### What to review

This changes the internal representation of `Schema`. Some questions I'm wondering:

- Are there other parts of the codebase which could depend on this? I found one failing test in the GraphQL part, but there might be other parts no covered by tests.
- Are there any known hacks that customers are using to poke into this? Despite this being internal, are there any risk that this might practically break something?

### Testing

This only adds an internal capability and hence I'm trusting that the existing test suite covers it. I've loaded the Test Studio locally.

### Notes for release

Not required.
