### PR TITLE
chore: enable manifest update with tags in production

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -100,8 +100,6 @@ jobs:
         run: pnpm bundle-manager publish --tag=next
 
       - name: Upload bundles to production bucket
-        # NOTE: we're not uploading prereleases to production bucket yet
-        if: ${{ false }}
         env:
           GOOGLE_PROJECT_ID: ${{ secrets.GCS_PRODUCTION_PROJECT_ID }}
           GCLOUD_SERVICE_KEY: ${{ secrets.GCS_PRODUCTION_SERVICE_KEY }}

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -122,12 +122,12 @@ jobs:
           echo "Using version: $version"
           pnpm bundle-manager tag --tag=stable --target-version="$version"
 
-      # - name: Update manifest with stable tag (production)
-      #   env:
-      #     GOOGLE_PROJECT_ID: ${{ secrets.GCS_PRODUCTION_PROJECT_ID }}
-      #     GCLOUD_SERVICE_KEY: ${{ secrets.GCS_PRODUCTION_SERVICE_KEY }}
-      #     GCLOUD_BUCKET: ${{ secrets.GCS_PRODUCTION_BUCKET }}
-      #   run: |
-      #     version="${{ needs.get-version.outputs.version }}"
-      #     echo "Using version: $version"
-      #     pnpm bundle-manager tag --tag=stable --target-version="$version"
+      - name: Update manifest with stable tag (production)
+        env:
+          GOOGLE_PROJECT_ID: ${{ secrets.GCS_PRODUCTION_PROJECT_ID }}
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCS_PRODUCTION_SERVICE_KEY }}
+          GCLOUD_BUCKET: ${{ secrets.GCS_PRODUCTION_BUCKET }}
+        run: |
+          version="${{ needs.get-version.outputs.version }}"
+          echo "Using version: $version"
+          pnpm bundle-manager tag --tag=stable --target-version="$version"


### PR DESCRIPTION
### Description
We have this enabled in `release-latest` and it currently silently fails because we don't support tagging in production yet. 

Best to have this in place for when we do.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
