### PR TITLE
chore(core): update pin button tooltips text

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -105,9 +105,9 @@ const releasesLocaleStrings = {
   'dashboard.details.published-on': 'Published on {{date}}',
 
   /** Text for the releases detail screen in the pin release button. */
-  'dashboard.details.pin-release': 'Navigate this release in the Studio',
+  'dashboard.details.pin-release': 'Pin release to studio',
   /** Text for the releases detail screen in the unpin release button. */
-  'dashboard.details.unpin-release': 'Stop navigating this release in the Studio',
+  'dashboard.details.unpin-release': 'Unpin release from studio',
 
   /** Activity inspector button text */
   'dashboard.details.activity': 'Activity',

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
@@ -336,7 +336,7 @@ describe('after releases have loaded', () => {
     })
 
     it('should not show the pin release button', () => {
-      expect(screen.queryByText('Navigate this release in the Studio')).not.toBeInTheDocument()
+      expect(screen.queryByText('Pin release to studio')).not.toBeInTheDocument()
     })
   })
 
@@ -375,7 +375,7 @@ describe('after releases have loaded', () => {
     })
 
     it('should not show the pin release button', () => {
-      expect(screen.queryByText('Navigate this release in the Studio')).not.toBeInTheDocument()
+      expect(screen.queryByText('Pin release to studio')).not.toBeInTheDocument()
     })
 
     it('should not show the publish button', () => {


### PR DESCRIPTION
### Description
Small one:
Updates the tooltip text from **pin / unpin release** to a more descriptive text:
- Pin release to studio
- Unpin release from studio


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Does it looks good?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open the studio, visit the releases list and the release detail screen, new text should show.


<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
