### PR TITLE
fix(ci): build with a valid semver for pkg.pr.new releases

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           PACKAGES=$(pnpx tsx scripts/listPublishedPackages.ts)
           echo "packages=${PACKAGES}" >> "$GITHUB_OUTPUT"
-          VERSION="$(jq -r .version lerna.json)-pkg.pr.new@$(git rev-parse --short HEAD)"
+          VERSION="$(jq -r .version lerna.json)-pkg.pr.new+$(git rev-parse --short HEAD)"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - run: pnpm build


### PR DESCRIPTION
### Description
When building for pkg.pr.new we set the current sanity version to eg. `sanity@4.1.1-pkg.pr.new@b2c9ef1`:

https://github.com/sanity-io/sanity/blob/99a4e98e7b6ca421175cd029663d8efdabebf24a/.github/workflows/pkg-pr-new.yml#L39

This is not a valid semver, and causes the version check request to fail later on, eg: https://qk0wb6qx.api.sanity.io/v1/help?tag=sanity.studio.module.version-check&m=sanity%404.1.1-pkg.pr.new%40b2c9ef1 and might cause unexpected behavior later on.

This fixes the issue by replacing the `@` with a `+`, which is the official supported delimiter for build info, so the above example will now be `sanity@4.1.1-pkg.pr.new+b2c9ef1`, which should pass as a valid semver (https://qk0wb6qx.api.sanity.io/v1/help?tag=sanity.studio.module.version-check&m=sanity%404.1.1-pkg.pr.new%2Baa8818ea42)
