### PR TITLE
fix: handle imperative focus state in slug input correctly

### DIFF
--- a/dev/studio-e2e-testing/package.json
+++ b/dev/studio-e2e-testing/package.json
@@ -24,7 +24,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "sanity": "workspace:*",
-    "sanity-plugin-markdown": "^5.0.0",
+    "sanity-plugin-markdown": "^5.1.1",
     "sanity-plugin-media": "^3.0.0",
     "sanity-plugin-mux-input": "^2.5.0",
     "sanity-test-studio": "workspace:*",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -60,7 +60,7 @@
     "rxjs": "^7.8.0",
     "sanity": "workspace:*",
     "sanity-plugin-hotspot-array": "^2.0.0",
-    "sanity-plugin-markdown": "^5.0.0",
+    "sanity-plugin-markdown": "^5.1.1",
     "sanity-plugin-media": "^3.0.0",
     "sanity-plugin-mux-input": "^2.5.0",
     "styled-components": "^6.1.15"

--- a/dev/test-studio/preview/Markdown.tsx
+++ b/dev/test-studio/preview/Markdown.tsx
@@ -1,0 +1,50 @@
+import {stegaClean} from '@sanity/client/stega'
+import {Box, Card, Code, Stack, Text} from '@sanity/ui'
+import {createDataAttribute} from '@sanity/visual-editing/create-data-attribute'
+import Refractor from 'react-refractor'
+import markdown from 'refractor/lang/markdown'
+
+import {useQuery} from './loader'
+
+Refractor.registerLanguage(markdown)
+
+export function Markdown(): React.JSX.Element {
+  const {data, loading, error} = useQuery<
+    {
+      _id: string
+      _type: string
+      title: string | null
+      markdown: string | null
+    }[]
+  >(/* groq */ `*[_type == "markdownTest"][0..10]{_id,_type,title,markdown}`)
+
+  if (error) {
+    throw error
+  }
+
+  if (loading) {
+    return <p>Loading...</p>
+  }
+
+  return (
+    <Box paddingX={4}>
+      {data?.map((item) => {
+        const dataAttribute = createDataAttribute({id: item._id, type: item._type})
+        return (
+          <Card key={item._id} padding={4}>
+            <Stack space={4}>
+              <Text weight={'bold'}>{item.title}</Text>
+              <Code
+                data-sanity={dataAttribute('markdown')}
+                language="markdown"
+                style={{overflowX: 'auto', overflowY: 'clip', paddingBlock: '1rem'}}
+              >
+                {stegaClean(item.markdown)}
+              </Code>
+            </Stack>
+          </Card>
+        )
+      })}
+    </Box>
+  )
+}

--- a/dev/test-studio/preview/main.tsx
+++ b/dev/test-studio/preview/main.tsx
@@ -5,10 +5,11 @@ import {createRoot} from 'react-dom/client'
 
 import {FieldGroups} from './FieldGroups'
 import {useLiveMode} from './loader'
