### PR TITLE
chore(cli): bump sanity dep to ^4 for app templates

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/templates/appQuickstart.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/appQuickstart.ts
@@ -9,7 +9,7 @@ const appTemplate: ProjectTemplate = {
   },
   devDependencies: {
     '@types/react': '^19',
-    'sanity': '^3',
+    'sanity': '^4',
     'typescript': '^5.1.6',
   },
   entry: './src/App.tsx',

--- a/packages/@sanity/cli/src/actions/init-project/templates/appSanityUi.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/appSanityUi.ts
@@ -11,7 +11,7 @@ const appSanityUiTemplate: ProjectTemplate = {
   },
   devDependencies: {
     '@types/react': '^19',
-    'sanity': '^3',
+    'sanity': '^4',
     'typescript': '^5.1.6',
   },
   entry: './src/App.tsx',


### PR DESCRIPTION
### Description

Updates the `sanity` dependency to `^4` for Sanity app templates.

### What to review

- The new `sanity` dependency is specified as the latest version (v4)

### Testing

- Verified the correct version was installed when init'ing new apps using both templates

### Notes for release

- None, internal
