### PR TITLE
test: add tests for structure hooks

### DIFF
--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useCreatePathSyncChannel.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useCreatePathSyncChannel.mock.ts
@@ -1,0 +1,8 @@
+import {Subject} from 'rxjs'
+import {type Mock} from 'vitest'
+
+import {useCreatePathSyncChannel} from '../../useCreatePathSyncChannel'
+
+export const mockUseCreatePathSyncChannelReturn = new Subject()
+
+export const mockUseCreatePathSyncChannel = useCreatePathSyncChannel as Mock<typeof useCreatePathSyncChannel>

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useCreatePathSyncChannel.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useCreatePathSyncChannel.mock.ts
@@ -5,4 +5,6 @@ import {useCreatePathSyncChannel} from '../../useCreatePathSyncChannel'
 
 export const mockUseCreatePathSyncChannelReturn = new Subject()
 
-export const mockUseCreatePathSyncChannel = useCreatePathSyncChannel as Mock<typeof useCreatePathSyncChannel>
+export const mockUseCreatePathSyncChannel = useCreatePathSyncChannel as Mock<
+  typeof useCreatePathSyncChannel
+>

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useDiffViewRouter.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useDiffViewRouter.mock.ts
@@ -1,0 +1,10 @@
+import {type Mock, type Mocked, vi} from 'vitest'
+
+import {type DiffViewRouter, useDiffViewRouter} from '../../useDiffViewRouter'
+
+export const useDiffViewRouterMockReturn: Mocked<DiffViewRouter> = {
+  navigateDiffView: vi.fn(),
+  exitDiffView: vi.fn(),
+}
+
+export const mockUseDiffViewRouter = useDiffViewRouter as Mock<typeof useDiffViewRouter>

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/usePathSyncChannel.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/usePathSyncChannel.mock.ts
@@ -1,0 +1,13 @@
+import {Subject} from 'rxjs'
+import {type Mock, type Mocked, vi} from 'vitest'
+
+import {type usePathSyncChannel as usePathSyncChannelFn} from '../../usePathSyncChannel'
+
+export const usePathSyncChannelMockReturn: Mocked<ReturnType<typeof usePathSyncChannelFn>> = {
+  push: vi.fn(),
+  path: new Subject(),
+}
+
+export const mockUsePathSyncChannel = (
+  usePathSyncChannelFn as unknown as Mock<typeof usePathSyncChannelFn>
+)

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/usePathSyncChannel.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/usePathSyncChannel.mock.ts
@@ -8,6 +8,6 @@ export const usePathSyncChannelMockReturn: Mocked<ReturnType<typeof usePathSyncC
   path: new Subject(),
 }
 
