### PR TITLE
fix(sanity): add a warning for version info dialog if appId is missing

### DIFF
--- a/packages/sanity/src/_singletons/context/PackageVersionInfoContext.tsx
+++ b/packages/sanity/src/_singletons/context/PackageVersionInfoContext.tsx
@@ -22,9 +22,10 @@ export type PackageVersionInfoContextValue = {
   isAutoUpdating: boolean
 
   /**
-   * What is the base version (i.e. the version in package.json at the time the Studio was deployed)
+   * If an importmap for the sanity module exists in the DOM, includes details
+   * will be undefined if no importmap is found
    */
-  baseVersion: SemVer | undefined
+  importMapInfo?: {valid: false; error: Error} | {valid: true; minVersion: SemVer; appId?: string}
 
   /**
    * What is the version tagged as latest (periodically checked)
@@ -51,9 +52,6 @@ export const PackageVersionInfoContext = createContext<PackageVersionInfoContext
   {
     isAutoUpdating: false,
     checkForUpdates: () => {},
-    get baseVersion(): never {
-      throw new Error('PackageVersionInfoContext not provided')
-    },
     get currentVersion(): never {
       throw new Error('PackageVersionInfoContext not provided')
     },

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -10,6 +10,13 @@ import {type LocaleResourceBundle} from '../types'
  * @hidden
  */
 export const studioLocaleStrings = defineLocalesResources('studio', {
+  /** "Configuration issue" header */
+  'about-dialog.configuration-issue.header': 'Configuration issue detected',
+  /** Message shown if sanity.cli.ts is missing deployment.appId */
+  'about-dialog.configuration-issue.missing-appid':
+    'Auto updates is enabled, but no <code>deployment.appId</code> configured in <code>sanity.cli.ts</code>. This Studio is updating against the <strong>latest</strong>-channel.',
+  /** "View documentation" link for auto-updating studios */
+  'about-dialog.configuration-issue.missing-appid.view-documentation': 'View documentation',
   /** "Disabled" status for auto-updates in About-dialog */
   'about-dialog.version-info.auto-updates.disabled': 'Auto Updates not enabled',
   /** "Enabled" status for auto-updates in About-dialog */

--- a/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
@@ -1,4 +1,4 @@
-import {CogIcon, GithubIcon, LaunchIcon, RefreshIcon} from '@sanity/icons'
+import {CogIcon, GithubIcon, LaunchIcon, RefreshIcon, WarningOutlineIcon} from '@sanity/icons'
 import {SanityMonogram} from '@sanity/logos'
 import {Badge, Card, Flex, Grid, Spinner, Stack, Text} from '@sanity/ui'
 import {useEffect, useId} from 'react'
@@ -6,8 +6,9 @@ import semver, {type SemVer} from 'semver'
 import {styled} from 'styled-components'
 
 import {Button, Dialog, Tooltip} from '../../../../../ui-components'
+import {TextWithTone} from '../../../../components'
 import {isProd} from '../../../../environment'
-import {useTranslation} from '../../../../i18n'
+import {Translate, useTranslation} from '../../../../i18n'
 import {useEnvAwareSanityWebsiteUrl} from '../../../hooks/useEnvAwareSanityWebsiteUrl'
 import {usePackageVersionStatus} from '../../../packageVersionStatus/usePackageVersionStatus'
 import {useWorkspace} from '../../../workspace'
@@ -59,6 +60,7 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
     isAutoUpdating,
     autoUpdatingVersion,
     currentVersion,
+    importMapInfo,
     latestTaggedVersion,
     versionCheckStatus,
     checkForUpdates,
@@ -85,6 +87,36 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
   const githubUrl = resolveGithubURLFromVersion(currentVersion)
   const sanityWebsiteUrl = useEnvAwareSanityWebsiteUrl()
 
+  const importMapWarning =
+    importMapInfo?.valid && !importMapInfo.appId ? (
+      <Card padding={4} tone="caution">
+        <Flex align="flex-start" gap={3}>
+          <TextWithTone tone="caution">
+            <WarningOutlineIcon />
+          </TextWithTone>
+          <Stack space={4}>
+            <TextWithTone size={1} tone="caution" weight="medium">
+              {t('about-dialog.configuration-issue.header')}
+            </TextWithTone>
+            <TextWithTone size={1} tone="caution">
+              <Translate t={t} i18nKey="about-dialog.configuration-issue.missing-appid" />
+            </TextWithTone>
+            <TextWithTone size={1} tone="caution">
+              <Text muted size={1}>
+                <a
+                  href="https://www.sanity.io/docs/studio/latest-version-of-sanity"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {t('about-dialog.configuration-issue.missing-appid.view-documentation')} &rarr;
+                </a>
+              </Text>
+            </TextWithTone>
+          </Stack>
+        </Flex>
+        <Stack space={2} />
+      </Card>
+    ) : null
   return (
     <Dialog width={0} onClickOutside={onClose} id={dialogId} padding={false}>
       {versionCheckStatus?.checking ? (
@@ -237,8 +269,8 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
               </Flex>
             </Card>
           ) : null}
+          {importMapWarning}
         </Stack>
-
         <Stack paddingX={3}>
           <Button tone="primary" text="OK" paddingY={3} onClick={onClose} />
         </Stack>

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -45,21 +45,20 @@ const getSanityImportMapEntryValue = memoize(() =>
   DEBUG_IMPORT_MAP ? DEBUG_VALUES.importMapUrl : getSanityImportMapUrl(),
 )
 
-const getImportMapInfo = memoize(() => {
-  const sanityPackageImportMapEntryValue = getSanityImportMapEntryValue()
-
-  if (!sanityPackageImportMapEntryValue) {
-    return {
-      valid: false as const,
-      error: new Error('No import map entry for module "sanity" found in DOM'),
-    }
-  }
-  return parseImportMapModuleCdnUrl(sanityPackageImportMapEntryValue)
-})
+// Note: in theory, and in the future, there might be multiple auto-updateable packages
+// but for now, we only care about the `sanity`-package
+const REFERENCE_PACKAGE = 'sanity'
 
 export function PackageVersionStatusProvider({children}: {children: ReactNode}) {
   const importMapInfo = useMemo(() => {
-    const result = getImportMapInfo()
+    const importMapUrl = getSanityImportMapEntryValue()
+    if (!importMapUrl) {
+      return {
+        valid: false as const,
+        error: new Error('No import map entry for module "sanity" found in DOM'),
+      }
+    }
+    const result = parseImportMapModuleCdnUrl(importMapUrl)
     if (!result.valid) {
       console.warn(
         new Error(
@@ -102,34 +101,40 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
     lastCheckRef.current = new Date().getTime()
     setVersionCheckStatus((current) => ({...current, checking: true}))
 
-    // Note: in theory, and in the future, there might be multiple auto-updateable packages
-    // but for now, we only care about the `sanity`-package
-    Promise.all([
-      DEBUG_AUTO_UPDATE_VERSION
-        ? Promise.resolve(DEBUG_VALUES.autoUpdateVersion)
-        : isAutoUpdating && importMapInfo.valid
+    const minVersion = importMapInfo.valid
+      ? semver.coerce(importMapInfo.minVersion, {includePrerelease: true})!
+      : currentVersion
+
+    // fetch the current version of the sanity package on the 'latest' tag
+    const resolveLatestTaggedVersion = DEBUG_LATEST_VERSION
+      ? Promise.resolve(DEBUG_VALUES.latestVersion)
+      : fetchLatestAvailableVersionForPackage({
+          packageName: REFERENCE_PACKAGE,
+          minVersion,
+          tag: 'latest',
+        })
+
+    // fetch the current version based on manage/brett configuration for appid
+    const resolveAutoUpdatingVersion = DEBUG_AUTO_UPDATE_VERSION
+      ? Promise.resolve(DEBUG_VALUES.autoUpdateVersion)
+      : importMapInfo.valid
+        ? importMapInfo.appId
           ? fetchLatestAutoUpdatingVersion({
-              packageName: 'sanity',
-              minVersion: semver.coerce(importMapInfo.minVersion, {includePrerelease: true})!,
+              packageName: REFERENCE_PACKAGE,
+              minVersion,
               appId: importMapInfo.appId,
             })
-          : Promise.resolve(undefined),
-      DEBUG_LATEST_VERSION
-        ? Promise.resolve(DEBUG_VALUES.latestVersion)
-        : fetchLatestAvailableVersionForPackage({
-            packageName: 'sanity',
-            minVersion: importMapInfo.valid
-              ? semver.coerce(importMapInfo.minVersion, {includePrerelease: true})!
-              : currentVersion,
-            tag: 'latest',
-          }),
-    ])
-      .then(([nextAutoUpdatingVersion, nextLatestTaggedVersion]) => {
+          : // if studio is auto-updating but has no appId, the auto-updating version will be from `latest`
+            resolveLatestTaggedVersion
+        : undefined
+
+    Promise.all([resolveLatestTaggedVersion, resolveAutoUpdatingVersion])
+      .then(([nextLatestVersion, nextAutoUpdatingVersion]) => {
         setAutoUpdatingVersionRaw(nextAutoUpdatingVersion)
-        setLatestTaggedVersionRaw(nextLatestTaggedVersion)
+        setLatestTaggedVersionRaw(nextLatestVersion)
       })
       .finally(() => setVersionCheckStatus({lastCheckedAt: new Date(), checking: false}))
-  }, [currentVersion, importMapInfo, isAutoUpdating])
+  }, [currentVersion, importMapInfo])
 
   useEffect(() => {
     async function poll() {


### PR DESCRIPTION
### Description
Fixes a couple of minor issues with the studio version checker:

- It currently adds a console.warn in dev when it doesn't find an import map (this was an unindended change introduced in #10637)
- Simplifies "current version" check in case no appId is configured (saves a request since fetching the current `latest` version and the current auto-updating version is the same request if no appId is configured.
- Passes import map info through context down to the verison info dialog so we can tell if appId is missing, and show a configuration warning. This should clear up some confusion in cases where the studio doesn't load the version configured in sanity.io/manage

<img width="404" height="528" alt="image" src="https://github.com/user-attachments/assets/8f75fb09-2837-496f-a06c-be7419234d26" />


### What to review
Makes sense?

### Testing
Easiest way to test is by changing the debug values here:

https://github.com/sanity-io/sanity/blob/fe650d2133191eb605dea91c0f26bad8ed6d807a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx#L27-L38

e.g. by setting importMapUrl to a non-appid based url

### Notes for release

- Version info dialog will now include a warning if an auto-update configuration issue is detected