### PR TITLE
Add tests for diff view hooks

### DIFF
--- a/packages/sanity/src/core/i18n/hooks/__tests__/__mocks__/useLocale.mock.ts
+++ b/packages/sanity/src/core/i18n/hooks/__tests__/__mocks__/useLocale.mock.ts
@@ -1,0 +1,16 @@
+import {type Mock, type Mocked, vi} from 'vitest'
+
+import {type Locale} from '../../types'
+import {useLocale, useCurrentLocale} from '../useLocale'
+
+export const mockLocale: Locale = {id: 'en-US', title: 'English'}
+
+export const useLocaleMockReturn: Mocked<ReturnType<typeof useLocale>> = {
+  locales: [mockLocale],
+  currentLocale: mockLocale,
+  __internal: {i18next: {} as any},
+  changeLocale: vi.fn(),
+}
+
+export const mockUseLocale = useLocale as Mock<typeof useLocale>
+export const mockUseCurrentLocale = useCurrentLocale as Mock<typeof useCurrentLocale>

--- a/packages/sanity/src/core/i18n/hooks/__tests__/useI18nText.test.ts
+++ b/packages/sanity/src/core/i18n/hooks/__tests__/useI18nText.test.ts
@@ -1,0 +1,28 @@
+import {renderHook} from '@testing-library/react'
+import {describe, it, expect, vi} from 'vitest'
+
+import {useI18nText} from '../useI18nText'
+import {useTranslation} from '../useTranslation'
+
+vi.mock('../useTranslation', () => ({useTranslation: vi.fn()}))
+
+const mockUseTranslation = useTranslation as unknown as ReturnType<typeof vi.fn>
+
+const node = {
+  title: 'Title',
+  i18n: {title: {key: 'titleKey', ns: 'test'}},
+}
+
+describe('useI18nText', () => {
+  it('returns translated values', () => {
+    mockUseTranslation.mockReturnValue({t: vi.fn(() => 'Translated')})
+    const {result} = renderHook(() => useI18nText(node))
+    expect(result.current.title).toBe('Translated')
+  })
+
+  it('falls back to default', () => {
+    mockUseTranslation.mockReturnValue({t: vi.fn(() => 'Default')})
+    const {result} = renderHook(() => useI18nText({label: 'Label'} as any))
+    expect(result.current.label).toBe('Label')
+  })
+})