-export const mockUsePathSyncChannel = (
-  usePathSyncChannelFn as unknown as Mock<typeof usePathSyncChannelFn>
-)
+export const mockUsePathSyncChannel = usePathSyncChannelFn as unknown as Mock<
+  typeof usePathSyncChannelFn
+>

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/useCreatePathSyncChannel.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/useCreatePathSyncChannel.test.ts
@@ -1,0 +1,22 @@
+import {renderHook} from '@testing-library/react'
+import {Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {useCreatePathSyncChannel} from '../useCreatePathSyncChannel'
+
+describe('useCreatePathSyncChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('returns a Subject instance', () => {
+    const {result} = renderHook(() => useCreatePathSyncChannel())
+    expect(result.current).toBeInstanceOf(Subject)
+  })
+
+  it('returns the same instance between renders', () => {
+    const {result, rerender} = renderHook(() => useCreatePathSyncChannel())
+    const first = result.current
+    rerender()
+    expect(result.current).toBe(first)
+  })
+})

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/useDiffViewRouter.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/useDiffViewRouter.test.ts
@@ -1,0 +1,64 @@
+import {renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {
+  DIFF_SEARCH_PARAM_DELIMITER,
+  DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_SEARCH_PARAMETER,
+} from '../constants'
+import {useDiffViewRouter} from '../useDiffViewRouter'
+import {mockUseRouter, mockUseRouterReturn} from '../../../../../test/mocks/useRouter.mock'
+
+vi.mock('sanity/router', () => ({
+  useRouter: vi.fn(() => mockUseRouterReturn),
+}))
+
+describe('useDiffViewRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('navigateDiffView updates router search params', () => {
+    mockUseRouterReturn.state._searchParams = [['foo', 'bar']]
+    const {result} = renderHook(() => useDiffViewRouter())
+
+    result.current.navigateDiffView({
+      mode: 'version',
+      previousDocument: {type: 'book', id: 'a'},
+      nextDocument: {type: 'book', id: 'b'},
+    })
+
+    expect(mockUseRouterReturn.navigate).toHaveBeenCalledWith({
+      ...mockUseRouterReturn.state,
+      _searchParams: [
+        ['foo', 'bar'],
+        [DIFF_VIEW_SEARCH_PARAMETER, 'version'],
+        [
+          DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
+          ['book', 'a'].join(DIFF_SEARCH_PARAM_DELIMITER),
+        ],
+        [
+          DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER,
+          ['book', 'b'].join(DIFF_SEARCH_PARAM_DELIMITER),
+        ],
+      ],
+    })
+  })
+
+  it('exitDiffView removes diff related params', () => {
+    mockUseRouterReturn.state._searchParams = [
+      [DIFF_VIEW_SEARCH_PARAMETER, 'version'],
+      [DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER, 'a,a'],
+      [DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER, 'b,b'],
+      ['other', '1'],
+    ]
+    const {result} = renderHook(() => useDiffViewRouter())
+
+    result.current.exitDiffView()
+
+    expect(mockUseRouterReturn.navigate).toHaveBeenCalledWith({
+      ...mockUseRouterReturn.state,
+      _searchParams: [['other', '1']],
+    })
+  })
+})

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/useDiffViewRouter.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/useDiffViewRouter.test.ts
@@ -37,10 +37,7 @@ describe('useDiffViewRouter', () => {
           DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
           ['book', 'a'].join(DIFF_SEARCH_PARAM_DELIMITER),
         ],
-        [
-          DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER,
-          ['book', 'b'].join(DIFF_SEARCH_PARAM_DELIMITER),
-        ],
+        [DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER, ['book', 'b'].join(DIFF_SEARCH_PARAM_DELIMITER)],
       ],
     })
   })

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/usePathSyncChannel.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/usePathSyncChannel.test.ts
@@ -1,0 +1,35 @@
+import {renderHook} from '@testing-library/react'
+import {Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {type PathSyncState} from '../types/pathSyncChannel'
+import {usePathSyncChannel} from '../usePathSyncChannel'
+
+describe('usePathSyncChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('push sends state with source id', () => {
+    const syncChannel = new Subject<PathSyncState>()
+    const {result} = renderHook(() => usePathSyncChannel({syncChannel, id: 'pane'}))
+    const spy = vi.spyOn(syncChannel, 'next')
+
+    result.current.push({path: ['foo']})
+    expect(spy).toHaveBeenCalledWith({path: ['foo'], source: 'pane'})
+  })
+
+  it('path emits changes from other sources and ignores duplicates', () => {
+    const syncChannel = new Subject<PathSyncState>()
+    const {result} = renderHook(() => usePathSyncChannel({syncChannel, id: 'a'}))
+    const values: any[] = []
+    const sub = result.current.path.subscribe((v) => values.push(v))
+
+    syncChannel.next({path: ['foo'], source: 'a'})
+    syncChannel.next({path: ['foo'], source: 'b'})
+    syncChannel.next({path: ['foo'], source: 'b'})
+    syncChannel.next({path: ['bar'], source: 'b'})
+    sub.unsubscribe()
+
+    expect(values).toEqual([['foo'], ['bar']])
+  })
+})

--- a/packages/sanity/src/structure/hooks/__tests__/__mocks__/useDocumentIdStack.mock.ts
+++ b/packages/sanity/src/structure/hooks/__tests__/__mocks__/useDocumentIdStack.mock.ts
@@ -1,0 +1,17 @@
+import {type Mock, type Mocked} from 'vitest'
+
+import {
+  type DocumentIdStack,
+  useDocumentIdStack as useDocumentIdStackFn,
+} from '../../useDocumentIdStack'
+
+export const useDocumentIdStackMockReturn: Mocked<DocumentIdStack> = {
+  position: 0,
+  previousId: undefined,
+  nextId: undefined,
+  stack: [],
+}
+
+export const mockUseDocumentIdStack = useDocumentIdStackFn as unknown as Mock<
+  typeof useDocumentIdStackFn
+>

--- a/packages/sanity/src/structure/hooks/__tests__/__mocks__/useFilteredReleases.mock.ts
+++ b/packages/sanity/src/structure/hooks/__tests__/__mocks__/useFilteredReleases.mock.ts
@@ -1,0 +1,13 @@
+import {type Mock, type Mocked} from 'vitest'
+
+import {useFilteredReleases as useFilteredReleasesFn} from '../../useFilteredReleases'
+
+export const useFilteredReleasesMockReturn: Mocked<ReturnType<typeof useFilteredReleasesFn>> = {
+  notCurrentReleases: [],
+  currentReleases: [],
+  inCreation: null,
+}
+
+export const mockUseFilteredReleases = useFilteredReleasesFn as unknown as Mock<
+  typeof useFilteredReleasesFn
+>

