### PR TITLE
fix(e2e): increase timeout for beforeEach in references popover test

### DIFF
--- a/e2e/tests/pte/referencesInPopover.spec.ts
+++ b/e2e/tests/pte/referencesInPopover.spec.ts
@@ -3,7 +3,8 @@ import {expect} from '@playwright/test'
 import {test} from '../../studio-test'
 
 test.describe('In PTE - references in popover', () => {
-  test.beforeEach(async ({page, createDraftDocument}) => {
+  test.beforeEach(async ({page, createDraftDocument}, testInfo) => {
+    testInfo.setTimeout(testInfo.timeout + 60_000)
     await createDraftDocument('/content/input-standard;portable-text;pt_allTheBellsAndWhistles')
 
     // Important since the having two documents side by side is vital to the test


### PR DESCRIPTION
### Description
Just found that playwright has a timeout of 30 secs in the `beforeEach` executions.
https://playwright.dev/docs/test-timeouts#test-timeout

See this failing test https://github.com/sanity-io/sanity/actions/runs/19129348197/job/54666763577?pr=11026

<img width="965" height="511" alt="Screenshot 2025-11-06 at 10 06 17" src="https://github.com/user-attachments/assets/829f0ba2-8800-4145-8f7a-f0a4e2ac2f85" />


This change increases the timeout of that before each function .

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
