### PR TITLE
fix(deps): add `@babel/parser` dependency required by `recast`

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -56,6 +56,7 @@
     "watch": "pkg-utils watch"
   },
   "dependencies": {
+    "@babel/parser": "^7.28.4",
     "@babel/traverse": "^7.28.3",
     "@sanity/client": "^7.11.0",
     "@sanity/codegen": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -556,10 +556,10 @@ importers:
         version: link:../../packages/@sanity/migrate
       '@sanity/preview-url-secret':
         specifier: ^2.1.15
-        version: 2.1.15(@sanity/client@7.11.0(debug@4.4.1))(@sanity/icons@3.7.4(react@19.1.1))(sanity@packages+sanity)
+        version: 2.1.15(@sanity/client@7.11.0)(@sanity/icons@3.7.4(react@19.1.1))(sanity@packages+sanity)
       '@sanity/react-loader':
         specifier: ^1.11.19
-        version: 1.11.19(@sanity/types@packages+@sanity+types)(react@19.1.1)(typescript@5.7.3)
+        version: 1.11.19(@sanity/types@packages+@sanity+types)(react@19.1.1)(typescript@5.9.2)
       '@sanity/tsdoc':
         specifier: 1.0.169
         version: 1.0.169(@emotion/is-prop-valid@1.3.1)(@types/babel__core@7.20.5)(@types/node@24.3.0)(babel-plugin-react-compiler@19.1.0-rc.3)(jiti@2.5.1)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@packages+sanity)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
@@ -583,7 +583,7 @@ importers:
         version: link:../../packages/@sanity/vision
       '@sanity/visual-editing':
         specifier: 3.0.4
-        version: 3.0.4(@emotion/is-prop-valid@1.3.1)(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@packages+sanity)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.7.3)
+        version: 3.0.4(@emotion/is-prop-valid@1.3.1)(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@packages+sanity)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.9.2)
       '@turf/helpers':
         specifier: ^6.5.0
         version: 6.5.0
@@ -902,6 +902,9 @@ importers:
 
   packages/@sanity/cli:
     dependencies:
+      '@babel/parser':
+        specifier: ^7.28.4
+        version: 7.28.4
       '@babel/traverse':
         specifier: ^7.28.3
         version: 7.28.4(supports-color@5.5.0)
@@ -1706,10 +1709,10 @@ importers:
         version: link:../@sanity/mutator
       '@sanity/presentation-comlink':
         specifier: ^1.0.29
-        version: 1.0.29(@sanity/client@7.11.0(debug@4.4.1))(@sanity/types@packages+@sanity+types)
+        version: 1.0.29(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)
       '@sanity/preview-url-secret':
         specifier: ^2.1.15
-        version: 2.1.15(@sanity/client@7.11.0(debug@4.4.1))(@sanity/icons@3.7.4(react@19.1.1))(sanity@packages+sanity)
+        version: 2.1.15(@sanity/client@7.11.0)(@sanity/icons@3.7.4(react@19.1.1))(sanity@packages+sanity)
       '@sanity/schema':
         specifier: workspace:*
         version: link:../@sanity/schema
