### PR TITLE
chore: only set auto merge if a pr was created

### DIFF
--- a/.github/workflows/generate-dts-tests-if-needed.yml
+++ b/.github/workflows/generate-dts-tests-if-needed.yml
@@ -50,6 +50,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Enable automerge on Pull Request
+        if: steps.create-pull-request.outputs.pull-request-number == 'created'
         run: gh pr merge --squash --auto "${{ steps.create-pull-request.outputs.pull-request-number }}"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/lint-fix-if-needed.yml
+++ b/.github/workflows/lint-fix-if-needed.yml
@@ -57,6 +57,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Enable automerge on Pull Request
+        if: steps.create-pull-request.outputs.pull-request-number == 'created'
         run: gh pr merge --squash --auto "${{ steps.create-pull-request.outputs.pull-request-number }}"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/pnpm-if-needed.yml
+++ b/.github/workflows/pnpm-if-needed.yml
@@ -49,6 +49,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Enable automerge on Pull Request
+        if: steps.create-pull-request.outputs.pull-request-number == 'created'
         run: gh pr merge --squash --auto "${{ steps.create-pull-request.outputs.pull-request-number }}"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/react-compiler.yml
+++ b/.github/workflows/react-compiler.yml
@@ -49,6 +49,7 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Enable automerge on Pull Request
+        if: steps.create-pull-request.outputs.pull-request-number == 'created'
         run: gh pr merge --squash --auto "${{ steps.create-pull-request.outputs.pull-request-number }}"
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### Description

#9983 introduced a regression where checks fail if no PR was made, as `steps.create-pull-request.outputs.pull-request-number` will be null, and GH doesn't like running `gh pr merge --squash --auto ""`:
- https://github.com/sanity-io/sanity/actions/runs/16348781503/job/46189644004
- https://github.com/sanity-io/sanity/actions/runs/16348781536/job/46189644011
It's fixed by adding a guard that only runs the auto merge command if a PR was created in the previous step.

### What to review

Makes sense?

### Testing

Have to merge to test 😬 

### Notes for release

N/A