### PR TITLE
fix(cli): fix error when running sanity undeploy for app

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/app/undeployAction.ts
@@ -34,6 +34,7 @@ export default async function undeployAppAction(
   const userApplication = await getUserApplication({
     client,
     appId,
+    isSdkApp: true,
   })
 
   spinner.succeed()


### PR DESCRIPTION
### Description
Fixes an error that can occur when running `sanity undeploy` for an SDK app.

### What to review
Makes sense? Can test against the preview release.

### Testing
Honestly not sure why existing tests didn't catch this not working in the first place.

### Notes for release

- Fixes an issue that could cause an error during `sanity undeploy` in an SDK app