### PR TITLE
feat: update telegram recipe function

### DIFF
--- a/examples/functions/telegram-notify/index.ts
+++ b/examples/functions/telegram-notify/index.ts
@@ -8,11 +8,9 @@ export const handler = documentEventHandler(async ({event}) => {
   const {_id, comment} = event.data
 
   if (!comment) {
-    // eslint-disable-next-line no-console
     console.log('No comment in event data')
     return
   } else if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID) {
-    // eslint-disable-next-line no-console
     console.log('Environment variables not set')
     return
   }
@@ -21,18 +19,27 @@ export const handler = documentEventHandler(async ({event}) => {
     const message = `New comment received: ${comment}`
     const studioUrl = `${STUDIO_URL}/structure/comment;${_id}`
 
+    // Build payload - conditionally include inline keyboard for non-localhost URLs
+    const payload = {
+      chat_id: TELEGRAM_CHAT_ID,
+      text: message,
+    }
+
+    // Telegram doesn't allow 'localhost' in the URL, so we include it in the message text instead
+    if (STUDIO_URL.includes('localhost')) {
+      payload.text += `\n\n📝 Open in Sanity Studio: ${studioUrl}`
+    } else {
+      payload.reply_markup = {
+        inline_keyboard: [[{text: '📝 Open in Sanity Studio', url: studioUrl}]],
+      }
+    }
+
     const response = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        chat_id: TELEGRAM_CHAT_ID,
-        text: message,
-        reply_markup: {
-          inline_keyboard: [[{text: '📝 Open in Sanity Studio', url: studioUrl}]],
-        },
-      }),
+      body: JSON.stringify(payload),
     })
 
     if (!response.ok) {
@@ -40,7 +47,6 @@ export const handler = documentEventHandler(async ({event}) => {
     }
 
     const result = await response.json()
-    // eslint-disable-next-line no-console
     console.log('Message sent successfully:', result)
   } catch (error) {
     console.error('Failed to send Telegram notification:', error)


### PR DESCRIPTION
### Description

I ran into the scenario where the the Telegram fetch rejected the message when studio url was a localhost URL.

The fix: I changed the code so that when using localhost, it puts the Studio URL in the message text instead of making it a clickable button.