### PR TITLE
fix: handling where no templates available and not showing create doc button

### DIFF
--- a/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -83,6 +83,8 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
     )
   }, [templatePermissions])
 
+  if (templateItems.length === 0) return null
+
   if (nothingGranted) {
     return (
       <InsufficientPermissionsMessageTooltip


### PR DESCRIPTION
### Description
After v3.96.0, the `PaneHeaderCreateButton` incorrectly renders in lists where it shouldn't appear.
A check on the template length was removed from `PaneHeaderActions.tsx` and so when `templateItems` is empty, `templatePermissions` becomes an empty array, causing `templatePermissions?.length !== 0` to evaluate to `false`, which makes `nothingGranted` `false` and allows the button to render when it shouldn't be.

This PR adds an early return no templates are available and returns null, ensuring the button only renders when templates exist.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes issue where 'Create new document' button would wrongly appear in lists where no templates were available to create documents from.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
