### PR TITLE
fix(sanity): unexpected type narrowing when array passed to `defineConfig`

### DIFF
--- a/packages/sanity/src/core/config/defineConfig.ts
+++ b/packages/sanity/src/core/config/defineConfig.ts
@@ -3,7 +3,7 @@ import {type Config} from './types'
 /**
  * @hidden
  * @beta */
-export function defineConfig<T extends Config>(config: T): T {
+export function defineConfig<const T extends Config>(config: T): T {
   return config
 }
 
@@ -13,6 +13,6 @@ export function defineConfig<T extends Config>(config: T): T {
  * @hidden
  * @beta
  */
-export function createConfig<T extends Config>(config: T): T {
+export function createConfig<const T extends Config>(config: T): T {
   return defineConfig(config)
 }


### PR DESCRIPTION
### Description

While adding a new `boolean` configuration option to Studio, I noticed an odd behaviour when providing an array of workspaces to `defineConfig`. When setting the boolean option to `false`, TypeScript seemed to narrow the allowed type to `false`, yielding this type error:

```
The types of <some boolean option> are incompatible between these types. Type 'boolean' is not assignable to type 'false'. (ts2322)
``` 

<img width="718" height="477" alt="Screenshot 2025-08-12 at 15 13 42" src="https://github.com/user-attachments/assets/366db762-d9b6-42c2-b8f3-1fe9429de77a" />

Bizarrely, this issue only seems to manifest when passing an array of four items or longer to `defineConfig`, regardless of the content of the items.

One way to fix this in userland is to cast the value to a constant:

```
 defineConfig([
  {
    someBooleanOption: false as const
  },
  // ...
```

<img width="310" height="310" alt="Screenshot 2025-08-12 at 15 14 05" src="https://github.com/user-attachments/assets/7524ab50-51b0-45f7-b804-8720c8dc76d4" />

However, we can solve this for our users by making `defineConfig`'s configuration type parameter constant.

### What to review

The `defineConfig` helper. Are there any negative consequences to making the type parameter constant?