### PR TITLE
feat(descriptors): serialize i18n properties

### DIFF
--- a/packages/@sanity/schema/src/descriptors/types.ts
+++ b/packages/@sanity/schema/src/descriptors/types.ts
@@ -116,7 +116,7 @@ export type ObjectGroup = {
   title?: string
   hidden?: true | FunctionMarker
   default?: true
-  i18n?: LocalizedMessage
+  i18n?: ObjectI18n
 }
 
 export interface ReferenceTypeDef extends SubtypeDef {
@@ -140,9 +140,16 @@ export type Validation = {
   message?: ValidationMessage
 }
 
-export type ValidationMessage = string | LocalizedMessage
+export type ValidationMessage = string | ObjectMessage
 
-export type LocalizedMessage = Record<string, string>
+export type ObjectMessage = Record<string, string>
+
+export type ObjectI18nValue = {
+  key: string
+  ns: string
+}
+
+export type ObjectI18n = Record<string, ObjectI18nValue>
 
 /** Field reference makes it possible for a rule to refer to another field in the same object. */
 export type FieldReference = {

--- a/packages/sanity/test/descriptors/schema.test.tsx
+++ b/packages/sanity/test/descriptors/schema.test.tsx
@@ -1460,7 +1460,163 @@ describe('Object', () => {
       ).toMatchObject([expected])
     })
 
-    test.todo('i18n')
+    describe('i18n', () => {
+      test('basic i18n support', () => {
+        expect(
+          convertType({
+            name: 'person',
+            type: 'object',
+            groups: [
+              {
+                name: 'settings',
+                title: 'Settings',
+                i18n: {
+                  title: {key: 'groups.settings.title', ns: 'studio'},
+                },
+              },
+            ],
+            fields: [{name: 'title', type: 'string'}],
+          }).typeDef.groups,
+        ).toMatchObject([
+          {
+            name: 'settings',
+            title: 'Settings',
+            i18n: {
+              title: {key: 'groups.settings.title', ns: 'studio'},
+            },
+          },
+        ])
+      })
+
+      test('i18n with multiple fields', () => {
+        expect(
+          convertType({
+            name: 'person',
+            type: 'object',
+            groups: [
+              {
+                name: 'advanced',
+                title: 'Advanced Settings',
+                i18n: {
+                  title: {key: 'groups.advanced.title', ns: 'studio'},
+                },
+              },
+            ],
+            fields: [{name: 'title', type: 'string'}],
+          }).typeDef.groups,
+        ).toMatchObject([
+          {
+            name: 'advanced',
+            title: 'Advanced Settings',
+            i18n: {
+              title: {key: 'groups.advanced.title', ns: 'studio'},
+            },
+          },
+        ])
+      })
+
+      test('invalid i18n format is ignored', () => {
+        expect(
+          convertType({
+            name: 'person',
+            type: 'object',
+            groups: [
+              {
+                name: 'settings',
+                title: 'Settings',
+                i18n: 'invalid',
+              } as any,
+            ],
+            fields: [{name: 'title', type: 'string'}],
+          }).typeDef.groups,
+        ).toMatchObject([
+          {
+            name: 'settings',
+            title: 'Settings',
+            i18n: undefined,
+          },
+        ])
+      })
+
+      test('i18n with missing properties is ignored', () => {
+        expect(
+          convertType({
+            name: 'person',
+            type: 'object',
+            groups: [
+              {
+                name: 'settings',
+                title: 'Settings',
+                i18n: {
+                  title: {key: 'groups.settings.title'},
+                },
+              } as any,
+            ],
+            fields: [{name: 'title', type: 'string'}],
+          }).typeDef.groups,
+        ).toMatchObject([
+          {
+            name: 'settings',
+            title: 'Settings',
+            i18n: undefined,
+          },
+        ])
+      })
+
+      test('empty i18n object is ignored', () => {
+        expect(
+          convertType({
+            name: 'person',
+            type: 'object',
+            groups: [
+              {
+                name: 'settings',
+                title: 'Settings',
+                i18n: {},
+              },
+            ],
+            fields: [{name: 'title', type: 'string'}],
+          }).typeDef.groups,
+        ).toMatchObject([
+          {
+            name: 'settings',
+            title: 'Settings',
+            i18n: undefined,
+          },
+        ])
+      })
+
+      test('i18n combined with other properties', () => {
+        expect(
+          convertType({
+            name: 'person',
+            type: 'object',
+            groups: [
+              {
+                name: 'settings',
+                title: 'Settings',
+                hidden: true,
+                default: true,
+                i18n: {
+                  title: {key: 'groups.settings.title', ns: 'studio'},
+                },
+              },
+            ],
+            fields: [{name: 'title', type: 'string'}],
+          }).typeDef.groups,
+        ).toMatchObject([
+          {
+            name: 'settings',
+            title: 'Settings',
+            hidden: true,
+            default: true,
+            i18n: {
+              title: {key: 'groups.settings.title', ns: 'studio'},
+            },
+          },
+        ])
+      })
+    })
   })
 
   test.todo('orderings')


### PR DESCRIPTION
### Description

Adds serialization of i18n properties to a descriptor.

### What to review

Mainly the conversion of the i18n struct the schema uses to the urn the descriptor seems to expect.

### Testing

👍 

### Notes for release

Not required.
