### PR TITLE
chore: using workflow jobs in latest release 

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -16,19 +16,18 @@ permissions:
   contents: write
 
 jobs:
-  release-latest:
+  build-and-validate:
     if: >
       github.event_name == 'workflow_dispatch' || 
       startsWith(github.event.head_commit.message, 'chore(release): publish ')
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write # to enable use of OIDC for npm provenance
+      contents: read
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      EXPECTED_NPM_USER: sanity-io
-
+    outputs:
+      version: ${{ steps.release-as.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,11 +43,6 @@ jobs:
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped
-
-      - name: Configure git
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
       - name: Get version from lerna.json
         id: release-as
@@ -66,6 +60,66 @@ jobs:
         env:
           RELEASE_AS: ${{ steps.release-as.outputs.version }}
 
+      - name: Cache build artifacts
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            node_modules
+            packages/*/lib
+            packages/*/dist
+          key: build-artifacts-${{ github.sha }}
+
+  git-operations:
+    if: ${{ github.event.inputs.publish != 'true' }}
+    needs: build-and-validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Tag and push version
+        run: |
+          git tag v$RELEASE_AS -m v$RELEASE_AS
+          git push origin v$RELEASE_AS
+        env:
+          RELEASE_AS: ${{ needs.build-and-validate.outputs.version }}
+
+  npm-publish:
+    needs: build-and-validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # to enable use of OIDC for npm provenance
+    env:
+      EXPECTED_NPM_USER: sanity-io
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: lts/*
+
+      - name: Restore build artifacts
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            node_modules
+            packages/*/lib
+            packages/*/dist
+          key: build-artifacts-${{ github.sha }}
+          fail-on-cache-miss: true
+
       - name: Set publishing config
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_PUBLISH_TOKEN}"
         env:
@@ -81,18 +135,38 @@ jobs:
           fi
           echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"
 
-      - name: Tag and push version
-        if: ${{ github.event.inputs.publish != 'true' }}
-        run: |
-          git tag v$RELEASE_AS -m v$RELEASE_AS
-          git push origin v$RELEASE_AS
-        env:
-          RELEASE_AS: ${{steps.release-as.outputs.version}}
-
       - name: Publish packages to npm
         run: pnpm -r publish
         env:
           NPM_CONFIG_PROVENANCE: true
+
+  bundle-upload:
+    needs: npm-publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: lts/*
+
+      - name: Restore build artifacts
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            node_modules
+            packages/*/lib
+            packages/*/dist
+          key: build-artifacts-${{ github.sha }}
+          fail-on-cache-miss: true
 
       - name: Build bundle
         run: pnpm run build:bundle

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -80,6 +80,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get version from lerna.json
+        id: release-as
+        run: |
+          version=$(jq -r .version lerna.json)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Configure git
         run: |
           git config --global user.name 'github-actions[bot]'
@@ -90,7 +96,7 @@ jobs:
           git tag v$RELEASE_AS -m v$RELEASE_AS
           git push origin v$RELEASE_AS
         env:
-          RELEASE_AS: ${{ needs.build-and-validate.outputs.version }}
+          RELEASE_AS: ${{ needs.build-and-validate.outputs.version || steps.release-as.outputs.version }}
 
   npm-publish:
     needs: build-and-validate
@@ -99,6 +105,8 @@ jobs:
       contents: read
       id-token: write # to enable use of OIDC for npm provenance
     env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       EXPECTED_NPM_USER: sanity-io
     steps:
       - uses: actions/checkout@v4
@@ -111,6 +119,7 @@ jobs:
           node-version: lts/*
 
       - name: Restore build artifacts
+        id: cache-restore
         uses: actions/cache/restore@v4
         with:
           path: |
@@ -118,7 +127,12 @@ jobs:
             packages/*/lib
             packages/*/dist
           key: build-artifacts-${{ github.sha }}
-          fail-on-cache-miss: true
+
+      - name: Install deps & build (if cache miss)
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        run: |
+          pnpm install --ignore-scripts
+          pnpm build --output-logs=full --log-order=grouped
 
       - name: Set publishing config
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_PUBLISH_TOKEN}"
@@ -159,6 +173,7 @@ jobs:
           node-version: lts/*
 
       - name: Restore build artifacts
+        id: cache-restore
         uses: actions/cache/restore@v4
         with:
           path: |
@@ -166,7 +181,12 @@ jobs:
             packages/*/lib
             packages/*/dist
           key: build-artifacts-${{ github.sha }}
-          fail-on-cache-miss: true
+
+      - name: Install deps & build (if cache miss)
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        run: |
+          pnpm install --ignore-scripts
+          pnpm build --output-logs=full --log-order=grouped
 
       - name: Build bundle
         run: pnpm run build:bundle

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      # - feature/test-release-workflow
   workflow_dispatch:
     inputs:
       publish:
@@ -91,14 +90,6 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-
-      # - name: Tag and push version (dry-run)
-      #   run: |
-      #     echo "DRY-RUN: Would have tagged version v${RELEASE_AS}"
-      #     echo "DRY-RUN: git tag v$RELEASE_AS -m v$RELEASE_AS"
-      #     echo "DRY-RUN: git push origin v$RELEASE_AS"
-      #   env:
-      #     RELEASE_AS: ${{ needs.build-and-validate.outputs.version || steps.release-as.outputs.version }}
       - name: Tag and push version
         run: |
           git tag v$RELEASE_AS -m v$RELEASE_AS
@@ -159,7 +150,6 @@ jobs:
 
       - name: Publish packages to npm
         run: pnpm -r publish
-        # run: pnpm -r publish --dry-run
         env:
           NPM_CONFIG_PROVENANCE: true
 

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      # - feature/test-release-workflow
   workflow_dispatch:
     inputs:
       publish:
@@ -91,6 +92,13 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
+      # - name: Tag and push version (dry-run)
+      #   run: |
+      #     echo "DRY-RUN: Would have tagged version v${RELEASE_AS}"
+      #     echo "DRY-RUN: git tag v$RELEASE_AS -m v$RELEASE_AS"
+      #     echo "DRY-RUN: git push origin v$RELEASE_AS"
+      #   env:
+      #     RELEASE_AS: ${{ needs.build-and-validate.outputs.version || steps.release-as.outputs.version }}
       - name: Tag and push version
         run: |
           git tag v$RELEASE_AS -m v$RELEASE_AS
@@ -151,6 +159,7 @@ jobs:
 
       - name: Publish packages to npm
         run: pnpm -r publish
+        # run: pnpm -r publish --dry-run
         env:
           NPM_CONFIG_PROVENANCE: true
 

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -38,7 +38,7 @@ jobs:
           cache: pnpm
           node-version: lts/*
 
-      - name: Install deps & build
+      - name: Install deps
         run: pnpm install --ignore-scripts
 
       - name: Build
@@ -59,15 +59,6 @@ jobs:
           fi
         env:
           RELEASE_AS: ${{ steps.release-as.outputs.version }}
-
-      - name: Cache build artifacts
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            node_modules
-            packages/*/lib
-            packages/*/dist
-          key: build-artifacts-${{ github.sha }}
 
   git-operations:
     if: ${{ github.event.inputs.publish != 'true' }}
@@ -90,6 +81,7 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
       - name: Tag and push version
         run: |
           git tag v$RELEASE_AS -m v$RELEASE_AS
@@ -98,7 +90,8 @@ jobs:
           RELEASE_AS: ${{ needs.build-and-validate.outputs.version || steps.release-as.outputs.version }}
 
   npm-publish:
-    needs: build-and-validate
+    needs: [build-and-validate, git-operations]
+    if: always() && needs.build-and-validate.result == 'success' && (needs.git-operations.result == 'success' || needs.git-operations.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -117,21 +110,11 @@ jobs:
           cache: pnpm
           node-version: lts/*
 
-      - name: Restore build artifacts
-        id: cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            node_modules
-            packages/*/lib
-            packages/*/dist
-          key: build-artifacts-${{ github.sha }}
+      - name: Install deps
+        run: pnpm install --ignore-scripts
 
-      - name: Install deps & build (if cache miss)
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: |
-          pnpm install --ignore-scripts
-          pnpm build --output-logs=full --log-order=grouped
+      - name: Build
+        run: pnpm build --output-logs=full --log-order=grouped
 
       - name: Set publishing config
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_PUBLISH_TOKEN}"
@@ -171,21 +154,11 @@ jobs:
           cache: pnpm
           node-version: lts/*
 
-      - name: Restore build artifacts
-        id: cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            node_modules
-            packages/*/lib
-            packages/*/dist
-          key: build-artifacts-${{ github.sha }}
+      - name: Install deps
+        run: pnpm install --ignore-scripts
 
-      - name: Install deps & build (if cache miss)
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        run: |
-          pnpm install --ignore-scripts
-          pnpm build --output-logs=full --log-order=grouped
+      - name: Build
+        run: pnpm build --output-logs=full --log-order=grouped
 
       - name: Build bundle
         run: pnpm run build:bundle


### PR DESCRIPTION
### Description
This makes improvements to the latest release flow by allowing for individual segments of the workflow to be rerun in isolation.
Jobs are now
`build-and-validate` to create the bundles to release
`git-operations` which includes tagging the new release
`npm-publish` which allows for rerunning the npm publish step if this fails
`bundle-upload` which contains everything related to updating the module-server manifest for auto-update studios, and can be rerun if it fails

Other updates include:
* scoping only relevant write and read permissions and env vars to each job
* caching the earlier `build-and-validate` step so that the artifacts can be reused if jobs are rerun
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
