### PR TITLE
fix(cli): improve autoUpdates config upgrade message

### DIFF
--- a/packages/sanity/src/_internal/cli/util/shouldAutoUpdate.ts
+++ b/packages/sanity/src/_internal/cli/util/shouldAutoUpdate.ts
@@ -45,7 +45,7 @@ export function shouldAutoUpdate({flags, cliConfig, output}: AutoUpdateSources):
         `The \`autoUpdates\` config has moved to \`deployment.autoUpdates\`.
 Please update \`sanity.cli.ts\` or \`sanity.cli.js\` and make the following change:
 ${chalk.red(`-  autoUpdates: ${cliConfig.autoUpdates},`)}
-${chalk.green(`+  deployment: {autoUpdates: ${cliConfig.autoUpdates}}}`)}
+${chalk.green(`+  deployment: {autoUpdates: ${cliConfig.autoUpdates}},`)}
 `,
       ),
     )


### PR DESCRIPTION

<img width="576" height="95" alt="Screenshot 2025-09-29 at 18 37 59" src="https://github.com/user-attachments/assets/3f7e9460-97ff-4c87-873c-27742b1f8964" />

Before:
-  autoUpdates: true,
+  deployment: {autoUpdates: true}}

After
-  autoUpdates: true,
+  deployment: {autoUpdates: true},

### Description

The message in the image is changed according to the description above.
This reduces confusion when copy-pasting the diff.

### What to review

Diff should be self-explanatory

### Testing

Create a sanity project with the following versions:
```
 "@sanity/vision": "4.6.0",
 "sanity": "4.6.0",
```

Then run `sanity deploy` from the CLI. Refer to screenshot above.

### Notes for release

Nothing