### PR TITLE
fix(cli): fix build error when using auto-updates with sdk apps

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/app/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/buildAction.ts
@@ -61,7 +61,7 @@ export default async function buildSanityApp(
 
   if (autoUpdatesEnabled) {
     // Get the clean version without build metadata: https://semver.org/#spec-item-10
-    const cleanSDKVersion = semver.parse(installedSanityVersion)?.version
+    const cleanSDKVersion = semver.parse(installedSdkVersion)?.version
     if (!cleanSDKVersion) {
       throw new Error(`Failed to parse installed SDK version: ${installedSdkVersion}`)
     }


### PR DESCRIPTION
### Description
Currently, enabling auto-updates for SDK apps fails with the following error:

```
> sanity build

ℹ Building with auto-updates enabled

Error: Unexpected HTTP response: 404 Not Found
```
This happens because of a regression introduced in #10422 where we used the version of the `sanity` dependency instead of the local sdk version when checking for new versions, so the cli ends up checking against `https://sanity-cdn.com/v1/modules/@sanity__sdk/default/%5E4.6.1/t1757424888`, which returns 404.

I don't think I've heard anyone running into this, so not sure if we really support auto-updates for sdk apps yet, but good to fix anyway.

### Notes for release
not sure if needed.