### PR TITLE
fix(cli): remove named export from SDK application templates

### DIFF
--- a/packages/@sanity/cli/templates/app-quickstart/src/App.tsx
+++ b/packages/@sanity/cli/templates/app-quickstart/src/App.tsx
@@ -3,7 +3,7 @@ import {SanityApp} from '@sanity/sdk-react'
 import {ExampleComponent} from './ExampleComponent'
 import './App.css'
 
-export function App() {
+function App() {
   // apps can access many different projects or other sources of data
   const sanityConfigs: SanityConfig[] = [
     {

--- a/packages/@sanity/cli/templates/app-sanity-ui/src/App.tsx
+++ b/packages/@sanity/cli/templates/app-sanity-ui/src/App.tsx
@@ -6,7 +6,7 @@ import {ExampleComponent} from './ExampleComponent'
 
 const theme = buildTheme()
 
-export function App() {
+function App() {
   // apps can access many different projects or other sources of data
   const sanityConfigs: SanityConfig[] = [
     {


### PR DESCRIPTION
### Description
Removes the named export from SDK app templates. The `getEntryModule` file [expects a default export](https://github.com/sanity-io/sanity/blob/1adedb59f02c0f6bf47dc45f424e023a6755341c/packages/sanity/src/_internal/cli/server/getEntryModule.ts#L33). This is also aligned with a vanilla Vite app. 

### What to review
Does this make sense?

### Testing
Probably the easiest way to test this is to make the same change in a local app template app (created via `npx sanity@latest init --template app-quickstart`) and match the generated files to this change.

### Notes for release
N/A