### PR TITLE
fix(types): remove `'strike'`/`'strike-through'` decorator confusion

### DIFF
--- a/packages/@sanity/types/src/schema/definition/type/block.ts
+++ b/packages/@sanity/types/src/schema/definition/type/block.ts
@@ -49,7 +49,7 @@ export interface BlockRule extends RuleDef<BlockRule, any[]> {}
  *           {title: 'Strong', value: 'strong'},
  *           {title: 'Emphasis', value: 'em'},
  *           {title: 'Underline', value: 'underline'},
- *           {title: 'Strike', value: 'strike'},
+ *           {title: 'Strike', value: 'strike-through'},
  *           {title: 'Code', value: 'code'},
  *         ]
  *       }
@@ -218,7 +218,7 @@ export interface BlockMarksDefinition {
  *           {title: 'Strong', value: 'strong'},
  *           {title: 'Emphasis', value: 'em'},
  *           {title: 'Underline', value: 'underline'},
- *           {title: 'Strike', value: 'strike'},
+ *           {title: 'Strike', value: 'strike-through'},
  *           {title: 'Code', value: 'code'},
  *         ],
  *         annotations: [

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Decorators.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Decorators.spec.tsx
@@ -30,7 +30,7 @@ const DEFAULT_DECORATORS = [
     icon: 'code',
   },
   {
-    name: 'strike',
+    name: 'strike-through',
     title: 'Strike',
     hotkey: undefined, // Currently not defined
     icon: 'strikethrough',


### PR DESCRIPTION
The default decorator is called `'strike-through'`.