### PR TITLE
feat(core): add media library field groq filters

### DIFF
--- a/dev/test-studio/schema/standard/images.ts
+++ b/dev/test-studio/schema/standard/images.ts
@@ -212,5 +212,25 @@ export default defineType({
         },
       },
     },
+    {
+      name: 'imageWithMediaLibraryFilters',
+      title: 'Image with Media Library filter',
+      type: 'image',
+      description: 'Should have custom Media Library filters',
+      options: {
+        mediaLibrary: {
+          filters: [
+            {
+              name: 'Has colourDetails aspect',
+              query: 'defined(aspects.colourDetails)',
+            },
+            // {
+            //   name: 'Wide',
+            //   query: 'currentVersion->metadata.dimensions.width > 4000',
+            // },
+          ],
+        },
+      },
+    },
   ],
 })

--- a/dev/test-studio/schema/standard/images.ts
+++ b/dev/test-studio/schema/standard/images.ts
@@ -220,14 +220,14 @@ export default defineType({
       options: {
         mediaLibrary: {
           filters: [
-            {
-              name: 'Has colourDetails aspect',
-              query: 'defined(aspects.colourDetails)',
-            },
             // {
-            //   name: 'Wide',
-            //   query: 'currentVersion->metadata.dimensions.width > 4000',
+            //   name: 'Has colourDetails aspect',
+            //   query: 'defined(aspects.colourDetails)',
             // },
+            {
+              name: 'Greater than 4000px wide',
+              query: 'currentVersion->metadata.dimensions.width > 4000',
+            },
           ],
         },
       },

--- a/packages/@sanity/types/src/schema/definition/type/file.ts
+++ b/packages/@sanity/types/src/schema/definition/type/file.ts
@@ -5,10 +5,22 @@ import {type InitialValueProperty} from '../../types'
 import {type ObjectDefinition, type ObjectOptions} from './object'
 
 /** @public */
+export interface MediaLibraryFilter {
+  name: string
+  query: string
+}
+
+/** @public */
+export interface MediaLibraryOptions {
+  filters?: MediaLibraryFilter[]
+}
+
+/** @public */
 export interface FileOptions extends ObjectOptions {
   storeOriginalFilename?: boolean
   accept?: string
   sources?: AssetSource[]
+  mediaLibrary?: MediaLibraryOptions
 }
 
 /** @public */

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
@@ -12,6 +12,7 @@ import {useSanityMediaLibraryConfig} from '../hooks/useSanityMediaLibraryConfig'
 import {type AssetSelectionItem, type AssetType, type PluginPostMessage} from '../types'
 import {AppDialog} from './Dialog'
 import {Iframe} from './Iframe'
+import {encodeBase64Url} from '../../../../../router/utils/base64url'
 
 export interface SelectAssetsDialogProps {
   dialogHeaderTitle?: ReactNode
@@ -65,7 +66,7 @@ export function SelectAssetsDialog(props: SelectAssetsDialogProps): ReactNode {
         })),
       )
     }
-    return `&filters=${btoa(JSON.stringify(filters))}`
+    return `&filters=${encodeBase64Url(JSON.stringify(filters))}`
   }, [schemaType?.options?.mediaLibrary?.filters])
 
   const pluginApiVersion = mediaLibraryConfig.__internal.pluginApiVersion

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
@@ -1,6 +1,6 @@
 import {type AssetFromSource, type FileSchemaType, type ImageSchemaType} from '@sanity/types'
 import {Flex, Stack, useTheme, useToast} from '@sanity/ui'
-import {type ReactNode, useCallback, useState} from 'react'
+import {type ReactNode, useCallback, useMemo, useState} from 'react'
 
 import {Button} from '../../../../../ui-components'
 import {useTranslation} from '../../../../i18n'
@@ -53,11 +53,26 @@ export function SelectAssetsDialog(props: SelectAssetsDialogProps): ReactNode {
   const [assetSelection, setAssetSelection] = useState<AssetSelectionItem[]>(props.selection)
   const [didSelect, setDidSelect] = useState(false)
 
+  const urlFilters = useMemo(() => {
+    const filters: any[] = []
+    if (schemaType?.options?.mediaLibrary?.filters) {
+      filters.push(
+        ...schemaType.options.mediaLibrary.filters.map((filter) => ({
+          type: 'groq',
+          name: filter.name,
+          query: filter.query,
+          active: true,
+        })),
+      )
+    }
+    return `&filters=${btoa(JSON.stringify(filters))}`
+  }, [schemaType?.options?.mediaLibrary?.filters])
+
   const pluginApiVersion = mediaLibraryConfig.__internal.pluginApiVersion
   const appBasePath = mediaLibraryConfig.__internal.appBasePath
   const iframeUrl =
     `${appHost}${appBasePath}/plugin/${pluginApiVersion}/library/${libraryId}/assets?selectionType=${selectionType}` +
-    `&selectAssetTypes=${selectAssetType === 'sanity.video' ? 'video' : selectAssetType}&scheme=${dark ? 'dark' : 'light'}&auth=${authType}`
+    `&selectAssetTypes=${selectAssetType === 'sanity.video' ? 'video' : selectAssetType}&scheme=${dark ? 'dark' : 'light'}&auth=${authType}${urlFilters}`
   const {onLinkAssets} = useLinkAssets({schemaType})
 
   const handleSelect = useCallback(async () => {

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
@@ -66,7 +66,6 @@ export function SelectAssetsDialog(props: SelectAssetsDialogProps): ReactNode {
         })),
       )
     }
