### PR TITLE
fix: add caching to the useHistory in the releases + fix lastEditedByIssue

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -219,7 +219,7 @@ function UpdatedAtCell({
   const bundleId = getReleaseIdFromReleaseDocumentId(releaseDocumentId)
   const historyDocumentId =
     datum.isPending || document?._id?.endsWith('-pending') ? undefined : document?._id
-  const {documentHistory} = useReleaseHistory(historyDocumentId, bundleId)
+  const {documentHistory} = useReleaseHistory(historyDocumentId, bundleId, document?._rev)
 
   return (
     <Flex


### PR DESCRIPTION
### Description

This PR adds caching to the useHistory but also fixes an issue where the lastEditedBy wasn't updating correctly and was instead relying on the latest editor it was showing the initial editor that it loaded with instead of auto updating as changes happen.

Before:
https://github.com/user-attachments/assets/35338a95-f79c-481f-b3a9-013d708eabea

After:
https://github.com/user-attachments/assets/6beb65c3-2014-487f-93ab-ea9c4dc747db

### What to review

Anything missing? Concerns?

### Testing

Existing tests should be enough

### Notes for release
Improvement on performance in the release detail
Fix issue where latest edited by user avatar wasn't updating with the right user
