### PR TITLE
feat: add schedule publish and unpublish noop actions for draft documents

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -24,6 +24,13 @@ const releasesLocaleStrings = {
   'action.open': 'Active',
   /** Action text for scheduling a release */
   'action.schedule': 'Schedule release...',
+  /** Action text for scheduling publish of a draft document */
+  'action.schedule-publish': 'Schedule Publish',
+  /** Action text for scheduling unpublish of a draft document */
+  'action.schedule-unpublish': 'Schedule Unpublish',
+  /** Tooltip text for when schedule unpublish is disabled because document is not published */
+  'action.schedule-unpublish.disabled.not-published':
+    'Document must be published to schedule unpublish',
   /** Action text for unpublishing a document in a release in the context menu */
   'action.unpublish': 'Unpublish',
   /** Action message for scheduling an unpublished of a document  */

--- a/packages/sanity/src/core/releases/plugin/documentActions/SchedulePublishAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/SchedulePublishAction.tsx
@@ -19,7 +19,8 @@ export const SchedulePublishAction: DocumentActionComponent = (
   const {t} = useTranslation(releasesLocaleNamespace)
 
   const handleSchedulePublish = useCallback(() => {
-    console.log('Schedule publish action triggered for document ID:', id)
+    // eslint-disable-next-line no-alert
+    alert(`Schedule publish action triggered for document ID: ${id}`)
   }, [id])
 
   return {

--- a/packages/sanity/src/core/releases/plugin/documentActions/SchedulePublishAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/SchedulePublishAction.tsx
@@ -1,0 +1,36 @@
+import {CalendarIcon} from '@sanity/icons'
+import {useCallback} from 'react'
+
+import {
+  type DocumentActionComponent,
+  type DocumentActionDescription,
+  type DocumentActionProps,
+} from '../../../config/document/actions'
+import {useTranslation} from '../../../i18n'
+import {releasesLocaleNamespace} from '../../i18n'
+
+/**
+ * @internal
+ */
+export const SchedulePublishAction: DocumentActionComponent = (
+  props: DocumentActionProps,
+): DocumentActionDescription | null => {
+  const {id} = props
+  const {t} = useTranslation(releasesLocaleNamespace)
+
+  const handleSchedulePublish = useCallback(() => {
+    // eslint-disable-next-line no-console
+    console.log('Schedule publish action triggered for document ID:', id)
+  }, [id])
+
+  return {
+    disabled: false,
+    icon: CalendarIcon,
+    label: t('action.schedule-publish'),
+    title: t('action.schedule-publish'),
+    onHandle: handleSchedulePublish,
+  }
+}
+
+SchedulePublishAction.action = 'schedule'
+SchedulePublishAction.displayName = 'SchedulePublishAction'

--- a/packages/sanity/src/core/releases/plugin/documentActions/SchedulePublishAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/SchedulePublishAction.tsx
@@ -19,7 +19,6 @@ export const SchedulePublishAction: DocumentActionComponent = (
   const {t} = useTranslation(releasesLocaleNamespace)
 
   const handleSchedulePublish = useCallback(() => {
-    // eslint-disable-next-line no-console
     console.log('Schedule publish action triggered for document ID:', id)
   }, [id])
 

--- a/packages/sanity/src/core/releases/plugin/documentActions/ScheduleUnpublishAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/ScheduleUnpublishAction.tsx
@@ -20,7 +20,8 @@ export const ScheduleUnpublishAction: DocumentActionComponent = (
   const isPublished = published !== null
 
   const handleScheduleUnpublish = useCallback(() => {
-    console.warn('Schedule unpublish action triggered for document ID:', id)
+    // eslint-disable-next-line no-alert
+    alert(`Schedule unpublish action triggered for document ID: ${id}`)
   }, [id])
 
   return {

--- a/packages/sanity/src/core/releases/plugin/documentActions/ScheduleUnpublishAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/ScheduleUnpublishAction.tsx
@@ -1,0 +1,37 @@
+import {UnpublishIcon} from '@sanity/icons'
+import {useCallback} from 'react'
+
+import {
+  type DocumentActionComponent,
+  type DocumentActionDescription,
+  type DocumentActionProps,
+} from '../../../config/document/actions'
+import {useTranslation} from '../../../i18n'
+import {releasesLocaleNamespace} from '../../i18n'
+
+/**
+ * @internal
+ */
+export const ScheduleUnpublishAction: DocumentActionComponent = (
+  props: DocumentActionProps,
+): DocumentActionDescription | null => {
+  const {id, published} = props
+  const {t} = useTranslation(releasesLocaleNamespace)
+  const isPublished = published !== null
+
+  const handleScheduleUnpublish = useCallback(() => {
+    console.warn('Schedule unpublish action triggered for document ID:', id)
+  }, [id])
+
+  return {
+    disabled: !isPublished,
+    tone: 'critical',
+    icon: UnpublishIcon,
+    label: t('action.schedule-unpublish'),
+    title: isPublished ? undefined : t('action.schedule-unpublish.disabled.not-published'),
+    onHandle: handleScheduleUnpublish,
+  }
+}
+
+ScheduleUnpublishAction.action = 'schedule'
+ScheduleUnpublishAction.displayName = 'ScheduleUnpublishAction'

--- a/packages/sanity/src/core/releases/plugin/documentActions/index.ts
+++ b/packages/sanity/src/core/releases/plugin/documentActions/index.ts
@@ -18,7 +18,7 @@ export default function resolveDocumentActions(
   }
 
   // Add SchedulePublishAction and ScheduleUnpublishAction only for draft documents
-  if (context.versionType === 'draft') {
+  if (context.__internal_releasesEnabled && context.versionType === 'draft') {
     const actionsExcludingOriginalSchedule = existingActions.filter(
       ({action}) => action !== 'schedule',
     )

--- a/packages/sanity/src/core/releases/plugin/documentActions/index.ts
+++ b/packages/sanity/src/core/releases/plugin/documentActions/index.ts
@@ -1,5 +1,5 @@
 import {type DocumentActionComponent} from '../../../config/document/actions'
-import {type DocumentActionsContext} from '../../../config/types'
+import {type DocumentActionsContext, QUOTA_EXCLUDED_RELEASES_ENABLED} from '../../../config/types'
 import {DiscardVersionAction} from './DiscardVersionAction'
 import {SchedulePublishAction} from './SchedulePublishAction'
 import {ScheduleUnpublishAction} from './ScheduleUnpublishAction'
@@ -17,8 +17,10 @@ export default function resolveDocumentActions(
     return duplicateAction.concat(DiscardVersionAction, UnpublishVersionAction)
   }
 
+  const isQuotaExcludedReleaseEnabled = context[QUOTA_EXCLUDED_RELEASES_ENABLED]
+
   // Add SchedulePublishAction and ScheduleUnpublishAction only for draft documents
-  if (context.__internal_releasesEnabled && context.versionType === 'draft') {
+  if (isQuotaExcludedReleaseEnabled && context.versionType === 'draft') {
     const actionsExcludingOriginalSchedule = existingActions.filter(
       ({action}) => action !== 'schedule',
     )

--- a/packages/sanity/src/core/releases/plugin/documentActions/index.ts
+++ b/packages/sanity/src/core/releases/plugin/documentActions/index.ts
@@ -1,6 +1,8 @@
 import {type DocumentActionComponent} from '../../../config/document/actions'
 import {type DocumentActionsContext} from '../../../config/types'
 import {DiscardVersionAction} from './DiscardVersionAction'
+import {SchedulePublishAction} from './SchedulePublishAction'
+import {ScheduleUnpublishAction} from './ScheduleUnpublishAction'
 import {UnpublishVersionAction} from './UnpublishVersionAction'
 
 type Action = DocumentActionComponent
@@ -15,5 +17,30 @@ export default function resolveDocumentActions(
     return duplicateAction.concat(DiscardVersionAction, UnpublishVersionAction)
   }
 
+  // Add SchedulePublishAction and ScheduleUnpublishAction only for draft documents
+  if (context.versionType === 'draft') {
+    const actionsExcludingOriginalSchedule = existingActions.filter(
+      ({action}) => action !== 'schedule',
+    )
+    const publishActionIndex = actionsExcludingOriginalSchedule.findIndex(
+      ({action}) => action === 'publish',
+    )
+    const nextAfterPublishIndex = publishActionIndex + 1
+    const hasPublishAction = publishActionIndex >= 0
+
+    const actionsBeforePublish = hasPublishAction
+      ? actionsExcludingOriginalSchedule.slice(0, nextAfterPublishIndex)
+      : []
+    const actionsAfterPublish = hasPublishAction
+      ? actionsExcludingOriginalSchedule.slice(nextAfterPublishIndex)
+      : actionsExcludingOriginalSchedule
+
+    return [
+      ...actionsBeforePublish,
+      SchedulePublishAction,
+      ScheduleUnpublishAction,
+      ...actionsAfterPublish,
+    ]
+  }
   return existingActions
 }


### PR DESCRIPTION
### Description
When the quota config flag is turned on:
<img width="242" height="252" alt="Screenshot 2025-08-15 at 11 46 04" src="https://github.com/user-attachments/assets/373b28cc-c82b-4afd-b818-53161467628a" />

When the quota config flag is not given in `sanity.config`:
<img width="233" height="211" alt="Screenshot 2025-08-15 at 11 46 51" src="https://github.com/user-attachments/assets/291112fb-39a2-4309-9987-34bbda1f06f1" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
