### PR TITLE
fix(sanity): scrolling in expanded Portable Text Editor

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.styles.tsx
@@ -64,5 +64,6 @@ export const ExpandedLayer = styled(Layer)`
 `
 
 export const StringDiffContainer = styled.div`
+  height: 100%;
   ${stringDiffContainerStyles}
 `


### PR DESCRIPTION
### Description

Commit 75e44c2b added support for showing inline diffs in Portable Text Editor. It adds a new container element to Portable Text Editor in order to provide the necessary styles. However, this container broke scrolling when Portable Text Editor is expanded.

This branch fixes scrolling in expanded Portable Text Editor, employing the same approach that other PTE container elements use (such as `UploadTargetCard`).

### What to review

Expanded Portable Text Editor can be scrolled.

### Testing

Verified in Test Studio.

### Notes for release

(Not needed. The bug hasn't been shipped in a stable release yet).