### PR TITLE
fix(ci): change expected npm user

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      EXPECTED_NPM_USER: sanity-io
+      EXPECTED_NPM_USER: sanity-svc.npm
     steps:
       - uses: actions/create-github-app-token@v2
         id: generate-token

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   build-and-validate:
     if: >
-      github.event_name == 'workflow_dispatch' || 
+      github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.head_commit.message, 'chore(release): publish ')
     runs-on: ubuntu-latest
     permissions:
@@ -98,7 +98,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      EXPECTED_NPM_USER: sanity-io
+      EXPECTED_NPM_USER: sanity-svc.npm
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      EXPECTED_NPM_USER: sanity-io
+      EXPECTED_NPM_USER: sanity-svc.npm
     steps:
       - uses: actions/create-github-app-token@v2
         id: generate-token

--- a/.github/workflows/tag-latest.yml
+++ b/.github/workflows/tag-latest.yml
@@ -47,7 +47,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      EXPECTED_NPM_USER: sanity-io
+      EXPECTED_NPM_USER: sanity-svc.npm
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/tag-stable.yml
+++ b/.github/workflows/tag-stable.yml
@@ -47,7 +47,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      EXPECTED_NPM_USER: sanity-io
+      EXPECTED_NPM_USER: sanity-svc.npm
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
### Description
We've changed the npm user the release token is associated with. This updates workflow to expect the right one.

### What to review
Makes sense?

### Testing
The release workflows should work again once this is merged

### Notes for release
n/a