### PR TITLE
feat: swapping to use baseId for createVersion server actions

### DIFF
--- a/packages/sanity/src/core/releases/hooks/__tests__/useVersionOperations.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useVersionOperations.test.tsx
@@ -35,7 +35,6 @@ describe('useVersionOperations', () => {
     expect(useReleaseOperationsMockReturn.createVersion).toHaveBeenCalledWith(
       'releaseId',
       'documentId',
-      undefined,
     )
     expect(mockedUseSetPerspective).toHaveBeenCalledWith('releaseId')
   })

--- a/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
+++ b/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
@@ -8,11 +8,7 @@ import {AddedVersion} from '../__telemetry__/releases.telemetry'
 import {useReleaseOperations} from '../store/useReleaseOperations'
 
 export interface VersionOperationsValue {
-  createVersion: (
-    releaseId: ReleaseId,
-    documentId: string,
-    initialValue?: Record<string, unknown>,
-  ) => Promise<void>
+  createVersion: (releaseId: ReleaseId, documentId: string) => Promise<void>
   discardVersion: (releaseId: string, documentId: string) => Promise<SingleActionResult>
   unpublishVersion: (documentId: string) => Promise<SingleActionResult>
   revertUnpublishVersion: (documentId: string) => Promise<SingleActionResult>
@@ -26,13 +22,9 @@ export function useVersionOperations(): VersionOperationsValue {
 
   const setPerspective = useSetPerspective()
 
-  const handleCreateVersion = async (
-    releaseId: ReleaseId,
-    documentId: string,
-    initialValue?: Record<string, unknown>,
-  ) => {
+  const handleCreateVersion = async (releaseId: ReleaseId, documentId: string) => {
     const origin = getDocumentVariantType(documentId)
-    await createVersion(releaseId, documentId, initialValue)
+    await createVersion(releaseId, documentId)
     setPerspective(releaseId)
     telemetry.log(AddedVersion, {
       documentOrigin: origin,

--- a/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
@@ -272,15 +272,12 @@ describe('createReleaseOperationsStore', () => {
 
   it('should create a version of a document', async () => {
     const store = createStore()
-    mockClient.getDocument.mockResolvedValue({_id: 'doc-id', data: 'example'})
-    await store.createVersion('release-id', 'doc-id', {newData: 'value'})
+    mockClient.getDocument.mockResolvedValue({_id: 'doc-id', _rev: 'doc-rev-id', data: 'example'})
+    await store.createVersion('release-id', 'doc-id')
     expect(mockClient.createVersion).toHaveBeenCalledWith(
       {
-        document: {
-          _id: `versions.release-id.doc-id`,
-          data: 'example',
-          newData: 'value',
-        },
+        baseId: 'doc-id',
+        ifBaseRevisionId: 'doc-rev-id',
         publishedId: 'doc-id',
         releaseId: 'release-id',
       },
@@ -293,6 +290,7 @@ describe('createReleaseOperationsStore', () => {
 
     mockClient.getDocument.mockResolvedValue({
       _id: 'doc-id',
+      _rev: 'doc-rev-id',
       artist: {
         _ref: 'some-artist-id',
         _strengthenOnPublish: {
@@ -377,82 +375,8 @@ describe('createReleaseOperationsStore', () => {
 
     expect(mockClient.createVersion).toHaveBeenCalledWith(
       {
-        document: {
-          _id: `versions.release-id.doc-id`,
-          artist: {
-            _ref: 'some-artist-id',
-            _strengthenOnPublish: {
-              template: {
-                id: 'artist',
-              },
-              type: 'artist',
-            },
-            _type: 'reference',
-          },
-          expectedWeakReference: {
-            _ref: 'expected-weak-reference',
-            _type: 'reference',
-            _weak: true,
-            _strengthenOnPublish: {
-              template: {
-                id: 'some-document',
-              },
-              type: 'some-document',
-              weak: true,
-            },
-          },
-          plants: [
-            {
-              _ref: 'some-plant-id',
-              _strengthenOnPublish: {
-                template: {
-                  id: 'plant',
-                },
-                type: 'plant',
-              },
-              _type: 'reference',
-            },
-            {
-              _ref: 'some-plant-id',
-              _strengthenOnPublish: {
-                template: {
-                  id: 'plant',
-                },
-                type: 'plant',
-              },
-              _type: 'reference',
-            },
-          ],
-          stores: [
-            {
-              name: 'some-store',
-              inventory: {
-                products: [
-                  {
-                    _ref: 'some-product-id',
-                    _strengthenOnPublish: {
-                      template: {
-                        id: 'product',
-                      },
-                      type: 'product',
-                    },
-                    _type: 'reference',
-                  },
-                  {
-                    _ref: 'some-product-id',
-                    _strengthenOnPublish: {
-                      template: {
-                        id: 'product',
-                      },
-                      type: 'product',
-                    },
-                    _type: 'reference',
-                  },
-                ],
-              },
-            },
-          ],
-        },
+        baseId: 'doc-id',
+        ifBaseRevisionId: 'doc-rev-id',
         publishedId: 'doc-id',
         releaseId: 'release-id',
       },

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -227,7 +227,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
         <DocumentNotInReleaseBanner
           documentId={value._id}
           currentRelease={selectedPerspective as ReleaseDocument}
-          value={displayed || undefined}
           isScheduledRelease={isScheduledRelease}
         />
       )

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DocumentNotInReleaseBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DocumentNotInReleaseBanner.tsx
@@ -26,12 +26,10 @@ type VersionCreateState = {
 export function DocumentNotInReleaseBanner({
   documentId,
   currentRelease,
-  value,
   isScheduledRelease,
 }: {
   documentId: string
   currentRelease: ReleaseDocument
-  value?: Record<string, unknown>
   isScheduledRelease?: boolean
 }): React.JSX.Element {
   const tone = getReleaseTone(currentRelease ?? LATEST)
@@ -46,11 +44,7 @@ export function DocumentNotInReleaseBanner({
     if (currentRelease._id) {
       setVersionCreateState({status: 'creating', lastUpdate: new Date()})
       try {
-        await createVersion(
-          getReleaseIdFromReleaseDocumentId(currentRelease._id),
-          documentId,
-          value,
-        )
+        await createVersion(getReleaseIdFromReleaseDocumentId(currentRelease._id), documentId)
         setVersionCreateState({status: 'created', lastUpdate: new Date()})
       } catch (err) {
         toast.push({
@@ -66,7 +60,7 @@ export function DocumentNotInReleaseBanner({
         setVersionCreateState(undefined)
       }
     }
-  }, [createVersion, currentRelease._id, documentId, t, toast, value])
+  }, [createVersion, currentRelease._id, documentId, t, toast])
 
   const now = useCurrentTime(200)
 


### PR DESCRIPTION
### Description
With the new version of sanity/client (7.8.0) it's now possible to pass a `baseId` to the `version.create` action rather than a `document`. This is the preferred approach as content lake will then find and create a new version of the provided `baseId`
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
(not sure if this is necessary for release notes, but added if it is):

Creating new versions of documents provides a `baseId` in the action call
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
