### PR TITLE
fix: latest release no lerna

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Only run NPM publishing
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -77,6 +83,7 @@ jobs:
 
       - name: Tag and push version
         run: |
+        if: ${{ github.event.inputs.publish != 'true' }}
           git tag v$RELEASE_AS -m v$RELEASE_AS
           git push origin v$RELEASE_AS
         env:


### PR DESCRIPTION
### Description
Changes here are:
1. removing `lerna publish` since we will use `pnpm ` to publish to npm
2. removing lerna entirely from `release-latest`, since the version bump is done when the release PR is created
3. extract the version to be releases on latest tag from `lerna.json` (which is bumped by the workflow the created the release PR)
4. git tags and pushes uses the version
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open to ideas...
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
