### PR TITLE
fix(core): allow losing focus inside popover modals, fix scroll in popover issue

### DIFF
--- a/dev/test-studio/schema/standard/portableText/allTheBellsAndWhistles.ts
+++ b/dev/test-studio/schema/standard/portableText/allTheBellsAndWhistles.ts
@@ -76,6 +76,21 @@ export const ptAllTheBellsAndWhistlesType = defineType({
                     description: 'Will open the link in a new tab when checked.',
                     initialValue: false,
                   },
+                  defineField({
+                    type: 'string',
+                    name: 'iconName',
+                    title: 'Icon',
+                  }),
+                  defineField({
+                    type: 'string',
+                    name: 'iconColor',
+                    title: 'Icon Color',
+                  }),
+                  defineField({
+                    type: 'string',
+                    name: 'iconSize',
+                    title: 'Icon Size',
+                  }),
                 ],
               }),
               defineField({

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -28,7 +28,13 @@ interface PopoverEditDialogProps {
  * Unlike Fragment (on some react versions) this does not absorb the ref prop
  */
 const NoopContainer = ({children, ...props}: PropsWithChildren) => (
-  <div {...props} style={{maxHeight: '60vh'}}>
+  <div
+    {...props}
+    style={{maxHeight: '60vh'}}
+    // Makes the div focusable so clicking on the popover will move the focus away from the input once focus lock is active
+    // Solves an issue when scrolling the popover and then clicking outside of the input will scroll back the popover to the input.
+    tabIndex={-1}
+  >
     {children}
   </div>
 )


### PR DESCRIPTION
### Description
A hard one to debug with a simple fix
Adds `tabIndex=-1` to the Focus Lock first container div. 

This is to let `FocusLock` know that this element is focusable, so if the user clicks in the popover it can lose the input focus while keeping the popover open and not scrolling to the input

See video for details:

https://github.com/user-attachments/assets/227a103c-aa84-4694-9ef2-11f3de2a10dc


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open the all bells and whistles document, it should be possible to click outside of an input in a popover while the input loses focus. 

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
