### PR TITLE
fix(core): replace deprecated `OneLinePlugin`

### DIFF
--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/StringInputPortableText.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/StringInputPortableText.tsx
@@ -6,7 +6,8 @@ import {
   useEditor,
 } from '@portabletext/editor'
 import {defineBehavior, forward, raise} from '@portabletext/editor/behaviors'
-import {BehaviorPlugin, EventListenerPlugin, OneLinePlugin} from '@portabletext/editor/plugins'
+import {BehaviorPlugin, EventListenerPlugin} from '@portabletext/editor/plugins'
+import {OneLinePlugin} from '@portabletext/plugin-one-line'
 import {type Path} from '@sanity/types'
 import {Card, useArrayProp, useRootTheme} from '@sanity/ui'
 import {useCallback, useEffect, useState} from 'react'


### PR DESCRIPTION
### Description

The `OneLinePlugin` exported from `@portabletext/editor/plugins` is no longer maintained. The replacement is a standalone plugin exported from `@portabletext/plugin-one-line`.

Blocks https://github.com/sanity-io/sanity/pull/11156

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Does `StringInputPortableText` still work as expected?

### Testing

Manual testing

### Notes for release

n/a