### PR TITLE
chore(deps): upgrade oxlint to v.1.16.0, fix `preserve-caught-error`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -112,6 +112,11 @@
       "matchPackageNames": ["@sanity/pkg-utils", "typescript"]
     },
     {
+      "description": "Always upgrade oxlint together",
+      "groupName": "oxlint",
+      "matchPackageNames": ["oxlint", "eslint-plugin-oxlint"]
+    },
+    {
       "description": "Due to our usage of useEffectEvent we need to use the experimental version of the plugin. Otherwise the exhaustive-deps rule will have false negatives",
       "matchPackageNames": [
         "eslint-plugin-react-hooks-with-use-effect-event",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -152,7 +152,8 @@
     "eslint/no-unsafe-optional-chaining": "warn",
     "promise/always-return": ["error", {"ignoreLastCallback": true}],
     // Temporarily disabled, will be re-enabled in the near term
-    "unicorn/prefer-set-has": "off"
+    "unicorn/prefer-set-has": "off",
+    "no-array-reverse": "off" // Requires polyfills for older browsers
   },
   "overrides": [
     {"files": ["scripts/**/*", "examples/functions/**/*"], "rules": {"no-console": "off"}}

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "lodash-es": "^4.17.21",
     "minimist": "^1.2.8",
     "npm-run-all2": "^6.2.6",
-    "oxlint": "1.14.0",
+    "oxlint": "1.16.0",
     "pkg-pr-new": "^0.0.54",
     "prettier": "catalog:",
     "read-package-up": "^11.0.0",

--- a/packages/@repo/eslint-config/package.json
+++ b/packages/@repo/eslint-config/package.json
@@ -17,7 +17,7 @@
     "eslint-config-turbo": "^2.5.6",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-oxlint": "1.14.0",
+    "eslint-plugin-oxlint": "1.16.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "6.0.0-rc.2",
     "eslint-plugin-react-hooks-with-use-effect-event": "npm:eslint-plugin-react-hooks@0.0.0-experimental-8a8e9a7e-20250912",

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -199,10 +199,12 @@ export default async function initSanity(
         if (useDefaultPlan) {
           print(`Using default plan.`)
         } else {
-          throw new Error(`Coupon "${intendedCoupon}" does not exist`)
+          throw new Error(`Coupon "${intendedCoupon}" does not exist`, {cause: err})
         }
       } else {
-        throw new Error(`Unable to validate coupon, please try again later:\n\n${err.message}`)
+        throw new Error(`Unable to validate coupon, please try again later:\n\n${err.message}`, {
+          cause: err,
+        })
       }
     }
   } else if (intendedPlan) {
@@ -228,10 +230,12 @@ export default async function initSanity(
         if (useDefaultPlan) {
           print(`Using default plan.`)
         } else {
-          throw new Error(`Plan id "${intendedPlan}" does not exist`)
+          throw new Error(`Plan id "${intendedPlan}" does not exist`, {cause: err})
         }
       } else {
-        throw new Error(`Unable to validate plan, please try again later:\n\n${err.message}`)
+        throw new Error(`Unable to validate plan, please try again later:\n\n${err.message}`, {
+          cause: err,
+        })
       }
     }
   }
@@ -855,7 +859,7 @@ export default async function initSanity(
           userAction: 'select',
         }
       }
