### PR TITLE
ci: skip heavy workflows when only examples/** change

### DIFF
--- a/.github/workflows/docReport.yml
+++ b/.github/workflows/docReport.yml
@@ -9,17 +9,52 @@ on:
       - "v*"
 
   pull_request:
+    paths-ignore:
+      - "examples/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+  precheck:
+    runs-on: ubuntu-latest
+    outputs:
+      examples_only: ${{ steps.check.outputs.examples_only }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: check
+        name: Check if only examples files changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          else
+            CHANGED_FILES=$(git diff --name-only HEAD~1)
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          EXAMPLES_ONLY="true"
+          while IFS= read -r file; do
+            if [[ ! "$file" =~ ^examples/ ]]; then
+              EXAMPLES_ONLY="false"
+              break
+            fi
+          done <<< "$CHANGED_FILES"
+
+          echo "examples_only=$EXAMPLES_ONLY" >> $GITHUB_OUTPUT
+
   report:
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    needs: [precheck]
+    # Skip only for PRs that change examples/** exclusively; always run on tags
+    if: github.event_name != 'pull_request' || needs.precheck.outputs.examples_only != 'true'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -11,12 +11,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  precheck:
+    runs-on: ubuntu-latest
+    outputs:
+      examples_only: ${{ steps.check.outputs.examples_only }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: check
+        name: Check if only examples files changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          else
+            CHANGED_FILES=$(git diff --name-only HEAD~1)
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          EXAMPLES_ONLY="true"
+          while IFS= read -r file; do
+            if [[ ! "$file" =~ ^examples/ ]]; then
+              EXAMPLES_ONLY="false"
+              break
+            fi
+          done <<< "$CHANGED_FILES"
+
+          echo "examples_only=$EXAMPLES_ONLY" >> $GITHUB_OUTPUT
+
   install:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    needs: [precheck]
+    if: needs.precheck.outputs.examples_only != 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -34,7 +66,8 @@ jobs:
 
   playwright-ct-test:
     timeout-minutes: 30
-    needs: [install]
+    needs: [precheck, install]
+    if: needs.precheck.outputs.examples_only != 'true'
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -93,8 +126,8 @@ jobs:
           retention-days: 30
 
   merge-reports:
-    if: always()
-    needs: [playwright-ct-test]
+    if: ${{ always() && needs.precheck.outputs.examples_only != 'true' }}
+    needs: [precheck, playwright-ct-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,12 +19,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  precheck:
+    runs-on: ubuntu-latest
+    outputs:
+      examples_only: ${{ steps.check.outputs.examples_only }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: check
+        name: Check if only examples files changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          else
+            CHANGED_FILES=$(git diff --name-only HEAD~1)
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          EXAMPLES_ONLY="true"
+          while IFS= read -r file; do
+            if [[ ! "$file" =~ ^examples/ ]]; then
+              EXAMPLES_ONLY="false"
+              break
+            fi
+          done <<< "$CHANGED_FILES"
+
+          echo "examples_only=$EXAMPLES_ONLY" >> $GITHUB_OUTPUT
+
   install:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    needs: [precheck]
+    if: needs.precheck.outputs.examples_only != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -82,7 +114,8 @@ jobs:
   dataset-setup:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    needs: [install]
+    needs: [precheck, install]
+    if: needs.precheck.outputs.examples_only != 'true'
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -127,7 +160,8 @@ jobs:
       # TODO: Add a dataset setup for main for each project [chromium, firefox]
   deploy-preview:
     runs-on: ubuntu-latest
-    needs: [install]
+    needs: [precheck, install]
+    if: needs.precheck.outputs.examples_only != 'true'
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -233,7 +267,8 @@ jobs:
   playwright-test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    needs: [deploy-preview, dataset-setup]
+    needs: [precheck, deploy-preview, dataset-setup]
+    if: needs.precheck.outputs.examples_only != 'true'
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -316,8 +351,8 @@ jobs:
           retention-days: 30
 
   merge-reports:
-    if: always()
-    needs: [playwright-test]
+    if: ${{ always() && needs.precheck.outputs.examples_only != 'true' }}
+    needs: [precheck, playwright-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -4,6 +4,8 @@ permissions:
 
 on:
   pull_request:
+    paths-ignore:
+      - "examples/**"
   workflow_dispatch:
     inputs:
       reference_tag:
@@ -26,12 +28,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  precheck:
+    runs-on: ubuntu-latest
+    outputs:
+      examples_only: ${{ steps.check.outputs.examples_only }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: check
+        name: Check if only examples files changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          else
+            CHANGED_FILES=$(git diff --name-only HEAD~1)
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          EXAMPLES_ONLY="true"
+          while IFS= read -r file; do
+            if [[ ! "$file" =~ ^examples/ ]]; then
+              EXAMPLES_ONLY="false"
+              break
+            fi
+          done <<< "$CHANGED_FILES"
+
+          echo "examples_only=$EXAMPLES_ONLY" >> $GITHUB_OUTPUT
+
   efps-test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    needs: [precheck]
+    if: needs.precheck.outputs.examples_only != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -95,8 +129,8 @@ jobs:
           retention-days: 30
 
   merge-reports:
-    if: always()
-    needs: [efps-test]
+    if: ${{ always() && needs.precheck.outputs.examples_only != 'true' }}
+    needs: [precheck, efps-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/formatCheck.yml
+++ b/.github/workflows/formatCheck.yml
@@ -17,20 +17,54 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check if only examples files changed
+        id: check_examples_only
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          else
+            CHANGED_FILES=$(git diff --name-only HEAD~1)
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          EXAMPLES_ONLY="true"
+          while IFS= read -r file; do
+            if [[ ! "$file" =~ ^examples/ ]]; then
+              EXAMPLES_ONLY="false"
+              break
+            fi
+          done <<< "$CHANGED_FILES"
+
+          echo "examples_only=$EXAMPLES_ONLY" >> $GITHUB_OUTPUT
+
+      - name: Skip format check for examples-only changes
+        if: steps.check_examples_only.outputs.examples_only == 'true'
+        run: |
+          echo "Only examples files changed, skipping format check"
+          exit 0
       - uses: pnpm/action-setup@v4
+        if: steps.check_examples_only.outputs.examples_only != 'true'
       - uses: actions/setup-node@v4
+        if: steps.check_examples_only.outputs.examples_only != 'true'
         with:
           cache: pnpm
           node-version: lts/*
 
       - name: Install project dependencies
+        if: steps.check_examples_only.outputs.examples_only != 'true'
         run: pnpm install
 
       - name: Cache Prettier
+        if: steps.check_examples_only.outputs.examples_only != 'true'
         uses: actions/cache@v4
         with:
           path: node_modules/.cache/prettier/.prettier-cache
           key: prettier-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Run format check
+        if: steps.check_examples_only.outputs.examples_only != 'true'
         run: pnpm turbo run check:format

--- a/.github/workflows/lintPr.yml
+++ b/.github/workflows/lintPr.yml
@@ -22,20 +22,53 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # needed for the --affected flag in turbo to work correctly
+      - name: Check if only examples files changed
+        id: check_examples_only
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          else
+            CHANGED_FILES=$(git diff --name-only HEAD~1)
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          EXAMPLES_ONLY="true"
+          while IFS= read -r file; do
+            if [[ ! "$file" =~ ^examples/ ]]; then
+              EXAMPLES_ONLY="false"
+              break
+            fi
+          done <<< "$CHANGED_FILES"
+
+          echo "examples_only=$EXAMPLES_ONLY" >> $GITHUB_OUTPUT
+
+      - name: Skip lint for examples-only changes
+        if: steps.check_examples_only.outputs.examples_only == 'true'
+        run: |
+          echo "Only examples files changed, skipping lint"
+          exit 0
       - uses: pnpm/action-setup@v4
+        if: steps.check_examples_only.outputs.examples_only != 'true'
       - uses: actions/setup-node@v4
+        if: steps.check_examples_only.outputs.examples_only != 'true'
         with:
           cache: pnpm
           node-version: lts/*
 
       - name: Install project dependencies
+        if: steps.check_examples_only.outputs.examples_only != 'true'
         run: pnpm install
 
       - name: Oxlint files
+        if: steps.check_examples_only.outputs.examples_only != 'true'
         run: pnpm turbo run check:oxlint -- --format github
 
       - name: Register Problem Matcher for ESLint that handles -f compact and shows warnings inline on PRs
+        if: steps.check_examples_only.outputs.examples_only != 'true'
         run: echo "::add-matcher::.github/eslint-compact.json"
 
       - name: ESLint files
+        if: steps.check_examples_only.outputs.examples_only != 'true'
         run: pnpm turbo run lint --affected --output-logs=full --continue -- -f compact

--- a/.github/workflows/typeCheck.yml
+++ b/.github/workflows/typeCheck.yml
@@ -11,16 +11,49 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check if only examples files changed
+        id: check_examples_only
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          else
+            CHANGED_FILES=$(git diff --name-only HEAD~1)
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          EXAMPLES_ONLY="true"
+          while IFS= read -r file; do
+            if [[ ! "$file" =~ ^examples/ ]]; then
+              EXAMPLES_ONLY="false"
+              break
+            fi
+          done <<< "$CHANGED_FILES"
+
+          echo "examples_only=$EXAMPLES_ONLY" >> $GITHUB_OUTPUT
+
+      - name: Skip type check for examples-only changes
+        if: steps.check_examples_only.outputs.examples_only == 'true'
+        run: |
+          echo "Only examples files changed, skipping type check"
+          exit 0
       - uses: pnpm/action-setup@v4
+        if: steps.check_examples_only.outputs.examples_only != 'true'
       - uses: actions/setup-node@v4
+        if: steps.check_examples_only.outputs.examples_only != 'true'
         with:
           cache: pnpm
           node-version: lts/*
 
       - name: Install project dependencies
+        if: steps.check_examples_only.outputs.examples_only != 'true'
         run: pnpm install
 
       - name: Check type system
+        if: steps.check_examples_only.outputs.examples_only != 'true'
         # Turbo will run type checks on all files in the project
         # and ensure that dependencies are built with @sanity/pkg-utils to output dts
         # used by other packages as they are type checked


### PR DESCRIPTION
This makes heavy workflows short-circuit when only files under examples/** change, while keeping depCheck.yml running.\n\nNotes:\n- Push-based jobs use HEAD~1 diff; PR jobs compare against base branch.\n- In this PR, examples-only check will be false (since the PR changes workflows), so jobs should run normally. After merge, PRs that only touch examples/** will skip heavy jobs.\n\nWorkflows updated:\n- formatCheck.yml, lintPr.yml, typeCheck.yml\n- e2e.yml, e2e-ct.yml, efps.yml\n- docReport.yml\n\nFollow-up: after merge, open a PR that touches only examples/** to verify skip behavior in CI.