### PR TITLE
chore: move overrides + peerDependencyRules to workspace config

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,13 +36,27 @@ catalog:
   # Note: there is currently a test failure in src/core/form/inputs/files/FileInput/__tests__/fileInput.test.tsx
   # that blocks us from upgrading to jsdom@27 – once that test is passing, the jsdom override can be removed from
   # the workspace package.json.
-  # × FileInput with empty state > renders the browse button with a tooltip when it has at least one element in assetSources 255ms
+  # The test failure looks like this:
+  # × FileInput with empty state > renders the browse button with a tooltip when it has at least one element in assetSources
   #     → Cannot create property 'border-width' on string '1px solid var(--card-border-color)'
   jsdom: ^26.1.0
   vite: ^7.1.7
   vitest: ^3.2.4
   styled-components: ^6.1.18
   typescript: 5.9.3
+
+overrides:
+  # The e2e-ui.yml workflow needs a @sanity/ui related override in the root package.json in order for it's pnpm add -w ./artifacts/sanity-ui-*.tgz to work its magic.
+  '@sanity/ui@3': '$@sanity/ui'
+  # We are currently blocked from upgrading to jsdom 27 because of a strange build error related to the new version of
+  # cssstyle required by jsdom 27. If this error is no longer present, it's safe to remove the following override.
+  jsdom: 26.1.0
+  vitest: $vitest
+
+peerDependencyRules:
+  allowAny:
+    - 'react'
+    - 'react-dom'
 
 catalogs:
   react18:


### PR DESCRIPTION
### Description
Moves pnpm overrides and peerDependencyRules to pnpm-workspace.yaml so we can have comments explaining why an override is needed.

### Testing
If CI is happy we're good

### Notes for release
n/a