-      throw new Error(`Failed to communicate with the Sanity API:\n${err.message}`)
+      throw new Error(`Failed to communicate with the Sanity API:\n${err.message}`, {cause: err})
     }
 
     if (projects.length === 0 && unattended) {

--- a/packages/@sanity/cli/src/actions/telemetry/setTelemetryConsent.ts
+++ b/packages/@sanity/cli/src/actions/telemetry/setTelemetryConsent.ts
@@ -86,6 +86,7 @@ export function createSetTelemetryConsentAction(status: SettableConsentStatus): 
         const errorMessage = resultMessages[status].failure(err.response?.body?.message)
         if (err.statusCode === 403) {
           // throw without stack trace from original error
+          // oxlint-disable-next-line preserve-caught-error is intentional
           throw new Error(errorMessage)
         } else {
           // if not 403, throw original error

--- a/packages/@sanity/cli/src/actions/typegen/generateAction.ts
+++ b/packages/@sanity/cli/src/actions/typegen/generateAction.ts
@@ -53,7 +53,7 @@ export default async function typegenGenerateAction(
       // If the user has not provided a specific schema path (eg we're using the default), give some help
       const hint =
         codegenConfig.schema === './schema.json' ? ` - did you run "sanity schema extract"?` : ''
-      throw new Error(`Schema file not found: ${codegenConfig.schema}${hint}`)
+      throw new Error(`Schema file not found: ${codegenConfig.schema}${hint}`, {cause: err})
     }
     throw err
   }

--- a/packages/@sanity/cli/src/util/getCliVersion.ts
+++ b/packages/@sanity/cli/src/util/getCliVersion.ts
@@ -16,7 +16,7 @@ export async function getCliPkg(): Promise<PackageJson> {
   try {
     data = await fs.readFile(path.join(cliPath, 'package.json'), 'utf-8')
   } catch (err) {
-    throw new Error(`Unable to read @sanity/cli/package.json: ${err.message}`)
+    throw new Error(`Unable to read @sanity/cli/package.json: ${err.message}`, {cause: err})
   }
 
   return JSON.parse(data)

--- a/packages/@sanity/cli/src/util/journeyConfig.ts
+++ b/packages/@sanity/cli/src/util/journeyConfig.ts
@@ -58,7 +58,7 @@ export async function getAndWriteJourneySchema(data: JourneySchemaWorkerData): P
     const indexContent = await assembleJourneyIndexContent(documentTypes)
     await fs.writeFile(path.join(schemasPath, `index.${fileExtension}`), indexContent)
   } catch (error) {
-    throw new Error(`Failed to fetch remote schema: ${error.message}`)
+    throw new Error(`Failed to fetch remote schema: ${error.message}`, {cause: error})
   }
 }
 

--- a/packages/@sanity/cli/src/util/loadEnv.ts
+++ b/packages/@sanity/cli/src/util/loadEnv.ts
@@ -63,7 +63,9 @@ export function loadEnv(
     // custom error handling until https://github.com/motdotla/dotenv-expand/issues/65 is fixed upstream
     // check for message "TypeError: Cannot read properties of undefined (reading 'split')"
     if (e.message.includes('split')) {
-      throw new Error('dotenv-expand failed to expand env vars. Maybe you need to escape `$`?')
+      throw new Error('dotenv-expand failed to expand env vars. Maybe you need to escape `$`?', {
+        cause: e,
+      })
     }
     throw e
   }

--- a/packages/@sanity/cli/src/util/resolveRootDir.ts
+++ b/packages/@sanity/cli/src/util/resolveRootDir.ts
@@ -10,7 +10,7 @@ export function resolveRootDir(cwd: string): string {
   try {
     return resolveProjectRoot(cwd) || cwd
   } catch (err) {
-    throw new Error(`Error occurred trying to resolve project root:\n${err.message}`)
+    throw new Error(`Error occurred trying to resolve project root:\n${err.message}`, {cause: err})
   }
 }
 

