### PR TITLE
chore(lint): disable `react/jsx-handler-names` rule

### DIFF
--- a/dev/test-studio/schema/presentation/CustomNavigator.tsx
+++ b/dev/test-studio/schema/presentation/CustomNavigator.tsx
@@ -91,7 +91,6 @@ export function CustomNavigator(): React.JSX.Element {
             icon={AddDocumentIcon}
             text="New Page"
             mode="ghost"
-            // eslint-disable-next-line react/jsx-handler-names
             onClick={createPageIntent.onClick}
             href={createPageIntent.href}
             as="a"

--- a/packages/@repo/eslint-config/index.js
+++ b/packages/@repo/eslint-config/index.js
@@ -108,6 +108,7 @@ export default [
       'import/default': 'off',
       'tsdoc/syntax': 'error',
       'react/no-unescaped-entities': 'off',
+      'react/jsx-handler-names': 'off',
       '@typescript-eslint/no-explicit-any': ['warn'],
       '@typescript-eslint/no-dupe-class-members': ['error'],
       '@typescript-eslint/no-shadow': ['error'],

--- a/packages/sanity/playwright-ct/tests/comments/CommentInput.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/comments/CommentInput.spec.tsx
@@ -52,7 +52,6 @@ test.describe('Comments', () => {
       let resolve!: () => void
       const submitted = Object.assign(new Promise<void>((r) => (resolve = r)), {resolve})
 
-      // eslint-disable-next-line react/jsx-handler-names
       await mount(<CommentsInputStory onSubmit={submitted.resolve} />)
       const $editable = page.getByTestId('comment-input-editable')
       await $editable.waitFor({state: 'visible'})

--- a/packages/sanity/src/core/comments/__workshop__/CommentsProviderStory.tsx
+++ b/packages/sanity/src/core/comments/__workshop__/CommentsProviderStory.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-handler-names */
 import {useSelect, useString} from '@sanity/ui-workshop'
 import {useMemo} from 'react'
 

--- a/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
@@ -372,9 +372,7 @@ function CommentsInspectorInner(
       return (
         <CommentsUpsellPanel
           data={upsellData}
-          // eslint-disable-next-line react/jsx-handler-names
           onPrimaryClick={upsellTelemetryLogs.panelPrimaryClicked}
-          // eslint-disable-next-line react/jsx-handler-names
           onSecondaryClick={upsellTelemetryLogs.panelSecondaryClicked}
         />
       )

--- a/packages/sanity/src/core/form/field/actions/FieldActionMenu.tsx
+++ b/packages/sanity/src/core/form/field/actions/FieldActionMenu.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/jsx-handler-names */
-
 import {EllipsisHorizontalIcon} from '@sanity/icons'
 import {Card, Menu} from '@sanity/ui'
 import {memo, useCallback, useId, useMemo, useState} from 'react'

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
@@ -53,7 +53,6 @@ export const InsertMenu = memo(function InsertMenu(props: InsertMenuProps) {
           }
           data-testid={`${item.type.name}-insert-menu-button`}
           icon={item.icon}
-          // eslint-disable-next-line react/jsx-handler-names
           onClick={item.handle}
           text={title}
           tooltipText={t(

--- a/packages/sanity/src/core/form/studio/FormBuilder.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilder.tsx
@@ -350,7 +350,6 @@ function RootInput(props: RootInputProps) {
 
   const arrayEditingModal = enhancedObjectDialogEnabled && (
     <EnhancedObjectDialog
-      // eslint-disable-next-line react/jsx-handler-names
       onPathFocus={rootInputProps.onPathFocus}
       onPathOpen={onPathOpen}
       openPath={openPath}

--- a/packages/sanity/src/core/form/studio/inputResolver/fieldResolver.tsx
+++ b/packages/sanity/src/core/form/studio/inputResolver/fieldResolver.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-handler-names */
 import {
   isBooleanSchemaType,
   isCrossDatasetReferenceSchemaType,

--- a/packages/sanity/src/core/scheduled-publishing/tool/schedules/Schedules.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/schedules/Schedules.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-handler-names */
 import {WarningOutlineIcon} from '@sanity/icons'
 import {Box, Card, Container, Flex, Text} from '@sanity/ui'
 import {styled} from 'styled-components'

--- a/packages/sanity/src/core/studio/components/navbar/navDrawer/NavDrawer.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/navDrawer/NavDrawer.tsx
@@ -227,7 +227,6 @@ export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
                       iconRight={LeaveIcon}
                       justify="flex-start"
                       mode="bleed"
-                      // eslint-disable-next-line react/jsx-handler-names
                       onClick={auth.logout}
                       size="large"
                       text={t('user-menu.action.sign-out')}

--- a/packages/sanity/src/structure/__workshop__/DocumentStateStory.tsx
+++ b/packages/sanity/src/structure/__workshop__/DocumentStateStory.tsx
@@ -96,7 +96,6 @@ function Debug(props: {documentId: string; documentType: string}) {
                     key={idx}
                     disabled={actionItem.disabled}
                     icon={actionItem.icon}
-                    // eslint-disable-next-line react/jsx-handler-names
                     onClick={actionItem.onHandle}
                     tone={actionItem.tone}
                     text={actionItem.label}
@@ -114,7 +113,6 @@ function Debug(props: {documentId: string; documentType: string}) {
                   footer={actionItem.dialog.footer}
                   header={actionItem.dialog.header}
                   id={`document-action-modal-${idx}`}
-                  // eslint-disable-next-line react/jsx-handler-names
                   onClose={actionItem.dialog.onClose}
                 >
                   {actionItem.dialog.content}

--- a/packages/sanity/src/structure/components/pane/PaneHeaderActionButton.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneHeaderActionButton.tsx
@@ -67,7 +67,6 @@ export function PaneHeaderMenuItemActionButton(props: PaneHeaderMenuItemActionBu
     <StatusButton
       disabled={isDisabled}
       icon={node.icon}
-      // eslint-disable-next-line react/jsx-handler-names
       onClick={node.onAction}
       selected={node.selected}
       tone={node.tone}

--- a/packages/sanity/src/structure/components/pane/PaneMenuButtonItem.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneMenuButtonItem.tsx
@@ -104,7 +104,6 @@ function PaneContextMenuItem(props: {disabled?: boolean; node: _PaneMenuItem}) {
         hotkeys={node.hotkey?.split('+')}
         icon={node.icon}
         iconRight={node.iconRight || (node.selected && CheckmarkIcon)}
-        // eslint-disable-next-line react/jsx-handler-names
         onClick={node.onAction}
         pressed={node.selected}
         text={title}

--- a/packages/sanity/src/structure/panes/document/statusBar/ActionStateDialog.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/ActionStateDialog.tsx
@@ -55,9 +55,7 @@ export function ActionStateDialog(props: ActionStateDialogProps) {
   return (
     <Dialog
       id={modalId}
-      // eslint-disable-next-line react/jsx-handler-names
       onClose={unknownModal.onClose}
-      // eslint-disable-next-line react/jsx-handler-names
       onClickOutside={unknownModal.onClose}
       width={1}
     >

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -80,7 +80,6 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
                 data-testid={`action-${toLowerCaseNoSpaces(firstActionState.label)}`}
                 disabled={disabled || Boolean(firstActionState.disabled)}
                 icon={firstActionState.icon}
-                // eslint-disable-next-line react/jsx-handler-names
                 onClick={firstActionState.onHandle}
                 ref={setButtonElement}
                 text={firstActionState.label}

--- a/packages/sanity/src/structure/panes/document/statusBar/dialogs/ModalDialog.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/dialogs/ModalDialog.tsx
@@ -29,9 +29,7 @@ export function ModalDialog(props: {dialog: DocumentActionModalDialogProps}) {
         footer={footer}
         header={dialog.header}
         id={dialogId}
-        // eslint-disable-next-line react/jsx-handler-names
         onClose={dialog.onClose}
-        // eslint-disable-next-line react/jsx-handler-names
         onClickOutside={dialog.onClose}
         width={dialog.width === undefined ? 1 : DIALOG_WIDTH_TO_UI_WIDTH[dialog.width]}
       >


### PR DESCRIPTION
This linter rule is extremely silly and annoying. Split from #10834 to make #10834
 itself a smaller PR.