### PR TITLE
fix(typegen): allow generating types to absolute path (#7620)

### DIFF
--- a/packages/@sanity/cli/src/actions/typegen/generateAction.ts
+++ b/packages/@sanity/cli/src/actions/typegen/generateAction.ts
@@ -1,5 +1,5 @@
 import {constants, mkdir, open, stat} from 'node:fs/promises'
-import {dirname, join} from 'node:path'
+import {dirname, isAbsolute, join} from 'node:path'
 import {Worker} from 'node:worker_threads'
 
 import {readConfig} from '@sanity/codegen'
@@ -58,7 +58,9 @@ export default async function typegenGenerateAction(
     throw err
   }
 
-  const outputPath = join(process.cwd(), codegenConfig.generates)
+  const outputPath = isAbsolute(codegenConfig.generates)
+    ? codegenConfig.generates
+    : join(process.cwd(), codegenConfig.generates)
   const outputDir = dirname(outputPath)
   await mkdir(outputDir, {recursive: true})
   const workerPath = await getCliWorkerPath('typegenGenerate')


### PR DESCRIPTION
### Description

This PR solves an issue where using an absolute path for the `generates` field of the typegen config didn't work. 

- fixes #7620

Thanks for reporting, @okj579 💚

### Testing

A test has been added for a config with an absolute output path.

### Notes for release

* fix bug where absolute typegen output path did not work