### PR TITLE
fix(sanity): presentation navigation issues and initial value handling

### DIFF
--- a/dev/test-studio/preview/InitialValues.tsx
+++ b/dev/test-studio/preview/InitialValues.tsx
@@ -1,0 +1,56 @@
+import {Box, Card, Flex, Heading, Stack, Text} from '@sanity/ui'
+
+import {useQuery} from './loader'
+
+export function InitialValues(): React.JSX.Element {
+  const {data, loading, error} = useQuery<
+    {
+      _id: string
+      _type: string
+      title: string | null
+      author: {
+        name: string | null
+      } | null
+    }[]
+  >(/* groq */ `*[_type == "book" && defined(title)] | order(_updatedAt desc) [0..9]{
+      _id, 
+      _type, 
+      title, 
+      "author": author->{name}
+    }`)
+
+  if (error) {
+    throw error
+  }
+
+  if (loading) {
+    return <p>Loading...</p>
+  }
+
+  if (!data?.length) {
+    return <p>No books found</p>
+  }
+
+  return (
+    <Stack padding={4} space={4}>
+      <Box>
+        <Heading as="h1" size={1}>
+          Books: Add an author
+        </Heading>
+      </Box>
+      {data.map((item, i) => (
+        <Card key={item._id} padding={4} shadow={2} radius={2}>
+          <Flex align="flex-start" justify="space-between" gap={3}>
+            <Stack space={2}>
+              <Heading as="h1" size={1}>
+                {item.title}
+              </Heading>
+              <Text size={1}>{item.author?.name || 'No Author'}</Text>
+            </Stack>
+            <Text size={1}>{i + 1}</Text>
+          </Flex>
+        </Card>
+      ))}
+    </Stack>
+  )
+}

--- a/dev/test-studio/preview/main.tsx
+++ b/dev/test-studio/preview/main.tsx
@@ -4,13 +4,16 @@ import {Suspense, useEffect, useState} from 'react'
 import {createRoot} from 'react-dom/client'
 
 import {FieldGroups} from './FieldGroups'
