### PR TITLE
fix(core): use publishedId when creating a child link

### DIFF
--- a/packages/sanity/src/presentation/paneRouter/ReferenceChildLink.tsx
+++ b/packages/sanity/src/presentation/paneRouter/ReferenceChildLink.tsx
@@ -1,5 +1,5 @@
 import {forwardRef} from 'react'
-import {pathToString} from 'sanity'
+import {getPublishedId, pathToString} from 'sanity'
 import {type ReferenceChildLinkProps} from 'sanity/structure'
 
 import {type PresentationSearchParams} from '../types'
@@ -15,7 +15,7 @@ export const ReferenceChildLink = forwardRef(function ReferenceChildLink(
     <ChildLink
       {...rest}
       ref={ref}
-      childId={documentId}
+      childId={getPublishedId(documentId)}
       childType={documentType}
       childPayload={template?.params}
       childParameters={{

--- a/packages/sanity/src/structure/components/paneRouter/ReferenceChildLink.tsx
+++ b/packages/sanity/src/structure/components/paneRouter/ReferenceChildLink.tsx
@@ -1,5 +1,6 @@
 import {toString as pathToString} from '@sanity/util/paths'
 import {type ForwardedRef, forwardRef} from 'react'
+import {getPublishedId} from 'sanity'
 
 import {ChildLink} from './ChildLink'
 import {type ReferenceChildLinkProps} from './types'
@@ -12,7 +13,7 @@ export const ReferenceChildLink = forwardRef(function ReferenceChildLink(
     <ChildLink
       {...rest}
       ref={ref}
-      childId={documentId}
+      childId={getPublishedId(documentId)}
       childPayload={template?.params}
       childParameters={{
         type: documentType,


### PR DESCRIPTION
### Description
Small fix
When using the ChildLink component, usually for references displays, the id could be a draft id or a version id.
This would lead to a url which will include the `drafts.` or `versions.xx` prefix, which we want to avoid

This change updates the ChildLink to use always the published id when creating a link to the ref.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
internal
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
