### PR TITLE
refactor(sanity): add export for detecting if using staging

### DIFF
--- a/packages/sanity/src/core/environment/index.ts
+++ b/packages/sanity/src/core/environment/index.ts
@@ -3,3 +3,11 @@ export const isDev = process.env.NODE_ENV !== 'production'
 
 /** @internal */
 export const isProd = !isDev
+
+/**
+ * Checks if the current environment is using staging or not.
+ *
+ * @internal
+ */
+// @ts-expect-error: __SANITY_STAGING__ is a global env variable set by the vite config
+export const isStaging = typeof __SANITY_STAGING__ !== 'undefined' && __SANITY_STAGING__ === true

--- a/packages/sanity/src/media-library/plugin/VideoInput/VideoPreview.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/VideoPreview.tsx
@@ -3,11 +3,10 @@ import {type AssetSource} from '@sanity/types'
 import {get, startCase} from 'lodash'
 import {type ReactNode, useCallback, useMemo, useState} from 'react'
 
+import {isStaging} from '../../../core/environment'
 import {ActionsMenu} from '../../../core/form/inputs/files/common/ActionsMenu'
 import {FileInputMenuItem} from '../../../core/form/inputs/files/common/FileInputMenuItem/FileInputMenuItem'
 import {UploadDropDownMenu} from '../../../core/form/inputs/files/common/UploadDropDownMenu'
-import {DEFAULT_API_VERSION} from '../../../core/form/studio/assetSourceMediaLibrary/constants'
-import {useClient} from '../../../core/hooks'
 import {useTranslation} from '../../../core/i18n'
 import {MenuItem} from '../../../ui-components/menuItem/MenuItem'
 import {CUSTOM_DOMAIN_PRODUCTION, CUSTOM_DOMAIN_STAGING} from './constants'
@@ -41,9 +40,6 @@ export function VideoPreview(props: VideoAssetProps) {
   const asset = value?.asset
   const sourcesFromSchema = schemaType.options?.sources
   const accept = get(schemaType, 'options.accept', '')
-  const isStaging = useClient({apiVersion: DEFAULT_API_VERSION})
-    .config()
-    .apiHost.endsWith('.sanity.work')
 
   const videoPlaybackParams = useMemo(() => {
     if (!asset?._ref) {
@@ -80,7 +76,6 @@ export function VideoPreview(props: VideoAssetProps) {
 
     return tokens ? {...baseProps, tokens} : baseProps
   }, [
-    isStaging,
     playbackInfoState.result?.aspectRatio,
     playbackInfoState.result?.id,
     isMenuOpen,

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -437,6 +437,7 @@ exports[`exports snapshot 1`] = `
     "isSearchStrategy": "function",
     "isSlug": "function",
     "isSpanSchemaType": "function",
+    "isStaging": "boolean",
     "isString": "function",
     "isStringInputProps": "function",
     "isStringSchemaType": "function",


### PR DESCRIPTION
### Description

Added a new `isStaging` export to detect when the application is running in a staging environment. This can be used across studio, where we repeat the check in various ways

### What to review

- The new `isStaging` function in `core/environment/index.ts` that uses a global environment variable `__SANITY_STAGING__`

### Notes for release

n/A