### PR TITLE
fix(core): tasks due dates showing incorrect value on timezones behind UTC

### DIFF
--- a/packages/sanity/src/core/tasks/components/activity/helpers/index.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/helpers/index.tsx
@@ -55,12 +55,14 @@ export function UserName({userId}: {userId: string}) {
 const DUE_BY_DATE_OPTIONS: UseDateTimeFormatOptions = {
   month: 'short',
   day: 'numeric',
+  timeZone: 'UTC',
 }
 
 function DueByChange({date}: {date: string}) {
   const dueBy = new Date(date)
   const dateFormatter = useDateTimeFormat(DUE_BY_DATE_OPTIONS)
   const formattedDate = dateFormatter.format(dueBy)
+
   return (
     <Strong>
       <NoWrap>{formattedDate}</NoWrap>

--- a/packages/sanity/src/core/tasks/components/form/fields/DateEditFormField.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/DateEditFormField.tsx
@@ -10,7 +10,7 @@ import {type CalendarLabels} from '../../../../components/inputs/DateInputs/cale
 import {DatePicker} from '../../../../components/inputs/DateInputs/DatePicker'
 import {type FormPatch, type PatchEvent, set, unset} from '../../../../form'
 import {getCalendarLabels} from '../../../../form/inputs/DateInputs/utils'
-import {useDateTimeFormat} from '../../../../hooks'
+import {useDateTimeFormat, type UseDateTimeFormatOptions} from '../../../../hooks'
 import {useTranslation} from '../../../../i18n'
 import {SCHEDULED_PUBLISHING_TIME_ZONE_SCOPE} from '../../../../studio/constants'
 import {tasksLocaleNamespace} from '../../../i18n'
@@ -18,6 +18,15 @@ import {tasksLocaleNamespace} from '../../../i18n'
 const serialize = (date: Date) => format(date, DEFAULT_DATE_FORMAT)
 const deserialize = (value: string | undefined) => parse(value || '', DEFAULT_DATE_FORMAT)
 
+const DUE_BY_DATE_OPTIONS: UseDateTimeFormatOptions = {
+  dateStyle: 'long',
+  timeZone: 'UTC',
+}
+const SHORT_DATE_OPTIONS: UseDateTimeFormatOptions = {
+  month: 'short',
+  day: 'numeric',
+  timeZone: 'UTC',
+}
 export function DateEditFormField(props: {
   value: string | undefined
   onChange: (patch: FormPatch | PatchEvent | FormPatch[]) => void
@@ -30,13 +39,14 @@ export function DateEditFormField(props: {
   const [pickerOpen, setPickerOpen] = useState(false)
   const popoverRef = useRef<HTMLDivElement | null>(null)
   const buttonRef = useRef<HTMLButtonElement | null>(null)
-  const dateFormatter = useDateTimeFormat({dateStyle: 'long'})
+  const longDateFormatter = useDateTimeFormat(DUE_BY_DATE_OPTIONS)
+  const shortDateFormatter = useDateTimeFormat(SHORT_DATE_OPTIONS)
   const dueByeDisplayValue = useMemo(() => {
     if (!value) return {short: '----', full: '----'}
-    const dueFormated = dateFormatter.format(new Date(value))
-    const [monthAndDay] = dueFormated.split(',')
-    return {short: monthAndDay, full: dueFormated}
-  }, [dateFormatter, value])
+    const dueFormatted = longDateFormatter.format(new Date(value))
+    const shortDueFormatted = shortDateFormatter.format(new Date(value))
+    return {short: shortDueFormatted, full: dueFormatted}
+  }, [longDateFormatter, shortDateFormatter, value])
 
   useClickOutsideEvent(
     () => setPickerOpen(false),

--- a/packages/sanity/src/core/tasks/components/list/TasksListItem.tsx
+++ b/packages/sanity/src/core/tasks/components/list/TasksListItem.tsx
@@ -12,7 +12,7 @@ import {useMemo} from 'react'
 import {styled} from 'styled-components'
 
 import {Tooltip} from '../../../../ui-components'
-import {useDateTimeFormat} from '../../../hooks'
+import {useDateTimeFormat, type UseDateTimeFormatOptions} from '../../../hooks'
 import {type TaskDocument} from '../../types'
 import {TasksUserAvatar} from '../TasksUserAvatar'
 import {DocumentPreview} from './DocumentPreview'
@@ -44,11 +44,23 @@ function getTargetDocumentMeta(target?: TaskDocument['target']) {
     _type: target?.documentType,
   }
 }
-
+const FULL_DATE_FORMAT_OPTIONS: UseDateTimeFormatOptions = {
+  dateStyle: 'medium',
+  timeZone: 'UTC',
+}
+const MONTH_AND_DAY_FORMAT_OPTIONS: UseDateTimeFormatOptions = {
+  month: 'short',
+  day: 'numeric',
+  timeZone: 'UTC',
+}
+const DAY_FORMAT_OPTIONS: UseDateTimeFormatOptions = {
+  weekday: 'long',
+  timeZone: 'UTC',
+}
 function TaskDueDate({dueBy}: {dueBy: string}) {
-  const fullDateFormatter = useDateTimeFormat({dateStyle: 'medium'})
-  const monthAndDayFormatter = useDateTimeFormat({month: 'short', day: 'numeric'})
-  const dayFormatter = useDateTimeFormat({weekday: 'long'})
+  const fullDateFormatter = useDateTimeFormat(FULL_DATE_FORMAT_OPTIONS)
+  const monthAndDayFormatter = useDateTimeFormat(MONTH_AND_DAY_FORMAT_OPTIONS)
+  const dayFormatter = useDateTimeFormat(DAY_FORMAT_OPTIONS)
 
   const dateOptions = useMemo(() => {
     const date = new Date(dueBy)


### PR DESCRIPTION
### Description
**Fixes timezone issue in task due date display**

Problem: Due dates were showing the previous day when viewed from timezones behind UTC (e.g., GMT-0700). For example, a due date of "2025-09-25" would display as "Sep 24" instead of "Sep 25".

Cause: When creating new Date("2025-09-25"), JavaScript interprets this as midnight UTC. In negative offset timezones, midnight UTC becomes the previous day (e.g., 5:00 PM on Sep 24 in GMT-0700).

Fix: Added timeZone: 'UTC' to the date formatter options use in Tasks components. This ensures the date is displayed in UTC timezone, preventing the day shift that occurs in negative offset timezones.



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Changes are correct and no other date display is missing

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Set your browser timezone to any timezone negative from UTC, for example San Francisco. Dates should display the correct value

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes issue where tasks displayed an incorrect date in the Tasks details and list components.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
