### PR TITLE
fix(core): fix issues with ML uploads

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -326,6 +326,18 @@ export default defineConfig([
     },
   },
   {
+    name: 'media-library-playground',
+    title: 'Media Library Playground (staging)',
+    projectId: '5iedwjzw',
+    dataset: 'production',
+    plugins: [sharedSettings({projectId: '5iedwjzw'})],
+    basePath: '/media-library-playground-staging',
+    apiHost: 'https://api.sanity.work',
+    auth: {
+      loginMethod: 'token',
+    },
+  },
+  {
     name: 'playground-staging',
     title: 'playground (Staging)',
     projectId: 'exx11uqh',

--- a/packages/@sanity/types/src/assets/types.ts
+++ b/packages/@sanity/types/src/assets/types.ts
@@ -154,6 +154,8 @@ export interface AssetSourceComponentProps {
   onClose: () => void
   onSelect: (assetFromSource: AssetFromSource[]) => void
   schemaType?: ImageSchemaType | FileSchemaType
+  /** @beta */
+  uploader?: AssetSourceUploader
 }
 
 /** @public */
@@ -166,6 +168,9 @@ export type AssetMetadataType =
   | 'blurhash'
   | 'none'
 
+/** @beta */
+export type AssetSourceUploaderClass = new (...args: any[]) => AssetSourceUploader
+
 /** @public */
 export interface AssetSource {
   name: string
@@ -176,7 +181,7 @@ export interface AssetSource {
   component: ComponentType<AssetSourceComponentProps>
   icon?: ComponentType<EmptyProps>
   /** @beta */
-  uploader?: AssetSourceUploader
+  Uploader?: AssetSourceUploaderClass
 }
 
 /** @beta */

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileAsset.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileAsset.tsx
@@ -53,7 +53,7 @@ export function FileAsset(props: FileAssetProps) {
   const [filesToUploadFromPaste, setFilesToUploadFromPaste] = useState<File[]>([])
   const elementRef = elementProps.ref?.current
 
-  const hasMultipleUploadSources = assetSources.filter((s) => Boolean(s.uploader)).length > 1
+  const hasMultipleUploadSources = assetSources.filter((s) => Boolean(s.Uploader)).length > 1
 
   const handleFileTargetFocus = useCallback(
     (event: React.FocusEvent) => {
@@ -179,7 +179,7 @@ export function FileAsset(props: FileAssetProps) {
         setShowDestinationSourcePicker(true)
         setFilesToUploadFromPaste(files)
       } else {
-        const firstAssetSourceWithUpload = assetSources.filter((s) => s.uploader)[0]
+        const firstAssetSourceWithUpload = assetSources.filter((s) => s.Uploader)[0]
         if (firstAssetSourceWithUpload) {
           onSelectFiles(firstAssetSourceWithUpload, files)
         }

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileInputAssetSource.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileInputAssetSource.tsx
@@ -15,6 +15,7 @@ export function FileAssetSource(props: FileAssetProps) {
     setSelectedAssetSource,
     onSelectAssets,
     value,
+    uploader,
   } = props
 
   const {t} = useTranslation()
@@ -49,6 +50,7 @@ export function FileAssetSource(props: FileAssetProps) {
             schemaType={schemaType}
             selectedAssets={[fileAsset]}
             selectionType="single"
+            uploader={uploader}
           />
         )}
       </WithReferencedAsset>
@@ -66,6 +68,7 @@ export function FileAssetSource(props: FileAssetProps) {
       schemaType={schemaType}
       selectedAssets={[]}
       selectionType="single"
+      uploader={uploader}
     />
   )
 }

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FilePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FilePreview.tsx
@@ -34,7 +34,7 @@ export function FilePreview(props: FileAssetProps) {
 
   const accept = get(schemaType, 'options.accept', '')
 
-  const assetSourcesWithUpload = assetSources.filter((s) => Boolean(s.uploader))
+  const assetSourcesWithUpload = assetSources.filter((s) => Boolean(s.Uploader))
 
   const handleSelectFileMenuItemClicked = useCallback(
     (event: React.MouseEvent) => {

--- a/packages/sanity/src/core/form/inputs/files/FileInput/__tests__/fileInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/__tests__/fileInput.test.tsx
@@ -78,7 +78,7 @@ describe('FileInput with empty state', () => {
       render: (inputProps) => (
         <BaseFileInput
           {...inputProps}
-          assetSources={[{name: 'source1', uploader: {}}, {name: 'source2'}] as any}
+          assetSources={[{name: 'source1', Uploader: {}}, {name: 'source2'}] as any}
         />
       ),
     })

--- a/packages/sanity/src/core/form/inputs/files/FileInput/types.ts
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/types.ts
@@ -1,4 +1,4 @@
-import {type AssetFromSource, type AssetSource} from '@sanity/types'
+import {type AssetFromSource, type AssetSource, type AssetSourceUploader} from '@sanity/types'
 
 import {type FileInfo} from '../common/styles'
 import {type BaseFileInputProps} from './FileInput'
@@ -21,4 +21,5 @@ export interface FileAssetProps extends Omit<BaseFileInputProps, 'renderDefault'
   setIsBrowseMenuOpen: (isBrowseMenuOpen: boolean) => void
   setIsUploading: (isUploading: boolean) => void
   setSelectedAssetSource: (assetSource: AssetSource | null) => void
+  uploader?: AssetSourceUploader
 }

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -2,7 +2,16 @@ import {isImageSource} from '@sanity/asset-utils'
 import {type AssetFromSource, type AssetSource, type UploadState} from '@sanity/types'
 import {Stack, useToast} from '@sanity/ui'
 import {get} from 'lodash'
-import {type FocusEvent, memo, type ReactNode, useCallback, useMemo, useRef, useState} from 'react'
+import {
+  type FocusEvent,
+  memo,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import {type Subscription} from 'rxjs'
 
 import {useTranslation} from '../../../../i18n'
@@ -14,7 +23,7 @@ import {UPLOAD_STATUS_KEY} from '../../../studio/uploads/constants'
 import {type Uploader, type UploadOptions} from '../../../studio/uploads/types'
 import {createInitialUploadPatches} from '../../../studio/uploads/utils'
 import {type InputProps} from '../../../types'
-import {handleSelectAssetFromSource as _handleSelectAssetFromSource} from '../common/assetSource'
+import {handleSelectAssetFromSource as handleSelectAssetFromSourceShared} from '../common/assetSource'
 import {UploadProgress} from '../common/UploadProgress'
 import {ImageInputAsset} from './ImageInputAsset'
 import {ImageInputAssetMenu} from './ImageInputAssetMenu'
@@ -150,14 +159,12 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
           }
         },
         error: (err) => {
-          // eslint-disable-next-line no-console
           console.error(err)
           push({
             status: 'error',
             description: t('inputs.image.upload-error.description'),
             title: t('inputs.image.upload-error.title'),
           })
-
           clearUploadStatus()
         },
         complete: () => {
@@ -206,7 +213,7 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
 
   const handleSelectAssetFromSource = useCallback(
     (assetsFromSource: AssetFromSource[]) => {
-      _handleSelectAssetFromSource({
+      handleSelectAssetFromSourceShared({
         assetsFromSource,
         onChange,
         type: schemaType,
@@ -216,6 +223,7 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
       })
 
       setSelectedAssetSource(null)
+      setIsUploading(false) // This function is also called on after a successful upload completion though an asset source, so reset that state here.
     },
     [onChange, resolveUploader, schemaType, uploadWith],
   )
@@ -250,10 +258,15 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
 
   const handleSelectFilesToUpload = useCallback(
     (assetSource: AssetSource, files: File[]) => {
+      if (files.length === 0) {
+        return
+      }
       setSelectedAssetSource(assetSource)
       const uploader = assetSource.uploader
       if (uploader) {
         try {
+          // Unsubscribe from the previous uploader
+          uploaderRef.current?.unsubscribe()
           uploaderRef.current = {
             unsubscribe: uploader.subscribe((event) => {
               switch (event.type) {
@@ -277,9 +290,8 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
                   break
                 case 'all-complete':
                   onChange(PatchEvent.from([unset([UPLOAD_STATUS_KEY])]))
-                  setSelectedAssetSource(null)
-                  setIsUploading(false)
                   setMenuOpen(false)
+                  uploaderRef.current?.unsubscribe()
                   uploaderRef.current = null
                   break
                 default:
@@ -293,6 +305,7 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
         } catch (err) {
           onChange(PatchEvent.from([unset([UPLOAD_STATUS_KEY])]))
           setIsUploading(false)
+          uploaderRef.current?.unsubscribe()
           setSelectedAssetSource(null)
           uploaderRef.current = null
           push({
@@ -306,6 +319,14 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
     },
     [onChange, push, schemaType, t],
   )
+
+  // Abort asset source uploads and unsubscribe from the uploader is the component unmounts
+  useEffect(() => {
+    return () => {
+      uploaderRef.current?.uploader?.abort()
+      uploaderRef.current?.unsubscribe()
+    }
+  }, [])
 
   const handleSelectImageFromAssetSource = useCallback((source: AssetSource) => {
     setSelectedAssetSource(source)

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAsset.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAsset.tsx
@@ -69,7 +69,7 @@ function ImageInputAssetComponent(props: {
   const [assetSourceDestination, setAssetSourceDestination] = useState<AssetSource | null>(null)
   const [showDestinationSourcePicker, setShowDestinationSourcePicker] = useState<boolean>(false)
   const [filesToUploadFromPaste, setFilesToUploadFromPaste] = useState<File[]>([])
-  const hasMultipleUploadSources = assetSources.filter((s) => Boolean(s.uploader)).length > 1
+  const hasMultipleUploadSources = assetSources.filter((s) => Boolean(s.Uploader)).length > 1
 
   const handleFilesOut = useCallback(() => {
     setHoveringFiles([])
@@ -122,7 +122,7 @@ function ImageInputAssetComponent(props: {
         setShowDestinationSourcePicker(true)
         setFilesToUploadFromPaste(files)
       } else {
-        const firstAssetSourceWithUpload = assetSources.filter((s) => s.uploader)[0]
+        const firstAssetSourceWithUpload = assetSources.filter((s) => s.Uploader)[0]
         if (firstAssetSourceWithUpload) {
           onSelectFiles(firstAssetSourceWithUpload, files)
         }

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
@@ -171,7 +171,7 @@ function ImageInputAssetMenuWithReferenceAssetComponent(
   const documentId = reference?._ref
   const observable = useMemo(() => observeAsset(documentId), [documentId, observeAsset])
   const asset = useObservable(observable)
-  const assetSourcesWithUpload = assetSources.filter((s) => Boolean(s.uploader))
+  const assetSourcesWithUpload = assetSources.filter((s) => Boolean(s.Uploader))
 
   // TODO: fix this in same style as FileInput
   const handleSelectFilesFromAssetSource = useCallback(

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetSource.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetSource.tsx
@@ -1,4 +1,4 @@
-import {type AssetFromSource, type AssetSource} from '@sanity/types'
+import {type AssetFromSource, type AssetSource, type AssetSourceUploader} from '@sanity/types'
 import {get} from 'lodash'
 import {memo, useMemo} from 'react'
 
@@ -10,6 +10,7 @@ function ImageInputAssetSourceComponent(
     selectedAssetSource: AssetSource | null
     handleAssetSourceClosed: () => void
     handleSelectAssetFromSource: (assetFromSource: AssetFromSource[]) => void
+    uploader?: AssetSourceUploader
   },
 ) {
   const {
@@ -19,6 +20,7 @@ function ImageInputAssetSourceComponent(
     observeAsset,
     schemaType,
     selectedAssetSource,
+    uploader,
     value,
   } = props
   const accept = useMemo(() => get(schemaType, 'options.accept', 'image/*'), [schemaType])
@@ -42,6 +44,7 @@ function ImageInputAssetSourceComponent(
             schemaType={schemaType}
             selectedAssets={[imageAsset]}
             selectionType="single"
+            uploader={uploader}
           />
         )}
       </WithReferencedAsset>
@@ -58,6 +61,7 @@ function ImageInputAssetSourceComponent(
       schemaType={schemaType}
       selectedAssets={[]}
       selectionType="single"
+      uploader={uploader}
     />
   )
 }

--- a/packages/sanity/src/core/form/inputs/files/common/UploadDestinationPicker.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/UploadDestinationPicker.tsx
@@ -27,7 +27,7 @@ export function UploadDestinationPicker(props: UploadDestinationPickerProps) {
   const {assetSources, onSelectAssetSource, text, onClose} = props
   const {t} = useTranslation()
 
-  const assetSourcesWithUpload = assetSources.filter((s) => Boolean(s.uploader))
+  const assetSourcesWithUpload = assetSources.filter((s) => Boolean(s.Uploader))
   const [modes, setModes] = useState<Record<string, 'bleed' | 'default'>>(
     assetSourcesWithUpload.reduce(
       (acc, source) => {

--- a/packages/sanity/src/core/form/inputs/files/common/UploadPlaceholder.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/UploadPlaceholder.tsx
@@ -53,7 +53,7 @@ function UploadPlaceholderComponent(props: UploadPlaceholderProps) {
   const source = useSource()
 
   const assetSourcesWithUpload = useMemo(() => {
-    const result: AssetSource[] = assetSources.filter((s) => Boolean(s.uploader))
+    const result: AssetSource[] = assetSources.filter((s) => Boolean(s.Uploader))
     // If no asset sources are available, we create a default one to upload to the dataset
     if (result.length === 0) {
       const options = {

--- a/packages/sanity/src/core/form/studio/assetSourceDataset/createAssetSource.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceDataset/createAssetSource.tsx
@@ -26,7 +26,7 @@ export function createDatasetImageAssetSource(props: CreateDatasetAssetSourcePro
     // i18nKey: 'asset-sources.dataset.image.title',
     component: DatasetAssetSource,
     icon: ImageIcon,
-    uploader: createDatasetUploader(props),
+    Uploader: createDatasetUploader(props),
   }
 }
 
@@ -43,6 +43,6 @@ export function createDatasetFileAssetSource(props: CreateDatasetAssetSourceProp
     // i18nKey: 'asset-sources.dataset.file.title',
     component: DatasetAssetSource,
     icon: DocumentsIcon,
-    uploader: createDatasetUploader(props),
+    Uploader: createDatasetUploader(props),
   }
 }

--- a/packages/sanity/src/core/form/studio/assetSourceDataset/uploader.ts
+++ b/packages/sanity/src/core/form/studio/assetSourceDataset/uploader.ts
@@ -1,7 +1,7 @@
 import {type SanityClient} from '@sanity/client'
 import {
-  type AssetSource,
   type AssetSourceUploader,
+  type AssetSourceUploaderClass,
   type AssetSourceUploadEvent,
   type AssetSourceUploadFile,
   type AssetSourceUploadSubscriber,
@@ -167,6 +167,10 @@ export class DatasetUploader implements AssetSourceUploader {
 
 export function createDatasetUploader(
   props: CreateDatasetAssetSourceProps,
-): AssetSource['uploader'] {
-  return new DatasetUploader(props)
+): AssetSourceUploaderClass {
+  return class DatasetAssetSourceUploader extends DatasetUploader {
+    constructor() {
+      super(props)
+    }
+  }
 }

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/createAssetSource.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/createAssetSource.tsx
@@ -27,7 +27,7 @@ export function createSanityMediaLibraryImageSource(
       <MediaLibraryAssetSource {...sourceProps} libraryId={props.libraryId} />
     ),
     icon: props.icon || ImageIcon,
-    uploader: new MediaLibraryUploader(),
+    Uploader: MediaLibraryUploader,
   }
 }
 
@@ -46,6 +46,6 @@ export function createSanityMediaLibraryFileSource(
       <MediaLibraryAssetSource {...sourceProps} libraryId={props.libraryId} />
     ),
     icon: props.icon || DocumentIcon,
-    uploader: new MediaLibraryUploader(),
+    Uploader: MediaLibraryUploader,
   }
 }

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/MediaLibraryAssetSource.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/MediaLibraryAssetSource.tsx
@@ -23,6 +23,7 @@ const MediaLibraryAssetSourceComponent = function MediaLibraryAssetSourceCompone
     onSelect,
     selectedAssets, // TODO: allow for pre-selected assets?
     schemaType,
+    uploader,
   } = props
 
   const {t} = useTranslation()
@@ -40,7 +41,7 @@ const MediaLibraryAssetSourceComponent = function MediaLibraryAssetSourceCompone
         onClose={onClose}
         onSelect={onSelect}
         schemaType={schemaType}
-        uploader={assetSource.uploader}
+        uploader={uploader}
       />
 
       <SelectAssetsDialog

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/uploader.ts
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/uploader.ts
@@ -15,7 +15,6 @@ export class MediaLibraryUploader implements AssetSourceUploader {
       this.files.length > 0 &&
       this.files.every((file) => ['complete', 'error', 'aborted'].includes(file.status))
     if (isDone) {
-      this.emit({type: 'all-complete', files: this.files})
       const hasError = this.files.some((file) => file.status === 'error')
       if (hasError) {
         this.emit({
@@ -23,6 +22,7 @@ export class MediaLibraryUploader implements AssetSourceUploader {
           files: this.files.filter((file) => file.status === 'error'),
         })
       }
+      this.emit({type: 'all-complete', files: this.files})
       this.reset()
     }
   }

--- a/packages/sanity/test/form/renderFileInput.tsx
+++ b/packages/sanity/test/form/renderFileInput.tsx
@@ -12,7 +12,7 @@ import {type TestRenderInputContext} from './renderInput'
 import {renderObjectInput} from './renderObjectInput'
 import {type TestRenderProps} from './types'
 
-const STUB_ASSET_SOURCES: AssetSource[] = [{uploader: {}, name: 'test-source'} as AssetSource] // @todo
+const STUB_ASSET_SOURCES: AssetSource[] = [{Uploader: {}, name: 'test-source'} as AssetSource] // @todo
 
 const STUB_OBSERVE_ASSET = () => EMPTY
 


### PR DESCRIPTION
### Description

This will improve subscription and state handling in Media Library uploading from the File and Image input.

It also changes how the AssetSourceUploader is initialized. Previously, it was initialized on the asset source level and shared across the various inputs using it. This made uploading to multiple fields in parallel more challenging. It's safer and easier to have the uploader instance in the field itself, encapsulating everything for that field without worrying about subscribers to the uploader in other fields.

This fixes a critical bug where an upload in a field could overwrite adjacent image and file fields in that document.

There are still things to improve here, but I think this should be done in a more holistic approach later.

 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the code changes look all right.


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
A schema like this should allow for parallel uploads through the ML in both image fields.

```
export default defineType({
  name: 'imagesTest',
  type: 'document',
  title: 'Images test',
  icon: ImagesIcon,
  fields: [
    {
      name: 'title',
      title: 'Title',
      type: 'string',
    },
    {
      type: 'image',
      name: 'firstImage',
      title: 'First image',
    },
    {
      type: 'image',
      name: 'secondImage',
      title: 'Second image',
    },
  ],
}
```
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
