### PR TITLE
feat(sanity): make `ReleasesNav` shareable

### DIFF
--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -11,6 +11,7 @@ export * from './FIXME'
 export * from './form'
 export * from './hooks'
 export * from './i18n'
+export {ReleasesNav} from './perspective/navbar/ReleasesNav'
 export {PerspectiveProvider} from './perspective/PerspectiveProvider'
 export {
   type PerspectiveContextValue,

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -17,6 +17,7 @@ export {
   type PerspectiveContextValue,
   type PerspectiveStack,
   type ReleaseId,
+  type ReleasesNavMenuItemPropsGetter,
   type SelectedPerspective,
 } from './perspective/types'
 export {useExcludedPerspective} from './perspective/useExcludedPerspective'

--- a/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenu.tsx
+++ b/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenu.tsx
@@ -7,7 +7,7 @@ import {styled} from 'styled-components'
 import {MenuButton} from '../../../ui-components'
 import {CreateReleaseDialog} from '../../releases/components/dialog/CreateReleaseDialog'
 import {oversizedButtonStyle} from '../styles'
-import {type ReleaseId} from '../types'
+import {type ReleaseId, type ReleasesNavMenuItemPropsGetter} from '../types'
 import {ReleasesList} from './ReleasesList'
 import {useScrollIndicatorVisibility} from './useScrollIndicatorVisibility'
 
@@ -22,9 +22,11 @@ const OversizedButton = styled(Button)`
 export function GlobalPerspectiveMenu({
   selectedReleaseId,
   areReleasesEnabled = true,
+  menuItemProps,
 }: {
   selectedReleaseId: ReleaseId | undefined
   areReleasesEnabled: boolean
+  menuItemProps?: ReleasesNavMenuItemPropsGetter
 }): React.JSX.Element {
   const [createBundleDialogOpen, setCreateBundleDialogOpen] = useState(false)
   const styledMenuRef = useRef<HTMLDivElement>(null)
@@ -60,6 +62,7 @@ export function GlobalPerspectiveMenu({
               scrollElementRef={scrollElementRef}
               selectedReleaseId={selectedReleaseId}
               setCreateBundleDialogOpen={setCreateBundleDialogOpen}
+              menuItemProps={menuItemProps}
             />
           </StyledMenu>
         }

--- a/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenuItem.tsx
+++ b/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenuItem.tsx
@@ -22,6 +22,7 @@ import {
   isPublishedPerspective,
   isReleaseScheduledOrScheduling,
 } from '../../releases/util/util'
+import {type ReleasesNavMenuItemPropsGetter} from '../types'
 import {GlobalPerspectiveMenuItemIndicator} from './PerspectiveLayerIndicator'
 
 export interface LayerRange {
@@ -86,6 +87,7 @@ export const GlobalPerspectiveMenuItem = forwardRef<
   {
     release: ReleaseDocument | 'published' | typeof LATEST
     rangePosition: rangePosition
+    menuItemProps?: ReleasesNavMenuItemPropsGetter
   }
 >((props, ref) => {
   const {release, rangePosition} = props
@@ -144,6 +146,7 @@ export const GlobalPerspectiveMenuItem = forwardRef<
         padding={1}
         pressed={active}
         data-testid={`release-${releaseId}`}
+        {...props.menuItemProps?.({perspective: release})}
       >
         <Flex align="flex-start" gap={1}>
           <Box

--- a/packages/sanity/src/core/perspective/navbar/ReleaseTypeMenuSection.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleaseTypeMenuSection.tsx
@@ -5,7 +5,7 @@ import {useCallback} from 'react'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {usePerspective} from '../../perspective/usePerspective'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
-import {type ReleaseId} from '../types'
+import {type ReleaseId, type ReleasesNavMenuItemPropsGetter} from '../types'
 import {
   getRangePosition,
   GlobalPerspectiveMenuItem,
@@ -25,11 +25,13 @@ export function ReleaseTypeMenuSection({
   releases,
   range,
   currentGlobalBundleMenuItemRef,
+  menuItemProps,
 }: {
   releaseType: ReleaseType
   releases: ReleaseDocument[]
   range: LayerRange
   currentGlobalBundleMenuItemRef: React.RefObject<ScrollElement>
+  menuItemProps?: ReleasesNavMenuItemPropsGetter
 }): React.JSX.Element | null {
   const {t} = useTranslation()
   const {selectedReleaseId} = usePerspective()
@@ -66,6 +68,7 @@ export function ReleaseTypeMenuSection({
             key={release._id}
             ref={getMenuItemRef(getReleaseIdFromReleaseDocumentId(release._id))}
             rangePosition={getRangePosition(range, releaseTypeOffset + index)}
+            menuItemProps={menuItemProps}
           />
         ))}
       </Flex>

--- a/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
@@ -8,6 +8,7 @@ import {useReleasesUpsell} from '../../releases/contexts/upsell/useReleasesUpsel
 import {useActiveReleases} from '../../releases/store/useActiveReleases'
 import {LATEST} from '../../releases/util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
+import {type ReleasesNavMenuItemPropsGetter} from '../types'
 import {usePerspective} from '../usePerspective'
 import {
   getRangePosition,
@@ -48,6 +49,7 @@ export function ReleasesList({
   selectedReleaseId,
   setCreateBundleDialogOpen,
   scrollElementRef,
+  menuItemProps,
 }: {
   areReleasesEnabled: boolean
   setScrollContainer: (el: HTMLDivElement) => void
@@ -56,6 +58,7 @@ export function ReleasesList({
   selectedReleaseId: string | undefined
   setCreateBundleDialogOpen: (open: boolean) => void
   scrollElementRef: RefObject<ScrollElement>
+  menuItemProps?: ReleasesNavMenuItemPropsGetter
 }): React.JSX.Element {
   const {guardWithReleaseLimitUpsell} = useReleasesUpsell()
 
@@ -132,10 +135,12 @@ export function ReleasesList({
           <GlobalPerspectiveMenuItem
             rangePosition={isRangeVisible ? getRangePosition(range, 0) : undefined}
             release={'published'}
+            menuItemProps={menuItemProps}
           />
           <GlobalPerspectiveMenuItem
             rangePosition={isRangeVisible ? getRangePosition(range, 1) : undefined}
             release={LATEST}
+            menuItemProps={menuItemProps}
           />
         </StyledPublishedBox>
         {areReleasesEnabled && (
@@ -147,6 +152,7 @@ export function ReleasesList({
                 releases={sortedReleaseTypeReleases[releaseType]}
                 range={range}
                 currentGlobalBundleMenuItemRef={scrollElementRef}
+                menuItemProps={menuItemProps}
               />
             ))}
           </>

--- a/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
@@ -37,6 +37,10 @@ const ReleasesNavContainer = styled(Card)`
 interface Props {
   withReleasesToolButton?: boolean
 }
+
+/**
+ * @internal
+ */
 export const ReleasesNav: ComponentType<Props> = ({withReleasesToolButton}) => {
   const releasesToolAvailable = useReleasesToolAvailable()
   const {selectedPerspective, selectedReleaseId} = usePerspective()

--- a/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
@@ -1,4 +1,5 @@
 import {Card} from '@sanity/ui'
+import {type ComponentType} from 'react'
 import {styled} from 'styled-components'
 
 import {usePerspective} from '../../perspective/usePerspective'
@@ -33,13 +34,16 @@ const ReleasesNavContainer = styled(Card)`
   }
 `
 
-export function ReleasesNav(): React.JSX.Element {
+interface Props {
+  withReleasesToolButton?: boolean
+}
+export const ReleasesNav: ComponentType<Props> = ({withReleasesToolButton}) => {
   const releasesToolAvailable = useReleasesToolAvailable()
   const {selectedPerspective, selectedReleaseId} = usePerspective()
 
   return (
     <ReleasesNavContainer flex="none" tone="inherit" radius="full" data-ui="ReleasesNav" border>
-      {releasesToolAvailable && <ReleasesToolLink />}
+      {withReleasesToolButton && releasesToolAvailable && <ReleasesToolLink />}
       <CurrentGlobalPerspectiveLabel selectedPerspective={selectedPerspective} />
       <GlobalPerspectiveMenu
         selectedReleaseId={selectedReleaseId}

--- a/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
@@ -5,6 +5,7 @@ import {styled} from 'styled-components'
 import {usePerspective} from '../../perspective/usePerspective'
 import {useReleasesToolAvailable} from '../../releases/hooks/useReleasesToolAvailable'
 import {ReleasesToolLink} from '../ReleasesToolLink'
+import {type ReleasesNavMenuItemPropsGetter} from '../types'
 import {CurrentGlobalPerspectiveLabel} from './currentGlobalPerspectiveLabel'
 import {GlobalPerspectiveMenu} from './GlobalPerspectiveMenu'
 
@@ -36,12 +37,13 @@ const ReleasesNavContainer = styled(Card)`
 
 interface Props {
   withReleasesToolButton?: boolean
+  menuItemProps?: ReleasesNavMenuItemPropsGetter
 }
 
 /**
  * @internal
  */
-export const ReleasesNav: ComponentType<Props> = ({withReleasesToolButton}) => {
+export const ReleasesNav: ComponentType<Props> = ({withReleasesToolButton, menuItemProps}) => {
   const releasesToolAvailable = useReleasesToolAvailable()
   const {selectedPerspective, selectedReleaseId} = usePerspective()
 
@@ -52,6 +54,7 @@ export const ReleasesNav: ComponentType<Props> = ({withReleasesToolButton}) => {
       <GlobalPerspectiveMenu
         selectedReleaseId={selectedReleaseId}
         areReleasesEnabled={releasesToolAvailable}
+        menuItemProps={menuItemProps}
       />
     </ReleasesNavContainer>
   )

--- a/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesNav.test.tsx
+++ b/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesNav.test.tsx
@@ -61,7 +61,7 @@ const renderTest = async () => {
   const wrapper = await createTestProvider({
     resources: [],
   })
-  currentRenderedInstance = render(<ReleasesNav />, {wrapper})
+  currentRenderedInstance = render(<ReleasesNav withReleasesToolButton />, {wrapper})
 
   return currentRenderedInstance
 }

--- a/packages/sanity/src/core/perspective/navbar/currentGlobalPerspectiveLabel.tsx
+++ b/packages/sanity/src/core/perspective/navbar/currentGlobalPerspectiveLabel.tsx
@@ -57,7 +57,14 @@ function AnimatedTextWidth({children, text}: {children: ReactNode; text: string}
       onAnimationStart={onAnimationStart}
       onAnimationComplete={onAnimationComplete}
     >
-      <div ref={textRef} style={{display: 'inline-block', whiteSpace: 'nowrap'}}>
+      <div
+        ref={textRef}
+        style={{
+          display: 'inline-block',
+          whiteSpace: 'nowrap',
+          verticalAlign: 'middle',
+        }}
+      >
         {children}
       </div>
     </motion.div>

--- a/packages/sanity/src/core/perspective/types.ts
+++ b/packages/sanity/src/core/perspective/types.ts
@@ -1,4 +1,7 @@
 import {type ClientPerspective, type ReleaseDocument} from '@sanity/client'
+// eslint-disable-next-line no-restricted-imports -- fine-grained control needed
+import {type MenuItem} from '@sanity/ui'
+import {type ComponentProps} from 'react'
 
 /**
  * @beta
@@ -40,3 +43,10 @@ export interface PerspectiveContextValue {
 }
 
 type ExtractArray<Union> = Union extends unknown[] ? Union : never
+
+/**
+ * @internal
+ */
+export type ReleasesNavMenuItemPropsGetter = (content: {
+  perspective: SelectedPerspective
+}) => Partial<ComponentProps<typeof MenuItem>>

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -272,7 +272,7 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
                   </SearchProvider>
                 </LayerProvider>
 
-                <ReleasesNav />
+                <ReleasesNav withReleasesToolButton />
                 {actionNodes}
                 {shouldRender.tools && <FreeTrial type="topbar" />}
                 <PresenceMenu />

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -154,6 +154,7 @@ exports[`exports snapshot 1`] = `
     "ReferenceInputPreviewCard": "object",
     "RelativeTime": "function",
     "ReleaseAvatar": "function",
+    "ReleasesNav": "function",
     "Resizable": "function",
     "ResourceCacheProvider": "function",
     "RevertChangesButton": "object",


### PR DESCRIPTION
### Description

This PR takes some steps to make the `ReleasesNav` component shareable, as it's a very useful component to use outside of the nav bar.

For example, here's an upcoming piece of work that uses it in a banner:

<img width="681" alt="Screenshot 2025-06-06 at 09 37 26" src="https://github.com/user-attachments/assets/f0af1bf8-ac9d-43bc-9077-ecbe220e07b6" />

In the future, we should consider moving the files to a different directory.

### What to review

- The new export.
- The new `menuItemProps` prop, which allows consumers to customise the props of each menu item. The screenshot above demonstrates this being used to make release menu items inactive if a new document cannot be created within.

### Testing

Existing tests passing.
