### PR TITLE
fix(ci): add concurrency for release-next job

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   release-next:
+    concurrency:
+      group: release_next
+
     # this runs in main, and we want to skip running it when release PRs are merged
     # format of the commit message is specified in lerna.json
     if: >


### PR DESCRIPTION
### Description

Makes sure we do one release of next at a time.

### What to review

I guess we now risk that the HEAD commit will not be published, but lets address that in a follow-up commit


### Notes for release
n/a