### PR TITLE
feat(core): sticky drop message

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/common/DropMessage.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/DropMessage.tsx
@@ -1,6 +1,7 @@
 import {AccessDeniedIcon, UploadIcon} from '@sanity/icons'
 import {type SchemaType} from '@sanity/types'
 import {Box, Inline, Text} from '@sanity/ui'
+import {styled} from 'styled-components'
 
 import {useTranslation} from '../../../../i18n'
 import {type FileLike, type UploaderResolver} from '../../../studio/uploads/types'
@@ -11,6 +12,13 @@ interface Props {
   resolveUploader: UploaderResolver
 }
 
+const Sticky = styled(Box)`
+  position: sticky;
+  top: 0;
+  bottom: 0;
+  margin: auto;
+`
+
 export function DropMessage(props: Props) {
   const {hoveringFiles, types, resolveUploader} = props
   const acceptedFiles = hoveringFiles.filter((file) =>
@@ -20,7 +28,7 @@ export function DropMessage(props: Props) {
   const multiple = types.length > 1
   const {t} = useTranslation()
   return (
-    <>
+    <Sticky paddingBottom={3} paddingTop={3}>
       {acceptedFiles.length > 0 ? (
         <>
           <Inline space={2}>
@@ -61,6 +69,6 @@ export function DropMessage(props: Props) {
           </Text>
         </Inline>
       )}
-    </>
+    </Sticky>
   )
 }


### PR DESCRIPTION
### Description

For massive arrays, the drop message can get lost depending on the scroll position. This will ensure that the drop message is always visible when dragging files over the input.

In this screenshot I'm in the bottom of a massive array. Notice how the drop message is sticky in the top of the screen:

<img width="1277" height="1273" alt="image" src="https://github.com/user-attachments/assets/0a053f42-5be9-49b7-96d9-b6ef57cf24a0" />

Previously, it was invisible as it was always centered vertically on the input.

If the center of the input is visible, it will behave just as before.

Video:

https://github.com/user-attachments/assets/e318c92c-b9e0-40d7-8118-54cddb4f000b


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That it works as expected.


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Create a large array somewhere (and/or reduce window height) where all items can't be fully shown.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Improved visibility for the file drop message on inputs.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
