### PR TITLE
feat(core): allow all fields group customizations

### DIFF
--- a/dev/test-studio/schema/debug/allFieldsGroupHidden.ts
+++ b/dev/test-studio/schema/debug/allFieldsGroupHidden.ts
@@ -1,0 +1,44 @@
+import {ALL_FIELDS_GROUP, defineField, defineType} from 'sanity'
+
+export const allFieldsGroupHidden = defineType({
+  name: 'allFieldsGroupHidden',
+  type: 'document',
+  title: 'All fields group hidden',
+
+  groups: [
+    {
+      name: 'details',
+      title: 'Details',
+      hidden: false,
+    },
+    {
+      name: 'config',
+      title: 'Config',
+    },
+    {
+      ...ALL_FIELDS_GROUP,
+      hidden: true,
+    },
+  ],
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      group: 'details',
+    }),
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      group: 'details',
+    },
+    {
+      name: 'locked',
+      title: 'Locked',
+      description: 'Used for testing the "locked" permissions pattern',
+      type: 'boolean',
+      group: 'config',
+    },
+  ],
+})

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -5,6 +5,7 @@ import {commentsCI} from './ci/comments'
 import conditionalFieldset from './ci/conditionalFieldset'
 import validationTest from './ci/validationCI'
 import actions from './debug/actions'
+import {allFieldsGroupHidden} from './debug/allFieldsGroupHidden'
 import {allNativeInputComponents} from './debug/allNativeInputComponents'
 import {arrayCapabilities} from './debug/arrayCapabilities'
 import button from './debug/button'
@@ -255,6 +256,7 @@ export function createSchemaTypes(projectId: string) {
     patchOnMountDebug,
     simpleArrayOfObjects,
     arrayCapabilities,
+    allFieldsGroupHidden,
     simpleReferences,
     reservedFieldNames,
     review,

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -40,6 +40,7 @@ export const PLUGIN_INPUT_TYPES = [
 
 export const DEBUG_INPUT_TYPES = [
   'actionsTest',
+  'allFieldsGroupHidden',
   'allNativeInputComponents',
   'collapsibleObjects',
   'commentsDebug',

--- a/packages/@sanity/schema/src/_exports/_internal.ts
+++ b/packages/@sanity/schema/src/_exports/_internal.ts
@@ -6,6 +6,7 @@ export {
   resolveSearchConfig,
   resolveSearchConfigForBaseFieldPaths,
 } from '../legacy/searchConfig/resolve'
+export {ALL_FIELDS_GROUP_NAME} from '../legacy/types/constants'
 export {builtinTypes} from '../sanity/builtinTypes'
 export {extractSchema} from '../sanity/extractSchema'
 export {groupProblems} from '../sanity/groupProblems'

--- a/packages/@sanity/schema/src/legacy/types/constants.ts
+++ b/packages/@sanity/schema/src/legacy/types/constants.ts
@@ -20,3 +20,5 @@ export const DEFAULT_OVERRIDEABLE_FIELDS = [
  * This is the set of properties which are _not_ inherited, but explicitly defined on this type.
  */
 export const OWN_PROPS_NAME = '_internal_ownProps'
+
+export const ALL_FIELDS_GROUP_NAME = 'all-fields'

--- a/packages/@sanity/schema/src/legacy/types/object.ts
+++ b/packages/@sanity/schema/src/legacy/types/object.ts
@@ -219,5 +219,10 @@ function createFieldsGroups(typeDef: ObjectDefinition, fields: ObjectField[]): F
     })
   })
 
-  return flatMap(groupsByName).filter((group) => group.fields.length > 0)
+  return flatMap(groupsByName).filter(
+    // All fields group is added by default in structure.
+    // To pass the properties from the schema to the form state, we need to include it in the list of groups.
+    // TODO: Move ALL_FIELDS_GROUP to this package and export it, rather than using a string.
+    (group) => group.fields.length > 0 || group.name === 'all-fields',
+  )
 }

--- a/packages/@sanity/schema/src/legacy/types/object.ts
+++ b/packages/@sanity/schema/src/legacy/types/object.ts
@@ -12,7 +12,7 @@ import guessOrderingConfig from '../ordering/guessOrderingConfig'
 import createPreviewGetter from '../preview/createPreviewGetter'
 import {normalizeSearchConfigs} from '../searchConfig/normalize'
 import {resolveSearchConfig} from '../searchConfig/resolve'
