### PR TITLE
chore(renovate): exclude `@portabletext/*` packages from the dev-non-major group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,7 +47,7 @@
         "replacement",
         "rollback"
       ],
-      "matchPackageNames": ["!@sanity/client", "!@sanity/ui"]
+      "matchPackageNames": ["!@portabletext/*", "!@sanity/client", "!@sanity/ui"]
     },
     {
       "matchDepTypes": ["dependencies"],
@@ -117,7 +117,8 @@
       "description": "Upgrade @portabletext/* packages together",
       "matchPackageNames": ["@portabletext/*"],
       "dependencyDashboardApproval": false,
-      "schedule": ["every weekday"]
+      "schedule": ["every weekday"],
+      "groupName": "portabletext"
     },
     {
       "description": "Group TypeScript related deps in a single PR, as they often have to update together",


### PR DESCRIPTION
Also, give the `@portabletext/*` group a `groupName`.