### PR TITLE
feat(cli): Add delta flags to functions test command

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -59,7 +59,7 @@
     "@babel/traverse": "^7.28.4",
     "@sanity/client": "^7.11.1",
     "@sanity/codegen": "workspace:*",
-    "@sanity/runtime-cli": "^10.5.1",
+    "@sanity/runtime-cli": "^10.6.1",
     "@sanity/telemetry": "^0.8.0",
     "@sanity/template-validator": "^2.4.3",
     "chalk": "^4.1.2",

--- a/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
+++ b/packages/@sanity/cli/src/commands/functions/testFunctionsCommand.ts
@@ -5,9 +5,16 @@ Arguments
   <name> The name of the Sanity Function
 
 Options
+  --event <create|update|delete> The type of event to simulate (default: 'create')
   --data <data> Data to send to the function
+  --data-before <data> Data to send to the function when event is update
+  --data-after <data> Data to send to the function when event is update
   --file <file> Read data from file and send to the function
+  --file-before <file> Read data from file and send to the function when event is update
+  --file-after <file> Read data from file and send to the function when event is update
   --document-id <id> Document to fetch and send to function
+  --document-id-before <id> Document to fetch and send to function when event is update
+  --document-id-after <id> Document to fetch and send to function when event is update
   --timeout <timeout> Execution timeout value in seconds
   --api <version> Sanity API Version to use
   --dataset <dataset> The Sanity dataset to use
@@ -24,16 +31,26 @@ Examples
 
   # Test function passing event data on command line and cap execution time to 60 seconds
   sanity functions test echo --data '{ "id": 1 }' --timeout 60
+
+  # Test function simulating an update event
+  sanity functions test echo --event update --data-before '{ "title": "before" }' --data-after '{ "title": "after" }'
 `
 
 export interface FunctionsTestFlags {
   'data'?: string
+  'data-before'?: string
+  'data-after'?: string
+  'event'?: string
   'file'?: string
+  'file-before'?: string
+  'file-after'?: string
   'timeout'?: number
   'api'?: string
   'dataset'?: string
   'project-id'?: string
   'document-id'?: string
+  'document-id-before'?: string
+  'document-id-after'?: string
   'with-user-token'?: boolean
 }
 
@@ -47,7 +64,7 @@ const testFunctionsCommand: CliCommandDefinition<FunctionsTestFlags> = {
   group: 'functions',
   helpText,
   signature:
-    '<name> [--data <json>] [--file <filename>] [--document-id <id>] [--timeout <seconds>] [--api <version>] [--dataset <name>] [--project-id] <id>] [--with-user-token]',
+    '<name> [--event create|update|delete] [--data <json>] [--data-before <json>] [--data-after <json>] [--file <filename>] [--file-before <filename>] [--file-after <filename>] [--document-id <id>] [--document-id-before <id>] [--document-id-before <id>] [--timeout <seconds>] [--api <version>] [--dataset <name>] [--project-id] <id>] [--with-user-token]',
   description: 'Invoke a local Sanity Function',
   async action(args, context) {
     const {apiClient, output, chalk} = context
@@ -84,6 +101,21 @@ const testFunctionsCommand: CliCommandDefinition<FunctionsTestFlags> = {
       )
     }
 
+    if (flags.event === 'update') {
+      const hasDataPair = flags['data-before'] && flags['data-after']
+      const hasFilePair = flags['file-before'] && flags['file-after']
+      const hasDocPair = flags['document-id-before'] && flags['document-id-after']
+
+      if (!(hasDataPair || hasFilePair || hasDocPair)) {
+        throw new Error(
+          'When using --event=update, you must provide one of the following flag pairs:\n' +
+            '  --data-before and --data-after\n' +
+            '  --file-before and --file-after\n' +
+            '  --document-id-before and --document-id-after',
+        )
+      }
+    }
+
     const cmdConfig = await initBlueprintConfig({
       bin: 'sanity',
       log: (message: string) => output.print(message),
@@ -97,8 +129,15 @@ const testFunctionsCommand: CliCommandDefinition<FunctionsTestFlags> = {
       args: {name},
       flags: {
         'data': flags.data,
+        'data-before': flags['data-before'],
+        'data-after': flags['data-after'],
         'file': flags.file,
+        'file-before': flags['file-before'],
+        'file-after': flags['file-after'],
         'document-id': flags['document-id'],
+        'document-id-before': flags['document-id-before'],
+        'document-id-after': flags['document-id-after'],
+        'event': flags.event,
         'timeout': flags.timeout,
         'api': flags.api,
         'dataset': flags.dataset || actualDataset,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -912,8 +912,8 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@sanity/runtime-cli':
-        specifier: ^10.5.1
-        version: 10.5.1(@types/node@24.3.0)(debug@4.4.1)(terser@5.43.1)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        specifier: ^10.6.1
+        version: 10.6.1(@types/node@24.3.0)(debug@4.4.1)(terser@5.43.1)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
       '@sanity/telemetry':
         specifier: ^0.8.0
         version: 0.8.1(react@19.1.1)
@@ -4878,8 +4878,8 @@ packages:
     peerDependencies:
       react: ^18.3 || ^19
 
-  '@sanity/runtime-cli@10.5.1':
-    resolution: {integrity: sha512-3TGl9TikdmqQ05vNbHykYDF90olmmR+ypq55D/WEMDj2fg/RsXtGPxs5tWLDt4wDKsUVFmot1i+F/zjBSfKphQ==}
+  '@sanity/runtime-cli@10.6.1':
+    resolution: {integrity: sha512-UyIUueygUANnDVYSCX/NYz0CsFbadBhPceVdvJuunwfKDDBVzKUmGfzMeKlT8M9f3zqqDg9chmcCXJu7ROCZLQ==}
     engines: {node: '>=20.19'}
     hasBin: true
 
@@ -15566,7 +15566,7 @@ snapshots:
       - debug
       - typescript
 
-  '@sanity/runtime-cli@10.5.1(@types/node@24.3.0)(debug@4.4.1)(terser@5.43.1)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)':
+  '@sanity/runtime-cli@10.6.1(@types/node@24.3.0)(debug@4.4.1)(terser@5.43.1)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)':
     dependencies:
       '@architect/hydrate': 4.0.8
       '@architect/inventory': 4.0.9


### PR DESCRIPTION
### Description

This PR adds new flags that allow user to simulate different event types like create, update and delete.

### What to review

Ensure flags and example follow proper format.

### Testing

Verified manually during development.

### Notes for release

This change enables support for testing with Delta GROQ function. When the `event` flag is set to update and before and after data is provided via one of the new flags (`data-before/after`, `file-before/after`, `document-id-before/after`), then delta functions in the filter will work as they do in the deployed functions.
