### PR TITLE
fix: use www for sanity website urls

### DIFF
--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -350,7 +350,7 @@ export interface CliConfig {
      * The ID of your Sanity studio or app. Generated when deploying your studio or app for the first time.
      * Get the appId either by
      * - Checking the output of `sanity deploy`.
-     * - Get it from your project's Studio tab in https://sanity.io/manage
+     * - Get it from your project's Studio tab in https://www.sanity.io/manage
      */
     appId?: string
 

--- a/packages/@sanity/vision/src/components/PerspectivePopover.tsx
+++ b/packages/@sanity/vision/src/components/PerspectivePopover.tsx
@@ -80,7 +80,10 @@ export function PerspectivePopover() {
 
             <Card>
               <Text>
-                <PerspectivePopoverLink href="https://sanity.io/docs/perspectives" target="_blank">
+                <PerspectivePopoverLink
+                  href="https://www.sanity.io/docs/perspectives"
+                  target="_blank"
+                >
                   {t('settings.perspectives.action.docs-link')} &rarr;
                 </PerspectivePopoverLink>
               </Text>

--- a/packages/sanity/src/_internal/cli/util/baseUrl.ts
+++ b/packages/sanity/src/_internal/cli/util/baseUrl.ts
@@ -1,2 +1,4 @@
 export const baseUrl =
-  process.env.SANITY_INTERNAL_ENV === 'staging' ? 'https://sanity.work' : 'https://sanity.io'
+  process.env.SANITY_INTERNAL_ENV === 'staging'
+    ? 'https://www.sanity.work'
+    : 'https://www.sanity.io'

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -438,7 +438,7 @@ export type AppsOptions = {
   canvas?: {
     enabled: boolean
     /**
-     * To allow the "Link to canvas" action on localhost, or in studios not listed under Studios in sanity.io/manage
+     * To allow the "Link to canvas" action on localhost, or in studios not listed under Studios in https://www.sanity.io/manage
      * provide a fallback origin as a string.
      *
      * The string must be the exactly equal `name` as shown for the Studio in manage, and the studio must have create-manifest.json available.
@@ -1265,7 +1265,7 @@ export interface BetaFeatures {
     startInCreateEnabled?: boolean
 
     /**
-     * To show the "Start in Create" button on localhost, or in studios not listed under Studios in sanity.io/manage
+     * To show the "Start in Create" button on localhost, or in studios not listed under Studios in https://www.sanity.io/manage
      * provide a fallback origin as a string.
      *
      * The string must be the exactly equal `name` as shown for the Studio in manage, and the studio must have create-manifest.json available.


### PR DESCRIPTION
### Description

Urls to sanity website should always include www. Missed a couple of places when updating urls in #10788.

### What to review
Makes sense?

### Notes for release

n/a