### PR TITLE
feat(init): update next.js init template to next-sanity v11

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -566,11 +566,11 @@ export default async function initSanity(
     }
 
     if (chosen === 'npm') {
-      await execa('npm', ['install', '--legacy-peer-deps', 'next-sanity@10'], execOptions)
+      await execa('npm', ['install', '--legacy-peer-deps', 'next-sanity@11'], execOptions)
     } else if (chosen === 'yarn') {
-      await execa('npx', ['install-peerdeps', '--yarn', 'next-sanity@10'], execOptions)
+      await execa('npx', ['install-peerdeps', '--yarn', 'next-sanity@11'], execOptions)
     } else if (chosen === 'pnpm') {
-      await execa('pnpm', ['install', 'next-sanity@10'], execOptions)
+      await execa('pnpm', ['install', 'next-sanity@11'], execOptions)
     }
 
     print(

--- a/packages/@sanity/cli/src/actions/init-project/templates/nextjs/index.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/nextjs/index.ts
@@ -168,15 +168,11 @@ export const client = createClient({
 const live = `// Querying with "sanityFetch" will keep content automatically updated
 // Before using it, import and render "<SanityLive />" in your layout, see
 // https://github.com/sanity-io/next-sanity#live-content-api for more information.
-import { defineLive } from "next-sanity";
+import { defineLive } from "next-sanity/live";
 import { client } from './client'
 
-export const { sanityFetch, SanityLive } = defineLive({ 
-  client: client.withConfig({ 
-    // Live content is currently only available on the experimental API
-    // https://www.sanity.io/docs/api-versioning
-    apiVersion: 'vX' 
-  }) 
+export const { sanityFetch, SanityLive } = defineLive({
+  client,
 });
 `
 

--- a/packages/@sanity/cli/test/__fixtures__/remote-template/package.json
+++ b/packages/@sanity/cli/test/__fixtures__/remote-template/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "next": "^15",
-    "next-sanity": "^10.0.6",
+    "next-sanity": "^11.0.1",
     "sanity": "^4.6.1"
   }
 }


### PR DESCRIPTION
### Description

Now that `next-sanity` [v11 is out](https://github.com/sanity-io/next-sanity/releases/tag/next-sanity-v11.0.0) it's time to update the install commands and the init template.

### What to review

Did I miss any spots related to `next-sanity` here?

### Testing

If the cli remote-template command still works we're good 🙌 

### Notes for release

Updated the `npx sanity@latest init` command in next.js contexts to use `next-sanity` v11.
