### PR TITLE
feat(schema): de-dupe re-used fields in the descriptor

### DIFF
--- a/dev/test-studio/schema/standard/portableText/manyEditors.js
+++ b/dev/test-studio/schema/standard/portableText/manyEditors.js
@@ -40,6 +40,81 @@ const myStringType = defineField({
   fields: [{type: 'string', name: 'mystring', validation: (Rule) => Rule.required()}],
 })
 
+const bodyMembers = [
+  defineArrayMember({
+    type: 'block',
+    marks: {
+      annotations: [linkType, myStringType],
+    },
+    of: [
+      {type: 'image', name: 'image'},
+      myStringType,
+      {
+        type: 'reference',
+        name: 'strongAuthorRef',
+        title: 'A strong author ref',
+        to: {type: 'author'},
+      },
+    ],
+    validation: (Rule) =>
+      Rule.custom((block) => {
+        const text = extractTextFromBlocks([block])
+        return text.length === 1 ? 'Please write a longer paragraph.' : true
+      }),
+    options: {
+      spellCheck: true,
+    },
+  }),
+  {
+    type: 'image',
+    name: 'image',
+    options: {
+      modal: {
+        // The default `type` of object blocks is 'dialog'
+        // type: 'dialog',
+        // The default `width` of object blocks is 'medium'
+        // width: 'small',
+      },
+    },
+  },
+  {
+    type: 'object',
+    name: 'callout',
+    title: 'Callout',
+    components: {
+      preview: CalloutPreview,
+    },
+    fields: [
+      {
+        type: 'string',
+        name: 'title',
+        title: 'Title',
+      },
+      {
+        type: 'string',
+        name: 'tone',
+        title: 'Tone',
+        options: {
+          list: [
+            {value: 'default', title: 'Default'},
+            {value: 'primary', title: 'Primary'},
+            {value: 'positive', title: 'Positive'},
+            {value: 'caution', title: 'Caution'},
+            {value: 'critical', title: 'Critical'},
+          ],
+        },
+      },
+    ],
+    preview: {
+      select: {
+        title: 'title',
+        tone: 'tone',
+      },
+    },
+  },
+  myStringType,
+]
+
 const createBodyField = (title, name, size = 1) => {
   const fields = []
   for (let i = 1; i <= size; i++) {
@@ -48,80 +123,7 @@ const createBodyField = (title, name, size = 1) => {
         name: `${name}${i}`,
         title: title,
         type: 'array',
-        of: [
-          defineArrayMember({
-            type: 'block',
-            marks: {
-              annotations: [linkType, myStringType],
-            },
-            of: [
-              {type: 'image', name: 'image'},
-              myStringType,
-              {
-                type: 'reference',
-                name: 'strongAuthorRef',
-                title: 'A strong author ref',
-                to: {type: 'author'},
-              },
-            ],
-            validation: (Rule) =>
-              Rule.custom((block) => {
-                const text = extractTextFromBlocks([block])
-                return text.length === 1 ? 'Please write a longer paragraph.' : true
-              }),
-            options: {
-              spellCheck: true,
-            },
-          }),
-          {
-            type: 'image',
-            name: 'image',
-            options: {
-              modal: {
-                // The default `type` of object blocks is 'dialog'
-                // type: 'dialog',
-                // The default `width` of object blocks is 'medium'
-                // width: 'small',
-              },
-            },
-          },
-          {
-            type: 'object',
-            name: 'callout',
-            title: 'Callout',
-            components: {
-              preview: CalloutPreview,
-            },
-            fields: [
-              {
-                type: 'string',
-                name: 'title',
-                title: 'Title',
-              },
-              {
-                type: 'string',
-                name: 'tone',
-                title: 'Tone',
-                options: {
-                  list: [
-                    {value: 'default', title: 'Default'},
-                    {value: 'primary', title: 'Primary'},
-                    {value: 'positive', title: 'Positive'},
-                    {value: 'caution', title: 'Caution'},
-                    {value: 'critical', title: 'Critical'},
-                  ],
-                },
-              },
-            ],
-            preview: {
-              select: {
-                title: 'title',
-                tone: 'tone',
-              },
-            },
-          },
-          myStringType,
-        ],
+        of: bodyMembers,
       }),
     )
   }

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -57,7 +57,7 @@
     "watch": "pkg-utils watch"
   },
   "dependencies": {
-    "@sanity/descriptors": "^1.1.1",
+    "@sanity/descriptors": "^1.2.1",
     "@sanity/generate-help-url": "^3.0.0",
     "@sanity/types": "workspace:*",
     "arrify": "^2.0.1",

--- a/packages/@sanity/schema/src/descriptors/types.ts
+++ b/packages/@sanity/schema/src/descriptors/types.ts
@@ -18,7 +18,7 @@ export interface CommonTypeDef extends EncodableObject {
   title?: string
   description?: string | JSXMarker
 
-  fields?: ObjectField[]
+  fields?: Array<ObjectField | HoistedMarker>
   groups?: ObjectGroup[]
   fieldsets?: ObjectFieldset[]
 
@@ -68,6 +68,9 @@ export type UnknownMarker = {__type: 'unknown'}
 /** Denotes a number which we've turned into a string for serialization. */
 export type NumberMarker = {__type: 'number'; value: string}
 
+/** Denotes a value which has been hoisted out into its own descriptor. */
+export type HoistedMarker = {__type: 'hoisted'; key: string}
+
 /**
  * Denotes an object. This is only used when we see an object with "__type" and
  * want to avoid it being interpreted as a marker.
@@ -91,7 +94,7 @@ export interface SubtypeDef extends CommonTypeDef {
 
 export interface ArrayTypeDef extends SubtypeDef {
   extends: 'array'
-  of: ArrayElement[]
+  of: Array<ArrayElement | HoistedMarker>
 }
 
 export type ArrayElement = {

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -280,7 +280,7 @@
     "@repo/test-config": "workspace:*",
     "@repo/tsconfig": "workspace:*",
     "@sanity/codegen": "workspace:*",
-    "@sanity/descriptors": "^1.1.1",
+    "@sanity/descriptors": "^1.2.1",
     "@sanity/eslint-config-i18n": "catalog:",
     "@sanity/generate-help-url": "^3.0.0",
     "@sanity/pkg-utils": "catalog:",

--- a/packages/sanity/src/_internal/cli/actions/schema/metafile.ts
+++ b/packages/sanity/src/_internal/cli/actions/schema/metafile.ts
@@ -68,5 +68,10 @@ export function generateMetafile(schema: SeralizedSchemaDebug): Metafile {
     processType(fakePath, entry)
   }
 
+  for (const [name, entry] of Object.entries(schema.hoisted)) {
+    const fakePath = `hoisted/${name}`
+    processType(fakePath, entry)
+  }
+
   return {outputs: {root: output}, inputs}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1531,8 +1531,8 @@ importers:
   packages/@sanity/schema:
     dependencies:
       '@sanity/descriptors':
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^1.2.1
+        version: 1.2.1
       '@sanity/generate-help-url':
         specifier: ^3.0.0
         version: 3.0.0
@@ -2356,8 +2356,8 @@ importers:
         specifier: workspace:*
         version: link:../@sanity/codegen
       '@sanity/descriptors':
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^1.2.1
+        version: 1.2.1
       '@sanity/eslint-config-i18n':
         specifier: 'catalog:'
         version: 2.0.0(eslint@9.39.1(jiti@2.6.1))
@@ -5265,8 +5265,8 @@ packages:
     resolution: {integrity: sha512-KhxRuCtJeZXxX8NGkNaBBgFfbIK3PYBDh2nnFrvw90QOl1Hm0P7SP/D1Sf64FCwUz6H73sq4iBhNKxFZWiwRpw==}
     engines: {node: '>=18'}
 
-  '@sanity/descriptors@1.1.1':
-    resolution: {integrity: sha512-pTqpyLhH3z4NDhjKHyfL+quVN0ixA8NikcdqxRmL2iqPZuJavi81eKm631PaUqJGbY1kh1+vHnO1/GgWIcjgxw==}
+  '@sanity/descriptors@1.2.1':
+    resolution: {integrity: sha512-QrniEsAHdKhiaEs+67ukCTZcWRBE4VqF+z/ATn27vBYcQAJ3LvlZUBXloAhaEcmgqRkT1G+RnuakpjWNnELm1A==}
     engines: {node: '>=18.0.0'}
 
   '@sanity/diff-match-patch@3.2.0':
@@ -16246,7 +16246,7 @@ snapshots:
       - debug
       - typescript
 
-  '@sanity/descriptors@1.1.1':
+  '@sanity/descriptors@1.2.1':
     dependencies:
       sha256-uint8array: 0.10.7
 


### PR DESCRIPTION
### Description

This changes the format of the schema descriptor (i.e. the server-side schema) to automatically detect when a field or array member is reused and then hoists it outside as a separate object.

### What to review

- That the overall algorithm makes sense and is correct. This shouldn't touch anything outside of the schema descriptor stuff.

### Testing

- I should probably add a unit test for the behavior here. I can look into that.

### Notes for release

N/A. Still only internal.
