### PR TITLE
fix(core): make sure empty strings aren't passed to the upload API

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/common/assetSource.ts
+++ b/packages/sanity/src/core/form/inputs/files/common/assetSource.ts
@@ -1,4 +1,5 @@
 import {type AssetFromSource, type FileSchemaType, type ImageSchemaType} from '@sanity/types'
+import {pickBy} from 'lodash'
 
 import {
   isVideoSchemaType,
@@ -49,6 +50,12 @@ export function handleSelectAssetFromSource({
   const description = assetProps?.description
   const creditLine = assetProps?.creditLine
   const source = assetProps?.source
+
+  const assetOptions = pickBy(
+    {label, title, description, creditLine, source},
+    (value) => value !== null && value !== undefined && value !== '',
+  )
+
   const assetPatches: FormPatch[] = isImage
     ? [unset(['hotspot']), unset(['crop']), unset(['media'])]
     : [unset(['media'])]
@@ -104,13 +111,7 @@ export function handleSelectAssetFromSource({
     case 'file': {
       const uploader = resolveUploader(type, firstAsset.value as FIXME)
       if (uploader) {
-        uploadWith(uploader, firstAsset.value as FIXME, {
-          label,
-          title,
-          description,
-          creditLine,
-          source,
-        })
+        uploadWith(uploader, firstAsset.value as FIXME, assetOptions)
       }
       break
     }
@@ -118,7 +119,7 @@ export function handleSelectAssetFromSource({
       base64ToFile(firstAsset.value as FIXME, originalFilename).then((file) => {
         const uploader = resolveUploader(type, file)
         if (uploader) {
-          uploadWith(uploader, file, {label, title, description, creditLine, source})
+          uploadWith(uploader, file, assetOptions)
         }
       })
       break
@@ -126,7 +127,7 @@ export function handleSelectAssetFromSource({
       urlToFile(firstAsset.value as FIXME, originalFilename).then((file) => {
         const uploader = resolveUploader(type, file)
         if (uploader) {
-          uploadWith(uploader, file, {label, title, description, creditLine, source})
+          uploadWith(uploader, file, assetOptions)
         }
       })
       break

--- a/packages/sanity/src/core/form/inputs/files/common/assetSource.ts
+++ b/packages/sanity/src/core/form/inputs/files/common/assetSource.ts
@@ -34,7 +34,6 @@ export function handleSelectAssetFromSource({
   uploadWith,
   isImage,
 }: Props): void {
-  // const {onChange, type, resolveUploader} = this.props
   if (!assetsFromSource) {
     throw new Error('No asset given')
   }


### PR DESCRIPTION
### Description

This will ensure all query params for the upload API are correctly set.

We had a problem yesterday where someone using a Bynder asset source started getting 400 errors because changes in the Bynder API caused it to start emitting empty strings for the asset description.

So, if the `description` and similar properties are empty strings, they should not be passed to the upload API.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the changes are correct.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
