### PR TITLE
fix(ci): use pnpm for pkg.pr.new

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -45,4 +45,4 @@ jobs:
 
       - run: |
           echo "Publishing to pkg.pr.new: ${{ steps.pre-flight.outputs.packages }}"
-          pnpm pnpx pkg-pr-new publish --no-template ${{ steps.pre-flight.outputs.packages }}
+          pnpx pkg-pr-new publish --pnpm --no-template ${{ steps.pre-flight.outputs.packages }}

--- a/packages/sanity/src/_internal/cli/util/packageManager/upgradePackages.ts
+++ b/packages/sanity/src/_internal/cli/util/packageManager/upgradePackages.ts
@@ -20,10 +20,10 @@ export async function upgradePackages(
     stdio: 'inherit',
   }
   const upgradePackageArgs = packages.map((pkg) => pkg.join('@'))
-  const npmArgs = ['upgrade', '--legacy-peer-deps', ...upgradePackageArgs]
   let result: ExecaReturnValue<string> | undefined
   if (packageManager === 'npm') {
-    output.print(`Running 'npm upgrade ${npmArgs.join(' ')}'`)
+    const npmArgs = ['install', '--legacy-peer-deps', ...upgradePackageArgs]
+    output.print(`Running 'npm ${npmArgs.join(' ')}'`)
     result = await execa('npm', npmArgs, execOptions)
   } else if (packageManager === 'yarn') {
     const yarnArgs = ['upgrade ', ...upgradePackageArgs]


### PR DESCRIPTION
### Description

Passes the [--pnpm arg](https://github.com/stackblitz-labs/pkg.pr.new#:~:text=also%20use%20the-,%2D%2Dpnpm,-or%20%2D%2Dyarn%20flag) to pkg.pr.new which makes it use `pnpm pack` instead of `npm pack`. Since it's currently using `npm pack`, `workspace:` protocol won't be replaced with the local version during publish, which means any attempt at installing a pr-version with npm will fail with the error: `npm error code EUNSUPPORTEDPROTOCOL`.

### What to review
the package published from this PR should be possible to install using npm (I've verified already)

### Testing
installing the pr release using npm should work

### Notes for release
n/a
