### PR TITLE
fix(actions): add write permissions to actions

### DIFF
--- a/.github/workflows/docReport.yml
+++ b/.github/workflows/docReport.yml
@@ -1,4 +1,6 @@
 name: Create Documentation Report
+permissions:
+  pull-requests: write # for comment
 
 on:
   # Build on version tags

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -1,4 +1,7 @@
 name: eFPS Test
+permissions:
+  pull-requests: write # for comment
+
 on:
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
### Description
Fixes issue seen here https://github.com/sanity-io/sanity/actions/runs/16075387820/job/45450694517?pr=9891

```
Run thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
Error: Resource not accessible by integration - https://docs.github.com/rest/issues/comments#update-an-issue-comment
```
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
