### PR TITLE
feat(cli): add API tokens management commands

### DIFF
--- a/packages/@sanity/cli/test/tokens.test.ts
+++ b/packages/@sanity/cli/test/tokens.test.ts
@@ -1,0 +1,77 @@
+import {describe, expect} from 'vitest'
+
+import {describeCliTest, testConcurrent} from './shared/describe'
+import {getTestRunArgs, runSanityCmdCommand, studioVersions} from './shared/environment'
+
+describeCliTest('CLI: `sanity tokens`', () => {
+  describe.each(studioVersions)('%s', (version) => {
+    let tokenCounter = 1
+    const testRunArgs = getTestRunArgs(version)
+
+    testConcurrent('tokens add/list/delete', async () => {
+      const tokenLabel = `test-token-${tokenCounter++}`
+
+      // `tokens add`
+      let result = await runSanityCmdCommand(version, ['tokens', 'add', tokenLabel])
+      expect(result.stdout).toMatch(/token created successfully/i)
+      expect(result.stdout).toContain(tokenLabel)
+      expect(result.stdout).toMatch(/token:/i)
+      expect(result.code).toBe(0)
+
+      // `tokens list` - verify token appears in list
+      result = await runSanityCmdCommand(version, ['tokens', 'list'])
+      expect(result.stdout).toContain(tokenLabel)
+      expect(result.code).toBe(0)
+
+      // `tokens delete` - clean up test token
+      result = await runSanityCmdCommand(version, ['tokens', 'delete', tokenLabel, '--yes'])
+      expect(result.stdout).toMatch(/token deleted successfully/i)
+      expect(result.code).toBe(0)
+
+      // `tokens list` - verify token was deleted
+      result = await runSanityCmdCommand(version, ['tokens', 'list'])
+      expect(result.stdout).not.toContain(tokenLabel)
+      expect(result.code).toBe(0)
+    })
+
+    testConcurrent('tokens list --format=json', async () => {
+      const tokenLabel = await addToken()
+      const result = await runSanityCmdCommand(version, ['tokens', 'list', '--format=json'])
+      expect(result.code).toBe(0)
+
+      const tokens = JSON.parse(result.stdout)
+      expect(Array.isArray(tokens)).toBe(true)
+      expect(tokens.some((token: any) => token.label === tokenLabel)).toBe(true)
+
+      // Clean up test token
+      await runSanityCmdCommand(version, ['tokens', 'delete', tokenLabel, '--yes'])
+    })
+
+    testConcurrent('tokens add with role', async () => {
+      const tokenLabel = `test-token-viewer-${tokenCounter++}`
+
+      const result = await runSanityCmdCommand(version, [
+        'tokens',
+        'add',
+        tokenLabel,
+        '--role=editor',
+      ])
+      expect(result.stdout).toMatch(/token created successfully/i)
+      expect(result.stdout).toContain(tokenLabel)
+      expect(result.stdout).toMatch(/role.*editor/i)
+      expect(result.code).toBe(0)
+
+      // Clean up test token
+      await runSanityCmdCommand(version, ['tokens', 'delete', tokenLabel, '--yes'])
+    })
+
+    // Helper method for adding a new unique token
+    async function addToken(): Promise<string> {
+      const tokenLabel = `test-token-${tokenCounter++}`
+      const result = await runSanityCmdCommand(version, ['tokens', 'add', tokenLabel, '--yes'])
+      expect(result.code).toBe(0)
+      expect(result.stdout).toMatch(/token created successfully/i)
+      return tokenLabel
+    }
+  })
+})

