### PR TITLE
fix(sanity): pasting Portable Text data into `StringInputPortableText`

### DIFF
--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/StringInputPortableText.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/StringInputPortableText.tsx
@@ -5,7 +5,8 @@ import {
   PortableTextEditable,
   useEditor,
 } from '@portabletext/editor'
-import {EventListenerPlugin, OneLinePlugin} from '@portabletext/editor/plugins'
+import {defineBehavior, forward, raise} from '@portabletext/editor/behaviors'
+import {BehaviorPlugin, EventListenerPlugin, OneLinePlugin} from '@portabletext/editor/plugins'
 import {type Path} from '@sanity/types'
 import {Card, useArrayProp, useRootTheme} from '@sanity/ui'
 import {useCallback, useEffect, useRef} from 'react'
@@ -182,6 +183,7 @@ export function StringInputPortableText(props: StringInputProps) {
         <EventListenerPlugin on={handleEditorEvent} />
         <UpdateValuePlugin value={props.value} />
         <UpdateReadOnlyPlugin readOnly={props.readOnly ?? false} />
+        <BehaviorPlugin behaviors={[plainTextPasteBehaviour, plainTextOneLineBehaviour]} />
         <StyledInput
           className={props.validationError ? INVALID_CLASS_NAME : undefined}
           renderPlaceholder={advancedVersionControl.enabled ? renderPlaceholder : undefined}
@@ -225,3 +227,39 @@ function UpdateValuePlugin(props: {value: string | undefined}) {
 
   return null
 }
+
+/**
+ * Convert pasted data to plain text.
+ *
+ * This is essential to allow pasting of data copied from Portable Text based fields. If pasting
+ * Portable Text data was permitted, it would cause a conflict with the expected data structure.
+ */
+const plainTextPasteBehaviour = defineBehavior({
+  on: 'clipboard.paste',
+  actions: [
+    (event) => [
+      raise({
+        type: 'insert.text',
+        text: event.event.originEvent.dataTransfer.getData('text'),
+      }),
+    ],
+  ],
+})
+
+/**
+ * Remove new lines from inserted text.
+ *
+ * This ensures new lines are removed when pasting data copied from Portable Text based fields. Each
+ * sequence of new line characters is replaced with a single space character.
+ */
+const plainTextOneLineBehaviour = defineBehavior({
+  on: 'insert.text',
+  actions: [
+    ({event}) => [
+      forward({
+        type: 'insert.text',
+        text: event.text.replaceAll(/\n+/g, ' '),
+      }),
+    ],
+  ],
+})


### PR DESCRIPTION
### Description

Pasting Portable Text data into `StringInputPortableText` breaks the input. Although it appears to reflect the pasted value, and the user can edit it, the updated value is never correctly emitted and the changes are not saved. This is because the structure of the pasted Portable Text data conflicts with the expected data structure.

This branch ensures Portable Text data is converted to text on paste. It also replaces each sequence of new line characters in inserted text with a single space character, to make sure new line characters cannot be inserted by pasting multi-line Portable Text data.

### What to review

The new behaviours in `StringInputPortableText`.

### Testing

Tested by pasting various instances of Portable Text data into `StringInputPortableText`. We should add a test for this if we're able to add Vitest Browser Mode to the project.

### Notes for release

Fixes a bug that would sometimes cause pasted text not to be saved when Advanced Version Control is switched on.