### PR TITLE
test: revert #9632

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Annotations.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Annotations.spec.tsx
@@ -5,11 +5,7 @@ import {AnnotationsStory} from './AnnotationsStory'
 
 test.describe('Portable Text Input', () => {
   test.describe('Annotations', () => {
-    test('Create a new link with keyboard only', async ({mount, page, browserName}) => {
-      if (browserName === 'webkit') {
-        test.skip(true, 'Currently not working in WebKit')
-      }
-
+    test('Create a new link with keyboard only', async ({mount, page}) => {
       const {getFocusedPortableTextEditor, insertPortableText} = testHelpers({
         page,
       })
@@ -76,12 +72,7 @@ test.describe('Portable Text Input', () => {
     test('Can create, and then open the existing annotation again for editing', async ({
       mount,
       page,
-      browserName,
     }) => {
-      if (browserName === 'webkit') {
-        test.skip(true, 'Currently not working in WebKit')
-      }
-
       const {getFocusedPortableTextEditor, insertPortableText} = testHelpers({
         page,
       })


### PR DESCRIPTION
This reverts commit 978176faa983e8f95d056a7e4f780ae13850811b.

Tests are now (somewhat) stable again due to an upstream PTE bugfix.