### PR TITLE
examples: add curly braces to blueprint projections for upcoming change

### DIFF
--- a/examples/README.template
+++ b/examples/README.template
@@ -135,7 +135,7 @@ BEST PRACTICE:
          event: {
            on: ["publish"],
            filter: "_type == 'document-type' && condition",
-           projection: "_id",
+           projection: "{_id}",
          },
        }),
      ],

--- a/examples/functions/algolia-document-sync/README.md
+++ b/examples/functions/algolia-document-sync/README.md
@@ -63,7 +63,7 @@ This function is built to be compatible with any of [the official "clean" templa
      event: {
        on: ['publish'],
        filter: "_type == 'post'",
-       projection: '_id, title, hideFromSearch',
+       projection: '{_id, title, hideFromSearch}',
      },
      env: {
        ALGOLIA_APP_ID: ALGOLIA_APP_ID,

--- a/examples/functions/algolia-document-sync/package.json
+++ b/examples/functions/algolia-document-sync/package.json
@@ -18,7 +18,7 @@
         "publish"
       ],
       "filter": "_type == 'post'",
-      "projection": "_id, title, hideFromSearch"
+      "projection": "{_id, title, hideFromSearch}"
     },
     "env": {
       "COMMENT": "ALGOLIA_APP_ID and ALGOLIA_WRITE_KEY env variables are required to sync documents to Algolia",

--- a/examples/functions/auto-summary/README.md
+++ b/examples/functions/auto-summary/README.md
@@ -79,7 +79,7 @@ npx sanity schema deploy
      event: {
        on: ['publish'],
        filter: "_type == 'post' && !defined(autoSummary)",
-       projection: '_id',
+       projection: '{_id}',
      },
    })
    ```

--- a/examples/functions/auto-summary/package.json
+++ b/examples/functions/auto-summary/package.json
@@ -17,7 +17,7 @@
         "publish"
       ],
       "filter": "_type == 'post' && !defined(autoSummary)",
-      "projection": "_id"
+      "projection": "{_id}"
     }
   },
   "exampleInstructions": "Add this resource to your Blueprint config's resources array. Go to README.md for more details on how to use this function."

--- a/examples/functions/auto-tag/README.md
+++ b/examples/functions/auto-tag/README.md
@@ -83,7 +83,7 @@ npx sanity schema deploy
          event: {
            on: ['publish'],
            filter: "_type == 'post' && !defined(tags)",
-           projection: '_id',
+           projection: '{_id}',
          },
        }),
      ],

--- a/examples/functions/auto-tag/package.json
+++ b/examples/functions/auto-tag/package.json
@@ -17,7 +17,7 @@
         "publish"
       ],
       "filter": "_type == 'post' && !defined(tags)",
-      "projection": "_id"
+      "projection": "{_id}"
     }
   },
   "exampleInstructions": "Add this resource to your Blueprint config's resources array. Go to README.md for more details on how to use this function."

--- a/examples/functions/brand-voice-validator/README.md
+++ b/examples/functions/brand-voice-validator/README.md
@@ -83,7 +83,7 @@ npx sanity schema deploy
          event: {
            on: ['publish'],
            filter: "_type == 'post'",
-           projection: '_id',
+           projection: '{_id}',
          },
        }),
      ],
@@ -173,7 +173,7 @@ export default defineBlueprint({
       event: {
         on: ['publish'],
         filter: "_type == 'post'",
-        projection: '_id',
+        projection: '{_id}',
       },
     }),
   ],

--- a/examples/functions/brand-voice-validator/package.json
+++ b/examples/functions/brand-voice-validator/package.json
@@ -17,7 +17,7 @@
         "publish"
       ],
       "filter": "_type == 'post'",
-      "projection": "_id"
+      "projection": "{_id}"
     }
   },
   "exampleInstructions": "Add this resource to your Blueprint config's resources array. Go to README.md for more details on how to use this function."

--- a/examples/functions/capture-tone-of-voice/README.md
+++ b/examples/functions/capture-tone-of-voice/README.md
@@ -83,7 +83,7 @@ npx sanity schema deploy
          event: {
            on: ['publish'],
            filter: "_type == 'post'",
-           projection: '_id',
+           projection: '{_id}',
          },
        }),
      ],
@@ -171,7 +171,7 @@ export default defineBlueprint({
       event: {
         on: ['publish'],
         filter: "_type == 'post'",
-        projection: '_id',
+        projection: '{_id}',
       },
     }),
   ],

--- a/examples/functions/capture-tone-of-voice/package.json
+++ b/examples/functions/capture-tone-of-voice/package.json
@@ -17,7 +17,7 @@
         "publish"
       ],
       "filter": "_type == 'post'",
-      "projection": "_id"
+      "projection": "{_id}"
     }
   },
   "exampleInstructions": "Add this resource to your Blueprint config's resources array. Go to README.md for more details on how to use this function."

--- a/examples/functions/first-published/README.md
+++ b/examples/functions/first-published/README.md
@@ -46,7 +46,7 @@ This Sanity Function automatically sets a `firstPublished` timestamp when a post
      timeout: 10,
      on: ['publish'],
      filter: "_type == 'post' && !defined(firstPublished)",
-     projection: '_id',
+     projection: '{_id}',
    })
    ```
 

