### PR TITLE
chore(ci): run dataset cleanup for individual pull requests

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,8 +1,6 @@
 name: "Cleanup: PR Merge/Closed"
 
 on:
-  # allow this workflow to be run manually
-  workflow_dispatch:
   # Build on closed or merged PRs
   pull_request:
     types: [closed]
@@ -52,4 +50,5 @@ jobs:
         env:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_STAGING }}
           SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
-        run: pnpm e2e:cleanup
+          PR_NUMBER: ${{ github.event.number }}
+        run: pnpm e2e:cleanup:pr

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "docs:report:cleanup": "node -r dotenv-flow/config -r esbuild-register scripts/doc-report/docReportCleanup",
     "docs:report:create": "node -r dotenv-flow/config -r esbuild-register scripts/doc-report/docReportCreate",
     "e2e:build": "pnpm turbo run build --filter=studio-e2e-testing",
-    "e2e:cleanup": "node -r dotenv-flow/config -r esbuild-register test/e2e/scripts/cleanup",
+    "e2e:cleanup:pr": "node -r dotenv-flow/config -r esbuild-register test/e2e/scripts/cleanupPr",
     "e2e:codegen": "node -r dotenv-flow/config ./node_modules/.bin/sanity-test codegen",
     "e2e:dev": "pnpm --filter studio-e2e-testing dev",
     "e2e:preview": "pnpm e2e:build && pnpm --filter studio-e2e-testing preview",

--- a/test/e2e/envVars.ts
+++ b/test/e2e/envVars.ts
@@ -2,7 +2,11 @@ import {loadEnvFiles} from '../../scripts/utils/loadEnvFiles'
 
 loadEnvFiles()
 
