### PR TITLE
fix(ci): upload modules after releasing next

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -40,30 +40,6 @@ jobs:
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped
 
-      - name: Build bundles
-        run: pnpm run build:bundle
-
-      - name: Upload bundles to staging bucket
-        env:
-          GOOGLE_PROJECT_ID: ${{ secrets.GCS_STAGING_PROJECT_ID }}
-          GCLOUD_SERVICE_KEY: ${{ secrets.GCS_STAGING_SERVICE_KEY }}
-          GCLOUD_BUCKET: ${{ secrets.GCS_STAGING_BUCKET }}
-        run: pnpm bundle-manager publish --tag=next
-
-      - name: Upload bundles to production bucket
-        # NOTE: we're not uploading prereleases to production bucket yet
-        if: ${{ false }}
-        env:
-          GOOGLE_PROJECT_ID: ${{ secrets.GCS_PRODUCTION_PROJECT_ID }}
-          GCLOUD_SERVICE_KEY: ${{ secrets.GCS_PRODUCTION_SERVICE_KEY }}
-          GCLOUD_BUCKET: ${{ secrets.GCS_PRODUCTION_BUCKET }}
-        run: pnpm bundle-manager publish --tag=next
-
-      - name: Set publishing config
-        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_PUBLISH_TOKEN}"
-        env:
-          NPM_PUBLISH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
-
       - name: Publish packages to npm
         # Note: ubuntu-latest ships with lerna installed on the system
         # (see https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#project-management)
@@ -84,3 +60,29 @@ jobs:
           --yes
         env:
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Build bundles
+        run: pnpm run build:bundle
+
+      # Note: we need to run this after publish so we get the updated version numbers from npx lerna publish
+      # ideally, the flow should be 1) bump packages using lerna version, 2) upload to module cdn, 3) lerna publish to npm from packages
+      - name: Upload bundles to staging bucket
+        env:
+          GOOGLE_PROJECT_ID: ${{ secrets.GCS_STAGING_PROJECT_ID }}
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCS_STAGING_SERVICE_KEY }}
+          GCLOUD_BUCKET: ${{ secrets.GCS_STAGING_BUCKET }}
+        run: pnpm bundle-manager publish --tag=next
+
+      - name: Upload bundles to production bucket
+        # NOTE: we're not uploading prereleases to production bucket yet
+        if: ${{ false }}
+        env:
+          GOOGLE_PROJECT_ID: ${{ secrets.GCS_PRODUCTION_PROJECT_ID }}
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCS_PRODUCTION_SERVICE_KEY }}
+          GCLOUD_BUCKET: ${{ secrets.GCS_PRODUCTION_BUCKET }}
+        run: pnpm bundle-manager publish --tag=next
+
+      - name: Set publishing config
+        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_PUBLISH_TOKEN}"
+        env:
+          NPM_PUBLISH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}


### PR DESCRIPTION
### Description
Realized after merging #9654 that since we bump and publish packages in the same operation, uploaded modules will not get the right version. Moving the bundle uploading to after version bump + npm release instead. As noted in a comment,        ideally, the flow here should be 1) bump packages using `lerna version`, 2) upload to module cdn, 3) publish packages to npm using `lerna publish from-packages`, but think it's less important for `next`-releases. This won't be an issue for the workflow that publishes to `latest`, since packages already have been bumped when that happens.


### What to review
Does the changes make sense?

### Testing
Tricky to test, but we'll se if it works after merging :)

### Notes for release

N/a