### PR TITLE
chore: use correct path for "groq" package

### DIFF
--- a/dev/tsconfig.dev.json
+++ b/dev/tsconfig.dev.json
@@ -16,7 +16,7 @@
       "@sanity/util/*": ["./packages/@sanity/util/src/_exports/*"],
       "@sanity/util": ["./packages/@sanity/util/src/_exports/index.ts"],
       "@sanity/vision": ["./packages/@sanity/vision/src/index.ts"],
-      "groq": ["./packages/groq/src/groq.ts"],
+      "groq": ["./packages/groq/src/_exports.mts.ts"],
       "sanity/_internal": ["./packages/sanity/src/_exports/_internal.ts"],
       "sanity/_singletons": ["./packages/sanity/src/_exports/_singletons.ts"],
       "sanity/_createContext": ["./packages/sanity/src/_exports/_createContext.ts"],


### PR DESCRIPTION
### Description

Using `import "groq"` _inside_ the monorepo caused strange errors (`groq__default.default is not a function`) because we had an incorrect path in `tsconfig.json`. This changes that.

### What to review

That the dev studios still work.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Not required.
