### PR TITLE
fix: update readme broken links

### DIFF
--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -84,11 +84,11 @@ Check out [the docs](https://www.sanity.io/docs/sanity-studio) and [plugins](htt
 
 ## Code of Conduct
 
-We aim to be an inclusive, welcoming community for everyone. To make that explicit, we have a [code of conduct](https://github.com/sanity-io/sanity/blob/current/CODE_OF_CONDUCT.md) that applies to communication around the project.
+We aim to be an inclusive, welcoming community for everyone. To make that explicit, we have a [code of conduct](https://github.com/sanity-io/sanity/blob/main/CODE_OF_CONDUCT.md) that applies to communication around the project.
 
 ## Want to contribute?
 
-Found a bug, or want to contribute code? Pull requests and issues are most welcome. Read our [contributing guidelines](https://github.com/sanity-io/sanity/blob/current/CONTRIBUTING.md) to learn how.
+Found a bug, or want to contribute code? Pull requests and issues are most welcome. Read our [contributing guidelines](https://github.com/sanity-io/sanity/blob/main/CONTRIBUTING.md) to learn how.
 
 ### Help Improve Sanity Studio translations
 
@@ -108,4 +108,4 @@ Your contributions not only improve Sanity Studio but also bring together a dive
 
 ## License
 
-Sanity Studio is available under the [_MIT License_](https://github.com/sanity-io/sanity/blob/current/LICENSE)
+Sanity Studio is available under the [_MIT License_](https://github.com/sanity-io/sanity/blob/main/LICENSE)


### PR DESCRIPTION
### Description

This pull request updates links in the `README.md` file of the `sanity` package to ensure they point to the correct branch (`main`) in the repository.

Documentation updates:

* Updated the `Code of Conduct` link to point to the `main` branch instead of the outdated `current` branch. (`packages/sanity/README.md`)
* Updated the `Contributing Guidelines` link to point to the `main` branch instead of the outdated `current` branch. (`packages/sanity/README.md`)
* Updated the `License` link to point to the `main` branch instead of the outdated `current` branch. (`packages/sanity/README.md`)
### What to review

- Verify that all three updated links in the README.md are functional and point to the correct documents
- Confirm that the `main` branch contains the referenced files (CODE_OF_CONDUCT.md, CONTRIBUTING.md, LICENSE)
- Check that no other documentation links in the repository still reference the deprecated `current` branch

Previously
<img width="1477" alt="image" src="https://github.com/user-attachments/assets/e3f71d05-5002-4e54-b48b-c2ed5ab49d81" />
Now
<img width="1616" alt="image" src="https://github.com/user-attachments/assets/9cc27783-8826-4393-8166-d4ca1f7326e7" />


### Testing

This change involves only documentation links, so testing consisted of:
- Manually verifying that the updated links resolve correctly
- Confirming that the `main` branch contains the referenced documents
- No automated tests are needed for this documentation fix

### Notes for release

**Not required** - This is a maintenance fix for documentation links and does not affect functionality or user-facing features. The change ensures that README links continue to work correctly after the branch rename from `current` to `main`.