### PR TITLE
fix: removing the document unpublish action from pseudo drafts

### DIFF
--- a/packages/sanity/src/structure/documentActions/UnpublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/UnpublishAction.tsx
@@ -8,6 +8,7 @@ import {
   useCurrentUser,
   useDocumentOperation,
   useDocumentPairPermissions,
+  usePerspective,
   useTranslation,
 } from 'sanity'
 
@@ -38,10 +39,12 @@ export const UnpublishAction: DocumentActionComponent = ({
     permission: 'unpublish',
   })
   const currentUser = useCurrentUser()
-  const {displayed} = useDocumentPane()
+  const {displayed, editState} = useDocumentPane()
   const {t} = useTranslation(structureLocaleNamespace)
+  const {selectedPerspective} = usePerspective()
 
-  const isDraft = displayed?._id && isDraftId(displayed?._id)
+  const isDraftExists = selectedPerspective === 'drafts' && !editState?.draft
+  const isDraft = (displayed?._id && isDraftId(displayed?._id)) || isDraftExists
 
   const handleCancel = useCallback(() => {
     setConfirmDialogOpen(false)


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue where when no draft version of a document existed, then the unpublish action would appear in the draft document's actions
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
