### PR TITLE
fix: issue with title and description were triggering revalidation / refetching

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -266,9 +266,20 @@ const getReleaseDocumentsObservable = ({
         releasesState.releases.get(getReleaseDocumentIdFromReleaseId(releaseId)),
       ),
       filter(Boolean), // Removes falsey values
-      distinctUntilChanged((prev, next) => prev._rev === next._rev),
+      distinctUntilChanged((prev, next) => {
+        // Only skip re-validation if the core fields that affect document validation haven't changed
+        // Return true to skip, false to trigger re-validation
+        // _rev wasn't enough since it changed on every edit of the release document itself
+        return prev.state === next.state && prev.finalDocumentStates === next.finalDocumentStates
+      }),
       switchMap((release) => {
-        const cacheKey = `${releaseId}-${release._rev}`
+        // Create cache key based on fields that affect document validation + _rev
+        const validationRelevantHash = [
+          release.state,
+          release.finalDocumentStates?.length || 0,
+          release._rev,
+        ].join('-')
+        const cacheKey = `${releaseId}-${validationRelevantHash}`
 
         if (!bundleDocumentsCache[cacheKey]) {
           let observable: ReleaseDocumentsObservableResult


### PR DESCRIPTION
### Description

Validation on releases was being retriggered because the _rev changed but only the metadata did which caused larger hiccups on the editing of the title and description

### What to review

Does this make sense?

### Testing

Existing tests should suffice. Tested manually, the caching should still work as expected

### Notes for release

Fixes slowness that made editing the title and description of a release difficult