### PR TITLE
refactor(core): use stderr printing instead of contextoutput

### DIFF
--- a/packages/@sanity/cli/src/util/printNewMajorMessage.ts
+++ b/packages/@sanity/cli/src/util/printNewMajorMessage.ts
@@ -15,5 +15,7 @@ Learn what this means for your apps at https://www.sanity.io/blog/a-major-versio
     padding: 1,
     margin: 1,
   })
-  context.output.print(boxedMessage)
+
+  // Print to stderr to prevent garbling command output
+  console.warn(boxedMessage)
 }

--- a/packages/@sanity/cli/test/dataset.test.ts
+++ b/packages/@sanity/cli/test/dataset.test.ts
@@ -38,8 +38,6 @@ describeCliTest('CLI: `sanity dataset`', () => {
         'visibility',
         'get',
         testRunArgs.aclDataset,
-        // TODO: remove once version 4 is released
-        '--hide-major-message',
       ])
       expect(result.stdout.trim()).toBe('public')
       expect(result.code).toBe(0)
@@ -51,8 +49,6 @@ describeCliTest('CLI: `sanity dataset`', () => {
         'set',
         testRunArgs.aclDataset,
         'private',
-        // TODO: remove once version 4 is released
-        '--hide-major-message',
       ])
       expect(result.stdout).toMatch(/visibility changed/i)
       expect(result.code).toBe(0)
@@ -63,8 +59,6 @@ describeCliTest('CLI: `sanity dataset`', () => {
         'visibility',
         'get',
         testRunArgs.aclDataset,
-        // TODO: remove once version 4 is released
-        '--hide-major-message',
       ])
       expect(result.stdout.trim()).toBe('private')
       expect(result.code).toBe(0)

--- a/packages/@sanity/cli/test/dev.test.ts
+++ b/packages/@sanity/cli/test/dev.test.ts
@@ -85,8 +85,7 @@ describeCliTest('CLI: `sanity dev`', () => {
         command: 'dev',
         port: testRunArgs.port - 3,
         basePath: '/config-base-path',
-        // TODO: remove '--hide-major-message' once version 4 is released
-        args: ['--port', `${testRunArgs.port - 3}`, '--load-in-dashboard', '--hide-major-message'],
+        args: ['--port', `${testRunArgs.port - 3}`, '--load-in-dashboard'],
         cwd: path.join(studiosPath, version),
         expectedTitle: 'Sanity Studio',
       })
@@ -104,8 +103,7 @@ describeCliTest('CLI: `sanity dev`', () => {
         command: 'dev',
         port: port,
         basePath: '/app-base-path',
-        // TODO: remove '--hide-major-message' once version 4 is released
-        args: ['--port', `${port}`, '--hide-major-message'],
+        args: ['--port', `${port}`],
         cwd: path.join(fixturesPath, 'app'),
         expectedTitle: 'Sanity Custom App',
       })