--- a/packages/sanity/src/_internal/cli/actions/tokens/addToken.ts
+++ b/packages/sanity/src/_internal/cli/actions/tokens/addToken.ts
@@ -1,0 +1,75 @@
+import {type CliCommandContext, type CliPrompter} from '@sanity/cli'
+import {type TokenResponse, type ProjectRole} from '../../commands/tokens/types'
+
+interface AddTokenFlags {
+  role?: string
+}
+
+export async function addToken(
+  givenLabel: string,
+  flags: AddTokenFlags,
+  context: CliCommandContext,
+): Promise<TokenResponse> {
+  const {apiClient, prompt, output} = context
+  const client = apiClient({requireUser: true, requireProject: true})
+
+  const label = givenLabel || (await promptForLabel(prompt))
+  const roleName = await (flags.role ? validateRole(flags.role, context) : promptForRole(context))
+
+  const response = await client.request<TokenResponse>({
+    method: 'POST',
+    url: '/tokens',
+    body: {label, roleName},
+  })
+
+  return response
+}
+
+async function promptForLabel(prompt: CliPrompter): Promise<string> {
+  return prompt.single({
+    type: 'input',
+    message: 'Token label:',
+    validate: (input) => (input && input.trim() ? true : 'Label cannot be empty'),
+  })
+}
+
+async function promptForRole(context: CliCommandContext): Promise<string> {
+  const {apiClient, prompt} = context
+  const client = apiClient({requireUser: true, requireProject: true})
+
+  const roles = await client.request<ProjectRole[]>({url: '/roles'})
+  const robotRoles = roles.filter((role) => role.appliesToRobots)
+
+  if (robotRoles.length === 0) {
+    throw new Error('No roles available for tokens')
+  }
+
+  const choices = robotRoles.map((role) => ({
+    name: `${role.title} (${role.name})`,
+    value: role.name,
+    short: role.title,
+  }))
+
+  return prompt.single({
+    type: 'list',
+    message: 'Select role for the token:',
+    choices,
+    default: 'editor',
+  })
+}
+
+async function validateRole(roleName: string, context: CliCommandContext): Promise<string> {
+  const {apiClient} = context
+  const client = apiClient({requireUser: true, requireProject: true})
+
+  const roles = await client.request<ProjectRole[]>({url: '/roles'})
+  const robotRoles = roles.filter((role) => role.appliesToRobots)
+
+  const role = robotRoles.find((r) => r.name === roleName)
+  if (!role) {
+    const availableRoles = robotRoles.map((r) => r.name).join(', ')
+    throw new Error(`Invalid role "${roleName}". Available roles: ${availableRoles}`)
+  }
+
+  return roleName
+}

--- a/packages/sanity/src/_internal/cli/actions/tokens/addToken.ts
+++ b/packages/sanity/src/_internal/cli/actions/tokens/addToken.ts
@@ -49,7 +49,7 @@ async function promptForLabel(prompt: CliPrompter, unattended?: boolean): Promis
 
 async function promptForRole(context: CliCommandContext, unattended?: boolean): Promise<string> {
   if (unattended || !isInteractive) {
-    return 'editor' // Default role for unattended mode
+    return 'viewer' // Default role for unattended mode
   }
 
   const {apiClient, prompt} = context
@@ -75,7 +75,7 @@ async function promptForRole(context: CliCommandContext, unattended?: boolean): 
     type: 'list',
     message: 'Select role for the token:',
     choices,
-    default: 'editor',
+    default: 'viewer',
   })
 }
 

--- a/packages/sanity/src/_internal/cli/actions/tokens/deleteToken.ts
+++ b/packages/sanity/src/_internal/cli/actions/tokens/deleteToken.ts
@@ -1,0 +1,87 @@
+import {type CliCommandContext} from '@sanity/cli'
+import {type Token} from '../../commands/tokens/types'
+
+interface DeleteTokenFlags {
+  force?: boolean
+}
+
+export async function deleteToken(
+  specifiedToken: string,
+  flags: DeleteTokenFlags,
+  context: CliCommandContext,
+): Promise<boolean> {
+  const {apiClient} = context
+  const client = apiClient({requireUser: true, requireProject: true})
+
+  const tokenId = await promptForToken(specifiedToken, context)
+
+  if (!flags.force && !(await confirmDeletion(tokenId, context))) {
+    return false
+  }
+
+  await client.request({
+    method: 'DELETE',
+    uri: `/tokens/${tokenId}`,
+  })
+
+  return true
+}
+
+async function promptForToken(
+  specified: string | undefined,
+  context: CliCommandContext,
+): Promise<string> {
+  const {prompt, apiClient} = context
+  const client = apiClient({requireUser: true, requireProject: true})
+
+  const tokens = await client.request<Token[]>({url: '/tokens'})
+
+  if (tokens.length === 0) {
+    throw new Error('No tokens found')
+  }
+
+  if (specified) {
+    // Try to find by ID first
+    let selected = tokens.find((token) => token.id === specified)
+
+    // If not found by ID, try to find by label
+    if (!selected) {
+      selected = tokens.find((token) => token.label.toLowerCase() === specified.toLowerCase())
+    }
+
+    if (!selected) {
+      throw new Error(`Token "${specified}" not found`)
+    }
+
+    return selected.id
+  }
+
+  const choices = tokens.map((token) => ({
+    value: token.id,
+    name: `${token.label} (${token.roles.map((r) => r.title).join(', ')})`,
+  }))
+
+  return prompt.single({
+    message: 'Select token to delete:',
+    type: 'list',
+    choices,
+  })
+}
+
+async function confirmDeletion(tokenId: string, context: CliCommandContext): Promise<boolean> {
+  const {prompt, apiClient} = context
+  const client = apiClient({requireUser: true, requireProject: true})
+
+  const tokens = await client.request<Token[]>({url: '/tokens'})
+  const token = tokens.find((t) => t.id === tokenId)
+
+  if (!token) {
+    throw new Error('Token not found')
+  }
+
+  return prompt.single({
+    type: 'confirm',
+    message: `Are you sure you want to delete the token "${token.label}"?`,
+    default: false,
+  })
+}

