### PR TITLE
fix(presentation): send presentation/refresh events for version documents changes

### DIFF
--- a/packages/sanity/src/presentation/editor/PostMessageRefreshMutations.tsx
+++ b/packages/sanity/src/presentation/editor/PostMessageRefreshMutations.tsx
@@ -1,5 +1,5 @@
 import {memo, startTransition, useEffect, useMemo, useState} from 'react'
-import {getPublishedId, type SanityDocument, useEditState} from 'sanity'
+import {getPublishedId, type SanityDocument, useEditState, usePerspective} from 'sanity'
 
 import {type ConnectionStatus, type VisualEditingConnection} from '../types'
 
@@ -14,7 +14,8 @@ export interface PostMessageRefreshMutationsProps {
 function PostMessageRefreshMutations(props: PostMessageRefreshMutationsProps): React.ReactNode {
   const {comlink, type, previewKitConnection, loadersConnection} = props
   const id = useMemo(() => getPublishedId(props.id), [props.id])
-  const {draft, published, ready} = useEditState(id, type, 'low')
+  const {selectedReleaseId} = usePerspective()
+  const {draft, published, ready, version} = useEditState(id, type, 'low', selectedReleaseId)
   const livePreviewEnabled =
     previewKitConnection === 'connected' || loadersConnection === 'connected'
 
@@ -26,6 +27,7 @@ function PostMessageRefreshMutations(props: PostMessageRefreshMutationsProps): R
         draft={draft}
         livePreviewEnabled={livePreviewEnabled}
         published={published}
+        version={version}
       />
     )
   }
@@ -38,13 +40,25 @@ interface PostMessageRefreshMutationsInnerProps
   livePreviewEnabled: boolean
   draft: SanityDocument | null
   published: SanityDocument | null
+  version: SanityDocument | null
 }
 function PostMessageRefreshMutationsInner(props: PostMessageRefreshMutationsInnerProps) {
-  const {comlink, draft, published, livePreviewEnabled} = props
+  const {comlink, draft, published, livePreviewEnabled, version} = props
   const [prevDraft, setPrevDraft] = useState(draft)
   const [prevPublished, setPrevPublished] = useState(published)
+  const [prevVersion, setPrevVersion] = useState(version)
 
   useEffect(() => {
+    if (prevVersion?._rev !== version?._rev) {
+      startTransition(() => setPrevVersion(version))
+      if (version) {
+        comlink?.post('presentation/refresh', {
+          source: 'mutation',
+          livePreviewEnabled,
+          document: parseDocument(version),
+        })
+      }
+    }
     if (prevDraft?._rev !== draft?._rev) {
       startTransition(() => setPrevDraft(draft))
       if (draft) {
@@ -65,7 +79,16 @@ function PostMessageRefreshMutationsInner(props: PostMessageRefreshMutationsInne
         })
       }
     }
-  }, [comlink, draft, livePreviewEnabled, prevDraft?._rev, prevPublished?._rev, published])
+  }, [
+    comlink,
+    draft,
+    livePreviewEnabled,
+    prevDraft?._rev,
+    prevPublished?._rev,
+    published,
+    prevVersion?._rev,
+    version,
+  ])
 
   return null
 }


### PR DESCRIPTION
### Description
Fixes an issue in where presentation was not refreshing the documents values on changes for version documents. 


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in where presentation was not refreshing the documents values on changes for version documents. 

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
