### PR TITLE
chore(renovate): group `@portabletext/*` deps PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,18 +47,12 @@
         "replacement",
         "rollback"
       ],
-      "matchPackageNames": [
-        "!@portabletext/block-tools",
-        "!@portabletext/editor",
-        "!@sanity/client",
-        "!@sanity/ui"
-      ]
+      "matchPackageNames": ["!@sanity/client", "!@sanity/ui"]
     },
     {
       "matchDepTypes": ["dependencies"],
       "matchPackageNames": [
-        "@portabletext/block-tools",
-        "@portabletext/editor",
+        "@portabletext/*",
         "@sanity/bifur-client",
         "@sanity/client",
         "@sanity/import",
@@ -116,6 +110,12 @@
         "styled-components",
         "typescript"
       ],
+      "dependencyDashboardApproval": false,
+      "schedule": ["every weekday"]
+    },
+    {
+      "description": "Upgrade @portabletext/* packages together",
+      "matchPackageNames": ["@portabletext/*"],
       "dependencyDashboardApproval": false,
       "schedule": ["every weekday"]
     },


### PR DESCRIPTION
Soon, a few more `@portabletext/*` dependencies will be added to the `sanity` package, and I thought it might be helpful to group these packages in a single Renovate PR.