### PR TITLE
feat(typegen): add support for vue

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInPath.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInPath.test.ts
@@ -57,6 +57,19 @@ describe('findQueriesInPath', () => {
     assert(res[0].type === 'queries') // workaround for TS
     expect(res[0].queries.length).toBe(1)
   })
+  test('can find and handle .vue files', async () => {
+    const stream = findQueriesInPath({
+      path: [path.join('**', 'typescript', '__tests__', 'fixtures', '*.vue')],
+    })
+    const res = []
+    for await (const result of stream) {
+      res.push(result)
+    }
+    expect(res.length).toBe(1)
+    expect(res[0].type).toBe('queries')
+    assert(res[0].type === 'queries') // workaround for TS
+    expect(res[0].queries.length).toBe(1)
+  })
 
   // This test is skipped by default because it's very slow, but it's useful to have it around for testing deterministic behavior
   suite.concurrent.skip(

--- a/packages/@sanity/codegen/src/typescript/__tests__/fixtures/import.vue
+++ b/packages/@sanity/codegen/src/typescript/__tests__/fixtures/import.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import groq from 'groq'
+const query = groq`*[_type == "myType"]`
+</script>
+
+<template>
+  <MyComponent>
+    <div>{{ query }}</div>
+  </MyComponent>
+</template>

--- a/packages/@sanity/codegen/src/typescript/__tests__/parseSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/parseSource.test.ts
@@ -28,4 +28,23 @@ export const prerender = true
     expect(parsed.type).toBe('File')
     expect(parsed.program.body.length).toBe(5)
   })
+  test('should parse vue', () => {
+    const source = `
+<script setup lang="ts">
+import groq from 'groq'
+const query = groq('*[_type == "myType"]')
+</script>
+
+<template>
+  <MyComponent>
+    <div>{{ query }}</div>
+  </MyComponent>
+</template>
+    `
+
+    const parsed = parseSourceFile(source, 'foo.vue', {})
+
+    expect(parsed.type).toBe('File')
+    expect(parsed.program.body.length).toBe(2)
+  })
 })

--- a/packages/@sanity/codegen/src/typescript/parseSource.ts
+++ b/packages/@sanity/codegen/src/typescript/parseSource.ts
@@ -13,6 +13,10 @@ export function parseSourceFile(
     // append .ts to the filename so babel will parse it as typescript
     filename += '.ts'
     source = parseAstro(source)
+  } else if (filename.endsWith('.vue')) {
+    // append .ts to the filename so babel will parse it as typescript
+    filename += '.ts'
+    source = parseVue(source)
   }
   const result = parse(source, {
     ...babelOptions,
@@ -38,4 +42,30 @@ function parseAstro(source: string): string {
       return codeFence.split('\n').slice(1, -1).join('\n')
     })
     .join('\n')
+}
+
+function parseVue(source: string): string {
+  // find all script tags, the js code is between <script> and </script>
+  // const matches = [...source.matchAll(/<script[^>]*>([\s\S]*?)<\/script>/g)]
+  // TODO: swap once this code runs in `ES2020`
+  const matches = matchAllPolyfill(source, /<script[^>]*>([\s\S]*?)<\/script>/g)
+  if (!matches.length) {
+    return ''
+  }
+
+  return matches.map((match) => match[1]).join('\n')
+}
+
+// TODO: remove once this code runs in `ES2020`
+function matchAllPolyfill(str: string, regex: RegExp): RegExpMatchArray[] {
+  if (!regex.global) {
+    throw new Error('matchAll polyfill requires a global regex (with /g flag)')
+  }
+
+  const matches = []
+  let match
+  while ((match = regex.exec(str)) !== null) {
+    matches.push(match)
+  }
+  return matches
 }


### PR DESCRIPTION
### Description

This PR adds support for `.vue` files when parsing source for typegen. It uses the same approach introduced in #8098 for `.astro`.

I also added a `matchAllPolyfill` that should be remove once `codegen` runs in ES2020. VScode was complaining about the use of `.matchAll` so I commented it out and left it for you to handle in the future once it is safe to use. Maybe it already is now that v4 required node v20?

### What to review

Check tests are properly written and passing. Consider updating `tsconfig` to support `ES2020` if appropiate and then remove `matchAllPolyfill` and the line using it. Uncomment the previous line using `.matchAll`.

Let me know if you want me to make these changes myself.

### Testing

I added tests both for `parseSource` and `findQueriesInPath` next to the Astro ones. Both should be passing.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
