### PR TITLE
fix(actions): Vercel deployment failure when PR titles "contain" double quotes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -160,11 +160,13 @@ jobs:
 
       - name: Deploy Project Artifacts to Vercel
         id: deploy
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message || github.event.pull_request.title }}
         run: |
           echo "DEPLOY_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_E2E_STUDIO_TOKEN }} \
           -m githubDeployment="1" \
           -m githubCommitAuthorName="${{ github.event.sender.name || 'GitHub Actions' }}" \
-          -m githubCommitMessage="${{ github.event.head_commit.message || github.event.pull_request.title }}" \
+          -m githubCommitMessage="$COMMIT_MESSAGE" \
           -m githubCommitOrg="${{ github.repository_owner }}" \
           -m githubCommitRef="${{ github.head_ref || github.ref_name }}" \
           -m githubCommitRepo="${{ github.event.repository.name }}" \
@@ -176,7 +178,7 @@ jobs:
       - name: Echo the preview URL
         run: |
           if [ -z "${{ steps.deploy.outputs.DEPLOY_URL }}" ]; then
-           echo "::error::Preview URL was not found. Deployment may have failed, does your PR title has double quotes? Try removing them."
+           echo "::error::Preview URL was not found. Deployment may have failed."
            exit 1
           fi
           echo "Preview URL: ${{ steps.deploy.outputs.DEPLOY_URL }}"


### PR DESCRIPTION
### Description
Fixes Vercel deployment failure when PR titles contain double quotes.
Vercel deployments were failing when PR titles contained double quotes. The issue was caused by improper shell quoting in the GitHub Actions workflow.

**Root Cause**
The commit message parameter was being passed directly to the shell command without proper escaping:
```bash
-m githubCommitMessage="${{ github.event.head_commit.message || github.event.pull_request.title }}"
```

When a PR title like `refactor(sanity): move "create release" menu item` was used, it would break the shell parsing, causing the deployment to fail.
[This was reported here to vercel and this was their response
](https://github.com/vercel/vercel/issues/13378)

>I think this is a shell quoting issue with your GitHub Actions workflow where the " is not properly escaped:
-m githubCommitMessage="refactor(sanity): move "create release" menu item to shared component" \ [link](https://github.com/sanity-io/sanity/actions/runs/15228095248/job/42832590430?pr=9493#step:10:5)
This causes the command to be vercel deploy --prebuilt ... -m githubCommitMessage="refactor(sanity): move "create with an args list of release" menu item to shared component" which gets interpreted as a path to the project you want to deploy.

**Solution**
Use an environment variable to safely pass the commit message to the shell command https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable

```yaml
- name: Deploy Project Artifacts to Vercel
  id: deploy
  env:
    COMMIT_MESSAGE: ${{ github.event.head_commit.message || github.event.pull_request.title }}
  run: |
    echo "DEPLOY_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_E2E_STUDIO_TOKEN }} \
    -m githubCommitMessage="$COMMIT_MESSAGE" \
    # ... other parameters
```


### Testing
If deployment to vercel works we are fine! 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->



### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
