### PR TITLE
chore: add GitHub Actions workflow for stable release

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -50,8 +50,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -104,8 +102,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1,0 +1,109 @@
+name: Release @stable
+
+on:
+  push:
+    branches:
+      - chore/stable-deployment-staging
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Semver version to tag as stable (e.g., 3.2.1 or 3.2.1-next.1.abc)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  release-stable:
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      EXPECTED_NPM_USER: sanity-io
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: lts/*
+
+      - name: Get version input
+        id: get-version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            version="${{ github.event.inputs.version }}"
+            echo "Using manual input version: $version"
+          else
+            # For push events, use hardcoded version
+            version="3.94.0"
+            echo "Using hardcoded version for push event: $version"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Validate semver version
+        run: |
+          version="${{ steps.get-version.outputs.version }}"
+          echo "Validating version: $version"
+
+          # Validate semver format (basic check for X.Y.Z or X.Y.Z-prerelease)
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9\.-]+)?$ ]]; then
+            echo "Error: Invalid semver format: $version"
+            echo "Expected format: X.Y.Z or X.Y.Z-prerelease (e.g., 3.2.1 or 3.2.1-next.1.abc)"
+            exit 1
+          fi
+
+          echo "✅ Version validation passed: $version"
+
+      - name: Install deps
+        run: pnpm install --ignore-scripts
+
+      - name: Set publishing config
+        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_PUBLISH_TOKEN}"
+        env:
+          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+      - name: Check valid token
+        run: |
+          WHOAMI_RESULT=$(npm whoami)
+          echo "npm whoami result: $WHOAMI_RESULT"
+          if [ "$WHOAMI_RESULT" != "$EXPECTED_NPM_USER" ]; then
+            echo "Error: npm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
+            exit 1
+          fi
+          echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"
+
+      - name: Update npm dist-tags to stable
+        run: |
+          # Get all published (non-private) packages in the workspace
+          packages=$(pnpx tsx scripts/listPublishedPackages.ts)
+          version="${{ steps.get-version.outputs.version }}"
+
+          echo "Tagging the following packages as stable: $packages"
+
+          # Convert relative paths to package names and apply dist-tag
+          for pkg_dir in $packages; do
+            pkg_name=$(jq -r '.name' "$pkg_dir/package.json")
+            echo "Tagging $pkg_name@$version as stable"
+            npm dist-tag add "$pkg_name@$version" stable
+          done
+
+          echo "✅ All packages tagged as stable"
+
+      - name: Update manifest with stable tag (staging)
+        env:
+          GOOGLE_PROJECT_ID: ${{ secrets.GCS_STAGING_PROJECT_ID }}
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCS_STAGING_SERVICE_KEY }}
+          GCLOUD_BUCKET: ${{ secrets.GCS_STAGING_BUCKET }}
+        run: pnpm bundle-manager tag --tag=stable --target-version=${{ steps.get-version.outputs.version }}
+
+      # - name: Update manifest with stable tag (production)
+      #   env:
+      #     GOOGLE_PROJECT_ID: ${{ secrets.GCS_PRODUCTION_PROJECT_ID }}
+      #     GCLOUD_SERVICE_KEY: ${{ secrets.GCS_PRODUCTION_SERVICE_KEY }}
+      #     GCLOUD_BUCKET: ${{ secrets.GCS_PRODUCTION_BUCKET }}
+      #   run: pnpm bundle-manager tag --tag=stable --target-version=${{ steps.get-version.outputs.version }}

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -29,7 +29,7 @@ jobs:
             echo "Using manual input version: $version"
           else
             # For push events, use hardcoded version
-            version="3.97.0"
+            version="3.90.0"
             echo "Using hardcoded version for push event: $version"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -15,23 +15,12 @@ permissions:
   contents: read
 
 jobs:
-  release-stable:
+  get-version:
+    name: Determine version
     runs-on: ubuntu-latest
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      EXPECTED_NPM_USER: sanity-io
-
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          cache: pnpm
-          node-version: lts/*
-
       - name: Get version input
         id: get-version
         run: |
@@ -40,7 +29,7 @@ jobs:
             echo "Using manual input version: $version"
           else
             # For push events, use hardcoded version
-            version="3.98.0"
+            version="3.97.0"
             echo "Using hardcoded version for push event: $version"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -58,6 +47,25 @@ jobs:
           fi
 
           echo "✅ Version validation passed: $version"
+
+  npm-tagging:
+    name: Update NPM dist-tags
+    needs: get-version
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      EXPECTED_NPM_USER: sanity-io
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: lts/*
 
       - name: Install deps
         run: pnpm install --ignore-scripts
@@ -81,8 +89,9 @@ jobs:
         run: |
           # Get all published (non-private) packages in the workspace
           packages=$(pnpx tsx scripts/listPublishedPackages.ts)
-          version="${{ steps.get-version.outputs.version }}"
+          version="${{ needs.get-version.outputs.version }}"
 
+          echo "Using version: $version"
           echo "Tagging the following packages as stable: $packages"
 
           # Convert relative paths to package names and apply dist-tag
@@ -94,16 +103,43 @@ jobs:
 
           echo "✅ All packages tagged as stable"
 
+  update-manifest:
+    name: Update bundle manifest
+    needs: get-version
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: lts/*
+
+      - name: Install deps
+        run: pnpm install --ignore-scripts
+
       - name: Update manifest with stable tag (staging)
         env:
           GOOGLE_PROJECT_ID: ${{ secrets.GCS_STAGING_PROJECT_ID }}
           GCLOUD_SERVICE_KEY: ${{ secrets.GCS_STAGING_SERVICE_KEY }}
           GCLOUD_BUCKET: ${{ secrets.GCS_STAGING_BUCKET }}
-        run: pnpm bundle-manager tag --tag=stable --target-version=${{ steps.get-version.outputs.version }}
+        run: |
+          version="${{ needs.get-version.outputs.version }}"
+          echo "Using version: $version"
+          pnpm bundle-manager tag --tag=stable --target-version="$version"
 
       # - name: Update manifest with stable tag (production)
       #   env:
       #     GOOGLE_PROJECT_ID: ${{ secrets.GCS_PRODUCTION_PROJECT_ID }}
       #     GCLOUD_SERVICE_KEY: ${{ secrets.GCS_PRODUCTION_SERVICE_KEY }}
       #     GCLOUD_BUCKET: ${{ secrets.GCS_PRODUCTION_BUCKET }}
-      #   run: pnpm bundle-manager tag --tag=stable --target-version=${{ steps.get-version.outputs.version }}
+      #   run: |
+      #     version="${{ needs.get-version.outputs.version }}"
+      #     echo "Using version: $version"
+      #     pnpm bundle-manager tag --tag=stable --target-version="$version"

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1,9 +1,6 @@
 name: Release @stable
 
 on:
-  push:
-    branches:
-      - chore/stable-deployment-staging
   workflow_dispatch:
     inputs:
       version:
@@ -24,14 +21,8 @@ jobs:
       - name: Get version input
         id: get-version
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            version="${{ github.event.inputs.version }}"
-            echo "Using manual input version: $version"
-          else
-            # For push events, use hardcoded version
-            version="3.90.0"
-            echo "Using hardcoded version for push event: $version"
-          fi
+          version="${{ github.event.inputs.version }}"
+          echo "Using version: $version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Validate semver version

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -40,7 +40,7 @@ jobs:
             echo "Using manual input version: $version"
           else
             # For push events, use hardcoded version
-            version="3.94.0"
+            version="3.98.0"
             echo "Using hardcoded version for push event: $version"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Description
Adds a new workflow for releasing the stable tag.

This flow will accept a version semver and will:
1. update the npm syslink tag for stable to point to the version
2. update the module-server manifest to tag stable with the new version

These are setup as jobs that can be rerun if there are any errors or issues with running the first time.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Testing this by running this with a branch trigger, verified this was working fine.
Also tested each individual job and verified these work fine also in isolation
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
