### PR TITLE
feat(cli): Add & update docstrings to AppConfig type

### DIFF
--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -297,11 +297,17 @@ export interface ReactCompilerConfig {
 }
 
 interface AppConfig {
+  /**
+   * The ID of your Sanity organization
+   */
   organizationId: string
   /**
-   * Defaults to './src/App'
+   * The entrypoint for your Sanity app. Defaults to './src/App'.
    */
   entry?: string
+  /**
+   * The ID of your Sanity app. Generated when deploying your app for the first time; check the output of `sanity deploy` for this.
+   */
   id?: string
 }
 


### PR DESCRIPTION
### Description

This PR adds and updates the docstrings for the `AppConfig` type, by user request. These should help to clarify the purpose of each field in the `AppConfig` object.

### What to review

Are the additions and updates correct and clear?

### Testing

N/A, reference docs update only

### Notes for release

None
