### PR TITLE
chore: fix `npx` sites that failed after adding packageManager checks

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Update version
         run: |
-          npx lerna version \
+          pnpm exec lerna version \
           --force-publish \
           --no-push \
           --sync-workspace-lock \
@@ -63,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Get version commit message
-        # get the commit message created by npx lerna version above (determined by lerna.json)
+        # get the commit message created by pnpm exec lerna version above (determined by lerna.json)
         id: version-commit
         run: echo "message=$(git log -1 --pretty=%B)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -34,7 +34,7 @@ jobs:
 
       - id: pre-flight
         run: |
-          PACKAGES=$(pnpx tsx scripts/listPublishedPackages.ts)
+          PACKAGES=$(pnpm exec tsx scripts/listPublishedPackages.ts)
           echo "packages=${PACKAGES}" >> "$GITHUB_OUTPUT"
           VERSION="$(jq -r .version lerna.json)-pkg.pr.new@$(git rev-parse --short HEAD)"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -45,4 +45,4 @@ jobs:
 
       - run: |
           echo "Publishing to pkg.pr.new: ${{ steps.pre-flight.outputs.packages }}"
-          pnpx pkg-pr-new publish --pnpm --no-template ${{ steps.pre-flight.outputs.packages }}
+          pnpm exec pkg-pr-new publish --pnpm --no-template ${{ steps.pre-flight.outputs.packages }}

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Publish packages to npm
         run: |
-          npx lerna publish \
+          pnpm exec lerna publish \
           --force-publish \
           --git-tag-version \
           --exact \

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -48,11 +48,11 @@ jobs:
       - name: Publish packages to npm
         # Note: ubuntu-latest ships with lerna installed on the system
         # (see https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#project-management)
-        # It's important that we call lerna using npx in the command below so we get the
+        # It's important that we call lerna using `pnpm exec` in the command below so we get the
         # locally installed lerna instead of the one installed on the system
         # Note: --no-git-reset is required for the bundle uploading step later on
         run: |
-          npx lerna publish \
+          pnpm exec lerna publish \
           --canary \
           --no-git-tag-version \
           --force-publish \
@@ -69,7 +69,7 @@ jobs:
       - name: Build bundles
         run: pnpm run build:bundle
 
-      # Note: we need to run this after publish so we get the updated version numbers from npx lerna publish
+      # Note: we need to run this after publish so we get the updated version numbers from `pnpm exec lerna publish`
       # ideally, the flow should be 1) bump packages using lerna version, 2) upload to module cdn, 3) lerna publish to npm from packages
       - name: Upload bundles to staging bucket
         env:

--- a/dev/test-create-integration-studio/package.json
+++ b/dev/test-create-integration-studio/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "../.bin/sanity build",
     "clean": "rimraf .sanity dist",
-    "deploy": "npx sanity deploy",
+    "deploy": "../.bin/sanity sanity deploy",
     "dev": "../.bin/sanity dev",
     "lint": "eslint .",
     "start": "../.bin/sanity start"

--- a/test/e2e/scripts/cleanup.ts
+++ b/test/e2e/scripts/cleanup.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 /**
  * Deletes old datasets from the e2e project that was created longer than DATASET_MAX_AGE ago
- * Run this via `npx tsx --env-file=<.env file> ./scripts/e2e/cleanupOldDatasets"`
+ * Run this via `pnpm exec tsx --env-file=<.env file> ./scripts/e2e/cleanupOldDatasets"`
  * Note for the future: ideally, this should be rewritten to check against open PRs on github
  * and only delete datasets for PRs that has been closed or merged
  */


### PR DESCRIPTION
### Description

After merging the new check for `packageManager` we have some GitHub actions that are failing:
- https://github.com/sanity-io/sanity/actions/runs/15968782681/job/45035024167
- https://github.com/sanity-io/sanity/actions/runs/15968782693/job/45035024276

### What to review

Did I miss anything?

### Testing

Not sure we can test without merging to main.

### Notes for release

N/A
