### PR TITLE
fix: overflow for titles

### DIFF
--- a/packages/sanity/src/core/form/studio/tree-editing/components/breadcrumbs/DialogBreadcrumbs.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/components/breadcrumbs/DialogBreadcrumbs.tsx
@@ -119,8 +119,7 @@ const MenuCard = function MenuCard(
           padding={1}
           style={{
             minWidth: 0,
-            overflowX: 'hidden',
-            overflowY: 'visible',
+            overflow: 'hidden',
           }}
           flex={isLast ? 1 : undefined}
         >


### PR DESCRIPTION
### Description

Before
<img width="1448" height="300" alt="image" src="https://github.com/user-attachments/assets/f1d5e4d4-d851-4e98-b3f5-ed1554a0ff7e" />


After
<img width="609" height="129" alt="image" src="https://github.com/user-attachments/assets/adc9c4cc-ca9d-45e4-a4fd-ccf56c789965" />


### What to review

Css changes

### Testing

Manually tested them across some different inputs

### Notes for release

N/A
