### PR TITLE
fix: scheduled pub action only shows when releases enabled

### DIFF
--- a/packages/sanity/src/core/comments/hooks/useResolveCommentsEnabled.ts
+++ b/packages/sanity/src/core/comments/hooks/useResolveCommentsEnabled.ts
@@ -1,6 +1,7 @@
 import {useMemo} from 'react'
 
 import {useFeatureEnabled} from '../../hooks'
+import {FEATURES} from '../../hooks/useFeatureEnabled'
 import {useSource} from '../../studio'
 import {getPublishedId} from '../../util'
 import {type CommentsUIMode} from '../types'
@@ -25,7 +26,7 @@ export function useResolveCommentsEnabled(
   documentType: string,
 ): ResolveCommentsEnabled {
   // Check if the projects plan has the feature enabled
-  const {enabled: featureEnabled, isLoading, error} = useFeatureEnabled('studioComments')
+  const {enabled: featureEnabled, isLoading, error} = useFeatureEnabled(FEATURES.studioComments)
 
   const {enabled} = useSource().document.comments
   // Check if the feature is enabled for the current document in the config

--- a/packages/sanity/src/core/comments/plugin/studio-layout/CommentsStudioLayout.tsx
+++ b/packages/sanity/src/core/comments/plugin/studio-layout/CommentsStudioLayout.tsx
@@ -1,11 +1,12 @@
 import {ConditionalWrapper} from '../../../../ui-components'
 import {type LayoutProps} from '../../../config'
 import {useFeatureEnabled} from '../../../hooks'
+import {FEATURES} from '../../../hooks/useFeatureEnabled'
 import {AddonDatasetProvider} from '../../../studio'
 import {CommentsOnboardingProvider, CommentsUpsellProvider} from '../../context'
 
 export function CommentsStudioLayout(props: LayoutProps) {
-  const {enabled, isLoading} = useFeatureEnabled('studioComments')
+  const {enabled, isLoading} = useFeatureEnabled(FEATURES.studioComments)
 
   return (
     <AddonDatasetProvider>

--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferenceInput.tsx
@@ -21,6 +21,7 @@ import {PreviewCard} from '../../../components'
 import {ContextMenuButton} from '../../../components/contextMenuButton'
 import {type FIXME} from '../../../FIXME'
 import {useFeatureEnabled} from '../../../hooks'
+import {FEATURES} from '../../../hooks/useFeatureEnabled'
 import {useTranslation} from '../../../i18n'
 import {getPublishedId, isNonNullable} from '../../../util'
 import {useDidUpdate} from '../../hooks/useDidUpdate'
@@ -140,7 +141,7 @@ export function CrossDatasetReferenceInput(props: CrossDatasetReferenceInputProp
   const refDoc = useMemo(() => ({_id: value?._ref}), [value?._ref])
 
   const loadableReferenceInfo = useReferenceInfo(refDoc as FIXME, getReferenceInfoMemo)
-  const featureInfo = useFeatureEnabled(CROSS_DATASET_FEATUREKEY)
+  const featureInfo = useFeatureEnabled(FEATURES.crossDatasetReferences)
 
   const [autocompletePopoverReferenceElement, setAutocompletePopoverReferenceElement] =
     useState<HTMLDivElement | null>(null)

--- a/packages/sanity/src/core/hooks/useFeatureEnabled.ts
+++ b/packages/sanity/src/core/hooks/useFeatureEnabled.ts
@@ -24,6 +24,13 @@ const INITIAL_LOADING_STATE: Features = {
   isLoading: true,
 }
 
+export const FEATURES: Record<string, string> = {
+  contentReleases: 'contentReleases',
+  studioComments: 'studioComments',
+  crossDatasetReferences: 'crossDatasetReferences',
+  scheduledPublishing: 'scheduledPublishing',
+  sanityTasks: 'sanityTasks',
+}
 /**
  * fetches all the enabled features for this project
  */
@@ -56,7 +63,7 @@ export function getFeatures({
 }
 
 /** @internal */
-export function useFeatureEnabled(featureKey: string): Features {
+export function useFeatureEnabled(featureKey: keyof typeof FEATURES): Features {
   const versionedClient = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const {projectId} = useSource()
 

--- a/packages/sanity/src/core/releases/contexts/upsell/ReleasesUpsellProvider.tsx
+++ b/packages/sanity/src/core/releases/contexts/upsell/ReleasesUpsellProvider.tsx
@@ -3,6 +3,7 @@ import {firstValueFrom} from 'rxjs'
 import {ReleasesUpsellContext} from 'sanity/_singletons'
 
 import {useFeatureEnabled} from '../../../hooks'
+import {FEATURES} from '../../../hooks/useFeatureEnabled'
 import {useUpsellData} from '../../../hooks/useUpsellData'
 import {UpsellDialog} from '../../../studio/upsell/UpsellDialog'
 import {useActiveReleases} from '../../store/useActiveReleases'
@@ -29,7 +30,7 @@ class StudioReleaseLimitExceededError extends Error {
 export function ReleasesUpsellProvider(props: {children: React.ReactNode}) {
   const [upsellDialogOpen, setUpsellDialogOpen] = useState(false)
   const {data: activeReleases} = useActiveReleases()
-  const {enabled: isReleasesFeatureEnabled} = useFeatureEnabled('contentReleases')
+  const {enabled: isReleasesFeatureEnabled} = useFeatureEnabled(FEATURES.contentReleases)
   const {upsellData, telemetryLogs} = useUpsellData({
     dataUri: '/journey/content-releases',
     feature: 'content-releases',

--- a/packages/sanity/src/core/releases/hooks/useIsReleasesPlus.ts
+++ b/packages/sanity/src/core/releases/hooks/useIsReleasesPlus.ts
@@ -2,7 +2,7 @@ import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
 import {of} from 'rxjs'
 
-import {useFeatureEnabled} from '../../hooks/useFeatureEnabled'
+import {FEATURES, useFeatureEnabled} from '../../hooks/useFeatureEnabled'
 import {useReleaseLimits} from '../store/useReleaseLimits'
 
 /**
@@ -11,7 +11,7 @@ import {useReleaseLimits} from '../store/useReleaseLimits'
  */
 export const useIsReleasesPlus = (): boolean => {
   const {releaseLimits$} = useReleaseLimits()
-  const {enabled: isReleasesFeatureEnabled} = useFeatureEnabled('contentReleases')
+  const {enabled: isReleasesFeatureEnabled} = useFeatureEnabled(FEATURES.contentReleases)
 
   /**
    * Only provide observable to cache store if releases is feature enabled

--- a/packages/sanity/src/core/releases/plugin/documentActions/SchedulePublishAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/SchedulePublishAction.tsx
@@ -8,12 +8,14 @@ import {
   type DocumentActionDescription,
   type DocumentActionProps,
 } from '../../../config/document/actions'
-import {useValidationStatus} from '../../../hooks'
+import {useFeatureEnabled, useValidationStatus} from '../../../hooks'
+import {FEATURES} from '../../../hooks/useFeatureEnabled'
 import {useTranslation} from '../../../i18n'
 import {usePerspective} from '../../../perspective/usePerspective'
 import {useDocumentPreviewValues} from '../../../tasks/hooks/useDocumentPreviewValues'
 import {ScheduleDraftDialog} from '../../components/dialog/ScheduleDraftDialog'
 import {useHasCardinalityOneReleaseVersions} from '../../hooks/useHasCardinalityOneReleaseVersions'
+import {useReleasesToolAvailable} from '../../hooks/useReleasesToolAvailable'
 import {useScheduleDraftOperations} from '../../hooks/useScheduleDraftOperations'
 import {releasesLocaleNamespace} from '../../i18n'
 
@@ -28,6 +30,8 @@ export const SchedulePublishAction: DocumentActionComponent = (
   const {createScheduledDraft} = useScheduleDraftOperations()
   const toast = useToast()
   const {perspectiveStack} = usePerspective()
+  const releasesToolAvailable = useReleasesToolAvailable()
+  const {enabled: releasesEnabled} = useFeatureEnabled(FEATURES.contentReleases)
 
   // Get document preview values to extract the title
   const {value: previewValues} = useDocumentPreviewValues({
@@ -89,6 +93,13 @@ export const SchedulePublishAction: DocumentActionComponent = (
     },
     [id, createScheduledDraft, previewValues?.title, toast, t],
   )
+
+  // scheduled publishing using scheduled drafts is not available if releases is not enabled
+  // releases may either be disabled in `sanity.config` as `releases.enabled: false`
+  // or might not be available on the project plan
+  if (!releasesToolAvailable || !releasesEnabled) {
+    return null
+  }
 
   if (!draft) {
     return null

--- a/packages/sanity/src/core/releases/store/useReleasePermissions.ts
+++ b/packages/sanity/src/core/releases/store/useReleasePermissions.ts
@@ -1,7 +1,7 @@
 import {type SingleActionResult} from '@sanity/client'
 import {useMemo} from 'react'
 
-import {useFeatureEnabled} from '../../hooks/useFeatureEnabled'
+import {FEATURES, useFeatureEnabled} from '../../hooks/useFeatureEnabled'
 import {useResourceCache} from '../../store/_legacy/ResourceCacheProvider'
 import {createReleasePermissionsStore} from './createReleasePermissionsStore'
 
@@ -20,7 +20,7 @@ export interface useReleasePermissionsValue {
  */
 export function useReleasePermissions(): useReleasePermissionsValue {
   const resourceCache = useResourceCache()
-  const contentReleasesFeature = useFeatureEnabled('contentReleases')
+  const contentReleasesFeature = useFeatureEnabled(FEATURES.contentReleases)
 
   return useMemo(() => {
     const releasePermissionsStore =

--- a/packages/sanity/src/core/scheduledPublishing/contexts/ScheduledPublishingEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/contexts/ScheduledPublishingEnabledProvider.test.tsx
@@ -2,8 +2,8 @@ import {renderHook} from '@testing-library/react'
 import {of} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
+import {useFeatureEnabled} from '../../hooks'
 import {useClient} from '../../hooks/useClient'
-import {useFeatureEnabled} from '../../hooks/useFeatureEnabled'
 import {useWorkspace} from '../../studio/workspace'
 import {cachedUsedScheduledPublishing} from '../tool/contexts/useHasUsedScheduledPublishing'
 import {
@@ -11,9 +11,7 @@ import {
   useScheduledPublishingEnabled,
 } from './ScheduledPublishingEnabledProvider'
 
-vi.mock('../../hooks/useFeatureEnabled', () => ({
-  useFeatureEnabled: vi.fn().mockReturnValue({}),
-}))
+vi.mock('../../hooks')
 
 vi.mock('../../studio/workspace', () => ({
   useWorkspace: vi.fn().mockReturnValue({}),

--- a/packages/sanity/src/core/scheduledPublishing/contexts/ScheduledPublishingEnabledProvider.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/contexts/ScheduledPublishingEnabledProvider.tsx
@@ -4,7 +4,7 @@ import {
   type ScheduledPublishingEnabledContextValue,
 } from 'sanity/_singletons'
 
-import {useFeatureEnabled} from '../../hooks/useFeatureEnabled'
+import {FEATURES, useFeatureEnabled} from '../../hooks/useFeatureEnabled'
 import {useWorkspace} from '../../studio/workspace'
 import {useHasUsedScheduledPublishing} from '../tool/contexts/useHasUsedScheduledPublishing'
 
@@ -19,7 +19,7 @@ interface ScheduledPublishingEnabledProviderProps {
 export function ScheduledPublishingEnabledProvider({
   children,
 }: ScheduledPublishingEnabledProviderProps) {
-  const {enabled, isLoading, error} = useFeatureEnabled('scheduledPublishing')
+  const {enabled, isLoading, error} = useFeatureEnabled(FEATURES.scheduledPublishing)
   const {scheduledPublishing} = useWorkspace()
 
   const isWorkspaceEnabled = scheduledPublishing.enabled

--- a/packages/sanity/src/core/scheduledPublishing/contexts/ScheduledPublishingEnabledProvider.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/contexts/ScheduledPublishingEnabledProvider.tsx
@@ -4,7 +4,8 @@ import {
   type ScheduledPublishingEnabledContextValue,
 } from 'sanity/_singletons'
 
-import {FEATURES, useFeatureEnabled} from '../../hooks/useFeatureEnabled'
+import {useFeatureEnabled} from '../../hooks'
+import {FEATURES} from '../../hooks/useFeatureEnabled'
 import {useWorkspace} from '../../studio/workspace'
 import {useHasUsedScheduledPublishing} from '../tool/contexts/useHasUsedScheduledPublishing'
 

--- a/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.test.tsx
@@ -1,14 +1,12 @@
 import {renderHook} from '@testing-library/react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {useFeatureEnabled} from '../../../hooks/useFeatureEnabled'
+import {useFeatureEnabled} from '../../../hooks'
 import {useWorkspace} from '../../../studio/workspace'
 import {TasksEnabledProvider} from './TasksEnabledProvider'
 import {useTasksEnabled} from './useTasksEnabled'
 
-vi.mock('../../../hooks/useFeatureEnabled', () => ({
-  useFeatureEnabled: vi.fn().mockReturnValue({}),
-}))
+vi.mock('../../../hooks')
 
 vi.mock('../../../studio/workspace', () => ({
   useWorkspace: vi.fn().mockReturnValue({}),

--- a/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.tsx
+++ b/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.tsx
@@ -1,7 +1,8 @@
 import {useMemo} from 'react'
 import {TasksEnabledContext} from 'sanity/_singletons'
 
-import {FEATURES, useFeatureEnabled} from '../../../hooks/useFeatureEnabled'
+import {useFeatureEnabled} from '../../../hooks'
+import {FEATURES} from '../../../hooks/useFeatureEnabled'
 import {useWorkspace} from '../../../studio/workspace'
 import {type TasksEnabledContextValue} from './types'
 

--- a/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.tsx
+++ b/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.tsx
@@ -1,7 +1,7 @@
 import {useMemo} from 'react'
 import {TasksEnabledContext} from 'sanity/_singletons'
 
-import {useFeatureEnabled} from '../../../hooks/useFeatureEnabled'
+import {FEATURES, useFeatureEnabled} from '../../../hooks/useFeatureEnabled'
 import {useWorkspace} from '../../../studio/workspace'
 import {type TasksEnabledContextValue} from './types'
 
@@ -13,7 +13,7 @@ interface TaksEnabledProviderProps {
  * @internal
  */
 export function TasksEnabledProvider({children}: TaksEnabledProviderProps) {
-  const {enabled, isLoading, error} = useFeatureEnabled('sanityTasks')
+  const {enabled, isLoading, error} = useFeatureEnabled(FEATURES.sanityTasks)
 
   const isWorkspaceEnabled = useWorkspace().tasks?.enabled
 

--- a/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.test.tsx
+++ b/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.test.tsx
@@ -10,7 +10,7 @@ import {type TaskDocument} from '../types'
 import {SetActiveDocument} from './structure/SetActiveDocument'
 import {TasksFooterOpenTasks} from './TasksFooterOpenTasks'
 
-vi.mock('../../hooks/useFeatureEnabled', () => ({
+vi.mock('../../hooks', () => ({
   useFeatureEnabled: vi.fn().mockReturnValue({enabled: true, isLoading: false}),
 }))
 vi.mock('../../studio/workspace', () => ({


### PR DESCRIPTION
### Description
Releases might be disabled in `sanity.config` or because the releases feature is not enabled for the project. In both of these cases the new 'Schedule Publish' action on a draft document should not be available. This PR adds this conditionality in.

When on a free project:
<img width="311" height="248" alt="Screenshot 2025-09-16 at 15 41 25" src="https://github.com/user-attachments/assets/22620a8a-5d7e-445d-8711-b165bdc9fa9e" />

With `releases.enabled: false` in `sanity.config` NOTE: 'Schedule' is the scheduled publish plugin action - I didn't touch the logic here:
<img width="332" height="246" alt="Screenshot 2025-09-16 at 15 42 25" src="https://github.com/user-attachments/assets/000ba245-63bf-4571-9fc8-62b498827578" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* Adds on constants for use with the `useFeatureFlagEnabled`
* Uses the new constants in `ScheduledPublishAction` to ensure that the action returns null JSX with the releases feature is not enabled
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manually tested with a free project
Manually tested with a project with `sanity.config` `releases.enabled: false`
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
