### PR TITLE
fix(deps): unpin `scrollmirror` now that it's MIT licensed

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -259,7 +259,7 @@
     "rxjs-exhaustmap-with-trailing": "^2.1.1",
     "rxjs-mergemap-array": "^0.1.0",
     "scroll-into-view-if-needed": "^3.0.3",
-    "scrollmirror": "1.2.0",
+    "scrollmirror": "^1.2.3",
     "semver": "^7.3.5",
     "shallow-equals": "^1.0.0",
     "speakingurl": "^14.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1893,8 +1893,8 @@ importers:
         specifier: ^3.0.3
         version: 3.1.0
       scrollmirror:
-        specifier: 1.2.0
-        version: 1.2.0
+        specifier: ^1.2.3
+        version: 1.2.3
       semver:
         specifier: ^7.3.5
         version: 7.7.2
@@ -10653,8 +10653,8 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
-  scrollmirror@1.2.0:
-    resolution: {integrity: sha512-81kLoolfRECsobTkCECpEDacpHXf2pDABtyZfj0wuEZXFBgODM+/NVuiFSB+gvoiWxjf//G+kt3tRkISvbNEGw==}
+  scrollmirror@1.2.3:
+    resolution: {integrity: sha512-WQBV3VWrMY+T5smh8DPmzQI5SA7jyHytPSRJRlKDhP8iTx5PsdIg9zsN1SoZISkNL1Xp2bLbRSK1+gpW1hJsCQ==}
 
   seek-bzip@1.0.6:
     resolution: {integrity: sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==}
@@ -22482,7 +22482,7 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
-  scrollmirror@1.2.0: {}
+  scrollmirror@1.2.3: {}
 
   seek-bzip@1.0.6:
     dependencies:


### PR DESCRIPTION
### Description

Fixes #9774, the `scrollmirror` dependency is no longer GPL, it's MIT, so we can use it with a standard semver range once again 🥳 

### What to review

It makes sense?

### Testing

If the is green we're good 👍 

### Notes for release

Fixes an issue where a dependency of `sanity` could get flagged as GPL licensed in license scanners. The dependency is `scrollmirror`, and the author @hirasso have gracefully relicensed it as MIT for us 💖 
