### PR TITLE
fix(structure): always render history restore action if seeing revision

### DIFF
--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -12,7 +12,7 @@ import {
 } from 'sanity'
 
 import {Button, Tooltip} from '../../../../ui-components'
-import {RenderActionCollectionState, type ResolvedAction} from '../../../components'
+import {RenderActionCollectionState, type ResolvedAction, usePaneRouter} from '../../../components'
 import {HistoryRestoreAction} from '../../../documentActions'
 import {toLowerCaseNoSpaces} from '../../../util/toLowerCaseNoSpaces'
 import {useDocumentPane} from '../useDocumentPane'
@@ -30,6 +30,9 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
   const {disabled, states} = props
   const {__internal_tasks} = useSource()
   const {editState} = useDocumentPane()
+  const {params} = usePaneRouter()
+  const showingRevision = Boolean(params?.rev)
+
   const {selectedReleaseId} = usePerspective()
   const [firstActionState, ...menuActionStates] = states
   const [buttonElement, setButtonElement] = useState<HTMLButtonElement | null>(null)
@@ -54,10 +57,13 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
       </Flex>
     )
   }, [firstActionState])
-  const showFirstActionButton = selectedReleaseId
-    ? // If the first action is a custom action and we are in a version document show it.
-      firstActionState && !isSanityDefinedAction(firstActionState)
-    : firstActionState && !editState?.liveEdit
+
+  const showFirstActionButton = showingRevision
+    ? Boolean(firstActionState)
+    : selectedReleaseId
+      ? // If the first action is a custom action and we are in a version document show it.
+        firstActionState && !isSanityDefinedAction(firstActionState)
+      : firstActionState && !editState?.liveEdit
 
   const sideMenuItems = useMemo(() => {
     return showFirstActionButton ? menuActionStates : [firstActionState, ...menuActionStates]


### PR DESCRIPTION
### Description
This PR fixes an issue in where the history restore action is not rendered for version documents by setting it always to true if we are displaying a revision.
It fixes an issue with the popover for the revision showing in an unexpected place.
Is this an issue in other places? Investigating:
| Before | Now |
|--------|--------|
| <img width="965" height="1000" alt="Screenshot 2025-09-05 at 13 48 08" src="https://github.com/user-attachments/assets/f3d0e951-ee55-45b0-9b2e-2afc994f4a9e" /> | <img width="967" height="991" alt="Screenshot 2025-09-05 at 13 44 11" src="https://github.com/user-attachments/assets/f74d0882-8b09-4240-a4a5-8f4ab5976b17" /> | 




<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Renders revert to revision action in version documents.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
