### PR TITLE
fix(presentation): hide locations banner if location is empty

### DIFF
--- a/packages/sanity/src/presentation/document/LocationsBanner.tsx
+++ b/packages/sanity/src/presentation/document/LocationsBanner.tsx
@@ -65,7 +65,7 @@ export function LocationsBanner(props: {
 
   const ToneIcon = tone ? TONE_ICONS[tone] : undefined
 
-  if (!resolvers) return null
+  if (!resolvers || status === 'empty') return null
   return (
     <Card padding={1} radius={2} border tone={tone}>
       <div style={{margin: -1}}>

--- a/packages/sanity/src/presentation/document/PresentationDocumentHeader.tsx
+++ b/packages/sanity/src/presentation/document/PresentationDocumentHeader.tsx
@@ -1,19 +1,28 @@
-import {rem, Stack} from '@sanity/ui'
+import {rem} from '@sanity/ui'
+// eslint-disable-next-line camelcase
+import {getTheme_v2} from '@sanity/ui/theme'
 import {type ReactNode, useContext} from 'react'
 import {type ObjectSchemaType, type PublishedId} from 'sanity'
 import {PresentationDocumentContext} from 'sanity/_singletons'
-import {styled} from 'styled-components'
+import {css, styled} from 'styled-components'
 
 import {type PresentationPluginOptions} from '../types'
 import {LocationsBanner} from './LocationsBanner'
 
-const LocationStack = styled(Stack)`
-  min-height: ${rem(42)};
+const LocationStack = styled.div((props) => {
+  const theme = getTheme_v2(props.theme)
+  return css`
+    display: flex;
+    flex-direction: column;
+    gap: ${rem(theme.space[2])};
+    min-height: ${rem(42)};
+    margin-bottom: ${rem(theme.space[5])};
 
-  & + &:empty {
-    display: none;
-  }
-`
+    &:empty {
+      display: none;
+    }
+  `
+})
 
 export function PresentationDocumentHeader(props: {
   documentId: PublishedId
@@ -33,20 +42,18 @@ export function PresentationDocumentHeader(props: {
   }
 
   return (
-    <LocationStack marginBottom={5} space={5}>
-      <Stack space={2}>
-        {contextOptions.map((_options, idx) => (
-          <LocationsBanner
-            key={idx}
-            documentId={documentId}
-            options={_options}
-            resolvers={resolvers[idx]}
-            schemaType={schemaType}
-            showPresentationTitle={contextOptions.length > 1}
-            version={version}
-          />
-        ))}
-      </Stack>
+    <LocationStack>
+      {contextOptions.map((_options, idx) => (
+        <LocationsBanner
+          key={idx}
+          documentId={documentId}
+          options={_options}
+          resolvers={resolvers[idx]}
+          schemaType={schemaType}
+          showPresentationTitle={contextOptions.length > 1}
+          version={version}
+        />
+      ))}
     </LocationStack>
   )
 }


### PR DESCRIPTION
### Description
With the changes added to support multiple presentation tools in the same document, documents started showing the Presentation header and location resolver saying **Presentation · Not used on any pages**
This is technically correct for the documents, because they haven't returned any value in the resolver, but it is a regression considering that users may not have set up all the documents to use presentation and they could be using it in the site, while the tool says it is not used.

Also, it's a change from what it used to be before this PR.

This PR updates this and restores the previous functionality, in where if no locations are present for a document it will not show the header.
|  | Before | Now |
|--------|--------|--------|
| With locations | <img width="682" alt="Screenshot 2025-06-16 at 09 20 36" src="https://github.com/user-attachments/assets/e72c18c3-9683-4add-b2ae-97a140a1dff4" /> | <img width="696" alt="Screenshot 2025-06-16 at 09 19 46" src="https://github.com/user-attachments/assets/21c19cda-34ee-4465-8b0d-432cd933449b" /> |
| No locations | <img width="785" alt="Screenshot 2025-06-16 at 09 20 25" src="https://github.com/user-attachments/assets/2ea2aff9-ada6-46a1-802f-44006f3d6de1" /> |<img width="791" alt="Screenshot 2025-06-16 at 09 19 55" src="https://github.com/user-attachments/assets/5735bbe0-f399-4109-93bd-736686961506" /> | 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is there something missing?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open a document with locations, it should show the banner.
The rest of documents should not show the banner
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in where presentation banner will show for documents even if it resolves to an empty location
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
