### PR TITLE
fix(presentation): persist scheduled draft perspective in location item

### DIFF
--- a/packages/sanity/src/presentation/document/LocationsBanner.tsx
+++ b/packages/sanity/src/presentation/document/LocationsBanner.tsx
@@ -10,6 +10,7 @@ import {type ComponentType, type ReactNode, useCallback, useContext, useState} f
 import {type ObjectSchemaType, useTranslation} from 'sanity'
 import {PresentationContext} from 'sanity/_singletons'
 import {useIntentLink} from 'sanity/router'
+import {usePaneRouter} from 'sanity/structure'
 
 import {DEFAULT_TOOL_NAME, DEFAULT_TOOL_TITLE} from '../constants'
 import {presentationLocaleNamespace} from '../i18n'
@@ -163,6 +164,7 @@ function LocationItem(props: {
   const currentPresentationToolName = useCurrentPresentationToolName()
   const isCurrentTool = toolName === currentPresentationToolName
   const navigate = presentation?.navigate
+  const {params: paneParams} = usePaneRouter()
 
   const presentationLinkProps = useIntentLink({
     intent: 'edit',
@@ -172,6 +174,7 @@ function LocationItem(props: {
       mode: 'presentation',
       presentation: toolName,
       ...presentation?.structureParams,
+      ...paneParams,
       preview: node.href,
     },
   })


### PR DESCRIPTION
### Description
Persist the scheduled draft perspective, which is a special perspective only set as part of the `paneParams` when navigating to presentation when clicking in the location items.

<img width="615" height="394" alt="Screenshot 2025-11-10 at 09 14 46" src="https://github.com/user-attachments/assets/7d222734-44a9-47f3-ae2b-ff13364b4d62" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Are changes ok?
Something to consider against passing all the router params instead of only the scheduled draft? I prefer to pass everything as it will also preserve existing inspectors open like history / comments 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open a document which is possible to preview in presentation, for example the `Simple Block` , navigate to a scheduled draft, when clicking in the location item and opening presentation the pane router perspective should be preserved
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in where the scheduled draft perspective was not passed to presentation when clicking in the location items.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
