### PR TITLE
feat(manifest): add studioVersion to improve UX of external studios in dashboard dev-setup

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/manifest/extractManifestAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/manifest/extractManifestAction.ts
@@ -13,6 +13,7 @@ import {
   type ManifestWorkspaceFile,
 } from '../../../manifest/manifestTypes'
 import {type ExtractManifestWorkerData} from '../../threads/extractManifest'
+import {readModuleVersion} from '../../util/readModuleVersion'
 import {getTimer} from '../../util/timing'
 
 export const MANIFEST_FILENAME = 'create-manifest.json'
@@ -95,10 +96,12 @@ async function extractManifest(
        * Version history:
        * 1: Initial release.
        * 2: Added tools file.
+       * 3. Added studioVersion field.
        */
-      version: 2,
+      version: 3,
       createdAt: new Date().toISOString(),
       workspaces: workspaceFiles,
+      studioVersion: await readModuleVersion(workDir, 'sanity'),
     }
 
     await writeFile(path, JSON.stringify(manifest, null, 2))

--- a/packages/sanity/src/_internal/manifest/manifestTypes.ts
+++ b/packages/sanity/src/_internal/manifest/manifestTypes.ts
@@ -16,6 +16,7 @@ export interface CreateManifest {
   version: number
   createdAt: string
   workspaces: ManifestWorkspaceFile[]
+  studioVersion: string | null
 }
 
 export interface ManifestWorkspaceFile extends Omit<CreateWorkspaceManifest, 'schema' | 'tools'> {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

We don't know the version of an externally hosted studio, however if we add it to the manifest _we could_. Since dashboard basically requires a manifest this doesn't seem unreasonable, the alternative for us would be to "scrape" through the app's JS and find info on it which imo is far too complex for the value this adds. So now we resolve the moduleVersion of `sanity` and add it to the manifest.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

* Is this the correct way to resolve the studio version? Is there a better way?
* Is there anything i'm missing from introducing this change?

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

Not sure we need to mention it...?