### PR TITLE
fix(core): use intent link for comments notification url

### DIFF
--- a/packages/sanity/src/structure/panes/document/comments/CommentsWrapper.tsx
+++ b/packages/sanity/src/structure/panes/document/comments/CommentsWrapper.tsx
@@ -7,6 +7,7 @@ import {
   usePerspective,
   useStudioUrl,
 } from 'sanity'
+import {useRouter} from 'sanity/router'
 
 import {usePaneRouter} from '../../../components'
 import {useDocumentPane} from '../useDocumentPane'
@@ -40,8 +41,9 @@ function CommentsProviderWrapper(props: CommentsWrapperProps) {
   const {enabled} = useCommentsEnabled()
   const {connectionState, onPathOpen, inspector, openInspector} = useDocumentPane()
   const {selectedReleaseId} = usePerspective()
-  const {params, setParams, createPathWithParams} = usePaneRouter()
+  const {params, setParams} = usePaneRouter()
   const {studioUrl} = useStudioUrl(window.location.origin)
+  const {resolveIntentLink} = useRouter()
 
   const selectedCommentId = params?.comment
   const paramsRef = useRef(params)
@@ -52,18 +54,15 @@ function CommentsProviderWrapper(props: CommentsWrapperProps) {
 
   const getCommentLink = useCallback(
     (commentId: string) => {
-      // Generate a path based on the current pane params.
-      // We force a value for `inspect` to ensure that this is included in URLs when comments
-      // are created outside of the inspector context (i.e. directly on the field)
-      // @todo: consider filtering pane router params and culling all non-active RHS panes prior to generating this link
-      const path = createPathWithParams({
-        ...paramsRef.current,
-        comment: commentId,
+      const intentLink = resolveIntentLink('edit', {
+        id: documentId,
+        type: documentType,
         inspect: COMMENTS_INSPECTOR_NAME,
+        comment: commentId,
       })
-      return `${studioUrl}${path}`
+      return `${studioUrl}${intentLink}`
     },
-    [createPathWithParams, studioUrl],
+    [documentId, documentType, resolveIntentLink, studioUrl],
   )
 
   const handleClearSelectedComment = useCallback(() => {


### PR DESCRIPTION
### Description
This PR updates how the notification url is created for comments.
Until now, we have been using a fixed path which replicates the path the user is seeing at the moment of creating the comment.
This works, but for some cases if the structure of an user is different to the user which created the comment, this won't work. Because maybe they don't have access to the same structure.

This changes that url to be an intent link, which is a battle tested approach and should work in all scenarios, even if the users have a different structure.


## Before:
`<studioUrl>/test/structure/author;1d953454-cafd-490f-8463-c6baebb6cf89%2Ccomment%3Dfbafae03-5866-4ce7-b836-e2b5f2067954%2Cinspect%3Dsanity%252Fcomments`

## Now:
`<studioUrl>/test/intent/edit/id=1d953454-cafd-490f-8463-c6baebb6cf89;type=author;inspect=sanity%2Fcomments;comment=ac2dbc1a-83d3-40c7-9c65-151ce0a81b16/`


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in where comments links sometimes didn't were able to open the correct document. 
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
