### PR TITLE
feat: allow disabling git init for new projects

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/bootstrapRemoteTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapRemoteTemplate.ts
@@ -38,6 +38,7 @@ const INITIAL_COMMIT_MESSAGE = 'Initial commit from Sanity CLI'
 export async function bootstrapRemoteTemplate(
   opts: BootstrapRemoteOptions,
   context: CliCommandContext,
+  disableGit?: boolean,
 ): Promise<void> {
   const {outputPath, repoInfo, bearerToken, variables, packageName} = opts
   const {output, apiClient} = context
@@ -103,8 +104,10 @@ export async function bootstrapRemoteTemplate(
   debug('Setting package name to %s', packageName)
   await tryApplyPackageName(outputPath, packageName)
 
-  debug('Initializing git repository')
-  tryGitInit(outputPath, INITIAL_COMMIT_MESSAGE)
+  if (!disableGit) {
+    debug('Initializing git repository')
+    tryGitInit(outputPath, INITIAL_COMMIT_MESSAGE)
+  }
 
   debug('Updating initial template metadata')
   await updateInitialTemplateMetadata(apiClient, variables.projectId, `external-${name}`)

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -28,6 +28,8 @@ Options
   --package-manager <name> Specify which package manager to use [allowed: ${allowedPackageManagersString}]
   --auto-updates Enable/disable auto updates of studio versions (default: true)
   --overwrite-files Overwrite existing files (default: false)
+  --git [message] Enable git initialization with optional commit message (default: true)
+  --disable-git Disable git initialization (default: false)
 
 Some flags are used when initializing a project in a specific framework.
 
@@ -86,7 +88,8 @@ export interface InitFlags {
   'quickstart'?: string
   'bare'?: boolean
   'env'?: boolean | string
-  'git'?: boolean | string
+  'git'?: string
+  'disable-git'?: true
 
   'output-path'?: string
   'project-plan'?: string


### PR DESCRIPTION
Partially resolves #9955 

### Description

Adds a `--disable-git` command to `sanity init` to prevent git initialization in new projects.

There is already a `--git` command but it only ever resolves as `true` or a string, so there's no way to prevent `git init` happening in a new Studio. PR also improves the typing of the existing `--git` to be a string or undefined since it's never parsed as a boolean.

This `--disable-git` flag name follows the convention of the [Next.js CLI](https://nextjs.org/docs/app/api-reference/cli/create-next-app).

### What to review

If we're happy with yet another flag?

### Testing

I didn't but I can?

### Notes for release

Adds a `--disable-git` command to `sanity init` to prevent git initialization in new projects.