### PR TITLE
chore(dev): improve test-studio setup when running against staging

### DIFF
--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -3,12 +3,18 @@ import path from 'node:path'
 import {defineCliConfig} from 'sanity/cli'
 import {type UserConfig} from 'vite'
 
-export default defineCliConfig({
-  api: {
-    projectId: 'ppsg7ml5',
-    dataset: 'test',
-  },
+const isStaging = process.env.SANITY_INTERNAL_ENV == 'staging'
 
+export default defineCliConfig({
+  api: isStaging
+    ? {
+        projectId: 'exx11uqh',
+        dataset: 'playground',
+      }
+    : {
+        projectId: 'ppsg7ml5',
+        dataset: 'test',
+      },
   // Can be overriden by:
   // A) `SANITY_STUDIO_REACT_STRICT_MODE=false pnpm dev`
   // B) creating a `.env` file locally that sets the same env variable as above

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -71,6 +71,16 @@ import {workshopTool} from './workshop'
 
 const localePlugins = [koKRLocale(), nbNOLocale(), nnNOLocale(), ptPTLocale(), svSELocale()]
 
+// @ts-expect-error - defined by vite
+const isStaging = globalThis.__SANITY_STAGING__ === true
+
+const envConfig = {
+  // use this for production workspaces
+  production: isStaging ? {apiHost: 'https://api.sanity.io'} : {},
+  // use this for staging workspaces
+  staging: isStaging ? {} : {apiHost: 'https://api.sanity.work'},
+}
+
 const sharedSettings = ({projectId}: {projectId: string}) => {
   return definePlugin({
     name: 'sharedSettings',
@@ -211,6 +221,7 @@ const defaultWorkspace = defineConfig({
   title: 'Test Studio',
   projectId: 'ppsg7ml5',
   dataset: 'test',
+  ...envConfig.production,
   plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
 
   onUncaughtError: (error, errorInfo) => {
@@ -290,6 +301,7 @@ export default defineConfig([
     dataset: 'partial-indexing-2',
     plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
     basePath: '/partial-indexing',
+    ...envConfig.production,
     search: {
       unstable_partialIndexing: {
         enabled: true,
@@ -310,6 +322,7 @@ export default defineConfig([
     title: 'tsdoc',
     projectId: 'ppsg7ml5',
     dataset: 'tsdoc-2',
+    ...envConfig.production,
     plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
     basePath: '/tsdoc',
     mediaLibrary: {
@@ -322,6 +335,7 @@ export default defineConfig([
     subtitle: 'Playground dataset',
     projectId: 'ppsg7ml5',
     dataset: 'playground',
+    ...envConfig.production,
     plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
     basePath: '/playground',
     beta: {
@@ -345,6 +359,7 @@ export default defineConfig([
     subtitle: 'Listener events debugging',
     projectId: 'ppsg7ml5',
     dataset: 'data-loss',
+    ...envConfig.production,
     plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
     basePath: '/listener-events',
     mediaLibrary: {
@@ -356,6 +371,7 @@ export default defineConfig([
     title: 'Test Studio (playground-partial-indexing)',
     subtitle: 'Playground dataset',
     projectId: 'ppsg7ml5',
+    ...envConfig.production,
     dataset: 'playground-partial-indexing',
     plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
     basePath: '/playground-partial-indexing',
@@ -369,9 +385,9 @@ export default defineConfig([
     subtitle: 'Staging dataset',
     projectId: 'exx11uqh',
     dataset: 'playground',
+    ...envConfig.staging,
     plugins: [sharedSettings({projectId: 'exx11uqh'})],
     basePath: '/staging',
-    apiHost: 'https://api.sanity.work',
     auth: {
       loginMethod: 'token',
     },
@@ -387,9 +403,9 @@ export default defineConfig([
     title: 'Media Library Playground (staging)',
     projectId: '5iedwjzw',
     dataset: 'production',
+    ...envConfig.staging,
     plugins: [sharedSettings({projectId: '5iedwjzw'})],
     basePath: '/media-library-playground-staging',
-    apiHost: 'https://api.sanity.work',
     auth: {
       loginMethod: 'token',
     },
@@ -402,9 +418,9 @@ export default defineConfig([
     title: 'playground (Staging)',
     projectId: 'exx11uqh',
     dataset: 'playground',
+    ...envConfig.staging,
     plugins: [sharedSettings({projectId: 'exx11uqh'})],
     basePath: '/playground-staging',
-    apiHost: 'https://api.sanity.work',
     auth: {
       loginMethod: 'token',
     },
@@ -417,6 +433,7 @@ export default defineConfig([
     title: 'Test Studio',
     subtitle: 'Components API playground',
     projectId: 'ppsg7ml5',
+    ...envConfig.production,
     dataset: 'test',
     plugins: [
       sharedSettings({projectId: 'ppsg7ml5'}),
@@ -456,6 +473,7 @@ export default defineConfig([
     title: 'Google Colors',
     projectId: 'ppsg7ml5',
     dataset: 'test',
+    ...envConfig.production,
     plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
     basePath: '/google',
     theme: googleTheme,
@@ -469,6 +487,7 @@ export default defineConfig([
     title: 'Vercel Colors',
     projectId: 'ppsg7ml5',
     dataset: 'test',
+    ...envConfig.production,
     plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
     basePath: '/vercel',
     theme: vercelTheme,
@@ -482,6 +501,7 @@ export default defineConfig([
     title: 'Tailwind Colors',
     projectId: 'ppsg7ml5',
     dataset: 'test',
+    ...envConfig.production,
     plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
     basePath: '/tailwind',
     theme: tailwindTheme,
@@ -495,6 +515,7 @@ export default defineConfig([
     title: 'Sanity AI Assist',
     projectId: 'ppsg7ml5',
     dataset: 'test',
+    ...envConfig.production,
     plugins: [sharedSettings({projectId: 'ppsg7ml5'}), assist()],
     basePath: '/ai-assist',
     mediaLibrary: {
@@ -506,6 +527,7 @@ export default defineConfig([
     title: 'Debug Stega Studio',
     projectId: 'ppsg7ml5',
     dataset: 'test',
+    ...envConfig.production,
     plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
     basePath: '/stega',
     form: {
@@ -528,6 +550,7 @@ export default defineConfig([
     releases: {enabled: true},
     projectId: 'pv8y60vp',
     dataset: 'production',
+    ...envConfig.production,
     schema: {types: presentationPreviewKitSchemaTypes},
     plugins: [
       structureTool(),
@@ -570,6 +593,7 @@ export default defineConfig([
     basePath: '/presentation-next-sanity',
     projectId: 'pv8y60vp',
     dataset: 'production',
+    ...envConfig.production,
     schema: {types: presentationNextSanitySchemaTypes},
     plugins: [
       assist(),


### PR DESCRIPTION
### Description
Improves devex when running the test studio against staging.

This is done by explicitly adding `apiHost` for workspaces that does not exist in the current env, so that e.g.:

- when running against staging, a production workspace will be configured with explicit `apiHost: 'https://api.sanity.io'`, whereas staging workspaces will have no apiHost set (defaulting to `https://api.sanity.work`)
- when running against production, staging workspaces will be configured with `apiHost: 'https://api.sanity.work'`, and production workspaces will be configured without apiHost (defaulting to `https://api.sanity.io`)

Also updated `sanity.cli.ts` to go against a staging prduction + dataset when running with `SANITY_INTERNAL_ENV=staging`

### What to review
All of these should work without issues:
- `pnpm dev`
- `SANITY_INTERNAL_ENV=staging pnpm dev`
- `sanity documents query '*[0]'`
- `SANITY_INTERNAL_ENV=staging sanity documents query '*[0]'`

### Notes for release
n/a – this is a quality of internal developer life improvement
