### PR TITLE
fix(structure): show the values of the deleted documents in the document pane

### DIFF
--- a/packages/sanity/src/structure/components/structureTool/StructureTitle.tsx
+++ b/packages/sanity/src/structure/components/structureTool/StructureTitle.tsx
@@ -31,16 +31,18 @@ const DocumentTitle = (props: {documentId: string; documentType: string}) => {
   const schemaType = schema.get(documentType) as ObjectSchemaType | undefined
 
   const {value, isLoading: previewValueIsLoading} = useValuePreview({
-    enabled: true,
+    enabled: !!documentValue,
     schemaType,
     value: documentValue,
   })
 
-  const documentTitle = isNewDocument
-    ? t('browser-document-title.new-document', {
-        schemaType: schemaType?.title || schemaType?.name,
-      })
-    : value?.title || t('browser-document-title.untitled-document')
+  const documentTitle = documentValue
+    ? isNewDocument
+      ? t('browser-document-title.new-document', {
+          schemaType: schemaType?.title || schemaType?.name,
+        })
+      : value?.title || t('browser-document-title.untitled-document')
+    : ''
 
   const settled = editState.ready && !previewValueIsLoading
   const newTitle = useConstructDocumentTitle(documentTitle)

--- a/packages/sanity/src/structure/hooks/useDocumentLastRev.ts
+++ b/packages/sanity/src/structure/hooks/useDocumentLastRev.ts
@@ -1,0 +1,30 @@
+import {type SanityDocument} from '@sanity/types'
+import {useEffect, useState} from 'react'
+import {useHistoryStore} from 'sanity'
+
+export const useDocumentLastRev = (documentId: string, lastNonDeletedRevId: string | null) => {
+  const historyStore = useHistoryStore()
+  const [lastRevisionDocument, setLastRevisionDocument] = useState<SanityDocument | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (lastNonDeletedRevId && documentId) {
+      setLoading(true)
+      historyStore
+        .getDocumentAtRevision(documentId, lastNonDeletedRevId)
+        .then((document) => {
+          setLastRevisionDocument(document || null)
+          setLoading(false)
+        })
+        .catch(() => {
+          setLastRevisionDocument(null)
+          setLoading(false)
+        })
+    } else {
+      setLastRevisionDocument(null)
+      setLoading(false)
+    }
+  }, [documentId, lastNonDeletedRevId, historyStore])
+
+  return {lastRevisionDocument, loading}
+}

--- a/packages/sanity/src/structure/hooks/useDocumentLastRev.ts
+++ b/packages/sanity/src/structure/hooks/useDocumentLastRev.ts
@@ -1,11 +1,25 @@
 import {type SanityDocument} from '@sanity/types'
 import {useEffect, useState} from 'react'
-import {useHistoryStore} from 'sanity'
+import {useHistoryStore, useTimelineSelector, useTimelineStore} from 'sanity'
 
