### PR TITLE
fix: resolves revert change popover sometimes closing without bubbling click events

### DIFF
--- a/packages/sanity/src/core/field/diff/components/ChangeList.tsx
+++ b/packages/sanity/src/core/field/diff/components/ChangeList.tsx
@@ -1,11 +1,11 @@
 import {type SanityDocument} from '@sanity/client'
 import {RevertIcon} from '@sanity/icons'
 import {type ObjectSchemaType} from '@sanity/types'
-import {Box, Card, Flex, Stack, Text, useClickOutsideEvent} from '@sanity/ui'
+import {Card, Stack, useClickOutsideEvent} from '@sanity/ui'
 import {useCallback, useContext, useMemo, useRef, useState} from 'react'
 import {DiffContext} from 'sanity/_singletons'
 
-import {Button, Popover} from '../../../../ui-components'
+import {Button} from '../../../../ui-components'
 import {useDocumentOperation} from '../../../hooks'
 import {useTranslation} from '../../../i18n'
 import {useDocumentPairPermissions} from '../../../store'
@@ -17,6 +17,7 @@ import {useDocumentChange} from '../hooks/useDocumentChange'
 import {ChangeListWrapper} from './ChangeList.styled'
 import {ChangeResolver} from './ChangeResolver'
 import {NoChanges} from './NoChanges'
