### PR TITLE
fix(core): use event timestamp in revision status line

### DIFF
--- a/packages/sanity/src/structure/panes/document/statusBar/RevisionStatusLine.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/RevisionStatusLine.tsx
@@ -1,7 +1,9 @@
 import {RestoreIcon} from '@sanity/icons'
 import {Box, Flex, Text} from '@sanity/ui'
 import {format} from 'date-fns'
+import {useContext} from 'react'
 import {Translate, useTranslation} from 'sanity'
+import {EventsContext} from 'sanity/_singletons'
 import {styled} from 'styled-components'
 
 import {useDocumentPane} from '../useDocumentPane'
@@ -18,8 +20,14 @@ export const StatusText = styled(Text)`
 
 export function RevisionStatusLine(): React.JSX.Element {
   const {displayed, revisionNotFound} = useDocumentPane()
+  // Using the context instead of  `useEvents` because the context could not exist if the document pane is not using the events store and is instead
+  // using the legacy timeline store.
+  const events = useContext(EventsContext)
+  const revision = events?.revision
+  const revisionEvent = events?.events.find((ev) => ev.id === revision?.revisionId)
+
   const {t} = useTranslation()
-  const date = displayed?._updatedAt || displayed?._createdAt
+  const date = revisionEvent?.timestamp || displayed?._updatedAt || displayed?._createdAt
 
   const message = {
     name: 'revision',


### PR DESCRIPTION
### Description
In some cases the `_updatedAt` value could be back dated, specially when doing a dataset import.
This PR updates the value we display in the status line in the document

Image of the issue:
Notice how the revision status line shows October but the event is from June, this is because the revision was using the `_updatedAt` value which in some cases could be different from the actual transaction date, which is what we use to display the timeline.

<img width="1371" height="785" alt="Screenshot 2025-10-29 at 15 01 17" src="https://github.com/user-attachments/assets/ff874ffa-a95e-4c04-855d-f04c543a6ebe" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an edge case in the history view of the document in where the date displayed at the footer of the document doesn't match with the time the transaction happened.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
