### PR TITLE
feat: can only create a single concurrent scheduled draft per document

### DIFF
--- a/packages/sanity/src/core/releases/hooks/__tests__/useHasCardinalityOneReleaseVersions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useHasCardinalityOneReleaseVersions.test.tsx
@@ -1,0 +1,179 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {useHasCardinalityOneReleaseVersions} from '../useHasCardinalityOneReleaseVersions'
+
+// Mock the dependencies
+vi.mock('../useDocumentVersions', () => ({
+  useDocumentVersions: vi.fn(),
+}))
+
+vi.mock('../../store/useActiveReleases', () => ({
+  useActiveReleases: vi.fn(),
+}))
+
+vi.mock('../../../util/draftUtils', () => ({
+  getVersionFromId: vi.fn(),
+}))
+
+vi.mock('../../../util/releaseUtils', () => ({
+  isCardinalityOneRelease: vi.fn(),
+}))
+
+vi.mock('../../util/getReleaseIdFromReleaseDocumentId', () => ({
+  getReleaseIdFromReleaseDocumentId: vi.fn(),
+}))
+
+const mockUseDocumentVersions = vi.mocked(
+  await import('../useDocumentVersions'),
+).useDocumentVersions
+const mockUseActiveReleases = vi.mocked(
+  await import('../../store/useActiveReleases'),
+).useActiveReleases
+const mockGetVersionFromId = vi.mocked(await import('../../../util/draftUtils')).getVersionFromId
+const mockIsCardinalityOneRelease = vi.mocked(
+  await import('../../../util/releaseUtils'),
+).isCardinalityOneRelease
+const mockGetReleaseIdFromReleaseDocumentId = vi.mocked(
+  await import('../../util/getReleaseIdFromReleaseDocumentId'),
+).getReleaseIdFromReleaseDocumentId
+
+describe('useHasCardinalityOneReleaseVersions', () => {
+  const mockDocumentId = 'test-document'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return false when no releases or document versions are available', () => {
+    mockUseActiveReleases.mockReturnValue({
+      data: [],
+      loading: false,
+      error: undefined,
+      dispatch: vi.fn(),
+    })
+    mockUseDocumentVersions.mockReturnValue({
+      data: [],
+      loading: false,
+    })
+
+    const {result} = renderHook(() => useHasCardinalityOneReleaseVersions(mockDocumentId))
+
+    expect(result.current).toBe(false)
+  })
+
+  it('should return false when document has no versions in cardinality one releases', () => {
+    const mockRelease: ReleaseDocument = {
+      _id: '_.releases.test-release',
+      _type: 'release',
+      _createdAt: '2023-01-01T00:00:00Z',
+      _updatedAt: '2023-01-01T00:00:00Z',
+      _rev: '1',
+      state: 'active',
+      metadata: {
+        title: 'Test Release',
+        description: '',
+        releaseType: 'scheduled',
+        cardinality: 'many', // Not cardinality one
+      },
+    }
+
+    mockUseActiveReleases.mockReturnValue({
+      data: [mockRelease],
+      loading: false,
+      error: undefined,
+      dispatch: vi.fn(),
+    })
+    mockUseDocumentVersions.mockReturnValue({
+      data: ['versions.test-release.test-document'],
+      loading: false,
+    })
+    mockGetVersionFromId.mockReturnValue('test-release')
+    mockGetReleaseIdFromReleaseDocumentId.mockReturnValue('test-release')
+    mockIsCardinalityOneRelease.mockReturnValue(false)
+
+    const {result} = renderHook(() => useHasCardinalityOneReleaseVersions(mockDocumentId))
+
+    expect(result.current).toBe(false)
+  })
+
+  it('should return true when document has versions in cardinality one releases', () => {
+    const mockRelease: ReleaseDocument = {
+      _id: '_.releases.scheduled-draft',
+      _type: 'release',
+      _createdAt: '2023-01-01T00:00:00Z',
+      _updatedAt: '2023-01-01T00:00:00Z',
+      _rev: '1',
+      state: 'active',
+      metadata: {
+        title: 'Scheduled Draft',
+        description: '',
+        releaseType: 'scheduled',
+        cardinality: 'one', // Cardinality one release
+      },
+    }
+
+    mockUseActiveReleases.mockReturnValue({
+      data: [mockRelease],
+      loading: false,
+      error: undefined,
+      dispatch: vi.fn(),
+    })
+    mockUseDocumentVersions.mockReturnValue({
+      data: ['versions.scheduled-draft.test-document'],
+      loading: false,
+    })
+    mockGetVersionFromId.mockReturnValue('scheduled-draft')
+    mockGetReleaseIdFromReleaseDocumentId.mockReturnValue('scheduled-draft')
+    mockIsCardinalityOneRelease.mockReturnValue(true)
+
+    const {result} = renderHook(() => useHasCardinalityOneReleaseVersions(mockDocumentId))
+
+    expect(result.current).toBe(true)
+  })
+
+  it('should filter out non-version documents correctly', () => {
+    const mockRelease: ReleaseDocument = {
+      _id: '_.releases.test-release',
+      _type: 'release',
+      _createdAt: '2023-01-01T00:00:00Z',
+      _updatedAt: '2023-01-01T00:00:00Z',
+      _rev: '1',
+      state: 'active',
+      metadata: {
+        title: 'Test Release',
+        description: '',
+        releaseType: 'scheduled',
+        cardinality: 'one',
+      },
+    }
+
+    mockUseActiveReleases.mockReturnValue({
+      data: [mockRelease],
+      loading: false,
+      error: undefined,
+      dispatch: vi.fn(),
+    })
+    mockUseDocumentVersions.mockReturnValue({
+      data: ['versions.test-release.test-document', 'drafts.test-document', 'test-document'],
+      loading: false,
+    })
+
+    // Mock getVersionFromId to return release ID only for version documents
+    mockGetVersionFromId.mockImplementation((id: string) => {
+      if (id.startsWith('versions.')) {
+        return 'test-release'
+      }
+      return undefined
+    })
+
+    mockGetReleaseIdFromReleaseDocumentId.mockReturnValue('test-release')
+    mockIsCardinalityOneRelease.mockReturnValue(true)
+
+    const {result} = renderHook(() => useHasCardinalityOneReleaseVersions(mockDocumentId))
+
+    expect(result.current).toBe(true)
+    expect(mockGetVersionFromId).toHaveBeenCalledTimes(3)
+  })
+})

