### PR TITLE
refactor: inline `$Tuple` type helper

### DIFF
--- a/packages/@repo/test-dts-exports/test/lib-check.test.ts
+++ b/packages/@repo/test-dts-exports/test/lib-check.test.ts
@@ -89,11 +89,6 @@ const filteredErrors = errors.filter((d) => {
     return false
   }
 
-  // Handled in https://github.com/sanity-io/sanity/pull/9987
-  if (file.fileName.includes('packages/sanity/lib/index.') && code === 2307) {
-    return false
-  }
-
   // Handled in https://github.com/sanity-io/sanity/pull/9988
   if (file.fileName.includes('packages/sanity/lib/index.') && code === 2717) {
     return false

--- a/packages/sanity/src/core/i18n/hooks/useTranslation.ts
+++ b/packages/sanity/src/core/i18n/hooks/useTranslation.ts
@@ -1,10 +1,13 @@
 /* eslint-disable @sanity/i18n/no-i18next-import */
 import {type FlatNamespace, type KeyPrefix, type Namespace, type TFunction} from 'i18next'
 import {type FallbackNs, useTranslation as useOriginalTranslation} from 'react-i18next'
-// @ts-expect-error types are missing
-import {type $Tuple} from 'react-i18next/helpers'
 
 import {maybeWrapT} from '../debug'
+
+/**
+ * Inlined from `react-i18next/helpers`, as our TSC doesn't support importing from it.
+ */
+type $Tuple<T> = readonly [T?, ...T[]]
 
 /**
  * Return value from the `useTranslate` hook


### PR DESCRIPTION
### Description

Doing so allows us to get rid of a `@ts-expect-error` directive, and one less exception to the DTS test suite (closes #9987).

### What to review

Enough context on the inline?

### Testing

If all is green we're good to go.

### Notes for release

N/A
