### PR TITLE
refactor: improve generated typings for `getCliClient`

### DIFF
--- a/packages/@repo/test-dts-exports/test/fixtures/@sanity.cli.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/@sanity.cli.test-d.ts
@@ -106,8 +106,6 @@ describe('@sanity/cli', () => {
     expectTypeOf<typeof defineCliConfig>().toBeFunction()
   })
   test('getCliClient', () => {
-    // This export has 2 declarations, run `TEST_DTS_EXPORTS_DIAGNOSTICS=duplicates pnpm generate:dts-exports` to see where each declaration is coming from
-    expectTypeOf<typeof getCliClient>().toBeFunction()
     expectTypeOf<typeof getCliClient>().not.toBeNever()
   })
   test('GraphQLAPIConfig', () => {

--- a/packages/@repo/test-dts-exports/test/fixtures/sanity.cli.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/sanity.cli.test-d.ts
@@ -27,8 +27,6 @@ describe('sanity/cli', () => {
     expectTypeOf<typeof defineCliConfig>().toBeFunction()
   })
   test('getCliClient', () => {
-    // This export has 2 declarations, run `TEST_DTS_EXPORTS_DIAGNOSTICS=duplicates pnpm generate:dts-exports` to see where each declaration is coming from
-    expectTypeOf<typeof getCliClient>().toBeFunction()
     expectTypeOf<typeof getCliClient>().not.toBeNever()
   })
   test('getStudioEnvironmentVariables', () => {

--- a/packages/@sanity/cli/src/cliClient.ts
+++ b/packages/@sanity/cli/src/cliClient.ts
@@ -13,7 +13,17 @@ export interface CliClientOptions {
   apiVersion?: string
 }
 
-export function getCliClient(options: CliClientOptions = {}): SanityClient {
+interface GetCliClient {
+  (options?: CliClientOptions): SanityClient
+  /**
+   * @internal
+   * @deprecated This is only for INTERNAL use, and should not be relied upon outside of official Sanity modules
+   * @returns A token to use when constructing a client without a `token` explicitly defined, or undefined
+   */
+  __internal__getToken: () => string | undefined
+}
+
+function getCliClientImpl(options: CliClientOptions = {}): SanityClient {
   if (typeof process !== 'object') {
     throw new Error('getCliClient() should only be called from node.js scripts')
   }
@@ -53,10 +63,8 @@ export function getCliClient(options: CliClientOptions = {}): SanityClient {
 }
 
 /* eslint-disable camelcase */
-/**
- * @internal
- * @deprecated This is only for INTERNAL use, and should not be relied upon outside of official Sanity modules
- * @returns A token to use when constructing a client without a `token` explicitly defined, or undefined
- */
-getCliClient.__internal__getToken = (): string | undefined => undefined
+getCliClientImpl.__internal__getToken = (): string | undefined => undefined
 /* eslint-enable camelcase */
+
+/** @internal */
+export const getCliClient: GetCliClient = getCliClientImpl


### PR DESCRIPTION
### Description

Follows up on #9826 and the generated typings of getCliClient.

The source of `getCliClient` [is](https://github.com/sanity-io/sanity/blob/de51f4535d9b3d059a359c90f101ca6884ca2764/packages/%40sanity/cli/src/cliClient.ts#L16-L61):
```ts
export function getCliClient(options: CliClientOptions = {}): SanityClient {
  // ...
}

/**
 * @internal
 * @deprecated This is only for INTERNAL use, and should not be relied upon outside of official Sanity modules
 * @returns A token to use when constructing a client without a `token` explicitly defined, or undefined
 */
getCliClient.__internal__getToken = (): string | undefined => undefined
```

Though `getCliClient.__internal__getToken` has a `@internal` tag and other doc blocks it's lost during dts generation, looking at `./@sanity/cli/lib/index.d.ts` shows:
```ts
export declare function getCliClient(options?: CliClientOptions): SanityClient

export declare namespace getCliClient {
  var __internal__getToken: () => string | undefined
}
```

Hovering over `__internal__getToken` outside of this monorepo (so that `@sanity/cli/lib/index.d.ts` is used in the IDE for resolving types, the monorepo is setup to go to `@sanity/cli/src/index.ts` and `@internal` survives that) shows no information or warning against using this internal property:
<img width="669" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/84539b5c-d9e7-4406-a068-94f19ac39d39" />

In this PR it changes the DTS generation to:
```ts
declare interface GetCliClient {
  (options?: CliClientOptions): SanityClient
  /**
   * @internal
   * @deprecated This is only for INTERNAL use, and should not be relied upon outside of official Sanity modules
   * @returns A token to use when constructing a client without a `token` explicitly defined, or undefined
   */
  __internal__getToken: () => string | undefined
}

/** @internal */
export declare const getCliClient: GetCliClient
```
And hovering over it now shows the doc blocks, as well as a strikethrough on the method itself due to the `@deprecated` tag:

<img width="824" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/4d3d6b89-f3a9-42ba-a319-72dd69a7d984" />





### What to review

Makes sense?

### Testing

If tests pass we're good. Only typings have changed, not code generated for runtime.

### Notes for release

N/A - it's an internal API.
