### PR TITLE
refactor(sanity): validate that there is no callbacks in aspects

### DIFF
--- a/packages/@sanity/schema/src/sanity/validateMediaLibraryAssetAspect.ts
+++ b/packages/@sanity/schema/src/sanity/validateMediaLibraryAssetAspect.ts
@@ -2,6 +2,7 @@ import {type SchemaValidationProblem} from '@sanity/types'
 
 import {groupProblems} from './groupProblems'
 import {validateSchema} from './validateSchema'
+import {validateNoCallbacks} from './validation/utils/validateNoCallbacks'
 
 function unsupportedTypeValidator(typeLabel: string) {
   return function () {
@@ -16,6 +17,13 @@ function unsupportedTypeValidator(typeLabel: string) {
   }
 }
 
+function noCallbacksVisitor(typeDef: any, visitorContext: any) {
+  return {
+    ...typeDef,
+    _problems: validateNoCallbacks(typeDef),
+  }
+}
+
 /**
  * Ensure that the provided value is a valid Media Library asset aspect that can be safely deployed.
  *
@@ -27,6 +35,7 @@ export function validateMediaLibraryAssetAspect(
   const input = [maybeAspect]
 
   const validated = validateSchema(input, {
+    transformCommonVisitors: (visitors) => [...visitors, noCallbacksVisitor],
     transformTypeVisitors: (typeVisitors) => ({
       ...typeVisitors,
       document: unsupportedTypeValidator('document'),

--- a/packages/@sanity/schema/src/sanity/validation/utils/validateNoCallbacks.ts
+++ b/packages/@sanity/schema/src/sanity/validation/utils/validateNoCallbacks.ts
@@ -1,0 +1,357 @@
+import {type SchemaValidationResult} from '../../typedefs'
+import {error} from '../createValidationResult'
+import {isComponentLike} from './isComponent'
+
+/**
+ * Validates that a type definition contains no callback functions or code.
+ * This is useful for contexts where schemas need to be serializable.
+ *
+ * @internal
+ */
+export function validateNoCallbacks(typeDef: any): SchemaValidationResult[] {
+  const problems: SchemaValidationResult[] = []
+
+  problems.push(...validateConditionalProperties(typeDef))
+  problems.push(...validateValueProperties(typeDef))
+  problems.push(...validateComponents(typeDef))
+  problems.push(...validateOptions(typeDef))
+  problems.push(...validateFieldsetsAndGroups(typeDef))
+  problems.push(...validateBlockSpecific(typeDef))
+
+  return problems
+}
+
+function validateConditionalProperties(typeDef: any): SchemaValidationResult[] {
+  const problems: SchemaValidationResult[] = []
+
+  if (typeof typeDef.hidden === 'function') {
+    problems.push(
+      error(`The "hidden" property cannot be a function. Use a static boolean value instead.`),
+    )
+  }
+
+  if (typeof typeDef.readOnly === 'function') {
+    problems.push(
+      error(`The "readOnly" property cannot be a function. Use a static boolean value instead.`),
+    )
+  }
+
+  return problems
+}
+
+function validateValueProperties(typeDef: any): SchemaValidationResult[] {
+  const problems: SchemaValidationResult[] = []
+
+  if (typeof typeDef.initialValue === 'function') {
+    problems.push(
+      error(`The "initialValue" property cannot be a function. Use a static value instead.`),
+    )
+  }
+
+  if (typeof typeDef.validation === 'function') {
+    problems.push(
+      error(`The "validation" property cannot be a function. Use static validation rules instead.`),
+    )
+  }
+
+  if (typeDef.validation && typeof typeDef.validation === 'object') {
+    const hasCustomValidator = checkForCustomValidators(typeDef.validation)
+    if (hasCustomValidator) {
+      problems.push(
+        error(`Custom validation functions are not supported. Use only built-in validation rules.`),
+      )
+    }
+  }
+
+  if (typeDef.preview?.prepare && typeof typeDef.preview.prepare === 'function') {
+    problems.push(error(`The "preview.prepare" property cannot be a function.`))
+  }
+
+  if (typeDef.blockEditor?.render) {
+    problems.push(error(`The "blockEditor.render" property cannot be a function.`))
+  }
+
+  return problems
+}
+
+function validateComponents(typeDef: any): SchemaValidationResult[] {
+  const problems: SchemaValidationResult[] = []
+
+  if (!typeDef.components) {
+    return problems
+  }
+
+  const componentProps = [
+    'input',
+    'field',
+    'item',
+    'preview',
+    'diff',
+    'block',
+    'inlineBlock',
+    'annotation',
+  ]
+
+  for (const prop of componentProps) {
+    if (typeDef.components[prop] && isComponentLike(typeDef.components[prop])) {
+      problems.push(error(`The "components.${prop}" property cannot be a component function.`))
+    }
+  }
+
+  if (typeDef.components.portableText?.plugins) {
+    problems.push(
+      error(`The "components.portableText.plugins" property cannot contain plugin functions.`),
+    )
+  }
+
+  return problems
+}
+
+function validateOptions(typeDef: any): SchemaValidationResult[] {
+  const problems: SchemaValidationResult[] = []
+
+  if (!typeDef.options || typeof typeDef.options !== 'object') {
+    return problems
+  }
+
+  problems.push(...validateCommonOptions(typeDef.options))
+  problems.push(...validateAssetSources(typeDef.options))
+  problems.push(...validateOtherFunctionOptions(typeDef.options))
+
+  return problems
+}
+
+function validateCommonOptions(options: any): SchemaValidationResult[] {
+  const problems: SchemaValidationResult[] = []
+
+  if (typeof options.filter === 'function') {
+    problems.push(
+      error(
+        `The "options.filter" property cannot be a function. Use a static GROQ filter string with filterParams instead.`,
+      ),
+    )
+  }
+
+  if (typeof options.source === 'function') {
+    problems.push(
+      error(
+        `The "options.source" property cannot be a function. Use a static string path instead.`,
+      ),
+    )
+  }
+
+  if (typeof options.slugify === 'function') {
+    problems.push(error(`The "options.slugify" property cannot be a function.`))
+  }
+
+  if (typeof options.isUnique === 'function') {
+    problems.push(error(`The "options.isUnique" property cannot be a function.`))
+  }
+
+  return problems
+}
+
+function validateAssetSources(options: any): SchemaValidationResult[] {
+  const problems: SchemaValidationResult[] = []
+
+  if (!Array.isArray(options.sources)) {
+    return problems
+  }
+
+  for (let i = 0; i < options.sources.length; i++) {
+    const source = options.sources[i]
+    if (!source) continue
+
+    if (source.component && isComponentLike(source.component)) {
+      problems.push(
+        error(`Asset source at index ${i} has a "component" property that cannot be a function.`),
+      )
+    }
+
+    if (source.icon && isComponentLike(source.icon)) {
+      problems.push(
+        error(`Asset source at index ${i} has an "icon" property that cannot be a component.`),
+      )
+    }
+
+    if (typeof source === 'function' || source.Uploader) {
+      problems.push(error(`Asset source at index ${i} contains functions or classes.`))
+    }
+  }
+
+  return problems
+}
+
+function validateOtherFunctionOptions(options: any): SchemaValidationResult[] {
+  const problems: SchemaValidationResult[] = []
+  const knownFunctionOptions = ['filter', 'source', 'slugify', 'isUnique']
+
+  for (const [key, value] of Object.entries(options)) {
+    if (typeof value === 'function' && !knownFunctionOptions.includes(key)) {
+      problems.push(error(`The "options.${key}" property cannot be a function.`))
+    }
+  }
+
+  return problems
+}
+
+function validateFieldsetsAndGroups(typeDef: any): SchemaValidationResult[] {
+  const problems: SchemaValidationResult[] = []
+
+  problems.push(...validateFieldsets(typeDef.fieldsets))
+  problems.push(...validateGroups(typeDef.groups))
+
+  return problems
+}
+
+function validateFieldsets(fieldsets: any): SchemaValidationResult[] {
+  const problems: SchemaValidationResult[] = []
+
+  if (!Array.isArray(fieldsets)) {
+    return problems
+  }
+
+  for (let i = 0; i < fieldsets.length; i++) {
+    const fieldset = fieldsets[i]
+    if (!fieldset) continue
+
+    if (typeof fieldset.hidden === 'function') {
+      problems.push(
+        error(`Fieldset at index ${i} has a "hidden" property that cannot be a function.`),
+      )
+    }
+
+    if (typeof fieldset.readOnly === 'function') {
+      problems.push(
+        error(`Fieldset at index ${i} has a "readOnly" property that cannot be a function.`),
+      )
+    }
+  }
+
+  return problems
+}
+
+function validateGroups(groups: any): SchemaValidationResult[] {
+  const problems: SchemaValidationResult[] = []
+
+  if (!Array.isArray(groups)) {
+    return problems
+  }
+
+  for (let i = 0; i < groups.length; i++) {
+    const group = groups[i]
+    if (!group) continue
+
+    if (typeof group.hidden === 'function') {
+      problems.push(
+        error(`Field group at index ${i} has a "hidden" property that cannot be a function.`),
+      )
+    }
+
+    if (group.icon && isComponentLike(group.icon)) {
+      problems.push(
+        error(`Field group at index ${i} has an "icon" property that cannot be a component.`),
+      )
+    }
+  }
+
+  return problems
+}
+
+function validateBlockSpecific(typeDef: any): SchemaValidationResult[] {
+  const problems: SchemaValidationResult[] = []
+
+  if (typeDef.type !== 'block') {
+    return problems
+  }
+
+  problems.push(...validateBlockStyles(typeDef.styles))
+  problems.push(...validateBlockMarks(typeDef.marks))
+
+  return problems
+}
+
+function validateBlockStyles(styles: any): SchemaValidationResult[] {
+  const problems: SchemaValidationResult[] = []
+
+  if (!Array.isArray(styles)) {
+    return problems
+  }
+
+  for (let i = 0; i < styles.length; i++) {
+    const style = styles[i]
+    if (style?.component && isComponentLike(style.component)) {
+      problems.push(
+        error(`Block style at index ${i} has a "component" property that cannot be a function.`),
+      )
+    }
+  }
+
+  return problems
+}
+
+function validateBlockMarks(marks: any): SchemaValidationResult[] {
+  const problems: SchemaValidationResult[] = []
+
+  if (!marks) {
+    return problems
+  }
+
+  if (Array.isArray(marks.decorators)) {
+    for (let i = 0; i < marks.decorators.length; i++) {
+      const decorator = marks.decorators[i]
+      if (decorator?.component && isComponentLike(decorator.component)) {
+        problems.push(
+          error(
+            `Block decorator at index ${i} has a "component" property that cannot be a function.`,
+          ),
+        )
+      }
+    }
+  }
+
+  if (Array.isArray(marks.annotations)) {
+    for (let i = 0; i < marks.annotations.length; i++) {
+      const annotation = marks.annotations[i]
+      if (annotation?.component && isComponentLike(annotation.component)) {
+        problems.push(
+          error(
+            `Block annotation at index ${i} has a "component" property that cannot be a function.`,
+          ),
+        )
+      }
+    }
+  }
+
+  return problems
+}
+
+/**
+ * Checks if a validation rule or array of rules contains custom validators
+ */
+function checkForCustomValidators(validation: any): boolean {
+  if (!validation) return false
+
+  // If it's an array, check each item
+  if (Array.isArray(validation)) {
+    return validation.some((v) => checkForCustomValidators(v))
+  }
+
+  // Check if it's a Rule object with custom validators
+  if (typeof validation === 'object') {
+    // Look for _rules array which contains the actual validation rules
+    if (Array.isArray(validation._rules)) {
+      return validation._rules.some((rule: any) => {
+        // Check if the rule has a custom validator function
+        return rule.flag === 'custom' && typeof rule.constraint === 'function'
+      })
+    }
+
+    // Also check for direct custom property (different Rule structure)
+    if (typeof validation.custom === 'function') {
+      return true
+    }
+  }
+
+  return false
+}

--- a/packages/@sanity/schema/test/validation/validateMediaLibraryAssetAspect.test.ts
+++ b/packages/@sanity/schema/test/validation/validateMediaLibraryAssetAspect.test.ts
@@ -1,0 +1,802 @@
+import {describe, expect, test} from 'vitest'
+
+import {validateMediaLibraryAssetAspect} from '../../src/sanity/validateMediaLibraryAssetAspect'
+
+describe('validateMediaLibraryAssetAspect', () => {
+  describe('unsupported types', () => {
+    test('should error on document type', () => {
+      const aspect = {
+        type: 'document',
+        name: 'myDoc',
+        fields: [{name: 'title', type: 'string'}],
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toHaveLength(1)
+      expect(errors[0][0].message).toContain('Type unsupported in Media Library aspects: document')
+    })
+
+    test('should error on image type', () => {
+      const aspect = {
+        type: 'image',
+        name: 'myImage',
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain('Type unsupported in Media Library aspects: image')
+    })
+
+    test('should error on file type', () => {
+      const aspect = {
+        type: 'file',
+        name: 'myFile',
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain('Type unsupported in Media Library aspects: file')
+    })
+
+    test('should error on reference type', () => {
+      const aspect = {
+        type: 'reference',
+        name: 'myRef',
+        to: [{type: 'document'}],
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain('Type unsupported in Media Library aspects: reference')
+    })
+
+    test('should error on crossDatasetReference type', () => {
+      const aspect = {
+        type: 'crossDatasetReference',
+        name: 'myCrossRef',
+        dataset: 'production',
+        projectId: 'abc123',
+        to: [{type: 'document'}],
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain(
+        'Type unsupported in Media Library aspects: cross dataset reference',
+      )
+    })
+  })
+
+  describe('conditional properties validation', () => {
+    test('should error on hidden as function', () => {
+      const aspect = {
+        type: 'string',
+        name: 'myString',
+        hidden: () => true,
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain('"hidden" property cannot be a function')
+    })
+
+    test('should allow hidden as boolean', () => {
+      const aspect = {
+        type: 'string',
+        name: 'myString',
+        hidden: true,
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(true)
+      expect(errors).toHaveLength(0)
+    })
+
+    test('should error on readOnly as function', () => {
+      const aspect = {
+        type: 'string',
+        name: 'myString',
+        readOnly: ({currentUser}: any) => !currentUser,
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain('"readOnly" property cannot be a function')
+    })
+
+    test('should allow readOnly as boolean', () => {
+      const aspect = {
+        type: 'string',
+        name: 'myString',
+        readOnly: false,
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(true)
+      expect(errors).toHaveLength(0)
+    })
+  })
+
+  describe('initialValue validation', () => {
+    test('should error on initialValue as function', () => {
+      const aspect = {
+        type: 'string',
+        name: 'myString',
+        initialValue: () => 'default value',
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain('"initialValue" property cannot be a function')
+    })
+
+    test('should allow initialValue as static value', () => {
+      const aspect = {
+        type: 'string',
+        name: 'myString',
+        initialValue: 'default value',
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(true)
+      expect(errors).toHaveLength(0)
+    })
+  })
+
+  describe('validation property validation', () => {
+    test('should error on validation as function', () => {
+      const aspect = {
+        type: 'string',
+        name: 'myString',
+        validation: (Rule: any) => Rule.required(),
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain('"validation" property cannot be a function')
+    })
+
+    test('should error on custom validation rule', () => {
+      // Simulate a Rule object with custom validator
+      const aspect = {
+        type: 'string',
+        name: 'myString',
+        validation: {
+          _rules: [
+            {flag: 'custom', constraint: (value: any) => value === 'test' || 'Must be test'},
+          ],
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain('Custom validation functions are not supported')
+    })
+
+    test('should allow static validation rules', () => {
+      const aspect = {
+        type: 'string',
+        name: 'myString',
+        validation: {
+          _rules: [{flag: 'required'}, {flag: 'min', constraint: 5}],
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(true)
+      expect(errors).toHaveLength(0)
+    })
+  })
+
+  describe('preview.prepare validation', () => {
+    test('should error on preview.prepare function', () => {
+      const aspect = {
+        type: 'object',
+        name: 'myObject',
+        fields: [{name: 'title', type: 'string'}],
+        preview: {
+          select: {title: 'title'},
+          prepare: ({title}: any) => ({title: title?.toUpperCase()}),
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain('"preview.prepare" property cannot be a function')
+    })
+
+    test('should allow preview.select without prepare', () => {
+      const aspect = {
+        type: 'object',
+        name: 'myObject',
+        fields: [{name: 'title', type: 'string'}],
+        preview: {
+          select: {title: 'title'},
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(true)
+      expect(errors).toHaveLength(0)
+    })
+  })
+
+  describe('components validation', () => {
+    test('should error on components.input', () => {
+      const TestComponent = () => null
+      const aspect = {
+        type: 'string',
+        name: 'myString',
+        components: {
+          input: TestComponent,
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain('"components.input" property cannot be a component')
+    })
+
+    test('should error on components.field', () => {
+      const TestComponent = () => null
+      const aspect = {
+        type: 'string',
+        name: 'myString',
+        components: {
+          field: TestComponent,
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain('"components.field" property cannot be a component')
+    })
+
+    test('should error on components.item', () => {
+      const TestComponent = () => null
+      const aspect = {
+        type: 'array',
+        name: 'myArray',
+        of: [{type: 'string'}],
+        components: {
+          item: TestComponent,
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain('"components.item" property cannot be a component')
+    })
+
+    test('should error on components.preview', () => {
+      const TestComponent = () => null
+      const aspect = {
+        type: 'object',
+        name: 'myObject',
+        fields: [{name: 'title', type: 'string'}],
+        components: {
+          preview: TestComponent,
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain('"components.preview" property cannot be a component')
+    })
+
+    test('should error on multiple component properties', () => {
+      const TestComponent = () => null
+      const aspect = {
+        type: 'object',
+        name: 'myObject',
+        fields: [{name: 'title', type: 'string'}],
+        components: {
+          input: TestComponent,
+          field: TestComponent,
+          preview: TestComponent,
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0].length).toBeGreaterThanOrEqual(3)
+    })
+  })
+
+  describe('options with functions validation', () => {
+    test('should error on options.filter as function (reference type)', () => {
+      const aspect = {
+        type: 'string',
+        name: 'myString',
+        options: {
+          filter: () => ({filter: '_type == "product"'}),
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain('"options.filter" property cannot be a function')
+    })
+
+    test('should error on slug options with functions', () => {
+      const aspect = {
+        type: 'slug',
+        name: 'mySlug',
+        options: {
+          source: (doc: any) => doc.title,
+          slugify: (input: string) => input.toLowerCase().replace(/\s+/g, '-'),
+          isUnique: async () => true,
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0].length).toBe(3)
+      const messages = errors[0].map((e) => e.message)
+      expect(
+        messages.some((m) => m.includes('"options.source" property cannot be a function')),
+      ).toBe(true)
+      expect(
+        messages.some((m) => m.includes('"options.slugify" property cannot be a function')),
+      ).toBe(true)
+      expect(
+        messages.some((m) => m.includes('"options.isUnique" property cannot be a function')),
+      ).toBe(true)
+    })
+
+    test('should allow slug with static options', () => {
+      const aspect = {
+        type: 'slug',
+        name: 'mySlug',
+        options: {
+          source: 'title',
+          maxLength: 96,
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(true)
+      expect(errors).toHaveLength(0)
+    })
+
+    test('should error on arbitrary function in options', () => {
+      const aspect = {
+        type: 'string',
+        name: 'myString',
+        options: {
+          customHandler: () => 'test',
+          transform: (val: any) => val.toUpperCase(),
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0].length).toBe(2)
+    })
+  })
+
+  describe('nested fields validation', () => {
+    test('should validate functions in nested object fields', () => {
+      const aspect = {
+        type: 'object',
+        name: 'myObject',
+        fields: [
+          {
+            name: 'nested',
+            type: 'object',
+            hidden: () => false,
+            fields: [
+              {
+                name: 'deep',
+                type: 'string',
+                initialValue: () => 'default',
+              },
+            ],
+          },
+        ],
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(2) // One for outer hidden, one for inner initialValue
+    })
+
+    test('should validate functions in array of fields', () => {
+      const aspect = {
+        type: 'array',
+        name: 'myArray',
+        of: [
+          {
+            type: 'object',
+            fields: [
+              {
+                name: 'title',
+                type: 'string',
+                hidden: ({parent}: any) => !parent,
+              },
+            ],
+          },
+        ],
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(
+        errors[0].some((e) => e.message.includes('"hidden" property cannot be a function')),
+      ).toBe(true)
+    })
+  })
+
+  describe('fieldsets and groups validation', () => {
+    test('should error on fieldset hidden as function', () => {
+      const aspect = {
+        type: 'object',
+        name: 'myObject',
+        fields: [{name: 'title', type: 'string', fieldset: 'main'}],
+        fieldsets: [
+          {
+            name: 'main',
+            title: 'Main',
+            hidden: () => false,
+          },
+        ],
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain(
+        'Fieldset at index 0 has a "hidden" property that cannot be a function',
+      )
+    })
+
+    test('should error on fieldset readOnly as function', () => {
+      const aspect = {
+        type: 'object',
+        name: 'myObject',
+        fields: [{name: 'title', type: 'string', fieldset: 'main'}],
+        fieldsets: [
+          {
+            name: 'main',
+            title: 'Main',
+            readOnly: ({currentUser}: any) => !currentUser?.isAdmin,
+          },
+        ],
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain(
+        'Fieldset at index 0 has a "readOnly" property that cannot be a function',
+      )
+    })
+
+    test('should error on group hidden as function', () => {
+      const aspect = {
+        type: 'object',
+        name: 'myObject',
+        fields: [{name: 'title', type: 'string', group: 'main'}],
+        groups: [
+          {
+            name: 'main',
+            title: 'Main',
+            hidden: ({currentUser}: any) => !currentUser,
+          },
+        ],
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain(
+        'Field group at index 0 has a "hidden" property that cannot be a function',
+      )
+    })
+
+    test('should error on group icon as component', () => {
+      const IconComponent = () => null
+      const aspect = {
+        type: 'object',
+        name: 'myObject',
+        fields: [{name: 'title', type: 'string', group: 'main'}],
+        groups: [
+          {
+            name: 'main',
+            title: 'Main',
+            icon: IconComponent,
+          },
+        ],
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      expect(errors).toHaveLength(1)
+      expect(errors[0][0].message).toContain(
+        'Field group at index 0 has an "icon" property that cannot be a component',
+      )
+    })
+  })
+
+  describe('block type specific validation', () => {
+    test('should error on block style component', () => {
+      const StyleComponent = () => null
+      const aspect = {
+        type: 'block',
+        name: 'myBlock',
+        styles: [
+          {title: 'Normal', value: 'normal'},
+          {title: 'Custom', value: 'custom', component: StyleComponent},
+        ],
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      // Block types create two error groups due to how groupProblems processes them
+      expect(errors).toHaveLength(2)
+      expect(errors[0][0].message).toContain('Block style at index 1 has a "component" property')
+      expect(errors[1][0].message).toContain('Block style at index 1 has a "component" property')
+    })
+
+    test('should error on block decorator component', () => {
+      const DecoratorComponent = () => null
+      const aspect = {
+        type: 'block',
+        name: 'myBlock',
+        marks: {
+          decorators: [
+            {title: 'Strong', value: 'strong'},
+            {title: 'Custom', value: 'custom', component: DecoratorComponent},
+          ],
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      // Block types create two error groups due to how groupProblems processes them
+      expect(errors).toHaveLength(2)
+      expect(errors[0][0].message).toContain(
+        'Block decorator at index 1 has a "component" property',
+      )
+      expect(errors[1][0].message).toContain(
+        'Block decorator at index 1 has a "component" property',
+      )
+    })
+
+    test('should error on block annotation component', () => {
+      const AnnotationComponent = () => null
+      const aspect = {
+        type: 'block',
+        name: 'myBlock',
+        marks: {
+          annotations: [
+            {
+              name: 'customLink',
+              type: 'object',
+              fields: [{name: 'href', type: 'url'}],
+              component: AnnotationComponent,
+            },
+          ],
+        },
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      // Block types create two error groups due to how groupProblems processes them
+      expect(errors).toHaveLength(2)
+      expect(errors[0][0].message).toContain(
+        'Block annotation at index 0 has a "component" property',
+      )
+      expect(errors[1][0].message).toContain(
+        'Block annotation at index 0 has a "component" property',
+      )
+    })
+  })
+
+  describe('valid aspects', () => {
+    test('should pass for valid string field', () => {
+      const aspect = {
+        type: 'string',
+        name: 'myString',
+        title: 'My String',
+        description: 'A simple string field',
+        initialValue: 'default',
+        hidden: false,
+        readOnly: false,
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(true)
+      expect(errors).toHaveLength(0)
+    })
+
+    test('should pass for valid object with fields', () => {
+      const aspect = {
+        type: 'object',
+        name: 'myObject',
+        title: 'My Object',
+        fields: [
+          {name: 'title', type: 'string', title: 'Title'},
+          {name: 'count', type: 'number', title: 'Count'},
+          {name: 'isActive', type: 'boolean', title: 'Active'},
+        ],
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(true)
+      expect(errors).toHaveLength(0)
+    })
+
+    test('should pass for valid array', () => {
+      const aspect = {
+        type: 'array',
+        name: 'myArray',
+        title: 'My Array',
+        of: [{type: 'string'}, {type: 'number'}],
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(true)
+      expect(errors).toHaveLength(0)
+    })
+
+    test('should pass for valid nested structure', () => {
+      const aspect = {
+        type: 'object',
+        name: 'complexObject',
+        fields: [
+          {
+            name: 'metadata',
+            type: 'object',
+            fields: [
+              {name: 'created', type: 'datetime'},
+              {name: 'author', type: 'string'},
+            ],
+          },
+          {
+            name: 'tags',
+            type: 'array',
+            of: [{type: 'string'}],
+          },
+        ],
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(true)
+      expect(errors).toHaveLength(0)
+    })
+  })
+
+  describe('multiple errors', () => {
+    test('should collect all validation errors', () => {
+      const TestComponent = () => null
+      const aspect = {
+        type: 'object',
+        name: 'myObject',
+        hidden: () => true,
+        readOnly: ({currentUser}: any) => !currentUser,
+        initialValue: () => ({}),
+        preview: {
+          prepare: () => ({title: 'test'}),
+        },
+        components: {
+          input: TestComponent,
+          field: TestComponent,
+        },
+        fields: [
+          {
+            name: 'title',
+            type: 'string',
+            hidden: () => false,
+            validation: (Rule: any) => Rule.required(),
+          },
+          {
+            name: 'slug',
+            type: 'slug',
+            options: {
+              source: () => 'title',
+              slugify: (str: string) => str.toLowerCase(),
+            },
+          },
+        ],
+      }
+
+      const [isValid, errors] = validateMediaLibraryAssetAspect(aspect)
+
+      expect(isValid).toBe(false)
+      // Should have multiple error groups (root object + nested fields)
+      expect(errors.length).toBeGreaterThan(1)
+
+      // Flatten all errors to check messages
+      const allErrors = errors.flat()
+      const errorMessages = allErrors.map((e) => e.message)
+
+      // Check for various error types
+      expect(errorMessages.some((m) => m.includes('"hidden" property cannot be a function'))).toBe(
+        true,
+      )
+      expect(
+        errorMessages.some((m) => m.includes('"readOnly" property cannot be a function')),
+      ).toBe(true)
+      expect(
+        errorMessages.some((m) => m.includes('"initialValue" property cannot be a function')),
+      ).toBe(true)
+      expect(
+        errorMessages.some((m) => m.includes('"preview.prepare" property cannot be a function')),
+      ).toBe(true)
+      expect(
+        errorMessages.some((m) => m.includes('"components.input" property cannot be a component')),
+      ).toBe(true)
+      expect(
+        errorMessages.some((m) => m.includes('"components.field" property cannot be a component')),
+      ).toBe(true)
+      expect(
+        errorMessages.some((m) => m.includes('"validation" property cannot be a function')),
+      ).toBe(true)
+      expect(
+        errorMessages.some((m) => m.includes('"options.source" property cannot be a function')),
+      ).toBe(true)
+      expect(
+        errorMessages.some((m) => m.includes('"options.slugify" property cannot be a function')),
+      ).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
### Description

Added validation to prevent callback functions in Media Library asset aspects. This ensures that asset aspects are serializable and can be safely deployed without relying on runtime code execution.

Part of DAM-766

### What to review

- The new `validateNoCallbacks` utility that checks for functions in schema definitions
- Integration with the existing `validateMediaLibraryAssetAspect` function
- Comprehensive test coverage for various schema patterns with callbacks

### Testing

Added extensive test coverage in `validateMediaLibraryAssetAspect.test.ts` that verifies:
- Detection of functions in conditional properties (hidden, readOnly)
- Detection of functions in initialValue, validation, and preview.prepare
- Detection of component functions in various contexts
- Detection of functions in options objects (filter, source, slugify, etc.)
- Detection of functions in fieldsets and groups
- Detection of component functions in block type styles, decorators, and annotations
- Validation of valid aspects without functions

### Notes for release

Added validation to prevent callback functions in Media Library asset aspects. Asset aspects must now use static values instead of functions for properties like `hidden`, `readOnly`, `initialValue`, `validation`, and component definitions. This ensures that asset aspects are fully serializable and can be safely deployed.