### PR TITLE
fix: resolving issue where release next would happen when merging rel…

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -10,6 +10,10 @@ permissions:
 
 jobs:
   release-next:
+    # this runs in main, and we want to skip running it when release PRs are merged
+    # format of the commit message is specified in lerna.json
+    if: >
+      !startsWith(github.event.head_commit.message, 'chore(release): publish')
     permissions:
       id-token: write # to enable use of OIDC for npm provenance
     runs-on: ubuntu-latest


### PR DESCRIPTION
…ease latest pr

### Description
Resolves an issue where the release of next would happen due to merging the release latest PR into main. In this case, the increment of the version would be incorrect, and also we don't wish to create a new next tag release in this case (as it has already been created when merging the changes that triggered the `create-release-pr` in.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
