### PR TITLE
fix: resolve `getAttribute` is not a function errors in PTE on next.js

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -2,7 +2,7 @@
 
 import {CloseIcon} from '@sanity/icons'
 import {Box, Flex, Text, useClickOutsideEvent, useGlobalKeyDown} from '@sanity/ui'
-import {type ReactNode, useCallback, useRef, useState} from 'react'
+import {type PropsWithChildren, type ReactNode, useCallback, useRef, useState} from 'react'
 import FocusLock from 'react-focus-lock'
 import {type PortableTextEditorElement} from 'sanity/_singletons'
 
@@ -22,6 +22,16 @@ interface PopoverEditDialogProps {
   title: string | ReactNode
   width?: ModalWidth
 }
+
+/**
+ * Wrapper for focus lock that maintains scroll on the popover
+ * Unlike Fragment (on some react versions) this does not absorb the ref prop
+ */
+const NoopContainer = ({children, ...props}: PropsWithChildren) => (
+  <div {...props} style={{maxHeight: '60vh'}}>
+    {children}
+  </div>
+)
 
 const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['top', 'bottom']
 
@@ -91,7 +101,7 @@ function Content(props: PopoverEditDialogProps) {
       containerElement={containerElement}
     >
       <FocusLock autoFocus whiteList={handleFocusLockWhiteList}>
-        <Flex ref={containerElement} direction="column" height="fill">
+        <Flex as={NoopContainer} ref={containerElement} direction="column" height="fill">
           <ContentHeaderBox flex="none" padding={1}>
             <Flex align="center">
               <Box flex={1} padding={2}>

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -2,7 +2,7 @@
 
 import {CloseIcon} from '@sanity/icons'
 import {Box, Flex, Text, useClickOutsideEvent, useGlobalKeyDown} from '@sanity/ui'
-import {Fragment, type ReactNode, useCallback, useRef, useState} from 'react'
+import {type ReactNode, useCallback, useRef, useState} from 'react'
 import FocusLock from 'react-focus-lock'
 import {type PortableTextEditorElement} from 'sanity/_singletons'
 
@@ -90,7 +90,7 @@ function Content(props: PopoverEditDialogProps) {
       scrollElement={contentElement}
       containerElement={containerElement}
     >
-      <FocusLock autoFocus as={Fragment} whiteList={handleFocusLockWhiteList}>
+      <FocusLock autoFocus whiteList={handleFocusLockWhiteList}>
         <Flex ref={containerElement} direction="column" height="fill">
           <ContentHeaderBox flex="none" padding={1}>
             <Flex align="center">


### PR DESCRIPTION
### Description

Looks like #8849 introduced a regression/issue. In an upcoming version of React (available on `next@canary`, or on `next@stable` with for example `experimental.viewTransition: true`) `Fragment` components can have a [`ref`](https://github.com/facebook/react/blob/37054867c15a7381abe0f73d98f3fecd06da52da/fixtures/dom/src/components/fixtures/fragment-refs/FocusCase.js#L45).
So it's no longer safe to give `<FocusLock>` an `as={Fragment}` prop.

### What to review

@jordanl17 do you recall the original reason why `as={Fragment}` where added, and if this PR might cause a regression?

### Testing

Clone https://github.com/sanity-io/template-nextjs-personal-website and add this below `reactCompiler: true` in `next.config.ts`:
```
viewTransition: true,
```

Next, run `npm install && npm run dev` and open `http://localhost:3000/studio/structure/settings` and click on a link mark in PTE to edit a PT link, you'll see this:
![image](https://github.com/user-attachments/assets/b0043c51-45bf-42a3-a09d-b8beda951bae)
It doesn't happen without `viewTransition: true`, since `react@19.1` doesn't support `ref` on `Fragment`, so `FocusLock` isn't thinking that the ref is set on a typical DOM element.

### Notes for release

Fixed an issue where `next@canary`, or `react@canary`, users would see an `getAttribute is not a function` error when attempting to edit a link in a Portable Text input field. You shouldn't have to choose between being able to fully use Sanity Studio's Portable Text Editor, or fun new React versions and features, and you no longer have to!

Fixes #9556, #9208, #9391
