### PR TITLE
refactor(core): use explicit mutation change

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -533,7 +533,11 @@ function EditorChangePlugin(
           })
           break
         case 'mutation':
-          props.onChange(event)
+          props.onChange({
+            type: 'mutation',
+            snapshot: event.value,
+            patches: event.patches,
+          })
           break
         case 'patch': {
           if (event.patch.type === 'diffMatchPatch' && event.patch.origin === 'local') {


### PR DESCRIPTION
The `event` object carries more properties. Writing out the explicit `'mutation'` change avoids carrying over extra properties.
