### PR TITLE
chore(ci): set up release automation

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -39,7 +39,7 @@ jobs:
         id: check_release
         run: |
           SKIP="false"
-          if [[ "$MESSAGE" == chore:\ release* ]]; then
+          if [[ $MESSAGE =~ ^chore\(release\):\ publish\  ]]; then
             SKIP="true"
           fi
           echo "skip=$SKIP" >> $GITHUB_OUTPUT

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -19,6 +19,11 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
+
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -72,7 +77,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           title: "${{steps.head-commit.outputs.message}}"
-          body: "I have created a release.\n\n Merging this PR will release v${{steps.release-as.outputs.version}} "
+          body: "I have created a release.\n\n Merging this PR will release v${{steps.release-as.outputs.version}} 🚀"
           branch: ci/release-main
           sign-commits: true
           # todo: change to main before merge

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -58,6 +58,7 @@ jobs:
           npx lerna version \
           --force-publish \
           --no-push \
+          --sync-workspace-lock \
           --conventional-commits \
           --yes
         env:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -3,8 +3,7 @@ name: Create Release PR
 on:
   push:
     branches:
-      # todo: change to main before merge
-      - release-automation-test/main
+      - main
 
 permissions:
   contents: read
@@ -27,8 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # todo: change to main before merge
-          ref: release-automation-test/main
+          ref: main
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
@@ -81,15 +79,11 @@ jobs:
           body: "I have created a release.\n\n Merging this PR will release v${{steps.release-as.outputs.version}} 🚀"
           branch: ci/release-main
           sign-commits: true
-          # todo: change to main before merge
-          base: release-automation-test/main
-          # todo: uncomment before merge
-          # team-reviewers: @sanity-io/studio
+          base: main
+          team-reviewers: "@sanity-io/studio"
           draft: false
 
       - name: Enable automerge on Pull Request
-        # todo: enable before merge
-        if: false
         run: gh pr merge --squash --auto "${{ steps.create-pull-request.outputs.pull-request-number }}"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -88,6 +88,8 @@ jobs:
           draft: false
 
       - name: Enable automerge on Pull Request
+        # todo: enable before merge
+        if: false
         run: gh pr merge --squash --auto "${{ steps.create-pull-request.outputs.pull-request-number }}"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           title: "${{steps.head-commit.outputs.message}}"
