### PR TITLE
feat(structure): add views and overview support to list panes

### DIFF
--- a/dev/test-studio/components/listViews/CustomListView.tsx
+++ b/dev/test-studio/components/listViews/CustomListView.tsx
@@ -1,0 +1,61 @@
+import {Card, Stack, Text} from '@sanity/ui'
+
+import {
+  type PaneListItem,
+  type PaneListItemDivider,
+} from '../../../../packages/sanity/src/structure/types'
+
+interface CustomListViewProps {
+  items: (PaneListItem<unknown> | PaneListItemDivider)[]
+  title: string
+  options?: Record<string, unknown>
+}
+
+export function CustomListView(props: CustomListViewProps) {
+  const {items, title, options} = props
+
+  return (
+    <Card padding={4}>
+      <Stack space={4}>
+        <Text size={3} weight="bold">
+          Custom List View: {title}
+        </Text>
+
+        <Text size={1} muted>
+          This is a custom view for the list! It has {items.length} items.
+        </Text>
+
+        {options && Object.keys(options).length > 0 && (
+          <Card padding={3} radius={2} shadow={1}>
+            <Text size={1} weight="semibold">
+              Options:
+            </Text>
+            <pre>{JSON.stringify(options, null, 2)}</pre>
+          </Card>
+        )}
+
+        <Card padding={3} radius={2} shadow={1}>
+          <Stack space={2}>
+            <Text size={1} weight="semibold">
+              Items:
+            </Text>
+            {items.map((item, idx) => {
+              if (item.type === 'divider') {
+                return (
+                  <Text key={`divider-${idx}`} size={1} muted>
+                    --- Divider ---
+                  </Text>
+                )
+              }
+              return (
+                <Text key={item.id} size={1}>
+                  • {item.title || item.id}
+                </Text>
+              )
+            })}
+          </Stack>
+        </Card>
+      </Stack>
+    </Card>
+  )
+}

--- a/dev/test-studio/components/listViews/ListOverview.tsx
+++ b/dev/test-studio/components/listViews/ListOverview.tsx
@@ -1,0 +1,31 @@
+import {Card, Code, Heading, Stack, Text} from '@sanity/ui'
+
+interface ListOverviewProps {
+  title: string
+  options?: Record<string, unknown>
+}
+
+export function ListOverview(props: ListOverviewProps) {
+  const {title, options} = props
+
+  return (
+    <Card padding={4}>
+      <Stack space={4}>
+        <Heading size={1}>Overview: {title}</Heading>
+
+        <Text>This is a custom overview component that appears when no list item is selected.</Text>
+
+        {options && Object.keys(options).length > 0 && (
+          <>
+            <Text weight="semibold">Options passed to component:</Text>
+            <Code language="json">{JSON.stringify(options, null, 2)}</Code>
+          </>
+        )}
+
+        <Text muted size={1}>
+          Select an item from the list to see its details.
+        </Text>
+      </Stack>
+    </Card>
+  )
+}

--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -23,6 +23,8 @@ import {
 
 import {DebugPane} from '../components/panes/debug'
 import {JsonDocumentDump} from '../components/panes/JsonDocumentDump'
+import {CustomListView} from '../components/listViews/CustomListView'
+import {ListOverview} from '../components/listViews/ListOverview'
 import {PerspectiveExample} from '../components/PerspectiveExample'
 import {TranslateExample} from '../components/TranslateExample'
 import {_buildTypeGroup} from './_buildTypeGroup'
@@ -255,6 +257,83 @@ export const structure: StructureResolver = (
                       filter: '_type == "author" || _type == "book"',
                     },
                   }).apiVersion('2023-07-28'),
