### PR TITLE
refactor(@cli): add new major version message 

### DIFF
--- a/packages/@sanity/cli/src/CommandRunner.ts
+++ b/packages/@sanity/cli/src/CommandRunner.ts
@@ -26,6 +26,7 @@ import {
 import {type CliConfigResult} from './util/getCliConfig'
 import {isCommandGroup} from './util/isCommandGroup'
 import {getNoSuchCommandText} from './util/noSuchCommandText'
+import {printNewMajorVersionMessage} from './util/printNewMajorMessage'
 
 interface Handlers {
   outputter: CliOutputter
@@ -54,6 +55,7 @@ export class CommandRunner {
     }
   }
 
+  // eslint-disable-next-line complexity
   async runCommand(
     commandOrGroup: string,
     args: CliCommandArguments,
@@ -111,6 +113,9 @@ export class CommandRunner {
     }
 
     debug(`Running command "${command.name}"`)
+
+    printNewMajorVersionMessage(context)
+
     return command.action(cmdArgs, context)
   }
 

--- a/packages/@sanity/cli/src/CommandRunner.ts
+++ b/packages/@sanity/cli/src/CommandRunner.ts
@@ -114,7 +114,12 @@ export class CommandRunner {
 
     debug(`Running command "${command.name}"`)
 
-    printNewMajorVersionMessage(context)
+    // Only print the major version message if the --hide-major-message flag is not present
+    // used for the tests
+    // TODO: remove once version 4 is released
+    if (!cmdArgs.extOptions['hide-major-message']) {
+      printNewMajorVersionMessage(context)
+    }
 
     return command.action(cmdArgs, context)
   }

--- a/packages/@sanity/cli/src/util/printNewMajorMessage.ts
+++ b/packages/@sanity/cli/src/util/printNewMajorMessage.ts
@@ -1,0 +1,19 @@
+import boxen from 'boxen'
+
+import {type CliCommandContext} from '../types'
+
+export function printNewMajorVersionMessage(context: CliCommandContext): void {
+  const {chalk} = context
+
+  const v4Message = chalk.yellow.bold(
+    'The `sanity` package is moving to v4 on July 15 and will require Node.js 20+.',
+  )
+  const message = `${v4Message}
+Learn what this means for your apps at https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason`
+
+  const boxedMessage = boxen(message, {
+    padding: 1,
+    margin: 1,
+  })
+  context.output.print(boxedMessage)
+}

--- a/packages/@sanity/cli/test/dataset.test.ts
+++ b/packages/@sanity/cli/test/dataset.test.ts
@@ -38,6 +38,8 @@ describeCliTest('CLI: `sanity dataset`', () => {
         'visibility',
         'get',
         testRunArgs.aclDataset,
+        // TODO: remove once version 4 is released
+        '--hide-major-message',
       ])
       expect(result.stdout.trim()).toBe('public')
       expect(result.code).toBe(0)
@@ -49,6 +51,8 @@ describeCliTest('CLI: `sanity dataset`', () => {
         'set',
         testRunArgs.aclDataset,
         'private',
+        // TODO: remove once version 4 is released
+        '--hide-major-message',
       ])
       expect(result.stdout).toMatch(/visibility changed/i)
       expect(result.code).toBe(0)
@@ -59,6 +63,8 @@ describeCliTest('CLI: `sanity dataset`', () => {
         'visibility',
         'get',
         testRunArgs.aclDataset,
+        // TODO: remove once version 4 is released
+        '--hide-major-message',
       ])
       expect(result.stdout.trim()).toBe('private')
       expect(result.code).toBe(0)

--- a/packages/@sanity/cli/test/dev.test.ts
+++ b/packages/@sanity/cli/test/dev.test.ts
@@ -85,7 +85,8 @@ describeCliTest('CLI: `sanity dev`', () => {
         command: 'dev',
         port: testRunArgs.port - 3,
         basePath: '/config-base-path',
-        args: ['--port', `${testRunArgs.port - 3}`, '--load-in-dashboard'],
+        // TODO: remove '--hide-major-message' once version 4 is released
+        args: ['--port', `${testRunArgs.port - 3}`, '--load-in-dashboard', '--hide-major-message'],
         cwd: path.join(studiosPath, version),
         expectedTitle: 'Sanity Studio',
       })
@@ -103,7 +104,8 @@ describeCliTest('CLI: `sanity dev`', () => {
         command: 'dev',
         port: port,
         basePath: '/app-base-path',
-        args: ['--port', `${port}`],
+        // TODO: remove '--hide-major-message' once version 4 is released
+        args: ['--port', `${port}`, '--hide-major-message'],
         cwd: path.join(fixturesPath, 'app'),
         expectedTitle: 'Sanity Custom App',
       })

--- a/packages/@sanity/cli/test/exec.test.ts
+++ b/packages/@sanity/cli/test/exec.test.ts
@@ -6,7 +6,12 @@ import {getCliUserEmail, runSanityCmdCommand, studioVersions} from './shared/env
 describeCliTest('CLI: `sanity exec`', () => {
   describe.each(studioVersions)('%s', (version) => {
     testConcurrent('sanity exec', async () => {
-      const result = await runSanityCmdCommand(version, ['exec', 'script.ts'])
+      const result = await runSanityCmdCommand(version, [
+        'exec',
+        'script.ts',
+        // TODO: remove once version 4 is released
+        '--hide-major-message',
+      ])
       const data = JSON.parse(result.stdout.trim())
       expect(Object.keys(data.user)).toHaveLength(0)
       // Check that we load from .env.development
@@ -15,7 +20,13 @@ describeCliTest('CLI: `sanity exec`', () => {
     })
 
     testConcurrent('sanity exec --with-user-token', async () => {
-      const result = await runSanityCmdCommand(version, ['exec', 'script.ts', '--with-user-token'])
+      const result = await runSanityCmdCommand(version, [
+        'exec',
+        'script.ts',
+        '--with-user-token',
+        // TODO: remove once version 4 is released
+        '--hide-major-message',
+      ])
       const data = JSON.parse(result.stdout.trim())
       expect(data.user.email).toBe(await getCliUserEmail())
       // Check that we load from .env.development
@@ -24,9 +35,14 @@ describeCliTest('CLI: `sanity exec`', () => {
     })
 
     testConcurrent('sanity exec with env override', async () => {
-      const result = await runSanityCmdCommand(version, ['exec', 'script.ts'], {
-        env: {SANITY_ACTIVE_ENV: 'production'},
-      })
+      const result = await runSanityCmdCommand(
+        version,
+        // TODO: remove '--hide-major-message' once version 4 is released
+        ['exec', 'script.ts', '--hide-major-message'],
+        {
+          env: {SANITY_ACTIVE_ENV: 'production'},
+        },
+      )
       const data = JSON.parse(result.stdout.trim())
       // Check that we load from .env.production
       expect(data.env.SANITY_STUDIO_MODE).toBe('production')

--- a/packages/@sanity/cli/test/graphql.test.ts
+++ b/packages/@sanity/cli/test/graphql.test.ts
@@ -8,7 +8,8 @@ describeCliTest('CLI: `sanity graphql`', () => {
   describeCliTest.each(studioVersions)('%s', (version) => {
     const testRunArgs = getTestRunArgs(version)
     const graphqlDataset = testRunArgs.graphqlDataset
-    const deployFlags = ['--force', '--dataset', graphqlDataset]
+    // TODO: remove '--hide-major-message' once version 4 is released
+    const deployFlags = ['--force', '--dataset', graphqlDataset, '--hide-major-message']
     const client = testClient.withConfig({dataset: graphqlDataset})
 
     testConcurrent('graphql deploy', async () => {
@@ -87,6 +88,8 @@ describeCliTest('CLI: `sanity graphql`', () => {
         '--dataset',
         graphqlDataset,
         '--force',
+        // TODO: remove once version 4 is released
+        '--hide-major-message',
       ])
       expect(result.code).toBe(0)
       expect(result.stdout).toMatch(/GraphQL API deleted/i)

--- a/packages/@sanity/cli/test/init.test.ts
+++ b/packages/@sanity/cli/test/init.test.ts
@@ -832,6 +832,8 @@ describeCliTest('CLI: `sanity init v3`', () => {
         `${baseTestPath}/${outpath}`,
         '--package-manager',
         'manual',
+        // TODO: remove once version 4 is released
+        '--hide-major-message',
       ])
 
       // Check if essential files exist
@@ -873,6 +875,8 @@ describeCliTest('CLI: `sanity init v3`', () => {
         `${baseTestPath}/${outpath}`,
         '--package-manager',
         'manual',
+        // TODO: remove once version 4 is released
+        '--hide-major-message',
       ])
 
       const hasPackageJson = await fs
@@ -913,6 +917,8 @@ describeCliTest('CLI: `sanity init v3`', () => {
         `${baseTestPath}/${outpath}`,
         '--package-manager',
         'manual',
+        // TODO: remove once version 4 is released
+        '--hide-major-message',
       ])
 
       const envContent = await fs.readFile(path.join(baseTestPath, outpath, '.env.local'), 'utf-8')
@@ -944,6 +950,8 @@ describeCliTest('CLI: `sanity init v3`', () => {
           `${baseTestPath}/${outpath}`,
           '--package-manager',
           'manual',
+          // TODO: remove once version 4 is released
+          '--hide-major-message',
         ]),
       ).rejects.toThrow()
     })
@@ -969,6 +977,8 @@ describeCliTest('CLI: `sanity init v3`', () => {
           `${baseTestPath}/${outpath}`,
           '--package-manager',
           'manual',
+          // TODO: remove once version 4 is released
+          '--hide-major-message',
         ]),
       ).rejects.toThrow(
         'GitHub repository not found. For private repositories, use --template-token to provide an access token',


### PR DESCRIPTION
### Description

> [!NOTE]
> Copy approved by docs 

Add cli message warning of the upcoming major version (4) on every command

<img width="893" alt="image" src="https://github.com/user-attachments/assets/3104d6a3-f274-462f-b38e-1b184788226e" />

### What to review

Should the style be different?

> [!Warning]
> A flag has been added but we don't want to make that be widely used (this will run for a very little time anyway), we want this in order to make the tests run smoothly since it is not something that should impact anything

### Testing

This will be removed in 2 weeks once we have it out, no tests have been added. 
To manually test:
- open branch
- pnpm build
- ~/[path-to-monorepo-root]/packages/@sanity/cli/bin/sanity init (or any other command)

### Notes for release

This will have to be aligned with docs for this release on how we want to say it. We might just want to add the same sort of messaging as we were given by docs

The `sanity` package is moving to v4 on July 15 and will require Node.js 20+.
Learn what this means for your apps at https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason`