### PR TITLE
docs(presentation): improve tsdoc comments on types

### DIFF
--- a/packages/sanity/src/presentation/types.ts
+++ b/packages/sanity/src/presentation/types.ts
@@ -17,26 +17,35 @@ export type {PreviewUrlResolver}
 
 /**
  * Represents a document location
- * @param title - Title of the document
- * @param href - URL of the document location
  * @public
  */
 export interface DocumentLocation {
+  /**
+   * Title of the document
+   */
   title: string
+  /**
+   * URL of the document location
+   */
   href: string
 }
 
 /**
- * State for describing document locations or providing a message if no document
- * locations are unavailable
- * @param locations - Array of document locations
- * @param message - Message to display if locations are unavailable
- * @param tone - Tone of the message
+ * State for describing document locations or providing a message if locations are unavailable
  * @public
  */
 export interface DocumentLocationsState {
+  /**
+   * Array of document locations
+   */
   locations?: DocumentLocation[]
+  /**
+   * Message to display if locations are unavailable
+   */
   message?: string
+  /**
+   * Tone of the message
+   */
   tone?: 'positive' | 'caution' | 'critical'
 }
 
@@ -66,15 +75,36 @@ export type DocumentLocationResolver = (
   | undefined
   | Observable<DocumentLocationsState | null | undefined>
 
-/** @public */
+/**
+ * Configuration options for Presentation tool's optional navigator component
+ * The navigator appears as a resizable sidebar panel
+ *
+ * @public
+ */
 export interface NavigatorOptions {
+  /**
+   * Minimum width of the navigator panel in pixels
+   */
   minWidth?: number
+  /**
+   * Maximum width of the navigator panel in pixels
+   */
   maxWidth?: number
+  /**
+   * React component to render in the navigator panel
+   */
   component: ComponentType
 }
 
-/** @public */
+/**
+ * Configuration options for Presentation tool's optional custom preview header component
+ *
+ * @public
+ */
 export interface HeaderOptions {
+  /**
+   * React component to render as the preview header, receives PreviewHeaderProps
+   */
   component: ComponentType<PreviewHeaderProps>
 }
 
@@ -226,32 +256,94 @@ export type DocumentLocationResolvers = Record<
 
 /**
  * Document location resolver object
- * @param select - object for selecting document fields
- * @param resolve - function that accepts a document with the selected fields and returns an optional document location state
  * @public
  */
 export type DocumentLocationResolverObject<K extends string = string> = {
+  /**
+   * Object for selecting document fields
+   */
   select: Record<K, string>
+  /**
+   * Function that accepts a document with the selected fields and returns an optional document location state
+   */
   // oxlint-disable-next-line no-explicit-any
   resolve: (value: Record<K, any> | null) => DocumentLocationsState | null | undefined | void
 }
 
 /**
+ * Context object passed to functions used in `DocumentResolver` definitions.
+ * Contains information about the current URL being matched against route patterns.
+ *
+ * @example
+ * For a route pattern `/blog/:category/:slug` matching URL `https://example.com/blog/tech/hello-world`:
+ * ```ts
+ * {
+ *   origin: 'https://example.com',
+ *   params: { category: 'tech', slug: 'hello-world' },
+ *   path: '/blog/tech/hello-world'
+ * }
+ * ```
+ *
  * @public
  */
 export interface DocumentResolverContext {
+  /**
+   * The origin (protocol + hostname + port) of the matched URL
+   */
   origin: string
+  /**
+   * Extracted route parameters from URL path matching (e.g., `:slug` → `{slug: 'value'}`)
+   */
   params: Record<string, string>
+  /**
+   * The pathname of the matched URL (without query parameters)
+   */
   path: string
 }
 
 /**
+ * Generic function type used in `DocumentResolver` definitions that receives a `DocumentResolverContext` and returns a computed value.
+ * @param context - `DocumentResolverContext` containing route information (origin, params, path)
+ * @returns Computed value based on the context (typically a string for filters or an object for parameters)
  * @public
  */
 export type ContextFn<T> = (context: DocumentResolverContext) => T
 
 /**
- * Object for resolving a document for a given route pattern
+ * Configuration object for resolving documents based on URL route patterns.
+ * Used to define the main document when navigating to specific URLs in
+ * Presentation tool's preview iframe.
+ *
+ * Supports three different resolution strategies:
+ *
+ * **Simple type-based resolution:**
+ * ```ts
+ * {
+ *   route: '/blog',
+ *   type: 'blog'  // Useful for singleton documents
+ * }
+ * ```
+ *
+ * **GROQ filter-based resolution:**
+ * ```ts
+ * {
+ *   route: '/blog/:category/:slug',
+ *   filter: ({ params }) => `_type == "post" && slug.current == "${params.slug}"`,
+ *   params: ({ params }) => ({ category: params.category })
+ * }
+ * ```
+ *
+ * **Advanced resolution with custom logic:**
+ * ```ts
+ * {
+ *   route: '/products/:id',
+ *   resolve: ({ params }) => ({
+ *     filter: `_type == "product" && _id == $id`,
+ *     params: { id: params.id }
+ *   })
+ * }
+ * ```
+ *
  * @public
  */
 export type DocumentResolver =
@@ -284,6 +376,7 @@ export type DocumentResolver =
     }
 
 /**
+ * Configuration options for the Presentation tool.
  * @public
  */
 export interface PresentationPluginOptions {
@@ -430,7 +523,10 @@ export type VisualEditingConnection = ChannelInstance<
  */
 export type LoaderConnection = ChannelInstance<LoaderControllerMsg, LoaderNodeMsg>
 
-/** @public */
+/**
+ * Represents the connection status between the Sanity Studio and Presentation's preview iframe.
+ * @public
+ */
 export type ConnectionStatus = 'connected' | 'connecting' | 'reconnecting' | 'idle'
 
 /** @public */


### PR DESCRIPTION
### Description

Small PR to improve TSDoc comments for Presentation's  type definitions in `packages/sanity/src/presentation/types.ts`. This includes adding missing descriptions, improving existing ones, and refactoring incorrect `@param` definitions on interfaces to correctly use inline comments for individual properties.

### What to review

That the comments follow the spec and the language used is acceptable.

### Testing

N/A

### Notes for release

N/A

cc @mmgj 