### PR TITLE
fix(sanity): do not attempt to provision media library

### DIFF
--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibrary.test.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibrary.test.tsx
@@ -1,6 +1,6 @@
 import {type SanityClient} from '@sanity/client'
 import {type AssetSourceComponentProps} from '@sanity/types'
-import {render, screen, waitFor} from '@testing-library/react'
+import {render, waitFor} from '@testing-library/react'
 import {noop} from 'lodash'
 import {describe, expect, test} from 'vitest'
 
@@ -60,25 +60,7 @@ describe('provisioning', () => {
     })
   })
 
-  test('renders error when there are no Media Libraries result', async () => {
-    const client = createMockSanityClient({
-      requests: {
-        '/projects/mock-project-id': {
-          organizationId,
-        },
-      },
-    })
-    const TestProvider = await createWrapperComponent(client as any)
-
-    const {getByTestId} = render(<TestProvider>{assetSourceComponent}</TestProvider>)
-
-    await waitFor(() => {
-      expect(getByTestId('media-library-provision-error')).toBeInTheDocument()
-      expect(getByTestId('ERROR_NO_MEDIA_LIBRARIES_FOUND')).toBeInTheDocument()
-    })
-  })
-
-  test('renders error if creating a new Media Library fails', async () => {
+  test('renders warning when there are no Media Libraries result', async () => {
     const client = createMockSanityClient({
       requests: {
         '/projects/mock-project-id': {
@@ -90,11 +72,11 @@ describe('provisioning', () => {
       },
     })
     const TestProvider = await createWrapperComponent(client as any)
+
     const {getByTestId} = render(<TestProvider>{assetSourceComponent}</TestProvider>)
 
     await waitFor(() => {
-      expect(getByTestId('media-library-provision-error')).toBeInTheDocument()
-      expect(getByTestId('ERROR_FAILED_TO_CREATE_MEDIA_LIBRARY')).toBeInTheDocument()
+      expect(getByTestId('media-library-absent-warning')).toBeInTheDocument()
     })
   })
 
@@ -127,49 +109,6 @@ describe('provisioning', () => {
     await waitFor(() => {
       expect(getByTestId('media-library-provision-error')).toBeInTheDocument()
       expect(getByTestId('MEDIA_LIBRARY_ERROR_UNEXPECTED')).toBeInTheDocument()
-    })
-  })
-
-  test('provisions a media library successfully', async () => {
-    const client = createMockSanityClient({
-      requests: {
-        '/projects/mock-project-id': {
-          organizationId,
-        },
-        '/media-libraries?organizationId=mock-organization-id': {
-          data: [],
-        },
-        // POST request response to provision a Media Library
-        '/media-libraries': {
-          id: 'mock-library-id',
-          name: 'Mock Media Library',
-          organizationId,
-          status: 'provisioning',
-        },
-        '/media-libraries/mock-library-id': {
-          id: 'mock-library-id',
-          name: 'Mock Media Library',
-          organizationId,
-          status: 'active',
-        },
-      },
-    })
-    const TestProvider = await createWrapperComponent(client as any)
-    render(<TestProvider>{assetSourceComponent}</TestProvider>)
-
-    // Provisioning message should be shown
-    await waitFor(() => {
-      expect(screen.queryByTestId('media-library-provisioning-message')).toBeInTheDocument()
-    })
-
-    // Provisioning message should not be shown after the Media Library is provisioned
-    await waitFor(() => {
-      expect(screen.queryByTestId('media-library-provisioning-message')).not.toBeInTheDocument()
-    })
-
-    // Media Library dialog should be shown
-    await waitFor(() => {
-      expect(screen.queryByTestId('media-library-plugin-dialog-select-assets')).toBeInTheDocument()
     })
   })
 })

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/EnsureMediaLibrary.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/EnsureMediaLibrary.tsx
@@ -1,5 +1,5 @@
 import {ErrorOutlineIcon} from '@sanity/icons'
-import {Card, Flex, Spinner, Stack, Text} from '@sanity/ui'
+import {Card, Flex, Stack, Text} from '@sanity/ui'
 import {useEffect} from 'react'
 
 import {useTranslation} from '../../../../i18n'
@@ -19,6 +19,21 @@ export function EnsureMediaLibrary(props: {
     }
   }, [id, onSetMediaLibraryId, status])
 
+  if (status === 'inactive') {
+    return (
+      <Card padding={4} radius={4} tone="caution" data-testid="media-library-absent-warning">
+        <Flex gap={3}>
+          <Text size={1}>
+            <ErrorOutlineIcon />
+          </Text>
+          <Text size={1} weight="semibold">
+            {t('asset-sources.media-library.error.no-media-library-provisioned')}
+          </Text>
+        </Flex>
+      </Card>
+    )
+  }
+
   if (status === 'error' && error) {
     const errorCodeTestId = error.code
     return (
@@ -37,21 +52,6 @@ export function EnsureMediaLibrary(props: {
       </Card>
     )
   }
-  if (status === 'provisioning') {
-    return (
-      <Card padding={4} radius={4} tone="caution">
-        <Flex gap={3}>
-          <Text size={1}>
-            <Spinner />
-          </Text>
-          <Stack space={4}>
-            <Text size={1} weight="semibold" data-testid="media-library-provisioning-message">
-              {t('asset-sources.media-library.info.provisioning')}
-            </Text>
-          </Stack>
-        </Flex>
-      </Card>
-    )
-  }
+
   return null
 }

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -172,13 +172,13 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'asset-sources.media-library.error.library-could-not-be-resolved':
     'Something went wrong trying to resolve the Media Library for this project.',
 
+  /** Error message shown when no media library has been provisioned for the current organization */
+  'asset-sources.media-library.error.no-media-library-provisioned':
+    'No media library has been provisioned for this organization.',
+
   /** Menu Items for Media Library Asset Source */
   'asset-sources.media-library.file.title': 'Media Library',
   'asset-sources.media-library.image.title': 'Media Library',
-
-  /** Info messages for the Media Library Asset Source  */
-  'asset-sources.media-library.info.provisioning':
-    'Please wait while we prepare your Media Library',
 
   /** Label when a release has been deleted by a different user */
   'banners.deleted-bundle-banner.text':


### PR DESCRIPTION
### Description

Users are no longer permitted to provision a media library themselves. Therefore, Studio must not attempt to provision a media library for users on the fly.

Instead, a warning is shown when attempting to interact with a Media Library asset source should no media library exist for the current organisation.

<img width="655" height="202" alt="Screenshot 2025-07-21 at 16 16 08" src="https://github.com/user-attachments/assets/0da9ab1d-4043-45ac-9052-eb2fff69ba0d" />

### What to review

Media Library asset sources, particularly when no media library exists for the current organisation.

### Testing

Updated unit tests.