### PR TITLE
fix(core): get correct document title when creating comments

### DIFF
--- a/packages/sanity/src/core/comments/hooks/use-comment-operations/useCommentOperations.ts
+++ b/packages/sanity/src/core/comments/hooks/use-comment-operations/useCommentOperations.ts
@@ -85,7 +85,12 @@ export function useCommentOperations(
     () => tools.find((tool) => tool.name === activeToolName),
     [activeToolName, tools],
   )
-  const {getNotificationValue} = useNotificationTarget({documentId, documentType, getCommentLink})
+  const {getNotificationValue} = useNotificationTarget({
+    documentId,
+    documentType,
+    getCommentLink,
+    documentVersionId,
+  })
 
   const handleCreate = useCallback(
     async (comment: CommentCreatePayload) => {

--- a/packages/sanity/src/core/comments/hooks/useNotificationTarget.ts
+++ b/packages/sanity/src/core/comments/hooks/useNotificationTarget.ts
@@ -12,6 +12,7 @@ interface NotificationTargetHookOptions {
   documentId: string
   documentType: string
   getCommentLink?: (commentId: string) => string
+  documentVersionId?: string
 }
 
 interface NotificationTargetHookValue {
@@ -31,7 +32,7 @@ interface NotificationTargetHookValue {
 export function useNotificationTarget(
   opts: NotificationTargetHookOptions,
 ): NotificationTargetHookValue {
-  const {documentId, documentType, getCommentLink} = opts || {}
+  const {documentId, documentType, getCommentLink, documentVersionId} = opts || {}
   const schemaType = useSchema().get(documentType)
   const {title: workspaceTitle} = useWorkspace()
 
@@ -39,8 +40,9 @@ export function useNotificationTarget(
 
   const previewStateObservable = useMemo(() => {
     if (!documentId || !schemaType) return of(null)
-    return getPreviewStateObservable(documentPreviewStore, schemaType, documentId)
-  }, [documentId, documentPreviewStore, schemaType])
+    const perspectiveStack = documentVersionId ? [documentVersionId, 'drafts'] : ['drafts']
+    return getPreviewStateObservable(documentPreviewStore, schemaType, documentId, perspectiveStack)
+  }, [documentId, documentPreviewStore, schemaType, documentVersionId])
   const previewState = useObservable(previewStateObservable)
 
   const {snapshot, original} = previewState || {}


### PR DESCRIPTION
### Description
When creating comments in a `version` document we were not updating the document title that is used for the notification target.
So if a document had a title in the draft or published version which was different to the release version the notification would contain the incorrect title.

With this changes, we will pass a perspective stack to the `getPreviewStateObservable` so it will now use the expected title.

See for example this comments [created here ](https://ppsg7ml5.api.sanity.io/v2025-03-20/data/query/test-cmts?query=*%5B_type+%3D%3D+%22comment%22+%26%26+target.document._ref+%3D%3D+%24documentId+%26%26+target.documentVersionId%3D%3D%24documentVersionId%5D+%7B%0A++_createdAt%2C%0A++_id%2C%0A+context+%7B%0A+++++notification+%7B%0A++++++++documentTitle%0A+++++%7D%0A+%7D%0A%7D+%7C+order%28_createdAt+desc%29&%24documentId=%22f60cd32f-c2bf-4ddf-8caf-6d1669dd7d5f%22&%24documentVersionId=%22rjOthGRpu%22&perspective=rjOthGRpu%2Cdrafts)
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Does the changes make sense?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Create a comment and see the notification target created, it should contain the correct title
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in where comments created in a version document could contain the title of the draft or published version in the notification email
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
