### PR TITLE
fix: pin `scrollmirror` to MIT licensed version

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -259,7 +259,7 @@
     "rxjs-exhaustmap-with-trailing": "^2.1.1",
     "rxjs-mergemap-array": "^0.1.0",
     "scroll-into-view-if-needed": "^3.0.3",
-    "scrollmirror": "^1.2.0",
+    "scrollmirror": "1.2.0",
     "semver": "^7.3.5",
     "shallow-equals": "^1.0.0",
     "speakingurl": "^14.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1898,8 +1898,8 @@ importers:
         specifier: ^3.0.3
         version: 3.1.0
       scrollmirror:
-        specifier: ^1.2.0
-        version: 1.2.2
+        specifier: 1.2.0
+        version: 1.2.0
       semver:
         specifier: ^7.3.5
         version: 7.7.2
@@ -10658,8 +10658,8 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
-  scrollmirror@1.2.2:
-    resolution: {integrity: sha512-pcHl63wuYOoNMgNftK8y73G6eO2uCaN670pWitjSIvvBx8rxLBfKhOA4AGQfWN5fdvCjN3Zmwlsrf3nOwIVDuQ==}
+  scrollmirror@1.2.0:
+    resolution: {integrity: sha512-81kLoolfRECsobTkCECpEDacpHXf2pDABtyZfj0wuEZXFBgODM+/NVuiFSB+gvoiWxjf//G+kt3tRkISvbNEGw==}
 
   seek-bzip@1.0.6:
     resolution: {integrity: sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==}
@@ -22487,7 +22487,7 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
-  scrollmirror@1.2.2: {}
+  scrollmirror@1.2.0: {}
 
   seek-bzip@1.0.6:
     dependencies:


### PR DESCRIPTION
### Description

Related to #9774. When we started using `scrollmirror` it was licensed as MIT. It has since changed its licensing to GPL. Unless they change back to MIT we'll have to look for a replacement library as our licensing policy doesn't permit GPL.

### What to review

Makes sense?

### Testing

If it builds it passes

### Notes for release

One of our dependencies changed its licensing from MIT to GPL. Our licensing policy doesn't allow GPL so we're pinning said dependency to the version still on MIT while we're evaluating our options.
