### PR TITLE
fix: make links to manage staging aware

### DIFF
--- a/packages/sanity/src/core/error/__tests__/isKnownError.test.ts
+++ b/packages/sanity/src/core/error/__tests__/isKnownError.test.ts
@@ -25,6 +25,7 @@ describe('#isKnownError', () => {
     expect(
       isKnownError(
         new CorsOriginError({
+          isStaging: false,
           projectId: 'test',
         }),
       ),

--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -130,7 +130,10 @@ const getCurrentUser = async (
 
     if (invalidCorsConfig) {
       // Throw a specific error on CORS-errors, to allow us to show a customized dialog
-      throw new CorsOriginError({projectId: client.config()?.projectId})
+      throw new CorsOriginError({
+        isStaging: client.config().apiHost.endsWith('.work'),
+        projectId: client.config()?.projectId,
+      })
     }
 
     // Some non-CORS error - is it one of those undefinable network errors?

--- a/packages/sanity/src/core/store/_legacy/cors/CorsOriginError.ts
+++ b/packages/sanity/src/core/store/_legacy/cors/CorsOriginError.ts
@@ -1,15 +1,18 @@
 /** @internal */
 export interface CorsOriginErrorOptions {
   projectId?: string
+  isStaging: boolean
 }
 
 /** @internal */
 export class CorsOriginError extends Error {
   projectId?: string
+  isStaging: boolean
 
-  constructor({projectId}: CorsOriginErrorOptions) {
+  constructor({projectId, isStaging}: CorsOriginErrorOptions) {
     super('CorsOriginError')
     this.name = 'CorsOriginError'
     this.projectId = projectId
+    this.isStaging = isStaging
   }
 }

--- a/packages/sanity/src/core/studio/StudioErrorBoundary.tsx
+++ b/packages/sanity/src/core/studio/StudioErrorBoundary.tsx
@@ -82,7 +82,12 @@ export function StudioErrorBoundary(props: StudioErrorBoundaryProps) {
   }
 
   if (caughtError.error instanceof CorsOriginError) {
-    return <CorsOriginErrorScreen projectId={caughtError.error.projectId} />
+    return (
+      <CorsOriginErrorScreen
+        projectId={caughtError.error.projectId}
+        isStaging={caughtError.error.isStaging}
+      />
+    )
   }
 
   if (caughtError.error instanceof SchemaError) {

--- a/packages/sanity/src/core/studio/StudioRootErrorHandler.tsx
+++ b/packages/sanity/src/core/studio/StudioRootErrorHandler.tsx
@@ -97,7 +97,12 @@ export function StudioRootErrorHandler(props: {children: ReactNode}) {
   }
 
   if (errorState.error instanceof CorsOriginError) {
-    return <CorsOriginErrorScreen projectId={errorState.error.projectId} />
+    return (
+      <CorsOriginErrorScreen
+        projectId={errorState.error.projectId}
+        isStaging={errorState.error.isStaging}
+      />
+    )
   }
 
   if (errorState.error instanceof SchemaError) {

--- a/packages/sanity/src/core/studio/components/navbar/navDrawer/ManageMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/navDrawer/ManageMenu.tsx
@@ -4,6 +4,7 @@ import {Card, Stack} from '@sanity/ui'
 import {Button} from '../../../../../ui-components'
 import {useTranslation} from '../../../../i18n'
 import {userHasRole} from '../../../../util'
+import {useEnvAwareSanityWebsiteUrl} from '../../../hooks/useEnvAwareSanityWebsiteUrl'
 import {useWorkspace} from '../../../workspace'
 import {FreeTrial} from '../free-trial'
 
@@ -12,6 +13,7 @@ export function ManageMenu() {
   const isAdmin = Boolean(currentUser && userHasRole(currentUser, 'administrator'))
 
   const {t} = useTranslation()
+  const envAwareWebsiteUrl = useEnvAwareSanityWebsiteUrl()
 
   return (
     <Card borderTop flex="none" padding={2}>
@@ -24,7 +26,7 @@ export function ManageMenu() {
           <Button
             aria-label={t('user-menu.action.manage-project-aria-label')}
             as="a"
-            href={`https://sanity.io/manage/project/${projectId}`}
+            href={`${envAwareWebsiteUrl}/manage/project/${projectId}`}
             icon={CogIcon}
             justify="flex-start"
             mode="bleed"
@@ -39,7 +41,7 @@ export function ManageMenu() {
             <Button
               aria-label={t('user-menu.action.invite-members-aria-label')}
               as="a"
-              href={`https://www.sanity.io/manage/project/${projectId}/members?invite=true`}
+              href={`${envAwareWebsiteUrl}/manage/project/${projectId}/members?invite=true`}
               icon={AddUserIcon}
               justify="flex-start"
               mode="bleed"

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
@@ -8,6 +8,7 @@ import {StatusButton} from '../../../../components'
 import {useTranslation} from '../../../../i18n'
 import {useGlobalPresence} from '../../../../store'
 import {useColorSchemeValue} from '../../../colorScheme'
+import {useEnvAwareSanityWebsiteUrl} from '../../../hooks/useEnvAwareSanityWebsiteUrl'
 import {useWorkspace} from '../../../workspace'
 import {PresenceMenuItem} from './PresenceMenuItem'
 
@@ -72,6 +73,7 @@ export function PresenceMenu() {
     [scheme],
   )
 
+  const envAwareWebsiteUrl = useEnvAwareSanityWebsiteUrl()
   return (
     <MenuButton
       button={button}
@@ -109,7 +111,7 @@ export function PresenceMenu() {
 
             <MenuItem
               as="a"
-              href={`https://www.sanity.io/manage/project/${projectId}/members?invite=true`}
+              href={`${envAwareWebsiteUrl}/manage/project/${projectId}/members?invite=true`}
               icon={AddUserIcon}
               onFocus={handleClearFocusedItem}
               rel="noopener noreferrer"

--- a/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
@@ -8,6 +8,7 @@ import {styled} from 'styled-components'
 import {Button, Dialog, Tooltip} from '../../../../../ui-components'
 import {isProd} from '../../../../environment'
 import {useTranslation} from '../../../../i18n'
+import {useEnvAwareSanityWebsiteUrl} from '../../../hooks/useEnvAwareSanityWebsiteUrl'
 import {usePackageVersionStatus} from '../../../packageVersionStatus/usePackageVersionStatus'
 import {useWorkspace} from '../../../workspace'
 
@@ -82,6 +83,7 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
   }, [checkForUpdates])
 
   const githubUrl = resolveGithubURLFromVersion(currentVersion)
+  const sanityWebsiteUrl = useEnvAwareSanityWebsiteUrl()
 
   return (
     <Dialog width={0} onClickOutside={onClose} id={dialogId} padding={false}>
@@ -206,7 +208,7 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
                 </Text>
                 <Button
                   as="a"
-                  href={`https://sanity.io/manage/project/${projectId}/studios?host=${document.location.hostname}`}
+                  href={`${sanityWebsiteUrl}/manage/project/${projectId}/studios?host=${document.location.hostname}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   mode="ghost"

--- a/packages/sanity/src/core/studio/components/navbar/userMenu/ManageMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/userMenu/ManageMenu.tsx
@@ -4,6 +4,7 @@ import {MenuDivider} from '@sanity/ui'
 import {MenuItem} from '../../../../../ui-components'
 import {useTranslation} from '../../../../i18n'
 import {userHasRole} from '../../../../util'
+import {useEnvAwareSanityWebsiteUrl} from '../../../hooks/useEnvAwareSanityWebsiteUrl'
 import {useWorkspace} from '../../../workspace'
 
 export function ManageMenu() {
@@ -11,14 +12,14 @@ export function ManageMenu() {
   const isAdmin = Boolean(currentUser && userHasRole(currentUser, 'administrator'))
 
   const {t} = useTranslation()
-
+  const envAwareWebsiteUrl = useEnvAwareSanityWebsiteUrl()
   return (
     <>
       <MenuDivider />
       <MenuItem
         as="a"
         aria-label={t('user-menu.action.manage-project-aria-label')}
-        href={`https://sanity.io/manage/project/${projectId}`}
+        href={`${envAwareWebsiteUrl}/manage/project/${projectId}`}
         target="_blank"
         text={t('user-menu.action.manage-project')}
         icon={CogIcon}
@@ -27,7 +28,7 @@ export function ManageMenu() {
         <MenuItem
           as="a"
           aria-label={t('user-menu.action.invite-members-aria-label')}
-          href={`https://www.sanity.io/manage/project/${projectId}/members?invite=true`}
+          href={`${envAwareWebsiteUrl}/manage/project/${projectId}/members?invite=true`}
           target="_blank"
           text={t('user-menu.action.invite-members')}
           icon={AddUserIcon}

--- a/packages/sanity/src/core/studio/hooks/useEnvAwareSanityWebsiteUrl.ts
+++ b/packages/sanity/src/core/studio/hooks/useEnvAwareSanityWebsiteUrl.ts
@@ -1,0 +1,11 @@
+import {useMemo} from 'react'
+
+import {useWorkspace} from '../workspace'
+
+export function useEnvAwareSanityWebsiteUrl() {
+  const {getClient} = useWorkspace()
+  return useMemo(() => {
+    const apiHost = getClient({apiVersion: '2025-08-15'}).config().apiHost
+    return apiHost.endsWith('.work') ? 'https://sanity.work' : 'https://sanity.io'
+  }, [getClient])
+}

--- a/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
@@ -8,6 +8,7 @@ import {Dialog} from '../../../ui-components'
 
 interface CorsOriginErrorScreenProps {
   projectId?: string
+  isStaging: boolean
 }
 
 export const ScreenReaderLabel = styled.label`
@@ -22,17 +23,20 @@ export const ScreenReaderLabel = styled.label`
 `
 
 export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
-  const {projectId} = props
+  const {projectId, isStaging} = props
 
   const origin = window.location.origin
   const corsUrl = useMemo(() => {
-    const url = new URL(`https://sanity.io/manage/project/${projectId}/api`)
+    const url = new URL(
+      `/manage/project/${projectId}/api`,
+      isStaging ? 'https://sanity.work' : 'https://sanity.io',
+    )
     url.searchParams.set('cors', 'add')
     url.searchParams.set('origin', origin)
     url.searchParams.set('credentials', '')
 
     return url.toString()
-  }, [origin, projectId])
+  }, [isStaging, origin, projectId])
 
   useEffect(() => {
     const handleFocus = () => {


### PR DESCRIPTION
### Description
Addresses a few common tripwires when running a studio against a staging workspace:
- Various links to manage goes to production, where the staging project does not exist
- The CORS error handler/dialog takes you to production, where the project does not exist.

This PR fixes this by adding an internal hook `useEnvAwareSanityWebsiteUrl()` which return sanity.work if the current workspace is configured to use `sanity.work` as as its apiUrl.

### What to review
Makes sense? I focused on links to manage for now, and left links to docs etc. to point to production as it does not seem like we'd want docs links to take us to sanity.work.

### Testing
Navigate to one of the staging dataset configured for test studio, click the menu items that takes you to manage (e.g. invite users, manage project)

### Notes for release
n/a – internal