### PR TITLE
fix(cli): remove workspace version specifier

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -62,7 +62,7 @@
     "@sanity/runtime-cli": "^10.0.0",
     "@sanity/telemetry": "^0.8.0",
     "@sanity/template-validator": "^2.4.3",
-    "@sanity/util": "workspace:4.2.0",
+    "@sanity/util": "workspace:*",
     "chalk": "^4.1.2",
     "debug": "^4.3.4",
     "decompress": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -896,7 +896,7 @@ importers:
         specifier: ^2.4.3
         version: 2.4.3
       '@sanity/util':
-        specifier: workspace:4.2.0
+        specifier: workspace:*
         version: link:../util
       chalk:
         specifier: ^4.1.2


### PR DESCRIPTION
### Description
Was looking into an issue with installilng next-tagged versions failing due to an attempt at installing a version of `@sanity/util` that didn't exist. Seems to have been caused by the version specifier here. Did a journey back in the version history, and it does not seem like it was intentional to specify version here. It started happening after it was set to `workspace:` (note the missing `*`) here: https://github.com/sanity-io/sanity/commit/97c3b32940f2324a9f0fc25097c33f1813374644#diff-6d67d183f0cfde1b995377d627f65ae08e2f2e6ee6a8ea061e447f4e80d1613aR66-R69
