### PR TITLE
fix(core): add condition in useDocumentTitle to allow for unpublished preview title

### DIFF
--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -1,10 +1,16 @@
-import {type PreviewValue, type SchemaType, type SortOrdering} from '@sanity/types'
+import {
+  type PreviewValue,
+  type SanityDocument,
+  type SchemaType,
+  type SortOrdering,
+} from '@sanity/types'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
 import {type Observable, of} from 'rxjs'
 import {catchError, map} from 'rxjs/operators'
 
 import {usePerspective} from '../perspective/usePerspective'
+import {isGoingToUnpublish} from '../releases/util/isGoingToUnpublish'
 import {useDocumentPreviewStore} from '../store'
 import {type Previewable} from './types'
 
@@ -43,8 +49,15 @@ function useDocumentPreview(props: {
     // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
     if (!enabled || !previewValue || !schemaType) return of(IDLE_STATE)
 
+    const updatedStack =
+      // when a version is slated for unpublishing then we need to remove the version from the stack
+      // and use the next one down
+      perspectiveStack.length > 1 && isGoingToUnpublish(previewValue as SanityDocument)
+        ? perspectiveStack.slice(1)
+        : perspectiveStack
+
     return observeForPreview(previewValue as Previewable, schemaType, {
-      perspective: perspectiveStack,
+      perspective: updatedStack,
       viewOptions: {ordering: ordering},
     }).pipe(
       map((event) => ({isLoading: false, value: event.snapshot || undefined})),

--- a/test/e2e/tests/releases/displayDocument/DisplayedDocument.spec.ts
+++ b/test/e2e/tests/releases/displayDocument/DisplayedDocument.spec.ts
@@ -444,5 +444,47 @@ test.describe('displayedDocument', () => {
 
       archiveAndDeleteRelease({sanityClient, dataset, releaseId: scheduledId})
     })
+
+    test('no draft, no publish, one version with _system.delete shows version name', async ({
+      page,
+      sanityClient,
+      _testContext,
+      browserName,
+    }) => {
+      test.slow()
+      skipIfBrowser(browserName)
+
+      const documentId = _testContext.getUniqueDocumentId()
+      const versionId = `versions.${asapReleaseId}.${documentId}`
+
+      // Create a document with a version that has _system.delete set to true
+      await createDocument(sanityClient, {
+        ...speciesDocumentNameASAP,
+        _id: versionId,
+        _system: {
+          delete: true,
+        },
+      })
+
+      await page.goto(`/content/species;${documentId}?perspective=${asapReleaseId}`)
+
+      // Wait for document to load
+      await expect(page.getByTestId('document-header-Draft-chip')).toBeVisible()
+      const asapChip = page.getByTestId('document-header-ASAP-Release-A-chip')
+      await expect(asapChip).toBeVisible()
+      await expect(page.getByTestId('field-name').getByTestId('string-input')).toBeVisible()
+
+      // Check that the version chip is selected
+      await expect(page.getByTestId('document-header-Draft-chip')).not.toHaveAttribute(
+        'data-selected',
+      )
+      await expect(asapChip).toHaveAttribute('data-selected')
+
+      // Check that the name field shows the version name
+      await expect(page.getByTestId('document-panel-document-title')).toHaveText('ASAP A')
+
+      // Clean up
+      await sanityClient.delete(versionId)
+    })
   })
 })

--- a/test/e2e/tests/releases/displayDocument/DisplayedDocument.spec.ts
+++ b/test/e2e/tests/releases/displayDocument/DisplayedDocument.spec.ts
@@ -457,6 +457,11 @@ test.describe('displayedDocument', () => {
       const documentId = _testContext.getUniqueDocumentId()
       const versionId = `versions.${asapReleaseId}.${documentId}`
 
+      const customPublished = await createDocument(sanityClient, {
+        ...speciesDocumentNamePublished,
+        _id: documentId,
+      })
+
       // Create a document with a version that has _system.delete set to true
       await createDocument(sanityClient, {
         ...speciesDocumentNameASAP,
@@ -480,11 +485,13 @@ test.describe('displayedDocument', () => {
       )
       await expect(asapChip).toHaveAttribute('data-selected')
 
+      await expect(page.getByTestId('document-panel-document-title')).not.toHaveText('Untitled')
       // Check that the name field shows the version name
-      await expect(page.getByTestId('document-panel-document-title')).toHaveText('ASAP A')
+      await expect(page.getByTestId('document-panel-document-title')).toHaveText('(ASAP A)')
 
       // Clean up
       await sanityClient.delete(versionId)
+      await sanityClient.delete(customPublished._id)
     })
   })
 })


### PR DESCRIPTION
### Description

Fixes issue where the preview of a document that is slated for unpublished shows the wrong preview

Before
![image](https://github.com/user-attachments/assets/37d183e9-e6b1-4c1e-bc62-7bd98a251062)

After
<img width="821" alt="image" src="https://github.com/user-attachments/assets/2217df42-5050-4ecc-b176-7ad6108829c4" />

### What to review

Check the code

### Testing

Automated test should suffice.
Otherwise, put a version to unpublish and double check that the document title appears as expected

Or you can go to [this document](https://test-studio-git-sapp-2635-follow-up.sanity.dev/test/structure/species;cb97aa56-63db-43f5-ae84-809d8ec93d5f?perspective=rooVsdzKz) 

### Notes for release

The document displayed of a version that will be unpublished within a release will show the right title