### PR TITLE
fix(schema): extract inline non-objects

### DIFF
--- a/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
+++ b/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
@@ -39,23 +39,8 @@ exports[`Extract schema test > Can extract inline documents 1`] = `
         "optional": true,
         "type": "objectAttribute",
         "value": {
-          "attributes": {
-            "_type": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string",
-                "value": "author",
-              },
-            },
-            "name": {
-              "optional": true,
-              "type": "objectAttribute",
-              "value": {
-                "type": "string",
-              },
-            },
-          },
-          "type": "object",
+          "name": "author",
+          "type": "inline",
         },
       },
       "inlineAuthors": {
@@ -64,15 +49,7 @@ exports[`Extract schema test > Can extract inline documents 1`] = `
         "value": {
           "of": {
             "attributes": {
-              "_type": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string",
-                  "value": "author",
-                },
-              },
-              "name": {
-                "optional": true,
+              "_key": {
                 "type": "objectAttribute",
                 "value": {
                   "type": "string",
@@ -80,15 +57,8 @@ exports[`Extract schema test > Can extract inline documents 1`] = `
               },
             },
             "rest": {
-              "attributes": {
-                "_key": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string",
-                  },
-                },
-              },
-              "type": "object",
+              "name": "author",
+              "type": "inline",
             },
             "type": "object",
           },
@@ -456,6 +426,162 @@ exports[`Extract schema test > Extracts  schema general 1`] = `
     },
   },
   {
+    "name": "sanity.imageMetadata",
+    "type": "type",
+    "value": {
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imageMetadata",
+          },
+        },
+        "blurHash": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+          },
+        },
+        "dimensions": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "name": "sanity.imageDimensions",
+            "type": "inline",
+          },
+        },
+        "hasAlpha": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean",
+          },
+        },
+        "isOpaque": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean",
+          },
+        },
+        "location": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "name": "geopoint",
+            "type": "inline",
+          },
+        },
+        "lqip": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+          },
+        },
+        "palette": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "name": "sanity.imagePalette",
+            "type": "inline",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  {
+    "name": "sanity.imageHotspot",
+    "type": "type",
+    "value": {
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imageHotspot",
+          },
+        },
+        "height": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "number",
+          },
+        },
+        "width": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "number",
+          },
+        },
+        "x": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "number",
+          },
+        },
+        "y": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "number",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  {
+    "name": "sanity.imageCrop",
+    "type": "type",
+    "value": {
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imageCrop",
+          },
+        },
+        "bottom": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "number",
+          },
+        },
+        "left": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "number",
+          },
+        },
+        "right": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "number",
+          },
+        },
+        "top": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "number",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  {
     "name": "geopoint",
     "type": "type",
     "value": {
@@ -523,10 +649,137 @@ exports[`Extract schema test > Extracts  schema general 1`] = `
     },
   },
   {
+    "name": "sanity.assetSourceData",
+    "type": "type",
+    "value": {
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.assetSourceData",
+          },
+        },
+        "id": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+          },
+        },
+        "name": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+          },
+        },
+        "url": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  {
     "name": "someTextType",
     "type": "type",
     "value": {
       "type": "string",
+    },
+  },
+  {
+    "name": "manuscript",
+    "type": "type",
+    "value": {
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "manuscript",
+          },
+        },
+        "asset": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "attributes": {
+              "_ref": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                },
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "reference",
+                },
+              },
+              "_weak": {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": {
+                  "type": "boolean",
+                },
+              },
+            },
+            "dereferencesTo": "sanity.fileAsset",
+            "type": "object",
+          },
+        },
+        "author": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "attributes": {
+              "_ref": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                },
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "reference",
+                },
+              },
+              "_weak": {
+                "optional": true,
+                "type": "objectAttribute",
+                "value": {
+                  "type": "boolean",
+                },
+              },
+            },
+            "dereferencesTo": "author",
+            "type": "object",
+          },
+        },
+        "description": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+          },
+        },
+        "media": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "unknown",
+          },
+        },
+      },
+      "type": "object",
     },
   },
   {
@@ -693,6 +946,36 @@ exports[`Extract schema test > Extracts  schema general 1`] = `
     "type": "type",
     "value": {
       "type": "string",
+    },
+  },
+  {
+    "name": "obj",
+    "type": "type",
+    "value": {
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "obj",
+          },
+        },
+        "field1": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+          },
+        },
+        "field2": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "number",
+          },
+        },
+      },
+      "type": "object",
     },
   },
   {
@@ -1272,114 +1555,16 @@ exports[`Extract schema test > Extracts  schema general 1`] = `
               "of": [
                 {
                   "attributes": {
-                    "_type": {
+                    "_key": {
                       "type": "objectAttribute",
                       "value": {
                         "type": "string",
-                        "value": "author",
-                      },
-                    },
-                    "name": {
-                      "optional": true,
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string",
-                      },
-                    },
-                    "profilePicture": {
-                      "optional": true,
-                      "type": "objectAttribute",
-                      "value": {
-                        "attributes": {
-                          "_type": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                              "value": "image",
-                            },
-                          },
-                          "asset": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "attributes": {
-                                "_ref": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string",
-                                  },
-                                },
-                                "_type": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string",
-                                    "value": "reference",
-                                  },
-                                },
-                                "_weak": {
-                                  "optional": true,
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "boolean",
-                                  },
-                                },
-                              },
-                              "dereferencesTo": "sanity.imageAsset",
-                              "type": "object",
-                            },
-                          },
-                          "attribution": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                            },
-                          },
-                          "caption": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                            },
-                          },
-                          "crop": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "name": "sanity.imageCrop",
-                              "type": "inline",
-                            },
-                          },
-                          "hotspot": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "name": "sanity.imageHotspot",
-                              "type": "inline",
-                            },
-                          },
-                          "media": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "unknown",
-                            },
-                          },
-                        },
-                        "type": "object",
                       },
                     },
                   },
                   "rest": {
-                    "attributes": {
-                      "_key": {
-                        "type": "objectAttribute",
-                        "value": {
-                          "type": "string",
-                        },
-                      },
-                    },
-                    "type": "object",
+                    "name": "author",
+                    "type": "inline",
                   },
                   "type": "object",
                 },
@@ -1483,114 +1668,16 @@ exports[`Extract schema test > Extracts  schema general 1`] = `
                                   "value": {
                                     "of": {
                                       "attributes": {
-                                        "_type": {
+                                        "_key": {
                                           "type": "objectAttribute",
                                           "value": {
                                             "type": "string",
-                                            "value": "author",
-                                          },
-                                        },
-                                        "name": {
-                                          "optional": true,
-                                          "type": "objectAttribute",
-                                          "value": {
-                                            "type": "string",
-                                          },
-                                        },
-                                        "profilePicture": {
-                                          "optional": true,
-                                          "type": "objectAttribute",
-                                          "value": {
-                                            "attributes": {
-                                              "_type": {
-                                                "type": "objectAttribute",
-                                                "value": {
-                                                  "type": "string",
-                                                  "value": "image",
-                                                },
-                                              },
-                                              "asset": {
-                                                "optional": true,
-                                                "type": "objectAttribute",
-                                                "value": {
-                                                  "attributes": {
-                                                    "_ref": {
-                                                      "type": "objectAttribute",
-                                                      "value": {
-                                                        "type": "string",
-                                                      },
-                                                    },
-                                                    "_type": {
-                                                      "type": "objectAttribute",
-                                                      "value": {
-                                                        "type": "string",
-                                                        "value": "reference",
-                                                      },
-                                                    },
-                                                    "_weak": {
-                                                      "optional": true,
-                                                      "type": "objectAttribute",
-                                                      "value": {
-                                                        "type": "boolean",
-                                                      },
-                                                    },
-                                                  },
-                                                  "dereferencesTo": "sanity.imageAsset",
-                                                  "type": "object",
-                                                },
-                                              },
-                                              "attribution": {
-                                                "optional": true,
-                                                "type": "objectAttribute",
-                                                "value": {
-                                                  "type": "string",
-                                                },
-                                              },
-                                              "caption": {
-                                                "optional": true,
-                                                "type": "objectAttribute",
-                                                "value": {
-                                                  "type": "string",
-                                                },
-                                              },
-                                              "crop": {
-                                                "optional": true,
-                                                "type": "objectAttribute",
-                                                "value": {
-                                                  "name": "sanity.imageCrop",
-                                                  "type": "inline",
-                                                },
-                                              },
-                                              "hotspot": {
-                                                "optional": true,
-                                                "type": "objectAttribute",
-                                                "value": {
-                                                  "name": "sanity.imageHotspot",
-                                                  "type": "inline",
-                                                },
-                                              },
-                                              "media": {
-                                                "optional": true,
-                                                "type": "objectAttribute",
-                                                "value": {
-                                                  "type": "unknown",
-                                                },
-                                              },
-                                            },
-                                            "type": "object",
                                           },
                                         },
                                       },
                                       "rest": {
-                                        "attributes": {
-                                          "_key": {
-                                            "type": "objectAttribute",
-                                            "value": {
-                                              "type": "string",
-                                            },
-                                          },
-                                        },
-                                        "type": "object",
+                                        "name": "author",
+                                        "type": "inline",
                                       },
                                       "type": "object",
                                     },
@@ -1884,114 +1971,16 @@ exports[`Extract schema test > Extracts  schema general 1`] = `
                       },
                       {
                         "attributes": {
-                          "_type": {
+                          "_key": {
                             "type": "objectAttribute",
                             "value": {
                               "type": "string",
-                              "value": "author",
-                            },
-                          },
-                          "name": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                            },
-                          },
-                          "profilePicture": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "attributes": {
-                                "_type": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string",
-                                    "value": "image",
-                                  },
-                                },
-                                "asset": {
-                                  "optional": true,
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "attributes": {
-                                      "_ref": {
-                                        "type": "objectAttribute",
-                                        "value": {
-                                          "type": "string",
-                                        },
-                                      },
-                                      "_type": {
-                                        "type": "objectAttribute",
-                                        "value": {
-                                          "type": "string",
-                                          "value": "reference",
-                                        },
-                                      },
-                                      "_weak": {
-                                        "optional": true,
-                                        "type": "objectAttribute",
-                                        "value": {
-                                          "type": "boolean",
-                                        },
-                                      },
-                                    },
-                                    "dereferencesTo": "sanity.imageAsset",
-                                    "type": "object",
-                                  },
-                                },
-                                "attribution": {
-                                  "optional": true,
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string",
-                                  },
-                                },
-                                "caption": {
-                                  "optional": true,
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string",
-                                  },
-                                },
-                                "crop": {
-                                  "optional": true,
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "name": "sanity.imageCrop",
-                                    "type": "inline",
-                                  },
-                                },
-                                "hotspot": {
-                                  "optional": true,
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "name": "sanity.imageHotspot",
-                                    "type": "inline",
-                                  },
-                                },
-                                "media": {
-                                  "optional": true,
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "unknown",
-                                  },
-                                },
-                              },
-                              "type": "object",
                             },
                           },
                         },
                         "rest": {
-                          "attributes": {
-                            "_key": {
-                              "type": "objectAttribute",
-                              "value": {
-                                "type": "string",
-                              },
-                            },
-                          },
-                          "type": "object",
+                          "name": "author",
+                          "type": "inline",
                         },
                         "type": "object",
                       },
@@ -2423,114 +2412,16 @@ exports[`Extract schema test > Extracts  schema general 1`] = `
                 },
                 {
                   "attributes": {
-                    "_type": {
+                    "_key": {
                       "type": "objectAttribute",
                       "value": {
                         "type": "string",
-                        "value": "author",
-                      },
-                    },
-                    "name": {
-                      "optional": true,
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string",
-                      },
-                    },
-                    "profilePicture": {
-                      "optional": true,
-                      "type": "objectAttribute",
-                      "value": {
-                        "attributes": {
-                          "_type": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                              "value": "image",
-                            },
-                          },
-                          "asset": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "attributes": {
-                                "_ref": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string",
-                                  },
-                                },
-                                "_type": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string",
-                                    "value": "reference",
-                                  },
-                                },
-                                "_weak": {
-                                  "optional": true,
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "boolean",
-                                  },
-                                },
-                              },
-                              "dereferencesTo": "sanity.imageAsset",
-                              "type": "object",
-                            },
-                          },
-                          "attribution": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                            },
-                          },
-                          "caption": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                            },
-                          },
-                          "crop": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "name": "sanity.imageCrop",
-                              "type": "inline",
-                            },
-                          },
-                          "hotspot": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "name": "sanity.imageHotspot",
-                              "type": "inline",
-                            },
-                          },
-                          "media": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "unknown",
-                            },
-                          },
-                        },
-                        "type": "object",
                       },
                     },
                   },
                   "rest": {
-                    "attributes": {
-                      "_key": {
-                        "type": "objectAttribute",
-                        "value": {
-                          "type": "string",
-                        },
-                      },
-                    },
-                    "type": "object",
+                    "name": "author",
+                    "type": "inline",
                   },
                   "type": "object",
                 },
