### PR TITLE
feat(cli): add command for visualizing schema bloat

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/schema/metafile.ts
+++ b/packages/sanity/src/_internal/cli/actions/schema/metafile.ts
@@ -1,0 +1,72 @@
+import {type SeralizedSchemaDebug, type SerializedTypeDebug} from '../../threads/validateSchema'
+
+// This implements the metafile format of ESBuild.
+type Metafile = {
+  inputs: Record<string, MetafileInput>
+  outputs: Record<string, MetafileOutput>
+}
+
+type MetafileOutput = {
+  imports: []
+  exports: []
+  inputs: Record<string, {bytesInOutput: number}>
+  bytes: number
+}
+
+type MetafileInput = {
+  bytes: number
+  imports: []
+  format: 'esm' | 'csj'
+}
+
+/** Converts the  */
+export function generateMetafile(schema: SeralizedSchemaDebug): Metafile {
+  const output: MetafileOutput = {
+    imports: [],
+    exports: [],
+    inputs: {},
+    bytes: 0,
+  }
+
+  // Generate a esbuild metafile
+  const inputs: Record<string, MetafileInput> = {}
+
+  function processType(path: string, entry: SerializedTypeDebug) {
+    let childSize = 0
+
+    if (entry.fields) {
+      for (const [name, fieldEntry] of Object.entries(entry.fields)) {
+        processType(`${path}/${name}`, fieldEntry)
+        childSize += fieldEntry.size
+      }
+    }
+
+    if (entry.of) {
+      for (const [name, fieldEntry] of Object.entries(entry.of)) {
+        processType(`${path}/${name}`, fieldEntry)
+        childSize += fieldEntry.size
+      }
+    }
+
+    const selfSize = entry.size - childSize
+
+    inputs[path] = {
+      bytes: selfSize,
+      imports: [],
+      format: 'esm',
+    }
+
+    output.inputs[path] = {
+      bytesInOutput: selfSize,
+    }
+
+    output.bytes += selfSize
+  }
+
+  for (const [name, entry] of Object.entries(schema.types)) {
+    const fakePath = `schema/${entry.extends}/${name}`
+    processType(fakePath, entry)
+  }
+
+  return {outputs: {root: output}, inputs}
+}

--- a/packages/sanity/src/_internal/cli/commands/schema/validateSchemaCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/schema/validateSchemaCommand.ts
@@ -7,6 +7,7 @@ Options
   --workspace <name> The name of the workspace to use when validating all schema types.
   --format <pretty|ndjson|json> The output format used to print schema errors and warnings.
   --level <error|warning> The minimum level reported out. Defaults to warning.
+  --debug-metafile-path <path> Optional path where a metafile
 
 Examples
   # Validates all schema types in a Sanity project with more than one workspace
@@ -17,6 +18,9 @@ Examples
 
   # Report out only errors
   sanity schema validate --level error
