### PR TITLE
feat(sanity): add strict version layering

### DIFF
--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -32,6 +32,7 @@ export * from './presence'
 export * from './preview'
 export {
   formatRelativeLocalePublishDate,
+  getDocumentIsInPerspective,
   getReleaseIdFromReleaseDocumentId,
   getReleaseTone,
   getVersionInlineBadge,

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -352,7 +352,12 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     [getDisplayed, value],
   )
 
-  const {previousId} = useDocumentIdStack({displayed, documentId, editState})
+  const {previousId} = useDocumentIdStack({
+    strict: true,
+    displayed,
+    documentId,
+    editState,
+  })
 
   const setTimelineRange = useCallback(
     (newSince: string, newRev: string | null) => {

--- a/packages/sanity/src/structure/types.ts
+++ b/packages/sanity/src/structure/types.ts
@@ -392,3 +392,26 @@ export type UnresolvedPaneNode =
 export type DocumentFieldMenuActionNode = DocumentFieldActionNode & {
   intent?: Intent
 }
+
+/**
+ * @internal
+ */
+export interface StrictVersionLayeringOptions {
+  /**
+   * By default, version layering includes all document versions, regardless of their expected
+   * publication time—or lack thereof. For example, it includes all ASAP and undecided versions,
+   * despite ASAP and undecided versions having no fixed chronology. There is no way to determine
+   * which ASAP or undecided version is expected to be published before another.
+   *
+   * It also includes any existing draft, which has no fixed chronology, either.
+   *
+   * This functionality is useful for listing all document versions in a deterministic order, but
+   * doesn't accurately portray the upstream and downstream versions based on expected publication
+   * time.
+   *
+   * In strict mode, version layering instead only includes versions that have a fixed chronology.
+   * **Cross-version layering is only effective for scheduled versions, with all other
+   * versions being layered directly onto the published version (if it exists).**
+   */
+  strict?: boolean
+}

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -309,6 +309,7 @@ exports[`exports snapshot 1`] = `
     "getCalendarLabels": "function",
     "getConfigContextFromSource": "function",
     "getDiffAtPath": "function",
+    "getDocumentIsInPerspective": "function",
     "getDocumentPairPermissions": "function",
     "getDocumentValuePermissions": "function",
     "getDocumentVariantType": "function",


### PR DESCRIPTION
### Description

By default, version layering includes all document versions, regardless of their expected publication time—or lack thereof. For example, it includes all ASAP and undecided versions, despite ASAP and undecided versions having no fixed chronology. There is no way to determine which ASAP or undecided version is expected to be published before another.

It also includes any existing draft, which has no fixed chronology, either.

This functionality is useful for listing all document versions in a deterministic order, but doesn't accurately portray the upstream and downstream versions based on expected publication time.

In strict mode, version layering instead only includes versions that have a fixed chronology. **Cross-version layering is only effective for scheduled versions, with all other versions being layered directly onto the published version (if it exists).**

***

In this PR, we make use of strict version layering to improve the upstream version that's selected by default when opening the side-by-side document comparison view.

In a future PR, we'll apply this same logic to inline diffs and field change indicators.

This improvement is a key aspect of advanced version control functionality.

[Walkthrough video](https://supercut.ai/share/ash/XsxUeMXg_bT6fybuIV4EdE).

### What to review

- The adjustments to the layering implementation.
- When opening the side-by-side document comparison view, the default upstream selected (the first pane) should reflect strict version layering. The default upstream should only be a version when viewing a scheduled version that has another scheduled version preceding it chronologically.

### Testing

The existing code does not have test coverage, and I have not dedicated the time to add it at this point. We should add tests here.

### Notes for release

When opening the side-by-side document comparison view, the first pane now correctly reflects the upstream version of the document. Usually this is the published version, but for scheduled versions it is the version whose expected publication date immediately precedes it.