### PR TITLE
refactor(schema): remove unused options to DescriptorConverter

### DIFF
--- a/packages/@sanity/schema/src/descriptors/convert.ts
+++ b/packages/@sanity/schema/src/descriptors/convert.ts
@@ -51,12 +51,7 @@ const MAX_DEPTH_UKNOWN = 5
 type UnknownRecord<T> = {[P in keyof T]: unknown}
 
 export class DescriptorConverter {
-  opts: Options
   cache: WeakMap<Schema, SetSynchronization<RegistryType>> = new WeakMap()
-
-  constructor(opts: Options) {
-    this.opts = opts
-  }
 
   /**
    * Returns a synchronization object for a schema.
@@ -69,7 +64,7 @@ export class DescriptorConverter {
 
     const builder = new SetBuilder()
     for (const name of schema.getLocalTypeNames()) {
-      const typeDef = convertTypeDef(schema.get(name)!, this.opts)
+      const typeDef = convertTypeDef(schema.get(name)!, {})
       builder.addObject('sanity.schema.namedType', {name, typeDef})
     }
 

--- a/packages/sanity/src/_internal/cli/threads/validateSchema.ts
+++ b/packages/sanity/src/_internal/cli/threads/validateSchema.ts
@@ -90,7 +90,7 @@ async function main() {
     let serializedDebug: ValidateSchemaWorkerResult['serializedDebug']
 
     if (debugSerialize) {
-      const conv = new DescriptorConverter({})
+      const conv = new DescriptorConverter()
       const set = conv.get(schema)
       serializedDebug = getSeralizedSchemaDebug(set)
     }

--- a/packages/sanity/src/core/schema/descriptors.ts
+++ b/packages/sanity/src/core/schema/descriptors.ts
@@ -1,20 +1,3 @@
 import {DescriptorConverter} from '@sanity/schema/_internal'
-import {type Rule, type SchemaValidationValue} from '@sanity/types'
 
-import {Rule as RuleClass} from '../validation'
-
-export const DESCRIPTOR_CONVERTER = new DescriptorConverter({
-  ruleClass: RuleClass,
-  validationExtractor: normalizeValidationValue,
-})
-
-function normalizeValidationValue(validation: SchemaValidationValue): Rule[] {
-  if (!validation) return []
-
-  if (Array.isArray(validation)) {
-    return validation.flatMap((inner) => normalizeValidationValue(inner))
-  } else if (typeof validation === 'object') {
-    return [validation]
-  }
-  return normalizeValidationValue(validation(new RuleClass()))
-}
+export const DESCRIPTOR_CONVERTER = new DescriptorConverter()

--- a/packages/sanity/test/descriptors/extractManifestToSchema.test.ts
+++ b/packages/sanity/test/descriptors/extractManifestToSchema.test.ts
@@ -5,7 +5,7 @@ import {describe, test} from 'vitest'
 
 import {expectManifestSchemaConversion} from './utils'
 
-const DESCRIPTOR_CONVERTER = new DescriptorConverter({})
+const DESCRIPTOR_CONVERTER = new DescriptorConverter()
 
 function validate(schema: Schema) {
   expectManifestSchemaConversion(schema, DESCRIPTOR_CONVERTER.get(schema))


### PR DESCRIPTION
### Description

I believe these were leftover from a refactoring by @dcilke related to how we deal with validations in the schema package.

### What to review

N/A.

### Testing

N/A.

### Notes for release

N/A.
