### PR TITLE
feat(sanity): add document panel banner for choosing new document destination

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1203,10 +1203,6 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
    * when there are templates/types available for creation
    */
   'new-document.create-new-document-label': 'New document…',
-  /** Tooltip message for add document button when the selected perspective is published  */
-  'new-document.disabled-published.tooltip': 'You cannot create new published documents',
-  /** Tooltip message for add document button when the selected perspective is for inactive release */
-  'new-document.disabled-release.tooltip': 'You cannot add documents to this release',
   /** Placeholder for the "filter" input within the new document menu */
   'new-document.filter-placeholder': 'Search document types',
   /** Loading indicator text within the new document menu */

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
@@ -16,9 +16,6 @@ import {Button, type ButtonProps, Tooltip, type TooltipProps} from '../../../../
 import {InsufficientPermissionsMessage} from '../../../../components'
 import {useSchema} from '../../../../hooks'
 import {useGetI18nText, useTranslation} from '../../../../i18n'
-import {usePerspective} from '../../../../perspective/usePerspective'
-import {useIsReleaseActive} from '../../../../releases/hooks/useIsReleaseActive'
-import {isPublishedPerspective} from '../../../../releases/util/util'
 import {useCurrentUser} from '../../../../store'
 import {useColorSchemeValue} from '../../../colorScheme'
 import {filterOptions} from './filter'
