### PR TITLE
fix(cli): don't coerce sanity version during build/dev

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/app/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/buildAction.ts
@@ -56,15 +56,15 @@ export default async function buildSanityApp(
   if (!installedSdkVersion) {
     throw new Error(`Failed to find installed @sanity/sdk-react version`)
   }
-  // Get the version without any tags if any
-  const coercedSdkVersion = semver.coerce(installedSdkVersion)?.version
+  // Get the clean version without build metadata: https://semver.org/#spec-item-10
+  const cleanSDKVersion = semver.parse(installedSanityVersion)?.version
   // Sanity might not be installed, but if it is we want to auto update it.
-  const coercedSanityVersion = semver.coerce(installedSanityVersion)?.version
-  if (autoUpdatesEnabled && !coercedSdkVersion) {
+  const cleanSanityVersion = semver.parse(installedSanityVersion)?.version
+  if (autoUpdatesEnabled && !cleanSDKVersion) {
     throw new Error(`Failed to parse installed SDK version: ${installedSdkVersion}`)
   }
-  const sdkVersion = encodeURIComponent(`^${coercedSdkVersion}`)
-  const sanityVersion = coercedSanityVersion && encodeURIComponent(`^${coercedSanityVersion}`)
+  const sdkVersion = encodeURIComponent(`^${cleanSDKVersion}`)
+  const sanityVersion = cleanSanityVersion && encodeURIComponent(`^${cleanSanityVersion}`)
   const autoUpdatesImports = getAppAutoUpdateImportMap({sdkVersion, sanityVersion})
 
   if (autoUpdatesEnabled) {

--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -62,12 +62,12 @@ export default async function buildSanityStudio(
 
   const autoUpdatesEnabled = shouldAutoUpdate({flags, cliConfig, output})
 
-  // Get the version without any tags if any
-  const coercedSanityVersion = semver.coerce(installedSanityVersion)?.version
-  if (autoUpdatesEnabled && !coercedSanityVersion) {
+  // Get the clean version without build metadata: https://semver.org/#spec-item-10
+  const cleanSanityVersion = semver.parse(installedSanityVersion)?.version
+  if (autoUpdatesEnabled && !cleanSanityVersion) {
     throw new Error(`Failed to parse installed Sanity version: ${installedSanityVersion}`)
   }
-  const version = encodeURIComponent(`^${coercedSanityVersion}`)
+  const version = encodeURIComponent(`^${cleanSanityVersion}`)
   const autoUpdatesImports = getStudioAutoUpdateImportMap(version)
 
   if (autoUpdatesEnabled) {

--- a/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
@@ -158,12 +158,12 @@ export default async function startSanityDevServer(
 
   const autoUpdatesEnabled = shouldAutoUpdate({flags, cliConfig})
 
-  // Get the version without any tags if any
-  const coercedSanityVersion = semver.coerce(installedSanityVersion)?.version
-  if (autoUpdatesEnabled && !coercedSanityVersion) {
+  // Get the clean version without build metadata: https://semver.org/#spec-item-10
+  const cleanSanityVersion = semver.parse(installedSanityVersion)?.version
+  if (autoUpdatesEnabled && !cleanSanityVersion) {
     throw new Error(`Failed to parse installed Sanity version: ${installedSanityVersion}`)
   }
-  const version = encodeURIComponent(`^${coercedSanityVersion}`)
+  const version = encodeURIComponent(`^${cleanSanityVersion}`)
   const autoUpdatesImports = getStudioAutoUpdateImportMap(version)
 
   if (autoUpdatesEnabled) {


### PR DESCRIPTION
### Description
When building for auto-updates, we use the `version` from `sanity`'s  package.json  as resolved from the current project. We use this both as `minVersion` when generating import maps, but also for checking if runtime version is different from local version. Using `semver.coerce` with the resovled version doesn't work with prereleases as it will then try to find an unreleased minor version, e.g. `4.5.0-next.10` will build with `^4.5.0` as minVersion before `4.5.0` is actually released.

### What to review
Does it make sense? It's not entirely clear to me why we used `semver.coerce` here in the first place - it would make sense if we read the sanity version from current studio's package.json => dependencies section, but can't see why it's needed when we get the exact version from node_modules.

 I'm assuming we want this for `@sanity/sdk` as well.

### Testing
Not sure how to test this other than manually. I've verified that using prerelease works with the preview build from this branch.

### Notes for release

n/a