### PR TITLE
feat(sanity): add workspace release count limit

### DIFF
--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -998,7 +998,7 @@ export type {
 export type DefaultPluginsWorkspaceOptions = {
   tasks: {enabled: boolean}
   scheduledPublishing: ScheduledPublishingPluginOptions
-  releases: {enabled: boolean}
+  releases: {enabled?: boolean}
 }
 
 /**

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -998,7 +998,13 @@ export type {
 export type DefaultPluginsWorkspaceOptions = {
   tasks: {enabled: boolean}
   scheduledPublishing: ScheduledPublishingPluginOptions
-  releases: {enabled?: boolean}
+  releases: {
+    enabled?: boolean
+    /**
+     * Limit the number of releases that can be created by this workspace.
+     */
+    limit?: number
+  }
 }
 
 /**

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1269,6 +1269,10 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.action.discard-version.failure': 'Failed to discard version',
   /** Action message for when a new release is created off an existing version, draft or published document */
   'release.action.new-release': 'New release',
+  /** Explanation provided when releases can't be created because the workspace release limit has been reached */
+  'release.action.new-release.limit-reached': 'This workspace is limited to {{count}} release',
+  'release.action.new-release.limit-reached_other':
+    'This workspace is limited to {{count}} releases',
   /** Tooltip message for not having permissions for creating new releases */
   'release.action.permission.error': 'You do not have permission to perform this action',
   /** Error message for when a version is set to be unpublished */


### PR DESCRIPTION
### Description

The new `releases.limit` configuration option can be used to prevent Studio users creating releases if the number of active releases in the dataset has reached the configured limit.

Other workspaces may have a different limit configured, and users are still able to create releases using the HTTP API directly. This is a purely client-side guard intended to help control release usage across an organisation.

<img width="359" alt="Screenshot 2025-05-27 at 14 44 48" src="https://github.com/user-attachments/assets/fa752f45-4251-4ed8-bcb3-7616dde750ef" />

<img width="599" alt="Screenshot 2025-05-27 at 14 45 07" src="https://github.com/user-attachments/assets/1370be87-eb8a-4dd6-bdbc-e33dfc7c2040" />

### What to review

- The "create new release" action.
- Whether there are any other surfaces that allow release creation in Studio that we've missed.

### Testing

- Tested with various limits configured across workspaces.

### Notes for release

The new `releases.limit` configuration option can be used to prevent Studio users creating releases if the number of active releases in the dataset has reached the configured limit. This is a purely client-side guard intended to help control release usage across an organisation.
