### PR TITLE
fix(cli): default dashboard url should use dev as the search param not url

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
@@ -49,7 +49,7 @@ const getDefaultDashboardURL = ({
   url: string
 }): string => {
   return `${baseUrl}/@${organizationId}?${new URLSearchParams({
-    url,
+    dev: url,
   }).toString()}`
 }
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

The default dashboard URL in the case that the CLI cannot hit the dashboard API endpoint was incorrect – found this in Greece when the internet was poor and it kept giving me the wrong value.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

Fixes a small issue where the CLI would give you the wrong dashboard URL when building an SDK app & the CLI could not accurate hit the dashboard endpoint to get the URL.