### PR TITLE
chore(test-dts-exports): disable skipLibCheck

### DIFF
--- a/packages/@repo/test-dts-exports/.depcheckrc.json
+++ b/packages/@repo/test-dts-exports/.depcheckrc.json
@@ -14,6 +14,7 @@
     "prettier",
     "groq",
     "sanity",
-    "vitest"
+    "vitest",
+    "typescript"
   ]
 }

--- a/packages/@repo/test-dts-exports/eslint.config.mjs
+++ b/packages/@repo/test-dts-exports/eslint.config.mjs
@@ -10,6 +10,8 @@ export default defineConfig([
       'simple-import-sort/imports': 'off',
       'max-statements': 'off',
       'unused-imports/no-unused-imports': 'off',
+      'import/no-named-default': 'off',
+      'no-warning-comments': 'error',
     },
   },
 ])

--- a/packages/@repo/test-dts-exports/package.json
+++ b/packages/@repo/test-dts-exports/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "generate:dts-exports": "node generate.mjs",
+    "lint": "eslint .",
     "test": "vitest run"
   },
   "dependencies": {
@@ -26,6 +27,7 @@
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/tsconfig": "workspace:*",
+    "@types/node": "^24.0.14",
     "ts-morph": "^26.0.0",
     "vitest": "^3.2.3"
   }

--- a/packages/@repo/test-dts-exports/test/lib-check.test.ts
+++ b/packages/@repo/test-dts-exports/test/lib-check.test.ts
@@ -1,0 +1,126 @@
+/**
+ * We can't just put `skipLibCheck: false` in the tsconfig.json because it doesn't let us filter out
+ * errors that come from node_modules that we don't control.
+ *
+ * This test file use the TypeScript compiler directly, and allows us to filter out errors that we can't fix
+ * limiting the scope of the errors to the files we control.
+ */
+
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+import ts from 'typescript'
+import {expect, test} from 'vitest'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const monorepoRoot = path.resolve(__dirname, '../../../..')
+const cwd = path.resolve(__dirname, '..')
+const configPath = ts.findConfigFile(cwd, ts.sys.fileExists, 'tsconfig.json')
+if (!configPath) throw new Error("Can't find tsconfig.json")
+
+const configFile = ts.readConfigFile(configPath, ts.sys.readFile)
+const tsconfig = ts.parseJsonConfigFileContent(configFile.config, ts.sys, cwd)
+const compilerOptions: ts.CompilerOptions = {
+  ...tsconfig.options,
+  // Enables type checking .d.ts files inside node_modules
+  skipLibCheck: false,
+  // Ensures that even though we call `program.emit` to get all diagnostics (ts.getPreEmitDiagnostics() only returns some errors) it won't actually emit files
+  noEmit: true,
+}
+
+const program = ts.createProgram(tsconfig.fileNames, compilerOptions)
+const emitResult = program.emit()
+
+const allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics)
+const errors = allDiagnostics.filter((diag) => diag.category === ts.DiagnosticCategory.Error)
+
+/**
+ * Filter out known false negatives that we either can't fix (because they originate in a third party library in node_modules),
+ * or it's fixable but it'll take time to land the fix.
+ * Feel free to add new false negatives to the list as you find them, just make sure to add context about the issue,
+ * and wether the intention is to fix it or not.
+ * If it originates from a sanity library the intention may be to fix it, but it shouldn't block the PR from landing.
+ */
+const filteredErrors = errors.filter((d) => {
+  const {file, code, messageText} = d
+
+  // We can't deal with errors without a file property so we don't skip over them
+  if (!file) return true
+
+  // We can't fix type issues in third party libraries
+  if (file.fileName.includes('node_modules/@types/inquirer')) {
+    return false
+  }
+  if (file.fileName.endsWith('node_modules/react-i18next/index.d.ts')) {
+    return false
+  }
+  if (file.fileName.endsWith('node_modules/rollup/dist/rollup.d.ts')) {
+    return false
+  }
+  if (file.fileName.endsWith('node_modules/slate-react/dist/components/text.d.ts')) {
+    return false
+  }
+  if (file.fileName.endsWith('node_modules/vite/dist/node/index.d.ts')) {
+    return false
+  }
+
+  // This error originates from a generated xstate machine declaration, so it's not code we can fix, it's a false negative
+  if (
+    file.fileName.includes('node_modules/@portabletext/editor/') &&
+    code === 2488 &&
+    messageText ===
+      `Type 'never' must have a '[Symbol.iterator]()' method that returns an iterator.`
+  ) {
+    return false
+  }
+
+  // Handled in https://github.com/sanity-io/sanity/pull/9984
+  if (file.fileName.includes('node_modules/@sanity/sdk/') && code === 2307) {
+    return false
+  }
+
+  // Handled in https://github.com/sanity-io/sanity/pull/9986
+  if (
+    (file.fileName.includes('packages/sanity/lib/_singletons.') ||
+      file.fileName.includes('packages/sanity/lib/desk.')) &&
+    (code === 2552 || code === 2304)
+  ) {
+    return false
+  }
+
+  // Handled in https://github.com/sanity-io/sanity/pull/9987
+  if (file.fileName.includes('packages/sanity/lib/index.') && code === 2307) {
+    return false
+  }
+
+  // Handled in https://github.com/sanity-io/sanity/pull/9988
+  if (file.fileName.includes('packages/sanity/lib/index.') && code === 2717) {
+    return false
+  }
+
+  return true
+})
+
+test('skipLibCheck: false', () => {
+  expect.hasAssertions()
+  // Pretty print errors so it's easier to handle, the formatting matches what `tsc --noEmit` does
+  filteredErrors.forEach((d) => {
+    console.error(
+      ts.formatDiagnosticsWithColorAndContext([d], {
+        getCanonicalFileName: (f) => f,
+        getCurrentDirectory: () => monorepoRoot,
+        getNewLine: () => ts.sys.newLine,
+      }),
+    )
+  })
+  if (filteredErrors.length > 0) {
+    expect(() => {
+      throw new Error(
+        'There are unexpected errors while checking the library typings. Check the logs above and update the filter conditions in this test file if needed.',
+      )
+    }).not.toThrow()
+  } else {
+    expect(filteredErrors).toHaveLength(0)
+  }
+})