--- a/packages/@sanity/codegen/src/readConfig.ts
+++ b/packages/@sanity/codegen/src/readConfig.ts
@@ -27,7 +27,10 @@ export async function readConfig(path: string): Promise<CodegenConfig> {
     return configDefintion.parseAsync(json)
   } catch (error) {
     if (error instanceof z.ZodError) {
-      throw new Error(`Error in config file\n ${error.errors.map((err) => err.message).join('\n')}`)
+      throw new Error(
+        `Error in config file\n ${error.errors.map((err) => err.message).join('\n')}`,
+        {cause: error},
+      )
     }
     if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') {
       return configDefintion.parse({})

--- a/packages/@sanity/util/src/createSafeJsonParser.ts
+++ b/packages/@sanity/util/src/createSafeJsonParser.ts
@@ -28,7 +28,7 @@ export function createSafeJsonParser<Type>({errorLabel}: Options): Parser<Type> 
       const errorLine = JSON.parse(errorJson)
       const error = errorLine && errorLine.error
       if (error && error.description) {
-        throw new Error(`${errorLabel}: ${error.description}\n\n${errorJson}\n`)
+        throw new Error(`${errorLabel}: ${error.description}\n\n${errorJson}\n`, {cause: err})
       }
 
       throw err

--- a/packages/groq/package.config.ts
+++ b/packages/groq/package.config.ts
@@ -3,7 +3,6 @@ import {defineConfig} from '@sanity/pkg-utils'
 
 export default defineConfig({
   ...baseConfig,
-  legacyExports: false,
   bundles: [
     {source: './src/_exports.cts.ts', require: './lib/groq.cjs'},
     {source: './src/_exports.mts.ts', import: './lib/groq.js'},

--- a/packages/sanity/src/_internal/cli/actions/backup/chooseBackupIdPrompt.ts
+++ b/packages/sanity/src/_internal/cli/actions/backup/chooseBackupIdPrompt.ts
@@ -37,7 +37,9 @@ async function chooseBackupIdPrompt(
       return selected
     }
   } catch (err) {
-    throw new Error(`Failed to fetch backups for dataset ${datasetName}: ${err.message}`)
+    throw new Error(`Failed to fetch backups for dataset ${datasetName}: ${err.message}`, {
+      cause: err,
+    })
   }
 
   throw new Error('No backups found')

--- a/packages/sanity/src/_internal/cli/actions/backup/fetchNextBackupPage.ts
+++ b/packages/sanity/src/_internal/cli/actions/backup/fetchNextBackupPage.ts
@@ -79,7 +79,7 @@ class PaginatedGetBackupStream extends Readable {
       if (msg === undefined) {
         msg = String(error)
       }
-      throw new Error(`Downloading dataset backup failed: ${msg}`)
+      throw new Error(`Downloading dataset backup failed: ${msg}`, {cause: error})
     }
   }
 }

--- a/packages/sanity/src/_internal/cli/actions/deploy/helpers.ts
+++ b/packages/sanity/src/_internal/cli/actions/deploy/helpers.ts
@@ -411,7 +411,7 @@ async function getOrCreateStudioFromConfig({
     spinner.fail()
     // if the name is taken, it should return a 409 so we relay to the user
     if ([402, 409].includes(e?.statusCode)) {
-      throw new Error(e?.response?.body?.message || 'Bad request') // just in case
+      throw new Error(e?.response?.body?.message || 'Bad request', {cause: e}) // just in case
     }
     debug('Error creating user application from config', e)
     // otherwise, it's a fatal error

--- a/packages/sanity/src/_internal/cli/actions/tokens/deleteToken.ts
+++ b/packages/sanity/src/_internal/cli/actions/tokens/deleteToken.ts
@@ -32,7 +32,7 @@ export async function deleteToken(
     return true
   } catch (err) {
     if (err.statusCode === 404) {
-      throw new Error(`Token with ID "${tokenId}" not found`)
+      throw new Error(`Token with ID "${tokenId}" not found`, {cause: err})
     }
     throw err
   }

--- a/packages/sanity/src/_internal/cli/commands/backup/downloadBackupCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/backup/downloadBackupCommand.ts
@@ -168,7 +168,7 @@ const downloadBackupCommand: CliCommandDefinition = {
     } catch (error) {
       progressSpinner.fail()
       const {message} = parseApiErr(error)
-      throw new Error(`Downloading dataset backup failed: ${message}`)
+      throw new Error(`Downloading dataset backup failed: ${message}`, {cause: error})
     }
 
     docOutStream.end()
@@ -183,7 +183,7 @@ const downloadBackupCommand: CliCommandDefinition = {
       })
     } catch (err) {
       progressSpinner.fail()
-      throw new Error(`Archiving backup failed: ${err.message}`)
+      throw new Error(`Archiving backup failed: ${err.message}`, {cause: err})
     }
 
     progressSpinner.set({

--- a/packages/sanity/src/_internal/cli/commands/backup/listBackupCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/backup/listBackupCommand.ts
@@ -92,7 +92,7 @@ const listDatasetBackupCommand: CliCommandDefinition<ListDatasetBackupFlags> = {
         query.before = flags.before
         query.after = flags.after
       } catch (err) {
-        throw new Error(`Parsing date flags: ${err}`)
+        throw new Error(`Parsing date flags: ${err}`, {cause: err})
       }
     }
 

--- a/packages/sanity/src/_internal/cli/commands/cors/deleteCorsOriginCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/cors/deleteCorsOriginCommand.ts
@@ -23,7 +23,7 @@ const deleteCorsOriginCommand: CliCommandDefinition = {
       await client.request({method: 'DELETE', uri: `/cors/${originId}`})
       output.print('Origin deleted')
     } catch (err) {
-      throw new Error(`Origin deletion failed:\n${err.message}`)
+      throw new Error(`Origin deletion failed:\n${err.message}`, {cause: err})
     }
   },
 }

