### PR TITLE
fix(core): improve error state for invalid reference filter

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -198,7 +198,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
               })
 
               console.error(error)
-              return of({hits: []})
+              return of({hits: [], searchString, isLoading: false})
             }),
           ),
         ),


### PR DESCRIPTION
### Description
Currently, if custom reference filter produces an invalid query, we show an error in a toast, but leave the spinner spinning. This PR fixes the issue by setting `isLoading: false` in case of an error

### Testing
scroll down to the "Invalid filter"-case in the reference test schema and compare
- old: https://test-studio.sanity.dev/test/structure/input-standard;referenceTest;c93a7869-6e13-44b9-8bff-424c4aaf0c81
- new: https://test-studio-git-reference-input-improve-error-state-inva-d6271f.sanity.dev/test/structure/input-standard;referenceTest;c93a7869-6e13-44b9-8bff-424c4aaf0c81

### Notes for release
- Improved error handling in case of invalid custom reference filter.
