### PR TITLE
feat(schema): introduce internal own props on each type

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/array.ts
+++ b/packages/@sanity/schema/src/legacy/types/array.ts
@@ -1,7 +1,7 @@
 import {pick} from 'lodash'
 
-import {DEFAULT_OVERRIDEABLE_FIELDS} from './constants'
-import {lazyGetter} from './utils'
+import {DEFAULT_OVERRIDEABLE_FIELDS, OWN_PROPS_NAME} from './constants'
+import {hiddenGetter, lazyGetter} from './utils'
 
 const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
@@ -25,6 +25,10 @@ export const ArrayType = {
         return createMemberType(ofTypeDef)
       })
     })
+    lazyGetter(parsed, OWN_PROPS_NAME, () => ({...subTypeDef, of: parsed.of}), {
+      enumerable: false,
+      writable: false,
+    })
 
     return subtype(parsed)
 
@@ -37,9 +41,11 @@ export const ArrayType = {
           if (extensionDef.of) {
             throw new Error('Cannot override `of` property of subtypes of "array"')
           }
-          const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
+          const ownProps = pick(extensionDef, OVERRIDABLE_FIELDS)
+          const current = Object.assign({}, parent, ownProps, {
             type: parent,
           })
+          hiddenGetter(current, OWN_PROPS_NAME, ownProps)
           return subtype(current)
         },
       }

--- a/packages/@sanity/schema/src/legacy/types/boolean.ts
+++ b/packages/@sanity/schema/src/legacy/types/boolean.ts
@@ -1,7 +1,8 @@
 import {pick} from 'lodash'
 
 import primitivePreview from '../preview/primitivePreview'
-import {DEFAULT_OVERRIDEABLE_FIELDS} from './constants'
+import {DEFAULT_OVERRIDEABLE_FIELDS, OWN_PROPS_NAME} from './constants'
+import {hiddenGetter} from './utils'
 
 const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
