### PR TITLE
fix(core): set `_updatedAt` to the creation time in version documents

### DIFF
--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -165,6 +165,8 @@ export function createReleaseOperationsStore(options: {
     const versionDocument = prepareVersionReferences({
       ...document,
       ...initialValue,
+      // This will automatically be set by CL when creating the version document.
+      _updatedAt: undefined,
       _id: getVersionId(documentId, releaseId),
     }) as IdentifiedSanityDocumentStub
 


### PR DESCRIPTION
### Description
When copying or creating a new version document it will set the `_updatedAt` value to the moment of creation, rather to the previous `_updatedAt` showing an outdated value.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Copy a document to a version, the `_updatedAt` value should be the moment of copying.
Add a document to a version, the `_updatedAt` value should be the moment of creation.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release


<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
