### PR TITLE
fix: corrects tense in auto-generated comment

### DIFF
--- a/packages/sanity/src/_internal/cli/server/getEntryModule.ts
+++ b/packages/sanity/src/_internal/cli/server/getEntryModule.ts
@@ -6,7 +6,7 @@
  */
 const entryModule = `
 // This file is auto-generated on 'sanity dev'
-// Modifications to this file is automatically discarded
+// Modifications to this file are automatically discarded
 import studioConfig from %STUDIO_CONFIG_LOCATION%
 import {renderStudio} from "sanity"
 
@@ -19,7 +19,7 @@ renderStudio(
 
 const noConfigEntryModule = `
 // This file is auto-generated on 'sanity dev'
-// Modifications to this file is automatically discarded
+// Modifications to this file are automatically discarded
 import {renderStudio} from "sanity"
 
 const studioConfig = {missingConfigFile: true}
@@ -33,7 +33,7 @@ renderStudio(
 
 const appEntryModule = `
 // This file is auto-generated on 'sanity dev'
-// Modifications to this file is automatically discarded
+// Modifications to this file are automatically discarded
 import {createRoot} from 'react-dom/client'
 import {createElement} from 'react'
 import App from %ENTRY%


### PR DESCRIPTION
Subject-verb disagreement.
"Modifications" (plural) needs "are" not "is".

### Description
This PR corrects a grammatical error in auto-generated warning comments from 
> Modifications to this file _is_ automatically discarded  
to 
> Modifications to this file _are_ automatically discarded  

### What to review
This is a minor grammar correction in developer-facing comments and should not affect any functionality. 