@@ -17,10 +18,15 @@ export const BooleanType = {
     return BOOLEAN_CORE
   },
   extend(subTypeDef: any) {
-    const parsed = Object.assign(pick(BOOLEAN_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
-      type: BOOLEAN_CORE,
+    const ownProps = {
+      ...subTypeDef,
       preview: primitivePreview,
+    }
+    const parsed = Object.assign(pick(BOOLEAN_CORE, OVERRIDABLE_FIELDS), ownProps, {
+      type: BOOLEAN_CORE,
     })
+
+    hiddenGetter(parsed, OWN_PROPS_NAME, ownProps)
 
     return subtype(parsed)
 
@@ -30,9 +36,11 @@ export const BooleanType = {
           return parent
         },
         extend: (extensionDef: any) => {
-          const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
+          const subOwnProps = pick(extensionDef, OVERRIDABLE_FIELDS)
+          const current = Object.assign({}, parent, subOwnProps, {
             type: parent,
           })
+          hiddenGetter(current, OWN_PROPS_NAME, subOwnProps)
           return subtype(current)
         },
       }

--- a/packages/@sanity/schema/src/legacy/types/constants.ts
+++ b/packages/@sanity/schema/src/legacy/types/constants.ts
@@ -14,3 +14,9 @@ export const DEFAULT_OVERRIDEABLE_FIELDS = [
   'initialValue',
   'deprecated',
 ]
+
+/**
+ * The property name used for each type where we store the "own props" of the type.
+ * This is the set of properties which are _not_ inherited, but explicitly defined on this type.
+ */
+export const OWN_PROPS_NAME = '_internal_ownProps'

--- a/packages/@sanity/schema/src/legacy/types/date.ts
+++ b/packages/@sanity/schema/src/legacy/types/date.ts
@@ -1,7 +1,8 @@
 import {pick} from 'lodash'
 
 import primitivePreview from '../preview/primitivePreview'
-import {DEFAULT_OVERRIDEABLE_FIELDS} from './constants'
+import {DEFAULT_OVERRIDEABLE_FIELDS, OWN_PROPS_NAME} from './constants'
+import {hiddenGetter} from './utils'
 
 const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
@@ -17,10 +18,16 @@ export const DateType = {
     return DATE_CORE
   },
   extend(subTypeDef: any) {
-    const parsed = Object.assign(pick(DATE_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
-      type: DATE_CORE,
+    const ownProps = {
+      ...subTypeDef,
       preview: primitivePreview,
+    }
+    const parsed = Object.assign(pick(DATE_CORE, OVERRIDABLE_FIELDS), ownProps, {
+      type: DATE_CORE,
     })
+
+    hiddenGetter(parsed, OWN_PROPS_NAME, ownProps)
+
     return subtype(parsed)
 
     function subtype(parent: any) {
@@ -29,9 +36,11 @@ export const DateType = {
           return parent
         },
         extend: (extensionDef: any) => {
-          const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
+          const subOwnProps = pick(extensionDef, OVERRIDABLE_FIELDS)
+          const current = Object.assign({}, parent, subOwnProps, {
             type: parent,
           })
+          hiddenGetter(current, OWN_PROPS_NAME, subOwnProps)
           return subtype(current)
         },
       }

--- a/packages/@sanity/schema/src/legacy/types/datetime.ts
+++ b/packages/@sanity/schema/src/legacy/types/datetime.ts
@@ -1,7 +1,8 @@
 import {pick} from 'lodash'
 
 import primitivePreview from '../preview/primitivePreview'
-import {DEFAULT_OVERRIDEABLE_FIELDS} from './constants'
+import {DEFAULT_OVERRIDEABLE_FIELDS, OWN_PROPS_NAME} from './constants'
+import {hiddenGetter} from './utils'
 
 const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
@@ -17,10 +18,14 @@ export const DateTimeType = {
     return DATETIME_CORE
   },
   extend(subTypeDef: any) {
-    const parsed = Object.assign(pick(DATETIME_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
-      type: DATETIME_CORE,
+    const ownProps = {
+      ...subTypeDef,
       preview: primitivePreview,
+    }
+    const parsed = Object.assign(pick(DATETIME_CORE, OVERRIDABLE_FIELDS), ownProps, {
+      type: DATETIME_CORE,
     })
+    hiddenGetter(parsed, OWN_PROPS_NAME, ownProps)
     return subtype(parsed)
 
     function subtype(parent: any) {
@@ -29,9 +34,11 @@ export const DateTimeType = {
           return parent
         },
         extend: (extensionDef: any) => {
-          const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
+          const subOwnProps = pick(extensionDef, OVERRIDABLE_FIELDS)
+          const current = Object.assign({}, parent, subOwnProps, {
             type: parent,
           })
+          hiddenGetter(current, OWN_PROPS_NAME, subOwnProps)
           return subtype(current)
         },
       }

--- a/packages/@sanity/schema/src/legacy/types/email.ts
+++ b/packages/@sanity/schema/src/legacy/types/email.ts
@@ -1,7 +1,8 @@
 import {pick} from 'lodash'
 
 import primitivePreview from '../preview/primitivePreview'
-import {DEFAULT_OVERRIDEABLE_FIELDS} from './constants'
+import {DEFAULT_OVERRIDEABLE_FIELDS, OWN_PROPS_NAME} from './constants'
+import {hiddenGetter} from './utils'
 
 const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
@@ -17,10 +18,14 @@ export const EmailType = {
     return EMAIL_CORE
   },
   extend(subTypeDef: any) {
-    const parsed = Object.assign(pick(EMAIL_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
-      type: EMAIL_CORE,
+    const ownProps = {
+      ...subTypeDef,
       preview: primitivePreview,
+    }
+    const parsed = Object.assign(pick(EMAIL_CORE, OVERRIDABLE_FIELDS), ownProps, {
+      type: EMAIL_CORE,
     })
+    hiddenGetter(parsed, OWN_PROPS_NAME, ownProps)
     return subtype(parsed)
 
     function subtype(parent: any) {
@@ -29,9 +34,11 @@ export const EmailType = {
           return parent
         },
         extend: (extensionDef: any) => {
-          const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
+          const subOwnProps = pick(extensionDef, OVERRIDABLE_FIELDS)
+          const current = Object.assign({}, parent, subOwnProps, {
             type: parent,
           })
+          hiddenGetter(current, OWN_PROPS_NAME, subOwnProps)
           return subtype(current)
         },
       }

--- a/packages/@sanity/schema/src/legacy/types/globalDocumentReference.ts
+++ b/packages/@sanity/schema/src/legacy/types/globalDocumentReference.ts
@@ -1,8 +1,8 @@
 import arrify from 'arrify'
 import {pick} from 'lodash'
 
-import {DEFAULT_OVERRIDEABLE_FIELDS} from './constants'
-import {lazyGetter} from './utils'
+import {DEFAULT_OVERRIDEABLE_FIELDS, OWN_PROPS_NAME} from './constants'
+import {hiddenGetter, lazyGetter} from './utils'
 
 export const REF_FIELD = {
   name: '_ref',
@@ -85,6 +85,18 @@ export const GlobalDocumentReferenceType = {
 
     lazyGetter(parsed, 'title', () => subTypeDef.title || buildTitle(parsed))
 
+    lazyGetter(
+      parsed,
+      OWN_PROPS_NAME,
+      () => ({
+        ...subTypeDef,
+        fields: parsed.fields,
+        to: parsed.to,
+        title: parsed.title,
+      }),
+      {enumerable: false, writable: false},
+    )
+
     return subtype(parsed)
 
     function subtype(parent: any) {
@@ -96,9 +108,11 @@ export const GlobalDocumentReferenceType = {
           if (extensionDef.of) {
             throw new Error('Cannot override `of` of subtypes of "globalDocumentReference"')
           }
-          const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
+          const ownProps = pick(extensionDef, OVERRIDABLE_FIELDS)
+          const current = Object.assign({}, parent, ownProps, {
             type: parent,
           })
+          hiddenGetter(current, OWN_PROPS_NAME, ownProps)
           return subtype(current)
         },
       }

--- a/packages/@sanity/schema/src/legacy/types/image.ts
+++ b/packages/@sanity/schema/src/legacy/types/image.ts
@@ -1,10 +1,10 @@
 import {pick, startCase} from 'lodash'
 
 import createPreviewGetter from '../preview/createPreviewGetter'
-import {DEFAULT_OVERRIDEABLE_FIELDS} from './constants'
+import {DEFAULT_OVERRIDEABLE_FIELDS, OWN_PROPS_NAME} from './constants'
 import {ASSET_FIELD, CROP_FIELD, HOTSPOT_FIELD, MEDIA_LIBRARY_ASSET_FIELD} from './image/fieldDefs'
 import {createFieldsets} from './object'
-import {lazyGetter} from './utils'
+import {hiddenGetter, lazyGetter} from './utils'
 
 const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
@@ -65,6 +65,20 @@ export const ImageType = {
 
     lazyGetter(parsed, 'preview', createPreviewGetter(Object.assign({}, subTypeDef, {fields})))
 
+    lazyGetter(
+      parsed,
+      OWN_PROPS_NAME,
+      () => ({
+        ...subTypeDef,
+        options,
+        fields: parsed.fields,
+        title: parsed.title,
+        fieldsets: parsed.fieldsets,
+        preview: parsed.preview,
+      }),
+      {enumerable: false, writable: false},
+    )
+
     return subtype(parsed)
 
     function subtype(parent: any) {
@@ -76,9 +90,11 @@ export const ImageType = {
           if (extensionDef.fields) {
             throw new Error('Cannot override `fields` of subtypes of "image"')
           }
-          const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
+          const ownProps = pick(extensionDef, OVERRIDABLE_FIELDS)
+          const current = Object.assign({}, parent, ownProps, {
             type: parent,
           })
+          hiddenGetter(current, OWN_PROPS_NAME, ownProps)
           return subtype(current)
         },
       }

--- a/packages/@sanity/schema/src/legacy/types/number.ts
+++ b/packages/@sanity/schema/src/legacy/types/number.ts
@@ -1,7 +1,8 @@
 import {pick} from 'lodash'
 
 import primitivePreview from '../preview/primitivePreview'
-import {DEFAULT_OVERRIDEABLE_FIELDS} from './constants'
+import {DEFAULT_OVERRIDEABLE_FIELDS, OWN_PROPS_NAME} from './constants'
+import {hiddenGetter} from './utils'
 
 const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
@@ -17,10 +18,16 @@ export const NumberType = {
     return NUMBER_CORE
   },
   extend(subTypeDef: any) {
-    const parsed = Object.assign(pick(NUMBER_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
-      type: NUMBER_CORE,
+    const ownProps = {
+      ...subTypeDef,
       preview: primitivePreview,
+    }
+
+    const parsed = Object.assign(pick(NUMBER_CORE, OVERRIDABLE_FIELDS), ownProps, {
+      type: NUMBER_CORE,
     })
+
+    hiddenGetter(parsed, OWN_PROPS_NAME, ownProps)
 
     return subtype(parsed)
 
@@ -30,9 +37,11 @@ export const NumberType = {
           return parent
         },
         extend: (extensionDef: any) => {
-          const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
+          const subOwnProps = pick(extensionDef, OVERRIDABLE_FIELDS)
+          const current = Object.assign({}, parent, subOwnProps, {
             type: parent,
           })
+          hiddenGetter(current, OWN_PROPS_NAME, subOwnProps)
           return subtype(current)
         },
       }

--- a/packages/@sanity/schema/src/legacy/types/object.ts
+++ b/packages/@sanity/schema/src/legacy/types/object.ts
@@ -13,7 +13,7 @@ import createPreviewGetter from '../preview/createPreviewGetter'
 import {normalizeSearchConfigs} from '../searchConfig/normalize'
 import {resolveSearchConfig} from '../searchConfig/resolve'
 import {DEFAULT_OVERRIDEABLE_FIELDS, OWN_PROPS_NAME} from './constants'
-import {lazyGetter} from './utils'
+import {hiddenGetter, lazyGetter} from './utils'
 
 const OVERRIDABLE_FIELDS = [
   ...DEFAULT_OVERRIDEABLE_FIELDS,
@@ -117,14 +117,18 @@ export const ObjectType = {
           if (extensionDef.fields) {
             throw new Error('Cannot override `fields` of subtypes of "object"')
           }
+
+          const subOwnProps = pick(extensionDef, OVERRIDABLE_FIELDS)
+          subOwnProps.title =
+            extensionDef.title ||
+            subTypeDef.title ||
+            (subTypeDef.name ? startCase(subTypeDef.name) : 'Object')
+
           const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
-            title:
-              extensionDef.title ||
-              subTypeDef.title ||
-              (subTypeDef.name ? startCase(subTypeDef.name) : 'Object'),
             type: parent,
           })
           lazyGetter(current, '__experimental_search', () => parent.__experimental_search)
+          hiddenGetter(current, OWN_PROPS_NAME, subOwnProps)
           return subtype(current)
         },
       }

--- a/packages/@sanity/schema/src/legacy/types/string.ts
+++ b/packages/@sanity/schema/src/legacy/types/string.ts
@@ -1,7 +1,8 @@
 import {pick} from 'lodash'
 
 import primitivePreview from '../preview/primitivePreview'
-import {DEFAULT_OVERRIDEABLE_FIELDS} from './constants'
+import {DEFAULT_OVERRIDEABLE_FIELDS, OWN_PROPS_NAME} from './constants'
+import {hiddenGetter} from './utils'
 
 const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
@@ -17,10 +18,16 @@ export const StringType = {
     return STRING_CORE
   },
   extend(subTypeDef: any) {
-    const parsed = Object.assign(pick(STRING_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
-      type: STRING_CORE,
+    const ownProps = {
+      ...subTypeDef,
       preview: primitivePreview,
+    }
+
+    const parsed = Object.assign(pick(STRING_CORE, OVERRIDABLE_FIELDS), ownProps, {
+      type: STRING_CORE,
     })
+
+    hiddenGetter(parsed, OWN_PROPS_NAME, ownProps)
 
     return subtype(parsed)
 
@@ -30,9 +37,11 @@ export const StringType = {
           return parent
         },
         extend: (extensionDef: any) => {
-          const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
+          const subOwnProps = pick(extensionDef, OVERRIDABLE_FIELDS)
+          const current = Object.assign({}, parent, subOwnProps, {
             type: parent,
           })
+          hiddenGetter(current, OWN_PROPS_NAME, subOwnProps)
           return subtype(current)
         },
       }

--- a/packages/@sanity/schema/src/legacy/types/text.ts
+++ b/packages/@sanity/schema/src/legacy/types/text.ts
@@ -1,7 +1,8 @@
 import {pick} from 'lodash'
 
 import primitivePreview from '../preview/primitivePreview'
-import {DEFAULT_OVERRIDEABLE_FIELDS} from './constants'
+import {DEFAULT_OVERRIDEABLE_FIELDS, OWN_PROPS_NAME} from './constants'
+import {hiddenGetter} from './utils'
 
 const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS, 'rows']
 
@@ -17,10 +18,16 @@ export const TextType = {
     return TEXT_CORE
   },
   extend(subTypeDef: any) {
-    const parsed = Object.assign(pick(TEXT_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
-      type: TEXT_CORE,
+    const ownProps = {
+      ...subTypeDef,
       preview: primitivePreview,
+    }
+
+    const parsed = Object.assign(pick(TEXT_CORE, OVERRIDABLE_FIELDS), ownProps, {
+      type: TEXT_CORE,
     })
+
+    hiddenGetter(parsed, OWN_PROPS_NAME, ownProps)
 
     return subtype(parsed)
 
@@ -30,9 +37,11 @@ export const TextType = {
           return parent
         },
         extend: (extensionDef: any) => {
-          const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
+          const subOwnProps = pick(extensionDef, OVERRIDABLE_FIELDS)
+          const current = Object.assign({}, parent, subOwnProps, {
             type: parent,
           })
+          hiddenGetter(current, OWN_PROPS_NAME, subOwnProps)
           return subtype(current)
         },
       }

--- a/packages/@sanity/schema/src/legacy/types/url.ts
+++ b/packages/@sanity/schema/src/legacy/types/url.ts
@@ -1,7 +1,8 @@
 import {pick} from 'lodash'
 
 import primitivePreview from '../preview/primitivePreview'
-import {DEFAULT_OVERRIDEABLE_FIELDS} from './constants'
+import {DEFAULT_OVERRIDEABLE_FIELDS, OWN_PROPS_NAME} from './constants'
+import {hiddenGetter} from './utils'
 
 const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
@@ -17,10 +18,17 @@ export const UrlType = {
     return URL_CORE
   },
   extend(subTypeDef: any) {
-    const parsed = Object.assign(pick(URL_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
-      type: URL_CORE,
+    const ownProps = {
+      ...subTypeDef,
       preview: primitivePreview,
+    }
+
+    const parsed = Object.assign(pick(URL_CORE, OVERRIDABLE_FIELDS), ownProps, {
+      type: URL_CORE,
     })
+
+    hiddenGetter(parsed, OWN_PROPS_NAME, ownProps)
+
     return subtype(parsed)
 
     function subtype(parent: any) {
@@ -29,9 +37,11 @@ export const UrlType = {
           return parent
         },
         extend: (extensionDef: any) => {
-          const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
+          const subOwnownProps = pick(extensionDef, OVERRIDABLE_FIELDS)
+          const current = Object.assign({}, parent, subOwnownProps, {
             type: parent,
           })
+          hiddenGetter(current, OWN_PROPS_NAME, subOwnownProps)
           return subtype(current)
         },
       }

--- a/packages/@sanity/schema/src/legacy/types/utils.ts
+++ b/packages/@sanity/schema/src/legacy/types/utils.ts
@@ -19,6 +19,15 @@ export function lazyGetter(target: any, key: any, getter: any, config: Config = 
   return target
 }
 
+export function hiddenGetter(target: any, key: string, value: unknown) {
+  Object.defineProperty(target, key, {
+    enumerable: false,
+    writable: false,
+    configurable: false,
+    value,
+  })
+}
+
 //
 // const o = lazyGetter({}, 'expensive', function() {
 //   console.log('doing expensive calculations')


### PR DESCRIPTION
### Description

This adds a new property (`_internal_ownProps`) on each `SchemaType`. This contains only the properties which was defined on _this_ specific type and _not_ the parent properties inherited from the super type. Without this it's impossible to know if a property on a type is defined there or inherited from the parent. This is intended to be used when serializing the schema as there we'd like to only serialize the properties where they are _defined_. 

### What to review

Make sure that this doesn't accidentally break anything. This is supposed to be 100% backwards compatible and not change the existing schema type in any way.

### Testing

No manual testing. Currently trusting the CI.

### Notes for release

Not required.
