### PR TITLE
fix: fix issue where single workspaces weren't opening the dropdown to show the new manage actions

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/home/HomeButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/home/HomeButton.tsx
@@ -1,11 +1,9 @@
-import {SanityMonogram} from '@sanity/logos'
-import {Box, Card, Flex, rem, Text} from '@sanity/ui'
+import {Card, Flex, rem} from '@sanity/ui'
 import {useStateLink} from 'sanity/router'
 import {styled} from 'styled-components'
 
 import {focusRingStyle} from '../../../../form/components/withFocusRing/helpers'
 import {useActiveWorkspace} from '../../../activeWorkspaceMatcher'
-import {useWorkspaces} from '../../../workspaces'
 import {WorkspacePreviewIcon} from '../workspace'
 
 const LOGO_MARK_SIZE = 25 // width and height, px
@@ -36,39 +34,20 @@ const StyledCard = styled(Card)`
 /**
  * Home button in the main navbar.
  *
- * If only one workspace is available:
- * - Displays the workspace icon (if defined), otherwise falls back to the Sanity logo.
- * - Displays the active workspace title.
- *
- * If multiple workspaces are available:
  * - Displays the workspace icon only.
  */
 export function HomeButton() {
-  const workspaces = useWorkspaces()
   const {activeWorkspace} = useActiveWorkspace()
   const {href: rootHref, onClick: handleRootClick} = useStateLink({state: {}})
-
-  const multipleWorkspaces = workspaces.length > 1
 
   return (
     <StyledCard as="a" href={rootHref} onClick={handleRootClick}>
       <Flex align="center">
         <LogoMarkContainer>
           <Flex align="center" height="fill" justify="center">
-            {multipleWorkspaces || activeWorkspace.customIcon ? (
-              <WorkspacePreviewIcon icon={activeWorkspace.icon} size="small" />
-            ) : (
-              <SanityMonogram width="100%" height="100%" />
-            )}
+            <WorkspacePreviewIcon icon={activeWorkspace.icon} size="small" />
           </Flex>
         </LogoMarkContainer>
-        {!multipleWorkspaces && (
-          <Box paddingX={2}>
-            <Text size={2} weight="medium">
-              {activeWorkspace.title}
-            </Text>
-          </Box>
-        )}
       </Flex>
     </StyledCard>
   )

--- a/packages/sanity/src/core/studio/components/navbar/workspace/ManageMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/ManageMenu.tsx
@@ -21,7 +21,7 @@ export function ManageMenu() {
         <WorkspacePreviewIcon icon={activeWorkspace.icon} size="large" />
         <Stack marginLeft={2} space={2}>
           <Text size={0}>{activeWorkspace.name}</Text>
-          <Text size={2} weight="medium">
+          <Text size={1} weight="medium">
             {activeWorkspace.title}
           </Text>
         </Stack>

--- a/packages/sanity/src/core/studio/components/navbar/workspace/ManageMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/ManageMenu.tsx
@@ -18,7 +18,7 @@ export function ManageMenu() {
   const {t} = useTranslation()
 
   return (
-    <Stack paddingX={5} paddingTop={4} paddingBottom={4}>
+    <Stack padding={4}>
       <Flex align="center">
         <WorkspacePreviewIcon icon={activeWorkspace.icon} size="large" />
         <Stack marginLeft={2} space={2}>

--- a/packages/sanity/src/core/studio/components/navbar/workspace/ManageMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/ManageMenu.tsx
@@ -16,7 +16,7 @@ export function ManageMenu() {
   const {t} = useTranslation()
 
   return (
-    <Stack paddingX={5} paddingTop={4} paddingBottom={3}>
+    <Stack paddingX={5} paddingTop={4} paddingBottom={4}>
       <Flex align="center">
         <WorkspacePreviewIcon icon={activeWorkspace.icon} size="large" />
         <Stack marginLeft={2} space={2}>

--- a/packages/sanity/src/core/studio/components/navbar/workspace/ManageMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/ManageMenu.tsx
@@ -3,6 +3,7 @@ import {Flex, Stack, Text} from '@sanity/ui'
 
 import {Button} from '../../../../../ui-components/button/Button'
 import {useTranslation} from '../../../../i18n'
+import {useProject} from '../../../../store/_legacy/project/useProject'
 import {userHasRole} from '../../../../util/userHasRole'
 import {useActiveWorkspace} from '../../../activeWorkspaceMatcher/useActiveWorkspace'
 import {useWorkspace} from '../../../workspace'
@@ -10,6 +11,7 @@ import {WorkspacePreviewIcon} from './WorkspacePreview'
 
 export function ManageMenu() {
   const {projectId, currentUser} = useWorkspace()
+  const {value: project} = useProject()
   const {activeWorkspace} = useActiveWorkspace()
   const isAdmin = Boolean(currentUser && userHasRole(currentUser, 'administrator'))
 
@@ -20,7 +22,7 @@ export function ManageMenu() {
       <Flex align="center">
         <WorkspacePreviewIcon icon={activeWorkspace.icon} size="large" />
         <Stack marginLeft={2} space={2}>
-          <Text size={0}>{activeWorkspace.name}</Text>
+          <Text size={0}>{project?.displayName}</Text>
           <Text size={1} weight="medium">
             {activeWorkspace.title}
           </Text>

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -31,12 +31,6 @@ export function WorkspaceMenuButton() {
   const [authStates] = useWorkspaceAuthStates(workspaces)
   const {t} = useTranslation()
 
-  const multipleWorkspaces = workspaces.length > 1
-
-  if (!multipleWorkspaces) {
-    return null
-  }
-
   const disabled = !authStates
 
   return (

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -60,8 +60,8 @@ export function WorkspaceMenuButton() {
             <ManageMenu />
             {workspaces.length > 1 && (
               <>
-                <MenuDivider />
-                <Box paddingTop={2}>
+                <MenuDivider style={{padding: 0}} />
+                <Box paddingTop={2} paddingBottom={1}>
                   <Box paddingX={5} paddingBottom={2}>
                     <Text size={0} weight="medium">
                       {t('workspaces.action.switch-workspace')}
@@ -96,7 +96,7 @@ export function WorkspaceMenuButton() {
                           __unstable_subtitle={workspace.subtitle}
                           __unstable_space={1}
                           text={workspace?.title || workspace.name}
-                          style={{paddingLeft: '2rem', paddingRight: '2rem'}}
+                          style={{marginLeft: '1rem', marginRight: '0.25rem'}}
                         />
                       )
                     })}

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
@@ -18,10 +18,12 @@ interface MediaProps {
 export const Media = styled.div<MediaProps>`
   width: ${(props) => (props.$size === 'small' ? '25px' : '41px')};
   height: ${(props) => (props.$size === 'small' ? '25px' : '41px')};
+  border-radius: 0.25rem;
 
   svg {
     width: 100%;
     height: 100%;
+    border-radius: inherit;
   }
 `
 


### PR DESCRIPTION
### Description

Fixes a few issues that were brought up:
- UI padding and sizes
- Fixes issue where the single workspaces weren't opening the dropdown
- Fixes the project title to show the displayedName

Single workspace
<img width="849" height="599" alt="image" src="https://github.com/user-attachments/assets/22b76b46-524b-44f9-9cb6-6e50c6306fc1" />

Multi workspace

<img width="849" height="599" alt="image" src="https://github.com/user-attachments/assets/7fb832da-7952-4fc3-9414-39a2576f43c0" />

### What to review

Jon and Kayla need to review the UI

### Testing

N/A 

### Notes for release

fixes issue where single workspaces weren't opening the dropdown with the manage actions