### PR TITLE
fix: RUN-544 Do not automatically open dev server UI

### DIFF
--- a/packages/@sanity/cli/src/commands/functions/devFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/devFunctionsCommand.ts
@@ -5,6 +5,7 @@ import {type CliCommandDefinition} from '../../types'
 const helpText = `
 Options
   --port <port> Port to start emulator on
+  --no-open Skip opening dev server in a browser tab
 
 Examples
   # Start dev server on default port
@@ -12,13 +13,18 @@ Examples
 
   # Start dev server on specific port
   sanity functions dev --port 3333
+
+  # Start dev server without opening a browser tab
+  sanity functions dev --no-open
 `
 
 export interface FunctionsDevFlags {
+  open?: boolean
   port?: number
 }
 
 const defaultFlags: FunctionsDevFlags = {
+  open: true,
   port: 8080,
 }
 
@@ -26,11 +32,12 @@ const devFunctionsCommand: CliCommandDefinition<FunctionsDevFlags> = {
   name: 'dev',
   group: 'functions',
   helpText,
-  signature: '[--port <port>]',
+  signature: '[--port <port> --no-open]',
   description: 'Start the Sanity Function emulator',
   async action(args, context) {
     const {apiClient, output} = context
     const flags = {...defaultFlags, ...args.extOptions}
+    const {open: shouldOpen} = flags
 
     const client = apiClient({requireUser: true, requireProject: false})
     const {token} = client.config()
@@ -57,7 +64,9 @@ const devFunctionsCommand: CliCommandDefinition<FunctionsDevFlags> = {
 
     if (!success) throw new Error(error)
 
-    open(`http://localhost:${flags.port}`)
+    if (shouldOpen) {
+      open(`http://localhost:${flags.port}`)
+    }
   },
 }
 


### PR DESCRIPTION
### Description

I'm going to stack a few minor fixes to the CLI for when integrating with `functions` commands.

### What to review

- [RUN-544](https://linear.app/sanity/issue/RUN-544/do-not-automatically-open-dev-server-ui)

### Testing

- RUN-544: Try `sanity functions dev`, that should open a new browser tab. Close the tab and run `sanity functions dev --no-open`. That will not open a tab but you should be able to open a new tab yourself to reach the dev server.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