+                ),
+
+              // Test list with custom views
+              S.listItem()
+                .title('List with Views (Test)')
+                .id('list-with-views-test')
+                .child(
+                  S.list()
+                    .title('Authors')
+                    .id('authors-with-views')
+                    .items([
+                      S.documentListItem().id('grrm').schemaType('author'),
+                      S.documentListItem().id('jrr-tolkien').schemaType('author'),
+                      S.divider(),
+                      S.listItem()
+                        .title('All Authors')
+                        .id('all-authors')
+                        .child(
+                          S.documentList({
+                            id: 'all-authors-list',
+                            title: 'All Authors',
+                            options: {filter: '_type == "author"'},
+                          }),
+                        ),
+                    ])
+                    .views([
+                      S.view
+                        .component(CustomListView)
+                        .id('custom-view')
+                        .title('Custom View')
+                        .options({message: 'Hello from custom view!', showDetails: true}),
+                      S.view
+                        .component(CustomListView)
+                        .id('another-view')
+                        .title('Another View')
+                        .options({message: 'This is another custom view'}),
+                    ]),
+                ),
+
+              // Test list with overview component
+              S.listItem()
+                .title('List with Overview (Test)')
+                .id('list-with-overview-test')
+                .child(
+                  S.list()
+                    .title('Books')
+                    .id('books-with-overview')
+                    .items([
+                      S.documentListItem().id('grrm').schemaType('author'),
+                      S.documentListItem().id('jrr-tolkien').schemaType('author'),
+                      S.divider(),
+                      S.listItem()
+                        .title('All Books')
+                        .id('all-books')
+                        .child(
+                          S.documentList({
+                            id: 'all-books-list',
+                            title: 'All Books',
+                            options: {filter: '_type == "book"'},
+                          }),
+                        ),
+                    ])
+                    .overview(
+                      S.component(ListOverview)
+                        .id('books-overview')
+                        .options({
+                          customMessage: 'Select an item to view details',
+                          showStats: true,
+                        }),
+                    )
+                    .views([
+                      S.view
+                        .component(CustomListView)
+                        .id('custom-books-view')
+                        .title('Custom Books View')
+                        .options({message: 'Custom view of books!'}),
+                    ]),
                 ),
 
               // A singleton not using `documentListItem`, eg no built-in preview

--- a/packages/sanity/src/structure/panes/list/ListHeaderTabs.tsx
+++ b/packages/sanity/src/structure/panes/list/ListHeaderTabs.tsx
@@ -1,0 +1,62 @@
+import {TabList} from '@sanity/ui'
+import {type ComponentType, type ReactNode, useCallback} from 'react'
+
+import {Tab} from '../../../ui-components'
+import {usePaneRouter} from '../../components'
+import {useListPane} from './useListPane'
+
+/**
+ * @internal
+ */
+export function ListHeaderTabs() {
+  const {activeViewId, views} = useListPane()
+
+  if (!views || views.length === 0) {
+    return null
+  }
+
+  // Create a combined array of all tabs (default list + custom views)
+  const allTabs = [
+    {id: '__list__', title: 'List', icon: undefined, isDefault: true},
+    ...views.map((view) => ({...view, isDefault: false})),
+  ]
+
+  return (
+    <TabList space={1}>
+      {allTabs.map((tab) => (
+        <ListHeaderTab
+          key={tab.id}
+          icon={tab.icon}
+          isActive={tab.isDefault ? activeViewId === null : activeViewId === tab.id}
+          label={tab.title}
+          viewId={tab.isDefault ? null : tab.id}
+        />
+      ))}
+    </TabList>
+  )
+}
+
+function ListHeaderTab(props: {
+  icon?: ComponentType | ReactNode
+  isActive: boolean
+  label: string
+  viewId: string | null
+}) {
+  const {icon, isActive, label, viewId} = props
+  const {setView} = usePaneRouter()
+  const handleClick = useCallback(() => setView(viewId), [setView, viewId])
+
+  const tabId = `list-view-tab-${viewId || 'default'}`
+  const panelId = `list-view-panel-${viewId || 'default'}`
+
+  return (
+    <Tab
+      aria-controls={panelId}
+      icon={icon}
+      id={tabId}
+      label={label}
+      onClick={handleClick}
+      selected={isActive}
+    />
+  )
+}

--- a/packages/sanity/src/structure/panes/list/ListPane.tsx
+++ b/packages/sanity/src/structure/panes/list/ListPane.tsx
@@ -1,10 +1,12 @@
 import {Card, Code} from '@sanity/ui'
+import {useMemo} from 'react'
 import {useI18nText} from 'sanity'
 
-import {Pane} from '../../components'
+import {Pane, usePaneRouter} from '../../components'
 import {_DEBUG} from '../../constants'
 import {type BaseStructureToolPaneProps} from '../types'
 import {ListPaneContent} from './ListPaneContent'
+import {ListPaneContext, type ListPaneContextValue} from './ListPaneContext'
 import {ListPaneHeader} from './ListPaneHeader'
 
 type ListPaneProps = BaseStructureToolPaneProps<'list'>