--- a/packages/@repo/test-dts-exports/tsconfig.json
+++ b/packages/@repo/test-dts-exports/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@repo/tsconfig/build.json",
   "include": ["./test"],
   "compilerOptions": {
+    "lib": ["dom", "ESNext"],
     "rootDir": ".",
     "emitDeclarationOnly": false,
     "noEmit": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ importers:
         version: 1.0.6(prettier@3.6.2)
       '@sanity/tsdoc':
         specifier: 1.0.169
-        version: 1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.15.32)(babel-plugin-react-compiler@19.1.0-rc.2)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
       '@sanity/ui':
         specifier: ^2.16.7
         version: 2.16.7(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
@@ -321,13 +321,13 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.7.0(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
+        version: 4.7.0(vite@6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
   dev/media-library-aspects-studio:
     dependencies:
@@ -540,7 +540,7 @@ importers:
         version: 1.11.13(@sanity/types@packages+@sanity+types)(react@19.1.0)(typescript@5.7.3)
       '@sanity/tsdoc':
         specifier: 1.0.169
-        version: 1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.15.32)(babel-plugin-react-compiler@19.1.0-rc.2)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@24.0.14)(babel-plugin-react-compiler@19.1.0-rc.2)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
       '@sanity/types':
         specifier: workspace:*
         version: link:../../packages/@sanity/types
@@ -549,7 +549,7 @@ importers:
         version: 2.16.7(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@sanity/ui-workshop':
         specifier: 'catalog:'
-        version: 2.1.5(@sanity/icons@3.7.4(react@19.1.0))(@sanity/ui@2.16.7(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 2.1.5(@sanity/icons@3.7.4(react@19.1.0))(@sanity/ui@2.16.7(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
       '@sanity/util':
         specifier: workspace:*
         version: link:../../packages/@sanity/util
@@ -628,7 +628,7 @@ importers:
         version: 19.1.0-rc.2
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
   packages/@repo/bundle-manager:
     dependencies:
@@ -665,7 +665,7 @@ importers:
         version: 4.17.12
       vitest:
         specifier: 3.2.3
-        version: 3.2.3(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
   packages/@repo/dev-aliases: {}
 
@@ -730,16 +730,16 @@ importers:
         version: link:../tsconfig
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.7.0(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
+        version: 4.7.0(vite@6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
+        version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
 
   packages/@repo/package.config:
     devDependencies:
@@ -757,7 +757,7 @@ importers:
         version: link:../dev-aliases
       vitest:
         specifier: 3.2.3
-        version: 3.2.3(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
   packages/@repo/test-dts-exports:
     dependencies:
@@ -801,12 +801,15 @@ importers:
       '@repo/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/node':
+        specifier: ^24.0.14
+        version: 24.0.14
       ts-morph:
         specifier: ^26.0.0
         version: 26.0.0
       vitest:
         specifier: 3.2.3
-        version: 3.2.3(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
   packages/@repo/test-exports:
     dependencies:
@@ -1172,7 +1175,7 @@ importers:
         version: 5.0.10
       vitest:
         specifier: 3.2.3
-        version: 3.2.3(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
   packages/@sanity/diff:
     dependencies:
@@ -1237,7 +1240,7 @@ importers:
         version: 5.0.10
       vitest:
         specifier: 3.2.3
-        version: 3.2.3(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
   packages/@sanity/mutator:
     dependencies:
@@ -1277,7 +1280,7 @@ importers:
         version: 5.0.10
       vitest:
         specifier: 3.2.3
-        version: 3.2.3(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
   packages/@sanity/schema:
     dependencies:
@@ -1335,7 +1338,7 @@ importers:
         version: 5.0.10
       vitest:
         specifier: 3.2.3
-        version: 3.2.3(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
   packages/@sanity/types:
     dependencies:
@@ -1363,7 +1366,7 @@ importers:
         version: 19.1.8
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.7.0(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
+        version: 4.7.0(vite@6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
       react:
         specifier: catalog:react18
         version: 18.3.1
@@ -1372,7 +1375,7 @@ importers:
         version: 5.0.10
       vitest:
         specifier: 3.2.3
-        version: 3.2.3(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
   packages/@sanity/util:
     dependencies:
@@ -1412,7 +1415,7 @@ importers:
         version: 5.0.10
       vitest:
         specifier: 3.2.3
-        version: 3.2.3(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
   packages/@sanity/vision:
     dependencies:
@@ -1545,7 +1548,7 @@ importers:
         version: 4.17.17
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.7.0(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
+        version: 4.7.0(vite@6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.2
         version: 19.1.0-rc.2
@@ -1566,7 +1569,7 @@ importers:
         version: 6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: 3.2.3
-        version: 3.2.3(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
   packages/create-sanity:
     dependencies:
@@ -2216,7 +2219,7 @@ importers:
         version: 17.0.33
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.7.0(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
+        version: 4.7.0(vite@6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.2
         version: 19.1.0-rc.2
@@ -2246,7 +2249,7 @@ importers:
         version: 19.1.0(react@19.1.0)
       rollup-plugin-sourcemaps:
         specifier: ^0.6.3
-        version: 0.6.3(@types/node@22.15.32)(rollup@4.43.0)
+        version: 0.6.3(@types/node@24.0.14)(rollup@4.43.0)
       sanity:
         specifier: workspace:*
         version: link:../../packages/sanity
@@ -2258,7 +2261,7 @@ importers:
         version: 0.7.4
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
       yargs:
         specifier: 17.3.0
         version: 17.3.0
@@ -5257,6 +5260,9 @@ packages:
   '@types/node@22.15.32':
     resolution: {integrity: sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==}
 
+  '@types/node@24.0.14':
+    resolution: {integrity: sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -5611,9 +5617,6 @@ packages:
 
   '@vitest/pretty-format@3.2.3':
     resolution: {integrity: sha512-yFglXGkr9hW/yEXngO+IKMhP0jxyFw2/qys/CK4fFUZnSltD+MU7dVYGrH8rvPcK/O6feXQA+EU33gjaBBbAng==}
-
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
   '@vitest/runner@3.2.3':
     resolution: {integrity: sha512-83HWYisT3IpMaU9LN+VN+/nLHVBCSIUKJzGxC5RWUOsK1h3USg7ojL+UXQR3b4o4UBIWCYdD2fxuzM7PQQ1u8w==}
@@ -11732,6 +11735,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
@@ -14084,6 +14090,14 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@microsoft/api-extractor-model@7.30.1(@types/node@24.0.14)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.10.1(@types/node@24.0.14)
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@microsoft/api-extractor@7.48.1(@types/node@22.15.32)':
     dependencies:
       '@microsoft/api-extractor-model': 7.30.1(@types/node@22.15.32)
@@ -14102,6 +14116,24 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@microsoft/api-extractor@7.48.1(@types/node@24.0.14)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.30.1(@types/node@24.0.14)
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.10.1(@types/node@24.0.14)
+      '@rushstack/rig-package': 0.5.3
+      '@rushstack/terminal': 0.14.4(@types/node@24.0.14)
+      '@rushstack/ts-command-line': 4.23.2(@types/node@24.0.14)
+      lodash: 4.17.21
+      minimatch: 3.0.8
+      resolve: 1.22.10
+      semver: 7.5.4
+      source-map: 0.6.1
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@microsoft/api-extractor@7.49.0(@types/node@22.15.32)':
     dependencies:
       '@microsoft/api-extractor-model': 7.30.1(@types/node@22.15.32)
@@ -14111,6 +14143,24 @@ snapshots:
       '@rushstack/rig-package': 0.5.3
       '@rushstack/terminal': 0.14.4(@types/node@22.15.32)
       '@rushstack/ts-command-line': 4.23.2(@types/node@22.15.32)
+      lodash: 4.17.21
+      minimatch: 3.0.8
+      resolve: 1.22.10
+      semver: 7.5.4
+      source-map: 0.6.1
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/api-extractor@7.49.0(@types/node@24.0.14)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.30.1(@types/node@24.0.14)
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.10.1(@types/node@24.0.14)
+      '@rushstack/rig-package': 0.5.3
+      '@rushstack/terminal': 0.14.4(@types/node@24.0.14)
+      '@rushstack/ts-command-line': 4.23.2(@types/node@24.0.14)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
@@ -14918,6 +14968,19 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.15.32
 
+  '@rushstack/node-core-library@5.10.1(@types/node@24.0.14)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 7.0.1
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.10
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 24.0.14
+
   '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.10
@@ -14930,9 +14993,25 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.15.32
 
+  '@rushstack/terminal@0.14.4(@types/node@24.0.14)':
+    dependencies:
+      '@rushstack/node-core-library': 5.10.1(@types/node@24.0.14)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 24.0.14
+
   '@rushstack/ts-command-line@4.23.2(@types/node@22.15.32)':
     dependencies:
       '@rushstack/terminal': 0.14.4(@types/node@22.15.32)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@rushstack/ts-command-line@4.23.2(@types/node@24.0.14)':
+    dependencies:
+      '@rushstack/terminal': 0.14.4(@types/node@24.0.14)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -15413,12 +15492,12 @@ snapshots:
       - debug
       - supports-color
 
-  '@sanity/pkg-utils@6.13.4(@types/babel__core@7.20.5)(@types/node@22.15.32)(babel-plugin-react-compiler@19.1.0-rc.2)(typescript@5.7.3)':
+  '@sanity/pkg-utils@6.13.4(@types/babel__core@7.20.5)(@types/node@24.0.14)(babel-plugin-react-compiler@19.1.0-rc.2)(typescript@5.7.3)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
       '@babel/types': 7.28.0
-      '@microsoft/api-extractor': 7.48.1(@types/node@22.15.32)
+      '@microsoft/api-extractor': 7.48.1(@types/node@24.0.14)
       '@microsoft/tsdoc-config': 0.17.1
       '@optimize-lodash/rollup-plugin': 5.0.0(rollup@4.43.0)
       '@rollup/plugin-alias': 5.1.1(rollup@4.43.0)
@@ -15635,7 +15714,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@sanity/tsdoc@1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.15.32)(babel-plugin-react-compiler@19.1.0-rc.2)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)':
+  '@sanity/tsdoc@1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)':
     dependencies:
       '@microsoft/api-extractor': 7.49.0(@types/node@22.15.32)
       '@microsoft/api-extractor-model': 7.30.1(@types/node@22.15.32)
@@ -15646,7 +15725,7 @@ snapshots:
       '@sanity/client': 6.29.1(debug@4.4.1)
       '@sanity/color': 3.0.6
       '@sanity/icons': 3.7.4(react@19.1.0)
-      '@sanity/pkg-utils': 6.13.4(@types/babel__core@7.20.5)(@types/node@22.15.32)(babel-plugin-react-compiler@19.1.0-rc.2)(typescript@5.7.3)
+      '@sanity/pkg-utils': 6.13.4(@types/babel__core@7.20.5)(@types/node@22.15.32)(babel-plugin-react-compiler@19.1.0-rc.2)(debug@4.4.1)(typescript@5.7.3)
       '@sanity/ui': 2.16.7(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@types/cpx': 1.5.5
       '@vitejs/plugin-react': 4.7.0(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
@@ -15674,6 +15753,64 @@ snapshots:
       tmp: 0.2.3
       typescript: 5.7.3
       vite: 6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/babel__core'
+      - '@types/node'
+      - babel-plugin-react-compiler
+      - debug
+      - jiti
+      - less
+      - lightningcss
+      - react-is
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  '@sanity/tsdoc@1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@24.0.14)(babel-plugin-react-compiler@19.1.0-rc.2)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@packages+sanity)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)':
+    dependencies:
+      '@microsoft/api-extractor': 7.49.0(@types/node@24.0.14)
+      '@microsoft/api-extractor-model': 7.30.1(@types/node@24.0.14)
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@portabletext/react': 3.2.1(react@19.1.0)
+      '@portabletext/toolkit': 2.0.17
+      '@sanity/client': 6.29.1(debug@4.4.1)
+      '@sanity/color': 3.0.6
+      '@sanity/icons': 3.7.4(react@19.1.0)
+      '@sanity/pkg-utils': 6.13.4(@types/babel__core@7.20.5)(@types/node@24.0.14)(babel-plugin-react-compiler@19.1.0-rc.2)(typescript@5.7.3)
+      '@sanity/ui': 2.16.7(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+      '@types/cpx': 1.5.5
+      '@vitejs/plugin-react': 4.7.0(vite@6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
+      cac: 6.7.14
+      chalk: 4.1.2
+      chokidar: 4.0.3
+      cors: 2.8.5
+      dotenv-flow: 3.3.0
+      esbuild: 0.24.2
+      esbuild-register: 3.6.0(esbuild@0.24.2)
+      express: 4.21.2
+      globby: 11.1.0
+      groq: 3.99.0
+      groq-js: 1.17.2
+      history: 5.3.0
+      jsonc-parser: 3.3.1
+      mkdirp: 1.0.4
+      pkg-up: 3.1.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-refractor: 2.2.0(react@19.1.0)
+      sanity: link:packages/sanity
+      slugify: 1.6.6
+      styled-components: 6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      tmp: 0.2.3
+      typescript: 5.7.3
+      vite: 6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/babel__core'
@@ -15746,11 +15883,11 @@ snapshots:
       - tsx
       - yaml
 
-  '@sanity/ui-workshop@2.1.5(@sanity/icons@3.7.4(react@19.1.0))(@sanity/ui@2.16.7(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)':
+  '@sanity/ui-workshop@2.1.5(@sanity/icons@3.7.4(react@19.1.0))(@sanity/ui@2.16.7(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.1.0)
       '@sanity/ui': 2.16.7(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
-      '@vitejs/plugin-react': 4.7.0(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitejs/plugin-react': 4.7.0(vite@6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
       axe-core: 4.10.3
       cac: 6.7.14
       chokidar: 3.6.0
@@ -15769,7 +15906,7 @@ snapshots:
       rimraf: 4.4.1
       segmented-property: 4.0.0
       styled-components: 6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      vite: 6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -16310,6 +16447,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.0.14':
+    dependencies:
+      undici-types: 7.8.0
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/object-inspect@1.13.0': {}
@@ -16649,6 +16790,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/coverage-v8@3.2.3(vitest@3.2.3(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -16684,11 +16837,15 @@ snapshots:
     optionalDependencies:
       vite: 6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
-  '@vitest/pretty-format@3.2.3':
+  '@vitest/mocker@3.2.3(vite@6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 3.2.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@3.2.3':
     dependencies:
       tinyrainbow: 2.0.0
 
@@ -22535,13 +22692,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rollup-plugin-sourcemaps@0.6.3(@types/node@22.15.32)(rollup@4.43.0):
+  rollup-plugin-sourcemaps@0.6.3(@types/node@24.0.14)(rollup@4.43.0):
     dependencies:
       '@rollup/pluginutils': 3.1.0(rollup@4.43.0)
       rollup: 4.43.0
       source-map-resolve: 0.6.0
     optionalDependencies:
-      '@types/node': 22.15.32
+      '@types/node': 24.0.14
 
   rollup@4.43.0:
     dependencies:
@@ -23815,6 +23972,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.8.0: {}
+
   undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.1
@@ -24073,6 +24232,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@3.2.3(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1(supports-color@5.5.0)
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)):
     dependencies:
       debug: 4.4.1(supports-color@5.5.0)
@@ -24080,6 +24260,17 @@ snapshots:
       tsconfck: 3.1.6(typescript@5.8.3)
     optionalDependencies:
       vite: 6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)):
+    dependencies:
+      debug: 4.4.1(supports-color@5.5.0)
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.8.3)
+    optionalDependencies:
+      vite: 6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -24118,6 +24309,23 @@ snapshots:
       tsx: 4.20.3
       yaml: 2.8.0
 
+  vite@6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      esbuild: 0.25.8
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.6
+      rollup: 4.43.0
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      '@types/node': 24.0.14
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      lightningcss: 1.30.1
+      terser: 5.42.0
+      tsx: 4.20.3
+      yaml: 2.8.0
+
   vitest-package-exports@0.1.1:
     dependencies:
       find-up-simple: 1.0.1
@@ -24128,7 +24336,7 @@ snapshots:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.3
       '@vitest/mocker': 3.2.3(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 3.2.3
       '@vitest/runner': 3.2.3
       '@vitest/snapshot': 3.2.3
       '@vitest/spy': 3.2.3
@@ -24171,7 +24379,7 @@ snapshots:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.3
       '@vitest/mocker': 3.2.3(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 3.2.3
       '@vitest/runner': 3.2.3
       '@vitest/snapshot': 3.2.3
       '@vitest/spy': 3.2.3
@@ -24194,6 +24402,49 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.15.32
+      jsdom: 23.2.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.3(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(jsdom@23.2.0)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.3
+      '@vitest/mocker': 3.2.3(vite@6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/pretty-format': 3.2.3
+      '@vitest/runner': 3.2.3
+      '@vitest/snapshot': 3.2.3
+      '@vitest/spy': 3.2.3
+      '@vitest/utils': 3.2.3
+      chai: 5.2.0
+      debug: 4.4.1(supports-color@5.5.0)
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.3.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite-node: 3.2.3(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 24.0.14
       jsdom: 23.2.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
### Description

The purpose of this PR is to add a new check that ensures that the `.d.ts` files we generate are valid and don't have type errors.
It's needed in order to land these PRs with confidence:
- https://github.com/sanity-io/sanity/pull/9714
- https://github.com/sanity-io/sanity/pull/8999

Unfortunately the code we ship on `main` already has issues when running type checking with `skipLibCheck: false`.
The `skipLibCheck` flag is a wide net, either it will type check all `.d.ts` and follow all rabbit holes through `node_modules`, or it will check none of them. 
This is a problem since some of the failing checks come from third party code that we have no way of "fixing", so we have to filter out expected errors from the unexpected.

Errors that are not actionable are already being filtered out, and they're currently from `@types/inquirer`, `react-i18next`, `rollup`, `slate-react`, `vite`, and an `xstate` related issue in `@portabletext/editor`. These are errors that are just noise, and a side-effect of us using `skipLibCheck: false`, while the industry convention is to run `skipLibCheck: true` and thus it's fine to ignore them. It's not the purpose of this PR to fix the JS ecosystem type error nits, the goal here is to setup a test suite that can catch regressions in our generated dts typings.

Errors that might be actionable are marked in the code, and split out into separate PRs to ensure they will be handled in some way:
- https://github.com/sanity-io/sanity/pull/9984
- https://github.com/sanity-io/sanity/pull/9986
- https://github.com/sanity-io/sanity/pull/9987
- https://github.com/sanity-io/sanity/pull/9988
- ~~https://github.com/sanity-io/sanity/pull/9989~~
Each possibly actionable error can be time confusing to handle, which is why it's out of scope to handle all of them before merging this PR.
Here's an example of changes that had to be made to `get-it` for it to pass the test in this PR:
- [Commit that changes the typing of `export const adapter`](https://github.com/sanity-io/get-it/commit/bbd0cc8b877c11995f5e9c753c92ca66664ea5ec)
- [Diff showing how it cleared up an `import from '../types'` statement where `'../types'` silently failed to resolve and `RequestAdapter_2` got implicitly set to `any`](https://npmdiff.dev/get-it/8.6.9/8.6.10/package/dist/index.d.cts)

These PRs makes sure that issues discovered while setting up the new dts test case are handled after merging this one:
- Either the error is fixed and the PR is able to remove the filter condition all together.
- If it can't be fixed, maybe because fixing it would require a breaking change in some way, the PR should update the filter condition to explain why we're choosing to continue exempting the error.

[There's more context on the type of issue we're detecting in the new test suite over on `@sanity/pkg-utils`](https://github.com/sanity-io/pkg-utils/issues/1648), [and the `@microsoft/api-extractor` issue it refers to.](https://github.com/microsoft/rushstack/issues/5106)

### What to review

Have a look at how the new test case is structured, and if it's clear what to do if new code fails the check and the filters have to be updated.
Also keep in mind that there's a plan [for moving this check into `@sanity/pkg-utils` itself](https://github.com/sanity-io/pkg-utils/issues/1648), the intention here is that the new test will help us land upgrades to `@sanity/pkg-utils` and debarrel our repo in the near term, and in the long term once `@sanity/pkg-utils` can run this check we can delete the complicated new test case that interacts with the TypeScript Compiler Node API.

### Testing

If all CI checks pass then we're good.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
