### PR TITLE
feat(sanity): add `StringInputPortableText` with inline diff support

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -335,6 +335,9 @@ export default defineConfig([
     mediaLibrary: {
       enabled: true,
     },
+    advancedVersionControl: {
+      enabled: true,
+    },
   },
   {
     name: 'listener-events',

--- a/packages/sanity/src/core/form/components/formField/styles.ts
+++ b/packages/sanity/src/core/form/components/formField/styles.ts
@@ -1,7 +1,7 @@
 import {Grid} from '@sanity/ui'
 import {styled} from 'styled-components'
 
-function focusRingBorderStyle(border: {color: string; width: number}): string {
+export function focusRingBorderStyle(border: {color: string; width: number}): string {
   return `inset 0 0 0 ${border.width}px ${border.color}`
 }
 

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -418,6 +418,8 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
 
 /**
  * Custom PTE plugin that translates `EditorEmittedEvent`s to `EditorChange`s
+ *
+ * @internal
  */
 function EditorChangePlugin(props: {onChange: (change: EditorChange) => void}) {
   const handleEditorEvent = useCallback(
@@ -534,8 +536,10 @@ function UpdateValuePlugin(props: {value: Array<PortableTextBlock> | undefined})
  * `EditorProvider` doesn't have a `readOnly` prop. Instead, this custom PTE
  * plugin listens for the prop change and sends a `toggle readOnly` event to
  * the editor.
+ *
+ * @internal
  */
-function UpdateReadOnlyPlugin(props: {readOnly: boolean}) {
+export function UpdateReadOnlyPlugin(props: {readOnly: boolean}) {
   const editor = useEditor()
 
   useEffect(() => {

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInput.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInput.tsx
@@ -1,13 +1,18 @@
-import {TextInput} from '@sanity/ui'
-
+import {useWorkspace} from '../../../studio/workspace'
 import {type StringInputProps} from '../../types'
+import {StringInputBasic} from './StringInputBasic/StringInputBasic'
+import {StringInputPortableText} from './StringInputPortableText/StringInputPortableText'
 
 /**
- *
  * @hidden
  * @beta
  */
 export function StringInput(props: StringInputProps) {
-  const {validationError, elementProps} = props
-  return <TextInput {...elementProps} customValidity={validationError} data-testid="string-input" />
+  const {advancedVersionControl} = useWorkspace()
+
+  if (advancedVersionControl?.enabled) {
+    return <StringInputPortableText {...props} />
+  }
+
+  return <StringInputBasic {...props} />
 }

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputBasic/StringInputBasic.test.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputBasic/StringInputBasic.test.tsx
@@ -1,14 +1,14 @@
 import userEvent from '@testing-library/user-event'
 import {describe, expect, it} from 'vitest'
 
-import {renderStringInput} from '../../../../../test/form/renderStringInput'
-import {StringInput} from './StringInput'
+import {renderStringInput} from '../../../../../../test/form/renderStringInput'
+import {StringInputBasic} from './StringInputBasic'
 
-describe('StringInput', () => {
+describe('StringInputBasic', () => {
   it('renders input value', async () => {
     const {result} = await renderStringInput({
       render: (inputProps) => (
-        <StringInput
+        <StringInputBasic
           {...inputProps}
           elementProps={{...inputProps.elementProps, value: 'test'}}
           value="test"
@@ -29,7 +29,7 @@ describe('StringInput', () => {
   it('emits onFocus', async () => {
     const {onFocus, result} = await renderStringInput({
       render: (inputProps) => (
-        <StringInput
+        <StringInputBasic
           {...inputProps}
           value="test"
           elementProps={{...inputProps.elementProps, value: 'test'}}
@@ -52,7 +52,7 @@ describe('StringInput', () => {
   it('emits `set` patch', async () => {
     const {onNativeChange, result} = await renderStringInput({
       render: (inputProps) => (
-        <StringInput
+        <StringInputBasic
           {...inputProps}
           value="tes"
           elementProps={{...inputProps.elementProps, value: 'tes'}}
@@ -75,7 +75,7 @@ describe('StringInput', () => {
   it('emits `unset` patch', async () => {
     const {onNativeChange, result} = await renderStringInput({
       render: (inputProps) => (
-        <StringInput
+        <StringInputBasic
           {...inputProps}
           value="t"
           elementProps={{...inputProps.elementProps, value: 't'}}

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputBasic/StringInputBasic.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputBasic/StringInputBasic.tsx
@@ -1,0 +1,15 @@
+import {TextInput} from '@sanity/ui'
+
+import {type StringInputProps} from '../../../types'
+
+/**
+ * This is the default string input implementation, powered by Sanity UI's `TextInput` component. It
+ * will likely be superseded by the Portable Text Editor based implementation in the future.
+ *
+ * @hidden
+ * @beta
+ */
+export function StringInputBasic(props: StringInputProps) {
+  const {validationError, elementProps} = props
+  return <TextInput {...elementProps} customValidity={validationError} data-testid="string-input" />
+}

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/StringInputPortableText.test.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/StringInputPortableText.test.tsx
@@ -1,0 +1,29 @@
+import {waitFor} from '@testing-library/react'
+import {describe, expect, it} from 'vitest'
+
+import {renderStringInput} from '../../../../../../test/form/renderStringInput'
+import {StringInputPortableText} from './StringInputPortableText'
+
+const INPUT_SELECTOR = '[data-testid="string-input-portable-text"]'
+
+// This is only partially tested at the moment, because jsdom does not support contenteditable. This
+// is a good candidate to adopt Vitest Browser Mode, which would allow the test suite to reach
+// parity with `StringInputBasic.test.tsx`.
+describe('StringInputPortableText', () => {
+  it('renders input value', async () => {
+    const {result} = await renderStringInput({
+      render: (inputProps) => <StringInputPortableText {...inputProps} value="test" />,
+      fieldDefinition: {
+        type: 'string',
+        name: 'string',
+        title: 'String',
+      },
+    })
+
+    const input = result.container.querySelector(INPUT_SELECTOR)
+
+    await waitFor(() => {
+      expect(input).toHaveTextContent('test')
+    })
+  })
+})

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/StringInputPortableText.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/StringInputPortableText.tsx
@@ -1,0 +1,229 @@
+import {
+  type EditorConfig,
+  type EditorEmittedEvent,
+  EditorProvider,
+  PortableTextEditable,
+  useEditor,
+} from '@portabletext/editor'
+import {EventListenerPlugin, OneLinePlugin} from '@portabletext/editor/plugins'
+import {type Path} from '@sanity/types'
+import {Card, useArrayProp, useRootTheme} from '@sanity/ui'
+import {useCallback, useEffect, useRef} from 'react'
+import {styled} from 'styled-components'
+
+import {useWorkspace} from '../../../../studio/workspace'
+import {set, unset} from '../../../patch/patch'
+import {type StringInputProps} from '../../../types'
+import {UpdateReadOnlyPlugin} from '../../PortableText/PortableTextInput'
+import {DeletedSegment} from './diff/segments'
+import {useOptimisticDiff} from './diff/useOptimisticDiff'
+import {packageValue} from './packageValue'
+import {
+  inputStyles,
+  responsiveInputPaddingStyle,
+  textInputBaseStyle,
+  textInputFontSizeStyle,
+  type TextInputInputStyleProps,
+  textInputRepresentationStyle,
+  type TextInputRepresentationStyleProps,
+  type TextInputResponsivePaddingStyleProps,
+  textInputRootStyle,
+} from './styles'
+import {unpackageValue} from './unpackageValue'
+
+export const ROOT_PATH: Path = [{_key: 'root'}, 'children', {_key: 'root'}]
+const INVALID_CLASS_NAME = 'invalid'
+
+const StyledRoot = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: block;
+  position: relative;
+`
+
+const StyledInput = styled(PortableTextEditable)<
+  TextInputInputStyleProps & TextInputResponsivePaddingStyleProps
+>`
+  ${textInputRootStyle}
+  ${textInputBaseStyle}
+  ${responsiveInputPaddingStyle}
+  ${textInputFontSizeStyle}
+  ${inputStyles}
+`
+
+const StyledEditorRepresentation = styled(Card)<TextInputRepresentationStyleProps>(
+  textInputRepresentationStyle,
+)
+
+const StyledPlaceholder = styled.span<TextInputResponsivePaddingStyleProps>`
+  ${responsiveInputPaddingStyle}
+`
+
+/**
+ * This string input implementation is powered by the Portable Text Editor. It's used when inline
+ * diffs are switched on, but this will likely expand in the future to support features such as
+ * presence carets, and eventually become the default/only input component.
+ *
+ * @hidden
+ * @beta
+ */
+export function StringInputPortableText(props: StringInputProps) {
+  const {advancedVersionControl} = useWorkspace()
+  const {
+    elementProps,
+    onChange,
+    value: definitiveValue,
+    __unstable_diff: definitiveDiff,
+    __unstable_computeDiff: computeDiff,
+  } = props
+  const {onFocus, onBlur} = elementProps
+
+  const {diff, rangeDecorations, onOptimisticChange} = useOptimisticDiff({
+    definitiveValue,
+    definitiveDiff,
+    computeDiff,
+  })
+
+  const handleEditorEvent = useCallback(
+    (event: EditorEmittedEvent) => {
+      if (event.type === 'focused') {
+        onFocus(event.event)
+        return
+      }
+
+      if (event.type === 'blurred') {
+        onBlur(event.event)
+        return
+      }
+
+      // The patch event occurs at the same time as user input, so it can be used to perform actions
+      // in tandem with the user's input. e.g. as soon as they type.
+      //
+      // On patch, set the optimistic value used to create an optimistic diff that can be rendered
+      // immediately to reflect the user's input that has not yet been committed.
+      if (
+        event.type === 'patch' &&
+        event.patch.type === 'diffMatchPatch' &&
+        event.patch.origin === 'local'
+      ) {
+        onOptimisticChange(event.patch.value)
+        return
+      }
+
+      // The mutation event occurs after user input (there is a debounce or throttle period), so it
+      // can be used to perform actions that are lower priority than rendering the user's input.
+      //
+      // On mutation, execute the relevant patches to commit the user's input.
+      if (event.type === 'mutation') {
+        const value = unpackageValue(event.value)
+        const valueRemainsUndefined = typeof definitiveValue === 'undefined' && value === ''
+        const valueBecomesUndefined = typeof definitiveValue !== 'undefined' && value === ''
+        const valueHasChanged = value !== definitiveValue && !valueRemainsUndefined
+
+        if (!valueHasChanged) {
+          return
+        }
+
+        if (valueBecomesUndefined) {
+          onChange(unset())
+          return
+        }
+
+        onChange(set(value))
+      }
+    },
+    [onFocus, onBlur, onOptimisticChange, definitiveValue, onChange],
+  )
+
+  const initialConfig = useRef<EditorConfig>({
+    initialValue: packageValue(props.value),
+    readOnly: props.readOnly ?? false,
+    schema: {
+      name: 'pteTransformer',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+        },
+      ],
+    },
+  })
+
+  const rootTheme = useRootTheme()
+  const fontSize = useArrayProp(2)
+  const padding = useArrayProp(3)
+  const radius = useArrayProp(2)
+  const space = useArrayProp(3)
+
+  const diffSegments = diff.type === 'string' ? diff.segments : undefined
+
+  // Range decorations are used to render deleted diff segments. However, rendering a range
+  // decoration necessitates that a range actually exists. In the instance that the entire value has
+  // been deleted, there is no range to decorate.
+  //
+  // Instead, the placeholder is used to render the delete diff segment when the entire value has been
+  // deleted.
+  const renderPlaceholder = useCallback(() => {
+    const isEntireValuedDeleted = diff.fromValue && diff.toValue === ''
+
+    if (isEntireValuedDeleted && diffSegments) {
+      return (
+        <StyledPlaceholder $fontSize={fontSize} $space={space} $padding={padding}>
+          <DeletedSegment segment={diffSegments[0]} />
+        </StyledPlaceholder>
+      )
+    }
+
+    return null
+  }, [diff.fromValue, diff.toValue, diffSegments, fontSize, space, padding])
+
+  return (
+    <StyledRoot>
+      <EditorProvider initialConfig={initialConfig.current}>
+        <OneLinePlugin />
+        <EventListenerPlugin on={handleEditorEvent} />
+        <UpdateValuePlugin value={props.value} />
+        <UpdateReadOnlyPlugin readOnly={props.readOnly ?? false} />
+        <StyledInput
+          className={props.validationError ? INVALID_CLASS_NAME : undefined}
+          renderPlaceholder={advancedVersionControl.enabled ? renderPlaceholder : undefined}
+          rangeDecorations={advancedVersionControl.enabled ? rangeDecorations : undefined}
+          $fontSize={fontSize}
+          $space={space}
+          $padding={padding}
+          $scheme={rootTheme.scheme}
+          $tone={rootTheme.tone}
+          data-scheme={rootTheme.scheme}
+          data-tone={rootTheme.tone}
+          data-testid="string-input-portable-text"
+        />
+      </EditorProvider>
+      <StyledEditorRepresentation
+        radius={radius}
+        $scheme={rootTheme.scheme}
+        $tone={rootTheme.tone}
+        data-scheme={rootTheme.scheme}
+        data-tone={rootTheme.tone}
+        data-border
+      />
+    </StyledRoot>
+  )
+}
+
+/**
+ * `EditorProvider` doesn't have a `value` prop. Instead, this custom PTE
+ * plugin listens for the prop change and sends an `update value` event to the
+ * editor.
+ */
+function UpdateValuePlugin(props: {value: string | undefined}) {
+  const editor = useEditor()
+
+  useEffect(() => {
+    editor.send({
+      type: 'update value',
+      value: packageValue(props.value),
+    })
+  }, [editor, props.value])
+
+  return null
+}

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/diff/computeRangeDecorations.test.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/diff/computeRangeDecorations.test.tsx
@@ -1,0 +1,113 @@
+import {diffInput, wrap} from '@sanity/diff'
+import {expect, it} from 'vitest'
+
+import {type ProvenanceDiffAnnotation} from '../../../../store/types/diff'
+import {computeRangeDecorations} from './computeRangeDecorations'
+
+const provenanceAnnotation: ProvenanceDiffAnnotation = {
+  provenance: {
+    bundle: 'published',
+  },
+}
+
+it('produces an array of range decorations for the provided diff', () => {
+  const diff = diffInput(wrap('a', provenanceAnnotation), wrap('b', provenanceAnnotation))
+
+  expect(computeRangeDecorations({diff})).toMatchInlineSnapshot(`
+    [
+      {
+        "component": [Function],
+        "payload": {
+          "action": "merged",
+          "id": "removed.a.added.b",
+        },
+        "selection": {
+          "anchor": {
+            "offset": 0,
+            "path": [
+              {
+                "_key": "root",
+              },
+              "children",
+              {
+                "_key": "root",
+              },
+            ],
+          },
+          "focus": {
+            "offset": 1,
+            "path": [
+              {
+                "_key": "root",
+              },
+              "children",
+              {
+                "_key": "root",
+              },
+            ],
+          },
+        },
+      },
+    ]
+  `)
+})
+
+it('merges overlapping range decorations', () => {
+  const diff = diffInput(wrap('a b', provenanceAnnotation), wrap('a c', provenanceAnnotation))
+
+  expect(computeRangeDecorations({diff})).toMatchInlineSnapshot(`
+    [
+      {
+        "component": [Function],
+        "payload": {
+          "action": "merged",
+          "id": "removed.b.added.c",
+        },
+        "selection": {
+          "anchor": {
+            "offset": 2,
+            "path": [
+              {
+                "_key": "root",
+              },
+              "children",
+              {
+                "_key": "root",
+              },
+            ],
+          },
+          "focus": {
+            "offset": 3,
+            "path": [
+              {
+                "_key": "root",
+              },
+              "children",
+              {
+                "_key": "root",
+              },
+            ],
+          },
+        },
+      },
+    ]
+  `)
+})
+
+it('applies the provided `mapPayload` function', () => {
+  const diff = diffInput(wrap('a', provenanceAnnotation), wrap('b', provenanceAnnotation))
+
+  const rangeDecorations = computeRangeDecorations({
+    diff,
+    mapPayload: (payload) => ({
+      ...payload,
+      extraKey: 'extraValue',
+    }),
+  })
+
+  expect(rangeDecorations).toSatisfy(
+    (value) =>
+      Array.isArray(value) &&
+      value.map(({payload}) => payload).every(({extraKey}) => extraKey === 'extraValue'),
+  )
+})

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/diff/computeRangeDecorations.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/diff/computeRangeDecorations.tsx
@@ -1,0 +1,130 @@
+import {type EditorSelection, type RangeDecoration} from '@portabletext/editor'
+import {type Diff} from '@sanity/diff'
+
+import {type ProvenanceDiffAnnotation} from '../../../../store/types/diff'
+import {ROOT_PATH} from '../StringInputPortableText'
+import {DeletedSegment, InsertedSegment} from './segments'
+
+interface ComputeRangeDecorationsOptions {
+  diff: Diff<ProvenanceDiffAnnotation>
+  mapPayload?: (payload: Record<string, unknown>) => Record<string, unknown>
+}
+
+export function computeRangeDecorations({
+  diff,
+  mapPayload = (payload) => payload,
+}: ComputeRangeDecorationsOptions): RangeDecoration[] {
+  if (diff.type !== 'string') {
+    return []
+  }
+
+  const segments = diff?.segments ?? []
+
+  const {rangeDecorations} = segments.reduce<{
+    rangeDecorations: RangeDecoration[]
+    position: number
+  }>(
+    (state, segment, index) => {
+      const previousSegment = segments.at(index - 1)
+      const previousDecoration = state.rangeDecorations.at(-1)
+
+      // Overlapping ranges cannot be given separate decorations. String diffs are calculated
+      // such that this is only a concern if an added segment immediately proceeds a removed
+      // segment; in this scenario, the removed segment decorates the starting position of the
+      // added segment. To solve this problem, the removed and added decorations are merged.
+      if (
+        segment.action === 'added' &&
+        previousDecoration?.payload?.action === 'removed' &&
+        typeof previousSegment !== 'undefined'
+      ) {
+        const isOverlapping = previousDecoration?.selection?.anchor?.offset === state.position
+
+        if (isOverlapping) {
+          state.rangeDecorations.splice(state.rangeDecorations.length - 1, 1, {
+            selection: rangeDecorationSelection(
+              state.position,
+              state.position + segment.text.length,
+            ),
+            component: ({children}) => {
+              return (
+                <span>
+                  <previousDecoration.component />
+                  <InsertedSegment segment={segment}>{children}</InsertedSegment>
+                </span>
+              )
+            },
+            payload: mapPayload({
+              id: segmentId(
+                previousDecoration?.payload?.action,
+                previousSegment.text,
+                'added',
+                segment.text,
+              ),
+              action: 'merged',
+            }),
+          })
+
+          state.position += segment.text.length
+          return state
+        }
+      }
+
+      if (segment.action === 'added') {
+        state.rangeDecorations.push({
+          selection: rangeDecorationSelection(state.position, state.position + segment.text.length),
+          component: (props) => <InsertedSegment segment={segment} {...props} />,
+          payload: mapPayload({
+            id: segmentId('added', segment.text),
+            action: segment.action,
+          }),
+        })
+
+        state.position += segment.text.length
+        return state
+      }
+
+      if (segment.action === 'removed') {
+        state.rangeDecorations.push({
+          selection: rangeDecorationSelection(state.position, state.position),
+          component: () => <DeletedSegment segment={segment} />,
+          payload: mapPayload({
+            id: segmentId('removed', segment.text),
+            action: segment.action,
+          }),
+        })
+
+        return state
+      }
+
+      if (segment.action === 'unchanged') {
+        state.position += segment.text.length
+        return state
+      }
+
+      return state
+    },
+    {
+      position: 0,
+      rangeDecorations: [],
+    },
+  )
+
+  return rangeDecorations
+}
+
+function segmentId(...path: string[]): string {
+  return path.join('.')
+}
+
+function rangeDecorationSelection(anchorOffset: number, focusOffset: number): EditorSelection {
+  return {
+    anchor: {
+      path: ROOT_PATH,
+      offset: anchorOffset,
+    },
+    focus: {
+      path: ROOT_PATH,
+      offset: focusOffset,
+    },
+  }
+}

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/diff/segments.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/diff/segments.tsx
@@ -1,0 +1,65 @@
+import {type StringDiffSegment} from '@sanity/diff'
+import {type BadgeTone, type ButtonTone} from '@sanity/ui'
+// eslint-disable-next-line camelcase
+import {getTheme_v2} from '@sanity/ui/theme'
+import {type ComponentType, type PropsWithChildren} from 'react'
+import {styled} from 'styled-components'
+
+import {getReleaseTone} from '../../../../../releases/util/getReleaseTone'
+import {type ProvenanceDiffAnnotation} from '../../../../store/types/diff'
+
+interface StyledSegmentProps {
+  $tone?: ButtonTone
+}
+
+const Segment = styled.span<StyledSegmentProps>`
+  ${({theme, $tone}) => {
+    if (typeof $tone === 'undefined') {
+      return undefined
+    }
+
+    const {color} = getTheme_v2(theme)
+
+    return {
+      backgroundColor: color.button.bleed[$tone]?.pressed?.bg,
+      color: color.button.bleed[$tone]?.pressed?.fg,
+    }
+  }}
+`
+
+interface SegmentProps {
+  segment: StringDiffSegment<ProvenanceDiffAnnotation>
+}
+
+export const DeletedSegment: ComponentType<SegmentProps> = ({segment}) => (
+  <Segment
+    as="del"
+    data-text={segment.text}
+    contentEditable={false}
+    aria-hidden
+    inert
+    $tone="critical"
+  />
+)
+
+export const InsertedSegment: ComponentType<PropsWithChildren<SegmentProps>> = ({
+  children,
+  segment,
+}) => {
+  return (
+    <Segment as="ins" $tone={segmentTone(segment)}>
+      {children}
+    </Segment>
+  )
+}
+
+function segmentTone(segment: StringDiffSegment<ProvenanceDiffAnnotation>): BadgeTone | undefined {
+  if (
+    segment.action !== 'unchanged' &&
+    typeof segment.annotation.provenance.bundle !== 'undefined'
+  ) {
+    return getReleaseTone(segment.annotation.provenance.bundle)
+  }
+
+  return undefined
+}

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/diff/useOptimisticDiff.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/diff/useOptimisticDiff.tsx
@@ -1,0 +1,74 @@
+import {type RangeDecoration} from '@portabletext/editor'
+import {type Diff} from '@sanity/diff'
+import {applyPatches, parsePatch} from '@sanity/diff-match-patch'
+import {useCallback, useEffect, useMemo, useState} from 'react'
+
+import {type ProvenanceDiffAnnotation} from '../../../../store/types/diff'
+import {type ComputeDiff} from '../../../../store/types/nodes'
+import {computeRangeDecorations} from './computeRangeDecorations'
+
+type InputOrigin = 'optimistic' | 'definitive'
+
+export interface OptimisticDiffOptions {
+  definitiveValue: string | undefined
+  definitiveDiff: Diff<ProvenanceDiffAnnotation>
+  computeDiff: ComputeDiff<ProvenanceDiffAnnotation>
+}
+
+export interface OptimisticDiffApi {
+  diff: Diff<ProvenanceDiffAnnotation>
+  rangeDecorations: RangeDecoration[]
+  onOptimisticChange: (value: string) => void
+}
+
+export function useOptimisticDiff({
+  definitiveValue,
+  definitiveDiff,
+  computeDiff,
+}: OptimisticDiffOptions): OptimisticDiffApi {
+  const [optimisticValue, setOptimisticValue] = useState(definitiveValue)
+  const [currentSignal, setCurrentSignal] = useState<InputOrigin>('definitive')
+  const optimisticDiff = useMemo(() => computeDiff(optimisticValue), [computeDiff, optimisticValue])
+
+  const diffsBySignal: Record<InputOrigin, Diff<ProvenanceDiffAnnotation>> = {
+    optimistic: optimisticDiff,
+    definitive: definitiveDiff,
+  }
+
+  const diff = diffsBySignal[currentSignal]
+
+  const onOptimisticChange = useCallback(
+    (value: string) => {
+      const [nextOptimisticValue] = applyPatches(parsePatch(value), optimisticValue ?? '')
+      setOptimisticValue(nextOptimisticValue)
+      setCurrentSignal('optimistic')
+    },
+    [optimisticValue],
+  )
+
+  useEffect(() => {
+    setCurrentSignal('definitive')
+    // Ensure the optimistic value is synced with the definitive value.
+    setOptimisticValue(definitiveValue)
+  }, [definitiveValue])
+
+  const rangeDecorations = useMemo(
+    () =>
+      computeRangeDecorations({
+        diff,
+        mapPayload: (payload) => ({
+          ...payload,
+          // Including the current signal in the payload ensures that the range decorations are
+          // rerendered when the signal changes.
+          currentSignal,
+        }),
+      }),
+    [diff, currentSignal],
+  )
+
+  return {
+    diff,
+    rangeDecorations,
+    onOptimisticChange,
+  }
+}

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/packageValue.test.ts
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/packageValue.test.ts
@@ -1,0 +1,39 @@
+import {expect, it} from 'vitest'
+
+import {packageValue} from './packageValue'
+
+it('produces a Portable Text value with the primitive value stored at the expected path', () => {
+  expect(packageValue('a')).toMatchInlineSnapshot(`
+    [
+      {
+        "_key": "root",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "root",
+            "_type": "span",
+            "text": "a",
+          },
+        ],
+      },
+    ]
+  `)
+})
+
+it('gracefully handles `undefined` input value', () => {
+  expect(packageValue(undefined)).toMatchInlineSnapshot(`
+    [
+      {
+        "_key": "root",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "root",
+            "_type": "span",
+            "text": "",
+          },
+        ],
+      },
+    ]
+  `)
+})

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/packageValue.ts
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/packageValue.ts
@@ -1,0 +1,26 @@
+import {type PortableTextBlock} from '@portabletext/react'
+
+/**
+ * Package a primitive string field value into a Portable Text value. This
+ * allows the primitive string to be used by a Portable Text Editor instance.
+ *
+ * The Portable Text value produced stores the primitive string at the path
+ * `[{_key: 'root'}, 'children', {_key: 'root'}]`.
+ *
+ * @internal
+ */
+export function packageValue(value: string | undefined) {
+  return [
+    {
+      _type: 'block',
+      _key: 'root',
+      children: [
+        {
+          _type: 'span',
+          _key: 'root',
+          text: value ?? '',
+        },
+      ],
+    },
+  ] satisfies PortableTextBlock[]
+}

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/styles.ts
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/styles.ts
@@ -1,0 +1,349 @@
+import {_responsive, type CardTone, rem, type ThemeProps} from '@sanity/ui'
+import {
+  // eslint-disable-next-line camelcase
+  getTheme_v2,
+  type ThemeColorSchemeKey,
+  type ThemeFontWeightKey,
+} from '@sanity/ui/theme'
+import {css, type CSSObject, type RuleSet} from 'styled-components'
+
+import {focusRingBorderStyle, focusRingStyle} from '../../../components/formField/styles'
+
+/**
+ * Heavily based on the styling provided by Sanity UI.
+ */
+const ROOT_STYLE = css`
+  &:not([hidden]) {
+    display: flex;
+  }
+
+  align-items: center;
+`
+
+/**
+ * Heavily based on the styling provided by Sanity UI.
+ */
+export function textInputRootStyle(): ReturnType<typeof css> {
+  return ROOT_STYLE
+}
+
+/**
+ * Heavily based on the styling provided by Sanity UI.
+ */
+export function textInputBaseStyle(
+  props: TextInputInputStyleProps & ThemeProps,
+): ReturnType<typeof css> {
+  const {$scheme, $tone, $weight} = props
+  const {color, font} = getTheme_v2(props.theme)
+
+  return css`
+    appearance: none;
+    background: none;
+    border: 0;
+    border-radius: 0;
+    outline: none;
+    width: 100%;
+    box-sizing: border-box;
+    font-family: ${font.text.family};
+    font-weight: ${($weight && font.text.weights[$weight]) || font.text.weights.regular};
+    margin: 0;
+    position: relative;
+    z-index: 1;
+    display: block;
+
+    /* NOTE: This is a hack to disable Chrome’s autofill styles */
+    &:-webkit-autofill,
+    &:-webkit-autofill:hover,
+    &:-webkit-autofill:focus,
+    &:-webkit-autofill:active {
+      -webkit-text-fill-color: var(--input-fg-color) !important;
+      transition: background-color 5000s;
+      transition-delay: 86400s /* 24h */;
+    }
+
+    /* &:is(textarea) */
+    &[data-as='textarea'] {
+      resize: none;
+    }
+
+    color: var(--input-fg-color);
+
+    &::placeholder {
+      color: var(--input-placeholder-color);
+    }
+
+    &[data-scheme='${$scheme}'][data-tone='${$tone}'] {
+      --input-fg-color: ${color.input.default.enabled.fg};
+      --input-placeholder-color: ${color.input.default.enabled.placeholder};
+
+      /* enabled */
+      &:not(:invalid):not(:disabled):not(:read-only) {
+        --input-fg-color: ${color.input.default.enabled.fg};
+        --input-placeholder-color: ${color.input.default.enabled.placeholder};
+      }
+
+      /* disabled */
+      &:not(:invalid):disabled {
+        --input-fg-color: ${color.input.default.disabled.fg};
+        --input-placeholder-color: ${color.input.default.disabled.placeholder};
+      }
+
+      /* invalid */
+      &:invalid {
+        --input-fg-color: ${color.input.invalid.enabled.fg};
+        --input-placeholder-color: ${color.input.invalid.enabled.placeholder};
+      }
+
+      /* readOnly */
+      &:read-only {
+        --input-fg-color: ${color.input.default.readOnly.fg};
+        --input-placeholder-color: ${color.input.default.readOnly.placeholder};
+      }
+    }
+  `
+}
+
+/**
+ * Heavily based on the styling provided by Sanity UI.
+ */
+export interface TextInputRepresentationStyleProps {
+  $hasPrefix?: boolean
+  $hasSuffix?: boolean
+  $scheme: ThemeColorSchemeKey
+  $tone: CardTone
+  $unstableDisableFocusRing?: boolean
+}
+
+/**
+ * Heavily based on the styling provided by Sanity UI.
+ */
+export function textInputRepresentationStyle(
+  props: TextInputRepresentationStyleProps & ThemeProps,
+): ReturnType<typeof css> {
+  const {$hasPrefix, $hasSuffix, $scheme, $tone, $unstableDisableFocusRing} = props
+  const {color, input} = getTheme_v2(props.theme)
+
+  return css`
+    --input-box-shadow: none;
+
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: block;
+    pointer-events: none;
+    z-index: 0;
+
+    background-color: var(--card-bg-color);
+    box-shadow: var(--input-box-shadow);
+
+    border-top-left-radius: ${$hasPrefix ? 0 : undefined};
+    border-bottom-left-radius: ${$hasPrefix ? 0 : undefined};
+    border-top-right-radius: ${$hasSuffix ? 0 : undefined};
+    border-bottom-right-radius: ${$hasSuffix ? 0 : undefined};
+
+    &[data-scheme='${$scheme}'][data-tone='${$tone}'] {
+      --card-bg-color: ${color.input.default.enabled.bg};
+      --card-fg-color: ${color.input.default.enabled.fg};
+
+      /* enabled */
+      *:not(:disabled) + &[data-border] {
+        --input-box-shadow: ${focusRingBorderStyle({
+          color: color.input.default.enabled.border,
+          width: input.border.width,
+        })};
+      }
+
+      /* invalid */
+      *:not(:disabled).invalid + & {
+        --card-bg-color: ${color.input.invalid.enabled.bg};
+        --card-fg-color: ${color.input.invalid.enabled.fg};
+
+        &[data-border] {
+          --input-box-shadow: ${focusRingBorderStyle({
+            color: color.input.invalid.enabled.border,
+            width: input.border.width,
+          })};
+        }
+      }
+
+      /* focused */
+      *:not(:disabled):focus + & {
+        &[data-border] {
+          --input-box-shadow: ${$unstableDisableFocusRing
+            ? undefined
+            : focusRingStyle({
+                border: {color: color.input.default.enabled.border, width: input.border.width},
+                focusRing: input.text.focusRing,
+              })};
+        }
+
+        &:not([data-border]) {
+          --input-box-shadow: ${$unstableDisableFocusRing
+            ? undefined
+            : focusRingStyle({focusRing: input.text.focusRing})};
+        }
+      }
+
+      /* disabled */
+      *:not(.invalid):disabled + & {
+        --card-bg-color: ${color.input.default.disabled.bg} !important;
+        --card-fg-color: ${color.input.default.disabled.fg} !important;
+        --card-icon-color: ${color.input.default.disabled.fg} !important;
+
+        &[data-border] {
+          --input-box-shadow: ${focusRingBorderStyle({
+            color: color.input.default.disabled.border,
+            width: input.border.width,
+          })};
+        }
+      }
+
+      *.invalid:disabled + & {
+        --card-bg-color: ${color.input.invalid.disabled.bg} !important;
+        --card-fg-color: ${color.input.invalid.disabled.fg} !important;
+        --card-icon-color: ${color.input.invalid.disabled.fg} !important;
+
+        &[data-border] {
+          --input-box-shadow: ${focusRingBorderStyle({
+            color: color.input.invalid.disabled.border,
+            width: input.border.width,
+          })};
+        }
+      }
+
+      /* readOnly */
+      *:not(.invalid):read-only + & {
+        --card-bg-color: ${color.input.default.readOnly.bg} !important;
+        --card-fg-color: ${color.input.default.readOnly.fg} !important;
+      }
+
+      *.invalid:read-only + & {
+        --card-bg-color: ${color.input.invalid.readOnly.bg} !important;
+        --card-fg-color: ${color.input.invalid.readOnly.fg} !important;
+      }
+
+      /* hovered */
+      @media (hover: hover) {
+        *:not(:disabled):not(:read-only):not(.invalid):hover + & {
+          --card-bg-color: ${color.input.default.hovered.bg};
+          --card-fg-color: ${color.input.default.hovered.fg};
+        }
+
+        *.invalid:not(:disabled):not(:read-only):hover + & {
+          --card-bg-color: ${color.input.invalid.hovered.bg};
+          --card-fg-color: ${color.input.invalid.hovered.fg};
+        }
+
+        *:not(:disabled):not(:read-only):not(.invalid):not(:focus):hover + &[data-border] {
+          --input-box-shadow: ${focusRingBorderStyle({
+            color: color.input.default.hovered.border,
+            width: input.border.width,
+          })};
+        }
+
+        *.invalid:not(:disabled):not(:read-only):not(:focus):hover + &[data-border] {
+          --input-box-shadow: ${focusRingBorderStyle({
+            color: color.input.invalid.hovered.border,
+            width: input.border.width,
+          })};
+        }
+      }
+    }
+  `
+}
+
+/**
+ * Heavily based on the styling provided by Sanity UI.
+ */
+export interface TextInputResponsivePaddingStyleProps {
+  $fontSize: number[]
+  $iconLeft?: boolean
+  $iconRight?: boolean
+  $padding: number[]
+  $space: number[]
+}
+
+/**
+ * Heavily based on the styling provided by Sanity UI.
+ */
+export function responsiveInputPaddingStyle(
+  props: TextInputResponsivePaddingStyleProps & ThemeProps,
+): CSSObject[] {
+  const {$fontSize, $iconLeft, $iconRight, $padding, $space} = props
+  const {font, media, space} = getTheme_v2(props.theme)
+  const len = Math.max($padding.length, $space.length, $fontSize.length)
+  const _padding: number[] = []
+  const _space: number[] = []
+  const _fontSize: number[] = []
+
+  for (let i = 0; i < len; i += 1) {
+    _fontSize[i] = $fontSize[i] === undefined ? _fontSize[i - 1] : $fontSize[i]
+    _padding[i] = $padding[i] === undefined ? _padding[i - 1] : $padding[i]
+    _space[i] = $space[i] === undefined ? _space[i - 1] : $space[i]
+  }
+
+  return _responsive(media, _padding, (_, i) => {
+    const size = font.text.sizes[_fontSize[i]] || font.text.sizes[2]
+    const emSize = size.lineHeight - size.ascenderHeight - size.descenderHeight
+    const p = space[_padding[i]]
+    const s = space[_space[i]]
+
+    const styles = {
+      paddingTop: rem(p - size.ascenderHeight),
+      paddingRight: rem(p),
+      paddingBottom: rem(p - size.descenderHeight),
+      paddingLeft: rem(p),
+    }
+
+    if ($iconRight) styles.paddingRight = rem(p + emSize + s)
+    if ($iconLeft) styles.paddingLeft = rem(p + emSize + s)
+
+    return styles
+  })
+}
+
+/**
+ * Heavily based on the styling provided by Sanity UI.
+ */
+export interface TextInputInputStyleProps {
+  $fontSize: number[]
+  $scheme: ThemeColorSchemeKey
+  $tone: CardTone
+  $weight?: ThemeFontWeightKey
+}
+
+/**
+ * Heavily based on the styling provided by Sanity UI.
+ */
+export function textInputFontSizeStyle(props: TextInputInputStyleProps & ThemeProps): CSSObject[] {
+  const {font, media} = getTheme_v2(props.theme)
+
+  return _responsive(media, props.$fontSize, (sizeIndex) => {
+    const size = font.text.sizes[sizeIndex] || font.text.sizes[2]
+
+    return {
+      fontSize: rem(size.fontSize),
+      lineHeight: size.lineHeight / size.fontSize,
+    }
+  })
+}
+
+export function inputStyles(): RuleSet {
+  return css`
+    del {
+      opacity: 0.5;
+      text-decoration: line-through;
+
+      &::before {
+        text-decoration: line-through;
+        content: attr(data-text);
+      }
+    }
+
+    ins {
+      text-decoration: none;
+    }
+  `
+}

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/unpackageValue.test.ts
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/unpackageValue.test.ts
@@ -1,0 +1,39 @@
+import {expect, it} from 'vitest'
+
+import {unpackageValue} from './unpackageValue'
+
+it('extracts the primitive value from a Portable Text value', () => {
+  expect(
+    unpackageValue([
+      {
+        _key: 'root',
+        _type: 'block',
+        children: [
+          {
+            _key: 'root',
+            _type: 'span',
+            text: 'a',
+          },
+        ],
+      },
+    ]),
+  ).toBe('a')
+})
+
+it('gracefully handles `undefined` output value', () => {
+  expect(
+    unpackageValue([
+      {
+        _key: 'root',
+        _type: 'block',
+        children: [
+          {
+            _key: 'root',
+            _type: 'span',
+            text: '',
+          },
+        ],
+      },
+    ]),
+  ).toBe('')
+})

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/unpackageValue.ts
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/unpackageValue.ts
@@ -1,0 +1,20 @@
+import {type PortableTextObject} from '@portabletext/editor'
+import {type PortableTextBlock} from '@portabletext/react'
+import {isPortableTextBlock} from '@portabletext/toolkit'
+
+/**
+ * Unpackage a primitive string field value from a Portable Text value.
+ *
+ * The primitive string must be stored at the path
+ * `[{_key: 'root'}, 'children', {_key: 'root'}]`.
+ *
+ * @internal
+ */
+export function unpackageValue(value: (PortableTextBlock | PortableTextObject)[] = []): string {
+  return (
+    value
+      .filter((block) => isPortableTextBlock(block))
+      .find(({_key}) => _key === 'root')
+      ?.children?.find(({_key}) => _key === 'root')?.text ?? ''
+  )
+}

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -204,6 +204,7 @@ exports[`exports snapshot 1`] = `
     "TransformPatches": "object",
     "Translate": "function",
     "UniversalArrayInput": "function",
+    "UpdateReadOnlyPlugin": "function",
     "UpsellDescriptionSerializer": "function",
     "UpsellDialogDismissed": "object",
     "UpsellDialogLearnMoreCtaClicked": "object",

--- a/packages/sanity/test/form/renderStringInput.tsx
+++ b/packages/sanity/test/form/renderStringInput.tsx
@@ -1,6 +1,7 @@
 import {type FieldDefinition, type StringSchemaType} from '@sanity/types'
 
 import {type PrimitiveInputElementProps, type StringInputProps} from '../../src/core'
+import {prepareDiffProps} from '../../src/core/form/store/formState'
 import {renderInput, type TestRenderInputContext, type TestRenderInputProps} from './renderInput'
 import {type TestRenderProps} from './types'
 
@@ -29,10 +30,13 @@ export async function renderStringInput(options: {
         ...elementProps,
         value: value as string,
       },
-      changed: false,
       schemaType: schemaType as StringSchemaType,
       value: value as string,
       renderDefault: noopRenderDefault,
+      ...prepareDiffProps({
+        schemaType,
+        comparisonValue: value,
+      }),
     }
   }
 


### PR DESCRIPTION
### Description

This branch introduces the new, Portable Text Editor based, primitive input component: `StringInputPortableText`.

<img width="637" height="120" alt="Screenshot 2025-09-08 at 14 40 27" src="https://github.com/user-attachments/assets/859e3c16-b0e6-4617-b9b0-8125c04aee71" />

This input component is used instead of the basic implementation when inline diffs are switched on. This is currently controlled by setting the `advancedVersionControl.enabled` Studio configuration option to `true`.

> [!TIP]
> I've switched this on in the Test Studio Playground workspace. Try navigating to `/playground/structure/input-standard;stringsTest;038a77b8-1a4c-4be7-8db6-79ac1612ae43%2Ctemplate%3DstringsTest?perspective=rAREWsMhm` to see inline diffs in action. [Vercel preview link](https://test-studio-git-feat-primitive-pte-fields.sanity.dev/playground/structure/input-standard;stringsTest;038a77b8-1a4c-4be7-8db6-79ac1612ae43?perspective=rAREWsMhm).

The Portable Text Editor based inputs will likely expand in the future to support features such as presence carets, and eventually become the default/only input component.

### What to review

The new `StringInputPortableText` input component. The easiest way to test this out is to go to the Vercel preview link included above and use any of the string fields.

### Testing

I've added unit tests for key functionality.

I intended to additionally replicate the `StringInputBasic` test suite (`StringInputBasic.test.tsx`) to ensure `StringInputPortableText` matches its behaviour. I've added these tests in `StringInputPortableText.test.tsx`, however, we are limited by jsdom's lack of support for `contenteditable`.

This is a good candidate to adopt Vitest Browser Mode, which would allow the test suite to reach parity with `StringInputBasic.test.tsx`. I don't think this is a blocker for now, because advanced version control is opt-in, and will initially be used by a low volume of people.

### Notes for release

Studio now supports the display of diffs inside fields. When viewing a version of a document in the editor, or viewing versions side by side in the "Compare versions" view, fields will display inline annotations reflecting how their content has changed.

<img width="660" height="120" alt="Screenshot of string field in Sanity Studio show diff annotation from 'Fall Collection 2025' to 'Autumn Collection 2025'" src="https://github.com/user-attachments/assets/2d6ac935-71bd-4b8b-91a3-68a11d0596ec" />

We have implemented this functionality for `string` fields to begin with, but are currently working to add it to other field types. To switch this on for a workspace, set the `advancedVersionControl.enabled` configuration option to `true`.

Note: this functionality is likely to change as we improve and expand it. Please let us know if you have any feedback.