### PR TITLE
fix(ci): rewrite tagged version for all packages

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -81,7 +81,7 @@ jobs:
           echo "COMMITS AHEAD: $COMMIT_COUNT"
           echo "COMMIT HASH: $COMMIT_HASH"
 
-          for pkg in $(lerna list --json | jq -r '.[].location'); do
+          for pkg in $(lerna list --all --json | jq -r '.[].location'); do
             jq --arg commit_count "$COMMIT_COUNT" --arg commit_hash "$COMMIT_HASH" '.version |= sub("\\.0$"; "." + $commit_count + "+"+$commit_hash)' "$pkg/package.json" > "$pkg/package.tmp.json"
             mv "$pkg/package.tmp.json" "$pkg/package.json"
           done


### PR DESCRIPTION
### Description
Since the source of the `process.env.PKG_VERSION` is coming from `@repo/package.bundle/package.json`, we now have an issue where `PKG_VERSION` is set to the version as bumped by lerna, but not updated with the version rewrite here:

https://github.com/sanity-io/sanity/blob/b75710805b8e9bc7b377ae4e181fd33a92e4e7c5/.github/workflows/release-next.yml#L60-L87

This PR fixes the rewrite so it rewrites all packages instead of only the ones that are published to npm.