### PR TITLE
fix: test workflow

### DIFF
--- a/.github/workflows/deleteme.yml
+++ b/.github/workflows/deleteme.yml
@@ -1,0 +1,32 @@
+name: Workflow alert test
+
+on:
+  push:
+    branches: [fix-alert-on-next-failure]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: |
+          echo "Simulating failure..."
+          exit 1
+
+  notify-on-failure:
+    needs: build
+    if: failure() # Only runs if 'build' fails
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": ":alert-dot: The workflow \"${{github.workflow}}\" on <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{github.repository}}> failed in branch <${{ github.server_url }}/${{ github.repository }}/tree/${{github.ref_name}}|${{github.ref_name}}> (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run >)"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_CI_ALERTS }}


### PR DESCRIPTION
### Description
Adds alerting in case of a failed `next` or `latest`-release.


### What to review
- not sure if we really need this for latest, but also don't think there is much harm in adding it either
 
### Testing
n/a

### Notes for release
n/a