### PR TITLE
test(cli): fix failing case using pnpm for init

### DIFF
--- a/packages/@sanity/cli/test/init.test.ts
+++ b/packages/@sanity/cli/test/init.test.ts
@@ -289,18 +289,34 @@ describeCliTest('CLI: `sanity init`', () => {
 
         await cleanOutputDirectory(outpath)
 
-        await runSanityCmdCommand(studioName, [
-          'init',
-          '--y',
-          '--project',
-          cliProjectId,
-          '--dataset',
-          testRunArgs.dataset,
-          '--output-path',
-          `${baseTestPath}/${outpath}`,
-          '--package-manager',
-          'pnpm',
-        ])
+        await runSanityCmdCommand(
+          studioName,
+          [
+            'init',
+            '--y',
+            '--project',
+            cliProjectId,
+            '--dataset',
+            testRunArgs.dataset,
+            '--output-path',
+            `${baseTestPath}/${outpath}`,
+            '--package-manager',
+            'pnpm',
+          ],
+          {
+            env: {
+              // when running tests via `pnpm test`, the 'npm_config_minimum_release_age' is set from
+              // monorepo workspace config. however, minimumReleaseAgeExclude is *not* set,
+              // so CLI tests using pnpm as package manager will fail during install of monorepo packages
+              // if less than the configured minimumReleaseAge value
+              // As a workaround, explicitly set it to `0` here
+              // Note: majority of tests are already running `npm install`, which doesn't (yet) support
+              // minimumReleaseAge, so this should not make a big difference
+              // eslint-disable-next-line camelcase
+              npm_config_minimum_release_age: '0',
+            },
+          },
+        )
 
         // Verify Next.js config files were created in the Next.js root (confirms the command completed successfully)
         const hasPnpmLock = await fs


### PR DESCRIPTION
### Description
- We run tests with `pnpm` (https://github.com/sanity-io/sanity/blob/main/.github/workflows/cli-test.yml#L103)
- pnpm sets various environment variables based on config found in the nearest pnpm-workspace.yaml
- pnpm also supports these env vars as config in projects where there are no `pnpm-workspace.yaml` present.
- among the supported env vars is `npm_config_minimum_release_age`, which is set from the [`minimumReleaseAge` config](https://pnpm.io/settings#minimumreleaseage)
- when pnpm is invoked from our CLI tests (like the CLI test for `sanity init` with pnpm as package manager, this env var propagates to the `pnpm install` we run as part of `sanity init  --package-manager pnpm`. This runs in a directory outside of the repo, so it has no `pnpm-workspace.yaml`

However: pnpm _does not_ seem to set a corresponding env var for `minimumReleaseAgeExclude` – this in turn causes the test for `sanity init` that is using pnpm as package manager to fail after we release packages from this repo, because the pnpm install subprocess running in the `sanity init`` test, sees `minimumReleaseAge` from https://github.com/sanity-io/sanity/blob/main/pnpm-workspace.yaml, but doesn't get the exclusion list (including packages from this repo, eg. @sanity/*).

### What to review
- Makes sense? This effectively means that we don't enforce min age for the test that uses `sanity init` with pnpm. This is already the case for the rest of the tests as they install dependencies with npm, which currently doesn't support minReleaseAge.

### Testing
- Tests should pass again.

### Notes for release
n/a – internal