### PR TITLE
examples: add mastodon and bluesky functions

### DIFF
--- a/examples/functions/bluesky-post/README.md
+++ b/examples/functions/bluesky-post/README.md
@@ -27,10 +27,21 @@ This function is built to be compatible with any of [the official "clean" templa
 This function expects your post schema to include:
 
 - `title` field (string)
-- `autoSummary` field (text) - for the post description
+- `blueskyPost` field (text) - for the post content
 - `slug` field (slug type with `current` property)
 
-Most official templates already include these fields, but you may need to add the `autoSummary` field.
+Most official templates already include the `title` and `slug` fields, but you will need to add the `blueskyPost` field.
+
+Add the `blueskyPost` field to your post schema:
+
+```javascript
+{
+  name: 'blueskyPost',
+  title: 'Bluesky Post Content',
+  type: 'text',
+  description: 'Content to post on Bluesky when this post is published'
+}
+```
 
 ## Implementation
 
@@ -96,7 +107,7 @@ Most official templates already include these fields, but you may need to add th
          event: {
            on: ['publish'],
            filter: "_type == 'post'",
-           projection: '_id, title, autoSummary, slug',
+           projection: '_id, title, blueskyPost, slug',
          },
          env: {
            BLUESKY_USERNAME: BLUESKY_USERNAME,
@@ -140,37 +151,23 @@ Most official templates already include these fields, but you may need to add th
 
 You can test the bluesky-post function locally using the Sanity CLI before deploying it to production.
 
-**Important:** This function requires valid Bluesky credentials but will NOT post to Bluesky during local testing. It will only log the content that would be posted.
+### Simple Testing Command
 
-### 1. Basic Function Test
+Test the function with an existing document ID from your dataset:
+
+```bash
+npx sanity functions test bluesky-post --document-id <insert-document-id> --dataset production --with-user-token
+```
+
+### Test with data from a JSON file
 
 Test the function with the included sample document:
 
 ```bash
-npx sanity functions test bluesky-post \
-  --file functions/bluesky-post/document.json \
-  --dataset production \
-  --with-user-token
+npx sanity functions test bluesky-post --file functions/bluesky-post/document.json
 ```
 
-### 2. Test with Real Document Data
-
-Test with a real document from your dataset:
-
-```bash
-# From the studio/ folder, export a real document for testing
-cd studio
-npx sanity documents query "*[_type == 'post'][0]" > ../real-post.json
-
-# Back to project root for function testing
-cd ..
-npx sanity functions test bluesky-post \
-  --file real-post.json \
-  --dataset production \
-  --with-user-token
-```
-
-### 3. Interactive Development Mode
+### Interactive Development Mode
 
 Start the development server for interactive testing:
 
@@ -182,9 +179,9 @@ This opens an interactive playground where you can test functions with custom da
 
 ### Testing Tips
 
-- **Local testing safety** - The function detects local testing and won't actually post to Bluesky
-- **Use real credentials** - You still need valid Bluesky credentials for testing the authentication
-- **Check logs** - Monitor console output to see the post content that would be sent
+- **Use real credentials** - You need valid Bluesky credentials for testing the authentication
+- **Warning: Live posting** - The function will actually post to Bluesky when tested locally
+- **Check logs** - Monitor console output to see the post content that was sent
 - **Test edge cases** - Try documents without summaries or slugs to ensure graceful handling
 
 ## Deploying your function
@@ -248,7 +245,7 @@ Once you've tested your function locally and are satisfied with its behavior, yo
 - A Sanity project with Functions enabled
 - A schema with a `post` document type containing:
   - `title` field (string)
-  - `autoSummary` field (text or string)
+  - `blueskyPost` field (text or string)
   - `slug` field (slug type with `current` property)
 - A Bluesky account with app password
 - Node.js v22.x for local testing
@@ -257,7 +254,7 @@ Once you've tested your function locally and are satisfied with its behavior, yo
 
 When you publish a post document, the function automatically:
 
-1. Extracts the post title, auto-summary, and slug
+1. Extracts the post title, bluesky post content, and slug
 2. Formats a social media post with this content
 3. Posts to Bluesky using your account credentials
 4. Logs the success or any errors
@@ -281,7 +278,7 @@ Modify the `postContent` template in `index.ts`:
 ```typescript
 const postContent = `🚀 ${title}
 
-${autoSummary}
+${blueskyPost}
 
 Read more: ${slug.current}`
 ```
@@ -299,7 +296,7 @@ filter: "_type == 'post' && defined(publishedAt)"
 Add more fields to the projection and use them in the post:
 
 ```typescript
-projection: '_id, title, autoSummary, slug, author'
+projection: '_id, title, blueskyPost, slug, author'
 ```
 
 ## Troubleshooting
@@ -318,8 +315,8 @@ projection: '_id, title, autoSummary, slug, author'
 
 **Error: "Post content too long"**
 
-- Cause: Combined title, summary, and slug exceed Bluesky's character limit
-- Solution: Truncate the auto-summary or modify the post format
+- Cause: Combined title, post content, and slug exceed Bluesky's character limit
+- Solution: Truncate the bluesky post content or modify the post format
 
 **Posts not appearing on Bluesky**
 

--- a/examples/functions/bluesky-post/README.md
+++ b/examples/functions/bluesky-post/README.md
@@ -1,0 +1,338 @@
+# Bluesky Post Function
+
+[Explore all examples](https://github.com/sanity-io/sanity/tree/main/examples)
+
+## Problem
+
+Content teams want to automatically share their published articles on Bluesky to increase reach and engagement. Manually cross-posting to social platforms is time-consuming and often forgotten, leading to missed opportunities for content promotion.
+
+## Solution
+
+This Sanity Function automatically posts to Bluesky when content is published using the `@humanwhocodes/crosspost` library. When a post is published, the function creates a Bluesky post containing the title, summary, and slug, helping maintain consistent social media presence without manual effort.
+
+## Benefits
+
+- **Automates social media sharing** by posting to Bluesky on content publish
+- **Saves time** by eliminating manual cross-posting tasks
+- **Ensures consistency** with automatic posting of title, summary, and link
+- **Increases content reach** by maintaining active social media presence
+- **Reduces missed opportunities** by never forgetting to share published content
+
+## Compatible Templates
+
+This function is built to be compatible with any of [the official "clean" templates](https://www.sanity.io/exchange/type=templates/by=sanity). We recommend testing the function out in one of those after you have installed them locally.
+
+### Schema Requirements
+
+This function expects your post schema to include:
+
+- `title` field (string)
+- `autoSummary` field (text) - for the post description
+- `slug` field (slug type with `current` property)
+
+Most official templates already include these fields, but you may need to add the `autoSummary` field.
+
+## Implementation
+
+**Important:** Run these commands from the root of your project (not inside the `studio/` folder).
+
+1. **Set up Bluesky Credentials**
+
+   First, you'll need to create a Bluesky app password for API access:
+   1. **Log into your Bluesky account:**
+      - Go to [bsky.app](https://bsky.app) and sign in with your account
+
+   2. **Create an App Password:**
+      - Navigate to Settings → Privacy and Security → App Passwords
+      - Or go directly to [bsky.app/settings/app-passwords](https://bsky.app/settings/app-passwords)
+      - Click "Add App Password"
+      - Give it a descriptive name (e.g., "Sanity Auto-Post")
+      - Click "Create App Password"
+
+   3. **Save your credentials:**
+      - **Username:** Your full Bluesky handle (e.g., `yourname.bsky.social`)
+      - **App Password:** The generated password in format `xxxx-xxxx-xxxx-xxxx`
+      - **Host:** Usually `bsky.social` (default)
+
+   **Important:** App passwords have the same abilities as your account password but are restricted from destructive actions like account deletion. Store them securely.
+
+2. **Initialize the example**
+
+   Run this if you haven't initialized blueprints:
+
+   ```bash
+   npx sanity blueprints init
+   ```
+
+   You'll be prompted to select your organization and Sanity studio.
+
+   Then run:
+
+   ```bash
+   npx sanity blueprints add function --example bluesky-post
+   ```
+
+3. **Add configuration to your blueprint**
+
+   ```ts
+   // sanity.blueprint.ts
+   import 'dotenv/config'
+   import process from 'node:process'
+   import {defineBlueprint, defineDocumentFunction} from '@sanity/blueprints'
+
+   const {BLUESKY_USERNAME, BLUESKY_PASSWORD, BLUESKY_HOST} = process.env
+   if (typeof BLUESKY_USERNAME !== 'string' || typeof BLUESKY_PASSWORD !== 'string') {
+     throw new Error('BLUESKY_USERNAME and BLUESKY_PASSWORD must be set')
+   }
+
+   export default defineBlueprint({
+     resources: [
+       defineDocumentFunction({
+         type: 'sanity.function.document',
+         name: 'bluesky-post',
+         src: './functions/bluesky-post',
+         memory: 1,
+         timeout: 10,
+         event: {
+           on: ['publish'],
+           filter: "_type == 'post'",
+           projection: '_id, title, autoSummary, slug',
+         },
+         env: {
+           BLUESKY_USERNAME: BLUESKY_USERNAME,
+           BLUESKY_PASSWORD: BLUESKY_PASSWORD,
+           BLUESKY_HOST: BLUESKY_HOST || 'bsky.social',
+         },
+       }),
+     ],
+   })
+   ```
+
+4. **Install dependencies**
+
+   Install dependencies in the project root:
+
+   ```bash
+   npm install dotenv
+   ```
+
+5. **Configure environment variables**
+
+   Create a `.env` file in your project root with the following variables:
+
+   ```env
+   # Required
+   BLUESKY_USERNAME=yourname.bsky.social
+   BLUESKY_PASSWORD=xxxx-xxxx-xxxx-xxxx
+
+   # Optional (defaults shown)
+   BLUESKY_HOST=bsky.social
+   ```
+
+   **Required:**
+   - `BLUESKY_USERNAME`: Your full Bluesky handle (e.g., `yourname.bsky.social`)
+   - `BLUESKY_PASSWORD`: Your Bluesky app password (19 characters with dashes)
+
+   **Optional:**
+   - `BLUESKY_HOST`: Bluesky instance host (default: 'bsky.social')
+
+## Testing the function locally
+
+You can test the bluesky-post function locally using the Sanity CLI before deploying it to production.
+
+**Important:** This function requires valid Bluesky credentials but will NOT post to Bluesky during local testing. It will only log the content that would be posted.
+
+### 1. Basic Function Test
+
+Test the function with the included sample document:
+
+```bash
+npx sanity functions test bluesky-post \
+  --file functions/bluesky-post/document.json \
+  --dataset production \
+  --with-user-token
+```
+
+### 2. Test with Real Document Data
+
+Test with a real document from your dataset:
+
+```bash
+# From the studio/ folder, export a real document for testing
+cd studio
+npx sanity documents query "*[_type == 'post'][0]" > ../real-post.json
+
+# Back to project root for function testing
+cd ..
+npx sanity functions test bluesky-post \
+  --file real-post.json \
+  --dataset production \
+  --with-user-token
+```
+
+### 3. Interactive Development Mode
+
+Start the development server for interactive testing:
+
+```bash
+npx sanity functions dev
+```
+
+This opens an interactive playground where you can test functions with custom data.
+
+### Testing Tips
+
+- **Local testing safety** - The function detects local testing and won't actually post to Bluesky
+- **Use real credentials** - You still need valid Bluesky credentials for testing the authentication
+- **Check logs** - Monitor console output to see the post content that would be sent
+- **Test edge cases** - Try documents without summaries or slugs to ensure graceful handling
+
+## Deploying your function
+
+Once you've tested your function locally and are satisfied with its behavior, you can deploy it to production.
+
+**Important:** Make sure you have the Deploy Studio permission for your Sanity project before attempting to deploy.
+
+### Prerequisites for deployment
+
+- Sanity CLI v3.92.0 or later
+- Deploy Studio permissions for your Sanity project
+- Node.js v22.x (matches production runtime)
+- Valid Bluesky credentials (username and app password)
+
+### Deploy to production
+
+1. **Verify your blueprint configuration**
+
+   Make sure your `sanity.blueprint.ts` file is properly configured with your function as shown in the implementation section above.
+
+2. **Deploy your blueprint**
+
+   From your project root, run:
+
+   ```bash
+   npx sanity blueprints deploy
+   ```
+
+   This command will:
+   - Package your function code
+   - Upload it to Sanity's infrastructure
+   - Configure the event triggers for post publications
+   - Make your bluesky-post function live in production
+
+3. **Add environment variables**
+
+   After deployment, you need to add your Bluesky credentials as environment variables:
+
+   ```bash
+   npx sanity functions env add bluesky-post BLUESKY_USERNAME "yourname.bsky.social"
+   npx sanity functions env add bluesky-post BLUESKY_PASSWORD "xxxx-xxxx-xxxx-xxxx"
+   npx sanity functions env add bluesky-post BLUESKY_HOST "bsky.social"
+   ```
+
+   You can verify the environment variables were added successfully:
+
+   ```bash
+   npx sanity functions env list bluesky-post
+   ```
+
+4. **Verify deployment**
+
+   After deployment, you can verify your function is active by:
+   - Checking the Sanity Studio under "Compute"
+   - Publishing a new post and confirming it appears on Bluesky
+   - Monitoring function logs in the CLI
+
+## Requirements
+
+- A Sanity project with Functions enabled
+- A schema with a `post` document type containing:
+  - `title` field (string)
+  - `autoSummary` field (text or string)
+  - `slug` field (slug type with `current` property)
+- A Bluesky account with app password
+- Node.js v22.x for local testing
+
+## Usage Example
+
+When you publish a post document, the function automatically:
+
+1. Extracts the post title, auto-summary, and slug
+2. Formats a social media post with this content
+3. Posts to Bluesky using your account credentials
+4. Logs the success or any errors
+
+**Example Bluesky post:**
+
+```text
+Getting Started with Sanity
+
+Learn how to build amazing content experiences with Sanity's headless CMS. This guide covers everything from setup to deployment.
+
+getting-started-with-sanity
+```
+
+## Customization
+
+### Change post format
+
+Modify the `postContent` template in `index.ts`:
+
+```typescript
+const postContent = `🚀 ${title}
+
+${autoSummary}
+
+Read more: ${slug.current}`
+```
+
+### Add conditional posting
+
+Only post certain types of content by updating the filter:
+
+```typescript
+filter: "_type == 'post' && defined(publishedAt)"
+```
+
+### Include additional fields
+
+Add more fields to the projection and use them in the post:
+
+```typescript
+projection: '_id, title, autoSummary, slug, author'
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**Error: "Authentication failed"**
+
+- Cause: Invalid Bluesky credentials or expired app password
+- Solution: Verify your username and app password are correct
+
+**Error: "Missing environment variable BLUESKY_USERNAME"**
+
+- Cause: Environment variables not set properly
+- Solution: Ensure all required environment variables are configured
+
+**Error: "Post content too long"**
+
+- Cause: Combined title, summary, and slug exceed Bluesky's character limit
+- Solution: Truncate the auto-summary or modify the post format
+
+**Posts not appearing on Bluesky**
+
+- Cause: Authentication issues or network problems
+- Solution: Check your Bluesky credentials and network connectivity
+
+**Function not triggering**
+
+- Cause: Blueprint filter or event configuration issues
+- Solution: Verify the filter matches your document structure and the event is set to 'publish'
+
+## Related Examples
+
+- [Mastodon Post Function](../mastodon-post/README.md) – Cross-post to Mastodon
+- [Slack Notification Function](../slack-notify/README.md) – Send notifications to Slack
+- [Auto-Summary Function](../auto-summary/README.md) – Generate summaries for content

--- a/examples/functions/bluesky-post/document.json
+++ b/examples/functions/bluesky-post/document.json
@@ -1,9 +1,7 @@
 {
   "_type": "post",
-  "_id": "drafts.test-bluesky-post-id",
-  "_updatedAt": "2024-01-15T10:30:00Z",
   "title": "Getting Started with Sanity Functions",
-  "autoSummary": "Learn how to build powerful serverless functions with Sanity that automatically respond to content changes. This guide covers setup, deployment, and best practices for creating functions that enhance your content workflow.",
+  "blueskyPost": "Learn how to build powerful serverless functions with Sanity that automatically respond to content changes. This guide covers setup, deployment, and best practices for creating functions that enhance your content workflow.",
   "slug": {
     "current": "getting-started-with-sanity-functions"
   }

--- a/examples/functions/bluesky-post/document.json
+++ b/examples/functions/bluesky-post/document.json
@@ -1,0 +1,10 @@
+{
+  "_type": "post",
+  "_id": "drafts.test-bluesky-post-id",
+  "_updatedAt": "2024-01-15T10:30:00Z",
+  "title": "Getting Started with Sanity Functions",
+  "autoSummary": "Learn how to build powerful serverless functions with Sanity that automatically respond to content changes. This guide covers setup, deployment, and best practices for creating functions that enhance your content workflow.",
+  "slug": {
+    "current": "getting-started-with-sanity-functions"
+  }
+}

--- a/examples/functions/bluesky-post/index.ts
+++ b/examples/functions/bluesky-post/index.ts
@@ -9,13 +9,13 @@ interface NotificationData {
   slug: {
     current: string
   }
-  autoSummary: string
+  blueskyPost: string
   title: string
 }
 
 export const handler = documentEventHandler<NotificationData>(async ({event}) => {
   const {data} = event
-  const {title, autoSummary, slug} = data
+  const {title, blueskyPost, slug} = data
 
   try {
     const bluesky = new BlueskyStrategy({
@@ -29,7 +29,7 @@ export const handler = documentEventHandler<NotificationData>(async ({event}) =>
 
     const postContent = `${title}
 
-${autoSummary}
+${blueskyPost}
 
 ${slug.current}`
 

--- a/examples/functions/bluesky-post/index.ts
+++ b/examples/functions/bluesky-post/index.ts
@@ -1,0 +1,42 @@
+import {env} from 'node:process'
+
+import {BlueskyStrategy, Client} from '@humanwhocodes/crosspost'
+import {documentEventHandler} from '@sanity/functions'
+
+const {BLUESKY_USERNAME = '', BLUESKY_PASSWORD = '', BLUESKY_HOST = 'bsky.social'} = env
+
+interface NotificationData {
+  slug: {
+    current: string
+  }
+  autoSummary: string
+  title: string
+}
+
+export const handler = documentEventHandler<NotificationData>(async ({event}) => {
+  const {data} = event
+  const {title, autoSummary, slug} = data
+
+  try {
+    const bluesky = new BlueskyStrategy({
+      identifier: BLUESKY_USERNAME,
+      password: BLUESKY_PASSWORD,
+      host: BLUESKY_HOST,
+    })
+    const client = new Client({
+      strategies: [bluesky],
+    })
+
+    const postContent = `${title}
+
+${autoSummary}
+
+${slug.current}`
+
+    await client.post(postContent)
+    console.log('Successfully sent post to Bluesky')
+  } catch (error) {
+    console.error('Error posting to Bluesky:', error)
+    throw error
+  }
+})

--- a/examples/functions/bluesky-post/package.json
+++ b/examples/functions/bluesky-post/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "bluesky-post",
+  "type": "module",
+  "main": "index.ts",
+  "dependencies": {
+    "@humanwhocodes/crosspost": "^0.1.1",
+    "@sanity/functions": "^1.0.3"
+  },
+  "blueprintResourceItem": {
+    "type": "sanity.function.document",
+    "name": "bluesky-post",
+    "src": "./functions/bluesky-post",
+    "memory": 1,
+    "timeout": 10,
+    "event": {
+      "on": [
+        "publish"
+      ],
+      "filter": "_type == 'post'",
+      "projection": "_id, title, autoSummary, slug"
+    },
+    "env": {
+      "COMMENT": "BLUESKY_USERNAME and BLUESKY_PASSWORD are required. BLUESKY_HOST defaults to bsky.social",
+      "BLUESKY_USERNAME": "BLUESKY_USERNAME",
+      "BLUESKY_PASSWORD": "BLUESKY_PASSWORD",
+      "BLUESKY_HOST": "BLUESKY_HOST"
+    }
+  },
+  "exampleInstructions": "Add this resource to your Blueprint config's resources array. Go to README.md for more details on how to use this function."
+}

--- a/examples/functions/mastodon-post/README.md
+++ b/examples/functions/mastodon-post/README.md
@@ -1,0 +1,402 @@
+# Mastodon Post Function
+
+[Explore all examples](https://github.com/sanity-io/sanity/tree/main/examples)
+
+## Problem
+
+Content teams want to automatically share their published articles on Mastodon to reach decentralized social media audiences. Manually cross-posting to multiple social platforms is time-consuming and often forgotten, leading to missed opportunities for content promotion across the fediverse.
+
+## Solution
+
+This Sanity Function automatically posts to Mastodon when content is published using the `@humanwhocodes/crosspost` library. When a post is published, the function creates a Mastodon post containing the title, summary, and slug, helping maintain consistent presence across decentralized social networks.
+
+## Benefits
+
+- **Automates fediverse sharing** by posting to Mastodon on content publish
+- **Saves time** by eliminating manual cross-posting tasks
+- **Reaches decentralized audiences** by sharing on Mastodon instances
+- **Ensures consistency** with automatic posting of title, summary, and link
+- **Reduces missed opportunities** by never forgetting to share published content
+
+## Compatible Templates
+
+This function is built to be compatible with any of [the official "clean" templates](https://www.sanity.io/exchange/type=templates/by=sanity). We recommend testing the function out in one of those after you have installed them locally.
+
+### Schema Requirements
+
+This function expects your post schema to include:
+
+- `title` field (string)
+- `autoSummary` field (text) - for the post description
+- `slug` field (slug type with `current` property)
+
+Most official templates already include these fields, but you may need to add the `autoSummary` field.
+
+## Implementation
+
+**Important:** Run these commands from the root of your project (not inside the `studio/` folder).
+
+1. **Set up Mastodon API Credentials**
+
+   You'll need to create a Mastodon application and get an access token. There are two methods:
+
+   ### Method 1: Web Interface (Recommended)
+   1. **Log into your Mastodon instance:**
+      - Go to your Mastodon instance (e.g., `mastodon.social`, `mastodon.online`, etc.)
+      - Sign in with your account
+
+   2. **Access Development Settings:**
+      - Click your profile picture → Preferences (or Settings)
+      - In the sidebar, click "Development"
+      - Click "New Application"
+
+   3. **Create Application:**
+      - **Application name:** Give it a descriptive name (e.g., "Sanity Auto-Post")
+      - **Application website:** Your website URL (optional)
+      - **Redirect URI:** Leave as default (`urn:ietf:wg:oauth:2.0:oob`)
+      - **Scopes:** Select `read` and `write` (required for posting)
+
+   4. **Get Access Token:**
+      - After creating the application, click on its name to view details
+      - Copy the "Your access token" - this is what you'll use as `MASTODON_TOKEN`
+      - Note your instance URL (e.g., `https://mastodon.social`) - this is your `MASTODON_HOST`
+
+   ### Method 2: Programmatic Registration
+
+   If you prefer to register programmatically, you can use the Mastodon API:
+
+   ```bash
+   # Register application
+   curl -X POST https://your-instance.com/api/v1/apps \
+     -F 'client_name=Sanity Auto-Post' \
+     -F 'redirect_uris=urn:ietf:wg:oauth:2.0:oob' \
+     -F 'scopes=read write'
+
+   # This returns client_id and client_secret
+   # Then get access token with these credentials
+   ```
+
+2. **Initialize the example**
+
+   Run this if you haven't initialized blueprints:
+
+   ```bash
+   npx sanity blueprints init
+   ```
+
+   You'll be prompted to select your organization and Sanity studio.
+
+   Then run:
+
+   ```bash
+   npx sanity blueprints add function --example mastodon-post
+   ```
+
+3. **Add configuration to your blueprint**
+
+   ```ts
+   // sanity.blueprint.ts
+   import 'dotenv/config'
+   import process from 'node:process'
+   import {defineBlueprint, defineDocumentFunction} from '@sanity/blueprints'
+
+   const {MASTODON_TOKEN, MASTODON_HOST} = process.env
+   if (typeof MASTODON_TOKEN !== 'string' || typeof MASTODON_HOST !== 'string') {
+     throw new Error('MASTODON_TOKEN and MASTODON_HOST must be set')
+   }
+
+   export default defineBlueprint({
+     resources: [
+       defineDocumentFunction({
+         type: 'sanity.function.document',
+         name: 'mastodon-post',
+         src: './functions/mastodon-post',
+         memory: 1,
+         timeout: 10,
+         event: {
+           on: ['publish'],
+           filter: "_type == 'post'",
+           projection: '_id, title, autoSummary, slug',
+         },
+         env: {
+           MASTODON_TOKEN: MASTODON_TOKEN,
+           MASTODON_HOST: MASTODON_HOST,
+         },
+       }),
+     ],
+   })
+   ```
+
+4. **Install dependencies**
+
+   Install dependencies in the project root:
+
+   ```bash
+   npm install dotenv
+   ```
+
+5. **Configure environment variables**
+
+   Create a `.env` file in your project root with the following variables:
+
+   ```env
+   # Required
+   MASTODON_TOKEN=your-access-token-here
+   MASTODON_HOST=https://your-instance.com
+
+   # Examples:
+   # MASTODON_HOST=https://mastodon.social
+   # MASTODON_HOST=https://mastodon.online
+   # MASTODON_HOST=https://fosstodon.org
+   ```
+
+   **Required:**
+   - `MASTODON_TOKEN`: Your Mastodon application access token
+   - `MASTODON_HOST`: Your Mastodon instance URL (including https://)
+
+## Testing the function locally
+
+You can test the mastodon-post function locally using the Sanity CLI before deploying it to production.
+
+**Important:** This function requires valid Mastodon credentials but will NOT post to Mastodon during local testing. It will only log the content that would be posted.
+
+### 1. Basic Function Test
+
+Test the function with the included sample document:
+
+```bash
+npx sanity functions test mastodon-post \
+  --file functions/mastodon-post/document.json \
+  --dataset production \
+  --with-user-token
+```
+
+### 2. Test with Real Document Data
+
+Test with a real document from your dataset:
+
+```bash
+# From the studio/ folder, export a real document for testing
+cd studio
+npx sanity documents query "*[_type == 'post'][0]" > ../real-post.json
+
+# Back to project root for function testing
+cd ..
+npx sanity functions test mastodon-post \
+  --file real-post.json \
+  --dataset production \
+  --with-user-token
+```
+
+### 3. Interactive Development Mode
+
+Start the development server for interactive testing:
+
+```bash
+npx sanity functions dev
+```
+
+This opens an interactive playground where you can test functions with custom data.
+
+### Testing Tips
+
+- **Local testing safety** - The function detects local testing and won't actually post to Mastodon
+- **Use real credentials** - You still need valid Mastodon credentials for testing the authentication
+- **Check logs** - Monitor console output to see the post content that would be sent
+- **Test different instances** - Verify your credentials work with your specific Mastodon instance
+- **Test edge cases** - Try documents without summaries or slugs to ensure graceful handling
+
+## Deploying your function
+
+Once you've tested your function locally and are satisfied with its behavior, you can deploy it to production.
+
+**Important:** Make sure you have the Deploy Studio permission for your Sanity project before attempting to deploy.
+
+### Prerequisites for deployment
+
+- Sanity CLI v3.92.0 or later
+- Deploy Studio permissions for your Sanity project
+- Node.js v22.x (matches production runtime)
+- Valid Mastodon credentials (access token and instance host)
+
+### Deploy to production
+
+1. **Verify your blueprint configuration**
+
+   Make sure your `sanity.blueprint.ts` file is properly configured with your function as shown in the implementation section above.
+
+2. **Deploy your blueprint**
+
+   From your project root, run:
+
+   ```bash
+   npx sanity blueprints deploy
+   ```
+
+   This command will:
+   - Package your function code
+   - Upload it to Sanity's infrastructure
+   - Configure the event triggers for post publications
+   - Make your mastodon-post function live in production
+
+3. **Add environment variables**
+
+   After deployment, you need to add your Mastodon credentials as environment variables:
+
+   ```bash
+   npx sanity functions env add mastodon-post MASTODON_TOKEN "your-access-token-here"
+   npx sanity functions env add mastodon-post MASTODON_HOST "https://your-instance.com"
+   ```
+
+   You can verify the environment variables were added successfully:
+
+   ```bash
+   npx sanity functions env list mastodon-post
+   ```
+
+4. **Verify deployment**
+
+   After deployment, you can verify your function is active by:
+   - Checking the Sanity Studio under "Compute"
+   - Publishing a new post and confirming it appears on Mastodon
+   - Monitoring function logs in the CLI
+
+## Requirements
+
+- A Sanity project with Functions enabled
+- A schema with a `post` document type containing:
+  - `title` field (string)
+  - `autoSummary` field (text or string)
+  - `slug` field (slug type with `current` property)
+- A Mastodon account on any instance
+- Mastodon application with access token
+- Node.js v22.x for local testing
+
+## Usage Example
+
+When you publish a post document, the function automatically:
+
+1. Extracts the post title, auto-summary, and slug
+2. Formats a social media post with this content
+3. Posts to your Mastodon instance using your access token
+4. Logs the success or any errors
+
+**Example Mastodon post:**
+
+```text
+Getting Started with Sanity
+
+Learn how to build amazing content experiences with Sanity's headless CMS. This guide covers everything from setup to deployment.
+
+getting-started-with-sanity
+```
+
+## Customization
+
+### Change post format
+
+Modify the `postContent` template in `index.ts`:
+
+```typescript
+const postContent = `🚀 ${title}
+
+${autoSummary}
+
+🔗 Read more: ${slug.current}
+
+#sanity #cms #webdev`
+```
+
+### Add conditional posting
+
+Only post certain types of content by updating the filter:
+
+```typescript
+filter: "_type == 'post' && defined(publishedAt)"
+```
+
+### Include additional fields
+
+Add more fields to the projection and use them in the post:
+
+```typescript
+projection: '_id, title, autoSummary, slug, author, tags'
+```
+
+### Add hashtags based on content
+
+```typescript
+const hashtags = data.tags?.map((tag) => `#${tag}`).join(' ') || ''
+const postContent = `${title}
+
+${autoSummary}
+
+${slug.current}
+
+${hashtags}`
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**Error: "Unauthorized" or "Invalid access token"**
+
+- Cause: Invalid or expired Mastodon access token
+- Solution: Regenerate your access token in your Mastodon application settings
+
+**Error: "Missing environment variable MASTODON_TOKEN"**
+
+- Cause: Environment variables not set properly
+- Solution: Ensure all required environment variables are configured
+
+**Error: "Host not found" or network errors**
+
+- Cause: Incorrect MASTODON_HOST or network connectivity issues
+- Solution: Verify your instance URL is correct and includes `https://`
+
+**Error: "Post content too long"**
+
+- Cause: Combined content exceeds Mastodon's character limit (usually 500 characters)
+- Solution: Truncate the auto-summary or modify the post format
+
+**Posts not appearing on Mastodon**
+
+- Cause: Authentication issues, network problems, or instance downtime
+- Solution: Check your credentials, network connectivity, and instance status
+
+**Function not triggering**
+
+- Cause: Blueprint filter or event configuration issues
+- Solution: Verify the filter matches your document structure and the event is set to 'publish'
+
+**Error: "Insufficient permissions"**
+
+- Cause: Access token doesn't have write permissions
+- Solution: Ensure your Mastodon application has `write` scope enabled
+
+## Mastodon Instance Considerations
+
+### Popular Instances
+
+- `mastodon.social` - General purpose, largest instance
+- `mastodon.online` - General purpose, well-moderated
+- `fosstodon.org` - Focus on free and open source software
+- `mas.to` - General purpose, privacy-focused
+- `hachyderm.io` - Tech and security focused
+
+### Instance-Specific Settings
+
+Some Mastodon instances may have:
+
+- Different character limits (some allow more than 500 characters)
+- Specific content policies
+- Different API rate limits
+
+Make sure your content complies with your instance's community guidelines.
+
+## Related Examples
+
+- [Bluesky Post Function](../bluesky-post/README.md) – Cross-post to Bluesky
+- [Slack Notification Function](../slack-notify/README.md) – Send notifications to Slack
+- [Auto-Summary Function](../auto-summary/README.md) – Generate summaries for content

--- a/examples/functions/mastodon-post/document.json
+++ b/examples/functions/mastodon-post/document.json
@@ -1,9 +1,7 @@
 {
   "_type": "post",
-  "_id": "drafts.test-mastodon-post-id",
-  "_updatedAt": "2024-01-15T10:30:00Z",
   "title": "Building with Sanity and the Fediverse",
-  "autoSummary": "Discover how to automatically share your content across decentralized social networks using Sanity Functions. This tutorial shows you how to connect your CMS to Mastodon and other fediverse platforms for seamless content distribution.",
+  "mastodonPost": "Discover how to automatically share your content across decentralized social networks using Sanity Functions. This tutorial shows you how to connect your CMS to Mastodon and other fediverse platforms for seamless content distribution.",
   "slug": {
     "current": "building-with-sanity-and-fediverse"
   }

--- a/examples/functions/mastodon-post/document.json
+++ b/examples/functions/mastodon-post/document.json
@@ -1,0 +1,10 @@
+{
+  "_type": "post",
+  "_id": "drafts.test-mastodon-post-id",
+  "_updatedAt": "2024-01-15T10:30:00Z",
+  "title": "Building with Sanity and the Fediverse",
+  "autoSummary": "Discover how to automatically share your content across decentralized social networks using Sanity Functions. This tutorial shows you how to connect your CMS to Mastodon and other fediverse platforms for seamless content distribution.",
+  "slug": {
+    "current": "building-with-sanity-and-fediverse"
+  }
+}

--- a/examples/functions/mastodon-post/index.ts
+++ b/examples/functions/mastodon-post/index.ts
@@ -9,13 +9,13 @@ interface NotificationData {
   slug: {
     current: string
   }
-  autoSummary: string
+  mastodonPost: string
   title: string
 }
 
 export const handler = documentEventHandler<NotificationData>(async ({event}) => {
   const {data} = event
-  const {title, autoSummary, slug} = data
+  const {title, mastodonPost, slug} = data
 
   try {
     const mastodon = new MastodonStrategy({
@@ -28,7 +28,7 @@ export const handler = documentEventHandler<NotificationData>(async ({event}) =>
 
     const postContent = `${title}
 
-${autoSummary}
+${mastodonPost}
 
 ${slug.current}`
 

--- a/examples/functions/mastodon-post/index.ts
+++ b/examples/functions/mastodon-post/index.ts
@@ -1,0 +1,41 @@
+import {env} from 'node:process'
+
+import {Client, MastodonStrategy} from '@humanwhocodes/crosspost'
+import {documentEventHandler} from '@sanity/functions'
+
+const {MASTODON_TOKEN = '', MASTODON_HOST = ''} = env
+
+interface NotificationData {
+  slug: {
+    current: string
+  }
+  autoSummary: string
+  title: string
+}
+
+export const handler = documentEventHandler<NotificationData>(async ({event}) => {
+  const {data} = event
+  const {title, autoSummary, slug} = data
+
+  try {
+    const mastodon = new MastodonStrategy({
+      accessToken: MASTODON_TOKEN,
+      host: MASTODON_HOST,
+    })
+    const client = new Client({
+      strategies: [mastodon],
+    })
+
+    const postContent = `${title}
+
+${autoSummary}
+
+${slug.current}`
+
+    await client.post(postContent)
+    console.log('Successfully sent post to Mastodon')
+  } catch (error) {
+    console.error('Error posting to Mastodon:', error)
+    throw error
+  }
+})

--- a/examples/functions/mastodon-post/package.json
+++ b/examples/functions/mastodon-post/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "mastodon-post",
+  "type": "module",
+  "main": "index.ts",
+  "dependencies": {
+    "@humanwhocodes/crosspost": "^0.1.1",
+    "@sanity/functions": "^1.0.3"
+  },
+  "blueprintResourceItem": {
+    "type": "sanity.function.document",
+    "name": "mastodon-post",
+    "src": "./functions/mastodon-post",
+    "memory": 1,
+    "timeout": 10,
+    "event": {
+      "on": [
+        "publish"
+      ],
+      "filter": "_type == 'post'",
+      "projection": "_id, title, autoSummary, slug"
+    },
+    "env": {
+      "COMMENT": "MASTODON_TOKEN and MASTODON_HOST are required",
+      "MASTODON_TOKEN": "MASTODON_TOKEN",
+      "MASTODON_HOST": "MASTODON_HOST"
+    }
+  },
+  "exampleInstructions": "Add this resource to your Blueprint config's resources array. Go to README.md for more details on how to use this function."
+}


### PR DESCRIPTION
### Description

Adding functions for Bluesky and Mastodon Post to the sanity example functions.  Credit goes to @macdonst  as the original author.  I've simply changed them a bit to add documntation and to make the code consistent with the other example functions.

### What to review

Review the examples/functions/bluesky-post and examples/functions/mastodon-post setup and testing.

### Testing

Follow the testing instructions. in the readme

### Notes for release

Added example functions for simple posting to Bluesky and Mastodon simply by publishing a post in Sanity.  Add functions to your project with `npx sanity blueprints add function --example mastodon-post` and `npx sanity blueprints add function --example bluesky-post`.  Credit Simon Macdonald
