### PR TITLE
fix: revert "fix(deps): update dependency @sanity/mutate to ^0.12.5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@repo/tsconfig": "workspace:*",
     "@repo/utils": "workspace:*",
     "@sanity/client": "^7.9.0",
-    "@sanity/mutate": "^0.12.5",
+    "@sanity/mutate": "^0.12.4",
     "@sanity/pkg-utils": "6.13.4",
     "@sanity/prettier-config": "^1.0.6",
     "@sanity/tsdoc": "1.0.169",

--- a/packages/@sanity/migrate/package.json
+++ b/packages/@sanity/migrate/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@sanity/client": "^7.9.0",
-    "@sanity/mutate": "^0.12.5",
+    "@sanity/mutate": "^0.12.4",
     "@sanity/types": "workspace:*",
     "@sanity/util": "workspace:*",
     "arrify": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
         specifier: ^7.9.0
         version: 7.9.0(debug@4.4.1)
       '@sanity/mutate':
-        specifier: ^0.12.5
-        version: 0.12.5(debug@4.4.1)
+        specifier: ^0.12.4
+        version: 0.12.4(debug@4.4.1)
       '@sanity/pkg-utils':
         specifier: 6.13.4
         version: 6.13.4(@types/babel__core@7.20.5)(@types/node@22.17.2)(babel-plugin-react-compiler@19.1.0-rc.2)(debug@4.4.1)(typescript@5.9.2)
@@ -1227,8 +1227,8 @@ importers:
         specifier: ^7.9.0
         version: 7.9.0(debug@4.4.1)
       '@sanity/mutate':
-        specifier: ^0.12.5
-        version: 0.12.5(debug@4.4.1)
+        specifier: ^0.12.4
+        version: 0.12.4(debug@4.4.1)
       '@sanity/types':
         specifier: workspace:*
         version: link:../types
@@ -4830,8 +4830,8 @@ packages:
       xstate:
         optional: true
 
-  '@sanity/mutate@0.12.5':
-    resolution: {integrity: sha512-vzCs62uTRaiCw1IIIFSqouUAHblWhfjL1s1rIcOLJgNZGDfF40cNeTHLD1JmdrK2/5v/T4oaX/0eEl5E9mPJ5w==}
+  '@sanity/mutate@0.12.4':
+    resolution: {integrity: sha512-CBPOOTCTyHFyhBL+seWpkGKJIE6lpaFd9yIeTIDt6miluBz6W8OKTNbaU6gPzOztqrr8KbrTaROiQAaMQDndQA==}
     engines: {node: '>=18'}
 
   '@sanity/mutator@3.99.0':
@@ -15540,9 +15540,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/mutate@0.12.5(debug@4.4.1)':
+  '@sanity/mutate@0.12.4(debug@4.4.1)':
     dependencies:
-      '@sanity/client': 7.9.0(debug@4.4.1)
+      '@sanity/client': 6.29.1(debug@4.4.1)
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/uuid': 3.0.2
       hotscript: 1.0.13
@@ -15799,7 +15799,7 @@ snapshots:
       '@sanity/diff-patch': 6.0.0
       '@sanity/json-match': 1.0.5
       '@sanity/message-protocol': 0.12.0
-      '@sanity/mutate': 0.12.5(debug@4.4.1)
+      '@sanity/mutate': 0.12.4(debug@4.4.1)
       '@sanity/types': 3.99.0(@types/react@19.1.11)(debug@4.4.1)
       groq: 3.88.1-typegen-experimental.0
       lodash-es: 4.17.21


### PR DESCRIPTION
Reverts sanity-io/sanity#10433 as this fails the export build step blocking our build process