### PR TITLE
fix(core): fixes issue where Sanity crashes when process is not defined

### DIFF
--- a/packages/sanity/src/core/version.ts
+++ b/packages/sanity/src/core/version.ts
@@ -5,4 +5,4 @@ import {version} from '../../package.json'
  * @beta
  */
 export const SANITY_VERSION =
-  process.env.PKG_BUILD_VERSION || process.env.PKG_VERSION || `${version}-dev`
+  process?.env?.PKG_BUILD_VERSION || process?.env?.PKG_VERSION || `${version}-dev`


### PR DESCRIPTION
### Description

`process.env` is not always exposed in every build stack. Sanity is now crashing when process.env is not defined.

### What to review

See if the change make sense.

### Notes for release

Fixed crash in builds where process.env is undefined.
