### PR TITLE
fix(core): avoid repeated failing org id requests

### DIFF
--- a/packages/sanity/src/core/store/_legacy/project/projectStore.ts
+++ b/packages/sanity/src/core/store/_legacy/project/projectStore.ts
@@ -24,11 +24,11 @@ const getOrganizationId = memoize(
       })
       .pipe(
         map((res) => res.organizationId),
-        repeat({delay: REFETCH_INTERVAL}),
-        shareReplay(1),
         catchError(() => {
           return of(null)
         }),
+        repeat({delay: REFETCH_INTERVAL}),
+        shareReplay({bufferSize: 1, refCount: true}),
       )
   },
   (client) => `${client.config().projectId}-${client.config().dataset}`,
@@ -43,12 +43,14 @@ export function createProjectStore(context: {client: SanityClient}): ProjectStor
   function get(): Observable<ProjectData> {
     return versionedClient.observable.request({
       url: `/projects/${projectId}`,
+      tag: 'get-project',
     })
   }
 
   function getDatasets() {
     return versionedClient.observable.request({
       url: `/projects/${projectId}/datasets`,
+      tag: 'get-datasets',
     })
   }
 


### PR DESCRIPTION
### Description
Fixes an issue that could cause repeated request being issued to the `/projects/<projectId>` endpoint in case of a non 2xx status code (e.g. after session expiry)

### What to review
- Makes sense?
- Also took the liberty of adding missing tags other requests in here as well

### Testing
For now, this requires manually checking if the issue is fixed.

### Notes for release
- Fixes an issue that could trigger repeated failing requests from the Studio to the `/projects/<projectId>` endpoint