@@ -2073,7 +2076,7 @@ importers:
         version: 3.3.2(@sanity/ui@3.0.14(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)))(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(jiti@2.5.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
       '@sanity/visual-editing-csm':
         specifier: ^2.0.24
-        version: 2.0.24(@sanity/client@7.11.0(debug@4.4.1))(@sanity/types@packages+@sanity+types)(typescript@5.9.2)
+        version: 2.0.24(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)(typescript@5.9.2)
       '@sentry/types':
         specifier: ^8.55.0
         version: 8.55.0
@@ -15109,12 +15112,12 @@ snapshots:
       uuid: 11.1.0
       xstate: 5.21.0
 
-  '@sanity/core-loader@1.8.18(@sanity/types@packages+@sanity+types)(typescript@5.7.3)':
+  '@sanity/core-loader@1.8.18(@sanity/types@packages+@sanity+types)(typescript@5.9.2)':
     dependencies:
       '@sanity/client': 7.11.0(debug@4.4.1)
       '@sanity/comlink': 3.0.9
-      '@sanity/presentation-comlink': 1.0.29(@sanity/client@7.11.0(debug@4.4.1))(@sanity/types@packages+@sanity+types)
-      '@sanity/visual-editing-csm': 2.0.24(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)(typescript@5.7.3)
+      '@sanity/presentation-comlink': 1.0.29(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)
+      '@sanity/visual-editing-csm': 2.0.24(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)(typescript@5.9.2)
     transitivePeerDependencies:
       - '@sanity/types'
       - debug
@@ -15495,11 +15498,11 @@ snapshots:
       - debug
       - supports-color
 
-  '@sanity/presentation-comlink@1.0.29(@sanity/client@7.11.0(debug@4.4.1))(@sanity/types@packages+@sanity+types)':
+  '@sanity/presentation-comlink@1.0.29(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)':
     dependencies:
       '@sanity/client': 7.11.0(debug@4.4.1)
       '@sanity/comlink': 3.0.9
-      '@sanity/visual-editing-types': 1.1.6(@sanity/client@7.11.0(debug@4.4.1))(@sanity/types@packages+@sanity+types)
+      '@sanity/visual-editing-types': 1.1.6(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)
     transitivePeerDependencies:
       - '@sanity/types'
 
@@ -15508,7 +15511,7 @@ snapshots:
       prettier: 3.6.2
       prettier-plugin-packagejson: 2.5.19(prettier@3.6.2)
 
-  '@sanity/preview-url-secret@2.1.15(@sanity/client@7.11.0(debug@4.4.1))(@sanity/icons@3.7.4(react@19.1.1))(sanity@packages+sanity)':
+  '@sanity/preview-url-secret@2.1.15(@sanity/client@7.11.0)(@sanity/icons@3.7.4(react@19.1.1))(sanity@packages+sanity)':
     dependencies:
       '@sanity/client': 7.11.0(debug@4.4.1)
       '@sanity/uuid': 3.0.2
@@ -15516,11 +15519,11 @@ snapshots:
       '@sanity/icons': 3.7.4(react@19.1.1)
       sanity: link:packages/sanity
 
-  '@sanity/react-loader@1.11.19(@sanity/types@packages+@sanity+types)(react@19.1.1)(typescript@5.7.3)':
+  '@sanity/react-loader@1.11.19(@sanity/types@packages+@sanity+types)(react@19.1.1)(typescript@5.9.2)':
     dependencies:
       '@sanity/client': 7.11.0(debug@4.4.1)
-      '@sanity/core-loader': 1.8.18(@sanity/types@packages+@sanity+types)(typescript@5.7.3)
-      '@sanity/visual-editing-csm': 2.0.24(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)(typescript@5.7.3)
+      '@sanity/core-loader': 1.8.18(@sanity/types@packages+@sanity+types)(typescript@5.9.2)
+      '@sanity/visual-editing-csm': 2.0.24(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)(typescript@5.9.2)
       react: 19.1.1
     transitivePeerDependencies:
       - '@sanity/types'
@@ -15811,40 +15814,31 @@ snapshots:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
 
-  '@sanity/visual-editing-csm@2.0.24(@sanity/client@7.11.0(debug@4.4.1))(@sanity/types@packages+@sanity+types)(typescript@5.9.2)':
+  '@sanity/visual-editing-csm@2.0.24(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)(typescript@5.9.2)':
     dependencies:
       '@sanity/client': 7.11.0(debug@4.4.1)
-      '@sanity/visual-editing-types': 1.1.6(@sanity/client@7.11.0(debug@4.4.1))(@sanity/types@packages+@sanity+types)
+      '@sanity/visual-editing-types': 1.1.6(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)
       valibot: 1.1.0(typescript@5.9.2)
     transitivePeerDependencies:
       - '@sanity/types'
       - typescript
 
-  '@sanity/visual-editing-csm@2.0.24(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)(typescript@5.7.3)':
-    dependencies:
-      '@sanity/client': 7.11.0(debug@4.4.1)
-      '@sanity/visual-editing-types': 1.1.6(@sanity/client@7.11.0(debug@4.4.1))(@sanity/types@packages+@sanity+types)
-      valibot: 1.1.0(typescript@5.7.3)
-    transitivePeerDependencies:
-      - '@sanity/types'
-      - typescript
-
-  '@sanity/visual-editing-types@1.1.6(@sanity/client@7.11.0(debug@4.4.1))(@sanity/types@packages+@sanity+types)':
+  '@sanity/visual-editing-types@1.1.6(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)':
     dependencies:
       '@sanity/client': 7.11.0(debug@4.4.1)
     optionalDependencies:
       '@sanity/types': link:packages/@sanity/types
 
-  '@sanity/visual-editing@3.0.4(@emotion/is-prop-valid@1.3.1)(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@packages+sanity)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.7.3)':
+  '@sanity/visual-editing@3.0.4(@emotion/is-prop-valid@1.3.1)(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@packages+sanity)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.9.2)':
     dependencies:
       '@sanity/comlink': 3.0.9
       '@sanity/icons': 3.7.4(react@19.1.1)
       '@sanity/insert-menu': 2.0.2(@emotion/is-prop-valid@1.3.1)(@sanity/types@packages+@sanity+types)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       '@sanity/mutate': 0.11.0-canary.4(xstate@5.21.0)
-      '@sanity/presentation-comlink': 1.0.29(@sanity/client@7.11.0(debug@4.4.1))(@sanity/types@packages+@sanity+types)
-      '@sanity/preview-url-secret': 2.1.15(@sanity/client@7.11.0(debug@4.4.1))(@sanity/icons@3.7.4(react@19.1.1))(sanity@packages+sanity)
+      '@sanity/presentation-comlink': 1.0.29(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)
+      '@sanity/preview-url-secret': 2.1.15(@sanity/client@7.11.0)(@sanity/icons@3.7.4(react@19.1.1))(sanity@packages+sanity)
       '@sanity/ui': 3.0.14(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
-      '@sanity/visual-editing-csm': 2.0.24(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)(typescript@5.7.3)
+      '@sanity/visual-editing-csm': 2.0.24(@sanity/client@7.11.0)(@sanity/types@packages+@sanity+types)(typescript@5.9.2)
       '@vercel/stega': 0.1.2
       get-random-values-esm: 1.0.2
       react: 19.1.1
@@ -23918,10 +23912,6 @@ snapshots:
   uuidv7@0.4.4: {}
 
   v8-compile-cache-lib@3.0.1: {}
-
-  valibot@1.1.0(typescript@5.7.3):
-    optionalDependencies:
-      typescript: 5.7.3
 
   valibot@1.1.0(typescript@5.9.2):
     optionalDependencies:


### PR DESCRIPTION
### Description

A similar fix had to be made in `@sanity/pkg-utils`: https://github.com/sanity-io/pkg-utils/commit/0459139362a9da679aa9a8ffbd22290abddd3e00
It solves strange CI build errors like this:
```bash
@sanity/diff:build: Error: Install @babel/parser to use the `typescript`, `flow`, or `babel` parsers
@sanity/diff:build:     at /vercel/path1/node_modules/.pnpm/recast@0.23.9/node_modules/recast/parsers/babel.js:17:19
@sanity/diff:build:     at Object.<anonymous> (/vercel/path1/node_modules/.pnpm/recast@0.23.9/node_modules/recast/parsers/babel.js:20:3)
@sanity/diff:build:     at Module._compile (node:internal/modules/cjs/loader:1688:14)
@sanity/diff:build:     at Object..js (node:internal/modules/cjs/loader:1820:10)
@sanity/diff:build:     at Module.load (node:internal/modules/cjs/loader:1423:32)
@sanity/diff:build:     at Function._load (node:internal/modules/cjs/loader:1246:12)
@sanity/diff:build:     at TracingChannel.traceSync (node:diagnostics_channel:322:14)
@sanity/diff:build:     at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
@sanity/diff:build:     at Module.require (node:internal/modules/cjs/loader:1445:12)
@sanity/diff:build:     at require (node:internal/modules/helpers:135:16)
```
[as seen here](https://vercel.com/sanity-sandbox/test-studio/HR4jZWFYnq9nxAhzrjnZ6Jy5EP5a?filter=errors)

### What to review

Should be straight forward.

### Testing

If the vercel and github deploys recover then we are in the clear.

### Notes for release

N/A - seems like an internal concern with our monorepo build setup
