### PR TITLE
fix(structure): pass edit intent params for pane to handle

### DIFF
--- a/packages/sanity/src/structure/getIntentState.ts
+++ b/packages/sanity/src/structure/getIntentState.ts
@@ -60,11 +60,14 @@ export function getIntentState(
 
 function getPaneParams(
   intent: string,
-  {template, version}: Record<string, string>,
-): {template?: string; version?: string} {
-  if (intent !== 'create') return EMPTY_PARAMS
-  if (template && version) return {template, version}
-  if (template) return {template}
-  if (version) return {version}
-  return EMPTY_PARAMS
+  {template, version, inspect, comment, task}: Record<string, string>,
+): {template?: string; version?: string; inspect?: string; comment?: string; task?: string} {
+  switch (intent) {
+    case 'create':
+      return {template, version}
+    case 'edit':
+      return {inspect, comment, task}
+    default:
+      return EMPTY_PARAMS
+  }
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

If a pane is open that can handle the edit intent no params are passed so the resolvedIntent fails. For example, if you open a comment from dashboard notifications to Document A comment 1 the pane will open, your comment will be highlighted. If you close the comment inspector & reclick the notification the inspector will not reopen.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

* Is there a reason `getPaneParams` only handled the `create` intent? Maybe this is historical and can be changed
* Are there any unforeseen consequences to adding this?

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I tried to add a test for `getIntentState` but given it has module state & `PaneNode` is a complicated type to mock i didn't end up writing any – happy to be told how to do this. 

To actually test it, I set up the dashboard locally to fire a comlink navigate event with the edit intent url incl. comment/inspect so i could deduce what this boiled down too.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
