### PR TITLE
feat(cli): add docs search and read commands

### DIFF
--- a/packages/@sanity/cli/src/actions/docs/readDoc.ts
+++ b/packages/@sanity/cli/src/actions/docs/readDoc.ts
@@ -15,7 +15,7 @@ export async function readDoc(
     const url = `https://www.sanity.io${options.path}.md`
 
     const response = await fetch(url, {
-      signal: AbortSignal.timeout(15000), // 15 second timeout for content
+      signal: AbortSignal.timeout(10000),
     })
 
     if (response.status === 404) {

--- a/packages/@sanity/cli/src/actions/docs/readDoc.ts
+++ b/packages/@sanity/cli/src/actions/docs/readDoc.ts
@@ -1,7 +1,7 @@
 import {type CliCommandContext} from '../../types'
 
-export interface ReadDocOptions {
-  slug: string
+interface ReadDocOptions {
+  path: string
 }
 
 export async function readDoc(
@@ -12,37 +12,27 @@ export async function readDoc(
 
   try {
     // Use production docs URL with .md extension
-    const url = `https://www.sanity.io${options.slug}.md`
+    const url = `https://www.sanity.io${options.path}.md`
 
     const response = await fetch(url, {
       signal: AbortSignal.timeout(15000), // 15 second timeout for content
     })
 
     if (response.status === 404) {
-      output.error(`Documentation article not found: ${options.slug}`)
+      output.error(`Article not found: ${options.path}`)
       return null
     }
 
     if (!response.ok) {
-      throw new Error(`Docs API returned ${response.status}: ${response.statusText}`)
+      context.output.error(`The article API is currently unavailable. Please try again later.`)
+      process.exit(1)
     }
 
     const markdownContent = await response.text()
     return markdownContent
   } catch (error) {
-    // Graceful error handling
-    if (error instanceof Error) {
-      if (error.name === 'AbortError' || error.name === 'TimeoutError') {
-        output.warn('Request timed out. Please check your connection and try again.')
-      } else if (error.message.includes('fetch')) {
-        output.warn('Unable to reach documentation. Please check your internet connection.')
-      } else {
-        output.warn(`Failed to read documentation: ${error.message}`)
-      }
-    } else {
-      output.warn('An unexpected error occurred while reading documentation.')
-    }
-
-    return null
+    context.output.error(`The article API is currently unavailable. Please try again later.`)
+    process.exit(1)
+    return null // satisfy TypeScript, though this line is unreachable
   }
 }

--- a/packages/@sanity/cli/src/actions/docs/readDoc.ts
+++ b/packages/@sanity/cli/src/actions/docs/readDoc.ts
@@ -1,0 +1,48 @@
+import {type CliCommandContext} from '../../types'
+
+export interface ReadDocOptions {
+  slug: string
+}
+
+export async function readDoc(
+  options: ReadDocOptions,
+  context: CliCommandContext,
+): Promise<string | null> {
+  const {output} = context
+
+  try {
+    // Use production docs URL with .md extension
+    const url = `https://www.sanity.io${options.slug}.md`
+
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(15000), // 15 second timeout for content
+    })
+
+    if (response.status === 404) {
+      output.error(`Documentation article not found: ${options.slug}`)
+      return null
+    }
+
+    if (!response.ok) {
+      throw new Error(`Docs API returned ${response.status}: ${response.statusText}`)
+    }
+
+    const markdownContent = await response.text()
+    return markdownContent
+  } catch (error) {
+    // Graceful error handling
+    if (error instanceof Error) {
+      if (error.name === 'AbortError' || error.name === 'TimeoutError') {
+        output.warn('Request timed out. Please check your connection and try again.')
+      } else if (error.message.includes('fetch')) {
+        output.warn('Unable to reach documentation. Please check your internet connection.')
+      } else {
+        output.warn(`Failed to read documentation: ${error.message}`)
+      }
+    } else {
+      output.warn('An unexpected error occurred while reading documentation.')
+    }
+
+    return null
+  }
+}

--- a/packages/@sanity/cli/src/actions/docs/searchDocs.ts
+++ b/packages/@sanity/cli/src/actions/docs/searchDocs.ts
@@ -18,36 +18,19 @@ export async function searchDocs(
   const {output} = context
   const {limit = 10} = options
 
-  try {
-    const baseUrl = 'https://www.sanity.io/docs/api/search/semantic'
-    const url = new URL(baseUrl)
-    url.searchParams.set('query', options.query)
+  const baseUrl = 'https://www.sanity.io/docs/api/search/semantic'
+  const url = new URL(baseUrl)
+  url.searchParams.set('query', options.query)
 
-    const response = await fetch(url, {
-      signal: AbortSignal.timeout(10000), // 10 second timeout
-    })
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(10000), // 10 second timeout
+  })
 
-    if (!response.ok) {
-      throw new Error(`Search API returned ${response.status}: ${response.statusText}`)
-    }
-
-    const results = await response.json()
-    return Array.isArray(results) ? results.slice(0, limit) : []
-  } catch (error) {
-    // Graceful error handling
-    if (error instanceof Error) {
-      if (error.name === 'AbortError' || error.name === 'TimeoutError') {
-        output.warn('Search request timed out. Please check your connection and try again.')
-      } else if (error.message.includes('fetch')) {
-        output.warn('Unable to reach documentation search. Please check your internet connection.')
-      } else {
-        output.warn(`Search failed: ${error.message}`)
-      }
-    } else {
-      output.warn('An unexpected error occurred while searching.')
-    }
-
-    // Return empty results on error
-    return []
+  if (!response.ok) {
+    output.error('The documentation search API is currently unavailable. Please try again later.')
+    process.exit(1)
   }
+
+  const results = await response.json()
+  return Array.isArray(results) ? results.slice(0, limit) : []
 }

--- a/packages/@sanity/cli/src/actions/docs/searchDocs.ts
+++ b/packages/@sanity/cli/src/actions/docs/searchDocs.ts
@@ -1,0 +1,53 @@
+import {type CliCommandContext} from '../../types'
+
+export interface SearchResult {
+  path: string
+  title: string
+  description: string
+}
+
+export interface SearchDocsOptions {
+  query: string
+  limit?: number
+}
+
+export async function searchDocs(
+  options: SearchDocsOptions,
+  context: CliCommandContext,
+): Promise<SearchResult[]> {
+  const {output} = context
+  const {limit = 10} = options
+
+  try {
+    const baseUrl = 'https://www.sanity.io/docs/api/search/semantic'
+    const url = new URL(baseUrl)
+    url.searchParams.set('query', options.query)
+
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(10000), // 10 second timeout
+    })
+
+    if (!response.ok) {
+      throw new Error(`Search API returned ${response.status}: ${response.statusText}`)
+    }
+
+    const results = await response.json()
+    return Array.isArray(results) ? results.slice(0, limit) : []
+  } catch (error) {
+    // Graceful error handling
+    if (error instanceof Error) {
+      if (error.name === 'AbortError' || error.name === 'TimeoutError') {
+        output.warn('Search request timed out. Please check your connection and try again.')
+      } else if (error.message.includes('fetch')) {
+        output.warn('Unable to reach documentation search. Please check your internet connection.')
+      } else {
+        output.warn(`Search failed: ${error.message}`)
+      }
+    } else {
+      output.warn('An unexpected error occurred while searching.')
+    }
+
+    // Return empty results on error
+    return []
+  }
+}

