### PR TITLE
fix(structure): pass the same documentId to the favorite toggle as to history

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelSubHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelSubHeader.tsx
@@ -54,7 +54,6 @@ export const DocumentPanelSubHeader = memo(function DocumentPanelHeader() {
     <CapabilityGate capability="comlink" condition="available">
       <FavoriteToggle
         resourceType="studio"
-        // use the version, draft or published id if it exists, otherwise use the documentId
         documentId={displayed?._id ?? documentId}
         documentType={displayed?._type ?? ''}
         resourceId={[activeWorkspace.projectId, activeWorkspace.dataset].join('.')}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

We're only ever passing the published id to the favorites toggle, which _normally_ resolves itself correctly when a user opens their favorite from dashboard _however_ you're not taken directly to the release which you are when you open that same item from the history widget in dashboard. This is because the history hook can pass us the `version` or `draft` id which is what we want to show a preview accurately.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

* Would there be a case where the toggle would show & the edit state not have an available id for us? 
* Does it make sense to fallback to the `documentId` prop?

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
