### PR TITLE
chore(ci): skip pkg.pr.new for main

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -4,9 +4,6 @@ permissions:
   pull-requests: write
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types: [opened, synchronize, labeled]
 


### PR DESCRIPTION
### Description
Skips pkg.pr.new builds for pushes to main. No need for pkg.pr.new in `main` since its already published to npm under the `next` tag.

### Notes for release
n/a