--- a/packages/sanity/src/_internal/cli/commands/dataset/alias/createAliasHandler.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/alias/createAliasHandler.ts
@@ -61,6 +61,6 @@ export const createAliasHandler: CliCommandAction = async (args, context) => {
       } successfully`,
     )
   } catch (err) {
-    throw new Error(`Dataset alias creation failed:\n${err.message}`)
+    throw new Error(`Dataset alias creation failed:\n${err.message}`, {cause: err})
   }
 }

--- a/packages/sanity/src/_internal/cli/commands/dataset/alias/linkAliasHandler.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/alias/linkAliasHandler.ts
@@ -71,6 +71,6 @@ export const linkAliasHandler: CliCommandAction = async (args, context) => {
     await aliasClient.updateAlias(client, aliasName, datasetName)
     output.print(`Dataset alias ${aliasOutputName} linked to ${datasetName} successfully`)
   } catch (err) {
-    throw new Error(`Dataset alias link failed:\n${err.message}`)
+    throw new Error(`Dataset alias link failed:\n${err.message}`, {cause: err})
   }
 }

--- a/packages/sanity/src/_internal/cli/commands/dataset/alias/unlinkAliasHandler.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/alias/unlinkAliasHandler.ts
@@ -67,6 +67,6 @@ export const unlinkAliasHandler: CliCommandAction<UnlinkFlags> = async (args, co
       `Dataset alias ${aliasOutputName} unlinked from ${result.datasetName} successfully`,
     )
   } catch (err) {
-    throw new Error(`Dataset alias unlink failed:\n${err.message}`)
+    throw new Error(`Dataset alias unlink failed:\n${err.message}`, {cause: err})
   }
 }

--- a/packages/sanity/src/_internal/cli/commands/dataset/createDatasetCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/createDatasetCommand.ts
@@ -61,7 +61,7 @@ const createDatasetCommand: CliCommandDefinition<CreateFlags> = {
       await client.datasets.create(datasetName, {aclMode})
       output.print('Dataset created successfully')
     } catch (err) {
-      throw new Error(`Dataset creation failed:\n${err.message}`)
+      throw new Error(`Dataset creation failed:\n${err.message}`, {cause: err})
     }
   },
 }

--- a/packages/sanity/src/_internal/cli/commands/documents/deleteDocumentsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/documents/deleteDocumentsCommand.ts
@@ -57,7 +57,9 @@ const deleteDocumentsCommand: CliCommandDefinition<DeleteFlags> = {
         )
       }
     } catch (err) {
-      throw new Error(`Failed to delete ${pluralize('document', ids.length)}:\n${err.message}`)
+      throw new Error(`Failed to delete ${pluralize('document', ids.length)}:\n${err.message}`, {
+        cause: err,
+      })
     }
   },
 }

--- a/packages/sanity/src/_internal/cli/commands/documents/getDocumentsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/documents/getDocumentsCommand.ts
@@ -47,7 +47,7 @@ const getDocumentsCommand: CliCommandDefinition<GetDocumentFlags> = {
 
       output.print(pretty ? colorizeJson(doc, chalk) : JSON.stringify(doc, null, 2))
     } catch (err) {
-      throw new Error(`Failed to fetch document:\n${err.message}`)
+      throw new Error(`Failed to fetch document:\n${err.message}`, {cause: err})
     }
   },
 }

--- a/packages/sanity/src/_internal/cli/commands/documents/queryDocumentsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/documents/queryDocumentsCommand.ts
@@ -101,7 +101,7 @@ export default {
 
       output.print(pretty ? colorizeJson(docs, chalk) : JSON.stringify(docs, null, 2))
     } catch (err) {
-      throw new Error(`Failed to run query:\n${err.message}`)
+      throw new Error(`Failed to run query:\n${err.message}`, {cause: err})
     }
   },
 }

--- a/packages/sanity/src/_internal/cli/commands/hook/deleteHookCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/hook/deleteHookCommand.ts
@@ -20,7 +20,7 @@ const deleteHookCommand: CliCommandDefinition = {
         .config({apiVersion: '2021-10-04'})
         .request({method: 'DELETE', uri: `/hooks/${hookId}`})
     } catch (err) {
-      throw new Error(`Hook deletion failed:\n${err.message}`)
+      throw new Error(`Hook deletion failed:\n${err.message}`, {cause: err})
     }
   },
 }

--- a/packages/sanity/src/_internal/cli/commands/hook/listHookLogsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/hook/listHookLogsCommand.ts
@@ -29,7 +29,7 @@ const listHookLogsCommand: CliCommandDefinition<ListHookFlags> = {
       messages = await client.request<HookMessage[]>({uri: `/hooks/${hookId}/messages`})
       attempts = await client.request<DeliveryAttempt[]>({uri: `/hooks/${hookId}/attempts`})
     } catch (err) {
-      throw new Error(`Hook logs retrieval failed:\n${err.message}`)
+      throw new Error(`Hook logs retrieval failed:\n${err.message}`, {cause: err})
     }
 
     const groupedAttempts = groupBy(attempts, 'messageId')

--- a/packages/sanity/src/_internal/cli/commands/hook/listHooksCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/hook/listHooksCommand.ts
@@ -19,7 +19,7 @@ const listHooksCommand: CliCommandDefinition = {
         .config({apiVersion: '2021-10-04'})
         .request<Hook[]>({uri: '/hooks'})
     } catch (err) {
-      throw new Error(`Hook list retrieval failed:\n${err.message}`)
+      throw new Error(`Hook list retrieval failed:\n${err.message}`, {cause: err})
     }
 
     hooks.forEach((hook) => {

--- a/packages/sanity/src/_internal/cli/commands/hook/printHookAttemptCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/hook/printHookAttemptCommand.ts
@@ -17,7 +17,7 @@ const printHookAttemptCommand: CliCommandDefinition = {
     try {
       attempt = await client.request<DeliveryAttempt>({uri: `/hooks/attempts/${attemptId}`})
     } catch (err) {
-      throw new Error(`Hook attempt retrieval failed:\n${err.message}`)
+      throw new Error(`Hook attempt retrieval failed:\n${err.message}`, {cause: err})
     }
 
     const {createdAt, resultCode, resultBody, failureReason, inProgress} = attempt

--- a/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
@@ -51,7 +51,9 @@ const listMigrationCommand: CliCommandDefinition = {
         )
         return
       }
-      throw new Error(`An error occurred while listing migrations: ${error.message}`)
+      throw new Error(`An error occurred while listing migrations: ${error.message}`, {
+        cause: error,
+      })
     }
   },
 }

--- a/packages/sanity/src/_internal/cli/commands/migration/utils/resolveMigrationScript.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/utils/resolveMigrationScript.ts
@@ -51,7 +51,7 @@ export function resolveMigrationScript(
         mod = require(absolutePath)
       } catch (err) {
         if (err.code !== 'MODULE_NOT_FOUND') {
-          throw new Error(`Error: ${err.message}"`)
+          throw new Error(`Error: ${err.message}"`, {cause: err})
         }
       }
       return {relativePath, absolutePath, mod}

