### PR TITLE
fix(ci): set SANITY_INTERNAL_ENV=staging when building esm bundles for staging

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -160,7 +160,10 @@ jobs:
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped
 
-      - name: Build bundle
+      - name: Build bundles for staging
+        env:
+          # sets the __SANITY_STAGING__ global variable to true in built bundles
+          SANITY_INTERNAL_ENV: "staging"
         run: pnpm run build:bundle
 
       - name: Upload bundles to staging bucket
@@ -169,6 +172,9 @@ jobs:
           GCLOUD_SERVICE_KEY: ${{ secrets.GCS_STAGING_SERVICE_KEY }}
           GCLOUD_BUCKET: ${{ secrets.GCS_STAGING_BUCKET }}
         run: pnpm bundle-manager publish --tag=latest
+
+      - name: Build bundles for production
+        run: pnpm run build:bundle
 
       - name: Upload bundles to production bucket
         env:

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -112,7 +112,9 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
 
-      - name: Build bundles
+      - name: Build bundles for staging
+        env:
+          SANITY_INTERNAL_ENV: "staging" # sets the __SANITY_STAGING__ global variable to true in built bundles
         run: pnpm run build:bundle
 
       # Note: we need to run this after publish so we get the updated version numbers from npx lerna publish
@@ -123,6 +125,9 @@ jobs:
           GCLOUD_SERVICE_KEY: ${{ secrets.GCS_STAGING_SERVICE_KEY }}
           GCLOUD_BUCKET: ${{ secrets.GCS_STAGING_BUCKET }}
         run: pnpm bundle-manager publish --tag=next
+
+      - name: Build bundles for production
+        run: pnpm run build:bundle
 
       - name: Upload bundles to production bucket
         env:

--- a/packages/@repo/package.bundle/src/package.bundle.ts
+++ b/packages/@repo/package.bundle/src/package.bundle.ts
@@ -8,6 +8,7 @@ import {version} from '../package.json'
 export const defaultConfig: UserConfig = {
   appType: 'custom',
   define: {
+    '__SANITY_STAGING__': process.env.SANITY_INTERNAL_ENV === 'staging',
     'process.env.PKG_VERSION': JSON.stringify(version),
     'process.env.NODE_ENV': '"production"',
     'process.env': {},


### PR DESCRIPTION
### Description
Currently, bulding esm bundles for staging does not define the `__SANITY_STAGING__` global variable used by this check:

https://github.com/sanity-io/sanity/blob/a44fd5b3a7e534e93ee0dfa95c6c382e952dafac/packages/sanity/src/core/studio/packageVersionStatus/checkForLatestVersions.ts#L7

As a consequence, esm bundles loaded from staging will call production to check what latest version is, which gives confusing behavior. This PR fixes the issue by defining `__SANITY_STAGING__` based on the value of the `SANITY_INTERNAL_ENV` env var.

### What to review
Does it make sense? A drawback here is that we now need to build bundles twice, but don't think there's any way around it.

### Testing
I've tested locally that running `SANITY_INTERNAL_ENV=staging pnpm run build:bundle` makes the `__SANITY_STAGING__` variable to be rewritten to `true`, resulting in the following bundle output for the part that fetches the latest version:
<img width="847" height="276" alt="image" src="https://github.com/user-attachments/assets/f7c21ee1-b474-4e8e-b305-4f6f38613f25" />


### Notes for release
n/a