### PR TITLE
feat(sanity): adopt stable GROQ API for `groq2024` search strategy

### DIFF
--- a/packages/sanity/src/core/search/groq2024/createGroq2024Search.ts
+++ b/packages/sanity/src/core/search/groq2024/createGroq2024Search.ts
@@ -47,31 +47,23 @@ export const createGroq2024Search: SearchStrategyFactory<Groq2024SearchResults> 
       mergedOptions,
     )
 
-    return client.observable
-      .withConfig({
-        // The GROQ functions that power `groq2024` are currently only available using API `vX`.
-        // TODO: Switch to stable API version before `groq2024` general availability.
-        // TODO: When moving to stable API version, consider that the version should work with releases.
-        apiVersion: 'vX',
-      })
-      .fetch<SanityDocumentLike[]>(query, params, options)
-      .pipe(
-        map((hits) => {
-          const hasNextPage =
-            typeof searchOptions.limit !== 'undefined' && hits.length > searchOptions.limit
+    return client.observable.fetch<SanityDocumentLike[]>(query, params, options).pipe(
+      map((hits) => {
+        const hasNextPage =
+          typeof searchOptions.limit !== 'undefined' && hits.length > searchOptions.limit
 
+        // Search overfetches by 1 to determine whether there is another page to fetch. Therefore,
+        // the penultimate result must be used to determine the start of the next page.
+        const lastResult = hasNextPage ? hits.at(-2) : hits.at(-1)
+
+        return {
+          type: 'groq2024',
           // Search overfetches by 1 to determine whether there is another page to fetch. Therefore,
-          // the penultimate result must be used to determine the start of the next page.
-          const lastResult = hasNextPage ? hits.at(-2) : hits.at(-1)
-
-          return {
-            type: 'groq2024',
-            // Search overfetches by 1 to determine whether there is another page to fetch. Therefore,
-            // exclude the final result if it's beyond the limit.
-            hits: hits.map((hit) => ({hit})).slice(0, searchOptions.limit),
-            nextCursor: hasNextPage ? getNextCursor({lastResult, sortOrder}) : undefined,
-          }
-        }),
-      )
+          // exclude the final result if it's beyond the limit.
+          hits: hits.map((hit) => ({hit})).slice(0, searchOptions.limit),
+          nextCursor: hasNextPage ? getNextCursor({lastResult, sortOrder}) : undefined,
+        }
+      }),
+    )
   }
 }


### PR DESCRIPTION
### Description

It's no longer necessary to use the experimental GROQ API when using the `groq2024` search strategy is switched on, as the required functionality has now been rolled out to all stable GROQ API versions.

### What to review

Searching with the `groq2024` strategy.

### Testing

Tested in Test Studio, and verified existing tests pass.

### Notes for release

The `groq2024` search strategy no longer uses the experimental GROQ API.