+import {InitialValues} from './InitialValues'
 import {useLiveMode} from './loader'
 import {LongList} from './LongList'
 import {Markdown} from './Markdown'
 import {SimpleBlockPortableText} from './SimpleBlockPortableText'
 
 function Main() {
-  const [id, setId] = useState<'simple' | 'nested' | 'markdown' | 'longlist'>('simple')
+  const [id, setId] = useState<'simple' | 'nested' | 'markdown' | 'longlist' | 'initialvalues'>(
+    'simple',
+  )
   return (
     <>
       <ThemeProvider theme={studioTheme}>
@@ -45,6 +48,13 @@ function Main() {
                 onClick={() => setId('longlist')}
                 selected={id === 'longlist'}
               />
+              <Tab
+                aria-controls="initialvalues-panel"
+                id="initialvalues-tab"
+                label="Initial Values"
+                onClick={() => setId('initialvalues')}
+                selected={id === 'initialvalues'}
+              />
             </TabList>
           </Box>
 
@@ -68,6 +78,11 @@ function Main() {
           {id === 'longlist' && (
             <TabPanel aria-labelledby="longlist-tab" id="longlist-panel">
               <LongList />
+            </TabPanel>
+          )}
+          {id === 'initialvalues' && (
+            <TabPanel aria-labelledby="initialvalues-tab" id="initialvalues-panel">
+              <InitialValues />
             </TabPanel>
           )}
         </Flex>

--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -514,14 +514,8 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     [onFocusPath, setFocusPath, handleSetOpenPath, updatePresenceThrottled],
   )
 
-  const disableBlurRef = useRef(false)
-
   const handleBlur = useCallback(
     (_blurredPath: Path) => {
-      if (disableBlurRef.current) {
-        return
-      }
-
       setFocusPath(EMPTY_ARRAY)
 
       if (focusPathRef.current !== EMPTY_ARRAY) {
@@ -538,8 +532,6 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
   const handleProgrammaticFocus = useCallback(
     (nextPath: Path) => {
       // Supports changing the focus path not by a user interaction, but by a programmatic change, e.g. the url path changes.
-      // to avoid the blur event to be triggered, we set a flag to disable it for a short period of time.
-      disableBlurRef.current = true
 
       if (!deepEquals(focusPathRef.current, nextPath)) {
         setFocusPath(nextPath)
@@ -548,11 +540,6 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
 
         focusPathRef.current = nextPath
       }
-
-      const timeout = setTimeout(() => {
-        disableBlurRef.current = false
-      }, 0)
-      return () => clearTimeout(timeout)
     },
     [onFocusPath, handleSetOpenPath],
   )

--- a/packages/sanity/src/presentation/PresentationContent.tsx
+++ b/packages/sanity/src/presentation/PresentationContent.tsx
@@ -4,12 +4,7 @@ import {
   type PropsWithChildren,
   type SetStateAction,
 } from 'react'
-import {
-  type CommentIntentGetter,
-  CommentsIntentProvider,
-  type Path,
-  type SanityDocument,
-} from 'sanity'
+import {type CommentIntentGetter, CommentsIntentProvider, type SanityDocument} from 'sanity'
 
 import {ContentEditor} from './editor/ContentEditor'
 import {DisplayedDocumentBroadcasterProvider} from './loader/DisplayedDocumentBroadcaster'
@@ -17,8 +12,10 @@ import {Panel} from './panels/Panel'
 import {PanelResizer} from './panels/PanelResizer'
 import {
   type MainDocumentState,
+  type PresentationNavigate,
   type PresentationParamsContextValue,
   type PresentationSearchParams,
+  type PresentationStateParams,
   type StructureDocumentPaneParams,
 } from './types'
 
@@ -28,7 +25,8 @@ export interface PresentationContentProps {
   documentType: PresentationParamsContextValue['type']
   getCommentIntent: CommentIntentGetter
   mainDocumentState: MainDocumentState | undefined
-  onFocusPath: (path: Path) => void
+  onEditReference: PresentationNavigate
+  onFocusPath: (state: Required<PresentationStateParams>) => void
   onStructureParams: (params: StructureDocumentPaneParams) => void
   searchParams: PresentationSearchParams
   setDisplayedDocument: Dispatch<SetStateAction<Partial<SanityDocument> | null | undefined>>
@@ -67,6 +65,7 @@ export const PresentationContent: FunctionComponent<PresentationContentProps> = 
     documentType,
     getCommentIntent,
     mainDocumentState,
+    onEditReference,
     onFocusPath,
     onStructureParams,
     searchParams,
@@ -84,6 +83,7 @@ export const PresentationContent: FunctionComponent<PresentationContentProps> = 
         documentId={documentId}
         documentType={documentType}
         mainDocumentState={mainDocumentState}
+        onEditReference={onEditReference}
         onFocusPath={onFocusPath}
         onStructureParams={onStructureParams}
         refs={documentsOnPage}

--- a/packages/sanity/src/presentation/PresentationNavigateProvider.tsx
+++ b/packages/sanity/src/presentation/PresentationNavigateProvider.tsx
@@ -1,7 +1,13 @@
 import {type FunctionComponent, type PropsWithChildren, useCallback} from 'react'
 import {PresentationNavigateContext} from 'sanity/_singletons'
 
-import {type PresentationNavigate, type PresentationNavigateContextValue} from './types'
+import {
+  type CombinedSearchParams,
+  type PresentationNavigate,
+  type PresentationNavigateContextValue,
+  type PresentationNavigateOptions,
+  type PresentationStateParams,
+} from './types'
 
 export const PresentationNavigateProvider: FunctionComponent<
   PropsWithChildren<{
@@ -11,8 +17,17 @@ export const PresentationNavigateProvider: FunctionComponent<
   const {children, navigate: _navigate} = props
 
   const navigate = useCallback<PresentationNavigateContextValue>(
-    (preview, document = undefined) => {
-      _navigate(document || {}, preview ? {preview} : {})
+    (preview, document) => {
+      if (preview || document) {
+        const obj: {
+          state?: PresentationStateParams
+          params?: CombinedSearchParams
+        } = {}
+        if (preview) obj.params = {preview}
+        if (document) obj.state = document
+        // Cast because navigate expects either params or state to be defined, which we guarantee above
+        _navigate(obj as PresentationNavigateOptions)
+      }
     },
     [_navigate],
   )

--- a/packages/sanity/src/presentation/document/LocationsBanner.tsx
+++ b/packages/sanity/src/presentation/document/LocationsBanner.tsx
@@ -177,7 +177,7 @@ function LocationItem(props: {
   })
 
   const handleCurrentToolClick = useCallback(() => {
-    navigate?.({}, {preview: node.href})
+    navigate?.({params: {preview: node.href}})
   }, [node.href, navigate])
 
   return (

--- a/packages/sanity/src/presentation/editor/ContentEditor.tsx
+++ b/packages/sanity/src/presentation/editor/ContentEditor.tsx
@@ -3,7 +3,6 @@ import {Box, Card, Flex, Text} from '@sanity/ui'
 import {type HTMLProps, useCallback, useMemo} from 'react'
 import {
   getPreviewValueWithFallback,
-  type Path,
   PreviewCard,
   SanityDefaultPreview,
   Translate,
@@ -15,7 +14,9 @@ import {StateLink} from 'sanity/router'
 import {presentationLocaleNamespace} from '../i18n'
 import {
   type MainDocumentState,
+  type PresentationNavigate,
   type PresentationSearchParams,
+  type PresentationStateParams,
   type StructureDocumentPaneParams,
 } from '../types'
 import {DocumentListPane} from './DocumentListPane'
@@ -26,7 +27,8 @@ export function ContentEditor(props: {
   documentId?: string
   documentType?: string
   mainDocumentState?: MainDocumentState
-  onFocusPath: (path: Path) => void
+  onEditReference: PresentationNavigate
+  onFocusPath: (state: Required<PresentationStateParams>) => void
   onStructureParams: (params: StructureDocumentPaneParams) => void
   refs: {_id: string; _type: string}[]
   structureParams: StructureDocumentPaneParams
@@ -36,6 +38,7 @@ export function ContentEditor(props: {
     documentId,
     documentType,
     mainDocumentState,
+    onEditReference,
     onFocusPath,
     onStructureParams,
     refs,
@@ -96,6 +99,7 @@ export function ContentEditor(props: {
       <DocumentPanel
         documentId={documentId}
         documentType={documentType}
+        onEditReference={onEditReference}
         onFocusPath={onFocusPath}
         onStructureParams={onStructureParams}
         searchParams={searchParams}
@@ -146,6 +150,7 @@ export function ContentEditor(props: {
 
       <DocumentListPane
         mainDocumentState={mainDocumentState}
+        onEditReference={onEditReference}
         onStructureParams={onStructureParams}
         searchParams={searchParams}
         refs={refs}

--- a/packages/sanity/src/presentation/editor/DocumentListPane.tsx
+++ b/packages/sanity/src/presentation/editor/DocumentListPane.tsx
@@ -12,13 +12,14 @@ import {styled} from 'styled-components'
 import {ErrorBoundary} from '../../ui-components'
 import {ErrorCard} from '../components/ErrorCard'
 import {presentationLocaleNamespace} from '../i18n'
+import {PresentationPaneRouterProvider} from '../paneRouter/PresentationPaneRouterProvider'
 import {
   type MainDocumentState,
+  type PresentationNavigate,
   type PresentationSearchParams,
   type StructureDocumentPaneParams,
 } from '../types'
 import {usePresentationTool} from '../usePresentationTool'
-import {PresentationPaneRouterProvider} from './PresentationPaneRouterProvider'
 
 const RootLayout = styled(PaneLayout)`
   height: 100%;
@@ -37,11 +38,12 @@ const WrappedCode = styled(Code)`
 
 export function DocumentListPane(props: {
   mainDocumentState?: MainDocumentState
+  onEditReference: PresentationNavigate
   onStructureParams: (params: StructureDocumentPaneParams) => void
   searchParams: PresentationSearchParams
   refs: {_id: string; _type: string}[]
 }): React.JSX.Element {
-  const {mainDocumentState, onStructureParams, searchParams, refs} = props
+  const {mainDocumentState, onEditReference, onStructureParams, searchParams, refs} = props
 
   const {t} = useTranslation(presentationLocaleNamespace)
   const {devMode} = usePresentationTool()
@@ -104,6 +106,7 @@ export function DocumentListPane(props: {
       <RootLayout>
         <StructureToolProvider>
           <PresentationPaneRouterProvider
+            onEditReference={onEditReference}
             onStructureParams={onStructureParams}
             structureParams={structureParams}
             searchParams={searchParams}

--- a/packages/sanity/src/presentation/editor/DocumentPane.tsx
+++ b/packages/sanity/src/presentation/editor/DocumentPane.tsx
@@ -1,3 +1,4 @@
+import {studioPath} from '@sanity/client/csm'
 import {Card, Code, Label, Stack} from '@sanity/ui'
 import {type ErrorInfo, Suspense, useCallback, useEffect, useMemo, useState} from 'react'
 import {type Path, useTranslation} from 'sanity'
@@ -12,10 +13,15 @@ import {styled} from 'styled-components'
 import {ErrorBoundary} from '../../ui-components'
 import {ErrorCard} from '../components/ErrorCard'
 import {presentationLocaleNamespace} from '../i18n'
+import {PresentationPaneRouterProvider} from '../paneRouter/PresentationPaneRouterProvider'
 import {PresentationSpinner} from '../PresentationSpinner'
-import {type PresentationSearchParams, type StructureDocumentPaneParams} from '../types'
+import {
+  type PresentationNavigate,
+  type PresentationSearchParams,
+  type PresentationStateParams,
+  type StructureDocumentPaneParams,
+} from '../types'
 import {usePresentationTool} from '../usePresentationTool'
-import {PresentationPaneRouterProvider} from './PresentationPaneRouterProvider'
 
 const WrappedCode = styled(Code)`
   white-space: pre-wrap;
@@ -24,13 +30,21 @@ const WrappedCode = styled(Code)`
 export function DocumentPane(props: {
   documentId: string
   documentType: string
-  onFocusPath: (path: Path) => void
+  onFocusPath: (state: Required<PresentationStateParams>) => void
+  onEditReference: PresentationNavigate
   onStructureParams: (params: StructureDocumentPaneParams) => void
   structureParams: StructureDocumentPaneParams
   searchParams: PresentationSearchParams
 }): React.JSX.Element {
-  const {documentId, documentType, onFocusPath, onStructureParams, searchParams, structureParams} =
-    props
+  const {
+    documentId,
+    documentType,
+    onFocusPath,
+    onEditReference,
+    onStructureParams,
+    searchParams,
+    structureParams,
+  } = props
   const {template, templateParams} = structureParams
 
   const {t} = useTranslation(presentationLocaleNamespace)
@@ -49,6 +63,17 @@ export function DocumentPane(props: {
       type: 'document',
     }),
     [documentId, documentType, template, templateParams],
+  )
+
+  const handleFocusPath = useCallback(
+    (path: Path) => {
+      return onFocusPath({
+        id: documentId,
+        type: documentType,
+        path: studioPath.toString(path),
+      })
+    },
+    [documentId, documentType, onFocusPath],
   )
 
   const [errorParams, setErrorParams] = useState<{
@@ -86,6 +111,7 @@ export function DocumentPane(props: {
       <PaneLayout style={{height: '100%'}}>
         <PresentationPaneRouterProvider
           searchParams={searchParams}
+          onEditReference={onEditReference}
           onStructureParams={onStructureParams}
           structureParams={structureParams}
         >
@@ -96,7 +122,7 @@ export function DocumentPane(props: {
               index={1}
               itemId="document"
               pane={paneDocumentNode}
-              onFocusPath={onFocusPath}
+              onFocusPath={handleFocusPath}
             />
           </Suspense>
         </PresentationPaneRouterProvider>

--- a/packages/sanity/src/presentation/editor/DocumentPanel.tsx
+++ b/packages/sanity/src/presentation/editor/DocumentPanel.tsx
@@ -1,24 +1,36 @@
-import {type Path} from 'sanity'
-
 import {StructureToolProvider} from '../../structure/StructureToolProvider'
-import {type PresentationSearchParams, type StructureDocumentPaneParams} from '../types'
+import {
+  type PresentationNavigate,
+  type PresentationSearchParams,
+  type PresentationStateParams,
+  type StructureDocumentPaneParams,
+} from '../types'
 import {DocumentPane} from './DocumentPane'
 
 export function DocumentPanel(props: {
   documentId: string
   documentType: string
-  onFocusPath: (path: Path) => void
+  onEditReference: PresentationNavigate
+  onFocusPath: (state: Required<PresentationStateParams>) => void
   onStructureParams: (params: StructureDocumentPaneParams) => void
   searchParams: PresentationSearchParams
   structureParams: StructureDocumentPaneParams
 }): React.JSX.Element {
-  const {documentId, documentType, onFocusPath, onStructureParams, searchParams, structureParams} =
-    props
+  const {
+    documentId,
+    documentType,
+    onFocusPath,
+    onEditReference,
+    onStructureParams,
+    searchParams,
+    structureParams,
+  } = props
   return (
     <StructureToolProvider>
       <DocumentPane
         documentId={documentId}
         documentType={documentType}
+        onEditReference={onEditReference}
         onFocusPath={onFocusPath}
         onStructureParams={onStructureParams}
         searchParams={searchParams}

--- a/packages/sanity/src/presentation/paneRouter/ChildLink.tsx
+++ b/packages/sanity/src/presentation/paneRouter/ChildLink.tsx
@@ -1,0 +1,27 @@
+import {forwardRef} from 'react'
+import {StateLink} from 'sanity/router'
+import {type ChildLinkProps} from 'sanity/structure'
+
+import {type PresentationSearchParams} from '../types'
+
+export const ChildLink = forwardRef(function ChildLink(
+  props: ChildLinkProps & {
+    childType: string
+    searchParams: PresentationSearchParams
+  },
+  ref: React.ForwardedRef<HTMLAnchorElement>,
+) {
+  const {childId, childType, childPayload, childParameters, searchParams, ...rest} = props
+
+  return (
+    <StateLink
+      {...rest}
+      ref={ref}
+      state={{
+        id: childId,
+        type: childType,
+        _searchParams: Object.entries({...searchParams, ...childParameters}),
+      }}
+    />
+  )
+})

--- a/packages/sanity/src/presentation/paneRouter/PresentationPaneRouterProvider.tsx
+++ b/packages/sanity/src/presentation/paneRouter/PresentationPaneRouterProvider.tsx
@@ -1,18 +1,23 @@
+import {toString as pathToString} from '@sanity/util/paths'
 import {forwardRef, type PropsWithChildren, useCallback, useMemo} from 'react'
 import {getPublishedId, useUnique} from 'sanity'
 import {StateLink, useRouter} from 'sanity/router'
 import {
   type BackLinkProps,
+  type ChildLinkProps,
   PaneRouterContext,
   type PaneRouterContextValue,
   type ReferenceChildLinkProps,
 } from 'sanity/structure'
 
 import {
+  type PresentationNavigate,
   type PresentationParamsContextValue,
   type PresentationSearchParams,
   type StructureDocumentPaneParams,
 } from '../types'
+import {ChildLink} from './ChildLink'
+import {ReferenceChildLink} from './ReferenceChildLink'
 
 function encodeQueryString(params: Record<string, unknown> = {}): string {
   const parts = Object.entries(params)
@@ -62,44 +67,18 @@ const BackLink = forwardRef(function BackLink(
   )
 })
 
-const ReferenceChildLink = forwardRef(function ReferenceChildLink(
-  props: ReferenceChildLinkProps & {searchParams: PresentationSearchParams},
-  ref: React.ForwardedRef<HTMLAnchorElement>,
-) {
-  const {
-    documentId,
-    documentType,
-    // oxlint-disable-next-line no-unused-vars
-    parentRefPath,
-    // oxlint-disable-next-line no-unused-vars
-    template,
-    searchParams,
-    ...restProps
-  } = props
-
-  return (
-    <StateLink
-      {...restProps}
-      ref={ref}
-      state={{
-        id: documentId,
-        type: documentType,
-        _searchParams: Object.entries(searchParams),
-      }}
-      title={undefined}
-    />
-  )
-})
+export type PresentationPaneRouterProviderProps = PropsWithChildren<{
+  onEditReference: PresentationNavigate
+  onStructureParams: (params: StructureDocumentPaneParams) => void
+  refs?: {_id: string; _type: string}[]
+  searchParams: PresentationSearchParams
+  structureParams: StructureDocumentPaneParams
+}>
 
 export function PresentationPaneRouterProvider(
-  props: PropsWithChildren<{
-    onStructureParams: (params: StructureDocumentPaneParams) => void
-    refs?: {_id: string; _type: string}[]
-    searchParams: PresentationSearchParams
-    structureParams: StructureDocumentPaneParams
-  }>,
+  props: PresentationPaneRouterProviderProps,
 ): React.JSX.Element {
-  const {children, onStructureParams, structureParams, searchParams, refs} = props
+  const {children, onEditReference, onStructureParams, structureParams, searchParams, refs} = props
 
   const {state: routerState, resolvePathFromState} = useRouter()
 
@@ -128,27 +107,36 @@ export function PresentationPaneRouterProvider(
       hasGroupSiblings: false,
       groupLength: 1,
       routerPanesState: [],
-      ChildLink: (childLinkProps) => {
-        const {childId, ...restProps} = childLinkProps
-        const ref = refs?.find((r) => r._id === childId || getPublishedId(r._id) === childId)
-        if (ref) {
+      ChildLink: forwardRef<HTMLAnchorElement, ChildLinkProps>(
+        function ContextChildLink(childLinkProps, ref) {
+          const {childId, ...rest} = childLinkProps
+          const doc = refs?.find((r) => r._id === childId || getPublishedId(r._id) === childId)
+
+          if (!doc) {
+            console.warn(`ChildLink: No document found for childId "${childId}"`)
+            return null
+          }
+
           return (
-            <StateLink
-              {...restProps}
-              state={{
-                id: childId,
-                type: ref._type,
-                _searchParams: Object.entries(searchParams),
-              }}
+            <ChildLink
+              {...rest}
+              ref={ref}
+              childId={childId}
+              childType={doc._type}
+              searchParams={searchParams}
             />
           )
-        }
-
-        return <div {...restProps} />
-      },
-      BackLink: (backLinkProps) => <BackLink {...backLinkProps} searchParams={searchParams} />,
-      ReferenceChildLink: (childLinkProps) => (
-        <ReferenceChildLink {...childLinkProps} searchParams={searchParams} />
+        },
+      ),
+      BackLink: forwardRef<HTMLAnchorElement, BackLinkProps>(
+        function ContextBackLink(backLinkProps, ref) {
+          return <BackLink {...backLinkProps} ref={ref} searchParams={searchParams} />
+        },
+      ),
+      ReferenceChildLink: forwardRef<HTMLAnchorElement, ReferenceChildLinkProps>(
+        function ContextReferenceChildLink(childLinkProps, ref) {
+          return <ReferenceChildLink {...childLinkProps} ref={ref} searchParams={searchParams} />
+        },
       ),
       ParameterizedLink: () => {
         throw new Error('ParameterizedLink not implemented')
@@ -157,7 +145,15 @@ export function PresentationPaneRouterProvider(
         console.warn('closeCurrentAndAfter')
       },
       handleEditReference: (options) => {
-        console.warn('handleEditReference', options)
+        const {id, template, type, parentRefPath, version} = options
+        onEditReference({
+          state: {id, type},
+          params: {
+            template: template.id,
+            parentRefPath: pathToString(parentRefPath),
+            version,
+          },
+        })
       },
       replaceCurrent: (pane) => {
         console.warn('replaceCurrent', pane)
@@ -186,7 +182,14 @@ export function PresentationPaneRouterProvider(
       },
       createPathWithParams,
     }
-  }, [createPathWithParams, onStructureParams, refs, searchParams, structureParams])
+  }, [
+    createPathWithParams,
+    onEditReference,
+    onStructureParams,
+    refs,
+    searchParams,
+    structureParams,
+  ])
 
   return <PaneRouterContext.Provider value={context}>{children}</PaneRouterContext.Provider>
 }

--- a/packages/sanity/src/presentation/paneRouter/ReferenceChildLink.tsx
+++ b/packages/sanity/src/presentation/paneRouter/ReferenceChildLink.tsx
@@ -1,0 +1,28 @@
+import {forwardRef} from 'react'
+import {pathToString} from 'sanity'
+import {type ReferenceChildLinkProps} from 'sanity/structure'
+
+import {type PresentationSearchParams} from '../types'
+import {ChildLink} from './ChildLink'
+
+export const ReferenceChildLink = forwardRef(function ReferenceChildLink(
+  props: ReferenceChildLinkProps & {searchParams: PresentationSearchParams},
+  ref: React.ForwardedRef<HTMLAnchorElement>,
+) {
+  const {documentId, documentType, parentRefPath, template, searchParams, ...rest} = props
+
+  return (
+    <ChildLink
+      {...rest}
+      ref={ref}
+      childId={documentId}
+      childType={documentType}
+      childPayload={template?.params}
+      childParameters={{
+        parentRefPath: pathToString(parentRefPath),
+        ...(template && {template: template?.id}),
+      }}
+      searchParams={searchParams}
+    />
+  )
+})

--- a/packages/sanity/src/presentation/types.ts
+++ b/packages/sanity/src/presentation/types.ts
@@ -339,11 +339,13 @@ export interface PresentationSearchParams {
  */
 export interface StructureDocumentPaneParams extends InspectorTab {
   inspect?: string
+  parentRefPath?: string
   path?: string
   rev?: string
   since?: string
   template?: string
   templateParams?: string
+  version?: string
   view?: string
 
   // assist
@@ -368,8 +370,7 @@ export interface InspectorTab {
  */
 export interface CombinedSearchParams
   extends StructureDocumentPaneParams,
-    PresentationSearchParams,
-    InspectorTab {}
+    PresentationSearchParams {}
 
 /**
  * All possible parameters that can be used to describe the state of the
@@ -378,15 +379,16 @@ export interface CombinedSearchParams
  */
 export interface PresentationParamsContextValue
   extends PresentationStateParams,
-    CombinedSearchParams,
-    InspectorTab {}
+    CombinedSearchParams {}
 
 /** @public */
-export type PresentationNavigate = (
-  nextState: PresentationStateParams,
-  nextSearchState?: CombinedSearchParams,
-  forceReplace?: boolean,
-) => void
+export type PresentationNavigateOptions = (
+  | {state: PresentationStateParams; params?: CombinedSearchParams}
+  | {params: CombinedSearchParams; state?: PresentationStateParams}
+) & {replace?: boolean}
+
+/** @public */
+export type PresentationNavigate = (options: PresentationNavigateOptions) => void
 
 /** @public */
 export type PresentationPerspective = Exclude<ClientPerspective, 'raw'>

--- a/packages/sanity/src/presentation/useMainDocument.ts
+++ b/packages/sanity/src/presentation/useMainDocument.ts
@@ -127,8 +127,10 @@ export function useMainDocument(props: {
       // resultant navigation states.
       if (navigationHistory.at(-1)?.id === navigationHistory.at(-2)?.id) {
         navigate?.({
-          id: doc?._id,
-          type: doc?._type,
+          state: {
+            id: doc?._id,
+            type: doc?._type,
+          },
         })
       }
     }

--- a/packages/sanity/src/presentation/useParams.ts
+++ b/packages/sanity/src/presentation/useParams.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-import {type MutableRefObject, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {type MutableRefObject, useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react'
 import {getPublishedId} from 'sanity'
 import {type RouterContextValue, type RouterState, type SearchParam} from 'sanity/router'
 
@@ -22,6 +22,36 @@ function pruneObject<T extends RouterState | PresentationParamsContextValue>(obj
   ) as T
 }
 
+/**
+ * Ensures the array contains all members of the union T.
+ */
+const exhaustiveTupleOf =
+  <T>() =>
+  <U extends T[]>(array: U & ([T] extends [U[number]] ? unknown : 'Invalid') & {0: T}) =>
+    array
+
+const maintainOnDocumentChange = exhaustiveTupleOf<keyof PresentationSearchParams>()([
+  'perspective',
+  'preview',
+  'viewport',
+])
+
+const maintainOnSameDocument = exhaustiveTupleOf<keyof StructureDocumentPaneParams>()([
+  'changesInspectorTab',
+  'comment',
+  'inspect',
+  'instruction',
+  'parentRefPath',
+  'path',
+  'pathKey',
+  'rev',
+  'since',
+  'template',
+  'templateParams',
+  'version',
+  'view',
+])
+
 export function useParams({
   initialPreviewUrl,
   routerNavigate,
@@ -37,6 +67,7 @@ export function useParams({
   }
   frameStateRef: MutableRefObject<FrameState>
 }): {
+  isSameDocument: (state: PresentationStateParams) => boolean
   navigate: PresentationNavigate
   navigationHistory: RouterState[]
   params: PresentationParamsContextValue
@@ -54,6 +85,7 @@ export function useParams({
       perspective: routerSearchParams.perspective,
       viewport: routerSearchParams.viewport,
       inspect: routerSearchParams.inspect,
+      parentRefPath: routerSearchParams.parentRefPath,
       rev: routerSearchParams.rev,
       since: routerSearchParams.since,
       template: routerSearchParams.template,
@@ -72,6 +104,7 @@ export function useParams({
     const pruned = pruneObject({
       inspect: params.inspect,
       path: params.path,
+      parentRefPath: params.parentRefPath,
       rev: params.rev,
       since: params.since,
       template: params.template,
@@ -92,6 +125,7 @@ export function useParams({
     params.instruction,
     params.path,
     params.pathKey,
+    params.parentRefPath,
     params.rev,
     params.since,
     params.template,
@@ -110,58 +144,71 @@ export function useParams({
 
   const routerStateRef = useRef(routerState)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     routerStateRef.current = routerState
   }, [routerState])
 
   const [navigationHistory, setNavigationHistory] = useState<RouterState[]>([routerState])
 
+  // Helper function to check if a given document is the same as the one in the
+  // current router state
+  const isSameDocument = useCallback(({id, type}: PresentationStateParams) => {
+    const {current} = routerStateRef
+    return id === current.id && type === current.type
+  }, [])
+
   const navigate = useCallback<PresentationNavigate>(
-    (nextState, nextSearchState = {}, forceReplace) => {
+    (options) => {
+      const {state, params, replace = false} = options
+
       // Force navigation to use published IDs only
-      if (nextState.id) nextState.id = getPublishedId(nextState.id)
+      if (state?.id) state.id = getPublishedId(state.id)
 
-      // Extract type, id and path as 'routerState'
-      const {_searchParams: routerSearchParams, ...routerState} = routerStateRef.current
+      // Get the current state and params
+      const {current} = routerStateRef
+      const currentState = {
+        id: current.id,
+        type: current.type,
+        path: current.path,
+      } satisfies PresentationStateParams
+      const currentParams = Object.fromEntries(current._searchParams || []) as CombinedSearchParams
 
-      // Convert array of search params to an object
-      const routerSearchState = (routerSearchParams || []).reduce((acc, [key, value]) => {
-        acc[key as keyof CombinedSearchParams] = value as undefined | 'history' | 'review'
+      // If state is provided, replace the current state with the provided
+      // state, otherwise maintain the current state
+      const nextState = state || currentState
+
+      // Different params need to be maintained under different conditions
+      const maintainedParamKeys = [
+        ...maintainOnDocumentChange,
+        ...(isSameDocument(nextState) ? maintainOnSameDocument : []),
+      ] satisfies (keyof CombinedSearchParams)[]
+
+      const maintainedParams = maintainedParamKeys.reduce((acc, key) => {
+        // @ts-expect-error changesInspectorTab union type doesn't play nicely
+        // here, if it were just a string it would be fine
+        acc[key] = currentParams[key]
         return acc
-      }, {} as CombinedSearchParams)
+      }, {} as Partial<CombinedSearchParams>)
 
-      // Merge routerState and incoming state
-      const state: RouterState = pruneObject({
-        ...routerState,
+      // If params are provided, merge them with the maintained params
+      const nextParams = {...maintainedParams, ...params}
+
+      const nextRouterState = {
         ...nextState,
-      })
+        _searchParams: Object.entries(nextParams).reduce(
+          (acc, [key, value]) => [...acc, [key, value] as SearchParam],
+          [] as SearchParam[],
+        ),
+      } satisfies RouterState
 
-      // Merge routerSearchState and incoming searchState
-      const searchState = pruneObject({
-        ...routerSearchState,
-        ...nextSearchState,
-      })
-
-      // If the document has changed, clear the template and templateParams
-      if (routerState.id !== state.id) {
-        delete searchState.template
-        delete searchState.templateParams
-      }
-
-      state._searchParams = Object.entries(searchState).reduce(
-        (acc, [key, value]) => [...acc, [key, value] as SearchParam],
-        [] as SearchParam[],
-      )
-
-      const replace = forceReplace ?? searchState.preview === frameStateRef.current.url
-
-      setNavigationHistory((prev) => [...prev, state])
-      routerNavigate(state, {replace})
+      setNavigationHistory((prev) => [...prev, nextRouterState])
+      routerNavigate(nextRouterState, {replace})
     },
-    [routerNavigate, frameStateRef],
+    [isSameDocument, routerNavigate],
   )
 
   return {
+    isSameDocument,
     navigate,
     navigationHistory,
     params,

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -2,7 +2,7 @@ import {useTelemetry} from '@sanity/telemetry/react'
 import {type ObjectSchemaType, type SanityDocument, type SanityDocumentLike} from '@sanity/types'
 import {useToast} from '@sanity/ui'
 import {fromString as pathFromString, resolveKeyedPath} from '@sanity/util/paths'
-import {memo, useCallback, useEffect, useMemo, useState} from 'react'
+import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {
   type DocumentActionsContext,
   type DocumentActionsVersionType,
@@ -571,16 +571,21 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     ],
   )
 
-  // Reset `focusPath` when `documentId` or `params.path` changes
+  const pathRef = useRef<string | undefined>(undefined)
   useEffect(() => {
     if (ready && params.path) {
       const {path, ...restParams} = params
-      const pathFromUrl = resolveKeyedPath(formStateRef.current?.value, pathFromString(path))
-      onProgrammaticFocus(pathFromUrl)
+
+      // trigger a focus when `params.path` changes
+      if (path !== pathRef.current) {
+        const pathFromUrl = resolveKeyedPath(formStateRef.current?.value, pathFromString(path))
+        onProgrammaticFocus(pathFromUrl)
+      }
 
       // remove the `path`-param from url after we have consumed it as the initial focus path
       paneRouter.setParams(restParams)
     }
+    pathRef.current = params.path
 
     return undefined
   }, [formStateRef, onProgrammaticFocus, paneRouter, params, ready])


### PR DESCRIPTION
### Description

This PR fixes missing support for editing references in Presentation Tool's pane router implementation. This should resolve [SAPP-2916](https://linear.app/sanity/issue/SAPP-2916/presentation-tool-create-action-generates-module-without-initial).

To support this change I've refactored/reworked Presentation's navigation handling so we aren't simply relying on debouncing all navigation calls. This was always an unpleasant workaround and was implemented before Presentation was migrated to the monorepo and changes to the imports from Structure we are using was trickier.

This should mean some cases where navigation events were being overridden, such as blur events not registering when clicking on a button that also triggered a navigation event (e.g. viewport switching) are now no longer present.

### What to review

- The changes made to Structure's `DocumentPaneProvider.tsx` and Core's `useDocumentForm`. I don't have much context about how these will affect other tools, but I suspect the changed code is/was Presentation specific anyway.
- The added `handleEditReference` implementation in `PresentationPaneRouterProvider` is passing the necessary params.

### Testing

- Use the new "Initial Values" tab in Presentation in the test studio to open a book document.
- Create an author reference.
- The author document should now open and be populated with the expected initial values.

### Notes for release

Fixed missing support for editing references in the Presentation tool.