### PR TITLE
fix(cli): check if is interactive before prompting to upgrade

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
@@ -170,18 +170,17 @@ export default async function startSanityDevServer(
     output.print(`${info} Running with auto-updates enabled`)
     // Check the versions
     const result = await compareDependencyVersions(autoUpdatesImports, workDir)
+    const message =
+      `The following local package versions are different from the versions currently served at runtime.\n` +
+      `When using auto updates, we recommend that you run with the same versions locally as will be used when deploying. \n\n` +
+      `${result.map((mod) => ` - ${mod.pkg} (local version: ${mod.installed}, runtime version: ${mod.remote})`).join('\n')} \n\n`
 
     // mismatch between local and auto-updating dependencies
     if (result?.length) {
       if (isInteractive) {
         const shouldUpgrade = await prompt.single({
           type: 'confirm',
-          message: chalk.yellow(
-            `The following local package versions are different from the versions currently served at runtime.\n` +
-              `When using auto updates, we recommend that you run with the same versions locally as will be used when deploying. \n\n` +
-              `${result.map((mod) => ` - ${mod.pkg} (local version: ${mod.installed}, runtime version: ${mod.remote})`).join('\n')} \n\n` +
-              `Do you want to upgrade local versions?`,
-          ),
+          message: chalk.yellow(`${message}Do you want to upgrade local versions?`),
           default: true,
         })
         if (shouldUpgrade) {
@@ -195,13 +194,7 @@ export default async function startSanityDevServer(
         }
       } else {
         // In this case we warn the user but we don't ask them if they want to upgrade because it's not interactive.
-        output.print(
-          chalk.yellow(
-            `The following local package versions are different from the versions currently served at runtime.\n` +
-              `When using auto updates, we recommend that you run with the same versions locally as will be used when deploying. \n\n` +
-              `${result.map((mod) => ` - ${mod.pkg} (local version: ${mod.installed}, runtime version: ${mod.remote})`).join('\n')} \n\n`,
-          ),
-        )
+        output.print(chalk.yellow(message))
       }
     }
   }


### PR DESCRIPTION
### Description

The [question for upgrade ](https://github.com/sanity-io/sanity/pull/9153/files#diff-bb8ffbe21f9725c6a83f4eed919e1215bff20eb65b73b9ffc4630b85850a2e9c) when using an autoupdate studio blocks the dev command when used in non interactive environments, like when running inside a pnpm workspace with `pnpm dev --filter=studio`

This PR uses the `isInteractive` check and skips the question if it is non interactive.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Are the changes correct?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing


<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
fixes an issue in where the studio dev command will get blocked if using auto update in a non interactive environment.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
