### PR TITLE
fix(sanity): excessive comment mutations when editing in PTE

### DIFF
--- a/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -10,7 +10,7 @@ import {isPortableTextTextBlock} from '@sanity/types'
 import {BoundaryElementProvider, Stack, usePortal} from '@sanity/ui'
 import * as PathUtils from '@sanity/util/paths'
 import {uuid} from '@sanity/uuid'
-import {debounce} from 'lodash'
+import {debounce, isEqual} from 'lodash'
 import {AnimatePresence} from 'motion/react'
 import {memo, startTransition, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 
@@ -324,7 +324,8 @@ export const CommentsPortableTextInputInner = memo(function CommentsPortableText
             ...(comment.target.path?.selection?.value
               .filter((r) => r._key !== nextRange[0]?._key)
               .concat(nextRange)
-              .flat() || EMPTY_ARRAY),
+              .flat()
+              .sort((a, b) => a._key.localeCompare(b._key)) || EMPTY_ARRAY),
           ]
         : EMPTY_ARRAY
 
@@ -342,7 +343,11 @@ export const CommentsPortableTextInputInner = memo(function CommentsPortableText
         },
       }
 
-      void operation.update(comment._id, nextComment)
+      const hasChanged = !isEqual(comment.target, nextComment.target)
+
+      if (hasChanged) {
+        void operation.update(comment._id, nextComment)
+      }
     })
 
     // Mark the range decorations as not dirty


### PR DESCRIPTION
### Description

PTE's `onDecorationMoved` hook is called whenever a range decoration moves. For example, when creating a new block in PTE, `onDecorationMoved` will be called for all subsequent range decorations.

However, this doesn't necessarily mean the comment's target selection changed.

This branch checks whether any part of the comment's target data has changed prior to submitting a mutation, skipping the mutation if it has not. This prevents the excessive comment mutations that currently occur every time the user makes edits in the PTE at a position preceding a comment.

Note: this branch adds sorting by `_key` when producing the next target selection value. This ensures the comparison is deterministic. The order of the array is immaterial beyond this, because the values are always addressed by their `_key`.


https://github.com/user-attachments/assets/08ddb3db-8c47-455c-90f6-1b48ce34d269


### What to review

Comments in PTE work correctly, but editing PTE no longer causes excessive comment mutations.

### Testing

Tested various scenarios in Test Studio. Existing comments tests succeed.

### Notes for release

Fixes a bug causing excessive mutations in the comments dataset when working in Portable Text Editor. In extreme cases, these mutations could result in rate limiting. Portable Text Editor no longer submits mutations for comments that are unchanged.