### PR TITLE
chore(efps): skip merge-reports step in main

### DIFF
--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -196,7 +196,7 @@ jobs:
           retention-days: 30
 
   merge-reports:
-    if: always()
+    if: ${{github.ref_name != 'main'}}
     needs: [efps-test]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description
small follow-up from #10962 which skips the merge-reports job in main.

### Notes for release
n/a