### PR TITLE
chore(cli): show media commands in CLI help

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/media/mediaGroup.ts
+++ b/packages/sanity/src/_internal/cli/commands/media/mediaGroup.ts
@@ -5,7 +5,6 @@ const mediaGroup: CliCommandGroupDefinition = {
   signature: '[COMMAND]',
   description: 'Manage Media Library.',
   isGroupRoot: true,
-  hideFromHelp: true,
 }
 
 export default mediaGroup


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Shows media command in CLI help