### PR TITLE
fix: issue where the discard dialog preview was chosing a broken preview

### DIFF
--- a/packages/sanity/src/core/preview/components/Preview.tsx
+++ b/packages/sanity/src/core/preview/components/Preview.tsx
@@ -1,11 +1,12 @@
 import {usePreviewComponent} from '../../form/form-components-hooks'
 import {type RenderPreviewCallbackProps} from '../../form/types'
+import {type PerspectiveStack} from '../../perspective/types'
 import {PreviewLoader} from '../index'
 
 /**
  * @internal
  */
-export function Preview(props: RenderPreviewCallbackProps) {
+export function Preview(props: RenderPreviewCallbackProps & {perspectiveStack?: PerspectiveStack}) {
   const PreviewComponent = usePreviewComponent()
   return <PreviewLoader {...props} component={PreviewComponent} />
 }

--- a/packages/sanity/src/core/preview/components/PreviewLoader.tsx
+++ b/packages/sanity/src/core/preview/components/PreviewLoader.tsx
@@ -3,6 +3,7 @@ import {type ComponentType, type CSSProperties, useMemo, useState} from 'react'
 import {type PreviewProps} from '../../components'
 import {type RenderPreviewCallbackProps} from '../../form'
 import {useTranslation} from '../../i18n'
+import {type PerspectiveStack} from '../../perspective/types'
 import {unstable_useValuePreview as useValuePreview} from '../useValuePreview'
 import {useVisibility} from '../useVisibility'
 import {_HIDE_DELAY} from './_constants'
@@ -19,6 +20,7 @@ import {_extractUploadState} from './_extractUploadState'
 export function PreviewLoader(
   props: RenderPreviewCallbackProps & {
     component: ComponentType<Omit<PreviewProps, 'renderDefault'>>
+    perspectiveStack?: PerspectiveStack
   },
 ): React.JSX.Element {
   const {
@@ -28,6 +30,7 @@ export function PreviewLoader(
     style: styleProp,
     schemaType,
     skipVisibilityCheck,
+    perspectiveStack,
     ...restProps
   } = props
 
@@ -47,6 +50,7 @@ export function PreviewLoader(
     enabled: skipVisibilityCheck || isVisible,
     schemaType,
     value,
+    perspectiveStack,
   })
 
   const style: CSSProperties = useMemo(

--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -1,4 +1,5 @@
 import {type ReleaseDocument} from '@sanity/client'
+import {getVersionNameFromId, type VersionId} from '@sanity/id-utils'
 import {Box, Stack, Text, useToast} from '@sanity/ui'
 import {useCallback, useState} from 'react'
 
@@ -34,6 +35,7 @@ export function DiscardVersionDialog(props: {
   const discardType = isDraftId(documentId) ? 'draft' : 'release'
   const releaseName =
     typeof fromPerspective === 'string' ? fromPerspective : fromPerspective.metadata.title
+  const currentRelease = getVersionNameFromId(documentId as VersionId)
 
   const schemaType = schema.get(documentType)
 
@@ -92,7 +94,11 @@ export function DiscardVersionDialog(props: {
     >
       <Stack space={3} paddingX={3} marginBottom={2}>
         {schemaType ? (
-          <Preview value={{_id: documentId}} schemaType={schemaType} />
+          <Preview
+            value={{_id: documentId}}
+            schemaType={schemaType}
+            perspectiveStack={[currentRelease]}
+          />
         ) : (
           <LoadingBlock />
         )}


### PR DESCRIPTION
### Description

When you are in the release detail but don't have that release pinned, the preview of the document when the **discard dialog was open was wrong / incorrect**

Before (showing the wrong preview - showing draft):
<img width="1191" height="859" alt="image" src="https://github.com/user-attachments/assets/feb9f33f-3cba-465c-b5d8-7eee950f7a2a" />

Before (showing undefined preview when only version exists):
<img width="1191" height="859" alt="image" src="https://github.com/user-attachments/assets/81eca840-def1-4ee8-803e-e2d125e75101" />

After:
<img width="1191" height="859" alt="image" src="https://github.com/user-attachments/assets/febedac7-b211-4f04-98be-a341a227a42d" />

After:
<img width="1191" height="859" alt="image" src="https://github.com/user-attachments/assets/5023c3da-ce7a-49ee-bf9a-84c510bf43fd" />

### What to review

In another PR, me and @bjoerge spoke about not adding insecurity to which perspective we were sending in because I ended up in a similar situation then as I did here for the PreviewLoader / useValue Preview. Here is the reason why I didn't make it a mandatory prompt: when I did it, I noticed that we were widely using this across the studio in many many different parts, the bug is a small self contained one. It didn't feel right to be making such a wide change with potential for blowing it out of purposing (some of the tests were failing upon my changes where I thought it should be straightforward but it ended not not being so)

If we feel strongly that these props should be mandatory, I can make the change and spend the time on it, however, I don't feel that the juice is worth the squeeze for this particular use case

### Testing

Manual tests done.
Don't feel we need to add new ones beyond the ones that already exist

### Notes for release
When discarding a version from the release detail, the preview will now be the correct one
