### PR TITLE
refactor(form): consider the perspective stack when checking for document availability

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/OptionPreview.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/OptionPreview.tsx
@@ -1,13 +1,9 @@
 import {type ReferenceSchemaType} from '@sanity/types'
-import {Stack, Text, TextSkeleton} from '@sanity/ui'
-import {type Observable} from 'rxjs'
+import {Stack} from '@sanity/ui'
 
 import {useTranslation} from '../../../i18n'
-import {Alert} from '../../components/Alert'
 import {type RenderPreviewCallback} from '../../types'
 import {ReferencePreview} from './ReferencePreview'
-import {type ReferenceInfo} from './types'
-import {useReferenceInfo} from './useReferenceInfo'
 
 /**
  * Used to preview a referenced type
@@ -17,69 +13,30 @@ import {useReferenceInfo} from './useReferenceInfo'
  */
 export function OptionPreview(props: {
   id: string
-  type: ReferenceSchemaType
-  getReferenceInfo: (id: string) => Observable<ReferenceInfo>
+  type: string
+  referenceType: ReferenceSchemaType
   renderPreview: RenderPreviewCallback
 }) {
-  const {getReferenceInfo, id: documentId, renderPreview} = props
-  const {isLoading, result: referenceInfo, error} = useReferenceInfo(documentId, getReferenceInfo)
+  const {referenceType, type, id: documentId, renderPreview} = props
+  const refType = referenceType.to.find((toType) => toType.name === type)
   const {t} = useTranslation()
-
-  if (isLoading) {
-    return (
-      <Stack space={2} padding={1}>
-        <TextSkeleton style={{maxWidth: 320}} radius={1} animated />
-        <TextSkeleton style={{maxWidth: 200}} radius={1} size={1} animated />
-      </Stack>
-    )
-  }
-
-  if (error) {
-    return (
-      <Stack space={2} padding={1}>
-        <Alert title={t('inputs.reference.error.failed-to-load-document-title')}>
-          <Text muted size={1}>
-            {error.message}
-          </Text>
-        </Alert>
-      </Stack>
-    )
-  }
-
-  if (!referenceInfo) {
-    return null
-  }
-
-  if (referenceInfo.availability.reason === 'PERMISSION_DENIED') {
-    return (
-      <Stack space={2} padding={1}>
-        {t('inputs.reference.error.missing-read-permissions-description')}
-      </Stack>
-    )
-  }
-
-  const refType = props.type.to.find((toType) => toType.name === referenceInfo.type)
 
   if (!refType) {
     return (
       <Stack space={2} padding={1}>
         {t('inputs.reference.error.invalid-search-result-type-title', {
-          returnedType: referenceInfo.type,
+          returnedType: type,
         })}
       </Stack>
     )
   }
-
   return (
-    referenceInfo &&
-    refType && (
-      <ReferencePreview
-        id={referenceInfo.id}
-        layout="default"
-        refType={refType}
-        renderPreview={renderPreview}
-        showTypeLabel={props.type.to.length > 1}
-      />
-    )
+    <ReferencePreview
+      id={documentId}
+      layout="default"
+      refType={refType}
+      renderPreview={renderPreview}
+      showTypeLabel={referenceType.to.length > 1}
+    />
   )
 }

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -228,20 +228,18 @@ export function ReferenceInput(props: ReferenceInputProps) {
 
   const renderOption = useCallback(
     (option: AutocompleteOption) => {
-      const documentId = option.hit.draft?._id || option.hit.published?._id || option.value
-
       return (
         <ReferenceInputPreviewCard forwardedAs="button" type="button" radius={2} tone="inherit">
           <OptionPreview
-            getReferenceInfo={getReferenceInfo}
-            id={documentId}
+            id={option.hit.id}
+            type={option.hit.type}
             renderPreview={renderPreview}
-            type={schemaType}
+            referenceType={schemaType}
           />
         </ReferenceInputPreviewCard>
       )
     },
-    [schemaType, getReferenceInfo, renderPreview],
+    [schemaType, renderPreview],
   )
 
   const renderValue = useCallback(() => {

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/useReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/useReferenceInput.tsx
@@ -36,7 +36,7 @@ interface Options {
 }
 
 export function useReferenceInput(options: Options) {
-  const {path, schemaType, version} = options
+  const {path, schemaType} = options
   const schema = useSchema()
   const perspective = usePerspective()
   const documentPreviewStore = useDocumentPreviewStore()
@@ -122,11 +122,8 @@ export function useReferenceInput(options: Options) {
 
   const getReferenceInfo = useCallback(
     (id: string) =>
-      adapter.getReferenceInfo(documentPreviewStore, id, schemaType, {
-        version,
-        perspective: perspective.perspectiveStack,
-      }),
-    [documentPreviewStore, schemaType, version, perspective.perspectiveStack],
+      adapter.getReferenceInfo(documentPreviewStore, id, schemaType, perspective.perspectiveStack),
+    [documentPreviewStore, schemaType, perspective.perspectiveStack],
   )
 
   return {

--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
@@ -31,30 +31,27 @@ export function getReferenceInfo(
   documentPreviewStore: DocumentPreviewStore,
   id: string,
   referenceType: ReferenceSchemaType,
-  {version, perspective}: {version?: string; perspective?: StackablePerspective[]} = {},
+  perspective?: StackablePerspective[],
 ): Observable<ReferenceInfo> {
-  const {publishedId, draftId, versionId} = getIdPair(id, {version})
+  const {publishedId, draftId} = getIdPair(id)
 
-  const pairAvailability$ = documentPreviewStore.unstable_observeDocumentPairAvailability(id, {
-    version,
-  })
+  const documentStackAvailability$ = documentPreviewStore.unstable_observeDocumentStackAvailability(
+    id,
+    perspective ?? ['published'],
+  )
 
-  return pairAvailability$.pipe(
-    switchMap((pairAvailability) => {
-      if (
-        !pairAvailability.draft.available &&
-        !pairAvailability.published.available &&
-        !pairAvailability.version?.available
-      ) {
-        // combine availability of draft + published
+  return documentStackAvailability$.pipe(
+    switchMap((stackAvailability) => {
+      // we only care about the first document in the stack that exists
+      const firstMatch = stackAvailability.find((doc) => {
+        return doc.availability.available || doc.availability.reason === 'PERMISSION_DENIED'
+      })
+
+      if (!firstMatch?.availability.available) {
         const availability =
-          pairAvailability.version?.reason === 'PERMISSION_DENIED' ||
-          pairAvailability.draft.reason === 'PERMISSION_DENIED' ||
-          pairAvailability.published.reason === 'PERMISSION_DENIED'
-            ? PERMISSION_DENIED
-            : NOT_FOUND
+          firstMatch?.availability?.reason === 'PERMISSION_DENIED' ? PERMISSION_DENIED : NOT_FOUND
 
-        // short circuit, neither draft nor published nor version is available so no point in trying to get preview
+        // short circuit, no version is available so no point in trying to get preview
         return of({
           id,
           type: undefined,
@@ -67,23 +64,17 @@ export function getReferenceInfo(
         } as const)
       }
 
-      const typeName$ = combineLatest([
-        documentPreviewStore.observeDocumentTypeFromId(draftId),
-        documentPreviewStore.observeDocumentTypeFromId(publishedId),
-        ...(versionId ? [documentPreviewStore.observeDocumentTypeFromId(versionId)] : []),
-      ]).pipe(
-        // assume draft + published + version are always same type
-        map(
-          ([draftTypeName, publishedTypeName, versionTypeName]) =>
-            versionTypeName || draftTypeName || publishedTypeName,
-        ),
+      const typeName$ = documentPreviewStore.observeDocumentTypeFromId(
+        draftId,
+        undefined,
+        perspective,
       )
 
       return typeName$.pipe(
         switchMap((typeName) => {
           if (!typeName) {
-            // we have already asserted that either the draft or the published document is readable, so
-            // if we get here we can't read the _type, so we're likely to be in an inconsistent state
+            // We have already asserted that there exists a readable version of the document.
+            // So if we get here, it means we can't read the _type, which again indicates we're in an inconsistent state and
             // waiting for an update to reach the client. Since we're in the context of a reactive stream based on
             // the _type we'll get it eventually
             return of({
@@ -127,16 +118,7 @@ export function getReferenceInfo(
 
           return combineLatest([previewState$, publishedDocumentExists$]).pipe(
             map(([previewState, publishedDocumentExists]): ReferenceInfo => {
-              const availability =
-                pairAvailability.version?.available ||
-                pairAvailability.draft.available ||
-                pairAvailability.published.available
-                  ? READABLE
-                  : pairAvailability.version?.reason === 'PERMISSION_DENIED' ||
-                      pairAvailability.draft.reason === 'PERMISSION_DENIED' ||
-                      pairAvailability.published.reason === 'PERMISSION_DENIED'
-                    ? PERMISSION_DENIED
-                    : NOT_FOUND
+              const availability = READABLE
               return {
                 type: typeName,
                 id: publishedId,

--- a/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
@@ -192,8 +192,8 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
 
   const getReferenceInfo = useCallback(
     (id: string, _type: ReferenceSchemaType) =>
-      adapter.getReferenceInfo(documentPreviewStore, id, _type),
-    [documentPreviewStore],
+      adapter.getReferenceInfo(documentPreviewStore, id, _type, perspectiveStack),
+    [documentPreviewStore, perspectiveStack],
   )
 
   return (

--- a/packages/sanity/src/core/preview/availability.ts
+++ b/packages/sanity/src/core/preview/availability.ts
@@ -1,4 +1,4 @@
-import {type SanityClient} from '@sanity/client'
+import {type SanityClient, type StackablePerspective} from '@sanity/client'
 import {flatten, keyBy} from 'lodash'
 import {combineLatest, defer, from, type Observable, of} from 'rxjs'
 import {distinctUntilChanged, map, mergeMap, reduce, switchMap} from 'rxjs/operators'
@@ -14,6 +14,7 @@ import {
 import {
   type AvailabilityResponse,
   type DocumentAvailability,
+  type DocumentStackAvailability,
   type DraftsModelDocumentAvailability,
   type ObservePathsFn,
 } from './types'
@@ -71,40 +72,10 @@ function mutConcat<T>(array: T[], chunks: T[]) {
   return array
 }
 
-export function createPreviewAvailabilityObserver(
+export function createDocumentAvailabilityObserver(
   versionedClient: SanityClient,
   observePaths: ObservePathsFn,
-): (id: string) => Observable<DraftsModelDocumentAvailability> {
-  /**
-   * Observable of metadata for the document with the given id
-   * If we can't read a document it is either because it's not readable or because it doesn't exist
-   *
-   * @internal
-   */
-  function observeDocumentAvailability(id: string): Observable<DocumentAvailability> {
-    // check for existence
-    return observePaths({_ref: id}, [['_rev'], ['_system']]).pipe(
-      map((res) => ({
-        hasRev: isRecord(res) && Boolean('_rev' in res && res?._rev),
-        isDeleted: isRecord(res) && res._system?.delete === true,
-      })),
-      distinctUntilChanged(),
-      switchMap(({hasRev, isDeleted}) => {
-        if (isDeleted) {
-          return of(AVAILABILITY_VERSION_DELETED)
-        }
-
-        return hasRev
-          ? // short circuit: if we can read the _rev field we know it both exists and is readable
-            of(AVAILABILITY_READABLE)
-          : // we can't read the _rev field for two possible reasons: 1) the document isn't readable or 2) the document doesn't exist
-            fetchDocumentReadability(id)
-      }),
-      swr(id),
-      map((ev) => ev.value),
-    )
-  }
-
+): (id: string) => Observable<DocumentAvailability> {
   const fetchDocumentReadability = debounceCollect(function fetchDocumentReadability(
     args: string[][],
   ): Observable<DocumentAvailability[]> {
@@ -147,6 +118,76 @@ export function createPreviewAvailabilityObserver(
     })
   }
 
+  /**
+   * Observable of metadata for the document with the given id
+   * If we can't read a document it is either because it's not readable or because it doesn't exist
+   *
+   * @internal
+   */
+  return function observeDocumentAvailability(id: string): Observable<DocumentAvailability> {
+    // check for existence first, observePaths is lightweight
+    return observePaths({_id: id}, [['_rev'], ['_system']]).pipe(
+      map((res) => ({
+        hasRev: isRecord(res) && Boolean('_rev' in res && res?._rev),
+        isDeleted: isRecord(res) && res._system?.delete === true,
+      })),
+      distinctUntilChanged(),
+      switchMap(({hasRev, isDeleted}) => {
+        if (isDeleted) {
+          return of(AVAILABILITY_VERSION_DELETED)
+        }
+
+        return hasRev
+          ? // short circuit: if we can read the _rev field we know it both exists and is readable
+            of(AVAILABILITY_READABLE)
+          : // we can't read the _rev field for two possible reasons: 1) the document isn't readable or 2) the document doesn't exist
+            fetchDocumentReadability(id)
+      }),
+      swr(id),
+      map((ev) => ev.value),
+    )
+  }
+}
+
+function ensurePublished(stack: StackablePerspective[]) {
+  return stack.includes('published') ? stack : stack.concat(['published'])
+}
+
+export function createDocumentStackAvailabilityObserver(
+  versionedClient: SanityClient,
+  observePaths: ObservePathsFn,
+): (id: string, perspective: StackablePerspective[]) => Observable<DocumentStackAvailability[]> {
+  const observeDocumentAvailability = createDocumentAvailabilityObserver(
+    versionedClient,
+    observePaths,
+  )
+
+  return (id: string, stack: StackablePerspective[]) => {
+    return combineLatest(
+      // explicitly check availability for published id (we're not using perspective in the following fetch here)
+      ensurePublished(stack).map((perspective) => {
+        const versionId =
+          perspective === 'drafts'
+            ? getDraftId(id)
+            : perspective === 'published'
+              ? getPublishedId(id)
+              : getVersionId(id, perspective)
+        return observeDocumentAvailability(versionId).pipe(
+          map((availability) => ({availability, id: versionId})),
+        )
+      }),
+    )
+  }
+}
+
+export function createPreviewAvailabilityObserver(
+  versionedClient: SanityClient,
+  observePaths: ObservePathsFn,
+): (id: string) => Observable<DraftsModelDocumentAvailability> {
+  const observeDocumentAvailability = createDocumentAvailabilityObserver(
+    versionedClient,
+    observePaths,
+  )
   /**
    * Returns an observable of metadata for a given drafts model document
    */

--- a/packages/sanity/src/core/preview/types.ts
+++ b/packages/sanity/src/core/preview/types.ts
@@ -104,6 +104,21 @@ export interface DraftsModelDocumentAvailability {
 /**
  * @hidden
  * @beta */
+export interface DocumentStackAvailability {
+  /**
+   * Document id
+   */
+  id: string
+
+  /**
+   * Availability for the document in this stack
+   */
+  availability: DocumentAvailability
+}
+
+/**
+ * @hidden
+ * @beta */
 export interface DraftsModelDocument<T extends SanityDocumentLike = SanityDocumentLike> {
   id: string
   type: string | null


### PR DESCRIPTION
### Description
This PR has two parts:

### Part 1 – skip availaiblity checks for search results
Currently, when we do a reference search, we first fetch matching documents from the query endpoint (using a search query). Then we take each returned document and pass them through an availability check. This is availablility check designed to check whether a document is available, or if it isnt: let us know why; does it not exist, or is it inaccessible due to the user's permissions? We use this info to display the appropriate UI in case where 1) the reference input has a value that references a document that doesn't exist, (e.g. a weak ref, or a reference marked with `_strengthenOnPublish`) or 2) if it references a document the user doesn't have read access to.

However, there should not be any need for doing this check on documents returned by a search, since the returned documents must already both exist and be readable to the current user, otherwise they wouldn't have been returned in the first place.

This part fixes an issue that could occur if you are in a release, search for a keyword that matches a document that's _not_ in the current release, but exists as a document in one of the other releases in the current stack. In this case, you'd see the document previewed as `Search returned a type that's not valid for this reference: ""`

### Part 2 – We still need to check for availability
If a reference input has a value that references a document, we still need to check the availability. The referenced document could exist as a version in any release in the current stack, so we check for existence of any of the potential versions. We do this by first using the lightweight preview observer to subscribe to the `_rev` of each document. If the document is available as a version in any of the releases in the stack, it counts as being available. This is handled by the new previewStore.observeDocumentStackAvailability, which takes a (published) document id, and returns an observable that emits an array of `{id: <versionId>, availability: DocumentAvailability}` info for each possible version in the list of releases. 

### Testing & review
I've done quite a bit of manual testing, but would appreciate some help in trying to make it break, and think of edge cases that I might be missing, or assumptions that I might be wrong about.

### Notes for release
- Fixes an issue with reference search that would sometimes display versions outside of current release as `Search returned a type that's not valid for this reference: ""`