### PR TITLE
fix: add translation for scheduled draft release title

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1475,6 +1475,9 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Header for the schedule publish dialog */
   'schedule-publish-dialog.header': 'Schedule draft for Publish',
 
+  /** Title for a scheduled draft release */
+  'scheduled-drafts.release.title': 'Scheduled publish',
+
   /** Accessibility label to open search action when the search would go fullscreen (eg on narrower screens) */
   'search.action-open-aria-label': 'Open search',
   /** Action label for adding a search filter */

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduleDraftOperations.ts
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduleDraftOperations.ts
@@ -1,6 +1,7 @@
 import {type BaseActionOptions, type ReleaseDocument} from '@sanity/client'
 import {useCallback} from 'react'
 
+import {useTranslation} from '../../i18n'
 import {useAllReleases} from '../../releases/store/useAllReleases'
 import {useReleaseOperations} from '../../releases/store/useReleaseOperations'
 import {createReleaseId} from '../../releases/util/createReleaseId'
@@ -39,6 +40,7 @@ export interface ScheduleDraftOperationsValue {
  * @internal
  */
 export function useScheduleDraftOperations(): ScheduleDraftOperationsValue {
+  const {t} = useTranslation()
   const releaseOperations = useReleaseOperations()
   const {data: allReleases} = useAllReleases()
 
@@ -68,7 +70,7 @@ export function useScheduleDraftOperations(): ScheduleDraftOperationsValue {
   const handleCreateScheduledDraft = useCallback(
     async (documentId: string, publishAt: Date, opts?: BaseActionOptions): Promise<string> => {
       // Create the release (but don't schedule it yet)
-      const releaseTitle = 'Scheduled publish'
+      const releaseTitle = t('scheduled-drafts.release.title')
       const releaseDocumentId = await createScheduledDraftRelease(releaseTitle, publishAt, opts)
 
       // Create a version of the document in the release (using draft as base)
@@ -81,7 +83,7 @@ export function useScheduleDraftOperations(): ScheduleDraftOperationsValue {
 
       return releaseDocumentId
     },
-    [releaseOperations, createScheduledDraftRelease],
+    [releaseOperations, createScheduledDraftRelease, t],
   )
 
   // used to immediately publish a scheduled draft


### PR DESCRIPTION
### Description
Creating a new scheduled draft still uses the same release title, however it is now being pulled from the i18n bundle rather than hard coded string:
<img width="334" height="97" alt="Screenshot 2025-10-29 at 16 44 28" src="https://github.com/user-attachments/assets/9abebd64-36c9-4bf5-8f67-7e2ca6c69a1d" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
