### PR TITLE
fix: update Popover component to allow overriding animation behavior

### DIFF
--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -276,6 +276,7 @@ export const VersionChip = memo(function VersionChip(props: {
       </Tooltip>
 
       <Popover
+        animate={false}
         content={
           <VersionContextMenu
             documentId={documentId}

--- a/packages/sanity/src/ui-components/popover/Popover.tsx
+++ b/packages/sanity/src/ui-components/popover/Popover.tsx
@@ -3,12 +3,13 @@ import {Popover as UIPopover, type PopoverProps as UIPopoverProps} from '@sanity
 import {type ForwardedRef, forwardRef, type HTMLProps} from 'react'
 
 /** @internal */
-export type PopoverProps = Omit<UIPopoverProps, 'animate'>
+export type PopoverProps = UIPopoverProps
 
 /**
- * Customized Sanity UI <Popover> that forces `animate=true`
+ * Customized Sanity UI <Popover> that defaults to `animate=true`
  *
- * All Popovers in the studio should be animated.
+ * All Popovers in the studio should be animated by default
+ * Can be overridden when nesting popovers to prevent AnimatePresence conflicts
  *
  * @internal
  */
@@ -16,5 +17,6 @@ export const Popover = forwardRef(function Popover(
   props: PopoverProps & Omit<HTMLProps<HTMLDivElement>, 'as' | 'children' | 'content' | 'width'>,
   ref: ForwardedRef<HTMLDivElement>,
 ) {
-  return <UIPopover {...props} animate ref={ref} />
+  const {animate = true, ...restProps} = props
+  return <UIPopover {...restProps} animate={animate} ref={ref} />
 })


### PR DESCRIPTION
### Description
This has been quite difficult to track down.
I've narrowed a fix down to setting `animate={false}` for a popover which has a nested menu within.

My current hypothesis is that when `animate` is set on a popover, `sanity/ui` wraps its children content in `AnimatePresence` from motion which controls when child components can mount and unmount based on animation state.

The nested MenuGroup popover tries to render when open={true}, but <AnimatePresence> intercepts this and blocks/delays rendering because it's waiting for animation coordination that the nested popover never provides.

I theorised a fix within `sanity/ui` however frustratingly I cannot replicate this issue in `sanity/ui`'s storybook. Even using the same ui version (3.1.6) and React (19.1.1), I can't replicate. Updating studio to use the latest ui (3.1.11) and react (19.2.0) I continue to see the issue.

So I can't truly attest to what the issue really is right now. I'm going to continue investigating, but for the time being I've found that disabling animation in this case resolves consistently, so think this is a good intermediate fix to provide.

Befor
<img width="353" height="171" alt="Screenshot 2025-10-29 at 15 29 25" src="https://github.com/user-attachments/assets/731db3f4-ad7a-413c-96bd-4939f4d697e5" />
e (intermittently):

After:
<img width="594" height="334" alt="Screenshot 2025-10-29 at 15 29 02" src="https://github.com/user-attachments/assets/aaeef9a7-5f4a-455d-893a-3fb31f69bed4" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue where sometimes the 'Copy version to' menu would not appear when trying to copy a document version to a release.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
