### PR TITLE
fix: replace deprecated `OneLinePlugin`

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -155,6 +155,7 @@
     "@portabletext/editor": "^2.17.2",
     "@portabletext/patches": "^1.1.8",
     "@portabletext/plugin-markdown-shortcuts": "^1.4.15",
+    "@portabletext/plugin-one-line": "^1.1.17",
     "@portabletext/react": "^4.0.3",
     "@portabletext/toolkit": "^3.0.1",
     "@rexxars/react-json-inspector": "^9.0.1",

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -1,7 +1,8 @@
 import {usePortableTextEditor} from '@portabletext/editor'
 import {defineBehavior} from '@portabletext/editor/behaviors'
-import {BehaviorPlugin, OneLinePlugin} from '@portabletext/editor/plugins'
+import {BehaviorPlugin} from '@portabletext/editor/plugins'
 import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
+import {OneLinePlugin} from '@portabletext/plugin-one-line'
 import {type ArraySchemaType, type PortableTextBlock} from '@sanity/types'
 import {type ComponentType, useMemo} from 'react'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1818,6 +1818,9 @@ importers:
       '@portabletext/plugin-markdown-shortcuts':
         specifier: ^1.4.15
         version: 1.4.15(@portabletext/editor@2.17.2(@portabletext/sanity-bridge@1.1.17(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types))(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types)(@types/react@19.1.17)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rxjs@7.8.2))(@types/react@19.1.17)(react@19.1.1)
+      '@portabletext/plugin-one-line':
+        specifier: ^1.1.17
+        version: 1.1.17(@portabletext/editor@2.17.2(@portabletext/sanity-bridge@1.1.17(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types))(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types)(@types/react@19.1.17)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rxjs@7.8.2))(react@19.1.1)
       '@portabletext/react':
         specifier: ^4.0.3
         version: 4.0.3(react@19.1.1)
@@ -4442,6 +4445,12 @@ packages:
 
   '@portabletext/plugin-markdown-shortcuts@1.4.15':
     resolution: {integrity: sha512-wQuvtZfWvVdNsJDx9b6FfteJvEY6g6spDgWyCuSliCoO7gMjsNYtvIZKXryEFRb3v58zkwhzXRpiMx8LYMr0ww==}
+    peerDependencies:
+      '@portabletext/editor': ^2.17.2
+      react: ^19
+
+  '@portabletext/plugin-one-line@1.1.17':
+    resolution: {integrity: sha512-sEDalkBudA1+Dm9NkPDu14BH1g0rU/dkR95MUxvjCtTwk6EGF8yLdIx2rImNKhAm1FhUoP3v+2TuRsbjYw/2Qw==}
     peerDependencies:
       '@portabletext/editor': ^2.17.2
       react: ^19
@@ -15267,6 +15276,11 @@ snapshots:
       react: 19.1.1
     transitivePeerDependencies:
       - '@types/react'
+
+  '@portabletext/plugin-one-line@1.1.17(@portabletext/editor@2.17.2(@portabletext/sanity-bridge@1.1.17(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types))(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types)(@types/react@19.1.17)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rxjs@7.8.2))(react@19.1.1)':
+    dependencies:
+      '@portabletext/editor': 2.17.2(@portabletext/sanity-bridge@1.1.17(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types))(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types)(@types/react@19.1.17)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rxjs@7.8.2)
+      react: 19.1.1
 
   '@portabletext/react@4.0.3(react@19.1.1)':
     dependencies:


### PR DESCRIPTION
### Description

The `OneLinePlugin` exported from `@portabletext/editor/plugins` is no longer maintained. The replacement is a standalone plugin exported from `@portabletext/plugin-one-line`.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Does Portable Text -> Custom Plugins -> One-Line Editor still work?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Manual testing.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

n/a
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
