### PR TITLE
Add Auto-Changelog Function

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,7 @@ The `functions/` directory contains examples of [Sanity Functions](https://www.s
 
 ### Available Function Examples
 
+- **[auto-changelog](./functions/auto-changelog/README.md)** - AI-powered automatic changelog generation from git commits
 - **[auto-tag](./functions/auto-tag/README.md)** - AI-powered automatic tagging for blog posts
 - **[first-published](./functions/first-published/README.md)** - Automatic timestamp tracking for first publication
 - **[slack-notify](./functions/slack-notify/README.md)** - Automatic Slack notifications when content is published

--- a/examples/functions/auto-changelog/README.md
+++ b/examples/functions/auto-changelog/README.md
@@ -1,0 +1,219 @@
+# Auto-Changelog Function
+
+[Explore all examples](https://github.com/sanity-io/sanity/tree/main/examples)
+
+## Problem
+
+Content teams need to track meaningful changes to documents for returning editors, but manually documenting every update is time-consuming and often forgotten during the editing process. Teams want to show content evolution while avoiding noise from minor formatting tweaks.
+
+## Solution
+
+This Sanity Function automatically generates changelog entries when documents are updated with meaningful changes. It uses AI to analyze both content and nested code block changes, filtering out formatting-only and minor modifications, and generates concise, reader-friendly descriptions of what actually changed. Fine-grained changes for all fields can still be track with Sanity's out of the box [History](https://www.sanity.io/docs/user-guides/history-experience).
+
+## Benefits
+
+- **Saves editorial time** by eliminating manual changelog maintenance
+- **Improves reader experience** with clear change tracking for returning visitors
+- **Reduces noise** by filtering out minor and formatting-only changes
+- **Scales automatically** as content volume grows
+- **Provides detailed code tracking** for technical posts with code examples
+- **Maintains content history** for better editorial workflows
+
+## Compatible Templates
+
+This function is built to be compatible with any of [the official "clean" templates](https://www.sanity.io/exchange/type=templates/by=sanity). We recommend testing the function out in one of those after you have installed them locally.
+
+## Requirements
+
+- A Sanity project with Functions enabled
+- A schema with a `post` document type containing:
+- A `content` field (rich text/portable text) for content analysis
+- A `changelog` field (array of strings) for storing generated entries
+- Access to Sanity's AI capabilities
+- Production deployment for testing (local testing not supported)
+
+## Usage Example
+
+When a content editor updates a blog post with meaningful changes, the function automatically:
+
+1. **Triggers** on update events for post documents with content or code block changes
+2. **Filters** out formatting-only changes using intelligent comparison
+3. **Analyzes** both content and code changes using AI
+4. **Generates** a concise, reader-friendly description of what changed
+5. **Appends** the changelog entry to the document's changelog array
+
+**Result:** Readers see clear change tracking like "Fixed syntax for the API call to use await; Added more context about the implementation process" without noise from minor formatting tweaks.
+
+### Adding the changelog field to your schema
+
+You'll need to add a `changelog` field to your post schema:
+
+1. Open your post schema file (e.g., `studio/src/schemaTypes/documents/post.ts`)
+2. Add this field to the `fields` array:
+
+```typescript
+defineField({
+  name: "changelog",
+  title: "Changelog",
+  type: "array",
+  of: [
+    defineArrayMember({
+      type: "string",
+    }),
+  ],
+  description: "List of changes made so returning readers can see how it has progressed.",
+}),
+```
+
+3. Deploy your updated schema:
+
+```bash
+# From the studio/ folder
+npx sanity schema deploy
+```
+
+## Implementation
+
+**Important:** Run these commands from the root of your project (not inside the `studio/` folder).
+
+1. **Initialize the example**
+
+   Run this if you haven't initialized blueprints:
+
+   ```bash
+   npx sanity blueprints init
+   ```
+
+   You'll be prompted to select your organization and Sanity studio.
+
+   Then run:
+
+   ```bash
+   npx sanity blueprints add function --example auto-changelog
+   ```
+
+2. **Add configuration to your blueprint**
+
+   Add the following resource to your `sanity.blueprint.ts`:
+
+   ```ts
+   defineDocumentFunction({
+     type: 'sanity.function.document',
+     src: './functions/auto-changelog',
+     memory: 2,
+     timeout: 30,
+     name: 'auto-changelog',
+     event: {
+       on: ['update'],
+       filter:
+         "_type == 'post' && (delta::changedAny(content) || delta::changedAny(content[_type == 'code']))",
+       projection:
+         "{_id, 'oldContent': pt::text(before().content), 'newContent': pt::text(after().content), changelog, 'oldCodeBlocks': before().content[_type == 'code'], 'newCodeBlocks': after().content[_type == 'code'], changelog}",
+     },
+   })
+   ```
+
+3. **Install dependencies**
+
+   Install dependencies in the project root:
+
+   ```bash
+   npm install
+   ```
+
+4. **Make sure you have a schema deployed**
+
+   From the studio folder, run:
+
+   ```bash
+   # In the studio/ folder
+   npx sanity schema deploy
+   ```
+
+## Local Development Limitations
+
+**Important:** This function cannot currently be tested locally as local development does not yet support GROQ functions and Delta GROQ operations used in the filter and projection.
+
+The function uses:
+
+- `delta::changedAny()` - GROQ delta functions for detecting changes
+- `pt::text()` - GROQ functions for portable text processing
+- Complex projections with `before()` and `after()` document states
+
+These features are currently only available in the Sanity production environment.
+
+### Testing Strategy
+
+- **Deploy to production** for testing with real document updates
+- **Monitor function logs** using the CLI:
+  ```bash
+  npx sanity functions logs auto-changelog --watch
+  ```
+- **Use staging/development dataset** if available for safer testing
+- **Test with small content changes** to verify behavior
+
+## Customization
+
+### Add Datetime Tracking
+
+To track when changes were made, you can add a datetime field to store timestamps alongside changelog entries. This requires modifying both your schema and the function:
+
+1. **Update your schema** to include a datetime field for change tracking:
+
+```typescript
+defineField({
+  name: "changeHistory",
+  title: "Change History",
+  type: "array",
+  of: [
+    defineArrayMember({
+      type: "object",
+      fields: [
+        defineField({
+          name: "change",
+          title: "Change Description",
+          type: "string",
+        }),
+        defineField({
+          name: "timestamp",
+          title: "Change Date",
+          type: "datetime",
+        }),
+      ],
+    }),
+  ],
+  description: "List of changes with timestamps for tracking when modifications were made.",
+}),
+```
+
+2. **Update the function** to store both the change description and timestamp by modifying the function code to append objects instead of strings to the array.
+
+### Modify AI Instructions
+
+Customize the changelog generation style by editing the `instruction` string in `index.ts`:
+
+```typescript
+instruction: `
+  Generate changelog entries focusing on:
+  - Technical accuracy for code changes
+  - User-facing impacts for content changes  
+  - Concise, professional tone
+  // ... your custom instructions
+`
+```
+
+### Adjust Timeout
+
+For longer posts with complex changes, you may need to increase the timeout:
+
+```ts
+timeout: 120, // Increase from 90 to 120 seconds
+```
+
+## Related Examples
+
+- [Auto-Summary Function](../auto-summary/README.md) – Automatically generate summaries for documents using AI
+- [Brand Voice Validator](../brand-voice-validator/README.md) – Validate content against brand guidelines
+- [Auto-Tag Function](../auto-tag/README.md) – Automatically generate tags for documents using AI
+
+---

--- a/examples/functions/auto-changelog/index.ts
+++ b/examples/functions/auto-changelog/index.ts
@@ -1,0 +1,98 @@
+import {documentEventHandler} from '@sanity/functions'
+import {createClient} from '@sanity/client'
+
+export const handler = documentEventHandler(async ({context, event}) => {
+  const client = createClient({
+    ...context.clientOptions,
+    apiVersion: 'vX',
+    useCdn: false,
+  })
+
+  try {
+    const {_id, oldContent, newContent, oldCodeBlocks, newCodeBlocks, changelog} = event.data
+
+    // Validate document ID
+    if (!_id) {
+      console.error('Missing document ID in event data')
+      return
+    }
+
+    // Validate that we have meaningful content to compare
+    if (!oldContent && !newContent && !oldCodeBlocks?.length && !newCodeBlocks?.length) {
+      console.log('No content changes detected. Skipping changelog update.')
+      return
+    }
+
+    const oldCode = getCodeText(oldCodeBlocks)
+    const newCode = getCodeText(newCodeBlocks)
+
+    // Only check for formatting changes if there are actually code blocks to compare
+    if (
+      (oldCodeBlocks?.length > 0 || newCodeBlocks?.length > 0) &&
+      isOnlyFormattingChange(oldCode, newCode)
+    ) {
+      console.log('Code change is only formatting. Skipping changelog update.')
+      return
+    }
+
+    const result = await client.agent.action.generate({
+      schemaId: '_.schemas.default',
+      forcePublishedWrite: true,
+      documentId: _id,
+      instruction: `
+        You are given two versions of a blog post:
+          - The "before" content: $oldContent
+          - The "after" content: $newContent
+          - The "before" code blocks: $oldCode
+          - The "after" code blocks: $newCode
+
+          Compare them carefully and describe the changes in a single, concise string.
+
+          Rules:
+          - For **code changes** (compare $oldCode vs. $newCode), explain *all modifications*, including minor adjustments (renaming variables, formatting, syntax changes).
+          - For **content changes** (compare $oldContent vs. $newContent), describe only *meaningful updates* (new sections, significant rewrites, added explanations, removed material). Ignore minor wording or formatting tweaks.
+          - If there are no meaningful changes, return nothing.
+
+          Format:
+          - Keep it short and reader-friendly.
+          - Separate multiple updates with semicolons.
+          - Examples:
+            - Fixed syntax for the API call to use await
+            - Clarified explanation of the model's limitations
+            - Added more context about my process
+      `,
+      instructionParams: {
+        oldContent: {type: 'constant', value: oldContent},
+        newContent: {type: 'constant', value: newContent},
+        oldCode: {type: 'constant', value: oldCode},
+        newCode: {type: 'constant', value: newCode},
+      },
+      target: {
+        path: 'changelog',
+        operation: 'append',
+      },
+    })
+
+    // Check if the changelog actually changed
+    if (JSON.stringify(result.changelog) === JSON.stringify(changelog)) {
+      console.log('Only minor changes detected - no changelog entry needed')
+    } else {
+      console.log('Generated changelog entry:', result.changelog)
+    }
+  } catch (error) {
+    console.error('Error appending changelog entry: ', error)
+  }
+})
+
+const getCodeText = (blocks: Array<{_type: string; code?: string}>) => {
+  if (!Array.isArray(blocks)) return ''
+  return blocks
+    .filter((block) => block._type === 'code' && typeof block.code === 'string')
+    .map((block) => block.code)
+    .join('\n\n')
+}
+
+const isOnlyFormattingChange = (oldCode: string, newCode: string): boolean => {
+  const normalize = (code: string) => code.replace(/\s+/g, '')
+  return normalize(oldCode) === normalize(newCode)
+}

--- a/examples/functions/auto-changelog/package.json
+++ b/examples/functions/auto-changelog/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "auto-changelog",
+  "version": "1.0.0",
+  "description": "Sanity Function that automatically generates changelog entries for documents when meaningful changes are made",
+  "keywords": [
+    "sanity",
+    "function",
+    "changelog",
+    "ai",
+    "automation"
+  ],
+  "license": "MIT",
+  "author": "Sanity",
+  "main": "index.ts",
+  "dependencies": {
+    "@sanity/client": "^7.10.0",
+    "@sanity/functions": "^1.0.3"
+  },
+  "blueprintResourceItem": {
+    "type": "sanity.function.document",
+    "name": "auto-changelog",
+    "src": "functions/auto-changelog",
+    "memory": 2,
+    "timeout": 30,
+    "event": {
+      "on": [
+        "update"
+      ],
+      "filter": "_type == 'post' && (delta::changedAny(content) || delta::changedAny(content[_type == 'code']))",
+      "projection": "{_id, 'oldContent': pt::text(before().content), 'newContent': pt::text(after().content), changelog, 'oldCodeBlocks': before().content[_type == 'code'], 'newCodeBlocks': after().content[_type == 'code'], changelog}"
+    }
+  }
+}

--- a/examples/functions/auto-changelog/pnpm-lock.yaml
+++ b/examples/functions/auto-changelog/pnpm-lock.yaml
@@ -1,0 +1,272 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    dependencies:
+      '@sanity/client':
+        specifier: ^7.10.0
+        version: 7.10.0
+      '@sanity/functions':
+        specifier: ^1.0.3
+        version: 1.0.3
+
+packages:
+  '@sanity/client@7.10.0':
+    resolution:
+      {
+        integrity: sha512-3UV6pJupue7UAZh4g5n0lYjuRsIb4c6IoqMywVLMHYoSOeHJfgSzbexOPGMNqvF+KUywUA0GyFi9cAVeMKofvw==,
+      }
+    engines: {node: '>=20'}
+
+  '@sanity/eventsource@5.0.2':
+    resolution:
+      {
+        integrity: sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==,
+      }
+
+  '@sanity/functions@1.0.3':
+    resolution:
+      {
+        integrity: sha512-aEDxl52oAmxinHIMwnUhy4sOGzuMH0NY+52GkEpLoK4Nw+2k45lvYIF7tqc8HxwYF9fKVyYaZ4PXOJpgeMn9/g==,
+      }
+    engines: {node: '>=20'}
+
+  '@types/event-source-polyfill@1.0.5':
+    resolution:
+      {
+        integrity: sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw==,
+      }
+
+  '@types/eventsource@1.1.15':
+    resolution:
+      {
+        integrity: sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==,
+      }
+
+  '@types/follow-redirects@1.14.4':
+    resolution:
+      {
+        integrity: sha512-GWXfsD0Jc1RWiFmMuMFCpXMzi9L7oPDVwxUnZdg89kDNnqsRfUKXEtUYtA98A6lig1WXH/CYY/fvPW9HuN5fTA==,
+      }
+
+  '@types/node@24.3.0':
+    resolution:
+      {
+        integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==,
+      }
+
+  decompress-response@7.0.0:
+    resolution:
+      {
+        integrity: sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==,
+      }
+    engines: {node: '>=10'}
+
+  event-source-polyfill@1.0.31:
+    resolution:
+      {
+        integrity: sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==,
+      }
+
+  eventsource@2.0.2:
+    resolution:
+      {
+        integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==,
+      }
+    engines: {node: '>=12.0.0'}
+
+  follow-redirects@1.15.11:
+    resolution:
+      {
+        integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==,
+      }
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  get-it@8.6.10:
+    resolution:
+      {
+        integrity: sha512-27StIK860ZVp2bhsG/aTWpcoA4OrFxtMqBbesa5sR23m5OxfVQYCnpm2rPQeo3gs5qsUk0FdkISLgXRJ4HynNw==,
+      }
+    engines: {node: '>=14.0.0'}
+
+  inherits@2.0.4:
+    resolution:
+      {
+        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
+      }
+
+  is-retry-allowed@2.2.0:
+    resolution:
+      {
+        integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==,
+      }
+    engines: {node: '>=10'}
+
+  mimic-response@3.1.0:
+    resolution:
+      {
+        integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==,
+      }
+    engines: {node: '>=10'}
+
+  nanoid@3.3.11:
+    resolution:
+      {
+        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+      }
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  readable-stream@3.6.2:
+    resolution:
+      {
+        integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==,
+      }
+    engines: {node: '>= 6'}
+
+  rxjs@7.8.2:
+    resolution:
+      {
+        integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==,
+      }
+
+  safe-buffer@5.2.1:
+    resolution:
+      {
+        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
+      }
+
+  string_decoder@1.3.0:
+    resolution:
+      {
+        integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
+      }
+
+  through2@4.0.2:
+    resolution:
+      {
+        integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==,
+      }
+
+  tslib@2.8.1:
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
+
+  tunnel-agent@0.6.0:
+    resolution:
+      {
+        integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
+      }
+
+  undici-types@7.10.0:
+    resolution:
+      {
+        integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==,
+      }
+
+  util-deprecate@1.0.2:
+    resolution:
+      {
+        integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
+      }
+
+snapshots:
+  '@sanity/client@7.10.0':
+    dependencies:
+      '@sanity/eventsource': 5.0.2
+      get-it: 8.6.10
+      nanoid: 3.3.11
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - debug
+
+  '@sanity/eventsource@5.0.2':
+    dependencies:
+      '@types/event-source-polyfill': 1.0.5
+      '@types/eventsource': 1.1.15
+      event-source-polyfill: 1.0.31
+      eventsource: 2.0.2
+
+  '@sanity/functions@1.0.3': {}
+
+  '@types/event-source-polyfill@1.0.5': {}
+
+  '@types/eventsource@1.1.15': {}
+
+  '@types/follow-redirects@1.14.4':
+    dependencies:
+      '@types/node': 24.3.0
+
+  '@types/node@24.3.0':
+    dependencies:
+      undici-types: 7.10.0
+
+  decompress-response@7.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  event-source-polyfill@1.0.31: {}
+
+  eventsource@2.0.2: {}
+
+  follow-redirects@1.15.11: {}
+
+  get-it@8.6.10:
+    dependencies:
+      '@types/follow-redirects': 1.14.4
+      decompress-response: 7.0.0
+      follow-redirects: 1.15.11
+      is-retry-allowed: 2.2.0
+      through2: 4.0.2
+      tunnel-agent: 0.6.0
+    transitivePeerDependencies:
+      - debug
+
+  inherits@2.0.4: {}
+
+  is-retry-allowed@2.2.0: {}
+
+  mimic-response@3.1.0: {}
+
+  nanoid@3.3.11: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safe-buffer@5.2.1: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  through2@4.0.2:
+    dependencies:
+      readable-stream: 3.6.2
+
+  tslib@2.8.1: {}
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  undici-types@7.10.0: {}
+
+  util-deprecate@1.0.2: {}


### PR DESCRIPTION
### Description

Credit to @johnsicili for this function recipe 👏 .  This function utilizes Agent Actions to analyze the GROQ delta of the `content` PTE field - returning to the `changelog` array what changed IF the change was meaningful

### What to review

Review the code and readme to make sure its align with our other functions

### Testing

Testing must be dont in production.  I used `npx sanity functions logs auto-changelog --watch` for testing in a production environment.

### Notes for release

If this makes release note, please credit John Siciliano
