### PR TITLE
chore: remove `@sanity/sdk` dts check exception

### DIFF
--- a/packages/@repo/test-dts-exports/test/lib-check.test.ts
+++ b/packages/@repo/test-dts-exports/test/lib-check.test.ts
@@ -75,11 +75,6 @@ const filteredErrors = errors.filter((d) => {
     return false
   }
 
-  // Handled in https://github.com/sanity-io/sanity/pull/9984
-  if (file.fileName.includes('node_modules/@sanity/sdk/') && code === 2307) {
-    return false
-  }
-
   // Handled in https://github.com/sanity-io/sanity/pull/9986
   if (
     (file.fileName.includes('packages/sanity/lib/_singletons.') ||


### PR DESCRIPTION
### Description

TypeScript reports reported these errors from `@sanity/sdk` when setting `skipLibCheck: false`:
```bash
node_modules/.pnpm/@sanity+sdk@2.1.0_@types+react@19.1.8_debug@4.4.1_immer@10.1.1_react@18.3.1_use-sync-external-store@1.5.0_react@18.3.1_/node_modules/@sanity/sdk/dist/index.d.ts:1:50 - error TS2307: Cannot find module './authStore' or its corresponding type declarations.

1 import {AuthStoreState as AuthStoreState_2} from './authStore'
                                                   ~~~~~~~~~~~~~

node_modules/.pnpm/@sanity+sdk@2.1.0_@types+react@19.1.8_debug@4.4.1_immer@10.1.1_react@18.3.1_use-sync-external-store@1.5.0_react@18.3.1_/node_modules/@sanity/sdk/dist/index.d.ts:2:32 - error TS2307: Cannot find module '../store/createActionBinder' or its corresponding type declarations.

2 import {BoundStoreAction} from '../store/createActionBinder'
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/.pnpm/@sanity+sdk@2.1.0_@types+react@19.1.8_debug@4.4.1_immer@10.1.1_react@18.3.1_use-sync-external-store@1.5.0_react@18.3.1_/node_modules/@sanity/sdk/dist/index.d.ts:3:54 - error TS2307: Cannot find module '../../store/createActionBinder' or its corresponding type declarations.

3 import {BoundStoreAction as BoundStoreAction_2} from '../../store/createActionBinder'
                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/.pnpm/@sanity+sdk@2.1.0_@types+react@19.1.8_debug@4.4.1_immer@10.1.1_react@18.3.1_use-sync-external-store@1.5.0_react@18.3.1_/node_modules/@sanity/sdk/dist/index.d.ts:12:72 - error TS2307: Cannot find module './permissions' or its corresponding type declarations.

12 import {DocumentPermissionsResult as DocumentPermissionsResult_2} from './permissions'
                                                                          ~~~~~~~~~~~~~~~

node_modules/.pnpm/@sanity+sdk@2.1.0_@types+react@19.1.8_debug@4.4.1_immer@10.1.1_react@18.3.1_use-sync-external-store@1.5.0_react@18.3.1_/node_modules/@sanity/sdk/dist/index.d.ts:13:56 - error TS2307: Cannot find module '../_exports' or its corresponding type declarations.

13 import {FetcherStoreState as FetcherStoreState_2} from '../_exports'
                                                          ~~~~~~~~~~~~~

node_modules/.pnpm/@sanity+sdk@2.1.0_@types+react@19.1.8_debug@4.4.1_immer@10.1.1_react@18.3.1_use-sync-external-store@1.5.0_react@18.3.1_/node_modules/@sanity/sdk/dist/index.d.ts:27:56 - error TS2307: Cannot find module './previewStore' or its corresponding type declarations.

27 import {PreviewStoreState as PreviewStoreState_2} from './previewStore'
                                                          ~~~~~~~~~~~~~~~~

node_modules/.pnpm/@sanity+sdk@2.1.0_@types+react@19.1.8_debug@4.4.1_immer@10.1.1_react@18.3.1_use-sync-external-store@1.5.0_react@18.3.1_/node_modules/@sanity/sdk/dist/index.d.ts:38:42 - error TS2307: Cannot find module './types' or its corresponding type declarations.

38 import {SanityUser as SanityUser_2} from './types'
                                            ~~~~~~~~~

node_modules/.pnpm/@sanity+sdk@2.1.0_@types+react@19.1.8_debug@4.4.1_immer@10.1.1_react@18.3.1_use-sync-external-store@1.5.0_react@18.3.1_/node_modules/@sanity/sdk/dist/index.d.ts:41:44 - error TS2307: Cannot find module '../_exports' or its corresponding type declarations.

41 import {StateSource as StateSource_2} from '../_exports'
                                              ~~~~~~~~~~~~~

node_modules/.pnpm/@sanity+sdk@2.1.0_@types+react@19.1.8_debug@4.4.1_immer@10.1.1_react@18.3.1_use-sync-external-store@1.5.0_react@18.3.1_/node_modules/@sanity/sdk/dist/index.d.ts:42:44 - error TS2307: Cannot find module '../../_exports' or its corresponding type declarations.

42 import {StateSource as StateSource_3} from '../../_exports'
                                              ~~~~~~~~~~~~~~~~

node_modules/.pnpm/@sanity+sdk@2.1.0_@types+react@19.1.8_debug@4.4.1_immer@10.1.1_react@18.3.1_use-sync-external-store@1.5.0_react@18.3.1_/node_modules/@sanity/sdk/dist/index.d.ts:47:46 - error TS2307: Cannot find module './previewStore' or its corresponding type declarations.

47 import {ValuePending as ValuePending_2} from './previewStore'
```

It was fixed in `@sanity/sdk` in https://github.com/sanity-io/sdk/pull/582, shipped in `2.1.1`, allowing us to remove this excemption.

### What to review

Makes sense?

### Testing

If the dts test pass we good.

### Notes for release

N/A