### PR TITLE
fix(sanity): PTE error upon patch type unexpected by optimistic change handler

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/diff/useOptimisticPortableTextDiff.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/diff/useOptimisticPortableTextDiff.ts
@@ -101,6 +101,18 @@ export function useOptimisticPortableTextDiff({
       // Find the changed node in the optimistic or definitive root block.
       const [node] = extractWithPath(arrayToJSONMatchPath(patch.path), rootBlock)
 
+      // If the node still cannot be found for any reason after all other work has been performed,
+      // skip optimistic state update.
+      //
+      // This allows Portable Text Editor to continue operating without error. The updated diff will
+      // still appear, but only after the change has propagated through the data layer.
+      //
+      // This may occur if a Portable Text Editor patch occurs that changes the value, but that
+      // the optimistic change handler doesn't expect.
+      if (typeof node === 'undefined') {
+        return
+      }
+
       // Apply the patch to the node.
       const [nextNodeValue] = applyPatches(
         parsePatch(patch.value),


### PR DESCRIPTION
### Description

The optimistic change handler used to recompute inline diffs is currently only designed to handle `diffMatchPatch` patches. However, PTE can emit other patch types that update content. For example, a `set` patch is emitted when a mark is added to a string (such as when a string is converted to an inline code block).

This currently causes PTE to emit an error, because the optimistic change handler is unable to resolve the optimistic value for patch types it's unaware of.

This branch updates the optimistic change handler to skip optimistic update if the updated optimistic value cannot be resolve for any reason. This allows PTE to gracefully continue operating when this scenario occurs; the display of the updated diff will simply be deferred until the change has propagated through the data layer. 

https://github.com/user-attachments/assets/1496caa5-b4d0-472e-89b7-5682ac7df876

https://github.com/user-attachments/assets/6f781e54-9659-49c5-aecc-09d3a444ded1

After the change, there is a brief period where the optimistic diff for the block is lost, but this is preferable to an error being emitted. In the future, we can make the optimistic change handler aware of more patch types. However, this is a great safe guard to have in place regardless.

### What to review

Typing an inline code block into a PTE using backticks. e.g. "this is some \`code\`".

### Testing

Verified reported error no longer occurs when using PTE in Test Studio.