### PR TITLE
fix(core): version chip disables context menu when releases are disabled

### DIFF
--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -25,6 +25,7 @@ import {useCanvasCompanionDocsStore} from '../../../canvas/store/useCanvasCompan
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {getDraftId, getPublishedId, getVersionId} from '../../../util/draftUtils'
 import {useReleasesUpsell} from '../../contexts/upsell/useReleasesUpsell'
+import { useReleasesToolAvailable } from '../../hooks/useReleasesToolAvailable'
 import {useVersionOperations} from '../../hooks/useVersionOperations'
 import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
 import {DiscardVersionDialog} from '../dialog/DiscardVersionDialog'
@@ -102,6 +103,7 @@ export const VersionChip = memo(function VersionChip(props: {
       disabled: contextMenuDisabled = false,
     },
   } = props
+  const releasesToolAvailable = useReleasesToolAvailable()
   const isLinked = useVersionIsLinked(documentId, fromRelease)
 
   const [contextMenuPoint, setContextMenuPoint] = useState<{x: number; y: number} | undefined>(
@@ -200,7 +202,7 @@ export const VersionChip = memo(function VersionChip(props: {
     } as HTMLElement
   }, [contextMenuPoint])
 
-  const contextMenuHandler = disabled ? undefined : handleContextMenu
+  const contextMenuHandler = disabled || !releasesToolAvailable ? undefined : handleContextMenu
 
   return (
     <>


### PR DESCRIPTION
### Description
| Before | After |
|--------|--------|
| ![context-menu-before](https://github.com/user-attachments/assets/2365260a-118a-4857-ab38-09697be40663) | ![context-menu-after](https://github.com/user-attachments/assets/48615f23-27d2-4fbc-8173-7876b43f2000) |
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue where it was possible to create a new document version when content releases feature was turned off for a Studio.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
