### PR TITLE
fix(cli): undeploy based on `appId`/`studioHost`

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/deploy/__tests__/undeployAction.test.ts
+++ b/packages/sanity/src/_internal/cli/actions/deploy/__tests__/undeployAction.test.ts
@@ -74,6 +74,87 @@ describe('undeployStudioAction', () => {
     expect(mockContext.output.print).toHaveBeenCalledWith('Nothing to undeploy.')
   })
 
+  it('resolves app using `appId` (preferred)', async () => {
+    helpers.getUserApplication.mockResolvedValueOnce(mockApplication)
+    helpers.deleteUserApplication.mockResolvedValueOnce(undefined)
+    ;(mockContext.prompt.single as Mock<typeof mockContext.prompt.single>).mockResolvedValueOnce(
+      true,
+    ) // User confirms
+
+    await undeployStudioAction(
+      {
+        extOptions: {},
+      } as CliCommandArguments<UndeployStudioActionFlags>,
+      {
+        ...mockContext,
+        cliConfig: {
+          ...mockContext.cliConfig,
+          deployment: {appId: mockApplication.id},
+          studioHost: 'abc123',
+        },
+      },
+    )
+
+    expect(helpers.getUserApplication).toHaveBeenCalledWith({
+      appId: mockApplication.id,
+      client: expect.anything(),
+    })
+
+    expect(mockContext.prompt.single).toHaveBeenCalledWith({
+      type: 'confirm',
+      default: false,
+      message: expect.stringContaining('undeploy'),
+    })
+    expect(helpers.deleteUserApplication).toHaveBeenCalledWith({
+      client: expect.anything(),
+      applicationId: 'app-id',
+      appType: 'studio',
+    })
+    expect(mockContext.output.print).toHaveBeenCalledWith(
+      expect.stringContaining('Studio undeploy scheduled.'),
+    )
+  })
+
+  it('resolves app using `studioHost` (fallback)', async () => {
+    helpers.getUserApplication.mockResolvedValueOnce(mockApplication)
+    helpers.deleteUserApplication.mockResolvedValueOnce(undefined)
+    ;(mockContext.prompt.single as Mock<typeof mockContext.prompt.single>).mockResolvedValueOnce(
+      true,
+    ) // User confirms
+
+    await undeployStudioAction(
+      {
+        extOptions: {},
+      } as CliCommandArguments<UndeployStudioActionFlags>,
+      {
+        ...mockContext,
+        cliConfig: {
+          ...mockContext.cliConfig,
+          studioHost: 'abc123',
+        },
+      },
+    )
+
+    expect(helpers.getUserApplication).toHaveBeenCalledWith({
+      appHost: 'abc123',
+      client: expect.anything(),
+    })
+
+    expect(mockContext.prompt.single).toHaveBeenCalledWith({
+      type: 'confirm',
+      default: false,
+      message: expect.stringContaining('undeploy'),
+    })
+    expect(helpers.deleteUserApplication).toHaveBeenCalledWith({
+      client: expect.anything(),
+      applicationId: 'app-id',
+      appType: 'studio',
+    })
+    expect(mockContext.output.print).toHaveBeenCalledWith(
+      expect.stringContaining('Studio undeploy scheduled.'),
+    )
+  })
+
   it('prompts the user for confirmation and undeploys if confirmed', async () => {
     helpers.getUserApplication.mockResolvedValueOnce(mockApplication)
     helpers.deleteUserApplication.mockResolvedValueOnce(undefined)

--- a/packages/sanity/src/_internal/cli/actions/deploy/undeployAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/deploy/undeployAction.ts
@@ -25,9 +25,11 @@ export default async function undeployStudioAction(
   // Check that the project has a studio hostname
   let spinner = output.spinner('Checking project info').start()
 
+  const appId = cliConfig?.deployment?.appId || undefined
+  const appHost = cliConfig?.studioHost || undefined
   const userApplication = await getUserApplication({
     client,
-    appHost: cliConfig && 'studioHost' in cliConfig ? cliConfig.studioHost : undefined,
+    ...(appId ? {appId} : {appHost}),
   })
 
   spinner.succeed()


### PR DESCRIPTION
### Description

When a studio project has an `deployment.appId` set, this should be used to undeploy. Currently it just fails with an error.

### What to review

Changes and tests make sense.

### Testing

New tests added.

### Notes for release

Fixes an issue where if a studio configuration did not have a `studioHost` property set, the `sanity undeploy` command might fail.