### PR TITLE
fix(presentation): always include origin in document resolver context

### DIFF
--- a/packages/sanity/src/presentation/__tests__/useMainDocument.test.ts
+++ b/packages/sanity/src/presentation/__tests__/useMainDocument.test.ts
@@ -7,7 +7,7 @@ describe('getRouteContext', () => {
     const path = '/type-slug/page-slug'
     const url = new URL(path, location.origin)
     expect(getRouteContext('/:type/:page', url)).toEqual({
-      origin: undefined,
+      origin: location.origin,
       path,
       params: {
         type: 'type-slug',
@@ -53,7 +53,7 @@ describe('getRouteContext', () => {
     const path = '/caf%C3%A9'
     const url = new URL(path, location.origin)
     expect(getRouteContext('/:slug', url)).toEqual({
-      origin: undefined,
+      origin: location.origin,
       path,
       params: {
         slug: 'café',

--- a/packages/sanity/src/presentation/types.ts
+++ b/packages/sanity/src/presentation/types.ts
@@ -240,7 +240,7 @@ export type DocumentLocationResolverObject<K extends string = string> = {
  * @public
  */
 export interface DocumentResolverContext {
-  origin: string | undefined
+  origin: string
   params: Record<string, string>
   path: string
 }

--- a/packages/sanity/src/presentation/useMainDocument.ts
+++ b/packages/sanity/src/presentation/useMainDocument.ts
@@ -60,22 +60,23 @@ export function getRouteContext(route: Path, url: URL): DocumentResolverContext 
   const routes = Array.isArray(route) ? route : [route]
 
   for (route of routes) {
-    let origin: DocumentResolverContext['origin']
+    let {origin} = url
     let path = route
 
     // Handle absolute URLs
     if (typeof route === 'string') {
       try {
         const absolute = new URL(route)
+
+        // If we are dealing with an absolute URL, ensure the origins match
+        if (absolute.origin !== origin) continue
+
         origin = absolute.origin
         path = absolute.pathname
       } catch {
         // Ignore, as we assume a relative path
       }
     }
-
-    // If an origin has been explicitly provided, check that it matches
-    if (origin && url.origin !== origin) continue
 
     try {
       const matcher = match<Record<string, string>>(path, {decode: decodeURIComponent})


### PR DESCRIPTION
### Description

Presentation provides a helper context object as part of its Main Document Resolver API.

For example, when providing a resolve function:

```ts
presentationTool({
  mainDocuments: defineDocuments([
    {
      route: "/pages/:type/:slug",
      resolve(ctx) {
        const { params } = ctx;
        return {
          filter: `_type == $type && slug.current == $slug}`,
          params: {
            type: params.type,
            slug: params.slug.replaceAll("_", "-"),
          },
        };
      },
    },
  ]),
});
```

Currently, the `origin` property of the context object is only defined if the `route` property provided in the resolver is an absolute URL. This isn't strictly necessary, as we can fallback to using the `targetOrigin` value for relative URLs.

This PR updates `getRouteContext` to always return an origin, even for relative routes.

### What to review

Confirm the new origin fallback is correct and doesn’t change expected behaviour for relative routes.

I'm not sure if this qualifies as a breaking change, but consumers relying on origin being `undefined` for relative routes will now see a string being returned. I'm not sure if this is strictly a _fix_ as we explicitly typed origin as `string | undefined` previously, so I suppose this behaviour was intentional at some point? Is this change acceptable?

### Notes for release

`origin` is now always included in the Main Document Resolver context object (`DocumentResolverContext`). Previously it would be `undefined` for relative URLs.