--- a/packages/sanity/src/core/releases/hooks/__tests__/useHasCardinalityOneReleaseVersions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useHasCardinalityOneReleaseVersions.test.tsx
@@ -63,7 +63,7 @@ describe('useHasCardinalityOneReleaseVersions', () => {
     expect(result.current).toBe(false)
   })
 
-  it('should return false when document has no versions in cardinality one releases', () => {
+  it('should return false when document only has cardinality many releases', () => {
     useActiveReleases.mockReturnValue({
       ...mockActiveReleasesReturn,
       data: [activeASAPRelease], // This has cardinality 'many'

--- a/packages/sanity/src/core/releases/hooks/index.ts
+++ b/packages/sanity/src/core/releases/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useDocumentVersions'
 export * from './useDocumentVersionTypeSortedList'
+export * from './useHasCardinalityOneReleaseVersions'
 export * from './useIsReleaseActive'
 export * from './useOnlyHasVersions'
 export * from './useScheduledDraftDocument'

--- a/packages/sanity/src/core/releases/hooks/useHasCardinalityOneReleaseVersions.ts
+++ b/packages/sanity/src/core/releases/hooks/useHasCardinalityOneReleaseVersions.ts
@@ -1,0 +1,31 @@
+import {useMemo} from 'react'
+
+import {getVersionFromId} from '../../util/draftUtils'
+import {isCardinalityOneRelease} from '../../util/releaseUtils'
+import {useActiveReleases} from '../store/useActiveReleases'
+import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
+import {useDocumentVersions} from './useDocumentVersions'
+
+/**
+ * Checks if a document has any versions in scheduled draft (cardinality one) releases.
+ *
+ * @param documentId - The ID of the document to check
+ * @returns boolean - true if the document has versions in any cardinality one releases
+ * @internal
+ */
+export function useHasCardinalityOneReleaseVersions(documentId: string): boolean {
+  const {data: allReleases} = useActiveReleases()
+  const {data: documentVersions} = useDocumentVersions({documentId})
+
+  return useMemo(() => {
+    if (!allReleases || !documentVersions) return false
+
+    const documentReleaseIds = documentVersions.map(getVersionFromId)
+
+    return allReleases.some((release) => {
+      const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
+
+      return documentReleaseIds.includes(releaseId) && isCardinalityOneRelease(release)
+    })
+  }, [allReleases, documentVersions])
+}

--- a/packages/sanity/src/core/releases/hooks/useHasCardinalityOneReleaseVersions.ts
+++ b/packages/sanity/src/core/releases/hooks/useHasCardinalityOneReleaseVersions.ts
@@ -7,7 +7,7 @@ import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromRelease
 import {useDocumentVersions} from './useDocumentVersions'
 
 /**
- * Checks if a document has any versions in scheduled draft (cardinality one) releases.
+ * Checks if a document has any versions in scheduled draft (`metadata.cardinality: 'one'`) releases.
  *
  * @param documentId - The ID of the document to check
  * @returns boolean - true if the document has versions in any cardinality one releases
@@ -20,7 +20,7 @@ export function useHasCardinalityOneReleaseVersions(documentId: string): boolean
   return useMemo(() => {
     if (!allReleases || !documentVersions) return false
 
-    const documentReleaseIds = documentVersions.map(getVersionFromId)
+    const documentReleaseIds = documentVersions.map(getVersionFromId).filter(Boolean)
 
     return allReleases.some((release) => {
       const releaseId = getReleaseIdFromReleaseDocumentId(release._id)

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -30,6 +30,12 @@ const releasesLocaleStrings = {
   'action.schedule': 'Schedule release...',
   /** Action text for scheduling publish of a draft document */
   'action.schedule-publish': 'Schedule Publish',
+  /** Tooltip text for when schedule publish is disabled due to validation errors */
+  'action.schedule-publish.disabled.validation-issues':
+    'Cannot Schedule Draft due to validation errors in the current draft.',
+  /** Tooltip text for when schedule publish is disabled due to cardinality one releases */
+  'action.schedule-publish.disabled.cardinality-one':
+    'A Scheduled Draft for this document already exists.',
   /** Action text for scheduling unpublish of a draft document */
   'action.schedule-unpublish': 'Schedule Unpublish',
   /** Tooltip text for when schedule unpublish is disabled because document is not published */

--- a/packages/sanity/src/core/releases/plugin/documentActions/SchedulePublishAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/SchedulePublishAction.tsx
@@ -11,6 +11,7 @@ import {useTranslation} from '../../../i18n'
 import {usePerspective} from '../../../perspective/usePerspective'
 import {useDocumentPreviewValues} from '../../../tasks/hooks/useDocumentPreviewValues'
 import {ScheduleDraftDialog} from '../../components/dialog/ScheduleDraftDialog'
+import {useHasCardinalityOneReleaseVersions} from '../../hooks/useHasCardinalityOneReleaseVersions'
 import {useScheduleDraftOperations} from '../../hooks/useScheduleDraftOperations'
 import {releasesLocaleNamespace} from '../../i18n'
 
@@ -32,6 +33,9 @@ export const SchedulePublishAction: DocumentActionComponent = (
     documentType: type,
     perspectiveStack,
   })
+
+  // Check if document has versions in cardinality one releases
+  const hasCardinalityOneReleaseVersions = useHasCardinalityOneReleaseVersions(id)
 
   const [dialogOpen, setDialogOpen] = useState(false)
   const [isScheduling, setIsScheduling] = useState(false)
@@ -86,6 +90,7 @@ export const SchedulePublishAction: DocumentActionComponent = (
 
   return {
     icon: CalendarIcon,
+    disabled: hasCardinalityOneReleaseVersions,
     label: t('action.schedule-publish'),
     title: t('action.schedule-publish'),
     onHandle: handleOpenDialog,

--- a/packages/sanity/src/core/releases/plugin/documentActions/SchedulePublishAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/SchedulePublishAction.tsx
@@ -1,4 +1,5 @@
 import {CalendarIcon} from '@sanity/icons'
+import {isValidationErrorMarker} from '@sanity/types'
 import {useToast} from '@sanity/ui'
 import {useCallback, useState} from 'react'
 
@@ -7,6 +8,7 @@ import {
   type DocumentActionDescription,
   type DocumentActionProps,
 } from '../../../config/document/actions'
+import {useValidationStatus} from '../../../hooks'
 import {useTranslation} from '../../../i18n'
 import {usePerspective} from '../../../perspective/usePerspective'
 import {useDocumentPreviewValues} from '../../../tasks/hooks/useDocumentPreviewValues'
@@ -33,6 +35,10 @@ export const SchedulePublishAction: DocumentActionComponent = (
     documentType: type,
     perspectiveStack,
   })
+
+  // Check validation status
+  const validationStatus = useValidationStatus(id, type)
+  const hasValidationErrors = validationStatus.validation.some(isValidationErrorMarker)
 
   // Check if document has versions in cardinality one releases
   const hasCardinalityOneReleaseVersions = useHasCardinalityOneReleaseVersions(id)
@@ -88,11 +94,18 @@ export const SchedulePublishAction: DocumentActionComponent = (
     return null
   }
 
+  const disabled = hasCardinalityOneReleaseVersions || hasValidationErrors
+  const title = hasCardinalityOneReleaseVersions
+    ? t('action.schedule-publish.disabled.cardinality-one')
+    : hasValidationErrors
+      ? t('action.schedule-publish.disabled.validation-issues')
+      : t('action.schedule-publish')
+
   return {
     icon: CalendarIcon,
-    disabled: hasCardinalityOneReleaseVersions,
+    disabled,
     label: t('action.schedule-publish'),
-    title: t('action.schedule-publish'),
+    title,
     onHandle: handleOpenDialog,
     dialog: dialogOpen && {
       type: 'custom',


### PR DESCRIPTION
### Description
This PR adds on 2 conditions to the `ScheduledPublishAction` which is the action shown on draft documents to allow for a Scheduled Draft (cardinality 'one' release) to be created to publish them.

The 2 conditions when the action might be disabled are:
1. When there is already a version of the document that exists within a cardinality 'one' release
2. When the draft document has validation errors (in which case we should not be allowing for scheduling of an invalid document

<img width="840" height="772" alt="Screenshot 2025-09-12 at 04 27 41" src="https://github.com/user-attachments/assets/9a1ba8f3-ce64-4ab4-88c4-ec26f308cb3b" />
<img width="837" height="776" alt="Screenshot 2025-09-12 at 04 27 00" src="https://github.com/user-attachments/assets/f07105a2-1b37-43b6-9379-b942c1757373" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Verified with manual testing since there are currently no tests of this action.
WIll add tests as fast-follow once scheduled drafts is released.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A - not currently public
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