--- a/packages/@sanity/cli/test/exec.test.ts
+++ b/packages/@sanity/cli/test/exec.test.ts
@@ -6,12 +6,7 @@ import {getCliUserEmail, runSanityCmdCommand, studioVersions} from './shared/env
 describeCliTest('CLI: `sanity exec`', () => {
   describe.each(studioVersions)('%s', (version) => {
     testConcurrent('sanity exec', async () => {
-      const result = await runSanityCmdCommand(version, [
-        'exec',
-        'script.ts',
-        // TODO: remove once version 4 is released
-        '--hide-major-message',
-      ])
+      const result = await runSanityCmdCommand(version, ['exec', 'script.ts'])
       const data = JSON.parse(result.stdout.trim())
       expect(Object.keys(data.user)).toHaveLength(0)
       // Check that we load from .env.development
@@ -20,13 +15,7 @@ describeCliTest('CLI: `sanity exec`', () => {
     })
 
     testConcurrent('sanity exec --with-user-token', async () => {
-      const result = await runSanityCmdCommand(version, [
-        'exec',
-        'script.ts',
-        '--with-user-token',
-        // TODO: remove once version 4 is released
-        '--hide-major-message',
-      ])
+      const result = await runSanityCmdCommand(version, ['exec', 'script.ts', '--with-user-token'])
       const data = JSON.parse(result.stdout.trim())
       expect(data.user.email).toBe(await getCliUserEmail())
       // Check that we load from .env.development
@@ -35,14 +24,9 @@ describeCliTest('CLI: `sanity exec`', () => {
     })
 
     testConcurrent('sanity exec with env override', async () => {
-      const result = await runSanityCmdCommand(
-        version,
-        // TODO: remove '--hide-major-message' once version 4 is released
-        ['exec', 'script.ts', '--hide-major-message'],
-        {
-          env: {SANITY_ACTIVE_ENV: 'production'},
-        },
-      )
+      const result = await runSanityCmdCommand(version, ['exec', 'script.ts'], {
+        env: {SANITY_ACTIVE_ENV: 'production'},
+      })
       const data = JSON.parse(result.stdout.trim())
       // Check that we load from .env.production
       expect(data.env.SANITY_STUDIO_MODE).toBe('production')

--- a/packages/@sanity/cli/test/graphql.test.ts
+++ b/packages/@sanity/cli/test/graphql.test.ts
@@ -8,8 +8,7 @@ describeCliTest('CLI: `sanity graphql`', () => {
   describeCliTest.each(studioVersions)('%s', (version) => {
     const testRunArgs = getTestRunArgs(version)
     const graphqlDataset = testRunArgs.graphqlDataset
-    // TODO: remove '--hide-major-message' once version 4 is released
-    const deployFlags = ['--force', '--dataset', graphqlDataset, '--hide-major-message']
+    const deployFlags = ['--force', '--dataset', graphqlDataset]
     const client = testClient.withConfig({dataset: graphqlDataset})
 
     testConcurrent('graphql deploy', async () => {
@@ -88,8 +87,6 @@ describeCliTest('CLI: `sanity graphql`', () => {
         '--dataset',
         graphqlDataset,
         '--force',
-        // TODO: remove once version 4 is released
-        '--hide-major-message',
       ])
       expect(result.code).toBe(0)
       expect(result.stdout).toMatch(/GraphQL API deleted/i)

--- a/packages/@sanity/cli/test/init.test.ts
+++ b/packages/@sanity/cli/test/init.test.ts
@@ -832,8 +832,6 @@ describeCliTest('CLI: `sanity init v3`', () => {
         `${baseTestPath}/${outpath}`,
         '--package-manager',
         'manual',
-        // TODO: remove once version 4 is released
-        '--hide-major-message',
       ])
 
       // Check if essential files exist
@@ -875,8 +873,6 @@ describeCliTest('CLI: `sanity init v3`', () => {
         `${baseTestPath}/${outpath}`,
         '--package-manager',
         'manual',
-        // TODO: remove once version 4 is released
-        '--hide-major-message',
       ])
 
       const hasPackageJson = await fs
@@ -917,8 +913,6 @@ describeCliTest('CLI: `sanity init v3`', () => {
         `${baseTestPath}/${outpath}`,
         '--package-manager',
         'manual',
-        // TODO: remove once version 4 is released
-        '--hide-major-message',
       ])
 
       const envContent = await fs.readFile(path.join(baseTestPath, outpath, '.env.local'), 'utf-8')
@@ -950,8 +944,6 @@ describeCliTest('CLI: `sanity init v3`', () => {
           `${baseTestPath}/${outpath}`,
           '--package-manager',
           'manual',
-          // TODO: remove once version 4 is released
-          '--hide-major-message',
         ]),
       ).rejects.toThrow()
     })
@@ -977,8 +969,6 @@ describeCliTest('CLI: `sanity init v3`', () => {
           `${baseTestPath}/${outpath}`,
           '--package-manager',
           'manual',
-          // TODO: remove once version 4 is released
-          '--hide-major-message',
         ]),
       ).rejects.toThrow(
         'GitHub repository not found. For private repositories, use --template-token to provide an access token',


### PR DESCRIPTION
### Description

Based on feedback from rune, made the error print using a stderr approach instead of a context output one.
This also streamlines and removes some complexity from the tests

### What to review

Did I miss anything?
I'm keeping the flag logic in the printing as is since it might still be useful to have

### Testing

1. open branch
2. pnpm build
3. ~/[path-to-monorepo-root]/packages/@sanity/cli/bin/sanity init (or any other command)

the tests will still pass

### Notes for release

N/A