### PR TITLE
chore: add validation to scheduled releases

### DIFF
--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -1,5 +1,5 @@
-import {ErrorOutlineIcon, LockIcon} from '@sanity/icons'
-import {Flex, Text} from '@sanity/ui'
+import {CheckmarkCircleIcon, ErrorOutlineIcon, LockIcon} from '@sanity/icons'
+import {Card, Flex, Text} from '@sanity/ui'
 // eslint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'
 import {Fragment} from 'react'
@@ -250,6 +250,31 @@ export const releasesOverviewColumnDefs: (
           return (
             <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border" gap={2}>
               {state === 'active' && <ReleaseColumnValidationLoading releaseId={_id} />}
+
+              {/**
+               * Show a checkmark for scheduled releases
+               * A scheduled release can't be anything other than valid
+               * Since it can't be edited via the API or the UI
+               * However we should still gives a visual indicator of that instead of showing nothing
+               */}
+              {state === 'scheduled' && (
+                <Card
+                  padding={0}
+                  radius="full"
+                  tone="neutral"
+                  style={{
+                    background: 'transparent',
+                  }}
+                >
+                  <Flex gap={2}>
+                    <Text size={1}>
+                      <Tooltip content={t('summary.all-documents-validated')}>
+                        <CheckmarkCircleIcon />
+                      </Tooltip>
+                    </Text>
+                  </Flex>
+                </Card>
+              )}
 
               {!isDeleted && (
                 <>


### PR DESCRIPTION
### Description

Add the loading for validation for scheduled releases.
Scheduled requests will not need to run and won't require validation to be run since you can't edit or add new documents unless you make the release active again. This can't be done via the API either so it's a safe approach that doesn't add to the load

<img width="710" height="483" alt="image" src="https://github.com/user-attachments/assets/d3873cd1-0b8b-46eb-8373-106a8f3a05ab" />

### What to review

Does this make sense?

### Testing

N/A
