### PR TITLE
fix: ignore env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,8 +51,10 @@ jspm_packages
 !/.vscode/extensions.json
 
 # Environment files
-# ignore all local .env files
+# ignore all .env files
 *.local
+.env
+.env.*
 
 # TypeScript
 tsconfig.tsbuildinfo


### PR DESCRIPTION
### Description
Can't see a reason to not always ignore common env file patterns. Having common env-file patterns in .gitignore reduces the risk of accidentally publishing secrets used during local testing etc. This should add ignores to common env file patterns at any directory level.

### What to review
- Did consider excluding `.env.example`, but now that it's already under version control I think its fine do leave it.

### Testing
- Try creating an env file, eg. `.env` file or `.env.local` or `.env.staging` anywhere under the repository root and make sure it's not included by `git add .`

### Notes for release
n/a – internal only