### PR TITLE
fix(core): use release limit instead of count for upsell dialog

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -377,6 +377,27 @@ export default defineConfig([
     mediaLibrary: {
       enabled: true,
     },
+    [QUOTA_EXCLUDED_RELEASES_ENABLED]: true,
+  },
+  {
+    name: 'growth',
+    title: 'Growth (staging)',
+
+    projectId: 'qroupali',
+    dataset: 'production',
+    ...envConfig.staging,
+    plugins: [sharedSettings({projectId: 'qroupali'})],
+    basePath: '/growth',
+    auth: {
+      loginMethod: 'token',
+    },
+    unstable_tasks: {
+      enabled: true,
+    },
+    mediaLibrary: {
+      enabled: true,
+    },
+    [QUOTA_EXCLUDED_RELEASES_ENABLED]: true,
   },
   {
     name: 'media-library-playground',

--- a/packages/sanity/src/core/releases/contexts/upsell/ReleasesUpsellProvider.tsx
+++ b/packages/sanity/src/core/releases/contexts/upsell/ReleasesUpsellProvider.tsx
@@ -1,10 +1,11 @@
 import {useCallback, useMemo, useState} from 'react'
-import {firstValueFrom} from 'rxjs'
+import {firstValueFrom, tap} from 'rxjs'
 import {ReleasesUpsellContext} from 'sanity/_singletons'
 
 import {useFeatureEnabled} from '../../../hooks'
 import {FEATURES} from '../../../hooks/useFeatureEnabled'
 import {useUpsellData} from '../../../hooks/useUpsellData'
+import {type UpsellDialogViewedInfo} from '../../../studio/upsell/__telemetry__/upsell.telemetry'
 import {UpsellDialog} from '../../../studio/upsell/UpsellDialog'
 import {useActiveReleases} from '../../store/useActiveReleases'
 import {useOrgActiveReleaseCount} from '../../store/useOrgActiveReleaseCount'
@@ -63,15 +64,12 @@ export function ReleasesUpsellProvider(props: {children: React.ReactNode}) {
     telemetryLogs.dialogDismissed()
   }, [telemetryLogs])
 
-  const [releaseCount, setReleaseCount] = useState<number | null>(null)
-
+  const [releaseLimit, setReleaseLimit] = useState<number | null>(null)
   const handleOpenDialog = useCallback(
-    (orgActiveReleaseCount?: number) => {
+    (source: UpsellDialogViewedInfo['source'] = 'navbar') => {
       setUpsellDialogOpen(true)
-      if (orgActiveReleaseCount !== undefined) {
-        setReleaseCount(orgActiveReleaseCount)
-      }
-      telemetryLogs.dialogViewed('navbar')
+
+      telemetryLogs.dialogViewed(source)
     },
     [telemetryLogs],
   )
@@ -85,8 +83,8 @@ export function ReleasesUpsellProvider(props: {children: React.ReactNode}) {
       throwError: boolean = false,
       whenResolved?: (hasPassed: boolean) => void,
     ) => {
-      const doUpsell: (count?: number) => false = (count) => {
-        handleOpenDialog(count)
+      const doUpsell = (): false => {
+        handleOpenDialog()
         if (throwError) {
           throw new StudioReleaseLimitExceededError()
         }
@@ -103,7 +101,11 @@ export function ReleasesUpsellProvider(props: {children: React.ReactNode}) {
           // if either fails then catch the error
           return await Promise.all([
             firstValueFrom(orgActiveReleaseCount$),
-            firstValueFrom(releaseLimits$),
+            firstValueFrom(
+              releaseLimits$.pipe(
+                tap((limit) => setReleaseLimit(limit?.orgActiveReleaseLimit || null)),
+              ),
+            ),
           ])
         } catch (e) {
           console.error('Error fetching release limits and org count for upsell:', e)
@@ -151,7 +153,7 @@ export function ReleasesUpsellProvider(props: {children: React.ReactNode}) {
 
       if (shouldShowDialog) {
         whenResolved?.(false)
-        return doUpsell(orgActiveReleaseCount)
+        return doUpsell()
       }
 
       whenResolved?.(true)
@@ -161,7 +163,10 @@ export function ReleasesUpsellProvider(props: {children: React.ReactNode}) {
   )
 
   const onReleaseLimitReached = useCallback(
-    (limit: number) => handleOpenDialog(limit),
+    (limit: number) => {
+      setReleaseLimit(limit)
+      handleOpenDialog()
+    },
     [handleOpenDialog],
   )
 
@@ -176,7 +181,7 @@ export function ReleasesUpsellProvider(props: {children: React.ReactNode}) {
     [mode, upsellDialogOpen, guardWithReleaseLimitUpsell, onReleaseLimitReached, telemetryLogs],
   )
 
-  const interpolation = releaseCount === null ? undefined : {releaseLimit: releaseCount}
+  const interpolation = releaseLimit === null ? undefined : {releaseLimit: releaseLimit}
 
   return (
     <ReleasesUpsellContext.Provider value={ctxValue}>


### PR DESCRIPTION
### Description
When doing the release limit interpolation for the upsell dialog I noticed that we were using an incorrect value, we were using how many releases the project has instead of the limit the project has.
For example, the project added as growth in the config has a limit of 2, b**ut has created 3 releases** so it's above the limit. 

From: 
>You've already created **3** releases - which is the maximum on your current plan.

<img width="289" height="429" alt="Screenshot 2025-10-27 at 10 25 17" src="https://github.com/user-attachments/assets/2ff72de8-a50d-4a02-8243-3c8fa24bb037" />

To
>You've already created **2** releases - which is the maximum on your current plan.
<img width="301" height="435" alt="Screenshot 2025-10-27 at 10 25 02" src="https://github.com/user-attachments/assets/309d3a71-11f9-4394-8f84-04ed22b65114" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
