### PR TITLE
chore: adjusting copy for staging revert content release

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -13,7 +13,7 @@ const releasesLocaleStrings = {
   /** Action text for showing the archived releases */
   'action.archived': 'Archived',
   /** Action text for reverting a release by creating a new release */
-  'action.create-revert-release': 'Stage in new release',
+  'action.create-revert-release': 'Create a new release',
   /** Action text for deleting a release */
   'action.delete-release': 'Delete release',
   /** Action text for duplicating a release */
@@ -278,8 +278,7 @@ const releasesLocaleStrings = {
   /** Title for the dialog confirming the revert of a release */
   'revert-dialog.confirm-revert.title': "Are you sure you want to revert the '{{title}}' release?",
   /** Checkbox label to confirm whether to create a staged release for revert or immediately revert */
-  'revert-dialog.confirm-revert.stage-revert-checkbox-label':
-    'Stage revert actions in a new release',
+  'revert-dialog.confirm-revert.stage-revert-checkbox-label': 'Immediately revert the release',
   /** Warning card text for when immediately revert a release with history */
   'revert-dialog.confirm-revert.warning-card':
     'Changes were made to documents in this release after they were published. Reverting will overwrite these changes.',

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/ReleaseRevertButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/ReleaseRevertButton.tsx
@@ -205,13 +205,13 @@ const ConfirmReleaseDialog = ({
       <Flex align="center" paddingTop={4}>
         <Checkbox
           onChange={() => setStageNewRevertRelease((current) => !current)}
-          id="stage-release"
+          id="immediate-revert-release"
           style={{display: 'block'}}
-          checked={stageNewRevertRelease}
+          checked={!stageNewRevertRelease}
         />
         <Box flex={1} paddingLeft={3}>
           <Text muted size={1}>
-            <label htmlFor="stage-release">
+            <label htmlFor="immediate-revert-release">
               {t('revert-dialog.confirm-revert.stage-revert-checkbox-label')}
             </label>
           </Text>


### PR DESCRIPTION
### Description
<img width="362" height="238" alt="Screenshot 2025-07-15 at 14 57 01" src="https://github.com/user-attachments/assets/6b5f5400-8272-4583-b3f2-e410c2220170" />
<img width="353" height="322" alt="Screenshot 2025-07-15 at 14 57 18" src="https://github.com/user-attachments/assets/ae1371fc-93fd-499f-8438-cb766d0b7efe" />
[note: the red warning card in the screenshot has always been there if the history of the document has other translog entries]
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* Does this adjusted copy make more sense that it's current state
* Any suggestions on how to make the staging process clearer for editors?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Improved clarity on the reverting process for content releases
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
