### PR TITLE
chore(efps): build reference studio on push to main

### DIFF
--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -5,6 +5,11 @@ permissions:
 on:
   # Build on pushes branches that have a PR (including drafts)
   pull_request:
+  push:
+    branches:
+      # deploy reference studio on push to main (but skip running actual perf tests)
+      - main
+
   workflow_dispatch:
     inputs:
       enable_profiler:


### PR DESCRIPTION
### Description
Builds and deploys the efps studio on push to main. Previously this has been done via the vercel git integration, but better to use the same workflow as we use for deploying from branches.

### What to review
- Makes sense?

### Testing
- We'll see how it goes when merged to main

### Notes for release
n/a