### PR TITLE
chore(cli): update runtime-cli

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -60,7 +60,7 @@
     "@babel/traverse": "^7.23.5",
     "@sanity/client": "^7.5.0",
     "@sanity/codegen": "workspace:*",
-    "@sanity/runtime-cli": "^7.6.5",
+    "@sanity/runtime-cli": "^8.0.0",
     "@sanity/telemetry": "^0.8.0",
     "@sanity/template-validator": "^2.4.3",
     "@sanity/util": "workspace:3.91.0",

--- a/packages/@sanity/cli/src/commands/blueprints/stacksBlueprintsCommand.ts
+++ b/packages/@sanity/cli/src/commands/blueprints/stacksBlueprintsCommand.ts
@@ -55,7 +55,7 @@ const stacksBlueprintsCommand: CliCommandDefinition<BlueprintsStacksFlags> = {
     const {success, error} = await blueprintStacksCore({
       ...cmdConfig.value,
       flags: {
-        projectId: flags['project-id'] ?? flags.projectId ?? flags.project,
+        'project-id': flags['project-id'] ?? flags.projectId ?? flags.project,
       },
     })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
         version: 1.0.3(prettier@3.5.3)
       '@sanity/tsdoc':
         specifier: 1.0.169
-        version: 1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.13.1)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.38.2)(yaml@2.8.0)
+        version: 1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.13.1)(babel-plugin-react-compiler@19.1.0-rc.2)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.38.2)(yaml@2.8.0)
       '@sanity/ui':
         specifier: ^2.15.18
         version: 2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
@@ -112,10 +112,10 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))
+        version: 4.5.1(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))
       '@vitest/coverage-v8':
         specifier: 3.2.2
-        version: 3.2.2(vitest@3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0))
+        version: 3.2.2(vitest@3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0))
       cac:
         specifier: ^6.7.12
         version: 6.7.14
@@ -247,13 +247,13 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+        version: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.8.3)(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))
+        version: 4.3.2(typescript@5.8.3)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))
       vitest:
         specifier: 3.2.2
-        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
+        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
       yargs:
         specifier: ^17.3.0
         version: 17.3.0
@@ -307,13 +307,13 @@ importers:
         version: 19.1.3(@types/react@19.1.3)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))
+        version: 4.5.1(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))
       typescript:
         specifier: 5.8.3
         version: 5.8.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+        version: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
 
   dev/media-library-aspects-studio:
     dependencies:
@@ -511,7 +511,7 @@ importers:
         version: 1.11.0(@sanity/types@packages+@sanity+types)(react@19.1.0)(typescript@5.7.3)
       '@sanity/tsdoc':
         specifier: 1.0.169
-        version: 1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.13.1)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.38.2)(yaml@2.8.0)
+        version: 1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.13.1)(babel-plugin-react-compiler@19.1.0-rc.2)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.38.2)(yaml@2.8.0)
       '@sanity/types':
         specifier: workspace:*
         version: link:../../packages/@sanity/types
@@ -520,7 +520,7 @@ importers:
         version: 2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@sanity/ui-workshop':
         specifier: ^1.0.0
-        version: 1.2.11(@sanity/icons@3.7.0(react@19.1.0))(@sanity/ui@2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@types/node@22.13.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.38.2)(yaml@2.8.0)
+        version: 1.2.11(@sanity/icons@3.7.0(react@19.1.0))(@sanity/ui@2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@types/node@22.13.1)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.38.2)(yaml@2.8.0)
       '@sanity/util':
         specifier: workspace:*
         version: link:../../packages/@sanity/util
@@ -599,7 +599,7 @@ importers:
         version: 19.1.0-rc.2
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+        version: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
 
   examples/blog-studio:
     dependencies:
@@ -686,7 +686,7 @@ importers:
         version: link:../dev-aliases
       vitest:
         specifier: 3.2.2
-        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
+        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
 
   packages/@repo/test-exports:
     dependencies:
@@ -745,8 +745,8 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@sanity/runtime-cli':
-        specifier: ^7.6.5
-        version: 7.6.5(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.8.0)
+        specifier: ^8.0.0
+        version: 8.0.0(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.8.0)
       '@sanity/telemetry':
         specifier: ^0.8.0
         version: 0.8.1(react@19.1.0)
