### PR TITLE
chore(structure): make the hover not clicable

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -68,6 +68,7 @@ const HorizontalScroller = styled(Card)<{$showGradient: boolean}>((props) => {
         width: 150px;
         background: linear-gradient(to right, ${rgba(theme.color.bg, 0)}, var(--card-bg-color));
         transition: 'opacity 300ms ease-out';
+        pointer-events: none;
       }
     `}
   `


### PR DESCRIPTION
### Description

Fixed issue where the overlay was preventing the clicking of the version chip when it was still active (Before the end)

https://github.com/user-attachments/assets/a02c6fc2-97f8-4948-b94a-1846b2cd15af

### What to review

- You should be able to click chips even if they still have the overlay (and not at the end?)

### Testing

N/A

### Notes for release

N/A (this will be introduced on the coming release)
