### PR TITLE
fix(cli): pipe stderr when installing dependencies

### DIFF
--- a/packages/@sanity/cli/src/packageManager/installPackages.ts
+++ b/packages/@sanity/cli/src/packageManager/installPackages.ts
@@ -18,11 +18,9 @@ export async function installDeclaredPackages(
     encoding: 'utf8',
     env: getPartialEnvWithNpmPath(cwd),
     cwd,
-    stdio: 'pipe',
+    // inherit stdin & stdout, pipe stderr
+    stdio: ['inherit', 'inherit', 'pipe'],
   }
-
-  // results of running execa with the selected package manager
-  let result: ExecaReturnValue<string> | undefined
 
   type PackageManagerLibs = Exclude<PackageManager, 'manual'>
   type InstallerArgs = {[key in PackageManagerLibs]: string[]}
@@ -39,16 +37,12 @@ export async function installDeclaredPackages(
     const progress = output.spinner(`Running ${cmd} ${args.join(' ')}\n`).start()
 
     // Perform the install command with execa
-    result = await execa(cmd, args, execOptions)
-
-    // If the install fails, log execa's stdout and throw…
-    if (result?.exitCode || result?.failed) {
-      progress.fail()
-      output.print(result.stdout)
-      throw new Error('Dependency installation failed')
-    } else {
-      // …otherwise, just mark the install as successful
+    try {
+      await execa(cmd, args, execOptions)
       progress.succeed()
+    } catch (err) {
+      progress.fail()
+      throw new Error('Dependency installation failed', {cause: err})
     }
   }
 
@@ -65,35 +59,38 @@ export async function installNewPackages(
 ): Promise<void> {
   const {packageManager, packages} = options
   const {output, workDir} = context
+
   const execOptions: CommonOptions<'utf8'> = {
     encoding: 'utf8',
     env: getPartialEnvWithNpmPath(workDir),
     cwd: workDir,
-    stdio: 'inherit',
+    // inherit stdin & stdout, pipe stderr
+    stdio: ['inherit', 'inherit', 'pipe'],
   }
 
   const npmArgs = ['install', '--legacy-peer-deps', '--save', ...packages]
-  let result: ExecaReturnValue<string> | undefined
+  let install: Promise<ExecaReturnValue<string>> | undefined
   if (packageManager === 'npm') {
     output.print(`Running 'npm ${npmArgs.join(' ')}'`)
-    result = await execa('npm', npmArgs, execOptions)
+    install = execa('npm', npmArgs, execOptions)
   } else if (packageManager === 'yarn') {
     const yarnArgs = ['add', ...packages]
     output.print(`Running 'yarn ${yarnArgs.join(' ')}'`)
-    result = await execa('yarn', yarnArgs, execOptions)
+    install = execa('yarn', yarnArgs, execOptions)
   } else if (packageManager === 'pnpm') {
     const pnpmArgs = ['add', '--save-prod', ...packages]
     output.print(`Running 'pnpm ${pnpmArgs.join(' ')}'`)
-    result = await execa('pnpm', pnpmArgs, execOptions)
+    install = execa('pnpm', pnpmArgs, execOptions)
   } else if (packageManager === 'bun') {
     const bunArgs = ['add', ...packages]
     output.print(`Running 'bun ${bunArgs.join(' ')}'`)
-    result = await execa('bun', bunArgs, execOptions)
+    install = execa('bun', bunArgs, execOptions)
   } else if (packageManager === 'manual') {
     output.print(`Manual installation selected - run 'npm ${npmArgs.join(' ')}' or equivalent`)
   }
-
-  if (result?.exitCode || result?.failed) {
-    throw new Error('Package installation failed')
+  try {
+    await install
+  } catch (error) {
+    throw new Error('Package installation failed', {cause: error})
   }
 }


### PR DESCRIPTION
### Description
Currently, if the install dependency step of `sanity init` fails, stderr is not piped though from `<packagemanager> install` to the parent process. This means any stderr from installing dependencies is not forwarded to the user – only a generic error description is shown.
Furthermore, if the the install step fails, the promise will throw, so we'll never reach the error handling here:
https://github.com/sanity-io/sanity/pull/10839/files#diff-64e4a629c81b4efb99bea3052ca7fc857e75d3bb0bcdba503904f7c3a4baab0cL42

This PR addresses both of these issues

### What to review
- Does the error handling look ok?

### Testing
- The only way to test this is to run `sanity init` from the preview build and somehow make sure the install dependencies step fail, then verify that the full stderr from the package manager is forwarded.
- Incidentally, this currently happens in CLI unit tests, so here is a side by side comparison of
	- [before](https://github.com/sanity-io/sanity/actions/runs/18526207126/job/52797525565?pr=10826#step:10:573)
	- [after](https://github.com/sanity-io/sanity/actions/runs/18521535940/job/52782363666?pr=10839#step:10:2869)

### Notes for release
- Forward stderr from failed package manager install step during `sanity init`
