### PR TITLE
fix(cli): mark @sanity/ui@3 as supported

### DIFF
--- a/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
+++ b/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
@@ -22,7 +22,7 @@ const PACKAGES = [
   {name: 'react', supported: ['^18 || ^19'], deprecatedBelow: null},
   {name: 'react-dom', supported: ['^18 || ^19'], deprecatedBelow: null},
   {name: 'styled-components', supported: ['^6'], deprecatedBelow: null},
-  {name: '@sanity/ui', supported: ['^2'], deprecatedBelow: null},
+  {name: '@sanity/ui', supported: ['^2', '^3'], deprecatedBelow: null},
 ]
 
 export async function checkStudioDependencyVersions(workDir: string): Promise<void> {


### PR DESCRIPTION
### Description
Currently, a Studio project with `@sanity/ui@3` added as a direct dependency will issue the following warning when running `sanity dev|build|deploy` saying that the version of Sanity UI is not supported:
```
> sanity dev


[WARN] The following package versions have not yet been marked as supported:

  @sanity/ui (installed: 3.0.5, want: ^2)

You _may_ encounter bugs while using these versions.

  To downgrade, run either:

  yarn add "@sanity/ui@2.0.0"

  or

  npm install "@sanity/ui@2.0.0"

  or

  pnpm install "@sanity/ui@2.0.0"
```

This is misleading, as Sanity UI is indeed supported, so this PR removes the warning by marking Sanity UI as supported.

### Testing
Can be tested by installing the preview build from pkg.pr.new in a studio that has `@sanity/ui` v3 installed as a direct dependency.

### Notes for release
- Marks `@sanity/ui@3.x` as supported