@@ -3071,114 +2962,16 @@ exports[`Extract schema test > Extracts  schema general 1`] = `
                 },
                 {
                   "attributes": {
-                    "_type": {
+                    "_key": {
                       "type": "objectAttribute",
                       "value": {
                         "type": "string",
-                        "value": "author",
-                      },
-                    },
-                    "name": {
-                      "optional": true,
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string",
-                      },
-                    },
-                    "profilePicture": {
-                      "optional": true,
-                      "type": "objectAttribute",
-                      "value": {
-                        "attributes": {
-                          "_type": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                              "value": "image",
-                            },
-                          },
-                          "asset": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "attributes": {
-                                "_ref": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string",
-                                  },
-                                },
-                                "_type": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string",
-                                    "value": "reference",
-                                  },
-                                },
-                                "_weak": {
-                                  "optional": true,
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "boolean",
-                                  },
-                                },
-                              },
-                              "dereferencesTo": "sanity.imageAsset",
-                              "type": "object",
-                            },
-                          },
-                          "attribution": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                            },
-                          },
-                          "caption": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                            },
-                          },
-                          "crop": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "name": "sanity.imageCrop",
-                              "type": "inline",
-                            },
-                          },
-                          "hotspot": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "name": "sanity.imageHotspot",
-                              "type": "inline",
-                            },
-                          },
-                          "media": {
-                            "optional": true,
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "unknown",
-                            },
-                          },
-                        },
-                        "type": "object",
                       },
                     },
                   },
                   "rest": {
-                    "attributes": {
-                      "_key": {
-                        "type": "objectAttribute",
-                        "value": {
-                          "type": "string",
-                        },
-                      },
-                    },
-                    "type": "object",
+                    "name": "author",
+                    "type": "inline",
                   },
                   "type": "object",
                 },
@@ -4262,94 +4055,6 @@ exports[`Extract schema test > Extracts  schema general 1`] = `
     "type": "document",
   },
   {
-    "name": "sanity.imageCrop",
-    "type": "type",
-    "value": {
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imageCrop",
-          },
-        },
-        "bottom": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "number",
-          },
-        },
-        "left": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "number",
-          },
-        },
-        "right": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "number",
-          },
-        },
-        "top": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "number",
-          },
-        },
-      },
-      "type": "object",
-    },
-  },
-  {
-    "name": "sanity.imageHotspot",
-    "type": "type",
-    "value": {
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imageHotspot",
-          },
-        },
-        "height": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "number",
-          },
-        },
-        "width": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "number",
-          },
-        },
-        "x": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "number",
-          },
-        },
-        "y": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "number",
-          },
-        },
-      },
-      "type": "object",
-    },
-  },
-  {
     "attributes": {
       "_createdAt": {
         "type": "objectAttribute",
@@ -4492,111 +4197,6 @@ exports[`Extract schema test > Extracts  schema general 1`] = `
     },
     "name": "sanity.imageAsset",
     "type": "document",
-  },
-  {
-    "name": "sanity.assetSourceData",
-    "type": "type",
-    "value": {
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.assetSourceData",
-          },
-        },
-        "id": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-          },
-        },
-        "name": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-          },
-        },
-        "url": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-          },
-        },
-      },
-      "type": "object",
-    },
-  },
-  {
-    "name": "sanity.imageMetadata",
-    "type": "type",
-    "value": {
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imageMetadata",
-          },
-        },
-        "blurHash": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-          },
-        },
-        "dimensions": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "name": "sanity.imageDimensions",
-            "type": "inline",
-          },
-        },
-        "hasAlpha": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "boolean",
-          },
-        },
-        "isOpaque": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "boolean",
-          },
-        },
-        "location": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "name": "geopoint",
-            "type": "inline",
-          },
-        },
-        "lqip": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-          },
-        },
-        "palette": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "name": "sanity.imagePalette",
-            "type": "inline",
-          },
-        },
-      },
-      "type": "object",
-    },
   },
   {
     "attributes": {
@@ -4818,6 +4418,14 @@ exports[`Extract schema test > Extracts  schema general 1`] = `
           "type": "inline",
         },
       },
+      "customUrlType": {
+        "optional": true,
+        "type": "objectAttribute",
+        "value": {
+          "name": "customUrlType",
+          "type": "inline",
+        },
+      },
       "list": {
         "optional": true,
         "type": "objectAttribute",
@@ -4843,90 +4451,8 @@ exports[`Extract schema test > Extracts  schema general 1`] = `
         "optional": true,
         "type": "objectAttribute",
         "value": {
-          "attributes": {
-            "_type": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string",
-                "value": "manuscript",
-              },
-            },
-            "asset": {
-              "optional": true,
-              "type": "objectAttribute",
-              "value": {
-                "attributes": {
-                  "_ref": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                    },
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "reference",
-                    },
-                  },
-                  "_weak": {
-                    "optional": true,
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "boolean",
-                    },
-                  },
-                },
-                "dereferencesTo": "sanity.fileAsset",
-                "type": "object",
-              },
-            },
-            "author": {
-              "optional": true,
-              "type": "objectAttribute",
-              "value": {
-                "attributes": {
-                  "_ref": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                    },
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "reference",
-                    },
-                  },
-                  "_weak": {
-                    "optional": true,
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "boolean",
-                    },
-                  },
-                },
-                "dereferencesTo": "author",
-                "type": "object",
-              },
-            },
-            "description": {
-              "optional": true,
-              "type": "objectAttribute",
-              "value": {
-                "type": "string",
-              },
-            },
-            "media": {
-              "optional": true,
-              "type": "objectAttribute",
-              "value": {
-                "type": "unknown",
-              },
-            },
-          },
-          "type": "object",
+          "name": "manuscript",
+          "type": "inline",
         },
       },
       "number": {
@@ -5068,123 +4594,10 @@ exports[`Extract schema test > Extracts  schema general 1`] = `
     "type": "document",
   },
   {
-    "name": "manuscript",
+    "name": "customUrlType",
     "type": "type",
     "value": {
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "manuscript",
-          },
-        },
-        "asset": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "attributes": {
-              "_ref": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string",
-                },
-              },
-              "_type": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string",
-                  "value": "reference",
-                },
-              },
-              "_weak": {
-                "optional": true,
-                "type": "objectAttribute",
-                "value": {
-                  "type": "boolean",
-                },
-              },
-            },
-            "dereferencesTo": "sanity.fileAsset",
-            "type": "object",
-          },
-        },
-        "author": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "attributes": {
-              "_ref": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string",
-                },
-              },
-              "_type": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string",
-                  "value": "reference",
-                },
-              },
-              "_weak": {
-                "optional": true,
-                "type": "objectAttribute",
-                "value": {
-                  "type": "boolean",
-                },
-              },
-            },
-            "dereferencesTo": "author",
-            "type": "object",
-          },
-        },
-        "description": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-          },
-        },
-        "media": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "unknown",
-          },
-        },
-      },
-      "type": "object",
-    },
-  },
-  {
-    "name": "obj",
-    "type": "type",
-    "value": {
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "obj",
-          },
-        },
-        "field1": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-          },
-        },
-        "field2": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "number",
-          },
-        },
-      },
-      "type": "object",
+      "type": "string",
     },
   },
 ]
