### PR TITLE
fix(e2e-test): deleting the document crashes the test

### DIFF
--- a/e2e/tests/releases/displayDocument/DisplayedDocument.spec.ts
+++ b/e2e/tests/releases/displayDocument/DisplayedDocument.spec.ts
@@ -488,10 +488,6 @@ test.describe('displayedDocument', () => {
       await expect(page.getByTestId('document-panel-document-title')).not.toHaveText('Untitled')
       // Check that the name field shows the version name
       await expect(page.getByTestId('document-panel-document-title')).toHaveText('(published)')
-
-      // Clean up
-      await sanityClient.delete(versionId)
-      await sanityClient.delete(customPublished._id)
     })
   })
 })


### PR DESCRIPTION
### Description
Fixes broken e2e test
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
