### PR TITLE
Add pnpm `minimumReleaseAge`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,3 +37,5 @@ catalogs:
   react18:
     react: ^18.3.1
     react-dom: ^18.3.1
+
+minimumReleaseAge: 4320


### PR DESCRIPTION
### Description

To reduce the risk of installing compromised packages, you can delay the installation of newly published versions. This PR sets minimumReleaseAge to 3 days.

https://pnpm.io/settings#minimumreleaseage

### What to review

Should we consider adding the [minimumReleaseAgeExclude](https://pnpm.io/settings#minimumreleaseageexclude) to exempt internal packages from the 3 day restriction?

### Testing

This is a build/package configuration change.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
