### PR TITLE
feat: add validation per release on the release overview + add caching

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -11,6 +11,7 @@ import {
   type HTMLProps,
   type RefAttributes,
   type RefObject,
+  useEffect,
   useMemo,
   useRef,
 } from 'react'
@@ -119,6 +120,15 @@ const TableInner = <TableData, AdditionalRowTableData>({
     estimateSize: () => ITEM_HEIGHT,
     overscan: 5,
   })
+
+  useEffect(() => {
+    // Sometimes the scrollCotaninerRef is not initially available
+    // This makes it that the table woudl then be blank when the data already exists
+    // This is a workaround to force the virtualizer to re-measure when the scroll container becomes available
+    if (scrollContainerRef.current) {
+      rowVirtualizer.measure()
+    }
+  }, [rowVirtualizer, scrollContainerRef])
 
   const rowActionColumnDef: Column = useMemo(
     () => ({

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -10,8 +10,6 @@ import {
   Fragment,
   type HTMLProps,
   type RefAttributes,
-  type RefObject,
-  useEffect,
   useMemo,
   useRef,
 } from 'react'
@@ -54,7 +52,7 @@ export interface TableProps<TableData, AdditionalRowTableData> {
     datum: RowDatum<TableData, AdditionalRowTableData> | unknown
   }) => React.ReactNode
   rowProps?: (datum: TableData) => Partial<TableRowProps>
-  scrollContainerRef: RefObject<HTMLDivElement | null>
+  scrollContainerRef: HTMLDivElement | null
   hideTableInlinePadding?: boolean
 }
 
@@ -116,19 +114,10 @@ const TableInner = <TableData, AdditionalRowTableData>({
 
   const rowVirtualizer = useVirtualizer({
     count: filteredData.length,
-    getScrollElement: () => scrollContainerRef.current,
+    getScrollElement: () => scrollContainerRef,
     estimateSize: () => ITEM_HEIGHT,
     overscan: 5,
   })
-
-  useEffect(() => {
-    // Sometimes the scrollCotaninerRef is not initially available
-    // This makes it that the table woudl then be blank when the data already exists
-    // This is a workaround to force the virtualizer to re-measure when the scroll container becomes available
-    if (scrollContainerRef.current) {
-      rowVirtualizer.measure()
-    }
-  }, [rowVirtualizer, scrollContainerRef])
 
   const rowActionColumnDef: Column = useMemo(
     () => ({

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
@@ -1,7 +1,7 @@
 import {ErrorOutlineIcon} from '@sanity/icons'
 import {Box, Card, Container, Flex, Heading, Stack, Text} from '@sanity/ui'
 import {motion} from 'framer-motion'
-import {useMemo, useRef, useState} from 'react'
+import {useMemo, useState} from 'react'
 import {useRouter} from 'sanity/router'
 
 import {LoadingBlock} from '../../../components'
@@ -42,8 +42,6 @@ export const ReleaseDetail = () => {
     .concat(archivedReleases)
     .find((candidate) => getReleaseIdFromReleaseDocumentId(candidate._id) === releaseId)
 
-  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
-
   const detailContent = useMemo(() => {
     if (bundleDocumentsError) {
       return (
@@ -73,12 +71,7 @@ export const ReleaseDetail = () => {
     if (!releaseInDetail) return null
 
     return (
-      <ReleaseSummary
-        isLoading={documentsLoading}
-        documents={results}
-        release={releaseInDetail}
-        scrollContainerRef={scrollContainerRef}
-      />
+      <ReleaseSummary isLoading={documentsLoading} documents={results} release={releaseInDetail} />
     )
   }, [bundleDocumentsError, documentsLoading, releaseInDetail, results, t])
 

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -2,7 +2,7 @@ import {type ReleaseDocument, type SanityDocument} from '@sanity/client'
 import {AddIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Card, Container, Stack, useToast} from '@sanity/ui'
-import {type RefObject, useCallback, useEffect, useMemo, useState} from 'react'
+import {useCallback, useEffect, useMemo, useState} from 'react'
 
 import {Button} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
@@ -28,7 +28,6 @@ export type BundleDocumentRow = DocumentInReleaseDetail
 
 export interface ReleaseSummaryProps {
   documents: DocumentInRelease[]
-  scrollContainerRef: RefObject<HTMLDivElement | null>
   release: ReleaseDocument
   isLoading?: boolean
 }
@@ -43,7 +42,8 @@ const isBundleDocumentRow = (
   'validation' in maybeBundleDocumentRow
 
 export function ReleaseSummary(props: ReleaseSummaryProps) {
-  const {documents, isLoading = false, release, scrollContainerRef} = props
+  const {documents, isLoading = false, release} = props
+  const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
   const toast = useToast()
   const {createVersion} = useReleaseOperations()
   const telemetry = useTelemetry()
@@ -158,8 +158,8 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
 
   return (
     <Card
+      ref={setScrollContainerRef}
       data-testid="document-table-card"
-      ref={scrollContainerRef}
       style={{
         height: '100%',
         overflow: 'auto',

--- a/packages/sanity/src/core/releases/tool/detail/ValidationProgressIndicator.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ValidationProgressIndicator.tsx
@@ -9,7 +9,13 @@ import {releasesLocaleNamespace} from '../../i18n'
 import {getDocumentValidationLoading} from '../../util/getDocumentValidationLoading'
 import {type DocumentInRelease} from './useBundleDocuments'
 
-export function ValidationProgressIndicator({documents}: {documents: DocumentInRelease[]}) {
+export function ValidationProgressIndicator({
+  documents,
+  isMinimal = false,
+}: {
+  documents: DocumentInRelease[]
+  isMinimal?: boolean
+}) {
   const totalCount = documents.length
   const {validatedCount, isValidating, hasError} = getDocumentValidationLoading(documents)
   const [showCheckmark, setShowCheckmark] = useState(false)
@@ -79,7 +85,7 @@ export function ValidationProgressIndicator({documents}: {documents: DocumentInR
             </Tooltip>
           )}
         </Text>
-        {!showCheckmark && (
+        {!showCheckmark && !isMinimal && (
           <Text muted size={1}>
             {isValidating
               ? t('summary.validating-documents', {validatedCount, totalCount})

--- a/packages/sanity/src/core/releases/tool/detail/ValidationProgressIndicator.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ValidationProgressIndicator.tsx
@@ -66,7 +66,7 @@ export function ValidationProgressIndicator({
 
   return (
     <Card
-      padding={2}
+      padding={isMinimal ? 0 : 2}
       radius="full"
       tone={tone}
       style={{

--- a/packages/sanity/src/core/releases/tool/detail/ValidationProgressIndicator.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ValidationProgressIndicator.tsx
@@ -11,15 +11,16 @@ import {type DocumentInRelease} from './useBundleDocuments'
 
 export function ValidationProgressIndicator({
   documents,
-  isMinimal = false,
+  layout = 'default',
 }: {
   documents: DocumentInRelease[]
-  isMinimal?: boolean
+  layout?: 'default' | 'minimal'
 }) {
   const totalCount = documents.length
   const {validatedCount, isValidating, hasError} = getDocumentValidationLoading(documents)
   const [showCheckmark, setShowCheckmark] = useState(false)
   const {t} = useTranslation(releasesLocaleNamespace)
+  const isMinimal = layout === 'minimal'
 
   const isFinished = useMemo(
     () => validatedCount === totalCount && validatedCount !== 0,

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -10,6 +10,7 @@ import {
   distinctUntilChanged,
   expand,
   filter,
+  finalize,
   map,
   reduce,
   shareReplay,
@@ -287,7 +288,12 @@ const getReleaseDocumentsObservable = ({
             })
           }
 
-          bundleDocumentsCache[cacheKey] = observable
+          bundleDocumentsCache[cacheKey] = observable.pipe(
+            finalize(() => {
+              delete bundleDocumentsCache[cacheKey]
+            }),
+            shareReplay(1),
+          )
         }
 
         return bundleDocumentsCache[cacheKey]

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -22,7 +22,7 @@ import {type LocaleSource} from '../../../i18n/types'
 import {type DocumentPreviewStore} from '../../../preview'
 import {useDocumentPreviewStore} from '../../../store/_legacy/datastores'
 import {useSource} from '../../../studio'
-import {scheduledYield} from '../../../util/postYield'
+import {schedulerYield} from '../../../util/schedulerYield'
 import {validateDocumentWithReferences, type ValidationStatus} from '../../../validation'
 import {useReleasesStore} from '../../store/useReleasesStore'
 import {getReleaseDocumentIdFromReleaseId} from '../../util/getReleaseDocumentIdFromReleaseId'
@@ -72,8 +72,8 @@ const getActiveReleaseDocumentsObservable = ({
       } satisfies DocumentValidationStatus)
     }
 
-    // Add scheduler.yield() before each document validation
-    return from(scheduledYield(() => Promise.resolve())).pipe(
+    // scheduledYield is used to provide some control over the main thread
+    return from(schedulerYield(() => Promise.resolve())).pipe(
       switchMap(() =>
         validateDocumentWithReferences(ctx, of(document)).pipe(
           map((validationStatus) => ({

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -108,7 +108,7 @@ export function ReleasesOverview() {
     [selectedPerspective],
   )
 
-  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+  const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
 
   const hasReleases = releases.length > 0 || archivedReleases.length > 0
   const loadingOrHasReleases = loading || hasReleases
@@ -425,7 +425,7 @@ export function ReleasesOverview() {
                   </Flex>
                 </Flex>
               </Card>
-              <Box ref={scrollContainerRef} marginTop={3} overflow={'auto'}>
+              <Box ref={setScrollContainerRef} marginTop={3} overflow={'auto'}>
                 {(loading || hasReleases) && (
                   <Table<TableRelease>
                     // for resetting filter and sort on table when filer changed

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -11,6 +11,7 @@ import {getPublishDateFromRelease, isReleaseScheduledOrScheduling} from '../../u
 import {ReleaseTime} from '../components/ReleaseTime'
 import {Headers} from '../components/Table/TableHeader'
 import {type Column} from '../components/Table/types'
+import {ReleaseColumnValidationLoading} from './columnCells/ReleaseColumnValidationLoading'
 import {ReleaseDocumentsCounter} from './columnCells/ReleaseDocumentsCounter'
 import {ReleaseNameCell} from './columnCells/ReleaseName'
 import {type Mode} from './queryParamUtils'
@@ -242,19 +243,28 @@ export const releasesOverviewColumnDefs: (
             <Headers.BasicHeader text={t('table-header.documents')} />
           </Flex>
         ),
-        cell: ({datum: {isDeleted, state, finalDocumentStates, documentsMetadata}, cellProps}) => (
-          <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
-            {!isDeleted && (
-              <ReleaseDocumentsCounter
-                documentCount={
-                  state === 'archived' || state === 'published'
-                    ? finalDocumentStates?.length
-                    : documentsMetadata?.documentCount
-                }
-              />
-            )}
-          </Flex>
-        ),
+        cell: ({
+          datum: {isDeleted, state, finalDocumentStates, documentsMetadata, _id},
+          cellProps,
+        }) => {
+          return (
+            <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border" gap={2}>
+              {state === 'active' && <ReleaseColumnValidationLoading releaseId={_id} />}
+
+              {!isDeleted && (
+                <>
+                  <ReleaseDocumentsCounter
+                    documentCount={
+                      state === 'archived' || state === 'published'
+                        ? finalDocumentStates?.length
+                        : documentsMetadata?.documentCount
+                    }
+                  />
+                </>
+              )}
+            </Flex>
+          )
+        },
       },
       'all',
     ),

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseColumnValidationLoading.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseColumnValidationLoading.tsx
@@ -11,6 +11,6 @@ export function ReleaseColumnValidationLoading({releaseId}: {releaseId: string})
   return loading ? (
     <Spinner size={1} muted />
   ) : (
-    <ValidationProgressIndicator isMinimal documents={documents} />
+    <ValidationProgressIndicator layout="minimal" documents={documents} />
   )
 }

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseColumnValidationLoading.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseColumnValidationLoading.tsx
@@ -1,0 +1,16 @@
+import {Spinner} from '@sanity/ui'
+
+import {getReleaseIdFromReleaseDocumentId} from '../../../util/getReleaseIdFromReleaseDocumentId'
+import {useBundleDocuments} from '../../detail/useBundleDocuments'
+import {ValidationProgressIndicator} from '../../detail/ValidationProgressIndicator'
+
+export function ReleaseColumnValidationLoading({releaseId}: {releaseId: string}) {
+  const rId = getReleaseIdFromReleaseDocumentId(releaseId)
+  const {results: documents, loading} = useBundleDocuments(rId)
+
+  return loading ? (
+    <Spinner size={1} muted />
+  ) : (
+    <ValidationProgressIndicator isMinimal documents={documents} />
+  )
+}

--- a/packages/sanity/src/core/util/postYield.ts
+++ b/packages/sanity/src/core/util/postYield.ts
@@ -1,0 +1,8 @@
+export function scheduledYield<Result>(
+  promise: () => Promise<Result>,
+): Promise<Result> | Promise<void> {
+  if ('scheduler' in window && typeof window.scheduler?.yield === 'function') {
+    return window.scheduler.yield()
+  }
+  return promise()
+}

--- a/packages/sanity/src/core/util/postYield.ts
+++ b/packages/sanity/src/core/util/postYield.ts
@@ -1,8 +1,0 @@
-export function scheduledYield<Result>(
-  promise: () => Promise<Result>,
-): Promise<Result> | Promise<void> {
-  if ('scheduler' in window && typeof window.scheduler?.yield === 'function') {
-    return window.scheduler.yield()
-  }
-  return promise()
-}

--- a/packages/sanity/src/core/util/schedulerYield.ts
+++ b/packages/sanity/src/core/util/schedulerYield.ts
@@ -1,0 +1,14 @@
+/**
+ * Schedule the provided callback using `scheduler.yield`, if it's available.
+ * This allows long-running work to be broken up so the browser stays responsive.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Scheduler/yield
+ * Otherwise, call it immediately.
+ */
+export function schedulerYield<Result>(
+  promise: () => Promise<Result>,
+): Promise<Result> | Promise<void> {
+  if ('scheduler' in window && typeof window.scheduler?.yield === 'function') {
+    return window.scheduler.yield()
+  }
+  return promise()
+}


### PR DESCRIPTION
### Description

Changed the fetching of the documents and validations so that they are grouped into requests versus attempting to send them off all in the a single way. I have attempted different solutions (both with rxjs and thought about workers) but came to the conclusion that for the work that we are currently this was the best approach. The largest deterrer for works is the overhead of work and the fact that we know we will have incoming work coming to these pages in the nearer future which might impact the structure of this feature anyway.

<img width="1179" height="741" alt="Screenshot 2025-09-04 at 10 34 16" src="https://github.com/user-attachments/assets/10b45b21-be9d-4441-97f8-6ab9567efedc" />

This is a good amount of juice for the squeeze.

**Overall**
- Added a method for caching the requests in the useBundleDocuments, this means that when navigating between the overview and the details will reuse the already existing data. It is also robust enough that if changes happen (such as validation changes), it is updated automatically
- With the grouping of the requests it means that the browser is able to more quickly move through the requests and not hang on any one/multiple in particular.
- An overall benefit is that this makes the validation even within the release detail faster than before.
- We can now get a quick indicator of where in the validation process it is for small or large releases, as well as if there are conflicts in the release / is ready
- There is a delay built in on the requests made as to make sure that the browser has enough space to breathe, one might expect that this would make the requests slower but the tests done to performance indicate that that is not the case
- Added `window.scheduler.yield()` while I don't think we hugely benefit for it here I do think it won't harm the performance and I think that in some instances (weaker machines and poorer network) that it might help.

**For the overview:**
- I have double checked that if someone makes a change that impacts the release validation (turning it from "valid" to "with errors" or the opposite, that the table will automatically work
- This solution also means that the validation that is being done on load that it will share its state with both the overview actions but the rendering of the actions within a detail of a release meaning that once a user goes into a release (and the validation might not be finished) the progress shown within the release will be the same one that is still occurring and has started on the release page. This means that a user should not feel that it takes _as long_ to validate even if they immediately head into the detail page.

**Times from performance tests**
Before adding validation to overview (validation done upon opening the menu and allowing publish/schedule 
- 1 document: 1min 3seconds
- 80 documents: 1min 10 s
- 1000 documents: 57 seconds

After adding validation to overview and changes to the hook (validation done upon opening the menu and allowing publish/schedule 
- 1 document: 32 seconds
- 80 documents: 42 seconds
- 1000 documents: 58 seconds

After adding validation to overview (validation done upon _all_ release ready): 1 min 4 seconds

> [!NOTE]
> With the caching, this is a one time demand, which helps a lot UX wise

### What to review

Does this make sense, did I miss something?
I have spoken with Bjørge about whether there was a different / better way to do the rxjs aspect to things but neither of us were able to get a better solution.

### Testing

Existing tests should suffice.

### Notes for release

Added validation overview per release in the list of releases page.