--- a/packages/sanity/src/_internal/cli/commands/tokens/addTokenCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/tokens/addTokenCommand.ts
@@ -52,7 +52,7 @@ const addTokenCommand: CliCommandDefinition<AddTokenFlags> = {
       output.print('')
       output.print('Copy the token above – this is your only chance to do so!')
     } catch (err) {
-      throw new Error(`Token creation failed:\n${err.message}`)
+      throw new Error(`Token creation failed:\n${err.message}`, {cause: err})
     }
   },
 }

--- a/packages/sanity/src/_internal/cli/commands/tokens/deleteTokenCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/tokens/deleteTokenCommand.ts
@@ -31,7 +31,7 @@ const deleteTokenCommand: CliCommandDefinition = {
         output.print('Token deleted successfully')
       }
     } catch (err) {
-      throw new Error(`Token deletion failed:\n${err.message}`)
+      throw new Error(`Token deletion failed:\n${err.message}`, {cause: err})
     }
   },
 }

--- a/packages/sanity/src/_internal/cli/commands/tokens/listTokensCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/tokens/listTokensCommand.ts
@@ -68,7 +68,7 @@ const listTokensCommand: CliCommandDefinition<ListTokensFlags> = {
 
       table.printTable()
     } catch (err) {
-      throw new Error(`Failed to list tokens:\n${err.message}`)
+      throw new Error(`Failed to list tokens:\n${err.message}`, {cause: err})
     }
   },
 }

