### PR TITLE
chore: adding release changelog to the latest release PR description

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -79,13 +79,32 @@ jobs:
       - name: Get version
         id: release-as
         run: echo "version=$(cat lerna.json | jq -r .version)" >> $GITHUB_OUTPUT
+
+      - name: Fetch latest tags
+        run: git fetch --tags --force
+
+      - name: Generate release notes
+        id: release-notes
+        run: |
+          {
+            echo "notes<<EOF"
+            pnpm release:notes
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
       - name: Create or update PR
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         id: create-pull-request
         with:
           token: ${{ steps.app-token.outputs.token }}
           title: "${{steps.version-commit.outputs.message}}"
-          body: "🤖 I have created a release **squib** **squob**\n\n Merging this PR will publish v${{steps.release-as.outputs.version}} to npm 🚀"
+          body: |
+            🤖 I have created a release **squib** **squob**
+
+            Merging this PR will publish v${{steps.release-as.outputs.version}} to npm 🚀
+
+            ## Release Notes Template
+
+            ${{steps.release-notes.outputs.notes}}
           commit-message: "${{steps.version-commit.outputs.message}}"
           branch: ci/release-main
           sign-commits: true

--- a/scripts/printReleaseNotesTemplate.ts
+++ b/scripts/printReleaseNotesTemplate.ts
@@ -49,12 +49,12 @@ Author | Message | Commit
 ${withPrLinks(execa.commandSync(CHANGELOG_COMMAND, {shell: true}).stdout)}
 `
 
-// eslint-disable-next-line no-console
-console.log(`
--------- SANITY RELEASE NOTES TEMPLATE --------
+console.log(`<!--
+SANITY RELEASE NOTES TEMPLATE
 Use the following template as a starting point for next release:
 A draft can be created here: https://github.com/sanity-io/sanity/releases/new
+-->
 
--------- BEGIN TEMPLATE --------
 ${TEMPLATE}
--------- END TEMPLATE --------`)
+<!-- END TEMPLATE -->
+`)


### PR DESCRIPTION
### Description
This add the outputs of `pnpm release:notes` to the latest release PR description, making it easier to come in and copy across to the new github release.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
