### PR TITLE
feat(schema): cache generated field/type objects

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/array.ts
+++ b/packages/@sanity/schema/src/legacy/types/array.ts
@@ -21,9 +21,7 @@ export const ArrayType = {
       type: ARRAY_CORE,
     })
     lazyGetter(parsed, 'of', () => {
-      return subTypeDef.of.map((ofTypeDef: any) => {
-        return createMemberType(ofTypeDef)
-      })
+      return subTypeDef.of.map((ofTypeDef: any) => createMemberType.cached(ofTypeDef))
     })
     lazyGetter(parsed, OWN_PROPS_NAME, () => ({...subTypeDef, of: parsed.of}), {
       enumerable: false,

--- a/packages/@sanity/schema/src/legacy/types/blocks/block.ts
+++ b/packages/@sanity/schema/src/legacy/types/blocks/block.ts
@@ -72,13 +72,7 @@ export const BlockType = {
     })
 
     lazyGetter(parsed, 'fields', () => {
-      return fields.map((fieldDef) => {
-        const {name, ...type} = fieldDef
-        return {
-          name: name,
-          type: extendMember(type),
-        }
-      })
+      return fields.map((fieldDef) => extendMember.cachedField(fieldDef))
     })
 
     lazyGetter(parsed, 'preview', createPreviewGetter(subTypeDef))

--- a/packages/@sanity/schema/src/legacy/types/blocks/span.ts
+++ b/packages/@sanity/schema/src/legacy/types/blocks/span.ts
@@ -56,13 +56,7 @@ export const SpanType = {
     })
 
     lazyGetter(parsed, 'fields', () => {
-      return fields.map((fieldDef) => {
-        const {name, ...type} = fieldDef
-        return {
-          name: name,
-          type: extendMember(type),
-        }
-      })
+      return fields.map((fieldDef) => extendMember.cachedField(fieldDef))
     })
 
     lazyGetter(parsed, 'annotations', () => annotations.map(extendMember))

--- a/packages/@sanity/schema/src/legacy/types/crossDatasetReference.ts
+++ b/packages/@sanity/schema/src/legacy/types/crossDatasetReference.ts
@@ -79,13 +79,7 @@ export const CrossDatasetReferenceType = {
     )
 
     lazyGetter(parsed, 'fields', () => {
-      return REFERENCE_FIELDS.map((fieldDef) => {
-        const {name, ...type} = fieldDef
-        return {
-          name: name,
-          type: createMemberType(type),
-        }
-      })
+      return REFERENCE_FIELDS.map((fieldDef) => createMemberType.cachedField(fieldDef))
     })
 
     lazyGetter(parsed, 'to', () => {

--- a/packages/@sanity/schema/src/legacy/types/globalDocumentReference.ts
+++ b/packages/@sanity/schema/src/legacy/types/globalDocumentReference.ts
@@ -66,13 +66,7 @@ export const GlobalDocumentReferenceType = {
     )
 
     lazyGetter(parsed, 'fields', () => {
-      return REFERENCE_FIELDS.map((fieldDef) => {
-        const {name, ...type} = fieldDef
-        return {
-          name: name,
-          type: createMemberType(type),
-        }
-      })
+      return REFERENCE_FIELDS.map((fieldDef) => createMemberType.cachedField(fieldDef))
     })
 
     lazyGetter(parsed, 'to', () => {

--- a/packages/@sanity/schema/src/legacy/types/object.ts
+++ b/packages/@sanity/schema/src/legacy/types/object.ts
@@ -42,22 +42,9 @@ export const ObjectType = {
       title: subTypeDef.title || (subTypeDef.name ? startCase(subTypeDef.name) : 'Object'),
       options: options,
       orderings: subTypeDef.orderings || guessOrderingConfig(subTypeDef),
-      fields: subTypeDef.fields.map((fieldDef: any) => {
-        const {name, fieldset, group, ...rest} = fieldDef
-
-        const compiledField = {
-          name,
-          group,
-          fieldset,
-        }
-
-        return lazyGetter(compiledField, 'type', () => {
-          return createMemberType({
-            ...rest,
-            title: fieldDef.title || startCase(name),
-          })
-        })
-      }),
+      fields: subTypeDef.fields.map((fieldDef: any) =>
+        createMemberType.cachedObjectField(fieldDef),
+      ),
     }
 
     const parsed = Object.assign(pick(this.get(), OVERRIDABLE_FIELDS), ownProps, {

--- a/packages/@sanity/schema/src/legacy/types/reference.ts
+++ b/packages/@sanity/schema/src/legacy/types/reference.ts
@@ -63,13 +63,7 @@ export const ReferenceType = {
     })
 
     lazyGetter(parsed, 'fields', () => {
-      return REFERENCE_FIELDS.map((fieldDef) => {
-        const {name, ...type} = fieldDef
-        return {
-          name: name,
-          type: createMemberType(type),
-        }
-      })
+      return REFERENCE_FIELDS.map((fieldDef) => createMemberType.cachedField(fieldDef))
     })
 
     lazyGetter(parsed, 'fieldsets', () => {


### PR DESCRIPTION
### Description

This makes sure that the same field/type definition always ends up becoming the exact same field/type object, making it possible to use `===` to compare them. In general, this should reduce the memory usage for customers who are reusing the same field multiple places.

This also enables us to later optimize this scenario when serializing as well.

(Note that this PR doesn't actually depend on #11224, but it was easier for me to have a full stack. If this gets attention before #11224 I will reorder them.)

### What to review

- Well, do you have knowledge of places where we might depend on the compiled field/type? 

### Testing

- I've tested the test-studio locally, but other than that I depend on the existing tests.

### Notes for release

N/A.
