### PR TITLE
feat: clarifying published doc has been edited and last published

### DIFF
--- a/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
@@ -89,7 +89,7 @@ type Mode = 'edited' | 'created' | 'draft' | 'published'
 
 const labels: Record<Mode, string> = {
   draft: 'document-status.edited',
-  published: 'document-status.date',
+  published: 'document-status.published',
   edited: 'document-status.edited',
   created: 'document-status.created',
 }
@@ -116,7 +116,7 @@ const VersionStatus = ({
     <Flex align="center" gap={2}>
       <ReleaseAvatar tone={tone} padding={0} />
       <Text size={1}>
-        {title || t('release.placeholder-untitled-release')}{' '}
+        {title || t('release.placeholder-untitled-release')} -{' '}
         <span style={{color: 'var(--card-muted-fg-color)'}}>
           {t(labels[mode], {date: relativeTime})}
         </span>

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -483,10 +483,12 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'document-status.date': '{{date}}',
   /** Label to show in the document footer indicating the last edited date of the document */
   'document-status.edited': 'Edited {{date}}',
+  /** Label to show in the document footer status line when a document was last published */
+  'document-status.last-published': 'Last published',
   /** Label to show in the document footer indicating the document is not published*/
   'document-status.not-published': 'Not published',
   /** Label to show in the document footer indicating the published date of the document */
-  'document-status.published': 'Published {{date}}',
+  'document-status.published': 'Edited {{date}}',
   /** Label to show in the document footer indicating the revision from date of the document */
   'document-status.revision-from': 'Revision from <em>{{date}}</em>',
 

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
@@ -35,6 +35,14 @@ const RELATIVE_TIME_OPTIONS = {
 const MotionButton = motion.create(Button)
 const MotionBox = motion.create(Box)
 
+function getDocumentStatusKey(timelineKey: string): string {
+  // the status line should show a different label than timeline changes view
+  if (timelineKey === 'timeline.operation.published') {
+    return 'document-status.last-published'
+  }
+  return timelineKey
+}
+
 const ButtonSkeleton = () => {
   return (
     <Flex align="center" gap={3} paddingLeft={1} paddingRight={2} paddingY={2}>
@@ -148,7 +156,9 @@ const EventsStatus = () => {
   return (
     <DocumentStatusButton
       author={event.author}
-      translationKey={TIMELINE_ITEM_I18N_KEY_MAPPING[event.documentVariantType][event.type]}
+      translationKey={getDocumentStatusKey(
+        TIMELINE_ITEM_I18N_KEY_MAPPING[event.documentVariantType][event.type],
+      )}
       timestamp={event.timestamp}
     />
   )
@@ -171,7 +181,7 @@ const TimelineStatus = () => {
   return (
     <DocumentStatusButton
       author={author}
-      translationKey={TIMELINE_ITEM_I18N_KEY_MAPPING_LEGACY[event.type]}
+      translationKey={getDocumentStatusKey(TIMELINE_ITEM_I18N_KEY_MAPPING_LEGACY[event.type])}
       timestamp={event.endTimestamp}
     />
   )


### PR DESCRIPTION
### Description
To clarify that the timestamps next to a published document represent the last published event timestamp the following changes have been made:

Preview components show '-' to clarify the timestamp represents the last edited time
Before:
<img width="355" height="193" alt="Screenshot 2025-11-18 at 12 08 02" src="https://github.com/user-attachments/assets/9155f277-2b7f-4534-9fd4-1bab97709d08" />

After:
<img width="363" height="195" alt="Screenshot 2025-11-18 at 12 12 01" src="https://github.com/user-attachments/assets/0282010f-5ea1-4093-9bc2-c35425ca2e11" />

Published versions status line button clarifies last published time
Before:
<img width="363" height="55" alt="Screenshot 2025-11-18 at 12 08 43" src="https://github.com/user-attachments/assets/cb77410f-cd33-4c33-9cd8-246a10ffd06f" />

After:
<img width="370" height="55" alt="Screenshot 2025-11-18 at 12 11 38" src="https://github.com/user-attachments/assets/05b1ace3-7b73-42f9-8d77-a5230a6a2ec1" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Improvements to document status copy for published documents, making it clear timestamps for published documents reflect the last edit/publish time
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