-import {DEFAULT_OVERRIDEABLE_FIELDS, OWN_PROPS_NAME} from './constants'
+import {ALL_FIELDS_GROUP_NAME, DEFAULT_OVERRIDEABLE_FIELDS, OWN_PROPS_NAME} from './constants'
 import {hiddenGetter, lazyGetter} from './utils'
 
 const OVERRIDABLE_FIELDS = [
@@ -222,7 +222,6 @@ function createFieldsGroups(typeDef: ObjectDefinition, fields: ObjectField[]): F
   return flatMap(groupsByName).filter(
     // All fields group is added by default in structure.
     // To pass the properties from the schema to the form state, we need to include it in the list of groups.
-    // TODO: Move ALL_FIELDS_GROUP to this package and export it, rather than using a string.
-    (group) => group.fields.length > 0 || group.name === 'all-fields',
+    (group) => group.fields.length > 0 || group.name === ALL_FIELDS_GROUP_NAME,
   )
 }

--- a/packages/sanity/src/core/form/store/constants.ts
+++ b/packages/sanity/src/core/form/store/constants.ts
@@ -12,6 +12,29 @@ export const MAX_FIELD_DEPTH = 20
  */
 export const AUTO_COLLAPSE_DEPTH = 3
 
+/**
+ * The "all fields" group definition
+ * Users can import this to create a custom "all fields" group.
+ * Name must be `all-fields` to be considered an "all fields" group.
+ *
+ * @example hides the all fields group.
+ * ```ts
+ *
+ * const author = defineType({
+ *   name: 'author',
+ *   title: 'Author',
+ *   type: 'document',
+ *   groups: [
+ *     {
+ *       ...ALL_FIELDS_GROUP,
+ *       hidden: true,
+ *     },
+ *   ],
+ * })
+ * ```
+ *
+ * @public
+ */
 export const ALL_FIELDS_GROUP: FieldGroup = {
   name: 'all-fields',
   title: 'All fields',

--- a/packages/sanity/src/core/form/store/constants.ts
+++ b/packages/sanity/src/core/form/store/constants.ts
@@ -1,3 +1,4 @@
+import {ALL_FIELDS_GROUP_NAME} from '@sanity/schema/_internal'
 import {type FieldGroup} from '@sanity/types'
 
 import {studioLocaleNamespace} from '../../i18n/localeNamespaces'
@@ -36,7 +37,7 @@ export const AUTO_COLLAPSE_DEPTH = 3
  * @public
  */
 export const ALL_FIELDS_GROUP: FieldGroup = {
-  name: 'all-fields',
+  name: ALL_FIELDS_GROUP_NAME,
   title: 'All fields',
   hidden: false,
   i18n: {

--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -1,5 +1,4 @@
 /* eslint-disable complexity */
-/* eslint-disable max-nested-callbacks */
 /* eslint-disable max-statements */
 /* eslint-disable no-else-return */
 

--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -799,37 +799,57 @@ export function createPrepareFormState({
     const readOnly = props.readOnly === true || props.readOnly?.value
 
     const schemaTypeGroupConfig = props.schemaType.groups || []
-    const defaultGroupName = (schemaTypeGroupConfig.find((g) => g.default) || ALL_FIELDS_GROUP)
-      ?.name
 
-    const groups = [ALL_FIELDS_GROUP, ...schemaTypeGroupConfig].flatMap(
-      (group): FormFieldGroup[] => {
-        const groupHidden =
-          props.hidden === true ||
+    const shouldRenderAllFieldsGroup =
+      // All fields can't be hidden when review changes is open or if the all fields group is selected
+      props.changesOpen || props.fieldGroupState?.value === ALL_FIELDS_GROUP.name
+
+    const isGroupHidden = (group: FormFieldGroup) =>
+      shouldRenderAllFieldsGroup && group.name === ALL_FIELDS_GROUP.name
+        ? false
+        : props.hidden === true ||
           props.hidden?.value ||
           props.hidden?.children?.[`group:${group.name}`]?.value
-        const isSelected = group.name === (props.fieldGroupState?.value || defaultGroupName)
 
-        // Set the "all-fields" group as selected when review changes is open to enable review of all
-        // fields and changes together. When review changes is closed - switch back to the selected tab.
-        const selected = props.changesOpen ? group.name === ALL_FIELDS_GROUP.name : isSelected
-        // Also disable non-selected groups when review changes is open
-        const disabled = props.changesOpen ? !selected : false
-
-        return groupHidden
-          ? []
-          : [
-              {
-                disabled,
-                icon: group?.icon,
-                name: group.name,
-                selected,
-                title: group.title,
-                i18n: group.i18n,
-              },
-            ]
-      },
+    const hasCustomAllFieldsGroup = schemaTypeGroupConfig.some(
+      (g) => g.name === ALL_FIELDS_GROUP.name,
     )
+    const groupsConfig = hasCustomAllFieldsGroup
+      ? schemaTypeGroupConfig
+      : [ALL_FIELDS_GROUP, ...schemaTypeGroupConfig]
+
+    const defaultGroup =
+      groupsConfig.find((g) => g.default) ||
+      // Use the first non-hidden group as default, if no default group is found.
+      groupsConfig.find((g) => !isGroupHidden(g)) ||
+      groupsConfig[0]
+
+    const defaultGroupName = defaultGroup.name
+
+    const groups = groupsConfig.flatMap((group): FormFieldGroup[] => {
+      const groupHidden = isGroupHidden(group)
+
+      const isSelected = group.name === (props.fieldGroupState?.value || defaultGroupName)
+
+      // Set the "all-fields" group as selected when review changes is open to enable review of all
+      // fields and changes together. When review changes is closed - switch back to the selected tab.
+      const selected = props.changesOpen ? group.name === ALL_FIELDS_GROUP.name : isSelected
+      // Also disable non-selected groups when review changes is open
+      const disabled = props.changesOpen ? !selected : false
+
+      return groupHidden
+        ? []
+        : [
+            {
+              disabled,
+              icon: group?.icon,
+              name: group.name,
+              selected,
+              title: group.title,
+              i18n: group.i18n,
+            },
+          ]
+    })
 
     const selectedGroup = groups.find((group) => group.selected)
 
@@ -936,7 +956,7 @@ export function createPrepareFormState({
 
     const visibleGroups = hasFieldGroups
       ? groups.flatMap((group) => {
-          // The "all fields" group is always visible
+          // The "all fields" group is always visible, unless it's hidden by the user. (See above)
           if (group.name === ALL_FIELDS_GROUP.name) {
             return group
           }

--- a/packages/sanity/src/core/form/store/index.ts
+++ b/packages/sanity/src/core/form/store/index.ts
@@ -1,4 +1,5 @@
 export {resolveConditionalProperty} from './conditional-property'
+export {ALL_FIELDS_GROUP} from './constants'
 export * from './stateTreeHelper'
 export * from './types'
 export * from './useFormState'

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -238,6 +238,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     onSetCollapsedFieldSet,
     openPath,
   } = useDocumentForm({
+    changesOpen,
     documentType,
     documentId,
     initialValue: initialValue,

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`exports snapshot 1`] = `
 {
   ".": {
+    "ALL_FIELDS_GROUP": "object",
     "ActiveWorkspaceMatcher": "function",
     "AddonDatasetProvider": "function",
     "ArrayOfObjectOptionsInput": "function",


### PR DESCRIPTION
### Description
Fixes: https://github.com/sanity-io/sanity/issues/3142

This feature has been requested by multiple users. 

It will allow users to hide the `all-fields` group if they want to. While we keep the option to render it if we think it's necessary.

When do we need to render it:
- A field path is focused and the field is not part of any group defined.
- Review changes panel is open.

**How can you select a field that is not part of any group?**
By deep linking to a field, for example from presentation.
By clicking on a comment which points to a field that is not part of any group.

**How do we know this?**
We can detect this by checking the `props.fieldGroupState?.value` property in the `prepareObjectInputState` function. [See code here ](https://github.com/sanity-io/sanity/compare/all-fields-tab?expand=1#diff-2e87a23f4cdf6d1b9e18a8c69dde48671de44a2a8064d816e62f5532e3a27ec7R805)

> [!WARNING]
> Hiding the all fields group will also hide from your users all the fields that are not part of a group. So if a field is missing from the groups, the authors won't be able to see it. 

https://www.loom.com/share/65b49c1828f54a99b9befac29c45da77



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Are there other use cases in where we could have the need to render the `all-fields` group?


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

You can go to https://test-studio-git-all-fields-tab.sanity.dev//test/structure/input-debug;allFieldsGroupHidden;731ea852-7bd5-436c-86db-368a0daae9d4 to see it in action.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

### Customizable "All fields" group
Developers can now customize, and even hide, the "All fields" group when using field groups. Use the new `ALL_FIELDS_GROUP` export, and override the existing properties as you would with your own groups.

```ts
import {ALL_FIELDS_GROUP, defineField, defineType} from 'sanity'

export default defineType({
  name: 'mySchemaType',
  type: 'document',
  groups: [
    {
      name: 'details',
      title: 'Details',
    },
    {
      ...ALL_FIELDS_GROUP,
      hidden: true,
    },
  ],
}
```
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
