### PR TITLE
fix: improve PortalProvider and PopoverContainer perf

### DIFF
--- a/packages/sanity/src/core/components/popoverDialog/PopoverContainer.tsx
+++ b/packages/sanity/src/core/components/popoverDialog/PopoverContainer.tsx
@@ -4,7 +4,6 @@ import {
   type ContainerProps,
   rem,
   type ResponsiveWidthStyleProps,
-  useArrayProp,
 } from '@sanity/ui'
 import {forwardRef, type ReactNode, type Ref} from 'react'
 import {styled} from 'styled-components'
@@ -32,8 +31,14 @@ export const PopoverContainer = forwardRef(function PopoverContainer(
   props: PopoverContainerProps,
   ref: Ref<HTMLDivElement>,
 ) {
-  const {width, ...restProps} = props
-  const widthArr = useArrayProp(width)
+  const {width = [], ...restProps} = props
 
-  return <StyledContainer {...restProps} data-ui="PopoverContainer" $width={widthArr} ref={ref} />
+  return (
+    <StyledContainer
+      {...restProps}
+      data-ui="PopoverContainer"
+      $width={Array.isArray(width) ? width : [width]}
+      ref={ref}
+    />
+  )
 })

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -300,6 +300,10 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     schemaType,
     workspace,
   ])
