### PR TITLE
feat(core): add history cleared event and compare to published

### DIFF
--- a/packages/sanity/src/core/field/diff/components/DiffTooltip.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffTooltip.tsx
@@ -93,12 +93,16 @@ function AnnotationItem({annotation}: {annotation: AnnotationDetails}) {
               borderRadius: 'calc(23px / 2)',
             }}
           >
-            <UserAvatar user={author} />
-            <Inline paddingLeft={2}>
-              <Text muted size={1} style={{color: color.text}}>
-                {user ? user.displayName : t('changes.loading-author')}
-              </Text>
-            </Inline>
+            {author && (
+              <>
+                <UserAvatar user={author} />
+                <Inline paddingLeft={2}>
+                  <Text muted size={1} style={{color: color.text}}>
+                    {user ? user.displayName : t('changes.loading-author')}
+                  </Text>
+                </Inline>
+              </>
+            )}
           </Flex>
           <Text as="time" muted size={1} dateTime={timestamp}>
             {timeAgo}

--- a/packages/sanity/src/core/field/diff/components/constants.ts
+++ b/packages/sanity/src/core/field/diff/components/constants.ts
@@ -6,6 +6,7 @@ import {
   EditIcon,
   type IconComponent,
   PublishIcon,
+  TimelineIcon,
   TrashIcon,
   UnpublishIcon,
 } from '@sanity/icons'
