### PR TITLE
chore: fix issues by `pnpm lint:fix`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -24,11 +24,13 @@ CHANGELOG.md
 /examples/*/static
 
 /packages/*/coverage
+/packages/*/dist
 /packages/*/lib
 /packages/*/node_modules
 
 /packages/@repo/*/node_modules
 /packages/@sanity/*/coverage
+/packages/@sanity/*/dist
 /packages/@sanity/*/lib
 /packages/@sanity/*/node_modules
 /packages/@sanity/client/umd

--- a/packages/sanity/src/core/field/types/portableText/diff/helpers.ts
+++ b/packages/sanity/src/core/field/types/portableText/diff/helpers.ts
@@ -350,14 +350,14 @@ function buildSegments(fromInput: string, toInput: string): StringDiffSegment[] 
 }
 
 export function getInlineObjects(diff: ObjectDiff): PortableTextObject[] {
-  const allChildren = [
-    ...(diff.toValue ? diff.toValue.children.filter((cld: any) => cld._type !== 'span') : []),
-  ]
+  const allChildren = diff.toValue
+    ? diff.toValue.children.filter((cld: any) => cld._type !== 'span')
+    : []
   const previousChildren = diff.fromValue
     ? diff.fromValue.children.filter((cld: any) => cld._type !== 'span')
     : []
   previousChildren.forEach((oCld: any) => {
-    if (!allChildren.some((cld) => oCld._key === cld._key)) {
+    if (!allChildren.some((cld: any) => oCld._key === cld._key)) {
       allChildren.push(oCld)
     }
   })

--- a/packages/sanity/src/router/RouteScope.tsx
+++ b/packages/sanity/src/router/RouteScope.tsx
@@ -133,7 +133,8 @@ export const RouteScope = function RouteScope(props: RouteScopeProps): React.JSX
 
   const childRouter: RouterContextValue = useMemo(() => {
     const parentState = parentRouter.state
-    const childState = {...(parentState[scope] || {})} as RouterState
+    const childState =
+      typeof parentState[scope] === 'object' ? ({...parentState[scope]} as RouterState) : {}
     if (__unsafe_disableScopedSearchParams) {
       childState._searchParams = parentState._searchParams
     }

--- a/packages/sanity/src/router/_resolveStateFromPath.ts
+++ b/packages/sanity/src/router/_resolveStateFromPath.ts
@@ -68,7 +68,7 @@ function matchPath(
 
   const mergedState: RouterState = {
     ...state,
-    ...(childState || {}),
+    ...(childState === null ? {} : childState),
     ...(selfParams.length > 0 ? {_searchParams: selfParams} : {}),
   }
 


### PR DESCRIPTION
### Description

There are still some adverse effects [to running `pnpm lint:fix`](https://github.com/sanity-io/sanity/pull/9667), this PR handles them, without running `pnpm lint:fix` on unrelated files (so we can test the bot).
[The failures where specifically](https://github.com/sanity-io/sanity/actions/runs/15685812311/job/44188587212?pr=9667):
```bash
Error: sanity:build: [error] src/core/field/types/portableText/diff/helpers.ts:360:28 - TS7006: Parameter 'cld' implicitly has an 'any' type.
Error: sanity:build: [error] src/router/RouteScope.tsx:136:25 - TS2698: Spread types may only be created from object types.
Error: sanity:build: [error] src/router/_resolveStateFromPath.ts:71:5 - TS2698: Spread types may only be created from object types.
Error: sanity:build: [error] src/core/field/types/portableText/diff/helpers.ts:360:28 - TS7006: Parameter 'cld' implicitly has an 'any' type.
Error: sanity:build: [error] src/router/RouteScope.tsx:136:25 - TS2698: Spread types may only be created from object types.
Error: sanity:build: [error] src/router/_resolveStateFromPath.ts:71:5 - TS2698: Spread types may only be created from object types.
Error: sanity:build: [error] 54031ms
Error: sanity:build: [error] failed to compile TypeScript definitions
sanity:build: 
Error: sanity:build: [error] Error: failed to compile TypeScript definitions
```

Also updates the `.prettierignore` filter with knowledge about the `pnpm build:bundle` scripts.

### What to review

Makes sense?

### Testing

If it passes the CI we're fine, and it'll then make a new PR and we'll know for sure if everything is fine 🤞 

### Notes for release

N/A