--- a/packages/sanity/src/core/i18n/hooks/__tests__/useLocale.test.tsx
+++ b/packages/sanity/src/core/i18n/hooks/__tests__/useLocale.test.tsx
@@ -1,0 +1,33 @@
+import {renderHook} from '@testing-library/react'
+import {describe, it, expect, vi} from 'vitest'
+
+import {LocaleContext} from 'sanity/_singletons'
+import {useLocale, useCurrentLocale} from '../useLocale'
+
+const wrapper = ({children}: {children: React.ReactNode}) => {
+  const value = {
+    locales: [{id: 'en-US', title: 'English'}],
+    currentLocale: {id: 'en-US', title: 'English'},
+    __internal: {i18next: {} as any},
+    changeLocale: vi.fn(),
+  }
+  return <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>
+}
+
+describe('useLocale', () => {
+  it('returns context value', () => {
+    const {result} = renderHook(() => useLocale(), {wrapper})
+    expect(result.current.currentLocale.id).toBe('en-US')
+  })
+
+  it('throws if context missing', () => {
+    expect(() => renderHook(() => useLocale())).toThrow('Sanity LocaleContext value missing')
+  })
+})
+
+describe('useCurrentLocale', () => {
+  it('returns current locale', () => {
+    const {result} = renderHook(() => useCurrentLocale(), {wrapper})
+    expect(result.current.id).toBe('en-US')
+  })
+})

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useCreatePathSyncChannel.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useCreatePathSyncChannel.mock.ts
@@ -1,0 +1,10 @@
+import {Subject} from 'rxjs'
+import {type Mock} from 'vitest'
+
+import {useCreatePathSyncChannel} from '../../useCreatePathSyncChannel'
+
+export const mockUseCreatePathSyncChannelReturn = new Subject()
+
+export const mockUseCreatePathSyncChannel = useCreatePathSyncChannel as Mock<
+  typeof useCreatePathSyncChannel
+>

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useDiffViewRouter.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useDiffViewRouter.mock.ts
@@ -1,0 +1,10 @@
+import {type Mock, type Mocked, vi} from 'vitest'
+
+import {type DiffViewRouter, useDiffViewRouter} from '../../useDiffViewRouter'
+
+export const useDiffViewRouterMockReturn: Mocked<DiffViewRouter> = {
+  navigateDiffView: vi.fn(),
+  exitDiffView: vi.fn(),
+}
+
+export const mockUseDiffViewRouter = useDiffViewRouter as Mock<typeof useDiffViewRouter>

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useDiffViewState.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useDiffViewState.mock.ts
@@ -1,0 +1,7 @@
+import {type Mock} from 'vitest'
+
+import {type useDiffViewState as useDiffViewStateFn} from '../../useDiffViewState'
+
+export const useDiffViewStateMockReturn = {isActive: false} as ReturnType<typeof useDiffViewStateFn>
+
+export const mockUseDiffViewState = useDiffViewStateFn as Mock<typeof useDiffViewStateFn>

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/usePathSyncChannel.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/usePathSyncChannel.mock.ts
@@ -1,0 +1,13 @@
+import {Subject} from 'rxjs'
+import {type Mock, type Mocked, vi} from 'vitest'
+
+import {type usePathSyncChannel as usePathSyncChannelFn} from '../../usePathSyncChannel'
+
+export const usePathSyncChannelMockReturn: Mocked<ReturnType<typeof usePathSyncChannelFn>> = {
+  push: vi.fn(),
+  path: new Subject(),
+}
+
+export const mockUsePathSyncChannel = usePathSyncChannelFn as unknown as Mock<
+  typeof usePathSyncChannelFn
+>

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useScrollMirror.mock.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/__mocks__/useScrollMirror.mock.ts
@@ -1,0 +1,5 @@
+import {type Mock} from 'vitest'
+
+import {type useScrollMirror as useScrollMirrorFn} from '../../useScrollMirror'
+
+export const mockUseScrollMirror = useScrollMirrorFn as Mock<typeof useScrollMirrorFn>

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/useCreatePathSyncChannel.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/useCreatePathSyncChannel.test.ts
@@ -1,0 +1,22 @@
+import {renderHook} from '@testing-library/react'
+import {Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {useCreatePathSyncChannel} from '../useCreatePathSyncChannel'
+
+describe('useCreatePathSyncChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('returns a Subject instance', () => {
+    const {result} = renderHook(() => useCreatePathSyncChannel())
+    expect(result.current).toBeInstanceOf(Subject)
+  })
+
+  it('returns the same instance between renders', () => {
+    const {result, rerender} = renderHook(() => useCreatePathSyncChannel())
+    const first = result.current
+    rerender()
+    expect(result.current).toBe(first)
+  })
+})

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/useDiffViewRouter.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/useDiffViewRouter.test.ts
@@ -1,0 +1,61 @@
+import {renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {
+  DIFF_SEARCH_PARAM_DELIMITER,
+  DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_SEARCH_PARAMETER,
+} from '../../constants'
+import {useDiffViewRouter} from '../useDiffViewRouter'
+import {mockUseRouter, mockUseRouterReturn} from '../../../../../test/mocks/useRouter.mock'
+
+vi.mock('sanity/router', () => ({
+  useRouter: vi.fn(() => mockUseRouterReturn),
+}))
+
+describe('useDiffViewRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('navigateDiffView updates router search params', () => {
+    mockUseRouterReturn.state._searchParams = [['foo', 'bar']]
+    const {result} = renderHook(() => useDiffViewRouter())
+
+    result.current.navigateDiffView({
+      mode: 'version',
+      previousDocument: {type: 'book', id: 'a'},
+      nextDocument: {type: 'book', id: 'b'},
+    })
+
+    expect(mockUseRouterReturn.navigate).toHaveBeenCalledWith({
+      ...mockUseRouterReturn.state,
+      _searchParams: [
+        ['foo', 'bar'],
+        [DIFF_VIEW_SEARCH_PARAMETER, 'version'],
+        [
+          DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
+          ['book', 'a'].join(DIFF_SEARCH_PARAM_DELIMITER),
+        ],
+        [DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER, ['book', 'b'].join(DIFF_SEARCH_PARAM_DELIMITER)],
+      ],
+    })
+  })
+
+  it('exitDiffView removes diff related params', () => {
+    mockUseRouterReturn.state._searchParams = [
+      [DIFF_VIEW_SEARCH_PARAMETER, 'version'],
+      [DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER, 'a,a'],
+      [DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER, 'b,b'],
+      ['other', '1'],
+    ]
+    const {result} = renderHook(() => useDiffViewRouter())
+
+    result.current.exitDiffView()
+
+    expect(mockUseRouterReturn.navigate).toHaveBeenCalledWith({
+      ...mockUseRouterReturn.state,
+      _searchParams: [['other', '1']],
+    })
+  })
+})

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/useDiffViewState.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/useDiffViewState.test.ts
@@ -1,0 +1,56 @@
+import {renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {
+  DIFF_SEARCH_PARAM_DELIMITER,
+  DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_SEARCH_PARAMETER,
+} from '../../constants'
+import {useDiffViewState} from '../useDiffViewState'
+import {mockUseRouter, mockUseRouterReturn} from '../../../../../test/mocks/useRouter.mock'
+
+vi.mock('sanity/router', () => ({
+  useRouter: vi.fn(() => mockUseRouterReturn),
+}))
+
+describe('useDiffViewState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns inactive when no params set', () => {
+    mockUseRouterReturn.state._searchParams = []
+    const {result} = renderHook(() => useDiffViewState())
+    expect(result.current).toEqual({isActive: false})
+  })
+
+  it('parses valid params', () => {
+    mockUseRouterReturn.state._searchParams = [
+      [DIFF_VIEW_SEARCH_PARAMETER, 'version'],
+      [
+        DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
+        ['book', 'a'].join(DIFF_SEARCH_PARAM_DELIMITER),
+      ],
+      [DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER, ['book', 'b'].join(DIFF_SEARCH_PARAM_DELIMITER)],
+    ]
+    const {result} = renderHook(() => useDiffViewState())
+    expect(result.current).toEqual({
+      isActive: true,
+      state: 'ready',
+      mode: 'version',
+      documents: {previous: {type: 'book', id: 'a'}, next: {type: 'book', id: 'b'}},
+    })
+  })
+
+  it('reports error for invalid params', () => {
+    const errors: any[] = []
+    mockUseRouterReturn.state._searchParams = [
+      [DIFF_VIEW_SEARCH_PARAMETER, 'invalid'],
+      [DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER, 'wrong'],
+    ]
+    const {result} = renderHook(() => useDiffViewState({onParamsError: (e) => errors.push(e)}))
+    expect(result.current).toEqual({isActive: false})
+    expect(errors.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/usePathSyncChannel.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/usePathSyncChannel.test.ts
@@ -1,0 +1,35 @@
+import {renderHook} from '@testing-library/react'
+import {Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {type PathSyncState} from '../types/pathSyncChannel'
+import {usePathSyncChannel} from '../usePathSyncChannel'
+
+describe('usePathSyncChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('push sends state with source id', () => {
+    const syncChannel = new Subject<PathSyncState>()
+    const {result} = renderHook(() => usePathSyncChannel({syncChannel, id: 'pane'}))
+    const spy = vi.spyOn(syncChannel, 'next')
+
+    result.current.push({path: ['foo']})
+    expect(spy).toHaveBeenCalledWith({path: ['foo'], source: 'pane'})
+  })
+
+  it('path emits changes from other sources and ignores duplicates', () => {
+    const syncChannel = new Subject<PathSyncState>()
+    const {result} = renderHook(() => usePathSyncChannel({syncChannel, id: 'a'}))
+    const values: any[] = []
+    const sub = result.current.path.subscribe((v) => values.push(v))
+
+    syncChannel.next({path: ['foo'], source: 'a'})
+    syncChannel.next({path: ['foo'], source: 'b'})
+    syncChannel.next({path: ['foo'], source: 'b'})
+    syncChannel.next({path: ['bar'], source: 'b'})
+    sub.unsubscribe()
+
+    expect(values).toEqual([['bar']])
+  })
+})

--- a/packages/sanity/src/structure/diffView/hooks/__tests__/useScrollMirror.test.tsx
+++ b/packages/sanity/src/structure/diffView/hooks/__tests__/useScrollMirror.test.tsx
@@ -1,0 +1,43 @@
+import {renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {useScrollMirror} from '../useScrollMirror'
+
+const created: HTMLElement[][] = []
+let destroyCount = 0
+
+vi.mock('scrollmirror', () => ({
+  default: class ScrollMirror {
+    constructor(public elements: HTMLElement[]) {
+      created.push(elements)
+    }
+    destroy() {
+      destroyCount++
+    }
+  },
+}))
+
+describe('useScrollMirror', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    created.length = 0
+    destroyCount = 0
+  })
+
+  it('initializes and destroys ScrollMirror', () => {
+    const el1 = document.createElement('div')
+    const el2 = document.createElement('div')
+    const {unmount} = renderHook(() => useScrollMirror([el1, el2]))
+
+    expect(created).toEqual([[el1, el2]])
+    unmount()
+    expect(destroyCount).toBe(1)
+  })
+
+  it('does nothing when all elements are null', () => {
+    const {unmount} = renderHook(() => useScrollMirror([null, null]))
+    unmount()
+    expect(created.length).toBe(0)
+    expect(destroyCount).toBe(0)
+  })
+})

