### PR TITLE
fix: remove unused initialValue parameter from createVersion method

### DIFF
--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -43,7 +43,6 @@ export interface ReleaseOperationsStore {
   createVersion: (
     releaseId: string,
     documentId: string,
-    initialValue?: Omit<EditableReleaseDocument, '_id' | '_type'>,
     opts?: BaseActionOptions,
   ) => Promise<SingleActionResult>
   discardVersion: (
@@ -158,7 +157,7 @@ export function createReleaseOperationsStore(options: {
     const document = await client.getDocument(documentId)
 
     if (!document) {
-      throw new Error(`Document with id ${documentId} not found and no initial value provided`)
+      throw new Error(`Document with id ${documentId} not found`)
     }
 
     return client.createVersion(


### PR DESCRIPTION
### Description
When adding `baseId` to the implementation of `createVersion` I mistakenly forgot to update the type signature in the createReleaseOperationsStore`.

This PR correct that - note that there is no usage across the codebase where `initialValue` was being passed anymore; everything had already been migrated to use `baseId`, this is just making sure the type matches the implementation.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
