### PR TITLE
fix: specify codeowners from function examples

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,4 +33,4 @@
 /packages/sanity/src/presentation/ @sanity-io/ecosystem
 
 # Examples
-/examples @mmgj @markmichon @kmelve
+/examples/functions @kmelve @kenjonespizza @iamkevingreen


### PR DESCRIPTION
This PR removes the docs team and add the right folks as codeowners for the `/examples/functions` folder. 