### PR TITLE
feat(media): allow setting aspect definition to public

### DIFF
--- a/packages/@sanity/types/src/mediaLibrary/defineAssetAspect.test.ts
+++ b/packages/@sanity/types/src/mediaLibrary/defineAssetAspect.test.ts
@@ -37,6 +37,7 @@ describe('defineAssetAspect', () => {
           "title": "Some Aspect",
           "type": "object",
         },
+        "public": undefined,
       }
     `)
   })
@@ -52,6 +53,23 @@ describe('defineAssetAspect', () => {
           type: 'string',
         }),
       ],
+    })
+
+    expect(aspect._id).toBe('someAspect')
+  })
+
+  it('can set public', () => {
+    const aspect = defineAssetAspect({
+      name: 'someAspect',
+      title: 'Some Aspect',
+      type: 'object',
+      fields: [
+        defineField({
+          name: 'test',
+          type: 'string',
+        }),
+      ],
+      public: true,
     })
 
     expect(aspect._id).toBe('someAspect')

--- a/packages/@sanity/types/src/mediaLibrary/defineAssetAspect.ts
+++ b/packages/@sanity/types/src/mediaLibrary/defineAssetAspect.ts
@@ -24,5 +24,6 @@ export function defineAssetAspect(
     ...(assetType && {
       assetType: Array.isArray(assetType) ? assetType : [assetType],
     }),
+    public: definition.public,
   }
 }

--- a/packages/@sanity/types/src/mediaLibrary/types.ts
+++ b/packages/@sanity/types/src/mediaLibrary/types.ts
@@ -14,6 +14,9 @@ export type MediaLibraryAssetAspectSupportedFieldDefinitions = FieldDefinition<
  */
 export type MediaLibraryAssetAspectDefinition = MediaLibraryAssetAspectSupportedFieldDefinitions & {
   assetType?: MediaLibraryAssetType | MediaLibraryAssetType[]
+
+  // Whether the aspect is publicly available from GROQ queries
+  public?: boolean
 }
 
 /**
@@ -47,4 +50,5 @@ export interface MediaLibraryAssetAspectDocument extends SanityDocumentLike {
    */
   assetType?: MediaLibraryAssetType[]
   definition: FieldDefinition
+  public?: boolean
 }


### PR DESCRIPTION
### Description

new groq method `media::aspect(REF, ASPECT_NAME)` checks if the aspect definition is set public to public before resolving the value

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

✅ 

### Notes for release

* Media Library: By setting `public` on the media library aspect you can now resolve aspect value from your datasets by using the new `media::aspect(MEDIA_REF, ASPECT_NAME)` GROQ method
