### PR TITLE
fix: stop publishing src folders to npm

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -43,7 +43,6 @@
     "bin",
     "codemods",
     "lib",
-    "src",
     "templates"
   ],
   "scripts": {

--- a/packages/@sanity/codegen/package.json
+++ b/packages/@sanity/codegen/package.json
@@ -37,8 +37,6 @@
   "types": "./lib/index.d.ts",
   "files": [
     "lib",
-    "src",
-    "!**/__tests__/**",
     "babel.config.json"
   ],
   "scripts": {

--- a/packages/@sanity/diff/package.json
+++ b/packages/@sanity/diff/package.json
@@ -36,8 +36,7 @@
   "module": "./lib/index.mjs",
   "types": "./lib/index.d.ts",
   "files": [
-    "lib",
-    "src"
+    "lib"
   ],
   "scripts": {
     "build": "pkg-utils build --strict --check --clean",

--- a/packages/@sanity/migrate/package.json
+++ b/packages/@sanity/migrate/package.json
@@ -37,9 +37,7 @@
   "module": "./lib/index.mjs",
   "types": "./lib/index.d.ts",
   "files": [
-    "lib",
-    "src",
-    "!**/__tests__/**"
+    "lib"
   ],
   "scripts": {
     "build": "pkg-utils build --strict --check --clean",

--- a/packages/@sanity/mutator/package.json
+++ b/packages/@sanity/mutator/package.json
@@ -36,8 +36,7 @@
   "module": "./lib/index.mjs",
   "types": "./lib/index.d.ts",
   "files": [
-    "lib",
-    "src"
+    "lib"
   ],
   "scripts": {
     "build": "pkg-utils build --strict --check --clean",

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -49,8 +49,7 @@
     }
   },
   "files": [
-    "lib",
-    "src"
+    "lib"
   ],
   "scripts": {
     "build": "pnpm clean && pkg-utils build --strict --check --clean",

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -37,8 +37,7 @@
   "module": "./lib/index.mjs",
   "types": "./lib/index.d.ts",
   "files": [
-    "lib",
-    "src"
+    "lib"
   ],
   "scripts": {
     "build": "pkg-utils build --strict --check --clean",

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -103,8 +103,7 @@
     }
   },
   "files": [
-    "lib",
-    "src"
+    "lib"
   ],
   "scripts": {
     "build": "pnpm clean && pkg-utils build --strict --check --clean",

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -39,8 +39,7 @@
   "module": "./lib/index.mjs",
   "types": "./lib/index.d.ts",
   "files": [
-    "lib",
-    "src"
+    "lib"
   ],
   "scripts": {
     "build": "pkg-utils build --strict --check --clean",

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -38,8 +38,7 @@
   "module": "./lib/groq.js",
   "types": "./lib/groq.d.ts",
   "files": [
-    "lib",
-    "src"
+    "lib"
   ],
   "scripts": {
     "build": "pkg-utils build --strict --check --clean",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -123,13 +123,7 @@
     "bin",
     "lib",
     "dist",
-    "src",
-    "static",
-    "!**/__test__/**",
-    "!**/__tests__/**",
-    "!**/__mocks__/**",
-    "!**/__fixtures__/**",
-    "!**/__workshop__/**"
+    "static"
   ],
   "scripts": {
     "build": "pnpm clean && pkg-utils build --strict --check --clean",


### PR DESCRIPTION
### Description

By publishing `src` folders to npm we add quite a bit to the packages:
<img width="633" alt="textplain" src="https://github.com/user-attachments/assets/4cf5214d-5556-4829-a579-df6410a3acb9" />
It's unclear what value it adds when we publish these.
The downsides are many, it increases install times for package managers. Not only are there a lot of large files in the src folders, but there's also deeply nested folder trees that package managers have to spend time creating even though they won't be used for anything.

It's making it difficult to use tools for analyzing changes, like npmdiff.
Here it's timing out while trying to diff our last two releases of `sanity`: https://npmdiff.dev/sanity/3.92.0/3.93.0/
Here's another tool that is able to handle small deltas, sometimes: https://app.renovatebot.com/package-diff?name=sanity&from=3.93.1-next.7.7b16d653b7&to=3.93.1-next.12.74d5316fb4
Increasing the range slightly causes it too to time out: https://app.renovatebot.com/package-diff?name=sanity&from=3.93.1-next.6.2e3d18b278&to=3.93.1-next.12.74d5316fb4

These tools are incredibly useful to verify that changes to our build tooling doesn't have regressions, and shipping the src folders frequently prevent us from being able to leverage them.


### What to review

Makes sense?

### Testing

If CI passes we should be good.

### Notes for release

We no longer publish `./src` folders to npm of our libraries. This reduces the space we take in your `node_modules` folders, and speeds up install times for your package managers.