### PR TITLE
perf: Improve createFieldDefinitions and related

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/fields.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/fields.ts
@@ -117,7 +117,7 @@ function getDocumentFieldDefinitions(
     prevFieldPath?: string
     prevTitlePath?: string[]
   }) {
-    if (depth <= MAX_OBJECT_TRAVERSAL_DEPTH) {
+    if (depth > MAX_OBJECT_TRAVERSAL_DEPTH) {
       return
     }
 


### PR DESCRIPTION
### Description

My team has seen severe delays opening the search dialog modal. After profiling, I saw the vast majority of the time was spent processing field definitions:

<img width="2098" height="2254" alt="image" src="https://github.com/user-attachments/assets/5ff802cc-ef3d-48b3-8caa-dc77118e50cc" />

The code working with the field definitions had many unnecessary iterations and memory allocations. I've reduced the iterations while keeping the original algorithm with one exception that the main difference is that consolidation logic was changed to rely on the fieldDefinitionId (which consists of the fields that were used to find the index).

#### Before 

https://github.com/user-attachments/assets/a05a5df5-b8d2-4701-a9c9-098581492430

#### After

https://github.com/user-attachments/assets/96acd9d4-f5da-4dc1-9467-82b557e1efb4


### What to review

Largest change is the consolidation logic where I'm using the id instead of re-searching the accumulated fields definitions during iteration.

### Testing

No user facing change was made. The existing tests cover it.

### Notes for release

Added by @stipsan:

Improves the performance of first render of the global search dialog (<kbd>Cmd</kbd>+<kbd>K</kbd>), especially on larger schemas.