### PR TITLE
fix(core): mention options in tasks comments showing as unauthorized

### DIFF
--- a/packages/sanity/src/core/comments/context/comments/CommentsProvider.tsx
+++ b/packages/sanity/src/core/comments/context/comments/CommentsProvider.tsx
@@ -156,17 +156,25 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
   )
 
   const threadItemsByStatus: ThreadItemsByStatus = useMemo(() => {
-    if (!schemaType || !currentUser) return EMPTY_COMMENTS_DATA
+    if (!currentUser) {
+      return EMPTY_COMMENTS_DATA
+    }
     const sorted = orderBy(data, ['_createdAt'], [sortOrder])
-
-    const items = buildCommentThreadItems({
-      comments: sorted,
-      currentUser,
-      documentValue,
-      schemaType,
-      type,
-    })
-
+    let items: CommentThreadItem[] = []
+    if (type === 'task') {
+      items = buildCommentThreadItems({comments: sorted, currentUser, documentValue, type})
+    } else {
+      if (!schemaType) {
+        return EMPTY_COMMENTS_DATA
+      }
+      items = buildCommentThreadItems({
+        comments: sorted,
+        currentUser,
+        documentValue,
+        schemaType,
+        type,
+      })
+    }
     return {
       open: items.filter((item) => item.parentComment.status === 'open'),
       resolved: items.filter((item) => item.parentComment.status === 'resolved'),

--- a/packages/sanity/src/core/comments/utils/buildCommentThreadItems.ts
+++ b/packages/sanity/src/core/comments/utils/buildCommentThreadItems.ts
@@ -2,18 +2,26 @@ import {type SanityDocument} from '@sanity/client'
 import {type CurrentUser, type SchemaType} from '@sanity/types'
 
 import {isTextSelectionComment} from '../helpers'
-import {type CommentDocument, type CommentsType, type CommentThreadItem} from '../types'
+import {type CommentDocument, type CommentThreadItem} from '../types'
 import {buildCommentBreadcrumbs} from './buildCommentBreadcrumbs'
 
 const EMPTY_ARRAY: [] = []
 
-interface BuildCommentThreadItemsProps {
-  comments: CommentDocument[]
-  currentUser: CurrentUser
-  documentValue: Partial<SanityDocument> | null
-  schemaType: SchemaType
-  type: CommentsType
-}
+type BuildCommentThreadItemsProps =
+  | {
+      comments: CommentDocument[]
+      currentUser: CurrentUser
+      documentValue: Partial<SanityDocument> | null
+      schemaType: SchemaType
+      type: 'field'
+    }
+  | {
+      schemaType?: undefined
+      comments: CommentDocument[]
+      currentUser: CurrentUser
+      documentValue: Partial<SanityDocument> | null
+      type: 'task'
+    }
 
 /**
  * This function formats comments into a structure that is easier to work with in the UI.


### PR DESCRIPTION
### Description
Mentions options for comments created in tasks are showing as `unauthorized` this is due to the `system_group` permissions query.

**You may wonder, how was this working before?**
For comments we use the **addon** dataset, so we were querying the groups from the **addon** dataset, but before [this change](https://github.com/sanity-io/sanity/commit/966e97a5f2405e8c9e9bceeb64b2249151d7a35b) we had a cache in place.
So if you queried the **non addon dataset** first, then the **addon dataset** was using the permissions from the **non addon dataset**, and that's why this was working before this change.

Now the cache is removed so this shows the issue, we were doing it wrong from the start. It was working because the cache was hiding this from us. That's also why we were seeing some cases of users reporting that they were seeing **unauthorized** users but then not anymore.


<img width="269" height="554" alt="Screenshot 2025-10-14 at 14 58 32" src="https://github.com/user-attachments/assets/8939e0ec-53f8-4113-99e7-c25fde6d0a8a" />

Given comments uses the **addon dataset** and we want to use the form when editing the task, we are adding the `TasksWorkspaceProvider` in [`TasksFormBuilder`](https://github.com/sanity-io/sanity/blob/fix-tasks-comments-mentions/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.tsx#L179-L180) this has the intended side effect of changing the `client` that is used to the `addon` client. 
This means that every call done to client inside this context will use the `x-comments` dataset.

Given this, the `mentionOptions` returned by the `useUserListWithPermissions` inside the `CommentsProvider` that is used for tasks comments is not finding any permissions when trying to query [`'*[_type == "system.group"]'`](https://github.com/sanity-io/sanity/blob/fix-tasks-comments-mentions/packages/sanity/src/core/hooks/useUserListWithPermissions.ts#L97) 

By moving the `CommentsProvider` inside the `<CurrentWorkspaceProvider>` this is fixed, because now this query will use the correct client.

<img width="331" height="660" alt="Screenshot 2025-10-14 at 15 01 21" src="https://github.com/user-attachments/assets/8167db69-94ce-4e97-90f6-c2f6183547cc" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?


-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in where users were shown as unauthorized in comments created inside tasks.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
