### PR TITLE
feat(sanity): skip unnecessary work when inline changes not switched on

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/diff/useOptimisticPortableTextDiff.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/diff/useOptimisticPortableTextDiff.ts
@@ -72,6 +72,10 @@ export function useOptimisticPortableTextDiff({
 
   const onOptimisticChange = useCallback<PortableTextOptimisticDiffApi['onOptimisticChange']>(
     (patch) => {
+      if (!displayInlineChanges) {
+        return
+      }
+
       const [rootPathSegment] = patch.path
 
       if (typeof rootPathSegment !== 'object' || !('_key' in rootPathSegment)) {
@@ -128,7 +132,7 @@ export function useOptimisticPortableTextDiff({
 
       setOptimisticValue(nextOptimisticValue)
     },
-    [definitiveValue, optimisticValue],
+    [definitiveValue, displayInlineChanges, optimisticValue],
   )
 
   // Reset the optimistic state after receiving definitive state.


### PR DESCRIPTION
### Description

Portable Text Editor computes its optimistic value after local changes occur, allowing inline diffs to be displayed as the user types or makes other changes.

This work is completely unnecessary when inline changes are not switched on. This branch skips the work in this scenario.

### What to review

Typing into PTE with and without inline changes switched on. Both work as they did before.

### Testing

Verified in Test Studio with inline changes switched on and off.