### PR TITLE
feat(sanity): refine `isNewDocument`

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/isNewDocument.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/isNewDocument.test.ts
@@ -1,0 +1,63 @@
+import {type SanityDocument} from '@sanity/types'
+import {expect, it} from 'vitest'
+
+import {isNewDocument} from './isNewDocument'
+
+const stubDocument: SanityDocument = {
+  _id: 'x',
+  _rev: 'x',
+  _type: 'x',
+  _createdAt: '2025-06-23',
+  _updatedAt: '2025-06-23',
+}
+
+it('returns `undefined` while the state is indeterminate', () => {
+  expect(
+    isNewDocument({
+      ready: false,
+      draft: null,
+      version: null,
+      published: null,
+    }),
+  ).toBeUndefined()
+})
+
+it('returns `true` if no version is present', () => {
+  expect(
+    isNewDocument({
+      ready: true,
+      draft: null,
+      version: null,
+      published: null,
+    }),
+  ).toBe(true)
+})
+
+it('returns `false` if any version is present', () => {
+  expect(
+    isNewDocument({
+      ready: true,
+      draft: stubDocument,
+      version: null,
+      published: null,
+    }),
+  ).toBe(false)
+
+  expect(
+    isNewDocument({
+      ready: true,
+      draft: null,
+      version: stubDocument,
+      published: null,
+    }),
+  ).toBe(false)
+
+  expect(
+    isNewDocument({
+      ready: true,
+      draft: null,
+      version: null,
+      published: stubDocument,
+    }),
+  ).toBe(false)
+})

--- a/packages/sanity/src/core/store/_legacy/document/isNewDocument.ts
+++ b/packages/sanity/src/core/store/_legacy/document/isNewDocument.ts
@@ -9,6 +9,7 @@ import {type EditStateFor} from './document-pair/editState'
  *
  * This is `undefined` while loading.
  *
+ * @returns A boolean reflecting whether any version of the document exists in the dataset, and `undefined` while loading.
  * @internal
  */
 export function isNewDocument(


### PR DESCRIPTION
### Description

Some small refinements around the `isNewDocument` function, based on the feedback shared in #9734.