### PR TITLE
feat(core): add way to revert unpublishing in a release

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1271,6 +1271,17 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
     'This workspace is limited to {{count}} releases',
   /** Tooltip message for not having permissions for creating new releases */
   'release.action.permission.error': 'You do not have permission to perform this action',
+  /** Error message description for when a version is reverted from being unpublished */
+  'release.action.revert-unpublish-version.failure.description':
+    'Please try again or check your connection. The version is still going to be unpublished upon release.',
+  /** Error message title for when a version is reverted from being unpublished */
+  'release.action.revert-unpublish-version.failure.title':
+    'Failed to revert from being unpublished on release.',
+  /** Action message description for when a version is reverted from being unpublished */
+  'release.action.revert-unpublish-version.success.description': 'You can now edit this version.',
+  /** Action message title for when a version is reverted from being unpublished */
+  'release.action.revert-unpublish-version.success.title':
+    'Successfully reverted <strong>{{title}}</strong> from being unpublished on release.',
   /** Error message for when a version is set to be unpublished */
   'release.action.unpublish-version.failure': 'Failed to set version to be unpublished on release',
   /** Action message for when a version is set to be unpublished successfully */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1276,12 +1276,12 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
     'Please try again or check your connection. The version is still going to be unpublished upon release.',
   /** Error message title for when a version is reverted from being unpublished */
   'release.action.revert-unpublish-version.failure.title':
-    'Failed to revert from being unpublished on release.',
+    'Failed to revert from setting to unpublish on release.',
   /** Action message description for when a version is reverted from being unpublished */
   'release.action.revert-unpublish-version.success.description': 'You can now edit this version.',
   /** Action message title for when a version is reverted from being unpublished */
   'release.action.revert-unpublish-version.success.title':
-    'Successfully reverted <strong>{{title}}</strong> from being unpublished on release.',
+    'Successfully reverted from setting to unpublish on release.',
   /** Error message for when a version is set to be unpublished */
   'release.action.unpublish-version.failure': 'Failed to set version to be unpublished on release',
   /** Action message for when a version is set to be unpublished successfully */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1273,7 +1273,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.action.permission.error': 'You do not have permission to perform this action',
   /** Error message description for when a version is reverted from being unpublished */
   'release.action.revert-unpublish-version.failure.description':
-    'Please try again or check your connection. The version is still going to be unpublished upon release.',
+    'Please try again or check your connection. The document is still going to be unpublished upon release.',
   /** Error message title for when a version is reverted from being unpublished */
   'release.action.revert-unpublish-version.failure.title':
     'Failed to revert from setting to unpublish on release.',

--- a/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
+++ b/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
@@ -15,12 +15,14 @@ export interface VersionOperationsValue {
   ) => Promise<void>
   discardVersion: (releaseId: string, documentId: string) => Promise<SingleActionResult>
   unpublishVersion: (documentId: string) => Promise<SingleActionResult>
