### PR TITLE
fix(core): sanitize authorization header from copy error details

### DIFF
--- a/packages/sanity/src/core/components/errorActions/useCopyErrorDetails.ts
+++ b/packages/sanity/src/core/components/errorActions/useCopyErrorDetails.ts
@@ -52,6 +52,46 @@ export function serializeError(): OperatorFunction<ErrorWithId, string> {
     // useful if the provided `error` value is an instance of `Error`, whose properties are
     // non-enumerable.
     const errorInfo = isRecord(error) ? pick(error, Object.getOwnPropertyNames(error)) : undefined
-    return JSON.stringify({error: errorInfo, eventId}, null, 2)
+
+    // Sanitize sensitive information from the error object
+    const sanitizedErrorInfo = sanitizeErrorInfo(errorInfo)
+
+    return JSON.stringify({error: sanitizedErrorInfo, eventId}, null, 2)
   })
+}
+
+const SENSITIVE_HEADERS = ['authorization']
+
+function sanitizeErrorInfo(obj: unknown): unknown {
+  if (!isRecord(obj)) {
+    return obj
+  }
+
+  const sanitized: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (key.toLowerCase() === 'headers' && isRecord(value)) {
+      // Sanitize headers object
+      const sanitizedHeaders: Record<string, unknown> = {}
+      for (const [headerName, headerValue] of Object.entries(value)) {
+        if (
+          SENSITIVE_HEADERS.some((sensitiveHeader) =>
+            headerName.toLowerCase().includes(sensitiveHeader),
+          )
+        ) {
+          sanitizedHeaders[headerName] = '[hidden]'
+        } else {
+          sanitizedHeaders[headerName] = headerValue
+        }
+      }
+      sanitized[key] = sanitizedHeaders
+    } else if (isRecord(value) || Array.isArray(value)) {
+      // Recursively sanitize nested objects and arrays
+      sanitized[key] = sanitizeErrorInfo(value)
+    } else {
+      sanitized[key] = value
+    }
+  }
+
+  return sanitized
 }


### PR DESCRIPTION
### Description
Replaces the `header.authorization` property for `[hidden]` when copying error details.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
