### PR TITLE
fix(sanity): hide new version if up to date

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
@@ -114,7 +114,7 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
             ) : null}
           </Flex>
 
-          {isAutoUpdating ? (
+          {isAutoUpdating && sanityPkgUpdateInfo.canUpdate ? (
             <>
               <Flex justify="flex-end" align="center">
                 <Text size={1} weight="semibold">
@@ -131,20 +131,18 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
                       : sanityPkgUpdateInfo.current,
                   )}
                 </Badge>
-                {sanityPkgUpdateInfo.canUpdate ? (
-                  <Button
-                    onClick={reload}
-                    mode="bleed"
-                    tone="primary"
-                    text={t('about-dialog.version-info.update-button.text')}
-                    tooltipProps={{
-                      content: (
-                        <Text size={1}>{t('about-dialog.version-info.reload-to-update')}</Text>
-                      ),
-                    }}
-                    icon={RefreshIcon}
-                  />
-                ) : null}
+                <Button
+                  onClick={reload}
+                  mode="bleed"
+                  tone="primary"
+                  text={t('about-dialog.version-info.update-button.text')}
+                  tooltipProps={{
+                    content: (
+                      <Text size={1}>{t('about-dialog.version-info.reload-to-update')}</Text>
+                    ),
+                  }}
+                  icon={RefreshIcon}
+                />
               </Flex>
             </>
           ) : !isUpToDate || isPrerelease ? (
@@ -156,7 +154,7 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
               </Flex>
               <Flex justify="flex-start" align="center" gap={2}>
                 <Badge tone="primary">
-                  {latestVersion ? ensureVersionPrefix(latestVersion.raw) : 'unknown'}
+                  {latestVersion ? ensureVersionPrefix(latestVersion.version) : 'unknown'}
                 </Badge>
                 {isPrerelease ? null : (
                   <Button


### PR DESCRIPTION
### Description
Fixes a small issue introduced with #10158:
If auto updates is enabled, and your studio version is up to date, we show current version as "New version".

#### Before
<img width="320" alt="image" src="https://github.com/user-attachments/assets/40030266-715c-4901-8021-6ecc0b1b3248" />


#### After
<img width="320" alt="image" src="https://github.com/user-attachments/assets/f10f71d9-2637-4052-9d44-98bbb512c759" />

### What to review
Looks sane? I additionally removed the `+sha` part of the version here

### Testing
n/a

### Notes for release
n/a