### PR TITLE
refactor(core): update padding for boolean

### DIFF
--- a/packages/sanity/src/core/form/inputs/BooleanInput.tsx
+++ b/packages/sanity/src/core/form/inputs/BooleanInput.tsx
@@ -40,7 +40,7 @@ export function BooleanInput(props: BooleanInputProps) {
   const tone: CardTone | undefined = readOnly ? 'transparent' : undefined
 
   const input = (
-    <Box padding={3}>
+    <Box padding={3} style={{paddingTop: '0.85rem'}}>
       <LayoutSpecificInput
         label={schemaType.title}
         {...elementProps}


### PR DESCRIPTION
### Description

Slight mis-alignment in the boolean input.

Before
![image](https://github.com/user-attachments/assets/849d32a4-ccf2-4835-b31d-741638543de8)

After
<img width="604" alt="image" src="https://github.com/user-attachments/assets/478d3d69-4f25-45db-b7cb-0ecd2e65e684" />

### What to review

Do you all see a better way?

### Notes for release

N/A (not worth mentioning)
