### PR TITLE
feat(core): adds View scheduled drafts menu action for scheduled drafts

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1338,6 +1338,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
     'Successfully set <strong>{{title}}</strong> to be unpublished on release',
   /** Action message for when the view release is pressed */
   'release.action.view-release': 'View release',
+  /** Action message for when the view scheduled drafts is pressed */
+  'release.action.view-scheduled-drafts': 'View scheduled drafts',
   /** Label for banner when release is scheduled */
   'release.banner.scheduled-for-publishing-on': 'Scheduled to be published on {{date}}',
   /** Label for Draft chip in document header */

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CanonicalReleaseContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CanonicalReleaseContextMenu.tsx
@@ -6,6 +6,7 @@ import {IntentLink} from 'sanity/router'
 
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
 import {useTranslation} from '../../../../i18n'
+import {RELEASES_INTENT} from '../../../plugin'
 import {CopyToReleaseMenuGroup} from './CopyToReleaseMenuGroup'
 
 interface CanonicalReleaseContextMenuProps {
@@ -50,7 +51,7 @@ export const CanonicalReleaseContextMenu = memo(function CanonicalReleaseContext
     <Menu>
       {isVersion && (
         <IntentLink
-          intent="release"
+          intent={RELEASES_INTENT}
           params={{id: fromRelease}}
           rel="noopener noreferrer"
           style={{textDecoration: 'none'}}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/ScheduledDraftContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/ScheduledDraftContextMenu.tsx
@@ -1,9 +1,13 @@
 import {type ReleaseDocument} from '@sanity/client'
+import {CalendarIcon} from '@sanity/icons'
 import {Menu, MenuDivider} from '@sanity/ui'
 import {memo} from 'react'
+import {IntentLink} from 'sanity/router'
 
 import {MenuItem} from '../../../../../ui-components'
+import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {useScheduledDraftMenuActions} from '../../../../singleDocRelease/hooks/useScheduledDraftMenuActions'
+import {RELEASES_SCHEDULED_DRAFTS_INTENT} from '../../../../singleDocRelease/plugin'
 import {CopyToReleaseMenuGroup} from './CopyToReleaseMenuGroup'
 
 interface ScheduledDraftContextMenuProps {
@@ -34,7 +38,7 @@ export const ScheduledDraftContextMenu = memo(function ScheduledDraftContextMenu
     onChangeSchedule,
     hasCreatePermission,
   } = props
-
+  const {t} = useTranslation()
   const isCopyToReleaseDisabled = disabled || !hasCreatePermission || isGoingToUnpublish
 
   const {actions, dialogs} = useScheduledDraftMenuActions({
@@ -49,6 +53,14 @@ export const ScheduledDraftContextMenu = memo(function ScheduledDraftContextMenu
       <Menu>
         <MenuItem {...actions.publishNow} />
         <MenuItem {...actions.editSchedule} />
+        <IntentLink
+          intent={RELEASES_SCHEDULED_DRAFTS_INTENT}
+          params={{view: 'drafts'}}
+          rel="noopener noreferrer"
+          style={{textDecoration: 'none'}}
+        >
+          <MenuItem icon={CalendarIcon} text={t('release.action.view-scheduled-drafts')} />
+        </IntentLink>
         <MenuDivider />
         <CopyToReleaseMenuGroup
           releases={releases}

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
@@ -1,5 +1,5 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {CalendarIcon, PublishIcon, TrashIcon} from '@sanity/icons'
+import {EditIcon, PublishIcon, TrashIcon} from '@sanity/icons'
 import {useToast} from '@sanity/ui'
 import {type ComponentProps, useCallback, useMemo, useState} from 'react'
 
@@ -112,7 +112,7 @@ export function useScheduledDraftMenuActions(
         'data-testid': 'publish-now-menu-item',
       },
       editSchedule: {
-        'icon': CalendarIcon,
+        'icon': EditIcon,
         'text': t('release.action.edit-schedule'),
         'tone': 'default' as const,
         'onClick': onEditSchedule || (() => handleMenuItemClick('edit-schedule')),


### PR DESCRIPTION
### Description
Adds `View scheduled drafts` action in context menu for easy discoverability of scheduled drafts documents.

Clicking the icon takes you to the schedules tool with the drafts selected.

https://github.com/user-attachments/assets/4213adbb-d85a-4e96-a2a1-88bce5ffbc87


#### Before
<img width="277" height="162" alt="Screenshot 2025-10-24 at 15 50 23" src="https://github.com/user-attachments/assets/8db4547e-24f8-47af-89da-a163a4accdf1" />

#### Now 
<img width="582" height="217" alt="Screenshot 2025-10-24 at 15 48 20" src="https://github.com/user-attachments/assets/4d040696-5c89-410c-8d9e-d8eaad8cd85d" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a not user facing yet
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
