### PR TITLE
fix(core): avoid workspace dependent hook CorsOriginError view

### DIFF
--- a/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
@@ -5,7 +5,6 @@ import {useEffect, useMemo} from 'react'
 import {styled} from 'styled-components'
 
 import {Dialog} from '../../../ui-components'
-import {useEnvAwareSanityWebsiteUrl} from '../hooks/useEnvAwareSanityWebsiteUrl'
 
 interface CorsOriginErrorScreenProps {
   projectId?: string
@@ -27,15 +26,17 @@ export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
   const {projectId, isStaging} = props
 
   const origin = window.location.origin
-  const sanityWebsiteUrl = useEnvAwareSanityWebsiteUrl()
   const corsUrl = useMemo(() => {
-    const url = new URL(`/manage/project/${projectId}/api`, sanityWebsiteUrl)
+    const url = new URL(
+      `/manage/project/${projectId}/api`,
+      isStaging ? 'https://sanity.work' : 'https://sanity.io',
+    )
     url.searchParams.set('cors', 'add')
     url.searchParams.set('origin', origin)
     url.searchParams.set('credentials', '')
 
     return url.toString()
-  }, [origin, projectId, sanityWebsiteUrl])
+  }, [isStaging, origin, projectId])
 
   useEffect(() => {
     const handleFocus = () => {


### PR DESCRIPTION
### Description

Turns out #10638 broke the Cors Origin Error screen as it tried to use the context provided by the WorkspaceProvider. However, in the CorsOriginError view, no workspace is provided. This partially reverts #10638, restoring the CorsOriginError screen.


### Testing
- Best way to test at this point is to run the test-studio at a random port which is not already a CORS origin for any of the projects in the test studio. I did:
- `cd dev/test-studio`
- `pnpm sanity dev -p 9876`

### Notes for release
- Fixes issue with CORS origin error handler