### PR TITLE
feat(descriptors): serialize orderings properties

### DIFF
--- a/packages/@sanity/schema/src/descriptors/types.ts
+++ b/packages/@sanity/schema/src/descriptors/types.ts
@@ -34,6 +34,8 @@ export interface CommonTypeDef extends EncodableObject {
 
   /** Number of rows which should be used by the `text` type. */
   rows?: string
+
+  orderings?: ObjectOrdering[]
 }
 
 /** In some scenarios we need to encode special information. */
@@ -117,6 +119,18 @@ export type ObjectGroup = {
   hidden?: true | FunctionMarker
   default?: true
   i18n?: ObjectI18n
+}
+
+export type ObjectOrdering = {
+  title: string
+  i18n?: ObjectI18n
+  name: string
+  by: ObjectOrderingBy[]
+}
+
+export type ObjectOrderingBy = {
+  field: string
+  direction: 'asc' | 'desc'
 }
 
 export interface ReferenceTypeDef extends SubtypeDef {

--- a/packages/sanity/test/descriptors/extractManifestToSchema.test.ts
+++ b/packages/sanity/test/descriptors/extractManifestToSchema.test.ts
@@ -507,9 +507,10 @@ describe('ManifestSchemaTypes[] converts to Schema', () => {
           components: {
             field: () => 'remove-components',
           },
-          orderings: [
-            {name: 'remove-orderings', title: '', by: [{field: 'title', direction: 'desc'}]},
-          ],
+          // orderings behaviour is validated in schema.test.ts
+          // orderings: [
+          //   {name: 'remove-orderings', title: '', by: [{field: 'title', direction: 'desc'}]},
+          // ],
           fields: [
             defineField({
               name: 'string',


### PR DESCRIPTION
### Description

Serialize the ordering property of a schema into a descriptor.

### What to review

Logic makes sense.

### Testing

👍 

### Notes for release

Not required.
