### PR TITLE
feat(core): allow disabling the built-in PTE Markdown shortcuts plugin

### DIFF
--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -136,6 +136,35 @@ export const customPlugins = defineType({
     },
 
     /**
+     * Markdown Shortcuts Disabled
+     */
+    {
+      type: 'array',
+      name: 'markdownShortcutsDisabled',
+      title: 'Markdown Shortcuts Disabled',
+      description: 'The markdown shortcuts are disabled',
+      of: [
+        {
+          type: 'block',
+        },
+      ],
+      components: {
+        portableText: {
+          plugins: (props) => {
+            return props.renderDefault({
+              ...props,
+              plugins: {
+                markdown: {
+                  enabled: false,
+                },
+              },
+            })
+          },
+        },
+      },
+    },
+
+    /**
      * Custom Decorator Shortcuts
      *
      * Uses the `CharacterPairDecoratorPlugin` add custom decorator shortcuts in the

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -73,7 +73,11 @@ export const DefaultPortableTextEditorPlugins = (
   props: Omit<PortableTextPluginsProps, 'renderDefault'>,
 ) => {
   if (!props.plugins.markdown.config) {
-    const {config, ...markdownShortcutsPluginProps} = props.plugins.markdown
+    const {enabled, config, ...markdownShortcutsPluginProps} = props.plugins.markdown
+
+    if (enabled === false) {
+      return null
+    }
 
     return <MarkdownShortcutsPlugin {...markdownShortcutsPluginProps} />
   }

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -454,6 +454,10 @@ export interface PortableTextPluginsProps {
         }
       | (MarkdownShortcutsPluginProps & {
           config?: undefined
+          /**
+           * @defaultValue true
+           */
+          enabled?: boolean
         })
   }
 }


### PR DESCRIPTION
### Description

`enabled: false` seems to be the idiomatic pattern to use here.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Test that markdown shortcuts work in PTE, but are disabled in the `markdownShortcutsDisabled` field in  http://localhost:3333/test/structure/input-standard;portable-text;customPlugins


### Testing

Manual testing.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

It is now possible to disable the built-in Markdown shortcuts plugin for the Portable Text Input.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
