### PR TITLE
chore(cli): skip sanity tokens tests

### DIFF
--- a/packages/@sanity/cli/test/tokens.test.ts
+++ b/packages/@sanity/cli/test/tokens.test.ts
@@ -1,9 +1,9 @@
 import {describe, expect} from 'vitest'
 
-import {describeCliTest, testConcurrent} from './shared/describe'
+import {testConcurrent} from './shared/describe'
 import {getTestRunArgs, runSanityCmdCommand, studioVersions} from './shared/environment'
 
-describeCliTest('CLI: `sanity tokens`', () => {
+describe.skip('CLI: `sanity tokens`', () => {
   describe.each(studioVersions)('%s', (version) => {
     const testRunArgs = getTestRunArgs(version)
     const testId = Math.random().toString(36).slice(2, 15)


### PR DESCRIPTION
### Description
Skipping tests because they are failing when running with the test runner.
Running it locally by triggering the commands with the terminal the action works as expected.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
