### PR TITLE
chore(deps): bump playwright to 1.52 and use pnpm catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@lerna-lite/publish": "^4.4.1",
     "@lerna-lite/run": "^4.4.1",
     "@lerna-lite/version": "^4.4.1",
-    "@playwright/test": "1.51.1",
+    "@playwright/test": "catalog:",
     "@repo/bundle-manager": "workspace:*",
     "@repo/dev-aliases": "workspace:*",
     "@repo/eslint-config": "workspace:*",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -283,8 +283,8 @@
     "yargs": "^17.3.0"
   },
   "devDependencies": {
-    "@playwright/experimental-ct-react": "1.51.1",
-    "@playwright/test": "1.51.1",
+    "@playwright/experimental-ct-react": "catalog:",
+    "@playwright/test": "catalog:",
     "@repo/dev-aliases": "workspace:*",
     "@repo/eslint-config": "workspace:*",
     "@repo/package.config": "workspace:*",

--- a/perf/efps/package.json
+++ b/perf/efps/package.json
@@ -31,7 +31,7 @@
     "dotenv": "^16.0.3",
     "globby": "^11.1.0",
     "ora": "^8.0.1",
-    "playwright": "^1.51.1",
+    "playwright": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "rollup-plugin-sourcemaps": "^0.6.3",

--- a/perf/tests/package.json
+++ b/perf/tests/package.json
@@ -15,7 +15,7 @@
     "studio:dev": "cd perf/studio && SANITY_STUDIO_DATASET=dev pnpm dev"
   },
   "dependencies": {
-    "@playwright/test": "1.51.1",
+    "@playwright/test": "catalog:",
     "@sanity/client": "^7.6.0",
     "@sanity/uuid": "^3.0.1",
     "dotenv": "^16.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@playwright/experimental-ct-react':
+      specifier: 1.52.0
+      version: 1.52.0
+    '@playwright/test':
+      specifier: 1.52.0
+      version: 1.52.0
     '@sanity/eslint-config-i18n':
       specifier: ^2.0.0
       version: 2.0.0
@@ -24,6 +30,9 @@ catalogs:
     globals:
       specifier: ^16.2.0
       version: 16.2.0
+    playwright:
+      specifier: 1.52.0
+      version: 1.52.0
     prettier:
       specifier: ^3.5.3
       version: 3.5.3
@@ -82,8 +91,8 @@ importers:
         specifier: ^4.4.1
         version: 4.4.1(@lerna-lite/publish@4.4.1)(@lerna-lite/run@4.4.1)(@types/node@22.13.1)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0)(typescript@5.8.3)
       '@playwright/test':
-        specifier: 1.51.1
-        version: 1.51.1
+        specifier: 'catalog:'
+        version: 1.52.0
       '@repo/bundle-manager':
         specifier: workspace:*
         version: link:packages/@repo/bundle-manager
@@ -1899,11 +1908,11 @@ importers:
         version: 17.3.0
     devDependencies:
       '@playwright/experimental-ct-react':
-        specifier: 1.51.1
-        version: 1.51.1(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.20.3)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        specifier: 'catalog:'
+        version: 1.52.0(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.20.3)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@playwright/test':
-        specifier: 1.51.1
-        version: 1.51.1
+        specifier: 'catalog:'
+        version: 1.52.0
       '@repo/dev-aliases':
         specifier: workspace:*
         version: link:../@repo/dev-aliases
@@ -2118,8 +2127,8 @@ importers:
         specifier: ^8.0.1
         version: 8.2.0
       playwright:
-        specifier: ^1.51.1
-        version: 1.51.1
+        specifier: 'catalog:'
+        version: 1.52.0
       react:
         specifier: 'catalog:'
         version: 19.1.0
@@ -2170,8 +2179,8 @@ importers:
   perf/tests:
     dependencies:
       '@playwright/test':
-        specifier: 1.51.1
-        version: 1.51.1
+        specifier: 'catalog:'
+        version: 1.52.0
       '@sanity/client':
         specifier: ^7.6.0
         version: 7.6.0(debug@4.4.1)
