### PR TITLE
fix(cli): fixes dev command message

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/app/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/devAction.ts
@@ -47,8 +47,7 @@ export default async function startAppDevServer(
 
   try {
     const spinner = output.spinner('Starting dev server').start()
-    await startDevServer({...config, skipStartLog: true, isApp: true})
-    spinner.succeed()
+    await startDevServer({...config, spinner, skipStartLog: true, isApp: true})
 
     output.print(`Dev server started on port ${config.httpPort}`)
     output.print(`View your app in the Sanity dashboard here:`)

--- a/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
@@ -228,8 +228,7 @@ export default async function startSanityDevServer(
 
   try {
     const spinner = output.spinner('Starting dev server').start()
-    await startDevServer({...config, skipStartLog: loadInDashboard})
-    spinner.succeed()
+    await startDevServer({...config, spinner, skipStartLog: loadInDashboard})
 
     if (loadInDashboard) {
       if (!organizationId) {
@@ -267,7 +266,7 @@ export function getDevServerConfig({
   workDir: string
   cliConfig?: CliConfig
   output: CliOutputter
-}): DevServerOptions {
+}): Omit<DevServerOptions, 'spinner'> {
   const configSpinner = output.spinner('Checking configuration files...')
   const baseConfig = getSharedServerConfig({
     flags: {

--- a/packages/sanity/src/_internal/cli/server/devServer.ts
+++ b/packages/sanity/src/_internal/cli/server/devServer.ts
@@ -1,4 +1,4 @@
-import {type ReactCompilerConfig, type UserViteConfig} from '@sanity/cli'
+import {type CliOutputter, type ReactCompilerConfig, type UserViteConfig} from '@sanity/cli'
 import chalk from 'chalk'
 
 import {debug} from './debug'
@@ -14,6 +14,7 @@ export interface DevServerOptions {
   httpHost?: string
   projectName?: string
 
+  spinner: ReturnType<CliOutputter['spinner']>
   reactStrictMode: boolean
   reactCompiler: ReactCompilerConfig | undefined
   vite?: UserViteConfig
@@ -29,6 +30,7 @@ export interface DevServer {
 export async function startDevServer(options: DevServerOptions): Promise<DevServer> {
   const {
     cwd,
+    spinner,
     httpPort,
     httpHost,
     basePath,
@@ -77,6 +79,9 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     const startupDuration = Date.now() - startTime
     const url = `http://${httpHost || 'localhost'}:${httpPort || '3333'}${basePath}`
     const appType = isApp ? 'Sanity application' : 'Sanity Studio'
+
+    // Close the spinner before printing the message
+    spinner.succeed()
     info(
       `${appType} ` +
         `using ${chalk.cyan(`vite@${require('vite/package.json').version}`)} ` +


### PR DESCRIPTION
### Description

This PR refactors the dev server startup process to pass the spinner instance to the `startDevServer` function, allowing it to control when the spinner succeeds. This change ensures the spinner is closed at the appropriate time after the server has fully started.

### What to review

- Check how the spinner is now passed from both `devAction.ts` and `appDevAction.ts` to the `startDevServer` function
- Review the updated type definition in `getDevServerConfig` to omit the spinner from the returned options
- Verify that the spinner is now closed inside the `startDevServer` function after the server has started

### Testing

Tested by running both `sanity dev` and `sanity app dev` commands to ensure the spinner behavior works correctly in both contexts.

### Notes for release

N/A