### PR TITLE
fix: dedupe listener events

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -148,6 +148,7 @@
     "@dnd-kit/modifiers": "^6.0.1",
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.2",
+    "@isaacs/ttlcache": "^1.4.1",
     "@juggle/resize-observer": "^3.4.0",
     "@mux/mux-player-react": "^3.5.3",
     "@portabletext/block-tools": "^3.5.3",

--- a/packages/sanity/src/core/store/_legacy/document/utils/dedupeListenerEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/utils/dedupeListenerEvents.ts
@@ -1,0 +1,41 @@
+import TTLCache from '@isaacs/ttlcache'
+import {type MonoTypeOperatorFunction, type Observable} from 'rxjs'
+import {mergeMap, scan} from 'rxjs/operators'
+
+import {debug} from '../debug'
+import {type ListenerEvent} from '../getPairListener'
+
+const DEFAULT_TTL = 120_000
+const DEFAULT_MAX_ENTRIES = 1000
+
+export function dedupeListenerEvents<T extends ListenerEvent>({
+  ttl = DEFAULT_TTL,
+  max = DEFAULT_MAX_ENTRIES,
+}: {
+  ttl?: number
+  max?: number
+} = {}): MonoTypeOperatorFunction<T> {
+  return (input$: Observable<T>) =>
+    input$.pipe(
+      scan(
+        ({seen}: {emit: T[]; seen: TTLCache<string, null>}, event: T) => {
+          if (event.type !== 'mutation') {
+            return {emit: [event], seen}
+          }
+          const key = `${event.transactionId}#${event.documentId}`
+          if (seen.has(key)) {
+            debug('Ignoring duplicate listener event: ', key)
+            return {seen, emit: []}
+          }
+          seen.set(key, null)
+          return {seen, emit: [event]}
+        },
+        {emit: [], seen: new TTLCache<string, null>({ttl, max})},
+      ),
+      mergeMap(
+        (state) =>
+          //  note: if state.emit is an empty array, nothing will be emitted
+          state.emit,
+      ),
+    )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1623,6 +1623,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@18.3.1)
+      '@isaacs/ttlcache':
+        specifier: ^1.4.1
+        version: 1.4.1
       '@juggle/resize-observer':
         specifier: ^3.4.0
         version: 3.4.0
@@ -3750,6 +3753,10 @@ packages:
 
   '@isaacs/string-locale-compare@1.1.0':
     resolution: {integrity: sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==}
+
+  '@isaacs/ttlcache@1.4.1':
+    resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
+    engines: {node: '>=12'}
 
   '@istanbuljs/schema@0.1.3':
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
@@ -13896,6 +13903,8 @@ snapshots:
       minipass: 7.1.2
 
   '@isaacs/string-locale-compare@1.1.0': {}
+
+  '@isaacs/ttlcache@1.4.1': {}
 
   '@istanbuljs/schema@0.1.3': {}
 


### PR DESCRIPTION
### Description

We currently do some deduping as part of `sequentializeListenerEvents`, but this could still lead to problems if duplicates are received at either edge of the buffer we maintain to check for gaps in mutation events. This makes sure we dedupe listener events on the listener stream level.

### What to review
I considered using `distinct(() => event.id)`, but that only supports flushing the set of already seen entries at discrete points in time, which could lead to duplicates coming in right before and after flushing. So instead I've opted for a ttlcache which clears entries after a while.  The assumption is that any duplicates would come relatively close to each other, either in time or in space.

### Notes for release

n/a