### PR TITLE
chore: remove pnpm config from workspace package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,18 +140,6 @@
     "vitest": "catalog:"
   },
   "packageManager": "pnpm@10.22.0",
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowAny": [
-        "react",
-        "react-dom"
-      ]
-    },
-    "overrides": {
-      "@sanity/ui@3": "$@sanity/ui",
-      "jsdom": "26.1.0",
-      "vitest": "$vitest"
-    }
-  },
+  "//": "pnpm settings moved to pnpm-workspace.yaml",
   "isSanityMonorepo": true
 }


### PR DESCRIPTION
### Description
Looks like I forgot to actually remove the pnpm config from `package.json` in #11155 🤦🏼 

This removes it, but leaves a "comment" about where it's gone.

### What to review

Looks ok? I verified that the config hasn't diverged since #11155

### Testing
n/a

### Notes for release
n/a