### PR TITLE
fix(core): close icon alignment in studio announcements card

### DIFF
--- a/packages/sanity/src/core/studio/studioAnnouncements/StudioAnnouncementsCard.tsx
+++ b/packages/sanity/src/core/studio/studioAnnouncements/StudioAnnouncementsCard.tsx
@@ -71,7 +71,7 @@ const Root = styled.div((props) => {
 const ButtonRoot = styled.div`
   z-index: 1;
   position: absolute;
-  top: 0px;
+  top: 2px;
   right: 6px;
 `
 


### PR DESCRIPTION
### Description
Before:
<img width="702" height="204" alt="image" src="https://github.com/user-attachments/assets/ed949fc7-cafc-480f-bcb9-f1c89c947b72" />

Now 
<img width="1196" height="348" alt="image" src="https://github.com/user-attachments/assets/54c0a411-07ca-4fc1-864a-e32bb2e22d45" />

<img width="1200" height="328" alt="image" src="https://github.com/user-attachments/assets/d1a1c038-44bd-4d50-84d9-7b9903eccf45" />



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