+  revertUnpublishVersion: (documentId: string) => Promise<SingleActionResult>
 }
 
 /** @internal */
 export function useVersionOperations(): VersionOperationsValue {
   const telemetry = useTelemetry()
-  const {createVersion, discardVersion, unpublishVersion} = useReleaseOperations()
+  const {createVersion, discardVersion, unpublishVersion, revertUnpublishVersion} =
+    useReleaseOperations()
 
   const setPerspective = useSetPerspective()
 
@@ -42,9 +44,13 @@ export function useVersionOperations(): VersionOperationsValue {
 
   const handleUnpublishVersion = async (documentId: string) => unpublishVersion(documentId)
 
+  const handleRevertUnpublishVersion = async (documentId: string) =>
+    revertUnpublishVersion(documentId)
+
   return {
     createVersion: handleCreateVersion,
     discardVersion: handleDiscardVersion,
     unpublishVersion: handleUnpublishVersion,
+    revertUnpublishVersion: handleRevertUnpublishVersion,
   }
 }

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -28,6 +28,8 @@ const releasesLocaleStrings = {
   'action.unpublish': 'Unpublish',
   /** Action message for scheduling an unpublished of a document  */
   'action.unpublish-doc-actions': 'Unpublish when releasing',
+  /** Action message for when document is scheduled for unpublishing a document and you want to no longer unpublish it */
+  'action.revert-unpublish-actions': 'Revert unpublish when releasing',
   /** Action text for unscheduling a release */
   'action.unschedule': 'Unschedule release',
   /** Action text for publishing all documents in a release (and the release itself) */

--- a/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
@@ -49,14 +49,14 @@ export const UnpublishVersionAction: DocumentActionComponent = (
         toast.push({
           closable: true,
           status: 'error',
-          title: t('release.action.revert-unpublish-version.failure.title'),
+          title: coreT('release.action.revert-unpublish-version.failure.title'),
           description: coreT('release.action.revert-unpublish-version.failure.description'),
         })
       }
     } else {
       setDialogOpen(true)
     }
-  }, [isAlreadyUnpublished, version, revertUnpublishVersion, toast, coreT, t])
+  }, [isAlreadyUnpublished, version, revertUnpublishVersion, toast, coreT])
 
   if (!version) return null
 

