### PR TITLE
feat: add default headers for studio client requests

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -8,6 +8,7 @@ import {defer} from 'rxjs'
 import {distinctUntilChanged, map, shareReplay, startWith, switchMap} from 'rxjs/operators'
 
 import {type AuthConfig} from '../../../config'
+import {DEFAULT_STUDIO_CLIENT_HEADERS} from '../../../studioClient'
 import {CorsOriginError} from '../cors'
 import {createBroadcastChannel} from './createBroadcastChannel'
 import {createLoginComponent} from './createLoginComponent'
@@ -195,6 +196,7 @@ export function _createAuthStore({
         requestTagPrefix: 'sanity.studio',
         ignoreBrowserTokenWarning: true,
         allowReconfigure: false,
+        headers: DEFAULT_STUDIO_CLIENT_HEADERS,
         ...hostOptions,
       }),
     ),
@@ -232,6 +234,7 @@ export function _createAuthStore({
       withCredentials: true,
       apiVersion: '2021-06-07',
       requestTagPrefix: 'sanity.studio',
+      headers: DEFAULT_STUDIO_CLIENT_HEADERS,
       ...hostOptions,
     })
 
@@ -276,6 +279,7 @@ export function _createAuthStore({
       ...(token ? {token} : {withCredentials: true}),
       apiVersion: '2021-06-07',
       requestTagPrefix: 'sanity.studio',
+      headers: DEFAULT_STUDIO_CLIENT_HEADERS,
       ...hostOptions,
     })
 

--- a/packages/sanity/src/core/store/_legacy/history/history/getJsonStream.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/getJsonStream.ts
@@ -1,5 +1,7 @@
 import {type TransactionLogEventWithEffects} from '@sanity/types'
 
