### PR TITLE
refactor(core): make sequentializeListenerEvents more robust

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/getPairListener.ts
+++ b/packages/sanity/src/core/store/_legacy/document/getPairListener.ts
@@ -116,6 +116,16 @@ export function getPairListener(
       ) as Observable<WelcomeEvent | MutationEvent | ReconnectEvent>
     ).pipe(
       dedupeListenerEvents(),
+      map((event): WelcomeEvent | MutationEvent | ReconnectEvent =>
+        event.type === 'mutation'
+          ? {
+              ...event,
+              // client equivalent of `event.messageDispatchedAt`
+              // note: consider moving this to client.listen()
+              messageReceivedAt: new Date().toString(),
+            }
+          : event,
+      ),
       shareReplayLatest({
         predicate: (event) => event.type === 'welcome' || event.type === 'reconnect',
       }),

--- a/packages/sanity/src/core/store/_legacy/document/types.ts
+++ b/packages/sanity/src/core/store/_legacy/document/types.ts
@@ -18,6 +18,7 @@ export interface MutationEvent {
   resultRev: string
   transactionTotalEvents: number
   transactionCurrentEvent: number
+  messageReceivedAt: string
   visibility: 'transaction' | 'query'
 
   transition: 'update' | 'appear' | 'disappear'


### PR DESCRIPTION
### Description
Adds a few improvements to our gap detection:

Currently, gap detection is based on when _a_ gap was first detected. However, there can be multiple gaps in our buffer, and if one gap resolves, we can allow for a little more time to let the next in line resolve. This could lead to gap recovery being triggered more often than needed, especially if there is latency in message delivery. 

This PR address this by adding a `messageReceivedAt ` property to listener events that reflects when the message was received by the client (this matches the `messageDispatchedAt` property on events sent from the server).

When we have a broken chain, we use this `messageReceivedAt` to check whether we have been out of sync for more than the deadline allows.

### What to review
Does it make sense?

### Testing
Existing tests updated

### Notes for release
n/a