### PR TITLE
fix(i18n): deprecate `minimalDays` property on week info

### DIFF
--- a/packages/sanity/src/core/hooks/__tests__/useUnitFormatter.test.tsx
+++ b/packages/sanity/src/core/hooks/__tests__/useUnitFormatter.test.tsx
@@ -23,7 +23,7 @@ describe('useUnitFormatter', () => {
           {
             id: 'fr-FR',
             title: 'Français',
-            weekInfo: {firstDay: 1, minimalDays: 2, weekend: [6, 7]},
+            weekInfo: {firstDay: 1, weekend: [6, 7]},
           },
         ]}
         i18next={i18next}

--- a/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
+++ b/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
@@ -38,7 +38,7 @@ async function getWrapper(bundles: LocaleResourceBundle[]) {
             {
               id: 'en-US',
               title: 'English',
-              weekInfo: {firstDay: 1, minimalDays: 2, weekend: [6, 7]},
+              weekInfo: {firstDay: 1, weekend: [6, 7]},
             },
           ]}
           i18next={i18next}

--- a/packages/sanity/src/core/i18n/locales.ts
+++ b/packages/sanity/src/core/i18n/locales.ts
@@ -17,7 +17,6 @@ export const usEnglishLocale = defineLocale({
   weekInfo: {
     firstDay: 7, // Sunday
     weekend: [6, 7], // Saturday, Sunday
-    minimalDays: 1,
   },
 })
 

--- a/packages/sanity/src/core/i18n/types.ts
+++ b/packages/sanity/src/core/i18n/types.ts
@@ -177,8 +177,9 @@ export interface LocaleWeekInfo {
 
   /**
    * An integer between 1 and 7 indicating the minimal days required in the first week of a month or year, for calendar purposes.
+   * @deprecated Kept for backwards compatibility in typings, but not used anywhere.
    */
-  minimalDays: 1 | 2 | 3 | 4 | 5 | 6 | 7
+  minimalDays?: 1 | 2 | 3 | 4 | 5 | 6 | 7
 }
 
 /**


### PR DESCRIPTION
### Description

The `minimalDays` property on the week info for locales has been deprecated. Since it is not used yet, it makes sense for us to also remove/deprecate it instead of hardcoding it.

This PR deprecates it, ensuring that locale plugins that has it defined continue to work without type checks failing, but also paving the way for us to remove it in an upcoming release.

### What to review

Tests still pass, code changes makes sense.

### Testing

No new tests needed.

### Notes for release

None