+  const portalElements = useMemo(
+    () => ({documentScrollElement: documentScrollElement}),
+    [documentScrollElement],
+  )
   const showFormView = features.resizablePanes || !showInspector
   return (
     <PaneContent>
@@ -311,10 +315,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
               <DocumentPanelSubHeader />
             </LegacyLayerProvider>
             <DocumentBox flex={2} overflow="hidden">
-              <PortalProvider
-                element={portalElement}
-                __unstable_elements={{documentScrollElement: documentScrollElement}}
-              >
+              <PortalProvider element={portalElement} __unstable_elements={portalElements}>
                 <BoundaryElementProvider element={documentScrollElement}>
                   <VirtualizerScrollInstanceProvider
                     scrollElement={documentScrollElement}

--- a/packages/sanity/src/structure/panes/document/timeline/events/EventsTimelineMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/events/EventsTimelineMenu.tsx
@@ -179,9 +179,15 @@ export function EventsTimelineMenu({event, events, mode, placement}: TimelineMen
       : t('timeline.no-previous-events')
 
   const buttonLabel = mode === 'rev' ? revLabel : sinceLabel
+  const portalElements = useMemo(
+    () => ({
+      [TIMELINE_MENU_PORTAL]: popoverRef,
+    }),
+    [popoverRef],
+  )
 
   return (
-    <PortalProvider __unstable_elements={{[TIMELINE_MENU_PORTAL]: popoverRef}}>
+    <PortalProvider __unstable_elements={portalElements}>
       <Root
         data-testid="timeline-menu"
         constrainSize

--- a/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
@@ -166,9 +166,10 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
     : t('timeline.since-version-missing')
 
   const buttonLabel = mode === 'rev' ? revLabel : sinceLabel
+  const portalElements = useMemo(() => ({[TIMELINE_MENU_PORTAL]: popoverRef}), [popoverRef])
 
   return (
-    <PortalProvider __unstable_elements={{[TIMELINE_MENU_PORTAL]: popoverRef}}>
+    <PortalProvider __unstable_elements={portalElements}>
       <Root
         data-testid="timeline-menu"
         constrainSize


### PR DESCRIPTION
### Description

- Speeds up `<PortalProvider>` instances by making sure `__unstable_elements` are memoized.
- Removes `useArrayProp` from `<PopoverContainer>` and instead lets React Compiler handle the array conversion memo ([before](https://playground.react.dev/#N4Igzg9grgTgxgUxALhASwLYAcIwC4AEwAOgHYEED6MCYOpYaAbggDRkUDCEpeAhmlIIY7cgTwBPLAgLdeAoTAAKMCFjCiKNDJvFSZAJVr1GLAOpoAJngAWAZUkAbBCrUaOBKGAQBBGDD4JVyxRAF8CADNVDAIAcgABMD5SNEkAeig0WLJMHHwiSNwAdz4YSyMI1j1pAiM+ODwAOQhLNmrDBAiCcKiIGNiaerxslOxcQmACMCcES27I6LjpiWdLAFo4PvoEXjARsjS0ggAVGzQwAnOCPgIi3ABrUuhSObwIAgw+e5kwWBlbPiEWwyOT8QTCAgAcwQeAuwIIm38CAatystluNh2nm8c0EjFa1wIOBwLBgADoDkdTjJWhE+FBHIRQQoIV5aAQAAafAAeFmsNg5GLQcBsBEsEFopFihDuMHutwQjkcqPRxIgpIuACNkfTvOJMUS1OrhJSEXxHHAGYD2akLkU0aLNXwcQQePqZJteDsZQ6KaRPdMCA4VrNmeCYAQALxTGaWAAUYcUAEoCAAeWrGHimBB82zB5zBC4APgIcbjWFU6hTkZLJDEAYm7owMnC0Yrbg8DYKnrBiiqzcsaBurabCDJSRSkjIHhoeFg5GomYYzAQcYHQ6q7fUZIAJPb+VU40xzdWS3G6xQKIcCABZL4-P76wHu2Q8XsQ6Gwl+Imgo-foopMXINlcWXAkbjVUk-UvVF+WQAhj2VSNkLiek3liAgAH44lIHgEAw+DtDjHsWRgABtRCAF0k10K8jjvb4pkfAEgQNRMIX-UUrgbAJwTmTUJGuY80EcPhNWcKYsHqMcPAoHlcxseDYgARgABlUgBSWJdFCJMkzIXTpxSL0YDpRACCUI1SXY5RKwuBBuTwHZLAuGzCyITszkcSwaFIeC6gaZpWgMoyHLyQgu0sklhBsqNChgEoygqOMIigf08DQN0ouNGAbLjDwtzAeDsust9SMLXQaAifzOlTAAJY4bwAGQAEWYABRZxm14ItRBTC8ESzRtOKqMkxpoaZ3JHQrOyG2DbD8CNozZRbAmCONOP00gZxhec03zUMyvDIgxrJCa8ELcJLEBPg1kySNiBAEqYqOxRHoIPcHUjYBOMW8Iqu+qrwjSIsDKTEBWBAT0IjQSEUBAEBQiAA)/[after](https://playground.react.dev/#N4Igzg9grgTgxgUxALhASwLYAcIwC4AEwAOgHYEED6MCYOpYaAbggDRkUDCEpeAhmlIIY7cgTwBPLAgLdeAoTAAKMCFjCiKNDJvFSZAJVr1GLAOpoAJngAWAZUkAbBCrUayAXwIAzVRgIA5AACYHykaJIA9FBoAWSYOPhEPrgA7nwwlkberHrSBEZ8cHgAchCWbHmGCN4EXr4Q-gE0RXhx4di4hMAEYE4IlnU+foF9Es6WALRwjfQIvGDtZJGRBAAqNmhgBFsEfASpuADWGdCkg3gQBBh8RzJgsDK2fIS2MnL8gsIEAOYIeNs3gQZjAaMUDlZbAcbPMCFAwAMdgwrDJ9jgcCwYAA6ZarDYyCrePhQRyED4Kb7w2gEAAGNwAHhZrDYadC0HAbARLBBaKQAoRDjAjgcEI5HBCoeiIJjtgAjBBwYkI8QwghSzG44F8RxwEkvakRbapSGc2V8BGDHgqmQzXjzAUmnGkW19AgOcYDclfGAEAC8vX6lgAFF7FABKAgAHgKxh4pgQTNs7ucrnUBAAfAQg0GsKp1BHfZmSGIXd1rRgZF5-bm3BxgXGy7bPopchXLGh9lXywgsaFwpIyHWaHhYORqLHkSwg22O7ka+osQASY3M3JBpjaguZoPFigUFYEACyt3ujxVL2tsh4ze+fwBl5BYIdzOhsKpg0EjAqezVamlwidPcIWZZACA3cVfUgwJiUuAICAAfkCUgeAQODQO0IMmwpGAAG1wIAXTDXR91WY87l6M9nleVVQ2+FcoV2UsYApQZZQkPYNzQRw+FlZxeiwIoezrCgGUTGxQICABGAAGaSAFIAl0DwwzDTxVNIeI7RgIlEAIJQ-0xWjlDzbYEHpPB5ksbYjNTbZd2BTZHEsGhSFAwpijKCpPEHIR6USQhSz0gzhCMv0UhgdJMmyINvCgZ08DQK19IxELr2woM63nMBQOS-8YBskzdBobw3JqSMAAk1kPAAZAARZgAFFnArXh01ECN7MCnp6M5f0cPw3IsSGmg+lsoZqxMnytH+Ucs2EqNk09NLvXmihgCGrERrwWyPFWrkXj4SYYl9YgQFywzlsUU69uXE1fWAABBUE+AkLEtie5iJCDHqI0QnqCFAnCevw3axCA4r7uK0GgMidM63U5SQFYEBbW8NAfhQEAQA8IA))

### What to review

All good?

### Testing

If tests pass and eFPS doesn't report regressions we're good!

### Notes for release

N/A - perf boost not significant enough to warrant callout
