### PR TITLE
chore(core): reverts adds `scheduledDrafts` config option 

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -5,7 +5,13 @@ import {BookIcon} from '@sanity/icons'
 import {SanityMonogram} from '@sanity/logos'
 import {debugSecrets} from '@sanity/preview-url-secret/sanity-plugin-debug-secrets'
 import {visionTool} from '@sanity/vision'
-import {DECISION_PARAMETERS_SCHEMA, defineConfig, definePlugin, type WorkspaceOptions} from 'sanity'
+import {
+  DECISION_PARAMETERS_SCHEMA,
+  defineConfig,
+  definePlugin,
+  QUOTA_EXCLUDED_RELEASES_ENABLED,
+  type WorkspaceOptions,
+} from 'sanity'
 import {defineDocuments, defineLocations, presentationTool} from 'sanity/presentation'
 import {structureTool} from 'sanity/structure'
 import {unsplashAssetSource, UnsplashIcon} from 'sanity-plugin-asset-source-unsplash'
@@ -228,9 +234,7 @@ const defaultWorkspace = defineConfig({
   mediaLibrary: {
     enabled: true,
   },
-  scheduledDrafts: {
-    enabled: false,
-  },
+  [QUOTA_EXCLUDED_RELEASES_ENABLED]: true,
   [DECISION_PARAMETERS_SCHEMA]: {
     audiences: ['aud-a', 'aud-b', 'aud-c'],
     locales: ['en-GB', 'en-US'],
@@ -375,9 +379,7 @@ export default defineConfig([
     mediaLibrary: {
       enabled: true,
     },
-    scheduledDrafts: {
-      enabled: true,
-    },
+    [QUOTA_EXCLUDED_RELEASES_ENABLED]: true,
   },
   {
     name: 'growth',
@@ -397,9 +399,7 @@ export default defineConfig([
     mediaLibrary: {
       enabled: true,
     },
-    scheduledDrafts: {
-      enabled: true,
-    },
+    [QUOTA_EXCLUDED_RELEASES_ENABLED]: true,
   },
   {
     name: 'media-library-playground',

--- a/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
@@ -1111,6 +1111,7 @@ import type {
   PUBLISHED,
   PublishedId,
   QueryParams,
+  QUOTA_EXCLUDED_RELEASES_ENABLED,
   ReactHook,
   RebasePatchMsg,
   ReconnectEvent,
@@ -4993,6 +4994,9 @@ describe('sanity', () => {
   })
   test('QueryParams', () => {
     expectTypeOf<QueryParams>().not.toBeNever()
+  })
+  test('QUOTA_EXCLUDED_RELEASES_ENABLED', () => {
+    expectTypeOf<typeof QUOTA_EXCLUDED_RELEASES_ENABLED>().not.toBeNever()
   })
   test('ReactHook', () => {
     expectTypeOf<ReactHook<any, any>>().not.toBeNever()

--- a/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
@@ -6,7 +6,7 @@ import {describe, expect, it} from 'vitest'
 import {createMockAuthStore} from '../../store'
 import {definePlugin} from '../definePlugin'
 import {createSourceFromConfig, createWorkspaceFromConfig, resolveConfig} from '../resolveConfig'
-import {type PluginOptions} from '../types'
+import {type PluginOptions, QUOTA_EXCLUDED_RELEASES_ENABLED} from '../types'
 
 describe('resolveConfig', () => {
   it('throws on invalid tools property', async () => {
@@ -160,9 +160,7 @@ describe('resolveConfig', () => {
         releases: {
           enabled: true,
         },
-        scheduledDrafts: {
-          enabled: true,
-        },
+        [QUOTA_EXCLUDED_RELEASES_ENABLED]: true,
       }),
     )
     expect(workspace.__internal.options.plugins).toMatchObject([
@@ -196,9 +194,7 @@ describe('resolveConfig', () => {
         releases: {
           enabled: false,
         },
-        scheduledDrafts: {
-          enabled: true,
-        },
+        [QUOTA_EXCLUDED_RELEASES_ENABLED]: true,
       }),
     )
     const pluginNames = workspace.__internal.options.plugins?.map((p) => p.name) ?? []
@@ -225,9 +221,7 @@ describe('resolveConfig', () => {
         releases: {
           enabled: true,
         },
-        scheduledDrafts: {
-          enabled: false,
-        },
+        [QUOTA_EXCLUDED_RELEASES_ENABLED]: false,
       }),
     )
     const pluginNames = workspace.__internal.options.plugins?.map((p) => p.name) ?? []
@@ -254,9 +248,7 @@ describe('resolveConfig', () => {
         releases: {
           enabled: false,
         },
-        scheduledDrafts: {
-          enabled: false,
-        },
+        [QUOTA_EXCLUDED_RELEASES_ENABLED]: false,
       }),
     )
     const pluginNames = workspace.__internal.options.plugins?.map((p) => p.name) ?? []

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -31,6 +31,7 @@ import {
   type DocumentLanguageFilterContext,
   type NewDocumentOptionsContext,
   type PluginOptions,
+  QUOTA_EXCLUDED_RELEASES_ENABLED,
   type ResolveProductionUrlContext,
   type Tool,
 } from './types'
@@ -529,15 +530,15 @@ export const serverDocumentActionsReducer = (opts: {
   return result
 }
 
-export const scheduledDraftsEnabledReducer = (opts: {
+export const internalQuotaExcludedReleasesEnabledReducer = (opts: {
   config: PluginOptions
-  initialValue: boolean
-}): boolean => {
+  initialValue: boolean | undefined
+}): boolean | undefined => {
   const {config, initialValue} = opts
   const flattenedConfig = flattenConfig(config, [])
 
-  const result = flattenedConfig.reduce((acc: boolean, {config: innerConfig}) => {
-    const enabled = innerConfig.scheduledDrafts?.enabled
+  const result = flattenedConfig.reduce((acc: boolean | undefined, {config: innerConfig}) => {
+    const enabled = innerConfig[QUOTA_EXCLUDED_RELEASES_ENABLED]
 
     if (typeof enabled === 'undefined') return acc
     if (typeof enabled === 'boolean') return enabled

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -46,6 +46,7 @@ import {
   initialDocumentActions,
   initialDocumentBadges,
   initialLanguageFilter,
+  internalQuotaExcludedReleasesEnabledReducer,
   internalTasksReducer,
   legacySearchEnabledReducer,
   mediaLibraryEnabledReducer,
@@ -55,7 +56,6 @@ import {
   partialIndexingEnabledReducer,
   releaseActionsReducer,
   resolveProductionUrlReducer,
-  scheduledDraftsEnabledReducer,
   schemaTemplatesReducer,
   searchStrategyReducer,
   serverDocumentActionsReducer,
@@ -75,6 +75,7 @@ import {
   type MissingConfigFile,
   type PluginOptions,
   type PreparedConfig,
+  QUOTA_EXCLUDED_RELEASES_ENABLED,
   type SingleWorkspace,
   type Source,
   type SourceClientOptions,
@@ -360,6 +361,10 @@ function resolveSource({
     projectId,
     schema,
     i18n: i18n.source,
+    [QUOTA_EXCLUDED_RELEASES_ENABLED]: internalQuotaExcludedReleasesEnabledReducer({
+      config,
+      initialValue: false,
+    }),
     [DECISION_PARAMETERS_SCHEMA]: decisionParametersSchemaReducer({
       config,
       initialValue: undefined,
@@ -779,9 +784,6 @@ function resolveSource({
         propertyName: 'advancedVersionControl.enabled',
         initialValue: false,
       }),
-    },
-    scheduledDrafts: {
-      enabled: scheduledDraftsEnabledReducer({config, initialValue: false}),
     },
 
     releases: config.releases

--- a/packages/sanity/src/core/config/resolveDefaultPlugins.ts
+++ b/packages/sanity/src/core/config/resolveDefaultPlugins.ts
@@ -12,6 +12,7 @@ import {
   type AppsOptions,
   type DefaultPluginsWorkspaceOptions,
   type PluginOptions,
+  QUOTA_EXCLUDED_RELEASES_ENABLED,
   type SingleWorkspace,
   type WorkspaceOptions,
 } from './types'
@@ -30,6 +31,7 @@ const defaultPlugins = [
 
 type DefaultPluginsOptions = DefaultPluginsWorkspaceOptions & {
   apps: AppsOptions
+  [QUOTA_EXCLUDED_RELEASES_ENABLED]: boolean
 }
 
 export function getDefaultPlugins(options: DefaultPluginsOptions, plugins?: PluginOptions[]) {
@@ -53,10 +55,10 @@ export function getDefaultPlugins(options: DefaultPluginsOptions, plugins?: Plug
     if (plugin.name === SCHEDULES_NAME) {
       // This tool is shared between releases and single doc release plugins.
       // and it needs to be enabled if either of the plugins are enabled.
-      return options.releases.enabled || options.scheduledDrafts?.enabled
+      return options.releases.enabled || options[QUOTA_EXCLUDED_RELEASES_ENABLED]
     }
     if (plugin.name === SINGLE_DOC_RELEASE_NAME) {
-      return options.scheduledDrafts?.enabled
+      return options[QUOTA_EXCLUDED_RELEASES_ENABLED]
     }
     return true
   })
@@ -93,6 +95,6 @@ export function getDefaultPluginsOptions(
       },
     },
     mediaLibrary: workspace?.mediaLibrary,
-    scheduledDrafts: workspace.scheduledDrafts ?? {enabled: false},
+    [QUOTA_EXCLUDED_RELEASES_ENABLED]: workspace[QUOTA_EXCLUDED_RELEASES_ENABLED] ?? false,
   }
 }

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -69,6 +69,12 @@ export interface GroupableActionDescription<GroupType = unknown> extends BaseAct
 }
 
 /**
+ * Symbol for enabling releases outside of quota restrictions for single docs
+ * @internal
+ */
+export const QUOTA_EXCLUDED_RELEASES_ENABLED = Symbol('__internal_quotaExcludedReleasesEnabled')
+
+/**
  * Symbol for configuring decision parameters schema
  * @beta
  */
@@ -260,6 +266,8 @@ export interface ConfigContext {
    * Localization resources
    */
   i18n: LocaleSource
+  /** @internal */
+  [QUOTA_EXCLUDED_RELEASES_ENABLED]?: boolean
   /** @beta */
   [DECISION_PARAMETERS_SCHEMA]?: DecisionParametersConfig
 }
@@ -506,8 +514,8 @@ export interface PluginOptions {
   /** @internal */
   __internal_serverDocumentActions?: WorkspaceOptions['__internal_serverDocumentActions']
 
-  /** Configuration for Scheduled drafts */
-  scheduledDrafts?: DefaultPluginsWorkspaceOptions['scheduledDrafts']
+  /** @internal */
+  [QUOTA_EXCLUDED_RELEASES_ENABLED]?: WorkspaceOptions[typeof QUOTA_EXCLUDED_RELEASES_ENABLED]
 
   /** @beta */
   [DECISION_PARAMETERS_SCHEMA]?: DecisionParametersConfig
@@ -633,7 +641,11 @@ export interface WorkspaceOptions extends SourceOptions {
     enabled?: boolean
   }
 
-  scheduledDrafts?: DefaultPluginsWorkspaceOptions['scheduledDrafts']
+  /**
+   * @hidden
+   * @internal
+   */
+  [QUOTA_EXCLUDED_RELEASES_ENABLED]?: boolean
 
   /**
    * @beta
@@ -714,6 +726,8 @@ export interface DocumentActionsContext extends ConfigContext {
   releaseId: string | undefined
   /** the type of the currently active document. */
   versionType: DocumentActionsVersionType
+  /** @internal */
+  [QUOTA_EXCLUDED_RELEASES_ENABLED]?: boolean
 }
 
 /**
@@ -996,9 +1010,6 @@ export interface Source {
   /** @beta */
   tasks?: WorkspaceOptions['tasks']
 
-  scheduledDrafts?: {
-    enabled: boolean
-  }
   /** @beta */
   releases?: {
     enabled?: boolean
@@ -1190,7 +1201,6 @@ export type {
 /** @beta */
 export type DefaultPluginsWorkspaceOptions = {
   tasks: {enabled: boolean}
-  scheduledDrafts: {enabled: boolean}
   scheduledPublishing: ScheduledPublishingPluginOptions
   releases: {
     enabled?: boolean

--- a/packages/sanity/src/core/singleDocRelease/context/SingleDocReleaseEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/context/SingleDocReleaseEnabledProvider.test.tsx
@@ -1,6 +1,7 @@
 import {renderHook} from '@testing-library/react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
+import {QUOTA_EXCLUDED_RELEASES_ENABLED} from '../../config/types'
 import {useFeatureEnabled} from '../../hooks'
 import {useSource} from '../../studio/source'
 import {
@@ -25,7 +26,9 @@ describe('SingleDocReleaseEnabledProvider', () => {
 
   it('should not show single doc releases if user opt out and the feature is not enabled (any plan)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: false})
-    useSourceMock.mockReturnValue({scheduledDrafts: {enabled: false}})
+    useSourceMock.mockReturnValue({
+      __internal: {options: {[QUOTA_EXCLUDED_RELEASES_ENABLED]: false}},
+    })
 
     const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
@@ -34,7 +37,9 @@ describe('SingleDocReleaseEnabledProvider', () => {
   })
   it('should not show single doc releases if user opt out and the feature is enabled (any plan)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: true, isLoading: false})
-    useSourceMock.mockReturnValue({scheduledDrafts: {enabled: false}})
+    useSourceMock.mockReturnValue({
+      __internal: {options: {[QUOTA_EXCLUDED_RELEASES_ENABLED]: false}},
+    })
 
     const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
@@ -44,7 +49,9 @@ describe('SingleDocReleaseEnabledProvider', () => {
 
   it('should show default mode if user hasnt opted out and the feature flag is enabled (growth or above)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: true, isLoading: false})
-    useSourceMock.mockReturnValue({scheduledDrafts: {enabled: true}})
+    useSourceMock.mockReturnValue({
+      __internal: {options: {[QUOTA_EXCLUDED_RELEASES_ENABLED]: true}},
+    })
 
     const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
@@ -54,7 +61,9 @@ describe('SingleDocReleaseEnabledProvider', () => {
 
   it('should show upsell mode if user has not opt out and the feature is not enabled (free plans)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: false})
-    useSourceMock.mockReturnValue({scheduledDrafts: {enabled: true}})
+    useSourceMock.mockReturnValue({
+      __internal: {options: {[QUOTA_EXCLUDED_RELEASES_ENABLED]: true}},
+    })
 
     const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
@@ -64,7 +73,9 @@ describe('SingleDocReleaseEnabledProvider', () => {
 
   it('should not show single doc releases if it is loading the feature', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: true})
-    useSourceMock.mockReturnValue({scheduledDrafts: {enabled: true}})
+    useSourceMock.mockReturnValue({
+      __internal: {options: {[QUOTA_EXCLUDED_RELEASES_ENABLED]: true}},
+    })
 
     const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
@@ -78,7 +89,9 @@ describe('SingleDocReleaseEnabledProvider', () => {
       isLoading: true,
       error: new Error('Something went wrong'),
     })
-    useSourceMock.mockReturnValue({scheduledDrafts: {enabled: true}})
+    useSourceMock.mockReturnValue({
+      __internal: {options: {[QUOTA_EXCLUDED_RELEASES_ENABLED]: true}},
+    })
 
     const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftsEnabled.ts
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftsEnabled.ts
@@ -1,3 +1,4 @@
+import {QUOTA_EXCLUDED_RELEASES_ENABLED} from '../../config/types'
 import {useSource} from '../../studio/source'
 
 /**
@@ -6,7 +7,8 @@ import {useSource} from '../../studio/source'
  */
 export function useScheduledDraftsEnabled(): boolean {
   const source = useSource()
-  const isEnabled = Boolean(source.scheduledDrafts?.enabled)
+  const sourceInternal = source.__internal
+  const isEnabled = Boolean(sourceInternal?.options?.[QUOTA_EXCLUDED_RELEASES_ENABLED])
 
   return isEnabled
 }

--- a/packages/sanity/src/core/singleDocRelease/plugin/documentActions/index.ts
+++ b/packages/sanity/src/core/singleDocRelease/plugin/documentActions/index.ts
@@ -1,5 +1,5 @@
 import {type DocumentActionComponent} from '../../../config/document/actions'
-import {type DocumentActionsContext} from '../../../config/types'
+import {type DocumentActionsContext, QUOTA_EXCLUDED_RELEASES_ENABLED} from '../../../config/types'
 import {
   DeleteScheduledDraftAction,
   EditScheduledDraftAction,
@@ -16,8 +16,10 @@ export default function resolveDocumentActions(
     return [PublishScheduledDraftAction, EditScheduledDraftAction, DeleteScheduledDraftAction]
   }
 
+  const isQuotaExcludedReleaseEnabled = context[QUOTA_EXCLUDED_RELEASES_ENABLED]
+
   // Add SchedulePublishAction only for draft documents
-  if (context.versionType === 'draft') {
+  if (isQuotaExcludedReleaseEnabled && context.versionType === 'draft') {
     const actionsExcludingOriginalSchedule = existingActions.filter(
       ({action}) => action !== 'schedule',
     )

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -150,6 +150,7 @@ exports[`exports snapshot 1`] = `
     "Preview": "function",
     "PreviewCard": "object",
     "PreviewLoader": "function",
+    "QUOTA_EXCLUDED_RELEASES_ENABLED": "symbol",
     "RELEASES_INTENT": "string",
     "RELEASES_STUDIO_CLIENT_OPTIONS": "object",
     "ReferenceInput": "function",


### PR DESCRIPTION
…ault) (#10946)"

This reverts commit 7d9e99a3ac7b36bc7593dd93f5d378593474577e.

### Description
This should be merged in Thursday, not today. 
Reverting
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
