### PR TITLE
feat: when scheduled drafts is enabled, showing banner in scheduled pub plugin

### DIFF
--- a/packages/sanity/src/core/releases/plugin/index.ts
+++ b/packages/sanity/src/core/releases/plugin/index.ts
@@ -24,6 +24,11 @@ export const RELEASES_INTENT = 'release'
 /**
  * @internal
  */
+export const RELEASES_SCHEDULED_DRAFTS_INTENT = 'releases-scheduled-drafts'
+
+/**
+ * @internal
+ */
 export const releases = definePlugin({
   name: RELEASES_NAME,
   studio: {
@@ -37,13 +42,21 @@ export const releases = definePlugin({
       title: 'Releases',
       component: ReleasesTool,
       router: route.create('/', [route.create('/:releaseId')]),
-      canHandleIntent: (intent) => {
-        // If intent is release, open the releases tool.
-        return Boolean(intent === RELEASES_INTENT)
-      },
+      canHandleIntent: (intent) =>
+        Boolean(intent === RELEASES_INTENT || intent === RELEASES_SCHEDULED_DRAFTS_INTENT),
       getIntentState(intent, params) {
         if (intent === RELEASES_INTENT) {
           return {releaseId: params.id}
+        }
+        if (intent === RELEASES_SCHEDULED_DRAFTS_INTENT) {
+          // Handle view parameter and convert to search params
+          const searchParams = []
+          if (params.view) {
+            searchParams.push(['view', params.view])
+          }
+          return {
+            _searchParams: searchParams,
+          }
         }
         return null
       },

--- a/packages/sanity/src/core/scheduled-publishing/tool/Tool.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/Tool.tsx
@@ -1,7 +1,7 @@
-import {Box, Container, Flex, Text, useTheme} from '@sanity/ui'
+import {Box, Card, Container, Flex, Text, useTheme} from '@sanity/ui'
 import {parse} from 'date-fns'
 import {useEffect, useMemo, useRef} from 'react'
-import {type RouterContextValue, useRouter} from 'sanity/router'
+import {Link, type RouterContextValue, useRouter} from 'sanity/router'
 import {styled} from 'styled-components'
 
 import {LoadingBlock} from '../../components/loadingBlock/LoadingBlock'
@@ -9,6 +9,8 @@ import {TimeZoneButton} from '../../components/timeZone/timeZoneButton/TimeZoneB
 import {useTimeZone} from '../../hooks/useTimeZone'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {useReleasesToolAvailable} from '../../releases/hooks/useReleasesToolAvailable'
+import {useScheduledDraftsEnabled} from '../../releases/hooks/useScheduledDraftsEnabled'
+import {RELEASES_SCHEDULED_DRAFTS_INTENT} from '../../releases/plugin'
 import {useScheduledPublishingEnabled} from '../../scheduledPublishing/contexts/ScheduledPublishingEnabledProvider'
 import {useWorkspace} from '../../studio/workspace'
 import TimeZoneButtonElementQuery from '../components/dialogs/TimeZoneButtonElementQuery'
@@ -37,6 +39,26 @@ const Column = styled(Box)`
 
 const NO_SCHEDULE: Schedule[] = []
 const DATE_SLUG_FORMAT = 'yyyy-MM-dd' // date-fns format
+
+function ScheduledDraftsBanner() {
+  const router = useRouter()
+  const isScheduledDraftsEnabled = useScheduledDraftsEnabled()
+
+  const releasesUrl = router.resolveIntentLink(RELEASES_SCHEDULED_DRAFTS_INTENT, {view: 'drafts'})
+
+  if (isScheduledDraftsEnabled) {
+    return (
+      <Card padding={4} tone="caution" width="fill">
+        <Flex gap={3} align="center" justify="center">
+          <Text size={1} weight="medium">
+            Scheduled Drafts is enabled for this Studio. All new Scheduled Drafts will be{' '}
+            <Link href={releasesUrl}>available here</Link>
+          </Text>
+        </Flex>
+      </Card>
+    )
+  }
+}
 
 export default function Tool() {
   const router = useRouter()
@@ -134,6 +156,7 @@ export default function Tool() {
           </Column>
           {/* RHS Column */}
           <Column display="flex" flex={1} overflow="hidden">
+            <ScheduledDraftsBanner />
             <TimeZoneButtonElementQuery
               style={{
                 background: theme.color.card.enabled.bg,


### PR DESCRIPTION
### Description
Adds a new warning banner when Scheduled Drafts is enabled, inside the Scheduled Publishing plugin:
![scheduledDraftsScheduledPubBannerPR](https://github.com/user-attachments/assets/5195358b-a311-4aa5-885a-8e1c926e289e)
Banner includes a link directly to the scheduled drafts list in content releases.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* Trying to get the link to work was a nightmare, settled on creating a new intent for the releases tool... thoughts?
* The banner only shows when scheduled drafts is enabled. if `releases.scheduledDrafts.enabled: false` then the banner won't show - the customer has explicitly opted out, so avoid noise
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Go here - https://test-studio-git-feat-sapp-3081-scheduled-drafts-banner-s-790ac1.sanity.dev/test/schedules/state/scheduled
To test the case that scheduled drafts is turned off, set this in `test-studio/sanity.config.ts`:
```
  ...
  [QUOTA_EXCLUDED_RELEASES_ENABLED]: false,
  ...
```
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
