### PR TITLE
fix(cli): use correct npm command for upgrading

### DIFF
--- a/packages/sanity/src/_internal/cli/util/packageManager/upgradePackages.ts
+++ b/packages/sanity/src/_internal/cli/util/packageManager/upgradePackages.ts
@@ -20,10 +20,10 @@ export async function upgradePackages(
     stdio: 'inherit',
   }
   const upgradePackageArgs = packages.map((pkg) => pkg.join('@'))
-  const npmArgs = ['upgrade', '--legacy-peer-deps', ...upgradePackageArgs]
   let result: ExecaReturnValue<string> | undefined
   if (packageManager === 'npm') {
-    output.print(`Running 'npm upgrade ${npmArgs.join(' ')}'`)
+    const npmArgs = ['install', '--legacy-peer-deps', ...upgradePackageArgs]
+    output.print(`Running 'npm ${npmArgs.join(' ')}'`)
     result = await execa('npm', npmArgs, execOptions)
   } else if (packageManager === 'yarn') {
     const yarnArgs = ['upgrade ', ...upgradePackageArgs]


### PR DESCRIPTION
fixes #9544

### Description
`npm upgrade` doesn't accept exact versions of packages, see report in #9544 

This changes the command we run so it uses `npm install package@version` instead.


### Testing
- A bit tricky to test, but can be tested by installing the pkg.pr.new version of the `sanity`-package built from this PR and pinning `@sanity/vision` to an older version in an auto-updating studio. Then, `npm run dev --yes` should run the npm command successfully.

### Notes for release
- fixes wrong npm command being invoked when prompted to update local versions in Auto-updating Studios