### PR TITLE
refactor: move info/debug to stederr by using console.warn

### DIFF
--- a/packages/@sanity/cli/bin/dev.js
+++ b/packages/@sanity/cli/bin/dev.js
@@ -16,10 +16,8 @@ register({
   supported: {'dynamic-import': false},
 })
 
-if (process.env.TEST !== 'true') {
-  // oxlint-disable-next-line no-console
-  console.log('\n️ⓘ Running local Sanity CLI from source\n')
-}
+// oxlint-disable-next-line no-console
+console.warn('\n️ⓘ Running local Sanity CLI from source\n')
 
 // Define the global `__DEV__` flag which is used to
 // - determine when to use `esbuild-register` in the Sanity development server

--- a/packages/@sanity/cli/src/cli.ts
+++ b/packages/@sanity/cli/src/cli.ts
@@ -253,15 +253,13 @@ function warnOnNonProductionEnvironment(): void {
     return
   }
 
-  if (process.env.TEST !== 'true') {
-    console.warn(
-      chalk.yellow(
-        knownEnvs.includes(sanityEnv)
-          ? `[WARN] Running in ${sanityEnv} environment mode\n`
-          : `[WARN] Running in ${chalk.red('UNKNOWN')} "${sanityEnv}" environment mode\n`,
-      ),
-    )
-  }
+  console.warn(
+    chalk.yellow(
+      knownEnvs.includes(sanityEnv)
+        ? `[WARN] Running in ${sanityEnv} environment mode\n`
+        : `[WARN] Running in ${chalk.red('UNKNOWN')} "${sanityEnv}" environment mode\n`,
+    ),
+  )
 }
 
 function loadAndSetEnvFromDotEnvFiles({

--- a/turbo.json
+++ b/turbo.json
@@ -61,7 +61,6 @@
     "SYSTEMROOT",
     "VISUAL",
     "EDITOR",
-    "TEST",
     // These should be passed through but not be used as cache keys since they are tokens
     "EFPS_SANITY_TOKEN_STAGING",
     "EFPS_SANITY_TOKEN_PROD,",


### PR DESCRIPTION
### Description

Print warn/info, but use `console.warn` to have it go to `stederr` instead of `stdout`. This way the output from commands can still be parsed as JSON, even if info about running CLI from source is printed.