### PR TITLE
chore: source .env vars from direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,7 +3,7 @@ export PATH="`pwd`/node_modules/.bin:$PATH"
 
 # /---
 # Source env vars in .env & .env.local
-env_files=(".env.local" ".env")
+env_files=(".env" ".env.local")
 set -a
 for env_file in "${env_files[@]}"; do
   if [ -f "$env_file" ]; then


### PR DESCRIPTION
### Description
Small quality of life improvement: source environment variables from .env and .env.local

### What to review

- Makes sense? Should it fail if it detects both .env and .env.local?

### Testing
- Make sure [direnv](https://direnv.net/) is installed
- cd into local repo clone
- add an env var to .env (eg. `echo >> TEST_DELETEME="foo"`)
- run `direnv allow`
- make sure `echo $TEST_DELETEME` prints out `foo`

### Notes for release
n/a – internal