### PR TITLE
chore: remove `sanity/lib/index.d.mts` dts check exception

### DIFF
--- a/packages/@repo/test-dts-exports/test/lib-check.test.ts
+++ b/packages/@repo/test-dts-exports/test/lib-check.test.ts
@@ -94,11 +94,6 @@ const filteredErrors = errors.filter((d) => {
     return false
   }
 
-  // Handled in https://github.com/sanity-io/sanity/pull/9988
-  if (file.fileName.includes('packages/sanity/lib/index.') && code === 2717) {
-    return false
-  }
-
   return true
 })
 


### PR DESCRIPTION
### Description

The error:
```bash
packages/sanity/lib/index.d.mts:18510:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'field' must be of type 'ComponentType<ArrayOfPrimitivesFieldProps> | undefined', but here has type 'ComponentType<ArrayOfPrimitivesFieldProps> | undefined'.

18510     field?: ComponentType<ArrayOfPrimitivesFieldProps>
          ~~~~~

  packages/sanity/lib/_singletons.d.mts:12801:5
    12801     field?: ComponentType<ArrayOfPrimitivesFieldProps>
              ~~~~~
    'field' was also declared here.

packages/sanity/lib/index.d.mts:18646:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'input' must be of type 'ComponentType<ReferenceInputProps> | undefined', but here has type 'ComponentType<ReferenceInputProps> | undefined'.

18646     input?: ComponentType<ReferenceInputProps>
          ~~~~~

  packages/sanity/lib/_singletons.d.mts:12937:5
    12937     input?: ComponentType<ReferenceInputProps>
              ~~~~~
    'input' was also declared here.

packages/sanity/lib/index.d.mts:18661:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'input' must be of type 'ComponentType<CrossDatasetReferenceInputProps> | undefined', but here has type 'ComponentType<CrossDatasetReferenceInputProps> | undefined'.

18661     input?: ComponentType<CrossDatasetReferenceInputProps>
          ~~~~~

  packages/sanity/lib/_singletons.d.mts:12952:5
    12952     input?: ComponentType<CrossDatasetReferenceInputProps>
              ~~~~~
    'input' was also declared here.

packages/sanity/lib/index.d.mts:18802:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'component' must be of type 'ComponentType<BlockDecoratorProps> | undefined', but here has type 'ComponentType<BlockDecoratorProps> | undefined'.

18802     component?: ComponentType<BlockDecoratorProps>
          ~~~~~~~~~

  packages/sanity/lib/_singletons.d.mts:13093:5
    13093     component?: ComponentType<BlockDecoratorProps>
              ~~~~~~~~~
    'component' was also declared here.

packages/sanity/lib/index.d.mts:18829:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'component' must be of type 'ComponentType<BlockStyleProps> | undefined', but here has type 'ComponentType<BlockStyleProps> | undefined'.

18829     component?: ComponentType<BlockStyleProps>
          ~~~~~~~~~

  packages/sanity/lib/_singletons.d.mts:13120:5
    13120     component?: ComponentType<BlockStyleProps>
              ~~~~~~~~~
    'component' was also declared here.

packages/sanity/lib/index.d.mts:18844:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'component' must be of type 'ComponentType<BlockListItemProps> | undefined', but here has type 'ComponentType<BlockListItemProps> | undefined'.

18844     component?: ComponentType<BlockListItemProps>
          ~~~~~~~~~

  packages/sanity/lib/_singletons.d.mts:13135:5
    13135     component?: ComponentType<BlockListItemProps>
              ~~~~~~~~~
    'component' was also declared here.
```

Help?!
<img width="500" height="559" alt="image" src="https://github.com/user-attachments/assets/89ebd9e5-b156-451d-a1a1-ff575db22420" />


### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
