### PR TITLE
refactor(core): adding internal feature symbol for single document releases

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -11,7 +11,12 @@ import {SanityMonogram} from '@sanity/logos'
 import {debugSecrets} from '@sanity/preview-url-secret/sanity-plugin-debug-secrets'
 import {tsdoc} from '@sanity/tsdoc/studio'
 import {visionTool} from '@sanity/vision'
-import {defineConfig, definePlugin, type WorkspaceOptions} from 'sanity'
+import {
+  defineConfig,
+  definePlugin,
+  QUOTA_EXCLUDED_RELEASES_ENABLED,
+  type WorkspaceOptions,
+} from 'sanity'
 import {defineDocuments, defineLocations, presentationTool} from 'sanity/presentation'
 import {structureTool} from 'sanity/structure'
 import {imageHotspotArrayPlugin} from 'sanity-plugin-hotspot-array'
@@ -227,8 +232,7 @@ const defaultWorkspace = defineConfig({
   mediaLibrary: {
     enabled: true,
   },
-  // eslint-disable-next-line camelcase
-  __internal_releasesEnabled: true,
+  [QUOTA_EXCLUDED_RELEASES_ENABLED]: true,
   document: {
     actions: (prev, ctx) => {
       if (ctx.schemaType === 'book' && ctx.releaseId) {

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -227,6 +227,8 @@ const defaultWorkspace = defineConfig({
   mediaLibrary: {
     enabled: true,
   },
+  // eslint-disable-next-line camelcase
+  __internal_releasesEnabled: true,
   document: {
     actions: (prev, ctx) => {
       if (ctx.schemaType === 'book' && ctx.releaseId) {

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -486,6 +486,29 @@ export const serverDocumentActionsReducer = (opts: {
   return result
 }
 
+export const internalReleasesEnabledReducer = (opts: {
+  config: PluginOptions
+  initialValue: boolean | undefined
+}): boolean | undefined => {
+  const {config, initialValue} = opts
+  const flattenedConfig = flattenConfig(config, [])
+
+  const result = flattenedConfig.reduce((acc: boolean | undefined, {config: innerConfig}) => {
+    const enabled = innerConfig.__internal_releasesEnabled
+
+    if (typeof enabled === 'undefined') return acc
+    if (typeof enabled === 'boolean') return enabled
+
+    throw new Error(
+      `Expected \`__internal_releasesEnabled\` to be a boolean, but received ${getPrintableType(
+        enabled,
+      )}`,
+    )
+  }, initialValue)
+
+  return result
+}
+
 export const partialIndexingEnabledReducer = (opts: {
   config: PluginOptions
   initialValue: boolean

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -28,6 +28,7 @@ import {
   type DocumentLanguageFilterContext,
   type NewDocumentOptionsContext,
   type PluginOptions,
+  QUOTA_EXCLUDED_RELEASES_ENABLED,
   type ResolveProductionUrlContext,
   type Tool,
 } from './types'
@@ -486,7 +487,7 @@ export const serverDocumentActionsReducer = (opts: {
   return result
 }
 
-export const internalReleasesEnabledReducer = (opts: {
+export const internalQuotaExcludedReleasesEnabledReducer = (opts: {
   config: PluginOptions
   initialValue: boolean | undefined
 }): boolean | undefined => {
@@ -494,16 +495,12 @@ export const internalReleasesEnabledReducer = (opts: {
   const flattenedConfig = flattenConfig(config, [])
 
   const result = flattenedConfig.reduce((acc: boolean | undefined, {config: innerConfig}) => {
-    const enabled = innerConfig.__internal_releasesEnabled
+    const enabled = innerConfig[QUOTA_EXCLUDED_RELEASES_ENABLED]
 
     if (typeof enabled === 'undefined') return acc
     if (typeof enabled === 'boolean') return enabled
 
-    throw new Error(
-      `Expected \`__internal_releasesEnabled\` to be a boolean, but received ${getPrintableType(
-        enabled,
-      )}`,
-    )
+    throw new Error(`Expected a boolean, but received ${getPrintableType(enabled)}`)
   }, initialValue)
 
   return result

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -44,7 +44,7 @@ import {
   initialDocumentActions,
   initialDocumentBadges,
   initialLanguageFilter,
-  internalReleasesEnabledReducer,
+  internalQuotaExcludedReleasesEnabledReducer,
   internalTasksReducer,
   legacySearchEnabledReducer,
   mediaLibraryEnabledReducer,
@@ -71,6 +71,7 @@ import {
   type MissingConfigFile,
   type PluginOptions,
   type PreparedConfig,
+  QUOTA_EXCLUDED_RELEASES_ENABLED,
   type SingleWorkspace,
   type Source,
   type SourceClientOptions,
@@ -356,8 +357,7 @@ function resolveSource({
     projectId,
     schema,
     i18n: i18n.source,
-    // eslint-disable-next-line camelcase
-    __internal_releasesEnabled: internalReleasesEnabledReducer({
+    [QUOTA_EXCLUDED_RELEASES_ENABLED]: internalQuotaExcludedReleasesEnabledReducer({
       config,
       initialValue: false,
     }),

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -44,6 +44,7 @@ import {
   initialDocumentActions,
   initialDocumentBadges,
   initialLanguageFilter,
+  internalReleasesEnabledReducer,
   internalTasksReducer,
   legacySearchEnabledReducer,
   mediaLibraryEnabledReducer,
@@ -355,6 +356,11 @@ function resolveSource({
     projectId,
     schema,
     i18n: i18n.source,
+    // eslint-disable-next-line camelcase
+    __internal_releasesEnabled: internalReleasesEnabledReducer({
+      config,
+      initialValue: false,
+    }),
   }
 
   // <TEMPORARY UGLY HACK TO PRINT DEPRECATION WARNINGS ON USE>

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -39,7 +39,7 @@ import {type StudioComponents, type StudioComponentsPluginOptions} from './studi
  * Symbol for enabling releases outside of quota restrictions for single docs
  * @internal
  */
-export const QUOTA_EXCLUDED_RELEASES_ENABLED = Symbol('__internal_releasesEnabled')
+export const QUOTA_EXCLUDED_RELEASES_ENABLED = Symbol('__internal_quotaExcludedReleasesEnabled')
 
 /**
  * @hidden

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -36,6 +36,12 @@ import {type FormComponents} from './form'
 import {type StudioComponents, type StudioComponentsPluginOptions} from './studio'
 
 /**
+ * Symbol for enabling releases outside of quota restrictions for single docs
+ * @internal
+ */
+export const QUOTA_EXCLUDED_RELEASES_ENABLED = Symbol('__internal_releasesEnabled')
+
+/**
  * @hidden
  * @beta
  */
@@ -214,7 +220,7 @@ export interface ConfigContext {
    */
   i18n: LocaleSource
   /** @internal */
-  __internal_releasesEnabled?: boolean
+  [QUOTA_EXCLUDED_RELEASES_ENABLED]?: boolean
 }
 
 /** @public */
@@ -451,7 +457,7 @@ export interface PluginOptions {
   __internal_serverDocumentActions?: WorkspaceOptions['__internal_serverDocumentActions']
 
   /** @internal */
-  __internal_releasesEnabled?: WorkspaceOptions['__internal_releasesEnabled']
+  [QUOTA_EXCLUDED_RELEASES_ENABLED]?: WorkspaceOptions[typeof QUOTA_EXCLUDED_RELEASES_ENABLED]
 
   /** Configuration for studio beta features.
    * @internal
@@ -575,7 +581,7 @@ export interface WorkspaceOptions extends SourceOptions {
    * @hidden
    * @internal
    */
-  __internal_releasesEnabled?: boolean
+  [QUOTA_EXCLUDED_RELEASES_ENABLED]?: boolean
 
   scheduledPublishing?: DefaultPluginsWorkspaceOptions['scheduledPublishing']
 }
@@ -647,7 +653,7 @@ export interface DocumentActionsContext extends ConfigContext {
   /** the type of the currently active document. */
   versionType: DocumentActionsVersionType
   /** @internal */
-  __internal_releasesEnabled?: boolean
+  [QUOTA_EXCLUDED_RELEASES_ENABLED]?: boolean
 }
 
 /**

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -213,6 +213,8 @@ export interface ConfigContext {
    * Localization resources
    */
   i18n: LocaleSource
+  /** @internal */
+  __internal_releasesEnabled?: boolean
 }
 
 /** @public */
@@ -448,6 +450,9 @@ export interface PluginOptions {
   /** @internal */
   __internal_serverDocumentActions?: WorkspaceOptions['__internal_serverDocumentActions']
 
+  /** @internal */
+  __internal_releasesEnabled?: WorkspaceOptions['__internal_releasesEnabled']
+
   /** Configuration for studio beta features.
    * @internal
    */
@@ -566,6 +571,12 @@ export interface WorkspaceOptions extends SourceOptions {
     enabled?: boolean
   }
 
+  /**
+   * @hidden
+   * @internal
+   */
+  __internal_releasesEnabled?: boolean
+
   scheduledPublishing?: DefaultPluginsWorkspaceOptions['scheduledPublishing']
 }
 
@@ -635,6 +646,8 @@ export interface DocumentActionsContext extends ConfigContext {
   releaseId: string | undefined
   /** the type of the currently active document. */
   versionType: DocumentActionsVersionType
+  /** @internal */
+  __internal_releasesEnabled?: boolean
 }
 
 /**

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -148,6 +148,7 @@ exports[`exports snapshot 1`] = `
     "Preview": "function",
     "PreviewCard": "object",
     "PreviewLoader": "function",
+    "QUOTA_EXCLUDED_RELEASES_ENABLED": "symbol",
     "RELEASES_INTENT": "string",
     "RELEASES_STUDIO_CLIENT_OPTIONS": "object",
     "ReferenceInput": "function",


### PR DESCRIPTION
### Description
This is an internal only config property to allow for dev testing of new releases features.

This will be used both inside the release's document actions resolver, and inside the releases' tool components to feature flag views and logic.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
