### PR TITLE
chore: reduce lint:fix noise

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -98,6 +98,8 @@
     "jest/valid-expect": "off",
     "jest/valid-title": "off",
     "jest/valid-describe-callback": "off",
+    "jsx_a11y/no-autofocus": "off",
+    "unicorn/require-post-message-target-origin": "off", // disabled since it can't distinguish between `window.postMessage` and node `Worker#postMessage`
     // Since we use useEffectEvent, we can't use the oxlint checker for this rule, as it doesn't understand effect event semantics
     "react/exhaustive-deps": "off",
     // Handy rules that are disabled by default
@@ -105,7 +107,6 @@
     "eslint/no-console": ["error", {"allow": ["warn", "error"]}],
     // These rules should be enabled in the future, they are disabled for now to reduce the PR scope for landing oxlint
     "typescript/no-explicit-any": "warn",
-    "unicorn/prefer-set-has": "warn",
     "eslint/no-await-in-loop": "warn",
     "unicorn/no-new-array": "warn",
     "unicorn/consistent-function-scoping": "warn",
@@ -116,9 +117,7 @@
     "eslint/no-unused-vars": "warn",
     "typescript/prefer-ts-expect-error": "warn",
     "unicorn/no-useless-fallback-in-spread": "warn",
-    "jsx_a11y/no-autofocus": "warn",
     "import/no-named-as-default": "warn",
-    "unicorn/require-post-message-target-origin": "warn",
     "unicorn/prefer-string-starts-ends-with": "warn",
     "unicorn/no-single-promise-in-promise-methods": "warn",
     "import/no-named-as-default-member": "warn",
@@ -144,7 +143,9 @@
     "react/iframe-missing-sandbox": "warn",
     "jsx_a11y/iframe-has-title": "warn",
     "promise/no-callback-in-promise": "warn",
-    "eslint/no-unsafe-optional-chaining": "warn"
+    "eslint/no-unsafe-optional-chaining": "warn",
+    // Temporarily disabled, will be re-enabled in the near term
+    "unicorn/prefer-set-has": "off"
   },
   "overrides": [{"files": ["scripts/**/*"], "rules": {"no-console": "off"}}]
 }


### PR DESCRIPTION
### Description

Some rules set to `warn` still triggers when running `--fix`, this wasn't the intention when landing #9629. This PR dials it back a bit so we can handle it properly.

### What to review

Enough inline context?

### Testing

We have to merge before the bot reruns and we know for sure it's fixed.

### Notes for release

N/A