### PR TITLE
fix(core): handle tasks with undefined dates

### DIFF
--- a/packages/sanity/src/core/tasks/components/form/fields/DateEditFormField.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/DateEditFormField.tsx
@@ -16,10 +16,10 @@ import {SCHEDULED_PUBLISHING_TIME_ZONE_SCOPE} from '../../../../studio/constants
 import {tasksLocaleNamespace} from '../../../i18n'
 
 const serialize = (date: Date) => format(date, DEFAULT_DATE_FORMAT)
-const deserialize = (value: string) => parse(value, DEFAULT_DATE_FORMAT)
+const deserialize = (value: string | undefined) => parse(value || '', DEFAULT_DATE_FORMAT)
 
 export function DateEditFormField(props: {
-  value: string
+  value: string | undefined
   onChange: (patch: FormPatch | PatchEvent | FormPatch[]) => void
   path: Path
 }) {


### PR DESCRIPTION
### Description
Fixes https://github.com/sanity-io/sanity/issues/9792
When opening a task with no due date assigned it should not crash.

#### Before
https://github.com/user-attachments/assets/758f1da6-1637-4218-a2b8-2bf0e148a0fa 

#### After
https://github.com/user-attachments/assets/179028f7-e4a1-4fb6-a13b-3c0bcbbd6c1c 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in where tasks with no due dates crash to open
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->


