### PR TITLE
fix(core): add 10th text level in PTE

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/text/constants.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/constants.ts
@@ -1,7 +1,7 @@
 import {type ResponsivePaddingProps} from '@sanity/ui'
 import {type ElementType} from 'react'
 
-export const TEXT_LEVELS = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+export const TEXT_LEVELS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 export const TEXT_BULLET_MARKERS = ['●', '○', '■']
 


### PR DESCRIPTION
### Description

Before this change, a numbered list item indented to the 10th level would have count `0`. Now, it has the correct count, `1`.

Before:
![Screenshot 2025-06-24 at 09 43 45](https://github.com/user-attachments/assets/2595db32-ad8f-4f14-a9d3-06272122edf4)

After:
![Screenshot 2025-06-24 at 09 44 46](https://github.com/user-attachments/assets/3adac24d-637c-4c79-8397-9217251761ab)

### What to review

Try it out!

### Testing

n/a

### Notes for release

The Portable Text Editor now displays the correct list count for numbered list items outdented to the 10th level.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
