### PR TITLE
chore(deps): catalog @sanity/client

### DIFF
--- a/dev/efps/package.json
+++ b/dev/efps/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/utils": "workspace:*",
-    "@sanity/client": "^7.12.1",
+    "@sanity/client": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@types/yargs": "^17.0.34",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -25,7 +25,7 @@
     "@portabletext/toolkit": "^4.0.0",
     "@sanity/assist": "^5.0.2",
     "@sanity/cli": "workspace:*",
-    "@sanity/client": "^7.12.1",
+    "@sanity/client": "catalog:",
     "@sanity/color": "^3.0.6",
     "@sanity/color-input": "^4.0.6",
     "@sanity/google-maps-input": "^4.2.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -20,7 +20,7 @@
     "@repo/eslint-config": "workspace:*",
     "@repo/tsconfig": "workspace:*",
     "@repo/utils": "workspace:*",
-    "@sanity/client": "^7.12.1",
+    "@sanity/client": "catalog:",
     "@sanity/uuid": "^3.0.2",
     "eslint": "catalog:",
     "tsx": "^4.20.6"

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@babel/parser": "^7.28.5",
     "@babel/traverse": "^7.28.4",
-    "@sanity/client": "^7.12.1",
+    "@sanity/client": "catalog:",
     "@sanity/codegen": "workspace:*",
     "@sanity/runtime-cli": "^11.1.3",
     "@sanity/telemetry": "^0.8.0",