--- a/packages/sanity/src/structure/hooks/__tests__/__mocks__/useDocumentIdStack.mock.ts
+++ b/packages/sanity/src/structure/hooks/__tests__/__mocks__/useDocumentIdStack.mock.ts
@@ -1,0 +1,12 @@
+import {type Mock, type Mocked} from 'vitest'
+
+import {type useDocumentIdStack as useDocumentIdStackFn} from '../../useDocumentIdStack'
+
+export const useDocumentIdStackMockReturn: Mocked<ReturnType<typeof useDocumentIdStackFn>> = {
+  position: -1,
+  stack: [],
+  previousId: undefined,
+  nextId: undefined,
+}
+
+export const mockUseDocumentIdStack = useDocumentIdStackFn as Mock<typeof useDocumentIdStackFn>

--- a/packages/sanity/src/structure/hooks/__tests__/__mocks__/useFilteredReleases.mock.ts
+++ b/packages/sanity/src/structure/hooks/__tests__/__mocks__/useFilteredReleases.mock.ts
@@ -1,0 +1,11 @@
+import {type Mock, type Mocked} from 'vitest'
+
+import {type useFilteredReleases as useFilteredReleasesFn} from '../../useFilteredReleases'
+
+export const useFilteredReleasesMockReturn: Mocked<ReturnType<typeof useFilteredReleasesFn>> = {
+  currentReleases: [],
+  notCurrentReleases: [],
+  inCreation: null,
+}
+
+export const mockUseFilteredReleases = useFilteredReleasesFn as Mock<typeof useFilteredReleasesFn>