--- a/examples/functions/first-published/package.json
+++ b/examples/functions/first-published/package.json
@@ -14,7 +14,7 @@
       "publish"
     ],
     "filter": "_type == 'post' && !defined(firstPublished)",
-    "projection": "_id"
+    "projection": "{_id}"
   },
   "exampleInstructions": "Add this configuration to your blueprint config's resources array. Go to README.md for more details."
 }

--- a/examples/functions/slack-notify/README.md
+++ b/examples/functions/slack-notify/README.md
@@ -96,7 +96,7 @@ Most official templates already include these fields.
          event: {
            on: ['publish'],
            filter: "_type == 'post'",
-           projection: '_id, title, slug, _updatedAt',
+           projection: '{_id, title, slug, _updatedAt}',
          },
          env: {
            SLACK_OAUTH_TOKEN: process.env.SLACK_OAUTH_TOKEN,
@@ -242,7 +242,7 @@ export default defineBlueprint({
       event: {
         on: ['publish'],
         filter: "_type == 'post'",
-        projection: '_id, title, slug, _updatedAt',
+        projection: '{_id, title, slug, _updatedAt}',
       },
     }),
   ],

--- a/examples/functions/slack-notify/package.json
+++ b/examples/functions/slack-notify/package.json
@@ -17,7 +17,7 @@
         "publish"
       ],
       "filter": "_type == 'post'",
-      "projection": "_id, title, slug, _updatedAt"
+      "projection": "{_id, title, slug, _updatedAt}"
     },
     "env": {
       "COMMENT": "SLACK_OAUTH_TOKEN and SLACK_CHANNEL are required. Optional: BASE_URL, STUDIO_URL as they will default to dev mode localhost urls",

--- a/examples/functions/telegram-notify/README.md
+++ b/examples/functions/telegram-notify/README.md
@@ -130,7 +130,7 @@ export default defineBlueprint({
       event: {
         on: ['publish'],
         filter: '_type == "comment" && defined(comment)',
-        projection: '_id, comment',
+        projection: '{_id, comment}',
       },
       env: {TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID},
     }),

--- a/examples/functions/telegram-notify/package.json
+++ b/examples/functions/telegram-notify/package.json
@@ -15,7 +15,7 @@
         "publish"
       ],
       "filter": "_type == 'comment' && defined(comment)",
-      "projection": "_id, comment"
+      "projection": "{_id, comment}"
     },
     "env": {
       "COMMENT": "TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID, and STUDIO_URL are required",


### PR DESCRIPTION
### Description

This PR adds curly braces `{_id, field1, etc}` to the existing example functions.

### What to review

Review that I got all the functions.

### Testing

I'm not sure we can "test" this.  I assume the `npx sanity blueprints add function --example function-name` command will already be tested and ready when we merge

### Notes for release

This is an update to the function examples for the breaking change coming where Blueprint projections will require curly braces.  
