### PR TITLE
add a function for product-slug mutations for d2c schemas

### DIFF
--- a/examples/functions/product-slug-mutation/README.md
+++ b/examples/functions/product-slug-mutation/README.md
@@ -1,0 +1,249 @@
+# Product Slug Mutation Function
+
+[Explore all examples](https://github.com/sanity-io/sanity/tree/main/examples)
+
+## Problem
+
+When working with e-commerce products in Sanity, you often need to maintain both a nested slug structure (like `store.slug.current`) and a root-level slug field for easier querying and URL generation. Manually keeping these two slug fields in sync is error-prone and time-consuming, leading to inconsistent URLs and broken links.
+
+While this is a real example if you're using Sanity Connect Shopify app, it's also a good example of manipulating data in your schema that you might not have control of. Rather than write a custom Sync for your product data, this small change can improve some of the UX that would otherwise be out of your control.
+
+## Solution
+
+This function automatically synchronizes the nested `store.slug.current` field to a root-level `slug.current` field whenever a product document is published. It uses Sanity's document event handlers to trigger on publish events and ensures the root slug is always up-to-date with the store slug.
+
+## Benefits
+
+- **Eliminates manual slug synchronization** - No more forgetting to update both slug fields
+- **Prevents broken URLs** - Ensures consistent slug structure across your application
+- **Improves query performance** - Root-level slugs are easier to query and index
+- **Reduces content management errors** - Automatic synchronization prevents human error
+- **Maintains data consistency** - Guarantees both slug fields always match
+
+## Implementation
+
+1. **Initialize the example**
+
+   For a new project:
+
+   ```bash
+   npx sanity blueprints init --example product-slug-mutation
+   ```
+
+   For an existing project:
+
+   ```bash
+   npx sanity blueprints add function --example product-slug-mutation
+   ```
+
+2. **Add configuration to your blueprint**
+
+   ```ts
+   // sanity.blueprint.ts
+   defineDocumentFunction({
+     name: 'product-slug-mutation',
+     memory: 1,
+     timeout: 10,
+     on: ['publish'],
+     filter: "_type == 'product' && store.slug.current != slug.current",
+     projection: '_id'
+   })
+   ```
+
+3. **Add the slug field to your schema**
+
+   ```ts
+   // schemas/product.ts
+   export default {
+     name: 'product',
+     type: 'document',
+     fields: [
+       // ... other fields
+       {
+         name: 'slug',
+         type: 'slug',
+         title: 'URL Slug',
+         description: 'This field is automatically synced with store.slug.current',
+         readOnly: true, // Since it's managed by the function
+       },
+       // ... other fields
+     ]
+   }
+   ```
+
+4. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+5. **Deploy the function**
+
+   ```bash
+   npx sanity functions deploy
+   ```
+
+## Testing the function locally
+
+You can test the product-slug-mutation function locally using the Sanity CLI before deploying:
+
+
+### 1. Interactive Development Mode
+
+Start the development server for interactive testing:
+
+```bash
+npx sanity functions dev
+```
+
+### 2. Test with Custom Data
+
+Given that we assume you already have data or at least test data from doing our e-commerce learn tutorial, we assume you have a product doucment already, and given products are only created from the Shopify pipeline it makes sense to only modify an existing product document.
+
+Test with your own product document data:
+
+```bash
+npx sanity functions test product-slug-mutation --data '{
+  "_type": "product",
+  "_id": "my-product-123",
+  "title": "Test Product",
+  "store": {
+    "slug": {
+      "current": "test-product"
+    }
+  }
+}'
+```
+
+### 4. Test with Real Document Data
+
+Capture a real product document from your dataset:
+
+```bash
+# Export a real product document for testing
+npx sanity documents get "product-id" > test-product.json
+
+# Test with the real document
+npx sanity functions test product-slug-mutation --file test-product.json
+```
+
+### 5. Enable Debugging
+
+Add temporary logging to your function:
+
+```typescript
+// Add debugging logs
+console.log('Event data:', JSON.stringify(event.data, null, 2))
+console.log('Result:', result)
+```
+
+### Testing Tips
+
+- **Use Node.js v22.x** locally to match production runtime
+- **Test edge cases** like missing slug fields or malformed data
+- **Check function logs** in CLI output for debugging
+- **Verify the slug synchronization** by checking both fields after testing
+
+## Requirements
+
+- A Sanity project with Functions enabled
+- Ideally a schema with products linked from Sanity-Connect (Shopify plugin)
+- Product documents with the following schema structure:
+  - `_type: 'product'`
+  - `store.slug.current` (string) - The source slug field
+  - `slug.current` (string) - The target slug field to be synchronized
+- Node.js v22.x or later for local testing
+
+## Usage Example
+
+When a product document is published, the function automatically:
+
+1. **Triggers on publish** - Detects when a product document is published
+2. **Checks slug fields** - Verifies both `store.slug.current` and `slug.current` exist
+3. **Synchronizes slugs** - Copies the value from `store.slug.current` to `slug.current`
+4. **Updates document** - Saves the changes using `setIfMissing` to avoid overwriting existing data
+
+This results in consistent slug structure across your e-commerce application, making it easier to generate URLs and query products by their slugs.
+
+## Customization
+
+### Modifying the Filter Condition
+
+You can customize when the function triggers by modifying the filter condition:
+
+```ts
+// Trigger on all product publishes (removes slug comparison)
+filter: "_type == 'product'"
+
+// Trigger only when store slug is different from root slug
+filter: "_type == 'product' && store.slug.current != slug.current"
+```
+
+### Changing the Slug Field Names
+
+If your schema uses different field names, update the interface and logic:
+
+```typescript
+interface SanityProduct {
+  _type: 'product'
+  _id: string
+  title: string
+  // Change field names to match your schema
+  customStore: {
+    customSlug: {
+      current: string
+    }
+  }
+}
+```
+
+### Adding Additional Fields
+
+You can extend the function to synchronize other fields as well:
+
+```typescript
+const result = await client.patch(data._id, {
+  setIfMissing: {
+    slug: {
+      current: data.store.slug.current,
+    },
+    // Add more field synchronizations
+    seoTitle: data.store.title,
+    urlPath: `/products/${data.store.slug.current}`,
+  },
+})
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**Error: "Cannot find module '@sanity/client'"**
+- Cause: Dependencies not installed
+- Solution: Run `npm install` in the function directory
+
+**Error: "Function not triggered on product publish"**
+- Cause: Filter condition too restrictive
+- Solution: Check that your product documents match the filter condition in the blueprint configuration
+
+**Error: "Slug fields not synchronized"**
+- Cause: Missing or malformed slug data
+- Solution: Verify that `store.slug.current` exists and contains valid string data
+
+**Error: "Permission denied"**
+- Cause: Function lacks write permissions
+- Solution: Ensure your Sanity project has Functions enabled and proper permissions configured
+
+### Debugging Steps
+
+1. **Check function logs** in the Sanity dashboard
+2. **Verify document structure** matches the expected interface
+3. **Test with simple data** to isolate the issue
+4. **Review filter conditions** to ensure they match your data
+
+## Related Examples
+
+- [Auto-Tag Function](https://github.com/sanity-io/sanity/tree/main/examples/functions/auto-tag) - Automatically tag documents based on content
+- [SEO Field Sync](https://github.com/sanity-io/sanity/tree/main/examples/functions/seo-sync) - Synchronize SEO fields across document types
+- [URL Generation](https://github.com/sanity-io/sanity/tree/main/examples/functions/url-generation) - Generate and validate URL structures
+

--- a/examples/functions/product-slug-mutation/document.json
+++ b/examples/functions/product-slug-mutation/document.json
@@ -1,0 +1,11 @@
+{
+  "_type": "product",
+  "_id": "test-product-123",
+  "title": "My First Product",
+  "store": {
+    "slug": {
+      "current": "my-first-product"
+    }
+  },
+  "publishedAt": "2024-01-15T10:00:00.000Z"
+}

--- a/examples/functions/product-slug-mutation/index.ts
+++ b/examples/functions/product-slug-mutation/index.ts
@@ -1,0 +1,39 @@
+import {createClient} from '@sanity/client'
+import {type DocumentEvent, documentEventHandler, type FunctionContext} from '@sanity/functions'
+
+interface SanityProduct {
+  _type: 'product'
+  _id: string
+  title: string
+  store: {
+    slug: {
+      current: string
+    }
+  }
+}
+
+export const handler = documentEventHandler(
+  async ({context, event}: {context: FunctionContext; event: DocumentEvent<SanityProduct>}) => {
+    const client = createClient({
+      ...context.clientOptions,
+      dataset: 'production',
+      useCdn: false,
+    })
+    const {data} = event
+
+    try {
+      const result = await client.patch(data._id, {
+        setIfMissing: {
+          slug: {
+            current: data.store.slug.current,
+          },
+        },
+      })
+      // eslint-disable-next-line no-console
+      console.log('Set root slug for product:', data._id, result)
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error setting root slug for product:', error)
+    }
+  },
+)

--- a/examples/functions/product-slug-mutation/package.json
+++ b/examples/functions/product-slug-mutation/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "product-slug-mutation",
+  "type": "module",
+  "main": "index.ts",
+  "dependencies": {
+    "@sanity/client": "^7.6.0",
+    "@sanity/functions": "1.0.2"
+  },
+  "blueprintResourceItem": {
+    "name": "product-slug-mutation",
+    "memory": 1,
+    "timeout": 10,
+    "on": [
+      "publish"
+    ],
+    "filter": "_type == 'product' && store.slug.current != slug.current",
+    "projection": "_id"
+  },
+  "exampleInstructions": "Add this configuration to your blueprint config's resources array. Go to README.md for more details."
+}


### PR DESCRIPTION
### Description

Adds a mutation for product schema, allows customers to add a slug a the product of the product document vs the previous pattern of the proxy slug. I find this pattern nicer for both groq, and complex CTA modules, so everything follows a slug.current vs the product being store.slug.current experience. 

### What to review

Review the steps for testing, make sure the context is there to explain it

### Testing

Best to test with a Sanity connected to Shopify-Connect, can also emulate the product sync to trigger the slug generation

