### PR TITLE
refactor(sanity): generalize import map generation

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -14,12 +14,12 @@ import {getTimer} from '../../util/timing'
 import {BuildTrace} from './build.telemetry'
 import {buildVendorDependencies} from '../../server/buildVendorDependencies'
 import {compareDependencyVersions} from '../../util/compareDependencyVersions'
-import {getStudioAutoUpdateImportMap} from '../../util/getAutoUpdatesImportMap'
 import {shouldAutoUpdate} from '../../util/shouldAutoUpdate'
 import {formatModuleSizes, sortModulesBySize} from '../../util/moduleFormatUtils'
 import {upgradePackages} from '../../util/packageManager/upgradePackages'
 import {getPackageManagerChoice} from '../../util/packageManager/packageManagerChoice'
 import {isInteractive} from '../../util/isInteractive'
+import {getAutoUpdatesImportMap} from '../../util/getAutoUpdatesImportMap'
 
 export interface BuildSanityStudioCommandFlags {
   'yes'?: boolean
@@ -62,19 +62,24 @@ export default async function buildSanityStudio(
 
   const autoUpdatesEnabled = shouldAutoUpdate({flags, cliConfig, output})
 
-  // Get the clean version without build metadata: https://semver.org/#spec-item-10
-  const cleanSanityVersion = semver.parse(installedSanityVersion)?.version
-  if (autoUpdatesEnabled && !cleanSanityVersion) {
-    throw new Error(`Failed to parse installed Sanity version: ${installedSanityVersion}`)
-  }
-  const version = encodeURIComponent(`^${cleanSanityVersion}`)
-  const autoUpdatesImports = getStudioAutoUpdateImportMap(version)
-
+  let autoUpdatesImports = {}
   if (autoUpdatesEnabled) {
+    // Get the clean version without build metadata: https://semver.org/#spec-item-10
+    const cleanSanityVersion = semver.parse(installedSanityVersion)?.version
+    if (!cleanSanityVersion) {
+      throw new Error(`Failed to parse installed Sanity version: ${installedSanityVersion}`)
+    }
+
+    const sanityDependencies = [
+      {name: 'sanity', version: cleanSanityVersion},
+      {name: '@sanity/vision', version: cleanSanityVersion},
+    ]
+    autoUpdatesImports = getAutoUpdatesImportMap(sanityDependencies)
+
     output.print(`${info} Building with auto-updates enabled`)
 
     // Check the versions
-    const result = await compareDependencyVersions(autoUpdatesImports, workDir)
+    const result = await compareDependencyVersions(sanityDependencies, workDir)
 
     if (result?.length) {
       const warning =

--- a/packages/sanity/src/_internal/cli/util/__tests__/compareDependencyVersions.test.ts
+++ b/packages/sanity/src/_internal/cli/util/__tests__/compareDependencyVersions.test.ts
@@ -11,19 +11,15 @@ const mockedFetch = vi.fn()
 const mockedResolveFrom = vi.mocked(resolveFrom)
 const mockedReadPackageManifest = vi.mocked(readPackageManifest)
 
-const autoUpdatesImports = {
-  'sanity': 'v1/modules/sanity',
-  'sanity/': 'v1/modules/sanity/',
-  '@sanity/vision': 'v1/modules/@sanity__vision',
-  '@sanity/vision/': 'v1/modules/@sanity__vision/',
-}
+const autoUpdatePackages = [
+  {name: 'sanity', version: '1.0.0'},
+  {name: '@sanity/vision', version: '1.0.0'},
+]
 
-const appAutoUpdatesImports = {
-  '@sanity/sdk-react': 'v1/modules/@sanity__sdk-react',
-  '@sanity/sdk-react/': 'v1/modules/@sanity__sdk-react/',
-  '@sanity/sdk': 'v1/modules/@sanity__sdk',
-  '@sanity/sdk/': 'v1/modules/@sanity__sdk/',
-}
+const appAutoUpdatePackages = [
+  {name: '@sanity/sdk-react', version: '1.0.0'},
+  {name: '@sanity/sdk', version: '1.0.0'},
+]
 
 describe('compareDependencyVersions', () => {
   beforeEach(() => {
@@ -64,11 +60,9 @@ describe('compareDependencyVersions', () => {
           version: '3.40.0',
         })
 
-      const result = await compareDependencyVersions(
-        autoUpdatesImports,
-        '/test/workdir',
-        mockedFetch,
-      )
+      const result = await compareDependencyVersions(autoUpdatePackages, '/test/workdir', {
+        fetchFn: mockedFetch,
+      })
 
       expect(result).toEqual([])
     })
@@ -107,11 +101,9 @@ describe('compareDependencyVersions', () => {
           version: '3.40.0',
         })
 
-      const result = await compareDependencyVersions(
-        autoUpdatesImports,
-        '/test/workdir',
-        mockedFetch,
-      )
+      const result = await compareDependencyVersions(autoUpdatePackages, '/test/workdir', {
+        fetchFn: mockedFetch,
+      })
 
       expect(result).toEqual([
         {
@@ -155,11 +147,9 @@ describe('compareDependencyVersions', () => {
           version: '3.30.0',
         })
 
-      const result = await compareDependencyVersions(
-        autoUpdatesImports,
-        '/test/workdir',
-        mockedFetch,
-      )
+      const result = await compareDependencyVersions(autoUpdatePackages, '/test/workdir', {
+        fetchFn: mockedFetch,
+      })
 
       expect(result).toEqual([
         {
@@ -209,11 +199,9 @@ describe('compareDependencyVersions', () => {
           version: '3.40.0',
         })
 
-      const result = await compareDependencyVersions(
-        autoUpdatesImports,
-        '/test/workdir',
-        mockedFetch,
-      )
+      const result = await compareDependencyVersions(autoUpdatePackages, '/test/workdir', {
+        fetchFn: mockedFetch,
+      })
 
       expect(result).toEqual([
         {
@@ -243,11 +231,9 @@ describe('compareDependencyVersions', () => {
         version: '0.0.0',
       })
 
-      const result = await compareDependencyVersions(
-        autoUpdatesImports,
-        '/test/workdir',
-        mockedFetch,
-      )
+      const result = await compareDependencyVersions(autoUpdatePackages, '/test/workdir', {
+        fetchFn: mockedFetch,
+      })
 
       expect(mockedReadPackageManifest).toHaveBeenCalledTimes(1)
 
@@ -305,11 +291,9 @@ describe('compareDependencyVersions', () => {
           version: '0.1.0',
         })
 
-      const result = await compareDependencyVersions(
-        appAutoUpdatesImports,
-        '/test/workdir',
-        mockedFetch,
-      )
+      const result = await compareDependencyVersions(appAutoUpdatePackages, '/test/workdir', {
+        fetchFn: mockedFetch,
+      })
 
       expect(result).toEqual([])
     })
@@ -348,11 +332,9 @@ describe('compareDependencyVersions', () => {
           version: '0.1.0',
         })
 
-      const result = await compareDependencyVersions(
-        appAutoUpdatesImports,
-        '/test/workdir',
-        mockedFetch,
-      )
+      const result = await compareDependencyVersions(appAutoUpdatePackages, '/test/workdir', {
+        fetchFn: mockedFetch,
+      })
 
       expect(result).toEqual([
         {
@@ -396,11 +378,9 @@ describe('compareDependencyVersions', () => {
           version: '0.1.0',
         })
 
-      const result = await compareDependencyVersions(
-        appAutoUpdatesImports,
-        '/test/workdir',
-        mockedFetch,
-      )
+      const result = await compareDependencyVersions(appAutoUpdatePackages, '/test/workdir', {
+        fetchFn: mockedFetch,
+      })
 
       expect(result).toEqual([
         {
@@ -450,11 +430,9 @@ describe('compareDependencyVersions', () => {
           version: '0.2.0',
         })
 
-      const result = await compareDependencyVersions(
-        appAutoUpdatesImports,
-        '/test/workdir',
-        mockedFetch,
-      )
+      const result = await compareDependencyVersions(appAutoUpdatePackages, '/test/workdir', {
+        fetchFn: mockedFetch,
+      })
 
       expect(result).toEqual([
         {
@@ -488,11 +466,9 @@ describe('compareDependencyVersions', () => {
         version: '0.0.0',
       })
 
-      const result = await compareDependencyVersions(
-        appAutoUpdatesImports,
-        '/test/workdir',
-        mockedFetch,
-      )
+      const result = await compareDependencyVersions(appAutoUpdatePackages, '/test/workdir', {
+        fetchFn: mockedFetch,
+      })
 
       expect(mockedReadPackageManifest).toHaveBeenCalledTimes(1)
 

--- a/packages/sanity/src/_internal/cli/util/__tests__/getAutoUpdateImportMap.test.ts
+++ b/packages/sanity/src/_internal/cli/util/__tests__/getAutoUpdateImportMap.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, test} from 'vitest'
+
+import {getAutoUpdatesImportMap} from '../getAutoUpdatesImportMap'
+
+describe('getAutoUpdateImportMap()', () => {
+  test('works with sanity package', () => {
+    const autoUpdatesImportMap = getAutoUpdatesImportMap([{name: 'sanity', version: '3.2.0'}], {
+      timestamp: 1755770630,
+      baseUrl: 'https://sanity-cdn.com',
+    })
+    expect(autoUpdatesImportMap).toEqual({
+      'sanity': 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1755770630',
+      'sanity/': 'https://sanity-cdn.com/v1/modules/sanity/default/%5E3.2.0/t1755770630/',
+    })
+  })
+  test('works with scoped packages', () => {
+    expect(
+      getAutoUpdatesImportMap([{name: '@sanity/vision', version: '4.2.0'}], {
+        timestamp: 1755770630,
+        baseUrl: 'https://sanity-cdn.com',
+      }),
+    ).toEqual({
+      '@sanity/vision':
+        'https://sanity-cdn.com/v1/modules/@sanity__vision/default/%5E4.2.0/t1755770630',
+      '@sanity/vision/':
+        'https://sanity-cdn.com/v1/modules/@sanity__vision/default/%5E4.2.0/t1755770630/',
+    })
+  })
+  test('works with sdk packages', () => {
+    expect(
+      getAutoUpdatesImportMap(
+        [
+          {name: '@sanity/sdk', version: '1.0.0'},
+          {name: '@sanity/sdk-react', version: '1.3.0'},
+        ],
+        {timestamp: 1755770630, baseUrl: 'https://sanity-cdn.com'},
+      ),
+    ).toEqual({
+      '@sanity/sdk': 'https://sanity-cdn.com/v1/modules/@sanity__sdk/default/%5E1.0.0/t1755770630',
+      '@sanity/sdk/':
+        'https://sanity-cdn.com/v1/modules/@sanity__sdk/default/%5E1.0.0/t1755770630/',
+      '@sanity/sdk-react':
+        'https://sanity-cdn.com/v1/modules/@sanity__sdk-react/default/%5E1.3.0/t1755770630',
+      '@sanity/sdk-react/':
+        'https://sanity-cdn.com/v1/modules/@sanity__sdk-react/default/%5E1.3.0/t1755770630/',
+    })
+  })
+})

--- a/packages/sanity/src/_internal/cli/util/getAutoUpdatesImportMap.ts
+++ b/packages/sanity/src/_internal/cli/util/getAutoUpdatesImportMap.ts
@@ -1,80 +1,51 @@
-/**
- * @internal
- */
-export interface StudioAutoUpdatesImportMap {
-  'sanity': string
-  'sanity/': string
-  '@sanity/vision'?: string
-  '@sanity/vision/'?: string
-}
-
-export interface SanityAppAutoUpdatesImportMap extends Partial<StudioAutoUpdatesImportMap> {
-  '@sanity/sdk': string
-  '@sanity/sdk/': string
-  '@sanity/sdk-react': string
-  '@sanity/sdk-react/': string
-}
-
 const MODULES_HOST =
   process.env.SANITY_INTERNAL_ENV === 'staging'
     ? 'https://sanity-cdn.work'
     : 'https://sanity-cdn.com'
 
-function getTimestamp(): string {
-  return `t${Math.floor(Date.now() / 1000)}`
+function currentUnixTime(): number {
+  return Math.floor(Date.now() / 1000)
 }
 
+type Package = {version: string; name: string}
 /**
  * @internal
  */
-export function getStudioAutoUpdateImportMap(
-  version: string,
-  includeVision = true,
-): StudioAutoUpdatesImportMap {
-  const timestamp = getTimestamp()
-
-  const autoUpdatesImports = {
-    'sanity': `${MODULES_HOST}/v1/modules/sanity/default/${version}/${timestamp}`,
-    'sanity/': `${MODULES_HOST}/v1/modules/sanity/default/${version}/${timestamp}/`,
-  }
-
-  if (includeVision) {
-    return {
-      ...autoUpdatesImports,
-      '@sanity/vision': `${MODULES_HOST}/v1/modules/@sanity__vision/default/${version}/${timestamp}`,
-      '@sanity/vision/': `${MODULES_HOST}/v1/modules/@sanity__vision/default/${version}/${timestamp}/`,
-    }
-  }
-
-  return autoUpdatesImports
+export function getAutoUpdatesImportMap<const Pkg extends Package>(
+  packages: Pkg[],
+  options: {timestamp?: number; baseUrl?: string} = {},
+) {
+  return Object.fromEntries(
+    packages.flatMap((pkg) => getAppAutoUpdateImportMapForPackage(pkg, options)),
+  ) as {[K in Pkg['name'] | `${Pkg['name']}/`]: string}
 }
 
-interface GetAppAutoUpdateImportMapOptions {
-  sdkVersion: string
-  sanityVersion?: string
+function getAppAutoUpdateImportMapForPackage<const Pkg extends Package>(
+  pkg: Pkg,
+  options: {timestamp?: number; baseUrl?: string} = {},
+): [[Pkg['name'], string], [`${Pkg['name']}/`, string]] {
+  const moduleUrl = getModuleUrl(pkg, options)
+
+  return [
+    [pkg.name, moduleUrl],
+    [`${pkg.name}/`, `${moduleUrl}/`],
+  ]
+}
+
+export function getModuleUrl(pkg: Package, options: {timestamp?: number; baseUrl?: string} = {}) {
+  const {timestamp = currentUnixTime()} = options
+  const encodedMinVer = encodeURIComponent(`^${pkg.version}`)
+  return `${options.baseUrl || MODULES_HOST}/v1/modules/${rewriteScopedPackage(pkg.name)}/default/${encodedMinVer}/t${timestamp}`
 }
 
 /**
- * @internal
+ * replaces '/' with '__' similar to how eg `@types/scope__pkg` are rewritten
+ * scoped packages are stored this way both in the manifest and in the cloud storage bucket
  */
-export function getAppAutoUpdateImportMap(
-  options: GetAppAutoUpdateImportMapOptions,
-): SanityAppAutoUpdatesImportMap {
-  const timestamp = getTimestamp()
-
-  const {sdkVersion, sanityVersion} = options
-
-  const autoUpdatesImports: SanityAppAutoUpdatesImportMap = {
-    '@sanity/sdk': `${MODULES_HOST}/v1/modules/@sanity__sdk/default/${sdkVersion}/${timestamp}`,
-    '@sanity/sdk/': `${MODULES_HOST}/v1/modules/@sanity__sdk/default/${sdkVersion}/${timestamp}/`,
-    '@sanity/sdk-react': `${MODULES_HOST}/v1/modules/@sanity__sdk-react/default/${sdkVersion}/${timestamp}`,
-    '@sanity/sdk-react/': `${MODULES_HOST}/v1/modules/@sanity__sdk-react/default/${sdkVersion}/${timestamp}/`,
+function rewriteScopedPackage(pkgName: string) {
+  if (!pkgName.includes('@')) {
+    return pkgName
   }
-
-  if (sanityVersion) {
-    const sanityImportMap = getStudioAutoUpdateImportMap(sanityVersion, false)
-    return {...autoUpdatesImports, ...sanityImportMap}
-  }
-
-  return autoUpdatesImports
+  const [scope, ...pkg] = pkgName.split('/')
+  return `${scope}__${pkg.join('')}`
 }


### PR DESCRIPTION
### Description

Refactors how we generate import maps for auto updating studios. This is a foundation for follow-up work to support a new module url that includes app-id.

### What to review
- This should not cause any observed changes in the CLI commands that relies on import map generation, e.g. `sanity build`, `sanity deploy`, `sanity app build` and `sanity app deploy`

### Testing
Most touched code paths had tests already, added new tests for `getAutoUpdatesImportMap`, so overall test coverage should increase a little.

### Notes for release
n/a – internal only