### PR TITLE
fix(core): fix issue where document for unpublished should show the preview for the published document and not untitled

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -154,7 +154,8 @@ const getActiveReleaseDocumentsObservable = ({
                   }
 
                   // remove the first stack (since we want to get the previous perspective)
-                  const [, ...updatedPerspectiveStack] = perspectiveStack
+                  const updatedPerspectiveStack =
+                    perspectiveStack.length > 1 ? perspectiveStack.slice(1) : perspectiveStack
 
                   const previousPerspective = updatedPerspectiveStack[0]
 

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -153,7 +153,9 @@ const getActiveReleaseDocumentsObservable = ({
                     return of(value)
                   }
 
-                  // remove the first stack (since we want to get the previous perspective)
+                  //If we don't receive a snapshot here, it means the document will be unpublished in the release.
+                  // In which case, to preview it we need its latest known version instead (e.g. one perspective stack level up)
+                  // To do this we need to remove the first item from the start of the array
                   const updatedPerspectiveStack =
                     perspectiveStack.length > 1 ? perspectiveStack.slice(1) : perspectiveStack
 


### PR DESCRIPTION
### Description

Fix issue where an unpublished document preview was showing up as "Untitled" in the release detail page

Before:
<img width="1054" alt="image" src="https://github.com/user-attachments/assets/ef279800-d919-43ee-b425-d70f21786843" />

After (previous version in the perspective stack has the value "Kayla's version") :
<img width="1384" alt="image" src="https://github.com/user-attachments/assets/fee90e21-d5d3-4a35-8ffb-d6858cb64aa3" />

### What to review

- As left in the comments: when there is only the published + drafts combo (no previous version), it will show the preview for the draft. This follows through with the behaviour in other parts of the studio (like the document list items preview)

### Testing

Existing tests should suffice

manually:
Go to any version document that has a published version and select unpublish on release in the document actions.
When viewing the release in the detail page, the preview shouldn't be untitled and show instead show the previous document preview based on the perspective stack

### Notes for release

The preview of documents slated for unpublishing in a release will now show the published document preview
