### PR TITLE
fix(cli): Add missing flag to blueprints add example

### DIFF
--- a/packages/@sanity/cli/src/commands/blueprints/addBlueprintsCommand.ts
+++ b/packages/@sanity/cli/src/commands/blueprints/addBlueprintsCommand.ts
@@ -20,7 +20,7 @@ Examples:
   sanity blueprints add function
 
   # Add a Function with a specific name and install helpers with npm
-  sanity blueprints add function --name my-function -i
+  sanity blueprints add function --name my-function -i --helpers
 
   # Add a Function with a specific type
   sanity blueprints add function --fn-type document-publish


### PR DESCRIPTION
### Description

Small fix for an invalid example in the help for `blueprints add`

### What to review

Verify help text is now correct

### Testing

Tested locally on the existing CLI

### Notes for release

n/a