@@ -939,10 +939,10 @@ importers:
         version: 6.2.1
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+        version: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
       vitest:
         specifier: 3.2.2
-        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
+        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
       which:
         specifier: ^2.0.2
         version: 2.0.2
@@ -1024,7 +1024,7 @@ importers:
         version: 5.0.10
       vitest:
         specifier: 3.2.2
-        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
+        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
 
   packages/@sanity/diff:
     dependencies:
@@ -1083,7 +1083,7 @@ importers:
         version: 5.0.10
       vitest:
         specifier: 3.2.2
-        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
+        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
 
   packages/@sanity/mutator:
     dependencies:
@@ -1120,7 +1120,7 @@ importers:
         version: 5.0.10
       vitest:
         specifier: 3.2.2
-        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
+        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
 
   packages/@sanity/schema:
     dependencies:
@@ -1172,7 +1172,7 @@ importers:
         version: 5.0.10
       vitest:
         specifier: 3.2.2
-        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
+        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
 
   packages/@sanity/types:
     dependencies:
@@ -1194,7 +1194,7 @@ importers:
         version: 19.1.3
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))
+        version: 4.5.1(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1203,7 +1203,7 @@ importers:
         version: 5.0.10
       vitest:
         specifier: 3.2.2
-        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
+        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
 
   packages/@sanity/util:
     dependencies:
@@ -1240,7 +1240,7 @@ importers:
         version: 5.0.10
       vitest:
         specifier: 3.2.2
-        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
+        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
 
   packages/@sanity/vision:
     dependencies:
@@ -1529,7 +1529,7 @@ importers:
         version: 3.0.4
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))
+        version: 4.5.1(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))
       '@xstate/react':
         specifier: ^5.0.5
         version: 5.0.5(@types/react@19.1.3)(react@18.3.1)(xstate@5.19.4)
@@ -1784,7 +1784,7 @@ importers:
         version: 11.1.0
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+        version: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
       which:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1797,7 +1797,7 @@ importers:
     devDependencies:
       '@playwright/experimental-ct-react':
         specifier: 1.51.1
-        version: 1.51.1(@types/node@22.13.1)(terser@5.38.2)(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))(yaml@2.8.0)
+        version: 1.51.1(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))(yaml@2.8.0)
       '@playwright/test':
         specifier: 1.51.1
         version: 1.51.1
@@ -1821,10 +1821,10 @@ importers:
         version: 6.13.4(@types/babel__core@7.20.5)(@types/node@22.13.1)(babel-plugin-react-compiler@19.1.0-rc.2)(debug@4.4.1)(typescript@5.8.3)
       '@sanity/tsdoc':
         specifier: 1.0.169
-        version: 1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.13.1)(babel-plugin-react-compiler@19.1.0-rc.2)(debug@4.4.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.38.2)(yaml@2.8.0)
+        version: 1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.13.1)(babel-plugin-react-compiler@19.1.0-rc.2)(debug@4.4.1)(jiti@2.4.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.38.2)(yaml@2.8.0)
       '@sanity/ui-workshop':
         specifier: ^1.2.11
-        version: 1.2.11(@sanity/icons@3.7.0(react@18.3.1))(@sanity/ui@2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.38.2)(yaml@2.8.0)
+        version: 1.2.11(@sanity/icons@3.7.0(react@18.3.1))(@sanity/ui@2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/node@22.13.1)(jiti@2.4.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.38.2)(yaml@2.8.0)
       '@sanity/visual-editing-csm':
         specifier: ^2.0.18
         version: 2.0.18(@sanity/client@7.5.0(debug@4.4.1))(@sanity/types@packages+@sanity+types)(typescript@5.8.3)
@@ -1917,7 +1917,7 @@ importers:
         version: 2.2.5(react@18.3.1)
       vitest:
         specifier: 3.2.2
-        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
+        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
       vitest-package-exports:
         specifier: ^0.1.1
         version: 0.1.1
