### PR TITLE
refactor: reduce react compiler bailouts

### DIFF
--- a/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
@@ -251,9 +251,8 @@ function CommentsInspectorInner(
         closeDeleteDialog()
       } catch (err) {
         setDeleteError(err)
-      } finally {
-        setDeleteLoading(false)
       }
+      setDeleteLoading(false)
     },
     [closeDeleteDialog, operation],
   )

--- a/packages/sanity/src/core/create/studio-app/useStudioAppIdStore.ts
+++ b/packages/sanity/src/core/create/studio-app/useStudioAppIdStore.ts
@@ -63,11 +63,10 @@ export function useStudioAppIdStoreInner(props: {
       try {
         const entry = await cache.get({projectId, appIdFetcher})
         if (mounted) setStudioApp(entry)
-      } catch (err) {
+      } catch {
         if (mounted) setStudioApp(undefined)
-      } finally {
-        if (mounted) setLoading(false)
       }
+      if (mounted) setLoading(false)
     }
 
     if (enabled) {

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -152,9 +152,8 @@ export function BlockObject(props: BlockObjectProps) {
       PortableTextEditor.delete(editor, selfSelection, {mode: 'blocks'})
     } catch (err) {
       console.error(err)
-    } finally {
-      isDeleting.current = true
     }
+    isDeleting.current = true
   }, [editor, selfSelection])
 
   // Focus the editor if this object is removed because it was deleted.
@@ -295,75 +294,64 @@ export function BlockObject(props: BlockObjectProps) {
     [memberItem, setElementRef, setDivElement],
   )
 