@@ -14,43 +16,58 @@ type ListPaneProps = BaseStructureToolPaneProps<'list'>
  */
 export function ListPane(props: ListPaneProps) {
   const {childItemId, index, isActive, isSelected, pane, paneKey} = props
+  const {params} = usePaneRouter()
 
-  const {defaultLayout, displayOptions, items, menuItems, menuItemGroups} = pane
+  const {defaultLayout, displayOptions, items, menuItems, menuItemGroups, views} = pane
   const showIcons = displayOptions?.showIcons !== false
   const {title} = useI18nText(pane)
 
+  // Determine active view from URL params
+  const activeViewId = params?.view ?? null
+
+  // Create context value for list pane
+  const listPaneContextValue: ListPaneContextValue = useMemo(
+    () => ({
+      activeViewId,
+      views: views || [],
+    }),
+    [activeViewId, views],
+  )
+
   return (
-    <Pane
-      currentMaxWidth={350}
-      data-testid="structure-tool-list-pane"
-      data-ui="ListPane"
-      id={paneKey}
-      maxWidth={640}
-      minWidth={320}
-      selected={isSelected}
-    >
-      {_DEBUG && (
-        <Card padding={4} tone="transparent">
-          <Code>{pane.source || '(none)'}</Code>
-        </Card>
-      )}
+    <ListPaneContext.Provider value={listPaneContextValue}>
+      <Pane
+        currentMaxWidth={350}
+        data-testid="structure-tool-list-pane"
+        data-ui="ListPane"
+        id={paneKey}
+        maxWidth={640}
+        minWidth={320}
+        selected={isSelected}
+      >
+        {_DEBUG && (
+          <Card padding={4} tone="transparent">
+            <Code>{pane.source || '(none)'}</Code>
+          </Card>
+        )}
 
-      <ListPaneHeader
-        index={index}
-        menuItems={menuItems}
-        menuItemGroups={menuItemGroups}
-        title={title}
-      />
+        <ListPaneHeader
+          index={index}
+          menuItems={menuItems}
+          menuItemGroups={menuItemGroups}
+          title={title}
+        />
 
-      <ListPaneContent
-        key={paneKey}
-        childItemId={childItemId}
-        isActive={isActive}
-        items={items}
-        layout={defaultLayout}
-        showIcons={showIcons}
-        title={title}
-      />
-    </Pane>
+        <ListPaneContent
+          key={paneKey}
+          childItemId={childItemId}
+          isActive={isActive}
+          items={items}
+          layout={defaultLayout}
+          showIcons={showIcons}
+          title={title}
+        />
+      </Pane>
+    </ListPaneContext.Provider>
   )
 }

--- a/packages/sanity/src/structure/panes/list/ListPaneContext.ts
+++ b/packages/sanity/src/structure/panes/list/ListPaneContext.ts
@@ -1,0 +1,12 @@
+import {createContext} from 'react'
+
+import {type View} from '../../structureBuilder'
+
+/** @internal */
+export interface ListPaneContextValue {
+  activeViewId: string | null
+  views: View[]
+}
+
+/** @internal */
+export const ListPaneContext = createContext<ListPaneContextValue | null>(null)

--- a/packages/sanity/src/structure/panes/list/ListPaneHeader.tsx
+++ b/packages/sanity/src/structure/panes/list/ListPaneHeader.tsx
@@ -1,9 +1,12 @@
 import {ArrowLeftIcon} from '@sanity/icons'
+import {useMemo} from 'react'
 
 import {Button} from '../../../ui-components'
 import {BackLink, PaneHeader, PaneHeaderActions, usePane} from '../../components'
 import {type PaneMenuItem, type PaneMenuItemGroup} from '../../types'
 import {useStructureTool} from '../../useStructureTool'
