### PR TITLE
feat(cli): update React and friends for Studios created via init

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/templates/appQuickstart.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/appQuickstart.ts
@@ -8,7 +8,7 @@ const appTemplate: ProjectTemplate = {
     'react-dom': '^19',
   },
   devDependencies: {
-    '@types/react': '^18.0.25',
+    '@types/react': '^19',
     'sanity': '^3',
     'typescript': '^5.1.6',
   },

--- a/packages/@sanity/cli/src/actions/init-project/templates/appSanityUi.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/appSanityUi.ts
@@ -10,7 +10,7 @@ const appSanityUiTemplate: ProjectTemplate = {
     'styled-components': '^6.1.17',
   },
   devDependencies: {
-    '@types/react': '^18.0.25',
+    '@types/react': '^19',
     'sanity': '^3',
     'typescript': '^5.1.6',
   },

--- a/packages/@sanity/cli/src/studioDependencies.ts
+++ b/packages/@sanity/cli/src/studioDependencies.ts
@@ -8,18 +8,18 @@ export const studioDependencies = {
     '@sanity/vision': 'latest',
 
     // Non-Sanity dependencies
-    'react': '^18.2.0',
-    'react-dom': '^18.2.0',
-    'styled-components': '^6.1.15',
+    'react': '^19.1',
+    'react-dom': '^19.1',
+    'styled-components': '^6.1.18',
   },
 
   devDependencies: {
     // Linting/tooling
     '@sanity/eslint-config-studio': 'latest',
     // When using typescript, we'll want the these types too, so might as well install them
-    '@types/react': '^18.0.25',
-    'eslint': '^9.9.0',
-    'prettier': '^3.0.2',
-    'typescript': '^5.1.6', // Peer dependency of eslint-config-studio (implicitly)
+    '@types/react': '^19.1',
+    'eslint': '^9.28',
+    'prettier': '^3.5',
+    'typescript': '^5.8', // Peer dependency of eslint-config-studio (implicitly)
   },
 }


### PR DESCRIPTION
### Description

Updates versions of various dependencies created via `sanity init` / `npm create sanity`

The significant changes here are `react` and `react-dom`, but they should be low risk as Studio has supported React 19 for a while now and development happens against v19 of both.

### What to review
Can be reviewed by installing the CLI via the pkg.pr.new version of this branch and running `sanity init` (make sure you install it globally)

### Notes for release

- Bumps version of React to 19 for Studios created via `sanity init` or `npm create sanity`