### PR TITLE
feat(sanity): use upstream version as comparison value in document editor

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -165,8 +165,12 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   )
 
   const getComparisonValue = useCallback(
-    (editState: EditStateFor) => {
-      return changesOpen ? sinceDocument || editState?.published : editState?.published || null
+    (upstreamEditState: EditStateFor) => {
+      const upstream = upstreamEditState.version ?? upstreamEditState.published
+      if (changesOpen) {
+        return sinceDocument || upstream
+      }
+      return upstream || null
     },
     [changesOpen, sinceDocument],
   )
@@ -220,6 +224,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
   const {
     editState,
+    upstreamEditState,
     connectionState,
     focusPath,
     onChange,
@@ -454,7 +459,11 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     })
   }, [documentId, documentType, schemaType, onChange, setDocumentMeta])
 
-  const compareValue = useMemo(() => getComparisonValue(editState), [editState, getComparisonValue])
+  const compareValue = useMemo(
+    () => getComparisonValue(upstreamEditState),
+    [upstreamEditState, getComparisonValue],
+  )
+
   const isDeleted = useMemo(() => getIsDeleted(editState), [editState, getIsDeleted])
   const revisionNotFound = onOlderRevision && !revisionDocument
 


### PR DESCRIPTION
### Description

This PR updates the document editor so that documents are compared to the correct upstream version. The upstream version is used to determine whether fields have changed, and to compute each field's inline diff.

At the moment, the document is always compared to the published version (unless the history inspector is open with a custom selection). This is correct in most scenarios, except for when viewing a scheduled version. Scheduled versions should be compared to the version whose expected publication date immediately precedes it.

This is achieved by adding a low priority subscription to the edit state of the upstream version. We may consider refactoring this in the future by adding the upstream document to `EditStateFor` itself.

#### Before

❌ When viewing the scheduled "Ash" version, the "Title" field's value is compared to the published version:

<img width="988" height="452" alt="before" src="https://github.com/user-attachments/assets/fb359581-33a8-42c7-a79c-b3ec4fd33d75" />

#### After

✅ When viewing the scheduled "Ash" version, the "Title" field's value is compared to the version whose expected publication date immediately precedes it ("Bjørge's test release"):

<img width="988" height="467" alt="after" src="https://github.com/user-attachments/assets/251bbfb4-4bad-4292-ba36-5f4893eb7352" />

***

Note that the history inspector ("Review changes") still reviews changes in the history of the document, rather than by comparing it to its upstream version. This will continue to evolve as we work on Advanced Version Control.

### What to review

The change indicators and inline diffs in the document editor.

### Testing

Existing tests pass.

### Notes for release

When viewing a document, the editor now correctly reflects the upstream version of the document. Usually this is the published version, but for scheduled versions it is the version whose expected publication date immediately precedes it.