### PR TITLE
chore(lint): enable strict jsx key rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -87,6 +87,7 @@
     ],
     "typescript/ban-ts-comment": "error",
     "typescript/prefer-ts-expect-error": "error",
+    "react/jsx-key": "error",
     // Not relevant as we use the modern jsx-runtime transform
     "react-in-jsx-scope": "off",
     // Not relevant due to React Compiler
@@ -144,7 +145,6 @@
     "jsx_a11y/aria-role": "warn",
     "jsx_a11y/label-has-associated-control": "warn",
     "unicorn/prefer-add-event-listener": "warn",
-    "react/jsx-key": "warn",
     "jsx_a11y/role-supports-aria-props": "warn",
     "unicorn/no-useless-length-check": "warn",
     "react/iframe-missing-sandbox": "warn",

--- a/dev/test-studio/plugins/language-filter/LanguageFilterMenuButton.tsx
+++ b/dev/test-studio/plugins/language-filter/LanguageFilterMenuButton.tsx
@@ -95,8 +95,8 @@ export function LanguageFilterMenuButton(props: LanguageFilterMenuButtonProps) {
 
         {languageOptions.map((lang) => (
           <LanguageFilterOption
-            id={lang.id}
             key={lang.id}
+            id={lang.id}
             onToggle={toggleLanguage}
             selected={selectedLanguages.includes(lang.id)}
             title={lang.title}

--- a/dev/test-studio/schema/debug/components/AuthorReferenceInput.tsx
+++ b/dev/test-studio/schema/debug/components/AuthorReferenceInput.tsx
@@ -97,8 +97,8 @@ export const AuthorReferenceInput = forwardRef(function AuthorReferenceInput(
       ) : (
         authors.map((author, i) => (
           <Button
-            ref={i === 0 ? inputRef : undefined}
             key={author._id}
+            ref={i === 0 ? inputRef : undefined}
             type="button"
             // className={current === author._id ? styles.activeButton : styles.button}
             onClick={readOnly ? noop : () => handleChange(author)}

--- a/dev/test-studio/schema/debug/components/DebugStega.tsx
+++ b/dev/test-studio/schema/debug/components/DebugStega.tsx
@@ -129,8 +129,8 @@ function InputDebugger(props: InputProps) {
 
               return (
                 <Button
-                  as="a"
                   key={href}
+                  as="a"
                   href={href}
                   tone="primary"
                   size={0}

--- a/dev/test-studio/schema/docs/v3/form-components-api/components.tsx
+++ b/dev/test-studio/schema/docs/v3/form-components-api/components.tsx
@@ -33,7 +33,7 @@ export function FormInput(props: InputProps) {
 
         <Flex align="center" gap={4}>
           {Object.entries(COMPONENT_COLORS).map(([key, value]) => (
-            <Inline space={2} key={key}>
+            <Inline key={key} space={2}>
               <div style={{width: '1em', height: '1em', background: value, borderRadius: '50%'}} />
               <Text size={1} weight="semibold">
                 {key.charAt(0).toUpperCase() + key.slice(1)}

--- a/packages/@repo/eslint-config/index.js
+++ b/packages/@repo/eslint-config/index.js
@@ -138,6 +138,16 @@ export default [
       'unicorn/prefer-keyboard-event-key': 'error',
       'unicorn/custom-error-definition': 'error',
       'no-warning-comments': 'off',
+      'react/jsx-sort-props': [
+        'error',
+        {
+          // The JSX transform might use `React.createElement` instead of the jsx runtime if the order of `key` is wrong: https://github.com/facebook/react/issues/20031#issuecomment-710346866
+          reservedFirst: ['key'],
+          // While alphabetical sorting usually makes the code more readable, it's tricky to enable it while PRs are in-flight as it creates a very large diff.
+          // Thus for now it's disabled.
+          noSortAlphabetically: true,
+        },
+      ],
     },
     settings: {
       'import/extensions': extensions,

--- a/packages/sanity/src/core/changeIndicators/overlay/ConnectorsOverlay.tsx
+++ b/packages/sanity/src/core/changeIndicators/overlay/ConnectorsOverlay.tsx
@@ -134,9 +134,9 @@ export function ConnectorsOverlay(props: ConnectorsOverlayProps) {
     <SvgWrapper style={{zIndex: visibleConnector && visibleConnector.field.zIndex}}>
       {visibleConnector?.change && (
         <ConnectorGroup
+          key={visibleConnector.field.id}
           field={visibleConnector.field}
           change={visibleConnector.change}
-          key={visibleConnector.field.id}
           onSetFocus={onSetFocus}
           setHovered={setHovered}
         />

--- a/packages/sanity/src/core/comments/components/CommentBreadcrumbs.tsx
+++ b/packages/sanity/src/core/comments/components/CommentBreadcrumbs.tsx
@@ -19,7 +19,7 @@ const separator = (
 
 const renderItem = (item: string, index: number) => {
   return (
-    <Box as="li" key={`${item}-${index}`}>
+    <Box key={`${item}-${index}`} as="li">
       <Text textOverflow="ellipsis" size={1} weight="medium">
         {item}
       </Text>

--- a/packages/sanity/src/core/comments/components/list/CommentsList.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsList.tsx
@@ -157,18 +157,18 @@ const CommentsListInner = forwardRef(function CommentsListInner(
 
               return (
                 <Stack
-                  as="li"
                   key={fieldPath}
+                  as="li"
                   paddingTop={3}
                   {...applyCommentsGroupAttr(firstThreadId)}
                 >
                   <CommentThreadLayout
+                    key={fieldPath}
                     breadcrumbs={breadcrumbs}
                     canCreateNewThread={status === 'open'}
                     currentUser={currentUser}
                     fieldPath={fieldPath}
                     isSelected={newThreadSelected}
-                    key={fieldPath}
                     mentionOptions={mentionOptions}
                     mode={mode}
                     onNewThreadCreate={onNewThreadCreate}
@@ -195,11 +195,11 @@ const CommentsListInner = forwardRef(function CommentsListInner(
 
                       return (
                         <CommentsListItem
+                          key={item.parentComment._id}
                           canReply={canReply}
                           currentUser={currentUser}
                           hasReferencedValue={item.hasReferencedValue}
                           isSelected={threadIsSelected}
-                          key={item.parentComment._id}
                           mentionOptions={mentionOptions}
                           mode={mode}
                           onCopyLink={onCopyLink}

--- a/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
@@ -266,7 +266,7 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
   const renderedReplies = useMemo(
     () =>
       splicedReplies.map((reply) => (
-        <Stack as="li" key={reply._id} {...applyCommentIdAttr(reply._id)}>
+        <Stack key={reply._id} as="li" {...applyCommentIdAttr(reply._id)}>
           <CommentsListItemLayout
             avatarSize={avatarConfig.avatarSize}
             canDelete={reply.authorId === currentUser.id}

--- a/packages/sanity/src/core/comments/components/reactions/CommentReactionsBar.tsx
+++ b/packages/sanity/src/core/comments/components/reactions/CommentReactionsBar.tsx
@@ -155,8 +155,8 @@ export const CommentReactionsBar = memo(function CommentReactionsBar(
 
           return (
             <CommentReactionsUsersTooltip
-              currentUser={currentUser}
               key={name}
+              currentUser={currentUser}
               reactionName={name}
               userIds={userIds}
             >

--- a/packages/sanity/src/core/comments/components/reactions/CommentReactionsMenu.tsx
+++ b/packages/sanity/src/core/comments/components/reactions/CommentReactionsMenu.tsx
@@ -79,10 +79,10 @@ export function CommentReactionsMenu(props: CommentReactionsMenuProps) {
 
         return (
           <UIButton
+            key={o.shortName}
             aria-label={t('reactions.react-with-aria-label', {
               reactionName: o.title || o.shortName,
             })}
-            key={o.shortName}
             mode="bleed"
             onClick={handleOptionClick}
             padding={2}

--- a/packages/sanity/src/core/comments/components/reactions/CommentReactionsUsersTooltip.tsx
+++ b/packages/sanity/src/core/comments/components/reactions/CommentReactionsUsersTooltip.tsx
@@ -126,7 +126,7 @@ function FormattedUserList({currentUserId, userIds}: {currentUserId: string; use
     // in an element that does _not_ have a leading non-whitespace literal following it.
     elements.push(
       // Key (value) is user ID, thus unique
-      <InlineText weight="medium" key={item.value}>
+      <InlineText key={item.value} weight="medium">
         <UserDisplayName currentUserId={currentUserId} isFirst={i === 0} userId={item.value} />
       </InlineText>,
     )

--- a/packages/sanity/src/core/components/InsufficientPermissionsMessage.tsx
+++ b/packages/sanity/src/core/components/InsufficientPermissionsMessage.tsx
@@ -47,10 +47,8 @@ export function InsufficientPermissionsMessage({
           .formatToParts(roles.map((role) => role.title || startCase(role.name)))
           .map((i, index) =>
             i.type === 'element' ? (
-              // eslint-disable-next-line react/no-array-index-key
               <code key={`${i.value}-${index}`}>{i.value}</code>
             ) : (
-              // eslint-disable-next-line react/no-array-index-key
               <Fragment key={`${i.value}-${index}`}>{i.value}</Fragment>
             ),
           )}

--- a/packages/sanity/src/core/components/commandList/__tests__/CommandList.test.tsx
+++ b/packages/sanity/src/core/components/commandList/__tests__/CommandList.test.tsx
@@ -33,7 +33,7 @@ function TestComponent(props: TestComponentProps) {
 
   const renderItem = useCallback((item: Item) => {
     return (
-      <button type="button" key={item.toString()} data-testid="button">
+      <button key={item.toString()} type="button" data-testid="button">
         Button
       </button>
     )

--- a/packages/sanity/src/core/components/inputs/DateFilters/calendar/CalendarMonth.tsx
+++ b/packages/sanity/src/core/components/inputs/DateFilters/calendar/CalendarMonth.tsx
@@ -50,12 +50,11 @@ export function CalendarMonth(props: CalendarMonthProps) {
 
             return (
               <CalendarDay
+                key={`${weekIdx}-${dayIdx}`}
                 date={dayDate}
                 focused={focused}
                 isCurrentMonth={isCurrentMonth}
                 isToday={isToday}
-                // eslint-disable-next-line react/no-array-index-key
-                key={`${weekIdx}-${dayIdx}`}
                 onSelect={props.onSelect}
                 selected={selected}
                 disabled={disabled}

--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
@@ -440,7 +440,7 @@ function CalendarMonthSelect(props: {
       <Box flex={1}>
         <Select fontSize={1} radius={2} value={value} onChange={onChange} padding={2}>
           {monthNames.map((monthName, i) => (
-            // eslint-disable-next-line react/no-array-index-key
+            // oxlint-disable-next-line no-array-index-key
             <option key={i} value={i}>
               {monthName}
             </option>

--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/CalendarMonth.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/CalendarMonth.tsx
@@ -55,12 +55,11 @@ export function CalendarMonth(props: CalendarMonthProps) {
 
             return (
               <CalendarDay
+                key={`${weekIdx}-${dayIdx}`}
                 date={date}
                 focused={focused}
                 isCurrentMonth={isCurrentMonth}
                 isToday={isToday}
-                // eslint-disable-next-line react/no-array-index-key
-                key={`${weekIdx}-${dayIdx}`}
                 onSelect={props.onSelect}
                 selected={selected}
                 isPastDisabled={props.isPastDisabled}

--- a/packages/sanity/src/core/components/rovingFocus/__workshop__/RovingFocusStory.tsx
+++ b/packages/sanity/src/core/components/rovingFocus/__workshop__/RovingFocusStory.tsx
@@ -46,9 +46,9 @@ export default function RovingFocusStory() {
         >
           {OPTIONS.map((num) => (
             <Button
+              key={num}
               text={`Option ${num + 1}`}
               disabled={Boolean(withDisabled && num % 2)}
-              key={num}
               mode="ghost"
             />
           ))}

--- a/packages/sanity/src/core/field/diff/components/ChangeBreadcrumb.tsx
+++ b/packages/sanity/src/core/field/diff/components/ChangeBreadcrumb.tsx
@@ -24,7 +24,8 @@ export function ChangeBreadcrumb(props: {change?: FieldChangeNode; titlePath: Ch
           return null
         }
 
-        return <ChangeTitleSegment change={change} key={idx} segment={titleSegment} />
+        // oxlint-disable-next-line no-array-index-key
+        return <ChangeTitleSegment key={idx} change={change} segment={titleSegment} />
       })}
     </Breadcrumbs>
   )

--- a/packages/sanity/src/core/field/diff/components/ChangeList.tsx
+++ b/packages/sanity/src/core/field/diff/components/ChangeList.tsx
@@ -105,8 +105,8 @@ export function ChangeList({diff, fields, schemaType}: ChangeListProps): React.J
           {changes.map((change) => (
             <div key={change.key}>
               <ChangeResolver
-                change={change}
                 key={change.key}
+                change={change}
                 data-revert-all-changes-hover={confirmRevertAllHover ? '' : undefined}
                 readOnly={isReadOnly || change?.readOnly}
                 hidden={change?.hidden}

--- a/packages/sanity/src/core/field/diff/components/DiffString.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffString.tsx
@@ -82,7 +82,7 @@ export function DiffString(props: {diff: StringDiff}) {
     <>
       {(diff.segments || []).map((segment, segmentIndex) => (
         <DiffStringSegment
-          // eslint-disable-next-line react/no-array-index-key
+          // oxlint-disable-next-line no-array-index-key
           key={segmentIndex}
           segment={segment}
         />

--- a/packages/sanity/src/core/field/diff/components/DiffTooltip.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffTooltip.tsx
@@ -53,7 +53,8 @@ function DiffTooltipWithAnnotation(props: DiffTooltipWithAnnotationsProps) {
       </Text>
       <Stack space={2}>
         {annotations.map((annotation, idx) => (
-          <AnnotationItem annotation={annotation} key={idx} />
+          // oxlint-disable-next-line no-array-index-key
+          <AnnotationItem key={idx} annotation={annotation} />
         ))}
       </Stack>
     </Stack>

--- a/packages/sanity/src/core/field/diff/components/Event.tsx
+++ b/packages/sanity/src/core/field/diff/components/Event.tsx
@@ -85,7 +85,7 @@ const UserLine = ({userId}: {userId: string}) => {
   const [user, loading] = useUser(userId)
 
   return (
-    <Flex align="center" gap={2} key={userId} padding={1}>
+    <Flex key={userId} align="center" gap={2} padding={1}>
       <Box>{loading || !user ? <AvatarSkeleton animated /> : <UserAvatar user={user} />}</Box>
       <Box>
         {loading || !user?.displayName ? (

--- a/packages/sanity/src/core/field/types/array/diff/ArrayOfOptionsFieldDiff.tsx
+++ b/packages/sanity/src/core/field/types/array/diff/ArrayOfOptionsFieldDiff.tsx
@@ -49,7 +49,7 @@ export const ArrayOfOptionsFieldDiff: DiffComponent<ArrayDiff> = ({diff, schemaT
           const color = getAnnotationColor(colorManager, annotation)
           const action = isPresent ? t('changes.added-label') : t('changes.removed-label')
           return (
-            <Flex align="center" key={getItemKey(diff, index)}>
+            <Flex key={getItemKey(diff, index)} align="center">
               <DiffTooltip annotations={annotation ? [annotation] : []} description={action}>
                 <Flex align="center">
                   <Checkbox checked={!isPresent} color={color} />

--- a/packages/sanity/src/core/field/types/portableText/diff/components/PortableText.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/PortableText.tsx
@@ -85,9 +85,9 @@ export function PortableText(props: Props): React.JSX.Element {
           if (textDiff && textDiff.action !== 'unchanged') {
             return (
               <DiffCard
+                key={`empty-block-${block._key}`}
                 annotation={textDiff.annotation}
                 as={textDiff.action === 'removed' ? 'del' : 'ins'}
-                key={`empty-block-${block._key}`}
                 tooltip={{
                   description: t('changes.portable-text.empty-text', {context: textDiff.action}),
                 }}
@@ -169,8 +169,8 @@ export function PortableText(props: Props): React.JSX.Element {
               : undefined
             const text = (
               <Text
-                diff={textDiff}
                 key={`text-${child._key}-${segIndex}`}
+                diff={textDiff}
                 path={[{_key: block._key}, 'children', {_key: child._key}]}
                 childDiff={childDiff}
                 segment={seg}
@@ -210,11 +210,11 @@ export function PortableText(props: Props): React.JSX.Element {
                   )
                 returnedChildren.push(
                   <Annotation
+                    key={key}
                     object={endedAnnotation.object}
                     diff={annotationDiff}
                     path={[{_key: block._key}, 'children', {_key: child._key}]}
                     schemaType={objectSchemaType}
-                    key={key}
                   >
                     <>{annotationSegments[endedAnnotation.mark]}</>
                   </Annotation>,
@@ -290,8 +290,7 @@ function renderTextSegment({
     activeMarks.forEach((mark) => {
       if (isDecorator(mark, spanSchemaType)) {
         children = (
-          // eslint-disable-next-line react/no-array-index-key
-          <Decorator mark={mark} key={`decorator-${mark}-${child._key}-${segIndex}`}>
+          <Decorator key={`decorator-${mark}-${child._key}-${segIndex}`} mark={mark}>
             {children}
           </Decorator>
         )
@@ -378,8 +377,8 @@ function renderDecorators({
   ) {
     returned = (
       <DiffCard
-        annotation={marksAnnotation}
         key={`diffcard-annotation-${segIndex}-${marksChanged.join('-')}`}
+        annotation={marksAnnotation}
         as={'ins'}
         tooltip={{
           description: t('changes.portable-text.changed-formatting'),

--- a/packages/sanity/src/core/form/components/formField/FormFieldValidationStatus.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldValidationStatus.tsx
@@ -79,8 +79,8 @@ export function FormFieldValidationStatus(props: FormFieldValidationStatusProps)
           {!showSummary && (
             <>
               {validation.map((item, itemIndex) => (
-                // eslint-disable-next-line react/no-array-index-key
-                <FormFieldValidationStatusItem validation={item} key={itemIndex} />
+                // oxlint-disable-next-line no-array-index-key
+                <FormFieldValidationStatusItem key={itemIndex} validation={item} />
               ))}
             </>
           )}

--- a/packages/sanity/src/core/form/components/tagInput/tagInput.tsx
+++ b/packages/sanity/src/core/form/components/tagInput/tagInput.tsx
@@ -267,7 +267,6 @@ export const TagInput = forwardRef(
 
         <div className="content">
           {value.map((tag, tagIndex) => (
-            // eslint-disable-next-line react/no-array-index-key
             <TagBox key={`tag-${tagIndex}`}>
               <Tag
                 enabled={enabled}

--- a/packages/sanity/src/core/form/field/actions/FieldActionMenu.tsx
+++ b/packages/sanity/src/core/form/field/actions/FieldActionMenu.tsx
@@ -76,7 +76,7 @@ export const FieldActionMenu = memo(function FieldActionMenu(props: FieldActionM
     <>
       {rootNodes.map((node, idx) => (
         <RootFieldActionMenuNode
-          // eslint-disable-next-line react/no-array-index-key
+          // oxlint-disable-next-line no-array-index-key
           key={idx}
           node={node}
           onOpen={handleOpen}
@@ -154,10 +154,10 @@ function RootFieldActionMenuGroup(props: {
           {node.children.map((action, idx) => {
             return (
               <FieldActionMenuNode
+                // oxlint-disable-next-line no-array-index-key
+                key={idx}
                 action={action}
                 isFirst={idx === 0}
-                // eslint-disable-next-line react/no-array-index-key
-                key={idx}
                 prevIsGroup={node.children[idx - 1]?.type === 'group'}
               />
             )

--- a/packages/sanity/src/core/form/field/actions/FieldActionMenuGroup.tsx
+++ b/packages/sanity/src/core/form/field/actions/FieldActionMenuGroup.tsx
@@ -25,10 +25,10 @@ export function FieldActionMenuGroup(props: {group: DocumentFieldActionGroup}) {
 
         {group.children.map((item, idx) => (
           <FieldActionMenuNode
+            // oxlint-disable-next-line no-array-index-key
+            key={idx}
             action={item}
             isFirst={idx === 0}
-            // eslint-disable-next-line react/no-array-index-key
-            key={idx}
             prevIsGroup={group.children[idx - 1]?.type === 'group'}
           />
         ))}
@@ -40,10 +40,10 @@ export function FieldActionMenuGroup(props: {group: DocumentFieldActionGroup}) {
     <MenuGroup icon={group.icon} popover={POPOVER_PROPS} text={title} tone={group.tone}>
       {group.children.map((item, idx) => (
         <FieldActionMenuNode
+          // oxlint-disable-next-line no-array-index-key
+          key={idx}
           action={item}
           isFirst={idx === 0}
-          // eslint-disable-next-line react/no-array-index-key
-          key={idx}
           prevIsGroup={group.children[idx - 1]?.type === 'group'}
         />
       ))}

--- a/packages/sanity/src/core/form/field/actions/FieldActionsResolver.tsx
+++ b/packages/sanity/src/core/form/field/actions/FieldActionsResolver.tsx
@@ -94,7 +94,7 @@ export const FieldActionsResolver = memo(function FieldActionsResolver(props: Fi
     <>
       {FieldActions.map((FieldAction, key) => (
         <FieldAction
-          // eslint-disable-next-line react/no-array-index-key
+          // oxlint-disable-next-line no-array-index-key
           key={key}
         />
       ))}

--- a/packages/sanity/src/core/form/inputs/InvalidValueInput/InvalidValueInput.tsx
+++ b/packages/sanity/src/core/form/inputs/InvalidValueInput/InvalidValueInput.tsx
@@ -120,7 +120,7 @@ export const InvalidValueInput = forwardRef(
             {validTypes.length !== 1 && (
               <Stack as="ul" space={2}>
                 {validTypes.map((validType) => (
-                  <Text as="li" key={validType}>
+                  <Text key={validType} as="li">
                     <code>{validType}</code>
                   </Text>
                 ))}
@@ -149,8 +149,8 @@ export const InvalidValueInput = forwardRef(
               <Stack space={1}>
                 {converters.map((converter) => (
                   <ConvertButton
-                    converter={converter}
                     key={`${converter.from}-${converter.to}`}
+                    converter={converter}
                     onConvert={handleConvertTo}
                     value={value}
                   />

--- a/packages/sanity/src/core/form/inputs/InvalidValueInput/UntypedValueInput.tsx
+++ b/packages/sanity/src/core/form/inputs/InvalidValueInput/UntypedValueInput.tsx
@@ -112,7 +112,7 @@ export function UntypedValueInput({validTypes, value, onChange}: UntypedValueInp
           {!isSingleValidType && (
             <Stack as="ul" space={2}>
               {validTypes.map((validType) => (
-                <Text as="li" key={validType} muted size={1}>
+                <Text key={validType} as="li" muted size={1}>
                   <code>{validType}</code>
                 </Text>
               ))}

--- a/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
@@ -49,11 +49,11 @@ const GroupTabs = ({
 
         return (
           <GroupTab
+            key={`${inputId}-${group.name}-tab`}
             aria-controls={`${inputId}-field-group-fields`}
             autoFocus={shouldAutoFocus && group.selected}
             disabled={disabled || group.disabled}
             icon={group?.icon}
-            key={`${inputId}-${group.name}-tab`}
             name={group.name}
             onClick={onClick}
             selected={Boolean(group.selected)}
@@ -100,9 +100,9 @@ const GroupSelect = ({
 
         return (
           <GroupOption
+            key={`${inputId}-${group.name}-tab`}
             aria-controls={`${inputId}-field-group-fields`}
             disabled={group.disabled}
-            key={`${inputId}-${group.name}-tab`}
             name={group.name}
             selected={Boolean(group.selected)}
             title={title}

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -319,6 +319,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
             count: rejected.length,
           }),
           description: rejected.map((task, i) => (
+            // oxlint-disable-next-line no-array-index-key
             <Flex key={i} gap={2} padding={2}>
               <Box>
                 <Text weight="medium">{task.file.name}</Text>

--- a/packages/sanity/src/core/form/inputs/PortableText/__workshop__/listCounter/ListCounterStory.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__workshop__/listCounter/ListCounterStory.tsx
@@ -121,7 +121,8 @@ export function ListCounterStory() {
       <Container width={1}>
         <EditableWrapper data-debug={debug ? '' : undefined} space={space}>
           {items.map((item, itemIndex) => (
-            <Block fontSize={fontSize} index={itemIndex} key={itemIndex} value={item} />
+            // oxlint-disable-next-line no-array-index-key
+            <Block key={itemIndex} fontSize={fontSize} index={itemIndex} value={item} />
           ))}
         </EditableWrapper>
       </Container>

--- a/packages/sanity/src/core/form/inputs/PortableText/_legacyDefaultParts/Markers.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/_legacyDefaultParts/Markers.tsx
@@ -52,7 +52,6 @@ export function DefaultMarkers(props: MarkersProps) {
     <Stack space={1}>
       {validation.length > 0 &&
         validation.map(({message, level}, index) => (
-          // eslint-disable-next-line react/no-array-index-key
           <Flex key={`validationItem-${index}`}>
             <Box marginRight={2} marginBottom={index + 1 === validation.length ? 0 : 2}>
               <IconText

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
@@ -89,6 +89,7 @@ export const ActionMenu = memo(function ActionMenu(props: ActionMenuProps) {
         const active = activeKeys.includes(action.key)
         return (
           <CollapseMenuButton
+            key={action.key}
             aria-label={t('toolbar.portable-text.action-button-aria-label', {
               action: action.title || action.key,
             })}
@@ -97,8 +98,6 @@ export const ActionMenu = memo(function ActionMenu(props: ActionMenuProps) {
             mode="bleed"
             dividerBefore={action.firstInGroup}
             icon={getActionIcon(action, active)}
-            key={action.key}
-            // eslint-disable-next-line react/jsx-no-bind
             onClick={() => action.handle(active)}
             selected={active}
             text={action.title || action.key}

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
@@ -40,6 +40,7 @@ export const InsertMenu = memo(function InsertMenu(props: InsertMenuProps) {
 
       return (
         <CollapseMenuButton
+          key={item.key}
           aria-label={t(
             item.inline
               ? 'inputs.portable-text.action.insert-inline-object-aria-label'
@@ -52,8 +53,7 @@ export const InsertMenu = memo(function InsertMenu(props: InsertMenuProps) {
           }
           data-testid={`${item.type.name}-insert-menu-button`}
           icon={item.icon}
-          key={item.key}
-          // eslint-disable-next-line react/jsx-no-bind, react/jsx-handler-names
+          // eslint-disable-next-line react/jsx-handler-names
           onClick={item.handle}
           text={title}
           tooltipText={t(

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
@@ -84,8 +84,8 @@ export function CreateButton(props: Props) {
         <Menu ref={menuRef}>
           {createOptions.map((createOption) => (
             <Tooltip
-              disabled={createOption.permission.granted}
               key={createOption.id}
+              disabled={createOption.permission.granted}
               content={
                 <InsufficientPermissionsMessage
                   currentUser={currentUser}

--- a/packages/sanity/src/core/form/inputs/SelectInput.tsx
+++ b/packages/sanity/src/core/form/inputs/SelectInput.tsx
@@ -143,10 +143,11 @@ const RadioSelect = forwardRef(function RadioSelect(
       <Layout space={3} role="group">
         {items.map((item, index) => (
           <RadioSelectItem
+            // oxlint-disable-next-line no-array-index-key
+            key={index}
             customValidity={customValidity}
             inputId={inputId}
             item={item}
-            key={index}
             onChange={onChange}
             onFocus={onFocus}
             readOnly={readOnly}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
@@ -168,6 +168,7 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
     return [
       !disableActions.includes('remove') && (
         <MenuItem
+          key="remove"
           text={t('inputs.array.action.remove')}
           tone="critical"
           icon={TrashIcon}
@@ -175,10 +176,16 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
         />
       ),
       !disableActions.includes('copy') && (
-        <MenuItem text={t('inputs.array.action.copy')} icon={CopyIcon} onClick={handleCopy} />
+        <MenuItem
+          key="copy"
+          text={t('inputs.array.action.copy')}
+          icon={CopyIcon}
+          onClick={handleCopy}
+        />
       ),
       !disableActions.includes('duplicate') && (
         <MenuItem
+          key="duplicate"
           text={t('inputs.array.action.duplicate')}
           icon={AddDocumentIcon}
           onClick={handleDuplicate}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/InsertMenuGroups.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/InsertMenuGroups.tsx
@@ -54,7 +54,7 @@ export function InsertMenuGroup(
     return <MenuItem key={pos} text={text} icon={icon} onClick={() => onInsert(pos, types[0])} />
   }
   return (
-    <MenuGroup text={text} key={pos} popover={MENU_POPOVER_PROPS}>
+    <MenuGroup key={pos} text={text} popover={MENU_POPOVER_PROPS}>
       {types?.map((insertableType) => (
         <MenuItem
           key={insertableType.name}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
@@ -231,8 +231,8 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
                   const member = members[virtualRow.index]
                   return (
                     <Item
-                      ref={virtualizer.measureElement}
                       key={virtualRow.key}
+                      ref={virtualizer.measureElement}
                       sortable={sortable}
                       data-index={virtualRow.index}
                       id={member.key}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfOptionsInput/ArrayOfObjectOptionsInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfOptionsInput/ArrayOfObjectOptionsInput.tsx
@@ -119,6 +119,7 @@ export function ArrayOfObjectOptionsInput(props: ArrayOfObjectsInputProps) {
           const disabled = !optionType
 
           return (
+            // oxlint-disable-next-line no-array-index-key
             <Flex key={index} align="center" as="label" muted={disabled}>
               <Checkbox
                 disabled={disabled}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfOptionsInput/ArrayOfPrimitiveOptionsInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfOptionsInput/ArrayOfPrimitiveOptionsInput.tsx
@@ -85,6 +85,7 @@ export function ArrayOfPrimitiveOptionsInput(props: ArrayOfPrimitivesInputProps)
           const disabled = !optionType
 
           return (
+            // oxlint-disable-next-line no-array-index-key
             <Flex key={index} align="center" as="label" muted={disabled}>
               <Checkbox
                 disabled={disabled}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions.tsx
@@ -87,6 +87,7 @@ export function ArrayOfPrimitivesFunctions<
                 const icon = memberDef.icon || memberDef.type?.icon || referenceIcon
                 return (
                   <MenuItem
+                    // oxlint-disable-next-line no-array-index-key
                     key={i}
                     text={memberDef.title || memberDef.type?.name}
                     onClick={() => insertItem(memberDef)}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
@@ -106,6 +106,7 @@ export const ItemRow = forwardRef(function ItemRow(
         ),
         !(disableActions.includes('add') || disableActions.includes('addBefore')) && (
           <InsertMenuGroup
+            key="add-before"
             pos="before"
             types={insertableTypes}
             onInsert={handleInsert}
@@ -115,6 +116,7 @@ export const ItemRow = forwardRef(function ItemRow(
         ),
         !disableActions.includes('add') && !disableActions.includes('addAfter') && (
           <InsertMenuGroup
+            key="add-after"
             pos="after"
             types={insertableTypes}
             onInsert={handleInsert}

--- a/packages/sanity/src/core/form/inputs/arrays/common/uploadTarget/uploadTarget.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/common/uploadTarget/uploadTarget.tsx
@@ -100,6 +100,7 @@ export function uploadTarget<Props>(
               count: rejected.length,
             }),
             description: rejected.map((task, i) => (
+              // oxlint-disable-next-line no-array-index-key
               <Flex key={i} gap={2} padding={2}>
                 <Box>
                   <Text weight="medium">{task.file.name}</Text>

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
@@ -10,7 +10,7 @@ import {
 } from '@sanity/types'
 import {useToast} from '@sanity/ui'
 import {get} from 'lodash'
-import {useCallback, useEffect, useRef, useState} from 'react'
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react'
 import {type Observable} from 'rxjs'
 
 import {useTranslation} from '../../../../i18n'
@@ -324,8 +324,20 @@ export function BaseFileInput(props: BaseFileInputProps) {
         if (member.kind === 'error') {
           return <MemberFieldError key={member.key} member={member} />
         }
-        //@ts-expect-error all possible cases should be covered
-        return <>{t('inputs.file.error.unknown-member-kind', {kind: member.kind})}</>
+
+        return (
+          <Fragment
+            key={
+              //@ts-expect-error all possible cases should be covered
+              member.key
+            }
+          >
+            {t('inputs.file.error.unknown-member-kind', {
+              //@ts-expect-error all possible cases should be covered
+              kind: member.kind,
+            })}
+          </Fragment>
+        )
       })}
       {selectedAssetSource && (
         <FileAssetSource

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -9,6 +9,7 @@ import {Stack, useToast} from '@sanity/ui'
 import {get} from 'lodash'
 import {
   type FocusEvent,
+  Fragment,
   memo,
   type ReactNode,
   useCallback,
@@ -592,8 +593,20 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
         if (member.kind === 'error') {
           return <MemberFieldError key={member.key} member={member} />
         }
-        //@ts-expect-error all possible cases should be covered
-        return <>{t('inputs.image.error.unknown-member-kind', {kind: member.kind})}</>
+
+        return (
+          <Fragment
+            key={
+              //@ts-expect-error all possible cases should be covered
+              member.key
+            }
+          >
+            {t('inputs.image.error.unknown-member-kind', {
+              //@ts-expect-error all possible cases should be covered
+              kind: member.kind,
+            })}
+          </Fragment>
+        )
       })}
 
       {hotspotField && focusPath[0] === 'hotspot' && (

--- a/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
@@ -206,7 +206,7 @@ export function ImageToolInput(props: ImageToolInputProps) {
           <Box marginTop={2}>
             <Grid columns={4} gap={1}>
               {hotspotPreviews.map(({title, aspectRatio}) => (
-                <Box marginTop={2} key={title}>
+                <Box key={title} marginTop={2}>
                   <Heading as="h4" size={0}>
                     {title}
                   </Heading>

--- a/packages/sanity/src/core/form/inputs/files/common/UploadDestinationPicker.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/UploadDestinationPicker.tsx
@@ -115,8 +115,8 @@ export function UploadDestinationPicker(props: UploadDestinationPickerProps) {
               const Icon = assetSource.icon
               return (
                 <TargetButton
-                  data-asset-source-name={assetSource.name}
                   key={assetSource.name}
+                  data-asset-source-name={assetSource.name}
                   mode={modes[assetSource.name]}
                   onClick={handleClick}
                   onDragEnter={handleDragEnter}

--- a/packages/sanity/src/core/form/inputs/files/common/UploadDropDownMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/UploadDropDownMenu.tsx
@@ -93,6 +93,7 @@ function UploadDropDownMenuComponent(
       const isDefaultSource = assetSource.name === assetSources[0].name
       return (
         <MenuItem
+          key={`${inputId}-menu-button`}
           {...{[ASSET_SOURCE_DATA_ATTRIBUTE]: assetSource.name}}
           badgeText={
             isDefaultSource
@@ -103,7 +104,6 @@ function UploadDropDownMenuComponent(
           disabled={uploadsDisabled}
           htmlFor={inputId}
           icon={assetSource.icon}
-          key={`${inputId}-menu-button`}
           onClick={handleMenuItemClick}
           renderMenuItem={renderMenuItemLabel}
           text={

--- a/packages/sanity/src/core/form/members/object/MemberFieldset.tsx
+++ b/packages/sanity/src/core/form/members/object/MemberFieldset.tsx
@@ -66,6 +66,7 @@ export const MemberFieldSet = memo(function MemberFieldSet(props: {
         }
         return (
           <MemberField
+            key={fieldsetMember.key}
             member={fieldsetMember}
             renderAnnotation={renderAnnotation}
             renderBlock={renderBlock}
@@ -74,7 +75,6 @@ export const MemberFieldSet = memo(function MemberFieldSet(props: {
             renderInput={renderInput}
             renderItem={renderItem}
             renderPreview={renderPreview}
-            key={fieldsetMember.key}
           />
         )
       })}

--- a/packages/sanity/src/core/form/studio/assetSourceDataset/shared/AssetUsageList.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceDataset/shared/AssetUsageList.tsx
@@ -49,7 +49,7 @@ const DocumentLink = ({document}: {document: SanityDocument}) => {
   )
 
   return (
-    <Card as={LinkComponent} radius={2} key={document._id} data-as="a" tabIndex={0}>
+    <Card key={document._id} as={LinkComponent} radius={2} data-as="a" tabIndex={0}>
       <Flex align="center" gap={2}>
         <Preview
           layout="default"

--- a/packages/sanity/src/core/form/studio/tree-editing/components/TreeEditingDialog.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/components/TreeEditingDialog.tsx
@@ -231,13 +231,13 @@ export function TreeEditingDialog(props: TreeEditingDialogProps): React.JSX.Elem
       >
         <AnimatePresence initial={false} mode="wait" onExitComplete={handleAnimationExitComplete}>
           <MotionFlex
+            key={toString(treeState.relativePath)}
             animate="animate"
             data-testid="tree-editing-dialog-content"
             direction="column"
             exit="exit"
             height="fill"
             initial="initial"
-            key={toString(treeState.relativePath)}
             overflow="hidden"
             padding={1}
             sizing="border"

--- a/packages/sanity/src/core/form/studio/tree-editing/components/tree-menu/TreeEditingMenu.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/components/tree-menu/TreeEditingMenu.tsx
@@ -25,8 +25,8 @@ export const TreeEditingMenu = memo(function TreeEditingMenu(
 
         return (
           <TreeEditingMenuItem
-            item={item}
             key={toString(item.path)}
+            item={item}
             onPathSelect={onPathSelect}
             selectedPath={selectedPath}
             siblingHasChildren={siblingHasChildren}

--- a/packages/sanity/src/core/form/studio/tree-editing/components/tree-menu/TreeEditingMenuItem.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/components/tree-menu/TreeEditingMenuItem.tsx
@@ -180,9 +180,9 @@ export function TreeEditingMenuItem(props: TreeEditingMenuItemProps): React.JSX.
 
   return (
     <Stack
+      key={stringPath}
       aria-expanded={open}
       as="li"
-      key={stringPath}
       ref={setRootElement}
       role="treeitem"
       space={1}
@@ -240,8 +240,8 @@ export function TreeEditingMenuItem(props: TreeEditingMenuItemProps): React.JSX.
 
             return (
               <TreeEditingMenuItem
-                item={child}
                 key={toString(child.path)}
+                item={child}
                 onPathSelect={onPathSelect}
                 selectedPath={selectedPath}
                 siblingHasChildren={childSiblingHasChildren}

--- a/packages/sanity/src/core/form/utils/fallback-preview/PreviewArray.tsx
+++ b/packages/sanity/src/core/form/utils/fallback-preview/PreviewArray.tsx
@@ -17,6 +17,7 @@ export function PreviewArray(props: Props) {
     <ul>
       {value.map((item, i) => {
         return (
+          // oxlint-disable-next-line no-array-index-key
           <li key={i}>
             <PreviewAny {...rest} value={item} _depth={_depth + 1} maxDepth={maxDepth} />
           </li>

--- a/packages/sanity/src/core/i18n/components/LocaleProvider.tsx
+++ b/packages/sanity/src/core/i18n/components/LocaleProvider.tsx
@@ -79,7 +79,7 @@ export function LocaleProviderBase({
     <Suspense fallback={<LoadingBlock />}>
       <I18nextProvider i18n={i18next}>
         {/* Use locale as key to force re-render, updating non-reactive parts */}
-        <LocaleContext.Provider value={context} key={currentLocale.id}>
+        <LocaleContext.Provider key={currentLocale.id} value={context}>
           {children}
         </LocaleContext.Provider>
       </I18nextProvider>

--- a/packages/sanity/src/core/perspective/navbar/ReleaseTypeMenuSection.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleaseTypeMenuSection.tsx
@@ -64,8 +64,8 @@ export function ReleaseTypeMenuSection({
       <Flex direction="column" gap={1}>
         {releases.map((release, index) => (
           <GlobalPerspectiveMenuItem
-            release={release}
             key={release._id}
+            release={release}
             ref={getMenuItemRef(getReleaseIdFromReleaseDocumentId(release._id))}
             rangePosition={getRangePosition(range, releaseTypeOffset + index)}
             menuItemProps={menuItemProps}

--- a/packages/sanity/src/core/presence/PresenceTooltip.tsx
+++ b/packages/sanity/src/core/presence/PresenceTooltip.tsx
@@ -23,7 +23,7 @@ export function PresenceTooltip(props: PresenceTooltipProps) {
     () => (
       <Stack sizing="border">
         {items.map((item) => (
-          <Flex align="center" gap={2} key={item.user.id}>
+          <Flex key={item.user.id} align="center" gap={2}>
             <div>
               <UserAvatar user={item.user} status="online" />
             </div>

--- a/packages/sanity/src/core/presence/overlay/RegionsWithIntersections.tsx
+++ b/packages/sanity/src/core/presence/overlay/RegionsWithIntersections.tsx
@@ -173,10 +173,10 @@ export const RegionsWithIntersections = forwardRef(function RegionsWithIntersect
         const forceWidth = region.rect.width === 0
         return (
           <MiddleRegionWrapper
+            key={region.id}
             $debug={DEBUG}
             io={io}
             onIntersection={onIntersection}
-            key={region.id}
             id={region.id}
             style={{
               width: forceWidth ? 1 : region.rect.width,

--- a/packages/sanity/src/core/presence/overlay/StickyOverlay.tsx
+++ b/packages/sanity/src/core/presence/overlay/StickyOverlay.tsx
@@ -268,7 +268,7 @@ const PresenceDock = memo(function PresenceDock(props: {
   )
 
   return (
-    <div data-dock={position} key={`sticky-${position}`} style={style}>
+    <div key={`sticky-${position}`} data-dock={position} style={style}>
       <FieldPresenceInner
         position={position}
         maxAvatars={MAX_AVATARS_DOCK}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
@@ -112,8 +112,8 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: {
             {optionsReleaseList.map((release) => {
               return (
                 <MenuItem
-                  as="a"
                   key={release._id}
+                  as="a"
                   onClick={() => onCreateVersion(release._id)}
                   renderMenuItem={() => <VersionContextMenuItem release={release} />}
                   disabled={disabled}

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -201,14 +201,14 @@ export const ReleaseScheduleButton = ({
 
     return (
       <Dialog
-        id="confirm-schedule-dialog"
-        data-testid="confirm-schedule-dialog"
         /**
          * rerenderDialog should force this function to rerun
          * since the selected scheduled date was in the future when selected
          * but at time of submit it is in the past
          */
         key={rerenderDialog}
+        id="confirm-schedule-dialog"
+        data-testid="confirm-schedule-dialog"
         header={t('schedule-dialog.confirm-title', {
           documentsLength: documents.length,
           count: documents.length,

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -195,8 +195,8 @@ export function ReleasesOverview() {
     return (
       <AnimatePresence>
         <MotionButton
-          {...groupModeButtonBaseProps}
           key="open-group"
+          {...groupModeButtonBaseProps}
           onClick={handleReleaseGroupModeChange}
           selected={releaseGroupMode === 'active'}
           text={t('action.open')}
@@ -209,8 +209,8 @@ export function ReleasesOverview() {
         >
           <div>
             <MotionButton
-              {...groupModeButtonBaseProps}
               key="archived-group"
+              {...groupModeButtonBaseProps}
               disabled={groupModeButtonBaseProps.disabled || !archivedReleases.length}
               onClick={handleReleaseGroupModeChange}
               selected={releaseGroupMode === 'archived'}

--- a/packages/sanity/src/core/scheduled-publishing/components/dateInputs/base/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/dateInputs/base/calendar/Calendar.tsx
@@ -337,7 +337,7 @@ function CalendarMonthSelect(props: {
       <Box flex={1}>
         <Select radius={0} value={value} onChange={onChange}>
           {MONTH_NAMES.map((m, i) => (
-            // eslint-disable-next-line react/no-array-index-key
+            // oxlint-disable-next-line no-array-index-key
             <option key={i} value={i}>
               {m}
             </option>

--- a/packages/sanity/src/core/scheduled-publishing/components/dateInputs/base/calendar/CalendarMonth.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/dateInputs/base/calendar/CalendarMonth.tsx
@@ -40,13 +40,12 @@ export function CalendarMonth(props: CalendarMonthProps) {
 
             return (
               <CalendarDay
+                key={`${weekIdx}-${dayIdx}`}
                 date={date}
                 focused={focused}
                 isCurrentMonth={isCurrentMonth}
                 isToday={isToday}
                 customValidation={customValidation}
-                // eslint-disable-next-line react/no-array-index-key
-                key={`${weekIdx}-${dayIdx}`}
                 onSelect={props.onSelect}
                 selected={selected}
               />

--- a/packages/sanity/src/core/scheduled-publishing/components/validation/ValidationList.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/validation/ValidationList.tsx
@@ -56,7 +56,7 @@ export function ValidationList(props: ValidationListProps) {
       {hasErrors &&
         errors.map((_error, i) => (
           <ValidationListItem
-            // eslint-disable-next-line react/no-array-index-key
+            // oxlint-disable-next-line no-array-index-key
             key={i}
             truncate={truncate}
             path={resolvePathTitle(_error.path)}
@@ -67,7 +67,7 @@ export function ValidationList(props: ValidationListProps) {
       {hasWarnings &&
         warnings.map((_warning, i) => (
           <ValidationListItem
-            // eslint-disable-next-line react/no-array-index-key
+            // oxlint-disable-next-line no-array-index-key
             key={i}
             truncate={truncate}
             path={resolvePathTitle(_warning.path)}
@@ -78,7 +78,7 @@ export function ValidationList(props: ValidationListProps) {
       {hasInfo &&
         info.map((_info, i) => (
           <ValidationListItem
-            // eslint-disable-next-line react/no-array-index-key
+            // oxlint-disable-next-line no-array-index-key
             key={i}
             truncate={truncate}
             path={resolvePathTitle(_info.path)}

--- a/packages/sanity/src/core/scheduled-publishing/tool/scheduleFilters/ScheduleFilters.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/scheduleFilters/ScheduleFilters.tsx
@@ -57,8 +57,8 @@ export const ScheduleFilters = (props: ScheduleFiltersProps) => {
               <Menu style={{minWidth: '175px'}}>
                 {SCHEDULE_FILTERS.map((filter) => (
                   <MenuItem
-                    iconRight={filter === scheduleState ? CheckmarkIcon : undefined}
                     key={filter}
+                    iconRight={filter === scheduleState ? CheckmarkIcon : undefined}
                     onClick={handleMenuClick.bind(undefined, {state: filter})}
                     text={SCHEDULE_STATE_DICTIONARY[filter].title}
                   />

--- a/packages/sanity/src/core/scheduled-publishing/tool/schedules/VirtualListItem.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/schedules/VirtualListItem.tsx
@@ -41,8 +41,8 @@ export function VirtualListItem(props: Props) {
 
   return (
     <Box
-      data-index={virtualRow.index}
       key={virtualRow.key}
+      data-index={virtualRow.index}
       paddingBottom={2}
       ref={measureElement}
       style={style}

--- a/packages/sanity/src/core/store/_legacy/__workshop__/HistoryTimelineStory.tsx
+++ b/packages/sanity/src/core/store/_legacy/__workshop__/HistoryTimelineStory.tsx
@@ -136,8 +136,8 @@ export default function HistoryTimelineStory() {
               {chunks.map((chunk) => {
                 return (
                   <Card
-                    as="button"
                     key={chunk.id}
+                    as="button"
                     onClick={handleRevClick(chunk)}
                     padding={3}
                     selected={realRevChunk === chunk}
@@ -162,8 +162,8 @@ export default function HistoryTimelineStory() {
                 {chunks.map((chunk) => {
                   return (
                     <Card
-                      as="button"
                       key={chunk.id}
+                      as="button"
                       onClick={handleSinceClick(chunk)}
                       padding={3}
                       selected={sinceTime === chunk}

--- a/packages/sanity/src/core/store/_legacy/authStore/createLoginComponent.tsx
+++ b/packages/sanity/src/core/store/_legacy/authStore/createLoginComponent.tsx
@@ -147,7 +147,6 @@ export function createLoginComponent({
         <Stack space={2}>
           {providers.map((provider, index) => (
             <Button
-              // eslint-disable-next-line react/no-array-index-key
               key={`${provider.url}_${index}`}
               as="a"
               icon={providerLogos[provider.name] || <CustomLogo provider={provider} />}

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -176,8 +176,8 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
 
         return (
           <Button
-            iconRight={action?.icon}
             key={action.name}
+            iconRight={action?.icon}
             mode="bleed"
             onClick={action?.onAction}
             selected={action.selected}

--- a/packages/sanity/src/core/studio/components/navbar/navDrawer/ApperanceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/navDrawer/ApperanceMenu.tsx
@@ -19,7 +19,7 @@ export function AppearanceMenu({
     <Card borderTop flex="none" padding={2} overflow="auto">
       <Stack as="ul" space={1}>
         {options.map(({icon, label, name, onSelect, selected, title}) => (
-          <Stack as="li" key={name}>
+          <Stack key={name} as="li">
             <Button
               aria-label={label}
               icon={icon}

--- a/packages/sanity/src/core/studio/components/navbar/navDrawer/NavDrawer.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/navDrawer/NavDrawer.tsx
@@ -118,9 +118,9 @@ export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
 
         return (
           <Button
+            key={action.name}
             icon={action?.icon}
             justify="flex-start"
-            key={action.name}
             mode="bleed"
             // eslint-disable-next-line react/jsx-no-bind
             onClick={() => handleActionClick(action.onAction)}

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentList.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentList.tsx
@@ -43,8 +43,8 @@ export function NewDocumentList(props: NewDocumentListProps) {
     (item: NewDocumentOption) => {
       return (
         <NewDocumentListOption
-          currentUser={currentUser}
           key={item.id}
+          currentUser={currentUser}
           onClick={handleDocumentClick}
           option={item}
           preview={preview}

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
@@ -46,8 +46,8 @@ export function NewDocumentListOption(props: NewDocumentListOptionProps) {
 
   return (
     <Tooltip
-      disabled={option.hasPermission}
       key={option.id}
+      disabled={option.hasPermission}
       portal
       content={
         <InsufficientPermissionsMessage currentUser={currentUser} context="create-document" />

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
@@ -82,8 +82,8 @@ export function PresenceMenu() {
           {hasPresence &&
             presence.map((item) => (
               <PresenceMenuItem
-                focused={focusedId === item.user.id}
                 key={item.user.id}
+                focused={focusedId === item.user.id}
                 onFocus={handleItemFocus}
                 locations={item.locations}
                 user={item.user}

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
@@ -103,9 +103,9 @@ function SubSection({subSection}: {subSection: Section}) {
             if (!item.url) return null
             return (
               <MenuItem
+                key={item._key}
                 as="a"
                 tone="default"
-                key={item._key}
                 text={item.title}
                 href={item.url}
                 target="_blank"

--- a/packages/sanity/src/core/studio/components/navbar/search/components/SortMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/SortMenu.tsx
@@ -86,12 +86,12 @@ export function SortMenu() {
             <Menu>
               {menuOrderings.map((item, index) => {
                 if (isSearchDivider(item)) {
-                  // eslint-disable-next-line react/no-array-index-key
+                  // oxlint-disable-next-line no-array-index-key
                   return <MenuDivider key={index} />
                 }
                 return (
                   <CustomMenuItem
-                    // eslint-disable-next-line react/no-array-index-key
+                    // oxlint-disable-next-line no-array-index-key
                     key={index}
                     ordering={item}
                   />

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/Filters.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/Filters.tsx
@@ -61,9 +61,9 @@ export function Filters({showTypeFilter = true}: {showTypeFilter?: boolean}) {
             const key = getFilterKey(filter)
             return (
               <FilterButton
+                key={key}
                 filter={filter}
                 initialOpen={isMounted && lastAddedFilterKey === key}
-                key={key}
               />
             )
           })}

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/common/FilterDetails.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/common/FilterDetails.tsx
@@ -27,7 +27,7 @@ export function FilterDetails({filter}: FilterDetailsProps) {
             {fieldDefinition.titlePath.slice(0, -1).map((pathTitle, index) => {
               return (
                 <Fragment
-                  // eslint-disable-next-line react/no-array-index-key
+                  // oxlint-disable-next-line no-array-index-key
                   key={index}
                 >
                   <span>{pathTitle}</span>

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/documentTypes/items/DocumentTypeFilterItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/documentTypes/items/DocumentTypeFilterItem.tsx
@@ -37,9 +37,9 @@ export const DocumentTypeFilterItem = memo(function TypeFilterItem({
   return (
     <Box {...rest}>
       <Button
+        key={type.title ?? type.name}
         iconRight={selected && CheckmarkIcon}
         justify="flex-start"
-        key={type.title ?? type.name}
         mode="bleed"
         onClick={handleClick}
         width="fill"

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/FilterForm.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/FilterForm.tsx
@@ -72,9 +72,9 @@ export function FilterForm({filter}: FilterFormProps) {
           {Component && (
             <Card borderTop padding={3}>
               <Component
-                fieldDefinition={fieldDefinition}
                 // re-render on new operators
                 key={filter.operatorType}
+                fieldDefinition={fieldDefinition}
                 onChange={handleValueChange}
                 value={filter.value}
               />

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/OperatorsMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/OperatorsMenuButton.tsx
@@ -75,7 +75,7 @@ export function OperatorsMenuButton({filter, operator}: OperatorsMenuButtonProps
                 }
                 return (
                   <CustomMenuItem
-                    // eslint-disable-next-line react/no-array-index-key
+                    // oxlint-disable-next-line no-array-index-key
                     key={index}
                     onClick={handleClick}
                     operator={menuOperator}
@@ -84,7 +84,7 @@ export function OperatorsMenuButton({filter, operator}: OperatorsMenuButtonProps
                 )
               }
               if (item.type === 'divider') {
-                // eslint-disable-next-line react/no-array-index-key
+                // oxlint-disable-next-line no-array-index-key
                 return <MenuDivider key={index} />
               }
               return null

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/asset/Asset.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/asset/Asset.tsx
@@ -155,8 +155,8 @@ export function SearchFilterAssetInput(type?: AssetType) {
                       <Menu>
                         {assetSources.map((source) => (
                           <MenuItem
-                            icon={source.icon || ImageIcon}
                             key={source.name}
+                            icon={source.icon || ImageIcon}
                             // eslint-disable-next-line react/jsx-no-bind
                             onClick={() => handleSelectAssetSource(source)}
                             text={

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/CalendarMonth.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/CalendarMonth.tsx
@@ -45,12 +45,7 @@ export function CalendarMonth({hidden, onSelect}: CalendarMonthProps) {
         {useWeeksOfMonth(focusedDate).map((week, weekIdx) =>
           week.days.map((weekDayDate, dayIdx) => {
             return (
-              <CalendarDay
-                date={weekDayDate}
-                // eslint-disable-next-line react/no-array-index-key
-                key={`${weekIdx}-${dayIdx}`}
-                onSelect={onSelect}
-              />
+              <CalendarDay key={`${weekIdx}-${dayIdx}`} date={weekDayDate} onSelect={onSelect} />
             )
           }),
         )}

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/string/StringList.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/string/StringList.tsx
@@ -113,7 +113,7 @@ export function SearchFilterStringListInput({
         <Menu>
           {items.map((item, index) => (
             <CustomMenuItem
-              // eslint-disable-next-line react/no-array-index-key
+              // oxlint-disable-next-line no-array-index-key
               key={index}
               onClick={handleClick}
               selected={item.value === value}

--- a/packages/sanity/src/core/studio/components/navbar/search/components/recentSearches/item/RecentSearchItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/recentSearches/item/RecentSearchItem.tsx
@@ -122,8 +122,8 @@ export function RecentSearchItem({
             )}
             {/* Filters */}
             {value?.filters?.map((filter, i) => {
-              // eslint-disable-next-line react/no-array-index-key
-              return <FilterPill filter={filter} key={i} />
+              // oxlint-disable-next-line no-array-index-key
+              return <FilterPill key={i} filter={filter} />
             })}
           </Flex>
 

--- a/packages/sanity/src/core/studio/components/navbar/tools/ToolCollapseMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/tools/ToolCollapseMenu.tsx
@@ -53,10 +53,9 @@ export function ToolCollapseMenu(props: ToolCollapseMenuProps) {
 
         return (
           <Button
+            key={`${tool.name}-${index}`}
             as={Link}
             data-as="a"
-            // eslint-disable-next-line react/no-array-index-key
-            key={`${tool.name}-${index}`}
             mode="bleed"
             selected={activeToolName === tool.name}
             text={title}

--- a/packages/sanity/src/core/studio/components/navbar/tools/ToolVerticalMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/tools/ToolVerticalMenu.tsx
@@ -33,7 +33,7 @@ export function ToolVerticalMenu(props: ToolVerticalMenuProps) {
           })
 
           return (
-            <Stack as="li" key={tool.name}>
+            <Stack key={tool.name} as="li">
               <Button
                 as={Link}
                 justify="flex-start"

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
@@ -57,6 +57,7 @@ export function WorkspaceAuth() {
         >
           <Stack padding={2} paddingBottom={3} paddingTop={4}>
             <LoginComponent
+              key={selectedWorkspaceName}
               projectId={selectedWorkspace.projectId}
               redirectPath={
                 window.location.pathname.startsWith(selectedWorkspace.basePath)
@@ -65,7 +66,6 @@ export function WorkspaceAuth() {
                     `${window.location.pathname}${window.location.search}`
                   : selectedWorkspace.basePath
               }
-              key={selectedWorkspaceName}
             />
           </Stack>
         </Layout>
@@ -113,9 +113,9 @@ export function WorkspaceAuth() {
 
           return (
             <Card
+              key={workspace.name}
               as="button"
               radius={2}
-              key={workspace.name}
               padding={2}
               // eslint-disable-next-line react/jsx-no-bind
               onClick={handleSelectWorkspace}

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -82,11 +82,11 @@ export function WorkspaceMenuButton() {
               // we can remove this and use setActiveWorkspace instead
               return (
                 <MenuItem
+                  key={workspace.name}
                   as="a"
                   href={workspace.basePath}
                   badgeText={STATE_TITLES[state]}
                   iconRight={isSelected ? CheckmarkIcon : undefined}
-                  key={workspace.name}
                   pressed={isSelected}
                   preview={<WorkspacePreviewIcon icon={workspace.icon} size="small" />}
                   selected={isSelected}

--- a/packages/sanity/src/core/studio/screens/schemaErrors/SchemaProblemGroups.tsx
+++ b/packages/sanity/src/core/studio/screens/schemaErrors/SchemaProblemGroups.tsx
@@ -48,7 +48,8 @@ export function SchemaProblemGroups(props: {problemGroups: SchemaValidationProbl
         const isWarning = problem.severity === 'warning'
         const schemaType = getTypeInfo(group)
         return (
-          <Card border key={i} padding={4} radius={2} tone={TONES[problem.severity]}>
+          // oxlint-disable-next-line no-array-index-key
+          <Card key={i} border padding={4} radius={2} tone={TONES[problem.severity]}>
             <Flex>
               <Box marginRight={3}>
                 <Text muted size={1}>
@@ -82,7 +83,8 @@ export function SchemaProblemGroups(props: {problemGroups: SchemaValidationProbl
                         segment.name || `<anonymous ${segment.type}>`,
                       )}:${segment.type}`
                       return (
-                        <Text title={text} key={j} size={1} textOverflow="ellipsis">
+                        // oxlint-disable-next-line no-array-index-key
+                        <Text key={j} title={text} size={1} textOverflow="ellipsis">
                           <SegmentSpan>{text}</SegmentSpan>
                         </Text>
                       )
@@ -90,7 +92,8 @@ export function SchemaProblemGroups(props: {problemGroups: SchemaValidationProbl
 
                     if (segment.kind === 'property') {
                       return (
-                        <Text title={segment.name} key={j} size={1} textOverflow="ellipsis">
+                        // oxlint-disable-next-line no-array-index-key
+                        <Text key={j} title={segment.name} size={1} textOverflow="ellipsis">
                           <SegmentSpan>{segment.name}</SegmentSpan>
                         </Text>
                       )

--- a/packages/sanity/src/core/studio/workspaceLoader/ErrorMessage.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/ErrorMessage.tsx
@@ -42,7 +42,8 @@ export function ErrorMessage({error, message, path, stack}: ErrorMessageProps) {
 
       <Flex as="ul" direction="column" gap={2}>
         {path.map(({name, type}, index) => (
-          <ListItem forwardedAs="li" gap={2} align="center" key={index}>
+          // oxlint-disable-next-line no-array-index-key
+          <ListItem key={index} forwardedAs="li" gap={2} align="center">
             <Box>
               <Code>{name}</Code>
             </Box>

--- a/packages/sanity/src/core/tasks/components/activity/TasksActivityLog.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/TasksActivityLog.tsx
@@ -280,8 +280,8 @@ export function TasksActivityLog(props: TasksActivityLogProps) {
 
                     return (
                       <TasksActivityCommentItem
-                        currentUser={currentUser}
                         key={item.payload.parentComment._id}
+                        currentUser={currentUser}
                         mentionOptions={mentionOptions}
                         onCreateRetry={handleCommentCreateRetry}
                         onDelete={handleDeleteCommentStart}

--- a/packages/sanity/src/core/tasks/components/form/fields/assignee/AssigneeSelectionMenu.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/assignee/AssigneeSelectionMenu.tsx
@@ -120,9 +120,9 @@ function MentionsMenu({onSelect, value = ''}: {onSelect: SelectItemHandler; valu
     (user: UserWithPermission) => {
       return (
         <MentionUserMenuItem
+          key={user.id}
           user={user}
           onSelect={onSelect}
-          key={user.id}
           pressed={user.id === value}
         />
       )

--- a/packages/sanity/src/core/tasks/components/sidebar/TasksHeaderDraftsMenu.tsx
+++ b/packages/sanity/src/core/tasks/components/sidebar/TasksHeaderDraftsMenu.tsx
@@ -95,9 +95,9 @@ export function TasksHeaderDraftsMenu() {
           {draftTasks?.map((task) => {
             return (
               <TasksDraftsMenuItem
+                key={task._id}
                 isSelected={selectedTask === task._id}
                 item={task}
-                key={task._id}
                 onSelect={handleSelectTask}
               />
             )

--- a/packages/sanity/src/media-library/plugin/VideoInput/VideoInput.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/VideoInput.tsx
@@ -7,7 +7,7 @@ import {
 } from '@sanity/types'
 import {useToast} from '@sanity/ui'
 import {get} from 'lodash'
-import {useCallback, useEffect, useRef, useState} from 'react'
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react'
 import {type Observable} from 'rxjs'
 
 import {handleSelectAssetFromSource as handleSelectAssetFromSourceShared} from '../../../core/form/inputs/files/common/assetSource'
@@ -334,8 +334,20 @@ export function BaseVideoInput(props: BaseVideoInputProps) {
         if (member.kind === 'error') {
           return <MemberFieldError key={member.key} member={member} />
         }
-        //@ts-expect-error all possible cases should be covered
-        return <>{t('inputs.file.error.unknown-member-kind', {kind: member.kind})}</>
+
+        return (
+          <Fragment
+            key={
+              //@ts-expect-error all possible cases should be covered
+              member.key
+            }
+          >
+            {t('inputs.file.error.unknown-member-kind', {
+              //@ts-expect-error all possible cases should be covered
+              kind: member.kind,
+            })}
+          </Fragment>
+        )
       })}
       {selectedAssetSource && (
         <VideoInputAssetSource

--- a/packages/sanity/src/presentation/document/LocationsBanner.tsx
+++ b/packages/sanity/src/presentation/document/LocationsBanner.tsx
@@ -134,10 +134,10 @@ export function LocationsBanner(props: {
 
                 return (
                   <LocationItem
+                    key={l.href}
                     active={active}
                     documentId={documentId}
                     documentType={schemaType.name}
-                    key={l.href}
                     node={l}
                     toolName={options.name || DEFAULT_TOOL_NAME}
                   />
@@ -182,9 +182,9 @@ function LocationItem(props: {
 
   return (
     <Card
+      key={node.href}
       {...(isCurrentTool ? {} : presentationLinkProps)}
       as="a"
-      key={node.href}
       onClick={isCurrentTool ? handleCurrentToolClick : presentationLinkProps.onClick}
       padding={3}
       radius={1}

--- a/packages/sanity/src/presentation/document/PresentationDocumentHeader.tsx
+++ b/packages/sanity/src/presentation/document/PresentationDocumentHeader.tsx
@@ -45,6 +45,7 @@ export function PresentationDocumentHeader(props: {
     <LocationStack>
       {contextOptions.map((_options, idx) => (
         <LocationsBanner
+          // oxlint-disable-next-line no-array-index-key
           key={idx}
           documentId={documentId}
           options={_options}

--- a/packages/sanity/src/structure/__workshop__/DocumentStateStory.tsx
+++ b/packages/sanity/src/structure/__workshop__/DocumentStateStory.tsx
@@ -98,9 +98,10 @@ function Debug(props: {documentId: string; documentType: string}) {
               (actionItem, idx) =>
                 actionItem && (
                   <Button
+                    // oxlint-disable-next-line no-array-index-key
+                    key={idx}
                     disabled={actionItem.disabled}
                     icon={actionItem.icon}
-                    key={idx}
                     // eslint-disable-next-line react/jsx-handler-names
                     onClick={actionItem.onHandle}
                     tone={actionItem.tone}
@@ -114,10 +115,11 @@ function Debug(props: {documentId: string; documentType: string}) {
             if (actionItem?.dialog && actionItem.dialog.type === 'dialog') {
               return (
                 <Dialog
+                  // oxlint-disable-next-line no-array-index-key
+                  key={idx}
                   footer={actionItem.dialog.footer}
                   header={actionItem.dialog.header}
                   id={`document-action-modal-${idx}`}
-                  key={idx}
                   // eslint-disable-next-line react/jsx-handler-names
                   onClose={actionItem.dialog.onClose}
                 >
@@ -182,10 +184,11 @@ function DocumentActionResolver(props: {
     <>
       {actionHooks.map((actionHook, idx) => (
         <DocumentActionHook
+          // oxlint-disable-next-line no-array-index-key
+          key={idx}
           actionHook={actionHook}
           editState={editState}
           index={idx}
-          key={idx}
           onUpdate={updateDescription}
         />
       ))}

--- a/packages/sanity/src/structure/__workshop__/ResolvePanesStory.tsx
+++ b/packages/sanity/src/structure/__workshop__/ResolvePanesStory.tsx
@@ -41,7 +41,7 @@ function ResolvePanesStory() {
     <Box padding={4}>
       <Stack marginBottom={5} space={3}>
         {testPaths.map((testPath, idx) => (
-          <Flex align="center" as="label" key={idx}>
+          <Flex key={idx} align="center" as="label">
             <Radio
               checked={String(idx) === testKey}
               name="path"
@@ -67,7 +67,7 @@ function ResolvePanesStory() {
 
           if (resolvedPane === LOADING_PANE) {
             return (
-              <Card border key={idx} padding={4} tone={paneData.active ? 'primary' : undefined}>
+              <Card key={idx} border padding={4} tone={paneData.active ? 'primary' : undefined}>
                 <Text>[Loading…]</Text>
               </Card>
             )
@@ -75,7 +75,7 @@ function ResolvePanesStory() {
 
           if (resolvedPane.type === 'list') {
             return (
-              <Card border key={idx} padding={4} tone={paneData.active ? 'primary' : undefined}>
+              <Card key={idx} border padding={4} tone={paneData.active ? 'primary' : undefined}>
                 <Stack space={3}>
                   <Text>[List] {resolvedPane.title}</Text>
                   <Text size={1}>
@@ -91,7 +91,7 @@ function ResolvePanesStory() {
 
           if (resolvedPane.type === 'documentList') {
             return (
-              <Card border key={idx} padding={4} tone={paneData.active ? 'primary' : undefined}>
+              <Card key={idx} border padding={4} tone={paneData.active ? 'primary' : undefined}>
                 <Stack space={3}>
                   <Text>[DocumentList] {resolvedPane.title}</Text>
                   <Text size={1}>
@@ -107,7 +107,7 @@ function ResolvePanesStory() {
 
           if (resolvedPane.type === 'document') {
             return (
-              <Card border key={idx} padding={4} tone={paneData.active ? 'primary' : undefined}>
+              <Card key={idx} border padding={4} tone={paneData.active ? 'primary' : undefined}>
                 <Stack space={3}>
                   <Text>[Document]</Text>
                   <Text size={1}>
@@ -122,7 +122,7 @@ function ResolvePanesStory() {
           }
 
           return (
-            <Card border key={idx} padding={4} tone={paneData.active ? 'primary' : undefined}>
+            <Card key={idx} border padding={4} tone={paneData.active ? 'primary' : undefined}>
               <Text>
                 [{resolvedPane.type}] {resolvedPane.title}
               </Text>

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -132,7 +132,7 @@ export function ConfirmDeleteDialogBody({
           {internalReferences.totalCount > 0 && (
             <Stack as="ul" marginBottom={2} space={2} data-testid="internal-references">
               {internalReferences?.references.map((item) => (
-                <Box as="li" key={item._id}>
+                <Box key={item._id} as="li">
                   {renderPreviewItem(item)}
                 </Box>
               ))}
@@ -217,7 +217,6 @@ export function ConfirmDeleteDialogBody({
                         return 'projectId' in reference
                       })
                       .map(({projectId, datasetName, documentId}, index) => (
-                        // eslint-disable-next-line react/no-array-index-key
                         <tr key={`${documentId}-${index}`}>
                           <td>
                             <Text size={1}>{projectId}</Text>

--- a/packages/sanity/src/structure/components/pane/PaneContextMenuButton.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneContextMenuButton.tsx
@@ -58,7 +58,7 @@ export function PaneContextMenuButton(props: PaneContextMenuButtonProps) {
           )}
           {nodes.map((node, nodeIndex) => {
             const isAfterGroup = nodes[nodeIndex - 1]?.type === 'group'
-            return <PaneMenuButtonItem isAfterGroup={isAfterGroup} key={node.key} node={node} />
+            return <PaneMenuButtonItem key={node.key} isAfterGroup={isAfterGroup} node={node} />
           })}
         </Menu>
       }

--- a/packages/sanity/src/structure/components/pane/PaneHeaderActionButton.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneHeaderActionButton.tsx
@@ -140,9 +140,9 @@ function PaneHeaderMenuGroupActionButton(props: PaneHeaderMenuGroupActionButtonP
           {node.children.map((child, idx) => {
             return (
               <PaneMenuButtonItem
+                key={child.key}
                 disabled={Boolean(node.disabled)}
                 isAfterGroup={node.children[idx - 1]?.type === 'group'}
-                key={child.key}
                 node={child}
               />
             )

--- a/packages/sanity/src/structure/components/pane/PaneMenuButtonItem.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneMenuButtonItem.tsx
@@ -40,9 +40,9 @@ export function PaneMenuButtonItem(props: {
           {isAfterGroup && <MenuDivider />}
           {node.children.map((child, childIndex) => (
             <PaneMenuButtonItem
+              key={child.key}
               disabled={disabled || Boolean(node.disabled)}
               isAfterGroup={node.children[childIndex - 1]?.type === 'group'}
-              key={child.key}
               node={child}
             />
           ))}
@@ -61,9 +61,9 @@ export function PaneMenuButtonItem(props: {
         >
           {node.children.map((child, childIndex) => (
             <PaneMenuButtonItem
+              key={child.key}
               disabled={disabled || Boolean(node.disabled)}
               isAfterGroup={node.children[childIndex - 1]?.type === 'group'}
-              key={child.key}
               node={child}
             />
           ))}

--- a/packages/sanity/src/structure/components/pane/__workshop__/SplitPanesStory/ListPane/ListPane.tsx
+++ b/packages/sanity/src/structure/components/pane/__workshop__/SplitPanesStory/ListPane/ListPane.tsx
@@ -46,8 +46,8 @@ export function ListPane(props: {
         <Stack padding={2} space={1}>
           {node.items.map((item) => (
             <Card
-              as="button"
               key={item.id}
+              as="button"
               onClick={() => setPath((p) => p.slice(0, index + 1).concat([item.id]))}
               padding={3}
               radius={2}

--- a/packages/sanity/src/structure/components/pane/__workshop__/SplitPanesStory/SplitPanesStory.tsx
+++ b/packages/sanity/src/structure/components/pane/__workshop__/SplitPanesStory/SplitPanesStory.tsx
@@ -74,17 +74,17 @@ function StructureTool(props: {
         if (pane.type === 'list') {
           return (
             <ListPane
+              key={key}
               active={i === path.length - 2}
               childId={path[i + 1]}
               index={i}
-              key={key}
               node={pane}
               setPath={setPath}
             />
           )
         }
 
-        return <DocumentPane index={i} key={key} node={pane} setPath={setPath} />
+        return <DocumentPane key={key} index={i} node={pane} setPath={setPath} />
       })}
     </PaneLayout>
   )

--- a/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -175,8 +175,8 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
 
             return (
               <InsufficientPermissionsMessageTooltip
-                context="create-document-type"
                 key={item.id}
+                context="create-document-type"
                 reveal={disabled}
                 loading={isTemplatePermissionsLoading}
               >

--- a/packages/sanity/src/structure/components/structureTool/StructureError.tsx
+++ b/packages/sanity/src/structure/components/structureTool/StructureError.tsx
@@ -71,7 +71,6 @@ export function StructureError({error}: StructureErrorProps) {
                 {/* TODO: it seems like the path is off by one and includes */}
                 {/* `root` twice  */}
                 {path.slice(1).map((segment, i) => (
-                  // eslint-disable-next-line react/no-array-index-key
                   <PathSegment key={`${segment}-${i}`}>{segment}</PathSegment>
                 ))}
               </Code>

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTabs.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTabs.tsx
@@ -24,10 +24,10 @@ export function DocumentHeaderTabs() {
     <TabList space={1}>
       {views.map((view, index) => (
         <DocumentHeaderTab
+          key={view.id}
           icon={view.icon}
           id={`${paneKey}tab-${view.id}`}
           isActive={activeViewId === view.id}
-          key={view.id}
           label={view.title}
           tabPanelId={tabPanelId}
           viewId={index === 0 ? null : (view.id ?? null)}

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -183,11 +183,7 @@ export const DocumentPanelHeader = memo(
             <>
               {unstable_languageFilter.map((LanguageFilterComponent, idx) => {
                 return (
-                  <LanguageFilterComponent
-                    // eslint-disable-next-line react/no-array-index-key
-                    key={`language-filter-${idx}`}
-                    schemaType={schemaType}
-                  />
+                  <LanguageFilterComponent key={`language-filter-${idx}`} schemaType={schemaType} />
                 )
               })}
             </>
@@ -208,9 +204,9 @@ export const DocumentPanelHeader = memo(
 
           {showSplitPaneButton && (
             <Button
+              key="split-pane-button"
               aria-label={t('buttons.split-pane-button.aria-label')}
               icon={SplitVerticalIcon}
-              key="split-pane-button"
               mode="bleed"
               onClick={onPaneSplit}
               tooltipProps={{content: t('buttons.split-pane-button.tooltip')}}
@@ -219,8 +215,8 @@ export const DocumentPanelHeader = memo(
 
           {showSplitPaneCloseButton && (
             <Button
-              icon={CloseIcon}
               key="close-view-button"
+              icon={CloseIcon}
               mode="bleed"
               onClick={onPaneClose}
               tooltipProps={{content: t('buttons.split-pane-close-button.title')}}
@@ -229,8 +225,8 @@ export const DocumentPanelHeader = memo(
 
           {showPaneGroupCloseButton && (
             <Button
-              icon={CloseIcon}
               key="close-view-button"
+              icon={CloseIcon}
               mode="bleed"
               tooltipProps={{content: t('buttons.split-pane-close-group-button.title')}}
               as={BackLink}
@@ -333,8 +329,8 @@ const DocumentPanelHeaderActionDialog = memo(function DocumentPanelHeaderActionD
     ({handleAction}) => (
       <div ref={setReferenceElement}>
         <PaneContextMenuButton
-          nodes={contextMenuNodes}
           key="context-menu"
+          nodes={contextMenuNodes}
           actionsNodes={
             states.length > 0
               ? states.map((actionState, actionIndex) => (

--- a/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
@@ -78,7 +78,7 @@ export function ValidationInspector(props: DocumentInspectorProps) {
               <Stack space={2}>
                 {validation.map((marker, i) => (
                   <ValidationCard
-                    // eslint-disable-next-line react/no-array-index-key
+                    // oxlint-disable-next-line no-array-index-key
                     key={i}
                     marker={marker}
                     onOpen={handleOpen}
@@ -169,6 +169,7 @@ function DocumentNodePathBreadcrumbs(props: {
   return (
     <Text size={1}>
       {pathTitles.map((t, i) => (
+        // oxlint-disable-next-line no-array-index-key
         <Fragment key={i}>
           {i > 0 && <span style={{color: 'var(--card-muted-fg-color)', opacity: 0.5}}> / </span>}
           <span style={{fontWeight: 500}}>{t.title || t.name}</span>

--- a/packages/sanity/src/structure/panes/document/statusBar/ActionMenuButton.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/ActionMenuButton.tsx
@@ -86,11 +86,11 @@ export function ActionMenuButton(props: ActionMenuButtonProps) {
           <Menu padding={1}>
             {actionStates.map((actionState, idx) => (
               <ActionMenuListItem
+                // oxlint-disable-next-line no-array-index-key
+                key={idx}
                 actionState={actionState}
                 disabled={disabled}
                 index={idx}
-                // eslint-disable-next-line react/no-array-index-key
-                key={idx}
                 onAction={handleAction}
               />
             ))}

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentBadges.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentBadges.tsx
@@ -25,9 +25,9 @@ const DocumentBadgesInner = memo(function DocumentBadgesInner({states}: Document
     <Inline space={1}>
       {states.map((badge, index) => (
         <Tooltip
+          key={`${badge.label}-${index}`}
           content={badge.title}
           disabled={!badge.title}
-          key={`${badge.label}-${index}`}
           placement="top"
           portal
         >

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -121,11 +121,11 @@ export const DocumentStatusBarActions = memo(function DocumentStatusBarActions()
   >(
     ({states}) => (
       <DocumentStatusBarActionsInner
+        // Use document ID as key to make sure that the actions state is reset when the document changes
+        key={documentId}
         disabled={connectionState !== 'connected'}
         showMenu={actions.length > 1}
         states={states}
-        // Use document ID as key to make sure that the actions state is reset when the document changes
-        key={documentId}
       />
     ),
     [actions.length, connectionState, documentId],

--- a/packages/sanity/src/structure/panes/document/timeline/events/EventsTimeline.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/events/EventsTimeline.tsx
@@ -180,9 +180,9 @@ export const EventsTimeline = ({
       }
       return (
         <TimelineItemWrapper
+          key={event.timestamp}
           paddingBottom={1}
           paddingRight={1}
-          key={event.timestamp}
           animate="animate"
           exit="exit"
           initial="initial"

--- a/packages/sanity/src/structure/panes/document/timeline/timelineItem.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/timelineItem.tsx
@@ -75,7 +75,7 @@ const UserLine = ({userId}: {userId: string}) => {
   const [user, loading] = useUser(userId)
 
   return (
-    <Flex align="center" gap={2} key={userId} padding={1}>
+    <Flex key={userId} align="center" gap={2} padding={1}>
       <Box>{loading || !user ? <AvatarSkeleton animated /> : <UserAvatar user={user} />}</Box>
       <Box>
         {loading || !user?.displayName ? (

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -217,6 +217,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
         />
       </Box>
       <DocumentListPaneContent
+        key={paneKey}
         childItemId={childItemId}
         error={error}
         filterIsSimpleTypeConstraint={!!typeName}
@@ -231,7 +232,6 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
         isRetrying={isRetrying}
         isConnected={connected}
         items={items}
-        key={paneKey}
         layout={layout}
         muted={loadingVariant === 'subtle'}
         loadingVariant={loadingVariant}

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx
@@ -68,7 +68,7 @@ function LoadingView(props: {layout?: GeneralPreviewLayoutKey}) {
   return (
     <Stack paddingX={3} paddingY={2} paddingTop={0} space={1}>
       {SKELETON_ITEMS.map((num) => (
-        <SanityDefaultPreview isPlaceholder layout={layout} key={num} />
+        <SanityDefaultPreview key={num} isPlaceholder layout={layout} />
       ))}
     </Stack>
   )
@@ -267,13 +267,13 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
       <RootBox overflow="hidden" height="fill" $opacity={muted ? 0.8 : 1}>
         <CommandListBox>
           <CommandList
+            key={key}
             activeItemDataAttr="data-hovered"
             ariaLabel={paneTitle}
             canReceiveFocus
             inputElement={searchInputElement}
             itemHeight={51}
             items={items}
-            key={key}
             onEndReached={handleEndReached}
             onlyShowSelectionWhenActive
             overscan={10}

--- a/packages/sanity/src/structure/panes/documentList/PaneContainer.tsx
+++ b/packages/sanity/src/structure/panes/documentList/PaneContainer.tsx
@@ -113,7 +113,7 @@ export const PaneContainer = memo(function PaneContainer(
 
   const isSheetListLayout = layout === 'sheetList'
   const paneLayout = isSheetListLayout ? (
-    <DocumentSheetListPane {...props} key={props.pane.id} />
+    <DocumentSheetListPane key={props.pane.id} {...props} />
   ) : (
     <DocumentListPane {...props} sortOrder={sortOrderRaw} layout={layout} />
   )

--- a/packages/sanity/src/structure/panes/documentList/sheetList/DocumentSheetListHeader.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/DocumentSheetListHeader.tsx
@@ -63,11 +63,11 @@ export function DocumentSheetListHeader(props: DocumentSheetListHeaderProps) {
 
   return (
     <HeaderTag
+      key={header.id}
       style={{
         left: header.column.getStart('left') ?? undefined,
         borderRight: `${borderWidth}px solid var(--card-border-color)`,
       }}
-      key={header.id}
       data-testid={`header-${header.id}`}
       width={header.getSize()}
     >

--- a/packages/sanity/src/structure/panes/documentList/sheetList/DocumentSheetListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/sheetList/DocumentSheetListPane.tsx
@@ -99,13 +99,13 @@ function DocumentSheetListPaneInner({
   const renderRow = useCallback((row: Row<SanityDocument>) => {
     return (
       <Box
-        as="tr"
         key={row.original._id + row.id}
+        as="tr"
         paddingY={2}
         style={{display: 'flex', width: '100%'}}
       >
         {row.getVisibleCells().map((cell) => (
-          <SheetListCell {...cell} key={row.original._id + cell.id} />
+          <SheetListCell key={row.original._id + cell.id} {...cell} />
         ))}
       </Box>
     )
@@ -128,7 +128,7 @@ function DocumentSheetListPaneInner({
           <Table>
             <thead>
               {table.getHeaderGroups().map((headerGroup) => (
-                <Box as="tr" key={headerGroup.id}>
+                <Box key={headerGroup.id} as="tr">
                   {headerGroup.headers.map((header) => (
                     <DocumentSheetListHeader
                       key={header.id}

--- a/packages/sanity/src/structure/panes/list/ListPane.tsx
+++ b/packages/sanity/src/structure/panes/list/ListPane.tsx
@@ -43,11 +43,11 @@ export function ListPane(props: ListPaneProps) {
       />
 
       <ListPaneContent
+        key={paneKey}
         childItemId={childItemId}
         isActive={isActive}
         items={items}
         layout={defaultLayout}
-        key={paneKey}
         showIcons={showIcons}
         title={title}
       />

--- a/packages/sanity/src/structure/panes/list/ListPaneContent.tsx
+++ b/packages/sanity/src/structure/panes/list/ListPaneContent.tsx
@@ -116,9 +116,9 @@ export function ListPaneContent(props: ListPaneContentProps) {
 
       return (
         <PaneItem
+          key={item.id}
           icon={shouldShowIconForItem(item) ? item.icon : false}
           id={item.id}
-          key={item.id}
           layout={layout}
           marginBottom={1}
           pressed={pressed}


### PR DESCRIPTION
### Description

There is a little known de-opt condition in the JSX transformer that can lead to `React.createElement` to be used, instead of the modern JSX runtime, if the `key` property happens after an object spread, instead of before.

In other words, this snippet:
```jsx
export default <div key="foo" {...props} />
```
Produces:
```jsx
import { jsx } from "react/jsx-runtime";

export default jsx("div", { ...props }, "foo");
```
While this:
```jsx
export default <div {...props} key="foo" />
```
Actually produces the classic `createElement`:
```jsx
import { createElement } from "react";

export default createElement("div", {
  ...props,
  key: "foo"
});
```

See these examples:
- [esbuild](https://esbuild.github.io/try/#dAAwLjI1LjgALS10YXJnZXQ9ZXMyMDI0Ci0tbG9hZGVyPXRzeAotLWpzeD1hdXRvbWF0aWMKLS1taW5pZnktc3ludGF4Ci0tc291cmNlbWFwAGNvbnN0IHByb3BzID0ge2tleTogJ2Jhcid9CgpleHBvcnQgY29uc3QgeWF5ID0gPGRpdiBrZXk9ImZvbyIgey4uLnByb3BzfSAvPgoKZXhwb3J0IGNvbnN0IG5heSA9IDxkaXYgey4uLnByb3BzfSBrZXk9ImZvbyIgLz4)
- [rollup](https://rollupjs.org/repl/?version=4.45.1&shareable=JTdCJTIyZXhhbXBsZSUyMiUzQW51bGwlMkMlMjJtb2R1bGVzJTIyJTNBJTVCJTdCJTIyY29kZSUyMiUzQSUyMmNvbnN0JTIwcHJvcHMlMjAlM0QlMjAlN0JrZXklM0ElMjAnYmFyJyU3RCU1Q24lNUNuZXhwb3J0JTIwY29uc3QlMjB5YXklMjAlM0QlMjAlM0NkaXYlMjBrZXklM0QlNUMlMjJmb28lNUMlMjIlMjAlN0IuLi5wcm9wcyU3RCUyMCUyRiUzRSU1Q24lNUNuZXhwb3J0JTIwY29uc3QlMjBuYXklMjAlM0QlMjAlM0NkaXYlMjAlN0IuLi5wcm9wcyU3RCUyMGtleSUzRCU1QyUyMmZvbyU1QyUyMiUyMCUyRiUzRSUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTJDJTIybmFtZSUyMiUzQSUyMm1haW4uanMlMjIlN0QlNUQlMkMlMjJvcHRpb25zJTIyJTNBJTdCJTIyanN4JTIyJTNBJTdCJTIybW9kZSUyMiUzQSUyMmF1dG9tYXRpYyUyMiU3RCUyQyUyMm91dHB1dCUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmVzJTIyJTdEJTdEJTdE)
- [rolldown](https://repl.rolldown.rs/#eNptkMEOgjAMhl+l6YWLmfdFfQUTz7sgbGYRumUMhCx7dytIJMFjt/9rvzahQZnQUq1HEbvxUxDKzcMBK64rR10EH5zv4AzpqScJxb0MRVakSI/ehQhLaConjpxqOwDHzgqNcwohCSFmPsPxsoPoB22CW/54YRWNMoZe5wMG1zS1e5Fg3tgHq67qf36WHWw7D4yT15Dg9o1dfbSsABlMcC0UK14oWtSWNnIH8BkUASjanqDWpuybFcLMpgOPbsqou4j5DQ5Df78=)
- [babel](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.42&spec=false&loose=false&code_lz=MYewdgzgLgBADgJxHCMC8MDeBrApgTwC4YByAIwEMESBfAKDtwA84QFZRJZ8L90YAPABMAlgDcYefGgBEAMxAgZWAHRrEyCDRgB6AHwNmrdjE7QYYXv2HjV6pCm1TZCpbr1A&forceAllTransforms=false&modules=false&shippedProposals=false&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact%2Cstage-2&prettier=false&targets=&version=7.28.1&externalPlugins=&assumptions=%7B%7D)
- [swc](https://play.swc.rs/?version=1.13.2&code=H4sIAAAAAAAAA0vOzysuUSgoyi8oVrBVqM5OrbRSUE9KLFKv5eJKrSjILypRSAYrqUysBCqwScksUwAqslVKy89XUqjW09MD661V0LdD05CH0ICkDKFX3w4AJiASbHwAAAA%3D&config=H4sIAAAAAAAAA1VQOw6DMAzdOQXy3KFCVYfeoYewUoNSkY9sRypC3L0JBFo2%2B33sZ89N28JbDDzaOZe5ichCfPQZkckrfjICOkUSwzYqXHZWpVDKiVZk2QhQ5IG0mEi6a3erBhhDEMpwj6NQxZz1tp%2F%2BV5rgIpPIWVik6Ifx8J83MnrpA7syCJjQ6FYlr9YVD2DS4FCtgWVpqhNceKV1ZH1AOXLLfYefaI94xAErz925Xr98AW0LewZMAQAA)

[This is a bit of a problem](https://github.com/facebook/react/issues/20031#issuecomment-710346866), as `React.createElement` is slower than the JSX runtime, for [reasons detailed here.](https://github.com/reactjs/rfcs/blob/createlement-rfc/text/0000-create-element-changes.md#motivation) [It's also explained in the announcement blogpost.](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)

The solution is to ensure that `key` is always before spreads. The easiest way to do that is to use both the ESLint rule that sorts props with special treatment for `key` that ensures consistency with `key` always being the first prop, and the oxlint rule `react/jsx-key` which knows about the `key` after `{...props}` problem in particular.


### What to review

Is there enough context?

### Testing

If all tests pass we're good.

### Notes for release

N/A – this PR gives a small perf boost, but not enough to warrant a callout in release notes.
