### PR TITLE
chore: add `sanity` as workspace dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "playwright": "catalog:",
     "prettier": "catalog:",
     "prettier-plugin-packagejson": "^2.5.19",
+    "sanity": "workspace:*",
     "tsx": "^4.20.6",
     "turbo": "^2.5.8",
     "typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       prettier-plugin-packagejson:
         specifier: ^2.5.19
         version: 2.5.19(prettier@3.6.2)
+      sanity:
+        specifier: workspace:*
+        version: link:packages/sanity
       tsx:
         specifier: ^4.20.6
         version: 4.20.6


### PR DESCRIPTION
### Description
Recent cleanup both removed sanity as a workspace dependency and also public hoisting which lifted the sanity package up to root node_modules had the unintended effect that the bin from the `sanity`-package would no longer be placed in `node_modules/.bin` – which again means that running `sanity` inside the monroepo would no longer get the cli from the workspace sanity package.

### What to review

### Testing
Running `sanity` from within the monorepo should now pick the `sanity`-executable from packages/sanity


### Notes for release
n/a