### PR TITLE
refactor(perf): deprecate `<ConditionalWrapper>`

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "blazejkustra.react-compiler-marker",
     "dbaeumer.vscode-eslint",
     "eamodio.gitlens",
     "github.vscode-github-actions",

--- a/dev/test-studio/schema/debug/components/CreateDraft.tsx
+++ b/dev/test-studio/schema/debug/components/CreateDraft.tsx
@@ -20,9 +20,8 @@ export function CreateDraft() {
       })
     } catch (e) {
       setError(e)
-    } finally {
-      setCreatingDraft(false)
     }
+    setCreatingDraft(false)
   }, [client, documentId, documentType, value])
 
   return (

--- a/dev/test-studio/schema/debug/components/CustomFontStringInput.tsx
+++ b/dev/test-studio/schema/debug/components/CustomFontStringInput.tsx
@@ -1,27 +1,22 @@
-import {Component} from 'react'
 import {set, type StringInputProps} from 'sanity'
 
 import styles from './CustomFontStringInput.module.css'
 
-export default class CustomStringInput extends Component<StringInputProps> {
-  handleChange = (event) => {
-    this.props.onChange(set(event.target.value))
-  }
-
-  render() {
-    const {value, schemaType} = this.props
-    return (
-      <div>
-        <h3>{schemaType.title}</h3>
-        <p>{schemaType.description}</p>
-        <input
-          type="text"
-          className={styles.input}
-          placeholder={schemaType.placeholder}
-          onChange={this.handleChange}
-          value={value}
-        />
-      </div>
-    )
-  }
+export default function CustomFontStringInput(props: StringInputProps) {
+  const {value, schemaType, onChange} = props
+  return (
+    <div>
+      <h3>{schemaType.title}</h3>
+      <p>{schemaType.description}</p>
+      <input
+        type="text"
+        className={styles.input}
+        placeholder={schemaType.placeholder}
+        onChange={(event) => {
+          onChange(set(event.target.value))
+        }}
+        value={value}
+      />
+    </div>
+  )
 }

--- a/dev/test-studio/schema/debug/components/CustomMyObjectInput.tsx
+++ b/dev/test-studio/schema/debug/components/CustomMyObjectInput.tsx
@@ -1,29 +1,26 @@
-import {Component} from 'react'
 import {type ObjectInputProps, set, setIfMissing} from 'sanity'
 
-export default class CustomMyObjectInput extends Component<ObjectInputProps> {
-  handleChange = (field, event) => {
-    const {schemaType, onChange} = this.props
-    onChange([setIfMissing({_type: schemaType.name}), set(event.target.value, [field.name])])
-  }
-
-  render() {
-    const {value, schemaType} = this.props
-    return (
-      <div style={{backgroundColor: '#f5ad3d'}}>
-        <h3>{schemaType.title}</h3>
-        <p>{schemaType.description}</p>
-        {schemaType.fields.map((field) => (
-          <li key={field.name}>
-            <input
-              type="text"
-              value={(value && value[field.name]) || ''}
-              placeholder={schemaType.placeholder}
-              onChange={(event) => this.handleChange(field, event)}
-            />
-          </li>
-        ))}
-      </div>
-    )
-  }
+export default function CustomMyObjectInput(props: ObjectInputProps) {
+  const {value, schemaType, onChange} = props
+  return (
+    <div style={{backgroundColor: '#f5ad3d'}}>
+      <h3>{schemaType.title}</h3>
+      <p>{schemaType.description}</p>
+      {schemaType.fields.map((field) => (
+        <li key={field.name}>
+          <input
+            type="text"
+            value={(value && value[field.name]) || ''}
+            placeholder={schemaType.placeholder}
+            onChange={(event) => {
+              onChange([
+                setIfMissing({_type: schemaType.name}),
+                set(event.target.value, [field.name]),
+              ])
+            }}
+          />
+        </li>
+      ))}
+    </div>
+  )
 }

--- a/dev/test-studio/schema/debug/components/CustomObjectSelectInput.tsx
+++ b/dev/test-studio/schema/debug/components/CustomObjectSelectInput.tsx
@@ -13,6 +13,9 @@ type CustomObjectSelectInputProps = ObjectInputProps<Value, CustomSchemaType>
 const EMPTY_ARRAY: Value[] = []
 
 let objectSelectInputIdx = 0
+function getObjectSelectInputIdx() {
+  return String(++objectSelectInputIdx)
+}
 
 export const CustomObjectSelectInput = forwardRef(function CustomObjectSelectInput(
   props: CustomObjectSelectInputProps,
@@ -22,7 +25,7 @@ export const CustomObjectSelectInput = forwardRef(function CustomObjectSelectInp
 
   const items = (schemaType.options && schemaType.options.list) || EMPTY_ARRAY
   const errors = validation.filter(isValidationError)
-  const [inputId] = useState(() => String(++objectSelectInputIdx))
+  const [inputId] = useState(() => getObjectSelectInputIdx())
 
   const handleChange = useCallback(
     (evt: any) => {

--- a/dev/test-studio/schema/debug/components/CustomStringInput.tsx
+++ b/dev/test-studio/schema/debug/components/CustomStringInput.tsx
@@ -1,24 +1,20 @@
-import {Component} from 'react'
 import {set, type StringInputProps} from 'sanity'
 
-export default class CustomStringInput extends Component<StringInputProps> {
-  handleChange = (event) => {
-    this.props.onChange(set(event.target.value))
-  }
+export default function CustomStringInput(props: StringInputProps) {
+  const {value, schemaType, onChange} = props
 
-  render() {
-    const {value, schemaType} = this.props
-    return (
-      <div style={{backgroundColor: '#f5ad3d'}}>
-        <h3>{schemaType.title}</h3>
-        <p>{schemaType.description}</p>
-        <input
-          type="text"
-          placeholder={schemaType.placeholder}
-          onChange={this.handleChange}
-          value={value}
-        />
-      </div>
-    )
-  }
+  return (
+    <div style={{backgroundColor: '#f5ad3d'}}>
+      <h3>{schemaType.title}</h3>
+      <p>{schemaType.description}</p>
+      <input
+        type="text"
+        placeholder={schemaType.placeholder}
+        onChange={(event) => {
+          onChange(set(event.target.value))
+        }}
+        value={value}
+      />
+    </div>
+  )
 }

--- a/dev/test-studio/schema/debug/components/DebugStega.tsx
+++ b/dev/test-studio/schema/debug/components/DebugStega.tsx
@@ -89,8 +89,9 @@ function InputDebugger(props: InputProps) {
         .filter(Boolean)
         .join('')}`,
     ]
+    const key = `$['${sourcePath}']`
     const mappings = {
-      [`$['${sourcePath}']`]: {
+      [key]: {
         source: {
           document: 0,
           path: 0,

--- a/packages/sanity/src/core/comments/__workshop__/CommentsProviderStory.tsx
+++ b/packages/sanity/src/core/comments/__workshop__/CommentsProviderStory.tsx
@@ -1,7 +1,6 @@
 import {useSelect, useString} from '@sanity/ui-workshop'
 import {useMemo} from 'react'
 
-import {ConditionalWrapper} from '../../../ui-components'
 import {useCurrentUser} from '../../store'
 import {AddonDatasetProvider} from '../../studio'
 import {CommentsList, CommentsUpsellPanel} from '../components'
@@ -21,17 +20,17 @@ export default function CommentsProviderStory() {
   const _type = useString('_type', 'author') || 'author'
   const _id = useString('_id', 'grrm') || 'grrm'
   const _mode = useSelect('_mode', MODES) || ('default' as keyof typeof MODES)
+  const children = <Inner mode={_mode} />
 
   return (
     <AddonDatasetProvider>
       <CommentsEnabledProvider documentType={_type} documentId={_id}>
         <CommentsProvider documentType={_type} documentId={_id} type="field" sortOrder="desc">
-          <ConditionalWrapper
-            condition={_mode === 'upsell'}
-            wrapper={(children) => <CommentsUpsellProvider>{children}</CommentsUpsellProvider>}
-          >
-            <Inner mode={_mode} />
-          </ConditionalWrapper>
+          {_mode === 'upsell' ? (
+            <CommentsUpsellProvider>{children}</CommentsUpsellProvider>
+          ) : (
+            children
+          )}
         </CommentsProvider>
       </CommentsEnabledProvider>
     </AddonDatasetProvider>

--- a/packages/sanity/src/core/comments/plugin/studio-layout/CommentsStudioLayout.tsx
+++ b/packages/sanity/src/core/comments/plugin/studio-layout/CommentsStudioLayout.tsx
@@ -1,4 +1,3 @@
-import {ConditionalWrapper} from '../../../../ui-components'
 import {type LayoutProps} from '../../../config'
 import {useFeatureEnabled} from '../../../hooks'
 import {FEATURES} from '../../../hooks/useFeatureEnabled'
@@ -7,16 +6,16 @@ import {CommentsOnboardingProvider, CommentsUpsellProvider} from '../../context'
 
 export function CommentsStudioLayout(props: LayoutProps) {
   const {enabled, isLoading} = useFeatureEnabled(FEATURES.studioComments)
+  const children = props.renderDefault(props)
 
   return (
     <AddonDatasetProvider>
       <CommentsOnboardingProvider>
-        <ConditionalWrapper
-          condition={!enabled && !isLoading}
-          wrapper={(children) => <CommentsUpsellProvider>{children}</CommentsUpsellProvider>}
-        >
-          {props.renderDefault(props)}
-        </ConditionalWrapper>
+        {!enabled && !isLoading ? (
+          <CommentsUpsellProvider>{children}</CommentsUpsellProvider>
+        ) : (
+          children
+        )}
       </CommentsOnboardingProvider>
     </AddonDatasetProvider>
   )

--- a/packages/sanity/src/core/scheduled-publishing/plugin/SchedulePublishingStudioLayout.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/plugin/SchedulePublishingStudioLayout.tsx
@@ -1,4 +1,3 @@
-import {ConditionalWrapper} from '../../../ui-components/conditionalWrapper/ConditionalWrapper'
 import {type LayoutProps} from '../../config/studio/types'
 import {
   ScheduledPublishingEnabledProvider,
@@ -12,16 +11,11 @@ function SchedulePublishingStudioLayoutInner(props: LayoutProps) {
     return props.renderDefault(props)
   }
 
-  return (
-    <ConditionalWrapper
-      condition={mode === 'upsell'}
-      wrapper={(children) => (
-        <SchedulePublishingUpsellProvider>{children}</SchedulePublishingUpsellProvider>
-      )}
-    >
-      {props.renderDefault(props)}
-    </ConditionalWrapper>
-  )
+  const children = props.renderDefault(props)
+  if (mode === 'upsell') {
+    return <SchedulePublishingUpsellProvider>{children}</SchedulePublishingUpsellProvider>
+  }
+  return children
 }
 
 export function SchedulePublishingStudioLayout(props: LayoutProps) {

--- a/packages/sanity/src/core/studio/upsell/upsellDescriptionSerializer/UpsellDescriptionSerializer.tsx
+++ b/packages/sanity/src/core/studio/upsell/upsellDescriptionSerializer/UpsellDescriptionSerializer.tsx
@@ -11,7 +11,6 @@ import {getTheme_v2} from '@sanity/ui/theme'
 import {type ReactNode, useEffect, useMemo, useState} from 'react'
 import {css, styled} from 'styled-components'
 
-import {ConditionalWrapper} from '../../../../ui-components/conditionalWrapper'
 import {interpolateTemplate} from '../../../util/interpolateTemplate'
 import {transformBlocks} from './helpers'
 
@@ -90,8 +89,6 @@ const DynamicIconContainer = styled.span<{$inline: boolean}>`
     }
   }
 `
-
-const accentSpanWrapper = (children: ReactNode) => <AccentSpan>{children}</AccentSpan>
 
 const DynamicIcon = (props: {icon: {url: string}; inline?: boolean}) => {
   const [__html, setHtml] = useState('')
@@ -268,19 +265,20 @@ const createComponents = ({
     },
     types: {
       inlineIcon: (props) => {
-        return (
-          <ConditionalWrapper condition={props.value.accent} wrapper={accentSpanWrapper}>
-            {props.value.sanityIcon ? (
-              <InlineIcon
-                symbol={props.value.sanityIcon}
-                $hasTextLeft={props.value.hasTextLeft}
-                $hasTextRight={props.value.hasTextRight}
-              />
-            ) : (
-              <>{props.value.icon?.url && <DynamicIcon icon={props.value.icon} inline />}</>
-            )}
-          </ConditionalWrapper>
+        const children = props.value.sanityIcon ? (
+          <InlineIcon
+            symbol={props.value.sanityIcon}
+            $hasTextLeft={props.value.hasTextLeft}
+            $hasTextRight={props.value.hasTextRight}
+          />
+        ) : (
+          <>{props.value.icon?.url && <DynamicIcon icon={props.value.icon} inline />}</>
         )
+
+        if (props.value.accent) {
+          return <AccentSpan>{children}</AccentSpan>
+        }
+        return children
       },
       divider: () => (
         <Box marginY={3}>

--- a/packages/sanity/src/core/tasks/plugin/TasksStudioLayout.tsx
+++ b/packages/sanity/src/core/tasks/plugin/TasksStudioLayout.tsx
@@ -1,4 +1,3 @@
-import {ConditionalWrapper} from '../../../ui-components'
 import {type LayoutProps} from '../../config'
 import {AddonDatasetProvider} from '../../studio'
 import {
@@ -15,18 +14,22 @@ const TasksStudioLayoutInner = (props: LayoutProps) => {
   if (!enabled) {
     return props.renderDefault(props)
   }
-  return (
-    <AddonDatasetProvider>
-      <ConditionalWrapper
-        condition={mode === 'upsell'}
-        wrapper={(children) => <TasksUpsellProvider>{children}</TasksUpsellProvider>}
-      >
-        <TasksProvider>
-          <TasksNavigationProvider>{props.renderDefault(props)}</TasksNavigationProvider>
-        </TasksProvider>
-      </ConditionalWrapper>
-    </AddonDatasetProvider>
+
+  const children = (
+    <TasksProvider>
+      <TasksNavigationProvider>{props.renderDefault(props)}</TasksNavigationProvider>
+    </TasksProvider>
   )
+
+  if (mode === 'upsell') {
+    return (
+      <AddonDatasetProvider>
+        <TasksUpsellProvider>{children}</TasksUpsellProvider>
+      </AddonDatasetProvider>
+    )
+  }
+
+  return <AddonDatasetProvider>{children}</AddonDatasetProvider>
 }
 
 export function TasksStudioLayout(props: LayoutProps) {

--- a/packages/sanity/src/ui-components/button/Button.tsx
+++ b/packages/sanity/src/ui-components/button/Button.tsx
@@ -1,14 +1,10 @@
 /* eslint-disable no-restricted-imports */
 
 import {Button as UIButton, type ButtonProps as UIButtonProps} from '@sanity/ui'
-import {type ForwardedRef, forwardRef, type HTMLProps, useCallback} from 'react'
+import {type ForwardedRef, forwardRef, type HTMLProps} from 'react'
 import {styled} from 'styled-components'
 
 import {Tooltip, type TooltipProps} from '..'
-import {
-  ConditionalWrapper,
-  type ConditionalWrapperRenderWrapperCallback,
-} from '../conditionalWrapper'
 
 type BaseButtonProps = Pick<
   UIButtonProps,
@@ -74,23 +70,20 @@ export const Button = forwardRef(function Button(
   }: ButtonProps & Omit<HTMLProps<HTMLButtonElement>, 'as' | 'size' | 'title'>,
   ref: ForwardedRef<HTMLButtonElement>,
 ) {
-  const renderWrapper = useCallback<ConditionalWrapperRenderWrapperCallback>(
-    (children) => {
-      return (
-        <Tooltip content={tooltipProps?.content} portal {...tooltipProps}>
-          {/* This span is needed to make the tooltip work in disabled buttons */}
-          <TooltipButtonWrapper>{children}</TooltipButtonWrapper>
-        </Tooltip>
-      )
-    },
-    [tooltipProps],
-  )
-
   const sizeProps = size === 'default' ? DEFAULT_BUTTON_PROPS : LARGE_BUTTON_PROPS
 
-  return (
-    <ConditionalWrapper condition={!!tooltipProps} wrapper={renderWrapper}>
-      <UIButton {...rest} {...sizeProps} paddingY={paddingY} ref={ref} mode={mode} tone={tone} />
-    </ConditionalWrapper>
+  const children = (
+    <UIButton {...rest} {...sizeProps} paddingY={paddingY} ref={ref} mode={mode} tone={tone} />
   )
+
+  if (tooltipProps) {
+    return (
+      <Tooltip content={tooltipProps?.content} portal {...tooltipProps}>
+        {/* This span is needed to make the tooltip work in disabled buttons */}
+        <TooltipButtonWrapper>{children}</TooltipButtonWrapper>
+      </Tooltip>
+    )
+  }
+
+  return children
 })

--- a/packages/sanity/src/ui-components/conditionalWrapper/ConditionalWrapper.tsx
+++ b/packages/sanity/src/ui-components/conditionalWrapper/ConditionalWrapper.tsx
@@ -4,6 +4,7 @@ export type ConditionalWrapperRenderWrapperCallback = (children: React.ReactNode
  * A helper component that conditionally wraps its children in a wrapper component.
  *
  * @internal
+ * @deprecated do not use this, just do the conditional inline, it performs better with React Compiler without the redirection of a wrapper
  */
 export function ConditionalWrapper({
   children,

--- a/packages/sanity/src/ui-components/menuGroup/MenuGroup.tsx
+++ b/packages/sanity/src/ui-components/menuGroup/MenuGroup.tsx
@@ -1,11 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import {MenuGroup as UIMenuGroup, type MenuGroupProps as UIMenuGroupProps} from '@sanity/ui'
-import {type HTMLProps, useCallback} from 'react'
+import {type HTMLProps} from 'react'
 
-import {
-  ConditionalWrapper,
-  type ConditionalWrapperRenderWrapperCallback,
-} from '../conditionalWrapper/ConditionalWrapper'
 import {Tooltip, type TooltipProps} from '../tooltip/Tooltip'
 
 /** @internal */
@@ -24,21 +20,16 @@ export const MenuGroup = (
 ) => {
   const {tooltipProps} = props
 
-  const renderWrapper = useCallback<ConditionalWrapperRenderWrapperCallback>(
-    (children) => {
-      return (
-        <Tooltip content={tooltipProps?.content} portal {...tooltipProps}>
-          {/* This div is needed to make the tooltip work in disabled menu items */}
-          <div>{children}</div>
-        </Tooltip>
-      )
-    },
-    [tooltipProps],
-  )
+  const children = <UIMenuGroup {...props} fontSize={1} padding={3} />
 
-  return (
-    <ConditionalWrapper condition={!!tooltipProps} wrapper={renderWrapper}>
-      <UIMenuGroup {...props} fontSize={1} padding={3} />
-    </ConditionalWrapper>
-  )
+  if (tooltipProps) {
+    return (
+      <Tooltip content={tooltipProps?.content} portal {...tooltipProps}>
+        {/* This div is needed to make the tooltip work in disabled menu items */}
+        <div>{children}</div>
+      </Tooltip>
+    )
+  }
+
+  return children
 }

--- a/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
+++ b/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
@@ -8,24 +8,12 @@ import {
   Stack,
   Text,
 } from '@sanity/ui'
-import {
-  forwardRef,
-  type HTMLProps,
-  isValidElement,
-  type ReactNode,
-  type Ref,
-  useCallback,
-  useMemo,
-} from 'react'
+import {forwardRef, type HTMLProps, isValidElement, type ReactNode, type Ref, useMemo} from 'react'
 import {isValidElementType} from 'react-is'
 import {styled} from 'styled-components'
 
 import {Hotkeys} from '../../core/components/Hotkeys'
 import {Tooltip, type TooltipProps} from '..'
-import {
-  ConditionalWrapper,
-  type ConditionalWrapperRenderWrapperCallback,
-} from '../conditionalWrapper'
 
 const FONT_SIZE = 1
 const SUBTITLE_FONT_SIZE = 0
@@ -168,32 +156,29 @@ export const MenuItem = forwardRef(function MenuItem(
     IconRight,
   ])
 
-  const renderWrapper = useCallback<ConditionalWrapperRenderWrapperCallback>(
-    (children) => {
-      return (
-        <Tooltip content={tooltipProps?.content} portal {...tooltipProps}>
-          {/* This div is needed to make the tooltip work in disabled menu items */}
-          <div>{children}</div>
-        </Tooltip>
-      )
-    },
-    [tooltipProps],
+  const children = (
+    <UIMenuItem
+      disabled={disabled}
+      paddingLeft={preview ? 1 : 3}
+      paddingRight={3}
+      paddingY={preview ? 1 : 3}
+      ref={ref}
+      {...rest}
+    >
+      {typeof childrenProp === 'undefined' && typeof renderMenuItem === 'function'
+        ? renderMenuItem(menuItemContent)
+        : menuItemContent}
+    </UIMenuItem>
   )
 
-  return (
-    <ConditionalWrapper condition={!!tooltipProps} wrapper={renderWrapper}>
-      <UIMenuItem
-        disabled={disabled}
-        paddingLeft={preview ? 1 : 3}
-        paddingRight={3}
-        paddingY={preview ? 1 : 3}
-        ref={ref}
-        {...rest}
-      >
-        {typeof childrenProp === 'undefined' && typeof renderMenuItem === 'function'
-          ? renderMenuItem(menuItemContent)
-          : menuItemContent}
-      </UIMenuItem>
-    </ConditionalWrapper>
-  )
+  if (tooltipProps) {
+    return (
+      <Tooltip content={tooltipProps?.content} portal {...tooltipProps}>
+        {/* This div is needed to make the tooltip work in disabled menu items */}
+        <div>{children}</div>
+      </Tooltip>
+    )
+  }
+
+  return children
 })


### PR DESCRIPTION
Split from #10834 to make #10834 smaller and easier to review.
This one focuses on replacing `<ConditionalWrapper>` with inline conditionals. It helps React Compiler better understand the tree structure and it yields better results. It's also easier for humans and LLMs to understand what the JSX tree actually looks like.