### PR TITLE
fix(core): add perspectiveStack to tasks for preview title

### DIFF
--- a/packages/sanity/src/core/tasks/hooks/useDocumentPreviewValues.ts
+++ b/packages/sanity/src/core/tasks/hooks/useDocumentPreviewValues.ts
@@ -4,6 +4,7 @@ import {useObservable} from 'react-rx'
 import {of} from 'rxjs'
 
 import {useSchema} from '../../hooks'
+import {usePerspective} from '../../perspective/usePerspective'
 import {getPreviewStateObservable} from '../../preview'
 import {useDocumentPreviewStore} from '../../store'
 
@@ -23,11 +24,11 @@ export function useDocumentPreviewValues(options: PreviewHookOptions): PreviewHo
   const schemaType = useSchema().get(documentType)
 
   const documentPreviewStore = useDocumentPreviewStore()
-
+  const {perspectiveStack} = usePerspective()
   const previewStateObservable = useMemo(() => {
     if (!documentId || !schemaType) return of(null)
-    return getPreviewStateObservable(documentPreviewStore, schemaType, documentId)
-  }, [documentId, documentPreviewStore, schemaType])
+    return getPreviewStateObservable(documentPreviewStore, schemaType, documentId, perspectiveStack)
+  }, [documentId, documentPreviewStore, schemaType, perspectiveStack])
   const previewState = useObservable(previewStateObservable)
 
   const isLoading = previewState?.isLoading ?? true


### PR DESCRIPTION
### Description

Fixes issue where the snapshot for the document in a task was showing as undefined due to a missing perspective stack in the observable

Before
<img width="2150" height="1156" alt="image" src="https://github.com/user-attachments/assets/8b637ab5-7eec-4680-84e0-85fc55005591" />

After
<img width="1098" height="361" alt="image" src="https://github.com/user-attachments/assets/a54cbc2e-4368-430d-8a8f-e85ebbff241e" />


### What to review

That everything works as expected

### Testing

Manual testing

1. Create a new document in the Studio and give it a title.
2. Leave the document in draft state (do not publish it).
3. Create a task that references this draft document.
4. Go to the tasks list view — the referenced document appears as the right title.

### Notes for release

Fixes an issue where the title for a draft document with a task wasn't showing up when opening the task list view.
