### PR TITLE
fix(studio): pass asset type as context instead of argument

### DIFF
--- a/packages/sanity/src/core/form/studio/assetSourceDataset/shared/SelectAssetsDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceDataset/shared/SelectAssetsDialog.tsx
@@ -225,7 +225,7 @@ const SelectAssetsComponent = function SelectAssetsComponent(
       header={
         dialogHeaderTitle ||
         t('asset-source.dialog.default-title', {
-          context: assetType,
+          context: assetType === 'sanity.video' ? 'video' : assetType,
         })
       }
       id={_elementId}

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/MediaLibraryAssetSource.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/MediaLibraryAssetSource.tsx
@@ -50,7 +50,7 @@ const MediaLibraryAssetSourceComponent = function MediaLibraryAssetSourceCompone
           dialogHeaderTitle={
             dialogHeaderTitle ||
             t('asset-sources.media-library.select-dialog.title', {
-              assetType: assetType,
+              context: assetType === 'sanity.video' ? 'video' : assetType,
               targetTitle: schemaType?.title,
             })
           }

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -134,14 +134,20 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'asset-source.dialog.default-title_file': 'Select file',
   /** Select asset dialog title for images */
   'asset-source.dialog.default-title_image': 'Select image',
+  /** Select asset dialog title for videos */
+  'asset-source.dialog.default-title_video': 'Select video',
   /** Insert asset error */
   'asset-source.dialog.insert-asset-error':
     'Error inserting asset. See the console for more information.',
   /** Select asset dialog load more items */
   'asset-source.dialog.load-more': 'Load more',
-  /** Text shown when selecting a file but there's no files to select from */
+  /** Text shown when selecting a file but there's no files to select from
+   * @deprecated no longer in use
+   */
   'asset-source.dialog.no-assets_file': 'No files',
-  /** Text shown when selecting an image but there's no images to select from */
+  /** Text shown when selecting an image but there's no images to select from
+   * @deprecated no longer in use
+   */
   'asset-source.dialog.no-assets_image': 'No images',
   'asset-source.file.asset-list.action.delete.disabled-cannot-delete-current-file':
     'Cannot delete currently selected file',
@@ -211,7 +217,9 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'asset-sources.media-library.image.title': 'Media Library',
 
   /** Info messages for the Media Library Asset Source  */
-  'asset-sources.media-library.select-dialog.title': 'Selecting {{assetType}} for {{targetTitle}}',
+  'asset-sources.media-library.select-dialog.title_file': 'Selecting file for {{targetTitle}}',
+  'asset-sources.media-library.select-dialog.title_image': 'Selecting image for {{targetTitle}}',
+  'asset-sources.media-library.select-dialog.title_video': 'Selecting video for {{targetTitle}}',
 
   /** Warning message shown when uploading already existing files to the Media Library Asset Source */
   'asset-sources.media-library.warning.file-already-exist.description':


### PR DESCRIPTION
### Description

The locale string `asset-sources.media-library.select-dialog.title` inserts `{{assetType}}` which is a union of `image`, `file` or `sanity.video`. This results in translations with english words mixed in, e.g. "Velger image for blogginnlegg" or (even worse) "Velger sanity.video for blogginnlegg". Instead of passing the `assetType` as as-is, we can instead pass it as context, which allows us to translate each union value individually.

### What to review
- Also discovered a translation string that didn't seem to be in use, so took the liberty of marking it as deprecated.

### Testing


### Notes for release
- Improved translation strings for asset dialog
