### PR TITLE
fix: workaround rollup@4.46.0 regression

### DIFF
--- a/packages/sanity/src/core/comments/plugin/inspector/CommentsInspectorFeedbackFooter.tsx
+++ b/packages/sanity/src/core/comments/plugin/inspector/CommentsInspectorFeedbackFooter.tsx
@@ -17,7 +17,7 @@ const Link = styled.a`
 
 const FooterCard = styled(Card)({
   position: 'relative',
-  zIndex: 1,
+  zIndex: '1',
 })
 
 export function CommentsInspectorFeedbackFooter() {

--- a/packages/sanity/src/core/comments/plugin/inspector/CommentsInspectorHeader.tsx
+++ b/packages/sanity/src/core/comments/plugin/inspector/CommentsInspectorHeader.tsx
@@ -10,8 +10,8 @@ import {type CommentStatus, type CommentsUIMode} from '../../types'
 
 const Root = styled(Card)({
   position: 'relative',
-  zIndex: 1,
-  lineHeight: 0,
+  zIndex: '1',
+  lineHeight: '0',
 })
 
 interface CommentsInspectorHeaderProps {

--- a/packages/sanity/src/core/form/components/tagInput/tagInput.tsx
+++ b/packages/sanity/src/core/form/components/tagInput/tagInput.tsx
@@ -37,7 +37,7 @@ const Root = styled(Card)((props: {theme: Theme}): CSSObject => {
 
     '& > .content': {
       position: 'relative',
-      lineHeight: 0,
+      lineHeight: '0',
       margin: `-${space} 0 0 -${space}`,
     },
 
@@ -94,9 +94,9 @@ const Input = styled.input((props: {theme: Theme}): CSSObject => {
     'borderRadius': 0,
     'outline': 'none',
     'fontSize': rem(size.fontSize),
-    'lineHeight': size.lineHeight / size.fontSize,
+    'lineHeight': `${size.lineHeight / size.fontSize}`,
     'fontFamily': font.family,
-    'fontWeight': font.weights.regular,
+    'fontWeight': `${font.weights.regular}`,
     'margin': 0,
     'display': 'block',
     'minWidth': '1px',

--- a/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorHeader.tsx
@@ -17,8 +17,8 @@ export interface DocumentInspectorHeaderProps {
 
 const Root = styled(Card)({
   position: 'relative',
-  zIndex: 1,
-  lineHeight: 0,
+  zIndex: '1',
+  lineHeight: '0',
 })
 
 /** @internal */


### PR DESCRIPTION
### Description

[The workaround is for the issue detailed here.](https://github.com/rollup/rollup/issues/6040) Since the issue only affects cases where we use the object version of `styled-components` with units that should not have `px`, [as listed here](https://github.com/emotion-js/emotion/blob/49229553967b6050c92d9602eb577bdc48167e91/packages/unitless/src/index.ts#L2-L50), we can avoid the issue by converting said object css that are `number` to `string`.
This change is future compatible, once https://github.com/rollup/rollup/pull/6041 is merged and released we can keep the workaround in place. It's a good rule of thumb in general to not rely on implicit behavior anyway.

Similar workarounds were done in `@sanity/ui`:
- https://github.com/sanity-io/ui/releases/tag/v2.16.11
- https://github.com/sanity-io/ui/releases/tag/v3.0.3

### What to review

Makes sense?

### Testing

If tests pass we're good.

### Notes for release

N/A - we already have a workaround in place that's sufficient, this doesn't change that.
