### PR TITLE
chore: add long list component to preview test app

### DIFF
--- a/dev/test-studio/preview/LongList.tsx
+++ b/dev/test-studio/preview/LongList.tsx
@@ -1,0 +1,50 @@
+import {Box, Card, Flex, Heading, Stack, Text} from '@sanity/ui'
+
+import {useQuery} from './loader'
+
+export function LongList(): React.JSX.Element {
+  const {data, loading, error} = useQuery<{
+    _id: string
+    _type: string
+    title: string | null
+    objectArrayWithPrefinedStringField: Array<{
+      _key: string
+      _type: string
+      fieldA: string | null
+      fieldB: string | null
+      fieldC: string | null
+    }>
+  } | null>(
+    /* groq */ `*[_type == "arraysTest" && count(objectArrayWithPrefinedStringField) >= 20][0]{_id, _type, title, objectArrayWithPrefinedStringField[]{_key, _type, fieldA, fieldB, fieldC}}`,
+  )
+
+  if (error) {
+    throw error
+  }
+
+  if (loading) {
+    return <p>Loading...</p>
+  }
+
+  return (
+    <Stack padding={4} space={4}>
+      <Box>
+        <Heading as="h1" size={1}>
+          {data.title}
+        </Heading>
+      </Box>
+      {data.objectArrayWithPrefinedStringField.map((item, i) => (
+        <Card key={item._key} padding={4} shadow={2} radius={2}>
+          <Flex align="flex-start" justify="space-between" gap={3}>
+            <Stack space={2}>
+              <Text>{item.fieldA || 'N/A'}</Text>
+              <Text>{item.fieldB || 'N/A'}</Text>
+              <Text>{item.fieldC || 'N/A'}</Text>
+            </Stack>
+            <Text size={1}>{i + 1}</Text>
+          </Flex>
+        </Card>
+      ))}
+    </Stack>
+  )
+}

--- a/dev/test-studio/preview/main.tsx
+++ b/dev/test-studio/preview/main.tsx
@@ -5,11 +5,12 @@ import {createRoot} from 'react-dom/client'
 
 import {FieldGroups} from './FieldGroups'
 import {useLiveMode} from './loader'
+import {LongList} from './LongList'
 import {Markdown} from './Markdown'
 import {SimpleBlockPortableText} from './SimpleBlockPortableText'
 
 function Main() {
-  const [id, setId] = useState<'simple' | 'nested' | 'markdown'>('simple')
+  const [id, setId] = useState<'simple' | 'nested' | 'markdown' | 'longlist'>('simple')
   return (
     <>
       <ThemeProvider theme={studioTheme}>
@@ -31,11 +32,18 @@ function Main() {
                 selected={id === 'nested'}
               />
               <Tab
-                aria-controls="markdown-pabel"
+                aria-controls="markdown-panel"
                 id="markdown-tab"
                 label="Markdown"
                 onClick={() => setId('markdown')}
                 selected={id === 'markdown'}
+              />
+              <Tab
+                aria-controls="longlist-panel"
+                id="longlist-tab"
+                label="Long List"
+                onClick={() => setId('longlist')}
+                selected={id === 'longlist'}
               />
             </TabList>
           </Box>
@@ -55,6 +63,11 @@ function Main() {
           {id === 'markdown' && (
             <TabPanel aria-labelledby="markdown-tab" id="markdown-panel">
               <Markdown />
+            </TabPanel>
+          )}
+          {id === 'longlist' && (
+            <TabPanel aria-labelledby="longlist-tab" id="longlist-panel">
+              <LongList />
             </TabPanel>
           )}
         </Flex>


### PR DESCRIPTION
### Description

Adds a component to the test studio preview app for rendering a long list of objects in Presentation.

This is intended as a starting point to investigate an issue where focusing on a field within an array item can sometimes open a modal without the list itself scrolling to the item itself.

For context: When an array item modal is open without its corresponding item being in view, focus behaviour is buggy. Focusing outside of the initial field will cause the modal to close. Subsequently scrolling the list will trigger the modal to re-open as soon as the relevant list item becomes visible.

https://github.com/user-attachments/assets/d7773c88-f7a3-43d9-8633-15a75eedc685

It's possible the issue is related to virtualization: it's possible to focus a list item by clicking an overlay in Presentation when the corresponding list item in the document pane is not actually rendered in the DOM. This is not a concern in the context of the Structure tool as users are unable to focus on a list item without it already being rendered.

### What to review

N/A

### Testing

N/A

### Notes for release

N/A
