### PR TITLE
fix(sanity): revert switch on enhanced object dialog by default (#11094)

### DIFF
--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -130,6 +130,13 @@ const defaultConfig = defineConfig({
       fieldTypes: ['string'],
     }),
   ],
+  beta: {
+    form: {
+      enhancedObjectDialog: {
+        enabled: true,
+      },
+    },
+  },
   announcements: {
     enabled: false,
   },

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -84,6 +84,14 @@ const sharedSettings = ({projectId}: {projectId: string}) => {
       bundles: testStudioLocaleBundles,
     },
 
+    beta: {
+      form: {
+        enhancedObjectDialog: {
+          enabled: true,
+        },
+      },
+    },
+
     mediaLibrary: {
       enabled: true,
     },

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -749,7 +749,7 @@ function resolveSource({
       },
       form: {
         enhancedObjectDialog: {
-          enabled: enhancedObjectDialogEnabledReducer({config, initialValue: true}),
+          enabled: enhancedObjectDialogEnabledReducer({config, initialValue: false}),
         },
       },
       create: {


### PR DESCRIPTION
### Description

This reverts commit f58536e844516005c4a63fdea7edc49558f955eb. We'd like to double check the status of this before switching it on by default.