### PR TITLE
fix(core): close release dialog immediately after release creation

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
@@ -55,6 +55,8 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
         const releaseValue = createReleaseMetadata(release)
 
         await createRelease(releaseValue)
+        // Close the dialog after creating the release.
+        onCancel()
         telemetry.log(CreatedRelease, {origin})
 
         // TODO: Remove this! temporary fix to give some time for the release to be created and the releases store state updated before closing the dialog.


### PR DESCRIPTION
### Description
This PR updates the release creation action from the release dialog.
This dialog uses the `useGuardWithReleaseLimitUpsell` hook, which returns a promise that on resolve, if the user has reach the limit, it will show the upsell dialog.
This dialog was incorrectly showing when hitting the limit after the creation on the first time.
So, if your limit is 2, then after creating the second release the upsell was showing.

This changes fixes it by immediately closing the release dialog after creation succeeded, and unmounts the hook which sets the upsell dialog.

https://github.com/user-attachments/assets/a7925426-5401-4a13-865a-9c3c67c521e8



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Create a release that gets you to the limit, the upsell should not show until you try to create a new one.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
