### PR TITLE
feat: virtualising release documents table

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -165,6 +165,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
             borderBottom
             display="flex"
             data-index={datum.index}
+            as="tr"
             style={{
               height: `${datum.virtualRow.size}px`,
               position: 'absolute',
@@ -186,7 +187,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
                     {...datum, isLoading: loading} as RowDatum<TableData, AdditionalRowTableData>
                   }
                   cellProps={{
-                    as: 'div',
+                    as: 'td',
                     id: String(id),
                     style: {...style, width: width || undefined},
                   }}
@@ -207,6 +208,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
           borderBottom
           display="flex"
           padding={4}
+          as="tr"
           style={{
             justifyContent: 'center',
             position: 'absolute',
@@ -317,6 +319,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
             height: `${rowVirtualizer.getTotalSize()}px`,
             position: 'relative',
           }}
+          as="tbody"
         >
           {tableContent()}
         </Box>

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -2,19 +2,13 @@
 // The `use no memo` directive is due to a known issue with react-virtual and react compiler: https://github.com/TanStack/virtual/issues/736
 
 import {Box, Card, type CardProps, Flex, rem, Stack, Text, useTheme} from '@sanity/ui'
-import {
-  defaultRangeExtractor,
-  type Range,
-  useVirtualizer,
-  type VirtualItem,
-} from '@tanstack/react-virtual'
+import {useVirtualizer, type VirtualItem} from '@tanstack/react-virtual'
 import {isValid} from 'date-fns'
 import {get} from 'lodash'
 import {
   type CSSProperties,
   Fragment,
   type HTMLProps,
-  type MutableRefObject,
   type RefAttributes,
   type RefObject,
   useMemo,
@@ -66,33 +60,6 @@ export interface TableProps<TableData, AdditionalRowTableData> {
 const ITEM_HEIGHT = 59
 const LOADING_ROW_COUNT = 3
 
-/**
- * This function modifies the rangeExtractor to account for the offset of the virtualizer
- * in this case, the parent with overflow (the element over which the scroll happens) and the start of the virtualizer
- * don't match, because there are some elements rendered on top of the virtualizer.
- * This, will take care of adding more elements to the start of the virtualizer to account for the offset.
- */
-const withVirtualizerOffset = ({
-  scrollContainerRef,
-  virtualizerContainerRef,
-  range,
-}: {
-  scrollContainerRef: MutableRefObject<HTMLDivElement | null>
-  virtualizerContainerRef: MutableRefObject<HTMLDivElement | null>
-  range: Range
-}) => {
-  const parentOffset = scrollContainerRef.current?.offsetTop ?? 0
-  const virtualizerOffset = virtualizerContainerRef.current?.offsetTop ?? 0
-  const virtualizerScrollMargin = virtualizerOffset - parentOffset
-  const topItemsOffset = Math.ceil(virtualizerScrollMargin / ITEM_HEIGHT)
-  const startIndexWithOffset = range.startIndex - topItemsOffset
-  const result = defaultRangeExtractor({
-    ...range,
-    // By modifying the startIndex, we are adding more elements to the start of the virtualizer
-    startIndex: startIndexWithOffset > 0 ? startIndexWithOffset : 0,
-  })
-  return result
-}
 const TableInner = <TableData, AdditionalRowTableData>({
   columnDefs,
   data,
@@ -151,8 +118,6 @@ const TableInner = <TableData, AdditionalRowTableData>({
     getScrollElement: () => scrollContainerRef.current,
     estimateSize: () => ITEM_HEIGHT,
     overscan: 5,
-    rangeExtractor: (range) =>
-      withVirtualizerOffset({scrollContainerRef, virtualizerContainerRef, range}),
   })
 
   const rowActionColumnDef: Column = useMemo(
@@ -197,12 +162,16 @@ const TableInner = <TableData, AdditionalRowTableData>({
           <Card
             key={cardKey}
             data-testid="table-row"
-            as="tr"
             borderBottom
             display="flex"
+            data-index={datum.index}
             style={{
               height: `${datum.virtualRow.size}px`,
-              transform: `translateY(${datum.virtualRow.start - datum.index * datum.virtualRow.size}px)`,
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              transform: `translateY(${datum.virtualRow.start}px)`,
               paddingInline: `max(
                 calc((100% - var(--maxInlineSize)) / 2),
                 var(--paddingInline)
@@ -217,7 +186,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
                     {...datum, isLoading: loading} as RowDatum<TableData, AdditionalRowTableData>
                   }
                   cellProps={{
-                    as: 'td',
+                    as: 'div',
                     id: String(id),
                     style: {...style, width: width || undefined},
                   }}
@@ -235,15 +204,18 @@ const TableInner = <TableData, AdditionalRowTableData>({
     if (typeof emptyState === 'string') {
       return (
         <Card
-          as="tr"
           borderBottom
           display="flex"
           padding={4}
           style={{
             justifyContent: 'center',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
           }}
         >
-          <Text as="td" muted size={1}>
+          <Text muted size={1}>
             {emptyState}
           </Text>
         </Card>
@@ -302,6 +274,14 @@ const TableInner = <TableData, AdditionalRowTableData>({
       return emptyContent
     }
 
+    // oxlint-disable-next-line no-console
+    console.log(
+      'Virtual items:',
+      rowVirtualizer.getVirtualItems().map((v) => v.index),
+      'Total:',
+      filteredData.length,
+    )
+
     return rowVirtualizer.getVirtualItems().map((virtualRow, index) => {
       const datum = filteredData[virtualRow.index]
       return renderRow({
@@ -331,8 +311,15 @@ const TableInner = <TableData, AdditionalRowTableData>({
             headers={headers}
             searchDisabled={loading || (!searchTerm && !data.length)}
           />
-          <Stack as="tbody">{tableContent()}</Stack>
         </Stack>
+        <Box
+          style={{
+            height: `${rowVirtualizer.getTotalSize()}px`,
+            position: 'relative',
+          }}
+        >
+          {tableContent()}
+        </Box>
       </div>
     </div>
   )

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -305,16 +305,16 @@ const TableInner = <TableData, AdditionalRowTableData>({
             headers={headers}
             searchDisabled={loading || (!searchTerm && !data.length)}
           />
+          <Box
+            style={{
+              height: `${rowVirtualizer.getTotalSize()}px`,
+              position: 'relative',
+            }}
+            as="tbody"
+          >
+            {tableContent()}
+          </Box>
         </Stack>
-        <Box
-          style={{
-            height: `${rowVirtualizer.getTotalSize()}px`,
-            position: 'relative',
-          }}
-          as="tbody"
-        >
-          {tableContent()}
-        </Box>
       </div>
     </div>
   )

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -276,14 +276,6 @@ const TableInner = <TableData, AdditionalRowTableData>({
       return emptyContent
     }
 
-    // oxlint-disable-next-line no-console
-    console.log(
-      'Virtual items:',
-      rowVirtualizer.getVirtualItems().map((v) => v.index),
-      'Total:',
-      filteredData.length,
-    )
-
     return rowVirtualizer.getVirtualItems().map((virtualRow, index) => {
       const datum = filteredData[virtualRow.index]
       return renderRow({

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -181,8 +181,8 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
       style={{
         height: '100%',
         overflow: 'auto',
-        scrollbarWidth: 'none' /* Firefox */,
-        msOverflowStyle: 'none' /* IE and Edge */,
+        scrollbarWidth: 'none',
+        msOverflowStyle: 'none',
       }}
       className="hide-scrollbar"
     >

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -174,7 +174,18 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
   )
 
   return (
-    <Card borderTop data-testid="document-table-card" ref={scrollContainerRef}>
+    <Card
+      borderTop
+      data-testid="document-table-card"
+      ref={scrollContainerRef}
+      style={{
+        height: '100%',
+        overflow: 'auto',
+        scrollbarWidth: 'none' /* Firefox */,
+        msOverflowStyle: 'none' /* IE and Edge */,
+      }}
+      className="hide-scrollbar"
+    >
       <Table<DocumentWithHistory>
         loading={isLoading}
         data={tableData}


### PR DESCRIPTION
### Description

- Adds virtualisation to the list, changed the implementation because initially the issue was related to the scrolling, but when fixing the scrolling issue, it was giving problems with janky scrolling and "white" ghosts components
  - The way that I went ahead to fix this was to make the structure closer to what we do in the `CommandList` (which is a list we use in the document list in the structure): Each virtual row is now absolutely positioned within the container, just like CommandList items.

https://github.com/user-attachments/assets/7cbf7f6d-a712-415f-b142-f0c99e28dfce

Before making this refactor, if the items were virtualised as they were, we would be re-rendering and recreating the table and rows. With the virtual container, only the absolutely positioned divs (rows) are created/destroyed as needed.

Doing some tests in firefox profiler, the difference in the first loading times speaks for itself for large releases (150+ docs) where the load times (from black screen to fully loaded data) has been reduced by 50%
  
### What to review

Does this make sense? Could we do this in some other way?

### Testing

If all tests pass everything should be fine.

Validation, search, filter and sorting on the table work as before
You can test it by going to different releases, however, you can test it specifically when running the very long release

### Notes for release

Make document list in release detail virtualised