### PR TITLE
chore(schema): fix internal typing of RuleSpec and FieldReference

### DIFF
--- a/packages/@sanity/types/src/validation/types.ts
+++ b/packages/@sanity/types/src/validation/types.ts
@@ -209,13 +209,13 @@ export type RuleSpec =
   | {flag: 'either'; constraint: Rule[]}
   | {flag: 'presence'; constraint: 'optional' | 'required'}
   | {flag: 'custom'; constraint: CustomValidator}
-  | {flag: 'min'; constraint: number | string}
-  | {flag: 'max'; constraint: number | string}
-  | {flag: 'length'; constraint: number}
+  | {flag: 'min'; constraint: number | string | FieldReference}
+  | {flag: 'max'; constraint: number | string | FieldReference}
+  | {flag: 'length'; constraint: number | FieldReference}
   | {flag: 'valid'; constraint: unknown[]}
-  | {flag: 'precision'; constraint: number}
-  | {flag: 'lessThan'; constraint: number}
-  | {flag: 'greaterThan'; constraint: number}
+  | {flag: 'precision'; constraint: number | FieldReference}
+  | {flag: 'lessThan'; constraint: number | FieldReference}
+  | {flag: 'greaterThan'; constraint: number | FieldReference}
   | {flag: 'stringCasing'; constraint: 'uppercase' | 'lowercase'}
   | {flag: 'assetRequired'; constraint: {assetType: 'asset' | 'image' | 'file'}}
   | {
@@ -320,7 +320,7 @@ export type Validator<T = any, Value = any> = (
  */
 export type Validators = Partial<{
   [P in RuleSpec['flag']]: Validator<
-    ConditionalIndexAccess<Extract<RuleSpec, {flag: P}>, 'constraint'>
+    Exclude<ConditionalIndexAccess<Extract<RuleSpec, {flag: P}>, 'constraint'>, FieldReference>
   >
 }>
 

--- a/packages/sanity/src/core/validation/Rule.ts
+++ b/packages/sanity/src/core/validation/Rule.ts
@@ -1,5 +1,6 @@
 import {
   type CustomValidator,
+  type FieldReference,
   type FieldRules,
   type LocalizedValidationMessages,
   type Rule as IRule,
@@ -236,15 +237,15 @@ export const Rule: RuleClass = class Rule implements IRule {
     return this.cloneWithRules([{flag: 'custom', constraint: fn as CustomValidator}])
   }
 
-  min(len: number | string): Rule {
+  min(len: number | string | FieldReference): Rule {
     return this.cloneWithRules([{flag: 'min', constraint: len}])
   }
 
-  max(len: number | string): Rule {
+  max(len: number | string | FieldReference): Rule {
     return this.cloneWithRules([{flag: 'max', constraint: len}])
   }
 
-  length(len: number): Rule {
+  length(len: number | FieldReference): Rule {
     return this.cloneWithRules([{flag: 'length', constraint: len}])
   }
 
@@ -258,7 +259,7 @@ export const Rule: RuleClass = class Rule implements IRule {
     return this.cloneWithRules([{flag: 'integer'}])
   }
 
-  precision(limit: number): Rule {
+  precision(limit: number | FieldReference): Rule {
     return this.cloneWithRules([{flag: 'precision', constraint: limit}])
   }
 
@@ -270,11 +271,11 @@ export const Rule: RuleClass = class Rule implements IRule {
     return this.cloneWithRules([{flag: 'lessThan', constraint: 0}])
   }
 
-  greaterThan(num: number): Rule {
+  greaterThan(num: number | FieldReference): Rule {
     return this.cloneWithRules([{flag: 'greaterThan', constraint: num}])
   }
 
-  lessThan(num: number): Rule {
+  lessThan(num: number | FieldReference): Rule {
     return this.cloneWithRules([{flag: 'lessThan', constraint: num}])
   }
 


### PR DESCRIPTION
### Description

This is purely a type fix: The definition of `RuleSpec` was actually wrong. The `constraint` field _can_ be set to a FieldReference in some cases. However, when invoking a validator, then we turn every field reference into a concrete value. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

N/A.

### Notes for release

Not required.