### PR TITLE
fix(cli): disable dynamic-import when running cli from local source

### DIFF
--- a/packages/@sanity/cli/bin/dev.js
+++ b/packages/@sanity/cli/bin/dev.js
@@ -4,8 +4,16 @@ const {register} = require('esbuild-register/dist/node')
 
 register({
   target: `node${process.version.slice(1)}`,
-  supported: {'dynamic-import': true},
   jsx: 'automatic',
+
+  /**
+   * Set 'dynamic-import': false to force esbuild to transpile dynamic import() calls
+   * to require() calls. When set to true, esbuild preserves dynamic imports, causing
+   * Node.js to try resolving them natively, which fails for .ts files since Node.js
+   * can't find TypeScript files. By transpiling to require(), esbuild-register can
+   * properly handle the module resolution for TypeScript files during development.
+   */
+  supported: {'dynamic-import': false},
 })
 
 if (process.env.TEST !== 'true') {


### PR DESCRIPTION
### Description

Set `'dynamic-import': false` to force esbuild to transpile dynamic import() calls to require() calls. When set to true, esbuild preserves dynamic imports, causing Node.js to try resolving them natively, which fails for .ts files since Node.js can't find TypeScript files. By transpiling to require(), esbuild-register can properly handle the module resolution for TypeScript files during development.

Before this change, if running with the cli from source (as it is when `SANITY_CLI_RUN_FROM_SOURCE=1` which is default when running with nix), the cli would fail during dynamic loading of the `generateTypesCommand` with this error:

```
+ Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/kristoffer.brabrand/development/sanity/sanity/packages/@sanity/cli/src/actions/typegen/generateAction' imported from /Users/kristoffer.brabrand/development/sanity/sanity/packages/@sanity/cli/src/commands/typegen/generateTypesCommand.ts
```