--- a/packages/sanity/src/structure/hooks/__tests__/useDocumentIdStack.test.ts
+++ b/packages/sanity/src/structure/hooks/__tests__/useDocumentIdStack.test.ts
@@ -1,0 +1,36 @@
+import {renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {useDocumentIdStack} from '../useDocumentIdStack'
+import {mockUseFilteredReleases} from './__mocks__/useFilteredReleases.mock'
+
+vi.mock('../useFilteredReleases')
+
+const mockFilteredReleasesReturn = {
+  currentReleases: [{_id: '_.releases.r1'}],
+  notCurrentReleases: [],
+  inCreation: null,
+}
+
+describe('useDocumentIdStack', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseFilteredReleases.mockReturnValue(mockFilteredReleasesReturn as any)
+  })
+
+  it('returns stack positions based on filtered releases', () => {
+    const editState = {
+      id: 'foo',
+      draft: {_id: 'drafts.foo'},
+      published: {_id: 'foo'},
+    }
+    const {result} = renderHook(() =>
+      useDocumentIdStack({displayed: {_id: 'drafts.foo'}, documentId: 'foo', editState}),
+    )
+
+    expect(result.current.stack).toEqual(['foo', 'drafts.foo', 'versions.r1.foo'])
+    expect(result.current.position).toBe(1)
+    expect(result.current.previousId).toBe('foo')
+    expect(result.current.nextId).toBe('versions.r1.foo')
+  })
+})

--- a/packages/sanity/src/structure/hooks/__tests__/useFilteredReleases.test.ts
+++ b/packages/sanity/src/structure/hooks/__tests__/useFilteredReleases.test.ts
@@ -1,0 +1,67 @@
+import {renderHook} from '@testing-library/react'
+import {useActiveReleases, useArchivedReleases, useDocumentVersions, usePerspective} from 'sanity'
+import {beforeEach, describe, expect, it, type Mock, type MockedFunction, vi} from 'vitest'
+
+import {usePaneRouter} from '../components/paneRouter/usePaneRouter'
+import {useFilteredReleases} from '../useFilteredReleases'
+
+vi.mock('sanity', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useActiveReleases: vi.fn(),
+  useArchivedReleases: vi.fn(),
+  useDocumentVersions: vi.fn(),
+  usePerspective: vi.fn(),
+}))
+
+vi.mock('../components/paneRouter/usePaneRouter', () => ({
+  usePaneRouter: vi.fn(),
+}))
+
+const mockUseActiveReleases = useActiveReleases as MockedFunction<typeof useActiveReleases>
+const mockUseArchivedReleases = useArchivedReleases as MockedFunction<typeof useArchivedReleases>
+const mockUseDocumentVersions = useDocumentVersions as MockedFunction<typeof useDocumentVersions>
+const mockUsePerspective = usePerspective as MockedFunction<typeof usePerspective>
+const mockUsePaneRouter = usePaneRouter as Mock<typeof usePaneRouter>
+
+describe('useFilteredReleases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseActiveReleases.mockReturnValue({data: [], loading: false} as any)
+    mockUseArchivedReleases.mockReturnValue({data: [], loading: false} as any)
+    mockUseDocumentVersions.mockReturnValue({data: undefined, loading: false} as any)
+    mockUsePerspective.mockReturnValue({selectedReleaseId: undefined} as any)
+    mockUsePaneRouter.mockReturnValue({params: {}} as any)
+  })
+
+  it('returns empty arrays when no document versions', () => {
+    const {result} = renderHook(() =>
+      useFilteredReleases({displayed: {_id: 'foo'}, documentId: 'foo'}),
+    )
+
+    expect(result.current).toEqual({
+      notCurrentReleases: [],
+      currentReleases: [],
+      inCreation: null,
+    })
+  })
+
+  it('groups releases and adds archived release when historyVersion matches', () => {
+    const releases = [{_id: '_.releases.r1'}, {_id: '_.releases.r2'}]
+    const archived = [{_id: '_.releases.r3', state: 'archived'}]
+    mockUseActiveReleases.mockReturnValue({data: releases, loading: false} as any)
+    mockUseArchivedReleases.mockReturnValue({data: archived, loading: false} as any)
+    mockUseDocumentVersions.mockReturnValue({
+      data: ['versions.r1.foo'],
+      loading: false,
+    } as any)
+    mockUsePaneRouter.mockReturnValue({params: {historyVersion: 'r3'}} as any)
+
+    const {result} = renderHook(() =>
+      useFilteredReleases({displayed: {_id: 'foo', _createdAt: 't'}, documentId: 'foo'}),
+    )
+
+    expect(result.current.currentReleases).toEqual([releases[0], archived[0]])
+    expect(result.current.notCurrentReleases).toEqual([releases[1]])
+    expect(result.current.inCreation).toBe(null)
+  })
+})


### PR DESCRIPTION
## Summary
- add mocks for `useFilteredReleases` and `useDocumentIdStack`
- test `useFilteredReleases` hook
- test `useDocumentIdStack` hook

## Testing
- `pnpm run test:vitest` *(fails: long runtime and test warnings)*