### PR TITLE
fix(sanity): ensure `useDocumentForm` uses provided release id

### DIFF
--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -31,7 +31,6 @@ import {useSchema} from '../hooks/useSchema'
 import {useValidationStatus} from '../hooks/useValidationStatus'
 import {getSelectedPerspective} from '../perspective/getSelectedPerspective'
 import {type ReleaseId} from '../perspective/types'
-import {usePerspective} from '../perspective/usePerspective'
 import {useDocumentVersions} from '../releases/hooks/useDocumentVersions'
 import {useDocumentVersionTypeSortedList} from '../releases/hooks/useDocumentVersionTypeSortedList'
 import {useOnlyHasVersions} from '../releases/hooks/useOnlyHasVersions'
@@ -145,7 +144,6 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
   const presenceStore = usePresenceStore()
   const {data: releases} = useActiveReleases()
   const {data: documentVersions} = useDocumentVersions({documentId})
-  const {selectedReleaseId} = usePerspective()
 
   const schemaType = schema.get(documentType) as ObjectSchemaType | undefined
   if (!schemaType) {
@@ -174,18 +172,18 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
 
   const activeDocumentReleaseId = useMemo(() => {
     // if a document version exists with the selected release id, then it should use that
-    if (documentVersions.some((id) => getVersionFromId(id) === selectedReleaseId)) {
-      return selectedReleaseId
+    if (documentVersions.some((id) => getVersionFromId(id) === releaseId)) {
+      return releaseId
     }
 
     // check if the selected version is the only version, if it isn't and it doesn't exist in the release
     // then it needs to use the documentVersions
-    if (selectedReleaseId && (!documentVersions || !onlyHasVersions)) {
-      return selectedReleaseId
+    if (releaseId && (!documentVersions || !onlyHasVersions)) {
+      return releaseId
     }
 
     return getVersionFromId(firstVersion ?? '')
-  }, [documentVersions, onlyHasVersions, selectedReleaseId, firstVersion])
+  }, [documentVersions, onlyHasVersions, releaseId, firstVersion])
 
   const editState = useEditState(documentId, documentType, 'default', activeDocumentReleaseId)
 


### PR DESCRIPTION
### Description

Previously, `useDocumentForm` retrieved the current release id from context, short circuiting any consumer explicitly providing a release id parameter. This caused an issue in the split screen diff view in which the document panes would sometimes reflect the globally selected perspective, instead of the version selected locally in the pane.

Now, `useDocumentForm` respects the release id parameter again. Existing consumers already pass the globally selected perspective where relevant, so reaching up to the context from inside the hook is unnecessary.

### What to review

The document version shown in the document editor pane and the split screen diff view.

### Testing

- Verified existing tests work.
- Verified the change this was introduced for (#8759) still works correctly.
- Verified the correct versions are displayed in the split screen diff view.
- Verified the correct version is still displayed in the document editor pane.
- Verified all consumers of `useDocumentForm` provide a `releaseId` parameter where relevant.

### Notes for release

Fixes an issue that would sometimes cause the incorrect document version to appear in the document comparison view.