+import {ListHeaderTabs} from './ListHeaderTabs'
+import {useListPane} from './useListPane'
 
 interface ListPaneHeaderProps {
   index: number
@@ -15,8 +18,14 @@ interface ListPaneHeaderProps {
 export const ListPaneHeader = ({index, menuItems, menuItemGroups, title}: ListPaneHeaderProps) => {
   const {features} = useStructureTool()
   const {collapsed, isLast} = usePane()
+  const {views} = useListPane()
+
   // Prevent focus if this is the last (non-collapsed) pane.
   const tabIndex = isLast && !collapsed ? -1 : 0
+
+  // Show tabs if views are defined
+  const showTabs = views && views.length > 0
+  const tabs = useMemo(() => showTabs && <ListHeaderTabs />, [showTabs])
 
   return (
     <PaneHeader
@@ -33,6 +42,7 @@ export const ListPaneHeader = ({index, menuItems, menuItemGroups, title}: ListPa
           />
         )
       }
+      tabs={tabs}
       tabIndex={tabIndex}
       title={title}
     />

--- a/packages/sanity/src/structure/panes/list/useListPane.ts
+++ b/packages/sanity/src/structure/panes/list/useListPane.ts
@@ -1,0 +1,12 @@
+import {useContext} from 'react'
+
+import {ListPaneContext, type ListPaneContextValue} from './ListPaneContext'
+
+/** @internal */
+export function useListPane(): ListPaneContextValue {
+  const pane = useContext(ListPaneContext)
+  if (!pane) {
+    throw new Error('useListPane must be used within a ListPane component')
+  }
+  return pane
+}

--- a/packages/sanity/src/structure/types.ts
+++ b/packages/sanity/src/structure/types.ts
@@ -357,6 +357,8 @@ export interface ListPaneNode extends BaseResolvedPaneNode<'list'> {
   defaultLayout?: GeneralPreviewLayoutKey
   displayOptions?: {showIcons?: boolean}
   items?: Array<PaneListItem | PaneListItemDivider>
+  views?: View[]
+  overview?: CustomComponentPaneNode
   // TODO: mark as unstable or remove
   source?: string
 }


### PR DESCRIPTION
## Summary

This PR implements support for custom views and overview components in Structure Builder list panes, enabling developers to create more flexible and customizable list experiences in Sanity Studio.

## Features

### 1. List Views

Add `.views()` method to `ListBuilder` enabling custom view components alongside the default list view:

```typescript
S.list()
  .title('My List')
  .items([...])
  .views([
    S.view.component(CustomView).id('custom').title('Custom View')
  ])
```

**Implementation:**
- Extended `ListBuilder` with `views()` method accepting array of `ViewBuilder` objects
- Created `ListPaneContext` and `useListPane` hook for state management
- Added `ListHeaderTabs` component for view tab navigation
- Modified `ListPaneContent` to switch between default list and custom views
- View state persists in URL via `?view=viewId` parameter

### 2. List Overview

Add `.overview()` method to `ListBuilder` for displaying a default component in the center pane when no list item is selected:

```typescript
S.list()
  .title('My List')
  .items([...])
  .overview(
    S.component(OverviewComponent).id('overview')
  )
```

**Implementation:**
- Extended `ListBuilder` with `overview()` method accepting `Component`/`ComponentBuilder`/`ComponentInput`
- Modified `createResolvedPaneNodeStream.ts` to create implicit child pane when list has overview
- Created `createOverviewChildResolver()` for navigation between overview and list items
- Overview appears in center pane by default when no item selected
- Selecting a list item navigates to that item's child pane

## Files Modified

- `packages/sanity/src/structure/structureBuilder/List.ts`
- `packages/sanity/src/structure/types.ts`
- `packages/sanity/src/structure/panes/list/ListPane.tsx`
- `packages/sanity/src/structure/panes/list/ListPaneContent.tsx`
- `packages/sanity/src/structure/panes/list/ListPaneHeader.tsx`
- `packages/sanity/src/structure/structureResolvers/createResolvedPaneNodeStream.ts`

## Files Created

- `packages/sanity/src/structure/panes/list/ListPaneContext.ts`
- `packages/sanity/src/structure/panes/list/useListPane.ts`
- `packages/sanity/src/structure/panes/list/ListHeaderTabs.tsx`
- `dev/test-studio/components/listViews/CustomListView.tsx`
- `dev/test-studio/components/listViews/ListOverview.tsx`

## Testing

Test examples have been added to `dev/test-studio/structure/resolveStructure.ts`:

1. **List with Views** - Demonstrates custom view components
2. **List with Overview** - Demonstrates overview component that appears by default

## Design Decisions

### Following Established Patterns

- Views implementation mirrors `DocumentBuilder`/`DocumentPane` patterns
- Tab navigation follows existing `DocumentHeaderTabs` patterns
- Component serialization uses existing `ComponentBuilder` patterns
- Pane resolution follows existing implicit pane creation patterns (like `__edit__`)

### Overview as Sibling Pane

The overview renders as a separate pane in the center (not inside the list pane), which:
- Provides more space for overview content
- Maintains consistency with how document editors work
- Uses the same navigation patterns as list item children

🤖 Generated with [Claude Code](https://claude.com/claude-code)