### PR TITLE
chore(examples): update algolia to support update/delete events

### DIFF
--- a/examples/functions/algolia-document-sync/README.md
+++ b/examples/functions/algolia-document-sync/README.md
@@ -8,7 +8,7 @@ Content teams need to keep their search functionality up-to-date with their late
 
 ## Solution
 
-This Sanity Function automatically syncs published documents to Algolia's search index, ensuring your search functionality always reflects your latest content. When a post is published, the function sends the document data to Algolia, either creating a new search record or updating an existing one.
+This Sanity Function automatically syncs documents to Algolia's search index, ensuring your search functionality always reflects your latest content. When a post is published, the function sends the document data to Algolia, either creating a new search record or updating an existing one. When a document us updated or deleted, we also post additional information, as a result we can remove, hide posts/products etc as they're updated in Sanity.
 
 ## Benefits
 
@@ -61,9 +61,9 @@ This function is built to be compatible with any of [the official "clean" templa
      timeout: 10,
      src: './functions/algolia-document-sync',
      event: {
-       on: ['publish'],
+       on: ['create', 'update', 'delete'],
        filter: "_type == 'post'",
-       projection: '{_id, title, hideFromSearch}',
+       projection: '{_id, title, hideFromSearch, "operation": delta::operation()}',
      },
      env: {
        ALGOLIA_APP_ID: ALGOLIA_APP_ID,
@@ -83,6 +83,7 @@ This function is built to be compatible with any of [the official "clean" templa
 4. **Set up environment variables**
 
    Add your Algolia credentials to your root .env file:
+
    - `ALGOLIA_APP_ID`: Your Algolia application ID
    - `ALGOLIA_WRITE_KEY`: Your Algolia write API key
 

--- a/examples/functions/algolia-document-sync/index.ts
+++ b/examples/functions/algolia-document-sync/index.ts
@@ -6,25 +6,40 @@ import {algoliasearch} from 'algoliasearch'
 const {ALGOLIA_APP_ID = '', ALGOLIA_WRITE_KEY = ''} = env
 
 export const handler = documentEventHandler(async ({event}) => {
-  const {_id, title, hideFromSearch} = event.data
+  const {_id, title, hideFromSearch, operation} = event.data
 
   const algolia = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_WRITE_KEY)
+  if (operation === 'delete') {
+    try {
+      // We are assuming you already have an algolia instance setup with an index called 'posts'
+      // addOrUpdateObject documentation: https://www.algolia.com/doc/libraries/javascript/v5/methods/search/delete-object/?client=javascript
+      await algolia.deleteObject({
+        indexName: 'posts',
+        objectID: _id,
+      })
 
-  try {
-    // We are assuming you already have an algolia instance setup with an index called 'posts'
-    // addOrUpdateObject documentation: https://www.algolia.com/doc/libraries/javascript/v5/methods/search/add-or-update-object/?client=javascript
-    await algolia.addOrUpdateObject({
-      indexName: 'posts',
-      objectID: _id,
-      body: {
-        title,
-        hideFromSearch, // This is an optional field that you can use to hide a document from search results
-      },
-    })
+      console.log(`Successfully deleted document ${_id} ("${title}") from Algolia`)
+    } catch (error) {
+      console.error('Error syncing to Algolia:', error)
+      throw error
+    }
+  } else {
+    try {
+      // We are assuming you already have an algolia instance setup with an index called 'posts'
+      // addOrUpdateObject documentation: https://www.algolia.com/doc/libraries/javascript/v5/methods/search/add-or-update-object/?client=javascript
+      await algolia.addOrUpdateObject({
+        indexName: 'posts',
+        objectID: _id,
+        body: {
+          title,
+          hideFromSearch, // This is an optional field that you can use to hide a document from search results
+        },
+      })
 
-    console.log(`Successfully synced document ${_id} ("${title}") to Algolia`)
-  } catch (error) {
-    console.error('Error syncing to Algolia:', error)
-    throw error
+      console.log(`Successfully synced document ${_id} ("${title}") to Algolia`)
+    } catch (error) {
+      console.error('Error syncing to Algolia:', error)
+      throw error
+    }
   }
 })

--- a/examples/functions/algolia-document-sync/package.json
+++ b/examples/functions/algolia-document-sync/package.json
@@ -15,10 +15,12 @@
     "timeout": 10,
     "event": {
       "on": [
-        "publish"
+        "create",
+        "update",
+        "delete"
       ],
       "filter": "_type == 'post'",
-      "projection": "{_id, title, hideFromSearch}"
+      "projection": "{_id, title, hideFromSearch, 'operation': delta::operation()}"
     },
     "env": {
       "COMMENT": "ALGOLIA_APP_ID and ALGOLIA_WRITE_KEY env variables are required to sync documents to Algolia",


### PR DESCRIPTION
### Description

- replaced the on: ['published'] with on: ['create', 'update', 'delete']
- add delta operation for checking if documents are deleted
- update function to delete item from index if deleted

### What to review

Check updates to readme

### Testing

- ability to update/create should remain from `publish` event. 
- ability to delete should now remove the item from the algolia index. 

