### PR TITLE
fix(cli): skip auto update prompt for non-interactive sessions

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -100,6 +100,11 @@ export default async function buildSanityStudio(
               value: 'upgrade-and-proceed',
               name: `Upgrade and proceed with ${args.groupOrCommand}`,
             },
+            {
+              type: 'choice',
+              value: 'continue',
+              name: `Continue anyway`,
+            },
             {type: 'choice', name: 'Cancel', value: 'cancel'},
           ],
           default: 'upgrade-and-proceed',


### PR DESCRIPTION
Note: builds on #9575

Closes #9575

### Description
Small one to add back the "Continue anyway" option to `sanity deploy` and `sanity build`. Selecting it should fall through later conditions and continue with the command.

### Testing
Easiest way to test is probably to install the pkg.pr.new version in a studio with auto-updates enable, run sanity build and check that selecting "Continue anyway" will proceed with the command.

### Notes for release
- Adds back the "Continue anyway" option to `sanity deploy` and `sanity build`