### PR TITLE
feat(cli): choses a new port if dev server is conflicted for apps

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/app/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/devAction.ts
@@ -46,16 +46,20 @@ export default async function startAppDevServer(
   })
 
   try {
-    const spinner = output.spinner('Starting dev server').start()
-    await startDevServer({...config, spinner, skipStartLog: true, isApp: true})
+    output.print('Starting dev server')
+
+    const {server} = await startDevServer({...config, isApp: true})
+
+    const {port} = server.config.server
+    const httpHost = config.httpHost || 'localhost'
+
     const coreAppUrl = await getCoreAppURL({
       organizationId,
-      httpHost: config.httpHost,
-      httpPort: config.httpPort,
+      httpHost,
+      httpPort: port,
     })
-    spinner.succeed()
 
-    output.print(`Dev server started on port ${config.httpPort}`)
+    output.print(`Dev server started on port ${port}`)
     output.print(`View your app in the Sanity dashboard here:`)
     output.print(chalk.blue(chalk.underline(coreAppUrl)))
   } catch (err) {

--- a/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
@@ -227,8 +227,15 @@ export default async function startSanityDevServer(
   }
 
   try {
+    const startTime = Date.now()
     const spinner = output.spinner('Starting dev server').start()
-    await startDevServer({...config, spinner, skipStartLog: loadInDashboard})
+    const {server} = await startDevServer({...config})
+
+    const {info: loggerInfo} = server.config.logger
+    const {port} = server.config.server
+    const httpHost = config.httpHost || 'localhost'
+
+    spinner.succeed()
 
     if (loadInDashboard) {
       if (!organizationId) {
@@ -248,6 +255,17 @@ export default async function startSanityDevServer(
             }),
           ),
         ),
+      )
+    } else {
+      const startupDuration = Date.now() - startTime
+      const url = `http://${httpHost || 'localhost'}:${port}${config.basePath}`
+      const appType = 'Sanity Studio'
+
+      loggerInfo(
+        `${appType} ` +
+          `using ${chalk.cyan(`vite@${require('vite/package.json').version}`)} ` +
+          `ready in ${chalk.cyan(`${Math.ceil(startupDuration)}ms`)} ` +
+          `and running at ${chalk.cyan(url)}`,
       )
     }
   } catch (err) {

--- a/packages/sanity/src/_internal/cli/server/getViteConfig.ts
+++ b/packages/sanity/src/_internal/cli/server/getViteConfig.ts
@@ -110,7 +110,10 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     server: {
       host: server?.host,
       port: server?.port || 3333,
-      strictPort: true,
+      // Only enable strict port for studio,
+      // since apps can run on any port
+      strictPort: isApp ? false : true,
+
       /**
        * Significantly speed up startup time,
        * and most importantly eliminates the `new dependencies optimized: foobar. optimized dependencies changed. reloading`


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR improves on the port selection for apps. If the default port (3333) is conflicting it would select a new port automatically and print that. Note: This is only done for apps as for studios using cookie auth you would have to have CORS setup for the new port.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Changes makes sense
<img width="746" height="217" alt="Screenshot 2025-08-06 at 9 53 51 PM" src="https://github.com/user-attachments/assets/6f5461c4-eba1-4ee7-8734-9fe88776bc0f" />

Note that the Starting Dev server for apps is not a spinner anymore because we cannot control when Vite logs so it showed weird overlap. Studio dev server is unchanged

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Existing tests should suffice, we have hard time testing app in the current tests

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

Automatically select a new port when running `sanity dev` on **apps** if the default port is occupied
