### PR TITLE
fix(sanity): use project host when fetching video playback info

### DIFF
--- a/packages/sanity/src/media-library/plugin/VideoInput/useVideoPlaybackInfo.ts
+++ b/packages/sanity/src/media-library/plugin/VideoInput/useVideoPlaybackInfo.ts
@@ -88,12 +88,8 @@ export function useVideoPlaybackInfo(
       return null
     }
     return client.withConfig({
-      'apiVersion': DEFAULT_API_VERSION,
-      'requestTagPrefix': 'sanity.mediaLibrary.videoPlaybackInfo',
-      '~experimental_resource': {
-        type: 'media-library',
-        id: params.mediaLibraryId,
-      },
+      apiVersion: DEFAULT_API_VERSION,
+      requestTagPrefix: 'sanity.studio.mediaLibrary.videoPlaybackInfo',
     })
   }, [client, params])
 


### PR DESCRIPTION
### Description

The global domain lacks CORS, and this turned out to be an issue when fetching playback info. Have switched to using project domain.

Tested video playback functionality to ensure it continues to work properly without the removed configuration.

### Notes for release

n/a