### PR TITLE
fix: fix scrolling issue inside of popover modals in PTE

### DIFF
--- a/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
+++ b/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
@@ -57,6 +57,26 @@ export default defineType({
                         `This is not an external link. Consider using internal links instead.`,
                       ),
                   },
+                  {
+                    name: 'url2',
+                    type: 'string',
+                  },
+                  {
+                    name: 'url3',
+                    type: 'string',
+                  },
+                  {
+                    name: 'url4',
+                    type: 'string',
+                  },
+                  {
+                    name: 'url5',
+                    type: 'string',
+                  },
+                  {
+                    name: 'url6',
+                    type: 'string',
+                  },
                 ],
               },
               {

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.styles.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.styles.ts
@@ -4,16 +4,15 @@ import {styled} from 'styled-components'
 import {Popover} from '../../../../../../ui-components'
 
 export const RootPopover = styled(Popover)`
-  & > div {
-    overflow: hidden;
-    overflow: clip;
+  [data-ui='Popover__wrapper'] {
+    overflow: auto;
+    max-height: 60vh;
   }
 `
 
 export const ContentScrollerBox = styled(Box)`
   /* Prevent overflow caused by change indicator */
   overflow-x: hidden;
-  overflow-y: auto;
 `
 
 export const ContentHeaderBox = styled(Box)`

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -30,7 +30,6 @@ interface PopoverEditDialogProps {
 const NoopContainer = ({children, ...props}: PropsWithChildren) => (
   <div
     {...props}
-    style={{maxHeight: '60vh'}}
     // Makes the div focusable so clicking on the popover will move the focus away from the input once focus lock is active
     // Solves an issue when scrolling the popover and then clicking outside of the input will scroll back the popover to the input.
     tabIndex={-1}


### PR DESCRIPTION
### Description

Fixes issue where some of the inputs were being hidden when scrolling.

In the video, the schema goes up to URL 6, however, in the before, you'll see that it's inaccessible in the popover 

Before

https://github.com/user-attachments/assets/e4747c51-a834-4835-a39f-fef76c48d976

After

https://github.com/user-attachments/assets/d2032382-d52b-4969-b9e6-a387c903488d

### What to review

Does this make sense?

### Testing

N/A
Manual test should be enough, you can test it by going to the simple block in the test studio

### Notes for release

Fixes issue where long annotations in a PTE modal were being hidden when scrolling