### PR TITLE
chore: add dedupe preset to Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,8 @@
   ],
   "ignorePresets": [
     "github>sanity-io/renovate-config:group-non-major",
-    "github>sanity-io/renovate-config:workarounds-esm"
+    "github>sanity-io/renovate-config:workarounds-esm",
+    "github>sanity-io/renovate-config:dedupe"
   ],
   "minimumReleaseAge": "3 days",
   "packageRules": [


### PR DESCRIPTION
Let's see if this solves the issues with renovate PRs, my theory is that it running `pnpm dedupe` after updating is what causes some deps to be pulled in that fails the minimum age check
