### PR TITLE
Add "copy to clipboard" button to schema errors

### DIFF
--- a/packages/sanity/src/core/studio/hooks/useCopyToClipboard.ts
+++ b/packages/sanity/src/core/studio/hooks/useCopyToClipboard.ts
@@ -1,0 +1,30 @@
+// https://usehooks-ts.com/react-hook/use-copy-to-clipboard#hook
+import {useCallback, useState} from 'react'
+
+type CopiedValue = string | null
+
+type CopyFn = (text: string) => Promise<boolean>
+
+export function useCopyToClipboard(): [CopiedValue, CopyFn] {
+  const [copiedText, setCopiedText] = useState<CopiedValue>(null)
+
+  const copy: CopyFn = useCallback(async (text) => {
+    if (!navigator?.clipboard) {
+      console.warn('Clipboard not supported')
+      return false
+    }
+
+    // Try to save to clipboard then save it in the state if worked
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopiedText(text)
+      return true
+    } catch (error) {
+      console.warn('Copy failed', error)
+      setCopiedText(null)
+      return false
+    }
+  }, [])
+
+  return [copiedText, copy]
+}

--- a/packages/sanity/src/core/studio/screens/schemaErrors/SchemaErrorsScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/schemaErrors/SchemaErrorsScreen.tsx
@@ -1,8 +1,11 @@
-/* eslint-disable i18next/no-literal-string */
 import {type Schema} from '@sanity/types'
-import {Card, Container, Heading, Stack} from '@sanity/ui'
+import {Card, Container, Flex, Heading, Stack, useToast} from '@sanity/ui'
 import {useEffect} from 'react'
 
+import {Button} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n'
+import {useCopyToClipboard} from '../../hooks/useCopyToClipboard'
+import {formatSchemaErrorsToMarkdown} from './formatSchemaErrorsToMarkdown'
 import {reportWarnings} from './reportWarnings'
 import {SchemaProblemGroups} from './SchemaProblemGroups'
 