+import {DEFAULT_STUDIO_CLIENT_HEADERS} from '../../../../studioClient'
+
 type StreamResult = TransactionLogEventWithEffects | {error: {description?: string; type: string}}
 
 export async function getJsonStream(
@@ -7,8 +9,8 @@ export async function getJsonStream(
   token: string | undefined,
 ): Promise<ReadableStream<StreamResult>> {
   const options: RequestInit = token
-    ? {headers: {Authorization: `Bearer ${token}`}}
-    : {credentials: 'include'}
+    ? {headers: {...DEFAULT_STUDIO_CLIENT_HEADERS, Authorization: `Bearer ${token}`}}
+    : {credentials: 'include', headers: DEFAULT_STUDIO_CLIENT_HEADERS}
   const response = await fetch(url, options)
   return getStream(response)
 }

--- a/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
+++ b/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
@@ -3,7 +3,7 @@ import {useCallback, useContext, useEffect, useMemo, useState} from 'react'
 import {AddonDatasetContext} from 'sanity/_singletons'
 
 import {useClient} from '../../hooks'
-import {DEFAULT_STUDIO_CLIENT_HEADERS, DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {useWorkspace} from '../workspace'
 import {type AddonDatasetContextValue} from './types'
 
@@ -14,22 +14,16 @@ interface AddonDatasetSetupProviderProps {
 function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
   const {children} = props
   const {dataset, projectId} = useWorkspace()
-  const originalClient = useClient({
-    ...DEFAULT_STUDIO_CLIENT_OPTIONS,
-  })
+  const originalClient = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const [addonDatasetClient, setAddonDatasetClient] = useState<SanityClient | null>(null)
   const [isCreatingDataset, setIsCreatingDataset] = useState<boolean>(false)
   const [ready, setReady] = useState<boolean>(false)
 
   const getAddonDatasetName = useCallback(async (): Promise<string | undefined> => {
-    const res = await originalClient
-      .withConfig({
-        headers: DEFAULT_STUDIO_CLIENT_HEADERS,
-      })
-      .request({
-        uri: `/projects/${projectId}/datasets?datasetProfile=comments&addonFor=${dataset}`,
-        tag: 'sanity.studio',
-      })
+    const res = await originalClient.request({
+      uri: `/projects/${projectId}/datasets?datasetProfile=comments&addonFor=${dataset}`,
+      tag: 'sanity.studio',
+    })
 
     // The response is an array containing the addon dataset. We only expect
     // one addon dataset to be returned, so we return the name of the first
@@ -44,7 +38,6 @@ function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
         projectId,
         requestTagPrefix: 'sanity.studio',
         useCdn: false,
-        headers: DEFAULT_STUDIO_CLIENT_HEADERS,
       })
 
       return client
@@ -75,14 +68,10 @@ function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
 
     try {
       // 1. Create the addon dataset
-      const res = await originalClient
-        .withConfig({
-          headers: DEFAULT_STUDIO_CLIENT_HEADERS,
-        })
-        .request({
-          uri: `/comments/${dataset}/setup`,
-          method: 'POST',
-        })
+      const res = await originalClient.request({
+        uri: `/comments/${dataset}/setup`,
+        method: 'POST',
+      })
 
       const datasetName = res?.datasetName
 

--- a/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
+++ b/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
@@ -16,17 +16,20 @@ function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
   const {dataset, projectId} = useWorkspace()
   const originalClient = useClient({
     ...DEFAULT_STUDIO_CLIENT_OPTIONS,
-    headers: DEFAULT_STUDIO_CLIENT_HEADERS,
   })
   const [addonDatasetClient, setAddonDatasetClient] = useState<SanityClient | null>(null)
   const [isCreatingDataset, setIsCreatingDataset] = useState<boolean>(false)
   const [ready, setReady] = useState<boolean>(false)
 
   const getAddonDatasetName = useCallback(async (): Promise<string | undefined> => {
-    const res = await originalClient.request({
-      uri: `/projects/${projectId}/datasets?datasetProfile=comments&addonFor=${dataset}`,
-      tag: 'sanity.studio',
-    })
+    const res = await originalClient
+      .withConfig({
+        headers: DEFAULT_STUDIO_CLIENT_HEADERS,
+      })
+      .request({
+        uri: `/projects/${projectId}/datasets?datasetProfile=comments&addonFor=${dataset}`,
+        tag: 'sanity.studio',
+      })
 
     // The response is an array containing the addon dataset. We only expect
     // one addon dataset to be returned, so we return the name of the first
@@ -72,10 +75,14 @@ function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
 
     try {
       // 1. Create the addon dataset
-      const res = await originalClient.request({
-        uri: `/comments/${dataset}/setup`,
-        method: 'POST',
-      })
+      const res = await originalClient
+        .withConfig({
+          headers: DEFAULT_STUDIO_CLIENT_HEADERS,
+        })
+        .request({
+          uri: `/comments/${dataset}/setup`,
+          method: 'POST',
+        })
 
       const datasetName = res?.datasetName
 

--- a/packages/sanity/src/core/studioClient.ts
+++ b/packages/sanity/src/core/studioClient.ts
@@ -1,6 +1,7 @@
-import {type SanityClient} from '@sanity/client'
+import {type ClientConfig, type SanityClient} from '@sanity/client'
 
 import {type SourceClientOptions} from './config'
+import {SANITY_VERSION} from './version'
 
 /**
  * Unless otherwise specified, this is the API version we use for controlled
@@ -13,6 +14,15 @@ import {type SourceClientOptions} from './config'
  */
 export const DEFAULT_STUDIO_CLIENT_OPTIONS: SourceClientOptions = {
   apiVersion: '2025-02-19',
+}
+
+/**
+ * The headers that are applied to all studio client requests
+ *
+ * @internal
+ */
+export const DEFAULT_STUDIO_CLIENT_HEADERS: ClientConfig['headers'] = {
+  'x-sanity-studio-version': SANITY_VERSION,
 }
 
 export const versionedClient = (client: SanityClient, apiVersion?: string): SanityClient => {

--- a/packages/sanity/src/core/studioClient.ts
+++ b/packages/sanity/src/core/studioClient.ts
@@ -22,7 +22,7 @@ export const DEFAULT_STUDIO_CLIENT_OPTIONS: SourceClientOptions = {
  * @internal
  */
 export const DEFAULT_STUDIO_CLIENT_HEADERS: ClientConfig['headers'] = {
-  'x-sanity-studio-version': SANITY_VERSION,
+  'x-sanity-app': `studio@${SANITY_VERSION}`,
 }
 
 export const versionedClient = (client: SanityClient, apiVersion?: string): SanityClient => {

--- a/test/e2e/helpers/sanityClient.ts
+++ b/test/e2e/helpers/sanityClient.ts
@@ -1,6 +1,7 @@
 import {createClient, type SanityClient} from '@sanity/client'
 import {uuid} from '@sanity/uuid'
 
+import {SANITY_VERSION} from '../../../packages/sanity/src/core/version'
 import {readEnv} from './envVars'
 
 export class TestContext {
@@ -33,6 +34,9 @@ const testSanityClient = createClient({
   useCdn: false,
   apiVersion: '2021-08-31',
   apiHost: 'https://api.sanity.work',
+  headers: {
+    'x-sanity-studio-version': SANITY_VERSION,
+  },
 })
 
 /* eslint-disable callback-return*/

--- a/test/e2e/helpers/sanityClient.ts
+++ b/test/e2e/helpers/sanityClient.ts
@@ -1,7 +1,7 @@
 import {createClient, type SanityClient} from '@sanity/client'
 import {uuid} from '@sanity/uuid'
 
-import {SANITY_VERSION} from '../../../packages/sanity/src/core/version'
+// import {SANITY_VERSION} from '../../../packages/sanity/src/core/version'
 import {readEnv} from './envVars'
 
 export class TestContext {

--- a/test/e2e/helpers/sanityClient.ts
+++ b/test/e2e/helpers/sanityClient.ts
@@ -1,7 +1,6 @@
 import {createClient, type SanityClient} from '@sanity/client'
 import {uuid} from '@sanity/uuid'
 
-// import {SANITY_VERSION} from '../../../packages/sanity/src/core/version'
 import {readEnv} from './envVars'
 
 export class TestContext {
@@ -34,9 +33,6 @@ const testSanityClient = createClient({
   useCdn: false,
   apiVersion: '2021-08-31',
   apiHost: 'https://api.sanity.work',
-  // headers: {
-  //   'x-sanity-studio-version': SANITY_VERSION,
-  // },
 })
 
 /* eslint-disable callback-return*/

--- a/test/e2e/helpers/sanityClient.ts
+++ b/test/e2e/helpers/sanityClient.ts
@@ -34,9 +34,9 @@ const testSanityClient = createClient({
   useCdn: false,
   apiVersion: '2021-08-31',
   apiHost: 'https://api.sanity.work',
-  headers: {
-    'x-sanity-studio-version': SANITY_VERSION,
-  },
+  // headers: {
+  //   'x-sanity-studio-version': SANITY_VERSION,
+  // },
 })
 
 /* eslint-disable callback-return*/


### PR DESCRIPTION
### Description
New version of `sanity/client` supports passing custom headers to all client requests.

It would be useful for us to have the studio version attached in these headers - this PR attached the `x-sanity-studio-version` header to all requests (both through the client and a few that use other means, eg [for translog](packages/sanity/src/core/store/_legacy/history/history/getJsonStream.ts))
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Verified all network requests to sanity API include the studio-version header, and that the header is correct.
Downloaded a few HAR files from journeys through studio to ensure no requests were missing
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