-  return useMemo(
-    () => (
-      <Box ref={setRef} contentEditable={false}>
-        <Flex paddingBottom={1} marginY={3} style={debugRender()}>
-          <PreviewContainer {...innerPaddingProps}>
-            <Box flex={1}>
-              <Tooltip
-                placement="top"
-                portal="editor"
-                // If the object modal is open, disable the tooltip to avoid it rerendering the inner items when the validation changes.
-                disabled={isOpen ? true : !tooltipEnabled}
-                content={toolTipContent}
-              >
-                <div>{renderBlock && renderBlock(componentProps)}</div>
-              </Tooltip>
-            </Box>
+  return (
+    <Box ref={setRef} contentEditable={false}>
+      <Flex paddingBottom={1} marginY={3} style={debugRender()}>
+        <PreviewContainer {...innerPaddingProps}>
+          <Box flex={1}>
+            <Tooltip
+              placement="top"
+              portal="editor"
+              // If the object modal is open, disable the tooltip to avoid it rerendering the inner items when the validation changes.
+              disabled={isOpen ? true : !tooltipEnabled}
+              content={toolTipContent}
+            >
+              <div>
+                {renderBlock && <RenderBlock {...componentProps} renderBlock={renderBlock} />}
+              </div>
+            </Tooltip>
+          </Box>
 
-            {blockActionsEnabled && (
-              <BlockActionsOuter contentEditable={false} marginRight={3}>
-                <BlockActionsInner>
-                  {focused && (
-                    <BlockActions
-                      block={value}
-                      onChange={onChange}
-                      renderBlockActions={renderBlockActions}
-                    />
-                  )}
-                </BlockActionsInner>
-              </BlockActionsOuter>
-            )}
+          {blockActionsEnabled && (
+            <BlockActionsOuter contentEditable={false} marginRight={3}>
+              <BlockActionsInner>
+                {focused && (
+                  <BlockActions
+                    block={value}
+                    onChange={onChange}
+                    renderBlockActions={renderBlockActions}
+                  />
+                )}
+              </BlockActionsInner>
+            </BlockActionsOuter>
+          )}
 
-            {changeIndicatorVisible && (
-              <ChangeIndicatorWrapper
-                $hasChanges={memberItem.member.item.changed}
-                contentEditable={false}
-              >
-                <StyledChangeIndicatorWithProvidedFullPath
-                  hasFocus={focused}
-                  isChanged={memberItem.member.item.changed}
-                  path={memberItem.member.item.path}
-                  withHoverEffect={false}
-                />
-              </ChangeIndicatorWrapper>
-            )}
-            {changeHovered && <ReviewChangesHighlightBlock $fullScreen={Boolean(isFullscreen)} />}
-          </PreviewContainer>
-        </Flex>
-      </Box>
-    ),
-    [
-      blockActionsEnabled,
-      changeIndicatorVisible,
-      componentProps,
-      focused,
-      innerPaddingProps,
-      memberItem?.member?.item?.changed,
-      memberItem?.member?.item?.path,
-      onChange,
-      renderBlock,
-      renderBlockActions,
-      changeHovered,
-      isFullscreen,
-      setRef,
-      toolTipContent,
-      tooltipEnabled,
-      value,
-      isOpen,
-    ],
+          {changeIndicatorVisible && (
+            <ChangeIndicatorWrapper
+              $hasChanges={memberItem.member.item.changed}
+              contentEditable={false}
+            >
+              <StyledChangeIndicatorWithProvidedFullPath
+                hasFocus={focused}
+                isChanged={memberItem.member.item.changed}
+                path={memberItem.member.item.path}
+                withHoverEffect={false}
+              />
+            </ChangeIndicatorWrapper>
+          )}
+          {changeHovered && <ReviewChangesHighlightBlock $fullScreen={Boolean(isFullscreen)} />}
+        </PreviewContainer>
+      </Flex>
+    </Box>
   )
+}
+
+// Workaround for React Compiler being very strict on refs
+function RenderBlock(
+  props: Omit<BlockProps, 'renderDefault'> & {renderBlock: RenderBlockCallback},
+) {
+  const {renderBlock, ...componentProps} = props
+  return renderBlock(componentProps)
 }
 
 export const DefaultBlockObjectComponent = (

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -272,8 +272,9 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
       }
       setSelectedAssetSource(assetSource)
       if (assetSource.Uploader) {
-        try {
-          const uploader = new assetSource.Uploader()
+        // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+        const run = () => {
+          const uploader = new assetSource.Uploader!()
           // Unsubscribe from the previous uploader
           assetSourceUploader?.unsubscribe()
           setAssetSourceUploader({
@@ -317,6 +318,9 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
           setIsUploading(true)
           onChange(PatchEvent.from(createInitialUploadPatches(files[0])))
           uploader.upload(files, {schemaType, onChange: onChange as (patch: unknown) => void})
+        }
+        try {
+          run()
         } catch (err) {
           onChange(PatchEvent.from([unset([UPLOAD_STATUS_KEY])]))
           setIsUploading(false)
@@ -464,58 +468,59 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
     },
     [handleCancelUpload, handleStaleUpload, isUploading],
   )
-  const renderAsset = useCallback(() => {
-    if (value && typeof value.asset !== 'undefined' && !value?._upload && !isImageSource(value)) {
-      // eslint-disable-next-line react/display-name
-      return () => <InvalidImageWarning onClearValue={handleClearField} />
-    }
+  const renderAsset = useCallback(
+    (inputProps: Omit<InputProps, 'renderDefault'>) => {
+      if (value && typeof value.asset !== 'undefined' && !value?._upload && !isImageSource(value)) {
+        return <InvalidImageWarning onClearValue={handleClearField} />
+      }
 
-    // eslint-disable-next-line react/display-name
-    return (inputProps: Omit<InputProps, 'renderDefault'>) => (
-      <ImageInputAsset
-        assetSources={assetSources}
-        directUploads={directUploads !== false}
-        elementProps={elementProps}
-        handleClearUploadState={handleClearUploadState}
-        handleFileTargetFocus={handleFileTargetFocus}
-        hoveringFiles={hoveringFiles}
-        imageUrlBuilder={imageUrlBuilder}
-        inputProps={inputProps}
-        isStale={isStale}
-        onSelectFiles={handleSelectFilesToUpload}
-        readOnly={readOnly}
-        renderAssetMenu={renderAssetMenu}
-        renderPreview={renderPreview}
-        renderUploadPlaceholder={renderUploadPlaceholder}
-        renderUploadState={renderUploadState}
-        schemaType={schemaType}
-        setHoveringFiles={setHoveringFiles}
-        selectedAssetSource={selectedAssetSource}
-        tone={getFileTone()}
-        value={value}
-      />
-    )
-  }, [
-    assetSources,
-    directUploads,
-    elementProps,
-    getFileTone,
-    handleClearField,
-    handleClearUploadState,
-    handleFileTargetFocus,
-    handleSelectFilesToUpload,
-    hoveringFiles,
-    imageUrlBuilder,
-    isStale,
-    readOnly,
-    renderAssetMenu,
-    renderPreview,
-    renderUploadPlaceholder,
-    renderUploadState,
-    schemaType,
-    selectedAssetSource,
-    value,
-  ])
+      return (
+        <ImageInputAsset
+          assetSources={assetSources}
+          directUploads={directUploads !== false}
+          elementProps={elementProps}
+          handleClearUploadState={handleClearUploadState}
+          handleFileTargetFocus={handleFileTargetFocus}
+          hoveringFiles={hoveringFiles}
+          imageUrlBuilder={imageUrlBuilder}
+          inputProps={inputProps}
+          isStale={isStale}
+          onSelectFiles={handleSelectFilesToUpload}
+          readOnly={readOnly}
+          renderAssetMenu={renderAssetMenu}
+          renderPreview={renderPreview}
+          renderUploadPlaceholder={renderUploadPlaceholder}
+          renderUploadState={renderUploadState}
+          schemaType={schemaType}
+          setHoveringFiles={setHoveringFiles}
+          selectedAssetSource={selectedAssetSource}
+          tone={getFileTone()}
+          value={value}
+        />
+      )
+    },
+    [
+      assetSources,
+      directUploads,
+      elementProps,
+      getFileTone,
+      handleClearField,
+      handleClearUploadState,
+      handleFileTargetFocus,
+      handleSelectFilesToUpload,
+      hoveringFiles,
+      imageUrlBuilder,
+      isStale,
+      readOnly,
+      renderAssetMenu,
+      renderPreview,
+      renderUploadPlaceholder,
+      renderUploadState,
+      schemaType,
+      selectedAssetSource,
+      value,
+    ],
+  )
   const renderHotspotInput = useCallback(
     (inputProps: Omit<InputProps, 'renderDefault'>) => {
       return (
@@ -579,7 +584,7 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
               renderAnnotation={renderAnnotation}
               renderBlock={renderBlock}
               renderInlineBlock={renderInlineBlock}
-              renderInput={member.name === 'asset' ? renderAsset() : renderInput}
+              renderInput={member.name === 'asset' ? renderAsset : renderInput}
               renderField={member.name === 'asset' ? passThrough : renderField}
               renderItem={renderItem}
               renderPreview={renderPreviewProp}

--- a/packages/sanity/src/core/form/members/array/items/ArrayOfObjectsItem.tsx
+++ b/packages/sanity/src/core/form/members/array/items/ArrayOfObjectsItem.tsx
@@ -400,76 +400,6 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
     renderPreview,
   ])
 
-  const renderedInput = useMemo(() => renderInput(inputProps), [inputProps, renderInput])
-
-  const itemProps = useMemo((): Omit<ObjectItemProps, 'renderDefault'> => {
-    return {
-      key: member.key,
-      index: member.index,
-      level: member.item.level,
-      value: member.item.value,
-      compareValue: member.item.compareValue,
-      __unstable_computeDiff: member.item.__unstable_computeDiff,
-      hasUpstreamVersion: member.item.hasUpstreamVersion,
-      title: member.item.schemaType.title,
-      description: member.item.schemaType.description,
-      collapsible: member.collapsible,
-      collapsed: member.collapsed,
-      schemaType: member.item.schemaType,
-      parentSchemaType: member.parentSchemaType,
-      onInsert: handleInsert,
-      onCopy: handleCopy,
-      onRemove,
-      presence: member.item.presence,
-      validation: member.item.validation,
-      open: member.open,
-      onOpen: handleOpen,
-      onClose: handleClose,
-      onExpand: handleExpand,
-      onCollapse: handleCollapse,
-      readOnly: member.item.readOnly,
-      focused: member.item.focused,
-      onFocus: handleFocus,
-      onBlur: handleBlur,
-      inputId: member.item.id,
-      path: member.item.path,
-      children: renderedInput,
-      changed: member.item.changed,
-      inputProps,
-    }
-  }, [
-    member.key,
-    member.index,
-    member.item.level,
-    member.item.value,
-    member.item.compareValue,
-    member.item.__unstable_computeDiff,
-    member.item.hasUpstreamVersion,
-    member.item.schemaType,
-    member.item.presence,
-    member.item.validation,
-    member.item.readOnly,
-    member.item.focused,
-    member.item.id,
-    member.item.path,
-    member.item.changed,
-    member.collapsible,
-    member.collapsed,
-    member.parentSchemaType,
-    member.open,
-    handleInsert,
-    handleCopy,
-    onRemove,
-    handleOpen,
-    handleClose,
-    handleExpand,
-    handleCollapse,
-    handleFocus,
-    handleBlur,
-    renderedInput,
-    inputProps,
-  ])
-
   return (
     <FormCallbacksProvider
       onFieldGroupSelect={onFieldGroupSelect}
@@ -480,7 +410,60 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
       onPathBlur={onPathBlur}
       onPathFocus={onPathFocus}
     >
-      {useMemo(() => renderItem(itemProps), [itemProps, renderItem])}
+      <RenderItem
+        key={member.key}
+        index={member.index}
+        level={member.item.level}
+        value={member.item.value}
+        compareValue={member.item.compareValue}
+        __unstable_computeDiff={member.item.__unstable_computeDiff}
+        hasUpstreamVersion={member.item.hasUpstreamVersion}
+        title={member.item.schemaType.title}
+        description={member.item.schemaType.description}
+        collapsible={member.collapsible}
+        collapsed={member.collapsed}
+        schemaType={member.item.schemaType}
+        parentSchemaType={member.parentSchemaType}
+        onInsert={handleInsert}
+        onCopy={handleCopy}
+        onRemove={onRemove}
+        presence={member.item.presence}
+        validation={member.item.validation}
+        open={member.open}
+        onOpen={handleOpen}
+        onClose={handleClose}
+        onExpand={handleExpand}
+        onCollapse={handleCollapse}
+        readOnly={member.item.readOnly}
+        focused={member.item.focused}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        inputId={member.item.id}
+        path={member.item.path}
+        changed={member.item.changed}
+        inputProps={inputProps}
+        render={renderItem}
+      >
+        <RenderInput {...inputProps} render={renderInput} />
+      </RenderItem>
     </FormCallbacksProvider>
   )
+}
+
+// The RenderInput and RenderItem wrappers workaround the strict refs checks in React Compiler
+function RenderInput({
+  render,
+  ...props
+}: Omit<ObjectInputProps, 'renderDefault'> & {
+  render: RenderInputCallback
+}) {
+  return render(props)
+}
+function RenderItem({
+  render,
+  ...props
+}: Omit<ObjectItemProps, 'renderDefault'> & {
+  render: RenderArrayOfObjectsItemCallback
+}) {
+  return render(props)
 }

--- a/packages/sanity/src/core/form/members/array/items/ArrayOfPrimitivesItem.tsx
+++ b/packages/sanity/src/core/form/members/array/items/ArrayOfPrimitivesItem.tsx
@@ -170,8 +170,6 @@ export function ArrayOfPrimitivesItem(props: PrimitiveMemberItemProps) {
     elementProps,
   ])
 
-  const renderedInput = useMemo(() => renderInput(inputProps), [inputProps, renderInput])
-
   const onRemove = useCallback(() => {
     onChange(PatchEvent.from([unset([member.index])]))
   }, [member.index, onChange])
@@ -194,57 +192,53 @@ export function ArrayOfPrimitivesItem(props: PrimitiveMemberItemProps) {
     [getFormValue, member.item.path, onCopy],
   )
 
-  const itemProps = useMemo((): Omit<PrimitiveItemProps, 'renderDefault'> => {
-    return {
-      key: member.key,
-      index: member.index,
-      level: member.item.level,
-      value: member.item.value as FIXME,
-      changed: member.item.changed,
-      __unstable_computeDiff: member.item.__unstable_computeDiff,
-      hasUpstreamVersion: member.item.hasUpstreamVersion,
-      title: member.item.schemaType.title,
-      description: member.item.schemaType.description,
-      schemaType: member.item.schemaType as FIXME,
-      parentSchemaType: member.parentSchemaType,
-      onInsert,
-      onCopy: handleCopy,
-      onRemove,
-      presence: member.item.presence,
-      validation: member.item.validation,
-      readOnly: member.item.readOnly,
-      focused: member.item.focused,
-      onFocus: handleFocus,
-      onBlur: handleBlur,
-      inputId: member.item.id,
-      path: member.item.path,
-      children: renderedInput,
-    }
-  }, [
-    member.key,
-    member.index,
-    member.item.level,
-    member.item.value,
-    member.item.changed,
-    member.item.__unstable_computeDiff,
-    member.item.hasUpstreamVersion,
-    member.item.schemaType,
-    member.item.presence,
-    member.item.validation,
-    member.item.readOnly,
-    member.item.focused,
-    member.item.id,
-    member.item.path,
-    member.parentSchemaType,
-    onInsert,
-    handleCopy,
-    onRemove,
-    handleFocus,
-    handleBlur,
-    renderedInput,
-  ])
+  return (
+    <RenderItem
+      key={member.key}
+      index={member.index}
+      level={member.item.level}
+      value={member.item.value as FIXME}
+      changed={member.item.changed}
+      __unstable_computeDiff={member.item.__unstable_computeDiff}
+      hasUpstreamVersion={member.item.hasUpstreamVersion}
+      title={member.item.schemaType.title}
+      description={member.item.schemaType.description}
+      schemaType={member.item.schemaType as FIXME}
+      parentSchemaType={member.parentSchemaType}
+      onInsert={onInsert}
+      onCopy={handleCopy}
+      onRemove={onRemove}
+      presence={member.item.presence}
+      validation={member.item.validation}
+      readOnly={member.item.readOnly}
+      focused={member.item.focused}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      inputId={member.item.id}
+      path={member.item.path}
+      render={renderItem}
+    >
+      <RenderInput {...inputProps} render={renderInput} />
+    </RenderItem>
+  )
+}
 
