### PR TITLE
fix: issue where a slimple slug in an array was auto closing when focusing on it

### DIFF
--- a/dev/test-studio/schema/standard/arrays.tsx
+++ b/dev/test-studio/schema/standard/arrays.tsx
@@ -613,5 +613,31 @@ export default defineType({
         type,
       })),
     },
+    defineField({
+      name: 'slugs',
+      title: 'Slugs',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          type: 'slug',
+        }),
+      ],
+    }),
+    defineField({
+      name: 'slugsWithObject',
+      title: 'Slugs with object',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          type: 'object',
+          fields: [
+            defineField({
+              name: 'slug',
+              type: 'slug',
+            }),
+          ],
+        }),
+      ],
+    }),
   ],
 })

--- a/packages/sanity/src/core/form/inputs/Slug/SlugInput.tsx
+++ b/packages/sanity/src/core/form/inputs/Slug/SlugInput.tsx
@@ -113,7 +113,10 @@ export function SlugInput(props: SlugInputProps) {
   // Make sure the slug input is focused when the `focused` prop becomes true, regardless of wether the focusPath is `slug` or `slug.current` (both should work)
   useDidUpdate(focused, (hadFocus, hasFocus) => {
     if (!hadFocus && hasFocus) {
-      inputRef.current?.focus()
+      // Only focus if the input is not already focused to avoid triggering unnecessary blur events
+      if (document.activeElement !== inputRef.current) {
+        inputRef.current?.focus()
+      }
     }
   })
   // Handle stega visual editing links, which uses `slug.current` as the focus path
@@ -127,7 +130,10 @@ export function SlugInput(props: SlugInputProps) {
       currentFocusPath.length === 1 &&
       currentFocusPath[0] === 'current'
     ) {
-      inputRef.current?.focus()
+      // Only focus if the input is not already focused to avoid triggering unnecessary blur events
+      if (document.activeElement !== inputRef.current) {
+        inputRef.current?.focus()
+      }
     }
   })
 
@@ -145,7 +151,7 @@ export function SlugInput(props: SlugInputProps) {
             value={value?.current || ''}
             readOnly={readOnly}
             {...elementProps}
-            ref={inputRef}
+            ref={elementProps.ref ? undefined : inputRef}
           />
 
           {generateState?.status === 'error' && (


### PR DESCRIPTION
### Description

Fixes issue introduced in 3.92.0 reported https://github.com/sanity-io/sanity/issues/10093 and by other folks where opening an array with a slug was auto closing the dialog (preventing a user from changing the content)

Before:

https://github.com/user-attachments/assets/c334db41-b2c0-4aee-94f1-e95e74b6f626

After:

https://github.com/user-attachments/assets/d4668d93-c927-4b93-be39-748fc33f0cd5


### What to review

Did I miss something? Should I have done something differently?
I kept the automated tests out of it since it would likely require a larger work and a time sink I don't want to spend on now!

### Testing

Go to test/structure/input-standard;arraysTest in the deployed vercel
All the way at the bottom, there should be two arrays: slugs and slugs object.
The **slugs** array should work as expected now as shown in the video above

### Notes for release

Fixes issue where opening an array with a slug type input would auto close the dialog before being able to change the content
