### PR TITLE
fix(sanity): prevent undefined weights occurring in groq2024 search query

### DIFF
--- a/packages/sanity/src/core/search/common/deriveSearchWeightsFromType2024.ts
+++ b/packages/sanity/src/core/search/common/deriveSearchWeightsFromType2024.ts
@@ -124,7 +124,6 @@ function getLeafWeights(
         }
       } else if (t.jsonType === 'array' && !!t.of?.length) {
         for (const arrayItemType of t.of) {
-          // eslint-disable-next-line no-param-reassign
           recursiveResult = traverse(arrayItemType, `${path}[]`, depth + 1, recursiveResult)
         }
       }
@@ -195,7 +194,7 @@ const getPreviewWeights = (
           weight:
             PREVIEW_FIELD_WEIGHT_MAP[
               selectionKeysBySelectionPath[path] as keyof typeof PREVIEW_FIELD_WEIGHT_MAP
-            ],
+            ] ?? 0,
         },
       ]),
   )
@@ -209,7 +208,8 @@ const getPreviewWeights = (
             path,
             type: 'string',
             weight:
-              PREVIEW_FIELD_WEIGHT_MAP[previewFieldName as keyof typeof PREVIEW_FIELD_WEIGHT_MAP],
+              PREVIEW_FIELD_WEIGHT_MAP[previewFieldName as keyof typeof PREVIEW_FIELD_WEIGHT_MAP] ??
+              0,
           },
         ]
       }),

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
@@ -5,34 +5,36 @@ import {describe, expect, it} from 'vitest'
 import {DEFAULT_LIMIT} from '../weighted/createSearchQuery'
 import {createSearchQuery} from './createSearchQuery'
 
-const testType = Schema.compile({
-  types: [
-    defineType({
-      name: 'basic-schema-test',
-      type: 'document',
-      preview: {
-        select: {
-          title: 'title',
-        },
+const schemaTypes = [
+  defineType({
+    name: 'basic-schema-test',
+    type: 'document',
+    preview: {
+      select: {
+        title: 'title',
       },
-      fields: [
-        defineField({
-          name: 'title',
-          type: 'string',
-          options: {
-            search: {
-              weight: 10,
-            },
+    },
+    fields: [
+      defineField({
+        name: 'title',
+        type: 'string',
+        options: {
+          search: {
+            weight: 10,
           },
-        }),
-      ],
-    }),
-  ],
-}).get('basic-schema-test')
+        },
+      }),
+    ],
+  }),
+]
 
 describe('createSearchQuery', () => {
   describe('searchTerms', () => {
     it('should create query for basic type', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
       const {query, params} = createSearchQuery(
         {
           query: 'test',
@@ -58,6 +60,10 @@ describe('createSearchQuery', () => {
 
   describe('searchOptions', () => {
     it('should include drafts by default', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
       const {query, options} = createSearchQuery(
         {
           query: 'term0',
@@ -71,6 +77,10 @@ describe('createSearchQuery', () => {
     })
 
     it('should exclude drafts when configured', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
       const {query, options} = createSearchQuery(
         {
           query: 'term0',
@@ -85,6 +95,10 @@ describe('createSearchQuery', () => {
     })
 
     it('should use `raw` perspective when no perspective provided', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
       const {options} = createSearchQuery(
         {
           query: 'term0',
@@ -97,6 +111,10 @@ describe('createSearchQuery', () => {
     })
 
     it('should use `raw` perspective when empty perspective array provided', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
       const {options} = createSearchQuery(
         {
           query: 'term0',
@@ -110,6 +128,10 @@ describe('createSearchQuery', () => {
     })
 
     it('should use provided limit (plus one to determine existence of next page)', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
       const {params} = createSearchQuery(
         {
           query: 'term0',
@@ -125,6 +147,10 @@ describe('createSearchQuery', () => {
     })
 
     it('should add configured filter and params', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
       const {query, params} = createSearchQuery(
         {
           query: 'term',
@@ -139,6 +165,10 @@ describe('createSearchQuery', () => {
     })
 
     it('should use configured tag', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
       const {options} = createSearchQuery(
         {
           query: 'term',
@@ -152,6 +182,10 @@ describe('createSearchQuery', () => {
     })
 
     it('should use configured sort field and direction', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
       const {query} = createSearchQuery(
         {
           query: 'test',
@@ -177,6 +211,10 @@ describe('createSearchQuery', () => {
     })
 
     it('should use multiple sort fields and directions', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
       const {query} = createSearchQuery(
         {
           query: 'test',
@@ -213,6 +251,10 @@ describe('createSearchQuery', () => {
     })
 
     it('should order results by _score desc if no sort field and direction is configured', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
       const {query} = createSearchQuery(
         {
           query: 'test',
@@ -230,6 +272,10 @@ describe('createSearchQuery', () => {
     })
 
     it('should prepend comments (with new lines) if comments is configured', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
       const {query} = createSearchQuery(
         {
           query: 'test',


### PR DESCRIPTION
### Description

Previously, configuring a preview selection that has no weighting mapped (e.g. `media`) would result in that field being boosted by `undefined` in the resulting GROQ query when performing a search for a cross dataset reference, which is invalid GROQ.

To resolve this issue, the weighting now falls back to `0`, which is ultimately omitted from the resulting GROQ query altogether because it's unnecessary to boost by a neutral value when using the groq2024 strategy.

### What to review

Cross dataset reference search when the target schema has a `media` preview field selected.

### Testing

- Tested in Test Studio.
- Added unit tests.

### Notes for release

- Fixes cross dataset reference search issue affecting the groq2024 search strategy when the target schema type defined a `media` preview.