### PR TITLE
fix(structure): make document list search interactive when not connected

### DIFF
--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -15,7 +15,6 @@ import {
 } from 'sanity'
 import {keyframes, styled} from 'styled-components'
 
-import {Tooltip} from '../../../ui-components'
 import {structureLocaleNamespace} from '../../i18n'
 import {type BaseStructureToolPaneProps} from '../types'
 import {EMPTY_RECORD, FULL_LIST_LIMIT} from './constants'
@@ -194,35 +193,28 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   return (
     <>
       <Box paddingX={3} paddingBottom={3}>
-        <Tooltip
-          disabled={connected}
-          placement="bottom-end"
-          content={t('panes.document-list-pane.reconnecting')}
-        >
-          <TextInput
-            aria-label={t('panes.document-list-pane.search-input.aria-label')}
-            autoComplete="off"
-            border={false}
-            clearButton={Boolean(searchQuery)}
-            readOnly={Boolean(error || !connected)}
-            fontSize={[2, 2, 1]}
-            icon={textInputIcon}
-            iconRight={
-              !connected || (loadingVariant === 'subtle' && !searchInputValue)
-                ? DelayedSubtleSpinnerIcon
-                : null
-            }
-            onChange={handleQueryChange}
-            onClear={handleClearSearch}
-            onKeyDown={handleSearchKeyDown}
-            padding={2}
-            placeholder={t('panes.document-list-pane.search-input.placeholder')}
-            radius={2}
-            ref={setSearchInputElement}
-            spellCheck={false}
-            value={searchInputValue}
-          />
-        </Tooltip>
+        <TextInput
+          aria-label={t('panes.document-list-pane.search-input.aria-label')}
+          autoComplete="off"
+          border={false}
+          clearButton={Boolean(searchQuery)}
+          fontSize={[2, 2, 1]}
+          icon={textInputIcon}
+          iconRight={
+            !connected || (loadingVariant === 'subtle' && !searchInputValue)
+              ? DelayedSubtleSpinnerIcon
+              : null
+          }
+          onChange={handleQueryChange}
+          onClear={handleClearSearch}
+          onKeyDown={handleSearchKeyDown}
+          padding={2}
+          placeholder={t('panes.document-list-pane.search-input.placeholder')}
+          radius={2}
+          ref={setSearchInputElement}
+          spellCheck={false}
+          value={searchInputValue}
+        />
       </Box>
       <DocumentListPaneContent
         childItemId={childItemId}


### PR DESCRIPTION
Fixes #9480

### Description

Fixes a regression introduced by #5893 reported in #9480

This behavior actually has two separate causes:
1. Popover trashes the children DOM when switching between enabled/disabled
2. `connected` state is flipped when setting up a new eventsource listener (which happens as you type).

The second can be fixed in a better way (e.g. by tracking whether we're "re-issuing" the listener connection), but 1. will still be an issue, so figured we just remove the popover for now and allow typing even when the listener is not connected.

### What to review

- The issue reported in #9480 should no longer be possible to repro

### Testing

- fixes a regression in v3.89.0 that caused the search input in document list to lose focus while typing