--- a/packages/sanity/src/_internal/cli/commands/index.ts
+++ b/packages/sanity/src/_internal/cli/commands/index.ts
@@ -59,6 +59,10 @@ import schemaGroup from './schema/schemaGroup'
 import fetchSchemaCommand from './schema/schemaListCommand'
 import validateSchemaCommand from './schema/validateSchemaCommand'
 import startCommand from './start/startCommand'
+import addTokenCommand from './tokens/addTokenCommand'
+import deleteTokenCommand from './tokens/deleteTokenCommand'
+import listTokensCommand from './tokens/listTokensCommand'
+import tokensGroup from './tokens/tokensGroup'
 import inviteUserCommand from './users/inviteUserCommand'
 import listUsersCommand from './users/listUsersCommand'
 import usersGroup from './users/usersGroup'
@@ -85,6 +89,10 @@ const commands: (CliCommandDefinition | CliCommandGroupDefinition)[] = [
   listCorsOriginsCommand,
   addCorsOriginCommand,
   deleteCorsOriginCommand,
+  tokensGroup,
+  listTokensCommand,
+  addTokenCommand,
+  deleteTokenCommand,
   usersGroup,
   inviteUserCommand,
   listUsersCommand,

--- a/packages/sanity/src/_internal/cli/commands/tokens/addTokenCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/tokens/addTokenCommand.ts
@@ -6,9 +6,11 @@ Examples
   sanity tokens add "My API Token"
   sanity tokens add "My API Token" --role=editor
   sanity tokens add "My API Token" --role=viewer
+  sanity tokens add "CI Token" --role=editor --yes
 
 Options
   --role <role> Role to assign to the token. Default: editor
+  -y, --yes     Skip prompts and use defaults (unattended mode)
 `
 
 const addTokenCommand: CliCommandDefinition = {
@@ -20,10 +22,10 @@ const addTokenCommand: CliCommandDefinition = {
   action: async (args, context) => {
     const {output} = context
     const [label] = args.argsWithoutOptions
-    const {role} = args.extOptions as {role?: string}
+    const {role, yes, y} = args.extOptions as {role?: string; yes?: boolean; y?: boolean}
 
     try {
-      const token = await addToken(label, {role}, context)
+      const token = await addToken(label, {role, unattended: Boolean(yes || y)}, context)
       output.print(`Token created successfully!`)
       output.print(`Label: ${token.label}`)
       output.print(`Role: ${token.roles.map((r) => r.title).join(', ')}`)

--- a/packages/sanity/src/_internal/cli/commands/tokens/addTokenCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/tokens/addTokenCommand.ts
@@ -1,0 +1,39 @@
+import {type CliCommandDefinition} from '@sanity/cli'
+import {addToken} from '../../actions/tokens/addToken'
+
+const helpText = `
+Examples
+  sanity tokens add "My API Token"
+  sanity tokens add "My API Token" --role=editor
+  sanity tokens add "My API Token" --role=viewer
+
+Options
+  --role <role> Role to assign to the token. Default: editor
+`
+
+const addTokenCommand: CliCommandDefinition = {
+  name: 'add',
+  group: 'tokens',
+  signature: '[LABEL]',
+  helpText,
+  description: 'Create a new API token for this project',
+  action: async (args, context) => {
+    const {output} = context
+    const [label] = args.argsWithoutOptions
+    const {role} = args.extOptions as {role?: string}
+
+    try {
+      const token = await addToken(label, {role}, context)
+      output.print(`Token created successfully!`)
+      output.print(`Label: ${token.label}`)
+      output.print(`Role: ${token.roles.map((r) => r.title).join(', ')}`)
+      output.print(`Token: ${token.key}`)
+      output.print('')
+      output.print('⚠️  WARNING: This token will only be shown once. Store it securely!')
+    } catch (err) {
+      throw new Error(`Token creation failed:\n${err.message}`)
+    }
+  },
+}
+
+export default addTokenCommand

--- a/packages/sanity/src/_internal/cli/commands/tokens/addTokenCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/tokens/addTokenCommand.ts
@@ -28,10 +28,11 @@ const addTokenCommand: CliCommandDefinition = {
       const token = await addToken(label, {role, unattended: Boolean(yes || y)}, context)
       output.print(`Token created successfully!`)
       output.print(`Label: ${token.label}`)
+      output.print(`ID: ${token.id}`)
       output.print(`Role: ${token.roles.map((r) => r.title).join(', ')}`)
       output.print(`Token: ${token.key}`)
       output.print('')
-      output.print('⚠️  WARNING: This token will only be shown once. Store it securely!')
+      output.print('Copy the token above – this is your only chance to do so!')
     } catch (err) {
       throw new Error(`Token creation failed:\n${err.message}`)
     }

--- a/packages/sanity/src/_internal/cli/commands/tokens/addTokenCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/tokens/addTokenCommand.ts
@@ -9,7 +9,7 @@ Examples
   sanity tokens add "CI Token" --role=editor --yes
 
 Options
-  --role <role> Role to assign to the token. Default: editor
+  --role <role> Role to assign to the token. Default: viewer
   -y, --yes     Skip prompts and use defaults (unattended mode)
 `
 

--- a/packages/sanity/src/_internal/cli/commands/tokens/deleteTokenCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/tokens/deleteTokenCommand.ts
@@ -5,17 +5,18 @@ const helpText = `
 Examples
   sanity tokens delete
   sanity tokens delete silJ2lFmK6dONB
-  sanity tokens delete "My API Token"
   sanity tokens delete silJ2lFmK6dONB --yes
 
 Options
   -y, --yes     Skip confirmation prompt (unattended mode)
+
+Note: When specifying a token, you must use the token ID, not the label.
 `
 
 const deleteTokenCommand: CliCommandDefinition = {
   name: 'delete',
   group: 'tokens',
-  signature: '[TOKEN]',
+  signature: '[TOKEN_ID]',
   helpText,
   description: 'Delete an API token from this project',
   action: async (args, context) => {

--- a/packages/sanity/src/_internal/cli/commands/tokens/deleteTokenCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/tokens/deleteTokenCommand.ts
@@ -6,9 +6,10 @@ Examples
   sanity tokens delete
   sanity tokens delete silJ2lFmK6dONB
   sanity tokens delete "My API Token"
+  sanity tokens delete silJ2lFmK6dONB --yes
 
 Options
-  --force Skip confirmation prompt
+  -y, --yes     Skip confirmation prompt (unattended mode)
 `
 
 const deleteTokenCommand: CliCommandDefinition = {
@@ -20,10 +21,10 @@ const deleteTokenCommand: CliCommandDefinition = {
   action: async (args, context) => {
     const {output} = context
     const [token] = args.argsWithoutOptions
-    const {force} = args.extOptions as {force?: boolean}
+    const {yes, y} = args.extOptions as {yes?: boolean; y?: boolean}
 
     try {
-      const success = await deleteToken(token, {force}, context)
+      const success = await deleteToken(token, {unattended: Boolean(yes || y)}, context)
       if (success) {
         output.print('Token deleted successfully')
       }

--- a/packages/sanity/src/_internal/cli/commands/tokens/deleteTokenCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/tokens/deleteTokenCommand.ts
@@ -1,0 +1,36 @@
+import {type CliCommandDefinition} from '@sanity/cli'
+import {deleteToken} from '../../actions/tokens/deleteToken'
+
+const helpText = `
+Examples
+  sanity tokens delete
+  sanity tokens delete silJ2lFmK6dONB
+  sanity tokens delete "My API Token"
+
+Options
+  --force Skip confirmation prompt
+`
+
+const deleteTokenCommand: CliCommandDefinition = {
+  name: 'delete',
+  group: 'tokens',
+  signature: '[TOKEN]',
+  helpText,
+  description: 'Delete an API token from this project',
+  action: async (args, context) => {
+    const {output} = context
+    const [token] = args.argsWithoutOptions
+    const {force} = args.extOptions as {force?: boolean}
+
+    try {
+      const success = await deleteToken(token, {force}, context)
+      if (success) {
+        output.print('Token deleted successfully')
+      }
+    } catch (err) {
+      throw new Error(`Token deletion failed:\n${err.message}`)
+    }
+  },
+}
+
+export default deleteTokenCommand

--- a/packages/sanity/src/_internal/cli/commands/tokens/listTokensCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/tokens/listTokensCommand.ts
@@ -1,0 +1,48 @@
+import {type CliCommandDefinition} from '@sanity/cli'
+import {type Token} from './types'
+
+const helpText = `
+Examples
+  sanity tokens list
+  sanity tokens list --format=json
+
+Options
+  --format <format> Output format (table, json). Default: table
+`
+
+const listTokensCommand: CliCommandDefinition = {
+  name: 'list',
+  group: 'tokens',
+  signature: '',
+  helpText,
+  description: 'List all API tokens for this project',
+  action: async (args, context) => {
+    const {output, apiClient} = context
+    const {format} = args.extOptions as {format?: string}
+    const client = apiClient({requireUser: true, requireProject: true})
+
+    try {
+      const tokens = await client.request<Token[]>({url: '/tokens'})
+
+      if (format === 'json') {
+        output.print(JSON.stringify(tokens, null, 2))
+        return
+      }
+
+      if (tokens.length === 0) {
+        output.print('No tokens found')
+        return
+      }
+
+      output.print('API Tokens:')
+      tokens.forEach((token) => {
+        const roles = token.roles.map((role) => role.title).join(', ')
+        output.print(`  ${token.label} (${token.id}) - ${roles}`)
+      })
+    } catch (err) {
+      throw new Error(`Failed to list tokens:\n${err.message}`)
+    }
+  },
+}
+
+export default listTokensCommand

--- a/packages/sanity/src/_internal/cli/commands/tokens/listTokensCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/tokens/listTokensCommand.ts
@@ -1,4 +1,6 @@
 import {type CliCommandDefinition} from '@sanity/cli'
+import {Table} from 'console-table-printer'
+
 import {type Token} from './types'
 
 const helpText = `
@@ -19,10 +21,13 @@ const listTokensCommand: CliCommandDefinition = {
   action: async (args, context) => {
     const {output, apiClient} = context
     const {format} = args.extOptions as {format?: string}
-    const client = apiClient({requireUser: true, requireProject: true})
+    const client = apiClient({requireUser: true, requireProject: true}).config({
+      apiVersion: '2021-06-07',
+    })
 
     try {
-      const tokens = await client.request<Token[]>({url: '/tokens'})
+      const config = client.config()
+      const tokens = await client.request<Token[]>({url: `/projects/${config.projectId}/tokens`})
 
       if (format === 'json') {
         output.print(JSON.stringify(tokens, null, 2))
@@ -34,11 +39,29 @@ const listTokensCommand: CliCommandDefinition = {
         return
       }
 
-      output.print('API Tokens:')
-      tokens.forEach((token) => {
-        const roles = token.roles.map((role) => role.title).join(', ')
-        output.print(`  ${token.label} (${token.id}) - ${roles}`)
+      const table = new Table({
+        title: `Found ${tokens.length} API tokens`,
+        columns: [
+          {name: 'label', title: 'Label', alignment: 'left', maxLen: 50},
+          {name: 'id', title: 'Token ID', alignment: 'left', maxLen: 20},
+          {name: 'roles', title: 'Roles', alignment: 'left', maxLen: 30},
+        ],
       })
+
+      tokens.forEach((token) => {
+        const roles = token.roles?.map((role) => role.title).join(', ') || 'No roles'
+        const truncatedLabel =
+          token.label.length > 47 ? `${token.label.slice(0, 47)}...` : token.label
+        const truncatedRoles = roles.length > 27 ? `${roles.slice(0, 27)}...` : roles
+
+        table.addRow({
+          label: truncatedLabel,
+          id: token.id,
+          roles: truncatedRoles,
+        })
+      })
+
+      table.printTable()
     } catch (err) {
       throw new Error(`Failed to list tokens:\n${err.message}`)
     }

--- a/packages/sanity/src/_internal/cli/commands/tokens/tokensGroup.ts
+++ b/packages/sanity/src/_internal/cli/commands/tokens/tokensGroup.ts
@@ -1,0 +1,10 @@
+import {type CliCommandGroupDefinition} from '@sanity/cli'
+
+const tokensGroup: CliCommandGroupDefinition = {
+  name: 'tokens',
+  signature: '[COMMAND]',
+  isGroupRoot: true,
+  description: 'Manages API tokens for Sanity projects',
+}
+
+export default tokensGroup

--- a/packages/sanity/src/_internal/cli/commands/tokens/types.ts
+++ b/packages/sanity/src/_internal/cli/commands/tokens/types.ts
@@ -1,0 +1,30 @@
+export interface Token {
+  id: string
+  label: string
+  projectUserId: string
+  createdAt: string
+  roles: TokenRole[]
+}
+
+export interface TokenRole {
+  name: string
+  title: string
+}
+
+export interface TokenResponse {
+  id: string
+  key: string
+  roles: TokenRole[]
+  label: string
+  projectUserId: string
+}
+
+export interface ProjectRole {
+  name: string
+  title: string
+  description: string
+  isCustom: boolean
+  projectId: string
+  appliesToUsers: boolean
+  appliesToRobots: boolean
+}


### PR DESCRIPTION
### Description

This PR adds a complete API tokens management system to the Sanity CLI, providing commands to create, list, and delete API tokens for Sanity projects.

**What changes are introduced:**
- New `sanity tokens` command group with three subcommands:
  - `sanity tokens add` - Create new API tokens with role assignment
  - `sanity tokens list` - List all tokens with formatted table output  
  - `sanity tokens delete` - Delete existing tokens by ID
- Unattended mode support via `--yes/-y` flags for CI/automation
- Table formatting with column truncation and JSON output support

**Why these changes are introduced:**
- Developers need CLI tools to manage API tokens alongside other Sanity resources
- Automation workflows require non-interactive token management capabilities

### What to review

**Command functionality:**
1. Test the three main commands: `sanity tokens add`, `sanity tokens list`, `sanity tokens delete`
2. Verify unattended mode works with `--yes` flags
3. Check table formatting and JSON output with `--format=json`

**Integration:**
- Commands integrate with existing CLI structure
- API compatibility with v2021-06-07 endpoints
- Error handling for non-interactive environments

### Testing

✅ **Automated testing added:**
- Full add/list/delete workflow test
- JSON output format validation  
- Role assignment testing
- Proper cleanup in all test scenarios

### Notes for release

**What changed:**
New `sanity tokens` command group for managing API tokens via CLI.

**Command overview:**
```
usage: npx sanity tokens [--default] [-v|--version] [-d|--debug] [-h|--help] <command> [<args>]

Commands:
   add     Create a new API token for this project
   delete  Delete an API token from this project
   list    List all API tokens for this project

See 'npx sanity help tokens <command>' for specific information on a subcommand.
```

**Usage examples:**
```bash
# Interactive token creation (prompts for role)
sanity tokens add "My Token"

# Create token with specific role (no prompts)
sanity tokens add "CI Token" --role=editor

# Unattended mode with default role
sanity tokens add "Deploy Token" --yes

# List all tokens
sanity tokens list

# List as JSON
sanity tokens list --format=json

# Delete token (interactive selection)
sanity tokens delete

# Delete specific token by ID (unattended)
sanity tokens delete silJ2lFmK6dONB --yes
```

**Key features:**
- Default role is `viewer`
- Table output with automatic column truncation
- Unattended mode support for CI/CD workflows
- Token deletion requires exact token ID

**📝 Documentation note:**
This feature requires a new documentation page on the docsite covering the `sanity tokens` command group and its subcommands.