### PR TITLE
fix(core): don't open release create dialog after clicking documentation link

### DIFF
--- a/packages/sanity/src/core/releases/tool/overview/ReleasesEmptyState.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesEmptyState.tsx
@@ -1,5 +1,4 @@
 import {Flex, Inline, Text} from '@sanity/ui'
-import {useCallback} from 'react'
 
 import {Button} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
@@ -8,18 +7,10 @@ import {ReleaseIllustration} from '../resources/ReleaseIllustration'
 
 interface ReleasesEmptyStateProps {
   createReleaseButton?: React.ReactNode
-  onClickCreateRelease: () => void
 }
 
-export const ReleasesEmptyState = ({
-  createReleaseButton,
-  onClickCreateRelease,
-}: ReleasesEmptyStateProps) => {
+export const ReleasesEmptyState = ({createReleaseButton}: ReleasesEmptyStateProps) => {
   const {t} = useTranslation(releasesLocaleNamespace)
-
-  const handleDocumentationClick = useCallback(() => {
-    onClickCreateRelease()
-  }, [onClickCreateRelease])
 
   return (
     <Flex direction="column" flex={1} justify={'center'} align={'center'}>
@@ -38,7 +29,6 @@ export const ReleasesEmptyState = ({
             href="https://www.sanity.io/docs/content-releases"
             target="_blank"
             mode="ghost"
-            onClick={handleDocumentationClick}
             text={t('overview.action.documentation')}
           />
         </Inline>

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -402,13 +402,8 @@ export function ReleasesOverview() {
     : DEFAULT_RELEASES_OVERVIEW_SORT
 
   const releasesEmptyStateComponent = useCallback(
-    () => (
-      <ReleasesEmptyState
-        createReleaseButton={createReleaseButton}
-        onClickCreateRelease={handleOnClickCreateRelease}
-      />
-    ),
-    [createReleaseButton, handleOnClickCreateRelease],
+    () => <ReleasesEmptyState createReleaseButton={createReleaseButton} />,
+    [createReleaseButton],
   )
 
   const tableEmptyState = useMemo(() => {
@@ -474,10 +469,7 @@ export function ReleasesOverview() {
           )}
 
           {hasNoReleases && cardinalityView === 'releases' ? (
-            <ReleasesEmptyState
-              createReleaseButton={createReleaseButton}
-              onClickCreateRelease={handleOnClickCreateRelease}
-            />
+            <ReleasesEmptyState createReleaseButton={createReleaseButton} />
           ) : (
             <Box
               ref={setScrollContainerRef}


### PR DESCRIPTION
### Description
When clicking the documentation link in the releases empty state the user was redirected to a new tab because we use an anchor with `target=_blank`, but given we were also providing an onClick function, the releases modal was also opening, so you were coming back to that screen with an unexpected dialog.
I think this is an unintentional behavior, so this PR removes that.
<img width="381" height="329" alt="Screenshot 2025-10-28 at 09 22 15" src="https://github.com/user-attachments/assets/09ab8364-4459-4377-960c-4eeb97659d79" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Was this initially added for some reason?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