@@ -49,8 +46,6 @@ interface NewDocumentButtonProps {
 export function NewDocumentButton(props: NewDocumentButtonProps) {
   const {canCreateDocument, modal = 'popover', loading, options} = props
 
-  const isReleaseActive = useIsReleaseActive()
-  const {selectedPerspective} = usePerspective()
   const [open, setOpen] = useState<boolean>(false)
   const [searchQuery, setSearchQuery] = useState<string>('')
   const popoverRef = useRef<HTMLDivElement | null>(null)
@@ -65,7 +60,7 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
   const schema = useSchema()
 
   const hasNewDocumentOptions = options.length > 0
-  const disabled = !canCreateDocument || !hasNewDocumentOptions || !isReleaseActive
+  const disabled = !canCreateDocument || !hasNewDocumentOptions
   const placeholder = t('new-document.filter-placeholder')
   const title = t('new-document.title')
   const openDialogAriaLabel = t('new-document.open-dialog-aria-label')
@@ -179,13 +174,6 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
 
   // Tooltip content for the open button
   const tooltipContent: TooltipProps['content'] = useMemo(() => {
-    if (!isReleaseActive) {
-      const tooltipText = isPublishedPerspective(selectedPerspective)
-        ? t('new-document.disabled-published.tooltip')
-        : t('new-document.disabled-release.tooltip')
-
-      return <Text size={1}>{tooltipText}</Text>
-    }
     if (!hasNewDocumentOptions) {
       return <Text size={1}>{t('new-document.no-document-types-label')}</Text>
     }
@@ -197,14 +185,7 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
     return (
       <InsufficientPermissionsMessage currentUser={currentUser} context="create-any-document" />
     )
-  }, [
-    canCreateDocument,
-    currentUser,
-    hasNewDocumentOptions,
-    isReleaseActive,
-    selectedPerspective,
-    t,
-  ])
+  }, [canCreateDocument, currentUser, hasNewDocumentOptions, t])
 
   // Shared tooltip props for the popover and dialog
   const sharedTooltipProps: TooltipProps = useMemo(

--- a/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -3,12 +3,10 @@ import {Menu} from '@sanity/ui'
 import {type ComponentProps, type ForwardedRef, forwardRef, useMemo} from 'react'
 import {
   type InitialValueTemplateItem,
-  isPublishedPerspective,
   type ReleaseId,
   type Template,
   type TemplatePermissionsResult,
   useGetI18nText,
-  useIsReleaseActive,
   usePerspective,
   useTemplatePermissions,
   useTemplates,
@@ -57,11 +55,9 @@ interface PaneHeaderCreateButtonProps {
 
 export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonProps) {
   const templates = useTemplates()
-  const {selectedReleaseId, selectedPerspective} = usePerspective()
-  const isReleaseActive = useIsReleaseActive()
+  const {selectedReleaseId} = usePerspective()
 
   const {t} = useTranslation(structureLocaleNamespace)
-  const {t: tCore} = useTranslation()
   const getI18nText = useGetI18nText([...templateItems, ...templates])
 
   const [templatePermissions, isTemplatePermissionsLoading] = useTemplatePermissions({
@@ -106,18 +102,10 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
     )
   }
 
-  const disabledByPerspectiveTooltipProps = {
-    content: tCore(
-      isPublishedPerspective(selectedPerspective)
-        ? 'new-document.disabled-published.tooltip'
-        : 'new-document.disabled-release.tooltip',
-    ),
-  }
-
   if (templateItems.length === 1) {
     const firstItem = templateItems[0]
     const permissions = permissionsById[firstItem.id]
-    const disabled = !permissions?.granted || !isReleaseActive
+    const disabled = !permissions?.granted
     const intent = getIntent(templates, firstItem, selectedReleaseId)
     if (!intent) return null
 
@@ -134,11 +122,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
           mode="bleed"
           disabled={disabled}
           data-testid="action-intent-button"
-          tooltipProps={
-            disabled
-              ? disabledByPerspectiveTooltipProps
-              : {content: t('pane-header.create-new-button.tooltip')}
-          }
+          tooltipProps={{content: t('pane-header.create-new-button.tooltip')}}
         />
       </InsufficientPermissionsMessageTooltip>
     )
@@ -150,13 +134,8 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
         <Button
           icon={AddIcon}
           mode="bleed"
-          disabled={!isReleaseActive}
           data-testid="multi-action-intent-button"
-          tooltipProps={
-            isReleaseActive
-              ? {content: t('pane-header.create-new-button.tooltip')}
-              : disabledByPerspectiveTooltipProps
-          }
+          tooltipProps={{content: t('pane-header.create-new-button.tooltip')}}
         />
       }
       id="create-menu"

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -95,6 +95,15 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** Description for the archived release banner, rendered when viewing the history of a version document from the publihed view */
   'banners.archived-release.description':
     'This document version belongs to the archived <VersionBadge>{{title}}</VersionBadge> release',
+  /** The explanation displayed when a user attempts to create a new published document, but the schema type doesn't support live-editing */
+  'banners.choose-new-document-destination.cannot-create-published-document':
+    'Cannot create a published document.',
+  /** The prompt displayed when a user must select a different perspective in order to create a document */
+  'banners.choose-new-document-destination.choose-destination':
+    'Choose a destination for this document:',
+  /** The explanation displayed when a user attempts to create a new document in a release, but the selected release is inactive */
+  'banners.choose-new-document-destination.release-inactive':
+    'The <VersionBadge>{{title}}</VersionBadge> release is not active.',
   /** The text for the restore button on the deleted document banner */
   'banners.deleted-document-banner.restore-button.text': 'Restore most recent revision',
   /** The text content for the deleted document banner */

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -4,6 +4,7 @@ import {
   getSanityCreateLinkMetadata,
   getVersionFromId,
   isNewDocument,
+  isPerspectiveWriteable,
   isReleaseDocument,
   isReleaseScheduledOrScheduling,
   isSanityCreateLinked,
@@ -30,6 +31,7 @@ import {
 } from './banners'
 import {ArchivedReleaseDocumentBanner} from './banners/ArchivedReleaseDocumentBanner'
 import {CanvasLinkedBanner} from './banners/CanvasLinkedBanner'
+import {ChooseNewDocumentDestinationBanner} from './banners/ChooseNewDocumentDestinationBanner'
 import {CreateLinkedBanner} from './banners/CreateLinkedBanner'
 import {DocumentNotInReleaseBanner} from './banners/DocumentNotInReleaseBanner'
 import {DraftLiveEditBanner} from './banners/DraftLiveEditBanner'
@@ -179,6 +181,21 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
         displayed?._id &&
         getVersionFromId(displayed?._id) === selectedReleaseId,
     )
+
+    const isSelectedPerspectiveWriteable = isPerspectiveWriteable({
+      selectedPerspective,
+      schemaType,
+    })
+
+    if (!isSelectedPerspectiveWriteable.result && isNewDocument(editState)) {
+      return (
+        <ChooseNewDocumentDestinationBanner
+          schemaType={schemaType}
+          selectedPerspective={selectedPerspective}
+          reason={isSelectedPerspectiveWriteable.reason}
+        />
+      )
+    }
 
     if (documentInScheduledRelease) {
       return <ScheduledReleaseBanner currentRelease={selectedPerspective as ReleaseDocument} />

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ChooseNewDocumentDestinationBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ChooseNewDocumentDestinationBanner.tsx
@@ -1,0 +1,78 @@
+import {WarningOutlineIcon} from '@sanity/icons'
+import {type ObjectSchemaType} from '@sanity/types'
+import {Flex, Text} from '@sanity/ui'
+import {type ComponentType, useCallback} from 'react'
+import {
+  getVersionInlineBadge,
+  isPerspectiveWriteable,
+  isReleaseDocument,
+  type PerspectiveNotWriteableReason,
+  ReleasesNav,
+  type ReleasesNavMenuItemPropsGetter,
+  type SelectedPerspective,
+  Translate,
+  useTranslation,
+} from 'sanity'
+
+import {structureLocaleNamespace} from '../../../../i18n'
+import {Banner} from './Banner'
+
+interface Props {
+  schemaType: ObjectSchemaType
+  selectedPerspective: SelectedPerspective
+  reason: PerspectiveNotWriteableReason
+}
+
+/**
+ * This banner is displayed when a user attempts to create a new document in a perspective that's
+ * not writeable. For example:
+ *
+ * - The published perspective (unless the schema type supports live-editing).
+ * - Any release that's locked.
+ */
+export const ChooseNewDocumentDestinationBanner: ComponentType<Props> = ({
+  schemaType,
+  selectedPerspective,
+  reason,
+}) => {
+  const {t} = useTranslation(structureLocaleNamespace)
+
+  const menuItemProps = useCallback<ReleasesNavMenuItemPropsGetter>(
+    ({perspective}) => ({
+      disabled: !isPerspectiveWriteable({
+        selectedPerspective: perspective,
+        schemaType,
+      }).result,
+    }),
+    [schemaType],
+  )
+
+  return (
+    <Banner
+      tone="caution"
+      icon={WarningOutlineIcon}
+      content={
+        <Flex align="center" gap={2}>
+          <Text size={1}>
+            {reason === 'PUBLISHED_NOT_WRITEABLE' &&
+              t('banners.choose-new-document-destination.cannot-create-published-document')}
+            {reason === 'RELEASE_NOT_ACTIVE' && isReleaseDocument(selectedPerspective) && (
+              <Translate
+                t={t}
+                i18nKey="banners.choose-new-document-destination.release-inactive"
+                values={{
+                  title: selectedPerspective.metadata.title,
+                }}
+                components={{
+                  VersionBadge: getVersionInlineBadge(selectedPerspective),
+                }}
+              />
+            )}
+            <> {t('banners.choose-new-document-destination.choose-destination')}</>
+          </Text>
+          <ReleasesNav menuItemProps={menuItemProps} />
+        </Flex>
+      }
+    />
+  )
+}


### PR DESCRIPTION
### Description

Currently, document creation buttons are made inactive when the user is viewing a perspective in which document cannot be created. For example, it's not permitted to created new published documents.

This behaviour is a bit more complicated than it seems after taking into account factors such as live-editable documents (which _can_ be created as a published document), inactive releases, and the future ability to switch off the draft model in a workspace.

In an effort to simplify the implementation and the UI, this branch switches the create document buttons to always active. If the user attempts to create a document in a perspective in which it cannot be created, they are shown a read-only form and presented with a banner asking them to switch to a perspective in which the document can be created.

<img width="937" alt="Screenshot 2025-06-19 at 14 34 08" src="https://github.com/user-attachments/assets/b0960289-2f34-4993-b666-cf5f7b1abd04" />

After switching to a supported perspective, the user can proceed to create the document.

### What to review

The document creation buttons and perspective switching banner.

### Testing

Tested various scenarios in Test Studio.