### PR TITLE
fix(deps): pin react-virtual to v3.13.2

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -185,7 +185,7 @@
     "@sanity/uuid": "^3.0.2",
     "@sentry/react": "^8.33.0",
     "@tanstack/react-table": "^8.21.3",
-    "@tanstack/react-virtual": "^3.11.2",
+    "@tanstack/react-virtual": "3.13.2",
     "@types/react-is": "^19.0.0",
     "@types/shallow-equals": "^1.0.0",
     "@types/speakingurl": "^13.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1619,7 +1619,7 @@ importers:
         specifier: ^8.21.3
         version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-virtual':
-        specifier: ^3.11.2
+        specifier: 3.13.2
         version: 3.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react-is':
         specifier: ^19.0.0


### PR DESCRIPTION
### Description

When renovate [tries to bump `@tanstack/react-virtual` we have tests consistently failing](https://github.com/sanity-io/sanity/pull/9661). This PR pins `@tanstack/react-virtual` to the current working version according to our `pnpm-lockfile.yaml`, which is the version we've been testing on the monorepo for the last few months.
It buys us time to get to the bottom of the issue, and ensures userland don't pull in a potentially buggy version.

### What to review

Makes sense?

### Testing

Tests should pass just as on `main`.

### Notes for release

N/A
