### PR TITLE
fix: popover issue when closing and clicking different panes

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -83,15 +83,10 @@ function Content(props: PopoverEditDialogProps) {
     ),
   )
 
-  useClickOutsideEvent(
-    handleClose,
-    () => [referenceElement],
-    () => referenceBoundary,
-  )
-
   // This seems to work with regular refs as well, but it might be safer to use state.
   const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null)
   const containerElement = useRef<HTMLDivElement | null>(null)
+  const [parentElement, setParentElement] = useState<HTMLDivElement | null>(null)
 
   const handleFocusLockWhiteList = useCallback((element: HTMLElement) => {
     // This is needed in order for focusLock not to trap focus in the
@@ -100,37 +95,43 @@ function Content(props: PopoverEditDialogProps) {
     return Boolean(element.contentEditable) || Boolean(containerElement.current?.contains(element))
   }, [])
 
-  return (
-    <VirtualizerScrollInstanceProvider
-      scrollElement={contentElement}
-      containerElement={containerElement}
-    >
-      <FocusLock autoFocus whiteList={handleFocusLockWhiteList}>
-        <Flex as={NoopContainer} ref={containerElement} direction="column" height="fill">
-          <ContentHeaderBox flex="none" padding={1}>
-            <Flex align="center">
-              <Box flex={1} padding={2}>
-                <Text weight="medium">{title}</Text>
-              </Box>
+  useClickOutsideEvent(handleClose, () => [referenceElement, referenceBoundary, parentElement])
 
-              <Button
-                autoFocus
-                icon={CloseIcon}
-                mode="bleed"
-                onClick={handleClose}
-                tooltipProps={{content: 'Close'}}
-              />
-            </Flex>
-          </ContentHeaderBox>
-          <ContentScrollerBox flex={1}>
-            <PresenceOverlay margins={[0, 0, 1, 0]}>
-              <Box padding={3} ref={setContentElement}>
-                {props.children}
-              </Box>
-            </PresenceOverlay>
-          </ContentScrollerBox>
-        </Flex>
-      </FocusLock>
-    </VirtualizerScrollInstanceProvider>
+  return (
+    // The style will make the parent element not take up space in the DOM
+    // Mimicking a fragment
+    <div ref={setParentElement} style={{display: 'contents'}}>
+      <VirtualizerScrollInstanceProvider
+        scrollElement={contentElement}
+        containerElement={containerElement}
+      >
+        <FocusLock autoFocus whiteList={handleFocusLockWhiteList}>
+          <Flex as={NoopContainer} ref={containerElement} direction="column" height="fill">
+            <ContentHeaderBox flex="none" padding={1}>
+              <Flex align="center">
+                <Box flex={1} padding={2}>
+                  <Text weight="medium">{title}</Text>
+                </Box>
+
+                <Button
+                  autoFocus
+                  icon={CloseIcon}
+                  mode="bleed"
+                  onClick={handleClose}
+                  tooltipProps={{content: 'Close'}}
+                />
+              </Flex>
+            </ContentHeaderBox>
+            <ContentScrollerBox flex={1}>
+              <PresenceOverlay margins={[0, 0, 1, 0]}>
+                <Box padding={3} ref={setContentElement}>
+                  {props.children}
+                </Box>
+              </PresenceOverlay>
+            </ContentScrollerBox>
+          </Flex>
+        </FocusLock>
+      </VirtualizerScrollInstanceProvider>
+    </div>
   )
 }


### PR DESCRIPTION
### Description

Fix popover issue where if you opened a reference and attempted to click the input / any fields on that, it would not allow it

Before

https://github.com/user-attachments/assets/81eb6ce6-8396-4418-ac25-1fa2df704ea8

After

https://github.com/user-attachments/assets/108fb622-7faf-4f74-b0c8-6cb358b92786


### What to review

Does this make sense? Should we do something different?

### Testing

Existing tests should suffice,
I have also done separate manual tests to make sure that the scrolling within a popover in a PTE still works

https://github.com/user-attachments/assets/c663ed5f-cd24-4864-99b9-19016a357b75

as well manual tests to make sure that the popover doesn't close too early because you pressed something within it


### Notes for release

Fixes popover issues where if you opened a reference within a Portable Text Editor block and attempted to click a field from the opened reference, you would not be able to edit the content