### PR TITLE
chore: allow console logs in example functions

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -154,5 +154,7 @@
     // Temporarily disabled, will be re-enabled in the near term
     "unicorn/prefer-set-has": "off"
   },
-  "overrides": [{"files": ["scripts/**/*"], "rules": {"no-console": "off"}}]
+  "overrides": [
+    {"files": ["scripts/**/*", "examples/functions/**/*"], "rules": {"no-console": "off"}}
+  ]
 }

--- a/examples/functions/algolia-document-sync/index.ts
+++ b/examples/functions/algolia-document-sync/index.ts
@@ -22,10 +22,8 @@ export const handler = documentEventHandler(async ({event}) => {
       },
     })
 
-    // eslint-disable-next-line no-console
     console.log(`Successfully synced document ${_id} ("${title}") to Algolia`)
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('Error syncing to Algolia:', error)
     throw error
   }

--- a/examples/functions/auto-summary/index.ts
+++ b/examples/functions/auto-summary/index.ts
@@ -27,7 +27,6 @@ export const handler = documentEventHandler(async ({context, event}) => {
       schemaId: '_.schemas.default',
       forcePublishedWrite: true,
     })
-    // eslint-disable-next-line no-console
     console.log(
       local
         ? 'Generated summary (LOCAL TEST MODE - Content Lake not updated):'
@@ -35,7 +34,6 @@ export const handler = documentEventHandler(async ({context, event}) => {
       result.autoSummary,
     )
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('Error occurred during summary generation:', error)
   }
 })

--- a/examples/functions/auto-tag/index.ts
+++ b/examples/functions/auto-tag/index.ts
@@ -34,13 +34,11 @@ export const handler = documentEventHandler(async ({context, event}) => {
       schemaId: '_.schemas.default',
       forcePublishedWrite: true,
     })
-    // eslint-disable-next-line no-console
     console.log(
       local ? 'Generated tags (LOCAL TEST MODE - Content Lake not updated):' : 'Generated tags:',
       result.tags,
     )
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('Error occurred during tag generation:', error)
   }
 })

--- a/examples/functions/brand-voice-validator/index.ts
+++ b/examples/functions/brand-voice-validator/index.ts
@@ -59,7 +59,6 @@ Keep the language casual, clear, and friendly. Speak directly to readers as "you
       schemaId: '_.schemas.default',
       forcePublishedWrite: true,
     })
-    // eslint-disable-next-line no-console
     console.log(
       local
         ? 'Generated content suggestions (LOCAL TEST MODE - Content Lake not updated):'
@@ -67,7 +66,6 @@ Keep the language casual, clear, and friendly. Speak directly to readers as "you
       result.suggestedChanges,
     )
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('Error occurred during content suggestions generation:', error)
   }
 })

--- a/examples/functions/capture-tone-of-voice/index.ts
+++ b/examples/functions/capture-tone-of-voice/index.ts
@@ -32,7 +32,6 @@ export const handler = documentEventHandler(async ({context, event}) => {
       schemaId: '_.schemas.default',
       forcePublishedWrite: true,
     })
-    // eslint-disable-next-line no-console
     console.log(
       local
         ? 'Generated tone analysis (LOCAL TEST MODE - Content Lake not updated):'
@@ -40,7 +39,6 @@ export const handler = documentEventHandler(async ({context, event}) => {
       result.toneOfVoice,
     )
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('Error occurred during tone of voice generation:', error)
   }
 })

--- a/examples/functions/first-published/index.ts
+++ b/examples/functions/first-published/index.ts
@@ -18,7 +18,6 @@ export const handler = documentEventHandler(async ({context, event}) => {
         firstPublished: firstPublishedDate,
       })
       .commit({dryRun: local})
-    // eslint-disable-next-line no-console
     console.log(
       local
         ? `(LOCAL TEST MODE - Content Lake not updated) Set firstPublished timestamp for document (${data._id}): ${firstPublishedDate}  `
@@ -26,7 +25,6 @@ export const handler = documentEventHandler(async ({context, event}) => {
       result,
     )
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('Error setting firstPublished timestamp:', error)
   }
 })

--- a/examples/functions/slack-notify/index.ts
+++ b/examples/functions/slack-notify/index.ts
@@ -24,7 +24,6 @@ export const handler = documentEventHandler(async ({event}) => {
       text: message,
     })
 
-    // eslint-disable-next-line no-console
     console.log(
       'Slack notification sent successfully to channel:',
       SLACK_CHANNEL,
@@ -32,7 +31,6 @@ export const handler = documentEventHandler(async ({event}) => {
       message,
     )
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('Error sending Slack notification:', error)
     throw error
   }


### PR DESCRIPTION
### Description

Hi!  We have recently started a project called the Function Recipe Library.  Functions can be easily added to a project using `npx sanity blueprints add function --example slack-notify `.  Those functions that get pull live here [https://github.com/sanity-io/sanity/tree/main/examples/functions](https://github.com/sanity-io/sanity/tree/main/examples/functions).  We console log debugging data in all of these functions to make them easier to test and understand.  

This PR's purpose is to:
- Remove the need to use a comment to allow console logs
- Assuming it gets approved, remove the console logs.

### What to review

Review the proper formatting and effect of ```"overrides": [
    {"files": ["scripts/**/*", "examples/functions/**/*"], "rules": {"no-console": "off"}}
  ]```

### Testing

This shouldn't need too much testing, but testing could be done by adding the attempting to commit the `example/functions/<function-name>/index.ts` without the override comments and see if it gets flagged.

### Notes for release

I don't believe this requires any notes in the release