### PR TITLE
chore: fix vercel pnpm install issues with recast

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -8,6 +8,9 @@
 
 public-hoist-pattern[]=sanity
 
+; This is to solve inconsistent install issues where recast is not able to find @babel/parser due to differences in how pnpm install behaves on vercel and github actions
+public-hoist-pattern[]=@babel/parser
+
 ; This is needed for prettier to be able to use the plugin specified by the `@sanity/prettier-config` preset, as well as eslint plugins defined by `@repo/eslint-config`
 public-hoist-pattern[]=*eslint*
 public-hoist-pattern[]=*prettier*


### PR DESCRIPTION
### Description

We've been plagued [with strange install/build issues recently](https://vercel.com/sanity-sandbox/test-studio/G3nEaKuGVfJ8tanXUmbqkishypco?filter=errors):



```bash
@sanity/diff:build: /vercel/path1/node_modules/.pnpm/recast@0.23.9/node_modules/recast/parsers/babel.js:17
@sanity/diff:build:             throw new Error("Install @babel/parser to use the `typescript`, `flow`, or `babel` parsers");
@sanity/diff:build:                   ^
@sanity/diff:build: 
@sanity/diff:build: Error: Install @babel/parser to use the `typescript`, `flow`, or `babel` parsers
@sanity/diff:build:     at /vercel/path1/node_modules/.pnpm/recast@0.23.9/node_modules/recast/parsers/babel.js:17:19
@sanity/diff:build:     at Object.<anonymous> (/vercel/path1/node_modules/.pnpm/recast@0.23.9/node_modules/recast/parsers/babel.js:20:3)
@sanity/diff:build:     at Module._compile (node:internal/modules/cjs/loader:1730:14)
@sanity/diff:build:     at Object..js (node:internal/modules/cjs/loader:1895:10)
@sanity/diff:build:     at Module.load (node:internal/modules/cjs/loader:1465:32)
@sanity/diff:build:     at Function._load (node:internal/modules/cjs/loader:1282:12)
@sanity/diff:build:     at TracingChannel.traceSync (node:diagnostics_channel:322:14)
@sanity/diff:build:     at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
@sanity/diff:build:     at Module.require (node:internal/modules/cjs/loader:1487:12)
@sanity/diff:build:     at require (node:internal/modules/helpers:135:16)
@sanity/diff:build: 
@sanity/diff:build: Node.js v22.17.0
```

By adding hoisting for the dependency recast is looking for (`@babel/parser`) it'll always be able to find it, regardless of how `recast` itself is hoisted.

### What to review

Makes sense?

### Testing

If vercel builds without breaking the CI we good.

### Notes for release

N/A