### PR TITLE
fix(cli):update init output docs command text

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -717,9 +717,9 @@ export default async function initSanity(
     print(chalk.blue.underline('https://www.sanity.io/docs/app-sdk/sdk-configuration'))
     print('\n')
     print(`Other helpful commands:`)
-    print(`npx sanity docs       to open the documentation in a browser`)
-    print(`npx sanity dev        to start the development server for your app`)
-    print(`npx sanity deploy     to deploy your app`)
+    print(`npx sanity docs browse     to open the documentation in a browser`)
+    print(`npx sanity dev             to start the development server for your app`)
+    print(`npx sanity deploy          to deploy your app`)
   } else {
     //output for Studios here
     print(`✅ ${chalk.green.bold('Success!')} Your Studio has been created.`)
@@ -729,9 +729,9 @@ export default async function initSanity(
     )
     print('\n')
     print(`Other helpful commands:`)
-    print(`npx sanity docs     to open the documentation in a browser`)
-    print(`npx sanity manage   to open the project settings in a browser`)
-    print(`npx sanity help     to explore the CLI manual`)
+    print(`npx sanity docs browse     to open the documentation in a browser`)
+    print(`npx sanity manage          to open the project settings in a browser`)
+    print(`npx sanity help            to explore the CLI manual`)
   }
 
   if (isFirstProject) {


### PR DESCRIPTION
### Description

The updates to the `sanity docs` command changed it so it has sub-commands rather than acting on it's own.

This change updates the init text seen when users use npx create, etc, to initialize new projects.

### What to review

Init a new project to see if the text works, but really it's only a change to the output. Biggest concern is the added 6 characters breaching any line-length restrictions.

### Notes for release

N/A