### PR TITLE
fix(ci): set correct version for next packages

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -43,23 +43,46 @@ jobs:
         run: pnpm install --ignore-scripts
 
       - name: Bump canary versions
+        # Note: ubuntu-latest ships with lerna installed on the system
+        # (see https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#project-management)
+        # It's important that we call lerna using npx in the command below so we get the
+        # locally installed lerna instead of the one installed on the system
         run: |
           npx lerna version \
             --conventional-commits \
             --conventional-prerelease \
             --preid=next \
+            --force-publish \
             --no-git-tag-version \
             --exact \
             --yes
 
+      - name: Rewrite version
+        # Q: Why are we doing this?
+        # A:
+        # lerna version does not support --canary (for some reason, it's only supported for lerna publish)
+        # When publishing tagged next releases, we want the version to be:
+        # <conventional-commit-bump>.<commits-ahead>+<commit-hash>
+        # However, the lerna version command we run above does not append the commit hash, and it
+        # always sets the <commits-ahead> part to "0"
+        # So, in order to get the desired target version, we need to post-process package versions
+        # by manually getting the number of commits in the branch since last release, and replace the "0"
+        # with the correct number of commits ahead, and finally append the commit hash.
+        run: |
+          COMMIT_COUNT="0" # fallback refcount value
           COMMIT_HASH=$(git rev-parse --short HEAD)
-          TIMESTAMP=$(date -u +"%Y%m%d%H%M")
-          VERSION_SUFFIX="${COMMIT_HASH}-${TIMESTAMP}"
 
-          echo "Appending version suffix: $VERSION_SUFFIX"
+          TAG_INFO=$(git describe --tags --long --first-parent)
+
+          if [[ $TAG_INFO =~ ^(.+)-([0-9]+)-g([0-9a-f]+)$ ]]; then
+            COMMIT_COUNT="${BASH_REMATCH[2]}"
+          fi
+
+          echo "COMMITS AHEAD: $COMMIT_COUNT"
+          echo "COMMIT HASH: $COMMIT_HASH"
 
           for pkg in $(lerna list --json | jq -r '.[].location'); do
-            jq --arg suffix "$VERSION_SUFFIX" '.version += "-" + $suffix' "$pkg/package.json" > "$pkg/package.tmp.json"
+            jq --arg commit_count "$COMMIT_COUNT" --arg commit_hash "$COMMIT_HASH" '.version |= sub("\\.0$"; "." + $commit_count + "+"+$commit_hash)' "$pkg/package.json" > "$pkg/package.tmp.json"
             mv "$pkg/package.tmp.json" "$pkg/package.json"
           done
 
@@ -92,6 +115,8 @@ jobs:
       - name: Build bundles
         run: pnpm run build:bundle
 
+      # Note: we need to run this after publish so we get the updated version numbers from npx lerna publish
+      # ideally, the flow should be 1) bump packages using lerna version, 2) upload to module cdn, 3) lerna publish to npm from packages
       - name: Upload bundles to staging bucket
         env:
           GOOGLE_PROJECT_ID: ${{ secrets.GCS_STAGING_PROJECT_ID }}


### PR DESCRIPTION
### Description

This tweaks the next release workflow so that we get the correct version number.

Currently, the versions we publish are
`<conventional-commit-bump>-next.0-<commit-hash>-<timestamp>` where `0` is static. This is a result of lerna's lack of support for a `--canary` option with the `version` command. This PR modifies the workflow so that we manually set the desired version in a post-processing step after we've generated the conventional-commits bump.

Additionally, this PR adds back the `--force-publish` flag, so that all packages are bumped in concert.

### What to review
Does the changes make sense?

### Testing
Enabled this workflow to run for this branch in a commit that I've now removed, so here's a workflow run based on these changes: https://github.com/sanity-io/sanity/actions/runs/16621696718/job/47027411803 

### Notes for release

n/a