@@ -16,6 +17,7 @@ import {type DocumentVersionEventType} from '../../../store/events/types'
 import {type DocumentVariantType} from '../../../util/getDocumentVariantType'
 
 export const TIMELINE_ICON_COMPONENTS: Record<DocumentVersionEventType, IconComponent> = {
+  historyCleared: TimelineIcon,
   createDocumentVersion: AddCircleIcon,
   createLiveDocument: AddCircleIcon,
   deleteDocumentGroup: TrashIcon,
@@ -30,6 +32,7 @@ export const TIMELINE_ICON_COMPONENTS: Record<DocumentVersionEventType, IconComp
 
 export const TIMELINE_ITEM_EVENT_TONE: Record<DocumentVersionEventType, ThemeColorAvatarColorKey> =
   {
+    historyCleared: 'orange',
     createDocumentVersion: 'green',
     createLiveDocument: 'blue',
     updateLiveDocument: 'green',
@@ -52,6 +55,7 @@ export const TIMELINE_ITEM_I18N_KEY_MAPPING: Record<
 > = {
   published: {
     createDocumentVersion: 'timeline.operation.created',
+    historyCleared: 'timeline.operation.history-cleared',
     publishDocumentVersion: 'timeline.operation.published',
     updateLiveDocument: 'timeline.operation.edited-live',
     editDocumentVersion: 'timeline.operation.edited-draft',
@@ -64,6 +68,7 @@ export const TIMELINE_ITEM_I18N_KEY_MAPPING: Record<
   },
   draft: {
     createDocumentVersion: 'timeline.operation.draft-created',
+    historyCleared: 'timeline.operation.history-cleared',
     publishDocumentVersion: 'timeline.operation.published',
     updateLiveDocument: 'timeline.operation.edited-live',
     editDocumentVersion: 'timeline.operation.edited-draft',
@@ -76,6 +81,7 @@ export const TIMELINE_ITEM_I18N_KEY_MAPPING: Record<
   },
   version: {
     createDocumentVersion: 'timeline.operation.version-created',
+    historyCleared: 'timeline.operation.history-cleared',
     publishDocumentVersion: 'timeline.operation.published',
     updateLiveDocument: 'timeline.operation.edited-live',
     editDocumentVersion: 'timeline.operation.edited-draft',

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -329,7 +329,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'changes.loading-changes': 'Loading changes…',
   /** Error message shown when the document revision could not be found */
   'changes.missing-since-document-error':
-    "We couldn't find the document revision with id: <code>{{revisionId}}</code> you're trying to compare. <Break/> This is probably due to history retention settings of your plan. <Break/> Please select a different <strong>From</strong> entry.",
+    "We couldn't find the document revision with id: <code>{{revisionId}}</code> you're trying to compare. <Break/> This is probably due to history retention policy of your plan. <Break/> Please select a different <strong>From</strong> entry.",
   /** No Changes description in the Review Changes pane */
   'changes.no-changes-description':
     'Edit the document or select an older version in the timeline to see a list of changes appear in this panel.',
@@ -1875,6 +1875,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'timeline.operation.edited-live': 'Live edited',
   /** Label shown in review changes timeline when a document has been edited live, with a timestamp */
   'timeline.operation.edited-live_timestamp': 'Live edited: {{timestamp, datetime}}',
+  /** Label shown in review changes timeline when a document has been created */
+  'timeline.operation.history-cleared': 'Deleted by retention policy',
   /** Label shown in review changes timeline when a document was published */
   'timeline.operation.published': 'Published',
   /** Label shown in review changes timeline when a document was published, with a timestamp */

--- a/packages/sanity/src/core/store/events/getDocumentAtRevision.ts
+++ b/packages/sanity/src/core/store/events/getDocumentAtRevision.ts
@@ -1,7 +1,8 @@
 import {type SanityClient, type SanityDocument} from '@sanity/client'
-import {type Observable} from 'rxjs'
+import {type Observable, of} from 'rxjs'
 import {catchError, map, shareReplay, startWith} from 'rxjs/operators'
 
+import {HISTORY_CLEARED_EVENT_ID} from './getInitialFetchEvents'
 import {type EventsStoreRevision} from './types'
 
 const documentRevisionCache: Record<string, Observable<EventsStoreRevision>> = Object.create(null)
@@ -15,6 +16,9 @@ export function getDocumentAtRevision({
   documentId: string
   revisionId: string
 }): Observable<EventsStoreRevision | null> {
+  if (revisionId === HISTORY_CLEARED_EVENT_ID) {
+    return of({document: null, loading: false, revisionId: revisionId})
+  }
   const cacheKey = `${documentId}@${revisionId}`
   const dataset = client.config().dataset
   if (!documentRevisionCache[cacheKey]) {

--- a/packages/sanity/src/core/store/events/getDocumentChanges.ts
+++ b/packages/sanity/src/core/store/events/getDocumentChanges.ts
@@ -18,6 +18,7 @@ import {
 import {type Annotation, type ObjectDiff} from '../../field'
 import {wrapValue} from '../_legacy/history/history/diffValue'
 import {getDocumentTransactions} from './getDocumentTransactions'
+import {HISTORY_CLEARED_EVENT_ID} from './getInitialFetchEvents'
 import {
   type DocumentGroupEvent,
   type EventsStoreRevision,
@@ -231,6 +232,9 @@ export function getDocumentChanges({
           // For this case, we can use the remote transactions to calculate the diff.
           const viewingLatest = !to?._rev
           const getTransactions = (): Observable<TransactionLogEventWithEffects[]> => {
+            if (sinceDoc._rev === HISTORY_CLEARED_EVENT_ID) {
+              return of([])
+            }
             if (viewingLatest && lastResolvedSince === sinceDoc._rev) {
               // The document has been previously resolved and it's on latest, we can use the remote transactions, we don't need to fetch them again
               return of(removeDuplicatedTransactions(lastTransactions.concat(remoteTx)))

--- a/packages/sanity/src/core/store/events/types.ts
+++ b/packages/sanity/src/core/store/events/types.ts
@@ -156,6 +156,7 @@ export type DocumentGroupEvent =
   | CreateLiveDocumentEvent
   | UpdateLiveDocumentEvent
   | EditDocumentVersionEvent
+  | HistoryClearedEvent
 
 /**
  * @hidden
@@ -273,6 +274,15 @@ export interface CreateDocumentVersionEvent extends BaseEvent {
    * This is present when this creation event is already published.
    */
   parentId?: string
+}
+
+/**
+ * @hidden
+ * @beta
+ */
+export interface HistoryClearedEvent extends BaseEvent {
+  type: 'historyCleared'
+  documentId: string
 }
 
 /**

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -379,6 +379,13 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The description for the document unfavorite action */
   'document.favorites.remove-from-favorites': 'Remove from favorites',
 
+  /** The description for the events inspector when we can't load the document so we default to compare with published */
+  'events.compare-with-published.description':
+    "We're unable to load the changes for this document, probably due to history retention policy of your plan, this shows you how the <strong>{{version}}</strong> version compares to the <strong>published</strong> version.",
+
+  /** The title for the events inspector when we can't load the document so we default to compare with published */
+  'events.compare-with-published.title': 'Comparing with published',
+
   /**The title for the menu items that will be shown when expanding a publish release event to inspect the document */
   'events.inspect.release': 'Inspect <VersionBadge>{{releaseTitle}}</VersionBadge> document',
   /**The title for the menu items that will be shown when expanding a publish draft event to inspect the draft document*/

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -151,7 +151,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
   const getComparisonValue = useCallback(
     (editState: EditStateFor) => {
-      return changesOpen ? sinceDocument : editState?.published || null
+      return changesOpen ? sinceDocument || editState?.published : editState?.published || null
     },
     [changesOpen, sinceDocument],
   )

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/EventsInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/EventsInspector.tsx
@@ -1,3 +1,4 @@
+import {diffInput, wrap} from '@sanity/diff'
 import {BoundaryElementProvider, Box, Card, Flex, Spinner, Stack, Text} from '@sanity/ui'
 import {motion} from 'framer-motion'
 import {type ReactElement, useMemo, useState} from 'react'
@@ -7,15 +8,20 @@ import {
   ChangeList,
   ChangesError,
   type DocumentChangeContextInstance,
+  type DocumentGroupEvent,
+  isReleaseDocument,
   LoadingBlock,
   NoChanges,
+  type ObjectDiff,
   type ObjectSchemaType,
   ScrollContainer,
   Translate,
   useEvents,
+  usePerspective,
   useTranslation,
 } from 'sanity'
 import {DocumentChangeContext} from 'sanity/_singletons'
+import {structureLocaleNamespace} from 'sanity/structure'
 import {styled} from 'styled-components'
 
 import {EventsTimelineMenu} from '../../timeline/events/EventsTimelineMenu'
@@ -47,6 +53,67 @@ const DIFF_INITIAL_VALUE = {
   diff: null,
   loading: true,
   error: null,
+}
+
+const CompareWithPublishedView = () => {
+  const {documentId, schemaType, editState, displayed} = useDocumentPane()
+  const {selectedPerspective, selectedPerspectiveName, selectedReleaseId} = usePerspective()
+  const {t} = useTranslation(structureLocaleNamespace)
+  const rootDiff = useMemo(() => {
+    const diff = diffInput(
+      wrap(editState?.published ?? {}, {author: ''}),
+      wrap(displayed ?? {}, {author: ''}),
+    ) as ObjectDiff
+
+    return diff
+  }, [editState?.published, displayed])
+
+  if (selectedReleaseId && !editState?.version) {
+    return null
+  }
+  if (selectedPerspective === 'drafts' && !editState?.draft) {
+    return null
+  }
+  if (selectedPerspectiveName === 'published' || !displayed?._rev) {
+    return null
+  }
+  return (
+    <Stack space={2} marginBottom={3}>
+      <Card borderBottom paddingBottom={3}>
+        <Stack space={3} paddingTop={1}>
+          <Text size={1} weight="medium">
+            {t('events.compare-with-published.title')}
+          </Text>
+          <Text size={1} muted>
+            <Translate
+              i18nKey="events.compare-with-published.description"
+              t={t}
+              values={{
+                version: isReleaseDocument(selectedPerspective)
+                  ? selectedPerspective.metadata?.title
+                  : 'draft',
+              }}
+            />
+          </Text>
+        </Stack>
+      </Card>
+      <DocumentChangeContext.Provider
+        value={{
+          documentId,
+          schemaType,
+          rootDiff,
+          isComparingCurrent: true,
+          FieldWrapper: (props) => props.children,
+          value: displayed,
+          showFromValue: true,
+        }}
+      >
+        <Box paddingY={1}>
+          <ChangeList diff={rootDiff} schemaType={schemaType} />
+        </Box>
+      </DocumentChangeContext.Provider>
+    </Stack>
+  )
 }
 export function EventsInspector({showChanges}: {showChanges: boolean}): ReactElement {
   const {documentId, schemaType, timelineError, value, formState} = useDocumentPane()
@@ -162,6 +229,7 @@ export function EventsInspector({showChanges}: {showChanges: boolean}): ReactEle
                   loading={revision?.loading || sinceRevision?.loading || false}
                   schemaType={schemaType}
                   sameRevisionSelected={sinceEvent?.id === toEvent?.id}
+                  sinceEvent={sinceEvent}
                 />
               )}
             </Box>
@@ -178,15 +246,22 @@ function Content({
   loading,
   schemaType,
   sameRevisionSelected,
+  sinceEvent,
 }: {
   error?: Error | null
   documentContext: DocumentChangeContextInstance
   loading: boolean
   schemaType: ObjectSchemaType
   sameRevisionSelected: boolean
+  sinceEvent: DocumentGroupEvent | null
 }) {
   if (error) {
-    return <ChangesError error={error} />
+    return (
+      <>
+        <CompareWithPublishedView />
+        {sinceEvent?.type !== 'historyCleared' && <ChangesError error={error} />}
+      </>
+    )
   }
 
   if (loading) {


### PR DESCRIPTION
### Description
In some scenarios, according to users retention policy the events are removed.
Parts of the internal implementation on how to show the diffs and pull the transactions depend on this initial created event, but given transactions are removed after certain period of time the creation event is also removed.
This PR adds some changes to include a new event of the type `history-cleared` this will be added when there are no other events but we have access to some transactions and we want to show a diff to users.

When using the initial event in the from we will use the last published document as the document to compare against, that is what most users are expecting and what is more useful to show.
This same comparison with published view will show when there is any error fetching the events.

| Before | After |
|--------|--------|
|<img width="335" alt="Screenshot 2025-05-26 at 15 54 05" src="https://github.com/user-attachments/assets/b3df88ca-88cb-4a1b-bda3-d1903c7ff5fc" />|<img width="319" alt="Screenshot 2025-05-26 at 15 53 16" src="https://github.com/user-attachments/assets/b3eb146a-0670-414b-a1b0-7bb235d4a870" />| 



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is the new wording and ui correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
To test this you will need access to a project with low retention policy and a document with changes to the draft and the published. Where the changes to the draft have been removed from the translog

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
When retention is cleared add an option to compare the document to the `published` version of it.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
