### PR TITLE
fix(sanity): switch enhanced object dialog off by default (#11201)

### DIFF
--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -130,6 +130,13 @@ const defaultConfig = defineConfig({
       fieldTypes: ['string'],
     }),
   ],
+  beta: {
+    form: {
+      enhancedObjectDialog: {
+        enabled: true,
+      },
+    },
+  },
   announcements: {
     enabled: false,
   },

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -84,6 +84,14 @@ const sharedSettings = ({projectId}: {projectId: string}) => {
       bundles: testStudioLocaleBundles,
     },
 
+    beta: {
+      form: {
+        enhancedObjectDialog: {
+          enabled: true,
+        },
+      },
+    },
+
     mediaLibrary: {
       enabled: true,
     },

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -749,7 +749,7 @@ function resolveSource({
       },
       form: {
         enhancedObjectDialog: {
-          enabled: enhancedObjectDialogEnabledReducer({config, initialValue: true}),
+          enabled: enhancedObjectDialogEnabledReducer({config, initialValue: false}),
         },
       },
       create: {


### PR DESCRIPTION
### Description

This reverts commit 966f4b4f062b24e1705ebdc076843b12fbda50d7. We have temporarily reverted to enhanced object dialog being switched off by default due to a bug preventing arrays with custom input components from being opened.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
