### PR TITLE
fix: log the correct error name

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/getPairListener.ts
+++ b/packages/sanity/src/core/store/_legacy/document/getPairListener.ts
@@ -249,7 +249,7 @@ export function getPairListener(
   return merge(draftEvents$, publishedEvents$, versionEvents$).pipe(
     catchError((err, caught$) => {
       if (err instanceof OutOfSyncError) {
-        debug('Recovering from OutOfSyncError: %s', OutOfSyncError.name)
+        debug('Recovering from OutOfSyncError: %s', err.name)
         if (typeof options?.onSyncErrorRecovery === 'function') {
           options?.onSyncErrorRecovery(err)
         } else {


### PR DESCRIPTION
Tiny fix to debug logging when gap detection error recovery kicks in. We currently log `OutOfSyncError.name` which will always be… `OutOfSyncError`. So instead we should log the name of the actual error that's being thrown