-export const useDocumentLastRev = (documentId: string, lastNonDeletedRevId: string | null) => {
+export const useDocumentLastRev = (documentId: string, documentType: string) => {
   const historyStore = useHistoryStore()
   const [lastRevisionDocument, setLastRevisionDocument] = useState<SanityDocument | null>(null)
   const [loading, setLoading] = useState(false)
+
+  // Get the timeline store to access lastNonDeletedRevId
+  // needs to be done this way because otherwise the revision id will not be the most updated
+  // in case if you edit the document in between deletes, for example
+  const timelineStore = useTimelineStore({
+    documentId,
+    documentType,
+  })
+
+  // Get the lastNonDeletedRevId from the timeline store
+  const lastNonDeletedRevId = useTimelineSelector(
+    timelineStore,
+    (state) => state.lastNonDeletedRevId,
+  )
 
   useEffect(() => {
     if (lastNonDeletedRevId && documentId) {

--- a/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
@@ -102,4 +102,5 @@ export interface DocumentPaneContextValue {
   revisionId: string | null
   revisionNotFound: boolean
   lastNonDeletedRevId: string | null
+  lastRevisionDocument: SanityDocument | null
 }

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -137,7 +137,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   } = useDocumentPaneInspector({documentId, documentType, params, setParams: setPaneParams})
 
   const [isDeleting, setIsDeleting] = useState(false)
-  const {lastRevisionDocument} = useDocumentLastRev(documentId, lastNonDeletedRevId || '')
+  const {lastRevisionDocument} = useDocumentLastRev(documentId, documentType)
 
   /**
    * Determine if the current document is deleted.

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -506,6 +506,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
         revisionId,
         revisionNotFound,
         lastNonDeletedRevId,
+        lastRevisionDocument,
       }) satisfies DocumentPaneContextValue,
     [
       actions,
@@ -566,6 +567,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       revisionId,
       revisionNotFound,
       lastNonDeletedRevId,
+      lastRevisionDocument,
     ],
   )
 

--- a/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
+++ b/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
@@ -1,4 +1,9 @@
-import {unstable_useValuePreview as useValuePreview, useTranslation} from 'sanity'
+import {useMemo} from 'react'
+import {
+  prepareForPreview,
+  unstable_useValuePreview as useValuePreview,
+  useTranslation,
+} from 'sanity'
 
 import {structureLocaleNamespace} from '../../i18n'
 import {useDocumentPane} from './useDocumentPane'
@@ -23,14 +28,36 @@ export interface UseDocumentTitle {
  * @returns The document title or error. See {@link UseDocumentTitle}
  */
 export function useDocumentTitle(): UseDocumentTitle {
-  const {connectionState, schemaType, editState} = useDocumentPane()
+  const {connectionState, schemaType, editState, isDeleted, lastRevisionDocument} =
+    useDocumentPane()
   const {t} = useTranslation(structureLocaleNamespace)
   // follows the same logic as the StructureTitle component
-  const documentValue = editState?.version || editState?.draft || editState?.published
+  const documentValue = useMemo(() => {
+    return isDeleted
+      ? lastRevisionDocument
+      : editState?.version || editState?.draft || editState?.published
+  }, [isDeleted, lastRevisionDocument, editState])
   const subscribed = Boolean(documentValue)
 
+  // For deleted documents, we need to handle the preview differently since useValuePreview
+  // will return null for deleted documents. Instead, we directly prepare the preview
+  // from the lastRevisionDocument data.
+  const deletedDocumentPreview = useMemo(() => {
+    if (isDeleted && lastRevisionDocument && schemaType) {
+      try {
+        const prepared = prepareForPreview(lastRevisionDocument, schemaType)
+        return prepared
+      } catch (error) {
+        console.warn('Failed to prepare preview for deleted document:', error)
+        return null
+      }
+    }
+    return null
+  }, [isDeleted, lastRevisionDocument, schemaType])
+
   const {error, value} = useValuePreview({
-    enabled: subscribed,
+    // disable useValuePreview for deleted documents
+    enabled: subscribed && !isDeleted,
     schemaType,
     value: documentValue,
   })
@@ -39,7 +66,12 @@ export function useDocumentTitle(): UseDocumentTitle {
     return {error: undefined, title: undefined}
   }
 
-  if (!value) {
+  // For deleted documents, use the directly prepared preview
+  if (isDeleted && deletedDocumentPreview) {
+    return {error: undefined, title: deletedDocumentPreview.title}
+  }
+
+  if (!value && !isDeleted) {
     return {
       error: undefined,
       title: t('panes.document-header-title.new.text', {

--- a/test/e2e/tests/document-actions/delete.spec.ts
+++ b/test/e2e/tests/document-actions/delete.spec.ts
@@ -39,3 +39,38 @@ test(`published documents can be deleted`, async ({page, createDraftDocument}) =
 
   await expect(page.getByText('The document was successfully deleted')).toBeVisible()
 })
+
+test(`deleted document shows the right name from last revision`, async ({
+  page,
+  createDraftDocument,
+}) => {
+  test.slow()
+  const documentName = 'John Doe'
+
+  await createDraftDocument('/content/author')
+  await page.getByTestId('field-name').getByTestId('string-input').fill(documentName)
+
+  // Save the current URL before deletion
+  const documentUrl = page.url()
+
+  // Verify the name is displayed correctly before deletion
+  await expect(page.getByTestId('field-name').getByTestId('string-input')).toHaveValue(documentName)
+
+  // Delete the document
+  await page.getByTestId('action-menu-button').click()
+  await page.getByTestId('action-Delete').click()
+  await page.getByRole('button', {name: 'Delete now'}).click()
+
+  // Wait for deletion to complete
+  await expect(page.getByText('The document was successfully deleted')).toBeVisible()
+
+  // Navigate back to the original document URL once it's deleted since it navigates back to the initial structure
+  await page.goto(documentUrl)
+
+  // Verify that the form still shows the correct name from the last revision
+  // The form should display the last revision document content
+  await expect(page.getByTestId('field-name').getByTestId('string-input')).toHaveValue(documentName)
+
+  // Verify the document title in the header also shows the correct name
+  await expect(page.getByTestId('document-panel-document-title')).toHaveText(documentName)
+})


### PR DESCRIPTION
### Description

When going to a deleted URL link, still show the preview for the document + shows the right title in the document
This also makes updates to the tab title (removes it since as far as I know I can't find a way of displaying that document without the document pane context in a easy manner)

new behaviour
https://github.com/user-attachments/assets/57e1543c-0e6d-4593-9c12-a9c4f3418a7d

### What to review

Is there a better way of doing this?

### Testing

Added automated tests

### Notes for release

Fixes issue where if you navigated to a deleted document the document pane wouldn't show you a preview of the values
