### PR TITLE
chore(ci): use correct commit message for release pr

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -62,6 +62,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      - name: Get version commit message
+        # get the commit message created by npx lerna version above (determined by lerna.json)
+        id: version-commit
+        run: echo "message=$(git log -1 --pretty=%B)" >> $GITHUB_OUTPUT
+
       - name: Get version
         id: release-as
         run: echo "version=$(cat lerna.json | jq -r .version)" >> $GITHUB_OUTPUT
@@ -70,7 +75,7 @@ jobs:
         id: create-pull-request
         with:
           token: ${{ steps.app-token.outputs.token }}
-          title: "${{github.event.head_commit.message}}"
+          title: "${{steps.version-commit.outputs.message}}"
           body: "🤖 I have created a release **squib** **squob**\n\n Merging this PR will publish v${{steps.release-as.outputs.version}} to npm 🚀"
           branch: ci/release-main
           sign-commits: true


### PR DESCRIPTION
### Description

Turns out I introduced another silly mistake in #9555: instead of using the message from the _version commit_ created by `lerna version` we ended up using the commit message of the commit that triggered the workflow as the release PR title.

This restores the code that reads the commit message _after_ lerna version is done, assigns it to a workflow variable and uses it as comit title.

### What to review
Does it look correct?

### Testing

n/a - the release [PR](https://github.com/sanity-io/sanity/pull/9572) should get a pr reflecting the next version instead of the commit that triggered the workflow.

### Notes for release
n/a