### PR TITLE
fix(sanity): handle processing video assets

### DIFF
--- a/packages/sanity/src/media-library/plugin/VideoInput/VideoPreview.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/VideoPreview.tsx
@@ -63,12 +63,11 @@ export function VideoPreview(props: VideoAssetProps) {
 
   const playbackInfoState = useVideoPlaybackInfo(videoPlaybackParams)
 
-  const tokens = useMemo(() => {
-    return playbackInfoState.result ? getPlaybackTokens(playbackInfoState.result) : undefined
-  }, [playbackInfoState.result])
-
   const videoActionsMenuProps = useMemo(() => {
     const customDomain = isStaging ? CUSTOM_DOMAIN_STAGING : CUSTOM_DOMAIN_PRODUCTION
+    const tokens = playbackInfoState?.result
+      ? getPlaybackTokens(playbackInfoState.result)
+      : undefined
     const baseProps = {
       aspectRatio: playbackInfoState.result?.aspectRatio,
       customDomain,
@@ -79,14 +78,7 @@ export function VideoPreview(props: VideoAssetProps) {
     }
 
     return tokens ? {...baseProps, tokens} : baseProps
-  }, [
-    isStaging,
-    playbackInfoState.result?.aspectRatio,
-    playbackInfoState.result?.id,
-    isMenuOpen,
-    setBrowseButtonElement,
-    tokens,
-  ])
+  }, [isStaging, playbackInfoState, isMenuOpen, setBrowseButtonElement])
 
   const assetSourcesWithUpload = assetSources.filter((s) => Boolean(s.Uploader))
 
@@ -205,7 +197,15 @@ export function VideoPreview(props: VideoAssetProps) {
     return null
   }
 
-  if (playbackInfoState.isLoading || !playbackInfoState.result) {
+  if (playbackInfoState.isLoading) {
+    return <VideoSkeleton />
+  }
+
+  if (playbackInfoState.error) {
+    return <VideoSkeleton error={playbackInfoState.error} />
+  }
+
+  if (!playbackInfoState.result) {
     return <VideoSkeleton />
   }
 

--- a/packages/sanity/src/media-library/plugin/VideoInput/VideoSkeleton.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/VideoSkeleton.tsx
@@ -1,13 +1,15 @@
-import {Flex, Skeleton, Stack, TextSkeleton} from '@sanity/ui'
+import {Card, Flex, Skeleton, Stack, TextSkeleton} from '@sanity/ui'
 
-export function VideoSkeleton() {
+export function VideoSkeleton({error}: {error?: Error}) {
   return (
-    <Flex align="center" justify="flex-start" padding={2}>
-      <Skeleton padding={3} radius={1} animated />
-      <Stack flex={1} space={2} marginLeft={3}>
-        <TextSkeleton style={{width: '100%'}} radius={1} animated />
-        <TextSkeleton style={{width: '100%'}} radius={1} animated />
-      </Stack>
-    </Flex>
+    <Card padding={0} radius={0} tone={error ? 'critical' : 'default'}>
+      <Flex align="center" justify="flex-start" padding={2}>
+        <Skeleton padding={3} radius={1} animated={!error} />
+        <Stack flex={1} space={2} marginLeft={3}>
+          <TextSkeleton style={{width: '100%'}} radius={1} animated={!error} />
+          <TextSkeleton style={{width: '100%'}} radius={1} animated={!error} />
+        </Stack>
+      </Flex>
+    </Card>
   )
 }


### PR DESCRIPTION
### TL;DR

Improved video asset loading with polling and better error handling for the VideoInput component.

### What changed?

- Refactored `useVideoPlaybackInfo` hook to implement polling for video assets that are still processing
- Added proper error handling in `VideoPreview` to display error states
- Enhanced `VideoSkeleton` to support error states with visual feedback
- Optimized token generation by moving it inside the `videoActionsMenuProps` useMemo
- Added retry mechanism with a Subject-based approach for better reactivity

### How to test?

1. Upload a new large video asset to the Media Library - think 50-100mb
2. Observe the loading state while the video is processing
3. Verify that the UI properly transitions from loading to ready state

### Notes for release

Video assets often require processing time before they're ready for playback. The previous implementation didn't handle the "processing" state properly, leading to errors or indefinite loading states. This change implements a polling mechanism that checks if a video asset is ready, with proper timeout handling and visual feedback. It also improves error handling to provide a better user experience when videos fail to load.