### PR TITLE
fix(cli): add document-id flag to functions test

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -59,7 +59,7 @@
     "@babel/traverse": "^7.27.4",
     "@sanity/client": "^7.6.0",
     "@sanity/codegen": "workspace:*",
-    "@sanity/runtime-cli": "^9.1.2",
+    "@sanity/runtime-cli": "^9.2.0",
     "@sanity/telemetry": "^0.8.0",
     "@sanity/template-validator": "^2.4.3",
     "@sanity/util": "workspace:3.98.1",

--- a/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
@@ -7,6 +7,7 @@ Arguments
 Options
   --data <data> Data to send to the function
   --file <file> Read data from file and send to the function
+  --document-id <id> Document to fetch and send to function
   --timeout <timeout> Execution timeout value in seconds
   --api <version> Sanity API Version to use
   --dataset <dataset> The Sanity dataset to use
@@ -32,6 +33,7 @@ export interface FunctionsTestFlags {
   'api'?: string
   'dataset'?: string
   'project-id'?: string
+  'document-id'?: string
   'with-user-token'?: boolean
 }
 
@@ -45,7 +47,7 @@ const testFunctionsCommand: CliCommandDefinition<FunctionsTestFlags> = {
   group: 'functions',
   helpText,
   signature:
-    '<name> [--data <json>] [--file <filename>] [--timeout <seconds>] [--api <version>] [--dataset <name>] [--project-id] <id>] [--with-user-token]',
+    '<name> [--data <json>] [--file <filename>] [--document-id <id>] [--timeout <seconds>] [--api <version>] [--dataset <name>] [--project-id] <id>] [--with-user-token]',
   description: 'Invoke a local Sanity Function',
   async action(args, context) {
     const {apiClient, output, chalk} = context
@@ -96,6 +98,7 @@ const testFunctionsCommand: CliCommandDefinition<FunctionsTestFlags> = {
       flags: {
         'data': flags.data,
         'file': flags.file,
+        'document-id': flags['document-id'],
         'timeout': flags.timeout,
         'api': flags.api,
         'dataset': flags.dataset || actualDataset,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -884,8 +884,8 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@sanity/runtime-cli':
-        specifier: ^9.1.2
-        version: 9.1.2(@types/node@22.15.32)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+        specifier: ^9.2.0
+        version: 9.2.0(@types/node@22.15.32)(debug@4.4.1)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       '@sanity/telemetry':
         specifier: ^0.8.0
         version: 0.8.1(react@19.1.0)
@@ -4725,8 +4725,8 @@ packages:
     peerDependencies:
       react: ^18.3 || >=19.0.0-rc
 
-  '@sanity/runtime-cli@9.1.2':
-    resolution: {integrity: sha512-TOsWsCXaPqlnJj/XPJkJvdQHfuey2LJLZSTqz0wR3BvCNEppyKNalNGoUUNysyUAQnq0WsYOXhx7timXvp7Zzw==}
+  '@sanity/runtime-cli@9.2.0':
+    resolution: {integrity: sha512-7EJOkiOuw3HWw/JyN4jpCOXPURquLIaisjcppReTTqp/w9cw/Cbqdw+8bgQDMzZg8uphi9vOzJk5C4jx7Zg2RA==}
     engines: {node: '>=20.11.0'}
     hasBin: true
 
@@ -15347,12 +15347,13 @@ snapshots:
       - debug
       - typescript
 
-  '@sanity/runtime-cli@9.1.2(@types/node@22.15.32)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)':
+  '@sanity/runtime-cli@9.2.0(@types/node@22.15.32)(debug@4.4.1)(lightningcss@1.30.1)(terser@5.42.0)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)':
     dependencies:
       '@architect/hydrate': 4.0.8
       '@architect/inventory': 4.0.9
       '@oclif/core': 4.3.3
       '@oclif/plugin-help': 6.2.29
+      '@sanity/client': 7.6.0(debug@4.4.1)
       adm-zip: 0.5.16
       array-treeify: 0.1.5
       cardinal: 2.1.1
@@ -15372,6 +15373,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
+      - debug
       - less
       - lightningcss
       - sass


### PR DESCRIPTION
### Description

You can now just set a document ID in the test and dev commands to provide event data for the function being tested.

`functions test` - https://www.loom.com/share/17fbe195368d4c67b95cbaad5b858c4d

`functions dev` - https://www.loom.com/share/184df637a3824e409d2877f406c79ef3?sid=742b440c-977b-466f-8da1-cbd98e31b9aa

### What to review

Run the dev and test commands yourself and let me know what you think.

### Testing

Added a bunch of unit tests to `@sanity/runtime-cli`

### Notes for release

n/a
