### PR TITLE
fix(sanity): be more resilient to process.env not being processed

### DIFF
--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -221,7 +221,7 @@ export function prepareConfig(
         types: schemaTypes,
       })
 
-      if (process.env.SANITY_STUDIO_SCHEMA_DESCRIPTOR) {
+      if (typeof process !== 'undefined' && process?.env?.SANITY_STUDIO_SCHEMA_DESCRIPTOR) {
         const before = performance.now()
         const sync = DESCRIPTOR_CONVERTER.get(schema)
         const after = performance.now()


### PR DESCRIPTION
### Description

It appears that we can't rely on `process.env` always being set. We got one report where embedding Sanity inside React Router would cause a crash here because it doesn't provide a `process` object.

This changes the condition to gracefully handle cases where `process` is undefined or null.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

- Fixes a bug where Studio would start with the error message "process is not defined" in some scenario (e.g. embedded Studio in React Router).