### PR TITLE
chore: using lerna full for creating release PR

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -54,13 +54,15 @@ jobs:
       - name: Update version
         run: |
           npx lerna version \
-          --force-publish \
-          --no-push \
-          --sync-workspace-lock \
-          --conventional-commits \
-          --yes
+            --force-publish \
+            --no-git-tag-version \
+            --conventional-commits \
+            --yes
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Sync workspace lockfile
+        run: pnpm install --lockfile-only
 
       - name: Get version commit message
         # get the commit message created by npx lerna version above (determined by lerna.json)


### PR DESCRIPTION
### Description
We moved to using lerna rather than lerna-lite. This means that some options are not supported in the `lerna version` command used in `create-release-pr.yml`.

Changes:
* removing unusupported `sync-workspace-lock` flag
* replacing `sync-workspace-lock` with `pnpm install --lockfile-only` step
* swapping `no-push` flag for `no-git-tag-version`
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Did test this on a feature branch - because this workflow typically runs off main and generates a new PR from main, exact results were slightly differing from expected. It seems the easiest way of verifying if this is all working is to merge to main and test
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
