### PR TITLE
fix: pass `react-hooks/purity` checks

### DIFF
--- a/packages/@repo/eslint-config/index.js
+++ b/packages/@repo/eslint-config/index.js
@@ -209,7 +209,6 @@ export default [
     rules: {
       'react-hooks/immutability': 'warn',
       'react-hooks/preserve-manual-memoization': 'warn',
-      'react-hooks/purity': 'warn',
       'react-hooks/refs': 'warn',
       'react-hooks/set-state-in-effect': 'warn',
       'react-hooks/static-components': 'warn',


### PR DESCRIPTION
### Description

[Fixes:](https://playground.react.dev/#N4Igzg9grgTgxgUxALhAegFQAIFgDYCWAdgC4C0AJgWAIYBGeCWBAjABxEIAeJaREZQiQQwaeMmBIxiAcwA0AAVpECJAJ5pWHPgJokpBOlGESDRGYNUixYLBjQAdFQFsADhBgkswLAGU1RHAAknAQRFgAvlgAZjAQzlgA5Eo0KuqaoURgiU4Ebh5ePgBCEFxyWADCNDAU5RUQFAh1YSQ0xCLlABIINFTm5UFEhJzlvq1wANblACrcXlGx8UkpaRpQBDku7p7eWFBgCACi0dEIcCTl+wgASggUUIgwlwdjekwLcQmJMD3nm3nbQpYSRqRgUSIxT5JEFgsihfKcUjZJy5fI7YrGEhhCGLL4AOjxaAJRMJ6zh8XciJIyK2BV21AAIggAG44qGJYnEhBEZkEOJEZzckibJyZSRYABqBAQAHcsABeYHqMEAChKXAAlAADJxYLBiAgyIhkKzOMDILCIUgiADcTh1RCc0SggRIBGxPzwEF6AAUaDIECqNd5dVgZcQKBAZXivXA9O6iHjPd6KEGnBEnNxATEXecE1ggmiSIcYHEYL44D9uSrXHFXObdiIyxaS2WbThmUKghQAPwWyTScztmjGCC3L29PtYOgQCCMVKRYPAUNioFNjzlFld2r60fjlMQxW1iD1lHhS1hcUAbWTvQAgiQALoKvYvVrCLAAHiwRCgzjoIhYAAfFgKpBgqIEMm8eL8DK4EANRYAArAA+gADBhGpnnqq5YFe5RupMz6Klctz3I8YGSG8wbyiBVEfohLDlGhWGOueuGhC6JCRjKRC+GcYQULYioALJ6AAFni0Reh4YG3hQD5YGQWBQcIMFRkGwZoFgLAYSx2GvkcJxnCQYE0SBy7nnqBDRKBACEI5YvuvRLqGep6j8JCwOE4G0bsGZWZEbkXlkXjEMIMDMmIL4HCQgwRVFeBmRBWCERMQblEhmHBZ53mgeZlrzjA8UiIlKrhaVYisXqETlFejljggE4UI+rGhlcxynOcyV+ZZ7nMLZKqcaQPF8QJRBCV+iosVg8l+gGabnrVeENc5O7DdxUZjZkQmtQZuUwD5wWflUNRYOJCCGuJJDyg4IDRAQeB4HdWAQJ2MDSVGt0gA1L2uL0fQyAAmvKwBXgALJl5QAGzlAA7I+UT-RQgMABqg+DURgAQABesjfTONQiHdQHBXqn5SrKWBUGArh4DQajfdJ3AvRdV03XdD1PSTZPuSdLRtJwMBhgQFAkOJoMAMwRKTgX9eTryTMC-2IKD0My7z8tforEzKzQqvAJjstaybX7dL0shAYW2brjAn5oObgPG6b8ufrMPBAXe4S269cBwLAPzgvcg4yNTAQ0M4BBwMwRZ4vb7skM7LvucAjIslgABkGegZrLsndU4KE40wuiFQ+ygwATFEb0iJ9Mrfb9IBYMjgMY1EWKcN9laqFHYg83Lyd8zresG0bueD94tt4oKYC0AGmfZyq48T1+9SNGGl0yNdoOJDOeAUIkWO4wgoMsBrA8r-LwBTzPc8IAFl+m-ba8IEnj96hqD-vynU9UUrWerwaEwbGOMT7ADPkBa+pYPB4j-hMCIz8gFAS-t-SenZSDdgXoA9eICwEQMOOgrwQQGQWmvoQ7sCC0Av2QcvJ+aAdZvwns-AujCXaf1oSnVaTUDw9hzhfPOCcsDOGMHcVhE81qyG8BtUa-Edq2E-NNLAvDEiwUSFgC0WpiBYAACTAGkVtWRgkwB4ixAAMQIFwO4QYIhgC1BEQAZAQcP6vHOYYiTbBgtL+J6KDB6fkGMMYBKswHSzcU-IomIwhOPlmECohBJigzmv6e+UT+rCB4KDLhzUlFJDWj+KMaiLSJDWofFJ7kO4nzurWPI1Q1B3VKdZTIoN-CBBCGEHxl9cHfXpjAAMdT+GmzQKE12aB-HtCGeTeh4wJhDPtgw3OiDSCCxEKw+2lMZRv2YTUZ2rEIggDkCATID0ZAoBACACIQA)
```bash
# Summary

React Compiler compiled this function successfully, but there are lint errors that indicate potential issues with the original code.

## 1 Lint Errors

Error: Cannot call impure function during render

`Date.now` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent)

  22 |   const [, tick] = useReducer((state) => state + 1, 0)
  23 |
> 24 |   const countdownSeconds = Math.floor((reloadAt - Date.now()) / 1000)
     |                                                   ^^^^^^^^^^ Cannot call impure function
  25 |
  26 |   useEffect(() => {
  27 |     if (!autoReload) {
```

Date.now() during render is indeed impure, and that got me thinking. [We have these neats example of using `react-rx` with timers, that _are_ pure.](https://react-rx.dev/examples/counters) Why not use them?
I feel it's cleaner with `observable + useObservable + useEffect(maybeReload)`, instead of `useState + useReducer + Date.now() during render + useEffect(interval) + useEffect(maybeReload)` in addition to being pure.

### What to review

Does it make sense?

### Testing

I'm not sure if we have automated tests covering this, I've tested it manually by changing `lazy(() => import('./SanityVision'))` to `import('./SanityVision').then(() => Promise.reject(new TypeError('Importing a module script failed.')))` [here](https://github.com/sanity-io/sanity/blob/c15a2ef83750f8330f36378e24d0712d1c81f4a6/packages/%40sanity/vision/src/visionTool.ts#L18) to trigger the error with auto reload enabled.

### Notes for release

N/A