### PR TITLE
chore: update tooltip to clarify intended schedule dateTime

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1395,7 +1395,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.dialog.publish-scheduled-draft.header': 'Publish draft now',
   /** Label for description in tooltip to explain release types */
   'release.dialog.tooltip.description':
-    'The intended release time is used to create better previews and hints about whether documents conflict.',
+    "This is only for planning, previews and hints about whether documents conflict. Setting a time here will not schedule your release. You'll still need to run or schedule the release once all documents are ready.",
   /** Label for noting that a release time is not final */
   'release.dialog.tooltip.note': 'You can always change it later.',
   /** Title for tooltip to explain release time */


### PR DESCRIPTION
### Description
Before:
<img width="679" height="184" alt="Screenshot 2025-10-03 at 11 12 07" src="https://github.com/user-attachments/assets/25a361b2-beb4-4eb7-849d-93d450cc74d7" />

After:
<img width="664" height="209" alt="Screenshot 2025-10-03 at 11 11 39" src="https://github.com/user-attachments/assets/e4fd21d5-1c5b-4fb8-affa-f343024a8e8d" />

<!--
What changes are intro
duced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