--- a/packages/@sanity/cli/src/actions/docs/searchDocs.ts
+++ b/packages/@sanity/cli/src/actions/docs/searchDocs.ts
@@ -23,7 +23,7 @@ export async function searchDocs(
   url.searchParams.set('query', options.query)
 
   const response = await fetch(url, {
-    signal: AbortSignal.timeout(10000), // 10 second timeout
+    signal: AbortSignal.timeout(10000),
   })
 
   if (!response.ok) {

--- a/packages/@sanity/cli/src/commands/docs/browseCommand.ts
+++ b/packages/@sanity/cli/src/commands/docs/browseCommand.ts
@@ -1,6 +1,5 @@
-import open from 'open'
-
 import {type CliCommandDefinition} from '../../types'
+import {browse} from '../../util/browse'
 
 const browseCommand: CliCommandDefinition = {
   name: 'browse',
@@ -14,7 +13,7 @@ const browseCommand: CliCommandDefinition = {
     const url = 'https://www.sanity.io/docs'
 
     print(`Opening ${url}`)
-    await open(url)
+    await browse(url)
   },
 }
 

--- a/packages/@sanity/cli/src/commands/docs/browseCommand.ts
+++ b/packages/@sanity/cli/src/commands/docs/browseCommand.ts
@@ -7,7 +7,7 @@ const browseCommand: CliCommandDefinition = {
   group: 'docs',
   helpText: '',
   signature: '',
-  description: 'Opens Sanity documentation in your web browser',
+  description: 'Open Sanity docs in a web browser',
   async action(args, context) {
     const {output} = context
     const {print} = output

--- a/packages/@sanity/cli/src/commands/docs/browseCommand.ts
+++ b/packages/@sanity/cli/src/commands/docs/browseCommand.ts
@@ -2,11 +2,12 @@ import open from 'open'
 
 import {type CliCommandDefinition} from '../../types'
 
-const docsCommand: CliCommandDefinition = {
-  name: 'docs',
+const browseCommand: CliCommandDefinition = {
+  name: 'browse',
+  group: 'docs',
   helpText: '',
-  signature: 'docs',
-  description: 'Opens Sanity Studio documentation in your web browser',
+  signature: '',
+  description: 'Opens Sanity documentation in your web browser',
   async action(args, context) {
     const {output} = context
     const {print} = output
@@ -17,4 +18,4 @@ const docsCommand: CliCommandDefinition = {
   },
 }
 
-export default docsCommand
+export default browseCommand

--- a/packages/@sanity/cli/src/commands/docs/docsGroup.ts
+++ b/packages/@sanity/cli/src/commands/docs/docsGroup.ts
@@ -1,0 +1,10 @@
+import {type CliCommandGroupDefinition} from '../../types'
+
+const docsGroup: CliCommandGroupDefinition = {
+  name: 'docs',
+  signature: '[COMMAND]',
+  isGroupRoot: true,
+  description: 'Access Sanity documentation',
+}
+
+export default docsGroup

--- a/packages/@sanity/cli/src/commands/docs/readCommand.ts
+++ b/packages/@sanity/cli/src/commands/docs/readCommand.ts
@@ -1,0 +1,47 @@
+import {readDoc} from '../../actions/docs/readDoc'
+import {type CliCommandDefinition} from '../../types'
+
+const helpText = `
+Arguments
+  <slug> Slug of the documentation article
+
+Examples
+  # Read a documentation article
+  sanity docs read "studio-overview"
+
+  # Read a getting started guide
+  sanity docs read "getting-started"
+`
+
+const readCommand: CliCommandDefinition = {
+  name: 'read',
+  group: 'docs',
+  helpText,
+  signature: '<slug>',
+  description: 'Read a specific documentation article in markdown format',
+  async action(args, context) {
+    const {output} = context
+    const slug = args.argsWithoutOptions[0]
+
+    if (!slug) {
+      output.error('Please provide a documentation slug')
+      output.print('Usage: sanity docs read "article-slug"')
+      output.print('Example: sanity docs read "studio-overview"')
+      return
+    }
+
+    output.print(`Reading documentation: ${slug}`)
+
+    const content = await readDoc({slug}, context)
+
+    if (!content) {
+      return // Error already handled in readDoc
+    }
+
+    // Display markdown content
+    output.print('\n---\n')
+    output.print(content)
+  },
+}
+
+export default readCommand

--- a/packages/@sanity/cli/src/commands/docs/readCommand.ts
+++ b/packages/@sanity/cli/src/commands/docs/readCommand.ts
@@ -8,7 +8,7 @@ interface ReadCommandFlags {
 
 const helpText = `
 Arguments
-  <slug> Full path of the documentation article
+  <path> Article path
 
 Options
   -w, --web               Open the article in a web browser
@@ -26,23 +26,30 @@ const readCommand: CliCommandDefinition<ReadCommandFlags> = {
   name: 'read',
   group: 'docs',
   helpText,
-  signature: '<slug> [-w, --web]',
-  description: 'Read a documentation article',
+  signature: '<path> [-w, --web]',
+  description: 'Read an article',
   async action(args, context) {
     const {output} = context
     const flags = args.extOptions as ReadCommandFlags
-    const slug = args.argsWithoutOptions[0]
+    const path = args.argsWithoutOptions[0]
 
-    if (!slug) {
-      output.error('Please provide a documentation slug')
-      output.print('Usage: sanity docs read "article-slug"')
-      output.print('Example: sanity docs read "/docs/studio/installation"')
-      return
+    if (!path) {
+      output.error('Please provide an article path')
+      output.print('')
+      output.print(helpText)
+      process.exit(1)
+    }
+
+    if (!path.startsWith('/')) {
+      output.error('Article path must start with a forward slash (/)')
+      output.print('')
+      output.print(helpText)
+      process.exit(1)
     }
 
     // Open in web browser if --web or -w flag is provided
     if (flags.web || flags.w) {
-      const url = `https://www.sanity.io${slug}`
+      const url = `https://www.sanity.io${path}`
       output.print(`Opening ${url}`)
 
       const {default: open} = await import('open')
@@ -51,9 +58,9 @@ const readCommand: CliCommandDefinition<ReadCommandFlags> = {
     }
 
     // Default behavior: read as markdown in terminal
-    output.print(`Reading documentation: ${slug}`)
+    output.print(`Reading documentation: ${path}`)
 
-    const content = await readDoc({slug}, context)
+    const content = await readDoc({path}, context)
 
     if (!content) {
       return // Error already handled in readDoc

--- a/packages/@sanity/cli/src/commands/docs/readCommand.ts
+++ b/packages/@sanity/cli/src/commands/docs/readCommand.ts
@@ -1,5 +1,6 @@
 import {readDoc} from '../../actions/docs/readDoc'
 import {type CliCommandDefinition} from '../../types'
+import {browse} from '../../util/browse'
 
 interface ReadCommandFlags {
   w?: boolean
@@ -27,17 +28,18 @@ const readCommand: CliCommandDefinition<ReadCommandFlags> = {
   group: 'docs',
   helpText,
   signature: '<path> [-w, --web]',
-  description: 'Read an article',
+  description: 'Read a documentation article',
   async action(args, context) {
     const {output} = context
     const flags = args.extOptions as ReadCommandFlags
     const path = args.argsWithoutOptions[0]
 
-    if (!path) {
+    if (!path || typeof path !== 'string') {
       output.error('Please provide an article path')
       output.print('')
       output.print(helpText)
       process.exit(1)
+      return
     }
 
     if (!path.startsWith('/')) {
@@ -45,15 +47,14 @@ const readCommand: CliCommandDefinition<ReadCommandFlags> = {
       output.print('')
       output.print(helpText)
       process.exit(1)
+      return
     }
 
     // Open in web browser if --web or -w flag is provided
     if (flags.web || flags.w) {
       const url = `https://www.sanity.io${path}`
       output.print(`Opening ${url}`)
-
-      const {default: open} = await import('open')
-      await open(url)
+      await browse(url)
       return
     }
 

--- a/packages/@sanity/cli/src/commands/docs/readCommand.ts
+++ b/packages/@sanity/cli/src/commands/docs/readCommand.ts
@@ -1,35 +1,56 @@
 import {readDoc} from '../../actions/docs/readDoc'
 import {type CliCommandDefinition} from '../../types'
 
+interface ReadCommandFlags {
+  w?: boolean
+  web?: boolean
+}
+
 const helpText = `
 Arguments
-  <slug> Slug of the documentation article
+  <slug> Full path of the documentation article
+
+Options
+  -w, --web               Open the article in a web browser
 
 Examples
-  # Read a documentation article
-  sanity docs read "studio-overview"
+  # Read article as markdown in terminal
+  sanity docs read "/docs/studio/installation"
 
-  # Read a getting started guide
-  sanity docs read "getting-started"
+  # Open article in web browser
+  sanity docs read "/docs/studio/installation" --web
+  sanity docs read "/docs/studio/installation" -w
 `
 
-const readCommand: CliCommandDefinition = {
+const readCommand: CliCommandDefinition<ReadCommandFlags> = {
   name: 'read',
   group: 'docs',
   helpText,
-  signature: '<slug>',
-  description: 'Read a specific documentation article in markdown format',
+  signature: '<slug> [-w, --web]',
+  description: 'Read a documentation article',
   async action(args, context) {
     const {output} = context
+    const flags = args.extOptions as ReadCommandFlags
     const slug = args.argsWithoutOptions[0]
 
     if (!slug) {
       output.error('Please provide a documentation slug')
       output.print('Usage: sanity docs read "article-slug"')
-      output.print('Example: sanity docs read "studio-overview"')
+      output.print('Example: sanity docs read "/docs/studio/installation"')
       return
     }
 
+    // Open in web browser if --web or -w flag is provided
+    if (flags.web || flags.w) {
+      const url = `https://www.sanity.io${slug}`
+      output.print(`Opening ${url}`)
+
+      const {default: open} = await import('open')
+      await open(url)
+      return
+    }
+
+    // Default behavior: read as markdown in terminal
     output.print(`Reading documentation: ${slug}`)
 
     const content = await readDoc({slug}, context)

--- a/packages/@sanity/cli/src/commands/docs/readCommand.ts
+++ b/packages/@sanity/cli/src/commands/docs/readCommand.ts
@@ -9,18 +9,18 @@ interface ReadCommandFlags {
 
 const helpText = `
 Arguments
-  <path> Article path
+  <path> Path to article, found in search results and docs content as links
 
 Options
-  -w, --web               Open the article in a web browser
+  -w, --web               Open in a web browser
 
 Examples
-  # Read article as markdown in terminal
-  sanity docs read "/docs/studio/installation"
+  # Read as markdown in terminal
+  sanity docs read /docs/studio/installation
 
-  # Open article in web browser
-  sanity docs read "/docs/studio/installation" --web
-  sanity docs read "/docs/studio/installation" -w
+  # Open in web browser
+  sanity docs read /docs/studio/installation --web
+  sanity docs read /docs/studio/installation -w
 `
 
 const readCommand: CliCommandDefinition<ReadCommandFlags> = {
@@ -28,7 +28,7 @@ const readCommand: CliCommandDefinition<ReadCommandFlags> = {
   group: 'docs',
   helpText,
   signature: '<path> [-w, --web]',
-  description: 'Read a documentation article',
+  description: 'Read a specific article',
   async action(args, context) {
     const {output} = context
     const flags = args.extOptions as ReadCommandFlags
@@ -59,7 +59,7 @@ const readCommand: CliCommandDefinition<ReadCommandFlags> = {
     }
 
     // Default behavior: read as markdown in terminal
-    output.print(`Reading documentation: ${path}`)
+    output.print(`Reading article: ${path}`)
 
     const content = await readDoc({path}, context)
 

--- a/packages/@sanity/cli/src/commands/docs/searchCommand.ts
+++ b/packages/@sanity/cli/src/commands/docs/searchCommand.ts
@@ -1,5 +1,6 @@
 import {searchDocs} from '../../actions/docs/searchDocs'
 import {type CliCommandDefinition} from '../../types'
+import {isInteractive} from '../../util/isInteractive'
 
 interface SearchCommandFlags {
   limit?: number
@@ -68,8 +69,8 @@ const searchCommand: CliCommandDefinition<SearchCommandFlags> = {
       output.print('')
     })
 
-    // Interactive selection
-    if (results.length > 1) {
+    // Interactive selection (only in interactive environments)
+    if (results.length > 1 && isInteractive) {
       const choices = results.map((result, index) => ({
         name: `${result.title} (${result.path})`,
         value: index,

--- a/packages/@sanity/cli/src/commands/docs/searchCommand.ts
+++ b/packages/@sanity/cli/src/commands/docs/searchCommand.ts
@@ -1,0 +1,107 @@
+import {searchDocs} from '../../actions/docs/searchDocs'
+import {type CliCommandDefinition} from '../../types'
+
+interface SearchCommandFlags {
+  limit?: number
+}
+
+const helpText = `
+Arguments
+  <query> Search query for documentation
+
+Options
+  --limit <limit>   Maximum number of results to return [default: 10]
+
+Examples
+  # Search for documentation about schemas
+  sanity docs search "schema"
+
+  # Limit search results
+  sanity docs search "deployment" --limit=5
+`
+
+const defaultFlags = {
+  limit: 10,
+}
+
+const searchCommand: CliCommandDefinition<SearchCommandFlags> = {
+  name: 'search',
+  group: 'docs',
+  helpText,
+  signature: '<query> [--limit <limit>]',
+  description: 'Search the official Sanity documentation',
+  async action(args, context) {
+    const {output, prompt} = context
+    const flags = {...defaultFlags, ...args.extOptions}
+    const query = args.argsWithoutOptions[0]
+
+    if (!query) {
+      output.error('Please provide a search query')
+      output.print('Usage: sanity docs search "your query"')
+      return
+    }
+
+    output.print(`Searching documentation for: "${query}"`)
+
+    const results = await searchDocs(
+      {
+        query,
+        limit: flags.limit,
+      },
+      context,
+    )
+
+    if (results.length === 0) {
+      output.print('No results found. Try a different search term.')
+      return
+    }
+
+    // Table format
+    output.print(`\nFound ${results.length} result(s):\n`)
+
+    results.forEach((result, index) => {
+      output.print(`${index + 1}. ${result.title}`)
+      output.print(`   ${result.path}`)
+      if (result.description) {
+        output.print(`   ${result.description}`)
+      }
+      output.print('')
+    })
+
+    // Interactive selection
+    if (results.length > 1) {
+      const choices = results.map((result, index) => ({
+        name: `${result.title} (${result.path})`,
+        value: index,
+        short: result.title,
+      }))
+
+      try {
+        const selectedIndex = await prompt.single({
+          type: 'list',
+          message: 'Select an article to read:',
+          choices: [...choices, {name: 'Exit', value: -1, short: 'Exit'}],
+        })
+
+        if (typeof selectedIndex === 'number' && selectedIndex >= 0) {
+          const selected = results[selectedIndex]
+          output.print(`\nReading: ${selected.title}`)
+
+          // Read and display the article
+          const {readDoc} = await import('../../actions/docs/readDoc')
+          const content = await readDoc({slug: selected.path}, context)
+
+          if (content) {
+            output.print(`\n# ${selected.title}\n`)
+            output.print('---\n')
+            output.print(content)
+          }
+        }
+      } catch (error) {
+        // User cancelled or other error, just continue
+      }
+    }
+  },
+}
+
+export default searchCommand

--- a/packages/@sanity/cli/src/commands/docs/searchCommand.ts
+++ b/packages/@sanity/cli/src/commands/docs/searchCommand.ts
@@ -16,7 +16,10 @@ Options
 
 Examples
   # Search for documentation about schemas
-  sanity docs search "schema"
+  sanity docs search schema
+
+  # Search with phrase
+  sanity docs search "groq functions"
 
   # Limit search results
   sanity docs search "deployment" --limit=5
@@ -67,7 +70,6 @@ const searchCommand: CliCommandDefinition<SearchCommandFlags> = {
       return
     }
 
-    // Table format
     output.print(`\nFound ${results.length} result(s):\n`)
 
     results.forEach((result, index) => {

--- a/packages/@sanity/cli/src/commands/docs/searchCommand.ts
+++ b/packages/@sanity/cli/src/commands/docs/searchCommand.ts
@@ -41,6 +41,7 @@ const searchCommand: CliCommandDefinition<SearchCommandFlags> = {
       output.error('Please provide a search query')
       output.print('Usage: sanity docs search "your query"')
       process.exit(1)
+      return
     }
 
     output.print(`Searching documentation for: "${query}"`)

--- a/packages/@sanity/cli/src/commands/index.ts
+++ b/packages/@sanity/cli/src/commands/index.ts
@@ -11,7 +11,10 @@ import planBlueprintsCommand from './blueprints/planBlueprintsCommand'
 import listBlueprintsCommand from './blueprints/stacksBlueprintsCommand'
 import codemodCommand from './codemod/codemodCommand'
 import debugCommand from './debug/debugCommand'
-import docsCommand from './docs/docsCommand'
+import browseCommand from './docs/browseCommand'
+import docsGroup from './docs/docsGroup'
+import readCommand from './docs/readCommand'
+import searchCommand from './docs/searchCommand'
 import devfunctionsCommand from './functions/devFunctionsCommand'
 import envFunctionsCommand from './functions/envFunctionsCommand'
 import functionsGroup from './functions/functionsGroup'
@@ -40,7 +43,10 @@ export const baseCommands: (CliCommandDefinition | CliCommandGroupDefinition)[] 
   logoutCommand,
   installCommand,
   versionsCommand,
-  docsCommand,
+  docsGroup,
+  browseCommand,
+  searchCommand,
+  readCommand,
   manageCommand,
   debugCommand,
   helpCommand,

--- a/packages/@sanity/cli/src/util/browse.ts
+++ b/packages/@sanity/cli/src/util/browse.ts
@@ -1,0 +1,5 @@
+import open from 'open'
+
+export async function browse(url: string): Promise<void> {
+  await open(url)
+}

--- a/packages/@sanity/cli/test/docs.test.ts
+++ b/packages/@sanity/cli/test/docs.test.ts
@@ -1,0 +1,71 @@
+import {describe, expect} from 'vitest'
+
+import {describeCliTest, testConcurrent} from './shared/describe'
+import {runSanityCmdCommand, studioVersions} from './shared/environment'
+
+describeCliTest('CLI: `sanity docs`', () => {
+  describe.each(studioVersions)('%s', (version) => {
+    testConcurrent('docs browse', async () => {
+      const result = await runSanityCmdCommand(version, ['docs', 'browse'])
+      expect(result.stdout).toContain('Opening https://www.sanity.io/docs')
+      expect(result.code).toBe(0)
+    })
+
+    testConcurrent('docs search - basic functionality', async () => {
+      const result = await runSanityCmdCommand(version, ['docs', 'search', 'test'])
+      expect(result.stdout).toContain('Searching documentation for: "test"')
+      // Since API endpoints are placeholders, expect "No results found" or error handling
+      expect(result.stdout).toMatch(/No results found|Unable to reach documentation|Search failed/)
+      expect(result.code).toBe(0) // Should handle errors gracefully
+    })
+
+    testConcurrent('docs search - with limit option', async () => {
+      const result = await runSanityCmdCommand(version, ['docs', 'search', 'test', '--limit=5'])
+      expect(result.stdout).toContain('Searching documentation for: "test"')
+      expect(result.code).toBe(0)
+    })
+
+    testConcurrent('docs search - missing query', async () => {
+      const result = await runSanityCmdCommand(version, ['docs', 'search'])
+      expect(result.stderr).toContain('Please provide a search query')
+      expect(result.code).toBe(0) // CLI doesn't exit with error codes for user input errors
+    })
+
+    testConcurrent('docs read - basic functionality', async () => {
+      const result = await runSanityCmdCommand(version, ['docs', 'read', 'test-article'])
+      expect(result.stdout).toContain('Reading documentation: test-article')
+      // Since API endpoints are placeholders, expect error handling
+      expect(result.stderr).toMatch(
+        /Documentation article not found|Unable to reach documentation|Failed to read/,
+      )
+      expect(result.code).toBe(0) // Should handle errors gracefully
+    })
+
+    testConcurrent('docs read - missing path', async () => {
+      const result = await runSanityCmdCommand(version, ['docs', 'read'])
+      expect(result.stderr).toContain('Please provide a documentation path')
+      expect(result.code).toBe(0) // CLI doesn't exit with error codes for user input errors
+    })
+
+    testConcurrent('docs help', async () => {
+      const result = await runSanityCmdCommand(version, ['docs', '--help'])
+      expect(result.stdout).toContain('Commands:')
+      expect(result.stdout).toContain('browse')
+      expect(result.stdout).toContain('search')
+      expect(result.stdout).toContain('read')
+      expect(result.code).toBe(0)
+    })
+
+    testConcurrent('docs search help', async () => {
+      const result = await runSanityCmdCommand(version, ['docs', 'search', '--help'])
+      expect(result.stdout).toContain('Search the official Sanity documentation')
+      expect(result.code).toBe(0)
+    })
+
+    testConcurrent('docs read help', async () => {
+      const result = await runSanityCmdCommand(version, ['docs', 'read', '--help'])
+      expect(result.stdout).toContain('Read a specific documentation article')
+      expect(result.code).toBe(0)
+    })
+  })
+})

--- a/packages/@sanity/cli/test/docs.test.ts
+++ b/packages/@sanity/cli/test/docs.test.ts
@@ -75,7 +75,7 @@ describe('CLI: `sanity docs`', () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 500,
-      json: () => Promise.resolve([]), // Mock json function even for errors since process.exit doesn't actually exit in tests
+      json: () => Promise.resolve([]),
     })
 
     const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
@@ -140,7 +140,7 @@ describe('CLI: `sanity docs`', () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 500,
-      text: () => Promise.resolve(''), // Mock text function even for errors since process.exit doesn't actually exit in tests
+      text: () => Promise.resolve(''),
     })
 
     const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)


### PR DESCRIPTION
### Description

This PR adds `sanity docs search` and `sanity docs read` commands to the CLI, allowing developers and AI agents to search and read Sanity documentation directly from the terminal.

**What changes are introduced:**

- New `sanity docs search` command for searching documentation with semantic search
- New `sanity docs read` command for reading specific articles in markdown format
- Web browser integration with `-w,--web` flag for opening articles in browser
- Interactive article selection from search results in terminal environments
- Comprehensive test coverage with proper mocking strategies

**Why these changes are introduced:**

- Developers and AI agents need quick access to documentation without leaving their terminal workflow
- Semantic search provides more relevant results for documentation queries
- Terminal-first approach aligns with developer productivity tools and AI agent workflows
- Supports both interactive terminal use and automation/scripting workflows

### What to review

**Command functionality:**

1. Test documentation search: `sanity docs search "schema"`
2. Test phrase search: `sanity docs search "groq functions"`
3. Test search with limits: `sanity docs search "deployment" --limit=5`
4. Test reading articles: `sanity docs read /docs/studio/installation`
5. Test web browser opening: `sanity docs read /docs/studio/installation --web`
6. Test interactive article selection after search (in terminal environments)
7. Test non-interactive mode: `CI=1 sanity docs search "migrating to sanity"`
8. Verify error handling for invalid paths and API failures

### Testing

**Automated testing added:**

- Unit tests for search and read action functions with comprehensive coverage
- Mock strategies for fetch API and browser opening functionality
- Error path testing for API failures and network issues
- Input validation and path checking tests

**Manual testing completed:**

- Search functionality with various query types and limits
- Article reading in both terminal and browser modes
- Interactive article selection from search results
- Error handling for non-existent articles and API issues

### Notes for release

**What changed:**
New `sanity docs search` and `sanity docs read` commands for accessing Sanity documentation directly from the CLI.

**Command overview:**

```
usage: npx sanity docs [COMMAND]

Commands:
   browse   Open Sanity docs in a web browser
   search   Search Sanity docs  
   read     Read a specific article

See 'npx sanity help docs <command>' for specific information on a subcommand.
```

**Usage examples:**

```bash
# Search documentation
sanity docs search schema
sanity docs search "groq functions"
sanity docs search "deployment" --limit=5

# Read articles in terminal
sanity docs read /docs/studio/installation
sanity docs read /docs/content-modeling/schemas

# Open articles in web browser
sanity docs read /docs/studio/installation --web
sanity docs read /docs/studio/installation -w

# Interactive workflow (terminal environments)
sanity docs search "queries"
# Shows search results, then prompts to select an article to read

# Non-interactive mode (CI environments)
CI=1 sanity docs search "migrating to sanity"
# Shows search results without prompting for selection
```

**Key features:**

- Semantic search powered by Sanity's documentation search API
- Terminal-native markdown reading with proper formatting
- Web browser integration for visual documentation browsing
- Interactive article selection from search results in terminal environments
- Configurable result limits (default 10, customizable with --limit)
- Proper error handling and timeout management
- Help text examples demonstrate when to use quotes vs unquoted search terms
- Non-interactive mode support for CI/automation environments

**Documentation note:**
This feature requires updating the CLI documentation to include the new `docs search` and `docs read` commands, as CLI help texts are reproduced in docs articles.