### PR TITLE
fix(core): hide `getAddonDataset` error

### DIFF
--- a/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
+++ b/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
@@ -110,6 +110,11 @@ function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
         const client = handleCreateClient(addonDatasetName)
         setAddonDatasetClient(client)
       })
+      .catch((err) => {
+        // If the addon dataset does not exist or we don't have permission to access it,
+        // We can ignore this error.
+        // TODO: Surface error to the user when they try to use the comments feature.
+      })
       .finally(() => {
         setReady(true)
       })


### PR DESCRIPTION
### Description

With the changes introduced by this [PR](https://github.com/sanity-io/sanity/pull/9349/files#diff-aaca58ccaeed2a592175b96e43d4e697fb81b4c3cf1d156f9ecca7bfd183a395R79-R90) uncaught errors are surfaced to users with the error toast.
If a user doesn't have permissions to read the datasets, they will get an error back from the `getAddonDatasets` function. 

```json
{
"statusCode": 401,
"error": "Unauthorized",
"message": "User is missing required grant sanity.project.datasets/read to perform this operation"
}
```

Getting this error is ok, because they need datasets read permission, but we were not previously surfacing it to users and now users opening the studio, without this permission, will see an error.

This hides the error again, a new ticket will be created to show the error details and to give feedback on how to solve it once they try to use the comments feature.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
No error is shown when opening the studio with missing datasets read permission

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Assign yourself the `no dataset read` permissions in manage, open the studio, you should not see an error.


<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
fixes an issue in where users with no dataset read permissions were seeing an error toast on load.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