--- a/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
@@ -40,17 +40,11 @@ export const UnpublishVersionAction: DocumentActionComponent = (
 
   const [dialogOpen, setDialogOpen] = useState(false)
 
-  const handleDialogOpen = useCallback(async () => {
+  const handleOnClick = useCallback(async () => {
     // if the document is already unpublished, revert the unpublish
     if (isAlreadyUnpublished && version) {
       try {
         await revertUnpublishVersion(version._id)
-        toast.push({
-          closable: true,
-          status: 'success',
-          title: coreT('release.action.revert-unpublish-version.success.title'),
-          description: coreT('release.action.revert-unpublish-version.success.description'),
-        })
       } catch (err) {
         toast.push({
           closable: true,
@@ -96,7 +90,7 @@ export const UnpublishVersionAction: DocumentActionComponent = (
       ? t('action.revert-unpublish-actions')
       : t('action.unpublish-doc-actions'),
     icon: isAlreadyUnpublished ? RevertIcon : UnpublishIcon,
-    onHandle: handleDialogOpen,
+    onHandle: handleOnClick,
     disabled: !isPublished,
     /** @todo should be switched once we have the document actions updated */
     title: isAlreadyUnpublished

--- a/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
@@ -1,4 +1,4 @@
-import {TrashIcon, UnpublishIcon} from '@sanity/icons'
+import {RevertIcon, TrashIcon, UnpublishIcon} from '@sanity/icons'
 import {useToast} from '@sanity/ui'
 import {useCallback, useState} from 'react'
 
@@ -114,7 +114,7 @@ export const UnpublishVersionAction: DocumentActionComponent = (
     label: isAlreadyUnpublished
       ? t('action.revert-unpublish-actions')
       : t('action.unpublish-doc-actions'),
-    icon: UnpublishIcon,
+    icon: isAlreadyUnpublished ? RevertIcon : UnpublishIcon,
     onHandle: handleDialogOpen,
     disabled: !isPublished,
     /** @todo should be switched once we have the document actions updated */

--- a/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
@@ -8,9 +8,7 @@ import {
   type DocumentActionDescription,
   type DocumentActionProps,
 } from '../../../config/document/actions'
-import {useSchema} from '../../../hooks/useSchema'
-import {Translate, useTranslation} from '../../../i18n'
-import {unstable_useValuePreview as useValuePreview} from '../../../preview'
+import {useTranslation} from '../../../i18n'
 import {useDocumentPairPermissions} from '../../../store/_legacy/grants/documentPairPermissions'
 import {useCurrentUser} from '../../../store/user/hooks'
 import {UnpublishVersionDialog} from '../../components/dialog/UnpublishVersionDialog'
@@ -41,9 +39,6 @@ export const UnpublishVersionAction: DocumentActionComponent = (
   })
 
   const [dialogOpen, setDialogOpen] = useState(false)
-  const schema = useSchema()
-  const schemaType = schema.get(type)
-  const preview = useValuePreview({schemaType, value: {_id: version?._id}})
 
   const handleDialogOpen = useCallback(async () => {
     // if the document is already unpublished, revert the unpublish
@@ -53,13 +48,7 @@ export const UnpublishVersionAction: DocumentActionComponent = (
         toast.push({
           closable: true,
           status: 'success',
-          title: (
-            <Translate
-              t={coreT}
-              i18nKey={'release.action.revert-unpublish-version.success.title'}
-              values={{title: preview?.value?.title || version?._id}}
-            />
-          ),
+          title: coreT('release.action.revert-unpublish-version.success.title'),
           description: coreT('release.action.revert-unpublish-version.success.description'),
         })
       } catch (err) {
@@ -73,15 +62,7 @@ export const UnpublishVersionAction: DocumentActionComponent = (
     } else {
       setDialogOpen(true)
     }
-  }, [
-    isAlreadyUnpublished,
-    version,
-    revertUnpublishVersion,
-    toast,
-    coreT,
-    preview?.value?.title,
-    t,
-  ])
+  }, [isAlreadyUnpublished, version, revertUnpublishVersion, toast, coreT, t])
 
   if (!version) return null
 

--- a/packages/sanity/src/core/releases/store/__tests__/__mocks/createReleaseOperationsStore.mock.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/__mocks/createReleaseOperationsStore.mock.ts
@@ -19,6 +19,7 @@ export const createReleaseOperationsStoreReturn: Mocked<ReleaseOperationsStore> 
   revertRelease: vi.fn(),
   duplicateRelease: vi.fn(),
   unpublishVersion: vi.fn(),
+  revertUnpublishVersion: vi.fn(),
 }
 
 export const mockCreateReleaseOperationsStore = createReleaseOperationsStore as Mock<

--- a/packages/sanity/src/core/releases/store/__tests__/__mocks/useReleaseOperations.mock.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/__mocks/useReleaseOperations.mock.ts
@@ -17,6 +17,7 @@ export const useReleaseOperationsMockReturn: Mocked<ReleaseOperationsStore> = {
   revertRelease: vi.fn(),
   duplicateRelease: vi.fn(),
   unpublishVersion: vi.fn(),
+  revertUnpublishVersion: vi.fn(),
 }
 
 export const mockUseReleaseOperations = useReleaseOperations as Mock<typeof useReleaseOperations>

--- a/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
@@ -485,6 +485,72 @@ describe('createReleaseOperationsStore', () => {
     )
   })
 
+  it('should revert unpublish a version of a document', async () => {
+    const store = createStore()
+    const mockDocument = {
+      _id: 'versions.release-id.doc-id',
+      _type: 'document',
+      title: 'Test Document',
+      content: 'Test content',
+      _system: {someSystemData: 'value'},
+    }
+    mockClient.getDocument.mockResolvedValue(mockDocument)
+
+    await store.revertUnpublishVersion('versions.release-id.doc-id')
+
+    expect(mockClient.getDocument).toHaveBeenCalledWith('versions.release-id.doc-id')
+    expect(mockClient.action).toHaveBeenCalledWith(
+      {
+        actionType: 'sanity.action.document.version.replace',
+        document: {
+          _id: 'versions.release-id.doc-id',
+          _type: 'document',
+          title: 'Test Document',
+          content: 'Test content',
+        },
+      },
+      undefined,
+    )
+  })
+
+  it('should revert unpublish a version of a document with options', async () => {
+    const store = createStore()
+    const mockDocument = {
+      _id: 'versions.release-id.doc-id',
+      _type: 'document',
+      title: 'Test Document',
+    }
+    mockClient.getDocument.mockResolvedValue(mockDocument)
+    const opts = {dryRun: true}
+
+    await store.revertUnpublishVersion('versions.release-id.doc-id', opts)
+
+    expect(mockClient.getDocument).toHaveBeenCalledWith('versions.release-id.doc-id')
+    expect(mockClient.action).toHaveBeenCalledWith(
+      {
+        actionType: 'sanity.action.document.version.replace',
+        document: {
+          _id: 'versions.release-id.doc-id',
+          _type: 'document',
+          title: 'Test Document',
+        },
+      },
+      opts,
+    )
+  })
+
+  it('should throw an error when reverting unpublish for a non-existent document', async () => {
+    const store = createStore()
+    mockClient.getDocument.mockResolvedValue(null)
+
+    await expect(store.revertUnpublishVersion('versions.release-id.doc-id')).rejects.toThrow(
+      'Document with id versions.release-id.doc-id not found',
+    )
+
+    expect(mockClient.getDocument).toHaveBeenCalledWith('versions.release-id.doc-id')
+    expect(mockClient.action).not.toHaveBeenCalled()
+  })
+
   it('should create a release with options', async () => {
     const store = createStore()
     const release = activeASAPRelease

--- a/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
@@ -487,68 +487,40 @@ describe('createReleaseOperationsStore', () => {
 
   it('should revert unpublish a version of a document', async () => {
     const store = createStore()
-    const mockDocument = {
-      _id: 'versions.release-id.doc-id',
-      _type: 'document',
-      title: 'Test Document',
-      content: 'Test content',
-      _system: {someSystemData: 'value'},
-    }
-    mockClient.getDocument.mockResolvedValue(mockDocument)
-
-    await store.revertUnpublishVersion('versions.release-id.doc-id')
-
-    expect(mockClient.getDocument).toHaveBeenCalledWith('versions.release-id.doc-id')
-    expect(mockClient.action).toHaveBeenCalledWith(
-      {
-        actionType: 'sanity.action.document.version.replace',
-        document: {
-          _id: 'versions.release-id.doc-id',
-          _type: 'document',
-          title: 'Test Document',
-          content: 'Test content',
-        },
-      },
-      undefined,
-    )
-  })
-
-  it('should revert unpublish a version of a document with options', async () => {
-    const store = createStore()
-    const mockDocument = {
-      _id: 'versions.release-id.doc-id',
-      _type: 'document',
-      title: 'Test Document',
-    }
-    mockClient.getDocument.mockResolvedValue(mockDocument)
     const opts = {dryRun: true}
 
     await store.revertUnpublishVersion('versions.release-id.doc-id', opts)
 
-    expect(mockClient.getDocument).toHaveBeenCalledWith('versions.release-id.doc-id')
     expect(mockClient.action).toHaveBeenCalledWith(
       {
-        actionType: 'sanity.action.document.version.replace',
-        document: {
-          _id: 'versions.release-id.doc-id',
-          _type: 'document',
-          title: 'Test Document',
+        actionType: 'sanity.action.document.edit',
+        draftId: 'versions.release-id.doc-id',
+        publishedId: 'doc-id',
+        patch: {
+          unset: ['_system.delete'],
         },
       },
       opts,
     )
   })
 
-  it('should throw an error when reverting unpublish for a non-existent document', async () => {
+  it('should revert unpublish a version of a document with options', async () => {
     const store = createStore()
-    mockClient.getDocument.mockResolvedValue(null)
+    const opts = {dryRun: true}
 
-    await expect(store.revertUnpublishVersion('versions.release-id.doc-id')).rejects.toThrow(
-      'Document with id versions.release-id.doc-id not found',
+    await store.revertUnpublishVersion('versions.release-id.doc-id', opts)
+
+    expect(mockClient.action).toHaveBeenCalledWith(
+      {
+        actionType: 'sanity.action.document.edit',
+        draftId: 'versions.release-id.doc-id',
+        publishedId: 'doc-id',
+        patch: {
+          unset: ['_system.delete'],
+        },
+      },
+      opts,
     )
-
-    expect(mockClient.getDocument).toHaveBeenCalledWith('versions.release-id.doc-id')
-    expect(mockClient.action).not.toHaveBeenCalled()
   })
 
   it('should create a release with options', async () => {

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -248,7 +248,7 @@ export function createReleaseOperationsStore(options: {
   }
 
   const handleRevertUnpublishVersion = async (documentId: string, opts?: BaseActionOptions) => {
-    return client.action(
+    return await client.action(
       {
         actionType: 'sanity.action.document.edit',
         draftId: documentId,

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -248,24 +248,14 @@ export function createReleaseOperationsStore(options: {
   }
 
   const handleRevertUnpublishVersion = async (documentId: string, opts?: BaseActionOptions) => {
-    const currentDocument = await client.getDocument(documentId)
-
-    if (!currentDocument) {
-      throw new Error(`Document with id ${documentId} not found`)
-    }
-
-    const updatedDocument = {
-      ...currentDocument,
-      _system: {
-        ...currentDocument._system,
-        delete: undefined,
-      },
-    }
-
     return client.action(
       {
-        actionType: 'sanity.action.document.version.replace',
-        document: updatedDocument,
+        actionType: 'sanity.action.document.edit',
+        draftId: documentId,
+        publishedId: getPublishedId(documentId),
+        patch: {
+          unset: ['_system.delete'],
+        },
       },
       opts,
     )

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -256,7 +256,10 @@ export function createReleaseOperationsStore(options: {
 
     const updatedDocument = {
       ...currentDocument,
-      _system: undefined,
+      _system: {
+        ...currentDocument._system,
+        delete: undefined,
+      },
     }
 
     return client.action(

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -53,6 +53,10 @@ export interface ReleaseOperationsStore {
     opts?: BaseActionOptions,
   ) => Promise<SingleActionResult>
   unpublishVersion: (documentId: string, opts?: BaseActionOptions) => Promise<SingleActionResult>
+  revertUnpublishVersion: (
+    documentId: string,
+    opts?: BaseActionOptions,
+  ) => Promise<SingleActionResult>
 }
 
 export function createReleaseOperationsStore(options: {
@@ -243,6 +247,27 @@ export function createReleaseOperationsStore(options: {
     }
   }
 
+  const handleRevertUnpublishVersion = async (documentId: string, opts?: BaseActionOptions) => {
+    const currentDocument = await client.getDocument(documentId)
+
+    if (!currentDocument) {
+      throw new Error(`Document with id ${documentId} not found`)
+    }
+
+    const updatedDocument = {
+      ...currentDocument,
+      _system: undefined,
+    }
+
+    return client.action(
+      {
+        actionType: 'sanity.action.document.version.replace',
+        document: updatedDocument,
+      },
+      opts,
+    )
+  }
+
   return {
     archive: handleArchiveRelease,
     unarchive: handleUnarchiveRelease,
@@ -257,5 +282,6 @@ export function createReleaseOperationsStore(options: {
     createVersion: handleCreateVersion,
     discardVersion: handleDiscardVersion,
     unpublishVersion: handleUnpublishVersion,
+    revertUnpublishVersion: handleRevertUnpublishVersion,
   }
 }


### PR DESCRIPTION
### Description

Allow for a document that has been slated for unpublishing in a release to be returned to its original version state

https://github.com/user-attachments/assets/ee3fe5c2-16bc-41b8-9cf0-280b73d987a4

### What to review

The code and especially if there is a different method we should use in the [createReleaseOperationStore.ts](https://github.com/sanity-io/sanity/compare/main...sapp-2837#diff-093681b737c63cd3c2db92540b2c90f7340c442f77ab4ac5f51b24649b206eb6)
Also any naming / method titles, suggestions are welcome

### Testing

Added new automated tests

### Notes for release

We now allow for versions that were slated for unpublishing in a release to be returned to its original version state