### PR TITLE
fix(sanity): explicitly unset legacy inspect parameter

### DIFF
--- a/packages/sanity/src/presentation/paneRouter/PresentationPaneRouterProvider.tsx
+++ b/packages/sanity/src/presentation/paneRouter/PresentationPaneRouterProvider.tsx
@@ -167,13 +167,7 @@ export function PresentationPaneRouterProvider(
       setView: (viewId) => {
         console.warn('setView', viewId)
       },
-      setParams: (nextParams) => {
-        // @todo set inspect param to undefined manually as param is missing from object when closing inspector
-        onStructureParams({
-          ...nextParams,
-          inspect: nextParams.inspect ?? undefined,
-        } as StructureDocumentPaneParams)
-      },
+      setParams: onStructureParams,
       setPayload: (payload) => {
         console.warn('setPayload', payload)
       },

--- a/packages/sanity/src/structure/panes/document/useDocumentPaneInspector.ts
+++ b/packages/sanity/src/structure/panes/document/useDocumentPaneInspector.ts
@@ -1,4 +1,3 @@
-import {omit} from 'lodash'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {type DocumentInspector, useSource} from 'sanity'
 
@@ -142,7 +141,7 @@ export function useDocumentPaneInspector({
       if (toggle) {
         setParams({...params, inspect: 'on'})
       } else {
-        setParams(omit(params, 'inspect'))
+        setParams({...params, inspect: undefined})
       }
     },
     [inspectOpen, params, setParams],


### PR DESCRIPTION
### Description

Small change to fix an issue we've been working around in Presentation which I think makes sense to fix upstream.

When closing the legacy inspector panel, instead of using `omit` to remove the `inspect` parameter from the params object, we now explicitly set it to `undefined`. This just means that Presentation doesn't have to check if the parameter is present each time its pane router receives new params.

### What to review

- Check the change in `useDocumentPaneInspector.ts` where `inspect: undefined` is set instead of omitting the property is correct.

### Testing

The inspector functionality should be unchanged, ensure it opens and closes as before.

### Notes for release

N/A