+import {Markdown} from './Markdown'
 import {SimpleBlockPortableText} from './SimpleBlockPortableText'
 
 function Main() {
-  const [id, setId] = useState('simple')
+  const [id, setId] = useState<'simple' | 'nested' | 'markdown'>('simple')
   return (
     <>
       <ThemeProvider theme={studioTheme}>
@@ -29,6 +30,13 @@ function Main() {
                 onClick={() => setId('nested')}
                 selected={id === 'nested'}
               />
+              <Tab
+                aria-controls="markdown-pabel"
+                id="markdown-tab"
+                label="Markdown"
+                onClick={() => setId('markdown')}
+                selected={id === 'markdown'}
+              />
             </TabList>
           </Box>
 
@@ -41,6 +49,12 @@ function Main() {
           {id === 'nested' && (
             <TabPanel aria-labelledby="nested-tab" id="nested-panel">
               <FieldGroups />
+            </TabPanel>
+          )}
+
+          {id === 'markdown' && (
+            <TabPanel aria-labelledby="markdown-tab" id="markdown-panel">
+              <Markdown />
             </TabPanel>
           )}
         </Flex>

--- a/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
+++ b/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
@@ -41,6 +41,12 @@ export default defineType({
       type: 'string',
     },
     {
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: {source: 'title'},
+    },
+    {
       name: 'isMain',
       type: 'boolean',
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,8 +414,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sanity
       sanity-plugin-markdown:
-        specifier: ^5.0.0
-        version: 5.1.0(@emotion/is-prop-valid@1.3.1)(easymde@2.18.0)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        specifier: ^5.1.1
+        version: 5.1.1(@emotion/is-prop-valid@1.3.1)(easymde@2.18.0)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       sanity-plugin-media:
         specifier: ^3.0.0
         version: 3.0.2(@sanity/ui@2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
@@ -579,8 +579,8 @@ importers:
         specifier: ^2.0.0
         version: 2.2.0(@emotion/is-prop-valid@1.3.1)(@sanity/ui@2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       sanity-plugin-markdown:
-        specifier: ^5.0.0
-        version: 5.1.0(@emotion/is-prop-valid@1.3.1)(easymde@2.18.0)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        specifier: ^5.1.1
+        version: 5.1.1(@emotion/is-prop-valid@1.3.1)(easymde@2.18.0)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       sanity-plugin-media:
         specifier: ^3.0.0
         version: 3.0.2(@sanity/ui@2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
@@ -10796,8 +10796,8 @@ packages:
       sanity: ^3
       styled-components: ^6.1
 
-  sanity-plugin-markdown@5.1.0:
-    resolution: {integrity: sha512-lbgy5EdpgHEQKXiibV0zGdcGazTWCRxJ/7cqNOQa/u7yO4/ZAexQzmXzJp/KQaPdhgmJ1ejNwllSV8O7m0SA8w==}
+  sanity-plugin-markdown@5.1.1:
+    resolution: {integrity: sha512-sa3+9i5Mak7xGHHHHZsgPUx0iH9kzUEJsKM7EoWAHuD993lzAVKd3j0RvFpyiiGMbK95N5XZs4rPsQzRj3FPhA==}
     engines: {node: '>=18'}
     peerDependencies:
       easymde: ^2.18
@@ -22978,7 +22978,7 @@ snapshots:
       - '@emotion/is-prop-valid'
       - react-dom
 
-  sanity-plugin-markdown@5.1.0(@emotion/is-prop-valid@1.3.1)(easymde@2.18.0)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
+  sanity-plugin-markdown@5.1.1(@emotion/is-prop-valid@1.3.1)(easymde@2.18.0)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
     dependencies:
       '@sanity/incompatible-plugin': 1.0.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@sanity/ui': 2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))


### PR DESCRIPTION
### Description

Fixes an issue where clicking on a slug visual editing overlay simply won't focus the slug input.
In this PR two main paths for this is handled. In stega, although stega will be default filter out slugs, the Content Source Map is used to build the path to the field. Since the value lives on `slug.current`, that's what the path is too.
The same is true for folks using `import {createDataAttribute} from '@sanity/visual-editing/create-data-attribute'`:
```tsx
const dataAttribute = createDataAttribute({id: 'abc123', type: 'post'})

<article
  data-sanity={dataAttribute('slug.current')} // userland expects that to be the path, as they see that's the data structure it has
>
```

The Studio itself on the other hand, and the links it creates for comments, tasks, validation errors on slugs, they all use `slug` (if the field is named `slug`), not `slug.current`. That's the second path that's supported, ensuring that both patterns will focus the input field.

### What to review

Are there enough comments and context?

### Testing

Slugs are added to `SimpleBlockPortableText` on `http://localhost:3333/test/presentation` so you can click and test. If you click on the `<article>` node with a `data-sanity`, it links to `slug` and should focus the slug input.
If you click on the inline `<p data-sanity>` with the prefix text `slug:`, it uses `slug.current`, which should also work.
Finally, a new `Markdown` test in Presentation is added to test a similar issue that were fixed in `sanity-plugin-markdown` in [v5.1.1](https://github.com/sanity-io/sanity-plugin-markdown/releases/tag/v5.1.1).

### Notes for release

Click to edit on paths to slug inputs now focuses the slug input. It's amazing what modern technology can do 🤯 