### PR TITLE
fix(deps): update dependency next-sanity to v10

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -567,11 +567,11 @@ export default async function initSanity(
     }
 
     if (chosen === 'npm') {
-      await execa('npm', ['install', '--legacy-peer-deps', 'next-sanity@9'], execOptions)
+      await execa('npm', ['install', '--legacy-peer-deps', 'next-sanity@10'], execOptions)
     } else if (chosen === 'yarn') {
-      await execa('npx', ['install-peerdeps', '--yarn', 'next-sanity@9'], execOptions)
+      await execa('npx', ['install-peerdeps', '--yarn', 'next-sanity@10'], execOptions)
     } else if (chosen === 'pnpm') {
-      await execa('pnpm', ['install', 'next-sanity@9'], execOptions)
+      await execa('pnpm', ['install', 'next-sanity@10'], execOptions)
     }
 
     print(

--- a/packages/@sanity/cli/test/__fixtures__/remote-template/package.json
+++ b/packages/@sanity/cli/test/__fixtures__/remote-template/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "next": "^15",
-    "next-sanity": "^9",
+    "next-sanity": "^10",
     "sanity": "^3"
   }
 }


### PR DESCRIPTION
### Description

Now that `sanity` is v4 we should also use `next-sanity` v10, as it supports v4.

### What to review

Did I miss anything?

### Testing

If tests pass we're good 🙌 

### Notes for release

`npx sanity init` in `next` projects now use `next-sanity@v10`, which supports `sanity@v4` and has `next@v15.1` and `react@v19` as its baseline.
