### PR TITLE
fix(sanity): stale read-only styles rendered for `StringInputPortableText`

### DIFF
--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/styles.ts
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/styles.ts
@@ -77,7 +77,7 @@ export function textInputBaseStyle(
       --input-placeholder-color: ${color.input.default.enabled.placeholder};
 
       /* enabled */
-      &:not(:invalid):not(:disabled):not(:read-only) {
+      &:not(:invalid):not(:disabled):not([data-read-only='true']) {
         --input-fg-color: ${color.input.default.enabled.fg};
         --input-placeholder-color: ${color.input.default.enabled.placeholder};
       }
@@ -95,7 +95,7 @@ export function textInputBaseStyle(
       }
 
       /* readOnly */
-      &:read-only {
+      &[data-read-only='true'] {
         --input-fg-color: ${color.input.default.readOnly.fg};
         --input-placeholder-color: ${color.input.default.readOnly.placeholder};
       }
@@ -214,36 +214,37 @@ export function textInputRepresentationStyle(
       }
 
       /* readOnly */
-      *:not(.invalid):read-only + & {
+      *:not(.invalid)[data-read-only='true'] + & {
         --card-bg-color: ${color.input.default.readOnly.bg} !important;
         --card-fg-color: ${color.input.default.readOnly.fg} !important;
       }
 
-      *.invalid:read-only + & {
+      *.invalid[data-read-only='true'] + & {
         --card-bg-color: ${color.input.invalid.readOnly.bg} !important;
         --card-fg-color: ${color.input.invalid.readOnly.fg} !important;
       }
 
       /* hovered */
       @media (hover: hover) {
-        *:not(:disabled):not(:read-only):not(.invalid):hover + & {
+        *:not(:disabled):not([data-read-only='true']):not(.invalid):hover + & {
           --card-bg-color: ${color.input.default.hovered.bg};
           --card-fg-color: ${color.input.default.hovered.fg};
         }
 
-        *.invalid:not(:disabled):not(:read-only):hover + & {
+        *.invalid:not(:disabled):not([data-read-only='true']):hover + & {
           --card-bg-color: ${color.input.invalid.hovered.bg};
           --card-fg-color: ${color.input.invalid.hovered.fg};
         }
 
-        *:not(:disabled):not(:read-only):not(.invalid):not(:focus):hover + &[data-border] {
+        *:not(:disabled):not([data-read-only='true']):not(.invalid):not(:focus):hover
+          + &[data-border] {
           --input-box-shadow: ${focusRingBorderStyle({
             color: color.input.default.hovered.border,
             width: input.border.width,
           })};
         }
 
-        *.invalid:not(:disabled):not(:read-only):not(:focus):hover + &[data-border] {
+        *.invalid:not(:disabled):not([data-read-only='true']):not(:focus):hover + &[data-border] {
           --input-box-shadow: ${focusRingBorderStyle({
             color: color.input.invalid.hovered.border,
             width: input.border.width,


### PR DESCRIPTION
### Description

This branch fixes an issue  that occurs in Safari and Chrome when using the `:read-only` pseudo-class with a `contenteditable` element. Presence of `contenteditable="true"` is correctly reflected by the `:read-only` pseudo-class, but these browsers seem finicky about repainting when the `contenteditable` attribute changes.

This branch switches to using the Portable Text Editor's `data-read-only` attribute, which fixes the problem.

> [!NOTE]
> In the before video, the string input gets stuck in the read-only style until the user interacts with it.

https://github.com/user-attachments/assets/c083c9cc-4e48-41f3-946a-a8ea31276384

https://github.com/user-attachments/assets/45a493cb-4e0e-42d8-a887-e6b59754b1b0

### What to review

Input style when switching inline changes on _after_ they've been switched off.

### Testing

Tested in Safari, Chrome, and Firefox to ensure styles are updated when input exits read-only mode.