### PR TITLE
fix(sanity): avoid writing to message property of unknown caught value

### DIFF
--- a/packages/@sanity/cli/src/cli.ts
+++ b/packages/@sanity/cli/src/cli.ts
@@ -157,6 +157,9 @@ export async function runCli(cliRoot: string, {cliVersion}: {cliVersion: string}
       const error = typeof err.details === 'string' ? err.details : err
       // eslint-disable-next-line no-console
       console.error(`\n${error.stack ? neatStack(err) : error}`)
+      if (err.cause) {
+        console.error(`\nCaused by:\n\n${err.cause.stack ? neatStack(err.cause) : err.cause}`)
+      }
       // eslint-disable-next-line no-process-exit
       cliCommandTrace.error(error)
       process.exit(1)

--- a/packages/sanity/src/_internal/cli/util/getStudioWorkspaces.ts
+++ b/packages/sanity/src/_internal/cli/util/getStudioWorkspaces.ts
@@ -49,9 +49,9 @@ export function getStudioConfig({
       const mod = require(configPath)
       config = mod.__esModule && mod.default ? mod.default : mod
     } catch (err) {
-      const message = `Failed to load configuration file "${configPath}":\n${err.message}`
-      // this helps preserve the stack trace
-      throw Object.assign(err, {message})
+      throw new Error(`Failed to load configuration file "${configPath}"`, {
+        cause: err,
+      })
     }
 
     if (!config) throw new Error('Configuration did not export expected config shape')


### PR DESCRIPTION
### Description

During schema extraction, we were previously attempting to set the `message` property of an unknown caught value. We have received a couple of reports indicating an object is caught with only a getter defined for the `message` property, causing an error to be thrown when we attempt to set it, and thus concealing the underlying error.

This branch makes two changes to improve the situation:

1. Throws a new error with a cause, rather than attempting to manipulate the caught value.
2. Adds error cause reporting in the CLI runner's catch clause.

Note that I have not added recursive unfolding of error cause; only the outermost cause will be reported. This seems pragmatic given the CLI is currently being redeveloped.

We can see an example of this by throwing a contrived error object:

```
class ReadonlyError extends Error {
  constructor() {
    super()
    this.name = 'ReadonlyError'
  }

  get message() {
    return 'ReadOnly message'
  }
}
```

#### Before

<img width="1062" alt="Screenshot 2025-06-13 at 11 54 15" src="https://github.com/user-attachments/assets/8754f021-f263-44c7-a0dd-42f65f78440d" />

The underlying error has been concealed by the error we created ourselves by attempting to set the read-only `message` property of the caught value.

#### After

<img width="1058" alt="Screenshot 2025-06-13 at 11 57 33" src="https://github.com/user-attachments/assets/26f731ef-514e-4bb5-b555-0607f29fc155" />

The fact the configuration file failed to load is reported to the user, as well as the underlying cause.

### What to review

- The CLI catch clause.
- The `getStudioConfig` rethrow.

### Testing

Tested with various contrived thrown errors.

### Notes for release

Fixes an issue that could cause error details to be lost when running `sanity schema extract`.