### PR TITLE
chore: eslint ignore playwright ct report files

### DIFF
--- a/packages/sanity/.eslintignore
+++ b/packages/sanity/.eslintignore
@@ -7,3 +7,4 @@ presentation.js
 router.js
 structure.js
 /migrate/*
+/playwright-ct/report/*


### PR DESCRIPTION
### Description

Fixes errors like
```bash
sanity:lint: ✖ 14009 problems (14009 errors, 0 warnings)
sanity:lint:   3883 errors and 0 warnings potentially fixable with the `--fix` option.
```
where the errors originate in `/packages/sanity/playwright-ct/report/`, which is a small web app for viewing playwright reports.

In other words `pnpm lint` no longer runs _forever_