### PR TITLE
chore: latest release detects next

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -7,7 +7,6 @@ on:
       - completed
     branches:
       - main
-      - chore/latest-release-detects-next # For testing workflow integration
 
 permissions:
   contents: read
@@ -18,7 +17,7 @@ jobs:
     # Skip if the triggering commit was a release commit
     if: >
       github.event.workflow_run.conclusion != 'cancelled' &&
-      (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.head_branch == 'chore/latest-release-detects-next') &&
+      github.event.workflow_run.head_branch == 'main' &&
       !startsWith(github.event.workflow_run.head_commit.message, 'chore(release): publish')
     runs-on: ubuntu-latest
     permissions:
@@ -65,13 +64,13 @@ jobs:
           echo "workflow_url=$WORKFLOW_URL" >> $GITHUB_OUTPUT
 
           if [ "$WORKFLOW_CONCLUSION" = "success" ]; then
-            echo "✅ Release @next workflow succeeded"
+            echo "Release @next workflow succeeded"
             echo "release_failed=false" >> $GITHUB_OUTPUT
-            echo "status_message=✅ Release @next build succeeded for commit $COMMIT_SHA" >> $GITHUB_OUTPUT
+            echo "status_message=Release @next build succeeded for commit $COMMIT_SHA" >> $GITHUB_OUTPUT
           else
-            echo "❌ Release @next workflow failed with conclusion: $WORKFLOW_CONCLUSION"
+            echo "Release @next workflow failed with conclusion: $WORKFLOW_CONCLUSION"
             echo "release_failed=true" >> $GITHUB_OUTPUT
-            echo "status_message=❌ Release @next build failed with conclusion: $WORKFLOW_CONCLUSION for commit $COMMIT_SHA" >> $GITHUB_OUTPUT
+            echo "status_message=Release @next build failed with conclusion: $WORKFLOW_CONCLUSION for commit $COMMIT_SHA" >> $GITHUB_OUTPUT
           fi
 
       - name: Install deps & build
@@ -108,10 +107,7 @@ jobs:
         id: version-commit
         run: |
           VERSION=$(cat lerna.json | jq -r .version)
-          # echo "message=chore(release): publish v$VERSION" >> $GITHUB_OUTPUT
-
-          # For testing workflow integration
-          echo "message=chore(release): I LIKE TO SQUIB SQUOB v$VERSION" >> $GITHUB_OUTPUT
+          echo "message=chore(release): publish v$VERSION" >> $GITHUB_OUTPUT
 
       - name: Get version
         id: release-as
@@ -125,8 +121,6 @@ jobs:
           body: |
             🤖 I have created a release **squib** **squob**
 
-            ${{ github.event.workflow_run.head_branch != 'main' && '🧪 **TESTING MODE** - This PR was created from a feature branch to test the workflow integration.' || '' }}
-
             Merging this PR will publish v${{steps.release-as.outputs.version}} to npm 🚀
 
             ## Release @next Status
@@ -137,8 +131,8 @@ jobs:
 
             ${{ steps.check-release-next.outputs.release_failed == 'true' && '**This PR has been marked as draft due to the failed @next release.**' || '' }}
           commit-message: "${{steps.version-commit.outputs.message}}"
-          branch: ${{ github.event.workflow_run.head_branch == 'main' && 'ci/release-main' || 'ci/release-test' }}
+          branch: "ci/release-main"
           sign-commits: true
-          base: ${{ github.event.workflow_run.head_branch }}
+          base: main
           team-reviewers: "@sanity-io/studio"
           draft: ${{ steps.check-release-next.outputs.release_failed == 'true' }}

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - chore/latest-release-detects-next # For testing workflow integration
 
 permissions:
   contents: read # for checkout
@@ -71,13 +70,11 @@ jobs:
         run: pnpm build --output-logs=full --log-order=grouped
 
       - name: Set publishing config
-        if: github.ref == 'refs/heads/main'
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_PUBLISH_TOKEN}"
         env:
           NPM_PUBLISH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
 
       - name: Check valid token
-        if: github.ref == 'refs/heads/main'
         run: |
           WHOAMI_RESULT=$(npm whoami)
           echo "npm whoami result: $WHOAMI_RESULT"
@@ -88,7 +85,6 @@ jobs:
           echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"
 
       - name: Publish packages to npm
-        if: github.ref == 'refs/heads/main'
         run: pnpm -r publish --tag next --no-git-checks
         env:
           NPM_CONFIG_PROVENANCE: true
@@ -97,7 +93,6 @@ jobs:
         run: pnpm run build:bundle
 
       - name: Upload bundles to staging bucket
-        if: github.ref == 'refs/heads/main'
         env:
           GOOGLE_PROJECT_ID: ${{ secrets.GCS_STAGING_PROJECT_ID }}
           GCLOUD_SERVICE_KEY: ${{ secrets.GCS_STAGING_SERVICE_KEY }}


### PR DESCRIPTION
### Description
This addresses issues where our next release/build would fail, but we would not be aware when running the latest release. As such we would release a potentially broken release.

This change now moved the creation of the latest release PR to be triggered by the `release-next` workflow.

If `release-next` fails, then the created latest release PR will add a clear description that the next release failed. This is a first step implementation. Once this flow is verified as working well then we can change to blocking the merge of the latest release PR.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
