### PR TITLE
feat(sanity): allow workspace switching in Dashboard

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -10,7 +10,6 @@ import {
 import {styled} from 'styled-components'
 
 import {MenuButton, type MenuButtonProps, MenuItem, Tooltip} from '../../../../../ui-components'
-import {CapabilityGate} from '../../../../components/CapabilityGate'
 import {useTranslation} from '../../../../i18n'
 import {useActiveWorkspace} from '../../../activeWorkspaceMatcher'
 import {useWorkspaces} from '../../../workspaces'
@@ -54,11 +53,9 @@ export function WorkspaceMenuButton() {
                     {activeWorkspace.title}
                   </Text>
                 </Box>
-                <CapabilityGate capability="globalWorkspaceControl">
-                  <Text size={1}>
-                    <ChevronDownIcon />
-                  </Text>
-                </CapabilityGate>
+                <Text size={1}>
+                  <ChevronDownIcon />
+                </Text>
               </Flex>
             </UIButton>
           </Tooltip>
@@ -67,41 +64,39 @@ export function WorkspaceMenuButton() {
       id="workspace-menu"
       menu={
         !disabled && authStates ? (
-          <CapabilityGate capability="globalWorkspaceControl">
-            <StyledMenu>
-              {workspaces.map((workspace) => {
-                const authState = authStates[workspace.name]
+          <StyledMenu>
+            {workspaces.map((workspace) => {
+              const authState = authStates[workspace.name]
 
-                // eslint-disable-next-line no-nested-ternary
-                const state = authState.authenticated
-                  ? 'logged-in'
-                  : workspace.auth.LoginComponent
-                    ? 'logged-out'
-                    : 'no-access'
+              // eslint-disable-next-line no-nested-ternary
+              const state = authState.authenticated
+                ? 'logged-in'
+                : workspace.auth.LoginComponent
+                  ? 'logged-out'
+                  : 'no-access'
 
-                const isSelected = workspace.name === activeWorkspace.name
+              const isSelected = workspace.name === activeWorkspace.name
 
-                // we have a temporary need to make a hard direct link to the workspace
-                // because of possibly shared context between workspaces. When this is resolved,
-                // we can remove this and use setActiveWorkspace instead
-                return (
-                  <MenuItem
-                    as="a"
-                    href={workspace.basePath}
-                    badgeText={STATE_TITLES[state]}
-                    iconRight={isSelected ? CheckmarkIcon : undefined}
-                    key={workspace.name}
-                    pressed={isSelected}
-                    preview={<WorkspacePreviewIcon icon={workspace.icon} size="small" />}
-                    selected={isSelected}
-                    __unstable_subtitle={workspace.subtitle}
-                    __unstable_space={1}
-                    text={workspace?.title || workspace.name}
-                  />
-                )
-              })}
-            </StyledMenu>
-          </CapabilityGate>
+              // we have a temporary need to make a hard direct link to the workspace
+              // because of possibly shared context between workspaces. When this is resolved,
+              // we can remove this and use setActiveWorkspace instead
+              return (
+                <MenuItem
+                  as="a"
+                  href={workspace.basePath}
+                  badgeText={STATE_TITLES[state]}
+                  iconRight={isSelected ? CheckmarkIcon : undefined}
+                  key={workspace.name}
+                  pressed={isSelected}
+                  preview={<WorkspacePreviewIcon icon={workspace.icon} size="small" />}
+                  selected={isSelected}
+                  __unstable_subtitle={workspace.subtitle}
+                  __unstable_space={1}
+                  text={workspace?.title || workspace.name}
+                />
+              )
+            })}
+          </StyledMenu>
         ) : undefined
       }
       popover={POPOVER_PROPS}


### PR DESCRIPTION
### Description

This branch reverts the earlier commit that switched off workspace switching when Studio is rendered in Dashboard. We have decided this ability should be provided.

<img width="438" alt="Screenshot 2025-06-04 at 17 09 20" src="https://github.com/user-attachments/assets/e8e17107-caeb-4ec4-9dd3-7de9bcb7d5c7" />

### What to review

- The presence of the global workspace switcher when Studio is rendered in Dashboard.

### Testing

- Viewed Test Studio in Dashboard.

### Notes for release

When using Studio inside Dashboard, it's now possible to switch Studio workspaces again.