### PR TITLE
fix(telemetry): include react version

### DIFF
--- a/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
+++ b/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
@@ -5,7 +5,7 @@ import {
 } from '@sanity/telemetry'
 import {TelemetryProvider} from '@sanity/telemetry/react'
 import arrify from 'arrify'
-import {type ReactNode, useEffect, useMemo} from 'react'
+import {type ReactNode, useEffect, useMemo, version as reactVersion} from 'react'
 
 import {type Config} from '../../config'
 import {useClient} from '../../hooks'
@@ -92,6 +92,7 @@ export function StudioTelemetryProvider(props: {children: ReactNode; config: Con
         innerHeight: window.innerHeight,
         innerWidth: window.innerWidth,
       },
+      reactVersion,
       studioVersion: SANITY_VERSION,
       plugins: workspaces.flatMap(
         (workspace) =>


### PR DESCRIPTION
### Description

Adds the react version to telemetry, so we can get a handle on how many studios are on react 18 vs 19.

### What to review

Is this the correct place for adding it? I assume it is since it tracks the studio version in the same `useEffect`.

### Testing

Used telemetry debug techniques to test locally that it's sending the version, and that the version is usable (on the test studio `reactVersion` is `19.1.1`).

### Notes for release

Telemetry now collects the react version in addition to the sanity version. [See Telemetry for more information on what we data we collect, how to opt-out and more.](https://www.sanity.io/telemetry)
