### PR TITLE
chore: enable auto merge on chore prs

### DIFF
--- a/.github/workflows/generate-dts-tests-if-needed.yml
+++ b/.github/workflows/generate-dts-tests-if-needed.yml
@@ -39,6 +39,7 @@ jobs:
           app-id: ${{ secrets.ECOSPARK_APP_ID }}
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
+        id: create-pull-request
         with:
           body: "I ran `pnpm generate:dts-exports` 🧑‍💻. If you need to investigate where new imports are coming from run `TEST_DTS_EXPORTS_DIAGNOSTICS=full pnpm generate:dts-exports` 💡"
           branch: actions/generate-dts-tests-if-needed
@@ -47,3 +48,8 @@ jobs:
           sign-commits: true
           title: "chore(tests): generate dts tests 🤖 ✨"
           token: ${{ steps.app-token.outputs.token }}
+
+      - name: Enable automerge on Pull Request
+        run: gh pr merge --squash --auto "${{ steps.create-pull-request.outputs.pull-request-number }}"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/lint-fix-if-needed.yml
+++ b/.github/workflows/lint-fix-if-needed.yml
@@ -1,4 +1,3 @@
----
 name: Prettier & Lint --fix
 
 on:
@@ -47,6 +46,7 @@ jobs:
       - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         # Run even if `lint:fix` fails
         if: always()
+        id: create-pull-request
         with:
           body: "I ran `pnpm lint:fix` 🧑‍💻"
           branch: actions/lint-fix-if-needed
@@ -55,3 +55,8 @@ jobs:
           sign-commits: true
           title: "chore(lint): fix linter issues 🤖 ✨"
           token: ${{ steps.app-token.outputs.token }}
+
+      - name: Enable automerge on Pull Request
+        run: gh pr merge --squash --auto "${{ steps.create-pull-request.outputs.pull-request-number }}"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/pnpm-if-needed.yml
+++ b/.github/workflows/pnpm-if-needed.yml
@@ -1,4 +1,3 @@
----
 name: Dedupe lockfile
 
 on:
@@ -39,6 +38,7 @@ jobs:
           app-id: ${{ secrets.ECOSPARK_APP_ID }}
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
+        id: create-pull-request
         with:
           body: I ran `pnpm dedupe` 🧑‍💻
           branch: actions/dedupe-if-needed
@@ -47,3 +47,8 @@ jobs:
           sign-commits: true
           title: "chore(deps): dedupe pnpm-lock.yaml"
           token: ${{ steps.app-token.outputs.token }}
+
+      - name: Enable automerge on Pull Request
+        run: gh pr merge --squash --auto "${{ steps.create-pull-request.outputs.pull-request-number }}"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/react-compiler.yml
+++ b/.github/workflows/react-compiler.yml
@@ -38,6 +38,7 @@ jobs:
           fi
       - if: steps.check-changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
+        id: create-pull-request
         with:
           body: I ran `pnpm -r up react-compiler-runtime@rc babel-plugin-react-compiler@rc eslint-plugin-react-compiler@rc` 🧑‍💻
           branch: actions/react-compiler
@@ -46,3 +47,8 @@ jobs:
           sign-commits: true
           title: "fix(deps): update React Compiler dependencies 🤖 ✨"
           token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Enable automerge on Pull Request
+        run: gh pr merge --squash --auto "${{ steps.create-pull-request.outputs.pull-request-number }}"
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### Description

We have auto merge enabled for renovatebot prs, but not for these chore prs. This leads to us often forgetting to merge them after they've been approved. Enabling auto merge doesn't override the review rules, a human has to approve the PR for it to actually merge.

### What to review

Makes sense?

### Testing

Can't really test it before merging 😅 

### Notes for release

N/A