--- a/packages/sanity/src/structure/hooks/__tests__/useDocumentIdStack.test.ts
+++ b/packages/sanity/src/structure/hooks/__tests__/useDocumentIdStack.test.ts
@@ -1,0 +1,68 @@
+import {renderHook} from '@testing-library/react'
+import {getVersionId} from 'sanity'
+import {beforeEach, describe, expect, it, vi, type Mock} from 'vitest'
+
+import {useDocumentIdStack} from '../useDocumentIdStack'
+
+vi.mock('../useFilteredReleases', () => ({
+  useFilteredReleases: vi.fn(),
+}))
+
+import {useFilteredReleases} from '../useFilteredReleases'
+
+const mockUseFilteredReleases = useFilteredReleases as Mock<typeof useFilteredReleases>
+
+const baseEditState = {
+  id: 'foo',
+  published: {_id: 'foo'},
+  draft: {_id: 'drafts.foo'},
+}
+
+describe('useDocumentIdStack', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseFilteredReleases.mockReturnValue({
+      currentReleases: [],
+      notCurrentReleases: [],
+      inCreation: null,
+    })
+  })
+
+  it('returns stack including release versions', () => {
+    mockUseFilteredReleases.mockReturnValue({
+      currentReleases: [{_id: '_.releases.r1'}],
+      notCurrentReleases: [],
+      inCreation: null,
+    })
+
+    const {result} = renderHook(() =>
+      useDocumentIdStack({
+        displayed: {_id: 'foo'},
+        documentId: 'foo',
+        editState: baseEditState,
+      }),
+    )
+
+    expect(result.current.stack).toEqual([
+      baseEditState.published._id,
+      baseEditState.draft._id,
+      getVersionId('foo', 'r1'),
+    ])
+    expect(result.current.previousId).toBeUndefined()
+    expect(result.current.nextId).toBe('drafts.foo')
+  })
+
+  it('computes position for displayed document', () => {
+    const {result} = renderHook(() =>
+      useDocumentIdStack({
+        displayed: {_id: baseEditState.draft._id},
+        documentId: 'foo',
+        editState: baseEditState,
+      }),
+    )
+
+    expect(result.current.position).toBe(1)
+    expect(result.current.previousId).toBe('foo')
+    expect(result.current.nextId).toBeUndefined()
+  })
+})

