### PR TITLE
feat(cli): Improve undeploy output for apps

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts
@@ -50,9 +50,13 @@ export default async function undeployAppAction(
   const shouldUndeploy = await prompt.single({
     type: 'confirm',
     default: false,
-    message:
-      `This will undeploy ${chalk.yellow(userApplication.id)} and make it unavailable for your users.
-  The hostname will be available for anyone to claim.
+    message: `This will undeploy the following application:
+
+    Title: ${chalk.yellow(userApplication.title)}
+    ID:    ${chalk.yellow(userApplication.id)}
+
+  The application will no longer be available for any of your users if you proceed.
+
   Are you ${chalk.red('sure')} you want to undeploy?`.trim(),
   })
 
@@ -75,6 +79,6 @@ export default async function undeployAppAction(
   }
 
   output.print(
-    `Application undeploy scheduled. It might take a few minutes before ${chalk.yellow(userApplication.id)} is unavailable.`,
+    `Application undeploy scheduled. It might take a few minutes before ${chalk.yellow(userApplication.title)} is unavailable.`,
   )
 }


### PR DESCRIPTION
### Description

This PR updates the output of `npx sanity undeploy` for apps:

- Refers to the application by `title` in addition to `id` when confirming execution of the command
- Removes the mention of a hostname as this isn't currently a factor for custom apps
- Visually structures to output for better clarity
- Refers to the application by `title` in the summary of the command's execution

Before & after screenshots:

<img width="630" height="162" alt="Screenshot 2025-09-02 at 14 21 29" src="https://github.com/user-attachments/assets/df873181-383c-43ac-bffa-5ea761b2377a" />

<img width="822" height="253" alt="Screenshot 2025-09-02 at 14 32 32" src="https://github.com/user-attachments/assets/a53148a9-ec39-4a48-83ca-2a692f3b0902" />


### What to review

Is the new output clear and correct?

### Testing

Tested with local builds and deploying/undeploying an app.

### Notes for release

- The `sanity undeploy` command output has been improved for custom apps. It should now be clearer which application will be undeployed, as applications will be referenced by both their title and their ID.
