### PR TITLE
feat: add auto-retry workflow for failed jobs

### DIFF
--- a/.github/workflows/auto-retry-failed-jobs.yml
+++ b/.github/workflows/auto-retry-failed-jobs.yml
@@ -1,0 +1,25 @@
+name: Auto-rerun failed jobs (once)
+permissions:
+  actions: write # for rerunning failed jobs
+
+on:
+  # Trigger when test workflows complete with failure on first attempt
+  workflow_run:
+    workflows:
+      - "Unit tests"
+      - "End-to-End Tests"
+      - "End-to-End Component Tests"
+      - "CLI Unit tests"
+      - "eFPS Test"
+    types: [completed]
+
+jobs:
+  auto-retry:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun failed jobs only
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh run rerun ${{ github.event.workflow_run.id }} --failed


### PR DESCRIPTION
Adds automatic retry functionality for failed CI jobs.

This workflow automatically retries failed jobs once for the following workflows:
- Unit tests
- End-to-End Tests  
- End-to-End Component Tests
- CLI Unit tests
- eFPS Test

**Important**: This workflow must be on the main branch due to GitHub Actions workflow_run trigger limitations. workflow_run triggers only work when the workflow file exists on the default branch.

Once this is merged, the auto-retry functionality will be available for all feature branches.