### PR TITLE
fix(migrate): exports esm bundle for migrate package

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -83,6 +83,7 @@
     },
     "./migrate": {
       "source": "./src/_exports/migrate.ts",
+      "import": "./lib/migrate.mjs",
       "require": "./lib/migrate.js",
       "default": "./lib/migrate.js"
     },


### PR DESCRIPTION
### Description

Added the `import` field to the `./migrate` export in the `sanity` package's `package.json`. This ensures that ESM imports of the migrate functionality work correctly.

### What to review

Verify that the `import` field points to the correct file path (`./lib/migrate.mjs`) and that it aligns with the existing `require` and `default` fields.

### Testing

Tested by importing the migrate functionality in both ESM and CommonJS environments to ensure it resolves correctly.

### Notes for release

Fixed ESM imports for the migrate functionality in the `sanity` package by adding the proper `import` field to the package.json exports map.