### PR TITLE
chore: replace lerna run with pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "test:vitest": "vitest --run",
     "test:vitest:watch": "vitest --watch",
     "tsdoc:dev": "sanity-tsdoc dev",
-    "updated": "lerna updated",
     "watch": "pnpm --filter @sanity/* --filter sanity watch"
   },
   "lint-staged": {


### PR DESCRIPTION
### Description
After switching to lerna-lite, the package scripts that uses `lerna run` stopped working. This PR replaces `lerna run` with using pnpm instead, which should work equally well, if not better.

### What to review
Also removed the `updated` script, don't think anyone uses it.

### Testing

- Verify that the modified scripts previously using `lerna run` still works (I've confirmed they still work for me, fwiw)

### Notes for release
n/a – Internal