### PR TITLE
feat: support new Function document change events (`create`, `delete`, `update`) and filters (`includeDrafts` and `includeAllVersions`)

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -59,7 +59,7 @@
     "@babel/traverse": "^7.28.3",
     "@sanity/client": "^7.8.2",
     "@sanity/codegen": "workspace:*",
-    "@sanity/runtime-cli": "^10.1.4",
+    "@sanity/runtime-cli": "^10.2.0",
     "@sanity/telemetry": "^0.8.0",
     "@sanity/template-validator": "^2.4.3",
     "@sanity/util": "workspace:*",

--- a/packages/@sanity/cli/src/commands/blueprints/addBlueprintsCommand.ts
+++ b/packages/@sanity/cli/src/commands/blueprints/addBlueprintsCommand.ts
@@ -6,7 +6,7 @@ Arguments
 
 Options
   --name, -n <name>              Name of the Resource
-  --fn-type <type>               Type of Function to add (e.g. document-publish)
+  --fn-type <type>               Type of Function to add. Available options: "document-create", "document-delete", "document-update", "document-publish". Default: "document-publish"
   --fn-language, --lang <ts|js>  Language of the Function. Default: "ts"
   --js, --javascript             Shortcut for --fn-language=js
   --fn-helpers, --helpers        Add helpers to the Function
@@ -23,7 +23,7 @@ Examples:
   sanity blueprints add function --name my-function -i --helpers
 
   # Add a Function with a specific type
-  sanity blueprints add function --fn-type document-publish
+  sanity blueprints add function --fn-type document-create
 
   # Add a Function using an example
   sanity blueprints add function --example example-name
@@ -73,7 +73,7 @@ const addBlueprintsCommand: CliCommandDefinition<BlueprintsAddFlags> = {
   group: 'blueprints',
   helpText,
   signature:
-    '<type> [--name <name>] [--fn-type <document-publish>] [--fn-lang <ts|js>] [--javascript]',
+    '<type> [--name <name>] [--fn-type <document-create|document-delete|document-update|document-publish>] [--fn-lang <ts|js>] [--javascript]',
   description: 'Add a Resource to a Blueprint',
 
   async action(args, context) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -912,8 +912,8 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@sanity/runtime-cli':
-        specifier: ^10.1.4
-        version: 10.1.4(@types/node@22.17.2)(debug@4.4.1)(terser@5.43.1)(tsx@4.20.4)(typescript@5.8.3)(yaml@2.8.1)
+        specifier: ^10.2.0
+        version: 10.2.0(@types/node@22.17.2)(debug@4.4.1)(terser@5.43.1)(tsx@4.20.4)(typescript@5.8.3)(yaml@2.8.1)
       '@sanity/telemetry':
         specifier: ^0.8.0
         version: 0.8.1(react@19.1.1)
@@ -4858,8 +4858,8 @@ packages:
     peerDependencies:
       react: ^18.3 || >=19.0.0-rc
 
-  '@sanity/runtime-cli@10.1.4':
-    resolution: {integrity: sha512-JHkaVbtyKJAo+JH6QU+Svx/Qny+VgkWm+/RaASX5uIS/ArNItQu6fDvUViw7vdO1YxebYM8lDduq669eIypGaA==}
+  '@sanity/runtime-cli@10.2.0':
+    resolution: {integrity: sha512-2S+MeIl8mmAqgBPkDfPVTNoGJ3bXvzKgAjT00EZZhnWVqC+f9jDKTUUhFOJ5LGf7MIarB/yQ3Z0Jx5X2EkJKTg==}
     engines: {node: '>=20.19'}
     hasBin: true
 
@@ -15695,7 +15695,7 @@ snapshots:
       - debug
       - typescript
 
-  '@sanity/runtime-cli@10.1.4(@types/node@22.17.2)(debug@4.4.1)(terser@5.43.1)(tsx@4.20.4)(typescript@5.8.3)(yaml@2.8.1)':
+  '@sanity/runtime-cli@10.2.0(@types/node@22.17.2)(debug@4.4.1)(terser@5.43.1)(tsx@4.20.4)(typescript@5.8.3)(yaml@2.8.1)':
     dependencies:
       '@architect/hydrate': 4.0.8
       '@architect/inventory': 4.0.9


### PR DESCRIPTION
### Description

You can now trigger functions on more types of document change events! See the changelog entry [here](https://www.sanity.io/docs/changelog/15c41ae1-ac85-45c1-a5fe-81ff8da878ad) for all the details.

### What to review

Bumping the runtime-cli to 10.2 should pull in the new functionality. Also updated the help text for the `blueprints add function` command.

### Notes for release

See the changelog entry [here](https://www.sanity.io/docs/changelog/15c41ae1-ac85-45c1-a5fe-81ff8da878ad) for all the details