### PR TITLE
feat: synchronize schema to the server

### DIFF
--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -62,7 +62,7 @@
     "watch": "pkg-utils watch"
   },
   "dependencies": {
-    "@sanity/descriptors": "1.0.0",
+    "@sanity/descriptors": "^1.1.1",
     "@sanity/generate-help-url": "^3.0.0",
     "@sanity/types": "workspace:*",
     "arrify": "^2.0.1",

--- a/packages/@sanity/schema/src/_exports/_internal.ts
+++ b/packages/@sanity/schema/src/_exports/_internal.ts
@@ -1,4 +1,5 @@
 export {DescriptorConverter} from '../descriptors/convert'
+export * from '../descriptors/sync'
 export {isActionEnabled} from '../legacy/actionUtils'
 export {
   DEFAULT_MAX_FIELD_DEPTH,

--- a/packages/@sanity/schema/src/descriptors/sync.ts
+++ b/packages/@sanity/schema/src/descriptors/sync.ts
@@ -1,0 +1,28 @@
+import {
+  processSetSynchronization,
+  type SetSynchronization,
+  type SynchronizationRequest,
+  type SynchronizationResult,
+} from '@sanity/descriptors'
+
+import {type RegistryType} from './types'
+
+// This file provides wrapper types/functions for synchronizing a schema.
+// This avoids users of `@sanity/schema` to have to depend on `@sanity/descriptors`.
+
+export type SchemaSynchronizationRequest = SynchronizationRequest
+export type SchemaSynchronizationResult = SynchronizationResult
+
+/**
+ * Returns the next request that should be generated for synchronizing the
+ * schema, based on the previous response from the /synchronize endpoint.
+ *
+ * @param response - The previous response, or `null` if it's the first request.
+ * @returns The next request, or `null` if it's been fully synchronized.
+ */
+export function processSchemaSynchronization(
+  sync: SetSynchronization<RegistryType>,
+  response: SchemaSynchronizationResult | null,
+): SchemaSynchronizationRequest | null {
+  return processSetSynchronization(sync, response)
+}

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -20,7 +20,7 @@ import {
 } from '../form/studio/assetSourceMediaLibrary'
 import {type LocaleSource} from '../i18n'
 import {prepareI18n} from '../i18n/i18nConfig'
-import {createSchema, DESCRIPTOR_CONVERTER} from '../schema'
+import {createSchema} from '../schema'
 import {type AuthStore, createAuthStore, isAuthStore} from '../store/_legacy'
 import {validateWorkspaces} from '../studio'
 import {filterDefinitions} from '../studio/components/navbar/search/definitions/defaultFilters'
@@ -75,6 +75,7 @@ import {
   type WorkspaceOptions,
   type WorkspaceSummary,
 } from './types'
+import {uploadSchema} from './uploadSchema'
 
 type InternalSource = WorkspaceSummary['__internal']['sources'][number]
 
@@ -221,19 +222,6 @@ export function prepareConfig(
         name: source.name,
         types: schemaTypes,
       })
-
-      if (typeof process !== 'undefined' && process?.env?.SANITY_STUDIO_SCHEMA_DESCRIPTOR) {
-        const before = performance.now()
-        const sync = DESCRIPTOR_CONVERTER.get(schema)
-        const after = performance.now()
-        const duration = after - before
-        debug('Built schema for synchronization', {sync, duration})
-        if (duration > 1000) {
-          console.warn(
-            `Building schema for synchronization took more than 1 second (${duration}ms)`,
-          )
-        }
-      }
 
       const schemaValidationProblemGroups = schema._validation
       const schemaErrors = schemaValidationProblemGroups?.filter((msg) =>
@@ -726,6 +714,12 @@ function resolveSource({
       i18next: i18n.i18next,
       staticInitialValueTemplateItems,
       options: config,
+      schemaDescriptorId: authenticated
+        ? catchTap(uploadSchema(schema, getClient({apiVersion: '2025-06-01'})), (err) => {
+            debug('Uploading schema failed', {err})
+            return undefined
+          })
+        : Promise.resolve(undefined),
     },
     onUncaughtError: (error: Error, errorInfo: ErrorInfo) => {
       return onUncaughtErrorResolver({
@@ -811,4 +805,13 @@ function joinBasePath(rootPath: string, basePath?: string) {
     .join('/')
 
   return `/${joined}`
+}
+
+/**
+ * Registers a catch to a promise (to prevent it from being caught by the
+ * "unhandled promise" handler) while returning the original promise.
+ */
+function catchTap<T>(promise: Promise<T>, cb: (reason: unknown) => void): Promise<T> {
+  promise.catch(cb)
+  return promise
 }

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -882,6 +882,15 @@ export interface Source {
      * @internal
      */
     i18next: i18n
+
+    /**
+     * The schema descriptor ID.
+     *
+     * This can be `undefined` in the case where uploading the schema has been disabled.
+     *
+     * @internal
+     */
+    schemaDescriptorId: Promise<string | undefined>
   }
   /** @beta */
   tasks?: WorkspaceOptions['tasks']

--- a/packages/sanity/src/core/config/uploadSchema.ts
+++ b/packages/sanity/src/core/config/uploadSchema.ts
@@ -1,0 +1,91 @@
+import {type SanityClient} from '@sanity/client'
+import {
+  processSchemaSynchronization,
+  type SchemaSynchronizationResult,
+} from '@sanity/schema/_internal'
+import {type Schema} from '@sanity/types'
+
+import {isDev} from '../environment'
+import {DESCRIPTOR_CONVERTER} from '../schema'
+
+const MAX_SYNC_ITERATIONS = 5
+
+type ClaimRequest = {
+  contextKey: string
+  descriptorId: string
+}
+
+type ClaimResponse = {
+  /** How long the claim is valid for. */
+  expiresAt: string
+
+  /**
+   * Information to start the synchronization.
+   */
+  synchronization: SchemaSynchronizationResult
+}
+
+/**
+ * Uploads the schema to Content Lake, returning a schema descriptor ID.
+ */
+export async function uploadSchema(
+  schema: Schema,
+  client: SanityClient,
+): Promise<string | undefined> {
+  const isEnabled = typeof process !== 'undefined' && process?.env?.SANITY_STUDIO_SCHEMA_DESCRIPTOR
+  if (!isEnabled) return undefined
+
+  // The process for uploading the schema is based around two concepts:
+  //
+  // We first _claim_ the descriptor ID. This means that we're requesting that
+  // it should be propagated across Content Lake and be available everywhere.
+  // This ensures that it will not be removed. When the claim expires there's no
+  // longer a guarantee for the descriptor to exist on the server. Note that a
+  // claim can be valid even if the desciptor isn't on the server.
+  //
+  // The claim process also includes a "context key". This is a string
+  // describing the context in which the descriptor comes from. It will help the
+  // server synchronize the descriptor more effectively.
+  //
+  // The second step is then to actually synchronize it. This is a multi-step
+  // process where it tries to synchronize as much as possible in each step.
+
+  const before = performance.now()
+  const sync = DESCRIPTOR_CONVERTER.get(schema)
+  const after = performance.now()
+  const duration = after - before
+  if (duration > 1000) {
+    console.warn(`Building schema for synchronization took more than 1 second (${duration}ms)`)
+  }
+
+  const descriptorId = sync.set.id
+  const {projectId = '?', dataset = '?'} = client.config()
+  let contextKey = `dataset:${projectId}:${dataset}`
+  if (isDev) contextKey += '#dev'
+
+  const claimRequest: ClaimRequest = {descriptorId, contextKey}
+
+  const claimResponse = await client.request<ClaimResponse>({
+    uri: '/descriptors/claim',
+    method: 'POST',
+    body: claimRequest,
+    headers: {
+      // We mirror the format of Server-Timing: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing
+      'Client-Timing': `convertSchema;dur=${duration}`,
+    },
+  })
+
+  let syncResult = claimResponse.synchronization
+  for (let i = 0; i < MAX_SYNC_ITERATIONS; i++) {
+    const syncRequest = processSchemaSynchronization(sync, syncResult)
+    if (syncRequest === null) return descriptorId
+
+    syncResult = await client.request<SchemaSynchronizationResult>({
+      uri: '/descriptors/synchronize',
+      method: 'POST',
+      body: syncRequest,
+    })
+  }
+
+  throw new Error(`Schema synchronization didn't succeed in ${MAX_SYNC_ITERATIONS} iterations`)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1294,8 +1294,8 @@ importers:
   packages/@sanity/schema:
     dependencies:
       '@sanity/descriptors':
-        specifier: 1.0.0
-        version: 1.0.0
+        specifier: ^1.1.1
+        version: 1.1.1
       '@sanity/generate-help-url':
         specifier: ^3.0.0
         version: 3.0.0
@@ -4617,8 +4617,8 @@ packages:
     resolution: {integrity: sha512-7RXJrAuhki5x9BAM1uZcb1BOYvf+wNmUfvcmeb2kvIrlAcSuVfHStSFwmAMLOHyxtohp3wEcOpBswhbf2wU3Sw==}
     engines: {node: '>=18'}
 
-  '@sanity/descriptors@1.0.0':
-    resolution: {integrity: sha512-Gxp/N1GHkteSALUkURxMXZdKxl8LzUqfYMk0vq37Z4YznMs7wMDNHIgD5SwL3E3w6rQkALz69xki8hUBa23GsA==}
+  '@sanity/descriptors@1.1.1':
+    resolution: {integrity: sha512-pTqpyLhH3z4NDhjKHyfL+quVN0ixA8NikcdqxRmL2iqPZuJavi81eKm631PaUqJGbY1kh1+vHnO1/GgWIcjgxw==}
     engines: {node: '>=18.0.0'}
 
   '@sanity/diff-match-patch@3.2.0':
@@ -15088,7 +15088,7 @@ snapshots:
       - debug
       - typescript
 
-  '@sanity/descriptors@1.0.0':
+  '@sanity/descriptors@1.1.1':
     dependencies:
       sha256-uint8array: 0.10.7
 


### PR DESCRIPTION
### Description

This adds support for the Studio to automatically send the serialized schema when it loads (**when an environment variable is enabled**).

### What to review

Probably run it locally and see that it behaves as expected?

### Testing

I've tested this locally in the dev studio. I've verified that it works both in staging and the production workspace.

### Notes for release

N/A. Not user facing yet.