--- a/packages/sanity/src/_internal/cli/util/readPackageManifest.ts
+++ b/packages/sanity/src/_internal/cli/util/readPackageManifest.ts
@@ -31,7 +31,7 @@ export async function readPackageJson(filePath: string): Promise<PackageJson> {
   try {
     return JSON.parse(await readFile(filePath, 'utf8'))
   } catch (err) {
-    throw new Error(`Failed to read "${filePath}": ${err.message}`)
+    throw new Error(`Failed to read "${filePath}": ${err.message}`, {cause: err})
   }
 }
 /**
@@ -49,7 +49,7 @@ export async function readPackageManifest(
   try {
     manifest = {...defaults, ...(await readPackageJson(packageJsonPath))}
   } catch (err) {
-    throw new Error(`Failed to read "${packageJsonPath}": ${err.message}`)
+    throw new Error(`Failed to read "${packageJsonPath}": ${err.message}`, {cause: err})
   }
 
   if (!isPackageManifest(manifest)) {

--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -139,7 +139,7 @@ const getCurrentUser = async (
     // Some non-CORS error - is it one of those undefinable network errors?
     if (err.isNetworkError && !err.message && err.request && err.request.url) {
       const host = new URL(err.request.url).host
-      throw new Error(`Unknown network error attempting to reach ${host}`)
+      throw new Error(`Unknown network error attempting to reach ${host}`, {cause: err})
     }
 
     // Some other error, just throw it

--- a/packages/sanity/src/core/studio/copyPaste/__test__/mockClient.ts
+++ b/packages/sanity/src/core/studio/copyPaste/__test__/mockClient.ts
@@ -47,7 +47,7 @@ export function createMockClient(mockData: FIXME[]): ClientWithFetch {
               console.error('Error position:', (error as {position: number}).position)
             }
           }
-          throw new Error('Error in mock client query execution')
+          throw new Error('Error in mock client query execution', {cause: error})
         }
       },
     ),

--- a/packages/sanity/src/presentation/useMainDocument.ts
+++ b/packages/sanity/src/presentation/useMainDocument.ts
@@ -87,7 +87,7 @@ export function getRouteContext(route: Path, url: URL): DocumentResolverContext 
         return {origin, params, path}
       }
     } catch (e) {
-      throw new Error(`"${route}" is not a valid route pattern`)
+      throw new Error(`"${route}" is not a valid route pattern`, {cause: e})
     }
   }
   return undefined

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,8 +230,8 @@ importers:
         specifier: ^6.2.6
         version: 6.2.6
       oxlint:
-        specifier: 1.14.0
-        version: 1.14.0
+        specifier: 1.16.0
+        version: 1.16.0
       pkg-pr-new:
         specifier: ^0.0.54
         version: 0.0.54
@@ -791,8 +791,8 @@ importers:
         specifier: ^2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-oxlint:
-        specifier: 1.14.0
-        version: 1.14.0
+        specifier: 1.16.0
+        version: 1.16.0
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.35.0(jiti@2.5.1))
@@ -4081,43 +4081,43 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/darwin-arm64@1.14.0':
-    resolution: {integrity: sha512-rcTw0QWeOc6IeVp+Up7WtcwdS9l4j7TOq4tihF0Ud/fl+VUVdvDCPuZ9QTnLXJhwMXiyQRWdxRyI6XBwf80ncQ==}
+  '@oxlint/darwin-arm64@1.16.0':
+    resolution: {integrity: sha512-t9sBjbcG15Jgwgw2wY+rtfKEazdkKM/YhcdyjmGYeSjBXaczLfp/gZe03taC2qUHK+t6cxSYNkOLXRLWxaf3tw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/darwin-x64@1.14.0':
-    resolution: {integrity: sha512-TWFSEmyl2/DN4HoXNwQl0y/y3EXFJDctfv5MiDtVOV1GJKX80cGSIxMxXb08Q3CCWqteqEijmfSMo5TG8X1H/A==}
+  '@oxlint/darwin-x64@1.16.0':
+    resolution: {integrity: sha512-c9aeLQATeu27TK8gR/p8GfRBsuakx0zs+6UHFq/s8Kux+8tYb3pH1pql/XWUPbxubv48F2MpnD5zgjOrShAgag==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/linux-arm64-gnu@1.14.0':
-    resolution: {integrity: sha512-N1FqdKfwhVWPpMElv8qlGqdEefTbDYaRVhdGWOjs/2f7FESa5vX0cvA7ToqzkoXyXZI5DqByWiPML33njK30Kg==}
+  '@oxlint/linux-arm64-gnu@1.16.0':
+    resolution: {integrity: sha512-ZoBtxtRHhftbiKKeScpgUKIg4cu9s7rsBPCkjfMCY0uLjhKqm6ShPEaIuP8515+/Csouciz1ViZhbrya5ligAg==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint/linux-arm64-musl@1.14.0':
-    resolution: {integrity: sha512-v/BPuiateLBb7Gz1STb69EWjkgKdlPQ1NM56z+QQur21ly2hiMkBX2n0zEhqfu9PQVRUizu6AlsYuzcPY/zsIQ==}
+  '@oxlint/linux-arm64-musl@1.16.0':
+    resolution: {integrity: sha512-a/Dys7CTyj1eZIkD59k9Y3lp5YsHBUeZXR7qHTplKb41H+Ivm5OQPf+rfbCBSLMfCPZCeKQPW36GXOSYLNE1uw==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint/linux-x64-gnu@1.14.0':
-    resolution: {integrity: sha512-gUTp8KIrSYt97dn+tRRC3LKnH4xlHKCwrPwiDcGmLbCxojuN9/H5mnIhPKEfwNuZNdoKGS/ABuq3neVyvRCRtQ==}
+  '@oxlint/linux-x64-gnu@1.16.0':
+    resolution: {integrity: sha512-rsfv90ytLhl+s7aa8eE8gGwB1XGbiUA2oyUee/RhGRyeoZoe9/hHNtIcE2XndMYlJToROKmGyrTN4MD2c0xxLQ==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint/linux-x64-musl@1.14.0':
-    resolution: {integrity: sha512-DpN6cW2HPjYXeENG0JBbmubO8LtfKt6qJqEMBw9gUevbyBaX+k+Jn7sYgh6S23wGOkzmTNphBsf/7ulj4nIVYA==}
+  '@oxlint/linux-x64-musl@1.16.0':
+    resolution: {integrity: sha512-djwSL4harw46kdCwaORUvApyE9Y6JSnJ7pF5PHcQlJ7S1IusfjzYljXky4hONPO0otvXWdKq1GpJqhmtM0/xbg==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint/win32-arm64@1.14.0':
-    resolution: {integrity: sha512-oXxJksnUTUMgJ0NvjKS1mrCXAy1ttPgIVacRSlxQ+1XHy+aJDMM7I8fsCtoKoEcTIpPaD98eqUqlLYs0H2MGjA==}
+  '@oxlint/win32-arm64@1.16.0':
+    resolution: {integrity: sha512-lQBfW4hBiQ47P12UAFXyX3RVHlWCSYp6I89YhG+0zoLipxAfyB37P8G8N43T/fkUaleb8lvt0jyNG6jQTkCmhg==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/win32-x64@1.14.0':
-    resolution: {integrity: sha512-iRYy2rhTQKFztyx0jtNMRBnFpzsRwFdjWQ7sKKzJpmbijA3Tw3DCqlGT7QRgoVRF0+X/ccNGvvsrgMohPVfLeQ==}
+  '@oxlint/win32-x64@1.16.0':
+    resolution: {integrity: sha512-B5se3JnM4Xu6uHF78hAY9wdk/sdLFib1YwFsLY6rkQKEMFyi+vMZZlDaAS+s+Dt9q7q881U2OhNznZenJZdPdQ==}
     cpu: [x64]
     os: [win32]
 
@@ -7263,8 +7263,8 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
-  eslint-plugin-oxlint@1.14.0:
-    resolution: {integrity: sha512-0sRuw9X/2W9FsWis6RC46fpCOSu+yPFD9foEmJ0ypCE6XfFWO6qXJIYvNctE7QzkO8W8c2RcWP7G28Rl84dDpQ==}
+  eslint-plugin-oxlint@1.16.0:
+    resolution: {integrity: sha512-OwxJcCOt2S2xMA8LvbAbPjgi5IyIBpK8znvKYlhSWz3R0BWgKVhNcYIDEndAxvDcfob4WPahrq+53TUeJqqeFg==}
 
   eslint-plugin-react-hooks@0.0.0-experimental-8a8e9a7e-20250912:
     resolution: {integrity: sha512-YNau5W/LLgLsFINauIbrGJV4tU8Ksr7NlWBfTJGN7PuN6VnhajANHvzPWiAdhbsIvjP0SFILlgk6+8pltP8WOQ==}
@@ -9672,12 +9672,12 @@ packages:
   oxc-resolver@11.8.0:
     resolution: {integrity: sha512-iTBXOucxbG40DGURl0cXChZn1WbvXteW4F/U3SZNbhlixFhd3+ZoHU8cmavOSS+Ob9GUPEUoZhGpj1empxwAiQ==}
 
-  oxlint@1.14.0:
-    resolution: {integrity: sha512-oo0nq3zF9hmgATGc9esoMahLuEESOodUxEDeHDA2K7tbYcSfcmReE9G2QNppnq9rOSQHLTwlMtzGAjjttYaufQ==}
+  oxlint@1.16.0:
+    resolution: {integrity: sha512-o6z8s6QVw/d7QuxQ7QFfqDMrIcmHyU3J/MewxjqduJmy4vHt/s7OZISk8zEXjHXZzTWrcFakIrLqU/b9IKTcjg==}
     engines: {node: '>=8.*'}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.1.5'
+      oxlint-tsgolint: '>=0.2.0'
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
@@ -14473,28 +14473,28 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.8.0':
     optional: true
 
-  '@oxlint/darwin-arm64@1.14.0':
+  '@oxlint/darwin-arm64@1.16.0':
     optional: true
 
-  '@oxlint/darwin-x64@1.14.0':
+  '@oxlint/darwin-x64@1.16.0':
     optional: true
 
-  '@oxlint/linux-arm64-gnu@1.14.0':
+  '@oxlint/linux-arm64-gnu@1.16.0':
     optional: true
 
-  '@oxlint/linux-arm64-musl@1.14.0':
+  '@oxlint/linux-arm64-musl@1.16.0':
     optional: true
 
-  '@oxlint/linux-x64-gnu@1.14.0':
+  '@oxlint/linux-x64-gnu@1.16.0':
     optional: true
 
-  '@oxlint/linux-x64-musl@1.14.0':
+  '@oxlint/linux-x64-musl@1.16.0':
     optional: true
 
-  '@oxlint/win32-arm64@1.14.0':
+  '@oxlint/win32-arm64@1.16.0':
     optional: true
 
-  '@oxlint/win32-x64@1.14.0':
+  '@oxlint/win32-x64@1.16.0':
     optional: true
 
   '@pkgjs/parseargs@0.11.0':
@@ -18185,7 +18185,7 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-oxlint@1.14.0:
+  eslint-plugin-oxlint@1.16.0:
     dependencies:
       jsonc-parser: 3.3.1
 
@@ -21019,16 +21019,16 @@ snapshots:
       '@oxc-resolver/binding-win32-ia32-msvc': 11.8.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.8.0
 
-  oxlint@1.14.0:
+  oxlint@1.16.0:
     optionalDependencies:
-      '@oxlint/darwin-arm64': 1.14.0
-      '@oxlint/darwin-x64': 1.14.0
-      '@oxlint/linux-arm64-gnu': 1.14.0
-      '@oxlint/linux-arm64-musl': 1.14.0
-      '@oxlint/linux-x64-gnu': 1.14.0
-      '@oxlint/linux-x64-musl': 1.14.0
-      '@oxlint/win32-arm64': 1.14.0
-      '@oxlint/win32-x64': 1.14.0
+      '@oxlint/darwin-arm64': 1.16.0
+      '@oxlint/darwin-x64': 1.16.0
+      '@oxlint/linux-arm64-gnu': 1.16.0
+      '@oxlint/linux-arm64-musl': 1.16.0
+      '@oxlint/linux-x64-gnu': 1.16.0
+      '@oxlint/linux-x64-musl': 1.16.0
+      '@oxlint/win32-arm64': 1.16.0
+      '@oxlint/win32-x64': 1.16.0
 
   p-finally@1.0.0: {}
 


### PR DESCRIPTION
### Description

Renovatebot failed to bump oxlint as it has new rules that need to be fixed/configured.
- [I've disabled the `unicorn/no-array-reverse` rule](https://github.com/oxc-project/oxc/pull/13530) as I don't think we want to use `[].toReversed()` instead of `[].reverse()` without properly investigating browser support and such. At least TypeScript didn't like it without changing tsconfig's `target` so I've disabled the rule for now.
- [The new `preserve-caught-error` rule is awesome](https://github.com/oxc-project/oxc/pull/13748), it doesn't support `--fix` yet so I manually fixed the violations ☺️ 
- I've updated renovatebot to PR `oxlint` and `eslint-plugin-oxlint` together, as they're intended to be on exactly the same version.

### What to review

Does it make sense to forward `cause` in all the cases? Or should I suppress in some cases?

### Testing

CI good then we good!

### Notes for release

N/A
