### PR TITLE
chore(ci): add label to release PR

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -107,6 +107,7 @@ jobs:
             ${{steps.release-notes.outputs.notes}}
           commit-message: "${{steps.version-commit.outputs.message}}"
           branch: ci/release-main
+          labels: "next-release"
           sign-commits: true
           base: main
           team-reviewers: "@sanity-io/studio"


### PR DESCRIPTION
### Description
Smol fix that adds label to release-PRs which makes it easier to find and link to from internal docs etc.

### What to review
Is `next-release` a good label?
