### PR TITLE
feat(sanity): make enhanced object dialog opt out

### DIFF
--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -130,13 +130,6 @@ const defaultConfig = defineConfig({
       fieldTypes: ['string'],
     }),
   ],
-  beta: {
-    form: {
-      enhancedObjectDialog: {
-        enabled: true,
-      },
-    },
-  },
   announcements: {
     enabled: false,
   },

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -84,14 +84,6 @@ const sharedSettings = ({projectId}: {projectId: string}) => {
       bundles: testStudioLocaleBundles,
     },
 
-    beta: {
-      form: {
-        enhancedObjectDialog: {
-          enabled: true,
-        },
-      },
-    },
-
     mediaLibrary: {
       enabled: true,
     },

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -749,7 +749,7 @@ function resolveSource({
       },
       form: {
         enhancedObjectDialog: {
-          enabled: enhancedObjectDialogEnabledReducer({config, initialValue: false}),
+          enabled: enhancedObjectDialogEnabledReducer({config, initialValue: true}),
         },
       },
       create: {


### PR DESCRIPTION
This reverts commit dbb28d7ca421b63e18b1a4b61c96b2ec7f2d9596.

I will discuss this in the stand up, as far as my understanding on how we want to do the release plan this is the correct approach.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Enhanced object dialog (beta) improvements: the enhancedObjectdialog beta is now opt out by default.

In order to opt out, you will need to go to your `sanity.config.ts` and change / add a property `enhancedObjectDialog` and set it to `false`

```export default defineConfig({
// ...
  beta: {
    form: {
      enhancedObjectDialog: {
        enabled: false,
      },
    },
  },
})
```