@@ -1980,7 +1980,7 @@ importers:
         version: 17.0.33
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.5.1(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))
+        version: 4.5.1(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.2
         version: 19.1.0-rc.2
@@ -2022,7 +2022,7 @@ importers:
         version: 0.7.4
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+        version: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
       yargs:
         specifier: 17.3.0
         version: 17.3.0
@@ -2095,7 +2095,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 3.2.2
-        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
+        version: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
 
 packages:
 
@@ -4847,9 +4847,9 @@ packages:
     peerDependencies:
       react: ^18.3 || >=19.0.0-rc
 
-  '@sanity/runtime-cli@7.6.5':
-    resolution: {integrity: sha512-9wASjIokchkdeg00/9CbKBLdQz/ZfpcaEYDKP8qbIgVaImYno2Z+pKe2Zi30ZNrccQ6ct1EGT0J4KEQsBVPWpw==}
-    engines: {node: '>=18.20.0'}
+  '@sanity/runtime-cli@8.0.0':
+    resolution: {integrity: sha512-ApwAN3S2KhfUS1kpBTiYRTGqfXYrqhkYE0Ej3qGsAg42JbcchSsnQeqmIO+RUa2L9vq86IZoSkNUapXfnEkxLg==}
+    engines: {node: '>=20.11.0'}
     hasBin: true
 
   '@sanity/sdk@0.0.0-alpha.25':
@@ -5862,6 +5862,9 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  ansicolors@0.3.2:
+    resolution: {integrity: sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==}
+
   ansis@3.17.0:
     resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
     engines: {node: '>=14'}
@@ -6297,6 +6300,10 @@ packages:
   caniuse-lite@1.0.30001717:
     resolution: {integrity: sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==}
 
+  cardinal@2.1.1:
+    resolution: {integrity: sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==}
+    hasBin: true
+
   castable-video@1.0.10:
     resolution: {integrity: sha512-tJgUv+8/zE191y8EKojvB0eKIyKA9obIttd6Wpdm6x2qBmuwZ7wDgzVCSmf5cN2v9jBiuu0s7O5poz8a8cFX/w==}
 
@@ -6472,10 +6479,6 @@ packages:
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
-
-  color-json@3.0.5:
-    resolution: {integrity: sha512-DG4zae1GmHDBNsYTUe+GJiDnuKutxs2vVSkPRQqbeA6oEGBRQyRixV+HmIByasCfyf9L0CwHo8vOoiHqe7Lzng==}
-    engines: {node: '>=12'}
 
   color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
@@ -8733,6 +8736,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
@@ -10474,6 +10481,9 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redeyed@2.1.1:
+    resolution: {integrity: sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==}
 
   redux-observable@3.0.0-rc.2:
     resolution: {integrity: sha512-gG/pWIKgSrcTyyavm2so5tc7tuyCQ47p3VdCAG6wt+CV0WGhDr50cMQHLcYKxFZSGgTm19a8ZmyfJGndmGDpYg==}
@@ -15049,11 +15059,11 @@ snapshots:
 
   '@pkgr/core@0.2.4': {}
 
-  '@playwright/experimental-ct-core@1.51.1(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)':
+  '@playwright/experimental-ct-core@1.51.1(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)':
     dependencies:
       playwright: 1.51.1
       playwright-core: 1.51.1
-      vite: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -15067,10 +15077,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@playwright/experimental-ct-react@1.51.1(@types/node@22.13.1)(terser@5.38.2)(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))(yaml@2.8.0)':
+  '@playwright/experimental-ct-react@1.51.1(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
-      '@playwright/experimental-ct-core': 1.51.1(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
-      '@vitejs/plugin-react': 4.5.1(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))
+      '@playwright/experimental-ct-core': 1.51.1(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
+      '@vitejs/plugin-react': 4.5.1(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -15969,28 +15979,28 @@ snapshots:
       - debug
       - typescript
 
-  '@sanity/runtime-cli@7.6.5(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.8.0)':
+  '@sanity/runtime-cli@8.0.0(@types/node@22.13.1)(terser@5.38.2)(typescript@5.8.3)(yaml@2.8.0)':
     dependencies:
       '@oclif/core': 4.3.0
       '@oclif/plugin-help': 6.2.28
       adm-zip: 0.5.16
       array-treeify: 0.1.5
+      cardinal: 2.1.1
       chalk: 5.4.1
-      color-json: 3.0.5
       eventsource: 4.0.0
       find-up: 7.0.0
       groq-js: 1.17.0
       inquirer: 12.6.1(@types/node@22.13.1)
+      jiti: 2.4.2
       mime-types: 3.0.1
       ora: 8.2.0
-      vite: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
-      vite-tsconfig-paths: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))
+      vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
+      vite-tsconfig-paths: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))
       ws: 8.18.2
       xdg-basedir: 5.1.0
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
-      - jiti
       - less
       - lightningcss
       - sass
