### PR TITLE
refactor(core): update gradient to be more prominent

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/hook/useChipScrollPosition.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/hook/useChipScrollPosition.tsx
@@ -1,0 +1,61 @@
+import {useEffect, useState} from 'react'
+
+/**
+ * This hook is used to determine if the gradient should be shown on the chip scroll container.
+ * It uses an IntersectionObserver to observe the last child of the container and sets the showGradient state based on the intersection.
+ * @param containerRef - The ref to the container that contains all the chips
+ * @returns showGradient - A boolean that determines if the gradient should be shown
+ * @internal
+ */
+export function useChipScrollPosition(containerRef: React.RefObject<HTMLDivElement | null>) {
+  const [showGradient, setShowGradient] = useState(false)
+
+  useEffect(() => {
+    const checkOverflow = () => {
+      // container is the parent that contains all the chips
+      const container = containerRef.current
+      if (!container) return
+      const {scrollWidth, clientWidth} = container
+      const needsScrolling = scrollWidth > clientWidth
+
+      if (!needsScrolling) {
+        setShowGradient(false)
+        return
+      }
+
+      // Check if scrolled to the end
+      // becausee it doesn't need to show the gradient then
+      const {scrollLeft} = container
+      const isAtEnd = scrollLeft + clientWidth >= scrollWidth
+      setShowGradient(!isAtEnd)
+    }
+
+    function setupObservers() {
+      checkOverflow()
+      // container is the parent that contains all the chips
+      const container = containerRef.current
+      if (!container) return {observer: null}
+
+      const observer = new IntersectionObserver((entries) => {
+        const entry = entries[0]
+
+        if (entry) {
+          setShowGradient(entry.isIntersecting)
+        }
+      })
+
+      const lastChip = container.children[container.children.length - 1]
+      observer.observe(lastChip)
+
+      return {observer}
+    }
+
+    const {observer} = setupObservers()
+
+    return () => {
+      observer?.disconnect()
+    }
+  }, [containerRef])
+
+  return showGradient
+}


### PR DESCRIPTION
### Description

> [!Note]
> Design approved by Marius

Make gradient that shows that there are more release chips more prominent
Hide the gradient when reaching the end of the container

https://github.com/user-attachments/assets/b7df3ef6-4859-4fe1-be0b-83d18297a88b

https://github.com/user-attachments/assets/1f18cc26-112c-4c74-af0c-bdffe5bcd407

When there is no need for the gradient, it won't show
<img width="629" alt="image" src="https://github.com/user-attachments/assets/ff35c72e-9b76-4777-b745-763c7a4b6361" />

<img width="629" alt="image" src="https://github.com/user-attachments/assets/23509420-a1f1-436e-9990-e7ae501c8aca" />

### What to review

Does this make sense?

### Testing

N/A

### Notes for release

Updates the document header that shows a more prominent gradient when there are more release chips to see