### PR TITLE
chore: update slack to discord in readmes

### DIFF
--- a/dev/studio-e2e-testing/README.md
+++ b/dev/studio-e2e-testing/README.md
@@ -5,5 +5,5 @@ Congratulations, you have now installed the Sanity Content Studio, an open-sourc
 Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
-- [Join the Sanity community](https://snty.link/community/?utm_source=readme)
+- [Join the Sanity community](https://www.sanity.io/community/join?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/dev/studio-e2e-testing/README.md
+++ b/dev/studio-e2e-testing/README.md
@@ -5,5 +5,5 @@ Congratulations, you have now installed the Sanity Content Studio, an open-sourc
 Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
-- [Join the community Discord](https://snty.link/community/?utm_source=readme)
+- [Join the Sanity community](https://snty.link/community/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/dev/studio-e2e-testing/README.md
+++ b/dev/studio-e2e-testing/README.md
@@ -5,5 +5,5 @@ Congratulations, you have now installed the Sanity Content Studio, an open-sourc
 Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
-- [Join the community Slack](https://snty.link/community/?utm_source=readme)
+- [Join the community Discord](https://snty.link/community/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -712,7 +712,7 @@ export default async function initSanity(
   if (isFirstProject) {
     trace.log({step: 'sendCommunityInvite', selectedOption: 'yes'})
 
-    const DISCORD_INVITE_LINK = 'https://snty.link/community'
+    const DISCORD_INVITE_LINK = 'https://www.sanity.io/community/join'
 
     print(`\nJoin the Sanity community: ${chalk.cyan(DISCORD_INVITE_LINK)}`)
     print('We look forward to seeing you there!\n')

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -714,7 +714,7 @@ export default async function initSanity(
 
     const DISCORD_INVITE_LINK = 'https://snty.link/community'
 
-    print(`\nJoin our wonderful developer community as well: ${chalk.cyan(DISCORD_INVITE_LINK)}`)
+    print(`\nJoin the Sanity community: ${chalk.cyan(DISCORD_INVITE_LINK)}`)
     print('We look forward to seeing you there!\n')
   }
 

--- a/packages/@sanity/cli/templates/blog/README.md
+++ b/packages/@sanity/cli/templates/blog/README.md
@@ -7,5 +7,5 @@ Now you can do the following things:
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
 - Check out the example frontend: [React/Next.js](https://github.com/sanity-io/tutorial-sanity-blog-react-next)
 - [Read the blog post about this template](https://www.sanity.io/blog/build-your-own-blog-with-sanity-and-next-js?utm_source=readme)
-- [Join the community Discord](https://snty.link/community/?utm_source=readme)
+- [Join the Sanity community](https://snty.link/community/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/blog/README.md
+++ b/packages/@sanity/cli/templates/blog/README.md
@@ -7,5 +7,5 @@ Now you can do the following things:
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
 - Check out the example frontend: [React/Next.js](https://github.com/sanity-io/tutorial-sanity-blog-react-next)
 - [Read the blog post about this template](https://www.sanity.io/blog/build-your-own-blog-with-sanity-and-next-js?utm_source=readme)
-- [Join the Sanity community](https://snty.link/community/?utm_source=readme)
+- [Join the Sanity community](https://www.sanity.io/community/join?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/blog/README.md
+++ b/packages/@sanity/cli/templates/blog/README.md
@@ -7,5 +7,5 @@ Now you can do the following things:
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
 - Check out the example frontend: [React/Next.js](https://github.com/sanity-io/tutorial-sanity-blog-react-next)
 - [Read the blog post about this template](https://www.sanity.io/blog/build-your-own-blog-with-sanity-and-next-js?utm_source=readme)
-- [Join the community Slack](https://snty.link/community/?utm_source=readme)
+- [Join the community Discord](https://snty.link/community/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/clean/README.md
+++ b/packages/@sanity/cli/templates/clean/README.md
@@ -5,5 +5,5 @@ Congratulations, you have now installed the Sanity Content Studio, an open-sourc
 Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
-- [Join the Sanity community](https://snty.link/community/?utm_source=readme)
+- [Join the Sanity community](https://www.sanity.io/community/join?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/clean/README.md
+++ b/packages/@sanity/cli/templates/clean/README.md
@@ -5,5 +5,5 @@ Congratulations, you have now installed the Sanity Content Studio, an open-sourc
 Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
-- [Join the community Discord](https://snty.link/community/?utm_source=readme)
+- [Join the Sanity community](https://snty.link/community/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/clean/README.md
+++ b/packages/@sanity/cli/templates/clean/README.md
@@ -5,5 +5,5 @@ Congratulations, you have now installed the Sanity Content Studio, an open-sourc
 Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
-- [Join the community Slack](https://snty.link/community/?utm_source=readme)
+- [Join the community Discord](https://snty.link/community/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/ecommerce/README.md
+++ b/packages/@sanity/cli/templates/ecommerce/README.md
@@ -7,5 +7,5 @@ Now you can do the following things:
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
 - Check out the example frontend: [Vue/Nuxt.js](https://github.com/sanity-io/example-ecommerce-snipcart-vue)
 - [Read the blog post about this template](https://www.sanity.io/blog/e-commerce-vue-nuxt-snipcart?uutm_source=readme)
-- [Join the community Discord](https://snty.link/community/?utm_source=readme)
+- [Join the Sanity community](https://snty.link/community/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/ecommerce/README.md
+++ b/packages/@sanity/cli/templates/ecommerce/README.md
@@ -7,5 +7,5 @@ Now you can do the following things:
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
 - Check out the example frontend: [Vue/Nuxt.js](https://github.com/sanity-io/example-ecommerce-snipcart-vue)
 - [Read the blog post about this template](https://www.sanity.io/blog/e-commerce-vue-nuxt-snipcart?uutm_source=readme)
-- [Join the community Slack](https://snty.link/community/?utm_source=readme)
+- [Join the community Discord](https://snty.link/community/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/ecommerce/README.md
+++ b/packages/@sanity/cli/templates/ecommerce/README.md
@@ -7,5 +7,5 @@ Now you can do the following things:
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
 - Check out the example frontend: [Vue/Nuxt.js](https://github.com/sanity-io/example-ecommerce-snipcart-vue)
 - [Read the blog post about this template](https://www.sanity.io/blog/e-commerce-vue-nuxt-snipcart?uutm_source=readme)
-- [Join the Sanity community](https://snty.link/community/?utm_source=readme)
+- [Join the Sanity community](https://www.sanity.io/community/join?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/get-started/README.md
+++ b/packages/@sanity/cli/templates/get-started/README.md
@@ -5,5 +5,5 @@ Congratulations, you have now installed the Sanity Content Studio, an open-sourc
 Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
-- [Join the Sanity community](https://snty.link/community/?utm_source=readme)
+- [Join the Sanity community](https://www.sanity.io/community/join?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/get-started/README.md
+++ b/packages/@sanity/cli/templates/get-started/README.md
@@ -5,5 +5,5 @@ Congratulations, you have now installed the Sanity Content Studio, an open-sourc
 Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
-- [Join the community Discord](https://snty.link/community/?utm_source=readme)
+- [Join the Sanity community](https://snty.link/community/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/get-started/README.md
+++ b/packages/@sanity/cli/templates/get-started/README.md
@@ -5,5 +5,5 @@ Congratulations, you have now installed the Sanity Content Studio, an open-sourc
 Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
-- [Join the community Slack](https://snty.link/community/?utm_source=readme)
+- [Join the community Discord](https://snty.link/community/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/moviedb/README.md
+++ b/packages/@sanity/cli/templates/moviedb/README.md
@@ -6,5 +6,5 @@ Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
 - Check out one of the example frontends: [React](https://github.com/sanity-io/example-frontend-next-js) | [React Native](https://github.com/sanity-io/example-app-react-native) | [Vue](https://github.com/sanity-io/example-frontend-vue-js) | [PHP](https://github.com/sanity-io/example-frontend-silex-twig)
-- [Join the community Discord](https://snty.link/community/?utm_source=readme)
+- [Join the Sanity community](https://snty.link/community/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/moviedb/README.md
+++ b/packages/@sanity/cli/templates/moviedb/README.md
@@ -6,5 +6,5 @@ Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
 - Check out one of the example frontends: [React](https://github.com/sanity-io/example-frontend-next-js) | [React Native](https://github.com/sanity-io/example-app-react-native) | [Vue](https://github.com/sanity-io/example-frontend-vue-js) | [PHP](https://github.com/sanity-io/example-frontend-silex-twig)
-- [Join the community Slack](https://snty.link/community/?utm_source=readme)
+- [Join the community Discord](https://snty.link/community/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/moviedb/README.md
+++ b/packages/@sanity/cli/templates/moviedb/README.md
@@ -6,5 +6,5 @@ Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
 - Check out one of the example frontends: [React](https://github.com/sanity-io/example-frontend-next-js) | [React Native](https://github.com/sanity-io/example-app-react-native) | [Vue](https://github.com/sanity-io/example-frontend-vue-js) | [PHP](https://github.com/sanity-io/example-frontend-silex-twig)
-- [Join the Sanity community](https://snty.link/community/?utm_source=readme)
+- [Join the Sanity community](https://www.sanity.io/community/join?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/quickstart/README.md
+++ b/packages/@sanity/cli/templates/quickstart/README.md
@@ -5,5 +5,5 @@ Congratulations, you have now installed Sanity Studio, an open-source real-time 
 Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
-- [Join the community Discord](https://snty.link/community/?utm_source=readme)
+- [Join the Sanity community](https://snty.link/community/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/quickstart/README.md
+++ b/packages/@sanity/cli/templates/quickstart/README.md
@@ -5,5 +5,5 @@ Congratulations, you have now installed Sanity Studio, an open-source real-time 
 Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
-- [Join the community Slack](https://snty.link/community/?utm_source=readme)
+- [Join the community Discord](https://snty.link/community/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/@sanity/cli/templates/quickstart/README.md
+++ b/packages/@sanity/cli/templates/quickstart/README.md
@@ -5,5 +5,5 @@ Congratulations, you have now installed Sanity Studio, an open-source real-time 
 Now you can do the following things:
 
 - [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
-- [Join the Sanity community](https://snty.link/community/?utm_source=readme)
+- [Join the Sanity community](https://www.sanity.io/community/join?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)

--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -14,7 +14,7 @@
   <img alt="" src="https://img.shields.io/npm/v/sanity?style=flat">
   <img alt="" src="https://img.shields.io/npm/dm/@sanity/client?style=flat">
   <img alt="" src="https://img.shields.io/npm/l/sanity.svg?style=flat">
-  <a aria-label="Join the Sanity community" href="https://snty.link/community">
+  <a aria-label="Join the Sanity community" href="https://www.sanity.io/community/join?utm_source=readme">
     <img alt="" src="https://img.shields.io/badge/Join%20Slack-f03e2f?logo=Slack&style=flat"></a>
   <a aria-label="Follow Sanity on Bluesky" href="https://bsky.app/profile/sanity.io">
     <img alt="" src="https://img.shields.io/badge/follow-@sanity.io-blue?logo=bluesky"></a>

--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -80,7 +80,7 @@ Check out [the docs](https://www.sanity.io/docs/sanity-studio) and [plugins](htt
 - Subscribe to our [YouTube channel](https://www.youtube.com/@sanity_io)
 - Subscribe to [our blog by RSS](https://www.sanity.io/feed/rss)
 - Subscribe to our [newsletter](https://www.sanity.io/newsletter)
-- Join the [Sanity community](https://snty.link/community)
+- Join the [Sanity community](https://www.sanity.io/community/join?utm_source=readme)
 
 ## Code of Conduct
 

--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -14,7 +14,7 @@
   <img alt="" src="https://img.shields.io/npm/v/sanity?style=flat">
   <img alt="" src="https://img.shields.io/npm/dm/@sanity/client?style=flat">
   <img alt="" src="https://img.shields.io/npm/l/sanity.svg?style=flat">
-  <a aria-label="Join the community on Discord" href="https://snty.link/community">
+  <a aria-label="Join the Sanity community" href="https://snty.link/community">
     <img alt="" src="https://img.shields.io/badge/Join%20Slack-f03e2f?logo=Slack&style=flat"></a>
   <a aria-label="Follow Sanity on Bluesky" href="https://bsky.app/profile/sanity.io">
     <img alt="" src="https://img.shields.io/badge/follow-@sanity.io-blue?logo=bluesky"></a>
@@ -80,7 +80,7 @@ Check out [the docs](https://www.sanity.io/docs/sanity-studio) and [plugins](htt
 - Subscribe to our [YouTube channel](https://www.youtube.com/@sanity_io)
 - Subscribe to [our blog by RSS](https://www.sanity.io/feed/rss)
 - Subscribe to our [newsletter](https://www.sanity.io/newsletter)
-- Join the [developer community on Discord](https://snty.link/community)
+- Join the [Sanity community](https://snty.link/community)
 
 ## Code of Conduct
 


### PR DESCRIPTION
### Description

Readme's had the correct community link for Discord, but outdated link text.