### PR TITLE
test: update unit tests for the releasesOverview to reduce flakiness

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -217,14 +217,16 @@ const TableInner = <TableData, AdditionalRowTableData>({
             right: 0,
           }}
         >
-          <Text muted size={1}>
-            {emptyState}
-          </Text>
+          <td colSpan={amalgamatedColumnDefs.length}>
+            <Text muted size={1}>
+              {emptyState}
+            </Text>
+          </td>
         </Card>
       )
     }
     return emptyState()
-  }, [emptyState])
+  }, [amalgamatedColumnDefs.length, emptyState])
 
   const headers = useMemo(
     () =>

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -161,7 +161,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
         return (
           <Card
             key={cardKey}
-            data-testid="table-row"
+            data-testid={loading ? 'table-row-skeleton' : 'table-row'}
             borderBottom
             display="flex"
             data-index={datum.index}

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -1,7 +1,7 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {act, fireEvent, render, screen, waitFor, within} from '@testing-library/react'
 import {format, set} from 'date-fns'
-import {useState} from 'react'
+import {useEffect, useRef, useState} from 'react'
 import {useRouter} from 'sanity/router'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -122,12 +122,18 @@ const getWrapper = () =>
  * ReleasesOverview once the exact height wrapper has mounted
  */
 const TestComponent = () => {
-  const [hasWrapperRendered, setHasWrapperRendered] = useState<boolean>(false)
-  const updateWrapperRendered = () => setHasWrapperRendered(true)
+  const [hasWrapperRendered, setHasWrapperRendered] = useState(false)
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (wrapperRef.current) {
+      setHasWrapperRendered(true)
+    }
+  }, [])
 
   return (
-    <div style={{height: '400px'}} ref={updateWrapperRendered}>
-      <ReleasesOverview data-wrapperRendered={hasWrapperRendered?.toString()} />
+    <div style={{height: '400px'}} ref={wrapperRef}>
+      <ReleasesOverview data-wrapperRendered={hasWrapperRendered.toString()} />
     </div>
   )
 }

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -155,7 +155,7 @@ describe('ReleasesOverview', () => {
         resources: [releasesUsEnglishLocaleBundle],
       })
 
-      return render(<TestComponent />, {wrapper})
+      return await act(async () => render(<TestComponent />, {wrapper}))
     })
 
     it('shows loading state when releases are loading', async () => {
@@ -202,7 +202,7 @@ describe('ReleasesOverview', () => {
         resources: [releasesUsEnglishLocaleBundle],
       })
 
-      return render(<TestComponent />, {wrapper})
+      return await act(async () => render(<TestComponent />, {wrapper}))
     })
 
     it('shows a message about releases', () => {
@@ -249,7 +249,7 @@ describe('ReleasesOverview', () => {
 
       const wrapper = await getWrapper()
 
-      return render(<TestComponent />, {wrapper})
+      return await act(async () => render(<TestComponent />, {wrapper}))
     }
 
     beforeEach(async () => {
@@ -281,7 +281,7 @@ describe('ReleasesOverview', () => {
 
       const wrapper = await getWrapper()
 
-      return act(() => {
+      return await act(async () => {
         activeRender = render(<TestComponent />, {wrapper})
       })
     })


### PR DESCRIPTION
### Description

The releasesOverviews test, specifically the ones related to loading were very flaky and it's likely due to some improvements on the performance done on the table.

- Fixed some linting issues which made the document harder to read
- [x] Rewrote the tests to test still loading but focus on the table aspect
- [x] Fixed some warnings that we were getting and adding a lot of noise to the CI
```
When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser
    in TestApp
```
- [x] Fixed one last warning related
````
Warning: validateDOMNesting(...): <div> cannot appear as a child of <tr>.
    at div
````

### What to review

It's on the tin

### Testing

This PR is all tests!