### PR TITLE
fix: add commit-message field to release PR workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -86,6 +86,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           title: "${{steps.version-commit.outputs.message}}"
           body: "🤖 I have created a release **squib** **squob**\n\n Merging this PR will publish v${{steps.release-as.outputs.version}} to npm 🚀"
+          commit-message: "${{steps.version-commit.outputs.message}}"
           branch: ci/release-main
           sign-commits: true
           base: main


### PR DESCRIPTION
### Description
Currently, we are creating commit messages using the default from the github action:
<img width="428" alt="Screenshot 2025-07-08 at 15 51 38" src="https://github.com/user-attachments/assets/1f8da31c-1b48-4d08-a31a-0054d5830efc" />

But we really want to customise this - which this PR does.

Previously this was done by lerna-lite with `lerna version` where it would generate the commit, but now we have to generate that ourselves since we use lerna full.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
N/A
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
