### PR TITLE
chore(ci): retry tests in ci

### DIFF
--- a/.github/workflows/auto-retry-failed-jobs.yml
+++ b/.github/workflows/auto-retry-failed-jobs.yml
@@ -1,0 +1,23 @@
+name: Auto-rerun failed jobs (once)
+
+on:
+  workflow_run:
+    workflows:
+      - "Unit tests"
+      - "End-to-End Tests"
+      - "End-to-End Component Tests"
+      - "CLI Unit tests"
+      - "eFPS Test"
+    types: [completed]
+
+jobs:
+  retry-failed-jobs:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Rerun failed jobs of the failed run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh run rerun ${{ github.event.workflow_run.id }} --failed

--- a/.github/workflows/auto-retry-failed-jobs.yml
+++ b/.github/workflows/auto-retry-failed-jobs.yml
@@ -1,6 +1,9 @@
 name: Auto-rerun failed jobs (once)
+permissions:
+  actions: write # for rerunning failed jobs
 
 on:
+  # Trigger when test workflows complete with failure on first attempt
   workflow_run:
     workflows:
       - "Unit tests"
@@ -11,13 +14,12 @@ on:
     types: [completed]
 
 jobs:
-  retry-failed-jobs:
+  auto-retry:
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
+    timeout-minutes: 2
     runs-on: ubuntu-latest
-    permissions:
-      actions: write
     steps:
-      - name: Rerun failed jobs of the failed run
+      - name: Rerun failed jobs only
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh run rerun ${{ github.event.workflow_run.id }} --failed

--- a/packages/@sanity/util/test/createSafeJsonParser.test.ts
+++ b/packages/@sanity/util/test/createSafeJsonParser.test.ts
@@ -11,6 +11,14 @@ test('parse JSON', () => {
   expect(parse('{"someNumber": 42}')).toEqual({someNumber: 42})
 })
 
+// Temporary test to trigger GitHub Actions retry workflow
+// TODO: Remove this test after verifying retry functionality
+test('TEMP: trigger retry workflow - will fail on first attempt', () => {
+  // This test will always fail to trigger the retry workflow
+  // Remove this test once retry functionality is verified
+  expect(true).toBe(false)
+})
+
 test('parse JSON with interrupting error', () => {
   expect(() => parse('{"someString": "str{"error":{"description":"Some error"}}'))
     .toThrowErrorMatchingInlineSnapshot(`

--- a/packages/@sanity/util/test/createSafeJsonParser.test.ts
+++ b/packages/@sanity/util/test/createSafeJsonParser.test.ts
@@ -11,14 +11,6 @@ test('parse JSON', () => {
   expect(parse('{"someNumber": 42}')).toEqual({someNumber: 42})
 })
 
-// Temporary test to trigger GitHub Actions retry workflow
-// TODO: Remove this test after verifying retry functionality
-test('TEMP: trigger retry workflow - will fail on first attempt', () => {
-  // This test will always fail to trigger the retry workflow
-  // Remove this test once retry functionality is verified
-  expect(true).toBe(false)
-})
-
 test('parse JSON with interrupting error', () => {
   expect(() => parse('{"someString": "str{"error":{"description":"Some error"}}'))
     .toThrowErrorMatchingInlineSnapshot(`


### PR DESCRIPTION
### Description
This PR should add auto-retrying of our test workflows.

This needs to be merged to main to be tested. If it doesn't work as expected the I can revert.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
This can only be tested once this change and new workflow is in main.
Once merged then I will:
1. create a new feature branch PR
2. modify a unit test to fail
3. run `gh run list --workflow="Auto-rerun failed jobs (once)" --branch=<branch-name>` to verify that the retry is being run
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