-type KnownEnvVar = 'SANITY_E2E_PROJECT_ID' | 'SANITY_E2E_DATASET' | 'SANITY_E2E_SESSION_TOKEN'
+type KnownEnvVar =
+  | 'SANITY_E2E_PROJECT_ID'
+  | 'SANITY_E2E_DATASET'
+  | 'SANITY_E2E_SESSION_TOKEN'
+  | 'PR_NUMBER'
 
 export function readEnv(name: KnownEnvVar): string {
   const val = process.env[name]

--- a/test/e2e/envVars.ts
+++ b/test/e2e/envVars.ts
@@ -2,11 +2,11 @@ import {loadEnvFiles} from '../../scripts/utils/loadEnvFiles'
 
 loadEnvFiles()
 
-type KnownEnvVar =
-  | 'SANITY_E2E_PROJECT_ID'
+export type KnownEnvVar =
   | 'SANITY_E2E_DATASET'
-  | 'SANITY_E2E_SESSION_TOKEN'
+  | 'SANITY_E2E_PROJECT_ID'
   | 'PR_NUMBER'
+  | 'SANITY_E2E_SESSION_TOKEN'
 
 export function readEnv(name: KnownEnvVar): string {
   const val = process.env[name]

--- a/test/e2e/scripts/cleanup.ts
+++ b/test/e2e/scripts/cleanup.ts
@@ -1,4 +1,11 @@
 /* eslint-disable no-console */
+/**
+ * Deletes old datasets from the e2e project that was created longer than DATASET_MAX_AGE ago
+ * Run this via `npx tsx --env-file=<.env file> ./scripts/e2e/cleanupOldDatasets"`
+ * Note for the future: ideally, this should be rewritten to check against open PRs on github
+ * and only delete datasets for PRs that has been closed or merged
+ */
+
 import {readEnv} from '../envVars'
 
 const SANITY_E2E_PROJECT_ID = readEnv('SANITY_E2E_PROJECT_ID')
@@ -13,7 +20,7 @@ interface Dataset {
 }
 
 // If the dataset is older than this, delete it
-const DATASET_MAX_AGE = 1000 * 60 * 60
+const DATASET_MAX_AGE = 1000 * 60 * 60 * 24
 
 // Fetch a list of all datasets for the project
 async function listDatasets(): Promise<Dataset[]> {

--- a/test/e2e/scripts/cleanupPr.ts
+++ b/test/e2e/scripts/cleanupPr.ts
@@ -1,0 +1,43 @@
+/* eslint-disable no-console */
+import {startTimer} from '../../../scripts/utils/startTimer'
+import {readEnv} from '../envVars'
+import {createE2EClient} from './e2eClient'
+
+const prNumber = readEnv('PR_NUMBER')
+const studioE2EClient = createE2EClient('production')
+
+async function cleanupPr() {
+  const datasets = await studioE2EClient.datasets.list()
+  // gets all the datasets that belong to the PR but not the ones associated with comments
+  // since those will be removed automatically
+  const prDatasets = datasets.filter(
+    (ds) => ds.name.startsWith(`pr-${prNumber}-`) && !ds.name.endsWith('-comments'),
+  )
+
+  console.log(`Found ${prDatasets.length} datasets to clean up`)
+
+  for (const dataset of prDatasets) {
+    const timer = startTimer(`Deleting dataset ${dataset.name}`)
+    await studioE2EClient.datasets
+      .delete(dataset.name)
+      .then((res) => {
+        if (res.deleted) {
+          console.log('Deleted dataset')
+        } else {
+          console.log('Dataset was not deleted')
+        }
+      })
+      .catch((err) => {
+        throw new Error(`Something went wrong! ${err?.response?.body?.message}`)
+      })
+
+    timer.end()
+  }
+
+  console.log('PR cleanup complete')
+}
+
+cleanupPr().catch((error) => {
+  console.error('Cleanup failed:', error)
+  process.exit(1)
+})

--- a/test/e2e/scripts/e2eClient.ts
+++ b/test/e2e/scripts/e2eClient.ts
@@ -1,19 +1,13 @@
 import {createClient, type SanityClient} from '@sanity/client'
 
-import {readEnv} from '../../../scripts/utils/envVars'
 import {sanityIdify} from '../../../scripts/utils/sanityIdify'
-
-export type KnownEnvVar =
-  | 'SANITY_E2E_DATASET'
-  | 'SANITY_E2E_PROJECT_ID'
-  | 'SANITY_E2E_SESSION_TOKEN'
-  | 'PR_NUMBER'
+import {readEnv} from '../envVars'
 
 export function createE2EClient(dataset: string): SanityClient {
   return createClient({
-    projectId: readEnv<KnownEnvVar>('SANITY_E2E_PROJECT_ID'),
+    projectId: readEnv('SANITY_E2E_PROJECT_ID'),
     dataset: sanityIdify(dataset),
-    token: readEnv<KnownEnvVar>('SANITY_E2E_SESSION_TOKEN'),
+    token: readEnv('SANITY_E2E_SESSION_TOKEN'),
     apiVersion: '2023-02-03',
     useCdn: false,
     apiHost: 'https://api.sanity.work',

--- a/test/e2e/scripts/e2eClient.ts
+++ b/test/e2e/scripts/e2eClient.ts
@@ -1,13 +1,20 @@
 import {createClient, type SanityClient} from '@sanity/client'
 
-import {readEnv} from '../envVars'
+import {readEnv} from '../../../scripts/utils/envVars'
+import {sanityIdify} from '../../../scripts/utils/sanityIdify'
+
+export type KnownEnvVar =
+  | 'SANITY_E2E_DATASET'
+  | 'SANITY_E2E_PROJECT_ID'
+  | 'SANITY_E2E_SESSION_TOKEN'
+  | 'PR_NUMBER'
 
 export function createE2EClient(dataset: string): SanityClient {
   return createClient({
-    projectId: readEnv('SANITY_E2E_PROJECT_ID'),
-    token: readEnv('SANITY_E2E_SESSION_TOKEN'),
-    dataset: dataset,
-    apiVersion: '2025-05-22',
+    projectId: readEnv<KnownEnvVar>('SANITY_E2E_PROJECT_ID'),
+    dataset: sanityIdify(dataset),
+    token: readEnv<KnownEnvVar>('SANITY_E2E_SESSION_TOKEN'),
+    apiVersion: '2023-02-03',
     useCdn: false,
     apiHost: 'https://api.sanity.work',
   })

--- a/test/e2e/scripts/setup.ts
+++ b/test/e2e/scripts/setup.ts
@@ -1,11 +1,11 @@
-import {readEnv} from '../../../scripts/utils/envVars'
 import {sanityIdify} from '../../../scripts/utils/sanityIdify'
 import {startTimer} from '../../../scripts/utils/startTimer'
-import {createE2EClient, type KnownEnvVar} from './e2eClient'
+import {readEnv} from '../envVars'
+import {createE2EClient} from './e2eClient'
 
-const dataset = sanityIdify(readEnv<KnownEnvVar>('SANITY_E2E_DATASET'))
+const dataset = sanityIdify(readEnv('SANITY_E2E_DATASET'))
 
-const studioE2EClient = createE2EClient(readEnv<KnownEnvVar>('SANITY_E2E_DATASET'))
+const studioE2EClient = createE2EClient(readEnv('SANITY_E2E_DATASET'))
 
 studioE2EClient.datasets.list().then(async (datasets) => {
   // If the dataset doesn't exist, create it

--- a/test/e2e/scripts/setup.ts
+++ b/test/e2e/scripts/setup.ts
@@ -1,17 +1,17 @@
+import {readEnv} from '../../../scripts/utils/envVars'
+import {sanityIdify} from '../../../scripts/utils/sanityIdify'
 import {startTimer} from '../../../scripts/utils/startTimer'
-import {readEnv} from '../envVars'
-import {createE2EClient} from './e2eClient'
+import {createE2EClient, type KnownEnvVar} from './e2eClient'
 
-const SANITY_E2E_DATASET = readEnv('SANITY_E2E_DATASET')
-const studioE2EClient = createE2EClient(SANITY_E2E_DATASET)
+const dataset = sanityIdify(readEnv<KnownEnvVar>('SANITY_E2E_DATASET'))
 
-const datasetName = SANITY_E2E_DATASET
+const studioE2EClient = createE2EClient(readEnv<KnownEnvVar>('SANITY_E2E_DATASET'))
 
 studioE2EClient.datasets.list().then(async (datasets) => {
   // If the dataset doesn't exist, create it
-  if (!datasets.find((ds) => ds.name === datasetName)) {
-    const timer = startTimer(`Creating dataset ${datasetName}`)
-    await studioE2EClient.datasets.create(datasetName, {
+  if (!datasets.find((ds) => ds.name === dataset)) {
+    const timer = startTimer(`Creating dataset ${dataset}`)
+    await studioE2EClient.datasets.create(dataset, {
       aclMode: 'public',
     })
     timer.end()


### PR DESCRIPTION
### Description

Partially reverts #9479 to bring back the cleanup script that runs on PR close and deletes the dataset associated with the PR.

I'm leaving the "delete old datasets" script with a note that it can later be adjusted to use the GH api to periodically (e.g. twice a day) check against open/closed PRs and delete datasets for PRs that has been closed, which would be a better solution.

### Testing
The cleanup workflow should remove the dataset created by e2e tests for this PR

### Notes for release
n/a
