### PR TITLE
chore(groq): use rolling workspace version for `@repo/tsconfig`

### DIFF
--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/package.config": "workspace:*",
-    "@repo/tsconfig": "workspace:",
+    "@repo/tsconfig": "workspace:*",
     "@sanity/pkg-utils": "catalog:",
     "@types/node": "catalog:",
     "eslint": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1737,7 +1737,7 @@ importers:
         specifier: workspace:*
         version: link:../@repo/package.config
       '@repo/tsconfig':
-        specifier: 'workspace:'
+        specifier: workspace:*
         version: link:../@repo/tsconfig
       '@sanity/pkg-utils':
         specifier: 'catalog:'


### PR DESCRIPTION
### Description

Fixes wrong workspace protocol introduced in #10975

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
