### PR TITLE
test: remove flag from cli token tests

### DIFF
--- a/packages/@sanity/cli/test/tokens.test.ts
+++ b/packages/@sanity/cli/test/tokens.test.ts
@@ -12,13 +12,7 @@ describeCliTest('CLI: `sanity tokens`', () => {
       const tokenLabel = `test-token-${testId}-${Date.now()}`
 
       // `tokens add` with JSON output
-      let result = await runSanityCmdCommand(version, [
-        'tokens',
-        'add',
-        tokenLabel,
-        '--json',
-        '--hide-major-message',
-      ])
+      let result = await runSanityCmdCommand(version, ['tokens', 'add', tokenLabel, '--json'])
       expect(result.code).toBe(0)
 
       const token = JSON.parse(result.stdout)
@@ -44,12 +38,7 @@ describeCliTest('CLI: `sanity tokens`', () => {
 
     testConcurrent('tokens list --json', async () => {
       const {tokenLabel, tokenId} = await addToken()
-      const result = await runSanityCmdCommand(version, [
-        'tokens',
-        'list',
-        '--json',
-        '--hide-major-message',
-      ])
+      const result = await runSanityCmdCommand(version, ['tokens', 'list', '--json'])
       expect(result.code).toBe(0)
 
       const tokens = JSON.parse(result.stdout)
@@ -69,7 +58,6 @@ describeCliTest('CLI: `sanity tokens`', () => {
         tokenLabel,
         '--role=editor',
         '--json',
-        '--hide-major-message',
       ])
       expect(result.code).toBe(0)
 
@@ -90,7 +78,6 @@ describeCliTest('CLI: `sanity tokens`', () => {
         tokenLabel,
         '--yes',
         '--json',
-        '--hide-major-message',
       ])
       expect(result.code).toBe(0)
 


### PR DESCRIPTION
### Description

Remove unneeded tags that are adding noise to other PRs related to CLI

### What to review

Tests should still pass

### Testing

Tests should still pass

### Notes for release

N/A
