### PR TITLE
fix: make it possible to double click specific items in the inspect

### DIFF
--- a/packages/sanity/src/structure/panes/document/inspectDialog/InspectDialog.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectDialog/InspectDialog.tsx
@@ -122,7 +122,6 @@ export function InspectDialog(props: InspectDialogProps) {
               tabIndex={0}
               onKeyDown={maybeSelectAll}
               onDoubleClick={select}
-              onFocus={select}
               size={1}
             >
               {JSON.stringify(value, null, 2)}

--- a/packages/sanity/src/structure/panes/document/inspectDialog/helpers.ts
+++ b/packages/sanity/src/structure/panes/document/inspectDialog/helpers.ts
@@ -40,7 +40,7 @@ export function selectElement(element: HTMLElement): void {
 }
 
 export function select(event: any): void {
-  selectElement(event.currentTarget)
+  selectElement(event.target)
 }
 
 export function maybeSelectAll(event: any): void {


### PR DESCRIPTION
### Description

Add ability to select specific values / properties in the inspect - raw dialog in a document

Before

https://github.com/user-attachments/assets/c2c7cfa2-5274-4197-8b6f-56c5b333fbbb

After

https://github.com/user-attachments/assets/596df03a-ce3c-4b5c-a218-b6e4264c1e99

### Testing

Manual

### Notes for release

We are now able to select values in the raw json inspector of a document 
