### PR TITLE
fix(app server): stop spinner before printing url

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/app/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/devAction.ts
@@ -48,6 +48,7 @@ export default async function startAppDevServer(
   try {
     const spinner = output.spinner('Starting dev server').start()
     await startDevServer({...config, spinner, skipStartLog: true, isApp: true})
+    spinner.stop()
 
     output.print(`Dev server started on port ${config.httpPort}`)
     output.print(`View your app in the Sanity dashboard here:`)

--- a/packages/sanity/src/_internal/cli/actions/app/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/devAction.ts
@@ -48,7 +48,7 @@ export default async function startAppDevServer(
   try {
     const spinner = output.spinner('Starting dev server').start()
     await startDevServer({...config, spinner, skipStartLog: true, isApp: true})
-    spinner.stop()
+    spinner.succeed()
 
     output.print(`Dev server started on port ${config.httpPort}`)
     output.print(`View your app in the Sanity dashboard here:`)


### PR DESCRIPTION
### Description

This PR fixes an issue with the App Dev Server where the spinner would print in between the "View your app in the Sanity dashboard here:" and the app URL causing the app URL to be malformed and unclickable.

### What to review

Review that the spinner.stop() is placed correctly

### Testing

Ensure that the spinner stops once the dev server has started
