### PR TITLE
fix(sanity): poll asset state after linking without failing cors

### DIFF
--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/hooks/useLinkAssets.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/hooks/useLinkAssets.tsx
@@ -1,3 +1,4 @@
+import {type SanityClient} from '@sanity/client'
 import {
   type AssetFromSource,
   type FileSchemaType,
@@ -6,98 +7,33 @@ import {
   isImageSchemaType,
   type SanityDocument,
 } from '@sanity/types'
+import {get} from 'lodash'
 import {useCallback} from 'react'
+import {
+  delay,
+  firstValueFrom,
+  from,
+  map,
+  mergeMap,
+  type OperatorFunction,
+  retry,
+  timer,
+  toArray,
+} from 'rxjs'
 
 import {useClient} from '../../../../hooks'
 import {DEFAULT_API_VERSION} from '../constants'
 import {type AssetSelectionItem} from '../types'
 import {useMediaLibraryId} from './useMediaLibraryId'
 
-interface AssetResponse {
-  documents: SanityDocument[]
-  omitted: any[]
-}
-
-const isAssetReady = (response: AssetResponse): boolean => {
-  const videoAsset = response.documents.find((doc) => doc._type === 'sanity.videoAsset')
-  return videoAsset?.state === 'ready'
-}
-
 export function useLinkAssets({schemaType}: {schemaType?: ImageSchemaType | FileSchemaType}) {
   const libraryId = useMediaLibraryId()
   const client = useClient({apiVersion: DEFAULT_API_VERSION})
-  const mediaLibraryClient = useClient({
-    apiVersion: DEFAULT_API_VERSION,
-  }).withConfig({
-    '~experimental_resource': {
-      type: 'media-library',
-      id: libraryId ?? '',
-    },
-  })
 
-  const ensureAssetIsReady = useCallback(
-    async (assetId: string, assetInstanceId: string, signal?: AbortSignal) => {
-      const MAX_ATTEMPTS = 30 // 5 minutes total with 10 second intervals
-      const POLL_INTERVAL = 10000 // 10 seconds
-
-      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-        try {
-          // Check if we've been aborted
-          if (signal?.aborted) {
-            throw new Error('Asset polling was aborted')
-          }
-
-          const result = await mediaLibraryClient.request<AssetResponse>({
-            method: 'GET',
-            url: `media-libraries/${libraryId}/doc/${assetId},${assetInstanceId}`,
-            withCredentials: true,
-            signal, // Pass the abort signal to the request
-          })
-
-          // Check if the asset is ready
-          if (isAssetReady(result)) {
-            return result.documents
-          }
-
-          // If we haven't reached max attempts, wait before trying again
-          if (attempt < MAX_ATTEMPTS - 1) {
-            await new Promise((resolve, reject) => {
-              const timeoutId = setTimeout(resolve, POLL_INTERVAL)
-              // Clean up timeout if aborted
-              signal?.addEventListener('abort', () => {
-                clearTimeout(timeoutId)
-                reject(new Error('Asset polling was aborted'))
-              })
-            })
-          }
-        } catch (error) {
-          // If aborted, throw immediately
-          if (signal?.aborted) {
-            throw error
-          }
-          // If we haven't reached max attempts, wait before trying again
-          if (attempt < MAX_ATTEMPTS - 1) {
-            await new Promise((resolve, reject) => {
-              const timeoutId = setTimeout(resolve, POLL_INTERVAL)
-              // Clean up timeout if aborted
-              signal?.addEventListener('abort', () => {
-                clearTimeout(timeoutId)
-                reject(new Error('Asset polling was aborted'))
-              })
-            })
-          } else {
-            throw error // Throw the error on the last attempt
-          }
-        }
-      }
-
-      throw new Error('Asset failed to become ready after maximum attempts')
-    },
-    [libraryId, mediaLibraryClient],
-  )
-
-  const handleLinkAssets = useCallback(
-    async (assetSelection: AssetSelectionItem[], signal?: AbortSignal) => {
+  const handleLinkAssets = useCallback<
+    (assetSelection: AssetSelectionItem[]) => Promise<AssetFromSource[]>
+  >(
+    (assetSelection) => {
       if (!libraryId) {
         throw new Error('No libraryId found')
       }
@@ -106,51 +42,86 @@ export function useLinkAssets({schemaType}: {schemaType?: ImageSchemaType | File
       const metadataPropsFromSchema: ImageMetadataType[] | undefined =
         schemaType && isImageSchemaType(schemaType) ? schemaType.options?.metadata : undefined
 
-      const assetsFromSource: AssetFromSource[] = []
+      const assetsFromSource = from(assetSelection).pipe(
+        linkAsset({
+          client,
+          mediaLibraryId: libraryId,
+          metadataPropsFromSchema,
+        }),
+        toArray(),
+      )
 
-      for (const asset of assetSelection) {
-        // Check if we've been aborted
-        if (signal?.aborted) {
-          throw new Error('Asset linking was aborted')
-        }
-
-        if (asset.asset.assetType === 'sanity.videoAsset') {
-          // Ensure video asset is ready before linking
-          await ensureAssetIsReady(asset.asset._id, asset.assetInstanceId, signal)
-        }
-
-        // Link asset from media library to current dataset
-        try {
-          const result = await client.request({
-            method: 'POST',
-            url: `/assets/media-library-link/${client.config().dataset}?${metadataPropsFromSchema?.map((prop) => `meta[]=${prop}`).join('&') || ''}`,
-            withCredentials: true,
-            body: {
-              mediaLibraryId: libraryId,
-              assetInstanceId: asset.assetInstanceId,
-              assetId: asset.asset._id,
-            },
-            tag: 'media-library.link-asset',
-            signal,
-          })
-          const assetDocument: SanityDocument = result.document
-          assetsFromSource.push({
-            kind: 'assetDocumentId',
-            value: assetDocument._id,
-            mediaLibraryProps: {
-              mediaLibraryId: libraryId,
-              assetId: asset.asset._id,
-              assetInstanceId: asset.assetInstanceId,
-            },
-          })
-        } catch (error) {
-          console.error(error)
-          throw error
-        }
-      }
-      return assetsFromSource
+      return firstValueFrom(assetsFromSource, {
+        defaultValue: [],
+      })
     },
-    [client, libraryId, schemaType, ensureAssetIsReady],
+    [client, libraryId, schemaType],
   )
   return {onLinkAssets: handleLinkAssets}
+}
+
+interface AssetLinkingContext {
+  mediaLibraryId: string
+  metadataPropsFromSchema: ImageMetadataType[] | undefined
+  client: SanityClient
+}
+
+interface AssetLinkingResponse {
+  document: SanityDocument
+}
+
+function linkAsset({
+  client,
+  mediaLibraryId,
+  metadataPropsFromSchema,
+}: AssetLinkingContext): OperatorFunction<AssetSelectionItem, AssetFromSource> {
+  const RETRY_DELAY = 2_000
+  const RETRY_LIMIT = 10
+  const LINKING_DELAY = 1_000
+  const LINKING_CONCURRENCY = 5
+
+  return mergeMap((asset) => {
+    return client.observable
+      .request<AssetLinkingResponse>({
+        method: 'POST',
+        url: `/assets/media-library-link/${client.config().dataset}?${metadataPropsFromSchema?.map((prop) => `meta[]=${prop}`).join('&') || ''}`,
+        withCredentials: true,
+        body: {
+          mediaLibraryId,
+          assetInstanceId: asset.assetInstanceId,
+          assetId: asset.asset._id,
+        },
+        tag: 'media-library.link-asset',
+      })
+      .pipe(
+        retry({
+          count: RETRY_LIMIT,
+          delay(error) {
+            if (isAssetUnreadyError(error)) {
+              return timer(RETRY_DELAY)
+            }
+            throw error
+          },
+        }),
+        map<AssetLinkingResponse, AssetFromSource>(({document}) => ({
+          kind: 'assetDocumentId',
+          value: document._id,
+          mediaLibraryProps: {
+            mediaLibraryId,
+            assetId: asset.asset._id,
+            assetInstanceId: asset.assetInstanceId,
+          },
+        })),
+        delay(LINKING_DELAY),
+      )
+  }, LINKING_CONCURRENCY)
+}
+
+function isAssetUnreadyError(maybeError: unknown): boolean {
+  const isUnprocessable = get(maybeError, ['statusCode']) === 422
+
+  const isUnready =
+    get(maybeError, ['response', 'body', 'message']) === 'Media library asset is not ready'
+
+  return isUnprocessable && isUnready
 }


### PR DESCRIPTION
### Description

It is only possible to link a video asset from Media Library to the dataset after it has transitioned to a `"ready"` state. This was previously handled by polling the Media Library HTTP API to get the asset's state. Unfortunately, we later realised Media Library does not support CORS, and therefore is unusable for this purpose.

This branch changes the approach to simply attempt the linking process, retrying after a short delay if the linking failed because the asset isn't ready. Fortunately, this is a state we can identify based on the response to the linking request. The linking request is configured to retry every two seconds, with a maximum of ten retries. If multiple assets have been selected, linking will be executed with a concurrency of five.

Note: in the interest of expediency, I haven't connected the `AbortController`; none of the consumers of the linking function are actually providing one. We should revisit this.

### What to review

- Uploading and selecting Media Library assets.

### Testing

- Uploading and selecting Media Library assets in Test Studio in production deployment.