+
+  # Generate a report which can be analyzed with https://esbuild.github.io/analyze/
+  sanity schema validate --debug-metafile-path metafile.json
 `
 
 const validateDocumentsCommand: CliCommandDefinition = {

--- a/packages/sanity/src/_internal/cli/threads/validateSchema.ts
+++ b/packages/sanity/src/_internal/cli/threads/validateSchema.ts
@@ -1,5 +1,11 @@
 import {isMainThread, parentPort, workerData as _workerData} from 'node:worker_threads'
 
+import {
+  type EncodableObject,
+  type EncodableValue,
+  type SetSynchronization,
+} from '@sanity/descriptors'
+import {DescriptorConverter} from '@sanity/schema/_internal'
 import {type SchemaValidationProblem, type SchemaValidationProblemGroup} from '@sanity/types'
 
 import {getStudioWorkspaces} from '../util/getStudioWorkspaces'
@@ -10,17 +16,43 @@ export interface ValidateSchemaWorkerData {
   workDir: string
   workspace?: string
   level?: SchemaValidationProblem['severity']
+  debugSerialize?: boolean
 }
 
 /** @internal */
 export interface ValidateSchemaWorkerResult {
   validation: SchemaValidationProblemGroup[]
+  serializedDebug?: SeralizedSchemaDebug
+}
+
+/**
+ * Contains debug information about the serialized schema.
+ *
+ * @internal
+ **/
+export type SeralizedSchemaDebug = {
+  size: number
+  parent?: SeralizedSchemaDebug
+  types: Record<string, SerializedTypeDebug>
+}
+
+/**
+ * Contains debug information about a serialized type.
+ *
+ * @internal
+ **/
+export type SerializedTypeDebug = {
+  size: number
+  extends: string
+  fields?: Record<string, SerializedTypeDebug>
+  of?: Record<string, SerializedTypeDebug>
 }
 
 const {
   workDir,
   workspace: workspaceName,
   level = 'warning',
+  debugSerialize,
 } = _workerData as ValidateSchemaWorkerData
 
 async function main() {
@@ -55,6 +87,14 @@ async function main() {
     const schema = workspace.schema
     const validation = schema._validation!
 
+    let serializedDebug: ValidateSchemaWorkerResult['serializedDebug']
+
+    if (debugSerialize) {
+      const conv = new DescriptorConverter({})
+      const set = conv.get(schema)
+      serializedDebug = getSeralizedSchemaDebug(set)
+    }
+
     const result: ValidateSchemaWorkerResult = {
       validation: validation
         .map((group) => ({
@@ -64,11 +104,78 @@ async function main() {
           ),
         }))
         .filter((group) => group.problems.length),
+      serializedDebug,
     }
 
     parentPort?.postMessage(result)
+  } catch (err) {
+    console.error(err)
+    console.error(err.stack)
+    throw err
   } finally {
     cleanup()
+  }
+}
+
+function getSeralizedSchemaDebug(set: SetSynchronization<string>): SeralizedSchemaDebug {
+  let size = 0
+  const types: Record<string, SerializedTypeDebug> = {}
+
+  for (const [id, value] of Object.entries(set.objectValues)) {
+    const typeName = typeof value.name === 'string' ? value.name : id
+    if (isEncodableObject(value.typeDef)) {
+      const debug = getSerializedTypeDebug(value.typeDef)
+      types[typeName] = debug
+      size += debug.size
+    }
+  }
+
+  return {
+    size,
+    types,
+  }
+}
+
+function isEncodableObject(val: EncodableValue | undefined): val is EncodableObject {
+  return typeof val === 'object' && val !== null && !Array.isArray(val)
+}
+
+function getSerializedTypeDebug(typeDef: EncodableObject): SerializedTypeDebug {
+  const ext = typeof typeDef.extends === 'string' ? typeDef.extends : '<unknown>'
+  let fields: SerializedTypeDebug['fields']
+  let of: SerializedTypeDebug['of']
+
+  if (Array.isArray(typeDef.fields)) {
+    fields = {}
+
+    for (const field of typeDef.fields) {
+      if (!isEncodableObject(field)) continue
+      const name = field.name
+      const fieldTypeDef = field.typeDef
+      if (typeof name !== 'string' || !isEncodableObject(fieldTypeDef)) continue
+
+      fields[name] = getSerializedTypeDebug(fieldTypeDef)
+    }
+  }
+
+  if (Array.isArray(typeDef.of)) {
+    of = {}
+
+    for (const field of typeDef.of) {
+      if (!isEncodableObject(field)) continue
+      const name = field.name
+      const arrayTypeDef = field.typeDef
+      if (typeof name !== 'string' || !isEncodableObject(arrayTypeDef)) continue
+
+      of[name] = getSerializedTypeDebug(arrayTypeDef)
+    }
+  }
+
+  return {
+    size: JSON.stringify(typeDef).length,
+    extends: ext,
+    fields,
+    of,
   }
 }
 

--- a/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
+++ b/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
@@ -24,7 +24,12 @@ export function mockBrowserEnvironment(basePath: string): () => void {
     }
   }
 
+  const btoa = global.btoa
   const domCleanup = jsdomGlobal(jsdomDefaultHtml, {url: 'http://localhost:3333/'})
+
+  // Don't use jsdom's btoa as it's using the deprecatd `abab` package.
+  if (typeof btoa === 'function') global.btoa = btoa
+
   const windowCleanup = () => global.window.close()
   const globalCleanup = provideFakeGlobals(basePath)
   const cleanupFileLoader = addHook(


### PR DESCRIPTION
### Description

Due to the dynamic nature of `sanity.config.ts` it's very easy to create enormous schemas without really being aware of this. A common gotcha is to inline types/fields instead of defining a named type.

This adds a command `sanity schema validate --debug-metafile-path <path>` which writes a file with information about the size of the serialized schema which follows ESBuild's metafile format. This can then be analyzed through https://esbuild.github.io/analyze/.

Here are some screenshots on `dev/test-studio`'s schema:

<img width="1639" height="829" alt="Screenshot 2025-11-21 at 12 26 43" src="https://github.com/user-attachments/assets/f804b25a-22bc-49aa-aec0-8e4dc466ddcc" />

<img width="1305" height="657" alt="Screenshot 2025-11-21 at 12 26 51" src="https://github.com/user-attachments/assets/d943b847-ed7c-4290-b5ad-0a53cee079fe" />

<img width="1558" height="783" alt="Screenshot 2025-11-21 at 12 26 34" src="https://github.com/user-attachments/assets/66c180ed-7224-439d-a64c-d87db315cdd5" />

I've added this to the `sanity schema validate` command since it seems to be quite similar: It's about _analyzing_ the schema to help the developer understand potential problems.

### What to review

- Try this out on some Studioes maybe?

### Testing

- I've tested it on `dev/test-studio`

### Notes for release

- `sanity schema validate --debug-metafile-path <path>` is now available. I think we should have a separate guide for how to explore the schema bloat before this gets merged.
