### PR TITLE
fix: add with user token option to functions test command

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -59,7 +59,7 @@
     "@babel/traverse": "^7.27.4",
     "@sanity/client": "^7.6.0",
     "@sanity/codegen": "workspace:*",
-    "@sanity/runtime-cli": "^9.0.0",
+    "@sanity/runtime-cli": "^9.1.2",
     "@sanity/telemetry": "^0.8.0",
     "@sanity/template-validator": "^2.4.3",
     "@sanity/util": "workspace:3.96.0",

--- a/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
@@ -11,6 +11,7 @@ Options
   --api <version> Sanity API Version to use
   --dataset <dataset> The Sanity dataset to use
   --project-id <id> Sanity Project ID to use
+  --with-user-token Prime access token from CLI config into getCliClient()
 
 
 Examples
@@ -31,10 +32,12 @@ export interface FunctionsTestFlags {
   'api'?: string
   'dataset'?: string
   'project-id'?: string
+  'with-user-token'?: boolean
 }
 
 const defaultFlags: FunctionsTestFlags = {
-  timeout: 10, // seconds
+  'timeout': 10, // seconds
+  'with-user-token': false,
 }
 
 const testFunctionsCommand: CliCommandDefinition<FunctionsTestFlags> = {
@@ -42,7 +45,7 @@ const testFunctionsCommand: CliCommandDefinition<FunctionsTestFlags> = {
   group: 'functions',
   helpText,
   signature:
-    '<name> [--data <json>] [--file <filename>] [--timeout <seconds>] [--api <version>] [--dataset <name>] [--project-id] <id>]',
+    '<name> [--data <json>] [--file <filename>] [--timeout <seconds>] [--api <version>] [--dataset <name>] [--project-id] <id>] [--with-user-token]',
   description: 'Invoke a local Sanity Function',
   async action(args, context) {
     const {apiClient, output} = context
@@ -83,6 +86,7 @@ const testFunctionsCommand: CliCommandDefinition<FunctionsTestFlags> = {
         'api': flags.api,
         'dataset': flags.dataset || actualDataset,
         'project-id': flags['project-id'] || projectId,
+        'with-user-token': flags['with-user-token'],
       },
     })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -896,8 +896,8 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@sanity/runtime-cli':
-        specifier: ^9.0.0
-        version: 9.0.0(@types/node@22.15.32)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+        specifier: ^9.1.2
+        version: 9.1.2(@types/node@22.15.32)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       '@sanity/telemetry':
         specifier: ^0.8.0
         version: 0.8.1(react@19.1.0)
@@ -4787,8 +4787,8 @@ packages:
     peerDependencies:
       react: ^18.3 || >=19.0.0-rc
 
-  '@sanity/runtime-cli@9.0.0':
-    resolution: {integrity: sha512-GPhR/9nYmDYR5FnfsRLdufTvsW2b7fJBIc9xdD12MgKu3xinQNGn+7gMjcAaI44ptwO3VQU2t9B4w77Rrx8jRA==}
+  '@sanity/runtime-cli@9.1.2':
+    resolution: {integrity: sha512-TOsWsCXaPqlnJj/XPJkJvdQHfuey2LJLZSTqz0wR3BvCNEppyKNalNGoUUNysyUAQnq0WsYOXhx7timXvp7Zzw==}
     engines: {node: '>=20.11.0'}
     hasBin: true
 
@@ -15513,7 +15513,7 @@ snapshots:
       - debug
       - typescript
 
-  '@sanity/runtime-cli@9.0.0(@types/node@22.15.32)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)':
+  '@sanity/runtime-cli@9.1.2(@types/node@22.15.32)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)':
     dependencies:
       '@architect/hydrate': 4.0.8
       '@architect/inventory': 4.0.9


### PR DESCRIPTION
# Description
See: [RUN-610](https://linear.app/sanity/issue/RUN-610/do-not-automatically-pass-authenticated-token-to-functions-devtest)

The Sanity CLI does not automatically add the live user token to commands unless the user specifies it using the --with-user-token flag. This PR adds this flag to the sanity functions test command and a toggle switch to the dev server.

![Screenshot 2025-07-03 at 10 34 53](https://github.com/user-attachments/assets/8cbac7ca-e9f0-405b-acb6-890cf8c75c06)

# Testing

- Run the sanity functions test command with a function that prints out the context. You should not see context.clientOptions.token.
- Run the sanity functions test --with-user-token command with a function that prints out the context. You should see context.clientOptions.token.
- Fire up the dev server and test the some function toggling the "with token" switch.