-  return <>{useMemo(() => renderItem(itemProps as PrimitiveItemProps), [itemProps, renderItem])}</>
+// The RenderInput and RenderItem wrappers workaround the strict refs checks in React Compiler
+function RenderInput({
+  render,
+  ...props
+}: Omit<PrimitiveInputProps, 'renderDefault'> & {
+  render: RenderInputCallback
+}) {
+  return render(props)
+}
+function RenderItem({
+  render,
+  ...props
+}: Omit<PrimitiveItemProps, 'renderDefault'> & {
+  render: RenderArrayOfPrimitivesItemCallback
+}) {
+  return render(props)
 }
 
 function resolveNativeInputValue(

--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
@@ -449,50 +449,6 @@ export function ArrayOfObjectsField(props: {
     elementProps,
   ])
 
-  const renderedInput = useMemo(() => renderInput(inputProps), [inputProps, renderInput])
-
-  const fieldProps = useMemo((): Omit<ArrayFieldProps, 'renderDefault'> => {
-    return {
-      actions: fieldActions,
-      name: member.name,
-      index: member.index,
-      level: member.field.level,
-      value: member.field.value,
-      title: member.field.schemaType.title,
-      description: member.field.schemaType.description,
-      collapsible: member.collapsible,
-      collapsed: member.collapsed,
-      changed: member.field.changed,
-      onCollapse: handleCollapse,
-      onExpand: handleExpand,
-      schemaType: member.field.schemaType,
-      inputId: member.field.id,
-      path: member.field.path,
-      presence: member.field.presence,
-      validation: member.field.validation,
-      children: renderedInput,
-      inputProps: inputProps as ArrayOfObjectsInputProps,
-    }
-  }, [
-    fieldActions,
-    member.name,
-    member.index,
-    member.field.level,
-    member.field.value,
-    member.field.schemaType,
-    member.field.changed,
-    member.field.id,
-    member.field.path,
-    member.field.presence,
-    member.field.validation,
-    member.collapsible,
-    member.collapsed,
-    handleCollapse,
-    handleExpand,
-    renderedInput,
-    inputProps,
-  ])
-
   return (
     <FormCallbacksProvider
       onFieldGroupSelect={onFieldGroupSelect}
@@ -503,7 +459,47 @@ export function ArrayOfObjectsField(props: {
       onPathBlur={onPathBlur}
       onPathFocus={onPathFocus}
     >
-      {useMemo(() => renderField(fieldProps), [fieldProps, renderField])}
+      <RenderField
+        actions={fieldActions}
+        name={member.name}
+        index={member.index}
+        level={member.field.level}
+        value={member.field.value}
+        title={member.field.schemaType.title}
+        description={member.field.schemaType.description}
+        collapsible={member.collapsible}
+        collapsed={member.collapsed}
+        changed={member.field.changed}
+        onCollapse={handleCollapse}
+        onExpand={handleExpand}
+        schemaType={member.field.schemaType}
+        inputId={member.field.id}
+        path={member.field.path}
+        presence={member.field.presence}
+        validation={member.field.validation}
+        inputProps={inputProps as ArrayOfObjectsInputProps}
+        render={renderField}
+      >
+        <RenderInput {...inputProps} render={renderInput} />
+      </RenderField>
     </FormCallbacksProvider>
   )
+}
+
+// The RenderInput and RenderField wrappers workaround the strict refs checks in React Compiler
+function RenderInput({
+  render,
+  ...props
+}: Omit<ArrayOfObjectsInputProps, 'renderDefault'> & {
+  render: RenderInputCallback
+}) {
+  return render(props)
+}
+function RenderField({
+  render,
+  ...props
+}: Omit<ArrayFieldProps, 'renderDefault'> & {
+  render: RenderFieldCallback
+}) {
+  return render(props)
 }

--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfPrimitivesField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfPrimitivesField.tsx
@@ -403,50 +403,6 @@ export function ArrayOfPrimitivesField(props: {
     renderPreview,
   ])
 
-  const renderedInput = useMemo(() => renderInput(inputProps), [inputProps, renderInput])
-
-  const fieldProps: Omit<ArrayOfPrimitivesFieldProps, 'renderDefault'> = useMemo(() => {
-    return {
-      actions: fieldActions,
-      name: member.name,
-      index: member.index,
-      level: member.field.level,
-      value: member.field.value,
-      title: member.field.schemaType.title,
-      description: member.field.schemaType.description,
-      collapsible: member.collapsible,
-      collapsed: member.collapsed,
-      onExpand: handleExpand,
-      changed: member.field.changed,
-      onCollapse: handleCollapse,
-      schemaType: member.field.schemaType,
-      inputId: member.field.id,
-      path: member.field.path,
-      presence: member.field.presence,
-      validation: member.field.validation,
-      children: renderedInput,
-      inputProps: inputProps as ArrayOfPrimitivesInputProps,
-    }
-  }, [
-    fieldActions,
-    member.name,
-    member.index,
-    member.field.level,
-    member.field.value,
-    member.field.schemaType,
-    member.field.changed,
-    member.field.id,
-    member.field.path,
-    member.field.presence,
-    member.field.validation,
-    member.collapsible,
-    member.collapsed,
-    handleExpand,
-    handleCollapse,
-    renderedInput,
-    inputProps,
-  ])
-
   return (
     <FormCallbacksProvider
       onFieldGroupSelect={onFieldGroupSelect}
@@ -457,7 +413,47 @@ export function ArrayOfPrimitivesField(props: {
       onPathBlur={onPathBlur}
       onPathFocus={onPathFocus}
     >
-      {useMemo(() => renderField(fieldProps as FIXME), [fieldProps, renderField])}
+      <RenderField
+        actions={fieldActions}
+        name={member.name}
+        index={member.index}
+        level={member.field.level}
+        value={member.field.value}
+        title={member.field.schemaType.title}
+        description={member.field.schemaType.description}
+        collapsible={member.collapsible}
+        collapsed={member.collapsed}
+        onExpand={handleExpand}
+        changed={member.field.changed}
+        onCollapse={handleCollapse}
+        schemaType={member.field.schemaType}
+        inputId={member.field.id}
+        path={member.field.path}
+        presence={member.field.presence}
+        validation={member.field.validation}
+        inputProps={inputProps as ArrayOfPrimitivesInputProps}
+        render={renderField}
+      >
+        <RenderInput {...inputProps} render={renderInput} />
+      </RenderField>
     </FormCallbacksProvider>
   )
+}
+
+// The RenderInput and RenderField wrappers workaround the strict refs checks in React Compiler
+function RenderInput({
+  render,
+  ...props
+}: Omit<ArrayOfPrimitivesInputProps, 'renderDefault'> & {
+  render: RenderInputCallback
+}) {
+  return render(props)
+}
+function RenderField({
+  render,
+  ...props
+}: Omit<ArrayOfPrimitivesFieldProps, 'renderDefault'> & {
+  render: RenderFieldCallback
+}) {
+  return render(props as FIXME)
 }

--- a/packages/sanity/src/core/form/members/object/fields/ObjectField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ObjectField.tsx
@@ -260,60 +260,6 @@ export const ObjectField = function ObjectField(props: {
     renderPreview,
   ])
 
-  const renderedInput = useMemo(() => renderInput(inputProps), [inputProps, renderInput])
-
-  const fieldProps = useMemo((): Omit<ObjectFieldProps, 'renderDefault'> => {
-    return {
-      actions: fieldActions,
-      name: member.name,
-      index: member.index,
-      level: member.field.level,
-      value: member.field.value,
-      validation: member.field.validation,
-      presence: member.field.presence,
-      title: member.field.schemaType.title,
-      description: member.field.schemaType.description,
-
-      collapsible: member.collapsible,
-      collapsed: member.collapsed,
-      onCollapse: handleCollapse,
-      onExpand: handleExpand,
-
-      open: member.open,
-      changed: member.field.changed,
-
-      onOpen: handleOpen,
-      onClose: handleClose,
-
-      schemaType: member.field.schemaType,
-      inputId: member.field.id,
-      path: member.field.path,
-      children: renderedInput,
-      inputProps: inputProps as ObjectInputProps,
-    }
-  }, [
-    fieldActions,
-    member.name,
-    member.index,
-    member.field.level,
-    member.field.value,
-    member.field.validation,
-    member.field.presence,
-    member.field.schemaType,
-    member.field.changed,
-    member.field.id,
-    member.field.path,
-    member.collapsible,
-    member.collapsed,
-    member.open,
-    handleCollapse,
-    handleExpand,
-    handleOpen,
-    handleClose,
-    renderedInput,
-    inputProps,
-  ])
-
   return (
     <FormCallbacksProvider
       onFieldGroupSelect={onFieldGroupSelect}
@@ -324,7 +270,50 @@ export const ObjectField = function ObjectField(props: {
       onPathBlur={onPathBlur}
       onPathFocus={onPathFocus}
     >
-      {useMemo(() => renderField(fieldProps), [fieldProps, renderField])}
+      <RenderField
+        actions={fieldActions}
+        name={member.name}
+        index={member.index}
+        level={member.field.level}
+        value={member.field.value}
+        validation={member.field.validation}
+        presence={member.field.presence}
+        title={member.field.schemaType.title}
+        description={member.field.schemaType.description}
+        collapsible={member.collapsible}
+        collapsed={member.collapsed}
+        onCollapse={handleCollapse}
+        onExpand={handleExpand}
+        open={member.open}
+        changed={member.field.changed}
+        onOpen={handleOpen}
+        onClose={handleClose}
+        schemaType={member.field.schemaType}
+        inputId={member.field.id}
+        path={member.field.path}
+        inputProps={inputProps as ObjectInputProps}
+        render={renderField}
+      >
+        <RenderInput {...inputProps} render={renderInput} />
+      </RenderField>
     </FormCallbacksProvider>
   )
+}
+
+// The RenderInput and RenderField wrappers workaround the strict refs checks in React Compiler
+function RenderInput({
+  render,
+  ...props
+}: Omit<ObjectInputProps, 'renderDefault'> & {
+  render: RenderInputCallback
+}) {
+  return render(props)
+}
+function RenderField({
+  render,
+  ...props
+}: Omit<ObjectFieldProps, 'renderDefault'> & {
+  render: RenderFieldCallback
+}) {
+  return render(props)
 }

--- a/packages/sanity/src/core/form/members/object/fields/PrimitiveField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/PrimitiveField.tsx
@@ -85,16 +85,6 @@ export function PrimitiveField(props: {
     [member.name, member.field.schemaType, onChange],
   )
 
-  const validationError =
-    useMemo(
-      () =>
-        member.field.validation
-          .filter((item) => item.level === 'error')
-          .map((item) => item.message)
-          .join('\n'),
-      [member.field.validation],
-    ) || undefined
-
   const elementProps = useMemo(
     (): PrimitiveInputProps['elementProps'] => ({
       'onBlur': handleBlur,
@@ -124,6 +114,11 @@ export function PrimitiveField(props: {
   )
 
   const inputProps = useMemo((): Omit<PrimitiveInputProps, 'renderDefault'> => {
+    const validationError =
+      member.field.validation
+        .filter((item) => item.level === 'error')
+        .map((item) => item.message)
+        .join('\n') || undefined
     return {
       value: member.field.value as any,
       compareValue: member.field.compareValue,
@@ -159,45 +154,46 @@ export function PrimitiveField(props: {
     member.field.validation,
     member.field.presence,
     handleChange,
-    validationError,
     elementProps,
   ])
 
-  const renderedInput = useMemo(() => renderInput(inputProps), [inputProps, renderInput])
+  return (
+    <RenderField
+      actions={fieldActions}
+      changed={member.field.changed}
+      description={member.field.schemaType.description}
+      index={member.index}
+      inputId={member.field.id}
+      inputProps={inputProps as any}
+      level={member.field.level}
+      name={member.name}
+      path={member.field.path}
+      presence={member.field.presence}
+      schemaType={member.field.schemaType as any}
+      title={member.field.schemaType.title}
+      validation={member.field.validation}
+      value={member.field.value as any}
+      render={renderField}
+    >
+      <RenderInput {...inputProps} render={renderInput} />
+    </RenderField>
+  )
+}
 
-  const fieldProps = useMemo((): Omit<PrimitiveFieldProps, 'renderDefault'> => {
-    return {
-      actions: fieldActions,
-      changed: member.field.changed,
-      children: renderedInput,
-      description: member.field.schemaType.description,
-      index: member.index,
-      inputId: member.field.id,
-      inputProps: inputProps as any,
-      level: member.field.level,
-      name: member.name,
-      path: member.field.path,
-      presence: member.field.presence,
-      schemaType: member.field.schemaType as any,
-      title: member.field.schemaType.title,
-      validation: member.field.validation,
-      value: member.field.value as any,
-    }
-  }, [
-    fieldActions,
-    member.field.level,
-    member.field.value,
-    member.field.schemaType,
-    member.field.id,
-    member.field.path,
-    member.field.validation,
-    member.field.presence,
-    member.field.changed,
-    member.name,
-    member.index,
-    renderedInput,
-    inputProps,
-  ])
-
-  return <>{renderField(fieldProps)}</>
+// The RenderInput and RenderField wrappers workaround the strict refs checks in React Compiler
+function RenderInput({
+  render,
+  ...props
+}: Omit<PrimitiveInputProps, 'renderDefault'> & {
+  render: RenderInputCallback<PrimitiveInputProps>
+}) {
+  return render(props)
+}
+function RenderField({
+  render,
+  ...props
+}: Omit<PrimitiveFieldProps, 'renderDefault'> & {
+  render: RenderFieldCallback<PrimitiveFieldProps>
+}) {
+  return render(props)
 }

--- a/packages/sanity/src/core/hooks/useRecordDocumentHistoryEvent.ts
+++ b/packages/sanity/src/core/hooks/useRecordDocumentHistoryEvent.ts
@@ -82,7 +82,8 @@ export function useRecordDocumentHistoryEvent({
 
   const recordEvent = useCallback(
     (eventType: 'viewed' | 'edited' | 'created' | 'deleted') => {
-      try {
+      // The run() wrapper is a workaround for React Compiler not yet fully supporting try/catch syntax
+      const run = () => {
         const message: Events.HistoryMessage = {
           type: 'dashboard/v1/events/history',
           data: {
@@ -100,6 +101,9 @@ export function useRecordDocumentHistoryEvent({
         }
 
         node?.post?.(message.type, message.data)
+      }
+      try {
+        run()
       } catch (error) {
         console.error('Failed to record history event:', error)
         throw error

--- a/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
@@ -78,10 +78,9 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
             title: t('release.toast.create-release-error.title'),
           })
         }
-      } finally {
-        setIsSubmitting(false)
-        clearReleaseDataFromStorage()
       }
+      setIsSubmitting(false)
+      clearReleaseDataFromStorage()
     },
     [
       releasePromise,

--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -43,12 +43,16 @@ export function DiscardVersionDialog(props: {
     setIsDiscarding(true)
 
     if (isVersionId(documentId)) {
-      try {
+      // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+      const run = async () => {
         await discardVersion(
           getVersionFromId(documentId) ||
             getReleaseIdFromReleaseDocumentId((selectedPerspective as ReleaseDocument)._id),
           documentId,
         )
+      }
+      try {
+        await run()
       } catch (err) {
         toast.push({
           closable: true,

--- a/packages/sanity/src/core/releases/components/dialog/UnpublishVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/UnpublishVersionDialog.tsx
@@ -48,7 +48,8 @@ export function UnpublishVersionDialog(props: {
   const handleUnpublish = useCallback(async () => {
     setIsUnpublishing(true)
 
-    try {
+    // The run() wrapper instead of doing it inline in try/catch is because of the React Compiler not fully supporting the syntax yet
+    const run = async () => {
       await unpublishVersion(documentVersionId)
       toast.push({
         closable: true,
@@ -61,6 +62,9 @@ export function UnpublishVersionDialog(props: {
           />
         ),
       })
+    }
+    try {
+      await run()
     } catch (err) {
       toast.push({
         closable: true,
@@ -103,7 +107,6 @@ export function UnpublishVersionDialog(props: {
         ) : (
           <LoadingBlock />
         )}
-
         <Text muted size={1}>
           <Translate
             t={t}
@@ -133,7 +136,6 @@ export function UnpublishVersionDialog(props: {
             }}
           />
         </Text>
-
         <Text muted size={1}>
           {t('unpublish-dialog.description.lost-changes')}
         </Text>

--- a/packages/sanity/src/core/releases/hooks/useCopyToDrafts.ts
+++ b/packages/sanity/src/core/releases/hooks/useCopyToDrafts.ts
@@ -35,7 +35,8 @@ export function useCopyToDrafts(options: UseCopyToDraftsOptions) {
   const hasDraftVersion = Boolean(documentVersionInfo.draft)
 
   const handleCopyToDrafts = useCallback(async () => {
-    try {
+    // Workaround for React Compiler not yet fully supporting try/catch syntax
+    const run = async () => {
       const sourceDoc = await client.getDocument(sourceDocumentId)
 
       if (!sourceDoc) {
@@ -53,6 +54,9 @@ export function useCopyToDrafts(options: UseCopyToDraftsOptions) {
       })
 
       onNavigate()
+    }
+    try {
+      await run()
     } catch (err) {
       toast.push({
         closable: true,

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
@@ -75,7 +75,8 @@ export const ReleasePublishAllButton = ({
   const handleConfirmPublishAll = useCallback(async () => {
     if (!release) return
 
-    try {
+    // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+    const run = async () => {
       setPublishBundleStatus('publishing')
       await publishRelease(release._id)
       telemetry.log(PublishedRelease)
@@ -85,6 +86,9 @@ export const ReleasePublishAllButton = ({
       ) {
         setPerspective(isDraftModelEnabled ? 'drafts' : 'published')
       }
+    }
+    try {
+      await run()
     } catch (publishingError) {
       toast.push({
         status: 'error',
@@ -102,10 +106,9 @@ export const ReleasePublishAllButton = ({
         ),
       })
       console.error(publishingError)
-    } finally {
-      onConfirmDialogClose?.()
-      setPublishBundleStatus('idle')
     }
+    onConfirmDialogClose?.()
+    setPublishBundleStatus('idle')
   }, [
     release,
     publishRelease,

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/ReleaseRevertButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/ReleaseRevertButton.tsx
@@ -63,7 +63,8 @@ const ConfirmReleaseDialog = ({
 
     const revertReleaseId = createReleaseId()
 
-    try {
+    // The run().catch().finally() syntax instead of try/catch/finally is because of the React Compiler not fully supporting the syntax yet
+    const run = async () => {
       if (!documentRevertStates) {
         throw new Error('Unable to find documents to revert')
       }
@@ -137,21 +138,24 @@ const ConfirmReleaseDialog = ({
           ),
         })
       }
-    } catch (revertError) {
-      if (isReleaseLimitError(revertError)) return
-
-      toast.push({
-        status: 'error',
-        title: (
-          <Text muted size={1}>
-            <Translate t={t} i18nKey="toast.revert.error" values={{error: revertError.message}} />
-          </Text>
-        ),
-      })
-      console.error(revertError)
-    } finally {
-      setRevertReleaseStatus('idle')
     }
+    await run()
+      .catch((revertError) => {
+        if (isReleaseLimitError(revertError)) return
+
+        toast.push({
+          status: 'error',
+          title: (
+            <Text muted size={1}>
+              <Translate t={t} i18nKey="toast.revert.error" values={{error: revertError.message}} />
+            </Text>
+          ),
+        })
+        console.error(revertError)
+      })
+      .finally(() => {
+        setRevertReleaseStatus('idle')
+      })
   }, [
     setRevertReleaseStatus,
     getDocumentRevertStates,

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -110,7 +110,8 @@ export const ReleaseScheduleButton = ({
       return
     }
 
-    try {
+    // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+    const run = async () => {
       setStatus('scheduling')
       await schedule(release._id, publishAt)
       telemetry.log(ScheduledRelease)
@@ -129,6 +130,9 @@ export const ReleaseScheduleButton = ({
           </Text>
         ),
       })
+    }
+    try {
+      await run()
     } catch (schedulingError) {
       toast.push({
         status: 'error',
@@ -146,10 +150,9 @@ export const ReleaseScheduleButton = ({
         ),
       })
       console.error(schedulingError)
-    } finally {
-      onConfirmDialogClose?.()
-      setStatus('idle')
     }
+    onConfirmDialogClose?.()
+    setStatus('idle')
   }, [
     publishAt,
     isMenuItem,

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseUnscheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseUnscheduleButton.tsx
@@ -30,30 +30,34 @@ export const ReleaseUnscheduleButton = ({
   const [status, setStatus] = useState<'idle' | 'confirm' | 'unscheduling'>('idle')
 
   const handleConfirmSchedule = useCallback(async () => {
-    try {
+    // The run().catch().finally() syntax instead of try/catch/finally is because of the React Compiler not fully supporting the syntax yet
+    const run = async () => {
       setStatus('unscheduling')
       await unschedule(release._id)
       telemetry.log(UnscheduledRelease)
-    } catch (schedulingError) {
-      toast.push({
-        status: 'error',
-        title: (
-          <Text muted size={1}>
-            <Translate
-              t={t}
-              i18nKey="toast.unschedule.error"
-              values={{
-                title: release.metadata.title || tCore('release.placeholder-untitled-release'),
-                error: schedulingError.message,
-              }}
-            />
-          </Text>
-        ),
-      })
-      console.error(schedulingError)
-    } finally {
-      setStatus('idle')
     }
+    await run()
+      .catch((schedulingError) => {
+        toast.push({
+          status: 'error',
+          title: (
+            <Text muted size={1}>
+              <Translate
+                t={t}
+                i18nKey="toast.unschedule.error"
+                values={{
+                  title: release.metadata.title || tCore('release.placeholder-untitled-release'),
+                  error: schedulingError.message,
+                }}
+              />
+            </Text>
+          ),
+        })
+        console.error(schedulingError)
+      })
+      .finally(() => {
+        setStatus('idle')
+      })
   }, [unschedule, release._id, release.metadata.title, telemetry, toast, t, tCore])
 
   const confirmScheduleDialog = useMemo(() => {

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/useReleaseHistory.ts
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/useReleaseHistory.ts
@@ -68,7 +68,8 @@ export function useReleaseHistory(
     }
 
     await acquireHistorySlot()
-    try {
+    // The run().catch().finally() syntax instead of try/catch/finally is because of the React Compiler not fully supporting the syntax yet
+    const run = async () => {
       const transactions = await getTransactionsLogs(client, versionId, {
         tag: 'sanity.studio.releases.documents.history',
         effectFormat: 'mendoza',
@@ -85,12 +86,15 @@ export function useReleaseHistory(
           transactions,
         }
       }
-    } catch (error) {
-      console.error('Failed to fetch or parse document history:', error)
-      if (!cancelledRef.current) setHistory([])
-    } finally {
-      releaseHistorySlot()
     }
+    await run()
+      .catch((error) => {
+        console.error('Failed to fetch or parse document history:', error)
+        if (!cancelledRef.current) setHistory([])
+      })
+      .finally(() => {
+        releaseHistorySlot()
+      })
   }, [versionId, releaseDocumentId, documentRevision, client])
 
   useEffect(() => {

--- a/packages/sanity/src/core/releases/tool/overview/ConfirmScheduledDraftsDialog.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ConfirmScheduledDraftsDialog.tsx
@@ -121,9 +121,8 @@ export function ConfirmScheduledDraftsDialog({
         status: 'error',
         title: t('toast.confirm-active-scheduled-drafts.error', {error: error.message}),
       })
-    } finally {
-      setIsScheduling(false)
     }
+    setIsScheduling(false)
   }, [activeScheduledDrafts, scheduleActiveDrafts, onClose, toast, t])
 
   return (

--- a/packages/sanity/src/core/scheduled-publishing/hooks/useScheduleOperation.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/hooks/useScheduleOperation.tsx
@@ -80,7 +80,8 @@ export default function useScheduleOperation() {
     displayToast?: boolean
     documentId: string
   }) {
-    try {
+    // The run().catch() syntax instead of try/catch is because of the React Compiler not fully supporting the syntax yet
+    const run = async () => {
       const data = await api.create({date, documentId})
 
       window.dispatchEvent(
@@ -109,7 +110,8 @@ export default function useScheduleOperation() {
           status: 'success',
         })
       }
-    } catch (err) {
+    }
+    await run().catch((err) => {
       if (displayToast) {
         toast.push({
           closable: true,
@@ -120,7 +122,7 @@ export default function useScheduleOperation() {
           status: 'error',
         })
       }
-    }
+    })
   }
 
   async function deleteSchedule({
@@ -130,7 +132,8 @@ export default function useScheduleOperation() {
     displayToast?: boolean
     schedule: Schedule
   }) {
-    try {
+    // The run().catch() syntax instead of try/catch is because of the React Compiler not fully supporting the syntax yet
+    const run = async () => {
       await api.delete({scheduleId: schedule?.id})
 
       window.dispatchEvent(
@@ -148,7 +151,8 @@ export default function useScheduleOperation() {
           status: 'success',
         })
       }
-    } catch (err) {
+    }
+    await run().catch((err) => {
       if (displayToast) {
         toast.push({
           closable: true,
@@ -159,7 +163,7 @@ export default function useScheduleOperation() {
           status: 'error',
         })
       }
-    }
+    })
   }
 
   async function deleteSchedules({
@@ -169,7 +173,8 @@ export default function useScheduleOperation() {
     displayToast?: boolean
     schedules: Schedule[]
   }) {
-    try {
+    // The run().catch() syntax instead of try/catch is because of the React Compiler not fully supporting the syntax yet
+    const run = async () => {
       const scheduleIds = schedules.map((schedule) => schedule.id)
       const response = await api.deleteMultiple({scheduleIds})
 
@@ -225,7 +230,8 @@ export default function useScheduleOperation() {
           })
         }
       }
-    } catch (err) {
+    }
+    await run().catch((err) => {
       if (displayToast) {
         toast.push({
           closable: true,
@@ -236,7 +242,7 @@ export default function useScheduleOperation() {
           status: 'error',
         })
       }
-    }
+    })
   }
 
   async function publishSchedule({

--- a/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx
+++ b/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx
@@ -37,7 +37,8 @@ export function DeleteScheduledDraftDialog(
 
   const handleDeleteSchedule = useCallback(async () => {
     setIsDeleting(true)
-    try {
+    // The run().catch().finally() syntax instead of try/catch/finally is because of the React Compiler not fully supporting the syntax yet
+    const run = async () => {
       await operations.deleteScheduledDraft(release._id)
       toast.push({
         closable: true,
@@ -50,26 +51,29 @@ export function DeleteScheduledDraftDialog(
           />
         ),
       })
-    } catch (error) {
-      console.error('Failed to delete scheduled draft:', error)
-      toast.push({
-        closable: true,
-        status: 'error',
-        description: (
-          <Translate
-            t={t}
-            i18nKey="release.toast.delete-schedule-draft.error"
-            values={{
-              title: firstDocumentPreview?.title || t('preview.default.title-fallback'),
-              error: getErrorMessage(error),
-            }}
-          />
-        ),
-      })
-    } finally {
-      setIsDeleting(false)
-      onClose()
     }
+    await run()
+      .catch((error) => {
+        console.error('Failed to delete scheduled draft:', error)
+        toast.push({
+          closable: true,
+          status: 'error',
+          description: (
+            <Translate
+              t={t}
+              i18nKey="release.toast.delete-schedule-draft.error"
+              values={{
+                title: firstDocumentPreview?.title || t('preview.default.title-fallback'),
+                error: getErrorMessage(error),
+              }}
+            />
+          ),
+        })
+      })
+      .finally(() => {
+        setIsDeleting(false)
+        onClose()
+      })
   }, [release._id, operations, toast, t, firstDocumentPreview?.title, onClose])
 
   return (

--- a/packages/sanity/src/core/singleDocRelease/components/PublishScheduledDraftDialog.tsx
+++ b/packages/sanity/src/core/singleDocRelease/components/PublishScheduledDraftDialog.tsx
@@ -37,7 +37,8 @@ export function PublishScheduledDraftDialog(
 
   const handlePublishScheduledDraft = useCallback(async () => {
     setIsPublishing(true)
-    try {
+    // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+    const run = async () => {
       await operations.publishScheduledDraft(release)
       toast.push({
         closable: true,
@@ -50,6 +51,9 @@ export function PublishScheduledDraftDialog(
           />
         ),
       })
+    }
+    try {
+      await run()
     } catch (error) {
       console.error('Failed to run scheduled draft:', error)
       toast.push({
@@ -66,10 +70,9 @@ export function PublishScheduledDraftDialog(
           />
         ),
       })
-    } finally {
-      setIsPublishing(false)
-      onClose()
     }
+    setIsPublishing(false)
+    onClose()
   }, [operations, release, toast, t, firstDocumentPreview?.title, onClose])
 
   return (

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
@@ -62,9 +62,13 @@ export function useScheduledDraftMenuActions(
       if (!release) return
 
       setIsPerformingOperation(true)
-      try {
+      // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+      const run = async () => {
         await operations.rescheduleScheduledDraft(release, newPublishAt)
         onActionComplete?.()
+      }
+      try {
+        await run()
       } catch (error) {
         console.error('Failed to reschedule draft:', error)
         toast.push({
@@ -81,10 +85,9 @@ export function useScheduledDraftMenuActions(
             />
           ),
         })
-      } finally {
-        setIsPerformingOperation(false)
-        setSelectedAction(null)
       }
+      setIsPerformingOperation(false)
+      setSelectedAction(null)
     },
     [release, operations, onActionComplete, toast, t, firstDocumentPreview?.title],
   )

--- a/packages/sanity/src/core/studio/StudioErrorBoundary.tsx
+++ b/packages/sanity/src/core/studio/StudioErrorBoundary.tsx
@@ -52,11 +52,15 @@ export function StudioErrorBoundary(props: StudioErrorBoundaryProps) {
   const handleCatchError: ErrorBoundaryProps['onCatch'] = useCallback(
     (params) => {
       let eventId: string | undefined
-      try {
+      // The run() wrapper instead of doing it inline in try/catch is because of the React Compiler not fully supporting the syntax yet
+      const run = () => {
         eventId = errorReporter.reportError(params.error, {
           reactErrorInfo: params.info,
           errorBoundary: 'StudioErrorBoundary',
         })?.eventId
+      }
+      try {
+        run()
       } catch (e) {
         e.message = `Encountered an additional error when reporting error: ${e.message}`
         console.error(e)

--- a/packages/sanity/src/core/studio/StudioRootErrorHandler.tsx
+++ b/packages/sanity/src/core/studio/StudioRootErrorHandler.tsx
@@ -66,8 +66,12 @@ export function StudioRootErrorHandler(props: {children: ReactNode}) {
       }
 
       let eventId: string | undefined
+      // The run() wrapper instead of doing it inline in try/catch is because of the React Compiler not fully supporting the syntax yet
+      const run = () => {
+        eventId = errorReporter.reportError(event.error as unknown as Error)?.eventId
+      }
       try {
-        eventId = errorReporter.reportError(event.error)?.eventId
+        run()
       } catch (e) {
         e.message = `Encountered an additional error when reporting error: ${e.message}`
         console.error(e)

--- a/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
+++ b/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
@@ -61,12 +61,13 @@ function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
         setIsCreatingDataset(false)
         return client
       }
-    } catch (_) {
+    } catch {
       // If the dataset does not exist we will get an error, but we can ignore
       // it since we will create the dataset in the next step.
     }
 
-    try {
+    // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+    const run = async () => {
       // 1. Create the addon dataset
       const res = await originalClient.request({
         uri: `/comments/${dataset}/setup`,
@@ -89,11 +90,10 @@ function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
 
       // 4. Return the client so that the caller can use it to execute operations
       return client
-    } catch (err) {
-      throw err
-    } finally {
-      setIsCreatingDataset(false)
     }
+    return run().finally(() => {
+      setIsCreatingDataset(false)
+    })
   }, [dataset, getAddonDatasetName, handleCreateClient, originalClient])
 
   useEffect(() => {
@@ -107,7 +107,7 @@ function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
         const client = handleCreateClient(addonDatasetName)
         setAddonDatasetClient(client)
       })
-      .catch((err) => {
+      .catch(() => {
         // If the addon dataset does not exist or we don't have permission to access it,
         // We can ignore this error.
         // TODO: Surface error to the user when they try to use the comments feature.

--- a/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
+++ b/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-statements */
 import {useTelemetry} from '@sanity/telemetry/react'
 import {isIndexSegment, isKeySegment, type Path, type PathSegment} from '@sanity/types'
 import {useToast} from '@sanity/ui'
@@ -250,7 +249,8 @@ export const CopyPasteProvider: React.FC<{
       }
       copiedJsonTypes.push(sourceSchemaType.jsonType)
 
-      try {
+      // Workaround for try/catch not being fully supported by the React Compiler yet
+      const run = async () => {
         const {targetValue, errors} = await transferValue(transferValueOptions)
         const nonWarningErrors = errors.filter((error) => error.level !== 'warning')
         const _isEmptyValue = isEmptyValue(targetValue)
@@ -309,6 +309,9 @@ export const CopyPasteProvider: React.FC<{
             : [...prefixPatches, set(targetValue, targetPath)],
           targetSchemaTypeTitle,
         })
+      }
+      try {
+        await run()
       } catch (error) {
         toast.push({
           status: 'error',

--- a/packages/sanity/src/core/tasks/components/list/TasksStatus.tsx
+++ b/packages/sanity/src/core/tasks/components/list/TasksStatus.tsx
@@ -29,9 +29,8 @@ export function TasksStatus(props: TasksStatusProps) {
         }
       } catch (error) {
         console.error('An error occurred while updating the task status', error)
-      } finally {
-        setIsLoading(false)
       }
+      setIsLoading(false)
     },
     [documentId, operations],
   )

--- a/packages/sanity/src/core/tasks/hooks/useRemoveTask.ts
+++ b/packages/sanity/src/core/tasks/hooks/useRemoveTask.ts
@@ -24,20 +24,23 @@ export function useRemoveTask({id, onError, onRemoved}: RemoveTaskOptions): Remo
   const operations = useTaskOperations()
 
   const handleRemove = useCallback(async () => {
-    try {
+    // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+    const run = async () => {
       setRemoveStatus('loading')
       await operations.remove(id)
       onRemoved?.()
       setRemoveStatus('idle')
       await new Promise((resolve) => setTimeout(resolve, 300))
       setShowDialog(false)
+    }
+    try {
+      await run()
     } catch (e) {
       onError?.(e.message)
       setError(e.message)
       setRemoveStatus('error')
-    } finally {
-      setRemoveStatus('idle')
     }
+    setRemoveStatus('idle')
   }, [id, operations, onError, onRemoved])
 
   const handleOpenDialog = useCallback(() => {

--- a/packages/sanity/src/core/tasks/hooks/useTaskOperations.ts
+++ b/packages/sanity/src/core/tasks/hooks/useTaskOperations.ts
@@ -35,54 +35,34 @@ export function useTaskOperations(): TaskOperations {
       } satisfies Partial<TaskDocument>
 
       if (!client) {
-        try {
-          const newCreatedClient = await createAddonDataset()
-          if (!newCreatedClient) throw new Error('No addon client found. Unable to create task.')
-          const created = await newCreatedClient.create(task)
-          return created
-        } catch (err) {
-          // TODO: Handle error
-          throw err
-        }
+        const newCreatedClient = await createAddonDataset()
+        if (!newCreatedClient) throw new Error('No addon client found. Unable to create task.')
+        const created = await newCreatedClient.create(task)
+        return created
       }
 
-      try {
-        const created = await client.create(task)
-        return created
-      } catch (err) {
-        // TODO: Handle error
-        throw err
-      }
+      const created = await client.create(task)
+      return created
     },
     [client, createAddonDataset, currentUser],
   )
 
   const handleEdit = useCallback(
     async (id: string, set: TaskEditPayload) => {
-      try {
-        if (!client) {
-          throw new Error('No client. Unable to create task.')
-        }
-        const edited = (await client.patch(id).set(set).commit()) as TaskDocument
-        return edited
-      } catch (e) {
-        // TODO: Handle error
-        throw e
+      if (!client) {
+        throw new Error('No client. Unable to create task.')
       }
+      const edited = (await client.patch(id).set(set).commit()) as TaskDocument
+      return edited
     },
     [client],
   )
   const handleRemove = useCallback(
     async (id: string) => {
-      try {
-        if (!client) {
-          throw new Error('No client. Unable to create task.')
-        }
-        await client.delete(id)
-      } catch (e) {
-        // TODO: Handle error
-        throw e
+      if (!client) {
+        throw new Error('No client. Unable to create task.')
       }
+      await client.delete(id)
     },
     [client],
   )

--- a/packages/sanity/src/presentation/PresentationTool.tsx
+++ b/packages/sanity/src/presentation/PresentationTool.tsx
@@ -186,6 +186,8 @@ export default function PresentationTool(props: {
     navigate(options)
   })
 
+  const refreshRef = useRef<number>(undefined)
+
   useEffect(() => {
     if (!controller) return undefined
 
@@ -226,7 +228,8 @@ export default function PresentationTool(props: {
       }
 
       if (frameStateRef.current.url !== url) {
-        try {
+        // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+        const run = () => {
           // Handle bypass params being forwarded to the final URL
           const [urlWithoutSearch, search] = url.split('?')
           const searchParams = new URLSearchParams(search)
@@ -237,6 +240,9 @@ export default function PresentationTool(props: {
               preview: `${urlWithoutSearch}${searchParams.size > 0 ? '?' : ''}${searchParams}`,
             },
           })
+        }
+        try {
+          run()
         } catch {
           handleNavigate({params: {preview: url}})
         }
@@ -449,7 +455,6 @@ export default function PresentationTool(props: {
     unstable_navigator,
   })
 
-  const refreshRef = useRef<number>(undefined)
   const handleRefresh = useCallback(
     (fallback: () => void) => {
       presentationRef.send({type: 'iframe refresh'})

--- a/packages/sanity/src/presentation/preview/SharePreviewMenu.tsx
+++ b/packages/sanity/src/presentation/preview/SharePreviewMenu.tsx
@@ -21,7 +21,7 @@ import {
   useToast,
 } from '@sanity/ui'
 import {AnimatePresence, motion} from 'framer-motion'
-import {lazy, memo, Suspense, useCallback, useEffect, useMemo, useState} from 'react'
+import {lazy, Suspense, useCallback, useEffect, useMemo, useState} from 'react'
 import {useClient, useCurrentUser, useTranslation} from 'sanity'
 import {styled} from 'styled-components'
 
@@ -58,9 +58,7 @@ const MotionSpinner = motion.create(Spinner)
 const MotionText = motion.create(Text)
 const MotionMonogram = motion.create(StyledSanityMonogram)
 
-export const SharePreviewMenu = memo(function SharePreviewMenuComponent(
-  props: SharePreviewMenuProps,
-) {
+export function SharePreviewMenu(props: SharePreviewMenuProps): React.JSX.Element {
   const {
     canToggleSharePreviewAccess,
     canUseSharedPreviewAccess,
@@ -103,8 +101,9 @@ export const SharePreviewMenu = memo(function SharePreviewMenuComponent(
     })
   }, [pushToast, t])
 
-  const handleDisableSharing = useCallback(async () => {
-    try {
+  const handleDisableSharing = async () => {
+    // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+    const run = async () => {
       setDisabling(true)
       await disablePreviewAccessSharing(
         client,
@@ -113,14 +112,17 @@ export const SharePreviewMenu = memo(function SharePreviewMenuComponent(
         currentUser?.id,
       )
       setSecret(null)
+    }
+    try {
+      await run()
     } catch (error) {
       setError(error)
-    } finally {
-      setDisabling(false)
     }
-  }, [client, currentUser?.id])
-  const handleEnableSharing = useCallback(async () => {
-    try {
+    setDisabling(false)
+  }
+  const handleEnableSharing = async () => {
+    // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+    const run = async () => {
       setEnabling(true)
 
       const previewUrlSecret = await enablePreviewAccessSharing(
@@ -130,24 +132,30 @@ export const SharePreviewMenu = memo(function SharePreviewMenuComponent(
         currentUser?.id,
       )
       setSecret(previewUrlSecret.secret)
+    }
+    try {
+      await run()
     } catch (error) {
       setError(error)
-    } finally {
-      setEnabling(false)
     }
-  }, [client, currentUser?.id])
+    setEnabling(false)
+  }
 
-  const handleCopyUrl = useCallback(() => {
-    try {
+  const handleCopyUrl = useCallback(async () => {
+    // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+    const run = async () => {
       if (!url) {
         throw new Error('No URL to copy')
       }
-      void navigator.clipboard.writeText(url.toString())
+      await navigator.clipboard.writeText(url.toString())
       pushToast({
         closable: true,
         status: 'success',
         title: t('share-url.clipboard.status', {context: 'success'}),
       })
+    }
+    try {
+      await run()
     } catch (error) {
       setError(error)
     }
@@ -335,5 +343,4 @@ export const SharePreviewMenu = memo(function SharePreviewMenuComponent(
       }}
     />
   )
-})
-SharePreviewMenu.displayName = 'Memo(SharePreviewMenu)'
+}

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/EventsSelector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/EventsSelector.tsx
@@ -59,7 +59,8 @@ export function EventsSelector({showList}: {showList: boolean}) {
 
   const selectRev = useCallback(
     (event: DocumentGroupEvent) => {
-      try {
+      // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+      const run = () => {
         if (
           isDeleteDocumentVersionEvent(event) ||
           isDeleteDocumentGroupEvent(event) ||
@@ -72,6 +73,9 @@ export function EventsSelector({showList}: {showList: boolean}) {
         }
         const [since, rev] = findRangeForRevision(event.id)
         setTimelineRange(since, rev)
+      }
+      try {
+        run()
       } catch (err) {
         toast.push({
           closable: true,

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/HistorySelector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/HistorySelector.tsx
@@ -46,9 +46,13 @@ export function HistorySelector({showList}: {showList: boolean}) {
   const toast = useToast()
   const selectRev = useCallback(
     (revChunk: Chunk) => {
-      try {
+      // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+      const run = () => {
         const [sinceId, revId] = timelineStore?.findRangeForRev(revChunk) || [null, null]
         setTimelineRange(sinceId, revId)
+      }
+      try {
+        run()
       } catch (err) {
         toast.push({
           closable: true,

--- a/packages/sanity/src/structure/panes/document/timeline/events/EventsTimelineMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/events/EventsTimelineMenu.tsx
@@ -85,7 +85,8 @@ export function EventsTimelineMenu({event, events, mode, placement}: TimelineMen
 
   const selectRev = useCallback(
     (revEvent: DocumentGroupEvent) => {
-      try {
+      // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+      const run = () => {
         if (
           isDeleteDocumentVersionEvent(revEvent) ||
           isDeleteDocumentGroupEvent(revEvent) ||
@@ -99,6 +100,9 @@ export function EventsTimelineMenu({event, events, mode, placement}: TimelineMen
         const [since, rev] = findRangeForRevision(revEvent?.id)
         setTimelineRange(since, rev)
         handleClose()
+      }
+      try {
+        run()
       } catch (err) {
         toast.push({
           closable: true,

--- a/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
@@ -69,9 +69,13 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
 
   const selectRev = useCallback(
     (revChunk: Chunk) => {
-      try {
+      // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+      const run = () => {
         const [sinceId, revId] = timelineStore?.findRangeForRev(revChunk) || [null, null]
         setTimelineRange(sinceId, revId)
+      }
+      try {
+        run()
       } catch (err) {
         toast.push({
           closable: true,
@@ -86,9 +90,13 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
 
   const selectSince = useCallback(
     (sinceChunk: Chunk) => {
-      try {
+      // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+      const run = () => {
         const [sinceId, revId] = timelineStore?.findRangeForSince(sinceChunk) || [null, null]
         setTimelineRange(sinceId, revId)
+      }
+      try {
+        run()
       } catch (err) {
         toast.push({
           closable: true,


### PR DESCRIPTION
### Description

Split from #10834 to make #10834 smaller and to get to the bottom of failing e2e tests.

### What to review

Does everything make sense? There's full context available on #10834. This PR does not bump React Compiler from RC3 to v1, but it applies the same component refactors as in #10834 that reduce the amount of cases where the compiler will bail.

### Testing

If all CI tests pass then we're good.

### Notes for release

N/A - see #10834