### PR TITLE
fix(cli): `@date-fns/tz` crashing manifest extract

### DIFF
--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -115,8 +115,8 @@
     "watch": "pkg-utils watch"
   },
   "dependencies": {
-    "@date-fns/tz": "^1.2.0",
-    "@date-fns/utc": "^2.1.0",
+    "@date-fns/tz": "1.3.1",
+    "@date-fns/utc": "^2.1.1",
     "@sanity/client": "^7.8.2",
     "@sanity/types": "workspace:*",
     "date-fns": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1407,11 +1407,11 @@ importers:
   packages/@sanity/util:
     dependencies:
       '@date-fns/tz':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: 1.3.1
+        version: 1.3.1
       '@date-fns/utc':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.1.1
+        version: 2.1.1
       '@sanity/client':
         specifier: ^7.8.2
         version: 7.8.2(debug@4.4.1)
@@ -3098,11 +3098,11 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@date-fns/tz@1.2.0':
-    resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
+  '@date-fns/tz@1.3.1':
+    resolution: {integrity: sha512-LnBOyuj+piItX/D5BWBSckBsuZyOt7Jg2obGNiObq7qjl1A2/8F+i4RS8/MmkSdnw6hOe6afrJLCWrUWZw5Mlw==}
 
-  '@date-fns/utc@2.1.0':
-    resolution: {integrity: sha512-176grgAgU2U303rD2/vcOmNg0kGPbhzckuH1TEP2al7n0AQipZIy9P15usd2TKQCG1g+E1jX/ZVQSzs4sUDwgA==}
+  '@date-fns/utc@2.1.1':
+    resolution: {integrity: sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -13476,9 +13476,9 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@date-fns/tz@1.2.0': {}
+  '@date-fns/tz@1.3.1': {}
 
-  '@date-fns/utc@2.1.0': {}
+  '@date-fns/utc@2.1.1': {}
 
   '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
     dependencies:
@@ -16158,8 +16158,8 @@ snapshots:
 
   '@sanity/util@3.99.0(@types/react@19.1.9)':
     dependencies:
-      '@date-fns/tz': 1.2.0
-      '@date-fns/utc': 2.1.0
+      '@date-fns/tz': 1.3.1
+      '@date-fns/utc': 2.1.1
       '@sanity/client': 7.8.2(debug@4.4.1)
       '@sanity/types': 3.99.0(@types/react@19.1.9)(debug@4.4.1)
       date-fns: 4.1.0


### PR DESCRIPTION
### Description

Works around an issue where `@date-fns/tz` started shipping [broken CJS yesterday](https://npmdiff.dev/%40date-fns%2Ftz/1.3.1/1.4.0/package/package.json/).

```diff
 {
   "name": "@date-fns/tz",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "date-fns timezone utils",
   "type": "module",
-  "main": "index.cjs",
-  "module": "index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "require": {
         "types": "./index.d.cts",
-        "default": "./index.cjs"
+        "default": ""
```

It leads to [crashes like this](https://vercel.com/sanity-sandbox/template-nextjs-personal-website/2T6p3DZ3KRPZ9B4RRKvGumW455Hm?filter=errors):
``bash
- Extracting manifest
✗ Invalid "exports" main target "" defined in the package config /vercel/path0/node_modules/@date-fns/tz/package.json
Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" main target "" defined in the package config /vercel/path0/node_modules/@date-fns/tz/package.json

```

### What to review

Makes sense?

### Testing

If CLI tests pass we're good.

### Notes for release

Fixes an issue causing the `sanity manifest extract` cli command to crash with an `ERR_INVALID_PACKAGE_TARGET` error:
```bash
✗ Invalid "exports" main target "" defined in the package config /node_modules/@date-fns/tz/package.json
Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" main target "" defined in the package config /node_modules/@date-fns/tz/package.json
```
We've pinned `@date-fns/tz` to `v1.3.1` while we wait for a fix for `1.4.x`.
