### PR TITLE
feat(sanity): allow draft model to be switched off

### DIFF
--- a/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
@@ -11,6 +11,7 @@ import {
   useActiveReleases,
   type VersionInfoDocumentStub,
 } from '../../releases'
+import {useWorkspace} from '../../studio/workspace'
 
 interface DocumentStatusProps {
   draft?: PreviewValue | Partial<SanityDocument> | null
@@ -34,6 +35,12 @@ export function DocumentStatus({draft, published, versions, singleLine}: Documen
   const versionsList = useMemo(() => Object.entries(versions ?? {}), [versions])
   const {t} = useTranslation()
 
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
   return (
     <Flex
       align={singleLine ? 'center' : 'flex-start'}
@@ -49,7 +56,7 @@ export function DocumentStatus({draft, published, versions, singleLine}: Documen
           tone={'positive'}
         />
       )}
-      {draft && (
+      {isDraftModelEnabled && draft && (
         <VersionStatus
           title={t('release.chip.draft')}
           mode="draft"

--- a/packages/sanity/src/core/components/documentStatusIndicator/DocumentStatusIndicator.tsx
+++ b/packages/sanity/src/core/components/documentStatusIndicator/DocumentStatusIndicator.tsx
@@ -5,6 +5,7 @@ import {css, styled} from 'styled-components'
 import {RELEASE_TYPES_TONES, type VersionInfoDocumentStub} from '../../releases'
 import {useActiveReleases} from '../../releases/store/useActiveReleases'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
+import {useWorkspace} from '../../studio/workspace'
 
 interface DocumentStatusProps {
   draft?: VersionInfoDocumentStub | undefined
@@ -54,6 +55,13 @@ type Status = 'published' | 'draft' | 'asap' | 'scheduled' | 'undecided'
  */
 export function DocumentStatusIndicator({draft, published, versions}: DocumentStatusProps) {
   const {data: releases} = useActiveReleases()
+
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
   const versionsList = useMemo(
     () =>
       versions
@@ -79,8 +87,8 @@ export function DocumentStatusIndicator({draft, published, versions}: DocumentSt
       show: Boolean(published),
     },
     {
-      status: 'draft',
-      show: Boolean(draft),
+      status: 'draft' as const,
+      show: isDraftModelEnabled && Boolean(draft),
     },
     {
       status: 'asap',

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -521,6 +521,21 @@ export const legacySearchEnabledReducer: ConfigPropertyReducer<boolean, ConfigCo
   return prev
 }
 
+export const draftsEnabledReducer: ConfigPropertyReducer<boolean, ConfigContext> = (
+  prev,
+  {document},
+): boolean => {
+  if (typeof document?.drafts?.enabled === 'boolean') {
+    return document?.drafts?.enabled
+  }
+
+  if (typeof document?.drafts?.enabled !== 'undefined') {
+    throw new Error(`Expected boolean, but received ${getPrintableType(document?.drafts?.enabled)}`)
+  }
+
+  return prev
+}
+
 /**
  * Some projects may already be using the `enableLegacySearch` option. In order to gracefully
  * migrate to the `strategy` option, this reducer produces a value that respects any existing

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -35,6 +35,7 @@ import {
   documentCommentsEnabledReducer,
   documentInspectorsReducer,
   documentLanguageFilterReducer,
+  draftsEnabledReducer,
   eventsAPIReducer,
   fileAssetSourceResolver,
   imageAssetSourceResolver,
@@ -593,6 +594,15 @@ function resolveSource({
           propertyName: 'document.badges',
           reducer: documentBadgesReducer,
         }),
+      drafts: {
+        enabled: resolveConfigProperty({
+          config,
+          context,
+          reducer: draftsEnabledReducer,
+          propertyName: 'document.drafts.enabled',
+          initialValue: true,
+        }),
+      },
       unstable_fieldActions: (partialContext) =>
         resolveConfigProperty({
           config,

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -299,6 +299,18 @@ export interface DocumentPluginOptions {
   comments?: {
     enabled: boolean | ((context: DocumentCommentsEnabledContext) => boolean)
   }
+
+  drafts?: {
+    /**
+     * Whether the workspace provides the draft model for interacting with documents.
+     *
+     * When switched off, documents may only be edited:
+     *
+     *  - Inside a release.
+     *  - Outside a release if they support live-edit.
+     */
+    enabled?: boolean
+  }
 }
 
 /**
@@ -719,6 +731,18 @@ export interface Source {
      * @internal
      */
     components?: DocumentComponents
+
+    drafts: {
+      /**
+       * Whether the workspace provides the draft model for interacting with documents.
+       *
+       * When switched off, documents may only be edited:
+       *
+       *  - Inside a release.
+       *  - Outside a release if they support live-edit.
+       */
+      enabled: boolean
+    }
 
     /** @internal */
     unstable_fieldActions: (

--- a/packages/sanity/src/core/perspective/GlobalPerspectiveProvider.tsx
+++ b/packages/sanity/src/core/perspective/GlobalPerspectiveProvider.tsx
@@ -7,9 +7,10 @@ import {useTranslation} from '../i18n/hooks/useTranslation'
 import {Translate} from '../i18n/Translate'
 import {useActiveReleases} from '../releases/store/useActiveReleases'
 import {useArchivedReleases} from '../releases/store/useArchivedReleases'
-import {LATEST} from '../releases/util/const'
+import {LATEST, PUBLISHED} from '../releases/util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../releases/util/getReleaseIdFromReleaseDocumentId'
 import {isPublishedPerspective} from '../releases/util/util'
+import {useWorkspace} from '../studio/workspace'
 import {EMPTY_ARRAY} from '../util/empty'
 import {PerspectiveProvider} from './PerspectiveProvider'
 import {type ReleaseId} from './types'
@@ -102,10 +103,20 @@ const ResetPerspectiveHandler = () => {
 export function GlobalPerspectiveProvider({children}: {children: ReactNode}) {
   const router = useRouter()
 
-  const selectedPerspectiveName = router.stickyParams.perspective as
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
+  let selectedPerspectiveName = router.stickyParams.perspective as
     | 'published'
     | ReleaseId
     | undefined
+
+  if (!isDraftModelEnabled && typeof selectedPerspectiveName === 'undefined') {
+    selectedPerspectiveName = PUBLISHED
+  }
 
   const excludedPerspectives = useMemo(
     () => router.stickyParams.excludedPerspectives?.split(',') || EMPTY_ARRAY,

--- a/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
+++ b/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
@@ -3,6 +3,7 @@ import {PerspectiveContext} from 'sanity/_singletons'
 
 import {getReleasesPerspectiveStack} from '../releases/hooks/utils'
 import {useActiveReleases} from '../releases/store/useActiveReleases'
+import {useWorkspace} from '../studio/workspace'
 import {isSystemBundleName} from '../util/draftUtils'
 import {EMPTY_ARRAY} from '../util/empty'
 import {getSelectedPerspective} from './getSelectedPerspective'
@@ -22,6 +23,12 @@ export function PerspectiveProvider({
 }) {
   const {data: releases} = useActiveReleases()
 
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
   const selectedPerspective: SelectedPerspective = useMemo(
     () => getSelectedPerspective(selectedPerspectiveName, releases),
     [selectedPerspectiveName, releases],
@@ -33,8 +40,9 @@ export function PerspectiveProvider({
         releases,
         selectedPerspectiveName,
         excludedPerspectives,
+        isDraftModelEnabled,
       }),
-    [releases, selectedPerspectiveName, excludedPerspectives],
+    [releases, selectedPerspectiveName, excludedPerspectives, isDraftModelEnabled],
   )
 
   const value: PerspectiveContextValue = useMemo(

--- a/packages/sanity/src/core/perspective/isPerspectiveWriteable.ts
+++ b/packages/sanity/src/core/perspective/isPerspectiveWriteable.ts
@@ -1,7 +1,7 @@
 import {type ObjectSchemaType} from '@sanity/types'
 
 import {isReleaseDocument} from '../releases/store/types'
-import {isPublishedPerspective} from '../releases/util/util'
+import {isDraftPerspective, isPublishedPerspective} from '../releases/util/util'
 import {type SelectedPerspective} from './types'
 
 /**
@@ -11,6 +11,7 @@ export type PerspectiveNotWriteableReason =
   | 'INSUFFICIENT_DATA'
   | 'RELEASE_NOT_ACTIVE'
   | 'PUBLISHED_NOT_WRITEABLE'
+  | 'DRAFTS_NOT_WRITEABLE'
 
 /**
  * Check whether the provided schema type can be written to the provided perspective. This depends
@@ -22,9 +23,11 @@ export type PerspectiveNotWriteableReason =
  */
 export function isPerspectiveWriteable({
   selectedPerspective,
+  isDraftModelEnabled,
   schemaType,
 }: {
   selectedPerspective: SelectedPerspective
+  isDraftModelEnabled: boolean
   schemaType?: ObjectSchemaType
 }): {result: true} | {result: false; reason: PerspectiveNotWriteableReason} {
   if (typeof schemaType === 'undefined') {
@@ -45,6 +48,17 @@ export function isPerspectiveWriteable({
     return {
       result: false,
       reason: 'PUBLISHED_NOT_WRITEABLE',
+    }
+  }
+
+  if (
+    isDraftPerspective(selectedPerspective) &&
+    !isDraftModelEnabled &&
+    schemaType.liveEdit !== true
+  ) {
+    return {
+      result: false,
+      reason: 'DRAFTS_NOT_WRITEABLE',
     }
   }
 

--- a/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenuItem.tsx
+++ b/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenuItem.tsx
@@ -13,7 +13,7 @@ import {usePerspective} from '../../perspective/usePerspective'
 import {useSetPerspective} from '../../perspective/useSetPerspective'
 import {ReleaseAvatar} from '../../releases/components/ReleaseAvatar'
 import {isReleaseDocument} from '../../releases/store/types'
-import {type LATEST} from '../../releases/util/const'
+import {LATEST, PUBLISHED} from '../../releases/util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
 import {getReleaseTone} from '../../releases/util/getReleaseTone'
 import {
@@ -22,6 +22,7 @@ import {
   isPublishedPerspective,
   isReleaseScheduledOrScheduling,
 } from '../../releases/util/util'
+import {useWorkspace} from '../../studio/workspace'
 import {type ReleasesNavMenuItemPropsGetter} from '../types'
 import {GlobalPerspectiveMenuItemIndicator} from './PerspectiveLayerIndicator'
 
@@ -91,6 +92,14 @@ export const GlobalPerspectiveMenuItem = forwardRef<
   }
 >((props, ref) => {
   const {release, rangePosition} = props
+
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
+  const defaultPerspective = isDraftModelEnabled ? LATEST : PUBLISHED
   const {selectedPerspective, selectedPerspectiveName} = usePerspective()
   const setPerspective = useSetPerspective()
   const {toggleExcludedPerspective, isPerspectiveExcluded} = useExcludedPerspective()
@@ -98,9 +107,11 @@ export const GlobalPerspectiveMenuItem = forwardRef<
     ? getReleaseIdFromReleaseDocumentId(release._id)
     : release
 
+  const isDefaultPerspective = release === defaultPerspective
+
   const active = selectedPerspectiveName
     ? releaseId === selectedPerspectiveName
-    : isDraftPerspective(release)
+    : isDefaultPerspective
 
   const isReleasePerspectiveExcluded = isPerspectiveExcluded(releaseId)
 
@@ -135,7 +146,7 @@ export const GlobalPerspectiveMenuItem = forwardRef<
 
   return (
     <GlobalPerspectiveMenuItemIndicator
-      $isDraft={isDraftPerspective(release)}
+      $isDefaultPerspective={isDefaultPerspective}
       $first={rangePosition === 'first'}
       $last={rangePosition === 'last'}
       $inRange={Boolean(rangePosition)}

--- a/packages/sanity/src/core/perspective/navbar/PerspectiveLayerIndicator.tsx
+++ b/packages/sanity/src/core/perspective/navbar/PerspectiveLayerIndicator.tsx
@@ -10,9 +10,9 @@ export const GlobalPerspectiveMenuItemIndicator = styled.div<{
   $inRange: boolean
   $last: boolean
   $first: boolean
-  $isDraft: boolean
+  $isDefaultPerspective: boolean
 }>(
-  ({$inRange, $last, $first, $isDraft}) => css`
+  ({$inRange, $last, $first, $isDefaultPerspective}) => css`
     position: relative;
 
     --indicator-left: ${INDICATOR_LEFT_OFFSET}px;
@@ -32,7 +32,9 @@ export const GlobalPerspectiveMenuItemIndicator = styled.div<{
         left: var(--indicator-left);
         bottom: -var(--indicator-bottom);
         width: var(--indicator-width);
-        height: ${$isDraft ? 'calc(var(--indicator-bottom) + 12px)' : 'var(--indicator-bottom)'};
+        height: ${$isDefaultPerspective
+          ? 'calc(var(--indicator-bottom) + 12px)'
+          : 'var(--indicator-bottom)'};
         background-color: var(--card-border-color);
       }
     `}

--- a/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
@@ -6,7 +6,9 @@ import {css, styled} from 'styled-components'
 import {CreateReleaseMenuItem} from '../../releases/components/CreateReleaseMenuItem'
 import {useReleasesUpsell} from '../../releases/contexts/upsell/useReleasesUpsell'
 import {useActiveReleases} from '../../releases/store/useActiveReleases'
-import {LATEST} from '../../releases/util/const'
+import {useReleaseOperations} from '../../releases/store/useReleaseOperations'
+import {useReleasePermissions} from '../../releases/store/useReleasePermissions'
+import {LATEST, PUBLISHED} from '../../releases/util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
 import {type ReleasesNavMenuItemPropsGetter} from '../types'
 import {usePerspective} from '../usePerspective'
@@ -19,8 +21,6 @@ import {ReleaseTypeMenuSection} from './ReleaseTypeMenuSection'
 import {type ScrollElement} from './useScrollIndicatorVisibility'
 
 const orderedReleaseTypes: ReleaseType[] = ['asap', 'scheduled', 'undecided']
-
-const ASAP_RANGE_OFFSET = 2
 
 const StyledBox = styled(Box)`
   overflow: auto;
@@ -86,14 +86,13 @@ export function ReleasesList({
     const isDraftsPerspective = typeof selectedPerspectiveName === 'undefined'
     let lastIndex = isDraftsPerspective ? 1 : 0
 
+    const systemStack = [PUBLISHED, LATEST]
     const {asap, scheduled} = sortedReleaseTypeReleases
-    const countAsapReleases = asap.length
-    const countScheduledReleases = scheduled.length
 
     const offsets = {
-      asap: ASAP_RANGE_OFFSET,
-      scheduled: ASAP_RANGE_OFFSET + countAsapReleases,
-      undecided: ASAP_RANGE_OFFSET + countAsapReleases + countScheduledReleases,
+      asap: systemStack.length,
+      scheduled: systemStack.length + asap.length,
+      undecided: systemStack.length + asap.length + scheduled.length,
     }
 
     const adjustIndexForReleaseType = (type: ReleaseType) => {

--- a/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
@@ -6,10 +6,9 @@ import {css, styled} from 'styled-components'
 import {CreateReleaseMenuItem} from '../../releases/components/CreateReleaseMenuItem'
 import {useReleasesUpsell} from '../../releases/contexts/upsell/useReleasesUpsell'
 import {useActiveReleases} from '../../releases/store/useActiveReleases'
-import {useReleaseOperations} from '../../releases/store/useReleaseOperations'
-import {useReleasePermissions} from '../../releases/store/useReleasePermissions'
 import {LATEST, PUBLISHED} from '../../releases/util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
+import {useWorkspace} from '../../studio/workspace'
 import {type ReleasesNavMenuItemPropsGetter} from '../types'
 import {usePerspective} from '../usePerspective'
 import {
@@ -65,6 +64,12 @@ export function ReleasesList({
   const {loading, data: releases} = useActiveReleases()
   const {selectedPerspectiveName} = usePerspective()
 
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
   const handleCreateBundleClick = useCallback(
     () => guardWithReleaseLimitUpsell(() => setCreateBundleDialogOpen(true)),
     [guardWithReleaseLimitUpsell, setCreateBundleDialogOpen],
@@ -86,7 +91,7 @@ export function ReleasesList({
     const isDraftsPerspective = typeof selectedPerspectiveName === 'undefined'
     let lastIndex = isDraftsPerspective ? 1 : 0
 
-    const systemStack = [PUBLISHED, LATEST]
+    const systemStack = [PUBLISHED, isDraftModelEnabled ? LATEST : []].flat()
     const {asap, scheduled} = sortedReleaseTypeReleases
 
     const offsets = {
@@ -114,7 +119,7 @@ export function ReleasesList({
       lastIndex,
       offsets,
     }
-  }, [selectedPerspectiveName, selectedReleaseId, sortedReleaseTypeReleases])
+  }, [isDraftModelEnabled, selectedPerspectiveName, selectedReleaseId, sortedReleaseTypeReleases])
 
   if (loading) {
     return (
@@ -136,11 +141,13 @@ export function ReleasesList({
             release={'published'}
             menuItemProps={menuItemProps}
           />
-          <GlobalPerspectiveMenuItem
-            rangePosition={isRangeVisible ? getRangePosition(range, 1) : undefined}
-            release={LATEST}
-            menuItemProps={menuItemProps}
-          />
+          {isDraftModelEnabled && (
+            <GlobalPerspectiveMenuItem
+              rangePosition={isRangeVisible ? getRangePosition(range, 1) : undefined}
+              release={LATEST}
+              menuItemProps={menuItemProps}
+            />
+          )}
         </StyledPublishedBox>
         {areReleasesEnabled && (
           <>

--- a/packages/sanity/src/core/perspective/useSetPerspective.tsx
+++ b/packages/sanity/src/core/perspective/useSetPerspective.tsx
@@ -1,6 +1,8 @@
 import {useCallback} from 'react'
 import {useRouter} from 'sanity/router'
 
+import {LATEST, PUBLISHED} from '../releases/util/const'
+import {useWorkspace} from '../studio/workspace'
 import {type ReleaseId} from './types'
 
 /**
@@ -8,16 +10,25 @@ import {type ReleaseId} from './types'
  */
 export function useSetPerspective() {
   const router = useRouter()
+
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
+  const defaultPerspective = isDraftModelEnabled ? LATEST : PUBLISHED
+
   const setPerspective = useCallback(
     (releaseId: 'published' | 'drafts' | ReleaseId | undefined) => {
       router.navigate({
         stickyParams: {
           excludedPerspectives: null,
-          perspective: releaseId === 'drafts' ? '' : releaseId,
+          perspective: releaseId === defaultPerspective ? '' : releaseId,
         },
       })
     },
-    [router],
+    [defaultPerspective, router],
   )
   return setPerspective
 }

--- a/packages/sanity/src/core/releases/hooks/__tests__/utils.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/utils.test.ts
@@ -212,34 +212,90 @@ describe('getReleasesPerspectiveStack()', () => {
   const testCases: {
     selectedPerspectiveName: ReleaseId | 'published' | undefined
     excludedPerspectives: string[]
+    isDraftModelEnabled: boolean
     expected: string[]
   }[] = [
-    {selectedPerspectiveName: 'rasap1', excludedPerspectives: [], expected: ['rasap1', 'drafts']},
+    {
+      selectedPerspectiveName: 'rasap1',
+      isDraftModelEnabled: true,
+      excludedPerspectives: [],
+      expected: ['rasap1', 'drafts'],
+    },
+    {
+      selectedPerspectiveName: 'rasap1',
+      isDraftModelEnabled: false,
+      excludedPerspectives: [],
+      expected: ['rasap1', 'published'],
+    },
     {
       selectedPerspectiveName: 'rasap2',
+      isDraftModelEnabled: true,
       excludedPerspectives: [],
       expected: ['rasap2', 'rasap1', 'drafts'],
     },
     {
+      selectedPerspectiveName: 'rasap2',
+      isDraftModelEnabled: false,
+      excludedPerspectives: [],
+      expected: ['rasap2', 'rasap1', 'published'],
+    },
+    {
       selectedPerspectiveName: 'rundecided2',
+      isDraftModelEnabled: true,
       excludedPerspectives: [],
       expected: ['rundecided2', 'rfuture4', 'rfuture1', 'rasap2', 'rasap1', 'drafts'],
     },
     {
       selectedPerspectiveName: 'rundecided2',
+      isDraftModelEnabled: false,
+      excludedPerspectives: [],
+      expected: ['rundecided2', 'rfuture4', 'rfuture1', 'rasap2', 'rasap1', 'published'],
+    },
+    {
+      selectedPerspectiveName: 'rundecided2',
+      isDraftModelEnabled: true,
       excludedPerspectives: ['rfuture1', 'drafts'],
       expected: ['rundecided2', 'rfuture4', 'rasap2', 'rasap1'],
     },
-    {selectedPerspectiveName: 'published', excludedPerspectives: [], expected: ['published']},
-    {selectedPerspectiveName: undefined, excludedPerspectives: [], expected: ['drafts']},
+    {
+      selectedPerspectiveName: 'rundecided2',
+      isDraftModelEnabled: false,
+      excludedPerspectives: ['rfuture1', 'published'],
+      expected: ['rundecided2', 'rfuture4', 'rasap2', 'rasap1'],
+    },
+    {
+      selectedPerspectiveName: 'published',
+      isDraftModelEnabled: true,
+      excludedPerspectives: [],
+      expected: ['published'],
+    },
+    {
+      selectedPerspectiveName: 'published',
+      isDraftModelEnabled: false,
+      excludedPerspectives: [],
+      expected: ['published'],
+    },
+    {
+      selectedPerspectiveName: undefined,
+      isDraftModelEnabled: true,
+      excludedPerspectives: [],
+      expected: ['drafts'],
+    },
+    {
+      selectedPerspectiveName: undefined,
+      isDraftModelEnabled: false,
+      excludedPerspectives: [],
+      expected: ['published'],
+    },
   ]
   it.each(testCases)(
     'should return the correct release stack for %s',
-    ({selectedPerspectiveName, excludedPerspectives, expected}) => {
+    ({selectedPerspectiveName, isDraftModelEnabled, excludedPerspectives, expected}) => {
       const result = getReleasesPerspectiveStack({
         releases,
         selectedPerspectiveName,
         excludedPerspectives,
+        isDraftModelEnabled,
       })
       expect(result).toEqual(expected)
     },

--- a/packages/sanity/src/core/releases/hooks/utils.ts
+++ b/packages/sanity/src/core/releases/hooks/utils.ts
@@ -1,7 +1,6 @@
 import {type ClientPerspective, type ReleaseDocument} from '@sanity/client'
 
 import {type PerspectiveStack, type ReleaseId} from '../../perspective/types'
-import {DRAFTS_FOLDER} from '../../util/draftUtils'
 import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
 
 export function sortReleases(releases: ReleaseDocument[] = []): ReleaseDocument[] {
@@ -56,13 +55,16 @@ export function getReleasesPerspectiveStack({
   selectedPerspectiveName,
   releases,
   excludedPerspectives,
+  isDraftModelEnabled,
 }: {
   selectedPerspectiveName: ReleaseId | undefined | 'published'
   releases: ReleaseDocument[]
   excludedPerspectives: string[]
+  isDraftModelEnabled: boolean
 }): PerspectiveStack {
+  const defaultPerspective = isDraftModelEnabled ? DRAFTS : PUBLISHED
   if (!selectedPerspectiveName) {
-    return DRAFTS
+    return defaultPerspective
   }
   if (selectedPerspectiveName === 'published') {
     return PUBLISHED
@@ -76,6 +78,6 @@ export function getReleasesPerspectiveStack({
   }
   return sorted
     .slice(selectedIndex)
-    .concat(DRAFTS_FOLDER)
+    .concat(defaultPerspective)
     .filter((name) => !excludedPerspectives.includes(name))
 }

--- a/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderActions.tsx
+++ b/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderActions.tsx
@@ -151,9 +151,7 @@ export const PaneHeaderActions = memo(function PaneHeaderActions(props: PaneHead
 
   return (
     <Flex gap={1}>
-      {combinedInitialValueTemplates.length > 0 && (
-        <PaneHeaderCreateButton templateItems={combinedInitialValueTemplates} />
-      )}
+      <PaneHeaderCreateButton templateItems={combinedInitialValueTemplates} />
 
       {actionNodes.map((node) => (
         <PaneHeaderActionButton key={node.key} node={node} />

--- a/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -67,6 +67,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
   const nothingGranted = useMemo(() => {
     return (
       !isTemplatePermissionsLoading &&
+      templatePermissions?.length !== 0 &&
       templatePermissions?.every((permission) => !permission.granted)
     )
   }, [isTemplatePermissionsLoading, templatePermissions])

--- a/packages/sanity/src/structure/components/paneItem/helpers.tsx
+++ b/packages/sanity/src/structure/components/paneItem/helpers.tsx
@@ -8,7 +8,8 @@ import {type DocumentPreviewStore, getDraftId, getPublishedId} from 'sanity'
 
 import {type PaneItemPreviewState} from './types'
 
-export const isLiveEditEnabled = (schemaType: SchemaType) => schemaType.liveEdit === true
+export const isLiveEditEnabled = (schemaType: Pick<SchemaType, 'liveEdit'>) =>
+  schemaType.liveEdit === true
 
 export const getMissingDocumentFallback = (item: SanityDocument) => ({
   title: <em>{item.title ? String(item.title) : 'Missing document'}</em>,

--- a/packages/sanity/src/structure/diffView/versionMode/components/VersionModeHeader.tsx
+++ b/packages/sanity/src/structure/diffView/versionMode/components/VersionModeHeader.tsx
@@ -33,6 +33,7 @@ import {
   useDocumentVersions,
   useEditState,
   useTranslation,
+  useWorkspace,
 } from 'sanity'
 import {styled} from 'styled-components'
 
@@ -177,6 +178,12 @@ const VersionMenu: ComponentType<VersionMenuProps> = ({
   const {t: tStructure} = useTranslation(structureLocaleNamespace)
   const {t: tCore} = useTranslation()
 
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
   return (
     <MenuButton
       id={role}
@@ -201,7 +208,7 @@ const VersionMenu: ComponentType<VersionMenuProps> = ({
               documentId={documentId}
             />
           )}
-          {draft && (
+          {isDraftModelEnabled && draft && (
             <VersionMenuItem
               type="draft"
               onSelect={onSelectRelease}

--- a/packages/sanity/src/structure/hasObsoleteDraft.test.ts
+++ b/packages/sanity/src/structure/hasObsoleteDraft.test.ts
@@ -1,0 +1,151 @@
+import {type SanityDocument} from '@sanity/types'
+import {expect, it} from 'vitest'
+
+import {type Context} from './hasObsoleteDraft'
+import {hasObsoleteDraft} from './hasObsoleteDraft'
+
+const stubDocument: SanityDocument = {
+  _id: 'x',
+  _rev: 'x',
+  _type: 'x',
+  _createdAt: '2025-06-23',
+  _updatedAt: '2025-06-23',
+}
+
+const workspaceWithDraftModelActive: Context['workspace'] = {
+  document: {
+    drafts: {
+      enabled: true,
+    },
+  },
+}
+
+const workspaceWithDraftModelInactive: Context['workspace'] = {
+  document: {
+    drafts: {
+      enabled: false,
+    },
+  },
+}
+
+it('produces `undefined` result while the state is indeterminate', () => {
+  expect(
+    hasObsoleteDraft({
+      editState: {
+        ready: false,
+        draft: null,
+        version: null,
+        published: null,
+      },
+      workspace: workspaceWithDraftModelActive,
+      schemaType: {},
+    }).result,
+  ).toBeUndefined()
+})
+
+it('produces `false` result if there is no draft', () => {
+  expect(
+    hasObsoleteDraft({
+      editState: {
+        ready: true,
+        draft: null,
+        version: null,
+        published: null,
+      },
+      workspace: workspaceWithDraftModelActive,
+      schemaType: {},
+    }),
+  ).toEqual({
+    result: false,
+  })
+
+  expect(
+    hasObsoleteDraft({
+      editState: {
+        ready: true,
+        draft: null,
+        version: null,
+        published: stubDocument,
+      },
+      workspace: workspaceWithDraftModelActive,
+      schemaType: {},
+    }),
+  ).toEqual({
+    result: false,
+  })
+})
+
+it('produces `false` result if there is a draft, but there are no factors making it obsolete', () => {
+  expect(
+    hasObsoleteDraft({
+      editState: {
+        ready: true,
+        draft: stubDocument,
+        version: null,
+        published: null,
+      },
+      workspace: workspaceWithDraftModelActive,
+      schemaType: {},
+    }),
+  ).toEqual({
+    result: false,
+  })
+})
+
+it('produces `true` result if there is a draft, but the draft model is inactive', () => {
+  expect(
+    hasObsoleteDraft({
+      editState: {
+        ready: true,
+        draft: stubDocument,
+        version: null,
+        published: null,
+      },
+      workspace: workspaceWithDraftModelInactive,
+      schemaType: {},
+    }),
+  ).toEqual({
+    result: true,
+    reason: 'DRAFT_MODEL_INACTIVE',
+  })
+})
+
+it('produces `true` result if there is a draft, but live-edit is active', () => {
+  expect(
+    hasObsoleteDraft({
+      editState: {
+        ready: true,
+        draft: stubDocument,
+        version: null,
+        published: null,
+      },
+      workspace: workspaceWithDraftModelActive,
+      schemaType: {
+        liveEdit: true,
+      },
+    }),
+  ).toEqual({
+    result: true,
+    reason: 'LIVE_EDIT_ACTIVE',
+  })
+})
+
+it('follows the precedence of `DRAFT_MODEL_INACTIVE`, `LIVE_EDIT_ACTIVE`', () => {
+  expect(
+    hasObsoleteDraft({
+      editState: {
+        ready: true,
+        draft: stubDocument,
+        version: null,
+        published: null,
+      },
+      workspace: workspaceWithDraftModelInactive,
+      schemaType: {
+        liveEdit: true,
+      },
+    }),
+  ).toEqual({
+    result: true,
+    reason: 'DRAFT_MODEL_INACTIVE',
+  })
+})

--- a/packages/sanity/src/structure/hasObsoleteDraft.ts
+++ b/packages/sanity/src/structure/hasObsoleteDraft.ts
@@ -1,0 +1,64 @@
+import {type SchemaType} from '@sanity/types'
+import {type EditStateFor, type Workspace} from 'sanity'
+
+import {isLiveEditEnabled} from './components/paneItem/helpers'
+
+export interface Context {
+  editState: Pick<EditStateFor, 'ready' | 'draft' | 'published' | 'version'> | null
+  workspace: {
+    document: {
+      drafts: Pick<Workspace['document']['drafts'], 'enabled'>
+    }
+  }
+  schemaType: Pick<SchemaType, 'liveEdit'>
+}
+
+/**
+ * Determine whether a document has an obsolete draft. This occurs if a document has a draft while
+ * the draft model is inactive, or if a live-edit document has a draft.
+ */
+export function hasObsoleteDraft({editState, workspace, schemaType}: Context):
+  | {
+      result: true
+      reason: 'LIVE_EDIT_ACTIVE' | 'DRAFT_MODEL_INACTIVE'
+    }
+  | {result: false}
+  | {result: undefined} {
+  if (!editState?.ready) {
+    return {
+      result: undefined,
+    }
+  }
+
+  const draftExists = editState.draft !== null
+
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = workspace
+
+  if (draftExists === false) {
+    return {
+      result: false,
+    }
+  }
+
+  if (!isDraftModelEnabled) {
+    return {
+      result: true,
+      reason: 'DRAFT_MODEL_INACTIVE',
+    }
+  }
+
+  if (isLiveEditEnabled(schemaType)) {
+    return {
+      result: true,
+      reason: 'LIVE_EDIT_ACTIVE',
+    }
+  }
+
+  return {
+    result: false,
+  }
+}

--- a/packages/sanity/src/structure/hooks/useDocumentIdStack.ts
+++ b/packages/sanity/src/structure/hooks/useDocumentIdStack.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {getReleaseIdFromReleaseDocumentId, getVersionId} from 'sanity'
+import {getReleaseIdFromReleaseDocumentId, getVersionId, useWorkspace} from 'sanity'
 
 import {type DocumentPaneContextValue} from '../panes/document/DocumentPaneContext'
 import {useFilteredReleases} from './useFilteredReleases'
@@ -38,8 +38,18 @@ export function useDocumentIdStack({
   documentId,
   editState,
 }: Pick<DocumentPaneContextValue, 'displayed' | 'documentId' | 'editState'>): DocumentIdStack {
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
   const filteredReleases = useFilteredReleases({displayed, documentId})
-  const systemStack = [editState?.published?._id, editState?.draft?._id]
+
+  const systemStack = [
+    editState?.published?._id,
+    isDraftModelEnabled ? editState?.draft?._id : [],
+  ].flat()
 
   const releaseStack = filteredReleases.currentReleases.map(
     (release) =>

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -114,15 +114,19 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text content for the deprecated document type banner */
   'banners.deprecated-document-type-banner.text': 'This document type has been deprecated.',
   /** The text for publish action for discarding the version */
-  'banners.live-edit-draft-banner.discard.tooltip': 'Discard draft',
+  'banners.live-edit-draft-banner.discard.tooltip': 'Discard draft to continue editing.',
   /** The text for publish action for the draft banner */
-  'banners.live-edit-draft-banner.publish.tooltip': 'Publish to continue editing',
+  'banners.live-edit-draft-banner.publish.tooltip': 'Publish draft to continue editing.',
 
   /** The text content for the live edit document when it's a draft */
   'banners.live-edit-draft-banner.text':
     'The type <strong>{{schemaType}}</strong> has <code>liveEdit</code> enabled, but a draft version of this document exists. Publish or discard the draft in order to continue live editing it.',
   /** The label for the "compare draft" action */
   'banners.obsolete-draft.actions.compare-draft.text': 'Compare draft',
+  /** The label for the "discard draft" action */
+  'banners.obsolete-draft.actions.discard-draft.text': 'Discard draft',
+  /** The label for the "publish draft" action */
+  'banners.obsolete-draft.actions.publish-draft.text': 'Publish draft',
   /** The warning displayed when editing a document that has an obsolete draft because the draft model is not switched on */
   'banners.obsolete-draft.draft-model-inactive.text':
     'The workspace does not have drafts enabled, but a draft version of this document exists.',

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -95,6 +95,9 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** Description for the archived release banner, rendered when viewing the history of a version document from the publihed view */
   'banners.archived-release.description':
     'This document version belongs to the archived <VersionBadge>{{title}}</VersionBadge> release',
+  /** The explanation displayed when a user attempts to create a new draft document, but the draft model is not switched on */
+  'banners.choose-new-document-destination.cannot-create-draft-document':
+    'Cannot create a draft document.',
   /** The explanation displayed when a user attempts to create a new published document, but the schema type doesn't support live-editing */
   'banners.choose-new-document-destination.cannot-create-published-document':
     'Cannot create a published document.',

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -121,6 +121,8 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text content for the live edit document when it's a draft */
   'banners.live-edit-draft-banner.text':
     'The type <strong>{{schemaType}}</strong> has <code>liveEdit</code> enabled, but a draft version of this document exists. Publish or discard the draft in order to continue live editing it.',
+  /** The label for the "compare draft" action */
+  'banners.obsolete-draft.actions.compare-draft.text': 'Compare draft',
   /** The text for the permission check banner if the user only has one role, and it does not allow publishing this document */
   'banners.permission-check-banner.missing-permission_create_one':
     'Your role <Roles/> does not have permission to publish this document.',

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -123,6 +123,9 @@ const structureLocaleStrings = defineLocalesResources('structure', {
     'The type <strong>{{schemaType}}</strong> has <code>liveEdit</code> enabled, but a draft version of this document exists. Publish or discard the draft in order to continue live editing it.',
   /** The label for the "compare draft" action */
   'banners.obsolete-draft.actions.compare-draft.text': 'Compare draft',
+  /** The warning displayed when editing a document that has an obsolete draft because the draft model is not switched on */
+  'banners.obsolete-draft.draft-model-inactive.text':
+    'The workspace does not have drafts enabled, but a draft version of this document exists.',
   /** The text for the permission check banner if the user only has one role, and it does not allow publishing this document */
   'banners.permission-check-banner.missing-permission_create_one':
     'Your role <Roles/> does not have permission to publish this document.',

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -22,6 +22,7 @@ import {
   useStudioUrl,
   useTranslation,
   useUnique,
+  useWorkspace,
 } from 'sanity'
 import {DocumentPaneContext} from 'sanity/_singletons'
 
@@ -91,6 +92,12 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const {buildStudioUrl} = useStudioUrl()
 
   const perspective = usePerspective()
+
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
 
   const {selectedReleaseId, selectedPerspectiveName} = useMemo(() => {
     // TODO: COREL - Remove this after updating sanity-assist to use <PerspectiveProvider>
@@ -169,11 +176,19 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
         isDeleted ||
         !isPerspectiveWriteable({
           selectedPerspective: perspective.selectedPerspective,
+          isDraftModelEnabled,
           schemaType,
         }).result
       )
     },
-    [getIsDeleted, isDeleting, params.rev, perspective.selectedPerspective, schemaType],
+    [
+      getIsDeleted,
+      isDeleting,
+      isDraftModelEnabled,
+      params.rev,
+      perspective.selectedPerspective,
+      schemaType,
+    ],
   )
 
   const getDisplayed = useCallback(

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -72,6 +72,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       badges: documentBadges,
       unstable_fieldActions: fieldActionsResolver,
       unstable_languageFilter: languageFilterResolver,
+      drafts: {enabled: draftsEnabled},
     },
   } = useSource()
   const telemetry = useTelemetry()
@@ -249,12 +250,15 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       case selectedPerspectiveName === 'published':
         version = 'published'
         break
-      default:
+      case draftsEnabled:
         version = 'draft'
+        break
+      default:
+        version = 'published'
     }
 
     return version
-  }, [selectedPerspectiveName, selectedReleaseId, params, value._id])
+  }, [params.rev, selectedReleaseId, value._id, selectedPerspectiveName, draftsEnabled])
 
   const actionsPerspective = useMemo(() => getDocumentVersionType(), [getDocumentVersionType])
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -13,6 +13,7 @@ import {
   type ReleaseDocument,
   ScrollContainer,
   usePerspective,
+  useWorkspace,
   VirtualizerScrollInstanceProvider,
 } from 'sanity'
 import {css, styled} from 'styled-components'
@@ -104,6 +105,12 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
   const [documentScrollElement, setDocumentScrollElement] = useState<HTMLDivElement | null>(null)
   const formContainerElement = useRef<HTMLDivElement | null>(null)
 
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
   const requiredPermission = value._createdAt ? 'update' : 'create'
 
   const activeView = useMemo(
@@ -185,6 +192,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
 
     const isSelectedPerspectiveWriteable = isPerspectiveWriteable({
       selectedPerspective,
+      isDraftModelEnabled,
       schemaType,
     })
 
@@ -268,6 +276,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     selectedPerspective,
     displayed,
     selectedReleaseId,
+    isDraftModelEnabled,
     editState,
     ready,
     activeView.type,

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -254,6 +254,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
           documentId={documentId}
           schemaType={schemaType}
           i18nKey="banners.live-edit-draft-banner.text"
+          isEditBlocking
         />
       )
     }

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -236,6 +236,17 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
       )
     }
 
+    if (activeView.type === 'form' && !isDraftModelEnabled && draftExists && !selectedReleaseId) {
+      return (
+        <ObsoleteDraftBanner
+          displayed={displayed}
+          documentId={documentId}
+          schemaType={schemaType}
+          i18nKey="banners.obsolete-draft.draft-model-inactive.text"
+        />
+      )
+    }
+
     if (activeView.type === 'form' && isLiveEdit && draftExists && !selectedReleaseId) {
       return (
         <ObsoleteDraftBanner

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -36,7 +36,7 @@ import {CanvasLinkedBanner} from './banners/CanvasLinkedBanner'
 import {ChooseNewDocumentDestinationBanner} from './banners/ChooseNewDocumentDestinationBanner'
 import {CreateLinkedBanner} from './banners/CreateLinkedBanner'
 import {DocumentNotInReleaseBanner} from './banners/DocumentNotInReleaseBanner'
-import {DraftLiveEditBanner} from './banners/DraftLiveEditBanner'
+import {ObsoleteDraftBanner} from './banners/ObsoleteDraftBanner'
 import {OpenReleaseToEditBanner} from './banners/OpenReleaseToEditBanner'
 import {RevisionNotFoundBanner} from './banners/RevisionNotFoundBanner'
 import {ScheduledReleaseBanner} from './banners/ScheduledReleaseBanner'
@@ -155,6 +155,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
   }, [activeView, displayed, documentId, editState?.draft, editState?.published, schemaType, value])
 
   const isLiveEdit = isLiveEditEnabled(schemaType)
+  const draftExists = editState?.ready && editState.draft !== null
 
   // Scroll to top as `documentId` changes
   useEffect(() => {
@@ -235,18 +236,13 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
       )
     }
 
-    if (
-      activeView.type === 'form' &&
-      isLiveEdit &&
-      ready &&
-      editState?.draft?._id &&
-      !selectedReleaseId
-    ) {
+    if (activeView.type === 'form' && isLiveEdit && draftExists && !selectedReleaseId) {
       return (
-        <DraftLiveEditBanner
+        <ObsoleteDraftBanner
           displayed={displayed}
           documentId={documentId}
           schemaType={schemaType}
+          i18nKey="banners.live-edit-draft-banner.text"
         />
       )
     }
@@ -281,6 +277,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     ready,
     activeView.type,
     isLiveEdit,
+    draftExists,
     isPermissionsLoading,
     showCreateBanner,
     permissions?.granted,

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ChooseNewDocumentDestinationBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ChooseNewDocumentDestinationBanner.tsx
@@ -12,6 +12,7 @@ import {
   type SelectedPerspective,
   Translate,
   useTranslation,
+  useWorkspace,
 } from 'sanity'
 
 import {structureLocaleNamespace} from '../../../../i18n'
@@ -37,14 +38,21 @@ export const ChooseNewDocumentDestinationBanner: ComponentType<Props> = ({
 }) => {
   const {t} = useTranslation(structureLocaleNamespace)
 
+  const {
+    document: {
+      drafts: {enabled: isDraftModelEnabled},
+    },
+  } = useWorkspace()
+
   const menuItemProps = useCallback<ReleasesNavMenuItemPropsGetter>(
     ({perspective}) => ({
       disabled: !isPerspectiveWriteable({
         selectedPerspective: perspective,
+        isDraftModelEnabled,
         schemaType,
       }).result,
     }),
-    [schemaType],
+    [isDraftModelEnabled, schemaType],
   )
 
   return (

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ChooseNewDocumentDestinationBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ChooseNewDocumentDestinationBanner.tsx
@@ -64,6 +64,8 @@ export const ChooseNewDocumentDestinationBanner: ComponentType<Props> = ({
           <Text size={1}>
             {reason === 'PUBLISHED_NOT_WRITEABLE' &&
               t('banners.choose-new-document-destination.cannot-create-published-document')}
+            {reason === 'DRAFTS_NOT_WRITEABLE' &&
+              t('banners.choose-new-document-destination.cannot-create-draft-document')}
             {reason === 'RELEASE_NOT_ACTIVE' && isReleaseDocument(selectedPerspective) && (
               <Translate
                 t={t}

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ObsoleteDraftBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ObsoleteDraftBanner.tsx
@@ -3,9 +3,17 @@ import {ErrorOutlineIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Flex, Text} from '@sanity/ui'
 import {type ComponentType, useCallback, useEffect, useState} from 'react'
-import {type ObjectSchemaType, Translate, useDocumentOperation, useTranslation} from 'sanity'
+import {
+  getDraftId,
+  getPublishedId,
+  type ObjectSchemaType,
+  Translate,
+  useDocumentOperation,
+  useTranslation,
+} from 'sanity'
 
 import {Button} from '../../../../../ui-components'
+import {useDiffViewRouter} from '../../../../diffView/hooks/useDiffViewRouter'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {ResolvedLiveEdit} from './__telemetry__/DraftLiveEditBanner.telemetry'
 import {Banner} from './Banner'
@@ -49,6 +57,26 @@ export const ObsoleteDraftBanner: ComponentType<ObsoleteDraftBannerProps> = ({
     }
   })
 
+  const diffViewRouter = useDiffViewRouter()
+
+  const compareDraft = useCallback(() => {
+    if (typeof displayed?._id === 'undefined') {
+      return
+    }
+
+    diffViewRouter.navigateDiffView({
+      mode: 'version',
+      previousDocument: {
+        type: schemaType.name,
+        id: getPublishedId(displayed?._id),
+      },
+      nextDocument: {
+        type: schemaType.name,
+        id: getDraftId(displayed?._id),
+      },
+    })
+  }, [diffViewRouter, displayed?._id, schemaType.name])
+
   return (
     <Banner
       content={
@@ -56,19 +84,24 @@ export const ObsoleteDraftBanner: ComponentType<ObsoleteDraftBannerProps> = ({
           <Text size={1} weight="medium">
             <Translate t={t} i18nKey={i18nKey} values={{schemaType: schemaType.title}} />
           </Text>
-
+          <Button
+            text={t('banners.obsolete-draft.actions.compare-draft.text')}
+            mode="ghost"
+            onClick={compareDraft}
+          />
           <Button
             onClick={handlePublish}
             text={t('action.publish.live-edit.label')}
             tooltipProps={{content: t('banners.live-edit-draft-banner.publish.tooltip')}}
             loading={isPublishing}
+            tone="positive"
           />
-
           <Button
             onClick={handleDiscard}
             text={t('banners.live-edit-draft-banner.discard.tooltip')}
             tooltipProps={{content: t('banners.live-edit-draft-banner.discard.tooltip')}}
             loading={isDiscarding}
+            tone="caution"
           />
         </Flex>
       }

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ObsoleteDraftBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ObsoleteDraftBanner.tsx
@@ -23,6 +23,10 @@ interface ObsoleteDraftBannerProps {
   documentId: string
   schemaType: ObjectSchemaType
   i18nKey: string
+  /**
+   * Whether the user is blocked from editing the document while an obsolete draft exists.
+   */
+  isEditBlocking?: boolean
 }
 
 export const ObsoleteDraftBanner: ComponentType<ObsoleteDraftBannerProps> = ({
@@ -30,6 +34,7 @@ export const ObsoleteDraftBanner: ComponentType<ObsoleteDraftBannerProps> = ({
   documentId,
   schemaType,
   i18nKey,
+  isEditBlocking,
 }) => {
   const {t} = useTranslation(structureLocaleNamespace)
   const [isPublishing, setPublishing] = useState(false)
@@ -91,15 +96,27 @@ export const ObsoleteDraftBanner: ComponentType<ObsoleteDraftBannerProps> = ({
           />
           <Button
             onClick={handlePublish}
-            text={t('action.publish.live-edit.label')}
-            tooltipProps={{content: t('banners.live-edit-draft-banner.publish.tooltip')}}
+            text={t('banners.obsolete-draft.actions.publish-draft.text')}
+            tooltipProps={
+              isEditBlocking
+                ? {
+                    content: t('banners.live-edit-draft-banner.publish.tooltip'),
+                  }
+                : {}
+            }
             loading={isPublishing}
             tone="positive"
           />
           <Button
             onClick={handleDiscard}
-            text={t('banners.live-edit-draft-banner.discard.tooltip')}
-            tooltipProps={{content: t('banners.live-edit-draft-banner.discard.tooltip')}}
+            text={t('banners.obsolete-draft.actions.discard-draft.text')}
+            tooltipProps={
+              isEditBlocking
+                ? {
+                    content: t('banners.live-edit-draft-banner.discard.tooltip'),
+                  }
+                : {}
+            }
             loading={isDiscarding}
             tone="caution"
           />

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ObsoleteDraftBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ObsoleteDraftBanner.tsx
@@ -2,7 +2,7 @@ import {type SanityDocument} from '@sanity/client'
 import {ErrorOutlineIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Flex, Text} from '@sanity/ui'
-import {useCallback, useEffect, useState} from 'react'
+import {type ComponentType, useCallback, useEffect, useState} from 'react'
 import {type ObjectSchemaType, Translate, useDocumentOperation, useTranslation} from 'sanity'
 
 import {Button} from '../../../../../ui-components'
@@ -10,17 +10,19 @@ import {structureLocaleNamespace} from '../../../../i18n'
 import {ResolvedLiveEdit} from './__telemetry__/DraftLiveEditBanner.telemetry'
 import {Banner} from './Banner'
 
-interface DraftLiveEditBannerProps {
+interface ObsoleteDraftBannerProps {
   displayed: Partial<SanityDocument> | null
   documentId: string
   schemaType: ObjectSchemaType
+  i18nKey: string
 }
 
-export function DraftLiveEditBanner({
+export const ObsoleteDraftBanner: ComponentType<ObsoleteDraftBannerProps> = ({
   displayed,
   documentId,
   schemaType,
-}: DraftLiveEditBannerProps): React.JSX.Element | null {
+  i18nKey,
+}) => {
   const {t} = useTranslation(structureLocaleNamespace)
   const [isPublishing, setPublishing] = useState(false)
   const [isDiscarding, setDiscarding] = useState(false)
@@ -52,11 +54,7 @@ export function DraftLiveEditBanner({
       content={
         <Flex align="center" justify="space-between" gap={2}>
           <Text size={1} weight="medium">
-            <Translate
-              t={t}
-              i18nKey={'banners.live-edit-draft-banner.text'}
-              values={{schemaType: schemaType.title}}
-            />
+            <Translate t={t} i18nKey={i18nKey} values={{schemaType: schemaType.title}} />
           </Text>
 
           <Button

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -20,6 +20,7 @@ import {
   useSchema,
   useSetPerspective,
   useTranslation,
+  useWorkspace,
   VersionChip,
 } from 'sanity'
 
@@ -88,6 +89,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
   const isCreatingDocument = displayed && !displayed._createdAt
   const filteredReleases = useFilteredReleases({displayed, documentId})
   const onlyHasVersions = useOnlyHasVersions({documentId})
+  const workspace = useWorkspace()
 
   const handlePerspectiveChange = useCallback(
     (perspective: Parameters<typeof setPerspective>[0]) => () => {
@@ -201,6 +203,8 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
     return false
   }, [editState?.draft, isCreatingDocument, isLiveEdit, onlyHasVersions, selectedReleaseId])
 
+  const isDraftModelEnabled = workspace.document.drafts?.enabled
+
   return (
     <>
       <VersionChip
@@ -233,50 +237,53 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
           disabled: !editState?.published,
         }}
       />
-      <VersionChip
-        tooltipContent={
-          <Text size={1}>
-            {editState?.draft ? (
-              <>
-                {editState?.draft._updatedAt ? (
-                  <Translate
-                    t={t}
-                    i18nKey="release.chip.tooltip.edited-date"
-                    values={{date: dateTimeFormat.format(new Date(editState?.draft._updatedAt))}}
-                  />
-                ) : (
-                  <Translate
-                    t={t}
-                    i18nKey="release.chip.tooltip.created-date"
-                    values={{date: dateTimeFormat.format(new Date(editState?.draft._createdAt))}}
-                  />
-                )}
-              </>
-            ) : (
-              <>
-                {isLiveEdit
-                  ? t('release.chip.tooltip.draft-disabled.live-edit')
-                  : t('release.chip.tooltip.no-edits')}
-              </>
-            )}
-          </Text>
-        }
-        selected={isDraftSelected}
-        disabled={isDraftDisabled}
-        text={t('release.chip.draft')}
-        tone={editState?.draft ? 'caution' : 'neutral'}
-        onClick={handlePerspectiveChange('drafts')}
-        contextValues={{
-          documentId: editState?.draft?._id || editState?.published?._id || editState?.id || '',
-          menuReleaseId: editState?.draft?._id || editState?.published?._id || editState?.id || '',
-          releases: filteredReleases.notCurrentReleases,
-          releasesLoading: loading,
-          documentType: documentType,
-          fromRelease: 'draft',
-          isVersion: false,
-          disabled: !editState?.draft,
-        }}
-      />
+      {isDraftModelEnabled && (
+        <VersionChip
+          tooltipContent={
+            <Text size={1}>
+              {editState?.draft ? (
+                <>
+                  {editState?.draft._updatedAt ? (
+                    <Translate
+                      t={t}
+                      i18nKey="release.chip.tooltip.edited-date"
+                      values={{date: dateTimeFormat.format(new Date(editState?.draft._updatedAt))}}
+                    />
+                  ) : (
+                    <Translate
+                      t={t}
+                      i18nKey="release.chip.tooltip.created-date"
+                      values={{date: dateTimeFormat.format(new Date(editState?.draft._createdAt))}}
+                    />
+                  )}
+                </>
+              ) : (
+                <>
+                  {isLiveEdit
+                    ? t('release.chip.tooltip.draft-disabled.live-edit')
+                    : t('release.chip.tooltip.no-edits')}
+                </>
+              )}
+            </Text>
+          }
+          selected={isDraftSelected}
+          disabled={isDraftDisabled}
+          text={t('release.chip.draft')}
+          tone={editState?.draft ? 'caution' : 'neutral'}
+          onClick={handlePerspectiveChange('drafts')}
+          contextValues={{
+            documentId: editState?.draft?._id || editState?.published?._id || editState?.id || '',
+            menuReleaseId:
+              editState?.draft?._id || editState?.published?._id || editState?.id || '',
+            releases: filteredReleases.notCurrentReleases,
+            releasesLoading: loading,
+            documentType: documentType,
+            fromRelease: 'draft',
+            isVersion: false,
+            disabled: !editState?.draft,
+          }}
+        />
+      )}
       {filteredReleases.inCreation && (
         <VersionChip
           tooltipContent={<TooltipContent release={filteredReleases.inCreation} />}


### PR DESCRIPTION
### Description

This branch introduces the `document.drafts.enabled` configuration option for controlling whether the draft model is enabled. By default, this option is `true`.

[Video walkthrough](https://supercut.ai/share/ash/DlDFlTPlQyfkgITZk5_lTa).

When the draft model is switched off:

- Studio will display the published perspective by default.
- The drafts (latest) perspective is removed from the global perspective switcher.
- The drafts chip is removed from the document version chips.
- Draft documents are not shown in the document comparison view.
- Draft documents will not be loaded in document lists.
- Draft document status indicators will not appear in document previews.

If the user views a document that has an obsolete draft, they are presenting with a banner allowing them to compare it, and publish or discard it:

<img width="1043" alt="Screenshot 2025-06-19 at 15 21 47" src="https://github.com/user-attachments/assets/0b249007-897f-4516-98f4-a14fe10979b7" />

The "Compare draft" button opens the document comparison view, allowing the user to see the published document and draft document side by side, before deciding whether to publish or discard it.

This same affordance has been added to the existing banner that's displayed when live-edit is enabled for a schema type, and an obsolete draft exists:

<img width="1038" alt="Screenshot 2025-06-19 at 15 25 22" src="https://github.com/user-attachments/assets/f8e4e298-9742-42b8-82ea-2de80651bd14" />

### What to review

1. Does the general approach seem sound?
2. Are there any issues caused by making the published perspective the default (and removing the drafts perspective)?
3. Have we missed any places drafts are surfaced?

### Testing

Updated existing unit tests.

### Notes for release

The draft model can now be switched off by setting the `document.drafts.enabled` configuration option to `false`. When the draft model is switched off, drafts will not appear in Studio, and users may only create or edit documents inside a release (unless they are live-edit documents).

If the draft model is switched off while the dataset contains drafts, a banner will be displayed when opening the document in Studio allowing you to compare the draft content, and publish or discard the obsolete draft. This makes it possible to safely switch off the draft model without running a bulk document migration.

The draft model is switched on by default.