### PR TITLE
fix: only reading server metadata when unfocused from input

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
@@ -6,6 +6,7 @@ import {type ChangeEvent, useCallback, useEffect, useRef, useState} from 'react'
 import {css, styled} from 'styled-components'
 
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {useFocusAwareFormState} from '../../hooks/useFocusAwareFormState'
 
 const MAX_DESCRIPTION_HEIGHT = 200
 
@@ -95,16 +96,20 @@ export function TitleDescriptionForm({
 }): React.JSX.Element {
   const isReleaseOpen = getIsReleaseOpen(release)
   const descriptionRef = useRef<HTMLTextAreaElement | null>(null)
-
   const [scrollHeight, setScrollHeight] = useState(46)
-  const [value, setValue] = useState<EditableReleaseDocument>({
-    _id: release?._id,
-    metadata: {
-      title: release?.metadata.title,
-      description: release?.metadata.description,
-    },
-  })
   const {t} = useTranslation()
+
+  const {localData, updateLocalData, createFocusHandler, handleBlur} = useFocusAwareFormState({
+    externalValue: release,
+    id: release._id,
+    extractData: useCallback(
+      ({metadata}: EditableReleaseDocument) => ({
+        title: metadata.title,
+        description: metadata.description,
+      }),
+      [],
+    ),
+  })
 
   useEffect(() => {
     // make sure that the text area for the description has the right height initially
@@ -113,19 +118,15 @@ export function TitleDescriptionForm({
     }
   }, [])
 
-  useEffect(() => {
-    setValue(release)
-  }, [release])
-
   const handleTitleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       event.preventDefault()
       const title = event.target.value
-      onChange({...value, metadata: {...release.metadata, title}})
       // save the values to make input snappier while requests happen in the background
-      setValue({...value, metadata: {...release.metadata, title}})
+      updateLocalData({title})
+      onChange({...release, metadata: {...release.metadata, title}})
     },
-    [onChange, release.metadata, value],
+    [onChange, release, updateLocalData],
   )
 
   const handleDescriptionChange = useCallback(
@@ -134,9 +135,9 @@ export function TitleDescriptionForm({
       if (!isReleaseOpen) return
 
       const description = event.target.value
-      onChange({...value, metadata: {...release.metadata, description}})
       // save the values to make input snappier while requests happen in the background
-      setValue({...value, metadata: {...release.metadata, description}})
+      updateLocalData({description})
+      onChange({...release, metadata: {...release.metadata, description}})
 
       /** we must reset the height in order to make sure that if the text area shrinks,
        * that the actual input will change height as well */
@@ -152,16 +153,18 @@ export function TitleDescriptionForm({
 
       setScrollHeight(event.currentTarget.scrollHeight)
     },
-    [isReleaseOpen, onChange, release.metadata, value],
+    [isReleaseOpen, onChange, release, updateLocalData],
   )
 
-  const shouldShowDescription = isReleaseOpen || value.metadata.description
+  const shouldShowDescription = isReleaseOpen || localData.description
 
   return (
     <Stack space={3}>
       <TitleInput
         onChange={handleTitleChange}
-        value={value.metadata.title}
+        onFocus={createFocusHandler('title')}
+        onBlur={handleBlur}
+        value={localData.title}
         placeholder={t('release.placeholder-untitled-release')}
         data-testid="release-form-title"
         readOnly={!isReleaseOpen}
@@ -170,10 +173,12 @@ export function TitleDescriptionForm({
       {shouldShowDescription && (
         <DescriptionTextArea
           ref={descriptionRef}
-          autoFocus={!value}
-          value={value.metadata.description}
+          autoFocus={!localData.title}
+          value={localData.description}
           placeholder={t('release.form.placeholder-describe-release')}
           onChange={handleDescriptionChange}
+          onFocus={createFocusHandler('description')}
+          onBlur={handleBlur}
           style={{
             height: `${scrollHeight}px`,
             maxHeight: MAX_DESCRIPTION_HEIGHT,

--- a/packages/sanity/src/core/releases/hooks/useFocusAwareFormState.ts
+++ b/packages/sanity/src/core/releases/hooks/useFocusAwareFormState.ts
@@ -1,0 +1,68 @@
+import {useCallback, useEffect, useRef, useState} from 'react'
+
+interface UseFocusAwareFormStateOptions<T, TFormData extends Record<string, unknown>> {
+  /** The external value from props/server */
+  externalValue: T
+  id: string
+  extractData: (value: T) => TFormData
+}
+
+/**
+ * Hook for managing form state that syncs with external data while respecting per-field focus.
+ *
+ * This prevents the issue where server updates override user input during typing.
+ * The local state will sync with external data on a per-field basis when the field is not focused.
+ *
+ * @internal
+ */
+export function useFocusAwareFormState<T, TFormData extends Record<string, unknown>>({
+  externalValue,
+  id,
+  extractData,
+}: UseFocusAwareFormStateOptions<T, TFormData>) {
+  const [localData, setLocalData] = useState(() => extractData(externalValue))
+  const [focusedField, setFocusedField] = useState<string | null>(null)
+  const idRef = useRef(id)
+
+  // Sync external data to local state when:
+  // 1. ID changes (navigating to different item) - always sync all fields
+  // 2. Same ID - only sync unfocused fields (allow server updates for unfocused fields)
+  useEffect(() => {
+    const newData = extractData(externalValue)
+
+    if (idRef.current === id) {
+      setLocalData((prev) => {
+        const updated = {...prev} as Record<string, unknown>
+        Object.keys(newData).forEach((field) => {
+          if (focusedField !== field) {
+            updated[field] = (newData as Record<string, unknown>)[field]
+          }
+        })
+        return updated as TFormData
+      })
+    } else {
+      idRef.current = id
+      setLocalData(newData)
+      setFocusedField(null)
+    }
+  }, [externalValue, id, extractData, focusedField])
+
+  const createFocusHandler = useCallback(
+    (fieldName: string) => () => setFocusedField(fieldName),
+    [],
+  )
+
+  const handleBlur = useCallback(() => setFocusedField(null), [])
+
+  const updateLocalData = useCallback((updates: Partial<TFormData>) => {
+    setLocalData((prev) => ({...prev, ...updates}))
+  }, [])
+
+  return {
+    localData,
+    updateLocalData,
+    createFocusHandler,
+    handleBlur,
+    focusedField,
+  }
+}


### PR DESCRIPTION
### Description
There is an issue with editing a release title or description.

Because of interference between our optimistic state update and the debounced server call, typing into these fields would cause flickers (as we move between optimistic state, and the currently last resolved server state), and in many cases edits would be entirely lost.

The issue was:
1. I type a description of 'hello there'
2. After 200ms of debounce the server is called with 'the quick'
3. Whilst waiting for the server to resolve I have now typed 'the quick brown'
4. Server resolved, I see the description shift back to 'the quick' (that's on the server)
5. Another 200ms and the server is called and resolved with 'the quick brown', but in between I've continued typing
6. The end state ends up being some mush of what has been showing in optimistic state and what's resolved, something like 'the quick fox' entirely erasing 'brown'

Before:
![descriptionFlickerBeforePR](https://github.com/user-attachments/assets/50e28b37-08c5-407e-92f0-a31eedc01d87)

After:
![descriptionFlickerAfterPR](https://github.com/user-attachments/assets/eebcdf25-e37f-493d-b1f6-5c9781919998)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The change does the following:
* When focus is not on the title or description inputs then we read directly from the observable, keeping the presented state in realtime
* when I focus an input, we stop tracking the input state with the server and just use in memory
* When I start typing I see optimistic updates immediately; in the background we are 200ms debouncing the calls to the server to save
* When I blur, we move back to using the observable for the state
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
thoroughly tested and this resolves the flickering issues
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fix for an issue where editing the title or description of a Content Release would cause text flickering.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
