### PR TITLE
chore(ci): use 'release:latest' as label, make release PR draft

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -106,7 +106,7 @@ jobs:
             ${{steps.release-notes.outputs.notes}}
           commit-message: "${{steps.version-commit.outputs.message}}"
           branch: ci/release-main
-          labels: "autorelease:pending"
+          labels: "release:latest"
           sign-commits: true
           base: main
           team-reviewers: "@sanity-io/studio"


### PR DESCRIPTION
### Description
- Changes the label of the Release PR to `release:latest` instead of `release-next`
- Opens the release PR as a draft (this prevents it from being assigned and polluting our review request inbox)

### What to review
makes sense?


### Notes for release
n/a