### PR TITLE
fix: use www for website urls

### DIFF
--- a/packages/sanity/src/core/studio/hooks/useEnvAwareSanityWebsiteUrl.ts
+++ b/packages/sanity/src/core/studio/hooks/useEnvAwareSanityWebsiteUrl.ts
@@ -6,6 +6,6 @@ export function useEnvAwareSanityWebsiteUrl() {
   const {getClient} = useWorkspace()
   return useMemo(() => {
     const apiHost = getClient({apiVersion: '2025-08-15'}).config().apiHost
-    return apiHost.endsWith('.work') ? 'https://sanity.work' : 'https://sanity.io'
+    return apiHost.endsWith('.work') ? 'https://www.sanity.work' : 'https://www.sanity.io'
   }, [getClient])
 }

--- a/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
@@ -5,6 +5,7 @@ import {useEffect, useMemo} from 'react'
 import {styled} from 'styled-components'
 
 import {Dialog} from '../../../ui-components'
+import {useEnvAwareSanityWebsiteUrl} from '../hooks/useEnvAwareSanityWebsiteUrl'
 
 interface CorsOriginErrorScreenProps {
   projectId?: string
@@ -26,17 +27,15 @@ export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
   const {projectId, isStaging} = props
 
   const origin = window.location.origin
+  const sanityWebsiteUrl = useEnvAwareSanityWebsiteUrl()
   const corsUrl = useMemo(() => {
-    const url = new URL(
-      `/manage/project/${projectId}/api`,
-      isStaging ? 'https://sanity.work' : 'https://sanity.io',
-    )
+    const url = new URL(`/manage/project/${projectId}/api`, sanityWebsiteUrl)
     url.searchParams.set('cors', 'add')
     url.searchParams.set('origin', origin)
     url.searchParams.set('credentials', '')
 
     return url.toString()
-  }, [isStaging, origin, projectId])
+  }, [origin, projectId, sanityWebsiteUrl])
 
   useEffect(() => {
     const handleFocus = () => {


### PR DESCRIPTION
### Description
Includes `www` in website urls

### What to review
Makes sense?

### Testing
Links to e.g. manage from preview build should go to `www.sanity.io` instead of `sanity.io`

### Notes for release
n/a