### PR TITLE
refactor(core): improve studio version info dialog

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -11,13 +11,11 @@ import {type LocaleResourceBundle} from '../types'
  */
 export const studioLocaleStrings = defineLocalesResources('studio', {
   /** "Disabled" status for auto-updates in About-dialog */
-  'about-dialog.version-info.auto-updates.disabled': 'Disabled',
+  'about-dialog.version-info.auto-updates.disabled': 'Auto Updates not enabled',
   /** "Enabled" status for auto-updates in About-dialog */
-  'about-dialog.version-info.auto-updates.enabled': 'Enabled',
-  /** "Auto Updates" status header in About-dialog */
-  'about-dialog.version-info.auto-updates.header': 'Auto Updates',
+  'about-dialog.version-info.auto-updates.enabled': 'Auto Updates Enabled',
   /** "How to enable" next to Disabled state for Auto updates in about dialog */
-  'about-dialog.version-info.auto-updates.how-to-enable': 'How to enable',
+  'about-dialog.version-info.auto-updates.how-to-enable': 'Enable',
   /** Text displayed on the "Copy to clipboard"-button after clicked */
   'about-dialog.version-info.copy-to-clipboard-button.copied-text':
     'Copied to Clipboard. Happy pasting!',
@@ -26,11 +24,9 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** "Current version" header in about dialog  */
   'about-dialog.version-info.current-version.header': 'Current version',
   /** "How to upgrade" link text */
-  'about-dialog.version-info.how-to-upgrade': 'How to upgrade',
+  'about-dialog.version-info.how-to-upgrade': 'Update now',
   /** "Latest version" header in about dialog */
-  'about-dialog.version-info.latest-version.header': 'Latest version',
-  /** "Latest version" header in about dialog */
-  'about-dialog.version-info.latest-version.text': 'Latest version is {{latestVersion}}',
+  'about-dialog.version-info.latest-version.text': 'Latest available',
   /** "Up to date" status in About-dialog */
   'about-dialog.version-info.up-to-date': 'Up to date',
   /** "User agent" header in About-dialog */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -14,6 +14,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'about-dialog.version-info.auto-updates.disabled': 'Auto Updates not enabled',
   /** "Enabled" status for auto-updates in About-dialog */
   'about-dialog.version-info.auto-updates.enabled': 'Auto Updates Enabled',
+  /** @deprecated "Auto Updates" status header in About-dialog */
+  'about-dialog.version-info.auto-updates.header': 'Auto Updates',
   /** "How to enable" next to Disabled state for Auto updates in about dialog */
   'about-dialog.version-info.auto-updates.how-to-enable': 'Enable',
   /** Text displayed on the "Copy to clipboard"-button after clicked */
@@ -25,6 +27,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'about-dialog.version-info.current-version.header': 'Current version',
   /** "How to upgrade" link text */
   'about-dialog.version-info.how-to-upgrade': 'Update now',
+  /** @deprecated "Latest version" header in about dialog */
+  'about-dialog.version-info.latest-version.header': 'Latest version',
   /** "Latest version" header in about dialog */
   'about-dialog.version-info.latest-version.text': 'Latest version',
   /** "New version available" tooltip in About-dialog */
@@ -33,6 +37,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'about-dialog.version-info.tooltip.prerelease': 'Prerelease',
   /** "Up to date" tooltip in About-dialog */
   'about-dialog.version-info.tooltip.up-to-date': 'Up to date',
+  /** @deprecated "Up to date" status in About-dialog */
+  'about-dialog.version-info.up-to-date': 'Up to date',
 
   /** "User agent" header in About-dialog */
   'about-dialog.version-info.user-agent.header': 'User agent',

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -26,9 +26,14 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** "How to upgrade" link text */
   'about-dialog.version-info.how-to-upgrade': 'Update now',
   /** "Latest version" header in about dialog */
-  'about-dialog.version-info.latest-version.text': 'Latest available',
-  /** "Up to date" status in About-dialog */
-  'about-dialog.version-info.up-to-date': 'Up to date',
+  'about-dialog.version-info.latest-version.text': 'Latest version',
+  /** "New version available" tooltip in About-dialog */
+  'about-dialog.version-info.tooltip.new-version-available': 'New version available',
+  /** "Prerelease" tooltip in About-dialog */
+  'about-dialog.version-info.tooltip.prerelease': 'Prerelease',
+  /** "Up to date" tooltip in About-dialog */
+  'about-dialog.version-info.tooltip.up-to-date': 'Up to date',
+
   /** "User agent" header in About-dialog */
   'about-dialog.version-info.user-agent.header': 'User agent',
 

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
@@ -6,9 +6,9 @@ import {styled} from 'styled-components'
 import {Button, MenuButton} from '../../../../../ui-components'
 import {useTranslation} from '../../../../i18n'
 import {SANITY_VERSION} from '../../../../version'
-import {AboutDialog} from './AboutDialog'
 import {useGetHelpResources} from './helper-functions/hooks'
 import {ResourcesMenuItems} from './ResourcesMenuItems'
+import {StudioInfoDialog} from './StudioInfoDialog'
 
 const StyledMenu = styled(Menu)`
   max-width: 300px;
@@ -31,7 +31,7 @@ export function ResourcesButton() {
   return (
     <>
       {aboutDialogOpen && (
-        <AboutDialog
+        <StudioInfoDialog
           currentVersion={SANITY_VERSION}
           latestVersion={value?.latestVersion || 'unknown'}
           onClose={handleAboutDialogClose}

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
@@ -19,22 +19,22 @@ export function ResourcesButton() {
   const {t} = useTranslation()
 
   const {value, error, isLoading} = useGetHelpResources()
-  const [aboutDialogOpen, setAboutDialogOpen] = useState(false)
-  const handleAboutDialogClose = useCallback(() => {
-    setAboutDialogOpen(false)
+  const [studioInfoDialogOpen, setStudioInfoDialogOpen] = useState(false)
+  const handleStudioInfoDialogClose = useCallback(() => {
+    setStudioInfoDialogOpen(false)
   }, [])
 
   const handleAboutDialogOpen = useCallback(() => {
-    setAboutDialogOpen(true)
+    setStudioInfoDialogOpen(true)
   }, [])
 
   return (
     <>
-      {aboutDialogOpen && (
+      {studioInfoDialogOpen && (
         <StudioInfoDialog
           currentVersion={SANITY_VERSION}
           latestVersion={value?.latestVersion}
-          onClose={handleAboutDialogClose}
+          onClose={handleStudioInfoDialogClose}
         />
       )}
       <MenuButton

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
@@ -19,7 +19,7 @@ export function ResourcesButton() {
   const {t} = useTranslation()
 
   const {value, error, isLoading} = useGetHelpResources()
-  const [aboutDialogOpen, setAboutDialogOpen] = useState(false)
+  const [aboutDialogOpen, setAboutDialogOpen] = useState(true)
   const handleAboutDialogClose = useCallback(() => {
     setAboutDialogOpen(false)
   }, [])
@@ -33,7 +33,7 @@ export function ResourcesButton() {
       {aboutDialogOpen && (
         <StudioInfoDialog
           currentVersion={SANITY_VERSION}
-          latestVersion={value?.latestVersion || 'unknown'}
+          latestVersion={value?.latestVersion}
           onClose={handleAboutDialogClose}
         />
       )}

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
@@ -19,7 +19,7 @@ export function ResourcesButton() {
   const {t} = useTranslation()
 
   const {value, error, isLoading} = useGetHelpResources()
-  const [aboutDialogOpen, setAboutDialogOpen] = useState(true)
+  const [aboutDialogOpen, setAboutDialogOpen] = useState(false)
   const handleAboutDialogClose = useCallback(() => {
     setAboutDialogOpen(false)
   }, [])

--- a/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
@@ -11,7 +11,7 @@ interface AboutDialogProps {
   currentVersion?: string
   onClose: () => void
 }
-export function AboutDialog(props: AboutDialogProps) {
+export function StudioInfoDialog(props: AboutDialogProps) {
   const {t} = useTranslation()
 
   const {latestVersion, onClose, currentVersion} = props
@@ -57,13 +57,7 @@ ${navigator.userAgent}
   }, [copySuccess])
 
   return (
-    <Dialog
-      header={'About'}
-      width={1}
-      onClickOutside={onClose}
-      onClose={onClose}
-      id={aboutDialogId}
-    >
+    <Dialog width={1} onClickOutside={onClose} onClose={onClose} id={aboutDialogId}>
       <Stack space={4}>
         <Stack space={3}>
           <Text as="h2" size={1} weight="medium">

--- a/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
@@ -97,7 +97,7 @@ export function StudioInfoDialog(props: AboutDialogProps) {
           </Flex>
         ) : null}
         {
-          // todo: in dev we currently don't know whether auto updates is enabled
+          // note: in dev we currently don't know whether auto updates is enabled
           //  so instead of showing misleading info, we just don't show anything here
           isProd && !isAutoUpdating ? (
             <Card tone="transparent" padding={2} radius={3} marginX={2}>

--- a/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
@@ -27,7 +27,7 @@ const MonogramContainer = styled(Card).attrs({
 export function StudioInfoDialog(props: StudioInfoDialogProps) {
   const {t} = useTranslation()
   const {onClose} = props
-  const aboutDialogId = useId()
+  const dialogId = useId()
 
   const currentVersionParsed = props.currentVersion ? parse(props.currentVersion) : null
 
@@ -46,7 +46,7 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
 
   const isPrerelease = preids.length > 0
   return (
-    <Dialog width={0} onClickOutside={onClose} id={aboutDialogId} padding={false}>
+    <Dialog width={0} onClickOutside={onClose} id={dialogId} padding={false}>
       <Stack space={4} paddingY={3}>
         <Flex align="center" justify="center" paddingY={4}>
           <MonogramContainer>

--- a/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
@@ -1,130 +1,118 @@
-import {CheckmarkCircleIcon, CopyIcon} from '@sanity/icons'
-import {Stack, Text, useToast} from '@sanity/ui'
-import {useCallback, useEffect, useId, useState} from 'react'
+import {LaunchIcon} from '@sanity/icons'
+import {SanityMonogram} from '@sanity/logos'
+import {Badge, Card, Flex, Stack, Text} from '@sanity/ui'
+import {useId} from 'react'
+import {styled} from 'styled-components'
 
-import {Button, Dialog} from '../../../../../ui-components'
+import {Button, Dialog, Tooltip} from '../../../../../ui-components'
+import {isDev} from '../../../../environment'
 import {hasSanityPackageInImportMap} from '../../../../environment/hasSanityPackageInImportMap'
-import {Translate, useTranslation} from '../../../../i18n'
+import {useTranslation} from '../../../../i18n'
 
 interface AboutDialogProps {
   latestVersion: string
   currentVersion?: string
   onClose: () => void
 }
+
+const MonogramContainer = styled(Card).attrs({
+  overflow: 'hidden',
+  radius: 4,
+})`
+  height: ${75}px;
+  width: ${75}px;
+`
+
 export function StudioInfoDialog(props: AboutDialogProps) {
   const {t} = useTranslation()
 
-  const {latestVersion, onClose, currentVersion} = props
+  const {onClose} = props
+
+  const latestVersion = ensureVersionPrefix(props.latestVersion)
+  const currentVersion = props.currentVersion && ensureVersionPrefix(props.currentVersion)
   const aboutDialogId = useId()
-  const [copySuccess, setCopySuccess] = useState(false)
 
-  const {push} = useToast()
   const isAutoUpdating = hasSanityPackageInImportMap()
-
-  const text = `## Current version
-${currentVersion}
-
-## Latest version
-${latestVersion}
-
-## Auto updates
-${isAutoUpdating ? 'Enabled' : 'Disabled'}
-
-## Page URL
-${document.location.href}
-
-## User agent
-${navigator.userAgent}
-`
-
-  const handleCopyDetails = useCallback(() => {
-    navigator.clipboard.writeText(text).then(
-      () => {
-        setCopySuccess(true)
-      },
-      (err: unknown) => {
-        push({
-          status: 'warning',
-          title: `Unable to write to clipboard: ${(err && typeof err === 'object' && 'message' in err && err.message) || 'unknown error'}`,
-        })
-      },
-    )
-  }, [push, text])
-
-  useEffect(() => {
-    const timer = setTimeout(() => setCopySuccess(false), 3000)
-    return () => clearTimeout(timer)
-  }, [copySuccess])
+  const isUpToDate = latestVersion === removeSuffix(currentVersion || '', '-development')
 
   return (
-    <Dialog width={1} onClickOutside={onClose} onClose={onClose} id={aboutDialogId}>
+    <Dialog
+      width={isUpToDate && (isAutoUpdating || isDev) ? 0 : 1}
+      onClickOutside={onClose}
+      id={aboutDialogId}
+    >
       <Stack space={4}>
-        <Stack space={3}>
-          <Text as="h2" size={1} weight="medium">
-            {t('about-dialog.version-info.current-version.header')}
+        <Flex align="center" justify="center">
+          <MonogramContainer>
+            <SanityMonogram height={75} width={75} />
+          </MonogramContainer>
+        </Flex>
+        <Flex align="center" justify="center" gap={3}>
+          {/* eslint-disable-next-line i18next/no-literal-string */}
+          <Text as="h2" size={1} weight="semibold">
+            Sanity Studio
           </Text>
-          <Text muted size={1}>
-            {currentVersion}
-          </Text>
-        </Stack>
-        <Stack space={3}>
-          <Text as="h2" size={1} weight="medium">
-            {t('about-dialog.version-info.current-version.header')}
-          </Text>
-          <Text muted size={1}>
-            <Translate t={t} i18nKey="" components={{}} />
-            {t('about-dialog.version-info.latest-version.text', {latestVersion})}{' '}
-            {latestVersion === currentVersion ? (
-              <>({t('about-dialog.version-info.up-to-date')})</>
-            ) : (
-              <>
-                (
-                <a href="https://www.sanity.io/docs/upgrade">
-                  {t('about-dialog.version-info.how-to-upgrade')}
-                </a>
-                )
-              </>
-            )}
-          </Text>
-        </Stack>
-        <Stack space={3}>
-          <Text as="h2" size={1} weight="medium">
-            {t('about-dialog.version-info.auto-updates.header')}
-          </Text>
-          {isAutoUpdating ? (
-            <Text muted size={1}>
-              {t('about-dialog.version-info.auto-updates.enabled')}
-            </Text>
-          ) : (
-            <Text muted size={1}>
-              {t('about-dialog.version-info.auto-updates.disabled')} (
-              <a href="https://www.sanity.io/docs/auto-updating-studios">
-                {t('about-dialog.version-info.auto-updates.how-to-enable')}
-              </a>
-              )
-            </Text>
+          <Tooltip
+            content={
+              isUpToDate
+                ? t('about-dialog.version-info.up-to-date')
+                : t('about-dialog.version-info.latest-version.text', {
+                    latestVersion: latestVersion,
+                  })
+            }
+          >
+            <Badge tone={isUpToDate ? 'neutral' : 'caution'} overflow="hidden">
+              {latestVersion}
+            </Badge>
+          </Tooltip>
+          {isUpToDate ? null : (
+            <Button
+              as="a"
+              href="https://www.sanity.io/docs/upgrade"
+              target="_blank"
+              rel="noopener noreferrer"
+              mode="bleed"
+              text={t('about-dialog.version-info.how-to-upgrade')}
+              iconRight={LaunchIcon}
+            />
           )}
-        </Stack>
-        <Stack space={3}>
-          <Text as="h2" size={1} weight="medium">
-            {t('about-dialog.version-info.user-agent.header')}
-          </Text>
-          <Text muted size={1}>
-            {navigator.userAgent}
-          </Text>
-        </Stack>
-        <Button
-          icon={copySuccess ? CheckmarkCircleIcon : CopyIcon}
-          mode="bleed"
-          text={
-            copySuccess
-              ? t('about-dialog.version-info.copy-to-clipboard-button.copied-text')
-              : t('about-dialog.version-info.copy-to-clipboard-button.text')
-          }
-          paddingY={3}
-          onClick={handleCopyDetails}
-        />
+        </Flex>
+        {isUpToDate ? null : (
+          <Flex align="center" justify="center" gap={3}>
+            <Text size={1} weight="semibold">
+              {t('about-dialog.version-info.latest-version.text')}
+            </Text>
+            <Badge>{latestVersion}</Badge>
+          </Flex>
+        )}
+        {isAutoUpdating || isDev ? null : (
+          <Card tone="transparent" padding={4} radius={3}>
+            <Flex align="center" justify="center" gap={3}>
+              <Text size={1} muted>
+                {t('about-dialog.version-info.auto-updates.disabled')}
+              </Text>
+              <Button
+                as="a"
+                href="https://www.sanity.io/docs/auto-updating-studios"
+                target="_blank"
+                rel="noopener noreferrer"
+                mode="ghost"
+                text={t('about-dialog.version-info.auto-updates.how-to-enable')}
+                iconRight={LaunchIcon}
+              />
+            </Flex>
+          </Card>
+        )}
+        <Button tone="primary" text="OK" paddingY={3} onClick={onClose} />
       </Stack>
     </Dialog>
   )
+}
+
+function removeSuffix(str: string, suffix: string) {
+  return str.endsWith(suffix) ? str.slice(0, -suffix.length) : str
+}
+
+function ensureVersionPrefix(str: string) {
+  return str.startsWith('v') ? str : `v${str}`
 }

--- a/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
@@ -6,7 +6,7 @@ import {coerce, parse, prerelease} from 'semver'
 import {styled} from 'styled-components'
 
 import {Button, Dialog, Tooltip} from '../../../../../ui-components'
-import {isDev} from '../../../../environment'
+import {isProd} from '../../../../environment'
 import {hasSanityPackageInImportMap} from '../../../../environment/hasSanityPackageInImportMap'
 import {useTranslation} from '../../../../i18n'
 
@@ -96,27 +96,28 @@ export function StudioInfoDialog(props: AboutDialogProps) {
             )}
           </Flex>
         ) : null}
-        {!isAutoUpdating ||
-        // todo: in dev we currently don't know whether auto updates is enabled
-        //  so instead of showing misleading info, we just don't show anything here
-        isDev ? null : (
-          <Card tone="transparent" padding={2} radius={3} marginX={2}>
-            <Flex align="center" justify="space-evenly" gap={2}>
-              <Text size={1} muted>
-                {t('about-dialog.version-info.auto-updates.disabled')}
-              </Text>
-              <Button
-                as="a"
-                href="https://www.sanity.io/docs/auto-updating-studios"
-                target="_blank"
-                rel="noopener noreferrer"
-                mode="ghost"
-                text={t('about-dialog.version-info.auto-updates.how-to-enable')}
-                iconRight={LaunchIcon}
-              />
-            </Flex>
-          </Card>
-        )}
+        {
+          // todo: in dev we currently don't know whether auto updates is enabled
+          //  so instead of showing misleading info, we just don't show anything here
+          isProd && !isAutoUpdating ? (
+            <Card tone="transparent" padding={2} radius={3} marginX={2}>
+              <Flex align="center" justify="space-evenly" gap={2}>
+                <Text size={1} muted>
+                  {t('about-dialog.version-info.auto-updates.disabled')}
+                </Text>
+                <Button
+                  as="a"
+                  href="https://www.sanity.io/docs/auto-updating-studios"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  mode="ghost"
+                  text={t('about-dialog.version-info.auto-updates.how-to-enable')}
+                  iconRight={LaunchIcon}
+                />
+              </Flex>
+            </Card>
+          ) : null
+        }
 
         <Stack paddingX={3}>
           <Button tone="primary" text="OK" paddingY={3} onClick={onClose} />

--- a/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
@@ -10,7 +10,7 @@ import {isProd} from '../../../../environment'
 import {hasSanityPackageInImportMap} from '../../../../environment/hasSanityPackageInImportMap'
 import {useTranslation} from '../../../../i18n'
 
-interface AboutDialogProps {
+interface StudioInfoDialogProps {
   latestVersion?: string
   currentVersion?: string
   onClose: () => void
@@ -24,7 +24,7 @@ const MonogramContainer = styled(Card).attrs({
   width: ${75}px;
 `
 
-export function StudioInfoDialog(props: AboutDialogProps) {
+export function StudioInfoDialog(props: StudioInfoDialogProps) {
   const {t} = useTranslation()
   const {onClose} = props
   const aboutDialogId = useId()


### PR DESCRIPTION
### Description
This PR adds visual improvements and fixes to the Studio version dialog.

**Before**
<img width="689" height="390" alt="image" src="https://github.com/user-attachments/assets/6a4cf376-7f1f-496e-99dc-b38536aab7e1" />


**After**
<img width="364" height="309" alt="image" src="https://github.com/user-attachments/assets/5043ecb8-516d-45e6-9da5-612ab7f423d9" />

Notes:
- "Enable auto-updates" now only show in non-dev environments when auto-updates has not been enabled
- We now treat prereleases ahead of latest as "up to date", so if you're on e.g. next, you won't see "How to upgrade"-affordances (if you're on a prerelease that's behind latest on npm, it will tell you)

Future work:
- If auto-updates is enabled, we should be able to detect that a new version is available, and show a reload-button in this dialog (also, possibly with a subtle indicatior on the "Help and resources" menu button).

### What to review

- Easiest way to test manually is by checking out this branch and changing the version number in `packages/sanity/src/core/version.ts`
- Can also be tested by installing the preview release from pkg.pr.new (see comment below) and turning off auto updates and deploying (note – enabling auto-updates will cause your studio to load sanity from modules-cdn, so these changes can't be tested that way).

### Testing
For now, manual testing by modifying version.ts and toggling the various states in the dialog component

### Notes for release
- Adds visual improvements to the Studio version info dialog