### PR TITLE
fix: use generated react compiler typings

### DIFF
--- a/packages/@repo/test-dts-exports/test/fixtures/@sanity.cli.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/@sanity.cli.test-d.ts
@@ -106,7 +106,7 @@ describe('@sanity/cli', () => {
     expectTypeOf<PackageJson>().toBeObject()
   })
   test('ReactCompilerConfig', () => {
-    expectTypeOf<ReactCompilerConfig>().toBeObject()
+    expectTypeOf<ReactCompilerConfig>().not.toBeNever()
   })
   test('ResolvedCliCommand', () => {
     expectTypeOf<ResolvedCliCommand>().toBeObject()

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -95,6 +95,7 @@
     "@types/which": "^2.0.1",
     "@vercel/frameworks": "1.6.0",
     "@vercel/fs-detectors": "4.1.3",
+    "babel-plugin-react-compiler": "19.1.0-rc.3",
     "boxen": "^4.2.0",
     "clean-stack": "^3.0.1",
     "configstore": "^5.0.1",
@@ -127,6 +128,14 @@
     "vitest": "^3.2.4",
     "which": "^2.0.2",
     "xdg-basedir": "^4.0.0"
+  },
+  "peerDependencies": {
+    "babel-plugin-react-compiler": "*"
+  },
+  "peerDependenciesMeta": {
+    "babel-plugin-react-compiler": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -1,5 +1,6 @@
 import {type SanityClient} from '@sanity/client'
 import {type TelemetryLogger} from '@sanity/telemetry'
+import {type PluginOptions as ReactCompilerOptions} from 'babel-plugin-react-compiler'
 import type chalk from 'chalk'
 import {type Answers, type ChoiceCollection, type DistinctQuestion, type Separator} from 'inquirer'
 import {type Options, type Ora} from 'ora'
@@ -274,28 +275,9 @@ export interface GraphQLAPIConfig {
 }
 
 /**
- * Until these types are on npm: https://github.com/facebook/react/blob/0bc30748730063e561d87a24a4617526fdd38349/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts#L39-L122
  * @beta
  */
-export interface ReactCompilerConfig {
-  /**
-   * @see https://react.dev/learn/react-compiler#existing-projects
-   */
-  sources?: Array<string> | ((filename: string) => boolean) | null
-
-  /**
-   * The minimum major version of React that the compiler should emit code for. If the target is 19
-   * or higher, the compiler emits direct imports of React runtime APIs needed by the compiler. On
-   * versions prior to 19, an extra runtime package react-compiler-runtime is necessary to provide
-   * a userspace approximation of runtime APIs.
-   * @see https://react.dev/learn/react-compiler#using-react-compiler-with-react-17-or-18
-   */
-  target: '18' | '19'
-
-  panicThreshold?: 'ALL_ERRORS' | 'CRITICAL_ERRORS' | 'NONE'
-
-  compilationMode?: 'infer' | 'syntax' | 'annotation' | 'all'
-}
+export type ReactCompilerConfig = Partial<ReactCompilerOptions>
 
 interface AppConfig {
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,6 +1014,9 @@ importers:
       '@vercel/fs-detectors':
         specifier: 4.1.3
         version: 4.1.3
+      babel-plugin-react-compiler:
+        specifier: 19.1.0-rc.3
+        version: 19.1.0-rc.3
       boxen:
         specifier: ^4.2.0
         version: 4.2.0


### PR DESCRIPTION
### Description

[`@sanity/pkg-utils` now ship `ReactCompilerOptions` that use the typings exported by `babel-plugin-react-compiler`](https://github.com/sanity-io/pkg-utils/pull/1853). This PR makes the same change to `@sanity/cli`. The reason we used manual types were that `babel-plugin-react-compiler` did not export its typings in the early beta stage when we started using it.

### What to review

Missed anything?

### Testing

If type checks on the CI pass we good.

### Notes for release

The `reactCompiler` typings in `sanity.cli.ts` now re-export the typings from the `babel-plugin-react-compiler` package you have installed in your project. The React Compiler has shipped new features since we started supporting it, for example [Runtime Feature Flags with Gating](https://react.dev/learn/react-compiler/incremental-adoption#runtime-feature-flags-with-gating), and you can now easily adopt them by the updated typings.
[Read more about our React Compiler functionality here.](https://www.sanity.io/docs/help/react-compiler)