@@ -16043,7 +16053,7 @@ snapshots:
       '@actions/github': 6.0.0
       yaml: 2.8.0
 
-  '@sanity/tsdoc@1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.13.1)(babel-plugin-react-compiler@19.1.0-rc.2)(debug@4.4.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.38.2)(yaml@2.8.0)':
+  '@sanity/tsdoc@1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.13.1)(babel-plugin-react-compiler@19.1.0-rc.2)(debug@4.4.1)(jiti@2.4.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.38.2)(yaml@2.8.0)':
     dependencies:
       '@microsoft/api-extractor': 7.49.0(@types/node@22.13.1)
       '@microsoft/api-extractor-model': 7.30.1(@types/node@22.13.1)
@@ -16057,7 +16067,7 @@ snapshots:
       '@sanity/pkg-utils': 6.13.4(@types/babel__core@7.20.5)(@types/node@22.13.1)(babel-plugin-react-compiler@19.1.0-rc.2)(debug@4.4.1)(typescript@5.7.3)
       '@sanity/ui': 2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@types/cpx': 1.5.5
-      '@vitejs/plugin-react': 4.5.1(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))
+      '@vitejs/plugin-react': 4.5.1(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))
       cac: 6.7.14
       chalk: 4.1.2
       chokidar: 4.0.3
@@ -16081,7 +16091,7 @@ snapshots:
       styled-components: 6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tmp: 0.2.3
       typescript: 5.7.3
-      vite: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/babel__core'
@@ -16101,7 +16111,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@sanity/tsdoc@1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.13.1)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.38.2)(yaml@2.8.0)':
+  '@sanity/tsdoc@1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.13.1)(babel-plugin-react-compiler@19.1.0-rc.2)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.38.2)(yaml@2.8.0)':
     dependencies:
       '@microsoft/api-extractor': 7.49.0(@types/node@22.13.1)
       '@microsoft/api-extractor-model': 7.30.1(@types/node@22.13.1)
@@ -16115,7 +16125,7 @@ snapshots:
       '@sanity/pkg-utils': 6.13.4(@types/babel__core@7.20.5)(@types/node@22.13.1)(babel-plugin-react-compiler@19.1.0-rc.2)(typescript@5.7.3)
       '@sanity/ui': 2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@types/cpx': 1.5.5
-      '@vitejs/plugin-react': 4.5.1(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))
+      '@vitejs/plugin-react': 4.5.1(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))
       cac: 6.7.14
       chalk: 4.1.2
       chokidar: 4.0.3
@@ -16139,7 +16149,7 @@ snapshots:
       styled-components: 6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tmp: 0.2.3
       typescript: 5.7.3
-      vite: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/babel__core'
@@ -16166,11 +16176,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/ui-workshop@1.2.11(@sanity/icons@3.7.0(react@18.3.1))(@sanity/ui@2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.38.2)(yaml@2.8.0)':
+  '@sanity/ui-workshop@1.2.11(@sanity/icons@3.7.0(react@18.3.1))(@sanity/ui@2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/node@22.13.1)(jiti@2.4.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.38.2)(yaml@2.8.0)':
     dependencies:
       '@sanity/icons': 3.7.0(react@18.3.1)
       '@sanity/ui': 2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@vitejs/plugin-react': 4.5.1(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))
+      '@vitejs/plugin-react': 4.5.1(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))
       axe-core: 4.10.2
       cac: 6.7.14
       chokidar: 3.6.0
@@ -16186,7 +16196,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       segmented-property: 3.0.3
       styled-components: 6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      vite: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -16201,11 +16211,11 @@ snapshots:
       - tsx
       - yaml
 
-  '@sanity/ui-workshop@1.2.11(@sanity/icons@3.7.0(react@19.1.0))(@sanity/ui@2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@types/node@22.13.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.38.2)(yaml@2.8.0)':
+  '@sanity/ui-workshop@1.2.11(@sanity/icons@3.7.0(react@19.1.0))(@sanity/ui@2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@types/node@22.13.1)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.38.2)(yaml@2.8.0)':
     dependencies:
       '@sanity/icons': 3.7.0(react@19.1.0)
       '@sanity/ui': 2.15.18(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
-      '@vitejs/plugin-react': 4.5.1(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))
+      '@vitejs/plugin-react': 4.5.1(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))
       axe-core: 4.10.2
       cac: 6.7.14
       chokidar: 3.6.0
