### PR TITLE
feat(core): add one line portable text editor option

### DIFF
--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-bind */
 import {defineBehavior, effect, forward} from '@portabletext/editor/behaviors'
-import {BehaviorPlugin, DecoratorShortcutPlugin, OneLinePlugin} from '@portabletext/editor/plugins'
+import {BehaviorPlugin, DecoratorShortcutPlugin} from '@portabletext/editor/plugins'
 import {defineType} from 'sanity'
 
 export const customPlugins = defineType({
@@ -30,14 +30,7 @@ export const customPlugins = defineType({
       ],
       components: {
         portableText: {
-          plugins: (props) => {
-            return (
-              <>
-                {props.renderDefault(props)}
-                <OneLinePlugin />
-              </>
-            )
-          },
+          oneLine: true,
         },
       },
     },
@@ -210,6 +203,18 @@ export const customPlugins = defineType({
                 {props.renderDefault(props)}
                 <BehaviorPlugin
                   behaviors={[
+                    defineBehavior({
+                      on: '*',
+                      actions: [
+                        ({event}) => [
+                          effect(() => {
+                            // eslint-disable-next-line no-console
+                            console.log(event)
+                          }),
+                          forward(event),
+                        ],
+                      ],
+                    }),
                     defineBehavior({
                       on: 'insert.text',
                       actions: [

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -239,6 +239,7 @@ export interface BaseSchemaType extends Partial<DeprecationConfiguration> {
     item?: ComponentType<any>
     preview?: ComponentType<any>
     portableText?: {
+      oneLine?: boolean
       plugins?: ComponentType<any>
     }
   }

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -49,7 +49,7 @@ interface InputProps extends ArrayOfObjectsInputProps<PortableTextBlock> {
 }
 
 /** @internal */
-export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunctions'>): ReactNode {
+export function Compositor(props: Omit<InputProps, 'arrayFunctions'>): ReactNode {
   const {
     changed,
     elementRef,
@@ -83,6 +83,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     renderItem,
     renderPreview,
     resolveUploader,
+    schemaType,
     value,
   } = props
 
@@ -400,6 +401,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     return undefined
   })
 
+  const isOneLineEditor = schemaType.components?.portableText?.oneLine ?? false
   const editorNode = useMemo(
     () => (
       <UploadTargetCard
@@ -416,6 +418,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
           hotkeys={editorHotkeys}
           isActive={isActive}
           isFullscreen={isFullscreen}
+          isOneLine={isOneLineEditor}
           onItemOpen={onItemOpen}
           onCopy={onCopy}
           onPaste={onPaste}
@@ -447,6 +450,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       initialSelection,
       isActive,
       isFullscreen,
+      isOneLineEditor,
       onCopy,
       onItemOpen,
       onPaste,

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
@@ -7,16 +7,16 @@ import {css, styled} from 'styled-components'
 import {ScrollContainer} from '../../../components/scroll'
 import {createListName, TEXT_LEVELS} from './text'
 
-export const Root = styled(Card)`
+export const Root = styled(Card)<{$isOneLine: boolean}>`
   &[data-fullscreen='true'] {
     height: 100%;
   }
 
   &[data-fullscreen='false'] {
     min-height: 5em;
-    resize: vertical;
+    resize: ${({$isOneLine}) => ($isOneLine ? 'none' : 'vertical')};
     overflow: auto;
-    height: 19em;
+    height: ${({$isOneLine}) => ($isOneLine ? 'auto' : '19em')};
   }
 
   &:not([hidden]) {
@@ -68,7 +68,7 @@ export const Scroller = styled(ScrollContainer)`
   }
 `
 
-export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $readOnly?: boolean}>`
+export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $isOneLine: boolean}>`
   height: 100%;
   width: 100%;
   counter-reset: ${TEXT_LEVELS.map((l) => createListName(l)).join(' ')};
@@ -121,7 +121,8 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $readOnly?:
       padding-top: ${({$isFullscreen, theme}) => theme.sanity.space[$isFullscreen ? 5 : 3]}px;
     }
 
-    padding-bottom: ${({$isFullscreen, theme}) => theme.sanity.space[$isFullscreen ? 9 : 5]}px;
+    padding-bottom: ${({$isFullscreen, $isOneLine, theme}) =>
+      $isOneLine ? '0' : theme.sanity.space[$isFullscreen ? 9 : 5]}px;
 
     & > .pt-block {
       margin: 0 auto;

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -51,6 +51,7 @@ interface EditorProps {
   initialSelection?: EditorSelection
   isActive: boolean
   isFullscreen: boolean
+  isOneLine: boolean
   onCopy?: OnCopyFn
   onItemOpen: (path: Path) => void
   onPaste?: OnPasteFn
@@ -89,6 +90,7 @@ export function Editor(props: EditorProps): ReactNode {
     initialSelection,
     isActive,
     isFullscreen,
+    isOneLine,
     onCopy,
     onItemOpen,
     onPaste,
@@ -186,7 +188,7 @@ export function Editor(props: EditorProps): ReactNode {
   const collapsibleToolbar = id === FORM_BUILDER_DEFAULT_ID
 
   return (
-    <Root data-fullscreen={isFullscreen} data-testid="pt-editor">
+    <Root data-fullscreen={isFullscreen} data-testid="pt-editor" $isOneLine={isOneLine}>
       {isActive && !hideToolbar && (
         <TooltipDelayGroupProvider>
           <ToolbarCard data-testid="pt-editor__toolbar-card" shadow={1}>
@@ -207,6 +209,7 @@ export function Editor(props: EditorProps): ReactNode {
           <div>
             <EditableWrapper
               $isFullscreen={isFullscreen}
+              $isOneLine={isOneLine}
               tone={readOnly ? 'transparent' : 'default'}
             >
               <BoundaryElementProvider element={isFullscreen ? scrollElement : boundaryElement}>

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -1,4 +1,6 @@
+import {defineBehavior} from '@portabletext/editor/behaviors'
 import {
+  BehaviorPlugin,
   MarkdownPlugin,
   type MarkdownPluginConfig,
   OneLinePlugin,
@@ -45,7 +47,19 @@ export const PortableTextEditorPlugins = (props: {
 
   return (
     <>
-      {isOneLineEditor && <OneLinePlugin />}
+      {isOneLineEditor && (
+        <>
+          <OneLinePlugin />
+          <BehaviorPlugin
+            behaviors={[
+              defineBehavior({
+                on: 'insert.soft break',
+                actions: [],
+              }),
+            ]}
+          />
+        </>
+      )}
       {CustomComponent ? (
         <CustomComponent {...componentProps} />
       ) : (

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -1,4 +1,8 @@
-import {MarkdownPlugin, type MarkdownPluginConfig} from '@portabletext/editor/plugins'
+import {
+  MarkdownPlugin,
+  type MarkdownPluginConfig,
+  OneLinePlugin,
+} from '@portabletext/editor/plugins'
 import {type ArraySchemaType, type PortableTextBlock} from '@sanity/types'
 import {type ComponentType, useMemo} from 'react'
 
@@ -26,6 +30,7 @@ const markdownConfig: MarkdownPluginConfig = {
 export const PortableTextEditorPlugins = (props: {
   schemaType: ArraySchemaType<PortableTextBlock>
 }) => {
+  const isOneLineEditor = props.schemaType.components?.portableText?.oneLine ?? false
   const componentProps = useMemo(
     (): PortableTextPluginsProps => ({
       plugins: {markdown: {config: markdownConfig}},
@@ -38,10 +43,15 @@ export const PortableTextEditorPlugins = (props: {
     | ComponentType<PortableTextPluginsProps>
     | undefined
 
-  return CustomComponent ? (
-    <CustomComponent {...componentProps} />
-  ) : (
-    <RenderDefault {...componentProps} />
+  return (
+    <>
+      {isOneLineEditor && <OneLinePlugin />}
+      {CustomComponent ? (
+        <CustomComponent {...componentProps} />
+      ) : (
+        <RenderDefault {...componentProps} />
+      )}
+    </>
   )
 }
 

--- a/packages/sanity/src/core/form/types/definitionExtensions.ts
+++ b/packages/sanity/src/core/form/types/definitionExtensions.ts
@@ -52,7 +52,10 @@ declare module '@sanity/types' {
     input?: ComponentType<ArrayOfObjectsInputProps>
     item?: ComponentType<ObjectItemProps>
     preview?: ComponentType<PreviewProps>
-    portableText?: {plugins: ComponentType<PortableTextPluginsProps>}
+    portableText?: {
+      oneLine?: boolean
+      plugins?: ComponentType<PortableTextPluginsProps>
+    }
   }
 
   /**


### PR DESCRIPTION
### Description
Adds a new option to `components.portableText` so fields can define a new boolean that will update the Portable text editor to support only one line.
Trying to add a break, or a soft break won't have any effect.

The styling of the input is also updated, so it looks like a one line editor.

<img width="650" alt="Screenshot 2025-06-11 at 16 05 27" src="https://github.com/user-attachments/assets/47796d7a-a284-496b-afc6-c08c7592cf72" />

### How to setup 

```diff
    defineField({
      type: 'array',
      name: 'oneLineEditor',
      title: 'One-Line Editor',
      of: [{type: 'block'}],
+      components: {
+        portableText: {
+          oneLine: true,
+        },
      },
    })
```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
The one line plugin available here should not add extra breaks or soft breaks when clicking enter or inserting multiple items, the first portable text editor [in this document](https://test-studio-git-one-line-pte.sanity.dev/test/structure/input-standard;portable-text;customPlugins;62187f56-9ee0-45d3-894e-19f699ae3415) uses it

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Adds an option into `components.portableText` to transform your portable text editor into a one line editor

```diff
    defineField({
      type: 'array',
      name: 'oneLineEditor',
      title: 'One-Line Editor',
      of: [{type: 'block'}],
+      components: {
+        portableText: {
+          oneLine: true,
+        },
      },
    })
```

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