-          body: "I have created a release.\n\n Merging this PR will publish v${{steps.release-as.outputs.version}} to npm 🚀"
+          body: "🤖 I have created a release **squib** **squob**\n\n Merging this PR will publish v${{steps.release-as.outputs.version}} to npm 🚀"
           branch: ci/release-main
           sign-commits: true
           base: main

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,85 @@
+name: Create Release PR
+
+on:
+  push:
+    branches:
+      # todo: change to main before merge
+      - release-automation-test/main
+
+permissions:
+  contents: read
+
+jobs:
+  create-or-update-pr:
+    # this runs in main, and we want to skip running it when release PRs are merged
+    # format of the commit message is specified in lerna.json
+    if: >
+      !startsWith(github.event.head-commit.message, 'chore(release): publish')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: lts/*
+
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+
+      - name: Install deps & build
+        run: pnpm install --ignore-scripts
+
+      - name: Build
+        run: pnpm build --output-logs=full --log-order=grouped
+
+      - name: Configure git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Update version
+        run: |
+          npx lerna version \
+          --force-publish \
+          --no-push \
+          --conventional-commits \
+          --yes
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Get commit message
+        # get the commit message created by npx lerna version above (determined by lerna.json)
+        id: head-commit
+        run: echo "message=$(git log -1 --pretty=%B)" >> $GITHUB_OUTPUT
+
+      - name: Get version
+        id: release-as
+        run: echo "version=$(cat lerna.json | jq -r .version)" >> $GITHUB_OUTPUT
+      - name: Create or update PR
+        uses: peter-evans/create-pull-request@v7
+        id: create-pull-request
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          title: "${{steps.head-commit.outputs.message}}"
+          body: "I have created a release.\n\n Merging this PR will release v${{steps.release-as.outputs.version}} "
+          branch: ci/release-main
+          sign-commits: true
+          # todo: change to main before merge
+          base: release-automation-test/main
+          # todo: uncomment before merge
+          # team-reviewers: @sanity-io/studio
+          draft: false
+
+      - name: Enable automerge on Pull Request
+        run: gh pr merge --squash --auto "${{ steps.create-pull-request.outputs.pull-request-number }}"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # todo: change to main before merge
+          ref: release-automation-test/main
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           title: "${{steps.head-commit.outputs.message}}"
-          body: "I have created a release.\n\n Merging this PR will release v${{steps.release-as.outputs.version}} 🚀"
+          body: "I have created a release.\n\n Merging this PR will publish v${{steps.release-as.outputs.version}} to npm 🚀"
           branch: ci/release-main
           sign-commits: true
           base: main

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -45,12 +45,12 @@ jobs:
           NPM_PUBLISH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
 
       - name: Publish packages to npm
+        # todo: remove --dry-run before merge
         run: |
           npx lerna publish \
           --force-publish \
           --git-tag-version \
           --exact \
-          # todo: remove before merge \
           --dry-run \
           --yes \
           from-package
@@ -61,7 +61,8 @@ jobs:
       - name: Push tags and create release
         run: |
           git tag v$RELEASE_AS -m v$RELEASE_AS
-          git push origin --tags
+          # todo: uncomment before merge
+          # git push origin --tags
         env:
           RELEASE_AS: ${{steps.release-as.outputs.version}}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -1,0 +1,67 @@
+name: Release @latest
+
+on:
+  push:
+    branches:
+      # todo: change to main before merge
+      - release-automation-test/main
+
+permissions:
+  contents: write
+
+jobs:
+  release-latest:
+    if: >
+      startsWith(github.event.head_commit.message, 'chore(release): publish')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: lts/*
+
+      - name: Install deps & build
+        run: pnpm install --ignore-scripts
+
+      - name: Build
+        run: pnpm build --output-logs=full --log-order=grouped
+
+      - name: Configure git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Get version
+        id: release-as
+        run: echo "version=$(cat lerna.json | jq -r .version)" >> $GITHUB_OUTPUT
+
+      - name: Set publishing config
+        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_PUBLISH_TOKEN}"
+        env:
+          NPM_PUBLISH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
+
+      - name: Publish packages to npm
+        run: |
+          npx lerna publish \
+          --force-publish \
+          --git-tag-version \
+          --exact \
+          # todo: remove before merge \
+          --dry-run \
+          --yes \
+          from-package
+        env:
+          NPM_CONFIG_PROVENANCE: true
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Push tags and create release
+        run: |
+          git tag v$RELEASE_AS -m v$RELEASE_AS
+          git push origin --tags
+        env:
+          RELEASE_AS: ${{steps.release-as.outputs.version}}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -3,8 +3,7 @@ name: Release @latest
 on:
   push:
     branches:
-      # todo: change to main before merge
-      - release-automation-test/main
+      - main
 
 permissions:
   contents: write
@@ -12,7 +11,7 @@ permissions:
 jobs:
   release-latest:
     if: >
-      startsWith(github.event.head_commit.message, 'chore(release): publish')
+      startsWith(github.event.head_commit.message, 'chore(release): publish ')
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -49,13 +48,11 @@ jobs:
           NPM_PUBLISH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
 
       - name: Publish packages to npm
-        # todo: remove --dry-run before merge
         run: |
           npx lerna publish \
           --force-publish \
           --git-tag-version \
           --exact \
-          --dry-run \
           --yes \
           from-package
         env:
@@ -65,8 +62,7 @@ jobs:
       - name: Push tags and create release
         run: |
           git tag v$RELEASE_AS -m v$RELEASE_AS
-          # todo: uncomment before merge
-          # git push origin --tags
+          git push origin --tags
         env:
           RELEASE_AS: ${{steps.release-as.outputs.version}}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -14,6 +14,10 @@ jobs:
     if: >
       startsWith(github.event.head_commit.message, 'chore(release): publish')
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release (deprecated / will be removed)
 
 on:
   workflow_dispatch:

--- a/lerna.json
+++ b/lerna.json
@@ -12,5 +12,13 @@
     "packages/groq",
     "packages/sanity"
   ],
-  "version": "3.90.0"
+  "version": "3.90.0",
+  "command": {
+    "version": {
+      "changelogPreset": "conventionalcommits",
+      "message": "chore(release): publish %s",
+      "changelogIncludeCommitsClientLogin": " by %a (%e)",
+      "remoteClient": "github"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "@vitest/coverage-v8": "^3.1.1",
     "cac": "^6.7.12",
     "chalk": "^4.1.2",
+    "conventional-changelog-conventionalcommits": "^9.0.0",
     "depcheck": "^1.4.7",
     "dotenv": "^16.0.3",
     "dotenv-flow": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
+      conventional-changelog-conventionalcommits:
+        specifier: ^9.0.0
+        version: 9.0.0
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -6554,6 +6557,10 @@ packages:
 
   conventional-changelog-angular@8.0.0:
     resolution: {integrity: sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-conventionalcommits@9.0.0:
+    resolution: {integrity: sha512-5e48V0+DsWvQBEnnbBFhYQwYDzFPXVrakGPP1uSxekDkr5d7YWrmaWsgJpKFR0SkXmxK6qQr9O42uuLb9wpKxA==}
     engines: {node: '>=18'}
 
   conventional-changelog-preset-loader@5.0.0:
@@ -18122,6 +18129,10 @@ snapshots:
   content-type@1.0.5: {}
 
   conventional-changelog-angular@8.0.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.0.0:
     dependencies:
       compare-func: 2.0.0
 


### PR DESCRIPTION
### Description
Sets up release automation for packages in this repo.

Consists of two workflows:
- [create-release-pr.yml](https://github.com/sanity-io/sanity/blob/release-automation/.github/workflows/create-release-pr.yml): triggers on commits to main and maintains a PR with version bumps and changelog edits based on the unreleased commits in `main`, using conventional commits to guide version increments
- [release-latest.yml](https://github.com/sanity-io/sanity/blob/release-automation/.github/workflows/release-latest.yml): triggers when the release PR is merged to main, performs the publish to npm, and tags the version.

You can see an example of a release PR here: https://github.com/sanity-io/sanity/pull/9541 and a dry run of the workflow that triggers on release PR merge here: https://github.com/sanity-io/sanity/actions/runs/15404806470/job/43345304382


### What to review
The workflow files, this is deliberately kept a bit minimal for now, to get the basic workflow up and running. There's a lot of incremental improvements we can do here, like:
- automate creating draft release on github
- automate creating release note documents in Sanity (building on the work from @kmelve in #8826)
- the release PR itself is also quite minimal and it would be good if it included a summary of version changes, and the above links
- slack integration
- you name it


### Testing
I've done quite a bit of manual testing here, and dry ran several cycles of merge commit to main -> merge release pr -> new commit to main and everything seems to work as it should. 

### Notes for release
n/a
