### PR TITLE
fix(structure): render actions menu if sideMenuItems has actions

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -235,6 +235,9 @@ const defaultWorkspace = defineConfig({
       if (ctx.schemaType === 'author' && ctx.releaseId) {
         return [...prev, TestVersionAction]
       }
+      if (ctx.schemaType === 'playlist') {
+        return prev.filter(({action}) => action === 'delete')
+      }
 
       return prev
     },

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -21,14 +21,13 @@ import {ActionStateDialog} from './ActionStateDialog'
 
 interface DocumentStatusBarActionsInnerProps {
   disabled: boolean
-  showMenu: boolean
   states: ResolvedAction[]
 }
 
 const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInner(
   props: DocumentStatusBarActionsInnerProps,
 ) {
-  const {disabled, showMenu, states} = props
+  const {disabled, states} = props
   const {__internal_tasks} = useSource()
   const {editState} = useDocumentPane()
   const {selectedReleaseId} = usePerspective()
@@ -85,7 +84,7 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
           </Tooltip>
         </LayerProvider>
       )}
-      {showMenu && menuActionStates.length > 0 && (
+      {sideMenuItems.length > 0 && (
         <ActionMenuButton actionStates={sideMenuItems} disabled={disabled} />
       )}
       {firstActionState && firstActionState.dialog && (
@@ -123,11 +122,10 @@ export const DocumentStatusBarActions = memo(function DocumentStatusBarActions()
         // Use document ID as key to make sure that the actions state is reset when the document changes
         key={documentId}
         disabled={connectionState !== 'connected'}
-        showMenu={actions.length > 1}
         states={states}
       />
     ),
-    [actions.length, connectionState, documentId],
+    [connectionState, documentId],
   )
 
   if (actions.length === 0 || !actionProps) {
@@ -172,7 +170,6 @@ export const HistoryStatusBarActions = memo(function HistoryStatusBarActions() {
     ({states}) => (
       <DocumentStatusBarActionsInner
         disabled={connectionState !== 'connected' || Boolean(disabled)}
-        showMenu={false}
         states={states}
       />
     ),


### PR DESCRIPTION
### Description
Fixes an issue in where in live edit documents, if only 1 action was defined then the side menu was not rendered.
This is because we were giving the responsibility on deciding if we show the menu or not to the parent component, rather than checking in `DocumentStatusBarActionsInner` by using the `showMenu` prop.

However, in some cases the `actions.length` is equal to 1 and given we are not rendering the first action for live edits we need to render the action in the menu.
That is correctly calculated [here](https://github.com/sanity-io/sanity/compare/sapp-2875?expand=1#diff-03d1032a11101b44f7b434187bc60b3ab28590fb41259a719f358e4d2fe11094R62-R64)
```ts
  const sideMenuItems = useMemo(() => {
    return showFirstActionButton ? menuActionStates : [firstActionState, ...menuActionStates]
  }, [showFirstActionButton, firstActionState, menuActionStates])
```

So, instead of delegating the responsibility, this component will decide if it needs to render or not the menu by checking the `sideMenuItems.length` property. 


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Do changes look good?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open a Playlist document in structure, the menu should render.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
fixes an issue in where live editable documents with only 1 action were not rendering the action.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