@@ -4233,17 +4242,17 @@ packages:
     resolution: {integrity: sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/experimental-ct-core@1.51.1':
-    resolution: {integrity: sha512-kpRZWBT3SMukL1fx8BwEj385Pkgtp86bBKzmrmJU30lWlQiIDFNaIHosgxQC68c8y2mg3Una/lBSHNc2Fotgkw==}
+  '@playwright/experimental-ct-core@1.52.0':
+    resolution: {integrity: sha512-DiDEammXxt8OIFDfoNitoOZyHFJAu6aYi0abmHl0IZgOQHxccP6UX50aTEnSTTUWCfwUWB0Vd8TKJ6w122WJEw==}
     engines: {node: '>=18'}
 
-  '@playwright/experimental-ct-react@1.51.1':
-    resolution: {integrity: sha512-Lu14QiemO2TWfiL6TQPWBH2n+4IvPYH/W6cfblzYpLu/TZdJ7e608l3GwqAGRN5FJym3YOonC7x1Q5EAwcBarg==}
+  '@playwright/experimental-ct-react@1.52.0':
+    resolution: {integrity: sha512-r9gREinfeCAgnMp2Kpr6MnXSnKE06HlM0qWkortrtOHhD1xdGAT+mBBBP0YvPN2f169wGNIRuSOxp05MFZ+XaQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  '@playwright/test@1.51.1':
-    resolution: {integrity: sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==}
+  '@playwright/test@1.52.0':
+    resolution: {integrity: sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9703,13 +9712,13 @@ packages:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
 
-  playwright-core@1.51.1:
-    resolution: {integrity: sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==}
+  playwright-core@1.52.0:
+    resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.51.1:
-    resolution: {integrity: sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==}
+  playwright@1.52.0:
+    resolution: {integrity: sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -14427,10 +14436,10 @@ snapshots:
 
   '@pkgr/core@0.2.7': {}
 
-  '@playwright/experimental-ct-core@1.51.1(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.20.3)(yaml@2.8.0)':
+  '@playwright/experimental-ct-core@1.52.0(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.20.3)(yaml@2.8.0)':
     dependencies:
-      playwright: 1.51.1
-      playwright-core: 1.51.1
+      playwright: 1.52.0
+      playwright-core: 1.52.0
       vite: 6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -14445,9 +14454,9 @@ snapshots:
       - tsx
       - yaml
 
-  '@playwright/experimental-ct-react@1.51.1(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.20.3)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@playwright/experimental-ct-react@1.52.0(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.20.3)(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
-      '@playwright/experimental-ct-core': 1.51.1(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.20.3)(yaml@2.8.0)
+      '@playwright/experimental-ct-core': 1.52.0(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.20.3)(yaml@2.8.0)
       '@vitejs/plugin-react': 4.5.2(vite@6.3.5(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.20.3)(yaml@2.8.0))
     transitivePeerDependencies:
       - '@types/node'
@@ -14464,9 +14473,9 @@ snapshots:
       - vite
       - yaml
 
-  '@playwright/test@1.51.1':
+  '@playwright/test@1.52.0':
     dependencies:
-      playwright: 1.51.1
+      playwright: 1.52.0
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -21309,11 +21318,11 @@ snapshots:
     dependencies:
       find-up: 3.0.0
 
-  playwright-core@1.51.1: {}
+  playwright-core@1.52.0: {}
 
-  playwright@1.51.1:
+  playwright@1.52.0:
     dependencies:
-      playwright-core: 1.51.1
+      playwright-core: 1.52.0
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,12 +10,15 @@ packages:
   - packages/sanity/fixtures/examples/*
 
 catalog:
+  '@playwright/experimental-ct-react': 1.52.0
+  '@playwright/test': 1.52.0
   '@sanity/eslint-config-i18n': ^2.0.0
   '@sanity/eslint-config-studio': ^5.0.2
   '@vitejs/plugin-react': ^4.5.2
   esbuild-register: ^3.6.0
   esbuild: 0.25.5
   globals: ^16.2.0
+  playwright: 1.52.0
   prettier: ^3.5.3
   react-dom: ^19.1.0
   react: ^19.1.0


### PR DESCRIPTION
### Description

Seeing a really weird issue when trying to [bump playwright](https://github.com/sanity-io/sanity/pull/9673), the kanji test seems to [always fail](https://github.com/sanity-io/sanity/actions/runs/15700381266/job/44239828478):
```bash
    Call Log:
    - Timeout 30000ms exceeded while waiting on the predicate

      37 |     // Enter initial text and wait for the mutate call to be sent
      38 |     await field.fill(kanji)
    > 39 |     await expect.poll(getRemoteValue, {timeout: 30_000}).toBe(kanji)
```

Maybe we can avoid this issue by bumping to `1.52` instead of `1.53` 🤞 

### What to review

Makes sense?

### Testing

If tests pass 🤞 🤞 🤞 

### Notes for release

N/A
