### PR TITLE
chore(ci): rename "stable release" workflow to better reflect what it does

### DIFF
--- a/.github/workflows/tag-stable.yml
+++ b/.github/workflows/tag-stable.yml
@@ -1,5 +1,5 @@
-name: Release @stable
-run-name: Release @stable - ${{ github.event.inputs.version }}
+name: Tag @stable
+run-name: Tag @stable - ${{ github.event.inputs.version }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Description
The workflow to tag a release as stable is currently named `release-stable.yml`. This makes it easy to assume it actually publishes packages to npm, where in reality, it just moves a dist-tag. This PR renames the workflow to `Tag @stable` so it better reflects its purpose.

### What to review
Makes sense?

### Notes for release
n/a