-    // @ts-expect-error: util function is typed only for records, but we have an array
     return encodeJsonParams(filters)
   }, [schemaType?.options?.mediaLibrary?.filters])
 

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
@@ -1,6 +1,7 @@
 import {type AssetFromSource, type FileSchemaType, type ImageSchemaType} from '@sanity/types'
 import {Flex, Stack, useTheme, useToast} from '@sanity/ui'
 import {type ReactNode, useCallback, useMemo, useState} from 'react'
+import {encodeJsonParams} from 'sanity/router'
 
 import {Button} from '../../../../../ui-components'
 import {useTranslation} from '../../../../i18n'
@@ -12,7 +13,6 @@ import {useSanityMediaLibraryConfig} from '../hooks/useSanityMediaLibraryConfig'
 import {type AssetSelectionItem, type AssetType, type PluginPostMessage} from '../types'
 import {AppDialog} from './Dialog'
 import {Iframe} from './Iframe'
-import {encodeBase64Url} from '../../../../../router/utils/base64url'
 
 export interface SelectAssetsDialogProps {
   dialogHeaderTitle?: ReactNode
@@ -66,14 +66,15 @@ export function SelectAssetsDialog(props: SelectAssetsDialogProps): ReactNode {
         })),
       )
     }
-    return `&filters=${encodeBase64Url(JSON.stringify(filters))}`
+    // @ts-expect-error: util function is typed only for records, but we have an array
+    return encodeJsonParams(filters)
   }, [schemaType?.options?.mediaLibrary?.filters])
 
   const pluginApiVersion = mediaLibraryConfig.__internal.pluginApiVersion
   const appBasePath = mediaLibraryConfig.__internal.appBasePath
   const iframeUrl =
     `${appHost}${appBasePath}/plugin/${pluginApiVersion}/library/${libraryId}/assets?selectionType=${selectionType}` +
-    `&selectAssetTypes=${selectAssetType === 'sanity.video' ? 'video' : selectAssetType}&scheme=${dark ? 'dark' : 'light'}&auth=${authType}${urlFilters}`
+    `&selectAssetTypes=${selectAssetType === 'sanity.video' ? 'video' : selectAssetType}&scheme=${dark ? 'dark' : 'light'}&auth=${authType}&filters=${urlFilters}`
   const {onLinkAssets} = useLinkAssets({schemaType})
 
   const handleSelect = useCallback(async () => {

--- a/packages/sanity/src/router/utils/jsonParamsEncoding.ts
+++ b/packages/sanity/src/router/utils/jsonParamsEncoding.ts
@@ -8,7 +8,7 @@ import {decodeBase64Url, encodeBase64Url} from './base64url'
  * @internal
  * @hidden
  */
-export function decodeJsonParams(pathSegment = ''): Record<string, unknown> {
+export function decodeJsonParams(pathSegment = ''): any {
   const segment = decodeURIComponent(pathSegment)
 
   if (!segment) {
@@ -46,6 +46,6 @@ export function decodeJsonParams(pathSegment = ''): Record<string, unknown> {
  * @internal
  * @hidden
  */
-export function encodeJsonParams(params?: Record<string, unknown>): string {
+export function encodeJsonParams(params?: any): string {
   return params ? encodeBase64Url(JSON.stringify(params)) : ''
 }


### PR DESCRIPTION
### Description

This PR adds file schema options to configure GROQ filters for the Media Library selection dialog.


### What to review

Do we have any Media Library field options already? I added a new type `MediaLibraryOptions`.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

When using the `'Image with Media Library filter'` field in Dev Studio > Standard inputs > Images test, you should see the filters encoded and appended to the iframe url.

### Notes for release

Adds new schema options to file and image fields for Media Library asset selection, to allow a field to specific a groq filter that is applied to the assets shown in the selection dialog. Example:

```js
{
  name: 'imageWithMediaLibraryFilters',
  title: 'Image with Media Library filter',
  type: 'image',
  options: {
    mediaLibrary: {
      filters: [
        {
          name: 'Has colourDetails aspect',
          query: 'defined(aspects.colourDetails)',
        },
        {
          name: 'Greater than 4000px wide',
          query: 'currentVersion->metadata.dimensions.width > 4000',
        },
      ],
    },
  },
}
```