### PR TITLE
feat: draft perspective chip copies from published when  no draft exists

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -291,7 +291,6 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
             documentType: documentType,
             fromRelease: 'draft',
             isVersion: false,
-            disabled: !editState?.draft,
           }}
         />
       )}


### PR DESCRIPTION
### Description
| Before | After |
|--------|--------|
| <img width="350" height="89" alt="Screenshot 2025-08-15 at 00 23 19" src="https://github.com/user-attachments/assets/83df229f-eff7-4090-9bfa-139a9f8fdbc3" /> | <img width="647" height="308" alt="Screenshot 2025-08-15 at 00 22 47" src="https://github.com/user-attachments/assets/347da498-275d-481a-ac5b-409bc6e7b2be" /> | 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Have verified that copy version to will copy the published version, ONLY if the draft does not exist. Otherwise the existing behavior persists and the draft is the base to copy from
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
It is not always possible to copy a draft document to form the base of a new release document version.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
