### PR TITLE
fix(sanity): deduplicate global search results

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/reducer.ts
@@ -226,11 +226,11 @@ export function searchReducer(state: SearchReducerState, action: SearchAction): 
           ...state.result,
           error: null,
           hasLocal: true,
-          hits: state.result.hasLocal
-            ? removeDupes([...state.result.hits, ...action.hits].map(({hit}) => hit)).map(
-                (hit) => ({hit}),
-              )
-            : action.hits,
+          hits: removeDupes(
+            [...(state.result.hasLocal ? state.result.hits : []), ...action.hits].map(
+              ({hit}) => hit,
+            ),
+          ).map((hit) => ({hit})),
           loaded: true,
           loading: false,
         },


### PR DESCRIPTION
### Description

Search results were previously only deduplicated when merging subsequent pages of results into the aggregated local state.

This was incorrect; the `groq2024` search strategy yields a result for every version of the document, and therefore must be deduplicated.

| Before | After |
| --- | --- |
| <img width="848" height="412" alt="Screenshot 2025-07-18 at 16 18 19" src="https://github.com/user-attachments/assets/ce3be928-3c6d-4b71-8ef5-453270b7ba5c" /> | <img width="848" height="412" alt="Screenshot 2025-07-18 at 16 19 13" src="https://github.com/user-attachments/assets/4a93ceab-6406-4497-ba97-8cb5bf95b4b8" /> |

### What to review

Global search, particularly with the `groq2024` search strategy switched on.

### Testing

Tested in Test Studio, and verified existing tests pass.

### Notes for release

Fixes a bug that could cause duplicate results to appear in global search when using the `groq2024` search strategy.
