### PR TITLE
fix(deps): mark support for `react<19.2` and `@sanity/ui<3` as deprecated

### DIFF
--- a/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
+++ b/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
@@ -19,8 +19,8 @@ interface PackageInfo {
 // NOTE: when doing changes here, also remember to update versions in help docs at
 // https://sanity.io/admin/structure/docs;helpArticle;upgrade-packages
 const PACKAGES = [
-  {name: 'react', supported: ['^18 || ^19'], deprecatedBelow: '^19.2'},
-  {name: 'react-dom', supported: ['^18 || ^19'], deprecatedBelow: '^19.2'},
+  {name: 'react', supported: ['^18', '^19.2'], deprecatedBelow: '^19.2'},
+  {name: 'react-dom', supported: ['^18', '^19.2'], deprecatedBelow: '^19.2'},
   {name: 'styled-components', supported: ['^6'], deprecatedBelow: null},
   {name: '@sanity/ui', supported: ['^2', '^3'], deprecatedBelow: '^3'},
 ]


### PR DESCRIPTION
### Description

This marks React < 19.2 as deprecated, which will issue a warning when running `sanity dev` from now on:

```
> sanity dev

[WARN] The following package versions have been deprecated and should be upgraded:

  react (installed: 18.3.1, want: ^19.2)
  react-dom (installed: 18.3.1, want: ^19.2)

Support for these will be removed in a future release!

  To upgrade, run either:

  npm install "react@19.2.0" "react-dom@19.2.0"

  or

  yarn add "react@19.2.0" "react-dom@19.2.0"

  or

  pnpm add "react@19.2.0" "react-dom@19.2.0"


Read more at https://docs.sanity.io/help/upgrade-packages

✓ Checking configuration files...
✓ Starting dev server
Sanity Studio using vite@7.2.4 ready in 254ms and running at http://localhost:3333/
```

Note that React 18 is still _supported_, and will be so for the remaining releases on the 4.x line.

### Remaining tasks
- [x] The linked help article needs updating
- [ ] Publish a blog post outlining why we're doing this

### What to review
- The warning feels a bit heavy-handed to me. It's only deprecated after all. Should we change wording and/or offer a way to silence it?

### Testing

Follow [instructions](https://github.com/sanity-io/sanity/pull/11238#issuecomment-3571416793) to install preview build in an existing studio. Make sure `react` and `react-dom` versions are in the 18.x range. Observe the deprecation warning appear.

### Notes for release

TBD