### PR TITLE
chore(ci): set lerna loglevel=debug

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,7 @@
 {
   "$schema": "node_modules/@lerna-lite/cli/schemas/lerna-schema.json",
   "npmClient": "pnpm",
+  "loglevel": "debug",
   "packages": [
     "dev/*",
     "perf/tests",


### PR DESCRIPTION
### Description
Seeing an error when running `lerna version` that only happens in the github container (reported here: https://github.com/lerna-lite/lerna-lite/issues/1061). Enabling debug logging for lerna lite to get more details.