### PR TITLE
refactor(sanity): require complete `SanityDocument` for `compareValue`

### DIFF
--- a/packages/sanity/src/core/form/studio/FormBuilder.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilder.tsx
@@ -81,7 +81,7 @@ export interface FormBuilderProps
   schemaType: ObjectSchemaType
   validation: ValidationMarker[]
   value: FormDocumentValue | undefined
-  compareValue?: Partial<SanityDocument>
+  compareValue?: SanityDocument
 }
 
 /**

--- a/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
@@ -33,7 +33,7 @@ export interface DocumentPaneContextValue extends Pick<NodeChronologyProps, 'has
   closeInspector: (inspectorName?: string) => void
   collapsedFieldSets: StateTree<boolean> | undefined
   collapsedPaths: StateTree<boolean> | undefined
-  compareValue: Partial<SanityDocument> | null
+  compareValue: SanityDocument | null
   connectionState: 'connecting' | 'reconnecting' | 'connected'
   displayed: Partial<SanityDocument> | null
   displayInlineChanges?: boolean


### PR DESCRIPTION
### Description

This provides better compatibility with other parts of the code that we may wish to pass `compareValue` to, which are typed as `FormDocumentValue`. `Partial<SanityDocument>` doesn't require the `_type` and `_id` fields, whereas `FormDocumentValue` does.

We know these values are present in the data, because `compareValue` reflects an existent document. The type now reflects that.

### What to review

The changed type.

### Testing

Type check succeeds.