### PR TITLE
chore(ci): add placeholder comments to workflows

### DIFF
--- a/.github/workflows/docReport.yml
+++ b/.github/workflows/docReport.yml
@@ -27,6 +27,13 @@ jobs:
           cache: pnpm
           node-version: lts/*
 
+      - name: Add report comment placeholder
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          comment_tag: "docs-report"
+          message: Waiting for docs report to finish…
+
       - name: Install project dependencies
         run: pnpm install
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,6 +38,26 @@ jobs:
           cache: pnpm
           node-version: lts/*
 
+      - name: Add PR Comment placeholder for e2e Preview Environment
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          comment_tag: "e2e-preview-url"
+          message: |
+            ### 🧪 E2E Preview environment
+
+            Waiting for preview deployment to finish…
+
+      - name: Add PR Comment placeholder for e2e report
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          comment_tag: "playwright-e2e-report"
+          message: |
+            ### 📊 Playwright Test Report
+
+            Waiting for E2E tests to finish…
+
       - name: Install project dependencies
         run: pnpm install
 
@@ -189,7 +209,7 @@ jobs:
         with:
           comment_tag: "e2e-preview-url"
           message: |
-            ### 🧪 [E2E Preview environment](${{ steps.deploy.outputs.DEPLOY_URL }}) 
+            ### 🧪 [E2E Preview environment](${{ steps.deploy.outputs.DEPLOY_URL }})
 
             <details>
             <summary> 🔑 Environment Variables for Local Testing</summary>

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -43,6 +43,16 @@ jobs:
           cache: pnpm
           node-version: lts/*
 
+      - name: Add PR comment placeholder
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          comment_tag: "efps-report"
+          message: |
+            ### ⚡️ Editor Performance Report
+
+            Waiting for Editor Performance Tests to finish…
+
       - name: Install project dependencies
         run: pnpm install
 


### PR DESCRIPTION
### Description
A small little quality of life improvement:  our GitHub workflows that comments on PRs now creates a placeholder comment immediately and then update the comment when it’s done doing its work. This should reduce the oncoming stream of interruptions for those of us that have notifications enabled for github comments.

### What to review
The workflow changes. This PR shows the order of which the comments appear. Here's a screenshot taken right after opening this PR:

<img width="931" alt="image" src="https://github.com/user-attachments/assets/54231cfc-521b-46e6-9c25-f90c1c0e8e05" />