--- a/packages/@sanity/migrate/package.json
+++ b/packages/@sanity/migrate/package.json
@@ -49,7 +49,7 @@
     "watch": "pkg-utils watch"
   },
   "dependencies": {
-    "@sanity/client": "^7.12.1",
+    "@sanity/client": "catalog:",
     "@sanity/mutate": "^0.14.0",
     "@sanity/types": "workspace:*",
     "@sanity/util": "workspace:*",

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -50,7 +50,7 @@
     "watch": "pkg-utils watch"
   },
   "dependencies": {
-    "@sanity/client": "^7.12.1",
+    "@sanity/client": "catalog:",
     "@sanity/media-library-types": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -117,7 +117,7 @@
   "dependencies": {
     "@date-fns/tz": "^1.4.1",
     "@date-fns/utc": "^2.1.1",
-    "@sanity/client": "^7.12.1",
+    "@sanity/client": "catalog:",
     "@sanity/types": "workspace:*",
     "date-fns": "^4.1.0",
     "rxjs": "^7.8.2"

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -85,7 +85,7 @@
     "@repo/package.config": "workspace:*",
     "@repo/test-config": "workspace:*",
     "@repo/tsconfig": "workspace:*",
-    "@sanity/client": "^7.12.1",
+    "@sanity/client": "catalog:",
     "@sanity/eslint-config-i18n": "catalog:",
     "@sanity/pkg-utils": "catalog:",
     "@testing-library/react": "^16.3.0",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -164,7 +164,7 @@
     "@sanity/asset-utils": "^2.3.0",
     "@sanity/bifur-client": "^0.4.1",
     "@sanity/cli": "workspace:*",
-    "@sanity/client": "^7.12.1",
+    "@sanity/client": "catalog:",
     "@sanity/color": "^3.0.6",
     "@sanity/comlink": "^4.0.0",
     "@sanity/diff": "workspace:*",

--- a/perf/tests/package.json
+++ b/perf/tests/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@playwright/test": "catalog:",
-    "@sanity/client": "^7.12.1",
+    "@sanity/client": "catalog:",
     "@sanity/uuid": "^3.0.2",
     "dotenv": "^16.6.1",
     "execa": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@playwright/test':
       specifier: 1.56.1
       version: 1.56.1
+    '@sanity/client':
+      specifier: ^7.12.1
+      version: 7.12.1
     '@sanity/eslint-config-i18n':
       specifier: ^2.0.0
       version: 2.0.0
@@ -296,7 +299,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@repo/utils
       '@sanity/client':
-        specifier: ^7.12.1
+        specifier: 'catalog:'
         version: 7.12.1(debug@4.4.3)
       '@types/react':
         specifier: 'catalog:'
@@ -614,7 +617,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@sanity/cli
       '@sanity/client':
-        specifier: ^7.12.1
+        specifier: 'catalog:'
         version: 7.12.1(debug@4.4.3)
       '@sanity/color':
         specifier: ^3.0.6
@@ -762,7 +765,7 @@ importers:
         specifier: workspace:*
         version: link:../packages/@repo/utils
       '@sanity/client':
-        specifier: ^7.12.1
+        specifier: 'catalog:'
         version: 7.12.1(debug@4.4.3)
       '@sanity/uuid':
         specifier: ^3.0.2
@@ -1061,7 +1064,7 @@ importers:
         specifier: ^7.28.4
         version: 7.28.5(supports-color@5.5.0)
       '@sanity/client':
-        specifier: ^7.12.1
+        specifier: 'catalog:'
         version: 7.12.1(debug@4.4.3)
       '@sanity/codegen':
         specifier: workspace:*
@@ -1391,7 +1394,7 @@ importers:
   packages/@sanity/migrate:
     dependencies:
       '@sanity/client':
-        specifier: ^7.12.1
+        specifier: 'catalog:'
         version: 7.12.1(debug@4.4.3)
       '@sanity/mutate':
         specifier: ^0.14.0
@@ -1568,7 +1571,7 @@ importers:
   packages/@sanity/types:
     dependencies:
       '@sanity/client':
-        specifier: ^7.12.1
+        specifier: 'catalog:'
         version: 7.12.1(debug@4.4.3)
       '@sanity/media-library-types':
         specifier: ^1.0.1
@@ -1620,7 +1623,7 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       '@sanity/client':
-        specifier: ^7.12.1
+        specifier: 'catalog:'
         version: 7.12.1(debug@4.4.3)
       '@sanity/types':
         specifier: workspace:*
@@ -1757,7 +1760,7 @@ importers:
         specifier: workspace:*
         version: link:../../@repo/tsconfig
       '@sanity/client':
-        specifier: ^7.12.1
+        specifier: 'catalog:'
         version: 7.12.1(debug@4.4.3)
       '@sanity/eslint-config-i18n':
         specifier: 'catalog:'
@@ -1905,7 +1908,7 @@ importers:
         specifier: workspace:*
         version: link:../@sanity/cli
       '@sanity/client':
-        specifier: ^7.12.1
+        specifier: 'catalog:'
         version: 7.12.1(debug@4.4.3)
       '@sanity/color':
         specifier: ^3.0.6
@@ -2501,7 +2504,7 @@ importers:
         specifier: 'catalog:'
         version: 1.56.1
       '@sanity/client':
-        specifier: ^7.12.1
+        specifier: 'catalog:'
         version: 7.12.1(debug@4.4.3)
       '@sanity/uuid':
         specifier: ^3.0.2
@@ -2562,7 +2565,7 @@ importers:
         specifier: workspace:*
         version: link:../packages/@repo/utils
       '@sanity/client':
-        specifier: ^7.12.1
+        specifier: 'catalog:'
         version: 7.12.1(debug@4.4.3)
       '@types/lodash-es':
         specifier: ^4.17.12

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ packages:
 catalog:
   '@playwright/experimental-ct-react': 1.56.1
   '@playwright/test': 1.56.1
+  '@sanity/client': ^7.12.1
   '@sanity/eslint-config-i18n': ^2.0.0
   '@sanity/pkg-utils': ^8.1.13
   '@sanity/ui': ^3.1.5

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@repo/tsconfig": "workspace:*",
     "@repo/utils": "workspace:*",
-    "@sanity/client": "^7.12.1",
+    "@sanity/client": "catalog:",
     "@types/lodash-es": "^4.17.12",
     "@types/semver": "^7.7.1",
     "@types/yargs": "^17.0.33",


### PR DESCRIPTION
### Description
Moves `@sanity/client` to pnpm catalog to make it easier to maintain.

### What to review
I deliberately left out usage of `@sanity/client` in the `examples/`-folder since these are meant for copy+paste

### Testing
CI pass –> we're good

### Notes for release
n/a