### PR TITLE
feat(core): keep values when clicking off create release modal

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
@@ -8,6 +8,7 @@ import {useTranslation} from '../../../i18n'
 import {useSetPerspective} from '../../../perspective/useSetPerspective'
 import {CreatedRelease, type OriginInfo} from '../../__telemetry__/releases.telemetry'
 import {useCreateReleaseMetadata} from '../../hooks/useCreateReleaseMetadata'
+import {useReleaseFormStorage} from '../../hooks/useReleaseFormStorage'
 import {isReleaseLimitError} from '../../store/isReleaseLimitError'
 import {useReleaseOperations} from '../../store/useReleaseOperations'
 import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
@@ -28,6 +29,7 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
   const {t} = useTranslation()
   const telemetry = useTelemetry()
   const createReleaseMetadata = useCreateReleaseMetadata()
+  const {clearReleaseDataFromStorage} = useReleaseFormStorage()
 
   const [release, setRelease] = useState(getReleaseDefaults)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -54,6 +56,7 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
       } catch (err) {
         if (isReleaseLimitError(err)) {
           onCancel()
+          clearReleaseDataFromStorage()
         } else {
           console.error(err)
           toast.push({
@@ -64,19 +67,21 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
         }
       } finally {
         setIsSubmitting(false)
+        clearReleaseDataFromStorage()
       }
     },
     [
-      release,
-      toast,
       createReleaseMetadata,
+      release,
       createRelease,
       telemetry,
       origin,
       setPerspective,
       onSubmit,
       onCancel,
+      toast,
       t,
+      clearReleaseDataFromStorage,
     ],
   )
 
@@ -87,12 +92,17 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
   const dialogTitle = t('release.dialog.create.title')
   const dialogConfirm = t('release.dialog.create.confirm')
 
+  const handleOnClose = useCallback(() => {
+    clearReleaseDataFromStorage()
+    onCancel()
+  }, [clearReleaseDataFromStorage, onCancel])
+
   return (
     <Dialog
       onClickOutside={onCancel}
       header={dialogTitle}
       id="create-release-dialog"
-      onClose={onCancel}
+      onClose={handleOnClose}
       width={1}
       padding={false}
     >

--- a/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
@@ -71,23 +71,26 @@ export function ReleaseForm(props: {
     }
   }, [getStoredReleaseData, id, onChange])
 
