### PR TITLE
fix: fixing search for timezones

### DIFF
--- a/packages/sanity/src/core/components/timeZone/DialogTimeZone.tsx
+++ b/packages/sanity/src/core/components/timeZone/DialogTimeZone.tsx
@@ -142,6 +142,13 @@ const DialogTimeZone = (props: DialogTimeZoneProps) => {
             openButton
             options={allTimeZones}
             padding={4}
+            filterOption={(query: string, option: NormalizedTimeZone) => {
+              if (query === '') return true
+              return `${option.city} (GMT
+            ${option.offset}) ${option.alternativeName}`
+                ?.toLowerCase()
+                ?.includes(query?.toLowerCase())
+            }}
             placeholder={t('time-zone.action.search-for-timezone-placeholder')}
             popover={{
               boundaryElement:


### PR DESCRIPTION
### Description

When searching for timezones in the time zone modal, we were seeing that timezones that have spaces were not correctly being filtered in the list. This PR adds a custom `filterOption` on the `AutoComplete` function to make sure that it does the filtering correctly.

![Xnapper-2025-06-05-14 26 49](https://github.com/user-attachments/assets/72ec03bb-106d-4966-9b8a-793271af1e5a)

This allows you to search on all text that is shown in the rendering of the options in the timezone modal.

### What to review

Give it a test if you want!

### Testing


### Notes for release

Bug fix for wrong filtering results for timezone modal.
