### PR TITLE
fix(sanity): remove own presence avatar from list of users

### DIFF
--- a/packages/sanity/src/core/store/_legacy/presence/presence-store.ts
+++ b/packages/sanity/src/core/store/_legacy/presence/presence-store.ts
@@ -263,7 +263,12 @@ export function createPresenceStore(context: {
       }))
     }),
     withLatestFrom(debugIntrospect$),
-    map(([userAndSessions, debugIntrospect]) => userAndSessions),
+    map(([userAndSessions, debugIntrospect]) =>
+      userAndSessions.filter(
+        (userAndSession) =>
+          debugIntrospect || !userAndSession.sessions.some((sess) => sess.sessionId === SESSION_ID),
+      ),
+    ),
     map((userAndSessions) =>
       userAndSessions.map((userAndSession) => ({
         user: userAndSession.user,


### PR DESCRIPTION
### Description
Looks like we at some point inadvertedly stopped excluding your own session from the list of present users. This PR should fix it


### Notes for release
- Excludes current user from list of present Studio users