### PR TITLE
fix(sanity): use the correct colour for diffs in draft versions

### DIFF
--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/diff/segments.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/diff/segments.tsx
@@ -5,6 +5,7 @@ import {getTheme_v2} from '@sanity/ui/theme'
 import {type ComponentType, type PropsWithChildren} from 'react'
 import {styled} from 'styled-components'
 
+import {RELEASE_TYPES_TONES} from '../../../../../releases/util/const'
 import {getReleaseTone} from '../../../../../releases/util/getReleaseTone'
 import {type ProvenanceDiffAnnotation} from '../../../../store/types/diff'
 
@@ -23,6 +24,7 @@ const Segment = styled.span<StyledSegmentProps>`
     return {
       backgroundColor: color.button.bleed[$tone]?.pressed?.bg,
       color: color.button.bleed[$tone]?.pressed?.fg,
+      textDecoration: 'none',
     }
   }}
 `
@@ -58,6 +60,10 @@ function segmentTone(segment: StringDiffSegment<ProvenanceDiffAnnotation>): Badg
     segment.action !== 'unchanged' &&
     typeof segment.annotation.provenance.bundle !== 'undefined'
   ) {
+    if (segment.annotation.provenance.bundle === 'drafts') {
+      return RELEASE_TYPES_TONES.asap.tone
+    }
+
     return getReleaseTone(segment.annotation.provenance.bundle)
   }
 


### PR DESCRIPTION
### Description

Inline diff markers in drafts were being given the incorrect colour. This branch adds an exception to make sure drafts are handled the same way as ASAP and undecided versions. This makes sense from a temporal point of view, because all such versions have the published document as the upstream, and could be published at any time.

It'd be nice to do a refactor here eventually, but for now, this gets the job done.

#### Before

<img width="663" height="515" alt="Screenshot 2025-09-23 at 16 32 46" src="https://github.com/user-attachments/assets/6f93b1f5-c381-44c1-af3d-78c148cd7cfd" />

#### After

<img width="663" height="515" alt="Screenshot 2025-09-23 at 16 32 56" src="https://github.com/user-attachments/assets/67fac893-48bb-4b79-9494-fb19eb7dcc6e" />


### What to review

The colours applied to inline diff markers.

### Testing

Verified in Test Studio.

### Notes for release

Inline diff markers in drafts now use the correct color.