### PR TITLE
chore(actions): fail e2e tests if no preview url is found

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -174,7 +174,12 @@ jobs:
           -m githubCommitAuthorLogin="${{ github.event.sender.login || github.actor }}" | tail -n 1)" >> $GITHUB_OUTPUT
 
       - name: Echo the preview URL
-        run: echo ${{ steps.deploy.outputs.DEPLOY_URL }}
+        run: |
+          if [ -z "${{ steps.deploy.outputs.DEPLOY_URL }}" ]; then
+           echo "::error::Preview URL was not found. Deployment may have failed, does your PR title has double quotes? Try removing them."
+           exit 1
+          fi
+          echo "Preview URL: ${{ steps.deploy.outputs.DEPLOY_URL }}"
 
       - name: Add PR Comment with preview URL
         uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2


### PR DESCRIPTION
### Description
In some cases the preview url is not generated, in those cases the e2e tests will fail. 
This introduces a error when the preview url is not found and also warns about the use case that we have found for this to fail.
Seems that using  double quotes `""` on the pr title will make the vercel deploy action to fail.

See this [fail](https://github.com/sanity-io/sanity/actions/runs/15228095248/job/42832590430?pr=9493) and [this one](https://github.com/sanity-io/sanity/actions/runs/15188414156/job/42714856054?pr=9472)

![image](https://github.com/user-attachments/assets/237a7fe6-9dc7-4834-8f11-67b9222963b0)
![image](https://github.com/user-attachments/assets/13354bab-bc31-4a1f-a2eb-8aa9752af6ed)

Updating the titles fixed it, so now developers will be warned about it.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
