### PR TITLE
refactor: filter out video assets when exporting media library assets

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/media/exportAssetsAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/media/exportAssetsAction.ts
@@ -64,6 +64,12 @@ const exportAssetsAction: CliCommandAction<ExportAssetsFlags> = async (args, con
         if (typeof doc !== 'object' || doc === null || !('aspects' in doc)) {
           return false
         }
+
+        // Filter out video assets (we dont have access to the raw video file for now)
+        if ('assetType' in doc && doc.assetType === 'sanity.videoAsset') {
+          return false
+        }
+
         return (
           typeof doc.aspects === 'object' &&
           doc.aspects !== null &&

--- a/packages/sanity/src/_internal/cli/commands/media/exportMediaCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/media/exportMediaCommand.ts
@@ -5,7 +5,7 @@ Options
   --media-library-id The id of the target media library.
 
 Examples
-  # Export all assets and aspects.
+  # Export all file and image assets including their aspects.
   sanity media export
 `
 
@@ -17,7 +17,8 @@ const exportMediaCommand: CliCommandDefinition<MediaFlags> = {
   name: 'export',
   group: 'media',
   signature: '[FILE]',
-  description: 'Export an archive of all assets and aspect data from the target media library.',
+  description:
+    'Export an archive of all file and image assets including their aspect data from the target media library.',
   helpText,
   action: async (args, context) => {
     const mod = await import('../../actions/media/exportAssetsAction')


### PR DESCRIPTION
### Description

This change filters out video assets when exporting assets and asset documents from an Media Library with the `sanity media export` CLI command. The background for this is that we currently don't store the the source video files, and so we can't download the original when exporting.

Documentation has been updated to mention this caveat.

Fixes SAPP-2947

### What to review

- That the video assets are skipped when exporting

### Testing

Test by running the [CLI command](https://www.sanity.io/docs/media-library/media#d799c241f960) `sanity media export`

### Notes for release

- N/a