### PR TITLE
fix(auth): having no roles array on your user marks you as unauthorized

### DIFF
--- a/packages/sanity/src/core/studio/AuthBoundary.tsx
+++ b/packages/sanity/src/core/studio/AuthBoundary.tsx
@@ -33,7 +33,14 @@ export function AuthBoundary({
   useEffect(() => {
     const subscription = activeWorkspace.auth.state.subscribe({
       next: ({authenticated, currentUser}) => {
-        if (currentUser?.roles?.length === 0) {
+        /**
+         * If a user has never had any roles on for the given workspace project
+         * e.g. because they've only ever been an organization member thereby
+         * giving them implicit access to the studio then they will have no roles
+         * array on their user so to account for this case or the case that they have
+         * had roles removed then we need to set the logged in state to unauthorized.
+         */
+        if (!Array.isArray(currentUser?.roles) || currentUser.roles.length === 0) {
           setLoggedIn('unauthorized')
           if (currentUser?.provider) setLoginProvider(currentUser.provider)
           return


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

`something?.length === 0` will equal false because something is undefined. Thereby if a user has no roles on the project API because they've only ever been an organization member e.g. with developer role they will be marked as "authorized" which is inconsistent with the case that you _were_ a project member but you've had roles since removed.

#### Never been a project member

![CleanShot 2025-10-27 at 10.22.19@2x.png](https://app.graphite.dev/user-attachments/assets/d325c8ec-9ec2-4569-a28c-2e322d577f29.png)

#### Was a project member

![CleanShot 2025-10-27 at 10.22.38@2x.png](https://app.graphite.dev/user-attachments/assets/6313d645-f338-4fc6-80a3-292ba9c67f44.png)

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

* Is this the intended behaviour? I assume not because studio suddenly crashes in this case because you can't get the data you require on the project API since you're not a project member.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

Fixes an edge case where organization members who were never a project member can access the studio but see no data and subsequently the studio would crash on most interactions
