### PR TITLE
refactor: separate component for cardinality view picker and removing dup in the releases overview

### DIFF
--- a/packages/sanity/src/core/releases/tool/overview/CardinalityViewPicker.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/CardinalityViewPicker.tsx
@@ -1,0 +1,103 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {CalendarIcon, ChevronDownIcon} from '@sanity/icons'
+import {Flex, Menu, Text} from '@sanity/ui'
+import {useMemo} from 'react'
+
+import {Button} from '../../../../ui-components/button/Button'
+import {MenuButton} from '../../../../ui-components/menuButton'
+import {MenuItem} from '../../../../ui-components/menuItem'
+import {useTranslation} from '../../../i18n'
+import {isCardinalityOneRelease} from '../../../util/releaseUtils'
+import {releasesLocaleNamespace} from '../../i18n'
+import {type CardinalityView} from './queryParamUtils'
+
+interface CardinalityViewPickerProps {
+  cardinalityView: CardinalityView
+  loading: boolean
+  isScheduledDraftsEnabled: boolean
+  isDraftModelEnabled: boolean
+  allReleases: ReleaseDocument[]
+  onCardinalityViewChange: (view: CardinalityView) => () => void
+}
+
+export const CardinalityViewPicker = ({
+  cardinalityView,
+  loading,
+  isScheduledDraftsEnabled,
+  isDraftModelEnabled,
+  allReleases,
+  onCardinalityViewChange,
+}: CardinalityViewPickerProps) => {
+  const {t} = useTranslation(releasesLocaleNamespace)
+
+  const renderCardinalityMenuButton = useMemo(() => {
+    const currentViewText =
+      cardinalityView === 'releases' ? t('action.releases') : t('action.drafts')
+
+    return (
+      <MenuButton
+        id="cardinality-view-menu"
+        button={
+          <Button
+            mode="bleed"
+            paddingY={2}
+            text={currentViewText}
+            icon={CalendarIcon}
+            iconRight={ChevronDownIcon}
+            disabled={loading}
+            style={{fontWeight: 600}}
+          />
+        }
+        menu={
+          <Menu>
+            <MenuItem
+              text={t('action.releases')}
+              selected={cardinalityView === 'releases'}
+              onClick={onCardinalityViewChange('releases')}
+            />
+            <MenuItem
+              text={t('action.drafts')}
+              selected={cardinalityView === 'drafts'}
+              onClick={onCardinalityViewChange('drafts')}
+            />
+          </Menu>
+        }
+      />
+    )
+  }, [cardinalityView, loading, t, onCardinalityViewChange])
+
+  const renderReleasesLabel = useMemo(
+    () => (
+      <Flex align="center" gap={2}>
+        <CalendarIcon />
+        <Text size={1} weight="semibold">
+          {t('action.releases')}
+        </Text>
+      </Flex>
+    ),
+    [t],
+  )
+
+  const hasActiveCardinalityOneReleases = useMemo(
+    () => allReleases.some(isCardinalityOneRelease),
+    [allReleases],
+  )
+
+  if (!isScheduledDraftsEnabled) {
+    if (!hasActiveCardinalityOneReleases) {
+      return renderReleasesLabel
+    }
+    return renderCardinalityMenuButton
+  }
+
+  // When scheduled drafts are enabled, we need to check if drafts mode is also enabled
+  // If drafts mode is disabled, only show releases and drafts menu items if there are any cardinality one releases
+  // otherwise, show only the releases label
+  if (!isDraftModelEnabled) {
+    if (!hasActiveCardinalityOneReleases) {
+      return renderReleasesLabel
+    }
+  }
+
+  return renderCardinalityMenuButton
+}


### PR DESCRIPTION
### Description
I had a very messy duplication expression in the `ReleasesOverview` (for which I am very embarrassed to have ever let slip into main 😢.

This PR creates a new component for the cardinality view picker, since it's grown a little larger.

No functionality change.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
