### PR TITLE
feat: specific banner for archived (or published) scheduled drafts

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -95,6 +95,8 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** Description for the archived release banner, rendered when viewing the history of a version document from the publihed view */
   'banners.archived-release.description':
     'This document version belongs to the archived <VersionBadge>{{title}}</VersionBadge> release',
+  /** Description for the archived scheduled draft banner, rendered when viewing the history of a cardinality one release document */
+  'banners.archived-scheduled-draft.description': 'This scheduled draft is archived',
   /** The explanation displayed when a user attempts to create a new draft document, but the draft model is not switched on */
   'banners.choose-new-document-destination.cannot-create-draft-document':
     'Cannot create a draft document.',

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ArchivedReleaseDocumentBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ArchivedReleaseDocumentBanner.tsx
@@ -3,6 +3,7 @@ import {useMemo} from 'react'
 import {
   getReleaseIdFromReleaseDocumentId,
   getVersionInlineBadge,
+  isCardinalityOneRelease,
   Translate,
   useArchivedReleases,
   useTranslation,
@@ -33,10 +34,17 @@ export function ArchivedReleaseDocumentBanner(): React.JSX.Element {
     )
   }, [archivedReleases, params?.historyVersion])
 
-  const description =
-    release?.state === 'published'
-      ? 'banners.published-release.description'
-      : 'banners.archived-release.description'
+  const description = useMemo(() => {
+    if (release?.state === 'published') {
+      return 'banners.published-release.description'
+    }
+
+    if (release && isCardinalityOneRelease(release)) {
+      return 'banners.archived-scheduled-draft.description'
+    }
+
+    return 'banners.archived-release.description'
+  }, [release])
 
   const title = release?.metadata.title || tCore('release.placeholder-untitled-release')
 


### PR DESCRIPTION
### Description
This is a nicety for scheduled drafts - currently when clicking from the Releases Overview to view a published scheduled draft document, we show a banner where we reference to 'release'. Since this is more an internal impl. detail, adding this more appropriate banner feels tighter.

![archivedScheduledDraftPR](https://github.com/user-attachments/assets/77e2627f-2f46-4ff2-9a48-6c7c3ebbd35e)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A -  not publicly accessible
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
