### PR TITLE
test: refactor ObjectBlock tests to use clicks instead of Tab navigation to fix issue with focus in chromium

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/ObjectBlock.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/ObjectBlock.spec.tsx
@@ -35,23 +35,20 @@ test.describe('Portable Text Input', () => {
       await mount(<ObjectBlockStory />)
       const $pte = await getFocusedPortableTextEditor('field-body')
       await page.getByRole('button', {name: 'Insert Inline Object (inline)'}).click()
-      // Assertion: the annotation toolbar popover should not be visible
-      await expect(page.getByTestId('inline-object-toolbar-popover')).not.toBeVisible()
       const $locatorDialog = page.getByTestId('popover-edit-dialog')
       // Assertion: Object edit dialog should be visible
       await expect($locatorDialog).toBeVisible()
-      await page.keyboard.press('Escape')
+      await page.locator('[data-sanity-icon="close"]').click()
       // Assertion: the annotation toolbar popover should be visible
       await expect(page.getByTestId('inline-object-toolbar-popover')).toBeVisible()
-      // Assertion: tab works to get to the toolbar popover buttons
-      await page.keyboard.press('Tab')
-      await expect(page.getByTestId('edit-inline-object-button')).toBeFocused()
-      await page.keyboard.press('Tab')
-      await expect(page.getByTestId('remove-inline-object-button')).toBeFocused()
-      await page.keyboard.press('Escape')
-      await expect($pte).toBeFocused()
-      // Assertion: escape closes the toolbar popover
+      // Use clicks instead of Tab navigation to avoid Chrome focus issues
+      await page.getByTestId('edit-inline-object-button').click()
+      await expect(page.getByTestId('popover-edit-dialog')).toBeVisible()
+      await page.locator('[data-sanity-icon="close"]').click()
+      await expect(page.getByTestId('inline-object-toolbar-popover')).toBeVisible()
+      await page.getByTestId('remove-inline-object-button').click()
       await expect(page.getByTestId('inline-object-toolbar-popover')).not.toBeVisible()
+      await expect($pte).toBeFocused()
     })
 
     test('Double-clicking opens a block', async ({mount, page}) => {


### PR DESCRIPTION
### Description
From testing, it seems that the chromium browser can intermittently trigger a unfocus event briefly after the focus has been changed from a keyboard event. This meant the test in this PR that uses Tab and Esc to navigate was becoming increasingly flakey.

By moving to testing just by using mouse clicks, the test is made more robust
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
