### PR TITLE
fix: issue where trying to revert revision would open two dialogs 

### DIFF
--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -87,7 +87,7 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
       {sideMenuItems.length > 0 && (
         <ActionMenuButton actionStates={sideMenuItems} disabled={disabled} />
       )}
-      {firstActionState && firstActionState.dialog && (
+      {showFirstActionButton && firstActionState && firstActionState.dialog && (
         <ActionStateDialog dialog={firstActionState.dialog} referenceElement={buttonElement} />
       )}
     </Flex>


### PR DESCRIPTION
### Description

There was an issue where trying to revert to an older revision was opening two dialogues and preventing you from actually being able to revert to that revision

Before
https://github.com/user-attachments/assets/3e49e1e4-3f3d-4465-bd31-e12052c5a0ff

After

https://github.com/user-attachments/assets/5c37b66a-4d28-42c4-904c-2d5eee7d1835

### What to review

Does it make sense? is there a better solution?

### Testing

Existing tests should be enough

### Notes for release

Fixes issue where reverting to old revision in a document version was not possible
