### PR TITLE
Add tests for diff view hooks

### DIFF
--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useCreatePathSyncChannel.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useCreatePathSyncChannel.mock.ts
@@ -1,0 +1,8 @@
+import {Subject} from 'rxjs'
+import {type Mock} from 'vitest'
+
+import {useCreatePathSyncChannel} from '../../useCreatePathSyncChannel'
+
+export const mockUseCreatePathSyncChannelReturn = new Subject()
+
+export const mockUseCreatePathSyncChannel = useCreatePathSyncChannel as Mock<typeof useCreatePathSyncChannel>

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useDiffViewRouter.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useDiffViewRouter.mock.ts
@@ -1,0 +1,10 @@
+import {type Mock, type Mocked, vi} from 'vitest'
+
+import {type DiffViewRouter, useDiffViewRouter} from '../../useDiffViewRouter'
+
+export const useDiffViewRouterMockReturn: Mocked<DiffViewRouter> = {
+  navigateDiffView: vi.fn(),
+  exitDiffView: vi.fn(),
+}
+
+export const mockUseDiffViewRouter = useDiffViewRouter as Mock<typeof useDiffViewRouter>

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/usePathSyncChannel.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/usePathSyncChannel.mock.ts
@@ -1,0 +1,13 @@
+import {Subject} from 'rxjs'
+import {type Mock, type Mocked, vi} from 'vitest'
+
+import {type usePathSyncChannel as usePathSyncChannelFn} from '../../usePathSyncChannel'
+
+export const usePathSyncChannelMockReturn: Mocked<ReturnType<typeof usePathSyncChannelFn>> = {
+  push: vi.fn(),
+  path: new Subject(),
+}
+
+export const mockUsePathSyncChannel = (
+  usePathSyncChannelFn as unknown as Mock<typeof usePathSyncChannelFn>
+)

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/useCreatePathSyncChannel.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/useCreatePathSyncChannel.test.ts
@@ -1,0 +1,22 @@
+import {renderHook} from '@testing-library/react'
+import {Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {useCreatePathSyncChannel} from '../useCreatePathSyncChannel'
+
+describe('useCreatePathSyncChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('returns a Subject instance', () => {
+    const {result} = renderHook(() => useCreatePathSyncChannel())
+    expect(result.current).toBeInstanceOf(Subject)
+  })
+
+  it('returns the same instance between renders', () => {
+    const {result, rerender} = renderHook(() => useCreatePathSyncChannel())
+    const first = result.current
+    rerender()
+    expect(result.current).toBe(first)
+  })
+})

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/useDiffViewRouter.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/useDiffViewRouter.test.ts
@@ -1,0 +1,64 @@
+import {renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {
+  DIFF_SEARCH_PARAM_DELIMITER,
+  DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_SEARCH_PARAMETER,
+} from '../constants'
+import {useDiffViewRouter} from '../useDiffViewRouter'
+import {mockUseRouter, mockUseRouterReturn} from '../../../../../test/mocks/useRouter.mock'
+
+vi.mock('sanity/router', () => ({
+  useRouter: vi.fn(() => mockUseRouterReturn),
+}))
+
+describe('useDiffViewRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('navigateDiffView updates router search params', () => {
+    mockUseRouterReturn.state._searchParams = [['foo', 'bar']]
+    const {result} = renderHook(() => useDiffViewRouter())
+
+    result.current.navigateDiffView({
+      mode: 'version',
+      previousDocument: {type: 'book', id: 'a'},
+      nextDocument: {type: 'book', id: 'b'},
+    })
+
+    expect(mockUseRouterReturn.navigate).toHaveBeenCalledWith({
+      ...mockUseRouterReturn.state,
+      _searchParams: [
+        ['foo', 'bar'],
+        [DIFF_VIEW_SEARCH_PARAMETER, 'version'],
+        [
+          DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
+          ['book', 'a'].join(DIFF_SEARCH_PARAM_DELIMITER),
+        ],
+        [
+          DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER,
+          ['book', 'b'].join(DIFF_SEARCH_PARAM_DELIMITER),
+        ],
+      ],
+    })
+  })
+
+  it('exitDiffView removes diff related params', () => {
+    mockUseRouterReturn.state._searchParams = [
+      [DIFF_VIEW_SEARCH_PARAMETER, 'version'],
+      [DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER, 'a,a'],
+      [DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER, 'b,b'],
+      ['other', '1'],
+    ]
+    const {result} = renderHook(() => useDiffViewRouter())
+
+    result.current.exitDiffView()
+
+    expect(mockUseRouterReturn.navigate).toHaveBeenCalledWith({
+      ...mockUseRouterReturn.state,
+      _searchParams: [['other', '1']],
+    })
+  })
+})

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/usePathSyncChannel.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/usePathSyncChannel.test.ts
@@ -1,0 +1,35 @@
+import {renderHook} from '@testing-library/react'
+import {Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {type PathSyncState} from '../types/pathSyncChannel'
+import {usePathSyncChannel} from '../usePathSyncChannel'
+
+describe('usePathSyncChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('push sends state with source id', () => {
+    const syncChannel = new Subject<PathSyncState>()
+    const {result} = renderHook(() => usePathSyncChannel({syncChannel, id: 'pane'}))
+    const spy = vi.spyOn(syncChannel, 'next')
+
+    result.current.push({path: ['foo']})
+    expect(spy).toHaveBeenCalledWith({path: ['foo'], source: 'pane'})
+  })
+
+  it('path emits changes from other sources and ignores duplicates', () => {
+    const syncChannel = new Subject<PathSyncState>()
+    const {result} = renderHook(() => usePathSyncChannel({syncChannel, id: 'a'}))
+    const values: any[] = []
+    const sub = result.current.path.subscribe((v) => values.push(v))
+
+    syncChannel.next({path: ['foo'], source: 'a'})
+    syncChannel.next({path: ['foo'], source: 'b'})
+    syncChannel.next({path: ['foo'], source: 'b'})
+    syncChannel.next({path: ['bar'], source: 'b'})
+    sub.unsubscribe()
+
+    expect(values).toEqual([['foo'], ['bar']])
+  })
+})


### PR DESCRIPTION
## Summary
- add mock utilities for diff view hooks
- test `useCreatePathSyncChannel`
- test `usePathSyncChannel`
- test `useDiffViewRouter`

## Testing
- `pnpm run test:vitest` *(fails: connect EHOSTUNREACH)*