### PR TITLE
chore(ci): write coverage report on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,9 @@ jobs:
     if: ${{ !cancelled() }}
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      # Required to put a comment into the pull-request
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
### Description
Adds `pull-requests: write` as required permission for coverage reporting so we get coverage report as PR comments.

### What to review
If it works, we should get a comment on this PR

### Notes for release

n/a