@@ -16221,7 +16231,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       segmented-property: 3.0.3
       styled-components: 6.1.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      vite: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -17124,7 +17134,7 @@ snapshots:
 
   '@vercel/stega@0.1.2': {}
 
-  '@vitejs/plugin-react@4.5.1(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))':
+  '@vitejs/plugin-react@4.5.1(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.27.1)
@@ -17132,11 +17142,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.9
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.2(vitest@3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0))':
+  '@vitest/coverage-v8@3.2.2(vitest@3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -17151,7 +17161,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
+      vitest: 3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17163,13 +17173,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.2(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.2(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.2
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.2':
     dependencies:
@@ -17349,6 +17359,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
+
+  ansicolors@0.3.2: {}
 
   ansis@3.17.0: {}
 
@@ -17865,6 +17877,11 @@ snapshots:
 
   caniuse-lite@1.0.30001717: {}
 
+  cardinal@2.1.1:
+    dependencies:
+      ansicolors: 0.3.2
+      redeyed: 2.1.1
+
   castable-video@1.0.10:
     dependencies:
       custom-media-element: 1.3.3
@@ -18066,8 +18083,6 @@ snapshots:
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
-
-  color-json@3.0.5: {}
 
   color-name@1.1.3: {}
 
@@ -20690,6 +20705,8 @@ snapshots:
       filelist: 1.0.4
       minimatch: 3.1.2
 
+  jiti@2.4.2: {}
+
   jju@1.4.0: {}
 
   js-tokens@4.0.0: {}
@@ -22626,6 +22643,10 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  redeyed@2.1.1:
+    dependencies:
+      esprima: 4.0.1
+
   redux-observable@3.0.0-rc.2(redux@5.0.1)(rxjs@7.8.2):
     dependencies:
       redux: 5.0.1
@@ -24393,13 +24414,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.2(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0):
+  vite-node@3.2.2(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1(supports-color@9.4.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -24414,29 +24435,29 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@4.3.2(typescript@5.8.3)(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)):
+  vite-tsconfig-paths@4.3.2(typescript@5.8.3)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)):
     dependencies:
       debug: 4.4.1(supports-color@9.4.0)
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.8.3)
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)):
     dependencies:
       debug: 4.4.1(supports-color@9.4.0)
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.8.3)
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0):
+  vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.4(picomatch@4.0.2)
@@ -24447,6 +24468,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.1
       fsevents: 2.3.3
+      jiti: 2.4.2
       terser: 5.38.2
       yaml: 2.8.0
 
@@ -24455,11 +24477,11 @@ snapshots:
       find-up-simple: 1.0.0
       pathe: 2.0.3
 
-  vitest@3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0):
+  vitest@3.2.2(@types/debug@4.1.12)(@types/node@22.13.1)(jiti@2.4.2)(jsdom@23.2.0)(terser@5.38.2)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.2
-      '@vitest/mocker': 3.2.2(vite@6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.2(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.2
       '@vitest/runner': 3.2.2
       '@vitest/snapshot': 3.2.2
@@ -24477,8 +24499,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.0
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
-      vite-node: 3.2.2(@types/node@22.13.1)(terser@5.38.2)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
+      vite-node: 3.2.2(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12


### PR DESCRIPTION
The update here is small, but the primary purpose is to use new, TS-first experience for Blueprint manifest documents.

<img width="1094" alt="image" src="https://github.com/user-attachments/assets/843ce4c4-9d3b-4e27-ae4c-295245355d1a" />

`blueprints init` will allow a user to start a Blueprints project with a `sanity.blueprint.ts` file (the `blueprint.json` format is still supported!). The user will also get a package.json with `@sanity/blueprints` dependency and a stock `.gitignore` file with helpful Functions entries.

[The `@sanity/blueprints` package](https://github.com/sanity-io/blueprints-node) is new and we will be working on it more as feedback is returned and new resources are offered. Changes will be backward compatible, meaning the 3 main methods available now, will continue to be future-proof.