### PR TITLE
fix(structure,presentation): no extraneous deps eslint warning

### DIFF
--- a/packages/sanity/eslint.config.mjs
+++ b/packages/sanity/eslint.config.mjs
@@ -430,6 +430,12 @@ export default defineConfig([
       'import/no-unresolved': 'off',
     },
   },
+  {
+    files: ['src/structure/**/*', 'src/presentation/**/*'],
+    rules: {
+      'import/no-extraneous-dependencies': 'off',
+    },
+  },
   // An issue with the vitest suite prevented this file from changing the 'react-i18next' import to 'sanity'.
   // This should be fixed, and the rule is disabled here rather than with an inline comment to give the override visibility so we don't forget about it.
   {


### PR DESCRIPTION
### Description
Fixes no extraneous deps eslint warning in structure and presentation

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
