### PR TITLE
fix: datetime custom types resolves field wrapper

### DIFF
--- a/packages/sanity/src/core/form/studio/inputResolver/fieldResolver.tsx
+++ b/packages/sanity/src/core/form/studio/inputResolver/fieldResolver.tsx
@@ -268,6 +268,10 @@ export function defaultResolveFieldComponent(
 
   const typeChain = getTypeChain(schemaType, new Set())
 
+  if (typeChain.some((t) => isDateTimeSchemaType(t))) {
+    return DateTimeField as ComponentType<Omit<FieldProps, 'renderDefault'>>
+  }
+
   if (typeChain.some((t) => t.name === 'image' || t.name === 'file')) {
     return ImageOrFileField as ComponentType<Omit<FieldProps, 'renderDefault'>>
   }


### PR DESCRIPTION
### Description
Custom input types that extend the `datetime` input are not correctly being recognised by `isDateTimeSchemaType`. This means they fall-through to `PrimitiveField` and this causes the title to be rendered twice:
<img width="642" height="307" alt="Screenshot 2025-10-06 at 14 45 08" src="https://github.com/user-attachments/assets/cfef98c7-36fe-4d91-98f7-f5d5f6a691d3" />

Now it renders once:
<img width="640" height="269" alt="Screenshot 2025-10-06 at 14 44 11" src="https://github.com/user-attachments/assets/db019262-1417-49a9-b269-2caf34ada291" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
The test-studio doesn't have the correct schema setup to test this, but in `datetime.ts`:

```
export const customDateTime = defineType({
  title: 'Published At Custom Field',
  name: 'published_at',
  type: 'datetime',
  validation: (Rule) => Rule.required(),
})

export default defineType({
  ...,
  fields: [
      defineField({name: 'pub_at', type: 'published_at'}),
  ]
})
```
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue where creating a custom `datetime` field type would cause the field title to appear twice.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