+  const handleOnChangeAndStorage = useCallback(
+    (updatedValue: EditableReleaseDocument) => {
+      onChange(updatedValue)
+      saveReleaseDataToStorage({
+        ...updatedValue.metadata,
+      })
+    },
+    [onChange, saveReleaseDataToStorage],
+  )
+
   const handleBundlePublishAtCalendarChange = useCallback(
     (date: Date) => {
       setIntendedPublishAt(date)
-      const updatedValue = {
+
+      handleOnChangeAndStorage({
         ...value,
         metadata: {...value.metadata, intendedPublishAt: date.toISOString()},
-      }
-      onChange(updatedValue)
-
-      saveReleaseDataToStorage({
-        title: updatedValue.metadata?.title,
-        description: updatedValue.metadata?.description,
-        releaseType: updatedValue.metadata?.releaseType,
-        intendedPublishAt: date.toISOString(),
       })
     },
-    [value, onChange, saveReleaseDataToStorage],
+    [handleOnChangeAndStorage, value],
   )
 
   const handleButtonReleaseTypeChange = useCallback<MouseEventHandler<HTMLDivElement>>(
@@ -107,7 +110,7 @@ export function ReleaseForm(props: {
         setIntendedPublishAt(nextInputValue)
       }
 
-      const updatedValue = {
+      handleOnChangeAndStorage({
         ...value,
         metadata: {
           ...value.metadata,
@@ -115,41 +118,23 @@ export function ReleaseForm(props: {
           intendedPublishAt:
             (pickedReleaseType === 'scheduled' && nextInputValue.toISOString()) || undefined,
         },
-      }
-
-      onChange(updatedValue)
-
-      saveReleaseDataToStorage({
-        title: updatedValue.metadata?.title,
-        description: updatedValue.metadata?.description,
-        releaseType: pickedReleaseType,
-        intendedPublishAt: updatedValue.metadata?.intendedPublishAt,
       })
     },
-    [onChange, saveReleaseDataToStorage, value],
+    [handleOnChangeAndStorage, value],
   )
 
   const handleTitleDescriptionChange = useCallback(
     (updatedRelease: EditableReleaseDocument) => {
-      const updatedValue = {
+      handleOnChangeAndStorage({
         ...value,
         metadata: {
           ...value.metadata,
           title: updatedRelease.metadata.title,
           description: updatedRelease.metadata.description,
         },
-      }
-
-      onChange(updatedValue)
-
-      saveReleaseDataToStorage({
-        title: updatedRelease.metadata.title,
-        description: updatedRelease.metadata.description,
-        releaseType: updatedValue.metadata?.releaseType,
-        intendedPublishAt: updatedValue.metadata?.intendedPublishAt,
       })
     },
-    [onChange, saveReleaseDataToStorage, value],
+    [handleOnChangeAndStorage, value],
   )
 
   useEffect(() => {

--- a/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
@@ -97,14 +97,12 @@ export function TitleDescriptionForm({
   const descriptionRef = useRef<HTMLTextAreaElement | null>(null)
 
   const [scrollHeight, setScrollHeight] = useState(46)
-  const [value, setValue] = useState((): EditableReleaseDocument => {
-    return {
-      _id: release?._id,
-      metadata: {
-        title: release?.metadata.title,
-        description: release?.metadata.description,
-      },
-    } as const
+  const [value, setValue] = useState<EditableReleaseDocument>({
+    _id: release?._id,
+    metadata: {
+      title: release?.metadata.title,
+      description: release?.metadata.description,
+    },
   })
   const {t} = useTranslation()
 
@@ -114,6 +112,10 @@ export function TitleDescriptionForm({
       setScrollHeight(descriptionRef.current.scrollHeight)
     }
   }, [])
+
+  useEffect(() => {
+    setValue(release)
+  }, [release])
 
   const handleTitleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/sanity/src/core/releases/components/dialog/__tests__/ReleaseForm.test.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/__tests__/ReleaseForm.test.tsx
@@ -22,7 +22,22 @@ vi.mock('../../../store/useReleasesIds', () => ({
 
 vi.mock('../../../i18n/hooks/useTranslation', () => ({
   useTranslate: vi.fn().mockReturnValue({
-    t: vi.fn(),
+    t: vi.fn((key) => key),
+  }),
+}))
+
+vi.mock('../../../hooks/useTimeZone', () => ({
+  useTimeZone: vi.fn().mockReturnValue({
+    timeZone: {name: 'UTC'},
+    utcToCurrentZoneDate: vi.fn((date) => date),
+  }),
+}))
+
+vi.mock('../../hooks/useReleaseFormStorage', () => ({
+  useReleaseFormStorage: vi.fn().mockReturnValue({
+    getStoredReleaseData: vi.fn().mockReturnValue({}),
+    saveReleaseDataToStorage: vi.fn(),
+    clearReleaseDataFromStorage: vi.fn(),
   }),
 }))
 
@@ -40,6 +55,12 @@ describe('ReleaseForm', () => {
       description: '',
     },
   }
+
+  beforeEach(() => {
+    // Clear localStorage before each test
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
 
   describe('when creating a new release', () => {
     beforeEach(async () => {
@@ -87,7 +108,6 @@ describe('ReleaseForm', () => {
     it('should render the form fields', () => {
       expect(screen.getByTestId('release-form-title')).toBeInTheDocument()
       expect(screen.getByTestId('release-form-description')).toBeInTheDocument()
-      //expect(screen.getByTestId('release-form-publish-at')).toBeInTheDocument()
     })
 
     it('should call onChange when title input value changes', () => {
@@ -108,6 +128,10 @@ describe('ReleaseForm', () => {
         ...valueMock,
         metadata: {...valueMock.metadata, description: 'New Description'},
       })
+    })
+
+    it('should render release type selection menu', () => {
+      expect(screen.getByText('ASAP')).toBeInTheDocument()
     })
   })
 

--- a/packages/sanity/src/core/releases/components/documentHeader/dialog/CopyToNewReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/dialog/CopyToNewReleaseDialog.tsx
@@ -10,6 +10,7 @@ import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {Preview} from '../../../../preview/components/Preview'
 import {CreatedRelease} from '../../../__telemetry__/releases.telemetry'
 import {useCreateReleaseMetadata} from '../../../hooks/useCreateReleaseMetadata'
+import {useReleaseFormStorage} from '../../../hooks/useReleaseFormStorage'
 import {releasesLocaleNamespace} from '../../../i18n'
 import {isReleaseLimitError} from '../../../store/isReleaseLimitError'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
@@ -59,6 +60,7 @@ export function CopyToNewReleaseDialog(props: {
 
   const telemetry = useTelemetry()
   const {createRelease} = useReleaseOperations()
+  const {clearReleaseDataFromStorage} = useReleaseFormStorage()
 
   const displayTitle = title || t('release.placeholder-untitled-release')
 
@@ -103,6 +105,7 @@ export function CopyToNewReleaseDialog(props: {
       }
     } finally {
       setIsSubmitting(false)
+      clearReleaseDataFromStorage()
     }
   }, [
     release,
@@ -113,20 +116,26 @@ export function CopyToNewReleaseDialog(props: {
     onClose,
     toast,
     t,
+    clearReleaseDataFromStorage,
   ])
+
+  const handleOnClose = useCallback(() => {
+    clearReleaseDataFromStorage()
+    onClose()
+  }, [clearReleaseDataFromStorage, onClose])
 
   return (
     <Dialog
       id={'create-release-dialog'}
       header={t('release.dialog.copy-to-release.title')}
       onClickOutside={onClose}
-      onClose={onClose}
+      onClose={handleOnClose}
       padding={false}
       width={1}
       footer={{
         cancelButton: {
           disabled: isSubmitting,
-          onClick: onClose,
+          onClick: handleOnClose,
         },
         confirmButton: {
           text: t('release.action.add-to-new-release'),

--- a/packages/sanity/src/core/releases/hooks/useReleaseFormStorage.ts
+++ b/packages/sanity/src/core/releases/hooks/useReleaseFormStorage.ts
@@ -10,6 +10,15 @@ interface ReleaseFormDraft {
   intendedPublishAt?: string
 }
 
+/**
+ * This hook is used to store the release form data in localStorage.
+ * The main use case is when a user accidentally closes the dialog for a release before it is created .
+ *
+ * @returns an object with the following methods:
+ * - getStoredReleaseData: a function that returns the stored release form data
+ * - saveReleaseDataToStorage: a function that saves the release form data to localStorage
+ * - clearReleaseDataFromStorage: a function that clears the release form data from localStorage
+ */
 export function useReleaseFormStorage() {
   const getStoredReleaseData = useCallback((): ReleaseFormDraft => {
     const stored = localStorage.getItem(RELEASE_FORM_STORAGE_KEY)

--- a/packages/sanity/src/core/releases/hooks/useReleaseFormStorage.ts
+++ b/packages/sanity/src/core/releases/hooks/useReleaseFormStorage.ts
@@ -1,0 +1,28 @@
+import {type ReleaseType} from '@sanity/client'
+import {useCallback} from 'react'
+
+const RELEASE_FORM_STORAGE_KEY = 'studio.release-form.recovery'
+
+interface ReleaseFormDraft {
+  title?: string
+  description?: string
+  releaseType?: ReleaseType
+  intendedPublishAt?: string
+}
+
+export function useReleaseFormStorage() {
+  const getStoredReleaseData = useCallback((): ReleaseFormDraft => {
+    const stored = localStorage.getItem(RELEASE_FORM_STORAGE_KEY)
+    return stored ? JSON.parse(stored) : {}
+  }, [])
+
+  const saveReleaseDataToStorage = useCallback((data: ReleaseFormDraft) => {
+    localStorage.setItem(RELEASE_FORM_STORAGE_KEY, JSON.stringify(data))
+  }, [])
+
+  const clearReleaseDataFromStorage = useCallback(() => {
+    localStorage.removeItem(RELEASE_FORM_STORAGE_KEY)
+  }, [])
+
+  return {getStoredReleaseData, saveReleaseDataToStorage, clearReleaseDataFromStorage}
+}


### PR DESCRIPTION
### Description

> [!NOTE]
> Highly suggest reviewing and merging #9862 before this for ease of testing

https://github.com/user-attachments/assets/a55bfc1e-27ea-4695-91d0-e2a274d624a0

You should still be able to write, delete, etc do much of anything as before on the dialog.

The form is saved:
- When you click outside of the dialog and close the dialog

The form is cleared (as well as localstorage)
- When the cross at the top of the dialog is clicked, 
- When the cancel button is used (in the copy release dialog)

### What to review

Does it make sense?

### Testing

Added some automated tests 

### Notes for release

When clicking outside of the creating a release dialog, now the content will persist when re-opening the modal
