### PR TITLE
fix(core): actions flickering- remove cleanup step for hook states on change

### DIFF
--- a/packages/sanity/src/core/components/hookCollection/defineHookStateComponent.tsx
+++ b/packages/sanity/src/core/components/hookCollection/defineHookStateComponent.tsx
@@ -36,9 +36,6 @@ export function defineHookStateComponent<Args, State>({
       } else {
         handleNext(id, hookState)
       }
-      return () => {
-        handleNext(id, null)
-      }
     }, [handleNext, hookState])
 
     return null


### PR DESCRIPTION
### Description
Fixes https://github.com/sanity-io/sanity/issues/9863

This PR removes the cleanup step for the hook states that is happening on every change.
Now the following is happening:
-  Actions are rendered.
1) User types on input, 
2) This causes an update to `hookState`, triggering the cleanup part of the hook.
3) Actions are removed because of the state update, this happens immediately. And will schedule the [`requestSnapshotUpdate` ](https://github.com/sanity-io/sanity/blob/fix-action-flickering/packages/sanity/src/core/components/hookCollection/useHookCollectionStates.tsx#L75) function , but this function is [throttled ](https://github.com/sanity-io/sanity/blob/fix-action-flickering/packages/sanity/src/core/components/hookCollection/useHookCollectionStates.tsx#L53-L57) so it waits at least 60ms until the actions are added again to the state.
4) Action disappears 
5) Throttle time ends, action shows **Flickering!**

This effect is visible in safari and firefox because `postTask` is not available.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open the preview in safari, it should not flicker on type
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes actions flickering when typing on the form
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
