### PR TITLE
chore: remove sanity dependency for workspace root

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,6 @@
     "read-package-up": "^11.0.0",
     "rimraf": "^5.0.10",
     "rxjs": "^7.8.2",
-    "sanity": "workspace:*",
     "semver": "^7.7.2",
     "tsx": "^4.20.6",
     "turbo": "^2.5.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,9 +256,6 @@ importers:
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
-      sanity:
-        specifier: workspace:*
-        version: link:packages/sanity
       semver:
         specifier: ^7.7.2
         version: 7.7.3


### PR DESCRIPTION
Can't find any indication the `sanity` package is used by any of the code that lives outside of a workspace package here, so this should be safe to remove.
