### PR TITLE
chore: use git-only setting for changelog author info

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -17,7 +17,7 @@
     "version": {
       "changelogPreset": "conventionalcommits",
       "message": "chore(release): publish %s",
-      "changelogIncludeCommitsClientLogin": " by %a (%e)",
+      "changelogIncludeCommitsGitAuthor": " by %a (%e)",
       "remoteClient": "github"
     }
   }


### PR DESCRIPTION
Based on the suggestion from @ghiscoding here: https://github.com/sanity-io/sanity/pull/9543#discussion_r2124524117

> If you're only using Git details, then it would be better to use [--changelog-include-commits-git-author](https://github.com/lerna-lite/lerna-lite/tree/main/packages/version?rgh-link-date=2025-06-03T17%3A47%3A44Z#--changelog-include-commits-git-author-msg). The difference is that --changelog-include-commits-client-login does a GraphQL API fetching (which GitHub set a limit of 100 commits/fetch if I remember correctly) in order to get GitHub username login (%l) but with the --changelog-include-commits-git-author it's pulled directly from Git (no fetching required, and so a much lighter approach since %a and %e are both available in Git commits).

