### PR TITLE
fix: long release titles in open release to edit banner correctly flexed

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/OpenReleaseToEditBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/OpenReleaseToEditBanner.tsx
@@ -14,7 +14,6 @@ import {
   VersionInlineBadge,
 } from 'sanity'
 
-import {Button} from '../../../../../ui-components'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {Banner} from './Banner'
 
@@ -82,44 +81,41 @@ export function OpenReleaseToEditBannerInner({
   return (
     <Banner
       tone={tone}
-      paddingY={0}
       data-testid="open-release-to-edit-banner"
       content={
-        <Flex direction={'row'} align="center" justify="space-between" flex={1}>
-          <Text size={1}>
-            <Flex direction={'row'} gap={1}>
-              {documentVersionsTitleList.length > 1 ? (
-                <Translate
-                  t={t}
-                  i18nKey="banners.release.navigate-to-edit-description-multiple"
-                  components={{
-                    VersionBadge: () => (
-                      <VersionInlineBadge> {documentVersionsTitleList[0]}</VersionInlineBadge>
-                    ),
-                  }}
-                  values={{count: documentVersionsTitleList.length - 1}}
-                />
-              ) : (
-                <Translate
-                  t={t}
-                  i18nKey="banners.release.navigate-to-edit-description-single"
-                  components={{
-                    VersionBadge: () => (
-                      <VersionInlineBadge> {documentVersionsTitleList[0]}</VersionInlineBadge>
-                    ),
-                  }}
-                />
-              )}
-            </Flex>
-          </Text>
-
-          <Button
-            text={t('banners.release.action.open-to-edit')}
-            tone={tone}
-            onClick={handleGoToEdit}
-          />
-        </Flex>
+        <Text size={1}>
+          <Flex direction={'row'} gap={1} wrap="wrap">
+            {documentVersionsTitleList.length > 1 ? (
+              <Translate
+                t={t}
+                i18nKey="banners.release.navigate-to-edit-description-multiple"
+                components={{
+                  VersionBadge: () => (
+                    <VersionInlineBadge> {documentVersionsTitleList[0]}</VersionInlineBadge>
+                  ),
+                }}
+                values={{count: documentVersionsTitleList.length - 1}}
+              />
+            ) : (
+              <Translate
+                t={t}
+                i18nKey="banners.release.navigate-to-edit-description-single"
+                components={{
+                  VersionBadge: () => (
+                    <VersionInlineBadge> {documentVersionsTitleList[0]}</VersionInlineBadge>
+                  ),
+                }}
+              />
+            )}
+          </Flex>
+        </Text>
       }
+      action={{
+        text: t('banners.release.action.open-to-edit'),
+        tone: tone,
+        onClick: handleGoToEdit,
+        mode: 'default',
+      }}
     />
   )
 }


### PR DESCRIPTION
### Description
| Before | After |
|--------|--------|
| <img width="533" height="68" alt="Screenshot 2025-08-13 at 16 08 56" src="https://github.com/user-attachments/assets/2911d32e-672b-4b21-a922-193ffd08cdff" /> | <img width="551" height="81" alt="Screenshot 2025-08-13 at 16 08 26" src="https://github.com/user-attachments/assets/3cb31617-8727-46ff-a9cb-a8f73ecd0c64" /> |

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
1. Open up a release perspective
2. Create a new document in this release
3. Change to draft perspective
4. See the banner at the top of the document
5. Reduce the width of the document pane -> see that the banner splits text awkwardly
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue where text in document pane banners would split on narrow screens.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