@@ -18,11 +21,47 @@ export function SchemaErrorsScreen({schema}: SchemaErrorsScreenProps) {
 
   useEffect(() => reportWarnings(schema), [schema])
 
+  const toast = useToast()
+  const {t} = useTranslation('studio')
+  const {t: tCopyPaste} = useTranslation('copy-paste')
+  const [, copy] = useCopyToClipboard()
+  const handleCopyToClipboard = async () => {
+    const errorsText = formatSchemaErrorsToMarkdown(groupsWithErrors)
+
+    try {
+      await copy(errorsText)
+      toast.push({
+        status: 'success',
+        title: t(
+          'about-dialog.version-info.copy-to-clipboard-button.copied-text',
+          'Copied to clipboard',
+        ),
+      })
+    } catch {
+      toast.push({
+        status: 'error',
+        title: tCopyPaste(
+          'copy-paste.on-copy.validation.clipboard-not-supported.title',
+          'Clipboard not supported',
+        ),
+      })
+    }
+  }
+
   return (
     <Card height="fill" overflow="auto" paddingY={[4, 5, 6, 7]} paddingX={4} sizing="border">
       <Container width={1}>
         <Stack space={5}>
-          <Heading as="h1">Schema errors</Heading>
+          <Flex justify="space-between" align="center" gap={2}>
+            <Heading as="h1">{t('schema-errors.title', 'Schema errors')}</Heading>
+            <Button
+              text={t(
+                'about-dialog.version-info.copy-to-clipboard-button.text',
+                'Copy to clipboard',
+              )}
+              onClick={handleCopyToClipboard}
+            />
+          </Flex>
           <SchemaProblemGroups problemGroups={groupsWithErrors} />
         </Stack>
       </Container>

--- a/packages/sanity/src/core/studio/screens/schemaErrors/SchemaErrorsScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/schemaErrors/SchemaErrorsScreen.tsx
@@ -29,14 +29,24 @@ export function SchemaErrorsScreen({schema}: SchemaErrorsScreenProps) {
     const errorsText = formatSchemaErrorsToMarkdown(groupsWithErrors)
 
     try {
-      await copy(errorsText)
-      toast.push({
-        status: 'success',
-        title: t(
-          'about-dialog.version-info.copy-to-clipboard-button.copied-text',
-          'Copied to clipboard',
-        ),
-      })
+      const ok = await copy(errorsText)
+      if (ok) {
+        toast.push({
+          status: 'success',
+          title: t(
+            'about-dialog.version-info.copy-to-clipboard-button.copied-text',
+            'Copied to clipboard',
+          ),
+        })
+      } else {
+        toast.push({
+          status: 'error',
+          title: tCopyPaste(
+            'copy-paste.on-copy.validation.clipboard-not-supported.title',
+            'Clipboard not supported',
+          ),
+        })
+      }
     } catch {
       toast.push({
         status: 'error',

--- a/packages/sanity/src/core/studio/screens/schemaErrors/SchemaProblemGroups.tsx
+++ b/packages/sanity/src/core/studio/screens/schemaErrors/SchemaProblemGroups.tsx
@@ -133,7 +133,9 @@ export function SchemaProblemGroups(props: {problemGroups: SchemaValidationProbl
   )
 }
 
-function getTypeInfo(problem: SchemaValidationProblemGroup): {name: string; type: string} | null {
+export function getTypeInfo(
+  problem: SchemaValidationProblemGroup,
+): {name: string; type: string} | null {
   // note: unsure if the first segment here can ever be anything else than a type
   // a possible API improvement is to add schemaType info to the problem group interface itself
   const first = problem.path[0]

--- a/packages/sanity/src/core/studio/screens/schemaErrors/SchemaProblemGroups.tsx
+++ b/packages/sanity/src/core/studio/screens/schemaErrors/SchemaProblemGroups.tsx
@@ -8,6 +8,7 @@ import {useMemo} from 'react'
 import {styled} from 'styled-components'
 
 import {useTranslation} from '../../../i18n'
+import {getTypeInfo} from './getTypeInfo'
 
 const TONES: Record<'error' | 'warning', ThemeColorToneKey> = {
   error: 'critical',
@@ -131,18 +132,6 @@ export function SchemaProblemGroups(props: {problemGroups: SchemaValidationProbl
       })}
     </Stack>
   )
-}
-
-export function getTypeInfo(
-  problem: SchemaValidationProblemGroup,
-): {name: string; type: string} | null {
-  // note: unsure if the first segment here can ever be anything else than a type
-  // a possible API improvement is to add schemaType info to the problem group interface itself
-  const first = problem.path[0]
-  if (first.kind === 'type') {
-    return {name: first.name || `<anonymous ${first.type}>`, type: first.type}
-  }
-  return null
 }
 
 function _renderSegmentName(str: string) {

--- a/packages/sanity/src/core/studio/screens/schemaErrors/formatSchemaErrorsToMarkdown.ts
+++ b/packages/sanity/src/core/studio/screens/schemaErrors/formatSchemaErrorsToMarkdown.ts
@@ -2,7 +2,7 @@ import {generateHelpUrl} from '@sanity/generate-help-url'
 import {type SchemaValidationProblemGroup} from '@sanity/types'
 import {capitalize} from 'lodash'
 
-import {getTypeInfo} from './SchemaProblemGroups'
+import {getTypeInfo} from './getTypeInfo'
 
 export function formatSchemaErrorsToMarkdown(groups: SchemaValidationProblemGroup[]): string {
   let text = '# Schema errors\n\n'
@@ -19,15 +19,15 @@ export function formatSchemaErrorsToMarkdown(groups: SchemaValidationProblemGrou
       text += `## Unknown type\n\n`
     }
 
+    const parts: string[] = []
     for (const segment of group.path) {
-      text += `Path: `
       if (segment.kind === 'type') {
-        text += `${segment.name || `<anonymous ${segment.type}>`}:${segment.type}`
+        parts.push(`${segment.name || `<anonymous ${segment.type}>`}:${segment.type}`)
       } else if (segment.kind === 'property') {
-        text += `${segment.name}`
+        parts.push(`${segment.name}`)
       }
     }
-    text += '\n'
+    text += `Path: ${parts.join(' → ')}\n`
 
     for (const problem of group.problems) {
       text += `${capitalize(problem.severity)}: ${problem.message}\n`

--- a/packages/sanity/src/core/studio/screens/schemaErrors/formatSchemaErrorsToMarkdown.ts
+++ b/packages/sanity/src/core/studio/screens/schemaErrors/formatSchemaErrorsToMarkdown.ts
@@ -1,0 +1,43 @@
+import {generateHelpUrl} from '@sanity/generate-help-url'
+import {type SchemaValidationProblemGroup} from '@sanity/types'
+import {capitalize} from 'lodash'
+
+import {getTypeInfo} from './SchemaProblemGroups'
+
+export function formatSchemaErrorsToMarkdown(groups: SchemaValidationProblemGroup[]): string {
+  let text = '# Schema errors\n\n'
+
+  text +=
+    'There were errors while attempting to compile the configuration of your Sanity Studio Schema types.\n\n'
+
+  for (const group of groups) {
+    const schemaType = getTypeInfo(group)
+
+    if (schemaType) {
+      text += `## ${capitalize(schemaType.type)} type "${schemaType.name}"\n\n`
+    } else {
+      text += `## Unknown type\n\n`
+    }
+
+    for (const segment of group.path) {
+      text += `Path: `
+      if (segment.kind === 'type') {
+        text += `${segment.name || `<anonymous ${segment.type}>`}:${segment.type}`
+      } else if (segment.kind === 'property') {
+        text += `${segment.name}`
+      }
+    }
+    text += '\n'
+
+    for (const problem of group.problems) {
+      text += `${capitalize(problem.severity)}: ${problem.message}\n`
+      if (problem.helpId) {
+        text += `[View documentation for this ${problem.severity}](${generateHelpUrl(problem.helpId)})\n`
+      }
+    }
+
+    text += '\n'
+  }
+
+  return text
+}

--- a/packages/sanity/src/core/studio/screens/schemaErrors/getTypeInfo.ts
+++ b/packages/sanity/src/core/studio/screens/schemaErrors/getTypeInfo.ts
@@ -1,0 +1,13 @@
+import {type SchemaValidationProblemGroup} from '@sanity/types'
+
+export function getTypeInfo(
+  problem: SchemaValidationProblemGroup,
+): {name: string; type: string} | null {
+  // note: unsure if the first segment here can ever be anything else than a type
+  // a possible API improvement is to add schemaType info to the problem group interface itself
+  const first = problem.path[0]
+  if (first.kind === 'type') {
+    return {name: first.name || `<anonymous ${first.type}>`, type: first.type}
+  }
+  return null
+}


### PR DESCRIPTION
### Description

There's currently no good way to take schema errors in the browser and feed them to an LLM other than selecting the text manually and pasting it into your chat. This PR converts schema errors to markdown in a format friendly to paste into an LLM.

<img width="1120" height="815" alt="Screenshot 2025-09-08 at 13 41 32" src="https://github.com/user-attachments/assets/51b9c4ad-7f03-4b40-97ad-676c90f73b7d" />

### What to review

1. GPT-5 helped me write this PR. I have added a new hook because there seems to be no hook available to copy plain text to the clipboard. Only the studio's Copy/Paste Fields function which is very different.
2. I'm not sure if I need to do anything more with the localization on this. I _think_ I've used all existing keys for the strings.

### Testing

I did not add testing; should I?

### Notes for release

Schema errors screen now contains a button to copy schema type errors as Markdown.