### PR TITLE
fix(codegen): handle resolution of deeply nested imports using re-exports

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -139,6 +139,17 @@ describe('findQueries with the groq template', () => {
     expect(queries[0].result).toBe('*[_type == "foo bar"]')
   })
 
+  test('can import deeply nested files', () => {
+    const source = `
+      import { groq } from "groq";
+      import {query}  from "../__tests__/fixtures/deeplyNestedImports/root";
+      const someQuery = groq\`$\{query}\`
+    `
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(1)
+    expect(queries[0].result).toBe('* { foo, bar }')
+  })
+
   test('can import from export *', () => {
     const source = `
       import { groq } from "groq";
@@ -318,6 +329,17 @@ describe('findQueries with defineQuery', () => {
     const queries = findQueriesInSource(source, __filename, undefined)
     expect(queries.length).toBe(1)
     expect(queries[0].result).toBe('*[_type == "foo bar"]')
+  })
+
+  test('can import deeply nested files', () => {
+    const source = `
+      import {defineQuery} from "groq";
+      import {query}  from "../__tests__/fixtures/deeplyNestedImports/root";
+      const someQuery = defineQuery(\`$\{query}\`);
+    `
+    const queries = findQueriesInSource(source, __filename, undefined)
+    expect(queries.length).toBe(1)
+    expect(queries[0].result).toBe('* { foo, bar }')
   })
 
   test('should detect defineQuery calls that have been required', () => {

--- a/packages/@sanity/codegen/src/typescript/__tests__/fixtures/deeplyNestedImports/fragments/index.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/fixtures/deeplyNestedImports/fragments/index.ts
@@ -1,0 +1,1 @@
+export {fragment1, fragment2} from './nested/index'

--- a/packages/@sanity/codegen/src/typescript/__tests__/fixtures/deeplyNestedImports/fragments/nested/fragment1.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/fixtures/deeplyNestedImports/fragments/nested/fragment1.ts
@@ -1,0 +1,1 @@
+export const fragment1 = 'foo'

--- a/packages/@sanity/codegen/src/typescript/__tests__/fixtures/deeplyNestedImports/fragments/nested/fragment2.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/fixtures/deeplyNestedImports/fragments/nested/fragment2.ts
@@ -1,0 +1,1 @@
+export const fragment2 = 'bar'

--- a/packages/@sanity/codegen/src/typescript/__tests__/fixtures/deeplyNestedImports/fragments/nested/index.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/fixtures/deeplyNestedImports/fragments/nested/index.ts
@@ -1,0 +1,4 @@
+import {fragment1} from './fragment1'
+import {fragment2} from './fragment2'
+
+export {fragment1, fragment2}

--- a/packages/@sanity/codegen/src/typescript/__tests__/fixtures/deeplyNestedImports/root.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/fixtures/deeplyNestedImports/root.ts
@@ -1,0 +1,3 @@
+import {fragment1, fragment2} from './fragments/index'
+
+export const query = `* { ${fragment1}, ${fragment2} }`

--- a/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
+++ b/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
@@ -500,7 +500,7 @@ function resolveExportSpecifier({
       node: binding.path.node,
       file: tree,
       scope: newScope,
-      filename: importFileName,
+      filename: resolvedFile,
       babelConfig,
       resolver,
       fnArguments,


### PR DESCRIPTION
### Description

Resolution of imported files failed in some cases where files were deeply nested and used re-exports. This is something we saw when using `sanity typegen generate` in a large project that composed queries of multiple fragments in nested folders that were re-exported. 

The fix is using the resolved file path (`resolvedFile`) in when calling `resolveExpression` within `resolveExportSpecifier`. This was already done within `resolveImportSpecifier`. To me it looked like an oversight, but if there is a good reason why this was not done then this approach might not be the correct one.

### What to review

There might be a reason why `resolvedFile` was not already used here that I am not aware of, even though all the test suite still passes.

### Testing

Added tests with a deeply nested folder structure that uses re-exports. The tests fail without 
the fix

Also made this change manually within our projects `node_modules` and the `sanity typegen generate` command then successfully created the expected queries for us.
 

### Notes for release

- Fixes an issue where `sanity typegen generate` would not correctly resolve queries when using re-exports in nested folders
