### PR TITLE
chore(core): adds `scheduledDrafts` config option (off by default)

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -5,13 +5,7 @@ import {BookIcon} from '@sanity/icons'
 import {SanityMonogram} from '@sanity/logos'
 import {debugSecrets} from '@sanity/preview-url-secret/sanity-plugin-debug-secrets'
 import {visionTool} from '@sanity/vision'
-import {
-  DECISION_PARAMETERS_SCHEMA,
-  defineConfig,
-  definePlugin,
-  QUOTA_EXCLUDED_RELEASES_ENABLED,
-  type WorkspaceOptions,
-} from 'sanity'
+import {DECISION_PARAMETERS_SCHEMA, defineConfig, definePlugin, type WorkspaceOptions} from 'sanity'
 import {defineDocuments, defineLocations, presentationTool} from 'sanity/presentation'
 import {structureTool} from 'sanity/structure'
 import {unsplashAssetSource, UnsplashIcon} from 'sanity-plugin-asset-source-unsplash'
@@ -234,7 +228,9 @@ const defaultWorkspace = defineConfig({
   mediaLibrary: {
     enabled: true,
   },
-  [QUOTA_EXCLUDED_RELEASES_ENABLED]: true,
+  scheduledDrafts: {
+    enabled: false,
+  },
   [DECISION_PARAMETERS_SCHEMA]: {
     audiences: ['aud-a', 'aud-b', 'aud-c'],
     locales: ['en-GB', 'en-US'],
@@ -379,7 +375,9 @@ export default defineConfig([
     mediaLibrary: {
       enabled: true,
     },
-    [QUOTA_EXCLUDED_RELEASES_ENABLED]: true,
+    scheduledDrafts: {
+      enabled: true,
+    },
   },
   {
     name: 'growth',
@@ -399,7 +397,9 @@ export default defineConfig([
     mediaLibrary: {
       enabled: true,
     },
-    [QUOTA_EXCLUDED_RELEASES_ENABLED]: true,
+    scheduledDrafts: {
+      enabled: true,
+    },
   },
   {
     name: 'media-library-playground',

--- a/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
@@ -1110,7 +1110,6 @@ import type {
   PUBLISHED,
   PublishedId,
   QueryParams,
-  QUOTA_EXCLUDED_RELEASES_ENABLED,
   ReactHook,
   RebasePatchMsg,
   ReconnectEvent,
@@ -4987,9 +4986,6 @@ describe('sanity', () => {
   })
   test('QueryParams', () => {
     expectTypeOf<QueryParams>().not.toBeNever()
-  })
-  test('QUOTA_EXCLUDED_RELEASES_ENABLED', () => {
-    expectTypeOf<typeof QUOTA_EXCLUDED_RELEASES_ENABLED>().not.toBeNever()
   })
   test('ReactHook', () => {
     expectTypeOf<ReactHook<any, any>>().not.toBeNever()

--- a/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
@@ -6,7 +6,7 @@ import {describe, expect, it} from 'vitest'
 import {createMockAuthStore} from '../../store'
 import {definePlugin} from '../definePlugin'
 import {createSourceFromConfig, createWorkspaceFromConfig, resolveConfig} from '../resolveConfig'
-import {type PluginOptions, QUOTA_EXCLUDED_RELEASES_ENABLED} from '../types'
+import {type PluginOptions} from '../types'
 
 describe('resolveConfig', () => {
   it('throws on invalid tools property', async () => {
@@ -160,7 +160,9 @@ describe('resolveConfig', () => {
         releases: {
           enabled: true,
         },
-        [QUOTA_EXCLUDED_RELEASES_ENABLED]: true,
+        scheduledDrafts: {
+          enabled: true,
+        },
       }),
     )
     expect(workspace.__internal.options.plugins).toMatchObject([
@@ -194,7 +196,9 @@ describe('resolveConfig', () => {
         releases: {
           enabled: false,
         },
-        [QUOTA_EXCLUDED_RELEASES_ENABLED]: true,
+        scheduledDrafts: {
+          enabled: true,
+        },
       }),
     )
     const pluginNames = workspace.__internal.options.plugins?.map((p) => p.name) ?? []
@@ -221,7 +225,9 @@ describe('resolveConfig', () => {
         releases: {
           enabled: true,
         },
-        [QUOTA_EXCLUDED_RELEASES_ENABLED]: false,
+        scheduledDrafts: {
+          enabled: false,
+        },
       }),
     )
     const pluginNames = workspace.__internal.options.plugins?.map((p) => p.name) ?? []
@@ -248,7 +254,9 @@ describe('resolveConfig', () => {
         releases: {
           enabled: false,
         },
-        [QUOTA_EXCLUDED_RELEASES_ENABLED]: false,
+        scheduledDrafts: {
+          enabled: false,
+        },
       }),
     )
     const pluginNames = workspace.__internal.options.plugins?.map((p) => p.name) ?? []

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -31,7 +31,6 @@ import {
   type DocumentLanguageFilterContext,
   type NewDocumentOptionsContext,
   type PluginOptions,
-  QUOTA_EXCLUDED_RELEASES_ENABLED,
   type ResolveProductionUrlContext,
   type Tool,
 } from './types'
@@ -530,15 +529,15 @@ export const serverDocumentActionsReducer = (opts: {
   return result
 }
 
-export const internalQuotaExcludedReleasesEnabledReducer = (opts: {
+export const scheduledDraftsEnabledReducer = (opts: {
   config: PluginOptions
-  initialValue: boolean | undefined
-}): boolean | undefined => {
+  initialValue: boolean
+}): boolean => {
   const {config, initialValue} = opts
   const flattenedConfig = flattenConfig(config, [])
 
-  const result = flattenedConfig.reduce((acc: boolean | undefined, {config: innerConfig}) => {
-    const enabled = innerConfig[QUOTA_EXCLUDED_RELEASES_ENABLED]
+  const result = flattenedConfig.reduce((acc: boolean, {config: innerConfig}) => {
+    const enabled = innerConfig.scheduledDrafts?.enabled
 
     if (typeof enabled === 'undefined') return acc
     if (typeof enabled === 'boolean') return enabled

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -46,7 +46,6 @@ import {
   initialDocumentActions,
   initialDocumentBadges,
   initialLanguageFilter,
-  internalQuotaExcludedReleasesEnabledReducer,
   internalTasksReducer,
   legacySearchEnabledReducer,
   mediaLibraryEnabledReducer,
@@ -56,6 +55,7 @@ import {
   partialIndexingEnabledReducer,
   releaseActionsReducer,
   resolveProductionUrlReducer,
+  scheduledDraftsEnabledReducer,
   schemaTemplatesReducer,
   searchStrategyReducer,
   serverDocumentActionsReducer,
@@ -75,7 +75,6 @@ import {
   type MissingConfigFile,
   type PluginOptions,
   type PreparedConfig,
-  QUOTA_EXCLUDED_RELEASES_ENABLED,
   type SingleWorkspace,
   type Source,
   type SourceClientOptions,
@@ -361,10 +360,6 @@ function resolveSource({
     projectId,
     schema,
     i18n: i18n.source,
-    [QUOTA_EXCLUDED_RELEASES_ENABLED]: internalQuotaExcludedReleasesEnabledReducer({
-      config,
-      initialValue: false,
-    }),
     [DECISION_PARAMETERS_SCHEMA]: decisionParametersSchemaReducer({
       config,
       initialValue: undefined,
@@ -784,6 +779,9 @@ function resolveSource({
         propertyName: 'advancedVersionControl.enabled',
         initialValue: false,
       }),
+    },
+    scheduledDrafts: {
+      enabled: scheduledDraftsEnabledReducer({config, initialValue: false}),
     },
 
     releases: config.releases

--- a/packages/sanity/src/core/config/resolveDefaultPlugins.ts
+++ b/packages/sanity/src/core/config/resolveDefaultPlugins.ts
@@ -12,7 +12,6 @@ import {
   type AppsOptions,
   type DefaultPluginsWorkspaceOptions,
   type PluginOptions,
-  QUOTA_EXCLUDED_RELEASES_ENABLED,
   type SingleWorkspace,
   type WorkspaceOptions,
 } from './types'
@@ -31,7 +30,6 @@ const defaultPlugins = [
 
 type DefaultPluginsOptions = DefaultPluginsWorkspaceOptions & {
   apps: AppsOptions
-  [QUOTA_EXCLUDED_RELEASES_ENABLED]: boolean
 }
 
 export function getDefaultPlugins(options: DefaultPluginsOptions, plugins?: PluginOptions[]) {
@@ -55,10 +53,10 @@ export function getDefaultPlugins(options: DefaultPluginsOptions, plugins?: Plug
     if (plugin.name === SCHEDULES_NAME) {
       // This tool is shared between releases and single doc release plugins.
       // and it needs to be enabled if either of the plugins are enabled.
-      return options.releases.enabled || options[QUOTA_EXCLUDED_RELEASES_ENABLED]
+      return options.releases.enabled || options.scheduledDrafts?.enabled
     }
     if (plugin.name === SINGLE_DOC_RELEASE_NAME) {
-      return options[QUOTA_EXCLUDED_RELEASES_ENABLED]
+      return options.scheduledDrafts?.enabled
     }
     return true
   })
@@ -95,6 +93,6 @@ export function getDefaultPluginsOptions(
       },
     },
     mediaLibrary: workspace?.mediaLibrary,
-    [QUOTA_EXCLUDED_RELEASES_ENABLED]: workspace[QUOTA_EXCLUDED_RELEASES_ENABLED] ?? false,
+    scheduledDrafts: workspace.scheduledDrafts ?? {enabled: false},
   }
 }

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -69,12 +69,6 @@ export interface GroupableActionDescription<GroupType = unknown> extends BaseAct
 }
 
 /**
- * Symbol for enabling releases outside of quota restrictions for single docs
- * @internal
- */
-export const QUOTA_EXCLUDED_RELEASES_ENABLED = Symbol('__internal_quotaExcludedReleasesEnabled')
-
-/**
  * Symbol for configuring decision parameters schema
  * @beta
  */
@@ -266,8 +260,6 @@ export interface ConfigContext {
    * Localization resources
    */
   i18n: LocaleSource
-  /** @internal */
-  [QUOTA_EXCLUDED_RELEASES_ENABLED]?: boolean
   /** @beta */
   [DECISION_PARAMETERS_SCHEMA]?: DecisionParametersConfig
 }
@@ -514,8 +506,8 @@ export interface PluginOptions {
   /** @internal */
   __internal_serverDocumentActions?: WorkspaceOptions['__internal_serverDocumentActions']
 
-  /** @internal */
-  [QUOTA_EXCLUDED_RELEASES_ENABLED]?: WorkspaceOptions[typeof QUOTA_EXCLUDED_RELEASES_ENABLED]
+  /** Configuration for Scheduled drafts */
+  scheduledDrafts?: DefaultPluginsWorkspaceOptions['scheduledDrafts']
 
   /** @beta */
   [DECISION_PARAMETERS_SCHEMA]?: DecisionParametersConfig
@@ -641,11 +633,7 @@ export interface WorkspaceOptions extends SourceOptions {
     enabled?: boolean
   }
 
-  /**
-   * @hidden
-   * @internal
-   */
-  [QUOTA_EXCLUDED_RELEASES_ENABLED]?: boolean
+  scheduledDrafts?: DefaultPluginsWorkspaceOptions['scheduledDrafts']
 
   /**
    * @beta
@@ -726,8 +714,6 @@ export interface DocumentActionsContext extends ConfigContext {
   releaseId: string | undefined
   /** the type of the currently active document. */
   versionType: DocumentActionsVersionType
-  /** @internal */
-  [QUOTA_EXCLUDED_RELEASES_ENABLED]?: boolean
 }
 
 /**
@@ -1010,6 +996,9 @@ export interface Source {
   /** @beta */
   tasks?: WorkspaceOptions['tasks']
 
+  scheduledDrafts?: {
+    enabled: boolean
+  }
   /** @beta */
   releases?: {
     enabled?: boolean
@@ -1201,6 +1190,7 @@ export type {
 /** @beta */
 export type DefaultPluginsWorkspaceOptions = {
   tasks: {enabled: boolean}
+  scheduledDrafts: {enabled: boolean}
   scheduledPublishing: ScheduledPublishingPluginOptions
   releases: {
     enabled?: boolean

--- a/packages/sanity/src/core/singleDocRelease/context/SingleDocReleaseEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/context/SingleDocReleaseEnabledProvider.test.tsx
@@ -1,7 +1,6 @@
 import {renderHook} from '@testing-library/react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {QUOTA_EXCLUDED_RELEASES_ENABLED} from '../../config/types'
 import {useFeatureEnabled} from '../../hooks'
 import {useSource} from '../../studio/source'
 import {
@@ -26,9 +25,7 @@ describe('SingleDocReleaseEnabledProvider', () => {
 
   it('should not show single doc releases if user opt out and the feature is not enabled (any plan)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: false})
-    useSourceMock.mockReturnValue({
-      __internal: {options: {[QUOTA_EXCLUDED_RELEASES_ENABLED]: false}},
-    })
+    useSourceMock.mockReturnValue({scheduledDrafts: {enabled: false}})
 
     const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
@@ -37,9 +34,7 @@ describe('SingleDocReleaseEnabledProvider', () => {
   })
   it('should not show single doc releases if user opt out and the feature is enabled (any plan)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: true, isLoading: false})
-    useSourceMock.mockReturnValue({
-      __internal: {options: {[QUOTA_EXCLUDED_RELEASES_ENABLED]: false}},
-    })
+    useSourceMock.mockReturnValue({scheduledDrafts: {enabled: false}})
 
     const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
@@ -49,9 +44,7 @@ describe('SingleDocReleaseEnabledProvider', () => {
 
   it('should show default mode if user hasnt opted out and the feature flag is enabled (growth or above)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: true, isLoading: false})
-    useSourceMock.mockReturnValue({
-      __internal: {options: {[QUOTA_EXCLUDED_RELEASES_ENABLED]: true}},
-    })
+    useSourceMock.mockReturnValue({scheduledDrafts: {enabled: true}})
 
     const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
@@ -61,9 +54,7 @@ describe('SingleDocReleaseEnabledProvider', () => {
 
   it('should show upsell mode if user has not opt out and the feature is not enabled (free plans)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: false})
-    useSourceMock.mockReturnValue({
-      __internal: {options: {[QUOTA_EXCLUDED_RELEASES_ENABLED]: true}},
-    })
+    useSourceMock.mockReturnValue({scheduledDrafts: {enabled: true}})
 
     const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
@@ -73,9 +64,7 @@ describe('SingleDocReleaseEnabledProvider', () => {
 
   it('should not show single doc releases if it is loading the feature', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: true})
-    useSourceMock.mockReturnValue({
-      __internal: {options: {[QUOTA_EXCLUDED_RELEASES_ENABLED]: true}},
-    })
+    useSourceMock.mockReturnValue({scheduledDrafts: {enabled: true}})
 
     const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
@@ -89,9 +78,7 @@ describe('SingleDocReleaseEnabledProvider', () => {
       isLoading: true,
       error: new Error('Something went wrong'),
     })
-    useSourceMock.mockReturnValue({
-      __internal: {options: {[QUOTA_EXCLUDED_RELEASES_ENABLED]: true}},
-    })
+    useSourceMock.mockReturnValue({scheduledDrafts: {enabled: true}})
 
     const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftsEnabled.ts
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftsEnabled.ts
@@ -1,4 +1,3 @@
-import {QUOTA_EXCLUDED_RELEASES_ENABLED} from '../../config/types'
 import {useSource} from '../../studio/source'
 
 /**
@@ -7,8 +6,7 @@ import {useSource} from '../../studio/source'
  */
 export function useScheduledDraftsEnabled(): boolean {
   const source = useSource()
-  const sourceInternal = source.__internal
-  const isEnabled = Boolean(sourceInternal?.options?.[QUOTA_EXCLUDED_RELEASES_ENABLED])
+  const isEnabled = Boolean(source.scheduledDrafts?.enabled)
 
   return isEnabled
 }

--- a/packages/sanity/src/core/singleDocRelease/plugin/documentActions/index.ts
+++ b/packages/sanity/src/core/singleDocRelease/plugin/documentActions/index.ts
@@ -1,5 +1,5 @@
 import {type DocumentActionComponent} from '../../../config/document/actions'
-import {type DocumentActionsContext, QUOTA_EXCLUDED_RELEASES_ENABLED} from '../../../config/types'
+import {type DocumentActionsContext} from '../../../config/types'
 import {
   DeleteScheduledDraftAction,
   EditScheduledDraftAction,
@@ -16,10 +16,8 @@ export default function resolveDocumentActions(
     return [PublishScheduledDraftAction, EditScheduledDraftAction, DeleteScheduledDraftAction]
   }
 
-  const isQuotaExcludedReleaseEnabled = context[QUOTA_EXCLUDED_RELEASES_ENABLED]
-
   // Add SchedulePublishAction only for draft documents
-  if (isQuotaExcludedReleaseEnabled && context.versionType === 'draft') {
+  if (context.versionType === 'draft') {
     const actionsExcludingOriginalSchedule = existingActions.filter(
       ({action}) => action !== 'schedule',
     )

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -150,7 +150,6 @@ exports[`exports snapshot 1`] = `
     "Preview": "function",
     "PreviewCard": "object",
     "PreviewLoader": "function",
-    "QUOTA_EXCLUDED_RELEASES_ENABLED": "symbol",
     "RELEASES_INTENT": "string",
     "RELEASES_STUDIO_CLIENT_OPTIONS": "object",
     "ReferenceInput": "function",


### PR DESCRIPTION
### Description
This config option allows users to enable or disable the `scheduledDrafts` feature.
By default will be `disabled` so it's an opt in flag.

It will be soon changed to `enabled` for everyone.

```ts
defineConfig({
  ....config,
  scheduledDrafts: {
    enabled: true
 })
```
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Feature flag naming.
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
run the studio locally.
enable the flag, scheduled drafts should show.
Disable the flag, scheduled drafts actions and tool menu should not show.
Don't add the flag to config, scheduled drafts actions and tool should not show.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a internal
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
