### PR TITLE
chore(core): add workspace name to comments notification payload

### DIFF
--- a/packages/sanity/src/core/comments/hooks/use-comment-operations/createOperation.ts
+++ b/packages/sanity/src/core/comments/hooks/use-comment-operations/createOperation.ts
@@ -103,6 +103,7 @@ export async function createOperation(props: CreateOperationProps): Promise<void
       documentTitle = '',
       url = '',
       workspaceTitle = '',
+      workspaceName = '',
     } = getNotificationValue({commentId}) || {}
 
     const notification: CommentContext['notification'] = {
@@ -110,6 +111,7 @@ export async function createOperation(props: CreateOperationProps): Promise<void
       documentTitle,
       url,
       workspaceTitle,
+      workspaceName,
     }
 
     const intent = getIntent?.({id: documentId, type: documentType, path: comment.fieldPath})

--- a/packages/sanity/src/core/comments/hooks/useNotificationTarget.ts
+++ b/packages/sanity/src/core/comments/hooks/useNotificationTarget.ts
@@ -34,7 +34,7 @@ export function useNotificationTarget(
 ): NotificationTargetHookValue {
   const {documentId, documentType, getCommentLink, documentVersionId} = opts || {}
   const schemaType = useSchema().get(documentType)
-  const {title: workspaceTitle} = useWorkspace()
+  const {title: workspaceTitle, name: workspaceName} = useWorkspace()
 
   const documentPreviewStore = useDocumentPreviewStore()
 
@@ -53,8 +53,9 @@ export function useNotificationTarget(
       documentTitle,
       url: getCommentLink?.(commentId),
       workspaceTitle,
+      workspaceName,
     }),
-    [documentTitle, getCommentLink, workspaceTitle],
+    [documentTitle, getCommentLink, workspaceTitle, workspaceName],
   )
 
   return {

--- a/packages/sanity/src/core/comments/types.ts
+++ b/packages/sanity/src/core/comments/types.ts
@@ -100,6 +100,7 @@ export interface CommentContext {
     documentTitle: string
     url?: string
     workspaceTitle: string
+    workspaceName: string
     currentThreadLength?: number
     // Used in task comments, list of users that are subscribed to the task.
     subscribers?: string[]

--- a/packages/sanity/src/core/tasks/components/activity/TasksActivityLog.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/TasksActivityLog.tsx
@@ -62,7 +62,7 @@ export function TasksActivityLog(props: TasksActivityLogProps) {
   const {value, onChange, path, activityData = []} = props
   const currentUser = useCurrentUser()
 
-  const {title: workspaceTitle, basePath} = useWorkspace()
+  const {title: workspaceTitle, basePath, name: workspaceName} = useWorkspace()
   const {comments, mentionOptions, operation, getComment} = useComments()
   const [commentToDeleteId, setCommentToDeleteId] = useState<string | null>(null)
   const [commentDeleteError, setCommentDeleteError] = useState<Error | null>(null)
@@ -85,11 +85,12 @@ export function TasksActivityLog(props: TasksActivityLogProps) {
       return {
         documentTitle: value.title || 'Sanity task',
         url: studioUrl.toString(),
-        workspaceTitle: workspaceTitle,
-        subscribers: subscribers,
+        workspaceTitle,
+        workspaceName,
+        subscribers,
       }
     },
-    [basePath, value?._id, value.title, workspaceTitle, value.subscribers],
+    [basePath, value?._id, value.title, workspaceTitle, value.subscribers, workspaceName],
   )
 
   const handleCommentCreate = useCallback(

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksNotificationTarget.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksNotificationTarget.tsx
@@ -37,7 +37,7 @@ function TasksNotificationTargetInner(props: ObjectFieldProps<TaskDocument>) {
     ),
   )
   const {target, _id, context, _rev} = useFormValue([]) as TaskDocument
-  const {title: workspaceTitle, basePath} = useWorkspace()
+  const {title: workspaceTitle, basePath, name: workspaceName} = useWorkspace()
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const imageBuilder = useMemo(() => imageUrlBuilder(client), [client])
   const documentId = target?.document?._ref ?? ''
@@ -65,6 +65,7 @@ function TasksNotificationTargetInner(props: ObjectFieldProps<TaskDocument>) {
       workspaceTitle,
       targetContentImageUrl: imageUrl,
       targetContentTitle: targetContentTitle,
+      workspaceName,
     }
   }, [
     context?.notification?.url,
@@ -72,6 +73,7 @@ function TasksNotificationTargetInner(props: ObjectFieldProps<TaskDocument>) {
     basePath,
     activeToolName,
     workspaceTitle,
+    workspaceName,
     imageUrl,
     targetContentTitle,
   ])


### PR DESCRIPTION
### Description
Adds workspace name into the comments and tasks notifications payload, which is necessary for the dashboard notifications to work properly.

Yeah, ideally we would have an object workspace and then name and title:
```ts
type notificationPayload = {
 workspace: { 
    name: string;
    title:  string;
}
```
but given this needs to be backwards compatible I think it's easier to keep it as this and expose the two values at root level.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
If tests passes we are fine.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
internal
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
