### PR TITLE
fix(core): use `data-list-index` on PTE blocks to improve list counts

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
@@ -86,7 +86,14 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $isOneLine:
 
     ${TEXT_LEVELS.map((l) => {
       return css`
-        & > .pt-list-item-number[class~='pt-list-item-level-${l}'] {
+        /* Reset the list count each time a list index of 1 is encountered
+         * for the current level.
+         */
+        & [data-level='${l}'][data-list-index='1'] {
+          counter-set: ${createListName(l)} 1;
+        }
+        /* Otherwise, increment the list count for the current level. */
+        & [data-level='${l}']:not([data-list-index='1']) {
           counter-increment: ${createListName(l)};
         }
       `
@@ -99,18 +106,6 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $isOneLine:
 
     & > :not(.pt-list-item) + .pt-list-item {
       margin-top: ${({theme}) => theme.sanity.space[2]}px;
-    }
-
-    /* Reset the list count if the element is not a numbered list item */
-    & > :not(.pt-list-item-number) {
-      counter-set: ${TEXT_LEVELS.map((l) => createListName(l)).join(' ')};
-    }
-
-    /* Reset the list count all the sub-list items */
-    & > .pt-list-item-number.pt-list-item-level-${TEXT_LEVELS[0]} {
-      counter-set: ${TEXT_LEVELS.slice(1)
-        .map((l) => createListName(l))
-        .join(' ')};
     }
 
     & > .pt-list-item + :not(.pt-list-item) {


### PR DESCRIPTION
### Description

Calculating the correct list index using CSS is extremely tricky. Therefore, PTE now ships a `data-list-index` on each list block (a block with both `listItem` and `level`) by default. (Notice how the blocks now also have `data-level` as well.)

While a "list index" isn't a part of the stored Portable Text nor the protocol itself, it's universally understood that a block with `listItem` and `level` *is* a list item. At the same time, we want to make it as seamless as possible to adopt and style the Portable Text Editor, and thus, `data-list-index` came into play.

Under the hood, PTE does an efficient calculation of where a list block is positioned in its current list. This not only simplifies the CSS needed to keep track of the CSS counters. It also fixes tricky edge cases like this one:

```
1. foo
      1. bar
    i. baz
      1. new list
```

Before this change, "new list" would have count 2, but because of the indented parent, the correct count is 1 (Word and Google Docs agree).

Only if the parent is outdented, should the count be 2:

```
1. foo
      1. bar
        a. baz
      2. continuing "bar" list
```

### What to review

1. Can you find list count edge cases that aren't covered?
2. Are there more places in the code where we can make use of the new data attributes on blocks?

Note that the CSS in Studio misses the 10th list level. This is addressed in https://github.com/sanity-io/sanity/pull/9783.

### Testing

Not practical to write automated tests for. The list index logic has unit tests in the PTE codebase.

### Notes for release

Improved list counts in the Portable Text Editor.