### PR TITLE
fix: handle uploading assets already existing in the ML

### DIFF
--- a/packages/@sanity/types/src/assets/types.ts
+++ b/packages/@sanity/types/src/assets/types.ts
@@ -189,7 +189,7 @@ export interface AssetSourceUploadFile {
   id: string
   file: globalThis.File
   progress: number // 0 to 100
-  status: 'pending' | 'uploading' | 'complete' | 'error' | 'aborted'
+  status: 'pending' | 'uploading' | 'complete' | 'error' | 'aborted' | 'alreadyExists'
   error?: Error
   result?: unknown // The upload result in the source
 }

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/UploadAssetDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/UploadAssetDialog.tsx
@@ -120,6 +120,22 @@ export const UploadAssetsDialog = function UploadAssetsDialog(
       }
       const subscribe = () => {
         return uploader.subscribe((event) => {
+          if (event.type === 'all-complete') {
+            const existingFiles = event.files.filter((file) => file.status === 'alreadyExists')
+            existingFiles.forEach((file) => {
+              toast.push({
+                status: 'warning',
+                title: t('asset-sources.media-library.warning.file-already-exist.title', {
+                  filename: file.file.name,
+                }),
+                description: t(
+                  'asset-sources.media-library.warning.file-already-exist.description',
+                ),
+                closable: true,
+                duration: 10000,
+              })
+            })
+          }
           if (event.type === 'status' && event.status === 'aborted') {
             postMessage({
               type: 'abortUploadRequest',
@@ -139,7 +155,7 @@ export const UploadAssetsDialog = function UploadAssetsDialog(
       return uploaderRef.current.unsubscribe
     }
     return uploaderRef.current?.unsubscribe()
-  }, [open, pageReadyForUploads, postMessage, uploader, uploaderRef])
+  }, [open, pageReadyForUploads, postMessage, t, toast, uploader, uploaderRef])
 
   if (!open) {
     return null

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/uploader.ts
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/uploader.ts
@@ -13,7 +13,9 @@ export class MediaLibraryUploader implements AssetSourceUploader {
   private checkAllComplete(): void {
     const isDone =
       this.files.length > 0 &&
-      this.files.every((file) => ['complete', 'error', 'aborted'].includes(file.status))
+      this.files.every((file) =>
+        ['complete', 'error', 'aborted', 'alreadyExists'].includes(file.status),
+      )
     if (isDone) {
       const hasError = this.files.some((file) => file.status === 'error')
       if (hasError) {

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -204,6 +204,12 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Info messages for the Media Library Asset Source  */
   'asset-sources.media-library.select-dialog.title': 'Selecting {{assetType}} for {{targetTitle}}',
 
+  /** Warning message shown when uploading already existing files to the Media Library Asset Source */
+  'asset-sources.media-library.warning.file-already-exist.description':
+    'Using the existing file found in the library.',
+  'asset-sources.media-library.warning.file-already-exist.title':
+    "File: '{{filename}}' already exists",
+
   /** Label when a release has been deleted by a different user */
   'banners.deleted-bundle-banner.text':
     "The '<strong>{{title}}</strong>' release has been deleted.",


### PR DESCRIPTION
### Description

This will handle uploads through the studio to the Media Library where a file already exists.

It will instead use the current ML asset and notify the user through a toast:


<img width="694" height="995" alt="image" src="https://github.com/user-attachments/assets/04d3c2f4-06d5-4ef1-84e5-5936903fb40d" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is the toast sufficient for user feedback?

Is the text ok?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
* Fix an error that occurred when uploading assets to the Media Library that already exists in the library.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