--- a/packages/sanity/src/structure/hooks/__tests__/useFilteredReleases.test.ts
+++ b/packages/sanity/src/structure/hooks/__tests__/useFilteredReleases.test.ts
@@ -1,0 +1,67 @@
+import {renderHook} from '@testing-library/react'
+import {
+  getVersionId,
+  useActiveReleases,
+  useArchivedReleases,
+  useDocumentVersions,
+  usePerspective,
+} from 'sanity'
+import {beforeEach, describe, expect, it, vi, type Mock} from 'vitest'
+
+import {useFilteredReleases} from '../useFilteredReleases'
+
+vi.mock('sanity', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useActiveReleases: vi.fn(),
+  useArchivedReleases: vi.fn(),
+  useDocumentVersions: vi.fn(),
+  usePerspective: vi.fn(),
+}))
+vi.mock('../../components/paneRouter/usePaneRouter', () => ({
+  usePaneRouter: vi.fn(),
+}))
+
+import {usePaneRouter} from '../../components/paneRouter/usePaneRouter'
+
+const mockUseActiveReleases = useActiveReleases as Mock<typeof useActiveReleases>
+const mockUseArchivedReleases = useArchivedReleases as Mock<typeof useArchivedReleases>
+const mockUseDocumentVersions = useDocumentVersions as Mock<typeof useDocumentVersions>
+const mockUsePerspective = usePerspective as Mock<typeof usePerspective>
+const mockUsePaneRouter = usePaneRouter as Mock<typeof usePaneRouter>
+
+const releaseA = {_id: '_.releases.ra', _type: 'system.release', state: 'draft'}
+const releaseB = {_id: '_.releases.rb', _type: 'system.release', state: 'draft'}
+
+describe('useFilteredReleases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUsePaneRouter.mockReturnValue({params: {}})
+  })
+
+  it('categorizes current and non-current releases', () => {
+    mockUseActiveReleases.mockReturnValue({data: [releaseA, releaseB]})
+    mockUseArchivedReleases.mockReturnValue({data: []})
+    mockUseDocumentVersions.mockReturnValue({data: [getVersionId('foo', 'rb')]})
+    mockUsePerspective.mockReturnValue({selectedReleaseId: undefined} as any)
+
+    const {result} = renderHook(() =>
+      useFilteredReleases({displayed: {_id: 'foo'}, documentId: 'foo'}),
+    )
+
+    expect(result.current.currentReleases).toEqual([releaseB])
+    expect(result.current.notCurrentReleases).toEqual([releaseA])
+    expect(result.current.inCreation).toBeNull()
+  })
+
+  it('returns inCreation when creating new document for release', () => {
+    mockUseActiveReleases.mockReturnValue({data: [releaseA]})
+    mockUseArchivedReleases.mockReturnValue({data: []})
+    mockUseDocumentVersions.mockReturnValue({data: []})
+    mockUsePerspective.mockReturnValue({selectedReleaseId: 'ra'} as any)
+
+    const displayed = {_id: getVersionId('foo', 'ra')} as any
+    const {result} = renderHook(() => useFilteredReleases({displayed, documentId: 'foo'}))
+
+    expect(result.current.inCreation).toEqual(releaseA)
+  })
+})


### PR DESCRIPTION
## Summary
- add mock utilities for diff view hooks
- test `useCreatePathSyncChannel`
- test `usePathSyncChannel`
- test `useDiffViewRouter`
- test `useFilteredReleases`
- test `useDocumentIdStack`
- test `useDiffViewState`
- test `useScrollMirror`
- add i18n hook mocks
- test `useLocale` and `useI18nText`

## Testing
- `pnpm run test:vitest run packages/sanity/src/core/i18n/hooks/__tests__/useLocale.test.tsx`
- `pnpm run test:vitest run packages/sanity/src/core/i18n/hooks/__tests__/useI18nText.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_682d191b25e0832dbe4904ce33cfaa52