### PR TITLE
test(cli): ensure extractManifestSchemaTypes serialize

### DIFF
--- a/packages/@sanity/schema/src/_exports/_internal.ts
+++ b/packages/@sanity/schema/src/_exports/_internal.ts
@@ -8,6 +8,7 @@ export {
 } from '../legacy/searchConfig/resolve'
 export {ALL_FIELDS_GROUP_NAME} from '../legacy/types/constants'
 export {builtinTypes} from '../sanity/builtinTypes'
+export {createSchemaFromManifestTypes} from '../sanity/createSchemaFromManifestTypes'
 export {extractSchema} from '../sanity/extractSchema'
 export {groupProblems} from '../sanity/groupProblems'
 export {

--- a/packages/@sanity/schema/src/sanity/createSchemaFromManifestTypes.ts
+++ b/packages/@sanity/schema/src/sanity/createSchemaFromManifestTypes.ts
@@ -1,0 +1,25 @@
+import {Schema} from '../legacy/Schema'
+import {builtinTypes} from './builtinTypes'
+
+const builtinSchema = Schema.compile({
+  name: 'studio',
+  types: builtinTypes,
+})
+
+export function createSchemaFromManifestTypes(schemaDef: {name: string; types: unknown[]}) {
+  return Schema.compile({
+    name: schemaDef.name,
+    types: schemaDef.types.map(coerceType).filter(Boolean),
+    parent: builtinSchema,
+  })
+}
+
+function isRecord(val: unknown): val is Record<string, unknown> {
+  return val !== null && typeof val === 'object' && !Array.isArray(val)
+}
+
+function coerceType(obj: any) {
+  if (!isRecord(obj)) return undefined
+  // TODO: coerce validations
+  return obj
+}

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -294,6 +294,7 @@
     "@repo/package.config": "workspace:*",
     "@repo/test-config": "workspace:*",
     "@sanity/codegen": "workspace:*",
+    "@sanity/descriptors": "^1.1.1",
     "@sanity/eslint-config-i18n": "catalog:",
     "@sanity/generate-help-url": "^3.0.0",
     "@sanity/pkg-utils": "6.13.4",

--- a/packages/sanity/test/descriptors/extractManifestToSchema.test.ts
+++ b/packages/sanity/test/descriptors/extractManifestToSchema.test.ts
@@ -1,0 +1,1098 @@
+import {DescriptorConverter} from '@sanity/schema/_internal'
+import {defineArrayMember, defineField, defineType, type Schema} from '@sanity/types'
+import {createSchema} from 'sanity'
+import {describe, test} from 'vitest'
+
+import {expectManifestSchemaConversion} from './utils'
+
+const DESCRIPTOR_CONVERTER = new DescriptorConverter({})
+
+function validate(schema: Schema) {
+  expectManifestSchemaConversion(schema, DESCRIPTOR_CONVERTER.get(schema))
+}
+
+// The schemas are taken from packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
+describe('ManifestSchemaTypes[] converts to Schema', () => {
+  test('field with type', () => {
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          name: 'foo',
+          type: 'object',
+          fields: [
+            {
+              name: 'key',
+              type: 'string',
+            },
+          ],
+        }),
+        defineType({
+          name: 'bar',
+          type: 'object',
+          fields: [
+            {
+              name: 'foo',
+              type: 'foo',
+              options: [
+                {
+                  name: 'foo',
+                  type: 'foo',
+                  title: 'This one is being overriden',
+                },
+              ],
+            },
+          ],
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('can convert a simple schema', () => {
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          title: 'Valid document',
+          name: 'validDocument',
+          type: 'document',
+          fields: [
+            {
+              title: 'Title',
+              name: 'title',
+              type: 'string',
+            },
+            {
+              title: 'List',
+              name: 'list',
+              type: 'string',
+              options: {
+                list: ['a', 'b', 'c'],
+              },
+              validation: (Rule) => Rule.required(),
+            },
+            {
+              title: 'Number',
+              name: 'number',
+              type: 'number',
+            },
+            {
+              title: 'some other object',
+              name: 'someInlinedObject',
+              type: 'obj',
+            },
+            {
+              title: 'Manuscript',
+              name: 'manuscript',
+              type: 'manuscript',
+            },
+            {
+              title: 'Some text',
+              name: 'someTextType',
+              type: 'someTextType',
+            },
+            {
+              title: 'customStringType',
+              name: 'customStringType',
+              type: 'customStringType',
+            },
+            {
+              title: 'Blocks',
+              name: 'blocks',
+              type: 'array',
+              of: [{type: 'block'}],
+            },
+            {
+              type: 'reference',
+              name: 'other',
+              to: {
+                type: 'otherValidDocument',
+              },
+            },
+            {
+              type: 'reference',
+              name: 'others',
+              to: [
+                {
+                  type: 'otherValidDocument',
+                },
+              ],
+            },
+          ],
+        }),
+        {
+          title: 'Author',
+          name: 'author',
+          type: 'document',
+          fields: [
+            {
+              title: 'Name',
+              name: 'name',
+              type: 'string',
+            },
+            {
+              title: 'Profile picture',
+              name: 'profilePicture',
+              type: 'image',
+              options: {
+                hotspot: true,
+              },
+              fields: [
+                {
+                  name: 'caption',
+                  type: 'string',
+                  title: 'Caption',
+                },
+                {
+                  name: 'attribution',
+                  type: 'string',
+                  title: 'Attribution',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          title: 'Book',
+          name: 'book',
+          type: 'document',
+          fields: [
+            {
+              title: 'Name',
+              name: 'name',
+              type: 'string',
+            },
+          ],
+        },
+        // Block,
+        {
+          title: 'Other valid document',
+          name: 'otherValidDocument',
+          type: 'document',
+          fields: [
+            {
+              title: 'Title',
+              name: 'title',
+              type: 'string',
+            },
+          ],
+        },
+        {
+          type: 'object',
+          name: 'obj',
+          fields: [
+            {
+              title: 'Field #1',
+              name: 'field1',
+              type: 'string',
+            },
+            {
+              title: 'Field #2',
+              name: 'field2',
+              type: 'number',
+            },
+          ],
+        },
+        defineType({
+          name: 'customStringType',
+          title: 'My custom string type',
+          type: 'string',
+        }),
+        {
+          type: 'object',
+          name: 'code',
+          fields: [
+            {
+              title: 'The Code!',
+              name: 'thecode',
+              type: 'string',
+            },
+          ],
+        },
+        {
+          title: 'Manuscript',
+          name: 'manuscript',
+          type: 'file',
+          fields: [
+            {
+              name: 'description',
+              type: 'string',
+              title: 'Description',
+            },
+            {
+              name: 'author',
+              type: 'reference',
+              title: 'Author',
+              to: {type: 'author'},
+            },
+          ],
+        },
+        defineType({
+          name: 'someTextType',
+          type: 'text',
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('all fields are marked as optional without "enforceRequiredFields"', () => {
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        {
+          title: 'Book',
+          name: 'book',
+          type: 'document',
+          fields: [
+            {
+              title: 'Title',
+              name: 'title',
+              type: 'string',
+            },
+            defineField({
+              title: 'Subtitle',
+              name: 'subtitle',
+              type: 'string',
+              validation: (Rule) => Rule.required(),
+            }),
+            {
+              title: 'Another Title',
+              name: 'anotherTitle',
+              type: 'string',
+              validation: {_required: 'required'},
+            },
+          ],
+        },
+      ],
+    })
+
+    validate(schema)
+  })
+
+  // Skipping as extractManifestSchemaTypes does not allow `enforceRequiredFields`
+  test('optional is set when "enforceRequiredFields"', {skip: true}, () => {
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        {
+          title: 'Book',
+          name: 'book',
+          type: 'document',
+          fields: [
+            {
+              title: 'Title',
+              name: 'title',
+              type: 'string',
+            },
+            defineField({
+              title: 'Subtitle',
+              name: 'subtitle',
+              type: 'string',
+              validation: (Rule) => Rule.required(),
+            }),
+            {
+              title: 'Another Title',
+              name: 'anotherTitle',
+              type: 'string',
+              validation: {_required: 'required'},
+            },
+            {
+              title: 'Optional Title',
+              name: 'optionalTitle',
+              type: 'string',
+              validation: {_required: 'optional'},
+            },
+          ],
+        },
+      ],
+    })
+
+    validate(schema /*, {enforceRequiredFields: true} */)
+  })
+
+  test('can extract inline documents', () => {
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          title: 'Valid document',
+          name: 'validDocument',
+          type: 'document',
+          fields: [
+            {
+              title: 'inline author',
+              name: 'inlineAuthor',
+              type: 'author',
+            },
+            {
+              title: 'inline author',
+              name: 'inlineAuthors',
+              type: 'array',
+              of: [{type: 'author'}],
+            },
+            {
+              title: 'reference author',
+              name: 'referenceAuthor',
+              type: 'reference',
+              to: [{type: 'author'}],
+            },
+            {
+              title: 'references author',
+              name: 'referenceAuthors',
+              type: 'array',
+              of: [{type: 'reference', to: [{type: 'author'}]}],
+            },
+          ],
+        }),
+        {
+          title: 'Author',
+          name: 'author',
+          type: 'document',
+          fields: [
+            {
+              title: 'Name',
+              name: 'name',
+              type: 'string',
+            },
+          ],
+        },
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('will ignore global document reference types at the moment', () => {
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          title: 'Valid document',
+          name: 'validDocument',
+          type: 'document',
+          fields: [
+            {
+              type: 'globalDocumentSubtype',
+              name: 'author',
+            },
+            {
+              type: 'book',
+              name: 'book',
+            },
+          ],
+        }),
+        {
+          type: 'globalDocumentReference',
+          name: 'globalDocumentSubtype',
+          title: 'Subtype of global document references',
+          resourceType: 'dataset',
+          resourceId: 'exx11uqh.blog',
+          to: [
+            {
+              type: 'book',
+              preview: {
+                select: {
+                  title: 'title',
+                  media: 'coverImage',
+                },
+                prepare(val: any) {
+                  return {
+                    title: val.title,
+                    media: val.coverImage,
+                  }
+                },
+              },
+            },
+          ],
+        },
+        {
+          type: 'object',
+          title: 'Book',
+          name: 'book',
+          fields: [
+            {
+              type: 'string',
+              name: 'title',
+            },
+          ],
+        },
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('extracted schema should only include user defined types (and no built-in types)', () => {
+    const documentType = 'basic'
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          name: documentType,
+          type: 'document',
+          fields: [defineField({name: 'title', type: 'string'})],
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('indicate conditional for function values on hidden and readOnly fields', () => {
+    const documentType = 'basic'
+
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          name: documentType,
+          type: 'document',
+          readOnly: true,
+          hidden: false,
+          fields: [
+            defineField({
+              name: 'string',
+              type: 'string',
+              hidden: () => true,
+              readOnly: () => false,
+            }),
+          ],
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('should omit known non-serializable schema props ', () => {
+    const documentType = 'remove-props'
+
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          //include
+          name: documentType,
+          type: 'document',
+          title: 'My document',
+          description: 'Stuff',
+          deprecated: {
+            reason: 'old',
+          },
+          options: {
+            // @ts-expect-error - this is a test
+            custom: 'value',
+          },
+          initialValue: {title: 'Default'},
+          liveEdit: true,
+
+          //omit
+          icon: () => 'remove-icon',
+          groups: [{name: 'groups-are-removed'}],
+          // eslint-disable-next-line camelcase
+          __experimental_omnisearch_visibility: true,
+          // eslint-disable-next-line camelcase
+          __experimental_search: [
+            {
+              path: 'title',
+              weight: 100,
+            },
+          ],
+          // eslint-disable-next-line camelcase
+          __experimental_formPreviewTitle: true,
+          components: {
+            field: () => 'remove-components',
+          },
+          orderings: [
+            {name: 'remove-orderings', title: '', by: [{field: 'title', direction: 'desc'}]},
+          ],
+          fields: [
+            defineField({
+              name: 'string',
+              type: 'string',
+              group: 'groups-are-removed',
+            }),
+          ],
+          preview: {
+            select: {title: 'remove-preview'},
+          },
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('schema should include most userland properties', () => {
+    const documentType = 'basic'
+
+    const recursiveObject: any = {
+      repeat: 'string',
+    }
+    recursiveObject.recurse = recursiveObject
+
+    const customization: any = {
+      recursiveObject, // this one will be cut off at max-depth
+      serializableProp: 'dummy',
+      nonSerializableProp: () => {},
+      options: {
+        serializableOption: true,
+        nonSerializableOption: () => {},
+        nested: {
+          serializableOption: 1,
+          nonSerializableOption: () => {},
+        },
+      },
+    }
+
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          name: documentType,
+          type: 'document',
+          fields: [
+            defineField({
+              title: 'Nested',
+              name: 'nested',
+              type: 'object',
+              fields: [
+                defineField({
+                  title: 'Nested inline string',
+                  name: 'nestedString',
+                  type: 'string',
+                  ...customization,
+                }),
+              ],
+              ...customization,
+            }),
+          ],
+          ...customization,
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('should serialize fieldset config', () => {
+    const documentType = 'fieldsets'
+
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          name: documentType,
+          type: 'document',
+          fields: [
+            defineField({
+              name: 'string',
+              type: 'string',
+            }),
+          ],
+          preview: {
+            select: {title: 'title'},
+            prepare: () => ({
+              title: 'remove-prepare',
+            }),
+          },
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('serialize fieldless types', () => {
+    const documentType = 'fieldless-types'
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          title: 'Some document',
+          name: documentType,
+          type: 'document',
+          fields: [
+            defineField({title: 'String field', name: 'string', type: 'string'}),
+            defineField({title: 'Text field', name: 'text', type: 'text'}),
+            defineField({title: 'Number field', name: 'number', type: 'number'}),
+            defineField({title: 'Boolean field', name: 'boolean', type: 'boolean'}),
+            defineField({title: 'Date field', name: 'date', type: 'date'}),
+            defineField({title: 'Datetime field', name: 'datetime', type: 'datetime'}),
+            defineField({title: 'Geopoint field', name: 'geopoint', type: 'geopoint'}),
+            defineField({title: 'Basic image field', name: 'image', type: 'image'}),
+            defineField({title: 'Basic file field', name: 'file', type: 'file'}),
+            defineField({title: 'Slug field', name: 'slug', type: 'slug'}),
+            defineField({title: 'URL field', name: 'url', type: 'url'}),
+          ],
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('serialize types with fields', () => {
+    const documentType = 'field-types'
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          fields: [
+            {
+              name: 'existingType',
+              type: documentType,
+            },
+            {
+              fields: [
+                {
+                  name: 'nestedString',
+                  title: 'Nested inline string',
+                  type: 'string',
+                },
+                {
+                  fields: [
+                    {
+                      name: 'inner',
+                      title: 'Inner',
+                      type: 'number',
+                    },
+                  ],
+                  name: 'nestedTwice',
+                  title: 'Child object',
+                  type: 'object',
+                },
+              ],
+              name: 'nested',
+              title: 'Nested',
+              type: 'object',
+            },
+            {
+              fields: [
+                {
+                  name: 'title',
+                  title: 'Image title',
+                  type: 'string',
+                },
+              ],
+              name: 'image',
+              type: 'image',
+            },
+            {
+              fields: [
+                {
+                  name: 'title',
+                  title: 'File title',
+                  type: 'string',
+                },
+              ],
+              name: 'file',
+              type: 'file',
+            },
+          ],
+          name: documentType,
+          type: 'document',
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('serialize array-like fields (portable text tested separately)', () => {
+    const documentType = 'all-types'
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          title: 'Basic doc',
+          name: documentType,
+          type: 'document',
+          fields: [
+            defineField({
+              title: 'String array',
+              name: 'stringArray',
+              type: 'array',
+              of: [{type: 'string'}],
+            }),
+            defineField({
+              title: 'Number array',
+              name: 'numberArray',
+              type: 'array',
+              of: [{type: 'number'}],
+            }),
+            defineField({
+              title: 'Boolean array',
+              name: 'booleanArray',
+              type: 'array',
+              of: [{type: 'boolean'}],
+            }),
+            defineField({
+              name: 'objectArray',
+              type: 'array',
+              of: [
+                defineArrayMember({
+                  title: 'Anonymous object item',
+                  type: 'object',
+                  fields: [
+                    defineField({
+                      name: 'itemTitle',
+                      type: 'string',
+                    }),
+                  ],
+                }),
+                defineArrayMember({
+                  type: 'object',
+                  title: 'Inline named object item',
+                  name: 'item',
+                  fields: [
+                    defineField({
+                      name: 'otherTitle',
+                      type: 'string',
+                    }),
+                  ],
+                }),
+                defineArrayMember({
+                  title: 'Existing type object item',
+                  type: documentType,
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('serialize array with type reference and overridden typename', () => {
+    const arrayType = 'someArray'
+    const objectBaseType = 'someObject'
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          name: objectBaseType,
+          type: 'object',
+          fields: [
+            defineField({
+              name: 'title',
+              type: 'string',
+            }),
+          ],
+        }),
+        defineType({
+          name: arrayType,
+          type: 'array',
+          of: [{type: objectBaseType, name: 'override'}],
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('serialize schema with indirectly recursive structure', () => {
+    const arrayType = 'someArray'
+    const objectBaseType = 'someObject'
+    const otherObjectType = 'other'
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          name: objectBaseType,
+          type: 'object',
+          fields: [
+            defineField({
+              name: 'recurse',
+              type: otherObjectType,
+            }),
+          ],
+        }),
+        defineType({
+          name: otherObjectType,
+          type: 'object',
+          fields: [
+            defineField({
+              name: 'recurse2',
+              type: arrayType,
+            }),
+          ],
+        }),
+        defineType({
+          name: arrayType,
+          type: 'array',
+          of: [{type: objectBaseType}],
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('serialize portable text field', () => {
+    const documentType = 'pt'
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          name: documentType,
+          type: 'document',
+          fields: [
+            defineField({
+              title: 'Portable text',
+              name: 'pt',
+              type: 'array',
+              of: [
+                defineArrayMember({
+                  title: 'Block Title',
+                  name: 'block',
+                  type: 'block',
+                  of: [
+                    defineField({
+                      title: 'Inline block',
+                      name: 'inlineBlock',
+                      type: 'object',
+                      fields: [
+                        defineField({
+                          title: 'Inline value',
+                          name: 'value',
+                          type: 'string',
+                        }),
+                      ],
+                    }),
+                  ],
+                  marks: {
+                    annotations: [
+                      defineField({
+                        title: 'Annotation',
+                        name: 'annotation',
+                        type: 'object',
+                        fields: [
+                          defineField({
+                            title: 'Annotation value',
+                            name: 'value',
+                            type: 'string',
+                          }),
+                        ],
+                      }),
+                    ],
+                    decorators: [{title: 'Custom mark', value: 'custom'}],
+                  },
+                  lists: [{value: 'bullet', title: 'Bullet list'}],
+                  styles: [{value: 'customStyle', title: 'Custom style'}],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('serialize fields with references', () => {
+    const documentType = 'ref-types'
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          name: documentType,
+          type: 'document',
+          fields: [
+            defineField({
+              title: 'Reference to',
+              name: 'reference',
+              type: 'reference',
+              to: [{type: documentType}],
+            }),
+            defineField({
+              title: 'Cross dataset ref',
+              name: 'crossDatasetReference',
+              type: 'crossDatasetReference',
+              dataset: 'production',
+              studioUrl: () => 'cannot serialize studioUrl function',
+              to: [
+                {
+                  type: documentType,
+                  preview: {
+                    select: {title: 'title'},
+                    prepare: () => ({
+                      title: 'cannot serialize prepare function',
+                    }),
+                  },
+                },
+              ],
+            }),
+            defineField({
+              type: 'globalDocumentReference',
+              name: 'globalRef',
+              to: [
+                {
+                  type: documentType,
+                  preview: {
+                    select: {title: 'title'},
+                  },
+                },
+              ],
+              resourceId: 'a.b',
+              resourceType: 'dataset',
+              weak: true,
+            }),
+            defineField({
+              title: 'Reference array',
+              name: 'refArray',
+              type: 'array',
+              of: [
+                defineArrayMember({
+                  title: 'Reference to',
+                  name: 'reference',
+                  type: 'reference',
+                  to: [{type: documentType}],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('fieldsets and fieldset on fields is serialized', () => {
+    const documentType = 'basic'
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          name: documentType,
+          type: 'document',
+          fieldsets: [
+            {
+              name: 'test',
+              title: 'Test fieldset',
+              hidden: false,
+              readOnly: true,
+              options: {
+                collapsed: true,
+              },
+              description: 'my fieldset',
+            },
+            {
+              name: 'conditional',
+              hidden: () => true,
+              readOnly: () => true,
+            },
+          ],
+          fields: [
+            defineField({name: 'title', type: 'string', fieldset: 'test'}),
+            defineField({name: 'other', type: 'string', fieldset: 'conditional'}),
+          ],
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('do not serialize default titles (default titles added by Schema.compile based on type/field name)', () => {
+    const documentType = 'basic-document'
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          name: documentType,
+          type: 'document',
+          fieldsets: [
+            {name: 'someFieldset'},
+            {
+              name: 'conditional',
+              hidden: () => true,
+              readOnly: () => true,
+            },
+          ],
+          fields: [
+            defineField({name: 'title', type: 'string'}),
+            defineField({name: 'someField', type: 'array', of: [{type: 'string'}]}),
+            defineField({name: 'customTitleField', type: 'string', title: 'Custom'}),
+          ],
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  test('should use the inline type, not the global type for the array.of name-conflicting inline array object items', () => {
+    const documentType = 'basic-document'
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          type: 'object',
+          name: 'reusedObjectName', // this is the same as the item in conflictingInlineObjectNameArray below, but it has different fields
+          fields: [{name: 'number', type: 'number'}],
+        }),
+        defineType({
+          name: documentType,
+          type: 'document',
+          fields: [
+            defineField({
+              name: 'conflictingInlineObjectNameArray',
+              type: 'array',
+              of: [
+                defineArrayMember({
+                  type: 'object',
+                  // this is the type name as the object type above, but it is a different type, since this is an inline array item object def
+                  name: 'reusedObjectName',
+                  fields: [{name: 'string', type: 'string'}],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+
+  // FIXME: This test will fail because the block type title is set to the default title.
+  // When this is serialized, the title will not be set in the _internal_ownProps and thus
+  // not be serialized into the descriptor.
+  test.fails('Defining array type title same as default title should fail', () => {
+    const documentType = 'pt'
+    const schema = createSchema({
+      name: 'test',
+      types: [
+        defineType({
+          name: documentType,
+          type: 'document',
+          fields: [
+            defineField({
+              title: 'Portable text',
+              name: 'pt',
+              type: 'array',
+              of: [
+                defineArrayMember({
+                  title: 'Block',
+                  name: 'block',
+                  type: 'block',
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    })
+
+    validate(schema)
+  })
+})

--- a/packages/sanity/test/descriptors/schema.test.tsx
+++ b/packages/sanity/test/descriptors/schema.test.tsx
@@ -12,6 +12,7 @@ import {
   type ObjectField,
 } from '../../../@sanity/schema/src/descriptors/types'
 import {builtinSchema, createSchema, DESCRIPTOR_CONVERTER} from '../../src/core/schema'
+import {expectManifestSchemaConversion} from './utils'
 
 const findTypeInDesc = (
   name: string,
@@ -30,6 +31,9 @@ const convertType = (...types: SchemaTypeDefinition[]): EncodedNamedType => {
   }
 
   const desc = DESCRIPTOR_CONVERTER.get(schema)
+
+  expectManifestSchemaConversion(schema, desc)
+
   return findTypeInDesc(types[0].name, desc)!
 }
 

--- a/packages/sanity/test/descriptors/utils.ts
+++ b/packages/sanity/test/descriptors/utils.ts
@@ -1,0 +1,286 @@
+import {type EncodableObject, type EncodableValue} from '@sanity/descriptors'
+import {createSchemaFromManifestTypes} from '@sanity/schema/_internal'
+import {type Schema} from '@sanity/types'
+import {cloneDeep, startCase} from 'lodash'
+import {expect} from 'vitest'
+
+import {extractManifestSchemaTypes} from '../../src/_internal/manifest/extractWorkspaceManifest'
+import {DESCRIPTOR_CONVERTER} from '../../src/core/schema'
+
+type Descriptor = ReturnType<(typeof DESCRIPTOR_CONVERTER)['get']>
+
+export function expectManifestSchemaConversion(schema: Schema, schemaDescriptor: Descriptor) {
+  // Extract the manifest schema types
+  const manifestSchemaTypes = extractManifestSchemaTypes(schema)
+
+  // Serialize to simulate transmitting the schema over the server
+  const data = JSON.parse(JSON.stringify(manifestSchemaTypes))
+
+  // Convert the raw json back into a Schema
+  const converted = createSchemaFromManifestTypes({name: schema.name, types: data})
+
+  const convertedDescriptor = DESCRIPTOR_CONVERTER.get(converted)
+
+  // Compare the underlying typedefs since there are known inconsistencies between the serialized schemaschema
+  // and the serialized manifest schema
+  const convertedObjectValues = Object.values(convertedDescriptor.objectValues)
+  const schemaObjectValues = Object.values(schemaDescriptor.objectValues)
+  expect(convertedObjectValues.length).toEqual(schemaObjectValues.length)
+  for (const convertedObjectValue of convertedObjectValues) {
+    const schemaObjectValue = schemaObjectValues.find(
+      (t) => t.name === convertedObjectValue.name && t.type === convertedObjectValue.type,
+    )
+
+    expect(schemaObjectValue).toBeDefined()
+
+    const titles = extractTitleMap(convertedObjectValue.typeDef)
+    const stype = cloneDeep(schemaObjectValue?.typeDef)
+    normalizeSchemaDescriptorTypeDef(stype, titles)
+    expect(convertedObjectValue.typeDef).toStrictEqual(stype)
+  }
+}
+
+function extractTitleMap(data: unknown) {
+  const titles: Record<string, string> = {}
+
+  function extract(obj: any, path: string) {
+    if (!isObject(obj)) return
+
+    // Add title if it differs from the name
+    if (
+      'title' in obj &&
+      typeof obj.title === 'string' &&
+      (!('name' in obj) || (typeof obj.name === 'string' && startCase(obj.name) !== obj.title))
+    ) {
+      titles[`${path}.title`] = obj.title
+    }
+
+    // Process all properties
+    for (const [key, value] of Object.entries(obj)) {
+      if (key === 'title') return
+
+      if (Array.isArray(value)) {
+        value.forEach((item, i) => extract(item, `${path}.${key}[${i}]`))
+      } else if (value && typeof value === 'object') {
+        extract(value, `${path}.${key}`)
+      }
+    }
+  }
+
+  extract(data, '$')
+  return titles
+}
+
+// normalizeSchemaDescriptorTypeDef turns a descriptor type definition into a normalized version
+// which is equivalent to what the createSchemaFromManifest returns. This serves as documentation
+// for how well we're able to convert the manifest type into a descriptor. Preferably this
+// function should be empty (which would correspond to createSchemaFromManifest preserving all data).
+//
+// obj will be modified in place.
+function normalizeSchemaDescriptorTypeDef(
+  obj: EncodableValue | undefined,
+  titles: Record<string, string>,
+) {
+  if (!isEncodableObject(obj)) return
+
+  // The final form of options is determined by it's initial state. If the property starts as empty object,
+  // then it should end in a empty object. If options is "effictively" empty (i.e. all properties are undefined or empty objects)
+  // then options will be set to undefined.
+  const optionsAreEmpty = isEmptyObject(obj.options)
+
+  // Coerce titles which were added during extractManifestSchemaTypes. This can happen when the
+  // default title for a type isn't stripped by extractManifestSchemaTypes. For example:
+  //
+  //    { name: 'foo', type: 'string' }
+  //
+  // which will be extracted as:
+  //
+  //    { name: 'foo', type: 'string', title: 'String' }
+  //
+  coerceTitles(obj, titles)
+
+  // Remove any properties which are not serializable
+  unsetUnserializableTypesDeep(obj)
+
+  // Unset any fieldsets
+  normalizeFieldsets(obj)
+
+  // Remove all instances of groups must occur after handling fieldsets as
+  // the determination to keep a fieldset depends on the presence of groups
+  unsetKeyDeep(obj, 'groups')
+
+  // Remove any instance of i18nTitleKey, we only need to do this once since we
+  // need to remove all instances of the property
+  deleteKeyDeep(obj, 'i18nTitleKey')
+
+  // If options are effictively empty (i.e. it is just comprised of empty objects)
+  // the field is unset. This happens unless the object started out as empty before
+  // any normalization.
+  if (!optionsAreEmpty) {
+    normalizeOptions(obj)
+  }
+}
+
+function isEncodableObject(val: EncodableValue | undefined): val is EncodableObject {
+  return isRecord(val)
+}
+
+function isObject(val: unknown): val is object {
+  return val !== null && typeof val === 'object'
+}
+
+function isRecord(val: unknown): val is Record<string, unknown> {
+  return isObject(val) && !Array.isArray(val)
+}
+
+function isEmptyObject(obj: unknown) {
+  return isRecord(obj) && Object.keys(obj).length === 0
+}
+
+function deleteKeyDeep(obj: unknown, target: string) {
+  if (!isRecord(obj)) {
+    return
+  }
+
+  delete obj[target]
+
+  for (const val of Object.values(obj)) {
+    if (Array.isArray(val)) {
+      for (let i = 0; i < val.length; i++) {
+        deleteKeyDeep(val[i], target)
+      }
+    } else {
+      deleteKeyDeep(val, target)
+    }
+  }
+}
+
+function unsetKeyDeep(obj: unknown, target: string) {
+  if (!isRecord(obj)) {
+    return
+  }
+
+  if (target in obj) {
+    obj[target] = undefined
+  }
+
+  for (const val of Object.values(obj)) {
+    if (Array.isArray(val)) {
+      for (let i = 0; i < val.length; i++) {
+        unsetKeyDeep(val[i], target)
+      }
+    } else {
+      unsetKeyDeep(val, target)
+    }
+  }
+}
+
+// Check if options contain unserializable types
+function unsetUnserializableTypesDeep(obj: unknown) {
+  // Handle arrays
+  if (Array.isArray(obj)) {
+    obj.map((item) => unsetUnserializableTypesDeep(item))
+  }
+
+  if (!isRecord(obj)) return
+
+  // Handle objects
+  for (const key of Object.keys(obj)) {
+    if (
+      obj[key] &&
+      typeof obj[key] === 'object' &&
+      '__type' in obj[key] &&
+      typeof obj[key].__type === 'string' &&
+      ['function', 'cyclic', 'maxDepth', 'jsx'].includes(obj[key].__type)
+    ) {
+      // Known properties are unset
+      if (['hidden', 'readOnly', 'description'].includes(key)) {
+        obj[key] = undefined
+      } else {
+        // Custom props are deleted as they are undefined in extractManifestSchemaTypes and the
+        // serialization process will remove them
+        delete obj[key]
+      }
+    }
+
+    unsetUnserializableTypesDeep(obj[key])
+  }
+}
+
+function normalizeFieldsets(obj: EncodableObject) {
+  // extractWorkspaceManifest excludes fieldsets which are singluar (.single == true) except for when there are groups
+  if (Array.isArray(obj.fieldsets) && obj.fieldsets.length > 0) {
+    if (
+      (obj.fieldsets.length === 1 &&
+        (obj.groups === undefined || (Array.isArray(obj.groups) && obj.groups.length <= 1))) ||
+      obj.fieldsets.every(
+        (fieldset: any) =>
+          Object.values(fieldset).filter((v) => {
+            return v !== undefined
+          }).length <= 1,
+      )
+    ) {
+      obj.fieldsets = undefined
+    }
+  }
+}
+
+function coerceTitles(obj: EncodableObject, titles: Record<string, string>) {
+  for (const [jsonPath, title] of Object.entries(titles)) {
+    // Parse path: "$.foo.bar[0].title" → ["foo", "bar", "0", "title"]
+    const parts = jsonPath
+      .slice(2)
+      .split(/[.[\]]+/)
+      .filter(Boolean)
+
+    // Navigate to parent of target
+    let current: EncodableValue | undefined = obj
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i]
+      const isIndex = /^\d+$/.test(part)
+
+      if (isIndex && Array.isArray(current)) {
+        current = current[+part]
+      } else if (isRecord(current)) {
+        current = current[part]
+      } else {
+        break // Path doesn't exist
+      }
+    }
+
+    // Set title if undefined
+    if (isRecord(current)) {
+      const lastKey = parts[parts.length - 1]
+      if (current[lastKey] === undefined) {
+        current[lastKey] = title
+      }
+    }
+  }
+}
+
+function unsetEmptyObjectsDeep(obj: unknown) {
+  if (!isRecord(obj)) return
+
+  for (const key of Object.keys(obj)) {
+    unsetEmptyObjectsDeep(obj[key])
+
+    if (isEmptyObject(obj[key])) {
+      delete obj[key]
+    }
+  }
+}
+
+function normalizeOptions(obj: unknown) {
+  if (!isRecord(obj) || !isRecord(obj.options)) return
+
+  for (const key of Object.keys(obj.options)) {
+    if (obj.options[key] === null) {
+      delete obj.options[key]
+    }
+  }
+
+  unsetEmptyObjectsDeep(obj.options)
+  if (isEmptyObject(obj.options)) {
+    obj.options = undefined
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2065,6 +2065,9 @@ importers:
       '@sanity/codegen':
         specifier: workspace:*
         version: link:../@sanity/codegen
+      '@sanity/descriptors':
+        specifier: ^1.1.1
+        version: 1.1.1
       '@sanity/eslint-config-i18n':
         specifier: 'catalog:'
         version: 2.0.0(eslint@9.33.0(jiti@2.5.1))


### PR DESCRIPTION
### Description

Ensure the Schema generated from `extractManifestSchemaTypes` can be serialized back into a `Schema`. This is to ensure parity between the Schemas and that no information is lost.

### What to review

Tests pass and make sense

### Testing

It's all tests

### Notes for release

This is a testing only change.
