### PR TITLE
fix(cli): remove redundant curly brace in code example

### DIFF
--- a/packages/sanity/src/_internal/cli/util/getAppId.ts
+++ b/packages/sanity/src/_internal/cli/util/getAppId.ts
@@ -36,7 +36,7 @@ export function getAppId({cliConfig, output}: Options): string | undefined {
 Please update \`sanity.cli.ts\` or \`sanity.cli.js\` and move:
 ${chalk.red(`app: {id: "${appId}", ... }`)}
 to
-${chalk.green(`deployment: {appId: "${appId}", ... }}`)})
+${chalk.green(`deployment: {appId: "${appId}", ... }`)})
 `,
       ),
     )


### PR DESCRIPTION
### Description

Removes an extra curly brace snuck into the code example.

### Notes for release
n/a