### PR TITLE
chore(renovate): ignore ESM workarounds

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
     "github>sanity-io/renovate-config:studio-v3",
     ":dependencyDashboardApproval"
   ],
-  "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
+  "ignorePresets": ["github>sanity-io/renovate-config:group-non-major", "github>sanity-io/renovate-config:workarounds-esm"],
   "packageRules": [
     {
       "description": "Enable automerge with GitHub merge queues (note that this doesn't bypass required checks and code reviews)",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,10 @@
     "github>sanity-io/renovate-config:studio-v3",
     ":dependencyDashboardApproval"
   ],
-  "ignorePresets": ["github>sanity-io/renovate-config:group-non-major", "github>sanity-io/renovate-config:workarounds-esm"],
+  "ignorePresets": [
+    "github>sanity-io/renovate-config:group-non-major",
+    "github>sanity-io/renovate-config:workarounds-esm"
+  ],
   "packageRules": [
     {
       "description": "Enable automerge with GitHub merge queues (note that this doesn't bypass required checks and code reviews)",


### PR DESCRIPTION
We no longer need these workarounds: https://github.com/sanity-io/renovate-config/blob/main/workarounds-esm.json  Since we now have node 20.19 as the baseline