### PR TITLE
fix: issue where an unpublished documentwas howing up as undefined in the document list in a release detail

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
@@ -19,6 +19,7 @@ interface ReleaseDocumentPreviewProps {
   documentRevision?: string
   hasValidationError?: boolean
   layout?: PreviewLayoutKey
+  isGoingToBePublished?: boolean
 }
 
 const isArchivedRelease = (releaseState: ReleaseState | undefined) =>
@@ -31,6 +32,7 @@ export function ReleaseDocumentPreview({
   releaseState,
   documentRevision,
   layout,
+  isGoingToBePublished = false,
 }: ReleaseDocumentPreviewProps) {
   const documentPresence = useDocumentPresence(documentId)
 
@@ -95,9 +97,9 @@ export function ReleaseDocumentPreview({
   )
 
   const {isLoading: previewLoading, value: resolvedPreview} = useDocumentPreviewValues({
-    documentId,
+    documentId: isGoingToBePublished ? getPublishedId(documentId) : documentId,
     documentType: documentTypeName,
-    perspectiveStack: [getReleaseIdFromReleaseDocumentId(releaseId)],
+    perspectiveStack: isGoingToBePublished ? [] : [getReleaseIdFromReleaseDocumentId(releaseId)],
   })
 
   return (

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -12,6 +12,7 @@ import {RelativeTime} from '../../../../components/RelativeTime'
 import {useSchema} from '../../../../hooks'
 import {SanityDefaultPreview} from '../../../../preview/components/SanityDefaultPreview'
 import {getReleaseIdFromReleaseDocumentId} from '../../../util/getReleaseIdFromReleaseDocumentId'
+import {isGoingToUnpublish} from '../../../util/isGoingToUnpublish'
 import {ReleaseDocumentPreview} from '../../components/ReleaseDocumentPreview'
 import {Headers} from '../../components/Table/TableHeader'
 import {type Column, type InjectedTableProps} from '../../components/Table/types'
@@ -32,6 +33,8 @@ const MemoReleaseDocumentPreview = memo(
     releaseState?: ReleaseState
     documentRevision?: string
   }) {
+    const isGoingToBePublished = isGoingToUnpublish(item.document)
+
     return (
       <ReleaseDocumentPreview
         documentId={item.document._id}
@@ -39,6 +42,7 @@ const MemoReleaseDocumentPreview = memo(
         releaseId={releaseId}
         releaseState={releaseState}
         documentRevision={documentRevision}
+        isGoingToBePublished={isGoingToBePublished}
       />
     )
   },


### PR DESCRIPTION
### Description

Document was showing up as undefined if it was to unpublish in a release.
Thought we had fixed this but probably something that we did in between messed up the fetches or something, in any case this fixes it!

<img width="1470" height="352" alt="image" src="https://github.com/user-attachments/assets/b23bf0cf-8e4c-4f03-b34a-bc730ee18199" />

### What to review

Does the code make sense? Any concerns

### Testing

Existing tests should suffice 

### Notes for release

Fixes issue where a document that will be unpublished was showing as undefined in the document list
