### PR TITLE
feat(sanity): graduate `SelectedPerspective` to public type `TargetPerspective`

### DIFF
--- a/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
@@ -1324,6 +1324,7 @@ import type {
   systemBundles,
   TagsArrayInput,
   TagsArrayInputProps,
+  TargetPerspective,
   TelephoneInput,
   TelephoneInputProps,
   Template,
@@ -5621,6 +5622,9 @@ describe('sanity', () => {
   })
   test('TagsArrayInputProps', () => {
     expectTypeOf<TagsArrayInputProps>().not.toBeNever()
+  })
+  test('TargetPerspective', () => {
+    expectTypeOf<TargetPerspective>().not.toBeNever()
   })
   test('TelephoneInput', () => {
     expectTypeOf<typeof TelephoneInput>().toBeFunction()

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -23,6 +23,7 @@ export {
   type ReleaseId,
   type ReleasesNavMenuItemPropsGetter,
   type SelectedPerspective,
+  type TargetPerspective,
 } from './perspective/types'
 export {useExcludedPerspective} from './perspective/useExcludedPerspective'
 export {usePerspective} from './perspective/usePerspective'

--- a/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
+++ b/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
@@ -7,7 +7,7 @@ import {useWorkspace} from '../studio/workspace'
 import {isSystemBundleName} from '../util/draftUtils'
 import {EMPTY_ARRAY} from '../util/empty'
 import {getSelectedPerspective} from './getSelectedPerspective'
-import {type PerspectiveContextValue, type ReleaseId, type SelectedPerspective} from './types'
+import {type PerspectiveContextValue, type ReleaseId, type TargetPerspective} from './types'
 
 /**
  * @internal
@@ -29,7 +29,7 @@ export function PerspectiveProvider({
     },
   } = useWorkspace()
 
-  const selectedPerspective: SelectedPerspective = useMemo(
+  const selectedPerspective: TargetPerspective = useMemo(
     () => getSelectedPerspective(selectedPerspectiveName, releases),
     [selectedPerspectiveName, releases],
   )

--- a/packages/sanity/src/core/perspective/getSelectedPerspective.ts
+++ b/packages/sanity/src/core/perspective/getSelectedPerspective.ts
@@ -1,12 +1,12 @@
 import {type ReleaseDocument} from '@sanity/client'
 
 import {getReleaseIdFromReleaseDocumentId} from '../releases/util/getReleaseIdFromReleaseDocumentId'
-import {type ReleaseId, type SelectedPerspective} from './types'
+import {type ReleaseId, type TargetPerspective} from './types'
 
 export function getSelectedPerspective(
   selectedPerspectiveName: 'published' | ReleaseId | undefined,
   releases: ReleaseDocument[],
-): SelectedPerspective {
+): TargetPerspective {
   if (!selectedPerspectiveName) return 'drafts'
   if (selectedPerspectiveName === 'published') return 'published'
   const selectedRelease = releases.find(

--- a/packages/sanity/src/core/perspective/isPerspectiveWriteable.ts
+++ b/packages/sanity/src/core/perspective/isPerspectiveWriteable.ts
@@ -2,7 +2,7 @@ import {type ObjectSchemaType} from '@sanity/types'
 
 import {isReleaseDocument} from '../releases/store/types'
 import {isDraftPerspective, isPublishedPerspective} from '../releases/util/util'
-import {type SelectedPerspective} from './types'
+import {type TargetPerspective} from './types'
 
 /**
  * @internal
@@ -26,7 +26,7 @@ export function isPerspectiveWriteable({
   isDraftModelEnabled,
   schemaType,
 }: {
-  selectedPerspective: SelectedPerspective
+  selectedPerspective: TargetPerspective
   isDraftModelEnabled: boolean
   schemaType?: ObjectSchemaType
 }): {result: true} | {result: false; reason: PerspectiveNotWriteableReason} {

--- a/packages/sanity/src/core/perspective/navbar/currentGlobalPerspectiveLabel.tsx
+++ b/packages/sanity/src/core/perspective/navbar/currentGlobalPerspectiveLabel.tsx
@@ -21,7 +21,7 @@ import {isReleaseDocument} from '../../releases/store/types'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
 import {isDraftPerspective, isPublishedPerspective} from '../../releases/util/util'
 import {oversizedButtonStyle} from '../styles'
-import {type SelectedPerspective} from '../types'
+import {type TargetPerspective} from '../types'
 
 const OversizedButton = styled(IntentLink)`
   ${oversizedButtonStyle}
@@ -112,7 +112,7 @@ const ReleasesLink = ({selectedPerspective}: {selectedPerspective: ReleaseDocume
 export function CurrentGlobalPerspectiveLabel({
   selectedPerspective,
 }: {
-  selectedPerspective: SelectedPerspective
+  selectedPerspective: TargetPerspective
 }): React.JSX.Element | null {
   const {t} = useTranslation()
 

--- a/packages/sanity/src/core/perspective/types.ts
+++ b/packages/sanity/src/core/perspective/types.ts
@@ -3,6 +3,8 @@ import {type ClientPerspective, type ReleaseDocument} from '@sanity/client'
 import {type MenuItem} from '@sanity/ui'
 import {type ComponentProps} from 'react'
 
+import {type SystemBundle} from '../util/draftUtils'
+
 /**
  * @beta
  */
@@ -10,9 +12,18 @@ import {type ComponentProps} from 'react'
 export type ReleaseId = string
 
 /**
- * @beta
+ * A value representing a perspective, including the data describing it. This is either the name of a
+ * system bundle, or a document describing a release.
+ *
+ * @public
  */
-export type SelectedPerspective = ReleaseDocument | 'published' | 'drafts'
+export type TargetPerspective = ReleaseDocument | SystemBundle
+
+/**
+ * @beta
+ * @deprecated Use `TargetPerspective` instead.
+ */
+export type SelectedPerspective = TargetPerspective
 
 /**
  * @beta
@@ -31,7 +42,7 @@ export interface PerspectiveContextValue {
   selectedReleaseId: ReleaseId | undefined
 
   /* Return the current global release */
-  selectedPerspective: SelectedPerspective
+  selectedPerspective: TargetPerspective
   /**
    * The stacked array of perspectives ids ordered chronologically to represent the state of documents at the given point in time.
    * It can be used as the perspective param in the client to get the correct view of the documents.
@@ -48,5 +59,5 @@ type ExtractArray<Union> = Union extends unknown[] ? Union : never
  * @internal
  */
 export type ReleasesNavMenuItemPropsGetter = (content: {
-  perspective: SelectedPerspective
+  perspective: TargetPerspective
 }) => Partial<ComponentProps<typeof MenuItem>>

--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -7,7 +7,7 @@ import {Dialog} from '../../../../ui-components'
 import {LoadingBlock} from '../../../components'
 import {useDocumentOperation, useSchema} from '../../../hooks'
 import {Translate, useTranslation} from '../../../i18n'
-import {type SelectedPerspective} from '../../../perspective/types'
+import {type TargetPerspective} from '../../../perspective/types'
 import {usePerspective} from '../../../perspective/usePerspective'
 import {Preview} from '../../../preview'
 import {getPublishedId, getVersionFromId, isDraftId, isVersionId} from '../../../util/draftUtils'
@@ -21,7 +21,7 @@ export function DiscardVersionDialog(props: {
   onClose: () => void
   documentId: string
   documentType: string
-  fromPerspective: string | SelectedPerspective
+  fromPerspective: string | TargetPerspective
 }): React.JSX.Element {
   const {onClose, documentId, documentType, fromPerspective} = props
   const {t} = useTranslation(releasesLocaleNamespace)

--- a/packages/sanity/src/core/releases/util/getReleaseTone.ts
+++ b/packages/sanity/src/core/releases/util/getReleaseTone.ts
@@ -1,12 +1,12 @@
 import {type BadgeTone} from '@sanity/ui'
 
-import {type SelectedPerspective} from '../../perspective/types'
+import {type TargetPerspective} from '../../perspective/types'
 import {isReleaseDocument} from '../store/types'
 import {RELEASE_TYPES_TONES} from './const'
 import {isDraftPerspective, isPublishedPerspective} from './util'
 
 /** @internal */
-export function getReleaseTone(release: SelectedPerspective): BadgeTone {
+export function getReleaseTone(release: TargetPerspective): BadgeTone {
   if (isPublishedPerspective(release)) return 'positive'
   if (isDraftPerspective(release)) return 'default'
 

--- a/packages/sanity/src/core/releases/util/util.ts
+++ b/packages/sanity/src/core/releases/util/util.ts
@@ -1,6 +1,6 @@
 import {type EditableReleaseDocument, type ReleaseDocument, type ReleaseState} from '@sanity/client'
 
-import {type SelectedPerspective} from '../../perspective/types'
+import {type TargetPerspective} from '../../perspective/types'
 import {formatRelativeLocale, getVersionFromId, isVersionId} from '../../util'
 import {DEFAULT_RELEASE_TYPE, LATEST} from './const'
 import {createReleaseId} from './createReleaseId'
@@ -59,14 +59,14 @@ export function formatRelativeLocalePublishDate(release: ReleaseDocument): strin
 
 /** @internal */
 export function isPublishedPerspective(
-  perspective: SelectedPerspective | string,
+  perspective: TargetPerspective | string,
 ): perspective is 'published' {
   return perspective === 'published'
 }
 
 /** @internal */
 export function isDraftPerspective(
-  perspective: SelectedPerspective | string,
+  perspective: TargetPerspective | string,
 ): perspective is 'drafts' {
   return perspective === LATEST
 }

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -107,10 +107,30 @@ export function getDraftId(id: string): DraftId {
   return isDraftId(id) ? id : ((DRAFTS_PREFIX + id) as DraftId)
 }
 
-/** @internal */
+/**
+ * System bundles are sets of documents owned by the system.
+ *
+ * - Draft documents contain data that has not yet been published. These documents all exist in the "drafts" path.
+ * - Published documents contain data that has been published. These documents all exist in the root path.
+ *
+ * These differ to user bundles, which are created when a user establishes a custom set of documents
+ * (e.g. by creating a release).
+ *
+ * @public
+ */
 export const systemBundles = ['drafts', 'published'] as const
 
-/** @internal */
+/**
+ * System bundles are sets of documents owned by the system.
+ *
+ * - Draft documents contain data that has not yet been published. These documents all exist in the "drafts" path.
+ * - Published documents contain data that has been published. These documents all exist in the root path.
+ *
+ * These differ to user bundles, which are created when a user establishes a custom set of documents
+ * (e.g. by creating a release).
+ *
+ * @public
+ */
 export type SystemBundle = (typeof systemBundles)[number]
 
 /** @internal */

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ChooseNewDocumentDestinationBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ChooseNewDocumentDestinationBanner.tsx
@@ -9,7 +9,7 @@ import {
   type PerspectiveNotWriteableReason,
   ReleasesNav,
   type ReleasesNavMenuItemPropsGetter,
-  type SelectedPerspective,
+  type TargetPerspective,
   Translate,
   useTranslation,
   useWorkspace,
@@ -20,7 +20,7 @@ import {Banner} from './Banner'
 
 interface Props {
   schemaType: ObjectSchemaType
-  selectedPerspective: SelectedPerspective
+  selectedPerspective: TargetPerspective
   reason: PerspectiveNotWriteableReason
 }
 


### PR DESCRIPTION
### Description

This change graduates the `SelectedPerspective` type to a public API.  The name *`SelectedPerspective`* is somewhat meaningless in wider contexts, so it has been renamed to `TargetPerspective`, which better describes what this type is: the name of a system bundle, or a document describing a release, that can be the target of some perspective selection.

I intend to use `TargetPerspective` in a new public API, so this type must graduate to a public API.

`SelectedPerspective` remains, but has been marked as deprecated.

### What to review

- Does the name `TargetPerspective` make sense?
- Do you anticipate any issues in adding this to the public API?
- Do you anticipate any issues in deprecating `SelectedPerspective`?

### Testing

Type check passes.

### Notes for release

The beta `SelectedPerspective` type has been deprecated in favour of the new, public, `TargetPerspective` type. These types represent the same values. If you're using `SelectedPerspective` in your code, please migrate to `TargetPerspective`.