### PR TITLE
fix(sanity): mark document as consistent when refetching from server

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/buffered-doc/createObservableBufferedDocument.ts
+++ b/packages/sanity/src/core/store/_legacy/document/buffered-doc/createObservableBufferedDocument.ts
@@ -148,6 +148,8 @@ export const createObservableBufferedDocument = (listenerEvent$: Observable<List
           // it is usually because the connection has been down. Attempt to save pending changes (if any)
           bufferedDocument.commit()
         }
+        // mark as consistent when a new snapshot is received
+        consistency$.next(true)
         return createInitialBufferedDocument(listenerEvent.document || null)
       }
       if (bufferedDocument === null) {


### PR DESCRIPTION
### Description

Currently, if you get disconnected from the document listener while the document is in an "inconsistent" state, this state is never cleared after reconnecting. This PR fixes the issue by always emitting "consistent=true" when resetting the local document after a server reconnect.


### What to review
Does it make sense?

### Testing
Existing tests should pass, possibly with less flake. I was able to consistently repro this issue with a local proxy killing the eventsource connection every 10s and have verified that this patch fixes the issue.

### Notes for release
- Fixes an issue that could in some cases leave the document stuck in "Saving"-state after a connection loss.