### PR TITLE
fix(core): update buildCommentBreadCrumb recursivity

### DIFF
--- a/packages/sanity/src/core/comments/utils/buildCommentBreadcrumbs.ts
+++ b/packages/sanity/src/core/comments/utils/buildCommentBreadcrumbs.ts
@@ -76,13 +76,13 @@ export function buildCommentBreadcrumbs(
   const paths = PathUtils.fromString(fieldPath)
   const fieldPaths: CommentListBreadcrumbs = []
 
-  let currentSchemaType: ArraySchemaType<SchemaType> | ObjectFieldType<SchemaType> | null = null
+  let currentSchemaType: ArraySchemaType<SchemaType> | ObjectFieldType<SchemaType> = schemaType
 
   paths.forEach((seg, index) => {
     const currentPath = paths.slice(0, index + 1)
     const previousPath = paths.slice(0, index)
+    const field = getSchemaField(currentSchemaType, PathUtils.toString([seg]))
 
-    const field = getSchemaField(schemaType, PathUtils.toString(currentPath))
     const isKeySegment = seg.hasOwnProperty('_key')
 
     const parentValue = getValueAtPath(documentValue, previousPath)
@@ -101,7 +101,6 @@ export function buildCommentBreadcrumbs(
     // This can happen if the array item has been removed from the document value.
     if (isKeySegment && Array.isArray(parentValue)) {
       const arrayItemIndex = findArrayItemIndex(parentValue, seg)
-
       const isNumber = typeof arrayItemIndex === 'number'
 
       fieldPaths.push({


### PR DESCRIPTION
### Description
This PR updates how the `buildCommentBreadCrumbs` work.
This function tries to get the path on where a comment was made, this is by checking the document value and combining it with the schema.
There was a report in where comments made to objects inside arrays were not showing and that is because the function was not resolving the correct bread crumb.

What I noticed is that the `getSchemaField` function was trying to recursively get the field from the schema, but not respecting the values.
So a path with an array, was not resolved correctly, to sort that, there is a second part of the function which checks if the item is part of an array, and if it is, it will use the array schema to resolve the field, but when going deeper this stops working.

With this change, it simplifies how it gets the schema field, by using the previous resolved `currentSchemaType` which is being passed by when we get the field.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
New tests added which initially failed and now are passing.
Manual testing can be done by visiting for example t[his document in the preview,](https://test-studio-git-sapp-2756.sanity.dev/test/structure/input-standard;arraysTest;658b602f-428d-41bd-86cc-0a8a545abfd2%2Cinspect%3Dsanity%252Fcomments) which has comments, but they are not displayed in the [version we have in `main`](https://test-studio.sanity.dev/test/structure/input-standard;arraysTest;658b602f-428d-41bd-86cc-0a8a545abfd2%2Cinspect%3Dsanity%252Fcomments) because it won't find the field.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
fixes an issue in where comments created in objects in arrays were not displayed
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
