### PR TITLE
chore: add auto-updating dev studio

### DIFF
--- a/dev/auto-updating-studio/.gitignore
+++ b/dev/auto-updating-studio/.gitignore
@@ -1,0 +1,7 @@
+/dist
+
+# Ignore generated source files
+/workshop/scopes.js
+
+.env.*
+!.env.example

--- a/dev/auto-updating-studio/package.json
+++ b/dev/auto-updating-studio/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "auto-updating-studio",
+  "version": "1.0.0",
+  "private": true,
+  "keywords": [
+    "sanity"
+  ],
+  "license": "UNLICENSED",
+  "main": "package.json",
+  "scripts": {
+    "build": "sanity build",
+    "deploy": "sanity deploy",
+    "deploy-graphql": "sanity graphql deploy",
+    "dev": "sanity dev",
+    "start": "sanity start"
+  },
+  "dependencies": {
+    "@sanity/vision": "workspace:*",
+    "react": "catalog:",
+    "sanity": "workspace:*",
+    "styled-components": "catalog:"
+  }
+}

--- a/dev/auto-updating-studio/package.json
+++ b/dev/auto-updating-studio/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "sanity"
   ],
-  "license": "UNLICENSED",
+  "license": "MIT",
   "main": "package.json",
   "scripts": {
     "build": "sanity build",

--- a/dev/auto-updating-studio/sanity.cli.ts
+++ b/dev/auto-updating-studio/sanity.cli.ts
@@ -1,0 +1,14 @@
+import {defineCliConfig} from 'sanity/cli'
+
+export default defineCliConfig({
+  api: {
+    projectId: 'ppsg7ml5',
+    dataset: 'autoupdates',
+  },
+  /**
+   * Enable auto-updates for studios.
+   * Learn more at https://www.sanity.io/docs/cli#auto-updates
+   */
+  autoUpdates: true,
+  studioHost: 'auto-updating-test',
+})

--- a/dev/auto-updating-studio/sanity.config.ts
+++ b/dev/auto-updating-studio/sanity.config.ts
@@ -1,0 +1,18 @@
+import {defineConfig} from 'sanity'
+import {structureTool} from 'sanity/structure'
+import {visionTool} from '@sanity/vision'
+import {schemaTypes} from './schemaTypes'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Auto Updating Studios Test',
+
+  projectId: 'ppsg7ml5',
+  dataset: 'autoupdates',
+
+  plugins: [structureTool(), visionTool()],
+
+  schema: {
+    types: schemaTypes,
+  },
+})

--- a/dev/auto-updating-studio/schemaTypes/index.ts
+++ b/dev/auto-updating-studio/schemaTypes/index.ts
@@ -1,0 +1,1 @@
+export const schemaTypes = []

--- a/dev/auto-updating-studio/static/.gitkeep
+++ b/dev/auto-updating-studio/static/.gitkeep
@@ -1,0 +1,1 @@
+Files placed here will be served by the Sanity server under the `/static`-prefix

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,21 @@ importers:
         specifier: ^10.0.0
         version: 10.0.1
 
+  dev/auto-updating-studio:
+    dependencies:
+      '@sanity/vision':
+        specifier: workspace:*
+        version: link:../../packages/@sanity/vision
+      react:
+        specifier: 'catalog:'
+        version: 19.1.1
+      sanity:
+        specifier: workspace:*
+        version: link:../../packages/sanity
+      styled-components:
+        specifier: 'catalog:'
+        version: 6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+
   dev/depcheck-test: {}
 
   dev/design-studio:


### PR DESCRIPTION
Adds a dev/testing studio for auto updates so we have a canonical example project to look at during development.