### PR TITLE
chore(monorepo): add recommended extensions list to improve DX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ jspm_packages
 
 # VS Code settings
 /.vscode
+!/.vscode/extensions.json
 
 # Environment files
 # ignore all local .env files

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "dbaeumer.vscode-eslint",
+    "eamodio.gitlens",
     "github.vscode-github-actions",
     "mattpocock.ts-error-translator",
     "oxc.oxc-vscode",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "github.vscode-github-actions",
+    "mattpocock.ts-error-translator",
+    "oxc.oxc-vscode",
+    "sanity-io.vscode-sanity",
+    "statelyai.stately-vscode",
+    "styled-components.vscode-styled-components",
+    "Vercel.turbo-vsc",
+    "vitest.explorer"
+  ]
+}


### PR DESCRIPTION
### Description

Now that we use oxlint it can be confusing that if you search for `oxlint` on VS Code extensions you won't find anything, as the extension you need is called `oxc`.
To make it easier to see what extensions help you when working on the monorepo I'm adding a recommended list (it works with the VS Code derivatives, like Cursor, not just strictly VS Code).
While at it I've added some other extensions that are really helpful and might not be obvious that they exist.

### What to review

Are there more extensions we want to add while at it?

### Testing

Open the monorepo on this branch in your IDE, you should see a prompt in the bottom left corner like this:

![image](https://github.com/user-attachments/assets/3509444e-0698-4889-b455-1f2310f07f6c)

You should also be able to filter extensions by `@recommended` to see the full list:
![image](https://github.com/user-attachments/assets/78f059f8-7e11-4b14-a75a-60b172a3012e)


### Notes for release

N/A
