### PR TITLE
chore: changed the 'Join Slack' badge to reflect Discord community

### DIFF
--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -15,7 +15,7 @@
   <img alt="" src="https://img.shields.io/npm/dm/@sanity/client?style=flat">
   <img alt="" src="https://img.shields.io/npm/l/sanity.svg?style=flat">
   <a aria-label="Join the community on Discord" href="https://snty.link/community">
-    <img alt="" src="https://img.shields.io/badge/Join%20Slack-f03e2f?logo=Slack&style=flat"></a>
+    <img alt="" src="https://img.shields.io/badge/Join%20Discord-4d4d4d?logo=Discord&style=flat"></a>
   <a aria-label="Follow Sanity on Bluesky" href="https://bsky.app/profile/sanity.io">
     <img alt="" src="https://img.shields.io/badge/follow-@sanity.io-blue?logo=bluesky"></a>
 </div>


### PR DESCRIPTION
### Description

Updated the README to reflect the Community's move to Discord. 
The badge from shields.io was still displayed as Slack. 

### What to review

https://github.com/sanity-io/sanity/blob/d3ad7d5214f29d110a7e06d80986e82ce3e17463/packages/sanity/README.md?plain=1#L18

Swapped out the URI for the badge to pull in Discord's icon and updated the badge's text.


### Testing

n/a 

### Notes for release

Not required