### PR TITLE
chore(efps): use production url as reference

### DIFF
--- a/dev/efps/index.ts
+++ b/dev/efps/index.ts
@@ -34,7 +34,7 @@ const ENABLE_PROFILER = process.env.ENABLE_PROFILER === 'true'
 
 // eslint-disable-next-line turbo/no-undeclared-env-vars
 const RECORD_VIDEO = process.env.RECORD_VIDEO === 'true'
-const REFERENCE_STUDIO_URL = 'https://efps-git-main.sanity.dev'
+const REFERENCE_STUDIO_URL = 'https://efps.sanity.dev'
 
 const EXPERIMENT_STUDIO_URL = readEnv('STUDIO_URL')
 


### PR DESCRIPTION
### Description
Use efps.sanity.dev as the url of the reference studio instead of `git-main.efps.dev`, as the latter was assigned by the github integration


### Notes for release
n/a