### PR TITLE
fix(codegen): import json5 via default to match ESM entry

### DIFF
--- a/packages/@sanity/codegen/src/readConfig.ts
+++ b/packages/@sanity/codegen/src/readConfig.ts
@@ -1,6 +1,6 @@
 import {readFile} from 'node:fs/promises'
 
-import * as json5 from 'json5'
+import json5 from 'json5'
 import * as z from 'zod'
 
 export const configDefintion = z.object({


### PR DESCRIPTION
### Description

Updates the import of `json5` in Codegen's `readConfig.ts` from a namespace import to a default import.

The `json5` package’s ESM entry exports a single default object `{ parse, stringify }` and does not define parse/stringify as named exports. Using `import * as json5` produces a namespace with `{ default: { parse, stringify } }`, i.e. `json5.parse` is undefined.

I'm consuming Codegen in a package that builds with Vite. When building for production Rollup validates exports strictly and throws:

`"parse" is not exported by "[..]/json5/dist/index.mjs"`

Switching to a default import matches the package’s ESM shape and prevents this build-time error.

### What to review

Verify that the import statement change doesn't affect the functionality of the code that uses the `json5` library. The change should be straightforward as it's just modifying the import style.

### Testing

The existing tests should be sufficient to verify that this change doesn't break any functionality. The code that uses `json5` should continue to work as expected with the updated import style.

### Notes for release

N/A, doesn't affect functionality.