### PR TITLE
feat(core): add configurable `typography` plugin to PTE inputs

### DIFF
--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -70,6 +70,7 @@ export const customPlugins = defineType({
             return props.renderDefault({
               ...props,
               plugins: {
+                ...props.plugins,
                 markdown: {
                   boldDecorator: ({schema}) =>
                     schema.decorators.find((decorator) => decorator.name === 'bold')?.name,
@@ -120,6 +121,7 @@ export const customPlugins = defineType({
             return props.renderDefault({
               ...props,
               plugins: {
+                ...props.plugins,
                 markdown: {
                   config: {
                     boldDecorator: ({schema}) =>
@@ -154,6 +156,7 @@ export const customPlugins = defineType({
             return props.renderDefault({
               ...props,
               plugins: {
+                ...props.plugins,
                 markdown: {
                   enabled: false,
                 },
@@ -188,6 +191,7 @@ export const customPlugins = defineType({
                 {props.renderDefault({
                   ...props,
                   plugins: {
+                    ...props.plugins,
                     markdown: {
                       config: {
                         ...props.plugins.markdown,
@@ -235,6 +239,67 @@ export const customPlugins = defineType({
                 />
               </>
             )
+          },
+        },
+      },
+    },
+
+    /**
+     * All Typographic rules enabled
+     */
+    {
+      type: 'array',
+      name: 'allTypographicRulesEnabled',
+      title: 'All Typographic Rules Enabled',
+      description: 'All typographic rules are enabled',
+      of: [
+        {
+          type: 'block',
+        },
+      ],
+      components: {
+        portableText: {
+          plugins: (props) => {
+            return props.renderDefault({
+              ...props,
+              plugins: {
+                ...props.plugins,
+                typography: {
+                  ...props.plugins.typography,
+                  preset: 'all',
+                },
+              },
+            })
+          },
+        },
+      },
+    },
+
+    /**
+     * No Typographic rules enabled
+     */
+    {
+      type: 'array',
+      name: 'noTypographicRulesEnabled',
+      title: 'No Typographic Rules Enabled',
+      description: 'No typographic rules are enabled',
+      of: [
+        {
+          type: 'block',
+        },
+      ],
+      components: {
+        portableText: {
+          plugins: (props) => {
+            return props.renderDefault({
+              ...props,
+              plugins: {
+                ...props.plugins,
+                typography: {
+                  enabled: false,
+                },
+              },
+            })
           },
         },
       },

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -157,6 +157,7 @@
     "@portabletext/patches": "^2.0.0",
     "@portabletext/plugin-markdown-shortcuts": "^3.0.3",
     "@portabletext/plugin-one-line": "^2.1.2",
+    "@portabletext/plugin-typography": "^3.0.1",
     "@portabletext/react": "^5.0.0",
     "@portabletext/toolkit": "^4.0.0",
     "@rexxars/react-json-inspector": "^9.0.1",

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -1,4 +1,5 @@
 import {type MarkdownShortcutsPluginProps} from '@portabletext/plugin-markdown-shortcuts'
+import {type TypographyPluginProps} from '@portabletext/plugin-typography'
 import {
   type ArraySchemaType,
   type BlockDecoratorDefinition,
@@ -445,7 +446,7 @@ export interface BlockProps {
 export interface PortableTextPluginsProps {
   renderDefault: (props: PortableTextPluginsProps) => React.JSX.Element
   plugins: {
-    markdown:
+    markdown?:
       | {
           /**
            * @deprecated - add the configuration directly to `markdown` instead
@@ -459,6 +460,12 @@ export interface PortableTextPluginsProps {
            */
           enabled?: boolean
         })
+    typography?: {
+      /**
+       * @defaultValue true
+       */
+      enabled?: boolean
+    } & TypographyPluginProps
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1709,7 +1709,7 @@ importers:
         version: 3.0.2
       '@uiw/react-codemirror':
         specifier: ^4.25.1
-        version: 4.25.2(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.19.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.6)(codemirror@6.0.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 4.25.2(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.19.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.1)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.6)(codemirror@6.0.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       is-hotkey-esm:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1883,6 +1883,9 @@ importers:
       '@portabletext/plugin-one-line':
         specifier: ^2.1.2
         version: 2.1.2(@portabletext/editor@2.19.2(@portabletext/sanity-bridge@1.2.0(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types))(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types)(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2))(react@19.2.0)
+      '@portabletext/plugin-typography':
+        specifier: ^3.0.1
+        version: 3.0.1(@portabletext/editor@2.19.2(@portabletext/sanity-bridge@1.2.0(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types))(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types)(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2))(@types/react@19.2.2)(react@19.2.0)
       '@portabletext/react':
         specifier: ^5.0.0
         version: 5.0.0(react@19.2.0)
@@ -3275,8 +3278,8 @@ packages:
   '@codemirror/legacy-modes@6.5.2':
     resolution: {integrity: sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==}
 
-  '@codemirror/lint@6.9.2':
-    resolution: {integrity: sha512-sv3DylBiIyi+xKwRCJAAsBZZZWo82shJ/RTMymLabAdtbkV5cSKwWDeCgtUq3v8flTaXS2y1kKkICuRYtUswyQ==}
+  '@codemirror/lint@6.9.1':
+    resolution: {integrity: sha512-te7To1EQHePBQQzasDKWmK2xKINIXpk+xAiSYr9ZN+VB4KaT+/Hi2PEkeErTk5BV3PTz1TLyQL4MtJfPkKZ9sw==}
 
   '@codemirror/search@6.5.11':
     resolution: {integrity: sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==}
@@ -4539,6 +4542,13 @@ packages:
 
   '@portabletext/plugin-one-line@2.1.2':
     resolution: {integrity: sha512-dXIWBdkbzVgEYsgqh1LPiE4tWzMDjQ3293ltof/0tj4Bb2GFx/AM7YNYTxXEPdVSby5gQMqlXuMugpZ48x+ZRQ==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      '@portabletext/editor': ^2.19.2
+      react: ^18.3 || ^19
+
+  '@portabletext/plugin-typography@3.0.1':
+    resolution: {integrity: sha512-KhvBp+JOu5a231VSim0hdzMc0AGsAHfRSVsER/yPHB7YhmazQY7KxOlLass8Wk3h+bG/cJT9M3vWP7uRjX1kBw==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       '@portabletext/editor': ^2.19.2
@@ -13902,7 +13912,7 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.19.1
       '@codemirror/language': 6.11.3
-      '@codemirror/lint': 6.9.2
+      '@codemirror/lint': 6.9.1
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.6
       '@lezer/common': 1.3.0
@@ -13953,7 +13963,7 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.11.3
 
-  '@codemirror/lint@6.9.2':
+  '@codemirror/lint@6.9.1':
     dependencies:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.6
@@ -15461,6 +15471,15 @@ snapshots:
       react: 19.2.0
       react-compiler-runtime: 1.0.0(react@19.2.0)
 
+  '@portabletext/plugin-typography@3.0.1(@portabletext/editor@2.19.2(@portabletext/sanity-bridge@1.2.0(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types))(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types)(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2))(@types/react@19.2.2)(react@19.2.0)':
+    dependencies:
+      '@portabletext/editor': 2.19.2(@portabletext/sanity-bridge@1.2.0(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types))(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types)(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2)
+      '@portabletext/plugin-input-rule': 0.5.4(@portabletext/editor@2.19.2(@portabletext/sanity-bridge@1.2.0(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types))(@sanity/schema@packages+@sanity+schema)(@sanity/types@packages+@sanity+types)(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2))(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-compiler-runtime: 1.0.0(react@19.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@portabletext/react@5.0.0(react@19.2.0)':
     dependencies:
       '@portabletext/toolkit': 4.0.0
@@ -15853,7 +15872,7 @@ snapshots:
       '@sanity/incompatible-plugin': 1.0.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@sanity/ui': 3.1.11(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.0(react@19.2.0))(react-is@19.2.0)(react@19.2.0)(styled-components@6.1.19(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@uiw/codemirror-themes': 4.25.2(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)
-      '@uiw/react-codemirror': 4.25.2(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.19.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.6)(codemirror@6.0.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@uiw/react-codemirror': 4.25.2(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.19.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.1)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.6)(codemirror@6.0.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       sanity: link:packages/sanity
@@ -17177,12 +17196,12 @@ snapshots:
       '@typescript-eslint/types': 8.46.3
       eslint-visitor-keys: 4.2.1
 
-  '@uiw/codemirror-extensions-basic-setup@4.25.2(@codemirror/autocomplete@6.19.1)(@codemirror/commands@6.10.0)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)':
+  '@uiw/codemirror-extensions-basic-setup@4.25.2(@codemirror/autocomplete@6.19.1)(@codemirror/commands@6.10.0)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.1)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)':
     dependencies:
       '@codemirror/autocomplete': 6.19.1
       '@codemirror/commands': 6.10.0
       '@codemirror/language': 6.11.3
-      '@codemirror/lint': 6.9.2
+      '@codemirror/lint': 6.9.1
       '@codemirror/search': 6.5.11
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.6
@@ -17193,14 +17212,14 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.6
 
-  '@uiw/react-codemirror@4.25.2(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.19.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.6)(codemirror@6.0.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@uiw/react-codemirror@4.25.2(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.19.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.1)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.6)(codemirror@6.0.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@codemirror/commands': 6.10.0
       '@codemirror/state': 6.5.2
       '@codemirror/theme-one-dark': 6.1.3
       '@codemirror/view': 6.38.6
-      '@uiw/codemirror-extensions-basic-setup': 4.25.2(@codemirror/autocomplete@6.19.1)(@codemirror/commands@6.10.0)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)
+      '@uiw/codemirror-extensions-basic-setup': 4.25.2(@codemirror/autocomplete@6.19.1)(@codemirror/commands@6.10.0)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.1)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6)
       codemirror: 6.0.2
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -18527,7 +18546,7 @@ snapshots:
       '@codemirror/autocomplete': 6.19.1
       '@codemirror/commands': 6.10.0
       '@codemirror/language': 6.11.3
-      '@codemirror/lint': 6.9.2
+      '@codemirror/lint': 6.9.1
       '@codemirror/search': 6.5.11
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.6


### PR DESCRIPTION
### Description

The `@portabletext/plugin-typography` plugin has been added as a built-in plugin for PTE, configurable using the `portableText.plugins.typography` prop.

https://www.npmjs.com/package/@portabletext/plugin-typography

> [!NOTE]
> This plugin supports React 18 as well as 19

The default configuration adds a `guard` to the plugin which prevents it from running inside `'code'` decorators. The plugin also has available props to configure a `preset` or configure `enabled` and `disabled` rules. All of these props, along with the `guard`, are exposed.

The default `preset` is `'default'` and enables the default set of rules: https://www.npmjs.com/package/@portabletext/plugin-typography#rules-included

Note: In order to allow configuring a second plugin, the existing `markdown` has been made optional and it's now required to spread `...props.plugins` in order to not accidentally overwrite any built-in plugin.



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

1. Does the `portableText.plugins` config make sense? Is it correct to mark `markdown` and `typography` optional?
2. Is the `'default'` `preset` good enough or would you like to further adjust what rules are enabled in Studio by default? 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

1. Test any PTE input to verify that the typographic rules are enabled.
2. Test the fields in http://localhost:3333/test/structure/input-standard;portable-text;customPlugins where the plugin has been configured.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

A `typography` plugin has been enabled in all Portable Text Input. It is completely configurable, but out of the box it provides useful typographic transformations like smart quotes and turning `"->"` in `"→"`

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