+import {RevertChangesConfirmationPopover} from './RevertChangesConfirmationPopover'
 
 /** @internal */
 export interface ChangeListProps {
@@ -119,35 +120,11 @@ export function ChangeList({diff, fields, schemaType}: ChangeListProps): React.J
         </Stack>
 
         {showFooter && isComparingCurrent && !isPermissionsLoading && permissions?.granted && (
-          <Popover
-            content={
-              <Stack space={3}>
-                <Box paddingY={3}>
-                  <Text size={1}>
-                    {t('changes.action.revert-all-description', {
-                      count: changes.length,
-                    })}
-                  </Text>
-                </Box>
-                <Flex gap={3} justify="flex-end">
-                  <Button
-                    mode="ghost"
-                    text={t('changes.action.revert-all-cancel')}
-                    onClick={closeRevertAllChangesConfirmDialog}
-                  />
-                  <Button
-                    tone="critical"
-                    text={t('changes.action.revert-all-confirm')}
-                    onClick={revertAllChanges}
-                  />
-                </Flex>
-              </Stack>
-            }
+          <RevertChangesConfirmationPopover
             open={confirmRevertAllOpen}
-            padding={3}
-            placement={'left'}
-            portal
-            ref={revertAllContainerElementRef}
+            onConfirm={revertAllChanges}
+            onCancel={closeRevertAllChangesConfirmDialog}
+            changeCount={changes.length}
           >
             <Stack>
               <Button
@@ -162,7 +139,7 @@ export function ChangeList({diff, fields, schemaType}: ChangeListProps): React.J
                 size="large"
               />
             </Stack>
-          </Popover>
+          </RevertChangesConfirmationPopover>
         )}
       </Stack>
     </Card>

--- a/packages/sanity/src/core/field/diff/components/FieldChange.tsx
+++ b/packages/sanity/src/core/field/diff/components/FieldChange.tsx
@@ -1,9 +1,8 @@
 import {type ObjectSchemaType, type Path} from '@sanity/types'
-import {Box, Flex, Stack, Text, useClickOutsideEvent} from '@sanity/ui'
+import {Stack, useClickOutsideEvent} from '@sanity/ui'
 import {Fragment, type HTMLAttributes, useCallback, useMemo, useRef, useState} from 'react'
 import {DiffContext} from 'sanity/_singletons'
 
-import {Button, Popover} from '../../../../ui-components'
 import {useDocumentOperation} from '../../../hooks'
 import {useTranslation} from '../../../i18n'
 import {useDocumentPairPermissions} from '../../../store'
@@ -16,6 +15,7 @@ import {DiffInspectWrapper} from './DiffInspectWrapper'
 import {FallbackDiff} from './FallbackDiff'
 import {DiffBorder, FieldChangeContainer} from './FieldChange.styled'
 import {RevertChangesButton} from './RevertChangesButton'
+import {RevertChangesConfirmationPopover} from './RevertChangesConfirmationPopover'
 import {ValueError} from './ValueError'
 
 const ParentWrapper = ({
@@ -80,6 +80,7 @@ export function FieldChange(
 
   const handleRevertChanges = useCallback(() => {
     undoChange(change, rootDiff, ops)
+    setConfirmRevertOpen(false)
   }, [change, rootDiff, ops])
 
   const handleRevertChangesConfirm = useCallback(() => {
@@ -150,33 +151,11 @@ export function FieldChange(
                 )}
 
                 {isComparingCurrent && !isPermissionsLoading && permissions?.granted && (
-                  <Popover
-                    content={
-                      <Stack space={3}>
-                        <Box paddingY={3}>
-                          <Text size={1}>
-                            {t('changes.action.revert-changes-description', {count: 1})}
-                          </Text>
-                        </Box>
-                        <Flex gap={3} justify="flex-end">
-                          <Button
-                            mode="ghost"
-                            onClick={closeRevertChangesConfirmDialog}
-                            text={t('changes.action.revert-all-cancel')}
-                          />
-                          <Button
-                            tone="critical"
-                            onClick={handleRevertChanges}
-                            text={t('changes.action.revert-changes-confirm-change', {count: 1})}
-                          />
-                        </Flex>
-                      </Stack>
-                    }
+                  <RevertChangesConfirmationPopover
                     open={confirmRevertOpen}
-                    padding={3}
-                    portal
-                    placement="left"
-                    ref={popoverRef}
+                    onConfirm={handleRevertChanges}
+                    onCancel={closeRevertChangesConfirmDialog}
+                    changeCount={1}
                   >
                     <RevertChangesButton
                       changeCount={1}
@@ -187,7 +166,7 @@ export function FieldChange(
                       disabled={readOnly}
                       data-testid={`single-change-revert-button-${change?.key}`}
                     />
-                  </Popover>
+                  </RevertChangesConfirmationPopover>
                 )}
               </DiffInspectWrapper>
             </FieldWrapper>

--- a/packages/sanity/src/core/field/diff/components/GroupChange.tsx
+++ b/packages/sanity/src/core/field/diff/components/GroupChange.tsx
@@ -1,4 +1,4 @@
-import {Box, Flex, Stack, Text, useClickOutsideEvent} from '@sanity/ui'
+import {Box, Stack, useClickOutsideEvent} from '@sanity/ui'
 import {
   Fragment,
   type HTMLAttributes,
@@ -10,7 +10,6 @@ import {
 } from 'react'
 import {DiffContext} from 'sanity/_singletons'
 
-import {Button, Popover} from '../../../../ui-components'
 import {useDocumentOperation} from '../../../hooks'
 import {useTranslation} from '../../../i18n'
 import {useDocumentPairPermissions} from '../../../store'
@@ -25,6 +24,7 @@ import {ChangeBreadcrumb} from './ChangeBreadcrumb'
 import {ChangeResolver} from './ChangeResolver'
 import {ChangeListWrapper, GroupChangeContainer} from './GroupChange.styled'
 import {RevertChangesButton} from './RevertChangesButton'
+import {RevertChangesConfirmationPopover} from './RevertChangesConfirmationPopover'
 
 /** @internal */
 export function GroupChange(
@@ -63,10 +63,10 @@ export function GroupChange(
     permission: 'update',
   })
 
-  const handleRevertChanges = useCallback(
-    () => undoChange(group, rootDiff, docOperations),
-    [group, rootDiff, docOperations],
-  )
+  const handleRevertChanges = useCallback(() => {
+    undoChange(group, rootDiff, docOperations)
+    setConfirmRevertOpen(false)
+  }, [group, rootDiff, docOperations])
 
   const handleRevertChangesConfirm = useCallback(() => {
     setConfirmRevertOpen(true)
@@ -105,33 +105,11 @@ export function GroupChange(
             ))}
           </Stack>
           {isComparingCurrent && !isPermissionsLoading && permissions?.granted && (
-            <Popover
-              content={
-                <Stack space={3}>
-                  <Box paddingY={3}>
-                    <Text size={1}>
-                      {t('changes.action.revert-changes-description', {count: changes.length})}
-                    </Text>
-                  </Box>
-                  <Flex gap={3} justify="flex-end">
-                    <Button
-                      mode="ghost"
-                      onClick={closeRevertChangesConfirmDialog}
-                      text={t('changes.action.revert-all-cancel')}
-                    />
-                    <Button
-                      tone="critical"
-                      onClick={handleRevertChanges}
-                      text={t('changes.action.revert-changes-confirm-change', {count: 1})}
-                    />
-                  </Flex>
-                </Stack>
-              }
-              padding={3}
-              portal
-              placement="left"
+            <RevertChangesConfirmationPopover
               open={confirmRevertOpen}
-              ref={popoverRef}
+              onConfirm={handleRevertChanges}
+              onCancel={closeRevertChangesConfirmDialog}
+              changeCount={changes.length}
             >
               <Box>
                 <RevertChangesButton
@@ -143,7 +121,7 @@ export function GroupChange(
                   data-testid={`group-change-revert-button-${group.fieldsetName}`}
                 />
               </Box>
-            </Popover>
+            </RevertChangesConfirmationPopover>
           )}
         </Stack>
       ),
@@ -163,7 +141,6 @@ export function GroupChange(
       permissions?.granted,
       readOnly,
       revertButtonRef,
-      t,
     ],
   )
 

--- a/packages/sanity/src/core/field/diff/components/RevertChangesConfirmationPopover.tsx
+++ b/packages/sanity/src/core/field/diff/components/RevertChangesConfirmationPopover.tsx
@@ -1,0 +1,79 @@
+import {Box, Flex, Stack, Text} from '@sanity/ui'
+import {type ReactElement, useCallback} from 'react'
+
+import {Button, Popover} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n'
+
+interface RevertChangesConfirmationPopoverProps {
+  open: boolean
+  onConfirm: () => void
+  onCancel: () => void
+  changeCount: number
+  placement?: 'left' | 'top' | 'right' | 'bottom'
+  children: ReactElement
+}
+
+export function RevertChangesConfirmationPopover({
+  open,
+  onConfirm,
+  onCancel,
+  changeCount,
+  placement = 'left',
+  children,
+}: RevertChangesConfirmationPopoverProps) {
+  const {t} = useTranslation()
+
+  const handleCancel = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      onCancel()
+    },
+    [onCancel],
+  )
+
+  const handleConfirm = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      onConfirm()
+    },
+    [onConfirm],
+  )
+
+  return (
+    <Popover
+      content={
+        <Stack space={3}>
+          <Box paddingY={3}>
+            <Text size={1}>
+              {changeCount > 1
+                ? t('changes.action.revert-all-description', {count: changeCount})
+                : t('changes.action.revert-changes-description', {count: changeCount})}
+            </Text>
+          </Box>
+          <Flex gap={3} justify="flex-end">
+            <Button
+              mode="ghost"
+              onMouseDown={handleCancel}
+              text={t('changes.action.revert-all-cancel')}
+            />
+            <Button
+              tone="critical"
+              onMouseDown={handleConfirm}
+              text={
+                changeCount > 1
+                  ? t('changes.action.revert-all-confirm')
+                  : t('changes.action.revert-changes-confirm-change', {count: 1})
+              }
+            />
+          </Flex>
+        </Stack>
+      }
+      open={open}
+      padding={3}
+      portal
+      placement={placement}
+    >
+      {children}
+    </Popover>
+  )
+}


### PR DESCRIPTION
### Description
There were intermittent reports of the revert changes not working. I was able to replicate this, but only with reference fields.

It turned out that because we use a popover for the confirm buttons, this component was no longer (presumably a change in `sanity/ui`) bubbling click events up. So clicking on 'revert changes' was only closing the popover.

This change uses the `mousedown` event instead to catch the presses. This is less ideal, and also flags there are a11y issues likely around this flow which I have created a further task to be investigated and improved.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manually verified that this is now working for all fields where previously I was able to replicate for reference fields
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
