### PR TITLE
feat: adding chips to release summary to show count of release actions

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -1,7 +1,7 @@
 import {type ReleaseDocument, type SanityDocument} from '@sanity/client'
 import {AddIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Card, Container, useToast} from '@sanity/ui'
+import {Card, Container, Stack, useToast} from '@sanity/ui'
 import {type RefObject, useCallback, useEffect, useMemo, useState} from 'react'
 
 import {Button} from '../../../../ui-components'
@@ -14,6 +14,7 @@ import {useReleaseOperations} from '../../store/useReleaseOperations'
 import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
 import {Table} from '../components/Table/Table'
 import {AddDocumentSearch, type AddedDocument} from './AddDocumentSearch'
+import {ReleaseActionBadges} from './components/ReleaseActionBadges'
 import {DocumentActions} from './documentTable/DocumentActions'
 import {getDocumentTableColumnDefs} from './documentTable/DocumentTableColumnDefs'
 import {type DocumentHistory} from './documentTable/useReleaseHistory'
@@ -175,7 +176,6 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
 
   return (
     <Card
-      borderTop
       data-testid="document-table-card"
       ref={scrollContainerRef}
       style={{
@@ -186,18 +186,21 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
       }}
       className="hide-scrollbar"
     >
-      <Table<DocumentWithHistory>
-        loading={isLoading}
-        data={tableData}
-        emptyState={t('summary.no-documents')}
-        // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
-        rowId="document._id"
-        columnDefs={documentTableColumnDefs}
-        rowActions={renderRowActions}
-        searchFilter={filterRows}
-        scrollContainerRef={scrollContainerRef}
-        defaultSort={{column: 'search', direction: 'asc'}}
-      />
+      <Stack>
+        <ReleaseActionBadges documents={tableData} releaseState={release.state} />
+        <Table<DocumentWithHistory>
+          loading={isLoading}
+          data={tableData}
+          emptyState={t('summary.no-documents')}
+          // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
+          rowId="document._id"
+          columnDefs={documentTableColumnDefs}
+          rowActions={renderRowActions}
+          searchFilter={filterRows}
+          scrollContainerRef={scrollContainerRef}
+          defaultSort={{column: 'search', direction: 'asc'}}
+        />
+      </Stack>
       {release.state === 'active' && (
         <Container width={3}>
           <Card padding={3}>

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -188,18 +188,20 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
     >
       <Stack>
         <ReleaseActionBadges documents={tableData} releaseState={release.state} />
-        <Table<DocumentWithHistory>
-          loading={isLoading}
-          data={tableData}
-          emptyState={t('summary.no-documents')}
-          // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
-          rowId="document._id"
-          columnDefs={documentTableColumnDefs}
-          rowActions={renderRowActions}
-          searchFilter={filterRows}
-          scrollContainerRef={scrollContainerRef}
-          defaultSort={{column: 'search', direction: 'asc'}}
-        />
+        <Card borderTop>
+          <Table<DocumentWithHistory>
+            loading={isLoading}
+            data={tableData}
+            emptyState={t('summary.no-documents')}
+            // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
+            rowId="document._id"
+            columnDefs={documentTableColumnDefs}
+            rowActions={renderRowActions}
+            searchFilter={filterRows}
+            scrollContainerRef={scrollContainerRef}
+            defaultSort={{column: 'search', direction: 'asc'}}
+          />
+        </Card>
       </Stack>
       {release.state === 'active' && (
         <Container width={3}>

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -187,7 +187,11 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
       className="hide-scrollbar"
     >
       <Stack>
-        <ReleaseActionBadges documents={tableData} releaseState={release.state} />
+        <ReleaseActionBadges
+          documents={tableData}
+          releaseState={release.state}
+          isLoading={isLoading}
+        />
         <Card borderTop>
           <Table<DocumentWithHistory>
             loading={isLoading}

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
@@ -316,7 +316,7 @@ describe('ReleaseSummary', () => {
 
       const [firstDocumentRow] = screen.getAllByTestId('table-row')
 
-      expect(within(firstDocumentRow).getByTestId('change-badge-123')).toBeInTheDocument()
+      expect(within(firstDocumentRow).getByTestId('changed-badge-123')).toBeInTheDocument()
     })
 
     it('should show `add` if a document is not published and is not scheduled for unpublishing', async () => {
@@ -337,7 +337,7 @@ describe('ReleaseSummary', () => {
 
       const [firstDocumentRow] = screen.getAllByTestId('table-row')
 
-      expect(within(firstDocumentRow).getByTestId('add-badge-123')).toBeInTheDocument()
+      expect(within(firstDocumentRow).getByTestId('added-badge-123')).toBeInTheDocument()
     })
   })
 })

--- a/packages/sanity/src/core/releases/tool/detail/components/ReleaseActionBadges.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/components/ReleaseActionBadges.tsx
@@ -1,6 +1,6 @@
 import {type ReleaseState} from '@sanity/client'
-import {Badge, Box, Container, Flex} from '@sanity/ui'
-import {useMemo} from 'react'
+import {Badge, Box, Container, Flex, Skeleton} from '@sanity/ui'
+import {type ReactNode, useMemo} from 'react'
 
 import {useTranslation} from '../../../../i18n'
 import {releasesLocaleNamespace} from '../../../i18n'
@@ -10,9 +10,24 @@ import {type DocumentWithHistory} from '../ReleaseSummary'
 interface ReleaseActionBadgesProps {
   documents: DocumentWithHistory[]
   releaseState: ReleaseState
+  isLoading?: boolean
 }
 
-export function ReleaseActionBadges({documents, releaseState}: ReleaseActionBadgesProps) {
+const BadgesContainer = ({children}: {children: ReactNode}) => (
+  <Container width={3}>
+    <Box padding={3}>
+      <Flex align="center" gap={4} wrap="wrap">
+        {children}
+      </Flex>
+    </Box>
+  </Container>
+)
+
+export function ReleaseActionBadges({
+  documents,
+  releaseState,
+  isLoading = false,
+}: ReleaseActionBadgesProps) {
   const {t} = useTranslation(releasesLocaleNamespace)
 
   const actionCounts = useMemo(
@@ -31,26 +46,39 @@ export function ReleaseActionBadges({documents, releaseState}: ReleaseActionBadg
   )
 
   // Hide action badges for archived and published releases (same logic as table columns)
-  if (releaseState === 'archived' || releaseState === 'published' || !documents.length) {
-    return null
+  if (releaseState === 'archived' || releaseState === 'published') return null
+
+  if (isLoading) {
+    return (
+      <BadgesContainer>
+        {DOCUMENT_ACTION_CONFIGS.map(({key}) => (
+          <Skeleton
+            key={`skeleton-action-badge-${key}`}
+            animated
+            style={{width: '60px', height: '10px'}}
+            radius={2}
+            paddingX={3}
+            paddingY={2}
+          />
+        ))}
+      </BadgesContainer>
+    )
   }
 
-  return (
-    <Container width={3}>
-      <Box padding={3}>
-        <Flex align="center" gap={4} wrap="wrap">
-          {DOCUMENT_ACTION_CONFIGS.map(({key, tone, translationKey}) => {
-            const count = actionCounts[key]
-            if (count === 0) return null
+  if (!documents.length) return null
 
-            return (
-              <Badge key={key} paddingX={3} paddingY={2} radius={2} tone={tone}>
-                {t(translationKey)} {count}
-              </Badge>
-            )
-          })}
-        </Flex>
-      </Box>
-    </Container>
+  return (
+    <BadgesContainer>
+      {DOCUMENT_ACTION_CONFIGS.map(({key, tone, translationKey}) => {
+        const count = actionCounts[key]
+        if (count === 0) return null
+
+        return (
+          <Badge key={key} paddingX={3} paddingY={2} radius={2} tone={tone}>
+            {t(translationKey)} {count}
+          </Badge>
+        )
+      })}
+    </BadgesContainer>
   )
 }

--- a/packages/sanity/src/core/releases/tool/detail/components/ReleaseActionBadges.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/components/ReleaseActionBadges.tsx
@@ -1,0 +1,56 @@
+import {type ReleaseState} from '@sanity/client'
+import {Badge, Box, Container, Flex} from '@sanity/ui'
+import {useMemo} from 'react'
+
+import {useTranslation} from '../../../../i18n'
+import {releasesLocaleNamespace} from '../../../i18n'
+import {DOCUMENT_ACTION_CONFIGS, getDocumentActionType} from '../releaseDocumentActions'
+import {type DocumentWithHistory} from '../ReleaseSummary'
+
+interface ReleaseActionBadgesProps {
+  documents: DocumentWithHistory[]
+  releaseState: ReleaseState
+}
+
+export function ReleaseActionBadges({documents, releaseState}: ReleaseActionBadgesProps) {
+  const {t} = useTranslation(releasesLocaleNamespace)
+
+  const actionCounts = useMemo(
+    () =>
+      documents.reduce(
+        (counts, doc) => {
+          const actionType = getDocumentActionType(doc)
+          if (actionType) {
+            counts[actionType]++
+          }
+          return counts
+        },
+        {added: 0, changed: 0, unpublished: 0},
+      ),
+    [documents],
+  )
+
+  // Hide action badges for archived and published releases (same logic as table columns)
+  if (releaseState === 'archived' || releaseState === 'published' || !documents.length) {
+    return null
+  }
+
+  return (
+    <Container width={3}>
+      <Box padding={3}>
+        <Flex align="center" gap={4} wrap="wrap">
+          {DOCUMENT_ACTION_CONFIGS.map(({key, tone, translationKey}) => {
+            const count = actionCounts[key]
+            if (count === 0) return null
+
+            return (
+              <Badge key={key} paddingX={3} paddingY={2} radius={2} tone={tone}>
+                {t(translationKey)} {count}
+              </Badge>
+            )
+          })}
+        </Flex>
+      </Box>
+    </Container>
+  )
+}

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -11,10 +11,10 @@ import {UserAvatar} from '../../../../components'
 import {RelativeTime} from '../../../../components/RelativeTime'
 import {useSchema} from '../../../../hooks'
 import {SanityDefaultPreview} from '../../../../preview/components/SanityDefaultPreview'
-import {isGoingToUnpublish} from '../../../util/isGoingToUnpublish'
 import {ReleaseDocumentPreview} from '../../components/ReleaseDocumentPreview'
 import {Headers} from '../../components/Table/TableHeader'
 import {type Column} from '../../components/Table/types'
+import {getDocumentActionType, getReleaseDocumentActionConfig} from '../releaseDocumentActions'
 import {type BundleDocumentRow} from '../ReleaseSummary'
 import {type DocumentInRelease} from '../useBundleDocuments'
 
@@ -66,27 +66,19 @@ const documentActionColumn: (t: TFunction<'releases', undefined>) => Column<Bund
   ),
   cell: ({cellProps, datum}) => {
     const actionBadge = () => {
-      if (datum.isPending || datum.isLoading) return null
+      const actionType = getDocumentActionType(datum)
+      if (!actionType) return null
 
-      const willBeUnpublished = isGoingToUnpublish(datum.document)
-      if (willBeUnpublished) {
-        return (
-          <Badge radius={2} tone={'critical'} data-testid={`unpublish-badge-${datum.document._id}`}>
-            {t('table-body.action.unpublish')}
-          </Badge>
-        )
-      }
-      if (datum.document.publishedDocumentExists) {
-        return (
-          <Badge radius={2} tone={'caution'} data-testid={`change-badge-${datum.document._id}`}>
-            {t('table-body.action.change')}
-          </Badge>
-        )
-      }
+      const documentActionConfig = getReleaseDocumentActionConfig(actionType)
+      if (!documentActionConfig) return null
 
       return (
-        <Badge radius={2} tone={'positive'} data-testid={`add-badge-${datum.document._id}`}>
-          {t('table-body.action.add')}
+        <Badge
+          radius={2}
+          tone={documentActionConfig.tone}
+          data-testid={`${actionType}-badge-${datum.document._id}`}
+        >
+          {t(documentActionConfig.translationKey)}
         </Badge>
       )
     }

--- a/packages/sanity/src/core/releases/tool/detail/releaseDocumentActions.ts
+++ b/packages/sanity/src/core/releases/tool/detail/releaseDocumentActions.ts
@@ -1,0 +1,54 @@
+import {isGoingToUnpublish} from '../../util/isGoingToUnpublish'
+import {type BundleDocumentRow, type DocumentWithHistory} from './ReleaseSummary'
+
+export interface DocumentActionConfig {
+  key: 'added' | 'changed' | 'unpublished'
+  tone: 'positive' | 'caution' | 'critical'
+  translationKey: string
+}
+
+export const DOCUMENT_ACTION_CONFIGS: DocumentActionConfig[] = [
+  {
+    key: 'added',
+    tone: 'positive',
+    translationKey: 'table-body.action.add',
+  },
+  {
+    key: 'changed',
+    tone: 'caution',
+    translationKey: 'table-body.action.change',
+  },
+  {
+    key: 'unpublished',
+    tone: 'critical',
+    translationKey: 'table-body.action.unpublish',
+  },
+]
+
+/**
+ * Determines the action type for a document based on its state
+ */
+export function getDocumentActionType(
+  document: DocumentWithHistory | BundleDocumentRow,
+): DocumentActionConfig['key'] | null {
+  if (!document.document || document.isPending || document.previewValues?.isLoading) {
+    return null
+  }
+
+  const willBeUnpublished = isGoingToUnpublish(document.document)
+  if (willBeUnpublished) {
+    return 'unpublished'
+  }
+
+  if (document.document.publishedDocumentExists) {
+    return 'changed'
+  }
+
+  return 'added'
+}
+
+export function getReleaseDocumentActionConfig(
+  actionType: DocumentActionConfig['key'],
+): DocumentActionConfig | undefined {
+  return DOCUMENT_ACTION_CONFIGS.find(({key}) => key === actionType)
+}


### PR DESCRIPTION
### Description
<img width="1912" height="1644" alt="Screenshot 2025-08-08 at 19 18 00" src="https://github.com/user-attachments/assets/bdcaf61a-599a-4f55-9929-e191462caca5" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Releases now show a summary count of all documents, group by action in the release.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
