### PR TITLE
fix: version document restore revision and revert changes actions

### DIFF
--- a/packages/sanity/src/core/field/diff/components/ChangeList.tsx
+++ b/packages/sanity/src/core/field/diff/components/ChangeList.tsx
@@ -8,9 +8,10 @@ import {DiffContext} from 'sanity/_singletons'
 import {Button} from '../../../../ui-components'
 import {useDocumentOperation} from '../../../hooks'
 import {useTranslation} from '../../../i18n'
+import {usePerspective} from '../../../perspective/usePerspective'
 import {useDocumentPairPermissions} from '../../../store'
 import {unstable_useConditionalProperty as useConditionalProperty} from '../../conditional-property'
-import {type ChangeNode, type FieldOperationsAPI, type ObjectDiff} from '../../types'
+import {type ChangeNode, type ObjectDiff} from '../../types'
 import {buildObjectChangeList} from '../changes/buildChangeList'
 import {undoChange} from '../changes/undoChange'
 import {useDocumentChange} from '../hooks/useDocumentChange'
@@ -29,7 +30,8 @@ export interface ChangeListProps {
 /** @internal */
 export function ChangeList({diff, fields, schemaType}: ChangeListProps): React.JSX.Element | null {
   const {documentId, isComparingCurrent, value} = useDocumentChange()
-  const docOperations = useDocumentOperation(documentId, schemaType.name) as FieldOperationsAPI
+  const {selectedReleaseId} = usePerspective()
+  const docOperations = useDocumentOperation(documentId, schemaType.name, selectedReleaseId)
   const {path} = useContext(DiffContext)
   const isRoot = path.length === 0
   const [confirmRevertAllOpen, setConfirmRevertAllOpen] = useState(false)

--- a/packages/sanity/src/core/field/diff/components/FieldChange.tsx
+++ b/packages/sanity/src/core/field/diff/components/FieldChange.tsx
@@ -5,8 +5,9 @@ import {DiffContext} from 'sanity/_singletons'
 
 import {useDocumentOperation} from '../../../hooks'
 import {useTranslation} from '../../../i18n'
+import {usePerspective} from '../../../perspective/usePerspective'
 import {useDocumentPairPermissions} from '../../../store'
-import {type FieldChangeNode, type FieldOperationsAPI} from '../../types'
+import {type FieldChangeNode} from '../../types'
 import {undoChange} from '../changes/undoChange'
 import {useDocumentChange} from '../hooks'
 import {ChangeBreadcrumb} from './ChangeBreadcrumb'
@@ -66,7 +67,8 @@ export function FieldChange(
     isComparingCurrent,
     FieldWrapper = Fragment,
   } = useDocumentChange()
-  const ops = useDocumentOperation(documentId, schemaType.name) as FieldOperationsAPI
+  const {selectedReleaseId} = usePerspective()
+  const ops = useDocumentOperation(documentId, schemaType.name, selectedReleaseId)
   const [confirmRevertOpen, setConfirmRevertOpen] = useState(false)
   const [revertHovered, setRevertHovered] = useState(false)
   const buttonRef = useRef<HTMLButtonElement | null>(null)

--- a/packages/sanity/src/core/field/diff/components/GroupChange.tsx
+++ b/packages/sanity/src/core/field/diff/components/GroupChange.tsx
@@ -4,9 +4,10 @@ import {DiffContext} from 'sanity/_singletons'
 
 import {useDocumentOperation} from '../../../hooks'
 import {useTranslation} from '../../../i18n'
+import {usePerspective} from '../../../perspective/usePerspective'
 import {useDocumentPairPermissions} from '../../../store'
 import {pathsAreEqual} from '../../paths'
-import {type FieldOperationsAPI, type GroupChangeNode} from '../../types'
+import {type GroupChangeNode} from '../../types'
 import {isPTSchemaType} from '../../types/portableText/diff'
 import {useHover} from '../../utils/useHover'
 import {undoChange} from '../changes/undoChange'
@@ -45,7 +46,8 @@ export function GroupChange(
   const isNestedInDiff = pathsAreEqual(diffPath, groupPath)
   const [revertButtonRef, isRevertButtonHovered] = useHover<HTMLButtonElement>()
 
-  const docOperations = useDocumentOperation(documentId, schemaType.name) as FieldOperationsAPI
+  const {selectedReleaseId} = usePerspective()
+  const docOperations = useDocumentOperation(documentId, schemaType.name, selectedReleaseId)
   const [confirmRevertOpen, setConfirmRevertOpen] = useState(false)
 
   const [permissions, isPermissionsLoading] = useDocumentPairPermissions({

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/restore.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/restore.ts
@@ -5,7 +5,12 @@ import {type OperationImpl} from './types'
 export const restore: OperationImpl<[fromRevision: DocumentRevision]> = {
   disabled: (): false => false,
   execute: ({historyStore, schema, idPair, typeName}, fromRevision: DocumentRevision) => {
-    const targetId = isLiveEditEnabled(schema, typeName) ? idPair.publishedId : idPair.draftId
+    const targetId = idPair.versionId
+      ? idPair.versionId
+      : isLiveEditEnabled(schema, typeName)
+        ? idPair.publishedId
+        : idPair.draftId
+
     return historyStore.restore(idPair.publishedId, targetId, fromRevision)
   },
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/restore.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/restore.ts
@@ -8,7 +8,12 @@ export const restore: OperationImpl<[fromRevision: DocumentRevision]> = {
     {snapshots, historyStore, schema, idPair, typeName},
     fromRevision: DocumentRevision,
   ) => {
-    const targetId = isLiveEditEnabled(schema, typeName) ? idPair.publishedId : idPair.draftId
+    const targetId = idPair.versionId
+      ? idPair.versionId
+      : isLiveEditEnabled(schema, typeName)
+        ? idPair.publishedId
+        : idPair.draftId
+
     return historyStore.restore(idPair.publishedId, targetId, fromRevision, {
       fromDeleted: !snapshots.draft && !snapshots.published,
       useServerDocumentActions: true,


### PR DESCRIPTION
### Description
This Pr fixes two different issues present in version document in where reverting changes and restoring revisions were not working correctly by passing the correct document id to the actions.



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Are changes ok?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Create a version document, apply changes to it and try to revert them using the review changes inspector, it should work.
Create a version document, apply changes to it and try to restore a previous revision, it should work.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes issues when restoring documents to revisions in version document and reverting document changes.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
