### PR TITLE
fix(core): use `drafts` perspective for cross dataset refs previews

### DIFF
--- a/packages/sanity/src/core/preview/observeFields.ts
+++ b/packages/sanity/src/core/preview/observeFields.ts
@@ -175,7 +175,7 @@ export function createObserveFields(options: {
   const getBatchFetcherForDataset = memoize(
     function getBatchFetcherForDataset(apiConfig: ApiConfig) {
       const client = currentDatasetClient.withConfig(apiConfig)
-      const fetchAll = fetchAllDocumentPathsWith(client, ['published'])
+      const fetchAll = fetchAllDocumentPathsWith(client, ['drafts'])
       return debounceCollect(fetchAll, 10)
     },
     (apiConfig) => apiConfig.dataset + apiConfig.projectId,


### PR DESCRIPTION
### Description
By using the `published` perspective for the cross dataset refs preview search we limit ourselves into not showing the documents and the changes that have happened to the draft or version documents.
I think this is not necessary, it is noticeable in the incoming references work, given that if we want to display cross dataset incoming references we need to account for the drafts and version document which could have a reference to the main document.

**For example:**
In this case, I have an author which is referenced from another dataset by two books, one draft and one published. This is using the `IncomingReferences` component
If I use the `published` perspective, then the draft book won't show here

<img width="593" height="148" alt="Screenshot 2025-11-17 at 11 53 33" src="https://github.com/user-attachments/assets/939d986b-65d9-46d4-96a1-ba75a59ad042" />

<!--


What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is there an specific reason why we need `published` ?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
