### PR TITLE
feat: log schema errors on extraction failure

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/schema/formatSchemaValidation.ts
+++ b/packages/sanity/src/_internal/cli/actions/schema/formatSchemaValidation.ts
@@ -1,5 +1,6 @@
 import {isatty} from 'node:tty'
 
+import {generateHelpUrl} from '@sanity/generate-help-url'
 import {type SchemaValidationProblemGroup, type SchemaValidationProblemPath} from '@sanity/types'
 import chalk from 'chalk'
 import logSymbols from 'log-symbols'
@@ -82,7 +83,10 @@ export function formatSchemaValidation(validation: SchemaValidationProblemGroup[
           const formattedPath = `  ${chalk.bold(formatPath(group.path) || '(root)')}`
           const formattedMessages = group.problems
             .sort((a, b) => severityValues[a.severity] - severityValues[b.severity])
-            .map(({severity, message}) => `    ${logSymbols[severity]} ${message}`)
+            .map(({severity, message, helpId}) => {
+              const help = helpId ? `\n      See ${generateHelpUrl(helpId)}` : ''
+              return `    ${logSymbols[severity]} ${message}${help}`
+            })
             .join('\n')
 
           return `${formattedPath}\n${formattedMessages}`


### PR DESCRIPTION
### Description

When configuring Schema, errors are currently only ever thrown in the browser. This makes it impossible for LLMs to discover what is wrong with their configuration.

Sanity CLI contains schema extraction, which LLM's can use to validate schema configuration.

This update will also be useful to humans as well.

#### Currently: 

Schema extraction errors contain no information to debug the configuration:

```sh
npx sanity schema extract
✗ Failed to extract schema

SchemaError: SchemaError
    at ~/Sites/ai-powered-sanity-2025/apps/studio/node_modules/.pnpm/sanity@4.6.1_@emotion+is-prop-valid@1.2.2_@portabletext+sanity-bridge@1.1.8_@sanity+sch_6e222404477ef3dfed2adb92dda152b5/node_modules/sanity/lib/index.js:68184:17
    at Array.map (<anonymous>)
    at ~/Sites/ai-powered-sanity-2025/apps/studio/node_modules/.pnpm/sanity@4.6.1_@emotion+is-prop-valid@1.2.2_@portabletext+sanity-bridge@1.1.8_@sanity+sch_6e222404477ef3dfed2adb92dda152b5/node_modules/sanity/lib/index.js:68158:11
    at Array.map (<anonymous>)
    at prepareConfig (~/Sites/ai-powered-sanity-2025/apps/studio/node_modules/.pnpm/sanity@4.6.1_@emotion+is-prop-valid@1.2.2_@portabletext+sanity-bridge@1.1.8_@sanity+sch_6e222404477ef3dfed2adb92dda152b5/node_modules/sanity/lib/index.js:68142:34)
    at Object.resolveConfig (~/Sites/ai-powered-sanity-2025/apps/studio/node_modules/.pnpm/sanity@4.6.1_@emotion+is-prop-valid@1.2.2_@portabletext+sanity-bridge@1.1.8_@sanity+sch_6e222404477ef3dfed2adb92dda152b5/node_modules/sanity/lib/index.js:68664:7)
    at Object.getStudioWorkspaces (~/Sites/ai-powered-sanity-2025/apps/studio/node_modules/.pnpm/sanity@4.6.1_@emotion+is-prop-valid@1.2.2_@portabletext+sanity-bridge@1.1.8_@sanity+sch_6e222404477ef3dfed2adb92dda152b5/node_modules/sanity/lib/_chunks-cjs/getStudioWorkspaces.js:43:92)
    at main (~/Sites/ai-powered-sanity-2025/apps/studio/node_modules/.pnpm/sanity@4.6.1_@emotion+is-prop-valid@1.2.2_@portabletext+sanity-bridge@1.1.8_@sanity+sch_6e222404477ef3dfed2adb92dda152b5/node_modules/sanity/lib/_internal/cli/threads/extractSchema.js:10:50)
    at Object.<anonymous> (~/Sites/ai-powered-sanity-2025/apps/studio/node_modules/.pnpm/sanity@4.6.1_@emotion+is-prop-valid@1.2.2_@portabletext+sanity-bridge@1.1.8_@sanity+sch_6e222404477ef3dfed2adb92dda152b5/node_modules/sanity/lib/_internal/cli/threads/extractSchema.js:25:1)
```

#### After:

Errors contain rich validation errors:

```sh
npx sanity schema extract          
✗ Failed to extract schema

 ERROR   image 
  (root)
    ✖ Invalid type name: "image" is a reserved name.
      See https://docs.sanity.io/help/schema-type-name-reserved

SchemaError: SchemaError
    at ~/sites/sanity/packages/sanity/lib/index.js:68539:17
    at Array.map (<anonymous>)
    at ~/sites/sanity/packages/sanity/lib/index.js:68513:11
    at Array.map (<anonymous>)
    at prepareConfig (~/sites/sanity/packages/sanity/lib/index.js:68497:34)
    at Object.resolveConfig (~/sites/sanity/packages/sanity/lib/index.js:69033:7)
    at Object.getStudioWorkspaces (~/sites/sanity/packages/sanity/lib/_chunks-cjs/getStudioWorkspaces.js:43:92)
    at main (~/sites/sanity/packages/sanity/lib/_internal/cli/threads/extractSchema.js:10:50)
    at Object.<anonymous> (~/sites/sanity/packages/sanity/lib/_internal/cli/threads/extractSchema.js:25:1)
```

### What to review

This PR was written by GPT-5. I think it's fine except for the two helper functions (`extractValidationFromCoreSchemaError` and `isSchemaError`) that it has written. 

These were in response to telling it to not `as any` its way to victory.

### Testing

I've locally tested this build to receive the errors I've posted above.

### Notes for release

`schema extract` now reports errors with Studio schema configuration