### PR TITLE
chore(actions): add npm token validation to release actions

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      EXPECTED_NPM_USER: sanity-io
 
     steps:
       - uses: actions/checkout@v4
@@ -49,6 +50,16 @@ jobs:
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_PUBLISH_TOKEN}"
         env:
           NPM_PUBLISH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
+
+      - name: Check valid token
+        run: |
+          WHOAMI_RESULT=$(npm whoami)
+          echo "npm whoami result: $WHOAMI_RESULT"
+          if [ "$WHOAMI_RESULT" != "$EXPECTED_NPM_USER" ]; then
+            echo "Error: npm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
+            exit 1
+          fi
+          echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"
 
       - name: Publish packages to npm
         run: |

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - check-release-whoami
 
 permissions:
   contents: read # for checkout
@@ -17,7 +16,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      EXPECTED_NPM_USER: not-sanity-io
+      EXPECTED_NPM_USER: sanity-io
     steps:
       - uses: actions/create-github-app-token@v2
         id: generate-token


### PR DESCRIPTION
### Description

This PR adds a `whoami` check for the release actions, validating that the token we are using to release the packages is still valid and matches with `sanity-io` 

[This is an example of a passing attempt:
](https://github.com/sanity-io/sanity/actions/runs/16021243753/job/45198522924)

<img width="624" alt="Screenshot 2025-07-02 at 11 26 13" src="https://github.com/user-attachments/assets/a7a189e1-053b-49a8-8082-4a86140cd541" />

[This is an example of a failing one (by updating the expected value)](https://github.com/sanity-io/sanity/actions/runs/16021283491/job/45198653018)

<img width="615" alt="Screenshot 2025-07-02 at 11 26 51" src="https://github.com/user-attachments/assets/f3856b7a-17c3-4445-af73-5a4d01042f17" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
