### PR TITLE
test: add tests for diff view hooks

### DIFF
--- a/packages/sanity/src/core/hooks/__mocks__/useListFormat.mock.ts
+++ b/packages/sanity/src/core/hooks/__mocks__/useListFormat.mock.ts
@@ -1,0 +1,7 @@
+import {type Mock} from 'vitest'
+
+import {useListFormat} from '../useListFormat'
+
+export const useListFormatMockReturn = new Intl.ListFormat('en-US')
+
+export const mockUseListFormat = useListFormat as Mock<typeof useListFormat>

--- a/packages/sanity/src/core/hooks/__tests__/useListFormat.test.tsx
+++ b/packages/sanity/src/core/hooks/__tests__/useListFormat.test.tsx
@@ -1,0 +1,57 @@
+import {studioTheme, ThemeProvider} from '@sanity/ui'
+import {renderHook} from '@testing-library/react'
+import {beforeAll, beforeEach, describe, expect, it} from 'vitest'
+
+import {LocaleProviderBase, usEnglishLocale} from '../../i18n'
+import {studioDefaultLocaleResources} from '../../i18n/bundles/studio'
+import {prepareI18n} from '../../i18n/i18nConfig'
+import {useListFormat} from '../useListFormat'
+
+const frenchLocale = {
+  id: 'fr-FR',
+  title: 'Français',
+  weekInfo: {firstDay: 1, minimalDays: 2, weekend: [6, 7]},
+}
+
+describe('useListFormat', () => {
+  const {i18next} = prepareI18n({
+    projectId: 'test',
+    dataset: 'test',
+    name: 'test',
+    i18n: {bundles: [studioDefaultLocaleResources]},
+  })
+
+  const wrapper = ({children}: {children: React.ReactNode}) => (
+    <ThemeProvider theme={studioTheme}>
+      <LocaleProviderBase
+        locales={[usEnglishLocale, frenchLocale]}
+        i18next={i18next}
+        projectId="test"
+        sourceId="test"
+      >
+        {children}
+      </LocaleProviderBase>
+    </ThemeProvider>
+  )
+
+  beforeAll(() => i18next.init())
+  beforeEach(() => i18next.changeLanguage('en-US'))
+
+  it('formats lists using the active locale', async () => {
+    await i18next.changeLanguage('fr-FR')
+    const {result} = renderHook(() => useListFormat(), {wrapper})
+    expect(result.current.format(['a', 'b', 'c'])).toBe('a, b et c')
+  })
+
+  it('falls back to en-US narrow style when no provider', () => {
+    const {result} = renderHook(() => useListFormat())
+    expect(result.current.format(['a', 'b', 'c'])).toBe('a, b, c')
+  })
+
+  it('respects options passed in', () => {
+    const {result} = renderHook(() => useListFormat({style: 'short', type: 'disjunction'}), {
+      wrapper,
+    })
+    expect(result.current.format(['a', 'b', 'c'])).toBe('a, b, ou c')
+  })
+})

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useCreatePathSyncChannel.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useCreatePathSyncChannel.mock.ts
@@ -1,0 +1,10 @@
+import {Subject} from 'rxjs'
+import {type Mock} from 'vitest'
+
+import {useCreatePathSyncChannel} from '../../useCreatePathSyncChannel'
+
+export const mockUseCreatePathSyncChannelReturn = new Subject()
+
+export const mockUseCreatePathSyncChannel = useCreatePathSyncChannel as Mock<
+  typeof useCreatePathSyncChannel
+>

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useDiffViewRouter.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useDiffViewRouter.mock.ts
@@ -1,0 +1,10 @@
+import {type Mock, type Mocked, vi} from 'vitest'
+
+import {type DiffViewRouter, useDiffViewRouter} from '../../useDiffViewRouter'
+
+export const useDiffViewRouterMockReturn: Mocked<DiffViewRouter> = {
+  navigateDiffView: vi.fn(),
+  exitDiffView: vi.fn(),
+}
+
+export const mockUseDiffViewRouter = useDiffViewRouter as Mock<typeof useDiffViewRouter>

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/usePathSyncChannel.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/usePathSyncChannel.mock.ts
@@ -1,0 +1,13 @@
+import {Subject} from 'rxjs'
+import {type Mock, type Mocked, vi} from 'vitest'
+
+import {type usePathSyncChannel as usePathSyncChannelFn} from '../../usePathSyncChannel'
+
+export const usePathSyncChannelMockReturn: Mocked<ReturnType<typeof usePathSyncChannelFn>> = {
+  push: vi.fn(),
+  path: new Subject(),
+}
+
+export const mockUsePathSyncChannel = usePathSyncChannelFn as unknown as Mock<
+  typeof usePathSyncChannelFn
+>

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/useCreatePathSyncChannel.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/useCreatePathSyncChannel.test.ts
@@ -1,0 +1,22 @@
+import {renderHook} from '@testing-library/react'
+import {Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {useCreatePathSyncChannel} from '../useCreatePathSyncChannel'
+
+describe('useCreatePathSyncChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('returns a Subject instance', () => {
+    const {result} = renderHook(() => useCreatePathSyncChannel())
+    expect(result.current).toBeInstanceOf(Subject)
+  })
+
+  it('returns the same instance between renders', () => {
+    const {result, rerender} = renderHook(() => useCreatePathSyncChannel())
+    const first = result.current
+    rerender()
+    expect(result.current).toBe(first)
+  })
+})

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/useDiffViewRouter.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/useDiffViewRouter.test.ts
@@ -1,0 +1,61 @@
+import {renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {mockUseRouterReturn} from '../../../../../test/mocks/useRouter.mock'
+import {
+  DIFF_SEARCH_PARAM_DELIMITER,
+  DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_SEARCH_PARAMETER,
+} from '../constants'
+import {useDiffViewRouter} from '../useDiffViewRouter'
+
+vi.mock('sanity/router', () => ({
+  useRouter: vi.fn(() => mockUseRouterReturn),
+}))
+
+describe('useDiffViewRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('navigateDiffView updates router search params', () => {
+    mockUseRouterReturn.state._searchParams = [['foo', 'bar']]
+    const {result} = renderHook(() => useDiffViewRouter())
+
+    result.current.navigateDiffView({
+      mode: 'version',
+      previousDocument: {type: 'book', id: 'a'},
+      nextDocument: {type: 'book', id: 'b'},
+    })
+
+    expect(mockUseRouterReturn.navigate).toHaveBeenCalledWith({
+      ...mockUseRouterReturn.state,
+      _searchParams: [
+        ['foo', 'bar'],
+        [DIFF_VIEW_SEARCH_PARAMETER, 'version'],
+        [
+          DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
+          ['book', 'a'].join(DIFF_SEARCH_PARAM_DELIMITER),
+        ],
+        [DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER, ['book', 'b'].join(DIFF_SEARCH_PARAM_DELIMITER)],
+      ],
+    })
+  })
+
+  it('exitDiffView removes diff related params', () => {
+    mockUseRouterReturn.state._searchParams = [
+      [DIFF_VIEW_SEARCH_PARAMETER, 'version'],
+      [DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER, 'a,a'],
+      [DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER, 'b,b'],
+      ['other', '1'],
+    ]
+    const {result} = renderHook(() => useDiffViewRouter())
+
+    result.current.exitDiffView()
+
+    expect(mockUseRouterReturn.navigate).toHaveBeenCalledWith({
+      ...mockUseRouterReturn.state,
+      _searchParams: [['other', '1']],
+    })
+  })
+})

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/usePathSyncChannel.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/usePathSyncChannel.test.ts
@@ -1,0 +1,35 @@
+import {renderHook} from '@testing-library/react'
+import {Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {type PathSyncState} from '../types/pathSyncChannel'
+import {usePathSyncChannel} from '../usePathSyncChannel'
+
+describe('usePathSyncChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('push sends state with source id', () => {
+    const syncChannel = new Subject<PathSyncState>()
+    const {result} = renderHook(() => usePathSyncChannel({syncChannel, id: 'pane'}))
+    const spy = vi.spyOn(syncChannel, 'next')
+
+    result.current.push({path: ['foo']})
+    expect(spy).toHaveBeenCalledWith({path: ['foo'], source: 'pane'})
+  })
+
+  it('path emits changes from other sources and ignores duplicates', () => {
+    const syncChannel = new Subject<PathSyncState>()
+    const {result} = renderHook(() => usePathSyncChannel({syncChannel, id: 'a'}))
+    const values: any[] = []
+    const sub = result.current.path.subscribe((v) => values.push(v))
+
+    syncChannel.next({path: ['foo'], source: 'a'})
+    syncChannel.next({path: ['foo'], source: 'b'})
+    syncChannel.next({path: ['foo'], source: 'b'})
+    syncChannel.next({path: ['bar'], source: 'b'})
+    sub.unsubscribe()
+
+    expect(values).toEqual([['foo'], ['bar']])
+  })
+})


### PR DESCRIPTION
## Summary
- add mock utilities for diff view hooks
- test `useCreatePathSyncChannel`
- test `usePathSyncChannel`
- test `useDiffViewRouter`
- add `useListFormat` hook tests and mock

## Testing
- `pnpm run test:vitest`