### PR TITLE
chore(cli): update SDK templates to version ^2

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/templates/appQuickstart.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/appQuickstart.ts
@@ -2,8 +2,8 @@ import {type ProjectTemplate} from '../initProject'
 
 const appTemplate: ProjectTemplate = {
   dependencies: {
-    '@sanity/sdk': '^1',
-    '@sanity/sdk-react': '^1',
+    '@sanity/sdk': '^2',
+    '@sanity/sdk-react': '^2',
     'react': '^19',
     'react-dom': '^19',
   },

--- a/packages/@sanity/cli/src/actions/init-project/templates/appSanityUi.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/appSanityUi.ts
@@ -2,8 +2,8 @@ import {type ProjectTemplate} from '../initProject'
 
 const appSanityUiTemplate: ProjectTemplate = {
   dependencies: {
-    '@sanity/sdk': '^1',
-    '@sanity/sdk-react': '^1',
+    '@sanity/sdk': '^2',
+    '@sanity/sdk-react': '^2',
     '@sanity/ui': '^2',
     'react': '^19',
     'react-dom': '^19',


### PR DESCRIPTION
### Description

Updated the SDK dependencies in the app templates to use version 2 instead of version 1. This change updates both `@sanity/sdk` and `@sanity/sdk-react` from `^1` to `^2` in the appQuickstart and appSanityUi templates.

### What to review

- Verify that the version bump from `^1` to `^2` is appropriate for both SDK packages
- Check that the templates will work correctly with the updated SDK versions
- Ensure there are no compatibility issues with other dependencies in the templates

### Testing

Tested by creating new projects with these templates and verifying that they initialize correctly with the updated SDK versions.

### Notes for release

Updated the SDK dependencies in app templates to use version 2. New projects created with the CLI will now use `@sanity/sdk` and `@sanity/sdk-react` version 2.