### PR TITLE
fix(cli): respect prefers reduced motion for SDK template

### DIFF
--- a/packages/@sanity/cli/templates/app-quickstart/src/ExampleComponent.css
+++ b/packages/@sanity/cli/templates/app-quickstart/src/ExampleComponent.css
@@ -56,6 +56,12 @@
   animation: wave 4s infinite linear;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .example-avatar-container:after {
+    animation: none;
+  }
+}
+
 .example-avatar {
   inline-size: 4rem;
   aspect-ratio: 1;


### PR DESCRIPTION
### Description

Added a media query to disable the wave animation when the user has enabled the "prefers-reduced-motion" setting in their operating system. This improves accessibility by respecting user preferences for reduced motion, which can help prevent discomfort for users with vestibular disorders or motion sensitivity.

### What to review

- Check that the animation is properly disabled [when the "prefers-reduced-motion" setting is enabled](https://developer.chrome.com/docs/devtools/rendering/emulate-css#emulate_css_media_feature_prefers-reduced-motion)
- Verify that the animation still works normally for users without this setting
- Ensure the CSS selector properly targets the avatar container's after pseudo-element

### Testing

Tested by toggling the "prefers-reduced-motion" setting in the operating system and browser developer tools and confirming that the wave animation is disabled when this preference is set.

### Notes for release

Improved accessibility in the quickstart template by respecting the user's "prefers-reduced-motion" preference. The wave animation behind the avatar will now be disabled automatically for users who have indicated they prefer reduced motion in their system settings.