### PR TITLE
fix: Correctly fetch canvas documents linked to releases

### DIFF
--- a/packages/sanity/src/core/canvas/store/createCanvasCompanionDocsStore.ts
+++ b/packages/sanity/src/core/canvas/store/createCanvasCompanionDocsStore.ts
@@ -31,7 +31,6 @@ const getCompanionDocs = memoize(
       previewStore.unstable_observeDocumentIdSet(
         `_type == "sanity.canvas.link" && studioDocumentId in *[sanity::versionOf($publishedId)]._id`,
         {publishedId: id},
-        {apiVersion: 'v2025-02-19'}, // sanity::versionOf was released in version 2025-02-19
       )
 
     const getCompanionDoc$ = (id: string) =>


### PR DESCRIPTION
### Description

Updated the query for fetching versioned documents in `companionDocListener`. I've tested the original `studioDocumentId in path("versions.**."+ $publishedId)` but I think the `**` would have to be at the end for it to work correctly with `path`, and that's of no use to us here. Not sure if `match` is the best replacement for the case, but it seems to do the job.

This should then correctly lock editing for documents in a release that have a companion Canvas doc.

<img width="835" height="625" alt="image" src="https://github.com/user-attachments/assets/085019fb-67cc-4a47-b3a3-60c6a9fe862d" />

Edit: `match` wasn't the best replacement, ended up using a subquery with `sanity::versionOf`

### Context

We're adding a feature that allows users to link a Canvas document straight to a release version of a document in Studio, when previously we only supported connecting to Drafts. (See slack message for details.)

It's not really testable outside of a local setup. The Canvas PRs will follow in the next few days, but this can be shipped ahead of that since it's technically a fix and shouldn't affect any existing behaviors. 


### What to review

When a canvas document (PR open) is linked to a release document, it should get locked in Studio same way it does for Draft.

1. Go to canvas
2. Select project and schema type
3. Click "Create a new document" -> Select an active release
4. Click the document link to get to Studio
5. Editing should be disabled

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
I just did a quick manual test since it's a fairly small change and the feature didn't have a test suite anyway.


### Notes for release

This is part of a Canvas feature that will be announced separately.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