@@ -5296,6 +4709,29 @@ exports[`Extract schema test > inline reference types works 1`] = `
 exports[`Extract schema test > will ignore global document reference types at the moment 1`] = `
 [
   {
+    "name": "book",
+    "type": "type",
+    "value": {
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "book",
+          },
+        },
+        "title": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+  {
     "attributes": {
       "_createdAt": {
         "type": "objectAttribute",
@@ -5332,7 +4768,8 @@ exports[`Extract schema test > will ignore global document reference types at th
         "optional": true,
         "type": "objectAttribute",
         "value": {
-          "type": "unknown",
+          "name": "globalDocumentSubtype",
+          "type": "inline",
         },
       },
       "book": {
@@ -5346,29 +4783,6 @@ exports[`Extract schema test > will ignore global document reference types at th
     },
     "name": "validDocument",
     "type": "document",
-  },
-  {
-    "name": "book",
-    "type": "type",
-    "value": {
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "book",
-          },
-        },
-        "title": {
-          "optional": true,
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-          },
-        },
-      },
-      "type": "object",
-    },
   },
 ]
 `;


### PR DESCRIPTION
### Description

Fixes two bug:

* Only objects could be referenced inline in an extracted schema
* Only object usage were tracked as part of a dependency. This lead to using inline types like string to not be ordered properly. Fixes https://github.com/sanity-io/sanity/issues/7801

Note: this will lead to a diff in schema.json and sanity.types.ts since ordering matters.

### What to review

Does the asserted test results make sense?

### Testing

Yarr

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

Fixes a bug in typegen were ordering definition mattered for inline referenced non-objects. #7801
