### PR TITLE
fix(core): update error tooltip for copypaste

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/copy-paste.ts
+++ b/packages/sanity/src/core/i18n/bundles/copy-paste.ts
@@ -77,10 +77,9 @@ const copyPasteLocaleStrings = defineLocalesResources('copy-paste', {
   'copy-paste.on-copy.validation.no-value.title': 'Empty value, nothing to copy',
   /** The error message that is shown when the clipboard is not supported */
   'copy-paste.on-copy.validation.clipboard-not-supported.description':
-    'Please ensure you are using a modern browser and have granted clipboard permissions. You may need to enable clipboard access in your browser settings.',
+    'Clipboard access required to copy this content. Allow clipboard permissions in your browser settings, then try copying again.',
   /** The error message that is shown when the clipboard is not supported */
-  'copy-paste.on-copy.validation.clipboard-not-supported.title':
-    'Your browser does not support this action',
+  'copy-paste.on-copy.validation.clipboard-not-supported.title': 'Clipboard access blocked',
 })
 
 /**

--- a/packages/sanity/src/core/i18n/bundles/copy-paste.ts
+++ b/packages/sanity/src/core/i18n/bundles/copy-paste.ts
@@ -76,6 +76,9 @@ const copyPasteLocaleStrings = defineLocalesResources('copy-paste', {
   /** The error message that is shown when there is no value to copy */
   'copy-paste.on-copy.validation.no-value.title': 'Empty value, nothing to copy',
   /** The error message that is shown when the clipboard is not supported */
+  'copy-paste.on-copy.validation.clipboard-not-supported.description':
+    'Please ensure you are using a modern browser and have granted clipboard permissions. You may need to enable clipboard access in your browser settings.',
+  /** The error message that is shown when the clipboard is not supported */
   'copy-paste.on-copy.validation.clipboard-not-supported.title':
     'Your browser does not support this action',
 })

--- a/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
+++ b/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
@@ -158,7 +158,19 @@ export const CopyPasteProvider: React.FC<{
         value,
       )!
 
-      const clipboardItem = await getClipboardItem()
+      let clipboardItem: SanityClipboardItem | null = null
+      try {
+        clipboardItem = await getClipboardItem()
+      } catch (error) {
+        if (error.name === 'NotAllowedError') {
+          toast.push({
+            status: 'error',
+            title: t('copy-paste.on-copy.validation.clipboard-not-supported.title'),
+            description: t('copy-paste.on-copy.validation.clipboard-not-supported.description'),
+          })
+        }
+        return
+      }
 
       // Return early if no clipboard item or if clipboard item is invalid
       if (!clipboardItem) {

--- a/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
+++ b/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
@@ -139,6 +139,7 @@ export const CopyPasteProvider: React.FC<{
         toast.push({
           status: 'error',
           title: t('copy-paste.on-copy.validation.clipboard-not-supported.title'),
+          description: t('copy-paste.on-copy.validation.clipboard-not-supported.description'),
         })
       }
     },


### PR DESCRIPTION
### Description

Update error messages on both copy and paste when the browser doesn't allow for the action.
On paste, we are narrowing down to that specific error (while still throwing if any other error comes) but for this in particular it will no longer the an uncaught exception

<img width="829" alt="Amay of strings" src="https://github.com/user-attachments/assets/a2f883ec-13da-4b31-896d-7b044bf675ff" />

### What to review

Does this make sense?

### Testing

You can go to your browser and change the settings for the clipboard to blocked (in arc you need to go to settings, advanced settings and find clipboard for sanity)

### Notes for release

Updates error message to be more helpful when copy pasting is being blocked in the studio due to lack of permissions.